### PR TITLE
Fixes python keyerror if no port is specified and default should be used

### DIFF
--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -446,7 +446,7 @@ def connect_to_api(module, disconnect_atexit=True):
     hostname = module.params['hostname']
     username = module.params['username']
     password = module.params['password']
-    port = module.params['port'] or 443
+    port = module.params.get('port', 443)
     validate_certs = module.params['validate_certs']
 
     if validate_certs and not hasattr(ssl, 'SSLContext'):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Received python keyerror when port value was missing. Used python dict get method to properly default the port value

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (devel d1846425db) last updated 2018/01/09 19:53:23 (GMT +000)
  config file = /home/itmxg01/ansible/vmware-provisioning/ansible.cfg
  configured module search path = [u'/home/itmxg01/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/itmxg01/ansible/ansible/lib/ansible
  executable location = /home/itmxg01/ansible/ansible/bin/ansible
  python version = 2.7.5 (default, Aug  4 2017, 00:39:18) [GCC 4.8.5 20150623 (Red Hat 4.8.5-16)]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
