### PR TITLE
Remove ansible-test obsolete `net_*` target logic.

### DIFF
--- a/test/runner/lib/executor.py
+++ b/test/runner/lib/executor.py
@@ -373,7 +373,6 @@ def network_init(args, internal_targets):
         return
 
     platform_targets = set(a for t in internal_targets for a in t.aliases if a.startswith('network/'))
-    net_commands = set(a[4:] for t in internal_targets for a in t.aliases if a.startswith('net_'))
 
     instances = []  # type: list [lib.thread.WrappedThread]
 
@@ -384,10 +383,7 @@ def network_init(args, internal_targets):
         platform, version = platform_version.split('/', 1)
         platform_target = 'network/%s/' % platform
 
-        # check to see if the platform supports any of the platform agnostic tests we're going to run (if any)
-        platform_agnostic = any(os.path.exists('lib/ansible/modules/network/%s/%s_%s.py' % (platform, platform, command)) for command in net_commands)
-
-        if platform_target not in platform_targets and not platform_agnostic:
+        if platform_target not in platform_targets:
             display.warning('Skipping "%s" because selected tests do not target the "%s" platform.' % (
                 platform_version, platform))
             continue


### PR DESCRIPTION
##### SUMMARY

Remove ansible-test obsolete `net_*` target logic.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.5.0 (at-net-cleanup e7a547e6f1) last updated 2018/01/10 09:34:13 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.11 (default, Jan 22 2016, 08:29:18) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```
