### PR TITLE
azure_rm inventory should add "ansible_connection: winrm" in host_vars for windows hosts - fixes #34689

### DIFF
--- a/contrib/inventory/azure_rm.py
+++ b/contrib/inventory/azure_rm.py
@@ -620,7 +620,7 @@ class AzureInventory(object):
 
             # Add windows details
             if machine.os_profile is not None and machine.os_profile.windows_configuration is not None:
-                host_vars['ansible_connection']= 'winrm'
+                host_vars['ansible_connection'] = 'winrm'
                 host_vars['windows_auto_updates_enabled'] = \
                     machine.os_profile.windows_configuration.enable_automatic_updates
                 host_vars['windows_timezone'] = machine.os_profile.windows_configuration.time_zone

--- a/contrib/inventory/azure_rm.py
+++ b/contrib/inventory/azure_rm.py
@@ -620,6 +620,7 @@ class AzureInventory(object):
 
             # Add windows details
             if machine.os_profile is not None and machine.os_profile.windows_configuration is not None:
+                host_vars['ansible_connection']= 'winrm'
                 host_vars['windows_auto_updates_enabled'] = \
                     machine.os_profile.windows_configuration.enable_automatic_updates
                 host_vars['windows_timezone'] = machine.os_profile.windows_configuration.time_zone


### PR DESCRIPTION


##### SUMMARY

azure_rm inventory should add "ansible_connection: winrm" in host_vars for windows hosts

<!---


##### ISSUE TYPE

 - Bugfix Pull Request


##### COMPONENT NAME
contrib/inventory/azure_rm.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.2.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/fft/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/fft/.fftpython2/local/lib/python2.7/site-packages/ansible
  executable location = /home/fft/.fftpython2/bin/ansible
  python version = 2.7.14rc1 (default, Sep  5 2017, 18:16:23) [GCC 7.2.0]

```

##### ADDITIONAL INFORMATION

add the variable "ansible_connection: winrm" in host_vars for windows hosts