### PR TITLE
fix nxos_banner

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_banner.py
+++ b/lib/ansible/modules/network/nxos/nxos_banner.py
@@ -117,6 +117,8 @@ def map_config_to_obj(module):
 
     if isinstance(output, dict):
         output = list(output.values())[0]
+        if isinstance(output, dict):
+            output = list(output.values())[0]
 
     obj = {'banner': module.params['banner'], 'state': 'absent'}
     if output:


### PR DESCRIPTION
Signed-off-by: Trishna Guha <trishnaguha17@gmail.com>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
fixes https://github.com/ansible/ansible/issues/34646
`show banner ....` returns `[{u'banner_msg': {u'b_msg': u'User Access Verification\n'}}]` on nxapi transport on some images. The PR handles this.

Note: This doesn't fix idempotence issue https://github.com/ansible/ansible/pull/29088#issuecomment-356591170 for nxapi
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
modules/network/nxos/nxos_banner
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```