### PR TITLE
Fix Python 3.7 syntax error.

### DIFF
--- a/lib/ansible/cli/adhoc.py
+++ b/lib/ansible/cli/adhoc.py
@@ -83,13 +83,14 @@ class AdHocCLI(CLI):
         display.verbosity = self.options.verbosity
         self.validate_conflicts(runas_opts=True, vault_opts=True, fork_opts=True)
 
-    def _play_ds(self, pattern, async, poll):
+    def _play_ds(self, pattern, async_val, poll):
         check_raw = self.options.module_name in ('command', 'win_command', 'shell', 'win_shell', 'script', 'raw')
         return dict(
             name="Ansible Ad-Hoc",
             hosts=pattern,
             gather_facts='no',
-            tasks=[dict(action=dict(module=self.options.module_name, args=parse_kv(self.options.module_args, check_raw=check_raw)), async=async, poll=poll)]
+            tasks=[dict(action=dict(module=self.options.module_name, args=parse_kv(self.options.module_args, check_raw=check_raw)), async_val=async_val,
+                        poll=poll)]
         )
 
     def run(self):

--- a/test/compile/python3.7-skip.txt
+++ b/test/compile/python3.7-skip.txt
@@ -1,2 +1,1 @@
-lib/ansible/cli/adhoc.py
 lib/ansible/modules/packaging/os/yum_repository.py


### PR DESCRIPTION
##### SUMMARY

Fix Python 3.7 syntax error.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

lib/ansible/cli/adhoc.py

##### ANSIBLE VERSION

```
ansible 2.5.0 (py37-fix 7a75a6597a) last updated 2018/01/09 14:53:56 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```
