### PR TITLE
Error if a module is found to shadow a reserved keyword

### DIFF
--- a/lib/ansible/plugins/loader.py
+++ b/lib/ansible/plugins/loader.py
@@ -331,7 +331,7 @@ class PluginLoader:
         from ansible.vars.reserved import is_reserved_name
 
         plugin = self._find_plugin(name, mod_type=mod_type, ignore_deprecated=ignore_deprecated, check_aliases=check_aliases)
-        if plugin and is_reserved_name(name):
+        if plugin and self.package == 'ansible.modules' and is_reserved_name(name):
             raise AnsibleError(
                 'Module "%s" shadows the name of a reserved keyword. Please rename or remove this module. Found at %s' % (name, plugin)
             )

--- a/lib/ansible/plugins/loader.py
+++ b/lib/ansible/plugins/loader.py
@@ -234,20 +234,6 @@ class PluginLoader:
                 self._paths = None
                 display.debug('Added %s to loader search path' % (directory))
 
-    def find_plugin(self, name, mod_type='', ignore_deprecated=False, check_aliases=False):
-        ''' Find a plugin named name '''
-
-        # Import here to avoid circular import
-        from ansible.vars.reserved import is_reserved_name
-
-        plugin = self._find_plugin(name, mod_type=mod_type, ignore_deprecated=ignore_deprecated, check_aliases=check_aliases)
-        if plugin and is_reserved_name(name):
-            raise AnsibleError(
-                'Module "%s" shadows the name of a reserved keyword. Please rename or remove this module. Found at %s' % (name, plugin)
-            )
-
-        return plugin
-
     def _find_plugin(self, name, mod_type='', ignore_deprecated=False, check_aliases=False):
         ''' Find a plugin named name '''
 
@@ -337,6 +323,20 @@ class PluginLoader:
                 return pull_cache[alias_name]
 
         return None
+
+    def find_plugin(self, name, mod_type='', ignore_deprecated=False, check_aliases=False):
+        ''' Find a plugin named name '''
+
+        # Import here to avoid circular import
+        from ansible.vars.reserved import is_reserved_name
+
+        plugin = self._find_plugin(name, mod_type=mod_type, ignore_deprecated=ignore_deprecated, check_aliases=check_aliases)
+        if plugin and is_reserved_name(name):
+            raise AnsibleError(
+                'Module "%s" shadows the name of a reserved keyword. Please rename or remove this module. Found at %s' % (name, plugin)
+            )
+
+        return plugin
 
     def has_plugin(self, name):
         ''' Checks if a plugin named name exists '''

--- a/lib/ansible/plugins/loader.py
+++ b/lib/ansible/plugins/loader.py
@@ -16,6 +16,8 @@ import warnings
 
 from collections import defaultdict
 
+from functools import wraps
+
 from ansible import constants as C
 from ansible.errors import AnsibleError
 from ansible.module_utils._text import to_text
@@ -31,6 +33,7 @@ except ImportError:
 
 
 def check_if_plugin_is_reserved_name(func):
+    @wraps(func)
     def inner(self, name, *args, **kwargs):
         from ansible.vars.reserved import is_reserved_name
         plugin = func(self, name, *args, **kwargs)

--- a/lib/ansible/vars/reserved.py
+++ b/lib/ansible/vars/reserved.py
@@ -77,4 +77,8 @@ def warn_if_reserved(myvars):
         display.warning('Found variable using reserved name: %s' % varname)
 
 
+def is_reserved_name(name):
+    return name in _RESERVED_NAMES
+
+
 _RESERVED_NAMES = frozenset(get_reserved_names())

--- a/test/integration/targets/shadowed_module/aliases
+++ b/test/integration/targets/shadowed_module/aliases
@@ -1,0 +1,1 @@
+posix/ci/group3

--- a/test/integration/targets/shadowed_module/inventory
+++ b/test/integration/targets/shadowed_module/inventory
@@ -1,0 +1,1 @@
+../../inventory

--- a/test/integration/targets/shadowed_module/playbook.yml
+++ b/test/integration/targets/shadowed_module/playbook.yml
@@ -1,0 +1,6 @@
+---
+- hosts: localhost
+  gather_facts: false
+  tasks:
+    - command: whoami
+      tags: foo

--- a/test/integration/targets/shadowed_module/playbook_lookup.yml
+++ b/test/integration/targets/shadowed_module/playbook_lookup.yml
@@ -1,0 +1,6 @@
+---
+- hosts: localhost
+  gather_facts: false
+  tasks:
+    - debug:
+        msg: "{{ lookup('vars', 'inventory_hostname') }}"

--- a/test/integration/targets/shadowed_module/runme.sh
+++ b/test/integration/targets/shadowed_module/runme.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -ux
+
+OUT=$(ansible-playbook playbook.yml -i inventory -e @../../integration_config.yml "$@" 2>&1 | grep 'ERROR! Module "tags" shadows the name of a reserved keyword.')
+
+if [[ -z "$OUT" ]]; then
+    echo "Fake tags module did not cause error"
+    exit 1
+fi

--- a/test/integration/targets/shadowed_module/runme.sh
+++ b/test/integration/targets/shadowed_module/runme.sh
@@ -8,3 +8,7 @@ if [[ -z "$OUT" ]]; then
     echo "Fake tags module did not cause error"
     exit 1
 fi
+
+# This playbook calls a lookup which shadows a keyword.
+# This is an ok situation, and should not error
+ansible-playbook playbook_lookup.yml -i inventory -e @../../integration_config.yml "$@"


### PR DESCRIPTION
##### SUMMARY
Error if a module is found to shadow a reserved keyword

This prevents the error:

```
ERROR! conflicting action statements: command, tags
```

and replaces it with
```
ERROR! Module "tags" shadows the name of a reserved keyword. Please rename or remove this module. Found at /Users/matt/projects/ansibledev/playbooks/tags/library/tags
```

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
lib/ansible/plugins/loader.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```