### PR TITLE
Use Python 3.7.0a2 for default docker container.

### DIFF
--- a/test/runner/Dockerfile
+++ b/test/runner/Dockerfile
@@ -30,9 +30,10 @@ RUN apt-get update -y && \
 
 ADD https://raw.githubusercontent.com/pyenv/pyenv-installer/master/bin/pyenv-installer /tmp/pyenv-installer
 RUN bash -c 'PYENV_ROOT=/usr/local/opt/pyenv bash /tmp/pyenv-installer'
-RUN bash -c 'PYENV_ROOT=/usr/local/opt/pyenv /usr/local/opt/pyenv/bin/pyenv install 3.7-dev'
-RUN ln -s /usr/local/opt/pyenv/versions/3.7-dev/bin/python3.7 /usr/local/bin/python3.7
-RUN ln -s /usr/local/opt/pyenv/versions/3.7-dev/bin/pip3.7 /usr/local/bin/pip3.7
+COPY docker/python* /tmp/
+RUN bash -c 'PYENV_ROOT=/usr/local/opt/pyenv /usr/local/opt/pyenv/bin/pyenv install /tmp/python3.7.0a2'
+RUN ln -s /usr/local/opt/pyenv/versions/python3.7.0a2/bin/python3.7 /usr/local/bin/python3.7
+RUN ln -s /usr/local/opt/pyenv/versions/python3.7.0a2/bin/pip3.7 /usr/local/bin/pip3.7
 
 RUN rm /etc/apt/apt.conf.d/docker-clean
 RUN locale-gen en_US.UTF-8

--- a/test/runner/docker/python3.7.0a2
+++ b/test/runner/docker/python3.7.0a2
@@ -1,0 +1,8 @@
+#require_gcc
+install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+if has_tar_xz_support; then
+  install_package "Python-3.7.0a2" "https://www.python.org/ftp/python/3.7.0/Python-3.7.0a2.tar.xz#3e5adaa8a264b0c8eeab7b8a0185acec053b0d1547d2712ebc915153c4a52f28" ldflags_dirs standard verify_py37 ensurepip
+else
+  install_package "Python-3.7.0a2" "https://www.python.org/ftp/python/3.7.0/Python-3.7.0a2.tgz#e1fd8af5a80d99ab64e7754f1bdd6d8429bf82ead81c68809ce056af319577be" ldflags_dirs standard verify_py37 ensurepip
+fi


### PR DESCRIPTION
##### SUMMARY

Use Python 3.7.0a2 for default docker container.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

test/runner/Dockerfile

##### ANSIBLE VERSION

```
ansible 2.5.0 (docker-default cd2b9d12fd) last updated 2018/01/09 20:54:31 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```
