### PR TITLE
Fix version_added validation when empty.

### DIFF
--- a/test/sanity/validate-modules/main.py
+++ b/test/sanity/validate-modules/main.py
@@ -947,7 +947,7 @@ class ModuleValidator(Validator):
             return
 
         try:
-            version_added = StrictVersion(str(doc.get('version_added', '0.0')))
+            version_added = StrictVersion(str(doc.get('version_added', '0.0') or '0.0'))
         except ValueError:
             version_added = doc.get('version_added', '0.0')
             self.reporter.error(


### PR DESCRIPTION
##### SUMMARY

Fix version_added validation when empty.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

module validator

##### ANSIBLE VERSION

```
ansible 2.5.0 (validate-version-fix 1065da6c95) last updated 2018/01/10 12:53:01 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```
