### PR TITLE
Fix ec2_vpc_net tags

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_net.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_net.py
@@ -165,7 +165,8 @@ except ImportError:
     pass  # Handled by AnsibleAWSModule
 
 from ansible.module_utils.aws.core import AnsibleAWSModule
-from ansible.module_utils.ec2 import boto3_conn, get_aws_connection_info, ec2_argument_spec, ansible_dict_to_boto3_tag_list, camel_dict_to_snake_dict
+from ansible.module_utils.ec2 import (boto3_conn, get_aws_connection_info, ec2_argument_spec, camel_dict_to_snake_dict,
+                                      ansible_dict_to_boto3_tag_list, boto3_tag_list_to_ansible_dict)
 from ansible.module_utils.six import string_types
 
 
@@ -356,6 +357,7 @@ def main():
                     module.fail_json_aws(e, "Failed to update enabled dns hostnames attribute")
 
         final_state = camel_dict_to_snake_dict(get_vpc(module, connection, vpc_id))
+        final_state['tags'] = boto3_tag_list_to_ansible_dict(final_state.get('tags', []))
         final_state['id'] = final_state.pop('vpc_id')
 
         module.exit_json(changed=changed, vpc=final_state)

--- a/test/integration/targets/ec2_vpc_net/tasks/main.yml
+++ b/test/integration/targets/ec2_vpc_net/tasks/main.yml
@@ -250,6 +250,28 @@
 
     # ============================================================
 
+    - name: modify tags
+      ec2_vpc_net:
+        cidr_block: 20.0.0.0/24
+        name: "{{ resource_prefix }}"
+        dns_support: True
+        dns_hostnames: True
+        state: present
+        multi_ok: no
+        tags:
+          Ansible: Test
+        <<: *aws_connection_info
+      register: result
+
+    - name: assert the VPC has Name and Ansible tags
+      assert:
+        that:
+          - result.vpc.tags|length == 2
+          - 'result.vpc.tags.Ansible == "Test"'
+          - 'result.vpc.tags.Name == "{{ resource_prefix }}"'
+
+    # ============================================================
+
     - name: test check mode to delete a VPC
       ec2_vpc_net:
         cidr_block: 20.0.0.0/24


### PR DESCRIPTION
##### SUMMARY
PR #33105 broke the tags returned by ec2_vpc_net - it was returning the raw boto3 list instead of a dict as expected.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ec2_vpc_net

##### ANSIBLE VERSION
```
ansible 2.5.0
  config file = /home/ec2-user/repos/cmb-infosec-ansible/ansible.cfg
  configured module search path = [u'/home/ec2-user/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/ec2-user/ansible-env/lib/python2.7/site-packages/ansible
  executable location = /home/ec2-user/ansible-env/bin/ansible
  python version = 2.7.13+ (default, Feb 24 2017, 13:51:49) [GCC 4.8.5 20150623 (Red Hat 4.8.5-11)]
```


##### ADDITIONAL INFORMATION
before:
```
   "item": {
        "cidr_block": "10.12.64.0/20",
        "cidr_block_association_set": [
            {
                "association_id": "vpc-cidr-assoc-29026741",
                "cidr_block": "10.12.64.0/20",
                "cidr_block_state": {
                    "state": "associated"
                }
            }
        ],
        "classic_link_enabled": false,
        "dhcp_options_id": "dopt-7a2be01f",
        "id": "vpc-4eac0c28",
        "instance_tenancy": "default",
        "is_default": false,
        "state": "available",
        "tags": [
            {
                "key": "Environment",
                "value": "P03"
            },
            {
                "key": "TechOwner",
                "value": "InfoSec"
            },
            {
                "key": "SecurityClass",
                "value": "005"
            },
            {
                "key": "Product",
                "value": "INT|INT|InfoSec"
            },
            {
                "key": "Name",
                "value": "P03-Integration"
            },
            {
                "key": "BillingId",
                "value": "F301|InfoSec"
            }
        ]
    },

```
after:
```
    "item": {
        "cidr_block": "10.12.64.0/20",
        "cidr_block_association_set": [
            {
                "association_id": "vpc-cidr-assoc-29026741",
                "cidr_block": "10.12.64.0/20",
                "cidr_block_state": {
                    "state": "associated"
                }
            }
        ],
        "classic_link_enabled": false,
        "dhcp_options_id": "dopt-7a2be01f",
        "id": "vpc-4eac0c28",
        "instance_tenancy": "default",
        "is_default": false,
        "state": "available",
        "tags": {
            "BillingId": "F301|InfoSec",
            "Environment": "P03",
            "Name": "P03-Integration",
            "Product": "INT|INT|InfoSec",
            "SecurityClass": "005",
            "TechOwner": "InfoSec"
        }
```
