### PR TITLE
Fix Linux blockdevice size computation

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -1482,7 +1482,7 @@ class LinuxHardware(Hardware):
                     part['sectorsize'] = get_file_content(part_sysdir + "/queue/logical_block_size")
                     if not part['sectorsize']:
                         part['sectorsize'] = get_file_content(part_sysdir + "/queue/hw_sector_size",512)
-                    part['size'] = self.module.pretty_bytes((float(part['sectors']) * float(part['sectorsize'])))
+                    part['size'] = self.module.pretty_bytes((float(part['sectors']) * 512.0))
                     part['uuid'] = get_partition_uuid(partname)
                     self.get_holders(part, part_sysdir)
 
@@ -1502,7 +1502,7 @@ class LinuxHardware(Hardware):
             d['sectorsize'] = get_file_content(sysdir + "/queue/logical_block_size")
             if not d['sectorsize']:
                 d['sectorsize'] = get_file_content(sysdir + "/queue/hw_sector_size",512)
-            d['size'] = self.module.pretty_bytes(float(d['sectors']) * float(d['sectorsize']))
+            d['size'] = self.module.pretty_bytes(float(d['sectors']) * 512.0)
 
             d['host'] = ""
 


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Backport

Linux' sysfs _always_ reports device size in 512b sector units,
regardless of the device's actual, physical blocksize.

Backport of PR#34475 originally written by jtru

Original Commit ID: 603d31685c01caa62db137d8aab1a54180e3373d

Signed-off-by: Adam Miller <admiller@redhat.com>
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
facts

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.3.3.0 (stable-2.3-backport 09ad386259) last updated 2018/01/09 08:46:13 (GMT -500)                           
  config file = /etc/ansible/ansible.cfg                   
  configured module search path = Default w/o overrides    
  python version = 2.7.14 (default, Dec 11 2017, 14:52:53) [GCC 7.2.1 20170915 (Red Hat 7.2.1-2)]     
```

