### PR TITLE
failed, skipped, and unreachable all seem to be needed for various callbacks

### DIFF
--- a/lib/ansible/executor/task_result.py
+++ b/lib/ansible/executor/task_result.py
@@ -10,8 +10,8 @@ from copy import deepcopy
 from ansible.parsing.dataloader import DataLoader
 from ansible.vars.clean import strip_internal_keys
 
-_IGNORE = ('failed', 'skipped')
-_PRESERVE = ('attempts', 'changed', 'retries')
+_IGNORE = tuple()
+_PRESERVE = ('attempts', 'changed', 'retries', 'failed', 'unreachable', 'skipped')
 
 
 class TaskResult:


### PR DESCRIPTION
##### SUMMARY
failed, skipped, and unreachable all seem to be needed for various callbacks. Fixes #34716

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/executor/task_result.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```