### PR TITLE
fix nxos_bgp failure for graceful_restart warning

### DIFF
--- a/lib/ansible/module_utils/nxos.py
+++ b/lib/ansible/module_utils/nxos.py
@@ -176,7 +176,13 @@ class Cli:
         msgs = []
         for cmd in config:
             rc, out, err = self.exec_command(cmd)
-            if rc != 0:
+            if rc != 0 and 'no graceful-restart' in err:
+                if 'ISSU/HA will be affected if Graceful Restart is disabled' in err:
+                    out = ''
+                    msgs.append(out)
+                else:
+                    self._module.fail_json(msg=to_text(err, errors='surrogate_then_replace'))
+            elif rc != 0:
                 self._module.fail_json(msg=to_text(err, errors='surrogate_then_replace'))
             elif out:
                 msgs.append(out)


### PR DESCRIPTION
Signed-off-by: Trishna Guha <trishnaguha17@gmail.com>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
fixes https://github.com/ansible/ansible/issues/34586
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
module_utils/nxos.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.4
```