### PR TITLE
Add hash making inventory caches unique to inventory script ran

### DIFF
--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -456,6 +456,7 @@ class Ec2Inventory(object):
         cache_id = self.boto_profile or os.environ.get('AWS_ACCESS_KEY_ID', self.credentials.get('aws_access_key_id'))
         if cache_id:
             cache_name = '%s-%s' % (cache_name, cache_id)
+        cache_name += '-' + str(abs(hash(__file__)))[1:7]
         self.cache_path_cache = os.path.join(cache_dir, "%s.cache" % cache_name)
         self.cache_path_index = os.path.join(cache_dir, "%s.index" % cache_name)
         self.cache_max_age = config.getint('ec2', 'cache_max_age')


### PR DESCRIPTION
##### SUMMARY
Adds a unique hash to cache filenames so that running different inventory scripts results in unique caches.

We use multiple inventories within the same AWS account and what is happening is that after subsequent runs the second inventory script ran uses the cache from the first.
```
inventory/
├── ec2.py
├── production_us-east-1
|     ├── ec2.ini
|     └── ec2.py -> ../ec2.py
└── production_us-west-2
      ├── ec2.ini
      └── ec2.py -> ../ec2.py
```

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
contrib/ec2.py

##### ANSIBLE VERSION
Version being used with the problem.
```
ansible 2.4.2.0
  config file = /Users/jonnymcc/hbo/SRE-Grafana/ansible/ansible.cfg
  configured module search path = [u'/Users/jonnymcc/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.14 (default, Sep 25 2017, 09:53:17) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]
```

