### PR TITLE
Check existence of resource group before trying to write to it

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_deployment.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_deployment.py
@@ -490,13 +490,15 @@ class AzureRMDeploymentManager(AzureRMModuleBase):
                 uri=self.template_link
             )
 
-        params = self.rm_models.ResourceGroup(location=self.location, tags=self.tags)
+        # Check for the existence of the resource group. If we can't find it, create it
+        if not self.rm_client.resource_groups.check_existence(self.resource_group_name):
+            params = self.rm_models.ResourceGroup(location=self.location, tags=self.tags)
 
-        try:
-            self.rm_client.resource_groups.create_or_update(self.resource_group_name, params)
-        except CloudError as exc:
-            self.fail("Resource group create_or_update failed with status code: %s and message: %s" %
-                      (exc.status_code, exc.message))
+            try:
+                self.rm_client.resource_groups.create_or_update(self.resource_group_name, params)
+            except CloudError as exc:
+                self.fail("Resource group create_or_update failed with status code: %s and message: %s" %
+                          (exc.status_code, exc.message))
         try:
             result = self.rm_client.deployments.create_or_update(self.resource_group_name,
                                                                  self.deployment_name,


### PR DESCRIPTION
##### SUMMARY
Tries to check for the existence of a resource group nicely before trying to write it using `create_or_update`. This drops the requirement of the azure module to have the `Microsoft.Resources/subscriptions/resourcegroups/write` which anyone with a `Contributor` access level doesn't (however they might well have permission to deploy an ARM template into that Resource Group

Note this could probably be rolled out over most the modules in the azure stack. But I thought it would be easier to get feedback on this one (as this is the one I'm most interested in) and if it gathers interest then I can roll it out across the other modules.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
azure_rm_deployment.py

##### ANSIBLE VERSION
```
<username>@ ~ () $ ansible --version
ansible 2.4.2.0
  config file = None
  configured module search path = [u'/Users/<username>/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/Cellar/ansible/2.4.2.0_2/libexec/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.10 (default, Jul 15 2017, 17:16:57) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.31)]
```


##### ADDITIONAL INFORMATION
```

```
