### PR TITLE
Various fixes and changes for F5

### DIFF
--- a/lib/ansible/modules/network/f5/bigip_gtm_datacenter.py
+++ b/lib/ansible/modules/network/f5/bigip_gtm_datacenter.py
@@ -44,19 +44,18 @@ options:
         the virtual address and enables it. If C(enabled), enable the virtual
         address if it exists. If C(disabled), create the virtual address if
         needed, and set state to C(disabled).
-    required: False
     default: present
     choices:
       - present
       - absent
       - enabled
       - disabled
-notes:
-  - Requires the f5-sdk Python package on the host. This is as easy as
-    pip install f5-sdk.
+  partition:
+    description:
+      - Device partition to manage resources on.
+    default: Common
+    version_added: 2.5
 extends_documentation_fragment: f5
-requirements:
-  - f5-sdk
 author:
   - Tim Rupp (@caphrim007)
 '''
@@ -105,15 +104,38 @@ location:
   sample: 222 West 23rd
 '''
 
-from ansible.module_utils.f5_utils import AnsibleF5Client
-from ansible.module_utils.f5_utils import AnsibleF5Parameters
-from ansible.module_utils.f5_utils import HAS_F5SDK
-from ansible.module_utils.f5_utils import F5ModuleError
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import env_fallback
+
+HAS_DEVEL_IMPORTS = False
 
 try:
-    from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
+    # Sideband repository used for dev
+    from library.module_utils.network.f5.bigip import HAS_F5SDK
+    from library.module_utils.network.f5.bigip import F5Client
+    from library.module_utils.network.f5.common import F5ModuleError
+    from library.module_utils.network.f5.common import AnsibleF5Parameters
+    from library.module_utils.network.f5.common import cleanup_tokens
+    from library.module_utils.network.f5.common import fqdn_name
+    from library.module_utils.network.f5.common import f5_argument_spec
+    try:
+        from library.module_utils.network.f5.common import iControlUnexpectedHTTPError
+    except ImportError:
+        HAS_F5SDK = False
+    HAS_DEVEL_IMPORTS = True
 except ImportError:
-    HAS_F5SDK = False
+    # Upstream Ansible
+    from ansible.module_utils.network.f5.bigip import HAS_F5SDK
+    from ansible.module_utils.network.f5.bigip import F5Client
+    from ansible.module_utils.network.f5.common import F5ModuleError
+    from ansible.module_utils.network.f5.common import AnsibleF5Parameters
+    from ansible.module_utils.network.f5.common import cleanup_tokens
+    from ansible.module_utils.network.f5.common import fqdn_name
+    from ansible.module_utils.network.f5.common import f5_argument_spec
+    try:
+        from ansible.module_utils.network.f5.common import iControlUnexpectedHTTPError
+    except ImportError:
+        HAS_F5SDK = False
 
 
 class Parameters(AnsibleF5Parameters):
@@ -258,9 +280,10 @@ class Difference(object):
 
 
 class ModuleManager(object):
-    def __init__(self, client):
-        self.client = client
-        self.want = ModuleParameters(params=self.client.module.params)
+    def __init__(self, *args, **kwargs):
+        self.module = kwargs.pop('module', None)
+        self.client = kwargs.pop('client', None)
+        self.want = ModuleParameters(params=self.module.params)
         self.have = ApiParameters()
         self.changes = UsableChanges()
 
@@ -277,7 +300,7 @@ class ModuleManager(object):
         except iControlUnexpectedHTTPError as e:
             raise F5ModuleError(str(e))
 
-        reportable = ReportableChanges(self.changes.to_return())
+        reportable = ReportableChanges(params=self.changes.to_return())
         changes = reportable.to_return()
         result.update(**changes)
         result.update(dict(changed=changed))
@@ -287,7 +310,7 @@ class ModuleManager(object):
     def _announce_deprecations(self, result):
         warnings = result.pop('__warnings', [])
         for warning in warnings:
-            self.client.module.deprecate(
+            self.module.deprecate(
                 msg=warning['msg'],
                 version=warning['version']
             )
@@ -306,7 +329,7 @@ class ModuleManager(object):
                 else:
                     changed[k] = change
         if changed:
-            self.changes = UsableChanges(changed)
+            self.changes = UsableChanges(params=changed)
             return True
         return False
 
@@ -334,7 +357,7 @@ class ModuleManager(object):
             partition=self.want.partition
         )
         result = resource.attrs
-        return ApiParameters(result)
+        return ApiParameters(params=result)
 
     def exists(self):
         result = self.client.api.tm.gtm.datacenters.datacenter.exists(
@@ -347,7 +370,7 @@ class ModuleManager(object):
         self.have = self.read_current_from_device()
         if not self.should_update():
             return False
-        if self.client.check_mode:
+        if self.module.check_mode:
             return True
         self.update_on_device()
         return True
@@ -363,7 +386,7 @@ class ModuleManager(object):
     def create(self):
         self.have = ApiParameters()
         self.should_update()
-        if self.client.check_mode:
+        if self.module.check_mode:
             return True
         self.create_on_device()
         if self.exists():
@@ -380,7 +403,7 @@ class ModuleManager(object):
         )
 
     def remove(self):
-        if self.client.check_mode:
+        if self.module.check_mode:
             return True
         self.remove_from_device()
         if self.exists():
@@ -398,50 +421,44 @@ class ModuleManager(object):
 class ArgumentSpec(object):
     def __init__(self):
         self.supports_check_mode = True
-        self.argument_spec = dict(
+        argument_spec = dict(
             contact=dict(),
             description=dict(),
             location=dict(),
             name=dict(required=True),
             state=dict(
-                type='str',
                 default='present',
                 choices=['present', 'absent', 'disabled', 'enabled']
+            ),
+            partition=dict(
+                default='Common',
+                fallback=(env_fallback, ['F5_PARTITION'])
             )
         )
-        self.f5_product_name = 'bigip'
-
-
-def cleanup_tokens(client):
-    try:
-        resource = client.api.shared.authz.tokens_s.token.load(
-            name=client.api.icrs.token
-        )
-        resource.delete()
-    except Exception:
-        pass
+        self.argument_spec = {}
+        self.argument_spec.update(f5_argument_spec)
+        self.argument_spec.update(argument_spec)
 
 
 def main():
-    if not HAS_F5SDK:
-        raise F5ModuleError("The python f5-sdk module is required")
-
     spec = ArgumentSpec()
 
-    client = AnsibleF5Client(
+    module = AnsibleModule(
         argument_spec=spec.argument_spec,
-        supports_check_mode=spec.supports_check_mode,
-        f5_product_name=spec.f5_product_name
+        supports_check_mode=spec.supports_check_mode
     )
+    if not HAS_F5SDK:
+        module.fail_json(msg="The python f5-sdk module is required")
 
     try:
-        mm = ModuleManager(client)
+        client = F5Client(**module.params)
+        mm = ModuleManager(module=module, client=client)
         results = mm.exec_module()
         cleanup_tokens(client)
-        client.module.exit_json(**results)
-    except F5ModuleError as e:
+        module.exit_json(**results)
+    except F5ModuleError as ex:
         cleanup_tokens(client)
-        client.module.fail_json(msg=str(e))
+        module.fail_json(msg=str(ex))
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/network/f5/bigip_iapp_service.py
+++ b/lib/ansible/modules/network/f5/bigip_iapp_service.py
@@ -82,11 +82,6 @@ options:
         over any similar setting in the iApp Server payload that you provide in
         the C(parameters) field.
     version_added: 2.5
-notes:
-  - Requires the f5-sdk Python package on the host. This is as easy as pip
-    install f5-sdk.
-requirements:
-  - f5-sdk
 extends_documentation_fragment: f5
 author:
   - Tim Rupp (@caphrim007)
@@ -215,17 +210,39 @@ RETURN = r'''
 # only common fields returned
 '''
 
-from ansible.module_utils.f5_utils import AnsibleF5Client
-from ansible.module_utils.f5_utils import AnsibleF5Parameters
-from ansible.module_utils.f5_utils import HAS_F5SDK
-from ansible.module_utils.f5_utils import F5ModuleError
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import env_fallback
 from ansible.module_utils.six import iteritems
-from collections import defaultdict
+
+HAS_DEVEL_IMPORTS = False
 
 try:
-    from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
+    # Sideband repository used for dev
+    from library.module_utils.network.f5.bigip import HAS_F5SDK
+    from library.module_utils.network.f5.bigip import F5Client
+    from library.module_utils.network.f5.common import F5ModuleError
+    from library.module_utils.network.f5.common import AnsibleF5Parameters
+    from library.module_utils.network.f5.common import cleanup_tokens
+    from library.module_utils.network.f5.common import fqdn_name
+    from library.module_utils.network.f5.common import f5_argument_spec
+    try:
+        from library.module_utils.network.f5.common import iControlUnexpectedHTTPError
+    except ImportError:
+        HAS_F5SDK = False
+    HAS_DEVEL_IMPORTS = True
 except ImportError:
-    HAS_F5SDK = False
+    # Upstream Ansible
+    from ansible.module_utils.network.f5.bigip import HAS_F5SDK
+    from ansible.module_utils.network.f5.bigip import F5Client
+    from ansible.module_utils.network.f5.common import F5ModuleError
+    from ansible.module_utils.network.f5.common import AnsibleF5Parameters
+    from ansible.module_utils.network.f5.common import cleanup_tokens
+    from ansible.module_utils.network.f5.common import fqdn_name
+    from ansible.module_utils.network.f5.common import f5_argument_spec
+    try:
+        from ansible.module_utils.network.f5.common import iControlUnexpectedHTTPError
+    except ImportError:
+        HAS_F5SDK = False
 
 
 class Parameters(AnsibleF5Parameters):
@@ -241,35 +258,6 @@ class Parameters(AnsibleF5Parameters):
     ]
     updatables = ['tables', 'variables', 'lists', 'strict_updates', 'traffic_group']
 
-    def __init__(self, params=None):
-        self._values = defaultdict(lambda: None)
-        if params:
-            self.update(params=params)
-        self._values['__warnings'] = []
-
-    def update(self, params=None):
-        if params:
-            for k, v in iteritems(params):
-                if self.api_map is not None and k in self.api_map:
-                    map_key = self.api_map[k]
-                else:
-                    map_key = k
-
-                # Handle weird API parameters like `dns.proxy.__iter__` by
-                # using a map provided by the module developer
-                class_attr = getattr(type(self), map_key, None)
-                if isinstance(class_attr, property):
-                    # There is a mapped value for the api_map key
-                    if class_attr.fset is None:
-                        # If the mapped value does not have an associated setter
-                        self._values[map_key] = v
-                    else:
-                        # The mapped value has a setter
-                        setattr(self, map_key, v)
-                else:
-                    # If the mapped value is not a @property
-                    self._values[map_key] = v
-
     def _fqdn_name(self, value):
         if value is not None and not value.startswith('/'):
             return '/{0}/{1}'.format(self.partition, value)
@@ -279,16 +267,6 @@ class Parameters(AnsibleF5Parameters):
         result = {}
         for returnable in self.returnables:
             result[returnable] = getattr(self, returnable)
-        result = self._filter_params(result)
-        return result
-
-    def api_params(self):
-        result = {}
-        for api_attribute in self.api_attributes:
-            if self.api_map is not None and api_attribute in self.api_map:
-                result[api_attribute] = getattr(self, self.api_map[api_attribute])
-            else:
-                result[api_attribute] = getattr(self, api_attribute)
         result = self._filter_params(result)
         return result
 
@@ -489,10 +467,11 @@ class Difference(object):
 
 
 class ModuleManager(object):
-    def __init__(self, client):
-        self.client = client
+    def __init__(self, *args, **kwargs):
+        self.module = kwargs.get('module', None)
+        self.client = kwargs.get('client', None)
         self.have = None
-        self.want = Parameters(self.client.module.params)
+        self.want = Parameters(params=self.module.params)
         self.changes = Changes()
 
     def _set_changed_options(self):
@@ -501,7 +480,7 @@ class ModuleManager(object):
             if getattr(self.want, key) is not None:
                 changed[key] = getattr(self.want, key)
         if changed:
-            self.changes = Changes(changed)
+            self.changes = Changes(params=changed)
 
     def _update_changed_options(self):
         diff = Difference(self.want, self.have)
@@ -517,7 +496,7 @@ class ModuleManager(object):
                 else:
                     changed[k] = change
         if changed:
-            self.changes = Changes(changed)
+            self.changes = Changes(params=changed)
             return True
         return False
 
@@ -556,7 +535,7 @@ class ModuleManager(object):
         self._set_changed_options()
         if self.want.traffic_group is None and self.want.trafficGroup is None:
             self.want.update({'traffic_group': '/Common/traffic-group-1'})
-        if self.client.check_mode:
+        if self.module.check_mode:
             return True
         self.create_on_device()
         return True
@@ -565,7 +544,7 @@ class ModuleManager(object):
         self.have = self.read_current_from_device()
         if not self.should_update() and not self.want.force:
             return False
-        if self.client.check_mode:
+        if self.module.check_mode:
             return True
         self.update_on_device()
         return True
@@ -591,7 +570,7 @@ class ModuleManager(object):
             partition=self.want.partition
         ).to_dict()
         result.pop('_meta_data', None)
-        return Parameters(result)
+        return Parameters(params=result)
 
     def create_on_device(self):
         params = self.want.api_params()
@@ -607,7 +586,7 @@ class ModuleManager(object):
         return False
 
     def remove(self):
-        if self.client.check_mode:
+        if self.module.check_mode:
             return True
         self.remove_from_device()
         if self.exists():
@@ -626,7 +605,7 @@ class ModuleManager(object):
 class ArgumentSpec(object):
     def __init__(self):
         self.supports_check_mode = True
-        self.argument_spec = dict(
+        argument_spec = dict(
             name=dict(required=True),
             template=dict(),
             parameters=dict(
@@ -643,41 +622,36 @@ class ArgumentSpec(object):
             strict_updates=dict(
                 type='bool'
             ),
-            traffic_group=dict()
+            traffic_group=dict(),
+            partition=dict(
+                default='Common',
+                fallback=(env_fallback, ['F5_PARTITION'])
+            )
         )
-        self.f5_product_name = 'bigip'
-
-
-def cleanup_tokens(client):
-    try:
-        resource = client.api.shared.authz.tokens_s.token.load(
-            name=client.api.icrs.token
-        )
-        resource.delete()
-    except Exception:
-        pass
+        self.argument_spec = {}
+        self.argument_spec.update(f5_argument_spec)
+        self.argument_spec.update(argument_spec)
 
 
 def main():
     spec = ArgumentSpec()
 
-    client = AnsibleF5Client(
+    module = AnsibleModule(
         argument_spec=spec.argument_spec,
-        supports_check_mode=spec.supports_check_mode,
-        f5_product_name=spec.f5_product_name
+        supports_check_mode=spec.supports_check_mode
     )
+    if not HAS_F5SDK:
+        module.fail_json(msg="The python f5-sdk module is required")
 
     try:
-        if not HAS_F5SDK:
-            raise F5ModuleError("The python f5-sdk module is required")
-
-        mm = ModuleManager(client)
+        client = F5Client(**module.params)
+        mm = ModuleManager(module=module, client=client)
         results = mm.exec_module()
         cleanup_tokens(client)
-        client.module.exit_json(**results)
+        module.exit_json(**results)
     except F5ModuleError as e:
         cleanup_tokens(client)
-        client.module.fail_json(msg=str(e))
+        module.fail_json(msg=str(e))
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/network/f5/bigip_iapp_template.py
+++ b/lib/ansible/modules/network/f5/bigip_iapp_template.py
@@ -39,9 +39,7 @@ options:
         using it. This will not update the running service though. Use
         C(bigip_iapp_service) to do that. When C(no), will update the iApp
         only if there are no iApp services using the template.
-    choices:
-      - yes
-      - no
+    type: bool
   name:
     description:
       - The name of the iApp template that you want to delete. This option
@@ -65,9 +63,6 @@ options:
     description:
       - Device partition to manage resources on.
     default: Common
-notes:
-  - Requires the f5-sdk Python package on the host. This is as easy as pip
-    install f5-sdk.
 extends_documentation_fragment: f5
 author:
   - Tim Rupp (@caphrim007)
@@ -110,15 +105,40 @@ RETURN = r'''
 import re
 import uuid
 
-from ansible.module_utils.f5_utils import AnsibleF5Client
-from ansible.module_utils.f5_utils import AnsibleF5Parameters
-from ansible.module_utils.f5_utils import HAS_F5SDK
-from ansible.module_utils.f5_utils import F5ModuleError
-from ansible.module_utils.six import iteritems
-from collections import defaultdict
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import env_fallback
+
+HAS_DEVEL_IMPORTS = False
 
 try:
-    from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
+    # Sideband repository used for dev
+    from library.module_utils.network.f5.bigip import HAS_F5SDK
+    from library.module_utils.network.f5.bigip import F5Client
+    from library.module_utils.network.f5.common import F5ModuleError
+    from library.module_utils.network.f5.common import AnsibleF5Parameters
+    from library.module_utils.network.f5.common import cleanup_tokens
+    from library.module_utils.network.f5.common import fqdn_name
+    from library.module_utils.network.f5.common import f5_argument_spec
+    try:
+        from library.module_utils.network.f5.common import iControlUnexpectedHTTPError
+    except ImportError:
+        HAS_F5SDK = False
+    HAS_DEVEL_IMPORTS = True
+except ImportError:
+    # Upstream Ansible
+    from ansible.module_utils.network.f5.bigip import HAS_F5SDK
+    from ansible.module_utils.network.f5.bigip import F5Client
+    from ansible.module_utils.network.f5.common import F5ModuleError
+    from ansible.module_utils.network.f5.common import AnsibleF5Parameters
+    from ansible.module_utils.network.f5.common import cleanup_tokens
+    from ansible.module_utils.network.f5.common import fqdn_name
+    from ansible.module_utils.network.f5.common import f5_argument_spec
+    try:
+        from ansible.module_utils.network.f5.common import iControlUnexpectedHTTPError
+    except ImportError:
+        HAS_F5SDK = False
+
+try:
     from f5.utils.iapp_parser import NonextantTemplateNameException
 except ImportError:
     HAS_F5SDK = False
@@ -132,34 +152,6 @@ except ImportError:
 class Parameters(AnsibleF5Parameters):
     api_attributes = []
     returnables = []
-
-    def __init__(self, params=None):
-        self._values = defaultdict(lambda: None)
-        if params:
-            self.update(params=params)
-
-    def update(self, params=None):
-        if params:
-            for k, v in iteritems(params):
-                if self.api_map is not None and k in self.api_map:
-                    map_key = self.api_map[k]
-                else:
-                    map_key = k
-
-                # Handle weird API parameters like `dns.proxy.__iter__` by
-                # using a map provided by the module developer
-                class_attr = getattr(type(self), map_key, None)
-                if isinstance(class_attr, property):
-                    # There is a mapped value for the api_map key
-                    if class_attr.fset is None:
-                        # If the mapped value does not have an associated setter
-                        self._values[map_key] = v
-                    else:
-                        # The mapped value has a setter
-                        setattr(self, map_key, v)
-                else:
-                    # If the mapped value is not a @property
-                    self._values[map_key] = v
 
     @property
     def name(self):
@@ -196,16 +188,6 @@ class Parameters(AnsibleF5Parameters):
             result = self._filter_params(result)
         except Exception:
             pass
-        return result
-
-    def api_params(self):
-        result = {}
-        for api_attribute in self.api_attributes:
-            if self.api_map is not None and api_attribute in self.api_map:
-                result[api_attribute] = getattr(self, self.api_map[api_attribute])
-            else:
-                result[api_attribute] = getattr(self, api_attribute)
-        result = self._filter_params(result)
         return result
 
     def _squash_template_name_prefix(self):
@@ -252,9 +234,11 @@ class Parameters(AnsibleF5Parameters):
 
 
 class ModuleManager(object):
-    def __init__(self, client):
-        self.client = client
-        self.want = Parameters(self.client.module.params)
+    def __init__(self, *args, **kwargs):
+        self.module = kwargs.get('module', None)
+        self.client = kwargs.get('client', None)
+        self.have = None
+        self.want = Parameters(params=self.module.params)
         self.changes = Parameters()
 
     def exec_module(self):
@@ -290,7 +274,7 @@ class ModuleManager(object):
         if not self.want.force and self.template_in_use():
             return False
 
-        if self.client.check_mode:
+        if self.module.check_mode:
             return True
 
         self._remove_iapp_checksum()
@@ -314,7 +298,7 @@ class ModuleManager(object):
             partition=self.want.partition
         )
         result = resource.attrs
-        return Parameters(result)
+        return Parameters(params=result)
 
     def absent(self):
         changed = False
@@ -392,7 +376,7 @@ class ModuleManager(object):
         )
 
     def create(self):
-        if self.client.check_mode:
+        if self.module.check_mode:
             return True
         self.create_on_device()
         if self.exists():
@@ -419,7 +403,7 @@ class ModuleManager(object):
                 raise F5ModuleError(output.commandResult)
 
     def remove(self):
-        if self.client.check_mode:
+        if self.module.check_mode:
             return True
         self.remove_from_device()
         if self.exists():
@@ -437,7 +421,7 @@ class ModuleManager(object):
 class ArgumentSpec(object):
     def __init__(self):
         self.supports_check_mode = True
-        self.argument_spec = dict(
+        argument_spec = dict(
             name=dict(),
             state=dict(
                 default='present',
@@ -446,41 +430,36 @@ class ArgumentSpec(object):
             force=dict(
                 type='bool'
             ),
-            content=dict()
+            content=dict(),
+            partition=dict(
+                default='Common',
+                fallback=(env_fallback, ['F5_PARTITION'])
+            )
         )
-        self.f5_product_name = 'bigip'
-
-
-def cleanup_tokens(client):
-    try:
-        resource = client.api.shared.authz.tokens_s.token.load(
-            name=client.api.icrs.token
-        )
-        resource.delete()
-    except Exception:
-        pass
+        self.argument_spec = {}
+        self.argument_spec.update(f5_argument_spec)
+        self.argument_spec.update(argument_spec)
 
 
 def main():
     spec = ArgumentSpec()
 
-    client = AnsibleF5Client(
+    module = AnsibleModule(
         argument_spec=spec.argument_spec,
-        supports_check_mode=spec.supports_check_mode,
-        f5_product_name=spec.f5_product_name
+        supports_check_mode=spec.supports_check_mode
     )
+    if not HAS_F5SDK:
+        module.fail_json(msg="The python f5-sdk module is required")
 
     try:
-        if not HAS_F5SDK:
-            raise F5ModuleError("The python f5-sdk module is required")
-
-        mm = ModuleManager(client)
+        client = F5Client(**module.params)
+        mm = ModuleManager(module=module, client=client)
         results = mm.exec_module()
         cleanup_tokens(client)
-        client.module.exit_json(**results)
+        module.exit_json(**results)
     except F5ModuleError as e:
         cleanup_tokens(client)
-        client.module.fail_json(msg=str(e))
+        module.fail_json(msg=str(e))
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/network/f5/bigip_iapplx_package.py
+++ b/lib/ansible/modules/network/f5/bigip_iapplx_package.py
@@ -37,8 +37,6 @@ options:
       - present
       - absent
 notes:
-  - Requires the f5-sdk Python package on the host. This is as easy as pip
-    install f5-sdk.
   - Requires the rpm tool be installed on the host. This can be accomplished through
     different ways on each platform. On Debian based systems with C(apt);
     C(apt-get install rpm). On Mac with C(brew); C(brew install rpm).
@@ -46,7 +44,6 @@ notes:
   - Requires BIG-IP >= 12.1.0 because the required functionality is missing
     on versions earlier than that.
 requirements:
-  - f5-sdk >= 2.2.3
   - Requires BIG-IP >= 12.1.0
   - The 'rpm' tool installed on the Ansible controller
 extends_documentation_fragment: f5
@@ -91,16 +88,38 @@ import os
 import subprocess
 import time
 
-from ansible.module_utils.f5_utils import AnsibleF5Client
-from ansible.module_utils.f5_utils import AnsibleF5Parameters
-from ansible.module_utils.f5_utils import HAS_F5SDK
-from ansible.module_utils.f5_utils import F5ModuleError
 from distutils.version import LooseVersion
+from ansible.module_utils.basic import AnsibleModule
+
+HAS_DEVEL_IMPORTS = False
 
 try:
-    from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
+    # Sideband repository used for dev
+    from library.module_utils.network.f5.bigip import HAS_F5SDK
+    from library.module_utils.network.f5.bigip import F5Client
+    from library.module_utils.network.f5.common import F5ModuleError
+    from library.module_utils.network.f5.common import AnsibleF5Parameters
+    from library.module_utils.network.f5.common import cleanup_tokens
+    from library.module_utils.network.f5.common import fqdn_name
+    from library.module_utils.network.f5.common import f5_argument_spec
+    try:
+        from library.module_utils.network.f5.common import iControlUnexpectedHTTPError
+    except ImportError:
+        HAS_F5SDK = False
+    HAS_DEVEL_IMPORTS = True
 except ImportError:
-    HAS_F5SDK = False
+    # Upstream Ansible
+    from ansible.module_utils.network.f5.bigip import HAS_F5SDK
+    from ansible.module_utils.network.f5.bigip import F5Client
+    from ansible.module_utils.network.f5.common import F5ModuleError
+    from ansible.module_utils.network.f5.common import AnsibleF5Parameters
+    from ansible.module_utils.network.f5.common import cleanup_tokens
+    from ansible.module_utils.network.f5.common import fqdn_name
+    from ansible.module_utils.network.f5.common import f5_argument_spec
+    try:
+        from ansible.module_utils.network.f5.common import iControlUnexpectedHTTPError
+    except ImportError:
+        HAS_F5SDK = False
 
 
 class Parameters(AnsibleF5Parameters):
@@ -162,9 +181,10 @@ class Parameters(AnsibleF5Parameters):
 
 
 class ModuleManager(object):
-    def __init__(self, client):
-        self.client = client
-        self.want = Parameters(self.client.module.params)
+    def __init__(self, *args, **kwargs):
+        self.module = kwargs.get('module', None)
+        self.client = kwargs.get('client', None)
+        self.want = Parameters(params=self.module.params)
         self.changes = Parameters()
 
     def exec_module(self):
@@ -230,12 +250,17 @@ class ModuleManager(object):
         )
 
     def create(self):
-        if self.client.check_mode:
+        if self.module.check_mode:
             return True
         if not os.path.exists(self.want.package):
-            raise F5ModuleError(
-                "The specified iAppLX package was not found."
-            )
+            if self.want.package.startswith('/'):
+                raise F5ModuleError(
+                    "The specified iAppLX package was not found at {0}.".format(self.want.package)
+                )
+            else:
+                raise F5ModuleError(
+                    "The specified iAppLX package was not found in {0}.".format(os.getcwd())
+                )
         self.upload_to_device()
         self.create_on_device()
         self.enable_iapplx_on_device()
@@ -271,7 +296,7 @@ class ModuleManager(object):
             raise F5ModuleError(task.errorMessage)
 
     def remove(self):
-        if self.client.check_mode:
+        if self.module.check_mode:
             return True
         self.remove_from_device()
         if self.exists():
@@ -307,50 +332,42 @@ class ModuleManager(object):
 class ArgumentSpec(object):
     def __init__(self):
         self.supports_check_mode = True
-        self.argument_spec = dict(
+        argument_spec = dict(
             state=dict(
                 default='present',
                 choices=['present', 'absent']
             ),
             package=dict()
         )
-        self.f5_product_name = 'bigip'
+        self.argument_spec = {}
+        self.argument_spec.update(f5_argument_spec)
+        self.argument_spec.update(argument_spec)
         self.required_if = [
             ['state', 'present', ['package']]
         ]
 
 
-def cleanup_tokens(client):
-    try:
-        resource = client.api.shared.authz.tokens_s.token.load(
-            name=client.api.icrs.token
-        )
-        resource.delete()
-    except Exception:
-        pass
-
-
 def main():
-    if not HAS_F5SDK:
-        raise F5ModuleError("The python f5-sdk module is required")
-
     spec = ArgumentSpec()
 
-    client = AnsibleF5Client(
+    module = AnsibleModule(
         argument_spec=spec.argument_spec,
         supports_check_mode=spec.supports_check_mode,
-        f5_product_name=spec.f5_product_name,
         required_if=spec.required_if
     )
+    if not HAS_F5SDK:
+        module.fail_json(msg="The python f5-sdk module is required")
 
     try:
-        mm = ModuleManager(client)
+        client = F5Client(**module.params)
+        mm = ModuleManager(module=module, client=client)
         results = mm.exec_module()
         cleanup_tokens(client)
-        client.module.exit_json(**results)
+        module.exit_json(**results)
     except F5ModuleError as e:
         cleanup_tokens(client)
-        client.module.fail_json(msg=str(e))
+        module.fail_json(msg=str(e))
+
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/network/f5/bigip_irule.py
+++ b/lib/ansible/modules/network/f5/bigip_irule.py
@@ -54,12 +54,7 @@ options:
       - Device partition to manage resources on.
     default: Common
     version_added: 2.5
-notes:
-  - Requires the f5-sdk Python package on the host. This is as easy as
-    pip install f5-sdk.
 extends_documentation_fragment: f5
-requirements:
-  - f5-sdk
 author:
   - Tim Rupp (@caphrim007)
 '''
@@ -108,15 +103,38 @@ content:
 
 import os
 
-from ansible.module_utils.f5_utils import AnsibleF5Client
-from ansible.module_utils.f5_utils import AnsibleF5Parameters
-from ansible.module_utils.f5_utils import HAS_F5SDK
-from ansible.module_utils.f5_utils import F5ModuleError
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import env_fallback
+
+HAS_DEVEL_IMPORTS = False
 
 try:
-    from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
+    # Sideband repository used for dev
+    from library.module_utils.network.f5.bigip import HAS_F5SDK
+    from library.module_utils.network.f5.bigip import F5Client
+    from library.module_utils.network.f5.common import F5ModuleError
+    from library.module_utils.network.f5.common import AnsibleF5Parameters
+    from library.module_utils.network.f5.common import cleanup_tokens
+    from library.module_utils.network.f5.common import fqdn_name
+    from library.module_utils.network.f5.common import f5_argument_spec
+    try:
+        from library.module_utils.network.f5.common import iControlUnexpectedHTTPError
+    except ImportError:
+        HAS_F5SDK = False
+    HAS_DEVEL_IMPORTS = True
 except ImportError:
-    HAS_F5SDK = False
+    # Upstream Ansible
+    from ansible.module_utils.network.f5.bigip import HAS_F5SDK
+    from ansible.module_utils.network.f5.bigip import F5Client
+    from ansible.module_utils.network.f5.common import F5ModuleError
+    from ansible.module_utils.network.f5.common import AnsibleF5Parameters
+    from ansible.module_utils.network.f5.common import cleanup_tokens
+    from ansible.module_utils.network.f5.common import fqdn_name
+    from ansible.module_utils.network.f5.common import f5_argument_spec
+    try:
+        from ansible.module_utils.network.f5.common import iControlUnexpectedHTTPError
+    except ImportError:
+        HAS_F5SDK = False
 
 
 class Parameters(AnsibleF5Parameters):
@@ -146,16 +164,6 @@ class Parameters(AnsibleF5Parameters):
             pass
         return result
 
-    def api_params(self):
-        result = {}
-        for api_attribute in self.api_attributes:
-            if self.api_map is not None and api_attribute in self.api_map:
-                result[api_attribute] = getattr(self, self.api_map[api_attribute])
-            else:
-                result[api_attribute] = getattr(self, api_attribute)
-        result = self._filter_params(result)
-        return result
-
     @property
     def content(self):
         if self._values['content'] is None:
@@ -183,13 +191,15 @@ class Parameters(AnsibleF5Parameters):
 
 
 class ModuleManager(object):
-    def __init__(self, client):
-        self.client = client
+    def __init__(self, *args, **kwargs):
+        self.client = kwargs.get('client', None)
+        self.module = kwargs.get('module', None)
+        self.kwargs = kwargs
 
     def exec_module(self):
-        if self.client.module.params['module'] == 'ltm':
+        if self.module.params['module'] == 'ltm':
             manager = self.get_manager('ltm')
-        elif self.client.module.params['module'] == 'gtm':
+        elif self.module.params['module'] == 'gtm':
             manager = self.get_manager('gtm')
         else:
             raise F5ModuleError(
@@ -199,15 +209,16 @@ class ModuleManager(object):
 
     def get_manager(self, type):
         if type == 'ltm':
-            return LtmManager(self.client)
+            return LtmManager(**self.kwargs)
         elif type == 'gtm':
-            return GtmManager(self.client)
+            return GtmManager(**self.kwargs)
 
 
 class BaseManager(object):
-    def __init__(self, client):
-        self.client = client
-        self.want = Parameters(self.client.module.params)
+    def __init__(self, *args, **kwargs):
+        self.module = kwargs.get('module', None)
+        self.client = kwargs.get('client', None)
+        self.want = Parameters(params=self.module.params)
         self.changes = Parameters()
 
     def exec_module(self):
@@ -234,7 +245,7 @@ class BaseManager(object):
             if getattr(self.want, key) is not None:
                 changed[key] = getattr(self.want, key)
         if changed:
-            self.changes = Parameters(changed)
+            self.changes = Parameters(params=changed)
 
     def _update_changed_options(self):
         changed = {}
@@ -245,7 +256,7 @@ class BaseManager(object):
                 if attr1 != attr2:
                     changed[key] = attr1
         if changed:
-            self.changes = Parameters(changed)
+            self.changes = Parameters(params=changed)
             return True
         return False
 
@@ -261,7 +272,7 @@ class BaseManager(object):
 
     def create(self):
         self._set_changed_options()
-        if self.client.check_mode:
+        if self.module.check_mode:
             return True
         self.create_on_device()
         if not self.exists():
@@ -278,7 +289,7 @@ class BaseManager(object):
         self.have = self.read_current_from_device()
         if not self.should_update():
             return False
-        if self.client.check_mode:
+        if self.module.check_mode:
             return True
         self.update_on_device()
         return True
@@ -289,7 +300,7 @@ class BaseManager(object):
         return False
 
     def remove(self):
-        if self.client.check_mode:
+        if self.module.check_mode:
             return True
         self.remove_from_device()
         if self.exists():
@@ -328,7 +339,7 @@ class LtmManager(BaseManager):
             partition=self.want.partition
         )
         result = resource.attrs
-        return Parameters(result)
+        return Parameters(params=result)
 
     def remove_from_device(self):
         resource = self.client.api.tm.ltm.rules.rule.load(
@@ -345,7 +356,7 @@ class GtmManager(BaseManager):
             partition=self.want.partition
         )
         result = resource.attrs
-        return Parameters(result)
+        return Parameters(params=result)
 
     def remove_from_device(self):
         resource = self.client.api.tm.gtm.rules.rule.load(
@@ -382,7 +393,7 @@ class GtmManager(BaseManager):
 class ArgumentSpec(object):
     def __init__(self):
         self.supports_check_mode = True
-        self.argument_spec = dict(
+        argument_spec = dict(
             content=dict(
                 required=False,
                 default=None
@@ -395,45 +406,44 @@ class ArgumentSpec(object):
             module=dict(
                 required=True,
                 choices=['gtm', 'ltm']
+            ),
+            state=dict(
+                default='present',
+                choices=['present', 'absent']
+            ),
+            partition=dict(
+                default='Common',
+                fallback=(env_fallback, ['F5_PARTITION'])
             )
         )
+        self.argument_spec = {}
+        self.argument_spec.update(f5_argument_spec)
+        self.argument_spec.update(argument_spec)
         self.mutually_exclusive = [
             ['content', 'src']
         ]
-        self.f5_product_name = 'bigip'
-
-
-def cleanup_tokens(client):
-    try:
-        resource = client.api.shared.authz.tokens_s.token.load(
-            name=client.api.icrs.token
-        )
-        resource.delete()
-    except Exception:
-        pass
 
 
 def main():
     spec = ArgumentSpec()
 
-    client = AnsibleF5Client(
+    module = AnsibleModule(
         argument_spec=spec.argument_spec,
         supports_check_mode=spec.supports_check_mode,
-        f5_product_name=spec.f5_product_name,
-        mutually_exclusive=spec.mutually_exclusive,
+        mutually_exclusive=spec.mutually_exclusive
     )
+    if not HAS_F5SDK:
+        module.fail_json(msg="The python f5-sdk module is required")
 
     try:
-        if not HAS_F5SDK:
-            raise F5ModuleError("The python f5-sdk module is required")
-
-        mm = ModuleManager(client)
+        client = F5Client(**module.params)
+        mm = ModuleManager(module=module, client=client)
         results = mm.exec_module()
         cleanup_tokens(client)
-        client.module.exit_json(**results)
+        module.exit_json(**results)
     except F5ModuleError as e:
         cleanup_tokens(client)
-        client.module.fail_json(msg=str(e))
+        module.fail_json(msg=str(e))
 
 
 if __name__ == '__main__':

--- a/test/sanity/validate-modules/ignore.txt
+++ b/test/sanity/validate-modules/ignore.txt
@@ -41,13 +41,6 @@ lib/ansible/modules/net_tools/cloudflare_dns.py E317
 lib/ansible/modules/net_tools/haproxy.py E317
 lib/ansible/modules/net_tools/omapi_host.py E317
 lib/ansible/modules/network/cloudengine/ce_reboot.py E317
-lib/ansible/modules/network/f5/bigip_gtm_datacenter.py E321
-lib/ansible/modules/network/f5/bigip_gtm_facts.py E321
-lib/ansible/modules/network/f5/bigip_gtm_pool.py E321
-lib/ansible/modules/network/f5/bigip_gtm_server.py E321
-lib/ansible/modules/network/f5/bigip_gtm_wide_ip.py E321
-lib/ansible/modules/network/f5/bigip_hostname.py E317
-lib/ansible/modules/network/f5/bigip_iapplx_package.py E321
 lib/ansible/modules/network/f5/bigip_partition.py E321
 lib/ansible/modules/network/f5/bigip_policy.py E321
 lib/ansible/modules/network/f5/bigip_policy_rule.py E321

--- a/test/units/modules/network/f5/test_bigip_gtm_facts.py
+++ b/test/units/modules/network/f5/test_bigip_gtm_facts.py
@@ -17,7 +17,7 @@ if sys.version_info < (2, 7):
 from ansible.compat.tests import unittest
 from ansible.compat.tests.mock import Mock
 from ansible.compat.tests.mock import patch
-from ansible.module_utils.f5_utils import AnsibleF5Client
+from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six import iteritems
 
 try:
@@ -34,7 +34,8 @@ try:
     from library.bigip_gtm_facts import TypedWideIpFactManager
     from library.bigip_gtm_facts import UntypedWideIpFactManager
     from library.bigip_gtm_facts import ArgumentSpec
-    from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
+    from library.module_utils.network.f5.common import F5ModuleError
+    from library.module_utils.network.f5.common import iControlUnexpectedHTTPError
     from f5.bigip.tm.gtm.pool import A
     from f5.utils.responses.handlers import Stats
     from test.unit.modules.utils import set_module_args
@@ -53,7 +54,8 @@ except ImportError:
         from ansible.modules.network.f5.bigip_gtm_pool import TypedWideIpFactManager
         from ansible.modules.network.f5.bigip_gtm_pool import UntypedWideIpFactManager
         from ansible.modules.network.f5.bigip_gtm_pool import ArgumentSpec
-        from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
+        from ansible.module_utils.network.f5.common import F5ModuleError
+        from ansible.module_utils.network.f5.common import iControlUnexpectedHTTPError
         from f5.bigip.tm.gtm.pool import A
         from f5.utils.responses.handlers import Stats
         from units.modules.utils import set_module_args
@@ -100,13 +102,11 @@ class TestParameters(unittest.TestCase):
             include=['pool'],
             filter='name.*'
         )
-        p = Parameters(args)
+        p = Parameters(params=args)
         assert p.include == ['pool']
         assert p.filter == 'name.*'
 
 
-@patch('ansible.module_utils.f5_utils.AnsibleF5Client._get_mgmt_root',
-       return_value=True)
 class TestManager(unittest.TestCase):
 
     def setUp(self):
@@ -125,23 +125,22 @@ class TestManager(unittest.TestCase):
         collection = [FakeARecord(attrs=x) for x in fixture1['items']]
         stats = Stats(FakeStatResource(fixture2['entries']))
 
-        client = AnsibleF5Client(
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
 
         # Override methods in the specific type of manager
-        tfm = TypedPoolFactManager(client)
+        tfm = TypedPoolFactManager(module=module)
         tfm.read_collection_from_device = Mock(return_value=collection)
         tfm.read_stats_from_device = Mock(return_value=stats.stat)
 
-        tm = PoolFactManager(client)
+        tm = PoolFactManager(module=module)
         tm.version_is_less_than_12 = Mock(return_value=False)
         tm.get_manager = Mock(return_value=tfm)
 
         # Override methods to force specific logic in the module to happen
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.get_manager = Mock(return_value=tm)
         mm.gtm_provisioned = Mock(return_value=True)
 

--- a/test/units/modules/network/f5/test_bigip_gtm_server.py
+++ b/test/units/modules/network/f5/test_bigip_gtm_server.py
@@ -18,8 +18,7 @@ if sys.version_info < (2, 7):
 from ansible.compat.tests import unittest
 from ansible.compat.tests.mock import Mock
 from ansible.compat.tests.mock import patch
-from ansible.module_utils.f5_utils import AnsibleF5Client
-from ansible.module_utils.f5_utils import F5ModuleError
+from ansible.module_utils.basic import AnsibleModule
 
 try:
     from library.bigip_gtm_server import ApiParameters
@@ -28,7 +27,8 @@ try:
     from library.bigip_gtm_server import V1Manager
     from library.bigip_gtm_server import V2Manager
     from library.bigip_gtm_server import ArgumentSpec
-    from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
+    from library.module_utils.network.f5.common import F5ModuleError
+    from library.module_utils.network.f5.common import iControlUnexpectedHTTPError
     from test.unit.modules.utils import set_module_args
 except ImportError:
     try:
@@ -38,7 +38,8 @@ except ImportError:
         from ansible.modules.network.f5.bigip_gtm_server import V1Manager
         from ansible.modules.network.f5.bigip_gtm_server import V2Manager
         from ansible.modules.network.f5.bigip_gtm_server import ArgumentSpec
-        from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
+        from ansible.module_utils.network.f5.common import F5ModuleError
+        from ansible.module_utils.network.f5.common import iControlUnexpectedHTTPError
         from units.modules.utils import set_module_args
     except ImportError:
         raise SkipTest("F5 Ansible modules require the f5-sdk Python library")
@@ -114,7 +115,7 @@ class TestParameters(unittest.TestCase):
             ]
         )
 
-        p = ModuleParameters(args)
+        p = ModuleParameters(params=args)
         assert p.name == 'GTM_Server'
         assert p.datacenter == '/Common/New York'
         assert p.server_type == 'bigip'
@@ -124,7 +125,7 @@ class TestParameters(unittest.TestCase):
     def test_api_parameters(self):
         args = load_fixture('load_gtm_server_1.json')
 
-        p = ApiParameters(args)
+        p = ApiParameters(params=args)
         assert p.name == 'baz'
         assert p.datacenter == '/Common/foo'
         assert p.server_type == 'bigip'
@@ -132,8 +133,6 @@ class TestParameters(unittest.TestCase):
         assert p.virtual_server_discovery == 'disabled'
 
 
-@patch('ansible.module_utils.f5_utils.AnsibleF5Client._get_mgmt_root',
-       return_value=True)
 class TestV1Manager(unittest.TestCase):
 
     def setUp(self):
@@ -189,18 +188,17 @@ class TestV1Manager(unittest.TestCase):
             ]
         ))
 
-        client = AnsibleF5Client(
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
 
-        m1 = V1Manager(client)
+        m1 = V1Manager(module=module, params=module.params)
         m1.exists = Mock(side_effect=[False, True])
         m1.create_on_device = Mock(return_value=True)
 
         # Override methods in the specific type of manager
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.get_manager = Mock(return_value=m1)
         mm.version_is_less_than = Mock(return_value=True)
         mm.gtm_provisioned = Mock(return_value=True)
@@ -211,8 +209,6 @@ class TestV1Manager(unittest.TestCase):
         assert results['server_type'] == 'bigip'
 
 
-@patch('ansible.module_utils.f5_utils.AnsibleF5Client._get_mgmt_root',
-       return_value=True)
 class TestV2Manager(unittest.TestCase):
 
     def setUp(self):
@@ -268,18 +264,17 @@ class TestV2Manager(unittest.TestCase):
             ]
         ))
 
-        client = AnsibleF5Client(
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
 
-        m1 = V2Manager(client)
+        m1 = V2Manager(module=module)
         m1.exists = Mock(side_effect=[False, True])
         m1.create_on_device = Mock(return_value=True)
 
         # Override methods in the specific type of manager
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.get_manager = Mock(return_value=m1)
         mm.version_is_less_than = Mock(return_value=False)
         mm.gtm_provisioned = Mock(return_value=True)

--- a/test/units/modules/network/f5/test_bigip_gtm_wide_ip.py
+++ b/test/units/modules/network/f5/test_bigip_gtm_wide_ip.py
@@ -18,8 +18,7 @@ if sys.version_info < (2, 7):
 from ansible.compat.tests import unittest
 from ansible.compat.tests.mock import Mock
 from ansible.compat.tests.mock import patch
-from ansible.module_utils.f5_utils import AnsibleF5Client
-from ansible.module_utils.f5_utils import F5ModuleError
+from ansible.module_utils.basic import AnsibleModule
 
 try:
     from library.bigip_gtm_wide_ip import ApiParameters
@@ -28,7 +27,8 @@ try:
     from library.bigip_gtm_wide_ip import ArgumentSpec
     from library.bigip_gtm_wide_ip import UntypedManager
     from library.bigip_gtm_wide_ip import TypedManager
-    from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
+    from library.module_utils.network.f5.common import F5ModuleError
+    from library.module_utils.network.f5.common import iControlUnexpectedHTTPError
     from test.unit.modules.utils import set_module_args
 except ImportError:
     try:
@@ -38,7 +38,8 @@ except ImportError:
         from ansible.modules.network.f5.bigip_gtm_wide_ip import ArgumentSpec
         from ansible.modules.network.f5.bigip_gtm_wide_ip import UntypedManager
         from ansible.modules.network.f5.bigip_gtm_wide_ip import TypedManager
-        from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
+        from ansible.module_utils.network.f5.common import F5ModuleError
+        from ansible.module_utils.network.f5.common import iControlUnexpectedHTTPError
         from units.modules.utils import set_module_args
     except ImportError:
         raise SkipTest("F5 Ansible modules require the f5-sdk Python library")
@@ -71,7 +72,7 @@ class TestParameters(unittest.TestCase):
             name='foo.baz.bar',
             lb_method='round-robin',
         )
-        p = ModuleParameters(args)
+        p = ModuleParameters(params=args)
         assert p.name == 'foo.baz.bar'
         assert p.pool_lb_method == 'round-robin'
 
@@ -84,7 +85,7 @@ class TestParameters(unittest.TestCase):
                 )
             ]
         )
-        p = ModuleParameters(args)
+        p = ModuleParameters(params=args)
         assert len(p.pools) == 1
 
     def test_api_parameters(self):
@@ -92,13 +93,13 @@ class TestParameters(unittest.TestCase):
             name='foo.baz.bar',
             poolLbMode='round-robin'
         )
-        p = ApiParameters(args)
+        p = ApiParameters(params=args)
         assert p.name == 'foo.baz.bar'
         assert p.pool_lb_method == 'round-robin'
 
     def test_api_pools(self):
         args = load_fixture('load_gtm_wide_ip_with_pools.json')
-        p = ApiParameters(args)
+        p = ApiParameters(params=args)
         assert len(p.pools) == 1
         assert 'name' in p.pools[0]
         assert 'ratio' in p.pools[0]
@@ -111,13 +112,11 @@ class TestParameters(unittest.TestCase):
             lb_method='round-robin'
         )
         with pytest.raises(F5ModuleError) as excinfo:
-            p = ModuleParameters(args)
+            p = ModuleParameters(params=args)
             assert p.name == 'foo.baz'
         assert 'The provided name must be a valid FQDN' in str(excinfo)
 
 
-@patch('ansible.module_utils.f5_utils.AnsibleF5Client._get_mgmt_root',
-       return_value=True)
 class TestUntypedManager(unittest.TestCase):
 
     def setUp(self):
@@ -132,19 +131,18 @@ class TestUntypedManager(unittest.TestCase):
             user='admin'
         ))
 
-        client = AnsibleF5Client(
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
 
         # Override methods in the specific type of manager
-        tm = UntypedManager(client)
+        tm = UntypedManager(module=module, params=module.params)
         tm.exists = Mock(return_value=False)
         tm.create_on_device = Mock(return_value=True)
 
         # Override methods to force specific logic in the module to happen
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.version_is_less_than_12 = Mock(return_value=True)
         mm.get_manager = Mock(return_value=tm)
 
@@ -156,8 +154,6 @@ class TestUntypedManager(unittest.TestCase):
         assert results['lb_method'] == 'round-robin'
 
 
-@patch('ansible.module_utils.f5_utils.AnsibleF5Client._get_mgmt_root',
-       return_value=True)
 class TestTypedManager(unittest.TestCase):
 
     def setUp(self):
@@ -173,19 +169,18 @@ class TestTypedManager(unittest.TestCase):
             user='admin'
         ))
 
-        client = AnsibleF5Client(
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
 
         # Override methods in the specific type of manager
-        tm = TypedManager(client)
+        tm = TypedManager(module=module, params=module.params)
         tm.exists = Mock(return_value=False)
         tm.create_on_device = Mock(return_value=True)
 
         # Override methods to force specific logic in the module to happen
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.version_is_less_than_12 = Mock(return_value=False)
         mm.get_manager = Mock(return_value=tm)
 
@@ -206,19 +201,18 @@ class TestTypedManager(unittest.TestCase):
             user='admin'
         ))
 
-        client = AnsibleF5Client(
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
 
         # Override methods in the specific type of manager
-        tm = TypedManager(client)
+        tm = TypedManager(module=module, params=module.params)
         tm.exists = Mock(return_value=False)
         tm.create_on_device = Mock(return_value=True)
 
         # Override methods to force specific logic in the module to happen
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.version_is_less_than_12 = Mock(return_value=False)
         mm.get_manager = Mock(return_value=tm)
 
@@ -239,19 +233,18 @@ class TestTypedManager(unittest.TestCase):
             user='admin'
         ))
 
-        client = AnsibleF5Client(
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
 
         # Override methods in the specific type of manager
-        tm = TypedManager(client)
+        tm = TypedManager(module=module, params=module.params)
         tm.exists = Mock(return_value=False)
         tm.create_on_device = Mock(return_value=True)
 
         # Override methods to force specific logic in the module to happen
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.version_is_less_than_12 = Mock(return_value=False)
         mm.get_manager = Mock(return_value=tm)
 
@@ -278,19 +271,18 @@ class TestTypedManager(unittest.TestCase):
             user='admin'
         ))
 
-        client = AnsibleF5Client(
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
 
         # Override methods in the specific type of manager
-        tm = TypedManager(client)
+        tm = TypedManager(module=module, params=module.params)
         tm.exists = Mock(return_value=False)
         tm.create_on_device = Mock(return_value=True)
 
         # Override methods to force specific logic in the module to happen
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.version_is_less_than_12 = Mock(return_value=False)
         mm.get_manager = Mock(return_value=tm)
 
@@ -317,20 +309,19 @@ class TestTypedManager(unittest.TestCase):
             user='admin'
         ))
 
-        current = ApiParameters(load_fixture('load_gtm_wide_ip_with_pools.json'))
-        client = AnsibleF5Client(
+        current = ApiParameters(params=load_fixture('load_gtm_wide_ip_with_pools.json'))
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
 
         # Override methods in the specific type of manager
-        tm = TypedManager(client)
+        tm = TypedManager(module=module, params=module.params)
         tm.exists = Mock(return_value=True)
         tm.read_current_from_device = Mock(return_value=current)
 
         # Override methods to force specific logic in the module to happen
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.version_is_less_than_12 = Mock(return_value=False)
         mm.get_manager = Mock(return_value=tm)
 
@@ -358,21 +349,20 @@ class TestTypedManager(unittest.TestCase):
             user='admin'
         ))
 
-        current = ApiParameters(load_fixture('load_gtm_wide_ip_with_pools.json'))
-        client = AnsibleF5Client(
+        current = ApiParameters(params=load_fixture('load_gtm_wide_ip_with_pools.json'))
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
 
         # Override methods in the specific type of manager
-        tm = TypedManager(client)
+        tm = TypedManager(module=module, params=module.params)
         tm.exists = Mock(return_value=True)
         tm.read_current_from_device = Mock(return_value=current)
         tm.update_on_device = Mock(return_value=True)
 
         # Override methods to force specific logic in the module to happen
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.version_is_less_than_12 = Mock(return_value=False)
         mm.get_manager = Mock(return_value=tm)
 

--- a/test/units/modules/network/f5/test_bigip_hostname.py
+++ b/test/units/modules/network/f5/test_bigip_hostname.py
@@ -17,20 +17,22 @@ if sys.version_info < (2, 7):
 from ansible.compat.tests import unittest
 from ansible.compat.tests.mock import Mock
 from ansible.compat.tests.mock import patch
-from ansible.module_utils.f5_utils import AnsibleF5Client
+from ansible.module_utils.basic import AnsibleModule
 
 try:
     from library.bigip_hostname import Parameters
     from library.bigip_hostname import ModuleManager
     from library.bigip_hostname import ArgumentSpec
-    from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
+    from library.module_utils.network.f5.common import F5ModuleError
+    from library.module_utils.network.f5.common import iControlUnexpectedHTTPError
     from test.unit.modules.utils import set_module_args
 except ImportError:
     try:
         from ansible.modules.network.f5.bigip_hostname import Parameters
         from ansible.modules.network.f5.bigip_hostname import ModuleManager
         from ansible.modules.network.f5.bigip_hostname import ArgumentSpec
-        from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
+        from ansible.module_utils.network.f5.common import F5ModuleError
+        from ansible.module_utils.network.f5.common import iControlUnexpectedHTTPError
         from units.modules.utils import set_module_args
     except ImportError:
         raise SkipTest("F5 Ansible modules require the f5-sdk Python library")
@@ -62,12 +64,10 @@ class TestParameters(unittest.TestCase):
         args = dict(
             hostname='foo.internal.com'
         )
-        p = Parameters(args)
+        p = Parameters(params=args)
         assert p.hostname == 'foo.internal.com'
 
 
-@patch('ansible.module_utils.f5_utils.AnsibleF5Client._get_mgmt_root',
-       return_value=True)
 class TestManager(unittest.TestCase):
 
     def setUp(self):
@@ -88,14 +88,13 @@ class TestManager(unittest.TestCase):
                 hostname='foo.internal.com'
             )
         )
-        client = AnsibleF5Client(
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
 
         # Override methods to force specific logic in the module to happen
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.update_on_device = Mock(return_value=True)
         mm.read_current_from_device = Mock(return_value=current)
 

--- a/test/units/modules/network/f5/test_bigip_iapp_service.py
+++ b/test/units/modules/network/f5/test_bigip_iapp_service.py
@@ -17,20 +17,22 @@ if sys.version_info < (2, 7):
 from ansible.compat.tests import unittest
 from ansible.compat.tests.mock import Mock
 from ansible.compat.tests.mock import patch
-from ansible.module_utils.f5_utils import AnsibleF5Client
+from ansible.module_utils.basic import AnsibleModule
 
 try:
     from library.bigip_iapp_service import Parameters
     from library.bigip_iapp_service import ModuleManager
     from library.bigip_iapp_service import ArgumentSpec
-    from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
+    from library.module_utils.network.f5.common import F5ModuleError
+    from library.module_utils.network.f5.common import iControlUnexpectedHTTPError
     from test.unit.modules.utils import set_module_args
 except ImportError:
     try:
         from ansible.modules.network.f5.bigip_iapp_service import Parameters
         from ansible.modules.network.f5.bigip_iapp_service import ModuleManager
         from ansible.modules.network.f5.bigip_iapp_service import ArgumentSpec
-        from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
+        from ansible.module_utils.network.f5.common import F5ModuleError
+        from ansible.module_utils.network.f5.common import iControlUnexpectedHTTPError
         from units.modules.utils import set_module_args
     except ImportError:
         raise SkipTest("F5 Ansible modules require the f5-sdk Python library")
@@ -61,7 +63,7 @@ class TestParameters(unittest.TestCase):
 
     def test_module_parameters_keys(self):
         args = load_fixture('create_iapp_service_parameters_f5_http.json')
-        p = Parameters(args)
+        p = Parameters(params=args)
 
         # Assert the top-level keys
         assert p.name == 'http_example'
@@ -74,7 +76,7 @@ class TestParameters(unittest.TestCase):
 
     def test_module_parameters_lists(self):
         args = load_fixture('create_iapp_service_parameters_f5_http.json')
-        p = Parameters(args)
+        p = Parameters(params=args)
 
         assert 'lists' in p._values
 
@@ -90,7 +92,7 @@ class TestParameters(unittest.TestCase):
 
     def test_module_parameters_tables(self):
         args = load_fixture('create_iapp_service_parameters_f5_http.json')
-        p = Parameters(args)
+        p = Parameters(params=args)
 
         assert 'tables' in p._values
 
@@ -117,7 +119,7 @@ class TestParameters(unittest.TestCase):
 
     def test_module_parameters_variables(self):
         args = load_fixture('create_iapp_service_parameters_f5_http.json')
-        p = Parameters(args)
+        p = Parameters(params=args)
 
         assert 'variables' in p._values
         assert len(p.variables) == 34
@@ -140,13 +142,13 @@ class TestParameters(unittest.TestCase):
         args = dict(
             strict_updates=True
         )
-        p = Parameters(args)
+        p = Parameters(params=args)
         assert p.strict_updates == 'enabled'
 
         args = dict(
             strict_updates=False
         )
-        p = Parameters(args)
+        p = Parameters(params=args)
         assert p.strict_updates == 'disabled'
 
     def test_module_strict_updates_override_from_top_level(self):
@@ -156,7 +158,7 @@ class TestParameters(unittest.TestCase):
                 strictUpdates='disabled'
             )
         )
-        p = Parameters(args)
+        p = Parameters(params=args)
         assert p.strict_updates == 'enabled'
 
         args = dict(
@@ -165,7 +167,7 @@ class TestParameters(unittest.TestCase):
                 strictUpdates='enabled'
             )
         )
-        p = Parameters(args)
+        p = Parameters(params=args)
         assert p.strict_updates == 'disabled'
 
     def test_module_strict_updates_only_parameters(self):
@@ -174,7 +176,7 @@ class TestParameters(unittest.TestCase):
                 strictUpdates='disabled'
             )
         )
-        p = Parameters(args)
+        p = Parameters(params=args)
         assert p.strict_updates == 'disabled'
 
         args = dict(
@@ -182,20 +184,20 @@ class TestParameters(unittest.TestCase):
                 strictUpdates='enabled'
             )
         )
-        p = Parameters(args)
+        p = Parameters(params=args)
         assert p.strict_updates == 'enabled'
 
     def test_api_strict_updates_from_top_level(self):
         args = dict(
             strictUpdates='enabled'
         )
-        p = Parameters(args)
+        p = Parameters(params=args)
         assert p.strict_updates == 'enabled'
 
         args = dict(
             strictUpdates='disabled'
         )
-        p = Parameters(args)
+        p = Parameters(params=args)
         assert p.strict_updates == 'disabled'
 
     def test_api_parameters_variables(self):
@@ -208,7 +210,7 @@ class TestParameters(unittest.TestCase):
                 )
             ]
         )
-        p = Parameters(args)
+        p = Parameters(params=args)
         assert p.variables[0]['name'] == 'client__http_compression'
 
     def test_api_parameters_tables(self):
@@ -240,7 +242,7 @@ class TestParameters(unittest.TestCase):
                 }
             ]
         )
-        p = Parameters(args)
+        p = Parameters(params=args)
         assert p.tables[0]['name'] == 'pool__members'
         assert p.tables[0]['columnNames'] == ['addr', 'port', 'connection_limit']
         assert len(p.tables[0]['rows']) == 2
@@ -253,28 +255,28 @@ class TestParameters(unittest.TestCase):
         args = dict(
             deviceGroup='none'
         )
-        p = Parameters(args)
+        p = Parameters(params=args)
         assert p.deviceGroup == 'none'
 
     def test_api_parameters_inherited_traffic_group(self):
         args = dict(
             inheritedTrafficGroup='true'
         )
-        p = Parameters(args)
+        p = Parameters(params=args)
         assert p.inheritedTrafficGroup == 'true'
 
     def test_api_parameters_inherited_devicegroup(self):
         args = dict(
             inheritedDevicegroup='true'
         )
-        p = Parameters(args)
+        p = Parameters(params=args)
         assert p.inheritedDevicegroup == 'true'
 
     def test_api_parameters_traffic_group(self):
         args = dict(
             trafficGroup='/Common/traffic-group-local-only'
         )
-        p = Parameters(args)
+        p = Parameters(params=args)
         assert p.traffic_group == '/Common/traffic-group-local-only'
 
     def test_module_template_same_partition(self):
@@ -282,7 +284,7 @@ class TestParameters(unittest.TestCase):
             template='foo',
             partition='bar'
         )
-        p = Parameters(args)
+        p = Parameters(params=args)
         assert p.template == '/bar/foo'
 
     def test_module_template_same_partition_full_path(self):
@@ -290,7 +292,7 @@ class TestParameters(unittest.TestCase):
             template='/bar/foo',
             partition='bar'
         )
-        p = Parameters(args)
+        p = Parameters(params=args)
         assert p.template == '/bar/foo'
 
     def test_module_template_different_partition_full_path(self):
@@ -298,12 +300,10 @@ class TestParameters(unittest.TestCase):
             template='/Common/foo',
             partition='bar'
         )
-        p = Parameters(args)
+        p = Parameters(params=args)
         assert p.template == '/Common/foo'
 
 
-@patch('ansible.module_utils.f5_utils.AnsibleF5Client._get_mgmt_root',
-       return_value=True)
 class TestManager(unittest.TestCase):
 
     def setUp(self):
@@ -321,12 +321,11 @@ class TestManager(unittest.TestCase):
             user='admin'
         ))
 
-        client = AnsibleF5Client(
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
 
         # Override methods to force specific logic in the module to happen
         mm.exists = Mock(return_value=False)
@@ -352,12 +351,11 @@ class TestManager(unittest.TestCase):
         parameters = load_fixture('create_iapp_service_parameters_f5_http.json')
         current = Parameters(parameters)
 
-        client = AnsibleF5Client(
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
 
         # Override methods to force specific logic in the module to happen
         mm.exists = Mock(return_value=True)

--- a/test/units/modules/network/f5/test_bigip_iapp_template.py
+++ b/test/units/modules/network/f5/test_bigip_iapp_template.py
@@ -17,20 +17,22 @@ if sys.version_info < (2, 7):
 from ansible.compat.tests import unittest
 from ansible.compat.tests.mock import Mock
 from ansible.compat.tests.mock import patch
-from ansible.module_utils.f5_utils import AnsibleF5Client
+from ansible.module_utils.basic import AnsibleModule
 
 try:
     from library.bigip_iapp_template import Parameters
     from library.bigip_iapp_template import ModuleManager
     from library.bigip_iapp_template import ArgumentSpec
-    from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
+    from library.module_utils.network.f5.common import F5ModuleError
+    from library.module_utils.network.f5.common import iControlUnexpectedHTTPError
     from test.unit.modules.utils import set_module_args
 except ImportError:
     try:
         from ansible.modules.network.f5.bigip_iapp_template import Parameters
         from ansible.modules.network.f5.bigip_iapp_template import ArgumentSpec
         from ansible.modules.network.f5.bigip_iapp_template import ModuleManager
-        from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
+        from ansible.module_utils.network.f5.common import F5ModuleError
+        from ansible.module_utils.network.f5.common import iControlUnexpectedHTTPError
         from units.modules.utils import set_module_args
     except ImportError:
         raise SkipTest("F5 Ansible modules require the f5-sdk Python library")
@@ -63,12 +65,10 @@ class TestParameters(unittest.TestCase):
         args = dict(
             content=iapp
         )
-        p = Parameters(args)
+        p = Parameters(params=args)
         assert p.name == 'foo.iapp'
 
 
-@patch('ansible.module_utils.f5_utils.AnsibleF5Client._get_mgmt_root',
-       return_value=True)
 class TestManager(unittest.TestCase):
 
     def setUp(self):
@@ -83,12 +83,11 @@ class TestManager(unittest.TestCase):
             user='admin'
         ))
 
-        client = AnsibleF5Client(
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
 
         # Override methods to force specific logic in the module to happen
         mm.exists = Mock(side_effect=[False, True])
@@ -107,14 +106,13 @@ class TestManager(unittest.TestCase):
             user='admin'
         ))
 
-        current1 = Parameters(load_fixture('load_sys_application_template_w_new_checksum.json'))
-        current2 = Parameters(load_fixture('load_sys_application_template_w_old_checksum.json'))
-        client = AnsibleF5Client(
+        current1 = Parameters(params=load_fixture('load_sys_application_template_w_new_checksum.json'))
+        current2 = Parameters(params=load_fixture('load_sys_application_template_w_old_checksum.json'))
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
 
         # Override methods to force specific logic in the module to happen
         mm.exists = Mock(side_effect=[True, True])
@@ -138,12 +136,11 @@ class TestManager(unittest.TestCase):
             state='absent'
         ))
 
-        client = AnsibleF5Client(
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
 
         # Override methods to force specific logic in the module to happen
         mm.exists = Mock(side_effect=[True, False])
@@ -162,12 +159,11 @@ class TestManager(unittest.TestCase):
             state='absent'
         ))
 
-        client = AnsibleF5Client(
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
 
         # Override methods to force specific logic in the module to happen
         mm.exists = Mock(side_effect=[False, False])

--- a/test/units/modules/network/f5/test_bigip_iapplx_package.py
+++ b/test/units/modules/network/f5/test_bigip_iapplx_package.py
@@ -17,20 +17,22 @@ if sys.version_info < (2, 7):
 from ansible.compat.tests import unittest
 from ansible.compat.tests.mock import Mock
 from ansible.compat.tests.mock import patch
-from ansible.module_utils.f5_utils import AnsibleF5Client
+from ansible.module_utils.basic import AnsibleModule
 
 try:
     from library.bigip_iapp_template import Parameters
     from library.bigip_iapp_template import ModuleManager
     from library.bigip_iapp_template import ArgumentSpec
-    from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
+    from library.module_utils.network.f5.common import F5ModuleError
+    from library.module_utils.network.f5.common import iControlUnexpectedHTTPError
     from test.unit.modules.utils import set_module_args
 except ImportError:
     try:
         from ansible.modules.network.f5.bigip_iapp_template import Parameters
         from ansible.modules.network.f5.bigip_iapp_template import ArgumentSpec
         from ansible.modules.network.f5.bigip_iapp_template import ModuleManager
-        from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
+        from ansible.module_utils.network.f5.common import F5ModuleError
+        from ansible.module_utils.network.f5.common import iControlUnexpectedHTTPError
         from units.modules.utils import set_module_args
     except ImportError:
         raise SkipTest("F5 Ansible modules require the f5-sdk Python library")
@@ -63,12 +65,10 @@ class TestParameters(unittest.TestCase):
             package='MyApp-0.1.0-0001.noarch.rpm',
             state='present'
         )
-        p = Parameters(args)
+        p = Parameters(params=args)
         assert p.package == 'MyApp-0.1.0-0001.noarch.rpm'
 
 
-@patch('ansible.module_utils.f5_utils.AnsibleF5Client._get_mgmt_root',
-       return_value=True)
 class TestManager(unittest.TestCase):
 
     def setUp(self):
@@ -84,12 +84,11 @@ class TestManager(unittest.TestCase):
             user='admin'
         ))
 
-        client = AnsibleF5Client(
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
 
         # Override methods to force specific logic in the module to happen
         mm.exists = Mock(side_effect=[False, True])

--- a/test/units/modules/network/f5/test_bigip_irule.py
+++ b/test/units/modules/network/f5/test_bigip_irule.py
@@ -18,7 +18,7 @@ from ansible.compat.tests import unittest
 from ansible.compat.tests.mock import Mock
 from ansible.compat.tests.mock import patch
 from ansible.compat.tests.mock import mock_open
-from ansible.module_utils.f5_utils import AnsibleF5Client
+from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six import PY3
 
 try:
@@ -27,7 +27,8 @@ try:
     from library.bigip_irule import ArgumentSpec
     from library.bigip_irule import GtmManager
     from library.bigip_irule import LtmManager
-    from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
+    from library.module_utils.network.f5.common import F5ModuleError
+    from library.module_utils.network.f5.common import iControlUnexpectedHTTPError
     from test.unit.modules.utils import set_module_args
 except ImportError:
     try:
@@ -36,7 +37,8 @@ except ImportError:
         from ansible.modules.network.f5.bigip_irule import ArgumentSpec
         from ansible.modules.network.f5.bigip_irule import GtmManager
         from ansible.modules.network.f5.bigip_irule import LtmManager
-        from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
+        from ansible.module_utils.network.f5.common import F5ModuleError
+        from ansible.module_utils.network.f5.common import iControlUnexpectedHTTPError
         from units.modules.utils import set_module_args
     except ImportError:
         raise SkipTest("F5 Ansible modules require the f5-sdk Python library")
@@ -77,7 +79,7 @@ class TestParameters(unittest.TestCase):
             name='foo',
             state='present'
         )
-        p = Parameters(args)
+        p = Parameters(params=args)
         assert p.content == content.strip()
 
     def test_module_parameters_gtm(self):
@@ -88,7 +90,7 @@ class TestParameters(unittest.TestCase):
             name='foo',
             state='present'
         )
-        p = Parameters(args)
+        p = Parameters(params=args)
         assert p.content == content.strip()
 
     def test_api_parameters_ltm(self):
@@ -96,7 +98,7 @@ class TestParameters(unittest.TestCase):
         args = dict(
             apiAnonymous=content
         )
-        p = Parameters(args)
+        p = Parameters(params=args)
         assert p.content == content.strip()
 
     def test_return_api_params(self):
@@ -107,14 +109,12 @@ class TestParameters(unittest.TestCase):
             name='foo',
             state='present'
         )
-        p = Parameters(args)
+        p = Parameters(params=args)
         params = p.api_params()
 
         assert 'apiAnonymous' in params
 
 
-@patch('ansible.module_utils.f5_utils.AnsibleF5Client._get_mgmt_root',
-       return_value=True)
 class TestManager(unittest.TestCase):
 
     def setUp(self):
@@ -141,20 +141,19 @@ class TestManager(unittest.TestCase):
             user='admin'
         ))
 
-        client = AnsibleF5Client(
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
             supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name,
             mutually_exclusive=self.spec.mutually_exclusive,
         )
 
         # Override methods in the specific type of manager
-        tm = LtmManager(client)
+        tm = LtmManager(module=module, params=module.params)
         tm.exists = Mock(side_effect=[False, True])
         tm.create_on_device = Mock(return_value=True)
 
         # Override methods to force specific logic in the module to happen
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.get_manager = Mock(return_value=tm)
 
         results = mm.exec_module()
@@ -173,20 +172,19 @@ class TestManager(unittest.TestCase):
             user='admin'
         ))
 
-        client = AnsibleF5Client(
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
             supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name,
             mutually_exclusive=self.spec.mutually_exclusive,
         )
 
         # Override methods in the specific type of manager
-        tm = GtmManager(client)
+        tm = GtmManager(module=module, params=module.params)
         tm.exists = Mock(side_effect=[False, True])
         tm.create_on_device = Mock(return_value=True)
 
         # Override methods to force specific logic in the module to happen
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.get_manager = Mock(return_value=tm)
 
         results = mm.exec_module()
@@ -205,10 +203,9 @@ class TestManager(unittest.TestCase):
             user='admin'
         ))
 
-        client = AnsibleF5Client(
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
             supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name,
             mutually_exclusive=self.spec.mutually_exclusive,
         )
 
@@ -219,12 +216,12 @@ class TestManager(unittest.TestCase):
 
         with patch(builtins_name + '.open', mock_open(read_data='this is my content'), create=True):
             # Override methods in the specific type of manager
-            tm = GtmManager(client)
+            tm = GtmManager(module=module, params=module.params)
             tm.exists = Mock(side_effect=[False, True])
             tm.create_on_device = Mock(return_value=True)
 
             # Override methods to force specific logic in the module to happen
-            mm = ModuleManager(client)
+            mm = ModuleManager(module=module)
             mm.get_manager = Mock(return_value=tm)
 
             results = mm.exec_module()
@@ -249,10 +246,9 @@ class TestManager(unittest.TestCase):
         ))
 
         with patch('ansible.module_utils.basic.AnsibleModule.fail_json', unsafe=True) as mo:
-            AnsibleF5Client(
+            AnsibleModule(
                 argument_spec=self.spec.argument_spec,
                 supports_check_mode=self.spec.supports_check_mode,
-                f5_product_name=self.spec.f5_product_name,
                 mutually_exclusive=self.spec.mutually_exclusive,
             )
             mo.assert_called_once()


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Primarily, this patch contains refactors to remove tracebacks that
are generated when libraries are missing. There is also,

* Removed re-def of cleanup_tokens.
* Changed parameter args to be keywords.
* Changed imports to include new module_util locations.
* Imports also include developing (sideband) module_util locations.
* Changed to using F5Client and plain AnsibleModule to prevent tracebacks caused by missing libraries.
* Removed init and update methods from most Parameter classes (optimization) as its now included in module_utils.
* Changed module and module param references to take into account the new self.module arg. Minor bug fixes made during this refactor.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
various f5 modules

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.14 (default, Dec 12 2017, 16:55:09) [GCC 4.9.2]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
