### PR TITLE
Support advertised networks in bgp protocol

### DIFF
--- a/lib/ansible/module_utils/network/mlnxos/mlnxos.py
+++ b/lib/ansible/module_utils/network/mlnxos/mlnxos.py
@@ -141,7 +141,7 @@ def get_interfaces_config(module, interface_type, flags=None, json_fmt=True):
 
 
 def get_bgp_summary(module):
-    cmd = "show ip bgp summary"
+    cmd = "show running-config protocol bgp"
     return show_cmd(module, cmd, json_fmt=False, fail_on_error=False)
 
 

--- a/test/units/modules/network/mlnxos/fixtures/mlnxos_bgp_show.cfg
+++ b/test/units/modules/network/mlnxos/fixtures/mlnxos_bgp_show.cfg
@@ -1,6 +1,23 @@
-BGP router identifier 1.2.3.4, local AS number 172
-BGP table version is 1, main routing table version 1
---------          -         -- ------- -------  ------  --- ---- -------     ------------
-Neighbor          V         AS MsgRcvd MsgSent  TblVer  InQ OutQ Up/Down     State/PfxRcd
---------          -         -- ------- -------  ------  --- ---- -------     ------------
-10.2.3.4          4        173       0       0       1    0    0 Never       ACTIVE
+##
+## Running database "initial"
+## Generated at 2018/01/10 23:13:17 +0000
+## Hostname: r-neo-sw12
+##
+
+##
+## Running-config temporary prefix mode setting
+##
+no cli default prefix-modes enable
+
+##
+## BGP configuration
+##
+   protocol bgp
+   router bgp 172 vrf default
+   router bgp 172 vrf default router-id 1.2.3.4 force
+   router bgp 172 vrf default neighbor 10.2.3.4 remote-as 173
+   router bgp 172 vrf default network 172.16.1.0 /24
+##
+## Persistent prefix mode setting
+##
+cli default prefix-modes enable

--- a/test/units/modules/network/mlnxos/test_mlnxos_bgp.py
+++ b/test/units/modules/network/mlnxos/test_mlnxos_bgp.py
@@ -39,7 +39,8 @@ class TestMlnxosBgpModule(TestMlnxosModule):
     def test_bgp_no_change(self):
         neighbor = dict(remote_as=173, neighbor='10.2.3.4')
         set_module_args(dict(as_number=172, router_id='1.2.3.4',
-                             neighbors=[neighbor]))
+                             neighbors=[neighbor],
+                             networks=['172.16.1.0/24']))
         self.execute_module(changed=False)
 
     def test_bgp_remove(self):
@@ -60,11 +61,27 @@ class TestMlnxosBgpModule(TestMlnxosModule):
         neighbors = [dict(remote_as=173, neighbor='10.2.3.4'),
                      dict(remote_as=175, neighbor='10.2.3.5')]
         set_module_args(dict(as_number=172, router_id='1.2.3.4',
-                             neighbors=neighbors))
+                             neighbors=neighbors,
+                             networks=['172.16.1.0/24']))
         commands = ['router bgp 172 neighbor 10.2.3.5 remote-as 175']
         self.execute_module(changed=True, commands=commands)
 
     def test_bgp_del_neighbor(self):
-        set_module_args(dict(as_number=172))
+        set_module_args(dict(as_number=172,
+                             networks=['172.16.1.0/24']))
         commands = ['router bgp 172 no neighbor 10.2.3.4 remote-as 173']
+        self.execute_module(changed=True, commands=commands)
+
+    def test_bgp_add_network(self):
+        neighbors = [dict(remote_as=173, neighbor='10.2.3.4')]
+        set_module_args(dict(as_number=172, router_id='1.2.3.4',
+                             neighbors=neighbors,
+                             networks=['172.16.1.0/24', '172.16.2.0/24']))
+        commands = ['router bgp 172 network 172.16.2.0 /24']
+        self.execute_module(changed=True, commands=commands)
+
+    def test_bgp_del_network(self):
+        neighbors = [dict(remote_as=173, neighbor='10.2.3.4')]
+        set_module_args(dict(as_number=172, neighbors=neighbors))
+        commands = ['router bgp 172 no network 172.16.1.0 /24']
         self.execute_module(changed=True, commands=commands)


### PR DESCRIPTION
Signed-off-by: Samer Deeb <samerd@mellanox.com>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Add support for advertised networks in bgp protocol for Mellanox mlnxos network devices
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
modules/network/mlnxos/mlnxos_bgp

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (feature/net-bgp a47e347910) last updated 2018/01/11 05:42:47 (GMT +000)
  config file = /etc/ansible/ansible.cfg
  python version = 2.7.5 (default, Nov  6 2016, 00:28:07) [GCC 4.8.5 20150623 (Red Hat 4.8.5-11)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
