### PR TITLE
Changing documentation for back up as suggested by  Ganesh

### DIFF
--- a/lib/ansible/modules/network/enos/enos_config.py
+++ b/lib/ansible/modules/network/enos/enos_config.py
@@ -111,9 +111,9 @@ options:
     description:
       - This argument will cause the module to create a full backup of
         the current C(running-config) from the remote device before any
-        changes are made.  The backup file is written to the C(backup)
-        folder in the playbook root directory.  If the directory does not
-        exist, it is created.
+        changes are made.  The running configuration will be embedded
+        in the results under variable __backup__. The running-config
+        can be streamed to a file using copy command of Ansible.
     required: false
     default: no
     choices: ['yes', 'no']
@@ -149,6 +149,9 @@ EXAMPLES = """
   enos_config:
     src: config.cfg
     backup: yes
+    register: result
+
+- copy: content="{{ result.__backup__ }}" dest="{{ role_path }}/backup/running_config"
 """
 
 RETURN = """
@@ -273,6 +276,7 @@ def main():
 
     if module.params['backup']:
         result['__backup__'] = get_config(module)
+        result.update({'changed': True})
 
     run(module, result)
 

--- a/lib/ansible/modules/network/enos/enos_config.py
+++ b/lib/ansible/modules/network/enos/enos_config.py
@@ -276,7 +276,6 @@ def main():
 
     if module.params['backup']:
         result['__backup__'] = get_config(module)
-        result.update({'changed': True})
 
     run(module, result)
 


### PR DESCRIPTION
##### SUMMARY
Making the documentation correct for the backup option of the module enos_config. The r unning configuration will come as a json object in the result variable of the module. The user has to use the copy command of Ansible to copy the running configuration to a file in the location he desires.

##### ISSUE TYPE
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
lib/ansible/modules/network/enos/enos_config.py

##### ANSIBLE VERSION
ansible 2.5.0
config file = /etc/ansible/ansible.cfg
configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible-2.5.0-py2.7.egg/ansible
executable location = /usr/local/bin/ansible
python version = 2.7.6 (default, Oct 26 2016, 20:30:19) [GCC 4.8.4]

##### ADDITIONAL INFORMATION
This is a documentation update changes to make it more clear to user regarding the usage of config backup option
