### PR TITLE
Changing order of load and loadfp

### DIFF
--- a/lib/ansible/modules/network/enos/enos_config.py
+++ b/lib/ansible/modules/network/enos/enos_config.py
@@ -183,10 +183,7 @@ def get_running_config(module):
 def get_candidate(module):
     candidate = NetworkConfig(indent=1)
     if module.params['src']:
-        try:
-            candidate.load(module.params['src'])
-        except IOError:
-            candidate.loadfp(module.params['src'])
+        candidate.load(module.params['src'])
     elif module.params['lines']:
         parents = module.params['parents'] or list()
         candidate.add(module.params['lines'], parents=parents)

--- a/lib/ansible/modules/network/enos/enos_config.py
+++ b/lib/ansible/modules/network/enos/enos_config.py
@@ -184,9 +184,9 @@ def get_candidate(module):
     candidate = NetworkConfig(indent=1)
     if module.params['src']:
         try:
-            candidate.loadfp(module.params['src'])
-        except IOError:
             candidate.load(module.params['src'])
+        except IOError:
+            candidate.loadfp(module.params['src'])
     elif module.params['lines']:
         parents = module.params['parents'] or list()
         candidate.add(module.params['lines'], parents=parents)


### PR DESCRIPTION
##### SUMMARY
As Ganesh suggested in review comment loadfp api which does not handle relative path and templates correctly, I am interchanging its positions in code. Tested it for working fine. 


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/network/enos/enos_config.py

##### ANSIBLE VERSION
ansible 2.5.0
config file = /etc/ansible/ansible.cfg
configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible-2.5.0-py2.7.egg/ansible
executable location = /usr/local/bin/ansible
python version = 2.7.6 (default, Oct 26 2016, 20:30:19) [GCC 4.8.4]

##### ADDITIONAL INFORMATION
This is an effort to support Lenovo ENOS Switches in Ansible
