### PR TITLE
fix of some problems with user modification with skeleton informations under FreeBSD

### DIFF
--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -855,8 +855,8 @@ class FreeBsdUser(User):
             cmd.append('-c')
             cmd.append(self.comment)
 
-        if self.home is not None and info[5] != self.home:
-            if self.move_home:
+        if self.home is not None:
+            if (info[5] != self.home and self.move_home) or (not os.path.exists(self.home) and self.createhome):
                 cmd.append('-m')
             cmd.append('-d')
             cmd.append(self.home)

--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -861,6 +861,10 @@ class FreeBsdUser(User):
             cmd.append('-d')
             cmd.append(self.home)
 
+            if self.skeleton is not None:
+                cmd.append('-k')
+                cmd.append(self.skeleton)
+
         if self.group is not None:
             if not self.group_exists(self.group):
                 self.module.fail_json(msg="Group %s does not exist" % self.group)


### PR DESCRIPTION
##### SUMMARY
FreeBSD handles skeleton files somehow different than other OSs. Skeleton files in /etc/skel/ are prefixed with "dot". When adding or modifying a user with `pw` and argument `-m` files from the skeleton directory will be copied to the home directory of the user and the "dot" prefix will be removed. Ansible's own create_homedir() function only copies the skeleton files without renaming them properly under FreeBSD.

With this patch/bug fix the home directory of an existing user without existing home directory will be created properly under FreeBSD by using FreeBSD's own functions.

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
user

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```