### PR TITLE
Add Python 3.7 to CI unit test matrix.

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -14,6 +14,7 @@ matrix:
     - env: T=units/2.7
     - env: T=units/3.5
     - env: T=units/3.6
+    - env: T=units/3.7
 
     - env: T=windows/1
     - env: T=windows/2

--- a/test/units/module_utils/network/aci/test_aci.py
+++ b/test/units/module_utils/network/aci/test_aci.py
@@ -229,6 +229,8 @@ class AciRest(unittest.TestCase):
             error_text = to_native(u"Unable to parse output as XML, see 'raw' output. None (line 0)", errors='surrogate_or_strict')
         elif PY2:
             error_text = "Unable to parse output as XML, see 'raw' output. Document is empty, line 1, column 1 (line 1)"
+        elif sys.version_info >= (3, 7):
+            error_text = to_native(u"Unable to parse output as XML, see 'raw' output. None (line 0)", errors='surrogate_or_strict')
         else:
             error_text = "Unable to parse output as XML, see 'raw' output. Document is empty, line 1, column 1 (<string>, line 1)"
 

--- a/test/units/modules/cloud/amazon/placebo_fixtures.py
+++ b/test/units/modules/cloud/amazon/placebo_fixtures.py
@@ -1,3 +1,4 @@
+import errno
 import os
 import time
 import mock
@@ -64,7 +65,7 @@ def placeboify(request, monkeypatch):
         # make sure the directory for placebo test recordings is available
         os.makedirs(recordings_path)
     except OSError as e:
-        if e.errno != os.errno.EEXIST:
+        if e.errno != errno.EEXIST:
             raise
 
     pill = placebo.attach(session, data_path=recordings_path)


### PR DESCRIPTION
##### SUMMARY

Add Python 3.7 to CI unit test matrix.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

shippable.yml

##### ANSIBLE VERSION

```
ansible 2.5.0 (units37 ebe4068c9a) last updated 2018/01/09 20:36:24 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```
