### PR TITLE
Remove double-specified EC2 ASG test parameters

### DIFF
--- a/test/integration/targets/ec2_asg/tasks/main.yml
+++ b/test/integration/targets/ec2_asg/tasks/main.yml
@@ -41,8 +41,6 @@
       ec2_vpc_net:
         name: "{{ resource_prefix }}-vpc"
         cidr_block: 10.55.77.0/24
-        tags:
-          Name: Ansible Testing VPC
         tenancy: default
         <<: *aws_connection_info
       register: testing_vpc
@@ -56,13 +54,12 @@
 
     - name: Create subnet for use in testing
       ec2_vpc_subnet:
-        tags: "{{ resource_prefix }}-subnet"
         state: present
         vpc_id: "{{ testing_vpc.vpc.id }}"
         cidr: 10.55.77.0/24
         az: "{{ aws_region }}a"
         resource_tags:
-          Name: Ansible Testing Subnet
+          Name: "{{ resource_prefix }}-subnet"
         <<: *aws_connection_info
       register: testing_subnet
 
@@ -412,13 +409,9 @@
 
     - name: remove the subnet
       ec2_vpc_subnet:
-        tags: "{{ resource_prefix }}-subnet"
         state: absent
         vpc_id: "{{ testing_vpc.vpc.id }}"
         cidr: 10.55.77.0/24
-        az: "{{ aws_region }}a"
-        resource_tags:
-          Name: Ansible Testing Subnet
         <<: *aws_connection_info
       register: removed
       until: removed is not failed
@@ -430,9 +423,6 @@
         name: "{{ resource_prefix }}-vpc"
         cidr_block: 10.55.77.0/24
         state: absent
-        tags:
-          Name: Ansible Testing VPC
-        tenancy: default
         <<: *aws_connection_info
       register: removed
       until: removed is not failed


### PR DESCRIPTION
In the ec2_asg integration tests there are a couple places where
parameters are specified twice (as bot `tag.Name` and `name:`) and
others where those parameters aren't needed for the state requested.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
ec2_asg

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
