### PR TITLE
Error early if executing python version doesn't meet documented minimums

### DIFF
--- a/bin/ansible
+++ b/bin/ansible
@@ -43,11 +43,11 @@ from ansible.module_utils._text import to_text
 
 # Used for determining if the system is running a new enough python version
 # and should only restrict on our documented minimum versions
-_PY3_MIN = sys.version_info[:2] >= (3, 5) and sys.version_info[0] == 3
-_PY2_MIN = sys.version_info[:2] >= (2, 6) and sys.version_info[0] == 2
+_PY3_MIN = sys.version_info[:2] >= (3, 5)
+_PY2_MIN = (2, 6) <= sys.version_info[:2] < (3,)
 _PY_MIN = _PY3_MIN or _PY2_MIN
 if not _PY_MIN:
-    raise SystemExit('ERROR: Ansible requires a minimum of Python 2.6 or Python 3.5. Current version: %s' % ''.join(sys.version.splitlines()))
+    raise SystemExit('ERROR: Ansible requires a minimum of Python2 version 2.6 or Python3 version 3.5. Current version: %s' % ''.join(sys.version.splitlines()))
 
 
 class LastResort(object):

--- a/bin/ansible
+++ b/bin/ansible
@@ -41,6 +41,15 @@ from ansible.errors import AnsibleError, AnsibleOptionsError, AnsibleParserError
 from ansible.module_utils._text import to_text
 
 
+# Used for determining if the system is running a new enough python version
+# and should only restrict on our documented minimum versions
+_PY3_MIN = sys.version_info[:2] >= (3, 5) and sys.version_info[0] == 3
+_PY2_MIN = sys.version_info[:2] >= (2, 6) and sys.version_info[0] == 2
+_PY_MIN = _PY3_MIN or _PY2_MIN
+if not _PY_MIN:
+    raise SystemExit('ERROR: Ansible requires a minimum of Python 2.6 or Python 3.5. Current version: %s' % ''.join(sys.version.splitlines()))
+
+
 class LastResort(object):
     # OUTPUT OF LAST RESORT
     def display(self, msg, log_only=None):

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -232,6 +232,15 @@ PERM_BITS = 0o7777       # file mode permission bits
 EXEC_PERM_BITS = 0o0111  # execute permission bits
 DEFAULT_PERM = 0o0666    # default file permission bits
 
+# Used for determining if the system is running a new enough python version
+# and should only restrict on our documented minimum versions
+_PY3_MIN = sys.version_info[:2] >= (3, 5) and sys.version_info[0] == 3
+_PY2_MIN = sys.version_info[:2] >= (2, 6) and sys.version_info[0] == 2
+_PY_MIN = _PY3_MIN or _PY2_MIN
+if not _PY_MIN:
+    print('\n{"failed": true, "msg": "Ansible requires a minimum of Python 2.6 or Python 3.5. Current version: %s"}' % ''.join(sys.version.splitlines()))
+    sys.exit(1)
+
 
 def get_platform():
     ''' what's the platform?  example: Linux is a platform. '''

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -234,11 +234,14 @@ DEFAULT_PERM = 0o0666    # default file permission bits
 
 # Used for determining if the system is running a new enough python version
 # and should only restrict on our documented minimum versions
-_PY3_MIN = sys.version_info[:2] >= (3, 5) and sys.version_info[0] == 3
-_PY2_MIN = sys.version_info[:2] >= (2, 6) and sys.version_info[0] == 2
+_PY3_MIN = sys.version_info[:2] >= (3, 5)
+_PY2_MIN = (2, 6) <= sys.version_info[:2] < (3,)
 _PY_MIN = _PY3_MIN or _PY2_MIN
 if not _PY_MIN:
-    print('\n{"failed": true, "msg": "Ansible requires a minimum of Python 2.6 or Python 3.5. Current version: %s"}' % ''.join(sys.version.splitlines()))
+    print(
+        '\n{"failed": true, '
+        '"msg": "Ansible requires a minimum of Python2 version 2.6 or Python3 version 3.5. Current version: %s"}' % ''.join(sys.version.splitlines())
+    )
     sys.exit(1)
 
 


### PR DESCRIPTION
##### SUMMARY

Error early if executing python version doesn't meet documented minimums. Fixes #34597

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
bin/ansible
lib/ansible/module_utils/basic.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```