### PR TITLE
Fix ansible-test network-integration command.

### DIFF
--- a/test/runner/lib/executor.py
+++ b/test/runner/lib/executor.py
@@ -373,6 +373,7 @@ def network_init(args, internal_targets):
         return
 
     platform_targets = set(a for t in internal_targets for a in t.aliases if a.startswith('network/'))
+    net_commands = set(a[4:] for t in internal_targets for a in t.aliases if a.startswith('net_'))
 
     instances = []  # type: list [lib.thread.WrappedThread]
 
@@ -383,7 +384,10 @@ def network_init(args, internal_targets):
         platform, version = platform_version.split('/', 1)
         platform_target = 'network/%s/' % platform
 
-        if platform_target not in platform_targets and 'network/basics/' not in platform_targets:
+        # check to see if the platform supports any of the platform agnostic tests we're going to run (if any)
+        platform_agnostic = any(os.path.exists('lib/ansible/modules/network/%s/%s_%s.py' % (platform, platform, command)) for command in net_commands)
+
+        if platform_target not in platform_targets and not platform_agnostic:
             display.warning('Skipping "%s" because selected tests do not target the "%s" platform.' % (
                 platform_version, platform))
             continue

--- a/test/runner/lib/executor.py
+++ b/test/runner/lib/executor.py
@@ -440,6 +440,7 @@ def network_inventory(remotes):
     :rtype: str
     """
     groups = dict([(remote.platform, []) for remote in remotes])
+    net = []
 
     for remote in remotes:
         options = dict(
@@ -456,6 +457,10 @@ def network_inventory(remotes):
                 ' '.join('%s="%s"' % (k, options[k]) for k in sorted(options)),
             )
         )
+
+        net.append(remote.platform)
+
+    groups['net:children'] = net
 
     template = ''
 

--- a/test/utils/shippable/network.sh
+++ b/test/utils/shippable/network.sh
@@ -32,7 +32,6 @@ if [ -s /tmp/network.txt ]; then
 
     platforms=(
         --platform vyos/1.1.8
-        --platform ios/csr1000v
     )
 else
     echo "No changes requiring integration tests specific to networking were detected."

--- a/test/utils/shippable/network.sh
+++ b/test/utils/shippable/network.sh
@@ -18,9 +18,7 @@ provider="${P:-default}"
 # python versions to test in order
 # all versions run full tests
 python_versions=(
-    2.6
     2.7
-    3.5
     3.6
 )
 


### PR DESCRIPTION
##### SUMMARY

Update ansible-test network-integration command.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.5.0 (network-ci 8af0def42e) last updated 2018/01/09 12:26:05 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```
