### PR TITLE
Update developing_api.rst

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_api.rst
+++ b/docs/docsite/rst/dev_guide/developing_api.rst
@@ -68,7 +68,7 @@ In 2.0 things get a bit more complicated to start, but you end up with much more
     Options = namedtuple('Options', ['connection', 'module_path', 'forks', 'become', 'become_method', 'become_user', 'check', 'diff'])
     # initialize needed objects
     loader = DataLoader()
-    options = Options(connection='local', module_path='/path/to/mymodules', forks=100, become=None, become_method=None, become_user=None, check=False,
+    options = Options(connection='local', module_path=['/path/to/mymodules'], forks=100, become=None, become_method=None, become_user=None, check=False,
                       diff=False)
     passwords = dict(vault_pass='secret')
 


### PR DESCRIPTION
##### SUMMARY
Provided Module path needs to be array instead of a string variable in order to work.

##### ISSUE TYPE
 - Docs Pull Request

##### ANSIBLE VERSION
ansible 2.4.1.0
  config file = None
  configured module search path = [u'/home/ansible/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Aug  4 2017, 00:39:18) [GCC 4.8.5 20150623 (Red Hat 4.8.5-16)]


