### PR TITLE
ecs_ecr: Fix AWS ECR repository creation 

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ecs_ecr.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_ecr.py
@@ -152,6 +152,9 @@ class EcsEcr:
         self.ecr = boto3_conn(module, conn_type='client',
                               resource='ecr', region=region,
                               endpoint=ec2_url, **aws_connect_kwargs)
+        self.sts = boto3_conn(module, conn_type='client',
+                              resource='sts', region=region,
+                              endpoint=ec2_url, **aws_connect_kwargs)
         self.check_mode = module.check_mode
         self.changed = False
         self.skipped = False
@@ -181,10 +184,14 @@ class EcsEcr:
             raise
 
     def create_repository(self, registry_id, name):
+        if registry_id:
+            default_registry_id = self.sts.get_caller_identity().get('Account')
+            if registry_id != default_registry_id:
+                raise Exception('Cannot create repository in registry {}.'
+                                'Would be created in {} instead.'.format(
+                                    registry_id, default_registry_id))
         if not self.check_mode:
-            repo = self.ecr.create_repository(
-                repositoryName=name, **build_kwargs(registry_id)).get(
-                'repository')
+            repo = self.ecr.create_repository(repositoryName=name).get('repository')
             self.changed = True
             return repo
         else:

--- a/test/integration/targets/ecs_ecr/tasks/main.yml
+++ b/test/integration/targets/ecs_ecr/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - set_fact:
-    ecr_name: 'ecr-test-{{ ansible_date_time.epoch }}'
+    ecr_name: '{{ resource_prefix }}-ecr'
 
 - block:
 


### PR DESCRIPTION
##### SUMMARY
Remove the superfluous registry ID from create repository call, because it's not supported.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ecs_ecr

##### ANSIBLE VERSION
```
ansible-playbook 2.4.2.0
  config file = [redacted]
  configured module search path = [u'[redacted]', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible-playbook
  python version = 2.7.12 (default, Nov 20 2017, 18:23:56) [GCC 5.4.0 20160609]
```

##### ADDITIONAL INFORMATION
[Boto3 documentation][1] specifies 'repositoryName' as the only expected
argument. The `**build_kwargs(registry_id)` part also adds 'registryId' which,
when executed, fails with: 'Unknown parameter in input: “registryId”, must be
one of: repositoryName'.

[AWS API documentation][2] also lists only the 'repositoryName' parameter. I.e.
this is not a problem with the boto3 library.

The default registry ID for the account that's making the request will be used
when creating the rpository. This means that if the `registry_id` specified by
the user is different from the default registry ID, then the policy changes
following the repository creation would fail, because the repository will have
been created in one repository but subsequent calls try to modify it in
another. Added a safeguard against this scenario.

[1]: https://boto3.readthedocs.io/en/latest/reference/services/ecr.html#ECR.Client.create_repository
[2]: https://docs.aws.amazon.com/AmazonECR/latest/APIReference/API_CreateRepository.html
