### PR TITLE
win_dns_client: Fix to compare ordering of resolver IP Addresses

### DIFF
--- a/lib/ansible/modules/windows/win_dns_client.ps1
+++ b/lib/ansible/modules/windows/win_dns_client.ps1
@@ -140,7 +140,7 @@ Function Get-DnsClientMatch {
     }
 
     Else {
-        $v4_match = @(Compare-Object $current_dns_v4 $ipv4_addresses).Count -eq 0
+        $v4_match = @(Compare-Object $current_dns_v4 $ipv4_addresses -SyncWindow 0).Count -eq 0
     }
 
     # TODO: implement IPv6


### PR DESCRIPTION
 
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fix for bug #34651

This change forces the module to consider the ordering of DNS entries when determining whether a change is needed.  Previously, re-arranging the order of DNS resolvers was not detected as different, and therefore not changed.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
win_dns_clinet

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.2.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /bin/ansible
  python version = 2.7.5 (default, May 29 2017, 20:42:36) [GCC 4.8.5 20150623 (Red Hat 4.8.5-11)]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
Adding "-SyncWindow 0" flag to the Compare-Object call used to determine if the existing and proposed IP address lists are the same.  This makes the array comparison mark changes in order as a difference.


  