### PR TITLE
Support for accelerated networking and network security group for scaleset vms

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine_scaleset.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine_scaleset.py
@@ -185,7 +185,7 @@ options:
         default: ['all']
     enable_accelerated_networking:
         description:
-            - Indicates whether user wants to allow accelerated networking for virtual machines in scaleset.
+            - Indicates whether user wants to allow accelerated networking for virtual machines in scaleset being created.
         version_added: "2.7"
         type: bool
         default: false

--- a/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine_scaleset.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine_scaleset.py
@@ -188,7 +188,6 @@ options:
             - Indicates whether user wants to allow accelerated networking for virtual machines in scaleset being created.
         version_added: "2.7"
         type: bool
-        default: false
     security_group:
         description:
             - Existing security group with which to associate the subnet.
@@ -403,7 +402,7 @@ class AzureRMVirtualMachineScaleSet(AzureRMModuleBase):
             virtual_network_resource_group=dict(type='str'),
             virtual_network_name=dict(type='str', aliases=['virtual_network']),
             remove_on_absent=dict(type='list', default=['all']),
-            enable_accelerated_networking=dict(type='bool', default=False),
+            enable_accelerated_networking=dict(type='bool'),
             security_group=dict(type='raw', aliases=['security_group_name'])
         )
 

--- a/test/integration/targets/azure_rm_virtualmachine_scaleset/tasks/main.yml
+++ b/test/integration/targets/azure_rm_virtualmachine_scaleset/tasks/main.yml
@@ -181,7 +181,7 @@
       sku: Stable
       version: latest
     upgrade_policy: Manual
-    network_security_group: testNetworkSecurityGroup
+    security_group: testNetworkSecurityGroup
     enable_accelerated_networking: yes
   register: results
 
@@ -223,8 +223,9 @@
       sku: Stable
       version: latest
     upgrade_policy: Manual
-    network_security_group: testNetworkSecurityGroup2
-    network_security_group_resource_group: "{{ resource_group_secondary }}"
+    security_group:
+      name: testNetworkSecurityGroup2
+      resource_group: "{{ resource_group_secondary }}"
   register: results
 
 - name: Assert that VMSS ran

--- a/test/integration/targets/azure_rm_virtualmachine_scaleset/tasks/main.yml
+++ b/test/integration/targets/azure_rm_virtualmachine_scaleset/tasks/main.yml
@@ -110,23 +110,12 @@
     state: absent
     remove_on_absent: ['all']
     vm_size: Standard_DS1_v2
-    admin_username: testuser
     capacity: 2
-    virtual_network_name: testVnet
-    subnet_name: testSubnet
-    upgrade_policy: Manual
-    tier: Standard
-    os_disk_caching: ReadWrite
     image:
       offer: CoreOS
       publisher: CoreOS
       sku: Stable
       version: latest
-    data_disks:
-      - lun: 0
-        disk_size_gb: 64
-        caching: ReadWrite
-        managed_disk_type: Standard_LRS
 
 - name: Create VMSS (check mode)
   azure_rm_virtualmachine_scaleset:
@@ -161,38 +150,6 @@
   assert:
     that: results.changed
 
-- name: Create VMSS (check mode)
-  azure_rm_virtualmachine_scaleset:
-    resource_group: "{{ resource_group }}"
-    name: testVMSS{{ rpfx }}1
-    vm_size: Standard_DS1_v2
-    admin_username: testuser
-    ssh_password_enabled: true
-    admin_password: "Password1234!"
-    capacity: 2
-    virtual_network_name: testVnet
-    subnet_name: testSubnet
-    load_balancer: testLB
-    upgrade_policy: Manual
-    tier: Standard
-    managed_disk_type: Standard_LRS
-    os_disk_caching: ReadWrite
-    image:
-      offer: CoreOS
-      publisher: CoreOS
-      sku: Stable
-      version: latest
-    data_disks:
-      - lun: 0
-        disk_size_gb: 64
-        caching: ReadWrite
-        managed_disk_type: Standard_LRS
-  register: results
-
-- name: Assert that VMSS ran
-  assert:
-    that: results.changed
-
 - name: Delete VMSS
   azure_rm_virtualmachine_scaleset:
     resource_group: "{{ resource_group }}"
@@ -200,30 +157,19 @@
     state: absent
     remove_on_absent: ['all']
     vm_size: Standard_DS1_v2
-    admin_username: testuser
     capacity: 2
-    virtual_network_name: testVnet
-    subnet_name: testSubnet
-    upgrade_policy: Manual
-    tier: Standard
-    os_disk_caching: ReadWrite
     image:
       offer: CoreOS
       publisher: CoreOS
       sku: Stable
       version: latest
-    data_disks:
-      - lun: 0
-        disk_size_gb: 64
-        caching: ReadWrite
-        managed_disk_type: Standard_LRS
 
 - name: Create VMSS with security group in same resource group, with accelerated networking.
   azure_rm_virtualmachine_scaleset:
     resource_group: "{{ resource_group }}"
     name: testVMSWithAccNetworking
     vm_size: Standard_D3_v2
-    capacity: 2
+    capacity: 1
     virtual_network_name: testVnet
     subnet_name: testSubnet
     admin_username: testuser
@@ -252,12 +198,8 @@
     name: testVMSWithAccNetworking
     state: absent
     remove_on_absent: ['all']
-    vm_size: Standard_DS1_v2
-    admin_username: testuser
-    capacity: 2
-    virtual_network_name: testVnet
-    subnet_name: testSubnet
-    upgrade_policy: Manual
+    vm_size: Standard_D3_v2
+    capacity: 1
     image:
       offer: CoreOS
       publisher: CoreOS
@@ -269,7 +211,7 @@
     resource_group: "{{ resource_group }}"
     name: testVMSSNsgInDiffRscGrp
     vm_size: Standard_DS1_v2
-    capacity: 2
+    capacity: 1
     virtual_network_name: testVnet
     subnet_name: testSubnet
     admin_username: testuser
@@ -298,11 +240,7 @@
     state: absent
     remove_on_absent: ['all']
     vm_size: Standard_DS1_v2
-    admin_username: testuser
-    capacity: 2
-    virtual_network_name: testVnet
-    subnet_name: testSubnet
-    upgrade_policy: Manual
+    capacity: 1
     image:
       offer: CoreOS
       publisher: CoreOS

--- a/test/integration/targets/azure_rm_virtualmachine_scaleset/tasks/main.yml
+++ b/test/integration/targets/azure_rm_virtualmachine_scaleset/tasks/main.yml
@@ -22,6 +22,12 @@
     allocation_method: Static
     name: testPublicIP
 
+- name: Create load balancer
+  azure_rm_loadbalancer:
+    resource_group: "{{ resource_group }}"
+    name: testLB
+    public_ip_address_name: testPublicIP
+
 - name: Create network security group within same resource group of VMSS.
   azure_rm_securitygroup:
     resource_group: "{{ resource_group }}"
@@ -31,12 +37,6 @@
   azure_rm_securitygroup:
     resource_group: "{{ resource_group_secondary }}"
     name: testNetworkSecurityGroup2
-
-- name: Create load balancer
-  azure_rm_loadbalancer:
-    resource_group: "{{ resource_group }}"
-    name: testLB
-    public_ip_address_name: testPublicIP
 
 - name: Create VMSS
   azure_rm_virtualmachine_scaleset:
@@ -150,6 +150,38 @@
   assert:
     that: results.changed
 
+- name: Create VMSS
+  azure_rm_virtualmachine_scaleset:
+    resource_group: "{{ resource_group }}"
+    name: testVMSS{{ rpfx }}1
+    vm_size: Standard_DS1_v2
+    admin_username: testuser
+    ssh_password_enabled: true
+    admin_password: "Password1234!"
+    capacity: 2
+    virtual_network_name: testVnet
+    subnet_name: testSubnet
+    load_balancer: testLB
+    upgrade_policy: Manual
+    tier: Standard
+    managed_disk_type: Standard_LRS
+    os_disk_caching: ReadWrite
+    image:
+      offer: CoreOS
+      publisher: CoreOS
+      sku: Stable
+      version: latest
+    data_disks:
+      - lun: 0
+        disk_size_gb: 64
+        caching: ReadWrite
+        managed_disk_type: Standard_LRS
+  register: results
+
+- name: Assert that VMSS ran
+  assert:
+    that: results.changed
+
 - name: Delete VMSS
   azure_rm_virtualmachine_scaleset:
     resource_group: "{{ resource_group }}"
@@ -164,10 +196,36 @@
       sku: Stable
       version: latest
 
+- name: Create VMSS with security group in same resource group, with accelerated networking(check mode).
+  azure_rm_virtualmachine_scaleset:
+    resource_group: "{{ resource_group }}"
+    name: testVMSS{{ rpfx }}2
+    vm_size: Standard_D3_v2
+    capacity: 1
+    virtual_network_name: testVnet
+    subnet_name: testSubnet
+    admin_username: testuser
+    ssh_password_enabled: true
+    admin_password: "Password1234!"
+    image:
+      offer: CoreOS
+      publisher: CoreOS
+      sku: Stable
+      version: latest
+    upgrade_policy: Manual
+    security_group: testNetworkSecurityGroup
+    enable_accelerated_networking: yes
+  register: results
+  check_mode: yes
+
+- name: Assert that VMSS can be created
+  assert:
+    that: results.changed
+
 - name: Create VMSS with security group in same resource group, with accelerated networking.
   azure_rm_virtualmachine_scaleset:
     resource_group: "{{ resource_group }}"
-    name: testVMSWithAccNetworking
+    name: testVMSS{{ rpfx }}2
     vm_size: Standard_D3_v2
     capacity: 1
     virtual_network_name: testVnet
@@ -195,7 +253,7 @@
 - name: Delete VMSS
   azure_rm_virtualmachine_scaleset:
     resource_group: "{{ resource_group }}"
-    name: testVMSWithAccNetworking
+    name: testVMSS{{ rpfx }}2
     state: absent
     remove_on_absent: ['all']
     vm_size: Standard_D3_v2
@@ -206,10 +264,37 @@
       sku: Stable
       version: latest
 
+- name: Create VMSS with security group in different resource group(check mode).
+  azure_rm_virtualmachine_scaleset:
+    resource_group: "{{ resource_group }}"
+    name: testVMSS{{ rpfx }}3
+    vm_size: Standard_DS1_v2
+    capacity: 1
+    virtual_network_name: testVnet
+    subnet_name: testSubnet
+    admin_username: testuser
+    ssh_password_enabled: true
+    admin_password: "Password1234!"
+    image:
+      offer: CoreOS
+      publisher: CoreOS
+      sku: Stable
+      version: latest
+    upgrade_policy: Manual
+    security_group:
+      name: testNetworkSecurityGroup2
+      resource_group: "{{ resource_group_secondary }}"
+  register: results
+  check_mode: yes
+
+- name: Assert that VMSS ran
+  assert:
+    that: results.changed
+
 - name: Create VMSS with security group in different resource group.
   azure_rm_virtualmachine_scaleset:
     resource_group: "{{ resource_group }}"
-    name: testVMSSNsgInDiffRscGrp
+    name: testVMSS{{ rpfx }}3
     vm_size: Standard_DS1_v2
     capacity: 1
     virtual_network_name: testVnet
@@ -237,7 +322,7 @@
 - name: Delete VMSS
   azure_rm_virtualmachine_scaleset:
     resource_group: "{{ resource_group }}"
-    name: testVMSSNsgInDiffRscGrp
+    name: testVMSS{{ rpfx }}3
     state: absent
     remove_on_absent: ['all']
     vm_size: Standard_DS1_v2
@@ -251,7 +336,7 @@
 - name: Fail when instance type is not supported to enable accelerated networking
   azure_rm_virtualmachine_scaleset:
     resource_group: "{{ resource_group }}"
-    name: testVMSWithAccNetworking
+    name: testVMSS{{ rpfx }}4
     vm_size: Standard_DS1_v2
     virtual_network_name: testVnet
     subnet_name: testSubnet

--- a/test/integration/targets/azure_rm_virtualmachine_scaleset/tasks/main.yml
+++ b/test/integration/targets/azure_rm_virtualmachine_scaleset/tasks/main.yml
@@ -22,6 +22,16 @@
     allocation_method: Static
     name: testPublicIP
 
+- name: Create network security group within same resource group of VMSS.
+  azure_rm_securitygroup:
+    resource_group: "{{ resource_group }}"
+    name: testNetworkSecurityGroup
+
+- name: Create network security group in different resource group of VMSS.
+  azure_rm_securitygroup:
+    resource_group: "{{ resource_group_secondary }}"
+    name: testNetworkSecurityGroup2
+
 - name: Create load balancer
   azure_rm_loadbalancer:
     resource_group: "{{ resource_group }}"
@@ -207,6 +217,134 @@
         disk_size_gb: 64
         caching: ReadWrite
         managed_disk_type: Standard_LRS
+
+- name: Create VMSS with security group in same resource group, with accelerated networking.
+  azure_rm_virtualmachine_scaleset:
+    resource_group: "{{ resource_group }}"
+    name: testVMSWithAccNetworking
+    vm_size: Standard_D3_v2
+    capacity: 2
+    virtual_network_name: testVnet
+    subnet_name: testSubnet
+    admin_username: testuser
+    ssh_password_enabled: true
+    admin_password: "Password1234!"
+    image:
+      offer: CoreOS
+      publisher: CoreOS
+      sku: Stable
+      version: latest
+    upgrade_policy: Manual
+    network_security_group: testNetworkSecurityGroup
+    enable_accelerated_networking: yes
+  register: results
+
+- name: Assert that VMSS ran
+  assert:
+    that:
+      - 'results.changed'
+      - 'results.ansible_facts.azure_vmss.properties.virtualMachineProfile.networkProfile.networkInterfaceConfigurations.0.properties.enableAcceleratedNetworking == true'
+      - 'results.ansible_facts.azure_vmss.properties.virtualMachineProfile.networkProfile.networkInterfaceConfigurations.0.properties.networkSecurityGroup != {}'
+
+- name: Delete VMSS
+  azure_rm_virtualmachine_scaleset:
+    resource_group: "{{ resource_group }}"
+    name: testVMSWithAccNetworking
+    state: absent
+    remove_on_absent: ['all']
+    vm_size: Standard_DS1_v2
+    admin_username: testuser
+    capacity: 2
+    virtual_network_name: testVnet
+    subnet_name: testSubnet
+    upgrade_policy: Manual
+    image:
+      offer: CoreOS
+      publisher: CoreOS
+      sku: Stable
+      version: latest
+
+- name: Create VMSS with security group in different resource group.
+  azure_rm_virtualmachine_scaleset:
+    resource_group: "{{ resource_group }}"
+    name: testVMSSNsgInDiffRscGrp
+    vm_size: Standard_DS1_v2
+    capacity: 2
+    virtual_network_name: testVnet
+    subnet_name: testSubnet
+    admin_username: testuser
+    ssh_password_enabled: true
+    admin_password: "Password1234!"
+    image:
+      offer: CoreOS
+      publisher: CoreOS
+      sku: Stable
+      version: latest
+    upgrade_policy: Manual
+    network_security_group: testNetworkSecurityGroup2
+    network_security_group_resource_group: "{{ resource_group_secondary }}"
+  register: results
+
+- name: Assert that VMSS ran
+  assert:
+    that:
+      - 'results.changed'
+      - '"testNetworkSecurityGroup2" in results.ansible_facts.azure_vmss.properties.virtualMachineProfile.networkProfile.networkInterfaceConfigurations.0.properties.networkSecurityGroup.id'
+
+- name: Delete VMSS
+  azure_rm_virtualmachine_scaleset:
+    resource_group: "{{ resource_group }}"
+    name: testVMSSNsgInDiffRscGrp
+    state: absent
+    remove_on_absent: ['all']
+    vm_size: Standard_DS1_v2
+    admin_username: testuser
+    capacity: 2
+    virtual_network_name: testVnet
+    subnet_name: testSubnet
+    upgrade_policy: Manual
+    image:
+      offer: CoreOS
+      publisher: CoreOS
+      sku: Stable
+      version: latest
+
+- name: Fail when instance type is not supported to enable accelerated networking
+  azure_rm_virtualmachine_scaleset:
+    resource_group: "{{ resource_group }}"
+    name: testVMSWithAccNetworking
+    vm_size: Standard_DS1_v2
+    virtual_network_name: testVnet
+    subnet_name: testSubnet
+    admin_username: testuser
+    ssh_password_enabled: true
+    admin_password: "Password1234!"
+    image:
+      offer: CoreOS
+      publisher: CoreOS
+      sku: Stable
+      version: latest
+    upgrade_policy: Manual
+    enable_accelerated_networking: yes
+  register: results
+  ignore_errors: yes
+
+- name: Assert failure to show that accelerated networking is enabled only with supported instance types.
+  assert:
+    that:
+      - '"VMSizeIsNotPermittedToEnableAcceleratedNetworkingForVmss" in results.msg'
+
+- name: Delete network security group
+  azure_rm_securitygroup:
+    resource_group: "{{ resource_group }}"
+    name: testNetworkSecurityGroup
+    state: absent
+
+- name: Delete network security group
+  azure_rm_securitygroup:
+    resource_group: "{{ resource_group_secondary }}"
+    name: testNetworkSecurityGroup2
+    state: absent
 
 - name: Delete load balancer
   azure_rm_loadbalancer:


### PR DESCRIPTION
Fix for https://github.com/ansible/ansible/issues/34032
##### SUMMARY
Current azure_rm_virtualmachine_scaleset module does not have a support for attaching pre-created network security group to virtual machines in scaleset. Also, there is no provision for enabling accelerated networking for VMs. Adding the support through this PR.
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 
##### COMPONENT NAME
azure_rm_virtualmachine_scaleset

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.2.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/centos-dev/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Aug  4 2017, 00:39:18) [GCC 4.8.5 20150623 (Red Hat 4.8.5-16)]
```


##### ADDITIONAL INFORMATION
Extra Parameters added to current module:
1. network_security_group (type='str') -> name of network security group.
2. enable_accelerated_networking (type='bool', default='no') -> flag to be set to true, if user wants to enabled accelerated networking for VM interfaces.

Tested Following Use-Case:
Module execution by specifying existing network security group and flag to enable accelerated networking.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
---
- hosts: localhost
  vars:
    vm_image:
      offer: "{{ image_offer | default('CentOS') }}"
      publisher: "{{ image_publisher | default('OpenLogic') }}"
      sku: "{{ image_sku | default('7.4') }}"
      version: "{{ image_version | default('latest') }}"
  tasks:
    - name: Azure VMs | Create Scaleset
      azure_rm_virtualmachine_scaleset:
        resource_group: test-resource_group
        name: testpr-scale-set
        vm_size: Standard_D3_v2
        capacity: 1
        virtual_network_name: test-network
        subnet_name: test-subnet
        admin_username: centos
        ssh_password_enabled: false
        ssh_public_keys:
          - path: "/home/centos/.ssh/authorized_keys"
            key_data: "ssh-rsa AAAAB3NzaC1yc2EAAAADBQAAAAABAYDL/Op8/NENu+nFHS7INjLYoesYxhrVv975UFQWSBF1AYQBxkiJ5W5uQhvUTeZXF1ebR4xnMmRspWf3AWUIdEwXJglfe7p7lr/V4R/TSot0UAvjdXvRXQelIN+AmS2ZsVjcvmqRbubFmJIclo0OTjddHuX3ccYRD1XDUALxOEipcuemWB83Pt+DZnwpJks9dhHJCUCNEhL7McSt1B5dVNfh0Ng83WK0hh58SVx9b0fKD/eKLH00m7Tm9Ni/cisGR3TINs6TH+is56FPFBmFtT6Orx0D+SZUd44pBdfs8FYKsKsS9WoHYcRtEH1XmjpfmP3MLCwJ2VbLy0rD52GcrA6d centos-dev@localhost.localdomain"
        image: "{{ vm_image }}"
        upgrade_policy: Manual
        network_security_group: "test-sg"
        enable_accelerated_networking: yes
      register: vmset
    - debug:
        msg: "{{ vmset }}"
  environment:
    AZURE_SUBSCRIPTION_ID: "{{ azure_subscription_id | default('') }}"
    AZURE_REGION: "{{ azure_region | default('') }}"
    AZURE_AD_USER: "{{ azure_ad_user | default('') }}"
    AZURE_PASSWORD: "{{ azure_password | default('') }}"
  connection: local
```
Result: VM network interfaces are seen attached to network security group 'test-sg'. Also following output shows accelerated networking enabled for VM interface. Output as below.
```
[centos@testpr-scale-set000001 ~]$ lspci
0000:00:00.0 Host bridge: Intel Corporation 440BX/ZX/DX - 82443BX/ZX/DX Host bridge (AGP disabled) (rev 03)
0000:00:07.0 ISA bridge: Intel Corporation 82371AB/EB/MB PIIX4 ISA (rev 01)
0000:00:07.1 IDE interface: Intel Corporation 82371AB/EB/MB PIIX4 IDE (rev 01)
0000:00:07.3 Bridge: Intel Corporation 82371AB/EB/MB PIIX4 ACPI (rev 02)
0000:00:08.0 VGA compatible controller: Microsoft Corporation Hyper-V virtual VGA
_0001:00:02.0 Ethernet controller: Mellanox Technologies MT27500/MT27520 Family [ConnectX-3/ConnectX-3 Pro Virtual Function]_

[centos@testpr-scale-set000001 ~]$ ethtool -S eth0 | grep vf_
     vf_rx_packets: 5578
     vf_rx_bytes: 5396118
     vf_tx_packets: 17941
     vf_tx_bytes: 3257966
     vf_tx_dropped: 0
```
NOTE: These additional features/parameters are not affecting existing scaleset flow. Have tested normal scaleset creation as well. It worked without issues.