### PR TITLE
Fix Linux blockdevice size computation (#34475)

### DIFF
--- a/lib/ansible/module_utils/facts/hardware/linux.py
+++ b/lib/ansible/module_utils/facts/hardware/linux.py
@@ -601,7 +601,7 @@ class LinuxHardware(Hardware):
                     part['sectorsize'] = get_file_content(part_sysdir + "/queue/logical_block_size")
                     if not part['sectorsize']:
                         part['sectorsize'] = get_file_content(part_sysdir + "/queue/hw_sector_size", 512)
-                    part['size'] = bytes_to_human((float(part['sectors']) * float(part['sectorsize'])))
+                    part['size'] = bytes_to_human((float(part['sectors']) * 512.0))
                     part['uuid'] = get_partition_uuid(partname)
                     self.get_holders(part, part_sysdir)
 
@@ -621,7 +621,7 @@ class LinuxHardware(Hardware):
             d['sectorsize'] = get_file_content(sysdir + "/queue/logical_block_size")
             if not d['sectorsize']:
                 d['sectorsize'] = get_file_content(sysdir + "/queue/hw_sector_size", 512)
-            d['size'] = bytes_to_human(float(d['sectors']) * float(d['sectorsize']))
+            d['size'] = bytes_to_human(float(d['sectors']) * 512.0)
 
             d['host'] = ""
 


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
backport 

Linux' sysfs _always_ reports device size in 512b sector units,
regardless of the device's actual, physical blocksize.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
facts

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.3 (stable-2.4-backports 354e72a222) last updated 2018/01/09 08:37:20 (GMT -500)                            
  config file = /etc/ansible/ansible.cfg                   
  configured module search path = [u'/home/admiller/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']  
  ansible python module location = /home/admiller/src/dev/ansible/lib/ansible                                          
  executable location = /home/admiller/src/dev/ansible/bin/ansible                                                     
  python version = 2.7.14 (default, Dec 11 2017, 14:52:53) [GCC 7.2.1 20170915 (Red Hat 7.2.1-2)]   
```

