### PR TITLE
FreeBSD STABLE distribution not correctly parsed

### DIFF
--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -496,7 +496,7 @@ class Distribution(object):
     def get_distribution_FreeBSD(self):
         freebsd_facts = {}
         freebsd_facts['distribution_release'] = platform.release()
-        data = re.search(r'(\d+)\.(\d+)-RELEASE.*', freebsd_facts['distribution_release'])
+        data = re.search(r'(\d+)\.(\d+)-(RELEASE|STABLE).*', freebsd_facts['distribution_release'])
         if data:
             freebsd_facts['distribution_major_version'] = data.group(1)
             freebsd_facts['distribution_version'] = '%s.%s' % (data.group(1), data.group(2))


### PR DESCRIPTION
##### SUMMARY
setup only parses FreeBSD release versions. I.e. if parses: `11.1-RELEASE`. But FreeBSD also has a STABLE distribution concept, which looks like: `11.1-STABLE`.

This small patch picks that up so `ansible_distribution_version` and `ansible_distribution_major_version` are properly set.

Else `ansible_distribution_version` will look like: `FreeBSD 11.1-STABLE #0 r327519: Wed Jan  3 19:25:44 UTC 2018     root@releng2.nyi.freebsd.org:/usr/obj/usr/src/sys/GENERIC `.

And `ansible_distribution_major_version` is not set at all.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
setup module, but touches only `distribution.py`.

##### ANSIBLE VERSION
```
ansible 2.4.2.0 (freebsd-distribution-version-fix 4de7d4da23) last updated 2018/01/12 11:33:40 (GMT +1300)
  config file = None
  configured module search path = [u'/home/berend/src/ansible/library']
  ansible python module location = /home/berend/src/ansible/lib/ansible
  executable location = /home/berend/src/ansible/bin/ansible
  python version = 2.7.14 (default, Sep 23 2017, 22:06:14) [GCC 7.2.0]
```

##### ADDITIONAL INFORMATION
It's quite common to run the STABLE branch in FreeBSD. As the docs say: "STABLE" is the branch where development continues after a RELEASE, including bug fixes and new features. 

Run this command to get the setup:
```
ansible -u root -e ansible_python_interpreter=/usr/local/bin/python2.7 -m setup 35.153.133.47 | grep version
```

will return incorrect results against STABLE distribution.