### PR TITLE
Fix junos_netconf integration test failure

### DIFF
--- a/test/integration/targets/junos_netconf/tests/cli/changeport.yaml
+++ b/test/integration/targets/junos_netconf/tests/cli/changeport.yaml
@@ -1,7 +1,6 @@
 ---
 - debug: msg="START netconf/changeport.yaml on connection={{ ansible_connection }}"
 
-
 - name: Setup
   junos_netconf:
     state: present
@@ -33,25 +32,16 @@
     seconds: 10
 
 - name: Ensure we can communicate over 8022
-  junos_command:
-    rpcs:
-    - get-software-information
-    provider: "{{ netconf }}"
-    port: 8022
-  connection: netconf
+  include: "{{ role_path }}/tests/utils/junos_command.yaml ansible_connection=netconf ansible_port=8022 is_ignore_errors=false"
 
 - name: wait for persistent socket to timeout
   pause:
     seconds: 120
 
+
 # This protects against the port override above not being honoured and a bug setting the port
 - name: Ensure we can NOT communicate over default port
-  junos_command:
-    rpcs: get-software-information
-    provider: "{{ netconf }}"
-  register: result
-  connection: netconf
-  ignore_errors: true
+  include: "{{ role_path }}/tests/utils/junos_command.yaml ansible_connection=netconf ansible_port=830 is_ignore_errors=true"
 
 - assert:
     that:
@@ -67,10 +57,6 @@
     seconds: 120
 
 - name: Ensure we can communicate over netconf
-  junos_command:
-    rpcs:
-    - get-software-information
-    provider: "{{ netconf }}"
-  connection: netconf
+  include: "{{ role_path }}/tests/utils/junos_command.yaml ansible_connection=netconf ansible_port=830 is_ignore_errors=false"
 
 - debug: msg="END netconf/changeport.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/junos_netconf/tests/cli/netconf.yaml
+++ b/test/integration/targets/junos_netconf/tests/cli/netconf.yaml
@@ -23,13 +23,9 @@
     seconds: 10
 
 - name: Ensure we can communicate over netconf
-  junos_command:
-    rpcs: get-software-information
-    provider: "{{ netconf }}"
-  connection: netconf
+  include: "{{ role_path }}/tests/utils/junos_command.yaml ansible_connection=netconf ansible_port=830 is_ignore_errors=false"
 
 # Disable netconf
-
 - name: Disable netconf
   junos_netconf:
     state: absent
@@ -53,12 +49,7 @@
     seconds: 120
 
 - name: Ensure we can NOT talk via netconf
-  junos_command:
-    rpcs: get-software-information
-    provider: "{{ netconf }}"
-  register: result
-  connection: netconf
-  ignore_errors: true
+  include: "{{ role_path }}/tests/utils/junos_command.yaml ansible_connection=netconf ansible_port=830 is_ignore_errors=true"
 
 - assert:
     that:
@@ -68,6 +59,5 @@
   junos_netconf:
     state: present
   register: result
-
 
 - debug: msg="END netconf/netconfg.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/junos_netconf/tests/utils/junos_command.yaml
+++ b/test/integration/targets/junos_netconf/tests/utils/junos_command.yaml
@@ -1,0 +1,8 @@
+---
+- name: run junos_command to check netconf connectivity
+  junos_command:
+    rpcs: get-software-information
+    provider: "{{ netconf }}"
+    port: "{{ ansible_port }}"
+  register: result
+  ignore_errors: "{{ is_ignore_errors }}"

--- a/test/integration/targets/junos_netconf/tests/utils/junos_command.yaml
+++ b/test/integration/targets/junos_netconf/tests/utils/junos_command.yaml
@@ -2,7 +2,5 @@
 - name: run junos_command to check netconf connectivity
   junos_command:
     rpcs: get-software-information
-    provider: "{{ netconf }}"
-    port: "{{ ansible_port }}"
   register: result
   ignore_errors: "{{ is_ignore_errors }}"


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Set ansible_connection to netconf for junos_command module
in junos_netconf integration test
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Test Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
