### PR TITLE
Add a config toggle for agnostic become prompts

### DIFF
--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -320,14 +320,16 @@ class CLI(with_metaclass(ABCMeta, object)):
         becomepass = None
         become_prompt = ''
 
+        become_prompt_method = "BECOME" if C.AGNOSTIC_BECOME_PROMPT else op.become_method.upper()
+
         try:
             if op.ask_pass:
                 sshpass = getpass.getpass(prompt="SSH password: ")
-                become_prompt = "BECOME password[defaults to SSH password]: "
+                become_prompt = "%s password[defaults to SSH password]: " % become_prompt_method
                 if sshpass:
                     sshpass = to_bytes(sshpass, errors='strict', nonstring='simplerepr')
             else:
-                become_prompt = "BECOME password: "
+                become_prompt = "%s password: " % become_prompt_method
 
             if op.become_ask_pass:
                 becomepass = getpass.getpass(prompt=become_prompt)

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -159,6 +159,17 @@ BECOME_ALLOW_SAME_USER:
   - {key: become_allow_same_user, section: privilege_escalation}
   type: boolean
   yaml: {key: privilege_escalation.become_allow_same_user}
+AGNOSTIC_BECOME_PROMPT:
+  # TODO: Switch the default to True in either the Ansible 2.6 release or the 2.7 release, whichever happens after the Tower 3.3 release
+  name: Display an agnostic become prompt
+  default: False
+  type: boolean
+  description: Display an agnostic become prompt instead of displaying a prompt containing the command line supplied become method
+  env: [{name: ANSIBLE_AGNOSTIC_BECOME_PROMPT}]
+  ini:
+    - {key: agnostic_become_prompt, section: privilege_escalation}
+  yaml: {key: privilege_escalation.agnostic_become_prompt}
+  version_added: "2.5"
 CACHE_PLUGIN:
   name: Persistent Cache plugin
   default: memory


### PR DESCRIPTION
##### SUMMARY
Add a config toggle for agnostic become prompts, defaulting to False for the 2.5 release. Fixes #33999

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
`lib/ansible/cli/__init__.py`

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel/2.5
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```