### PR TITLE
Update ManageIQ Azure Tenant ID parameter

### DIFF
--- a/lib/ansible/modules/remote_management/manageiq/manageiq_provider.py
+++ b/lib/ansible/modules/remote_management/manageiq/manageiq_provider.py
@@ -61,10 +61,7 @@ options:
     default: null
     description: Microsoft Azure subscription ID. defaults to None.
     version_added: "2.5"
-# There doesn't currently appear to be an entry point for azure_tenant_id and
-# tenant_id is already in use. Therefore we use uid_ems until this has been created.
-# See discussion in https://gitter.im/ManageIQ/manageiq/providers
-  uid_ems:
+  azure_tenant_id:
     required: false
     default: null
     description: Tenant ID. defaults to None.
@@ -421,7 +418,7 @@ EXAMPLES = '''
     type: 'Azure'
     provider_region: 'northeurope'
     subscription: 'e272bd74-f661-484f-b223-88dd128a4049'
-    uid_ems: 'e272bd74-f661-484f-b223-88dd128a4048'
+    azure_tenant_id: 'e272bd74-f661-484f-b223-88dd128a4048'
     state: 'present'
     provider:
       hostname: 'azure.example.com'
@@ -704,7 +701,7 @@ def main():
         host_default_vnc_port_start=dict(),
         host_default_vnc_port_end=dict(),
         subscription=dict(),
-        uid_ems=dict(),
+        azure_tenant_id=dict(),
         type=dict(choices=supported_providers().keys()),
     )
     # add the manageiq connection arguments to the arguments
@@ -729,7 +726,7 @@ def main():
     host_default_vnc_port_start = module.params['host_default_vnc_port_start']
     host_default_vnc_port_end = module.params['host_default_vnc_port_end']
     subscription = module.params['subscription']
-    uid_ems = module.params['uid_ems']
+    uid_ems = module.params['azure_tenant_id']
     state = module.params['state']
 
     manageiq = ManageIQ(module)


### PR DESCRIPTION
##### SUMMARY
Currently the ManageIQ API does not support azure_tenant_id but
this is in the process of being fixed. This commit changes
the recently-committed parameter to allow for the upcoming change.

##### ISSUE TYPE
 - New Module Pull Request

##### COMPONENT NAME
remote_management/manageiq

##### ANSIBLE VERSION
```
ansible 2.5.0 (update-manageiq-azure-parameter-name 0f9027ba18) last updated 2018/01/12 15:16:09 (GMT +100)
```


##### ADDITIONAL INFORMATION
Upstream fixes landing shortly:

https://github.com/ManageIQ/manageiq/pull/16802
https://github.com/ManageIQ/manageiq-api/pull/279
