### PR TITLE
Ensure alternatives are displayed in deprecation warnings

### DIFF
--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -173,8 +173,8 @@ class CLI(with_metaclass(ABCMeta, object)):
         for deprecated in C.config.DEPRECATED:
             name = deprecated[0]
             why = deprecated[1]['why']
-            if 'alternative' in deprecated[1]:
-                alt = ', use %s instead' % deprecated[1]['alternative']
+            if 'alternatives' in deprecated[1]:
+                alt = ', use %s instead' % deprecated[1]['alternatives']
             else:
                 alt = ''
             ver = deprecated[1]['version']


### PR DESCRIPTION
##### SUMMARY
Use plural `alternatives` key to correctly display deprecation alternatives.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
utils display

##### ANSIBLE VERSION

```
ansible 2.5.0 (devel a0e96efec7) last updated 2018/01/10 09:54:03 (GMT +1000)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/will/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/will/src/ansible/lib/ansible
  executable location = /home/will/src/ansible/bin/ansible
  python version = 2.7.14 (default, Dec 11 2017, 14:52:53) [GCC 7.2.1 20170915 (Red Hat 7.2.1-2)]
```
