### PR TITLE
[WIP] Optionally use packaging.version if available, falling back to LooseVersion where not

### DIFF
--- a/contrib/inventory/foreman.py
+++ b/contrib/inventory/foreman.py
@@ -36,11 +36,18 @@ import re
 import sys
 from time import time
 from collections import defaultdict
-from distutils.version import LooseVersion, StrictVersion
+
+try:
+    from packaging.version import Version
+except ImportError:
+    try:
+        from pip._vendor.packaging.version import Version
+    except ImportError:
+        from distutils.version import LooseVersion as Version
 
 # 3rd party imports
 import requests
-if LooseVersion(requests.__version__) < LooseVersion('1.1.0'):
+if Version(requests.__version__) < Version('1.1.0'):
     print('This script requires python-requests 1.1 as a minimum version')
     sys.exit(1)
 

--- a/docs/bin/dump_keywords.py
+++ b/docs/bin/dump_keywords.py
@@ -2,7 +2,6 @@
 
 import optparse
 import re
-from distutils.version import LooseVersion
 
 import jinja2
 import yaml
@@ -12,6 +11,14 @@ from ansible.playbook import Play
 from ansible.playbook.block import Block
 from ansible.playbook.role import Role
 from ansible.playbook.task import Task
+
+try:
+    from packaging.version import Version
+except ImportError:
+    try:
+        from pip._vendor.packaging.version import Version
+    except ImportError:
+        from distutils.version import LooseVersion as Version
 
 template_file = 'playbooks_keywords.rst.j2'
 oblist = {}
@@ -70,7 +77,7 @@ outputname = options.output_dir + template_file.replace('.j2', '')
 tempvars = {'oblist': oblist, 'clist': clist}
 
 keyword_page = template.render(tempvars)
-if LooseVersion(jinja2.__version__) < LooseVersion('2.10'):
+if Version(jinja2.__version__) < Version('2.10'):
     # jinja2 < 2.10's indent filter indents blank lines.  Cleanup
     keyword_page = re.sub(' +\n', '\n', keyword_page)
 

--- a/docs/bin/plugin_formatter.py
+++ b/docs/bin/plugin_formatter.py
@@ -30,8 +30,15 @@ import re
 import sys
 import warnings
 from collections import defaultdict
-from distutils.version import LooseVersion
 from pprint import PrettyPrinter
+
+try:
+    from packaging.version import Version
+except ImportError:
+    try:
+        from pip._vendor.packaging.version import Version
+    except ImportError:
+        from distutils.version import LooseVersion as Version
 
 try:
     from html import escape as html_escape
@@ -447,7 +454,7 @@ def process_plugins(module_map, templates, outputname, output_dir, ansible_versi
         display.v('about to template %s' % module)
         display.vvvvv(pp.pformat(doc))
         text = templates['plugin'].render(doc)
-        if LooseVersion(jinja2.__version__) < LooseVersion('2.10'):
+        if Version(jinja2.__version__) < Version('2.10'):
             # jinja2 < 2.10's indent filter indents blank lines.  Cleanup
             text = re.sub(' +\n', '\n', text)
 

--- a/hacking/update_bundled.py
+++ b/hacking/update_bundled.py
@@ -3,7 +3,14 @@
 import glob
 import json
 import os.path
-from distutils.version import LooseVersion
+
+try:
+    from packaging.version import Version
+except ImportError:
+    try:
+        from pip._vendor.packaging.version import Version
+    except ImportError:
+        from distutils.version import LooseVersion as Version
 
 from ansible.module_utils.urls import open_url
 
@@ -26,7 +33,7 @@ for filename in glob.glob(os.path.join(basedir, '../lib/ansible/compat/*/__init_
         metadata = json.loads(data)
         pypi_fh = open_url('https://pypi.python.org/pypi/{0}/json'.format(metadata['pypi_name']))
         pypi_data = json.loads(pypi_fh.read().decode('utf-8'))
-        if LooseVersion(metadata['version']) < LooseVersion(pypi_data['info']['version']):
+        if Version(metadata['version']) < Version(pypi_data['info']['version']):
             print('UPDATE: {0} from {1} to {2} {3}'.format(
                 metadata['pypi_name'],
                 metadata['version'],

--- a/lib/ansible/galaxy/role.py
+++ b/lib/ansible/galaxy/role.py
@@ -28,13 +28,20 @@ import os
 import tarfile
 import tempfile
 import yaml
-from distutils.version import LooseVersion
 from shutil import rmtree
 
 from ansible.errors import AnsibleError
 from ansible.module_utils.urls import open_url
 from ansible.playbook.role.requirement import RoleRequirement
 from ansible.galaxy.api import GalaxyAPI
+
+try:
+    from packaging.version import Version
+except ImportError:
+    try:
+        from pip._vendor.packaging.version import Version
+    except ImportError:
+        from distutils.version import LooseVersion as Version
 
 try:
     from __main__ import display
@@ -233,9 +240,9 @@ class GalaxyRole(object):
                     # are no versions in the list, we'll grab the head
                     # of the master branch
                     if len(role_versions) > 0:
-                        loose_versions = [LooseVersion(a.get('name', None)) for a in role_versions]
-                        loose_versions.sort()
-                        self.version = str(loose_versions[-1])
+                        _versions = [Version(a.get('name', '')) for a in role_versions]
+                        _versions.sort()
+                        self.version = str(_versions[-1])
                     elif role_data.get('github_branch', None):
                         self.version = role_data['github_branch']
                     else:

--- a/lib/ansible/module_utils/docker_common.py
+++ b/lib/ansible/module_utils/docker_common.py
@@ -21,7 +21,13 @@ import re
 import json
 import sys
 import copy
-from distutils.version import LooseVersion
+try:
+    from packaging.version import Version
+except ImportError:
+    try:
+        from pip._vendor.packaging.version import Version
+    except ImportError:
+        from distutils.version import LooseVersion as Version
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six.moves.urllib.parse import urlparse
@@ -38,7 +44,7 @@ try:
     from docker.tls import TLSConfig
     from docker.constants import DEFAULT_TIMEOUT_SECONDS, DEFAULT_DOCKER_API_VERSION
     from docker import auth
-    if LooseVersion(docker_version) >= LooseVersion('2.0.0'):
+    if Version(docker_version) >= Version('2.0.0'):
         HAS_DOCKER_PY_2 = True
         from docker import APIClient as Client
         from docker.types import Ulimit, LogConfig
@@ -141,7 +147,7 @@ class AnsibleDockerClient(Client):
         if not HAS_DOCKER_PY:
             self.fail("Failed to import docker-py - %s. Try `pip install docker-py`" % HAS_DOCKER_ERROR)
 
-        if LooseVersion(docker_version) < LooseVersion(MIN_DOCKER_VERSION):
+        if Version(docker_version) < Version(MIN_DOCKER_VERSION):
             self.fail("Error: docker-py version is %s. Minimum version required is %s." % (docker_version,
                                                                                            MIN_DOCKER_VERSION))
 

--- a/lib/ansible/module_utils/facts/system/service_mgr.py
+++ b/lib/ansible/module_utils/facts/system/service_mgr.py
@@ -32,7 +32,13 @@ from ansible.module_utils.facts.collector import BaseFactCollector
 # that don't belong on production boxes.  Since our Solaris code doesn't
 # depend on LooseVersion, do not import it on Solaris.
 if platform.system() != 'SunOS':
-    from distutils.version import LooseVersion
+    try:
+        from packaging.version import Version
+    except ImportError:
+        try:
+            from pip._vendor.packaging.version import Version
+        except ImportError:
+            from distutils.version import LooseVersion as Version
 
 
 class ServiceMgrFactCollector(BaseFactCollector):
@@ -107,7 +113,7 @@ class ServiceMgrFactCollector(BaseFactCollector):
         # start with the easy ones
         elif collected_facts.get('ansible_distribution', None) == 'MacOSX':
             # FIXME: find way to query executable, version matching is not ideal
-            if LooseVersion(platform.mac_ver()[0]) >= LooseVersion('10.4'):
+            if Version(platform.mac_ver()[0]) >= Version('10.4'):
                 service_mgr_name = 'launchd'
             else:
                 service_mgr_name = 'systemstarter'

--- a/lib/ansible/module_utils/gcp.py
+++ b/lib/ansible/module_utils/gcp.py
@@ -31,7 +31,14 @@ import json
 import os
 import time
 import traceback
-from distutils.version import LooseVersion
+
+try:
+    from packaging.version import Version
+except ImportError:
+    try:
+        from pip._vendor.packaging.version import Version
+    except ImportError:
+        from distutils.version import LooseVersion as Version
 
 # libcloud
 try:
@@ -254,7 +261,7 @@ def _validate_credentials_file(module, credentials_file, require_valid_json=True
             # If the credentials are proper JSON and we do not have the minimum
             # required libcloud version, bail out and return a descriptive
             # error
-            if check_libcloud and LooseVersion(libcloud.__version__) < '0.17.0':
+            if check_libcloud and Version(libcloud.__version__) < Version('0.17.0'):
                 module.fail_json(msg='Using JSON credentials but libcloud minimum version not met. '
                                      'Upgrade to libcloud>=0.17.0.')
             return True
@@ -432,7 +439,7 @@ def check_min_pkg_version(pkg_name, minimum_version):
     from pkg_resources import get_distribution
     try:
         installed_version = get_distribution(pkg_name).version
-        return LooseVersion(installed_version) >= minimum_version
+        return Version(installed_version) >= Version(minimum_version)
     except Exception as e:
         return False
 

--- a/lib/ansible/module_utils/network/aos/aos.py
+++ b/lib/ansible/module_utils/network/aos/aos.py
@@ -38,7 +38,13 @@ from ansible.module_utils.network.aos.aos import (check_aos_version, get_aos_ses
 """
 import json
 
-from distutils.version import LooseVersion
+try:
+    from packaging.version import Version
+except ImportError:
+    try:
+        from pip._vendor.packaging.version import Version
+    except ImportError:
+        from distutils.version import LooseVersion as Version
 
 try:
     import yaml
@@ -69,7 +75,7 @@ def check_aos_version(module, min=False):
         import apstra.aosom
         AOS_PYEZ_VERSION = apstra.aosom.__version__
 
-        if not LooseVersion(AOS_PYEZ_VERSION) >= LooseVersion(min):
+        if not Version(AOS_PYEZ_VERSION) >= Version(min):
             module.fail_json(msg='aos-pyez >= %s is required for this module' % min)
 
     return True

--- a/lib/ansible/module_utils/network/avi/avi.py
+++ b/lib/ansible/module_utils/network/avi/avi.py
@@ -33,13 +33,19 @@
 
 from __future__ import absolute_import
 import os
-from distutils.version import LooseVersion
+try:
+    from packaging.version import Version
+except ImportError:
+    try:
+        from pip._vendor.packaging.version import Version
+    except ImportError:
+        from distutils.version import LooseVersion as Version
 
 HAS_AVI = True
 try:
     import avi.sdk
     sdk_version = getattr(avi.sdk, '__version__', None)
-    if ((sdk_version is None) or (sdk_version and (LooseVersion(sdk_version) < LooseVersion('17.2.4')))):
+    if ((sdk_version is None) or (sdk_version and (Version(sdk_version) < Version('17.2.4')))):
         # It allows the __version__ to be '' as that value is used in development builds
         raise ImportError
     from avi.sdk.utils.ansible_utils import avi_ansible_api

--- a/lib/ansible/module_utils/ovirt.py
+++ b/lib/ansible/module_utils/ovirt.py
@@ -25,13 +25,19 @@ import time
 
 from abc import ABCMeta, abstractmethod
 from datetime import datetime
-from distutils.version import LooseVersion
+try:
+    from packaging.version import Version
+except ImportError:
+    try:
+        from pip._vendor.packaging.version import Version
+    except ImportError:
+        from distutils.version import LooseVersion as Version
 
 try:
     from enum import Enum  # enum is a ovirtsdk4 requirement
     import ovirtsdk4 as sdk
     import ovirtsdk4.version as sdk_version
-    HAS_SDK = LooseVersion(sdk_version.VERSION) >= LooseVersion('4.0.0')
+    HAS_SDK = Version(sdk_version.VERSION) >= Version('4.0.0')
 except ImportError:
     HAS_SDK = False
 
@@ -402,7 +408,7 @@ def check_params(module):
 
 
 def engine_supported(connection, version):
-    return LooseVersion(engine_version(connection)) >= LooseVersion(version)
+    return Version(engine_version(connection)) >= Version(version)
 
 
 def check_support(version, connection, module, params):
@@ -410,11 +416,11 @@ def check_support(version, connection, module, params):
     Check if parameters used by user are supported by oVirt Python SDK
     and oVirt engine.
     """
-    api_version = LooseVersion(engine_version(connection))
-    version = LooseVersion(version)
+    api_version = Version(engine_version(connection))
+    version = Version(version)
     for param in params:
         if module.params.get(param) is not None:
-            return LooseVersion(sdk_version.VERSION) >= version and api_version >= version
+            return Version(sdk_version.VERSION) >= version and api_version >= version
 
     return True
 

--- a/lib/ansible/modules/cloud/amazon/ec2.py
+++ b/lib/ansible/modules/cloud/amazon/ec2.py
@@ -623,8 +623,15 @@ from ansible.module_utils.six import get_function_code, string_types
 from ansible.module_utils._text import to_text
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ec2 import get_aws_connection_info, ec2_argument_spec, ec2_connect
-from distutils.version import LooseVersion
 from ansible.module_utils.six import string_types
+
+try:
+    from packaging.version import Version
+except ImportError:
+    try:
+        from pip._vendor.packaging.version import Version
+    except ImportError:
+        from distutils.version import LooseVersion as Version
 
 try:
     import boto.ec2
@@ -820,7 +827,7 @@ def boto_supports_volume_encryption():
     Returns:
         True if boto library has the named param as an argument on the request_spot_instances method, else False
     """
-    return hasattr(boto, 'Version') and LooseVersion(boto.Version) >= LooseVersion('2.29.0')
+    return hasattr(boto, 'Version') and Version(boto.Version) >= Version('2.29.0')
 
 
 def create_block_device(module, ec2, volume):

--- a/lib/ansible/modules/cloud/amazon/ec2_vol.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vol.py
@@ -244,7 +244,13 @@ volume:
 
 import time
 
-from distutils.version import LooseVersion
+try:
+    from packaging.version import Version
+except ImportError:
+    try:
+        from pip._vendor.packaging.version import Version
+    except ImportError:
+        from distutils.version import LooseVersion as Version
 
 try:
     import boto
@@ -328,7 +334,7 @@ def boto_supports_volume_encryption():
     Returns:
         True if boto library has the named param as an argument on the request_spot_instances method, else False
     """
-    return hasattr(boto, 'Version') and LooseVersion(boto.Version) >= LooseVersion('2.29.0')
+    return hasattr(boto, 'Version') and Version(boto.Version) >= Version('2.29.0')
 
 
 def boto_supports_kms_key_id():
@@ -338,7 +344,7 @@ def boto_supports_kms_key_id():
     Returns:
         True if version is equal to or higher then the version needed, else False
     """
-    return hasattr(boto, 'Version') and LooseVersion(boto.Version) >= LooseVersion('2.39.0')
+    return hasattr(boto, 'Version') and Version(boto.Version) >= Version('2.39.0')
 
 
 def create_volume(module, ec2, zone):

--- a/lib/ansible/modules/cloud/centurylink/clc_aa_policy.py
+++ b/lib/ansible/modules/cloud/centurylink/clc_aa_policy.py
@@ -128,7 +128,13 @@ __version__ = '${version}'
 
 import os
 
-from distutils.version import LooseVersion
+try:
+    from packaging.version import Version
+except ImportError:
+    try:
+        from pip._vendor.packaging.version import Version
+    except ImportError:
+        from distutils.version import LooseVersion as Version
 
 try:
     import requests
@@ -171,7 +177,7 @@ class ClcAntiAffinityPolicy:
         if not REQUESTS_FOUND:
             self.module.fail_json(
                 msg='requests library is required for this module')
-        if requests.__version__ and LooseVersion(requests.__version__) < LooseVersion('2.5.0'):
+        if requests.__version__ and Version(requests.__version__) < Version('2.5.0'):
             self.module.fail_json(
                 msg='requests library  version should be >= 2.5.0')
 

--- a/lib/ansible/modules/cloud/centurylink/clc_alert_policy.py
+++ b/lib/ansible/modules/cloud/centurylink/clc_alert_policy.py
@@ -170,7 +170,14 @@ __version__ = '${version}'
 
 import json
 import os
-from distutils.version import LooseVersion
+
+try:
+    from packaging.version import Version
+except ImportError:
+    try:
+        from pip._vendor.packaging.version import Version
+    except ImportError:
+        from distutils.version import LooseVersion as Version
 
 try:
     import requests
@@ -213,7 +220,7 @@ class ClcAlertPolicy:
         if not REQUESTS_FOUND:
             self.module.fail_json(
                 msg='requests library is required for this module')
-        if requests.__version__ and LooseVersion(requests.__version__) < LooseVersion('2.5.0'):
+        if requests.__version__ and Version(requests.__version__) < Version('2.5.0'):
             self.module.fail_json(
                 msg='requests library  version should be >= 2.5.0')
 

--- a/lib/ansible/modules/cloud/centurylink/clc_blueprint_package.py
+++ b/lib/ansible/modules/cloud/centurylink/clc_blueprint_package.py
@@ -88,7 +88,14 @@ server_ids:
 __version__ = '${version}'
 
 import os
-from distutils.version import LooseVersion
+
+try:
+    from packaging.version import Version
+except ImportError:
+    try:
+        from pip._vendor.packaging.version import Version
+    except ImportError:
+        from distutils.version import LooseVersion as Version
 
 try:
     import requests
@@ -129,8 +136,7 @@ class ClcBlueprintPackage:
         if not REQUESTS_FOUND:
             self.module.fail_json(
                 msg='requests library is required for this module')
-        if requests.__version__ and LooseVersion(
-                requests.__version__) < LooseVersion('2.5.0'):
+        if requests.__version__ and Version(requests.__version__) < Version('2.5.0'):
             self.module.fail_json(
                 msg='requests library  version should be >= 2.5.0')
 

--- a/lib/ansible/modules/cloud/centurylink/clc_firewall_policy.py
+++ b/lib/ansible/modules/cloud/centurylink/clc_firewall_policy.py
@@ -168,7 +168,14 @@ __version__ = '${version}'
 import os
 from ansible.module_utils.six.moves.urllib.parse import urlparse
 from time import sleep
-from distutils.version import LooseVersion
+
+try:
+    from packaging.version import Version
+except ImportError:
+    try:
+        from pip._vendor.packaging.version import Version
+    except ImportError:
+        from distutils.version import LooseVersion as Version
 
 try:
     import requests
@@ -207,8 +214,7 @@ class ClcFirewallPolicy:
         if not REQUESTS_FOUND:
             self.module.fail_json(
                 msg='requests library is required for this module')
-        if requests.__version__ and LooseVersion(
-                requests.__version__) < LooseVersion('2.5.0'):
+        if requests.__version__ and Version(requests.__version__) < Version('2.5.0'):
             self.module.fail_json(
                 msg='requests library  version should be >= 2.5.0')
 

--- a/lib/ansible/modules/cloud/centurylink/clc_group.py
+++ b/lib/ansible/modules/cloud/centurylink/clc_group.py
@@ -208,7 +208,14 @@ group:
 __version__ = '${version}'
 
 import os
-from distutils.version import LooseVersion
+
+try:
+    from packaging.version import Version
+except ImportError:
+    try:
+        from pip._vendor.packaging.version import Version
+    except ImportError:
+        from distutils.version import LooseVersion as Version
 
 try:
     import requests
@@ -252,7 +259,7 @@ class ClcGroup(object):
         if not REQUESTS_FOUND:
             self.module.fail_json(
                 msg='requests library is required for this module')
-        if requests.__version__ and LooseVersion(requests.__version__) < LooseVersion('2.5.0'):
+        if requests.__version__ and Version(requests.__version__) < Version('2.5.0'):
             self.module.fail_json(
                 msg='requests library  version should be >= 2.5.0')
 

--- a/lib/ansible/modules/cloud/centurylink/clc_loadbalancer.py
+++ b/lib/ansible/modules/cloud/centurylink/clc_loadbalancer.py
@@ -214,7 +214,14 @@ __version__ = '${version}'
 import json
 import os
 from time import sleep
-from distutils.version import LooseVersion
+
+try:
+    from packaging.version import Version
+except ImportError:
+    try:
+        from pip._vendor.packaging.version import Version
+    except ImportError:
+        from distutils.version import LooseVersion as Version
 
 try:
     import requests
@@ -257,8 +264,7 @@ class ClcLoadBalancer:
         if not REQUESTS_FOUND:
             self.module.fail_json(
                 msg='requests library is required for this module')
-        if requests.__version__ and LooseVersion(
-                requests.__version__) < LooseVersion('2.5.0'):
+        if requests.__version__ and Version(requests.__version__) < Version('2.5.0'):
             self.module.fail_json(
                 msg='requests library  version should be >= 2.5.0')
 

--- a/lib/ansible/modules/cloud/centurylink/clc_modify_server.py
+++ b/lib/ansible/modules/cloud/centurylink/clc_modify_server.py
@@ -320,7 +320,14 @@ __version__ = '${version}'
 
 import json
 import os
-from distutils.version import LooseVersion
+
+try:
+    from packaging.version import Version
+except ImportError:
+    try:
+        from pip._vendor.packaging.version import Version
+    except ImportError:
+        from distutils.version import LooseVersion as Version
 
 try:
     import requests
@@ -362,8 +369,7 @@ class ClcModifyServer:
         if not REQUESTS_FOUND:
             self.module.fail_json(
                 msg='requests library is required for this module')
-        if requests.__version__ and LooseVersion(
-                requests.__version__) < LooseVersion('2.5.0'):
+        if requests.__version__ and Version(requests.__version__) < Version('2.5.0'):
             self.module.fail_json(
                 msg='requests library  version should be >= 2.5.0')
 

--- a/lib/ansible/modules/cloud/centurylink/clc_publicip.py
+++ b/lib/ansible/modules/cloud/centurylink/clc_publicip.py
@@ -120,7 +120,14 @@ server_ids:
 __version__ = '${version}'
 
 import os
-from distutils.version import LooseVersion
+
+try:
+    from packaging.version import Version
+except ImportError:
+    try:
+        from pip._vendor.packaging.version import Version
+    except ImportError:
+        from distutils.version import LooseVersion as Version
 
 try:
     import requests
@@ -160,7 +167,7 @@ class ClcPublicIp(object):
         if not REQUESTS_FOUND:
             self.module.fail_json(
                 msg='requests library is required for this module')
-        if requests.__version__ and LooseVersion(requests.__version__) < LooseVersion('2.5.0'):
+        if requests.__version__ and Version(requests.__version__) < Version('2.5.0'):
             self.module.fail_json(
                 msg='requests library  version should be >= 2.5.0')
 

--- a/lib/ansible/modules/cloud/centurylink/clc_server.py
+++ b/lib/ansible/modules/cloud/centurylink/clc_server.py
@@ -455,7 +455,14 @@ __version__ = '${version}'
 import json
 import os
 import time
-from distutils.version import LooseVersion
+
+try:
+    from packaging.version import Version
+except ImportError:
+    try:
+        from pip._vendor.packaging.version import Version
+    except ImportError:
+        from distutils.version import LooseVersion as Version
 
 try:
     import requests
@@ -498,8 +505,7 @@ class ClcServer:
         if not REQUESTS_FOUND:
             self.module.fail_json(
                 msg='requests library is required for this module')
-        if requests.__version__ and LooseVersion(
-                requests.__version__) < LooseVersion('2.5.0'):
+        if requests.__version__ and Version(requests.__version__) < Version('2.5.0'):
             self.module.fail_json(
                 msg='requests library  version should be >= 2.5.0')
 

--- a/lib/ansible/modules/cloud/centurylink/clc_server_snapshot.py
+++ b/lib/ansible/modules/cloud/centurylink/clc_server_snapshot.py
@@ -101,7 +101,14 @@ server_ids:
 __version__ = '${version}'
 
 import os
-from distutils.version import LooseVersion
+
+try:
+    from packaging.version import Version
+except ImportError:
+    try:
+        from pip._vendor.packaging.version import Version
+    except ImportError:
+        from distutils.version import LooseVersion as Version
 
 try:
     import requests
@@ -143,8 +150,7 @@ class ClcSnapshot:
         if not REQUESTS_FOUND:
             self.module.fail_json(
                 msg='requests library is required for this module')
-        if requests.__version__ and LooseVersion(
-                requests.__version__) < LooseVersion('2.5.0'):
+        if requests.__version__ and Version(requests.__version__) < Version('2.5.0'):
             self.module.fail_json(
                 msg='requests library  version should be >= 2.5.0')
 

--- a/lib/ansible/modules/cloud/digital_ocean/digital_ocean.py
+++ b/lib/ansible/modules/cloud/digital_ocean/digital_ocean.py
@@ -183,7 +183,13 @@ import os
 import time
 import traceback
 
-from distutils.version import LooseVersion
+try:
+    from packaging.version import Version
+except ImportError:
+    try:
+        from pip._vendor.packaging.version import Version
+    except ImportError:
+        from distutils.version import LooseVersion as Version
 
 try:
     # Imported as a dependency for dopy
@@ -196,7 +202,7 @@ HAS_DOPY = False
 try:
     import dopy
     from dopy.manager import DoError, DoManager
-    if LooseVersion(dopy.__version__) >= LooseVersion('0.3.2'):
+    if Version(dopy.__version__) >= Version('0.3.2'):
         HAS_DOPY = True
 except ImportError:
     pass

--- a/lib/ansible/modules/cloud/docker/docker_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_service.py
@@ -444,7 +444,14 @@ import re
 import sys
 import tempfile
 from contextlib import contextmanager
-from distutils.version import LooseVersion
+
+try:
+    from packaging.version import Version
+except ImportError:
+    try:
+        from pip._vendor.packaging.version import Version
+    except ImportError:
+        from distutils.version import LooseVersion as Version
 
 try:
     import yaml
@@ -614,7 +621,7 @@ class ContainerManager(DockerBaseClass):
             self.client.fail("Unable to load docker-compose. Try `pip install docker-compose`. Error: %s" %
                              HAS_COMPOSE_EXC)
 
-        if LooseVersion(compose_version) < LooseVersion(MINIMUM_COMPOSE_VERSION):
+        if Version(compose_version) < Version(MINIMUM_COMPOSE_VERSION):
             self.client.fail("Found docker-compose version %s. Minimum required version is %s. "
                              "Upgrade docker-compose to a min version of %s." %
                              (compose_version, MINIMUM_COMPOSE_VERSION, MINIMUM_COMPOSE_VERSION))

--- a/lib/ansible/modules/cloud/google/gcdns_record.py
+++ b/lib/ansible/modules/cloud/google/gcdns_record.py
@@ -309,7 +309,14 @@ zone_id:
 ################################################################################
 
 import socket
-from distutils.version import LooseVersion
+
+try:
+    from packaging.version import Version
+except ImportError:
+    try:
+        from pip._vendor.packaging.version import Version
+    except ImportError:
+        from distutils.version import LooseVersion as Version
 
 try:
     from libcloud import __version__ as LIBCLOUD_VERSION
@@ -542,7 +549,7 @@ def _sanity_check(module):
             msg='This module requires Apache libcloud %s or greater' % MINIMUM_LIBCLOUD_VERSION,
             changed=False
         )
-    elif LooseVersion(LIBCLOUD_VERSION) < MINIMUM_LIBCLOUD_VERSION:
+    elif Version(LIBCLOUD_VERSION) < Version(MINIMUM_LIBCLOUD_VERSION):
         module.fail_json(
             msg='This module requires Apache libcloud %s or greater' % MINIMUM_LIBCLOUD_VERSION,
             changed=False

--- a/lib/ansible/modules/cloud/google/gcdns_zone.py
+++ b/lib/ansible/modules/cloud/google/gcdns_zone.py
@@ -115,7 +115,14 @@ zone:
 # Imports
 ################################################################################
 
-from distutils.version import LooseVersion
+
+try:
+    from packaging.version import Version
+except ImportError:
+    try:
+        from pip._vendor.packaging.version import Version
+    except ImportError:
+        from distutils.version import LooseVersion as Version
 
 try:
     from libcloud import __version__ as LIBCLOUD_VERSION
@@ -285,7 +292,7 @@ def _sanity_check(module):
             msg='This module requires Apache libcloud %s or greater' % MINIMUM_LIBCLOUD_VERSION,
             changed=False
         )
-    elif LooseVersion(LIBCLOUD_VERSION) < MINIMUM_LIBCLOUD_VERSION:
+    elif Version(LIBCLOUD_VERSION) < Version(MINIMUM_LIBCLOUD_VERSION):
         module.fail_json(
             msg='This module requires Apache libcloud %s or greater' % MINIMUM_LIBCLOUD_VERSION,
             changed=False

--- a/lib/ansible/modules/cloud/rackspace/rax_cbs.py
+++ b/lib/ansible/modules/cloud/rackspace/rax_cbs.py
@@ -102,7 +102,13 @@ EXAMPLES = '''
       register: my_volume
 '''
 
-from distutils.version import LooseVersion
+try:
+    from packaging.version import Version
+except ImportError:
+    try:
+        from pip._vendor.packaging.version import Version
+    except ImportError:
+        from distutils.version import LooseVersion as Version
 
 try:
     import pyrax
@@ -132,7 +138,7 @@ def cloud_block_storage(module, state, name, description, meta, size,
     if image:
         # pyrax<1.9.3 did not have support for specifying an image when
         # creating a volume which is required for bootable volumes
-        if LooseVersion(pyrax.version.version) < LooseVersion('1.9.3'):
+        if Version(pyrax.version.version) < Version('1.9.3'):
             module.fail_json(msg='Creating a bootable volume requires '
                                  'pyrax>=1.9.3')
         image = rax_find_image(module, pyrax, image)

--- a/lib/ansible/modules/database/mongodb/mongodb_user.py
+++ b/lib/ansible/modules/database/mongodb/mongodb_user.py
@@ -195,7 +195,14 @@ user:
 import os
 import ssl as ssl_lib
 import traceback
-from distutils.version import LooseVersion
+
+try:
+    from packaging.version import Version
+except ImportError:
+    try:
+        from pip._vendor.packaging.version import Version
+    except ImportError:
+        from distutils.version import LooseVersion as Version
 
 try:
     from pymongo.errors import ConnectionFailure
@@ -231,19 +238,19 @@ def check_compatibility(module, client):
         module: Ansible module.
         client (cursor): Mongodb cursor on admin database.
     """
-    loose_srv_version = LooseVersion(client.server_info()['version'])
-    loose_driver_version = LooseVersion(PyMongoVersion)
+    loose_srv_version = Version(client.server_info()['version'])
+    loose_driver_version = Version(PyMongoVersion)
 
-    if loose_srv_version >= LooseVersion('3.2') and loose_driver_version < LooseVersion('3.2'):
+    if loose_srv_version >= Version('3.2') and loose_driver_version < Version('3.2'):
         module.fail_json(msg=' (Note: you must use pymongo 3.2+ with MongoDB >= 3.2)')
 
-    elif loose_srv_version >= LooseVersion('3.0') and loose_driver_version <= LooseVersion('2.8'):
+    elif loose_srv_version >= Version('3.0') and loose_driver_version <= Version('2.8'):
         module.fail_json(msg=' (Note: you must use pymongo 2.8+ with MongoDB 3.0)')
 
-    elif loose_srv_version >= LooseVersion('2.6') and loose_driver_version <= LooseVersion('2.7'):
+    elif loose_srv_version >= Version('2.6') and loose_driver_version <= Version('2.7'):
         module.fail_json(msg=' (Note: you must use pymongo 2.7+ with MongoDB 2.6)')
 
-    elif LooseVersion(PyMongoVersion) <= LooseVersion('2.5'):
+    elif Version(PyMongoVersion) <= Version('2.5'):
         module.fail_json(msg=' (Note: you must be on mongodb 2.4+ and pymongo 2.5+ to use the roles param)')
 
 
@@ -414,7 +421,7 @@ def main():
 
         if login_user is not None and login_password is not None:
             client.admin.authenticate(login_user, login_password, source=login_database)
-        elif LooseVersion(PyMongoVersion) >= LooseVersion('3.0'):
+        elif Version(PyMongoVersion) >= Version('3.0'):
             if db_name != "admin":
                 module.fail_json(msg='The localhost login exception only allows the first admin account to be created')
             # else: this has to be the first admin user added

--- a/lib/ansible/modules/files/xml.py
+++ b/lib/ansible/modules/files/xml.py
@@ -261,8 +261,15 @@ import re
 import traceback
 
 from collections import MutableMapping
-from distutils.version import LooseVersion
 from io import BytesIO
+
+try:
+    from packaging.version import Version
+except ImportError:
+    try:
+        from pip._vendor.packaging.version import Version
+    except ImportError:
+        from distutils.version import LooseVersion as Version
 
 try:
     from lxml import etree, objectify
@@ -777,9 +784,9 @@ def main():
     # Check if we have lxml 2.3.0 or newer installed
     if not HAS_LXML:
         module.fail_json(msg='The xml ansible module requires the lxml python library installed on the managed machine')
-    elif LooseVersion('.'.join(to_native(f) for f in etree.LXML_VERSION)) < LooseVersion('2.3.0'):
+    elif Version('.'.join(to_native(f) for f in etree.LXML_VERSION)) < Version('2.3.0'):
         module.fail_json(msg='The xml ansible module requires lxml 2.3.0 or newer installed on the managed machine')
-    elif LooseVersion('.'.join(to_native(f) for f in etree.LXML_VERSION)) < LooseVersion('3.0.0'):
+    elif Version('.'.join(to_native(f) for f in etree.LXML_VERSION)) < Version('3.0.0'):
         module.warn('Using lxml version lower than 3.0.0 does not guarantee predictable element attribute order.')
 
     # Check if the file exists

--- a/lib/ansible/modules/identity/ipa/ipa_subca.py
+++ b/lib/ansible/modules/identity/ipa/ipa_subca.py
@@ -74,10 +74,17 @@ subca:
   type: dict
 '''
 
-from distutils.version import LooseVersion
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ipa import IPAClient, ipa_argument_spec
 from ansible.module_utils._text import to_native
+
+try:
+    from packaging.version import Version
+except ImportError:
+    try:
+        from pip._vendor.packaging.version import Version
+    except ImportError:
+        from distutils.version import LooseVersion as Version
 
 
 class SubCAIPAClient(IPAClient):
@@ -162,7 +169,7 @@ def ensure(module, client):
                 client.subca_del(subca_name=subca_name)
     elif state == 'disable':
         ipa_version = client.get_ipa_version()
-        if LooseVersion(ipa_version) < LooseVersion('4.4.2'):
+        if Version(ipa_version) < Version('4.4.2'):
             module.fail_json(msg="Current version of IPA server [%s] does not support 'CA disable' option. Please upgrade to "
                                  "version greater than 4.4.2")
         if ipa_subca:
@@ -171,7 +178,7 @@ def ensure(module, client):
                 client.subca_disable(subca_name=subca_name)
     elif state == 'enable':
         ipa_version = client.get_ipa_version()
-        if LooseVersion(ipa_version) < LooseVersion('4.4.2'):
+        if Version(ipa_version) < Version('4.4.2'):
             module.fail_json(msg="Current version of IPA server [%s] does not support 'CA enable' option. Please upgrade to "
                                  "version greater than 4.4.2")
         if ipa_subca:

--- a/lib/ansible/modules/monitoring/circonus_annotation.py
+++ b/lib/ansible/modules/monitoring/circonus_annotation.py
@@ -140,7 +140,14 @@ annotation:
 import json
 import time
 import traceback
-from distutils.version import LooseVersion
+
+try:
+    from packaging.version import Version
+except ImportError:
+    try:
+        from pip._vendor.packaging.version import Version
+    except ImportError:
+        from distutils.version import LooseVersion as Version
 
 try:
     import requests
@@ -159,7 +166,7 @@ def check_requests_dep(module):
         module.fail_json(msg='requests is required for this module')
     else:
         required_version = '2.0.0' if PY3 else '1.0.0'
-        if LooseVersion(requests.__version__) < LooseVersion(required_version):
+        if Version(requests.__version__) < Version(required_version):
             module.fail_json(msg="'requests' library version should be >= %s, found: %s." % (required_version, requests.__version__))
 
 

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_template.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_template.py
@@ -202,12 +202,18 @@ template_json:
     }
 '''
 
-from distutils.version import LooseVersion
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 import json
 import traceback
 
+try:
+    from packaging.version import Version
+except ImportError:
+    try:
+        from pip._vendor.packaging.version import Version
+    except ImportError:
+        from distutils.version import LooseVersion as Version
 
 try:
     from zabbix_api import ZabbixAPI, ZabbixAPIException
@@ -417,7 +423,7 @@ class Template(object):
             # old api version support here
             api_version = self._zapi.api_version()
             # updateExisting for application removed from zabbix api after 3.2
-            if LooseVersion(api_version) <= LooseVersion('3.2.x'):
+            if Version(api_version) <= Version('3.2.x'):
                 update_rules['applications']['updateExisting'] = True
 
             self._zapi.configuration.import_({

--- a/lib/ansible/modules/network/f5/bigip_asm_policy.py
+++ b/lib/ansible/modules/network/f5/bigip_asm_policy.py
@@ -225,7 +225,14 @@ from ansible.module_utils.f5_utils import HAS_F5SDK
 from ansible.module_utils.f5_utils import F5ModuleError
 from ansible.module_utils.six import iteritems
 from collections import defaultdict
-from distutils.version import LooseVersion
+
+try:
+    from packaging.version import Version
+except ImportError:
+    try:
+        from pip._vendor.packaging.version import Version
+    except ImportError:
+        from distutils.version import LooseVersion as Version
 
 try:
     from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
@@ -728,7 +735,7 @@ class ModuleManager(object):
 
     def version_is_less_than_13(self):
         version = self.client.api.tmos_version
-        if LooseVersion(version) < LooseVersion('13.0.0'):
+        if Version(version) < Version('13.0.0'):
             return True
         else:
             return False

--- a/lib/ansible/modules/network/f5/bigip_gtm_facts.py
+++ b/lib/ansible/modules/network/f5/bigip_gtm_facts.py
@@ -185,7 +185,14 @@ from ansible.module_utils.f5_utils import F5ModuleError
 from ansible.module_utils.parsing.convert_bool import BOOLEANS_TRUE
 from ansible.module_utils.six import iteritems
 from collections import defaultdict
-from distutils.version import LooseVersion
+
+try:
+    from packaging.version import Version
+except ImportError:
+    try:
+        from pip._vendor.packaging.version import Version
+    except ImportError:
+        from distutils.version import LooseVersion as Version
 
 try:
     from f5.utils.responses.handlers import Stats
@@ -221,7 +228,7 @@ class BaseManager(object):
 
     def version_is_less_than_12(self):
         version = self.client.api.tmos_version
-        if LooseVersion(version) < LooseVersion('12.0.0'):
+        if Version(version) < Version('12.0.0'):
             return True
         else:
             return False

--- a/lib/ansible/modules/network/f5/bigip_gtm_pool.py
+++ b/lib/ansible/modules/network/f5/bigip_gtm_pool.py
@@ -184,7 +184,14 @@ from ansible.module_utils.f5_utils import HAS_F5SDK
 from ansible.module_utils.f5_utils import F5ModuleError
 from ansible.module_utils.six import iteritems
 from collections import defaultdict
-from distutils.version import LooseVersion
+
+try:
+    from packaging.version import Version
+except ImportError:
+    try:
+        from pip._vendor.packaging.version import Version
+    except ImportError:
+        from distutils.version import LooseVersion as Version
 
 try:
     from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
@@ -399,7 +406,7 @@ class ModuleManager(object):
 
     def version_is_less_than_12(self):
         version = self.client.api.tmos_version
-        if LooseVersion(version) < LooseVersion('12.0.0'):
+        if Version(version) < Version('12.0.0'):
             return True
         else:
             return False

--- a/lib/ansible/modules/network/f5/bigip_gtm_server.py
+++ b/lib/ansible/modules/network/f5/bigip_gtm_server.py
@@ -194,7 +194,14 @@ from ansible.module_utils.f5_utils import HAS_F5SDK
 from ansible.module_utils.f5_utils import F5ModuleError
 from ansible.module_utils.six import iteritems
 from collections import defaultdict
-from distutils.version import LooseVersion
+
+try:
+    from packaging.version import Version
+except ImportError:
+    try:
+        from pip._vendor.packaging.version import Version
+    except ImportError:
+        from distutils.version import LooseVersion as Version
 
 try:
     from collections import OrderedDict
@@ -529,7 +536,7 @@ class Difference(object):
         if not devices_change and not server_change:
             return None
         tmos_version = self.client.api.tmos_version
-        if LooseVersion(tmos_version) >= LooseVersion('13.0.0'):
+        if Version(tmos_version) >= Version('13.0.0'):
             result = self._handle_current_server_type_and_devices(
                 devices_change, server_change
             )
@@ -571,7 +578,7 @@ class ModuleManager(object):
 
     def version_is_less_than(self, version):
         tmos_version = self.client.api.tmos_version
-        if LooseVersion(tmos_version) < LooseVersion(version):
+        if Version(tmos_version) < Version(version):
             return True
         else:
             return False

--- a/lib/ansible/modules/network/f5/bigip_gtm_wide_ip.py
+++ b/lib/ansible/modules/network/f5/bigip_gtm_wide_ip.py
@@ -129,7 +129,14 @@ from ansible.module_utils.f5_utils import AnsibleF5Parameters
 from ansible.module_utils.f5_utils import HAS_F5SDK
 from ansible.module_utils.f5_utils import F5ModuleError
 from ansible.module_utils.six import iteritems
-from distutils.version import LooseVersion
+
+try:
+    from packaging.version import Version
+except ImportError:
+    try:
+        from pip._vendor.packaging.version import Version
+    except ImportError:
+        from distutils.version import LooseVersion as Version
 
 try:
     from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
@@ -387,7 +394,7 @@ class ModuleManager(object):
 
     def version_is_less_than_12(self):
         version = self.client.api.tmos_version
-        if LooseVersion(version) < LooseVersion('12.0.0'):
+        if Version(version) < Version('12.0.0'):
             return True
         else:
             return False

--- a/lib/ansible/modules/network/f5/bigip_iapplx_package.py
+++ b/lib/ansible/modules/network/f5/bigip_iapplx_package.py
@@ -95,7 +95,14 @@ from ansible.module_utils.f5_utils import AnsibleF5Client
 from ansible.module_utils.f5_utils import AnsibleF5Parameters
 from ansible.module_utils.f5_utils import HAS_F5SDK
 from ansible.module_utils.f5_utils import F5ModuleError
-from distutils.version import LooseVersion
+
+try:
+    from packaging.version import Version
+except ImportError:
+    try:
+        from pip._vendor.packaging.version import Version
+    except ImportError:
+        from distutils.version import LooseVersion as Version
 
 try:
     from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
@@ -173,7 +180,7 @@ class ModuleManager(object):
         state = self.want.state
 
         version = self.client.api.tmos_version
-        if LooseVersion(version) <= LooseVersion('12.0.0'):
+        if Version(version) <= Version('12.0.0'):
             raise F5ModuleError(
                 "This version of BIG-IP is not supported."
             )

--- a/lib/ansible/modules/network/f5/bigip_policy.py
+++ b/lib/ansible/modules/network/f5/bigip_policy.py
@@ -174,7 +174,14 @@ from ansible.module_utils.f5_utils import HAS_F5SDK
 from ansible.module_utils.f5_utils import F5ModuleError
 from ansible.module_utils.six import iteritems
 from collections import defaultdict
-from distutils.version import LooseVersion
+
+try:
+    from packaging.version import Version
+except ImportError:
+    try:
+        from pip._vendor.packaging.version import Version
+    except ImportError:
+        from distutils.version import LooseVersion as Version
 
 try:
     from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
@@ -805,7 +812,7 @@ class ModuleManager(object):
 
     def version_is_less_than_12(self):
         version = self.client.api.tmos_version
-        if LooseVersion(version) < LooseVersion('12.1.0'):
+        if Version(version) < Version('12.1.0'):
             return True
         else:
             return False

--- a/lib/ansible/modules/network/f5/bigip_qkview.py
+++ b/lib/ansible/modules/network/f5/bigip_qkview.py
@@ -118,7 +118,14 @@ from ansible.module_utils.f5_utils import AnsibleF5Client
 from ansible.module_utils.f5_utils import AnsibleF5Parameters
 from ansible.module_utils.f5_utils import HAS_F5SDK
 from ansible.module_utils.f5_utils import F5ModuleError
-from distutils.version import LooseVersion
+
+try:
+    from packaging.version import Version
+except ImportError:
+    try:
+        from pip._vendor.packaging.version import Version
+    except ImportError:
+        from distutils.version import LooseVersion as Version
 
 try:
     from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
@@ -232,7 +239,7 @@ class ModuleManager(object):
         :return: Bool
         """
         version = self.client.api.tmos_version
-        if LooseVersion(version) < LooseVersion('14.0.0'):
+        if Version(version) < Version('14.0.0'):
             return True
         else:
             return False

--- a/lib/ansible/modules/network/f5/bigip_snmp_trap.py
+++ b/lib/ansible/modules/network/f5/bigip_snmp_trap.py
@@ -132,7 +132,14 @@ from ansible.module_utils.f5_utils import AnsibleF5Client
 from ansible.module_utils.f5_utils import AnsibleF5Parameters
 from ansible.module_utils.f5_utils import HAS_F5SDK
 from ansible.module_utils.f5_utils import F5ModuleError
-from distutils.version import LooseVersion
+
+try:
+    from packaging.version import Version
+except ImportError:
+    try:
+        from pip._vendor.packaging.version import Version
+    except ImportError:
+        from distutils.version import LooseVersion as Version
 
 try:
     from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
@@ -242,7 +249,7 @@ class ModuleManager(object):
         :return: Bool
         """
         version = self.client.api.tmos_version
-        if LooseVersion(version) < LooseVersion('12.1.0'):
+        if Version(version) < Version('12.1.0'):
             return True
         else:
             return False

--- a/lib/ansible/modules/network/f5/bigip_ucs.py
+++ b/lib/ansible/modules/network/f5/bigip_ucs.py
@@ -185,12 +185,19 @@ import re
 import sys
 import time
 
-from distutils.version import LooseVersion
 from ansible.module_utils.f5_utils import AnsibleF5Client
 from ansible.module_utils.f5_utils import AnsibleF5Parameters
 from ansible.module_utils.f5_utils import HAS_F5SDK
 from ansible.module_utils.f5_utils import F5ModuleError
 from ansible.module_utils.six import iteritems
+
+try:
+    from packaging.version import Version
+except ImportError:
+    try:
+        from pip._vendor.packaging.version import Version
+    except ImportError:
+        from distutils.version import LooseVersion as Version
 
 try:
     from collections import OrderedDict
@@ -314,7 +321,7 @@ class ModuleManager(object):
         :return: Bool
         """
         version = self.client.api.tmos_version
-        if LooseVersion(version) < LooseVersion('12.1.0'):
+        if Version(version) < Version('12.1.0'):
             return True
         else:
             return False

--- a/lib/ansible/modules/network/f5/bigip_user.py
+++ b/lib/ansible/modules/network/f5/bigip_user.py
@@ -191,13 +191,20 @@ shell:
 
 import re
 
-from distutils.version import LooseVersion
 from ansible.module_utils.f5_utils import AnsibleF5Client
 from ansible.module_utils.f5_utils import AnsibleF5Parameters
 from ansible.module_utils.f5_utils import HAS_F5SDK
 from ansible.module_utils.f5_utils import F5ModuleError
 from ansible.module_utils.six import iteritems
 from collections import defaultdict
+
+try:
+    from packaging.version import Version
+except ImportError:
+    try:
+        from pip._vendor.packaging.version import Version
+    except ImportError:
+        from distutils.version import LooseVersion as Version
 
 try:
     from StringIO import StringIO
@@ -345,7 +352,7 @@ class ModuleManager(object):
         :return: Bool
         """
         version = self.client.api.tmos_version
-        if LooseVersion(version) < LooseVersion('13.0.0'):
+        if Version(version) < Version('13.0.0'):
             return True
         else:
             return False

--- a/lib/ansible/modules/packaging/os/dnf.py
+++ b/lib/ansible/modules/packaging/os/dnf.py
@@ -170,7 +170,14 @@ except ImportError:
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 from ansible.module_utils.six import PY2
-from distutils.version import LooseVersion
+
+try:
+    from packaging.version import Version
+except ImportError:
+    try:
+        from pip._vendor.packaging.version import Version
+    except ImportError:
+        from distutils.version import LooseVersion as Version
 
 
 def _ensure_dnf(module):
@@ -502,7 +509,7 @@ def main():
 
     # Check if autoremove is called correctly
     if params['autoremove'] is not None:
-        if LooseVersion(dnf.__version__) < LooseVersion('2.0.1'):
+        if Version(dnf.__version__) < Version('2.0.1'):
             module.fail_json(msg="Autoremove requires dnf>=2.0.1. Current dnf version is %s" % dnf.__version__)
         if params['state'] not in ["absent", None]:
             module.fail_json(msg="Autoremove should be used alone or with state=absent")

--- a/lib/ansible/modules/packaging/os/zypper_repository.py
+++ b/lib/ansible/modules/packaging/os/zypper_repository.py
@@ -145,7 +145,13 @@ EXAMPLES = '''
 
 REPO_OPTS = ['alias', 'name', 'priority', 'enabled', 'autorefresh', 'gpgcheck']
 
-from distutils.version import LooseVersion
+try:
+    from packaging.version import Version
+except ImportError:
+    try:
+        from pip._vendor.packaging.version import Version
+    except ImportError:
+        from distutils.version import LooseVersion as Version
 
 
 def _get_cmd(*args):
@@ -243,7 +249,7 @@ def addmodify_repo(module, repodata, old_repos, zypper_version, warnings):
     # priority on addrepo available since 1.12.25
     # https://github.com/openSUSE/zypper/blob/b9b3cb6db76c47dc4c47e26f6a4d2d4a0d12b06d/package/zypper.changes#L327-L336
     if repodata['priority']:
-        if zypper_version >= LooseVersion('1.12.25'):
+        if zypper_version >= Version('1.12.25'):
             cmd.extend(['--priority', str(repodata['priority'])])
         else:
             warnings.append("Setting priority only available for zypper >= 1.12.25. Ignoring priority argument.")
@@ -254,7 +260,7 @@ def addmodify_repo(module, repodata, old_repos, zypper_version, warnings):
     # gpgcheck available since 1.6.2
     # https://github.com/openSUSE/zypper/blob/b9b3cb6db76c47dc4c47e26f6a4d2d4a0d12b06d/package/zypper.changes#L2446-L2449
     # the default changed in the past, so don't assume a default here and show warning for old zypper versions
-    if zypper_version >= LooseVersion('1.6.2'):
+    if zypper_version >= Version('1.6.2'):
         if repodata['gpgcheck'] == '1':
             cmd.append('--gpgcheck')
         else:
@@ -289,8 +295,8 @@ def remove_repo(module, repo):
 def get_zypper_version(module):
     rc, stdout, stderr = module.run_command(['/usr/bin/zypper', '--version'])
     if rc != 0 or not stdout.startswith('zypper '):
-        return LooseVersion('1.0')
-    return LooseVersion(stdout.split()[1])
+        return Version('1.0')
+    return Version(stdout.split()[1])
 
 
 def runrefreshrepo(module, auto_import_keys=False, shortname=None):

--- a/lib/ansible/modules/source_control/git.py
+++ b/lib/ansible/modules/source_control/git.py
@@ -266,7 +266,13 @@ import stat
 import sys
 import shutil
 import tempfile
-from distutils.version import LooseVersion
+try:
+    from packaging.version import Version
+except ImportError:
+    try:
+        from pip._vendor.packaging.version import Version
+    except ImportError:
+        from distutils.version import LooseVersion as Version
 
 from ansible.module_utils.basic import AnsibleModule, get_module_path
 from ansible.module_utils.six import b, string_types
@@ -734,7 +740,7 @@ def fetch(git_path, module, repo, dest, version, remote, depth, bare, refspec, g
             refspecs = ['+refs/heads/*:refs/heads/*', '+refs/tags/*:refs/tags/*']
         else:
             # ensure all tags are fetched
-            if git_version_used >= LooseVersion('1.9'):
+            if git_version_used >= Version('1.9'):
                 fetch_cmd.append('--tags')
             else:
                 # old git versions have a bug in --tags that prevents updating existing tags
@@ -899,7 +905,7 @@ def git_version(git_path, module):
     rematch = re.search('git version (.*)$', to_native(out))
     if not rematch:
         return None
-    return LooseVersion(rematch.groups()[0])
+    return Version(rematch.groups()[0])
 
 
 def git_archive(git_path, module, dest, archive, archive_fmt, version):
@@ -1058,7 +1064,7 @@ def main():
 
     git_version_used = git_version(git_path, module)
 
-    if depth is not None and git_version_used < LooseVersion('1.9.1'):
+    if depth is not None and git_version_used < Version('1.9.1'):
         result['warnings'].append("Your git version is too old to fully support the depth argument. Falling back to full checkouts.")
         depth = None
 

--- a/lib/ansible/modules/source_control/git.py
+++ b/lib/ansible/modules/source_control/git.py
@@ -902,7 +902,7 @@ def git_version(git_path, module):
         # one could fail_json here, but the version info is not that important,
         # so let's try to fail only on actual git commands
         return None
-    rematch = re.search('git version (.*)$', to_native(out))
+    rematch = re.search(r'git version (\S*)', to_native(out))
     if not rematch:
         return None
     return Version(rematch.groups()[0])

--- a/lib/ansible/modules/system/hostname.py
+++ b/lib/ansible/modules/system/hostname.py
@@ -39,7 +39,6 @@ EXAMPLES = '''
 import os
 import socket
 import traceback
-from distutils.version import LooseVersion
 
 from ansible.module_utils.basic import (
     AnsibleModule,
@@ -50,6 +49,14 @@ from ansible.module_utils.basic import (
 )
 from ansible.module_utils.facts.system.service_mgr import ServiceMgrFactCollector
 from ansible.module_utils._text import to_native
+
+try:
+    from packaging.version import Version
+except ImportError:
+    try:
+        from pip._vendor.packaging.version import Version
+    except ImportError:
+        from distutils.version import LooseVersion as Version
 
 
 class UnimplementedStrategy(object):
@@ -568,7 +575,7 @@ class SLESHostname(Hostname):
     platform = 'Linux'
     distribution = 'Suse linux enterprise server '
     distribution_version = get_distribution_version()
-    if distribution_version and LooseVersion("10") <= LooseVersion(distribution_version) <= LooseVersion("12"):
+    if distribution_version and Version("10") <= Version(distribution_version) <= Version("12"):
         strategy_class = SLESStrategy
     else:
         strategy_class = UnimplementedStrategy

--- a/lib/ansible/modules/web_infrastructure/htpasswd.py
+++ b/lib/ansible/modules/web_infrastructure/htpasswd.py
@@ -95,7 +95,14 @@ EXAMPLES = """
 
 import os
 import tempfile
-from distutils.version import LooseVersion
+
+try:
+    from packaging.version import Version
+except ImportError:
+    try:
+        from pip._vendor.packaging.version import Version
+    except ImportError:
+        from distutils.version import LooseVersion as Version
 
 try:
     from passlib.apache import HtpasswdFile, htpasswd_context
@@ -129,7 +136,7 @@ def present(dest, username, password, crypt_scheme, create, check_mode):
         if check_mode:
             return ("Create %s" % dest, True)
         create_missing_directories(dest)
-        if LooseVersion(passlib.__version__) >= LooseVersion('1.6'):
+        if Version(passlib.__version__) >= Version('1.6'):
             ht = HtpasswdFile(dest, new=True, default_scheme=crypt_scheme, context=context)
         else:
             ht = HtpasswdFile(dest, autoload=False, default=crypt_scheme, context=context)
@@ -140,7 +147,7 @@ def present(dest, username, password, crypt_scheme, create, check_mode):
         ht.save()
         return ("Created %s and added %s" % (dest, username), True)
     else:
-        if LooseVersion(passlib.__version__) >= LooseVersion('1.6'):
+        if Version(passlib.__version__) >= Version('1.6'):
             ht = HtpasswdFile(dest, new=False, default_scheme=crypt_scheme, context=context)
         else:
             ht = HtpasswdFile(dest, default=crypt_scheme, context=context)
@@ -167,7 +174,7 @@ def absent(dest, username, check_mode):
     """ Ensures user is absent
 
     Returns (msg, changed) """
-    if LooseVersion(passlib.__version__) >= LooseVersion('1.6'):
+    if Version(passlib.__version__) >= Version('1.6'):
         ht = HtpasswdFile(dest, new=False)
     else:
         ht = HtpasswdFile(dest)

--- a/lib/ansible/plugins/connection/docker.py
+++ b/lib/ansible/plugins/connection/docker.py
@@ -45,7 +45,13 @@ import os.path
 import subprocess
 import re
 
-from distutils.version import LooseVersion
+try:
+    from packaging.version import Version
+except ImportError:
+    try:
+        from pip._vendor.packaging.version import Version
+    except ImportError:
+        from distutils.version import LooseVersion as Version
 
 import ansible.constants as C
 from ansible.errors import AnsibleError, AnsibleFileNotFound
@@ -88,7 +94,7 @@ class Connection(ConnectionBase):
                 raise AnsibleError("docker command not found in PATH")
 
         docker_version = self._get_docker_version()
-        if LooseVersion(docker_version) < LooseVersion(u'1.3'):
+        if Version(docker_version) < Version(u'1.3'):
             raise AnsibleError('docker connection type requires docker 1.3 or higher')
 
         # The remote user we will request from docker (if supported)
@@ -97,7 +103,7 @@ class Connection(ConnectionBase):
         self.actual_user = None
 
         if self._play_context.remote_user is not None:
-            if LooseVersion(docker_version) >= LooseVersion(u'1.7'):
+            if Version(docker_version) >= Version(u'1.7'):
                 # Support for specifying the exec user was added in docker 1.7
                 self.remote_user = self._play_context.remote_user
                 self.actual_user = self.remote_user

--- a/lib/ansible/plugins/test/core.py
+++ b/lib/ansible/plugins/test/core.py
@@ -25,11 +25,11 @@ from collections import MutableMapping, MutableSequence
 
 HAS_PACKAGING = False
 try:
-    from packaging.version import Version
+    from packaging.version import LegacyVersion, Version
     HAS_PACKAGING = True
 except ImportError:
     try:
-        from pip._vendor.packaging.version import Version
+        from pip._vendor.packaging.version import LegacyVersion, Version
         HAS_PACKAGING = True
     except ImportError:
         pass
@@ -115,10 +115,13 @@ def version_compare(value, version, operator='eq', strict=False):
     }
 
     if strict:
-        VersionClass = StrictVersion
-    else:
         if HAS_PACKAGING:
             VersionClass = Version
+        else:
+            VersionClass = StrictVersion
+    else:
+        if HAS_PACKAGING:
+            VersionClass = LegacyVersion
         else:
             VersionClass = LooseVersion
 


### PR DESCRIPTION
##### SUMMARY

Optionally use packaging.version if available, falling back to LooseVersion where not

Alternate implementation from https://github.com/ansible/ansible/pull/34427

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
various

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```