### PR TITLE
Make xattr test conditional on feature support.

### DIFF
--- a/test/integration/targets/xattr/defaults/main.yml
+++ b/test/integration/targets/xattr/defaults/main.yml
@@ -1,1 +1,1 @@
-test_file: ~/foo.txt
+test_file: "{{ output_dir }}/foo.txt"

--- a/test/integration/targets/xattr/tasks/main.yml
+++ b/test/integration/targets/xattr/tasks/main.yml
@@ -1,68 +1,11 @@
 - name: Setup
   include: setup.yml
 
-- name: Set attributes
-  xattr:
-    path: "{{ test_file }}"
-    key: user.foo
-    value: bar
-  register: xattr_set_result
+- name: Check availability of xattr support
+  command: setfattr -n user.foo {{ test_file }}
+  ignore_errors: yes
+  register: xattr
 
-- name: Get attributes
-  xattr:
-    path: "{{ test_file }}"
-  register: xattr_get_all_result
-
-- name: Get specific attribute
-  xattr:
-    path: "{{ test_file }}"
-    key: user.foo
-  register: xattr_get_specific_result
-
-- assert:
-    that:
-    - "xattr_set_result.changed"
-    - "xattr_get_all_result['xattr']['user.foo'] == 'bar'"
-    - "not xattr_get_all_result.changed"
-    - "xattr_get_specific_result['xattr']['user.foo'] == 'bar'"
-    - "not xattr_get_specific_result.changed"
-
-- name: Set attribute again
-  xattr:
-    path: "{{ test_file }}"
-    key: user.foo
-    value: bar
-  register: xattr_set_again_result
-
-- assert:
-    that:
-    - "not xattr_set_again_result.changed"
-
-- name: Unset attribute
-  xattr:
-    path: "{{ test_file }}"
-    key: user.foo
-    state: absent
-  register: xattr_unset_result
-
-- name: get attributes
-  xattr:
-    path: "{{ test_file }}"
-  register: xattr_get_after_unset_result
-
-- assert:
-    that:
-    - "xattr_unset_result.changed"
-    - "xattr_get_after_unset_result['xattr'] == {}"
-    - "not xattr_get_after_unset_result.changed"
-
-- name: Unset attribute again
-  xattr:
-    path: "{{ test_file }}"
-    key: user.foo
-    state: absent
-  register: xattr_unset_result
-
-- assert:
-    that:
-    - "not xattr_set_again_result.changed"
+- name: Test
+  include: test.yml
+  when: xattr is not failed

--- a/test/integration/targets/xattr/tasks/test.yml
+++ b/test/integration/targets/xattr/tasks/test.yml
@@ -1,0 +1,65 @@
+- name: Set attributes
+  xattr:
+    path: "{{ test_file }}"
+    key: user.foo
+    value: bar
+  register: xattr_set_result
+
+- name: Get attributes
+  xattr:
+    path: "{{ test_file }}"
+  register: xattr_get_all_result
+
+- name: Get specific attribute
+  xattr:
+    path: "{{ test_file }}"
+    key: user.foo
+  register: xattr_get_specific_result
+
+- assert:
+    that:
+    - "xattr_set_result.changed"
+    - "xattr_get_all_result['xattr']['user.foo'] == 'bar'"
+    - "not xattr_get_all_result.changed"
+    - "xattr_get_specific_result['xattr']['user.foo'] == 'bar'"
+    - "not xattr_get_specific_result.changed"
+
+- name: Set attribute again
+  xattr:
+    path: "{{ test_file }}"
+    key: user.foo
+    value: bar
+  register: xattr_set_again_result
+
+- assert:
+    that:
+    - "not xattr_set_again_result.changed"
+
+- name: Unset attribute
+  xattr:
+    path: "{{ test_file }}"
+    key: user.foo
+    state: absent
+  register: xattr_unset_result
+
+- name: get attributes
+  xattr:
+    path: "{{ test_file }}"
+  register: xattr_get_after_unset_result
+
+- assert:
+    that:
+    - "xattr_unset_result.changed"
+    - "xattr_get_after_unset_result['xattr'] == {}"
+    - "not xattr_get_after_unset_result.changed"
+
+- name: Unset attribute again
+  xattr:
+    path: "{{ test_file }}"
+    key: user.foo
+    state: absent
+  register: xattr_unset_result
+
+- assert:
+    that:
+    - "not xattr_set_again_result.changed"


### PR DESCRIPTION
##### SUMMARY

Make xattr test conditional on feature support.

This will allow the test to be automatically skipped when running in an environment that does not support extended attributes, such as newer docker installations.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

xattr integration tests

##### ANSIBLE VERSION

```
ansible 2.5.0 (test-xattr 21fec7a9c8) last updated 2018/01/08 22:31:33 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```
