### PR TITLE
Don't log AWS credentials when creating YAML anchor

### DIFF
--- a/test/integration/targets/ecs_cluster/tasks/main.yml
+++ b/test/integration/targets/ecs_cluster/tasks/main.yml
@@ -10,6 +10,7 @@
           aws_secret_key: "{{ aws_secret_key }}"
           security_token: "{{ security_token }}"
           region: "{{ aws_region }}"
+      no_log: yes
 
     - name: ensure IAM instance role exists
       iam_role:


### PR DESCRIPTION
##### SUMMARY
Turn `no_log` on when setting the fact.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ecs_cluster

##### ANSIBLE VERSION
```
ansible 2.5.0 (devel 7d037991a3) last updated 2018/01/09 19:09:41 (GMT +1000)
  config file = None
  configured module search path = [u'/Users/will/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/will/src/ansible/lib/ansible
  executable location = /Users/will/src/ansible/bin/ansible
  python version = 2.7.14 (default, Jan  6 2018, 12:16:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
