### PR TITLE
Add note to 2.4 porting guide about initial playbook relative host/group_vars and inheritance

### DIFF
--- a/docs/docsite/rst/porting_guide_2.4.rst
+++ b/docs/docsite/rst/porting_guide_2.4.rst
@@ -40,16 +40,12 @@ A bug was fixed with the inventory path/directory, which was defaulting to the c
 Initial playbook relative group_vars and host_vars
 --------------------------------------------------
 
-In Ansible versions prior to 2.4, the inventory system would maintain context of the initial playbook that was executed. This allowed successively
-included playbooks to inherit playbook file relative ``group_vars`` and ``host_vars``.
+In Ansible versions prior to 2.4, the inventory system would maintain context of the initial playbook that was executed. This allowed successively included playbooks to inherit playbook file-relative ``group_vars`` and ``host_vars``.
 
-After reviewing the history of this code, and comparing the outcome with expectations, we decided to not port this functionality into the new
-inventory system. This decision was made to reduce unexpected behavior, supporting a system of least surprise.
+Due to some behavioral inconsistencies, this functionality will not be included in the new
+inventory system starting with Ansible version 2.4.3.  
 
-The reasons this conclusion was met, was due to the intial playbook being considered part of the inventory and due to giving special treatment and
-meaning to the initial playbook and not successive included playbooks.
-
-Alternatives to this behavior in 2.4 can be achieved by using inventory file relative ``group_vars`` and ``host_vars``, ``vars_files``, or ``include_vars``.
+Similar functionality can still be achieved by using inventory file relative ``group_vars`` and ``host_vars``, ``vars_files``, or ``include_vars``.
 
 Deprecated
 ==========

--- a/docs/docsite/rst/porting_guide_2.4.rst
+++ b/docs/docsite/rst/porting_guide_2.4.rst
@@ -37,6 +37,20 @@ Since there is no longer a single inventory, the 'implicit localhost' doesn't ge
 
 A bug was fixed with the inventory path/directory, which was defaulting to the current working directory. This caused ``group_vars`` and ``host_vars`` to be picked up from the current working directory instead of just adjacent to the playbook or inventory directory when a host list (comma separated host names) was provided as inventory.
 
+Initial playbook relative group_vars and host_vars
+--------------------------------------------------
+
+In Ansible versions prior to 2.4, the inventory system would maintain context of the initial playbook that was executed. This allowed successively
+included playbooks to inherit playbook file relative ``group_vars`` and ``host_vars``.
+
+After reviewing the history of this code, and comparing the outcome with expectations, we decided to not port this functionality into the new
+inventory system. This decision was made to reduce unexpected behavior, supporting a system of least surprise.
+
+The reasons this conclusion was met, was due to the intial playbook being considered part of the inventory and due to giving special treatment and
+meaning to the initial playbook and not successive included playbooks.
+
+Alternatives to this behavior in 2.4 can be achieved by using inventory file relative ``group_vars`` and ``host_vars``, ``vars_files``, or ``include_vars``.
+
 Deprecated
 ==========
 

--- a/docs/docsite/rst/porting_guide_2.4.rst
+++ b/docs/docsite/rst/porting_guide_2.4.rst
@@ -40,12 +40,12 @@ A bug was fixed with the inventory path/directory, which was defaulting to the c
 Initial playbook relative group_vars and host_vars
 --------------------------------------------------
 
-In Ansible versions prior to 2.4, the inventory system would maintain context of the initial playbook that was executed. This allowed successively included playbooks to inherit playbook file-relative ``group_vars`` and ``host_vars``.
+In Ansible versions prior to 2.4, the inventory system would maintain context of the initial playbook that was executed. This allowed successively included playbooks to inherit group_vars and host_vars placed relative to the toplevel playbook file.
 
 Due to some behavioral inconsistencies, this functionality will not be included in the new
 inventory system starting with Ansible version 2.4.  
 
-Similar functionality can still be achieved by using inventory file relative ``group_vars`` and ``host_vars``, ``vars_files``, or ``include_vars``.
+Similar functionality can still be achieved by using vars_files, include_vars, or group_vars and host_vars placed relative to the inventory file.
 
 Deprecated
 ==========

--- a/docs/docsite/rst/porting_guide_2.4.rst
+++ b/docs/docsite/rst/porting_guide_2.4.rst
@@ -43,7 +43,7 @@ Initial playbook relative group_vars and host_vars
 In Ansible versions prior to 2.4, the inventory system would maintain context of the initial playbook that was executed. This allowed successively included playbooks to inherit playbook file-relative ``group_vars`` and ``host_vars``.
 
 Due to some behavioral inconsistencies, this functionality will not be included in the new
-inventory system starting with Ansible version 2.4.3.  
+inventory system starting with Ansible version 2.4.  
 
 Similar functionality can still be achieved by using inventory file relative ``group_vars`` and ``host_vars``, ``vars_files``, or ``include_vars``.
 

--- a/docs/docsite/rst/porting_guide_2.4.rst
+++ b/docs/docsite/rst/porting_guide_2.4.rst
@@ -40,7 +40,7 @@ A bug was fixed with the inventory path/directory, which was defaulting to the c
 Initial playbook relative group_vars and host_vars
 --------------------------------------------------
 
-In Ansible versions prior to 2.4, the inventory system would maintain context of the initial playbook that was executed. This allowed successively included playbooks to inherit group_vars and host_vars placed relative to the toplevel playbook file.
+In Ansible versions prior to 2.4, the inventory system would maintain the context of the initial playbook that was executed. This allowed successively included playbooks to inherit group_vars and host_vars placed relative to the top level playbook file.
 
 Due to some behavioral inconsistencies, this functionality will not be included in the new
 inventory system starting with Ansible version 2.4.  

--- a/docs/docsite/rst/porting_guide_2.4.rst
+++ b/docs/docsite/rst/porting_guide_2.4.rst
@@ -40,10 +40,10 @@ A bug was fixed with the inventory path/directory, which was defaulting to the c
 Initial playbook relative group_vars and host_vars
 --------------------------------------------------
 
-In Ansible versions prior to 2.4, the inventory system would maintain the context of the initial playbook that was executed. This allowed successively included playbooks to inherit group_vars and host_vars placed relative to the top level playbook file.
+In Ansible versions prior to 2.4, the inventory system would maintain the context of the initial playbook that was executed. This allowed successively included playbooks from other directories to inherit group_vars and host_vars placed relative to the top level playbook file.
 
 Due to some behavioral inconsistencies, this functionality will not be included in the new
-inventory system starting with Ansible version 2.4.  
+inventory system starting with Ansible version 2.4.
 
 Similar functionality can still be achieved by using vars_files, include_vars, or group_vars and host_vars placed relative to the inventory file.
 


### PR DESCRIPTION
##### SUMMARY

Add note to 2.4 porting guide about initial playbook relative host/group_vars and inheritance

Addresses #33177 

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
docs/docsite/rst/porting_guide_2.4.rst

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.4/2.5
```


##### ADDITIONAL INFORMATION

This change should also be backported to the stable-2.4 branch for docs versioning

cc @abadger 