### PR TITLE
Catch TemplateSyntaxError when escaping backslashes

### DIFF
--- a/lib/ansible/template/vars.py
+++ b/lib/ansible/template/vars.py
@@ -106,7 +106,7 @@ class AnsibleJ2Vars(Mapping):
                 value = self._templar.template(variable)
             except Exception as e:
                 try:
-                    raise type(e)(to_native(variable) + ': ' + e.message)
+                    raise type(e)(to_native(variable) + ': ' + e.message, e.lineno)
                 except AttributeError:
                     raise type(e)(to_native(variable) + ': ' + to_native(e))
             return value


### PR DESCRIPTION
##### SUMMARY
Missing `_escape_backslashes` exception causes problems when it's later
reraised as a TemplateSyntaxError rather than an AnsibleError


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
template/vars.py

##### ANSIBLE VERSION
```
ansible 2.5.0 (devel a0e96efec7) last updated 2018/01/10 09:54:03 (GMT +1000)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/will/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/will/src/ansible/lib/ansible
  executable location = /home/will/src/ansible/bin/ansible
  python version = 2.7.14 (default, Dec 11 2017, 14:52:53) [GCC 7.2.1 20170915 (Red Hat 7.2.1-2)]
```


##### ADDITIONAL INFORMATION
With the following playbook, an unfathomable exception occurs:

```
- hosts: localhost
  connection: local

  vars:
    thing_that_exists:
      broken_key: "{{ hello | open_brackets('need_a_backreference', '(.*)', 'xy\\1')| some_filter) }}"

  tasks:
  - debug:
      msg: "{{ thing_that_exists.key_that_doesnt | default(omit) }}"
```

Before:
```
TASK [debug] *********************************************************************************************************************************************************************************
task path: /home/will/tmp/ansible/template_issue/playbook.yml:9
fatal: [localhost]: FAILED! => {
    "msg": "Unexpected templating type error occurred on ({{ thing_that_exists.key_that_doesnt | default(omit) }}): __init__() takes at least 3 arguments (2 given)"
}
```

After:
```
TASK [debug] *********************************************************************************************************************************************************************************
task path: /home/will/tmp/ansible/template_issue/playbook.yml:9
fatal: [localhost]: FAILED! => {
    "msg": "{u'broken_key': u\"{{ hello | open_brackets('need_a_backreference', '(.*)', 'xy\\\\1')| some_filter) }}\"}: template error while templating string: unexpected ')'\n  line 1. String: {{ hello | open_brackets('need_a_backreference', '(.*)', 'xy\\1')| some_filter) }}"
}

```