### PR TITLE
Various F5 fixes

### DIFF
--- a/lib/ansible/modules/network/f5/bigip_command.py
+++ b/lib/ansible/modules/network/f5/bigip_command.py
@@ -162,65 +162,54 @@ failed_conditions:
 import re
 import time
 
-from ansible.module_utils.basic import env_fallback
-from ansible.module_utils.f5_utils import AnsibleF5Client
-from ansible.module_utils.f5_utils import AnsibleF5Parameters
-from ansible.module_utils.f5_utils import HAS_F5SDK
-from ansible.module_utils.f5_utils import F5ModuleError
-
 try:
     from ansible.module_utils.f5_utils import run_commands
     HAS_CLI_TRANSPORT = True
 except ImportError:
     HAS_CLI_TRANSPORT = False
 
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import env_fallback
 from ansible.module_utils.six import string_types
 from ansible.module_utils.network.common.parsing import FailedConditionsError
 from ansible.module_utils.network.common.parsing import Conditional
 from ansible.module_utils.network.common.utils import ComplexList
 from ansible.module_utils.network.common.utils import to_list
-from ansible.module_utils.six import iteritems
-from collections import defaultdict
 from collections import deque
 
+HAS_DEVEL_IMPORTS = False
+
 try:
-    from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
+    # Sideband repository used for dev
+    from library.module_utils.network.f5.bigip import HAS_F5SDK
+    from library.module_utils.network.f5.bigip import F5Client
+    from library.module_utils.network.f5.common import F5ModuleError
+    from library.module_utils.network.f5.common import AnsibleF5Parameters
+    from library.module_utils.network.f5.common import cleanup_tokens
+    from library.module_utils.network.f5.common import fqdn_name
+    from library.module_utils.network.f5.common import f5_argument_spec
+    try:
+        from library.module_utils.network.f5.common import iControlUnexpectedHTTPError
+    except ImportError:
+        HAS_F5SDK = False
+    HAS_DEVEL_IMPORTS = True
 except ImportError:
-    HAS_F5SDK = False
+    # Upstream Ansible
+    from ansible.module_utils.network.f5.bigip import HAS_F5SDK
+    from ansible.module_utils.network.f5.bigip import F5Client
+    from ansible.module_utils.network.f5.common import F5ModuleError
+    from ansible.module_utils.network.f5.common import AnsibleF5Parameters
+    from ansible.module_utils.network.f5.common import cleanup_tokens
+    from ansible.module_utils.network.f5.common import fqdn_name
+    from ansible.module_utils.network.f5.common import f5_argument_spec
+    try:
+        from ansible.module_utils.network.f5.common import iControlUnexpectedHTTPError
+    except ImportError:
+        HAS_F5SDK = False
 
 
 class Parameters(AnsibleF5Parameters):
     returnables = ['stdout', 'stdout_lines', 'warnings']
-
-    def __init__(self, params=None):
-        self._values = defaultdict(lambda: None)
-        self._values['__warnings'] = []
-        if params:
-            self.update(params=params)
-
-    def update(self, params=None):
-        if params:
-            for k, v in iteritems(params):
-                if self.api_map is not None and k in self.api_map:
-                    map_key = self.api_map[k]
-                else:
-                    map_key = k
-
-                # Handle weird API parameters like `dns.proxy.__iter__` by
-                # using a map provided by the module developer
-                class_attr = getattr(type(self), map_key, None)
-                if isinstance(class_attr, property):
-                    # There is a mapped value for the api_map key
-                    if class_attr.fset is None:
-                        # If the mapped value does not have
-                        # an associated setter
-                        self._values[map_key] = v
-                    else:
-                        # The mapped value has a setter
-                        setattr(self, map_key, v)
-                else:
-                    # If the mapped value is not a @property
-                    self._values[map_key] = v
 
     def to_return(self):
         result = {}
@@ -260,9 +249,10 @@ class Parameters(AnsibleF5Parameters):
 
 
 class ModuleManager(object):
-    def __init__(self, client):
-        self.client = client
-        self.want = Parameters(self.client.module.params)
+    def __init__(self, *args, **kwargs):
+        self.module = kwargs.get('module', None)
+        self.client = kwargs.get('client', None)
+        self.want = Parameters(params=self.module.params)
         self.changes = Parameters()
 
     def _to_lines(self, stdout):
@@ -278,7 +268,7 @@ class ModuleManager(object):
             'list', 'show',
             'modify cli preference pager disabled'
         ]
-        if self.client.module.params['transport'] != 'cli':
+        if self.module.params['transport'] != 'cli':
             valid_configs = list(map(self.want._ensure_tmsh_prefix, valid_configs))
         if any(cmd.startswith(x) for x in valid_configs):
             return True
@@ -308,12 +298,12 @@ class ModuleManager(object):
 
         conditionals = [Conditional(c) for c in wait_for]
 
-        if self.client.check_mode:
+        if self.module.check_mode:
             return
 
         while retries > 0:
-            if self.client.module.params['transport'] == 'cli' and HAS_CLI_TRANSPORT:
-                responses = self._run_commands(self.client.module, commands)
+            if self.module.params['transport'] == 'cli' and HAS_CLI_TRANSPORT:
+                responses = self._run_commands(self.module, commands)
             else:
                 responses = self.execute_on_device(commands)
 
@@ -334,11 +324,12 @@ class ModuleManager(object):
             errmsg = 'One or more conditional statements have not been satisfied'
             raise FailedConditionsError(errmsg, failed_conditions)
 
-        self.changes = Parameters({
+        changes = {
             'stdout': responses,
             'stdout_lines': self._to_lines(responses),
             'warnings': warnings
-        })
+        }
+        self.changes = Parameters(params=changes)
         if any(x for x in self.want.user_commands if x.startswith(changed)):
             return True
         return False
@@ -354,11 +345,11 @@ class ModuleManager(object):
             ),
         )
 
-        transform = ComplexList(spec, self.client.module)
+        transform = ComplexList(spec, self.module)
         commands = transform(commands)
 
         for index, item in enumerate(commands):
-            if not self._is_valid_mode(item['command']) and self.client.module.params['transport'] != 'cli':
+            if not self._is_valid_mode(item['command']) and self.module.params['transport'] != 'cli':
                 warnings.append(
                     'Using "write" commands is not idempotent. You should use '
                     'a module that is specifically made for that. If such a '
@@ -394,7 +385,7 @@ class ModuleManager(object):
 class ArgumentSpec(object):
     def __init__(self):
         self.supports_check_mode = True
-        self.argument_spec = dict(
+        argument_spec = dict(
             commands=dict(
                 type='raw',
                 required=True
@@ -421,44 +412,38 @@ class ArgumentSpec(object):
                 choices=['cli', 'rest']
             ),
             password=dict(
-                required=False,
                 fallback=(env_fallback, ['F5_PASSWORD']),
                 no_log=True
+            ),
+            partition=dict(
+                default='Common',
+                fallback=(env_fallback, ['F5_PARTITION'])
             )
         )
-        self.f5_product_name = 'bigip'
-
-
-def cleanup_tokens(client):
-    try:
-        resource = client.api.shared.authz.tokens_s.token.load(
-            name=client.api.icrs.token
-        )
-        resource.delete()
-    except Exception:
-        pass
+        self.argument_spec = {}
+        self.argument_spec.update(f5_argument_spec)
+        self.argument_spec.update(argument_spec)
 
 
 def main():
     spec = ArgumentSpec()
 
-    client = AnsibleF5Client(
+    module = AnsibleModule(
         argument_spec=spec.argument_spec,
-        supports_check_mode=spec.supports_check_mode,
-        f5_product_name=spec.f5_product_name
+        supports_check_mode=spec.supports_check_mode
     )
-
-    if client.module.params['transport'] != 'cli' and not HAS_F5SDK:
-        raise F5ModuleError("The python f5-sdk module is required to use the rest api")
+    if module.params['transport'] != 'cli' and not HAS_F5SDK:
+        module.fail_json(msg="The python f5-sdk module is required to use the rest api")
 
     try:
-        mm = ModuleManager(client)
+        client = F5Client(**module.params)
+        mm = ModuleManager(module=module, client=client)
         results = mm.exec_module()
         cleanup_tokens(client)
-        client.module.exit_json(**results)
+        module.exit_json(**results)
     except F5ModuleError as e:
         cleanup_tokens(client)
-        client.module.fail_json(msg=str(e))
+        module.fail_json(msg=str(e))
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/network/f5/bigip_configsync_actions.py
+++ b/lib/ansible/modules/network/f5/bigip_configsync_actions.py
@@ -1,1 +1,0 @@
-bigip_configsync_action.py

--- a/lib/ansible/modules/network/f5/bigip_device_dns.py
+++ b/lib/ansible/modules/network/f5/bigip_device_dns.py
@@ -55,12 +55,7 @@ options:
     choices:
       - absent
       - present
-notes:
-  - Requires the f5-sdk Python package on the host. This is as easy as pip
-    install f5-sdk.
 extends_documentation_fragment: f5
-requirements:
-  - f5-sdk
 author:
   - Tim Rupp (@caphrim007)
 '''
@@ -109,15 +104,37 @@ warnings:
   sample: ['...', '...']
 '''
 
-from ansible.module_utils.f5_utils import AnsibleF5Client
-from ansible.module_utils.f5_utils import AnsibleF5Parameters
-from ansible.module_utils.f5_utils import HAS_F5SDK
-from ansible.module_utils.f5_utils import F5ModuleError
+from ansible.module_utils.basic import AnsibleModule
+
+HAS_DEVEL_IMPORTS = False
 
 try:
-    from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
+    # Sideband repository used for dev
+    from library.module_utils.network.f5.bigip import HAS_F5SDK
+    from library.module_utils.network.f5.bigip import F5Client
+    from library.module_utils.network.f5.common import F5ModuleError
+    from library.module_utils.network.f5.common import AnsibleF5Parameters
+    from library.module_utils.network.f5.common import cleanup_tokens
+    from library.module_utils.network.f5.common import fqdn_name
+    from library.module_utils.network.f5.common import f5_argument_spec
+    try:
+        from library.module_utils.network.f5.common import iControlUnexpectedHTTPError
+    except ImportError:
+        HAS_F5SDK = False
+    HAS_DEVEL_IMPORTS = True
 except ImportError:
-    HAS_F5SDK = False
+    # Upstream Ansible
+    from ansible.module_utils.network.f5.bigip import HAS_F5SDK
+    from ansible.module_utils.network.f5.bigip import F5Client
+    from ansible.module_utils.network.f5.common import F5ModuleError
+    from ansible.module_utils.network.f5.common import AnsibleF5Parameters
+    from ansible.module_utils.network.f5.common import cleanup_tokens
+    from ansible.module_utils.network.f5.common import fqdn_name
+    from ansible.module_utils.network.f5.common import f5_argument_spec
+    try:
+        from ansible.module_utils.network.f5.common import iControlUnexpectedHTTPError
+    except ImportError:
+        HAS_F5SDK = False
 
 
 class Parameters(AnsibleF5Parameters):
@@ -148,16 +165,6 @@ class Parameters(AnsibleF5Parameters):
         result = {}
         for returnable in self.returnables:
             result[returnable] = getattr(self, returnable)
-        result = self._filter_params(result)
-        return result
-
-    def api_params(self):
-        result = {}
-        for api_attribute in self.api_attributes:
-            if self.api_map is not None and api_attribute in self.api_map:
-                result[api_attribute] = getattr(self, self.api_map[api_attribute])
-            else:
-                result[api_attribute] = getattr(self, api_attribute)
         result = self._filter_params(result)
         return result
 
@@ -211,10 +218,11 @@ class Parameters(AnsibleF5Parameters):
 
 
 class ModuleManager(object):
-    def __init__(self, client):
-        self.client = client
+    def __init__(self, *args, **kwargs):
+        self.module = kwargs.get('module', None)
+        self.client = kwargs.get('client', None)
+        self.want = Parameters(params=self.module.params)
         self.have = None
-        self.want = Parameters(self.client.module.params)
         self.changes = Parameters()
 
     def _update_changed_options(self):
@@ -226,7 +234,7 @@ class ModuleManager(object):
                 if attr1 != attr2:
                     changed[key] = attr1
         if changed:
-            self.changes = Parameters(changed)
+            self.changes = Parameters(params=changed)
             return True
         return False
 
@@ -260,13 +268,13 @@ class ModuleManager(object):
         if 'include' not in attrs:
             attrs['include'] = 4
         result.update(attrs)
-        return Parameters(result)
+        return Parameters(params=result)
 
     def update(self):
         self.have = self.read_current_from_device()
         if not self.should_update():
             return False
-        if self.client.check_mode:
+        if self.module.check_mode:
             return True
         self.update_on_device()
         return True
@@ -299,7 +307,7 @@ class ModuleManager(object):
                 if set_new != set_have:
                     changed[key] = list(set_new)
         if changed:
-            self.changes = Parameters(changed)
+            self.changes = Parameters(params=changed)
             return True
         return False
 
@@ -313,7 +321,7 @@ class ModuleManager(object):
         self.have = self.read_current_from_device()
         if not self.should_absent():
             return False
-        if self.client.check_mode:
+        if self.module.check_mode:
             return True
         self.absent_on_device()
         return True
@@ -327,11 +335,9 @@ class ModuleManager(object):
 class ArgumentSpec(object):
     def __init__(self):
         self.supports_check_mode = True
-        self.argument_spec = dict(
+        argument_spec = dict(
             cache=dict(
-                required=False,
-                choices=['disabled', 'enabled', 'disable', 'enable'],
-                default=None
+                choices=['disabled', 'enabled', 'disable', 'enable']
             ),
             name_servers=dict(
                 required=False,
@@ -355,48 +361,38 @@ class ArgumentSpec(object):
                 type='int'
             ),
             state=dict(
-                required=False,
                 default='present',
                 choices=['absent', 'present']
             )
         )
+        self.argument_spec = {}
+        self.argument_spec.update(f5_argument_spec)
+        self.argument_spec.update(argument_spec)
         self.required_one_of = [
             ['name_servers', 'search', 'forwarders', 'ip_version', 'cache']
         ]
-        self.f5_product_name = 'bigip'
-
-
-def cleanup_tokens(client):
-    try:
-        resource = client.api.shared.authz.tokens_s.token.load(
-            name=client.api.icrs.token
-        )
-        resource.delete()
-    except Exception:
-        pass
 
 
 def main():
-    if not HAS_F5SDK:
-        raise F5ModuleError("The python f5-sdk module is required")
-
     spec = ArgumentSpec()
 
-    client = AnsibleF5Client(
+    module = AnsibleModule(
         argument_spec=spec.argument_spec,
         supports_check_mode=spec.supports_check_mode,
-        f5_product_name=spec.f5_product_name,
         required_one_of=spec.required_one_of
     )
+    if not HAS_F5SDK:
+        module.fail_json(msg="The python f5-sdk module is required")
 
     try:
-        mm = ModuleManager(client)
+        client = F5Client(**module.params)
+        mm = ModuleManager(module=module, client=client)
         results = mm.exec_module()
         cleanup_tokens(client)
-        client.module.exit_json(**results)
-    except F5ModuleError as e:
+        module.exit_json(**results)
+    except F5ModuleError as ex:
         cleanup_tokens(client)
-        client.module.fail_json(msg=str(e))
+        module.fail_json(msg=str(ex))
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/network/f5/bigip_device_ntp.py
+++ b/lib/ansible/modules/network/f5/bigip_device_ntp.py
@@ -37,12 +37,7 @@ options:
       - The timezone to set for NTP lookups. At least one of C(ntp_servers) or
         C(timezone) is required.
     default: UTC
-notes:
-  - Requires the f5-sdk Python package on the host. This is as easy as pip
-    install f5-sdk.
 extends_documentation_fragment: f5
-requirements:
-  - f5-sdk
 author:
   - Tim Rupp (@caphrim007)
   - Wojciech Wypior (@wojtek0806)
@@ -82,16 +77,37 @@ timezone:
   sample: true
 '''
 
+from ansible.module_utils.basic import AnsibleModule
 
-from ansible.module_utils.f5_utils import AnsibleF5Client
-from ansible.module_utils.f5_utils import AnsibleF5Parameters
-from ansible.module_utils.f5_utils import HAS_F5SDK
-from ansible.module_utils.f5_utils import F5ModuleError
+HAS_DEVEL_IMPORTS = False
 
 try:
-    from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
+    # Sideband repository used for dev
+    from library.module_utils.network.f5.bigip import HAS_F5SDK
+    from library.module_utils.network.f5.bigip import F5Client
+    from library.module_utils.network.f5.common import F5ModuleError
+    from library.module_utils.network.f5.common import AnsibleF5Parameters
+    from library.module_utils.network.f5.common import cleanup_tokens
+    from library.module_utils.network.f5.common import fqdn_name
+    from library.module_utils.network.f5.common import f5_argument_spec
+    try:
+        from library.module_utils.network.f5.common import iControlUnexpectedHTTPError
+    except ImportError:
+        HAS_F5SDK = False
+    HAS_DEVEL_IMPORTS = True
 except ImportError:
-    HAS_F5SDK = False
+    # Upstream Ansible
+    from ansible.module_utils.network.f5.bigip import HAS_F5SDK
+    from ansible.module_utils.network.f5.bigip import F5Client
+    from ansible.module_utils.network.f5.common import F5ModuleError
+    from ansible.module_utils.network.f5.common import AnsibleF5Parameters
+    from ansible.module_utils.network.f5.common import cleanup_tokens
+    from ansible.module_utils.network.f5.common import fqdn_name
+    from ansible.module_utils.network.f5.common import f5_argument_spec
+    try:
+        from ansible.module_utils.network.f5.common import iControlUnexpectedHTTPError
+    except ImportError:
+        HAS_F5SDK = False
 
 
 class Parameters(AnsibleF5Parameters):
@@ -122,23 +138,13 @@ class Parameters(AnsibleF5Parameters):
         result = self._filter_params(result)
         return result
 
-    def api_params(self):
-        result = {}
-        for api_attribute in self.api_attributes:
-            if self.api_map is not None and api_attribute in self.api_map:
-                result[api_attribute] = getattr(self,
-                                                self.api_map[api_attribute])
-            else:
-                result[api_attribute] = getattr(self, api_attribute)
-        result = self._filter_params(result)
-        return result
-
 
 class ModuleManager(object):
-    def __init__(self, client):
-        self.client = client
+    def __init__(self, *args, **kwargs):
+        self.module = kwargs.get('module', None)
+        self.client = kwargs.get('client', None)
         self.have = None
-        self.want = Parameters(self.client.module.params)
+        self.want = Parameters(params=self.module.params)
         self.changes = Parameters()
 
     def _update_changed_options(self):
@@ -150,7 +156,7 @@ class ModuleManager(object):
                 if attr1 != attr2:
                     changed[key] = attr1
         if changed:
-            self.changes = Parameters(changed)
+            self.changes = Parameters(params=changed)
             return True
         return False
 
@@ -163,7 +169,7 @@ class ModuleManager(object):
                 if set_want != set_have:
                     changed[key] = list(set_want)
         if changed:
-            self.changes = Parameters(changed)
+            self.changes = Parameters(params=changed)
             return True
         return False
 
@@ -189,7 +195,7 @@ class ModuleManager(object):
         self.have = self.read_current_from_device()
         if not self.should_update():
             return False
-        if self.client.check_mode:
+        if self.module.check_mode:
             return True
         self.update_on_device()
         return True
@@ -210,7 +216,7 @@ class ModuleManager(object):
         self.have = self.read_current_from_device()
         if not self.should_absent():
             return False
-        if self.client.check_mode:
+        if self.module.check_mode:
             return True
         self.absent_on_device()
         return True
@@ -223,7 +229,7 @@ class ModuleManager(object):
     def read_current_from_device(self):
         resource = self.client.api.tm.sys.ntp.load()
         result = resource.attrs
-        return Parameters(result)
+        return Parameters(params=result)
 
     def absent_on_device(self):
         params = self.changes.api_params()
@@ -234,54 +240,45 @@ class ModuleManager(object):
 class ArgumentSpec(object):
     def __init__(self):
         self.supports_check_mode = True
-        self.argument_spec = dict(
+        argument_spec = dict(
             ntp_servers=dict(
-                required=False,
-                default=None,
                 type='list',
             ),
-            timezone=dict(
-                required=False,
-                default=None,
-            )
+            timezone=dict(),
+            state=dict(
+                default='present',
+                choices=['present', 'absent']
+            ),
         )
+        self.argument_spec = {}
+        self.argument_spec.update(f5_argument_spec)
+        self.argument_spec.update(argument_spec)
+
         self.required_one_of = [
             ['ntp_servers', 'timezone']
         ]
-        self.f5_product_name = 'bigip'
-
-
-def cleanup_tokens(client):
-    try:
-        resource = client.api.shared.authz.tokens_s.token.load(
-            name=client.api.icrs.token
-        )
-        resource.delete()
-    except Exception:
-        pass
 
 
 def main():
-    if not HAS_F5SDK:
-        raise F5ModuleError("The python f5-sdk module is required")
-
     spec = ArgumentSpec()
 
-    client = AnsibleF5Client(
+    module = AnsibleModule(
         argument_spec=spec.argument_spec,
         supports_check_mode=spec.supports_check_mode,
-        f5_product_name=spec.f5_product_name,
         required_one_of=spec.required_one_of
     )
+    if not HAS_F5SDK:
+        module.fail_json(msg="The python f5-sdk module is required")
 
     try:
-        mm = ModuleManager(client)
+        client = F5Client(**module.params)
+        mm = ModuleManager(module=module, client=client)
         results = mm.exec_module()
         cleanup_tokens(client)
-        client.module.exit_json(**results)
-    except F5ModuleError as e:
+        module.exit_json(**results)
+    except F5ModuleError as ex:
         cleanup_tokens(client)
-        client.module.fail_json(msg=str(e))
+        module.fail_json(msg=str(ex))
 
 
 if __name__ == '__main__':

--- a/test/sanity/validate-modules/ignore.txt
+++ b/test/sanity/validate-modules/ignore.txt
@@ -41,16 +41,6 @@ lib/ansible/modules/net_tools/cloudflare_dns.py E317
 lib/ansible/modules/net_tools/haproxy.py E317
 lib/ansible/modules/net_tools/omapi_host.py E317
 lib/ansible/modules/network/cloudengine/ce_reboot.py E317
-lib/ansible/modules/network/f5/bigip_asm_policy.py E321
-lib/ansible/modules/network/f5/bigip_config.py E321
-lib/ansible/modules/network/f5/bigip_configsync_action.py E321
-lib/ansible/modules/network/f5/bigip_configsync_actions.py E321
-lib/ansible/modules/network/f5/bigip_device_connectivity.py E321
-lib/ansible/modules/network/f5/bigip_device_dns.py E321
-lib/ansible/modules/network/f5/bigip_device_httpd.py E321
-lib/ansible/modules/network/f5/bigip_device_ntp.py E321
-lib/ansible/modules/network/f5/bigip_device_sshd.py E321
-lib/ansible/modules/network/f5/bigip_device_trust.py E321
 lib/ansible/modules/network/f5/bigip_gtm_datacenter.py E321
 lib/ansible/modules/network/f5/bigip_gtm_facts.py E321
 lib/ansible/modules/network/f5/bigip_gtm_pool.py E321

--- a/test/units/modules/network/f5/test_bigip_asm_policy.py
+++ b/test/units/modules/network/f5/test_bigip_asm_policy.py
@@ -18,8 +18,7 @@ if sys.version_info < (2, 7):
 from ansible.compat.tests import unittest
 from ansible.compat.tests.mock import Mock
 from ansible.compat.tests.mock import patch
-from ansible.module_utils.f5_utils import AnsibleF5Client
-from ansible.module_utils.f5_utils import F5ModuleError
+from ansible.module_utils.basic import AnsibleModule
 
 try:
     from library.bigip_asm_policy import V1Parameters
@@ -28,7 +27,8 @@ try:
     from library.bigip_asm_policy import V1Manager
     from library.bigip_asm_policy import V2Manager
     from library.bigip_asm_policy import ArgumentSpec
-    from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
+    from library.module_utils.network.f5.common import F5ModuleError
+    from library.module_utils.network.f5.common import iControlUnexpectedHTTPError
     from test.unit.modules.utils import set_module_args
 except ImportError:
     try:
@@ -38,7 +38,8 @@ except ImportError:
         from ansible.modules.network.f5.bigip_asm_policy import V1Manager
         from ansible.modules.network.f5.bigip_asm_policy import V2Manager
         from ansible.modules.network.f5.bigip_asm_policy import ArgumentSpec
-        from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
+        from ansible.module_utils.network.f5.common import F5ModuleError
+        from ansible.module_utils.network.f5.common import iControlUnexpectedHTTPError
         from units.modules.utils import set_module_args
     except ImportError:
         raise SkipTest("F5 Ansible modules require the f5-sdk Python library")
@@ -66,7 +67,7 @@ class TestParameters(unittest.TestCase):
             file='/var/fake/fake.xml'
         )
 
-        p = V1Parameters(args)
+        p = V1Parameters(params=args)
         assert p.name == 'fake_policy'
         assert p.state == 'present'
         assert p.file == '/var/fake/fake.xml'
@@ -78,14 +79,12 @@ class TestParameters(unittest.TestCase):
             template='LotusDomino 6.5 (http)'
         )
 
-        p = V1Parameters(args)
+        p = V1Parameters(params=args)
         assert p.name == 'fake_policy'
         assert p.state == 'present'
         assert p.template == 'POLICY_TEMPLATE_LOTUSDOMINO_6_5_HTTP'
 
 
-@patch('ansible.module_utils.f5_utils.AnsibleF5Client._get_mgmt_root',
-       return_value=True)
 class TestManager(unittest.TestCase):
     def setUp(self):
         self.spec = ArgumentSpec()
@@ -102,14 +101,13 @@ class TestManager(unittest.TestCase):
             user='admin',
         ))
 
-        current = V1Parameters(load_fixture('load_asm_policy_inactive.json'))
-        client = AnsibleF5Client(
+        current = V1Parameters(params=load_fixture('load_asm_policy_inactive.json'))
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
             supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
         )
 
-        v1 = V1Manager(client)
+        v1 = V1Manager(module=module)
         v1.exists = Mock(return_value=False)
         v1.import_to_device = Mock(return_value=True)
         v1.wait_for_task = Mock(side_effect=[True, True])
@@ -117,7 +115,7 @@ class TestManager(unittest.TestCase):
         v1.apply_on_device = Mock(return_value=True)
 
         # Override methods to force specific logic in the module to happen
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.version_is_less_than_13 = Mock(return_value=False)
         mm.get_manager = Mock(return_value=v1)
 
@@ -139,14 +137,13 @@ class TestManager(unittest.TestCase):
             user='admin',
         ))
 
-        current = V1Parameters(load_fixture('load_asm_policy_inactive.json'))
-        client = AnsibleF5Client(
+        current = V1Parameters(params=load_fixture('load_asm_policy_inactive.json'))
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
 
-        v1 = V1Manager(client)
+        v1 = V1Manager(module=module)
         v1.exists = Mock(return_value=False)
         v1.import_to_device = Mock(return_value=True)
         v1.wait_for_task = Mock(side_effect=[True, True])
@@ -156,7 +153,7 @@ class TestManager(unittest.TestCase):
         v1._file_is_missing = Mock(return_value=False)
 
         # Override methods to force specific logic in the module to happen
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.version_is_less_than_13 = Mock(return_value=False)
         mm.get_manager = Mock(return_value=v1)
 
@@ -177,14 +174,13 @@ class TestManager(unittest.TestCase):
             user='admin',
         ))
 
-        current = V1Parameters(load_fixture('load_asm_policy_inactive.json'))
-        client = AnsibleF5Client(
+        current = V1Parameters(params=load_fixture('load_asm_policy_inactive.json'))
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
 
-        v1 = V1Manager(client)
+        v1 = V1Manager(module=module)
         v1.exists = Mock(return_value=False)
         v1.import_to_device = Mock(return_value=True)
         v1.wait_for_task = Mock(side_effect=[True, True])
@@ -195,7 +191,7 @@ class TestManager(unittest.TestCase):
         v1._file_is_missing = Mock(return_value=False)
 
         # Override methods to force specific logic in the module to happen
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.version_is_less_than_13 = Mock(return_value=False)
         mm.get_manager = Mock(return_value=v1)
 
@@ -215,14 +211,13 @@ class TestManager(unittest.TestCase):
             user='admin',
         ))
 
-        current = V1Parameters(load_fixture('load_asm_policy_inactive.json'))
-        client = AnsibleF5Client(
+        current = V1Parameters(params=load_fixture('load_asm_policy_inactive.json'))
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
 
-        v1 = V1Manager(client)
+        v1 = V1Manager(module=module)
         v1.exists = Mock(return_value=True)
         v1.update_on_device = Mock(return_value=True)
         v1.wait_for_task = Mock(side_effect=[True, True])
@@ -230,7 +225,7 @@ class TestManager(unittest.TestCase):
         v1.apply_on_device = Mock(return_value=True)
 
         # Override methods to force specific logic in the module to happen
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.version_is_less_than_13 = Mock(return_value=False)
         mm.get_manager = Mock(return_value=v1)
 
@@ -249,20 +244,19 @@ class TestManager(unittest.TestCase):
             user='admin',
         ))
 
-        current = V1Parameters(load_fixture('load_asm_policy_active.json'))
-        client = AnsibleF5Client(
+        current = V1Parameters(params=load_fixture('load_asm_policy_active.json'))
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
 
         # Override methods to force specific logic in the module to happen
-        v1 = V1Manager(client)
+        v1 = V1Manager(module=module)
         v1.exists = Mock(return_value=True)
         v1.read_current_from_device = Mock(return_value=current)
 
         # Override methods to force specific logic in the module to happen
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.version_is_less_than_13 = Mock(return_value=False)
         mm.get_manager = Mock(return_value=v1)
 
@@ -280,21 +274,20 @@ class TestManager(unittest.TestCase):
             active='no'
         ))
 
-        current = V1Parameters(load_fixture('load_asm_policy_active.json'))
-        client = AnsibleF5Client(
+        current = V1Parameters(params=load_fixture('load_asm_policy_active.json'))
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
 
         # Override methods to force specific logic in the module to happen
-        v1 = V1Manager(client)
+        v1 = V1Manager(module=module)
         v1.exists = Mock(return_value=True)
         v1.read_current_from_device = Mock(return_value=current)
         v1.update_on_device = Mock(return_value=True)
 
         # Override methods to force specific logic in the module to happen
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.version_is_less_than_13 = Mock(return_value=False)
         mm.get_manager = Mock(return_value=v1)
 
@@ -313,20 +306,19 @@ class TestManager(unittest.TestCase):
             active='no'
         ))
 
-        current = V1Parameters(load_fixture('load_asm_policy_inactive.json'))
-        client = AnsibleF5Client(
+        current = V1Parameters(params=load_fixture('load_asm_policy_inactive.json'))
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
 
         # Override methods to force specific logic in the module to happen
-        v1 = V1Manager(client)
+        v1 = V1Manager(module=module)
         v1.exists = Mock(return_value=True)
         v1.read_current_from_device = Mock(return_value=current)
 
         # Override methods to force specific logic in the module to happen
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.version_is_less_than_13 = Mock(return_value=False)
         mm.get_manager = Mock(return_value=v1)
 
@@ -344,22 +336,21 @@ class TestManager(unittest.TestCase):
             user='admin',
         ))
 
-        current = V1Parameters(load_fixture('load_asm_policy_inactive.json'))
-        client = AnsibleF5Client(
+        current = V1Parameters(params=load_fixture('load_asm_policy_inactive.json'))
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
 
         # Override methods to force specific logic in the module to happen
-        v1 = V1Manager(client)
+        v1 = V1Manager(module=module)
         v1.exists = Mock(return_value=False)
         v1.import_to_device = Mock(return_value=True)
         v1.wait_for_task = Mock(side_effect=[True, True])
         v1.read_current_from_device = Mock(return_value=current)
 
         # Override methods to force specific logic in the module to happen
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.version_is_less_than_13 = Mock(return_value=False)
         mm.get_manager = Mock(return_value=v1)
 
@@ -380,15 +371,14 @@ class TestManager(unittest.TestCase):
             user='admin',
         ))
 
-        current = V1Parameters(load_fixture('load_asm_policy_inactive.json'))
-        client = AnsibleF5Client(
+        current = V1Parameters(params=load_fixture('load_asm_policy_inactive.json'))
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
 
         # Override methods to force specific logic in the module to happen
-        v1 = V1Manager(client)
+        v1 = V1Manager(module=module)
         v1.exists = Mock(return_value=False)
         v1.create_from_template_on_device = Mock(return_value=True)
         v1.wait_for_task = Mock(side_effect=[True, True])
@@ -396,7 +386,7 @@ class TestManager(unittest.TestCase):
         v1._file_is_missing = Mock(return_value=False)
 
         # Override methods to force specific logic in the module to happen
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.version_is_less_than_13 = Mock(return_value=False)
         mm.get_manager = Mock(return_value=v1)
 
@@ -416,14 +406,13 @@ class TestManager(unittest.TestCase):
             user='admin',
         ))
 
-        current = V1Parameters(load_fixture('load_asm_policy_inactive.json'))
-        client = AnsibleF5Client(
+        current = V1Parameters(params=load_fixture('load_asm_policy_inactive.json'))
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
 
-        v1 = V1Manager(client)
+        v1 = V1Manager(module=module)
         v1.exists = Mock(return_value=False)
         v1.import_to_device = Mock(return_value=True)
         v1.wait_for_task = Mock(side_effect=[True, True])
@@ -434,7 +423,7 @@ class TestManager(unittest.TestCase):
         v1._file_is_missing = Mock(return_value=False)
 
         # Override methods to force specific logic in the module to happen
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.version_is_less_than_13 = Mock(return_value=False)
         mm.get_manager = Mock(return_value=v1)
 
@@ -453,19 +442,18 @@ class TestManager(unittest.TestCase):
             user='admin',
         ))
 
-        client = AnsibleF5Client(
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
 
         # Override methods to force specific logic in the module to happen
-        v1 = V1Manager(client)
+        v1 = V1Manager(module=module)
         v1.exists = Mock(side_effect=[True, False])
         v1.remove_from_device = Mock(return_value=True)
 
         # Override methods to force specific logic in the module to happen
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.version_is_less_than_13 = Mock(return_value=False)
         mm.get_manager = Mock(return_value=v1)
 
@@ -483,21 +471,20 @@ class TestManager(unittest.TestCase):
             user='admin',
         ))
 
-        client = AnsibleF5Client(
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
 
         msg = 'Import policy task failed.'
         # Override methods to force specific logic in the module to happen
-        v1 = V1Manager(client)
+        v1 = V1Manager(module=module)
         v1.exists = Mock(return_value=False)
         v1.import_to_device = Mock(return_value=True)
         v1.wait_for_task = Mock(return_value=False)
 
         # Override methods to force specific logic in the module to happen
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.version_is_less_than_13 = Mock(return_value=False)
         mm.get_manager = Mock(return_value=v1)
 
@@ -515,16 +502,15 @@ class TestManager(unittest.TestCase):
             user='admin',
         ))
 
-        current = V1Parameters(load_fixture('load_asm_policy_inactive.json'))
-        client = AnsibleF5Client(
+        current = V1Parameters(params=load_fixture('load_asm_policy_inactive.json'))
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
 
         msg = 'Apply policy task failed.'
         # Override methods to force specific logic in the module to happen
-        v1 = V1Manager(client)
+        v1 = V1Manager(module=module)
         v1.exists = Mock(return_value=True)
         v1.wait_for_task = Mock(return_value=False)
         v1.update_on_device = Mock(return_value=True)
@@ -532,7 +518,7 @@ class TestManager(unittest.TestCase):
         v1.apply_on_device = Mock(return_value=True)
 
         # Override methods to force specific logic in the module to happen
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.version_is_less_than_13 = Mock(return_value=False)
         mm.get_manager = Mock(return_value=v1)
 
@@ -549,21 +535,20 @@ class TestManager(unittest.TestCase):
             user='admin',
         ))
 
-        client = AnsibleF5Client(
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
 
         msg = 'Failed to create ASM policy: fake_policy'
         # Override methods to force specific logic in the module to happen
-        v1 = V1Manager(client)
+        v1 = V1Manager(module=module)
         v1.exists = Mock(return_value=False)
         v1.create_on_device = Mock(return_value=False)
         v1._file_is_missing = Mock(return_value=False)
 
         # Override methods to force specific logic in the module to happen
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.version_is_less_than_13 = Mock(return_value=False)
         mm.get_manager = Mock(return_value=v1)
 
@@ -580,19 +565,18 @@ class TestManager(unittest.TestCase):
             user='admin',
         ))
 
-        client = AnsibleF5Client(
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
         msg = 'Failed to delete ASM policy: fake_policy'
         # Override methods to force specific logic in the module to happen
-        v1 = V1Manager(client)
+        v1 = V1Manager(module=module)
         v1.exists = Mock(side_effect=[True, True])
         v1.remove_from_device = Mock(return_value=True)
 
         # Override methods to force specific logic in the module to happen
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.version_is_less_than_13 = Mock(return_value=False)
         mm.get_manager = Mock(return_value=v1)
 

--- a/test/units/modules/network/f5/test_bigip_command.py
+++ b/test/units/modules/network/f5/test_bigip_command.py
@@ -17,20 +17,22 @@ if sys.version_info < (2, 7):
 from ansible.compat.tests import unittest
 from ansible.compat.tests.mock import patch
 from ansible.compat.tests.mock import Mock
-from ansible.module_utils.f5_utils import AnsibleF5Client
+from ansible.module_utils.basic import AnsibleModule
 
 try:
     from library.bigip_command import Parameters
     from library.bigip_command import ModuleManager
     from library.bigip_command import ArgumentSpec
-    from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
+    from library.module_utils.network.f5.common import F5ModuleError
+    from library.module_utils.network.f5.common import iControlUnexpectedHTTPError
     from test.unit.modules.utils import set_module_args
 except ImportError:
     try:
         from ansible.modules.network.f5.bigip_command import Parameters
         from ansible.modules.network.f5.bigip_command import ModuleManager
         from ansible.modules.network.f5.bigip_command import ArgumentSpec
-        from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
+        from ansible.module_utils.network.f5.common import F5ModuleError
+        from ansible.module_utils.network.f5.common import iControlUnexpectedHTTPError
         from units.modules.utils import set_module_args
     except ImportError:
         raise SkipTest("F5 Ansible modules require the f5-sdk Python library")
@@ -61,12 +63,10 @@ class TestParameters(unittest.TestCase):
             user='admin',
             password='password'
         )
-        p = Parameters(args)
+        p = Parameters(params=args)
         assert len(p.commands) == 2
 
 
-@patch('ansible.module_utils.f5_utils.AnsibleF5Client._get_mgmt_root',
-       return_value=True)
 class TestManager(unittest.TestCase):
 
     def setUp(self):
@@ -82,12 +82,12 @@ class TestManager(unittest.TestCase):
             password='password'
         ))
 
-        client = AnsibleF5Client(
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
-        mm = ModuleManager(client)
+
+        mm = ModuleManager(module=module)
         mm._run_commands = Mock(return_value=[])
         mm.execute_on_device = Mock(return_value=[])
 
@@ -107,12 +107,11 @@ class TestManager(unittest.TestCase):
             password='password'
         ))
 
-        client = AnsibleF5Client(
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm._run_commands = Mock(return_value=[])
         mm.execute_on_device = Mock(return_value=[])
 
@@ -132,12 +131,12 @@ class TestManager(unittest.TestCase):
             password='password',
             transport='cli'
         ))
-        client = AnsibleF5Client(
+
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm._run_commands = Mock(return_value=[])
         mm.execute_on_device = Mock(return_value=[])
 
@@ -159,12 +158,11 @@ class TestManager(unittest.TestCase):
             user='admin',
             password='password'
         ))
-        client = AnsibleF5Client(
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm._run_commands = Mock(return_value=[])
         mm.execute_on_device = Mock(return_value=[])
 

--- a/test/units/modules/network/f5/test_bigip_config.py
+++ b/test/units/modules/network/f5/test_bigip_config.py
@@ -17,20 +17,22 @@ if sys.version_info < (2, 7):
 from ansible.compat.tests import unittest
 from ansible.compat.tests.mock import Mock
 from ansible.compat.tests.mock import patch
-from ansible.module_utils.f5_utils import AnsibleF5Client
+from ansible.module_utils.basic import AnsibleModule
 
 try:
     from library.bigip_config import Parameters
     from library.bigip_config import ModuleManager
     from library.bigip_config import ArgumentSpec
-    from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
+    from library.module_utils.network.f5.common import F5ModuleError
+    from library.module_utils.network.f5.common import iControlUnexpectedHTTPError
     from test.unit.modules.utils import set_module_args
 except ImportError:
     try:
         from ansible.modules.network.f5.bigip_config import Parameters
         from ansible.modules.network.f5.bigip_config import ModuleManager
         from ansible.modules.network.f5.bigip_config import ArgumentSpec
-        from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
+        from ansible.module_utils.network.f5.common import F5ModuleError
+        from ansible.module_utils.network.f5.common import iControlUnexpectedHTTPError
         from units.modules.utils import set_module_args
     except ImportError:
         raise SkipTest("F5 Ansible modules require the f5-sdk Python library")
@@ -68,14 +70,12 @@ class TestParameters(unittest.TestCase):
             user='admin',
             password='password'
         )
-        p = Parameters(args)
+        p = Parameters(params=args)
         assert p.save == 'yes'
         assert p.reset == 'yes'
         assert p.merge_content == 'asdasd'
 
 
-@patch('ansible.module_utils.f5_utils.AnsibleF5Client._get_mgmt_root',
-       return_value=True)
 class TestManager(unittest.TestCase):
 
     def setUp(self):
@@ -92,12 +92,11 @@ class TestManager(unittest.TestCase):
             password='password'
         ))
 
-        client = AnsibleF5Client(
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
 
         # Override methods to force specific logic in the module to happen
         mm.exit_json = Mock(return_value=True)

--- a/test/units/modules/network/f5/test_bigip_configsync_action.py
+++ b/test/units/modules/network/f5/test_bigip_configsync_action.py
@@ -17,20 +17,22 @@ if sys.version_info < (2, 7):
 from ansible.compat.tests import unittest
 from ansible.compat.tests.mock import Mock
 from ansible.compat.tests.mock import patch
-from ansible.module_utils.f5_utils import AnsibleF5Client
+from ansible.module_utils.basic import AnsibleModule
 
 try:
     from library.bigip_configsync_actions import Parameters
     from library.bigip_configsync_actions import ModuleManager
     from library.bigip_configsync_actions import ArgumentSpec
-    from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
+    from library.module_utils.network.f5.common import F5ModuleError
+    from library.module_utils.network.f5.common import iControlUnexpectedHTTPError
     from test.unit.modules.utils import set_module_args
 except ImportError:
     try:
         from ansible.modules.network.f5.bigip_configsync_actions import Parameters
         from ansible.modules.network.f5.bigip_configsync_actions import ModuleManager
         from ansible.modules.network.f5.bigip_configsync_actions import ArgumentSpec
-        from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
+        from ansible.module_utils.network.f5.common import F5ModuleError
+        from ansible.module_utils.network.f5.common import iControlUnexpectedHTTPError
         from units.modules.utils import set_module_args
     except ImportError:
         raise SkipTest("F5 Ansible modules require the f5-sdk Python library")
@@ -65,7 +67,7 @@ class TestParameters(unittest.TestCase):
             overwrite_config=True,
             device_group="foo"
         )
-        p = Parameters(args)
+        p = Parameters(params=args)
         assert p.sync_device_to_group is True
         assert p.sync_group_to_device is True
         assert p.overwrite_config is True
@@ -78,15 +80,13 @@ class TestParameters(unittest.TestCase):
             overwrite_config='yes',
             device_group="foo"
         )
-        p = Parameters(args)
+        p = Parameters(params=args)
         assert p.sync_device_to_group is True
         assert p.sync_group_to_device is False
         assert p.overwrite_config is True
         assert p.device_group == 'foo'
 
 
-@patch('ansible.module_utils.f5_utils.AnsibleF5Client._get_mgmt_root',
-       return_value=True)
 class TestManager(unittest.TestCase):
 
     def setUp(self):
@@ -101,12 +101,11 @@ class TestManager(unittest.TestCase):
             user='admin'
         ))
 
-        client = AnsibleF5Client(
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
 
         # Override methods to force specific logic in the module to happen
         mm._device_group_exists = Mock(return_value=True)

--- a/test/units/modules/network/f5/test_bigip_device_connectivity.py
+++ b/test/units/modules/network/f5/test_bigip_device_connectivity.py
@@ -18,21 +18,24 @@ if sys.version_info < (2, 7):
 from ansible.compat.tests import unittest
 from ansible.compat.tests.mock import Mock
 from ansible.compat.tests.mock import patch
-from ansible.module_utils.f5_utils import AnsibleF5Client
-from ansible.module_utils.f5_utils import F5ModuleError
+from ansible.module_utils.basic import AnsibleModule
 
 try:
-    from library.bigip_device_connectivity import Parameters
+    from library.bigip_device_connectivity import ApiParameters
+    from library.bigip_device_connectivity import ModuleParameters
     from library.bigip_device_connectivity import ModuleManager
     from library.bigip_device_connectivity import ArgumentSpec
-    from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
+    from library.module_utils.network.f5.common import F5ModuleError
+    from library.module_utils.network.f5.common import iControlUnexpectedHTTPError
     from test.unit.modules.utils import set_module_args
 except ImportError:
     try:
-        from ansible.modules.network.f5.bigip_device_connectivity import Parameters
+        from ansible.modules.network.f5.bigip_device_connectivity import ApiParameters
+        from ansible.modules.network.f5.bigip_device_connectivity import ModuleParameters
         from ansible.modules.network.f5.bigip_device_connectivity import ModuleManager
         from ansible.modules.network.f5.bigip_device_connectivity import ArgumentSpec
-        from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
+        from ansible.module_utils.network.f5.common import F5ModuleError
+        from ansible.module_utils.network.f5.common import iControlUnexpectedHTTPError
         from units.modules.utils import set_module_args
     except ImportError:
         raise SkipTest("F5 Ansible modules require the f5-sdk Python library")
@@ -80,7 +83,7 @@ class TestParameters(unittest.TestCase):
             user='admin',
             password='password'
         )
-        p = Parameters(args)
+        p = ModuleParameters(params=args)
         assert p.multicast_port == 1010
         assert p.multicast_address == '10.10.10.10'
         assert p.multicast_interface == 'eth0'
@@ -100,7 +103,7 @@ class TestParameters(unittest.TestCase):
 
     def test_api_parameters(self):
         params = load_fixture('load_tm_cm_device.json')
-        p = Parameters(params)
+        p = ApiParameters(params=params)
         assert p.multicast_port == 62960
         assert p.multicast_address == '224.0.0.245'
         assert p.multicast_interface == 'eth0'
@@ -118,8 +121,6 @@ class TestParameters(unittest.TestCase):
         assert p.unicast_failover[0]['effectivePort'] == 1026
 
 
-@patch('ansible.module_utils.f5_utils.AnsibleF5Client._get_mgmt_root',
-       return_value=True)
 class TestManager(unittest.TestCase):
 
     def setUp(self):
@@ -141,14 +142,13 @@ class TestManager(unittest.TestCase):
 
         # Configure the parameters that would be returned by querying the
         # remote device
-        current = Parameters(load_fixture('load_tm_cm_device_default.json'))
+        current = ApiParameters(params=load_fixture('load_tm_cm_device_default.json'))
 
-        client = AnsibleF5Client(
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
 
         # Override methods to force specific logic in the module to happen
         mm.update_on_device = Mock(return_value=True)
@@ -159,7 +159,7 @@ class TestManager(unittest.TestCase):
         assert results['changed'] is True
         assert results['config_sync_ip'] == '10.1.30.1'
         assert results['mirror_primary_address'] == '10.1.30.1'
-        assert len(results.keys()) == 3
+        assert len(results.keys()) == 4
 
     def test_set_primary_mirror_address_none(self, *args):
         set_module_args(dict(
@@ -171,14 +171,13 @@ class TestManager(unittest.TestCase):
 
         # Configure the parameters that would be returned by querying the
         # remote device
-        current = Parameters(load_fixture('load_tm_cm_device.json'))
+        current = ApiParameters(params=load_fixture('load_tm_cm_device.json'))
 
-        client = AnsibleF5Client(
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
 
         # Override methods to force specific logic in the module to happen
         mm.update_on_device = Mock(return_value=True)
@@ -200,14 +199,13 @@ class TestManager(unittest.TestCase):
 
         # Configure the parameters that would be returned by querying the
         # remote device
-        current = Parameters(load_fixture('load_tm_cm_device.json'))
+        current = ApiParameters(params=load_fixture('load_tm_cm_device.json'))
 
-        client = AnsibleF5Client(
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
 
         # Override methods to force specific logic in the module to happen
         mm.update_on_device = Mock(return_value=True)
@@ -229,14 +227,13 @@ class TestManager(unittest.TestCase):
 
         # Configure the parameters that would be returned by querying the
         # remote device
-        current = Parameters(load_fixture('load_tm_cm_device.json'))
+        current = ApiParameters(params=load_fixture('load_tm_cm_device.json'))
 
-        client = AnsibleF5Client(
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
 
         # Override methods to force specific logic in the module to happen
         mm.update_on_device = Mock(return_value=True)
@@ -258,14 +255,13 @@ class TestManager(unittest.TestCase):
 
         # Configure the parameters that would be returned by querying the
         # remote device
-        current = Parameters(load_fixture('load_tm_cm_device.json'))
+        current = ApiParameters(params=load_fixture('load_tm_cm_device.json'))
 
-        client = AnsibleF5Client(
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
 
         # Override methods to force specific logic in the module to happen
         mm.update_on_device = Mock(return_value=True)
@@ -286,14 +282,13 @@ class TestManager(unittest.TestCase):
 
         # Configure the parameters that would be returned by querying the
         # remote device
-        current = Parameters(load_fixture('load_tm_cm_device.json'))
+        current = ApiParameters(params=load_fixture('load_tm_cm_device.json'))
 
-        client = AnsibleF5Client(
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
 
         # Override methods to force specific logic in the module to happen
         mm.update_on_device = Mock(return_value=True)
@@ -315,14 +310,13 @@ class TestManager(unittest.TestCase):
 
         # Configure the parameters that would be returned by querying the
         # remote device
-        current = Parameters(load_fixture('load_tm_cm_device.json'))
+        current = ApiParameters(params=load_fixture('load_tm_cm_device.json'))
 
-        client = AnsibleF5Client(
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
 
         # Override methods to force specific logic in the module to happen
         mm.update_on_device = Mock(return_value=True)
@@ -344,14 +338,13 @@ class TestManager(unittest.TestCase):
 
         # Configure the parameters that would be returned by querying the
         # remote device
-        current = Parameters(load_fixture('load_tm_cm_device.json'))
+        current = ApiParameters(params=load_fixture('load_tm_cm_device.json'))
 
-        client = AnsibleF5Client(
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
 
         # Override methods to force specific logic in the module to happen
         mm.update_on_device = Mock(return_value=True)

--- a/test/units/modules/network/f5/test_bigip_device_dns.py
+++ b/test/units/modules/network/f5/test_bigip_device_dns.py
@@ -18,21 +18,22 @@ if sys.version_info < (2, 7):
 from ansible.compat.tests import unittest
 from ansible.compat.tests.mock import Mock
 from ansible.compat.tests.mock import patch
-from ansible.module_utils.f5_utils import AnsibleF5Client
-from ansible.module_utils.f5_utils import F5ModuleError
+from ansible.module_utils.basic import AnsibleModule
 
 try:
     from library.bigip_device_dns import Parameters
     from library.bigip_device_dns import ModuleManager
     from library.bigip_device_dns import ArgumentSpec
-    from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
+    from library.module_utils.network.f5.common import F5ModuleError
+    from library.module_utils.network.f5.common import iControlUnexpectedHTTPError
     from test.unit.modules.utils import set_module_args
 except ImportError:
     try:
         from ansible.modules.network.f5.bigip_device_dns import Parameters
         from ansible.modules.network.f5.bigip_device_dns import ModuleManager
         from ansible.modules.network.f5.bigip_device_dns import ArgumentSpec
-        from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
+        from ansible.module_utils.network.f5.common import F5ModuleError
+        from ansible.module_utils.network.f5.common import iControlUnexpectedHTTPError
         from units.modules.utils import set_module_args
     except ImportError:
         raise SkipTest("F5 Ansible modules require the f5-sdk Python library")
@@ -71,7 +72,7 @@ class TestParameters(unittest.TestCase):
             user='admin',
             password='password'
         )
-        p = Parameters(args)
+        p = Parameters(params=args)
         assert p.cache == 'disable'
         assert p.name_servers == ['10.10.10.10', '11.11.11.11']
         assert p.search == ['14.14.14.14', '15.15.15.15']
@@ -83,16 +84,16 @@ class TestParameters(unittest.TestCase):
         args = dict(
             ip_version=6
         )
-        p = Parameters(args)
+        p = Parameters(params=args)
         assert p.ip_version == 'options inet6'
 
     def test_ensure_forwards_raises_exception(self):
         args = dict(
             forwarders=['12.12.12.12', '13.13.13.13'],
         )
-        p = Parameters(args)
+        p = Parameters(params=args)
         with pytest.raises(F5ModuleError) as ex:
-            foo = p.forwarders
+            p.forwarders
         assert 'The modifying of forwarders is not supported' in str(ex)
 
 
@@ -101,8 +102,6 @@ class TestManager(unittest.TestCase):
     def setUp(self):
         self.spec = ArgumentSpec()
 
-    @patch('ansible.module_utils.f5_utils.AnsibleF5Client._get_mgmt_root',
-           return_value=True)
     def test_update_settings(self, *args):
         set_module_args(dict(
             cache='disable',
@@ -123,12 +122,11 @@ class TestManager(unittest.TestCase):
             )
         )
 
-        client = AnsibleF5Client(
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
 
         # Override methods to force specific logic in the module to happen
         mm.update_on_device = Mock(return_value=True)

--- a/test/units/modules/network/f5/test_bigip_device_httpd.py
+++ b/test/units/modules/network/f5/test_bigip_device_httpd.py
@@ -17,20 +17,22 @@ if sys.version_info < (2, 7):
 from ansible.compat.tests import unittest
 from ansible.compat.tests.mock import Mock
 from ansible.compat.tests.mock import patch
-from ansible.module_utils.f5_utils import AnsibleF5Client
+from ansible.module_utils.basic import AnsibleModule
 
 try:
     from library.bigip_device_httpd import Parameters
     from library.bigip_device_httpd import ModuleManager
     from library.bigip_device_httpd import ArgumentSpec
-    from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
+    from library.module_utils.network.f5.common import F5ModuleError
+    from library.module_utils.network.f5.common import iControlUnexpectedHTTPError
     from test.unit.modules.utils import set_module_args
 except ImportError:
     try:
         from ansible.modules.network.f5.bigip_device_httpd import Parameters
         from ansible.modules.network.f5.bigip_device_httpd import ModuleManager
         from ansible.modules.network.f5.bigip_device_httpd import ArgumentSpec
-        from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
+        from ansible.module_utils.network.f5.common import F5ModuleError
+        from ansible.module_utils.network.f5.common import iControlUnexpectedHTTPError
         from units.modules.utils import set_module_args
     except ImportError:
         raise SkipTest("F5 Ansible modules require the f5-sdk Python library")
@@ -65,20 +67,18 @@ class TestParameters(unittest.TestCase):
             auth_pam_validate_ip='on'
         )
 
-        p = Parameters(args)
+        p = Parameters(params=args)
         assert p.auth_name == 'BIG-IP'
         assert p.auth_pam_idle_timeout == 1200
         assert p.auth_pam_validate_ip == 'on'
 
     def test_api_parameters(self):
         args = load_fixture('load_sys_httpd.json')
-        p = Parameters(args)
+        p = Parameters(params=args)
         assert p.auth_name == 'BIG-IP'
         assert p.auth_pam_idle_timeout == 1200
 
 
-@patch('ansible.module_utils.f5_utils.AnsibleF5Client._get_mgmt_root',
-       return_value=True)
 class TestModuleManager(unittest.TestCase):
 
     def setUp(self):
@@ -103,16 +103,13 @@ class TestModuleManager(unittest.TestCase):
             )
         )
 
-        current = Parameters(
-            load_fixture('load_sys_httpd.json')
-        )
+        current = Parameters(params=load_fixture('load_sys_httpd.json'))
 
-        client = AnsibleF5Client(
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
 
         # Override methods to force specific logic in the module to happen
         mm.update_on_device = Mock(return_value=True)

--- a/test/units/modules/network/f5/test_bigip_device_ntp.py
+++ b/test/units/modules/network/f5/test_bigip_device_ntp.py
@@ -17,20 +17,22 @@ if sys.version_info < (2, 7):
 from ansible.compat.tests import unittest
 from ansible.compat.tests.mock import Mock
 from ansible.compat.tests.mock import patch
-from ansible.module_utils.f5_utils import AnsibleF5Client
+from ansible.module_utils.basic import AnsibleModule
 
 try:
     from library.bigip_device_ntp import Parameters
     from library.bigip_device_ntp import ModuleManager
     from library.bigip_device_ntp import ArgumentSpec
-    from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
+    from library.module_utils.network.f5.common import F5ModuleError
+    from library.module_utils.network.f5.common import iControlUnexpectedHTTPError
     from test.unit.modules.utils import set_module_args
 except ImportError:
     try:
         from ansible.modules.network.f5.bigip_device_ntp import Parameters
         from ansible.modules.network.f5.bigip_device_ntp import ModuleManager
         from ansible.modules.network.f5.bigip_device_ntp import ArgumentSpec
-        from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
+        from ansible.module_utils.network.f5.common import F5ModuleError
+        from ansible.module_utils.network.f5.common import iControlUnexpectedHTTPError
         from units.modules.utils import set_module_args
     except ImportError:
         raise SkipTest("F5 Ansible modules require the f5-sdk Python library")
@@ -65,7 +67,7 @@ class TestParameters(unittest.TestCase):
             timezone='Arctic/Longyearbyen'
         )
 
-        p = Parameters(args)
+        p = Parameters(params=args)
         assert p.ntp_servers == ntp
         assert p.timezone == 'Arctic/Longyearbyen'
 
@@ -76,13 +78,11 @@ class TestParameters(unittest.TestCase):
             timezone='Arctic/Longyearbyen'
         )
 
-        p = Parameters(args)
+        p = Parameters(params=args)
         assert p.ntp_servers == ntp
         assert p.timezone == 'Arctic/Longyearbyen'
 
 
-@patch('ansible.module_utils.f5_utils.AnsibleF5Client._get_mgmt_root',
-       return_value=True)
 class TestModuleManager(unittest.TestCase):
 
     def setUp(self):
@@ -101,16 +101,13 @@ class TestModuleManager(unittest.TestCase):
 
         # Configure the parameters that would be returned by querying the
         # remote device
-        current = Parameters(
-            load_fixture('load_ntp.json')
-        )
+        current = Parameters(params=load_fixture('load_ntp.json'))
 
-        client = AnsibleF5Client(
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
 
         # Override methods to force specific logic in the module to happen
         mm.update_on_device = Mock(return_value=True)
@@ -132,16 +129,13 @@ class TestModuleManager(unittest.TestCase):
 
         # Configure the parameters that would be returned by querying the
         # remote device
-        current = Parameters(
-            load_fixture('load_ntp.json')
-        )
+        current = Parameters(params=load_fixture('load_ntp.json'))
 
-        client = AnsibleF5Client(
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
 
         # Override methods to force specific logic in the module to happen
         mm.update_on_device = Mock(return_value=True)
@@ -165,16 +159,13 @@ class TestModuleManager(unittest.TestCase):
 
         # Configure the parameters that would be returned by querying the
         # remote device
-        current = Parameters(
-            load_fixture('load_ntp.json')
-        )
+        current = Parameters(params=load_fixture('load_ntp.json'))
 
-        client = AnsibleF5Client(
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
 
         # Override methods to force specific logic in the module to happen
         mm.update_on_device = Mock(return_value=True)
@@ -200,16 +191,13 @@ class TestModuleManager(unittest.TestCase):
 
         # Configure the parameters that would be returned by querying the
         # remote device
-        current = Parameters(
-            load_fixture('load_ntp.json')
-        )
+        current = Parameters(params=load_fixture('load_ntp.json'))
 
-        client = AnsibleF5Client(
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
 
         # Override methods to force specific logic in the module to happen
         mm.absent_on_device = Mock(return_value=True)
@@ -233,16 +221,13 @@ class TestModuleManager(unittest.TestCase):
 
         # Configure the parameters that would be returned by querying the
         # remote device
-        current = Parameters(
-            load_fixture('load_ntp.json')
-        )
+        current = Parameters(params=load_fixture('load_ntp.json'))
 
-        client = AnsibleF5Client(
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
 
         # Override methods to force specific logic in the module to happen
         mm.absent_on_device = Mock(return_value=True)

--- a/test/units/modules/network/f5/test_bigip_device_sshd.py
+++ b/test/units/modules/network/f5/test_bigip_device_sshd.py
@@ -17,20 +17,22 @@ if sys.version_info < (2, 7):
 from ansible.compat.tests import unittest
 from ansible.compat.tests.mock import Mock
 from ansible.compat.tests.mock import patch
-from ansible.module_utils.f5_utils import AnsibleF5Client
+from ansible.module_utils.basic import AnsibleModule
 
 try:
     from library.bigip_device_sshd import Parameters
     from library.bigip_device_sshd import ModuleManager
     from library.bigip_device_sshd import ArgumentSpec
-    from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
+    from library.module_utils.network.f5.common import F5ModuleError
+    from library.module_utils.network.f5.common import iControlUnexpectedHTTPError
     from test.unit.modules.utils import set_module_args
 except ImportError:
     try:
         from ansible.modules.network.f5.bigip_device_sshd import Parameters
         from ansible.modules.network.f5.bigip_device_sshd import ModuleManager
         from ansible.modules.network.f5.bigip_device_sshd import ArgumentSpec
-        from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
+        from ansible.module_utils.network.f5.common import F5ModuleError
+        from ansible.module_utils.network.f5.common import iControlUnexpectedHTTPError
         from units.modules.utils import set_module_args
     except ImportError:
         raise SkipTest("F5 Ansible modules require the f5-sdk Python library")
@@ -71,7 +73,7 @@ class TestParameters(unittest.TestCase):
             user='admin',
             password='password'
         )
-        p = Parameters(args)
+        p = Parameters(params=args)
         assert p.allow == ['all']
         assert p.banner == 'enabled'
         assert p.banner_text == 'asdf'
@@ -86,8 +88,6 @@ class TestManager(unittest.TestCase):
     def setUp(self):
         self.spec = ArgumentSpec()
 
-    @patch('ansible.module_utils.f5_utils.AnsibleF5Client._get_mgmt_root',
-           return_value=True)
     def test_update_settings(self, *args):
         set_module_args(dict(
             allow=['all'],
@@ -110,12 +110,11 @@ class TestManager(unittest.TestCase):
             )
         )
 
-        client = AnsibleF5Client(
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
 
         # Override methods to force specific logic in the module to happen
         mm.update_on_device = Mock(return_value=True)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
This patch was primarily an effort to reduce traceback errors for
work that sivel was doing. Part of (and in some cases in addition to)
that, the following was done.

* Removed re-def of cleanup_tokens.
* Changed parameter args to be keywords.
* Changed imports to include new module_util locations.
* Imports also include developing (sideband) module_util locations.
* Changed to using F5Client and plain AnsibleModule to prevent tracebacks caused by missing libraries.
* Removed init and update methods from most Parameter classes (optimization) as its now included in module_utils.
* Changed module and module param references to take into account the new self.module arg.
* Minor bug fixes made during this refactor.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
various f5 modules

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0
  config file = /here/test/integration/ansible.cfg
  configured module search path = [u'/here/library']
  ansible python module location = /usr/local/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.14 (default, Dec 12 2017, 16:55:09) [GCC 4.9.2]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
