### PR TITLE
add optional runlevel kwarg for sysv_is_enabled

### DIFF
--- a/lib/ansible/module_utils/service.py
+++ b/lib/ansible/module_utils/service.py
@@ -39,14 +39,18 @@ from ansible.module_utils.six import PY2, b
 from ansible.module_utils._text import to_bytes, to_text
 
 
-def sysv_is_enabled(name):
+def sysv_is_enabled(name, runlevel=None):
     '''
     This function will check if the service name supplied
     is enabled in any of the sysv runlevels
 
     :arg name: name of the service to test for
+    :kw runlevel: runlevel to check (default: None)
     '''
-    return bool(glob.glob('/etc/rc?.d/S??%s' % name))
+    if runlevel:
+        return bool(glob.glob('/etc/rc%s.d/S??%s' % (runlevel, name)))
+    else:
+        return bool(glob.glob('/etc/rc?.d/S??%s' % name))
 
 
 def get_sysv_script(name):


### PR DESCRIPTION
Signed-off-by: Adam Miller <admiller@redhat.com>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
In assistance with picking up the work from bcoca on the new WIP `sysvinit` module, this change adds the ability to specify a runlevel to `sysv_is_enabled` when checking for a service daemon being enabled or not. Currently the check will return `True` for any runtime.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request


##### COMPONENT NAME
module_utils

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (module_utils 54bd85d78c) last updated 2018/01/12 15:19:12 (GMT -500)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/admiller/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/admiller/src/dev/ansible/lib/ansible
  executable location = /home/admiller/src/dev/ansible/bin/ansible
  python version = 2.7.14 (default, Dec 11 2017, 14:52:53) [GCC 7.2.1 20170915 (Red Hat 7.2.1-2)]
```


