### PR TITLE
Add validate_certs to jira module

### DIFF
--- a/lib/ansible/modules/web_infrastructure/jira.py
+++ b/lib/ansible/modules/web_infrastructure/jira.py
@@ -118,6 +118,13 @@ options:
       - Set timeout, in seconds, on requests to JIRA API.
     default: 10
 
+  validate_certs:
+    required: false
+    version_added: 2.5
+    description:
+      - Require valid SSL certificates (set to `false` if you'd like to use self-signed certificates)
+    default: true
+
 notes:
   - "Currently this only works with basic-auth."
 
@@ -391,6 +398,7 @@ def main():
             inwardissue=dict(),
             outwardissue=dict(),
             timeout=dict(type='float', default=10),
+            validate_certs=dict(default=True, type='bool'),
         ),
         supports_check_mode=False
     )


### PR DESCRIPTION


Signed-off-by: Adam Miller <admiller@redhat.com>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
The jira module uses ansible.module_utils.urls.fetch_url which will
attempt to get that value of the validate_certs parameter from the
module; if present it will honor it's value, otherwise it defaults
to True.

This patch adds that parameter to jira so that it can be specified
by the user and honored by ansible.module_utils.urls.fetch_url
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
jira

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (jira 7c54f58640) last updated 2018/01/11 14:09:46 (GMT -500)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/admiller/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/admiller/src/dev/ansible/lib/ansible
  executable location = /home/admiller/src/dev/ansible/bin/ansible
  python version = 2.7.14 (default, Dec 11 2017, 14:52:53) [GCC 7.2.1 20170915 (Red Hat 7.2.1-2)]
```


