### PR TITLE
Only pass extra create_trail options if set in module params

### DIFF
--- a/lib/ansible/modules/cloud/amazon/cloudtrail.py
+++ b/lib/ansible/modules/cloud/amazon/cloudtrail.py
@@ -485,7 +485,7 @@ def main():
     if module.params['cloudwatch_logs_log_group_arn']:
         ct_params['CloudWatchLogsLogGroupArn'] = module.params['cloudwatch_logs_log_group_arn']
 
-    if module.params['enable_log_file_validation']:
+    if module.params['enable_log_file_validation'] is not None:
         ct_params['EnableLogFileValidation'] = module.params['enable_log_file_validation']
 
     if module.params['kms_key_id']:
@@ -595,7 +595,9 @@ def main():
                 pass
             trail = dict()
             trail.update(ct_params)
-            trail['LogFileValidationEnabled'] = ct_params['EnableLogFileValidation']
+            if 'EnableLogFileValidation' not in ct_params:
+                ct_params['EnableLogFileValidation'] = False
+            trail['EnableLogFileValidation'] = ct_params['EnableLogFileValidation']
             trail.pop('EnableLogFileValidation')
             fake_arn = 'arn:aws:cloudtrail:' + region + ':' + acct_id + ':trail/' + ct_params['Name']
             trail['HasCustomEventSelectors'] = False

--- a/lib/ansible/modules/cloud/amazon/cloudtrail.py
+++ b/lib/ansible/modules/cloud/amazon/cloudtrail.py
@@ -62,7 +62,6 @@ options:
     description:
       - Specifies whether log file integrity validation is enabled.
       - CloudTrail will create a hash for every log file delivered and produce a signed digest file that can be used to ensure log files have not been tampered.
-    default: false
     version_added: "2.4"
     aliases: [ "log_file_validation_enabled" ]
   include_global_events:
@@ -444,7 +443,7 @@ def main():
         s3_key_prefix=dict(),
         sns_topic_name=dict(),
         is_multi_region_trail=dict(default=False, type='bool'),
-        enable_log_file_validation=dict(default=False, type='bool', aliases=['log_file_validation_enabled']),
+        enable_log_file_validation=dict(type='bool', aliases=['log_file_validation_enabled']),
         include_global_events=dict(default=True, type='bool', aliases=['include_global_service_events']),
         cloudwatch_logs_role_arn=dict(),
         cloudwatch_logs_log_group_arn=dict(),
@@ -472,12 +471,6 @@ def main():
         S3BucketName=module.params['s3_bucket_name'],
         IncludeGlobalServiceEvents=module.params['include_global_events'],
         IsMultiRegionTrail=module.params['is_multi_region_trail'],
-        EnableLogFileValidation=module.params['enable_log_file_validation'],
-        S3KeyPrefix='',
-        SnsTopicName='',
-        CloudWatchLogsRoleArn='',
-        CloudWatchLogsLogGroupArn='',
-        KmsKeyId=''
     )
 
     if module.params['s3_key_prefix']:
@@ -491,6 +484,9 @@ def main():
 
     if module.params['cloudwatch_logs_log_group_arn']:
         ct_params['CloudWatchLogsLogGroupArn'] = module.params['cloudwatch_logs_log_group_arn']
+
+    if module.params['enable_log_file_validation']:
+        ct_params['EnableLogFileValidation'] = module.params['enable_log_file_validation']
 
     if module.params['kms_key_id']:
         ct_params['KmsKeyId'] = module.params['kms_key_id']


### PR DESCRIPTION
##### SUMMARY

Fixes #34700  - the Amazon CloudTrail service in China (and I think some other regions) does not support the EnableLogFileValidation and KmsKeyId parameters.

The module currently defaults to setting the former as false and passing the latter as an empty string, which causes an UnsupportedOperationException.

This PR takes out the empty-string defaults, and lets the CloudTrail API default log file validation to false (see [here](https://docs.aws.amazon.com/awscloudtrail/latest/APIReference/API_CreateTrail.html#awscloudtrail-CreateTrail-request-EnableLogFileValidation) for the API reference).

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

cloudtrail

##### ANSIBLE VERSION
```
$ ansible --version
ansible 2.5.0 (cloudtrail-china-support 4913991103) last updated 2018/01/11 17:34:41 (GMT +100)
  config file = /Users/nbailey/.ansible.cfg
  configured module search path = [u'/Users/nbailey/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/nbailey/ansible/lib/ansible
  executable location = /Users/nbailey/ansible/bin/ansible
  python version = 2.7.10 (default, Oct 23 2015, 19:19:21) [GCC 4.2.1 Compatible Apple LLVM 7.0.0 (clang-700.0.59.5)]
```

Fix verified in US and China AWS regions; happy to adjust formatting if there are Ansible module-writing conventions I'm missing.