### PR TITLE
[fix] foreman.py unsupported entity error handling

### DIFF
--- a/lib/ansible/modules/remote_management/foreman/foreman.py
+++ b/lib/ansible/modules/remote_management/foreman/foreman.py
@@ -146,7 +146,7 @@ def main():
         ng.organization(params)
         module.exit_json(changed=True, result="%s updated" % entity)
     else:
-        module.fail_json(changed=False, result="Unsupported entity supplied")
+        module.fail_json(changed=False, msg="Unsupported entity (%s) supplied" % entity)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
##### SUMMARY

The foreman.py module should raise on error when an unsupported entity is passed. However, the module.fail_json arguments were not correct, and instead it would generate an opaque stack trace.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
foreman.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.3.3.0
  config file = /Users/dkimsey/ansible/ansible.cfg
  configured module search path = ['library/']
  python version = 3.6.2 (default, Jul 17 2017, 16:44:45) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```

##### ADDITIONAL INFORMATION
Given:
```
local_action:
  module: foreman
  server_url: 'https://{{katello_hostname}}'
  username: user
  password: pass
  entity: host
  params:
    location: 'The Other DC'
```

Current implementation:
```
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: AssertionError: implementation error -- msg to explain the error is required
fatal: [foo-001.example.com -> localhost]: FAILED! => {"changed": false, "failed": true, "module_stderr": "Traceback (most recent call last):\n  File \"/var/folders/rn/9821bpds6c3_4t2_x7kmd54d2n5085/T/ansible_eu21i9_m/ansible_module_foreman.py\", line 159, in <module>\n    main()\n  File \"/var/folders/rn/9821bpds6c3_4t2_x7kmd54d2n5085/T/ansible_eu21i9_m/ansible_module_foreman.py\", line 153, in main\n    module.fail_json(changed=False, result=\"Unsupported entity supplied\")\n  File \"/var/folders/rn/9821bpds6c3_4t2_x7kmd54d2n5085/T/ansible_eu21i9_m/ansible_modlib.zip/ansible/module_utils/basic.py\", line 1993, in fail_json\nAssertionError: implementation error -- msg to explain the error is required\n", "module_stdout": "", "msg": "MODULE FAILURE", "rc": 1}
```

After this patch:
```
fatal: [foo-001.example.com -> localhost]: FAILED! => {"changed": false, "failed": true, "msg": "Unsupported entity (host) supplied"}
```

Also, the module documentation is unclear that only the entity "organization" is supported. Support for other entities appears to be NYI. I did not alter the documentation to reflect that.

