### PR TITLE
Add decrypt_string option to ansible-vault

### DIFF
--- a/docs/docsite/rst/user_guide/vault.rst
+++ b/docs/docsite/rst/user_guide/vault.rst
@@ -194,6 +194,51 @@ Result::
 See also :ref:`single_encrypted_variable`
 
 
+.. _decrypt_string:
+
+Use decrypt_string to read encrypted variables from stdin
+`````````````````````````````````````````````````````````
+
+To view a string encrypted by :ref:`ansible-vault encrypt_string <ansible_vault_encrypt_string>`,
+use :ref:`ansible-vault decrypt_string <ansible_vault_decrypt_string>`. This command always
+takes input from standard input, and can decrypt either just the vaulted block, or the yaml dictionary.
+
+.. code-block:: bash
+
+    ansible-vault decrypt_string --vault-id dev@./password
+
+Output::
+
+    Reading plaintext input from stdin. (ctrl-d to end input)
+
+Input::
+
+    new_user_password: !vault |
+              $ANSIBLE_VAULT;1.2;AES256;dev
+              37636561366636643464376336303466613062633537323632306566653533383833366462366662
+              6565353063303065303831323539656138653863353230620a653638643639333133306331336365
+              62373737623337616130386137373461306535383538373162316263386165376131623631323434
+              3866363862363335620a376466656164383032633338306162326639643635663936623939666238
+              3161
+
+Result::
+
+    new_user_password: hunter42
+
+Input::
+
+              $ANSIBLE_VAULT;1.2;AES256;dev
+              37636561366636643464376336303466613062633537323632306566653533383833366462366662
+              6565353063303065303831323539656138653863353230620a653638643639333133306331336365
+              62373737623337616130386137373461306535383538373162316263386165376131623631323434
+              3866363862363335620a376466656164383032633338306162326639643635663936623939666238
+              3161
+
+Result::
+
+    hunter42
+
+
 .. _vault_ids:
 
 Vault Ids and Multiple Vault Passwords


### PR DESCRIPTION
##### SUMMARY
Allow encrypted strings inside variable files to be decrypted

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
ansible-vault

##### ANSIBLE VERSION
```
ansible 2.5.0 (devel 83b7ec69fc) last updated 2018/01/12 11:28:16 (GMT +1000)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/will/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/will/src/ansible/lib/ansible
  executable location = /home/will/src/ansible/bin/ansible
  python version = 2.7.14 (default, Dec 11 2017, 14:52:53) [GCC 7.2.1 20170915 (Red Hat 7.2.1-2)]
```


##### ADDITIONAL INFORMATION
