### PR TITLE
vr_server: fix assumption returned id is an int

### DIFF
--- a/lib/ansible/modules/cloud/vultr/vr_server.py
+++ b/lib/ansible/modules/cloud/vultr/vr_server.py
@@ -159,7 +159,7 @@ vultr_server:
     id:
       description: ID of the server
       returned: success
-      type: int
+      type: string
       sample: 10194376
     name:
       description: Name (label) of the server
@@ -319,7 +319,7 @@ class AnsibleVultrServer(Vultr):
 
         self.server = None
         self.returns = {
-            'SUBID': dict(key='id', convert_to='int'),
+            'SUBID': dict(key='id'),
             'label': dict(key='name'),
             'date_created': dict(),
             'allowed_bandwidth_gb': dict(convert_to='int'),


### PR DESCRIPTION
##### SUMMARY
looks like an int ID, but the api returns it as string, keep it the way it is returned.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
vr_server

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
