### PR TITLE
Fix ansible-config with python3

### DIFF
--- a/lib/ansible/config/manager.py
+++ b/lib/ansible/config/manager.py
@@ -116,7 +116,7 @@ def get_config_type(cfile):
 
     ftype = None
     if cfile is not None:
-        ext = os.path.splitext(cfile)[-1]
+        ext = to_text(os.path.splitext(cfile)[-1])
         if ext in ('.ini', '.cfg'):
             ftype = 'ini'
         elif ext in ('.yaml', '.yml'):


### PR DESCRIPTION
##### SUMMARY

When using the -c option, like "ansible-config -c ~/.ansible.cfg view"
with python 3, it fail with this error message:

  ERROR! Unsupported configuration file extension for b'/home/misc/.ansible.cfg': .cfg

Found by @pilou- 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ansible-config

##### ANSIBLE VERSION
latest devel
  