### PR TITLE
win_scheduled_task_stat: correctly return values from nested com values

### DIFF
--- a/lib/ansible/modules/windows/win_scheduled_task_stat.ps1
+++ b/lib/ansible/modules/windows/win_scheduled_task_stat.ps1
@@ -76,7 +76,7 @@ Function Get-PropertyValue($task_property, $com, $property) {
         $com_values = @{}
         $properties = Get-Member -InputObject $raw_value -MemberType Property | % {
             $com_value = Get-PropertyValue -task_property $property -com $raw_value -property $_.Name
-            $com_values.$property = $com_value
+            $com_values.$($_.Name) = $com_value
         }
 
         return ,$com_values
@@ -318,3 +318,4 @@ if ($name -ne $null) {
 $result = Convert-DictToSnakeCase -dict $result
 
 Exit-Json -obj $result
+

--- a/lib/ansible/modules/windows/win_scheduled_task_stat.py
+++ b/lib/ansible/modules/windows/win_scheduled_task_stat.py
@@ -219,7 +219,10 @@ settings:
       returned: ''
       type: dictionary
       sample: {
-          "idle_settings": "PT1H"
+          "idle_duration": "PT10M",
+          "restart_on_idle": false,
+          "stop_on_idle_end": true,
+          "wait_timeout": "PT1H"
       }
     maintenance_settings:
       description: The maintenance settings of the task.
@@ -237,7 +240,8 @@ settings:
       returned: ''
       type: dictionary
       sample: {
-          "network_settings": null
+          "id": null,
+          "name": null
       }
     priority:
       description: The priority level of the task.
@@ -343,7 +347,9 @@ triggers:
           "execution_time_limit": null,
           "id": null,
           "repetition": {
-              "repetition": false
+              "duration": null,
+              "interval": null,
+              "stop_at_duration_end": false
           },
           "start_boundary": null,
           "type": "TASK_TRIGGER_BOOT"
@@ -357,7 +363,9 @@ triggers:
           "months_of_year": "june,december",
           "random_delay": null,
           "repetition": {
-              "repetition": false
+              "duration": null,
+              "interval": null,
+              "stop_at_duration_end": false
           },
           "run_on_last_day_of_month": true,
           "start_boundary": "2017-09-20T03:44:38",

--- a/test/integration/targets/win_scheduled_task_stat/tasks/main.yml
+++ b/test/integration/targets/win_scheduled_task_stat/tasks/main.yml
@@ -114,11 +114,17 @@
     - stat_task_present.triggers|count == 2
     - stat_task_present.triggers[0].delay == "PT15M"
     - stat_task_present.triggers[0].type == "TASK_TRIGGER_BOOT"
+    - stat_task_present.triggers[0].repetition.stop_at_duration_end == False
+    - stat_task_present.triggers[0].repetition.duration == None
+    - stat_task_present.triggers[0].repetition.interval == None
     - stat_task_present.triggers[1].days_of_month == "5,15,30"
     - stat_task_present.triggers[1].months_of_year == "june,december"
     - stat_task_present.triggers[1].run_on_last_day_of_month == True
     - stat_task_present.triggers[1].start_boundary == "2017-09-20T03:44:38"
     - stat_task_present.triggers[1].type == "TASK_TRIGGER_MONTHLY"
+    - stat_task_present.triggers[1].repetition.stop_at_duration_end == False
+    - stat_task_present.triggers[1].repetition.duration == None
+    - stat_task_present.triggers[1].repetition.interval == None
 
 - name: change principal to system account so it will run in the next step
   win_scheduled_task:


### PR DESCRIPTION
##### SUMMARY
Fix return value for a nested com object inside a com property, before it would only return the last value of that com object under the parent prop name.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
win_scheduled_task_stat

##### ANSIBLE VERSION
```
2.5
```