### PR TITLE
fix dynamic include search path. Fixes #34782

### DIFF
--- a/lib/ansible/playbook/included_file.py
+++ b/lib/ansible/playbook/included_file.py
@@ -118,7 +118,8 @@ class IncludedFile:
                                     else:
                                         parent_include = parent_include._parent
                                 else:
-                                    cumulative_path = os.path.join(parent_include._role._role_path, "tasks")
+                                    if parent_include._role:
+                                        cumulative_path = os.path.join(parent_include._role._role_path, "tasks")
                                     include_target = templar.template(include_result['include'])
                                     include_file = loader.path_dwim_relative(loader.get_basedir(), cumulative_path, include_target)
 

--- a/lib/ansible/playbook/included_file.py
+++ b/lib/ansible/playbook/included_file.py
@@ -92,9 +92,9 @@ class IncludedFile:
                             if original_task._parent:
                                 # handle relative includes by walking up the list of parent include
                                 # tasks and checking the relative result to see if it exists
-                                parent_include = original_task._parent
+                                parent_include = original_task
                                 cumulative_path = None
-                                while parent_include is not None:
+                                while parent_include._parent is not None:
                                     if not isinstance(parent_include, TaskInclude):
                                         parent_include = parent_include._parent
                                         continue
@@ -108,7 +108,7 @@ class IncludedFile:
                                         cumulative_path = parent_include_dir
                                     include_target = templar.template(include_result['include'])
                                     if original_task._role:
-                                        new_basedir = os.path.join(original_task._role._role_path, 'tasks', cumulative_path)
+                                        new_basedir = os.path.join(original_task._role._role_path, cumulative_path)
                                         include_file = loader.path_dwim_relative(new_basedir, 'tasks', include_target)
                                     else:
                                         include_file = loader.path_dwim_relative(loader.get_basedir(), cumulative_path, include_target)
@@ -117,6 +117,10 @@ class IncludedFile:
                                         break
                                     else:
                                         parent_include = parent_include._parent
+                                else:
+                                    cumulative_path = os.path.join(parent_include._role._role_path, "tasks")
+                                    include_target = templar.template(include_result['include'])
+                                    include_file = loader.path_dwim_relative(loader.get_basedir(), cumulative_path, include_target)
 
                         if include_file is None:
                             if original_task._role:


### PR DESCRIPTION
##### SUMMARY
Fix search paths for include_tasks, when include_role is used

Fixes #34782
It Adds original role tasks folder to search path when using include_tasks.
Adds base  (first role which call include_role) tasks as well.


##### ISSUE TYPE
 - Bugfix Pull Request


##### COMPONENT NAME
dynamic_include strategy (I think)

##### ANSIBLE VERSION
```
ansible 2.5.0 (fix_dynamic_include_path e6b2a416bb) last updated 2018/01/12 08:32:10 (GMT +200)
  config file = None
  configured module search path = [u'/home/torgiren/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /tmp/ansible/lib/ansible
  executable location = /tmp/ansible/bin/ansible
  python version = 2.7.14 (default, Nov 26 2017, 14:35:36) [GCC 5.4.0]

```
2.4.0 as well

##### ADDITIONAL INFORMATION
full information is in issue