### PR TITLE
Enable tests which pass on Python 3.

### DIFF
--- a/test/integration/targets/ec2_key/aliases
+++ b/test/integration/targets/ec2_key/aliases
@@ -1,3 +1,2 @@
 cloud/aws
 posix/ci/cloud/group4/aws
-skip/python3

--- a/test/integration/targets/vmware_guest/aliases
+++ b/test/integration/targets/vmware_guest/aliases
@@ -1,4 +1,3 @@
 posix/ci/cloud/group4/vcenter
 cloud/vcenter
-skip/python3
 destructive

--- a/test/integration/targets/vmware_guest_powerstate/aliases
+++ b/test/integration/targets/vmware_guest_powerstate/aliases
@@ -1,4 +1,3 @@
 posix/ci/cloud/group4/vcenter
 cloud/vcenter
-skip/python3
 destructive

--- a/test/integration/targets/vmware_guest_snapshot/aliases
+++ b/test/integration/targets/vmware_guest_snapshot/aliases
@@ -1,4 +1,3 @@
 posix/ci/cloud/group4/vcenter
 cloud/vcenter
-skip/python3
 destructive


### PR DESCRIPTION
##### SUMMARY

Enable tests which pass on Python 3.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

integration tests

##### ANSIBLE VERSION

```
ansible 2.5.0 (py3-tests e2c96cce7d) last updated 2018/01/12 00:22:49 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```
