### PR TITLE
Various F5 related fixes for traceback raising

### DIFF
--- a/lib/ansible/modules/network/f5/bigip_monitor_http.py
+++ b/lib/ansible/modules/network/f5/bigip_monitor_http.py
@@ -88,12 +88,17 @@ options:
       - Device partition to manage resources on.
     default: Common
     version_added: 2.5
+  state:
+    description:
+      - When C(present), ensures that the monitor exists.
+      - When C(absent), ensures the monitor is removed.
+    default: present
+    choices:
+      - present
+      - absent
+    version_added: 2.5
 notes:
-  - Requires the f5-sdk Python package on the host. This is as easy as pip
-    install f5-sdk.
   - Requires BIG-IP software version >= 12
-requirements:
-  - f5-sdk >= 2.2.3
 extends_documentation_fragment: f5
 author:
   - Tim Rupp (@caphrim007)
@@ -159,25 +164,44 @@ time_until_up:
   sample: 2
 '''
 
-import os
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import env_fallback
+
+HAS_DEVEL_IMPORTS = False
+
+try:
+    # Sideband repository used for dev
+    from library.module_utils.network.f5.bigip import HAS_F5SDK
+    from library.module_utils.network.f5.bigip import F5Client
+    from library.module_utils.network.f5.common import F5ModuleError
+    from library.module_utils.network.f5.common import AnsibleF5Parameters
+    from library.module_utils.network.f5.common import cleanup_tokens
+    from library.module_utils.network.f5.common import fqdn_name
+    from library.module_utils.network.f5.common import f5_argument_spec
+    try:
+        from library.module_utils.network.f5.common import iControlUnexpectedHTTPError
+    except ImportError:
+        HAS_F5SDK = False
+    HAS_DEVEL_IMPORTS = True
+except ImportError:
+    # Upstream Ansible
+    from ansible.module_utils.network.f5.bigip import HAS_F5SDK
+    from ansible.module_utils.network.f5.bigip import F5Client
+    from ansible.module_utils.network.f5.common import F5ModuleError
+    from ansible.module_utils.network.f5.common import AnsibleF5Parameters
+    from ansible.module_utils.network.f5.common import cleanup_tokens
+    from ansible.module_utils.network.f5.common import fqdn_name
+    from ansible.module_utils.network.f5.common import f5_argument_spec
+    try:
+        from ansible.module_utils.network.f5.common import iControlUnexpectedHTTPError
+    except ImportError:
+        HAS_F5SDK = False
 
 try:
     import netaddr
     HAS_NETADDR = True
 except ImportError:
     HAS_NETADDR = False
-
-from ansible.module_utils.f5_utils import AnsibleF5Client
-from ansible.module_utils.f5_utils import AnsibleF5Parameters
-from ansible.module_utils.f5_utils import HAS_F5SDK
-from ansible.module_utils.f5_utils import F5ModuleError
-from ansible.module_utils.six import iteritems
-from collections import defaultdict
-
-try:
-    from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
-except ImportError:
-    HAS_F5SDK = False
 
 
 class Parameters(AnsibleF5Parameters):
@@ -202,36 +226,6 @@ class Parameters(AnsibleF5Parameters):
         'target_username', 'target_password'
     ]
 
-    def __init__(self, params=None):
-        self._values = defaultdict(lambda: None)
-        self._values['__warnings'] = []
-        if params:
-            self.update(params=params)
-
-    def update(self, params=None):
-        if params:
-            for k, v in iteritems(params):
-                if self.api_map is not None and k in self.api_map:
-                    map_key = self.api_map[k]
-                else:
-                    map_key = k
-
-                # Handle weird API parameters like `dns.proxy.__iter__` by
-                # using a map provided by the module developer
-                class_attr = getattr(type(self), map_key, None)
-                if isinstance(class_attr, property):
-                    # There is a mapped value for the api_map key
-                    if class_attr.fset is None:
-                        # If the mapped value does not have
-                        # an associated setter
-                        self._values[map_key] = v
-                    else:
-                        # The mapped value has a setter
-                        setattr(self, map_key, v)
-                else:
-                    # If the mapped value is not a @property
-                    self._values[map_key] = v
-
     def _fqdn_name(self, value):
         if value is not None and not value.startswith('/'):
             return '/{0}/{1}'.format(self.partition, value)
@@ -245,16 +239,6 @@ class Parameters(AnsibleF5Parameters):
             result = self._filter_params(result)
         except Exception:
             pass
-        return result
-
-    def api_params(self):
-        result = {}
-        for api_attribute in self.api_attributes:
-            if self.api_map is not None and api_attribute in self.api_map:
-                result[api_attribute] = getattr(self, self.api_map[api_attribute])
-            else:
-                result[api_attribute] = getattr(self, api_attribute)
-        result = self._filter_params(result)
         return result
 
     @property
@@ -409,10 +393,11 @@ class Difference(object):
 
 
 class ModuleManager(object):
-    def __init__(self, client):
-        self.client = client
+    def __init__(self, *args, **kwargs):
+        self.module = kwargs.get('module', None)
+        self.client = kwargs.get('client', None)
         self.have = None
-        self.want = Parameters(self.client.module.params)
+        self.want = Parameters(params=self.module.params)
         self.changes = Changes()
 
     def _set_changed_options(self):
@@ -421,7 +406,7 @@ class ModuleManager(object):
             if getattr(self.want, key) is not None:
                 changed[key] = getattr(self.want, key)
         if changed:
-            self.changes = Changes(changed)
+            self.changes = Changes(params=changed)
 
     def _update_changed_options(self):
         diff = Difference(self.want, self.have)
@@ -437,7 +422,7 @@ class ModuleManager(object):
                 else:
                     changed[k] = change
         if changed:
-            self.changes = Changes(changed)
+            self.changes = Changes(params=changed)
             return True
         return False
 
@@ -448,7 +433,7 @@ class ModuleManager(object):
         if self.have:
             warnings += self.have._values.get('__warnings', [])
         for warning in warnings:
-            self.client.module.deprecate(
+            self.module.deprecate(
                 msg=warning['msg'],
                 version=warning['version']
             )
@@ -492,7 +477,7 @@ class ModuleManager(object):
             self.want.update({'port': '*'})
         if self.want.send is None:
             self.want.update({'send': 'GET /\r\n'})
-        if self.client.check_mode:
+        if self.module.check_mode:
             return True
         self.create_on_device()
         return True
@@ -507,7 +492,7 @@ class ModuleManager(object):
         self.have = self.read_current_from_device()
         if not self.should_update():
             return False
-        if self.client.check_mode:
+        if self.module.check_mode:
             return True
         self.update_on_device()
         return True
@@ -518,7 +503,7 @@ class ModuleManager(object):
         return False
 
     def remove(self):
-        if self.client.check_mode:
+        if self.module.check_mode:
             return True
         self.remove_from_device()
         if self.exists():
@@ -531,7 +516,7 @@ class ModuleManager(object):
             partition=self.want.partition
         )
         result = resource.attrs
-        return Parameters(result)
+        return Parameters(params=result)
 
     def exists(self):
         result = self.client.api.tm.ltm.monitor.https.http.exists(
@@ -568,7 +553,7 @@ class ModuleManager(object):
 class ArgumentSpec(object):
     def __init__(self):
         self.supports_check_mode = True
-        self.argument_spec = dict(
+        argument_spec = dict(
             name=dict(required=True),
             parent=dict(default='/Common/http'),
             send=dict(),
@@ -581,48 +566,41 @@ class ArgumentSpec(object):
             time_until_up=dict(type='int'),
             target_username=dict(),
             target_password=dict(no_log=True),
-
-            # Deprecated params
-            parent_partition=dict(
-                removed_in_version='2.4'
+            state=dict(
+                default='present',
+                choices=['present', 'absent']
+            ),
+            partition=dict(
+                default='Common',
+                fallback=(env_fallback, ['F5_PARTITION'])
             )
         )
-        self.f5_product_name = 'bigip'
-
-
-def cleanup_tokens(client):
-    try:
-        resource = client.api.shared.authz.tokens_s.token.load(
-            name=client.api.icrs.token
-        )
-        resource.delete()
-    except Exception:
-        pass
+        self.argument_spec = {}
+        self.argument_spec.update(f5_argument_spec)
+        self.argument_spec.update(argument_spec)
 
 
 def main():
     spec = ArgumentSpec()
 
-    client = AnsibleF5Client(
+    module = AnsibleModule(
         argument_spec=spec.argument_spec,
-        supports_check_mode=spec.supports_check_mode,
-        f5_product_name=spec.f5_product_name
+        supports_check_mode=spec.supports_check_mode
     )
+    if not HAS_F5SDK:
+        module.fail_json(msg="The python f5-sdk module is required")
+    if not HAS_NETADDR:
+        module.fail_json(msg="The python netaddr module is required")
 
     try:
-        if not HAS_F5SDK:
-            raise F5ModuleError("The python f5-sdk module is required")
-
-        if not HAS_NETADDR:
-            raise F5ModuleError("The python netaddr module is required")
-
-        mm = ModuleManager(client)
+        client = F5Client(**module.params)
+        mm = ModuleManager(module=module, client=client)
         results = mm.exec_module()
         cleanup_tokens(client)
-        client.module.exit_json(**results)
-    except F5ModuleError as e:
+        module.exit_json(**results)
+    except F5ModuleError as ex:
         cleanup_tokens(client)
-        client.module.fail_json(msg=str(e))
+        module.fail_json(msg=str(ex))
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/network/f5/bigip_monitor_snmp_dca.py
+++ b/lib/ansible/modules/network/f5/bigip_monitor_snmp_dca.py
@@ -113,16 +113,21 @@ options:
     description:
       - Device partition to manage resources on.
     default: Common
+  state:
+    description:
+      - When C(present), ensures that the monitor exists.
+      - When C(absent), ensures the monitor is removed.
+    default: present
+    choices:
+      - present
+      - absent
+    version_added: 2.5
 notes:
-  - Requires the f5-sdk Python package on the host. This is as easy as pip
-    install f5-sdk.
   - Requires BIG-IP software version >= 12
   - This module does not support the C(variables) option because this option
     is broken in the REST API and does not function correctly in C(tmsh); for
     example you cannot remove user-defined params. Therefore, there is no way
     to automatically configure it.
-requirements:
-  - f5-sdk >= 2.2.3
 extends_documentation_fragment: f5
 author:
   - Tim Rupp (@caphrim007)
@@ -216,19 +221,38 @@ disk_threshold:
   sample: 34
 '''
 
-import os
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import env_fallback
 
-from ansible.module_utils.f5_utils import AnsibleF5Client
-from ansible.module_utils.f5_utils import AnsibleF5Parameters
-from ansible.module_utils.f5_utils import HAS_F5SDK
-from ansible.module_utils.f5_utils import F5ModuleError
-from ansible.module_utils.six import iteritems
-from collections import defaultdict
+HAS_DEVEL_IMPORTS = False
 
 try:
-    from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
+    # Sideband repository used for dev
+    from library.module_utils.network.f5.bigip import HAS_F5SDK
+    from library.module_utils.network.f5.bigip import F5Client
+    from library.module_utils.network.f5.common import F5ModuleError
+    from library.module_utils.network.f5.common import AnsibleF5Parameters
+    from library.module_utils.network.f5.common import cleanup_tokens
+    from library.module_utils.network.f5.common import fqdn_name
+    from library.module_utils.network.f5.common import f5_argument_spec
+    try:
+        from library.module_utils.network.f5.common import iControlUnexpectedHTTPError
+    except ImportError:
+        HAS_F5SDK = False
+    HAS_DEVEL_IMPORTS = True
 except ImportError:
-    HAS_F5SDK = False
+    # Upstream Ansible
+    from ansible.module_utils.network.f5.bigip import HAS_F5SDK
+    from ansible.module_utils.network.f5.bigip import F5Client
+    from ansible.module_utils.network.f5.common import F5ModuleError
+    from ansible.module_utils.network.f5.common import AnsibleF5Parameters
+    from ansible.module_utils.network.f5.common import cleanup_tokens
+    from ansible.module_utils.network.f5.common import fqdn_name
+    from ansible.module_utils.network.f5.common import f5_argument_spec
+    try:
+        from ansible.module_utils.network.f5.common import iControlUnexpectedHTTPError
+    except ImportError:
+        HAS_F5SDK = False
 
 
 class Parameters(AnsibleF5Parameters):
@@ -262,36 +286,6 @@ class Parameters(AnsibleF5Parameters):
         'memory_threshold', 'disk_coefficient', 'disk_threshold'
     ]
 
-    def __init__(self, params=None):
-        self._values = defaultdict(lambda: None)
-        self._values['__warnings'] = []
-        if params:
-            self.update(params=params)
-
-    def update(self, params=None):
-        if params:
-            for k, v in iteritems(params):
-                if self.api_map is not None and k in self.api_map:
-                    map_key = self.api_map[k]
-                else:
-                    map_key = k
-
-                # Handle weird API parameters like `dns.proxy.__iter__` by
-                # using a map provided by the module developer
-                class_attr = getattr(type(self), map_key, None)
-                if isinstance(class_attr, property):
-                    # There is a mapped value for the api_map key
-                    if class_attr.fset is None:
-                        # If the mapped value does not have
-                        # an associated setter
-                        self._values[map_key] = v
-                    else:
-                        # The mapped value has a setter
-                        setattr(self, map_key, v)
-                else:
-                    # If the mapped value is not a @property
-                    self._values[map_key] = v
-
     def _fqdn_name(self, value):
         if value is not None and not value.startswith('/'):
             return '/{0}/{1}'.format(self.partition, value)
@@ -306,16 +300,6 @@ class Parameters(AnsibleF5Parameters):
             return result
         except Exception:
             return result
-
-    def api_params(self):
-        result = {}
-        for api_attribute in self.api_attributes:
-            if self.api_map is not None and api_attribute in self.api_map:
-                result[api_attribute] = getattr(self, self.api_map[api_attribute])
-            else:
-                result[api_attribute] = getattr(self, api_attribute)
-        result = self._filter_params(result)
-        return result
 
     @property
     def interval(self):
@@ -392,6 +376,10 @@ class Parameters(AnsibleF5Parameters):
         return 'snmp_dca'
 
 
+class Changes(Parameters):
+    pass
+
+
 class Difference(object):
     def __init__(self, want, have=None):
         self.want = want
@@ -450,11 +438,12 @@ class Difference(object):
 
 
 class ModuleManager(object):
-    def __init__(self, client):
-        self.client = client
+    def __init__(self, *args, **kwargs):
+        self.module = kwargs.get('module', None)
+        self.client = kwargs.get('client', None)
         self.have = None
-        self.want = Parameters(self.client.module.params)
-        self.changes = Parameters()
+        self.want = Parameters(params=self.module.params)
+        self.changes = Changes()
 
     def _set_changed_options(self):
         changed = {}
@@ -462,7 +451,7 @@ class ModuleManager(object):
             if getattr(self.want, key) is not None:
                 changed[key] = getattr(self.want, key)
         if changed:
-            self.changes = Parameters(changed)
+            self.changes = Changes(params=changed)
 
     def _update_changed_options(self):
         diff = Difference(self.want, self.have)
@@ -475,7 +464,7 @@ class ModuleManager(object):
             else:
                 changed[k] = change
         if changed:
-            self.changes = Parameters(changed)
+            self.changes = Changes(params=changed)
             return True
         return False
 
@@ -486,7 +475,7 @@ class ModuleManager(object):
         if self.have:
             warnings += self.have._values.get('__warnings', [])
         for warning in warnings:
-            self.client.module.deprecate(
+            self.module.deprecate(
                 msg=warning['msg'],
                 version=warning['version']
             )
@@ -544,7 +533,7 @@ class ModuleManager(object):
         if self.want.disk_threshold is None:
             self.want.update({'disk_threshold': '90'})
 
-        if self.client.check_mode:
+        if self.module.check_mode:
             return True
         self.create_on_device()
         return True
@@ -559,7 +548,7 @@ class ModuleManager(object):
         self.have = self.read_current_from_device()
         if not self.should_update():
             return False
-        if self.client.check_mode:
+        if self.module.check_mode:
             return True
         self.update_on_device()
         return True
@@ -570,7 +559,7 @@ class ModuleManager(object):
         return False
 
     def remove(self):
-        if self.client.check_mode:
+        if self.module.check_mode:
             return True
         self.remove_from_device()
         if self.exists():
@@ -583,7 +572,7 @@ class ModuleManager(object):
             partition=self.want.partition
         )
         result = resource.attrs
-        return Parameters(result)
+        return Parameters(params=result)
 
     def exists(self):
         result = self.client.api.tm.ltm.monitor.snmp_dcas.snmp_dca.exists(
@@ -620,7 +609,7 @@ class ModuleManager(object):
 class ArgumentSpec(object):
     def __init__(self):
         self.supports_check_mode = True
-        self.argument_spec = dict(
+        argument_spec = dict(
             name=dict(required=True),
             description=dict(),
             parent=dict(default='/Common/snmp_dca'),
@@ -638,41 +627,40 @@ class ArgumentSpec(object):
             memory_coefficient=dict(),
             memory_threshold=dict(type='int'),
             disk_coefficient=dict(),
-            disk_threshold=dict(type='int')
+            disk_threshold=dict(type='int'),
+            state=dict(
+                default='present',
+                choices=['present', 'absent']
+            ),
+            partition=dict(
+                default='Common',
+                fallback=(env_fallback, ['F5_PARTITION'])
+            )
         )
-        self.f5_product_name = 'bigip'
-
-
-def cleanup_tokens(client):
-    try:
-        resource = client.api.shared.authz.tokens_s.token.load(
-            name=client.api.icrs.token
-        )
-        resource.delete()
-    except Exception:
-        pass
+        self.argument_spec = {}
+        self.argument_spec.update(f5_argument_spec)
+        self.argument_spec.update(argument_spec)
 
 
 def main():
     spec = ArgumentSpec()
 
-    client = AnsibleF5Client(
+    module = AnsibleModule(
         argument_spec=spec.argument_spec,
-        supports_check_mode=spec.supports_check_mode,
-        f5_product_name=spec.f5_product_name
+        supports_check_mode=spec.supports_check_mode
     )
+    if not HAS_F5SDK:
+        module.fail_json(msg="The python f5-sdk module is required")
 
     try:
-        if not HAS_F5SDK:
-            raise F5ModuleError("The python f5-sdk module is required")
-
-        mm = ModuleManager(client)
+        client = F5Client(**module.params)
+        mm = ModuleManager(module=module, client=client)
         results = mm.exec_module()
         cleanup_tokens(client)
-        client.module.exit_json(**results)
-    except F5ModuleError as e:
+        module.exit_json(**results)
+    except F5ModuleError as ex:
         cleanup_tokens(client)
-        client.module.fail_json(msg=str(e))
+        module.fail_json(msg=str(ex))
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/network/f5/bigip_monitor_tcp.py
+++ b/lib/ansible/modules/network/f5/bigip_monitor_tcp.py
@@ -91,12 +91,17 @@ options:
       - Device partition to manage resources on.
     default: Common
     version_added: 2.5
+  state:
+    description:
+      - When C(present), ensures that the monitor exists.
+      - When C(absent), ensures the monitor is removed.
+    default: present
+    choices:
+      - present
+      - absent
+    version_added: 2.5
 notes:
-  - Requires the f5-sdk Python package on the host. This is as easy as pip
-    install f5-sdk.
   - Requires BIG-IP software version >= 12
-requirements:
-  - f5-sdk >= 2.2.3
 extends_documentation_fragment: f5
 author:
   - Tim Rupp (@caphrim007)
@@ -168,25 +173,44 @@ time_until_up:
   sample: 2
 '''
 
-import os
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import env_fallback
+
+HAS_DEVEL_IMPORTS = False
+
+try:
+    # Sideband repository used for dev
+    from library.module_utils.network.f5.bigip import HAS_F5SDK
+    from library.module_utils.network.f5.bigip import F5Client
+    from library.module_utils.network.f5.common import F5ModuleError
+    from library.module_utils.network.f5.common import AnsibleF5Parameters
+    from library.module_utils.network.f5.common import cleanup_tokens
+    from library.module_utils.network.f5.common import fqdn_name
+    from library.module_utils.network.f5.common import f5_argument_spec
+    try:
+        from library.module_utils.network.f5.common import iControlUnexpectedHTTPError
+    except ImportError:
+        HAS_F5SDK = False
+    HAS_DEVEL_IMPORTS = True
+except ImportError:
+    # Upstream Ansible
+    from ansible.module_utils.network.f5.bigip import HAS_F5SDK
+    from ansible.module_utils.network.f5.bigip import F5Client
+    from ansible.module_utils.network.f5.common import F5ModuleError
+    from ansible.module_utils.network.f5.common import AnsibleF5Parameters
+    from ansible.module_utils.network.f5.common import cleanup_tokens
+    from ansible.module_utils.network.f5.common import fqdn_name
+    from ansible.module_utils.network.f5.common import f5_argument_spec
+    try:
+        from ansible.module_utils.network.f5.common import iControlUnexpectedHTTPError
+    except ImportError:
+        HAS_F5SDK = False
 
 try:
     import netaddr
     HAS_NETADDR = True
 except ImportError:
     HAS_NETADDR = False
-
-from ansible.module_utils.f5_utils import AnsibleF5Client
-from ansible.module_utils.f5_utils import AnsibleF5Parameters
-from ansible.module_utils.f5_utils import HAS_F5SDK
-from ansible.module_utils.f5_utils import F5ModuleError
-from ansible.module_utils.six import iteritems
-from collections import defaultdict
-
-try:
-    from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
-except ImportError:
-    HAS_F5SDK = False
 
 
 class Parameters(AnsibleF5Parameters):
@@ -209,36 +233,6 @@ class Parameters(AnsibleF5Parameters):
     updatables = [
         'destination', 'send', 'receive', 'interval', 'timeout', 'time_until_up'
     ]
-
-    def __init__(self, params=None):
-        self._values = defaultdict(lambda: None)
-        self._values['__warnings'] = []
-        if params:
-            self.update(params=params)
-
-    def update(self, params=None):
-        if params:
-            for k, v in iteritems(params):
-                if self.api_map is not None and k in self.api_map:
-                    map_key = self.api_map[k]
-                else:
-                    map_key = k
-
-                # Handle weird API parameters like `dns.proxy.__iter__` by
-                # using a map provided by the module developer
-                class_attr = getattr(type(self), map_key, None)
-                if isinstance(class_attr, property):
-                    # There is a mapped value for the api_map key
-                    if class_attr.fset is None:
-                        # If the mapped value does not have
-                        # an associated setter
-                        self._values[map_key] = v
-                    else:
-                        # The mapped value has a setter
-                        setattr(self, map_key, v)
-                else:
-                    # If the mapped value is not a @property
-                    self._values[map_key] = v
 
     def _fqdn_name(self, value):
         if value is not None and not value.startswith('/'):
@@ -334,6 +328,10 @@ class Parameters(AnsibleF5Parameters):
         return 'tcp'
 
 
+class Changes(Parameters):
+    pass
+
+
 class Difference(object):
     def __init__(self, want, have=None):
         self.want = want
@@ -402,11 +400,12 @@ class Difference(object):
 
 
 class ModuleManager(object):
-    def __init__(self, client):
-        self.client = client
+    def __init__(self, *args, **kwargs):
+        self.module = kwargs.get('module', None)
+        self.client = kwargs.get('client', None)
         self.have = None
-        self.want = Parameters(self.client.module.params)
-        self.changes = Parameters()
+        self.want = Parameters(params=self.module.params)
+        self.changes = Changes()
 
     def _set_changed_options(self):
         changed = {}
@@ -414,7 +413,7 @@ class ModuleManager(object):
             if getattr(self.want, key) is not None:
                 changed[key] = getattr(self.want, key)
         if changed:
-            self.changes = Parameters(changed)
+            self.changes = Changes(params=changed)
 
     def _update_changed_options(self):
         diff = Difference(self.want, self.have)
@@ -427,7 +426,7 @@ class ModuleManager(object):
             else:
                 changed[k] = change
         if changed:
-            self.changes = Parameters(changed)
+            self.changes = Changes(params=changed)
             return True
         return False
 
@@ -438,7 +437,7 @@ class ModuleManager(object):
         if self.have:
             warnings += self.have._values.get('__warnings', [])
         for warning in warnings:
-            self.client.module.deprecate(
+            self.module.deprecate(
                 msg=warning['msg'],
                 version=warning['version']
             )
@@ -471,7 +470,7 @@ class ModuleManager(object):
     def create(self):
         self._set_changed_options()
         self._set_default_creation_values()
-        if self.client.check_mode:
+        if self.module.check_mode:
             return True
         self.create_on_device()
         return True
@@ -486,7 +485,7 @@ class ModuleManager(object):
         self.have = self.read_current_from_device()
         if not self.should_update():
             return False
-        if self.client.check_mode:
+        if self.module.check_mode:
             return True
         self.update_on_device()
         return True
@@ -497,7 +496,7 @@ class ModuleManager(object):
         return False
 
     def remove(self):
-        if self.client.check_mode:
+        if self.module.check_mode:
             return True
         self.remove_from_device()
         if self.exists():
@@ -522,7 +521,7 @@ class ModuleManager(object):
             partition=self.want.partition
         )
         result = resource.attrs
-        return Parameters(result)
+        return Parameters(params=result)
 
     def exists(self):
         result = self.client.api.tm.ltm.monitor.tcps.tcp.exists(
@@ -559,7 +558,7 @@ class ModuleManager(object):
 class ArgumentSpec(object):
     def __init__(self):
         self.supports_check_mode = True
-        self.argument_spec = dict(
+        argument_spec = dict(
             name=dict(required=True),
             parent=dict(default='/Common/tcp'),
             send=dict(),
@@ -568,48 +567,46 @@ class ArgumentSpec(object):
             port=dict(type='int'),
             interval=dict(type='int'),
             timeout=dict(type='int'),
-            time_until_up=dict(type='int')
+            time_until_up=dict(type='int'),
+            state=dict(
+                default='present',
+                choices=['present', 'absent']
+            ),
+            partition=dict(
+                default='Common',
+                fallback=(env_fallback, ['F5_PARTITION'])
+            )
         )
-        self.f5_product_name = 'bigip'
+        self.argument_spec = {}
+        self.argument_spec.update(f5_argument_spec)
+        self.argument_spec.update(argument_spec)
         self.mutually_exclusive = [
             ['parent', 'parent_partition']
         ]
 
 
-def cleanup_tokens(client):
-    try:
-        resource = client.api.shared.authz.tokens_s.token.load(
-            name=client.api.icrs.token
-        )
-        resource.delete()
-    except Exception:
-        pass
-
-
 def main():
     spec = ArgumentSpec()
 
-    client = AnsibleF5Client(
+    module = AnsibleModule(
         argument_spec=spec.argument_spec,
         supports_check_mode=spec.supports_check_mode,
-        f5_product_name=spec.f5_product_name,
         mutually_exclusive=spec.mutually_exclusive
     )
+    if not HAS_F5SDK:
+        module.fail_json(msg="The python f5-sdk module is required")
+    if not HAS_NETADDR:
+        module.fail_json(msg="The python netaddr module is required")
 
     try:
-        if not HAS_F5SDK:
-            raise F5ModuleError("The python f5-sdk module is required")
-
-        if not HAS_NETADDR:
-            raise F5ModuleError("The python netaddr module is required")
-
-        mm = ModuleManager(client)
+        client = F5Client(**module.params)
+        mm = ModuleManager(module=module, client=client)
         results = mm.exec_module()
         cleanup_tokens(client)
-        client.module.exit_json(**results)
-    except F5ModuleError as e:
+        module.exit_json(**results)
+    except F5ModuleError as ex:
         cleanup_tokens(client)
-        client.module.fail_json(msg=str(e))
+        module.fail_json(msg=str(ex))
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/network/f5/bigip_monitor_tcp_echo.py
+++ b/lib/ansible/modules/network/f5/bigip_monitor_tcp_echo.py
@@ -65,12 +65,17 @@ options:
       - Device partition to manage resources on.
     default: Common
     version_added: 2.5
+  state:
+    description:
+      - When C(present), ensures that the monitor exists.
+      - When C(absent), ensures the monitor is removed.
+    default: present
+    choices:
+      - present
+      - absent
+    version_added: 2.5
 notes:
-  - Requires the f5-sdk Python package on the host. This is as easy as pip
-    install f5-sdk.
   - Requires BIG-IP software version >= 12
-requirements:
-  - f5-sdk >= 2.2.3
 extends_documentation_fragment: f5
 author:
   - Tim Rupp (@caphrim007)
@@ -127,23 +132,44 @@ time_until_up:
 
 import os
 
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import env_fallback
+
+HAS_DEVEL_IMPORTS = False
+
+try:
+    # Sideband repository used for dev
+    from library.module_utils.network.f5.bigip import HAS_F5SDK
+    from library.module_utils.network.f5.bigip import F5Client
+    from library.module_utils.network.f5.common import F5ModuleError
+    from library.module_utils.network.f5.common import AnsibleF5Parameters
+    from library.module_utils.network.f5.common import cleanup_tokens
+    from library.module_utils.network.f5.common import fqdn_name
+    from library.module_utils.network.f5.common import f5_argument_spec
+    try:
+        from library.module_utils.network.f5.common import iControlUnexpectedHTTPError
+    except ImportError:
+        HAS_F5SDK = False
+    HAS_DEVEL_IMPORTS = True
+except ImportError:
+    # Upstream Ansible
+    from ansible.module_utils.network.f5.bigip import HAS_F5SDK
+    from ansible.module_utils.network.f5.bigip import F5Client
+    from ansible.module_utils.network.f5.common import F5ModuleError
+    from ansible.module_utils.network.f5.common import AnsibleF5Parameters
+    from ansible.module_utils.network.f5.common import cleanup_tokens
+    from ansible.module_utils.network.f5.common import fqdn_name
+    from ansible.module_utils.network.f5.common import f5_argument_spec
+    try:
+        from ansible.module_utils.network.f5.common import iControlUnexpectedHTTPError
+    except ImportError:
+        HAS_F5SDK = False
+
 try:
     import netaddr
     HAS_NETADDR = True
 except ImportError:
     HAS_NETADDR = False
-
-from ansible.module_utils.f5_utils import AnsibleF5Client
-from ansible.module_utils.f5_utils import AnsibleF5Parameters
-from ansible.module_utils.f5_utils import HAS_F5SDK
-from ansible.module_utils.f5_utils import F5ModuleError
-from ansible.module_utils.six import iteritems
-from collections import defaultdict
-
-try:
-    from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
-except ImportError:
-    HAS_F5SDK = False
 
 
 class Parameters(AnsibleF5Parameters):
@@ -164,36 +190,6 @@ class Parameters(AnsibleF5Parameters):
         'ip', 'interval', 'timeout', 'time_until_up'
     ]
 
-    def __init__(self, params=None):
-        self._values = defaultdict(lambda: None)
-        self._values['__warnings'] = []
-        if params:
-            self.update(params=params)
-
-    def update(self, params=None):
-        if params:
-            for k, v in iteritems(params):
-                if self.api_map is not None and k in self.api_map:
-                    map_key = self.api_map[k]
-                else:
-                    map_key = k
-
-                # Handle weird API parameters like `dns.proxy.__iter__` by
-                # using a map provided by the module developer
-                class_attr = getattr(type(self), map_key, None)
-                if isinstance(class_attr, property):
-                    # There is a mapped value for the api_map key
-                    if class_attr.fset is None:
-                        # If the mapped value does not have
-                        # an associated setter
-                        self._values[map_key] = v
-                    else:
-                        # The mapped value has a setter
-                        setattr(self, map_key, v)
-                else:
-                    # If the mapped value is not a @property
-                    self._values[map_key] = v
-
     def _fqdn_name(self, value):
         if value is not None and not value.startswith('/'):
             return '/{0}/{1}'.format(self.partition, value)
@@ -208,16 +204,6 @@ class Parameters(AnsibleF5Parameters):
             return result
         except Exception:
             return result
-
-    def api_params(self):
-        result = {}
-        for api_attribute in self.api_attributes:
-            if self.api_map is not None and api_attribute in self.api_map:
-                result[api_attribute] = getattr(self, self.api_map[api_attribute])
-            else:
-                result[api_attribute] = getattr(self, api_attribute)
-        result = self._filter_params(result)
-        return result
 
     @property
     def interval(self):
@@ -279,6 +265,10 @@ class Parameters(AnsibleF5Parameters):
         return 'tcp_echo'
 
 
+class Changes(Parameters):
+    pass
+
+
 class Difference(object):
     def __init__(self, want, have=None):
         self.want = want
@@ -337,11 +327,12 @@ class Difference(object):
 
 
 class ModuleManager(object):
-    def __init__(self, client):
-        self.client = client
+    def __init__(self, *args, **kwargs):
+        self.module = kwargs.get('module', None)
+        self.client = kwargs.get('client', None)
         self.have = None
-        self.want = Parameters(self.client.module.params)
-        self.changes = Parameters()
+        self.want = Parameters(params=self.module.params)
+        self.changes = Changes()
 
     def _set_changed_options(self):
         changed = {}
@@ -349,7 +340,7 @@ class ModuleManager(object):
             if getattr(self.want, key) is not None:
                 changed[key] = getattr(self.want, key)
         if changed:
-            self.changes = Parameters(changed)
+            self.changes = Changes(params=changed)
 
     def _update_changed_options(self):
         diff = Difference(self.want, self.have)
@@ -362,7 +353,7 @@ class ModuleManager(object):
             else:
                 changed[k] = change
         if changed:
-            self.changes = Parameters(changed)
+            self.changes = Changes(params=changed)
             return True
         return False
 
@@ -373,7 +364,7 @@ class ModuleManager(object):
         if self.have:
             warnings += self.have._values.get('__warnings', [])
         for warning in warnings:
-            self.client.module.deprecate(
+            self.module.deprecate(
                 msg=warning['msg'],
                 version=warning['version']
             )
@@ -413,7 +404,7 @@ class ModuleManager(object):
             self.want.update({'time_until_up': 0})
         if self.want.ip is None:
             self.want.update({'ip': '*'})
-        if self.client.check_mode:
+        if self.module.check_mode:
             return True
         self.create_on_device()
         return True
@@ -428,7 +419,7 @@ class ModuleManager(object):
         self.have = self.read_current_from_device()
         if not self.should_update():
             return False
-        if self.client.check_mode:
+        if self.module.check_mode:
             return True
         self.update_on_device()
         return True
@@ -439,7 +430,7 @@ class ModuleManager(object):
         return False
 
     def remove(self):
-        if self.client.check_mode:
+        if self.module.check_mode:
             return True
         self.remove_from_device()
         if self.exists():
@@ -452,7 +443,7 @@ class ModuleManager(object):
             partition=self.want.partition
         )
         result = resource.attrs
-        return Parameters(result)
+        return Parameters(params=result)
 
     def exists(self):
         result = self.client.api.tm.ltm.monitor.tcp_echos.tcp_echo.exists(
@@ -489,50 +480,48 @@ class ModuleManager(object):
 class ArgumentSpec(object):
     def __init__(self):
         self.supports_check_mode = True
-        self.argument_spec = dict(
+        argument_spec = dict(
             name=dict(required=True),
             parent=dict(default='/Common/tcp_echo'),
             ip=dict(),
             interval=dict(type='int'),
             timeout=dict(type='int'),
-            time_until_up=dict(type='int')
+            time_until_up=dict(type='int'),
+            state=dict(
+                default='present',
+                choices=['present', 'absent']
+            ),
+            partition=dict(
+                default='Common',
+                fallback=(env_fallback, ['F5_PARTITION'])
+            )
         )
-        self.f5_product_name = 'bigip'
-
-
-def cleanup_tokens(client):
-    try:
-        resource = client.api.shared.authz.tokens_s.token.load(
-            name=client.api.icrs.token
-        )
-        resource.delete()
-    except Exception:
-        pass
+        self.argument_spec = {}
+        self.argument_spec.update(f5_argument_spec)
+        self.argument_spec.update(argument_spec)
 
 
 def main():
     spec = ArgumentSpec()
 
-    client = AnsibleF5Client(
+    module = AnsibleModule(
         argument_spec=spec.argument_spec,
-        supports_check_mode=spec.supports_check_mode,
-        f5_product_name=spec.f5_product_name
+        supports_check_mode=spec.supports_check_mode
     )
+    if not HAS_F5SDK:
+        module.fail_json(msg="The python f5-sdk module is required")
+    if not HAS_NETADDR:
+        module.fail_json(msg="The python netaddr module is required")
 
     try:
-        if not HAS_F5SDK:
-            raise F5ModuleError("The python f5-sdk module is required")
-
-        if not HAS_NETADDR:
-            raise F5ModuleError("The python netaddr module is required")
-
-        mm = ModuleManager(client)
+        client = F5Client(**module.params)
+        mm = ModuleManager(module=module, client=client)
         results = mm.exec_module()
         cleanup_tokens(client)
-        client.module.exit_json(**results)
-    except F5ModuleError as e:
+        module.exit_json(**results)
+    except F5ModuleError as ex:
         cleanup_tokens(client)
-        client.module.fail_json(msg=str(e))
+        module.fail_json(msg=str(ex))
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/network/f5/bigip_monitor_tcp_half_open.py
+++ b/lib/ansible/modules/network/f5/bigip_monitor_tcp_half_open.py
@@ -72,12 +72,17 @@ options:
       - Device partition to manage resources on.
     default: Common
     version_added: 2.5
+  state:
+    description:
+      - When C(present), ensures that the monitor exists.
+      - When C(absent), ensures the monitor is removed.
+    default: present
+    choices:
+      - present
+      - absent
+    version_added: 2.5
 notes:
-  - Requires the f5-sdk Python package on the host. This is as easy as pip
-    install f5-sdk.
   - Requires BIG-IP software version >= 12
-requirements:
-  - f5-sdk >= 2.2.3
 extends_documentation_fragment: f5
 author:
   - Tim Rupp (@caphrim007)
@@ -143,23 +148,44 @@ time_until_up:
 
 import os
 
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import env_fallback
+
+HAS_DEVEL_IMPORTS = False
+
+try:
+    # Sideband repository used for dev
+    from library.module_utils.network.f5.bigip import HAS_F5SDK
+    from library.module_utils.network.f5.bigip import F5Client
+    from library.module_utils.network.f5.common import F5ModuleError
+    from library.module_utils.network.f5.common import AnsibleF5Parameters
+    from library.module_utils.network.f5.common import cleanup_tokens
+    from library.module_utils.network.f5.common import fqdn_name
+    from library.module_utils.network.f5.common import f5_argument_spec
+    try:
+        from library.module_utils.network.f5.common import iControlUnexpectedHTTPError
+    except ImportError:
+        HAS_F5SDK = False
+    HAS_DEVEL_IMPORTS = True
+except ImportError:
+    # Upstream Ansible
+    from ansible.module_utils.network.f5.bigip import HAS_F5SDK
+    from ansible.module_utils.network.f5.bigip import F5Client
+    from ansible.module_utils.network.f5.common import F5ModuleError
+    from ansible.module_utils.network.f5.common import AnsibleF5Parameters
+    from ansible.module_utils.network.f5.common import cleanup_tokens
+    from ansible.module_utils.network.f5.common import fqdn_name
+    from ansible.module_utils.network.f5.common import f5_argument_spec
+    try:
+        from ansible.module_utils.network.f5.common import iControlUnexpectedHTTPError
+    except ImportError:
+        HAS_F5SDK = False
+
 try:
     import netaddr
     HAS_NETADDR = True
 except ImportError:
     HAS_NETADDR = False
-
-from ansible.module_utils.f5_utils import AnsibleF5Client
-from ansible.module_utils.f5_utils import AnsibleF5Parameters
-from ansible.module_utils.f5_utils import HAS_F5SDK
-from ansible.module_utils.f5_utils import F5ModuleError
-from ansible.module_utils.six import iteritems
-from collections import defaultdict
-
-try:
-    from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
-except ImportError:
-    HAS_F5SDK = False
 
 
 class Parameters(AnsibleF5Parameters):
@@ -183,36 +209,6 @@ class Parameters(AnsibleF5Parameters):
         'destination', 'send', 'receive', 'interval', 'timeout', 'time_until_up'
     ]
 
-    def __init__(self, params=None):
-        self._values = defaultdict(lambda: None)
-        self._values['__warnings'] = []
-        if params:
-            self.update(params=params)
-
-    def update(self, params=None):
-        if params:
-            for k, v in iteritems(params):
-                if self.api_map is not None and k in self.api_map:
-                    map_key = self.api_map[k]
-                else:
-                    map_key = k
-
-                # Handle weird API parameters like `dns.proxy.__iter__` by
-                # using a map provided by the module developer
-                class_attr = getattr(type(self), map_key, None)
-                if isinstance(class_attr, property):
-                    # There is a mapped value for the api_map key
-                    if class_attr.fset is None:
-                        # If the mapped value does not have
-                        # an associated setter
-                        self._values[map_key] = v
-                    else:
-                        # The mapped value has a setter
-                        setattr(self, map_key, v)
-                else:
-                    # If the mapped value is not a @property
-                    self._values[map_key] = v
-
     def _fqdn_name(self, value):
         if value is not None and not value.startswith('/'):
             return '/{0}/{1}'.format(self.partition, value)
@@ -227,16 +223,6 @@ class Parameters(AnsibleF5Parameters):
             return result
         except Exception:
             return result
-
-    def api_params(self):
-        result = {}
-        for api_attribute in self.api_attributes:
-            if self.api_map is not None and api_attribute in self.api_map:
-                result[api_attribute] = getattr(self, self.api_map[api_attribute])
-            else:
-                result[api_attribute] = getattr(self, api_attribute)
-        result = self._filter_params(result)
-        return result
 
     @property
     def destination(self):
@@ -314,6 +300,10 @@ class Parameters(AnsibleF5Parameters):
         return 'tcp_half_open'
 
 
+class Changes(Parameters):
+    pass
+
+
 class Difference(object):
     def __init__(self, want, have=None):
         self.want = want
@@ -382,11 +372,12 @@ class Difference(object):
 
 
 class ModuleManager(object):
-    def __init__(self, client):
-        self.client = client
+    def __init__(self, *args, **kwargs):
+        self.module = kwargs.get('module', None)
+        self.client = kwargs.get('client', None)
         self.have = None
-        self.want = Parameters(self.client.module.params)
-        self.changes = Parameters()
+        self.want = Parameters(params=self.module.params)
+        self.changes = Changes()
 
     def _set_changed_options(self):
         changed = {}
@@ -394,7 +385,7 @@ class ModuleManager(object):
             if getattr(self.want, key) is not None:
                 changed[key] = getattr(self.want, key)
         if changed:
-            self.changes = Parameters(changed)
+            self.changes = Changes(params=changed)
 
     def _update_changed_options(self):
         diff = Difference(self.want, self.have)
@@ -407,7 +398,7 @@ class ModuleManager(object):
             else:
                 changed[k] = change
         if changed:
-            self.changes = Parameters(changed)
+            self.changes = Changes(params=changed)
             return True
         return False
 
@@ -418,7 +409,7 @@ class ModuleManager(object):
         if self.have:
             warnings += self.have._values.get('__warnings', [])
         for warning in warnings:
-            self.client.module.deprecate(
+            self.module.deprecate(
                 msg=warning['msg'],
                 version=warning['version']
             )
@@ -460,7 +451,7 @@ class ModuleManager(object):
             self.want.update({'ip': '*'})
         if self.want.port is None:
             self.want.update({'port': '*'})
-        if self.client.check_mode:
+        if self.module.check_mode:
             return True
         self.create_on_device()
         return True
@@ -475,7 +466,7 @@ class ModuleManager(object):
         self.have = self.read_current_from_device()
         if not self.should_update():
             return False
-        if self.client.check_mode:
+        if self.module.check_mode:
             return True
         self.update_on_device()
         return True
@@ -486,7 +477,7 @@ class ModuleManager(object):
         return False
 
     def remove(self):
-        if self.client.check_mode:
+        if self.module.check_mode:
             return True
         self.remove_from_device()
         if self.exists():
@@ -499,7 +490,7 @@ class ModuleManager(object):
             partition=self.want.partition
         )
         result = resource.attrs
-        return Parameters(result)
+        return Parameters(params=result)
 
     def exists(self):
         result = self.client.api.tm.ltm.monitor.tcp_half_opens.tcp_half_open.exists(
@@ -536,51 +527,49 @@ class ModuleManager(object):
 class ArgumentSpec(object):
     def __init__(self):
         self.supports_check_mode = True
-        self.argument_spec = dict(
+        argument_spec = dict(
             name=dict(required=True),
             parent=dict(default='/Common/tcp_half_open'),
             ip=dict(),
             port=dict(type='int'),
             interval=dict(type='int'),
             timeout=dict(type='int'),
-            time_until_up=dict(type='int')
+            time_until_up=dict(type='int'),
+            state=dict(
+                default='present',
+                choices=['present', 'absent']
+            ),
+            partition=dict(
+                default='Common',
+                fallback=(env_fallback, ['F5_PARTITION'])
+            )
         )
-        self.f5_product_name = 'bigip'
-
-
-def cleanup_tokens(client):
-    try:
-        resource = client.api.shared.authz.tokens_s.token.load(
-            name=client.api.icrs.token
-        )
-        resource.delete()
-    except Exception:
-        pass
+        self.argument_spec = {}
+        self.argument_spec.update(f5_argument_spec)
+        self.argument_spec.update(argument_spec)
 
 
 def main():
     spec = ArgumentSpec()
 
-    client = AnsibleF5Client(
+    module = AnsibleModule(
         argument_spec=spec.argument_spec,
-        supports_check_mode=spec.supports_check_mode,
-        f5_product_name=spec.f5_product_name
+        supports_check_mode=spec.supports_check_mode
     )
+    if not HAS_F5SDK:
+        module.fail_json(msg="The python f5-sdk module is required")
+    if not HAS_NETADDR:
+        module.fail_json(msg="The python netaddr module is required")
 
     try:
-        if not HAS_F5SDK:
-            raise F5ModuleError("The python f5-sdk module is required")
-
-        if not HAS_NETADDR:
-            raise F5ModuleError("The python netaddr module is required")
-
-        mm = ModuleManager(client)
+        client = F5Client(**module.params)
+        mm = ModuleManager(module=module, client=client)
         results = mm.exec_module()
         cleanup_tokens(client)
-        client.module.exit_json(**results)
-    except F5ModuleError as e:
+        module.exit_json(**results)
+    except F5ModuleError as ex:
         cleanup_tokens(client)
-        client.module.fail_json(msg=str(e))
+        module.fail_json(msg=str(ex))
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/network/f5/bigip_monitor_udp.py
+++ b/lib/ansible/modules/network/f5/bigip_monitor_udp.py
@@ -82,12 +82,17 @@ options:
       - Device partition to manage resources on.
     default: Common
     version_added: 2.5
+  state:
+    description:
+      - When C(present), ensures that the monitor exists.
+      - When C(absent), ensures the monitor is removed.
+    default: present
+    choices:
+      - present
+      - absent
+    version_added: 2.5
 notes:
-  - Requires the f5-sdk Python package on the host. This is as easy as pip
-    install f5-sdk.
   - Requires BIG-IP software version >= 12
-requirements:
-  - f5-sdk >= 2.2.3
 extends_documentation_fragment: f5
 author:
   - Tim Rupp (@caphrim007)
@@ -144,23 +149,44 @@ time_until_up:
 
 import os
 
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import env_fallback
+
+HAS_DEVEL_IMPORTS = False
+
+try:
+    # Sideband repository used for dev
+    from library.module_utils.network.f5.bigip import HAS_F5SDK
+    from library.module_utils.network.f5.bigip import F5Client
+    from library.module_utils.network.f5.common import F5ModuleError
+    from library.module_utils.network.f5.common import AnsibleF5Parameters
+    from library.module_utils.network.f5.common import cleanup_tokens
+    from library.module_utils.network.f5.common import fqdn_name
+    from library.module_utils.network.f5.common import f5_argument_spec
+    try:
+        from library.module_utils.network.f5.common import iControlUnexpectedHTTPError
+    except ImportError:
+        HAS_F5SDK = False
+    HAS_DEVEL_IMPORTS = True
+except ImportError:
+    # Upstream Ansible
+    from ansible.module_utils.network.f5.bigip import HAS_F5SDK
+    from ansible.module_utils.network.f5.bigip import F5Client
+    from ansible.module_utils.network.f5.common import F5ModuleError
+    from ansible.module_utils.network.f5.common import AnsibleF5Parameters
+    from ansible.module_utils.network.f5.common import cleanup_tokens
+    from ansible.module_utils.network.f5.common import fqdn_name
+    from ansible.module_utils.network.f5.common import f5_argument_spec
+    try:
+        from ansible.module_utils.network.f5.common import iControlUnexpectedHTTPError
+    except ImportError:
+        HAS_F5SDK = False
+
 try:
     import netaddr
     HAS_NETADDR = True
 except ImportError:
     HAS_NETADDR = False
-
-from ansible.module_utils.f5_utils import AnsibleF5Client
-from ansible.module_utils.f5_utils import AnsibleF5Parameters
-from ansible.module_utils.f5_utils import HAS_F5SDK
-from ansible.module_utils.f5_utils import F5ModuleError
-from ansible.module_utils.six import iteritems
-from collections import defaultdict
-
-try:
-    from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
-except ImportError:
-    HAS_F5SDK = False
 
 
 class Parameters(AnsibleF5Parameters):
@@ -184,36 +210,6 @@ class Parameters(AnsibleF5Parameters):
         'destination', 'send', 'receive', 'interval', 'timeout', 'time_until_up'
     ]
 
-    def __init__(self, params=None):
-        self._values = defaultdict(lambda: None)
-        self._values['__warnings'] = []
-        if params:
-            self.update(params=params)
-
-    def update(self, params=None):
-        if params:
-            for k, v in iteritems(params):
-                if self.api_map is not None and k in self.api_map:
-                    map_key = self.api_map[k]
-                else:
-                    map_key = k
-
-                # Handle weird API parameters like `dns.proxy.__iter__` by
-                # using a map provided by the module developer
-                class_attr = getattr(type(self), map_key, None)
-                if isinstance(class_attr, property):
-                    # There is a mapped value for the api_map key
-                    if class_attr.fset is None:
-                        # If the mapped value does not have
-                        # an associated setter
-                        self._values[map_key] = v
-                    else:
-                        # The mapped value has a setter
-                        setattr(self, map_key, v)
-                else:
-                    # If the mapped value is not a @property
-                    self._values[map_key] = v
-
     def _fqdn_name(self, value):
         if value is not None and not value.startswith('/'):
             return '/{0}/{1}'.format(self.partition, value)
@@ -227,16 +223,6 @@ class Parameters(AnsibleF5Parameters):
             result = self._filter_params(result)
         except Exception:
             pass
-        return result
-
-    def api_params(self):
-        result = {}
-        for api_attribute in self.api_attributes:
-            if self.api_map is not None and api_attribute in self.api_map:
-                result[api_attribute] = getattr(self, self.api_map[api_attribute])
-            else:
-                result[api_attribute] = getattr(self, api_attribute)
-        result = self._filter_params(result)
         return result
 
     @property
@@ -387,10 +373,11 @@ class Difference(object):
 
 
 class ModuleManager(object):
-    def __init__(self, client):
-        self.client = client
+    def __init__(self, *args, **kwargs):
+        self.module = kwargs.get('module', None)
+        self.client = kwargs.get('client', None)
         self.have = None
-        self.want = Parameters(self.client.module.params)
+        self.want = Parameters(params=self.module.params)
         self.changes = Changes()
 
     def _set_changed_options(self):
@@ -399,7 +386,7 @@ class ModuleManager(object):
             if getattr(self.want, key) is not None:
                 changed[key] = getattr(self.want, key)
         if changed:
-            self.changes = Changes(changed)
+            self.changes = Changes(params=changed)
 
     def _update_changed_options(self):
         diff = Difference(self.want, self.have)
@@ -415,7 +402,7 @@ class ModuleManager(object):
                 else:
                     changed[k] = change
         if changed:
-            self.changes = Changes(changed)
+            self.changes = Changes(params=changed)
             return True
         return False
 
@@ -447,7 +434,7 @@ class ModuleManager(object):
     def _announce_deprecations(self, result):
         warnings = result.pop('__warnings', [])
         for warning in warnings:
-            self.client.module.deprecate(
+            self.module.deprecate(
                 msg=warning['msg'],
                 version=warning['version']
             )
@@ -472,7 +459,7 @@ class ModuleManager(object):
             self.want.update({'port': '*'})
         if self.want.send is None:
             self.want.update({'send': 'default send string'})
-        if self.client.check_mode:
+        if self.module.check_mode:
             return True
         self.create_on_device()
         return True
@@ -488,13 +475,13 @@ class ModuleManager(object):
         self.have = self.read_current_from_device()
         if not self.should_update():
             return False
-        if self.client.check_mode:
+        if self.module.check_mode:
             return True
         self.update_on_device()
         return True
 
     def remove(self):
-        if self.client.check_mode:
+        if self.module.check_mode:
             return True
         self.remove_from_device()
         if self.exists():
@@ -536,13 +523,13 @@ class ModuleManager(object):
             partition=self.want.partition
         )
         result = resource.attrs
-        return Parameters(result)
+        return Parameters(params=result)
 
 
 class ArgumentSpec(object):
     def __init__(self):
         self.supports_check_mode = True
-        self.argument_spec = dict(
+        argument_spec = dict(
             name=dict(required=True),
             parent=dict(default='/Common/udp'),
             send=dict(),
@@ -553,48 +540,41 @@ class ArgumentSpec(object):
             interval=dict(type='int'),
             timeout=dict(type='int'),
             time_until_up=dict(type='int'),
-
-            # Deprecated params
-            parent_partition=dict(
-                removed_in_version='2.4'
+            state=dict(
+                default='present',
+                choices=['present', 'absent']
+            ),
+            partition=dict(
+                default='Common',
+                fallback=(env_fallback, ['F5_PARTITION'])
             )
         )
-        self.f5_product_name = 'bigip'
-
-
-def cleanup_tokens(client):
-    try:
-        resource = client.api.shared.authz.tokens_s.token.load(
-            name=client.api.icrs.token
-        )
-        resource.delete()
-    except Exception:
-        pass
+        self.argument_spec = {}
+        self.argument_spec.update(f5_argument_spec)
+        self.argument_spec.update(argument_spec)
 
 
 def main():
     spec = ArgumentSpec()
 
-    client = AnsibleF5Client(
+    module = AnsibleModule(
         argument_spec=spec.argument_spec,
-        supports_check_mode=spec.supports_check_mode,
-        f5_product_name=spec.f5_product_name
+        supports_check_mode=spec.supports_check_mode
     )
+    if not HAS_F5SDK:
+        module.fail_json(msg="The python f5-sdk module is required")
+    if not HAS_NETADDR:
+        module.fail_json(msg="The python netaddr module is required")
 
     try:
-        if not HAS_F5SDK:
-            raise F5ModuleError("The python f5-sdk module is required")
-
-        if not HAS_NETADDR:
-            raise F5ModuleError("The python netaddr module is required")
-
-        mm = ModuleManager(client)
+        client = F5Client(**module.params)
+        mm = ModuleManager(module=module, client=client)
         results = mm.exec_module()
         cleanup_tokens(client)
-        client.module.exit_json(**results)
-    except F5ModuleError as e:
+        module.exit_json(**results)
+    except F5ModuleError as ex:
         cleanup_tokens(client)
-        client.module.fail_json(msg=str(e))
+        module.fail_json(msg=str(ex))
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/network/f5/bigip_partition.py
+++ b/lib/ansible/modules/network/f5/bigip_partition.py
@@ -36,11 +36,7 @@ options:
       - present
       - absent
 notes:
-  - Requires the f5-sdk Python package on the host. This is as easy as pip
-    install f5-sdk.
   - Requires BIG-IP software version >= 12
-requirements:
-  - f5-sdk >= 2.2.3
 extends_documentation_fragment: f5
 author:
   - Tim Rupp (@caphrim007)
@@ -105,17 +101,37 @@ description:
   sample: Example partition
 '''
 
-from ansible.module_utils.f5_utils import AnsibleF5Client
-from ansible.module_utils.f5_utils import AnsibleF5Parameters
-from ansible.module_utils.f5_utils import F5ModuleError
-from ansible.module_utils.six import iteritems
-from collections import defaultdict
+from ansible.module_utils.basic import AnsibleModule
+
+HAS_DEVEL_IMPORTS = False
 
 try:
-    from ansible.module_utils.f5_utils import HAS_F5SDK
-    from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
+    # Sideband repository used for dev
+    from library.module_utils.network.f5.bigip import HAS_F5SDK
+    from library.module_utils.network.f5.bigip import F5Client
+    from library.module_utils.network.f5.common import F5ModuleError
+    from library.module_utils.network.f5.common import AnsibleF5Parameters
+    from library.module_utils.network.f5.common import cleanup_tokens
+    from library.module_utils.network.f5.common import fqdn_name
+    from library.module_utils.network.f5.common import f5_argument_spec
+    try:
+        from library.module_utils.network.f5.common import iControlUnexpectedHTTPError
+    except ImportError:
+        HAS_F5SDK = False
+    HAS_DEVEL_IMPORTS = True
 except ImportError:
-    HAS_F5SDK = False
+    # Upstream Ansible
+    from ansible.module_utils.network.f5.bigip import HAS_F5SDK
+    from ansible.module_utils.network.f5.bigip import F5Client
+    from ansible.module_utils.network.f5.common import F5ModuleError
+    from ansible.module_utils.network.f5.common import AnsibleF5Parameters
+    from ansible.module_utils.network.f5.common import cleanup_tokens
+    from ansible.module_utils.network.f5.common import fqdn_name
+    from ansible.module_utils.network.f5.common import f5_argument_spec
+    try:
+        from ansible.module_utils.network.f5.common import iControlUnexpectedHTTPError
+    except ImportError:
+        HAS_F5SDK = False
 
 
 class Parameters(AnsibleF5Parameters):
@@ -135,36 +151,6 @@ class Parameters(AnsibleF5Parameters):
         'description', 'route_domain'
     ]
 
-    def __init__(self, params=None):
-        self._values = defaultdict(lambda: None)
-        self._values['__warnings'] = []
-        if params:
-            self.update(params=params)
-
-    def update(self, params=None):
-        if params:
-            for k, v in iteritems(params):
-                if self.api_map is not None and k in self.api_map:
-                    map_key = self.api_map[k]
-                else:
-                    map_key = k
-
-                # Handle weird API parameters like `dns.proxy.__iter__` by
-                # using a map provided by the module developer
-                class_attr = getattr(type(self), map_key, None)
-                if isinstance(class_attr, property):
-                    # There is a mapped value for the api_map key
-                    if class_attr.fset is None:
-                        # If the mapped value does not have
-                        # an associated setter
-                        self._values[map_key] = v
-                    else:
-                        # The mapped value has a setter
-                        setattr(self, map_key, v)
-                else:
-                    # If the mapped value is not a @property
-                    self._values[map_key] = v
-
     def to_return(self):
         result = {}
         try:
@@ -174,16 +160,6 @@ class Parameters(AnsibleF5Parameters):
             return result
         except Exception:
             return result
-
-    def api_params(self):
-        result = {}
-        for api_attribute in self.api_attributes:
-            if self.api_map is not None and api_attribute in self.api_map:
-                result[api_attribute] = getattr(self, self.api_map[api_attribute])
-            else:
-                result[api_attribute] = getattr(self, api_attribute)
-        result = self._filter_params(result)
-        return result
 
     @property
     def partition(self):
@@ -195,6 +171,10 @@ class Parameters(AnsibleF5Parameters):
         if self._values['route_domain'] is None:
             return None
         return int(self._values['route_domain'])
+
+
+class Changes(Parameters):
+    pass
 
 
 class Difference(object):
@@ -221,11 +201,12 @@ class Difference(object):
 
 
 class ModuleManager(object):
-    def __init__(self, client):
-        self.client = client
+    def __init__(self, *args, **kwargs):
+        self.module = kwargs.get('module', None)
+        self.client = kwargs.get('client', None)
         self.have = None
-        self.want = Parameters(self.client.module.params)
-        self.changes = Parameters()
+        self.want = Parameters(params=self.module.params)
+        self.changes = Changes()
 
     def _set_changed_options(self):
         changed = {}
@@ -233,7 +214,7 @@ class ModuleManager(object):
             if getattr(self.want, key) is not None:
                 changed[key] = getattr(self.want, key)
         if changed:
-            self.changes = Parameters(changed)
+            self.changes = Parameters(params=changed)
 
     def _update_changed_options(self):
         diff = Difference(self.want, self.have)
@@ -246,7 +227,7 @@ class ModuleManager(object):
             else:
                 changed[k] = change
         if changed:
-            self.changes = Parameters(changed)
+            self.changes = Parameters(params=changed)
             return True
         return False
 
@@ -275,7 +256,7 @@ class ModuleManager(object):
             return self.create()
 
     def create(self):
-        if self.client.check_mode:
+        if self.module.check_mode:
             return True
         self.create_on_device()
         if not self.exists():
@@ -292,7 +273,7 @@ class ModuleManager(object):
         self.have = self.read_current_from_device()
         if not self.should_update():
             return False
-        if self.client.check_mode:
+        if self.module.check_mode:
             return True
         self.update_on_device()
         return True
@@ -303,7 +284,7 @@ class ModuleManager(object):
         return False
 
     def remove(self):
-        if self.client.check_mode:
+        if self.module.check_mode:
             return True
         self.remove_from_device()
         if self.exists():
@@ -315,7 +296,7 @@ class ModuleManager(object):
             name=self.want.name
         )
         result = resource.attrs
-        return Parameters(result)
+        return Parameters(params=result)
 
     def exists(self):
         result = self.client.api.tm.auth.partitions.partition.exists(
@@ -348,44 +329,39 @@ class ModuleManager(object):
 class ArgumentSpec(object):
     def __init__(self):
         self.supports_check_mode = True
-        self.argument_spec = dict(
+        argument_spec = dict(
             name=dict(required=True),
             description=dict(),
             route_domain=dict(type='int'),
+            state=dict(
+                choices=['absent', 'present'],
+                default='present'
+            )
         )
-        self.f5_product_name = 'bigip'
-
-
-def cleanup_tokens(client):
-    try:
-        resource = client.api.shared.authz.tokens_s.token.load(
-            name=client.api.icrs.token
-        )
-        resource.delete()
-    except Exception:
-        pass
+        self.argument_spec = {}
+        self.argument_spec.update(f5_argument_spec)
+        self.argument_spec.update(argument_spec)
 
 
 def main():
-    if not HAS_F5SDK:
-        raise F5ModuleError("The python f5-sdk module is required")
-
     spec = ArgumentSpec()
 
-    client = AnsibleF5Client(
+    module = AnsibleModule(
         argument_spec=spec.argument_spec,
-        supports_check_mode=spec.supports_check_mode,
-        f5_product_name=spec.f5_product_name
+        supports_check_mode=spec.supports_check_mode
     )
+    if not HAS_F5SDK:
+        module.fail_json(msg="The python f5-sdk module is required")
 
     try:
-        mm = ModuleManager(client)
+        client = F5Client(**module.params)
+        mm = ModuleManager(module=module, client=client)
         results = mm.exec_module()
         cleanup_tokens(client)
-        client.module.exit_json(**results)
-    except F5ModuleError as e:
+        module.exit_json(**results)
+    except F5ModuleError as ex:
         cleanup_tokens(client)
-        client.module.fail_json(msg=str(e))
+        module.fail_json(msg=str(ex))
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/network/f5/bigip_policy.py
+++ b/lib/ansible/modules/network/f5/bigip_policy.py
@@ -72,11 +72,6 @@ options:
     description:
       - Device partition to manage resources on.
     default: Common
-notes:
-  - Requires the f5-sdk Python package on the host. This is as easy as
-    pip install f5-sdk
-requirements:
-  - f5-sdk
 extends_documentation_fragment: f5
 author:
   - Tim Rupp (@caphrim007)
@@ -166,68 +161,54 @@ rules:
   type: list
   sample: ['/Common/rule1', '/Common/rule2']
 '''
+
 import re
 
-from ansible.module_utils.f5_utils import AnsibleF5Client
-from ansible.module_utils.f5_utils import AnsibleF5Parameters
-from ansible.module_utils.f5_utils import HAS_F5SDK
-from ansible.module_utils.f5_utils import F5ModuleError
-from ansible.module_utils.six import iteritems
-from collections import defaultdict
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import env_fallback
 from distutils.version import LooseVersion
 
+HAS_DEVEL_IMPORTS = False
+
 try:
-    from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
+    # Sideband repository used for dev
+    from library.module_utils.network.f5.bigip import HAS_F5SDK
+    from library.module_utils.network.f5.bigip import F5Client
+    from library.module_utils.network.f5.common import F5ModuleError
+    from library.module_utils.network.f5.common import AnsibleF5Parameters
+    from library.module_utils.network.f5.common import cleanup_tokens
+    from library.module_utils.network.f5.common import fqdn_name
+    from library.module_utils.network.f5.common import f5_argument_spec
+    try:
+        from library.module_utils.network.f5.common import iControlUnexpectedHTTPError
+    except ImportError:
+        HAS_F5SDK = False
+    HAS_DEVEL_IMPORTS = True
+except ImportError:
+    # Upstream Ansible
+    from ansible.module_utils.network.f5.bigip import HAS_F5SDK
+    from ansible.module_utils.network.f5.bigip import F5Client
+    from ansible.module_utils.network.f5.common import F5ModuleError
+    from ansible.module_utils.network.f5.common import AnsibleF5Parameters
+    from ansible.module_utils.network.f5.common import cleanup_tokens
+    from ansible.module_utils.network.f5.common import fqdn_name
+    from ansible.module_utils.network.f5.common import f5_argument_spec
+    try:
+        from ansible.module_utils.network.f5.common import iControlUnexpectedHTTPError
+    except ImportError:
+        HAS_F5SDK = False
+
+try:
     from f5.sdk_exception import NonExtantPolicyRule
 except ImportError:
     HAS_F5SDK = False
 
 
 class Parameters(AnsibleF5Parameters):
-    def __init__(self, params=None):
-        self._values = defaultdict(lambda: None)
-        if params:
-            self.update(params=params)
-        self._values['__warning'] = []
-        self._values['__deprecated'] = []
-
-    def update(self, params=None):
-        if params:
-            for k, v in iteritems(params):
-                if self.api_map is not None and k in self.api_map:
-                    map_key = self.api_map[k]
-                else:
-                    map_key = k
-
-                # Handle weird API parameters like `dns.proxy.__iter__` by
-                # using a map provided by the module developer
-                class_attr = getattr(type(self), map_key, None)
-                if isinstance(class_attr, property):
-                    # There is a mapped value for the api_map key
-                    if class_attr.fset is None:
-                        # If the mapped value does not have an associated setter
-                        self._values[map_key] = v
-                    else:
-                        # The mapped value has a setter
-                        setattr(self, map_key, v)
-                else:
-                    # If the mapped value is not a @property
-                    self._values[map_key] = v
-
     def to_return(self):
         result = {}
         for returnable in self.returnables:
             result[returnable] = getattr(self, returnable)
-        result = self._filter_params(result)
-        return result
-
-    def api_params(self):
-        result = {}
-        for api_attribute in self.api_attributes:
-            if self.api_map is not None and api_attribute in self.api_map:
-                result[api_attribute] = getattr(self, self.api_map[api_attribute])
-            else:
-                result[api_attribute] = getattr(self, api_attribute)
         result = self._filter_params(result)
         return result
 
@@ -261,9 +242,7 @@ class Parameters(AnsibleF5Parameters):
                 return self._get_custom_strategy_name()
 
     def _get_builtin_strategy(self, strategy):
-        return '/{0}/{1}-match'.format(
-            self.partition, strategy
-        )
+        return '/Common/{0}-match'.format(strategy)
 
     def _get_custom_strategy_name(self):
         strategy = self._values['strategy']
@@ -314,9 +293,11 @@ class ComplexParameters(Parameters):
 
 
 class BaseManager(object):
-    def __init__(self, client):
-        self.client = client
+    def __init__(self, *args, **kwargs):
+        self.module = kwargs.get('module', None)
+        self.client = kwargs.get('client', None)
         self.have = None
+        self.want = Parameters(params=self.module.params)
 
     def _announce_deprecations(self):
         warnings = []
@@ -325,7 +306,7 @@ class BaseManager(object):
         if self.have:
             warnings += self.have._values.get('__deprecated', [])
         for warning in warnings:
-            self.client.module.deprecate(
+            self.module.deprecate(
                 msg=warning['msg'],
                 version=warning['version']
             )
@@ -337,7 +318,7 @@ class BaseManager(object):
         if self.have:
             warnings += self.have._values.get('__warning', [])
         for warning in warnings:
-            self.client.module.warn(warning['msg'])
+            self.module.warn(warning['msg'])
 
     def present(self):
         if self.exists():
@@ -386,9 +367,9 @@ class BaseManager(object):
 
 
 class SimpleManager(BaseManager):
-    def __init__(self, client):
-        super(SimpleManager, self).__init__(client)
-        self.want = SimpleParameters(self.client.module.params)
+    def __init__(self, *args, **kwargs):
+        super(SimpleManager, self).__init__(**kwargs)
+        self.want = SimpleParameters(params=self.module.params)
         self.have = SimpleParameters()
         self.changes = SimpleChanges()
 
@@ -398,7 +379,7 @@ class SimpleManager(BaseManager):
             if getattr(self.want, key) is not None:
                 changed[key] = getattr(self.want, key)
         if changed:
-            self.changes = SimpleChanges(changed)
+            self.changes = SimpleChanges(params=changed)
 
     def _update_changed_options(self):
         diff = Difference(self.want, self.have)
@@ -411,7 +392,7 @@ class SimpleManager(BaseManager):
             else:
                 changed[k] = change
         if changed:
-            self.changes = SimpleChanges(changed)
+            self.changes = SimpleChanges(params=changed)
             return True
         return False
 
@@ -445,7 +426,7 @@ class SimpleManager(BaseManager):
             partition=self.want.partition
         )
         rules = self._get_rule_names(resource)
-        result = SimpleParameters(resource.attrs)
+        result = SimpleParameters(params=resource.attrs)
         result.update(dict(rules=rules))
         return result
 
@@ -470,7 +451,7 @@ class SimpleManager(BaseManager):
     def create(self):
         self._validate_creation_parameters()
         self._set_changed_options()
-        if self.client.check_mode:
+        if self.module.check_mode:
             return True
         self.create_on_device()
         return True
@@ -491,7 +472,7 @@ class SimpleManager(BaseManager):
         self.have = self.read_current_from_device()
         if not self.should_update():
             return False
-        if self.client.check_mode:
+        if self.module.check_mode:
             return True
         self.update_on_device()
         return True
@@ -503,7 +484,7 @@ class SimpleManager(BaseManager):
         return changed
 
     def remove(self):
-        if self.client.check_mode:
+        if self.module.check_mode:
             return True
         self.remove_from_device()
         if self.exists():
@@ -519,9 +500,9 @@ class SimpleManager(BaseManager):
 
 
 class ComplexManager(BaseManager):
-    def __init__(self, client):
-        super(ComplexManager, self).__init__(client)
-        self.want = ComplexParameters(self.client.module.params)
+    def __init__(self, *args, **kwargs):
+        super(ComplexManager, self).__init__(**kwargs)
+        self.want = ComplexParameters(params=self.module.params)
         self.have = ComplexParameters()
         self.changes = ComplexChanges()
 
@@ -531,7 +512,7 @@ class ComplexManager(BaseManager):
             if getattr(self.want, key) is not None:
                 changed[key] = getattr(self.want, key)
         if changed:
-            self.changes = ComplexChanges(changed)
+            self.changes = ComplexChanges(params=changed)
 
     def _update_changed_options(self):
         diff = Difference(self.want, self.have)
@@ -544,7 +525,7 @@ class ComplexManager(BaseManager):
             else:
                 changed[k] = change
         if changed:
-            self.changes = ComplexChanges(changed)
+            self.changes = ComplexChanges(params=changed)
             return True
         return False
 
@@ -595,7 +576,7 @@ class ComplexManager(BaseManager):
         return changed
 
     def remove(self):
-        if self.client.check_mode:
+        if self.module.check_mode:
             return True
         self.remove_from_device()
         if self.draft_exists() or self.policy_exists():
@@ -631,7 +612,7 @@ class ComplexManager(BaseManager):
             )
 
         rules = self._get_rule_names(resource)
-        result = ComplexParameters(resource.attrs)
+        result = ComplexParameters(params=resource.attrs)
         result.update(dict(rules=rules))
         return result
 
@@ -697,7 +678,7 @@ class ComplexManager(BaseManager):
         self._validate_creation_parameters()
 
         self._set_changed_options()
-        if self.client.check_mode:
+        if self.module.check_mode:
             return True
 
         if not self.draft_exists():
@@ -716,7 +697,7 @@ class ComplexManager(BaseManager):
         self.have = self.read_current_from_device()
         if not self.should_update():
             return False
-        if self.client.check_mode:
+        if self.module.check_mode:
             return True
 
         if not self.draft_exists():
@@ -787,8 +768,10 @@ class Difference(object):
 
 
 class ModuleManager(object):
-    def __init__(self, client):
-        self.client = client
+    def __init__(self, *args, **kwargs):
+        self.module = kwargs.get('module', None)
+        self.client = kwargs.get('client', None)
+        self.kwargs = kwargs
 
     def exec_module(self):
         if self.version_is_less_than_12():
@@ -799,9 +782,9 @@ class ModuleManager(object):
 
     def get_manager(self, type):
         if type == 'simple':
-            return SimpleManager(self.client)
+            return SimpleManager(**self.kwargs)
         elif type == 'complex':
-            return ComplexManager(self.client)
+            return ComplexManager(**self.kwargs)
 
     def version_is_less_than_12(self):
         version = self.client.api.tmos_version
@@ -814,7 +797,7 @@ class ModuleManager(object):
 class ArgumentSpec(object):
     def __init__(self):
         self.supports_check_mode = True
-        self.argument_spec = dict(
+        argument_spec = dict(
             name=dict(
                 required=True
             ),
@@ -824,32 +807,38 @@ class ArgumentSpec(object):
                 choices=['first', 'all', 'best']
             ),
             state=dict(
-                required=False,
                 default='present',
                 choices=['absent', 'present', 'draft']
+            ),
+            partition=dict(
+                default='Common',
+                fallback=(env_fallback, ['F5_PARTITION'])
             )
         )
-        self.f5_product_name = 'bigip'
+        self.argument_spec = {}
+        self.argument_spec.update(f5_argument_spec)
+        self.argument_spec.update(argument_spec)
 
 
 def main():
-    if not HAS_F5SDK:
-        raise F5ModuleError("The python f5-sdk module is required")
-
     spec = ArgumentSpec()
 
-    client = AnsibleF5Client(
+    module = AnsibleModule(
         argument_spec=spec.argument_spec,
-        supports_check_mode=spec.supports_check_mode,
-        f5_product_name=spec.f5_product_name
+        supports_check_mode=spec.supports_check_mode
     )
+    if not HAS_F5SDK:
+        module.fail_json(msg="The python f5-sdk module is required")
 
     try:
-        mm = ModuleManager(client)
+        client = F5Client(**module.params)
+        mm = ModuleManager(module=module, client=client)
         results = mm.exec_module()
-        client.module.exit_json(**results)
-    except F5ModuleError as e:
-        client.module.fail_json(msg=str(e))
+        cleanup_tokens(client)
+        module.exit_json(**results)
+    except F5ModuleError as ex:
+        cleanup_tokens(client)
+        module.fail_json(msg=str(ex))
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/network/f5/bigip_policy_rule.py
+++ b/lib/ansible/modules/network/f5/bigip_policy_rule.py
@@ -93,12 +93,8 @@ options:
     description:
       - Device partition to manage resources on.
     default: Common
-notes:
-  - Requires the f5-sdk Python package on the host. This is as easy as pip
-    install f5-sdk.
 extends_documentation_fragment: f5
 requirements:
-  - f5-sdk >= 3.0.0
   - BIG-IP >= v12.1.0
 author:
   - Tim Rupp (@caphrim007)
@@ -194,18 +190,39 @@ description:
   sample: My rule
 '''
 
-from ansible.module_utils.f5_utils import AnsibleF5Client
-from ansible.module_utils.f5_utils import AnsibleF5Parameters
-from ansible.module_utils.f5_utils import HAS_F5SDK
-from ansible.module_utils.f5_utils import F5ModuleError
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import env_fallback
 from ansible.module_utils.six import iteritems
-from collections import defaultdict
 
+HAS_DEVEL_IMPORTS = False
 
 try:
-    from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
+    # Sideband repository used for dev
+    from library.module_utils.network.f5.bigip import HAS_F5SDK
+    from library.module_utils.network.f5.bigip import F5Client
+    from library.module_utils.network.f5.common import F5ModuleError
+    from library.module_utils.network.f5.common import AnsibleF5Parameters
+    from library.module_utils.network.f5.common import cleanup_tokens
+    from library.module_utils.network.f5.common import fqdn_name
+    from library.module_utils.network.f5.common import f5_argument_spec
+    try:
+        from library.module_utils.network.f5.common import iControlUnexpectedHTTPError
+    except ImportError:
+        HAS_F5SDK = False
+    HAS_DEVEL_IMPORTS = True
 except ImportError:
-    HAS_F5SDK = False
+    # Upstream Ansible
+    from ansible.module_utils.network.f5.bigip import HAS_F5SDK
+    from ansible.module_utils.network.f5.bigip import F5Client
+    from ansible.module_utils.network.f5.common import F5ModuleError
+    from ansible.module_utils.network.f5.common import AnsibleF5Parameters
+    from ansible.module_utils.network.f5.common import cleanup_tokens
+    from ansible.module_utils.network.f5.common import fqdn_name
+    from ansible.module_utils.network.f5.common import f5_argument_spec
+    try:
+        from ansible.module_utils.network.f5.common import iControlUnexpectedHTTPError
+    except ImportError:
+        HAS_F5SDK = False
 
 
 class Parameters(AnsibleF5Parameters):
@@ -220,45 +237,6 @@ class Parameters(AnsibleF5Parameters):
     updatables = [
         'actions', 'conditions', 'description'
     ]
-
-    def __init__(self, params=None):
-        self._values = defaultdict(lambda: None)
-        if params:
-            self.update(params=params)
-        self._values['__warnings'] = []
-
-    def update(self, params=None):
-        if params:
-            for k, v in iteritems(params):
-                if self.api_map is not None and k in self.api_map:
-                    map_key = self.api_map[k]
-                else:
-                    map_key = k
-
-                # Handle weird API parameters like `dns.proxy.__iter__` by
-                # using a map provided by the module developer
-                class_attr = getattr(type(self), map_key, None)
-                if isinstance(class_attr, property):
-                    # There is a mapped value for the api_map key
-                    if class_attr.fset is None:
-                        # If the mapped value does not have an associated setter
-                        self._values[map_key] = v
-                    else:
-                        # The mapped value has a setter
-                        setattr(self, map_key, v)
-                else:
-                    # If the mapped value is not a @property
-                    self._values[map_key] = v
-
-    def api_params(self):
-        result = {}
-        for api_attribute in self.api_attributes:
-            if self.api_map is not None and api_attribute in self.api_map:
-                result[api_attribute] = getattr(self, self.api_map[api_attribute])
-            else:
-                result[api_attribute] = getattr(self, api_attribute)
-        result = self._filter_params(result)
-        return result
 
     def _fqdn_name(self, value):
         if value is not None and not value.startswith('/'):
@@ -613,9 +591,10 @@ class Difference(object):
 
 
 class ModuleManager(object):
-    def __init__(self, client):
-        self.client = client
-        self.want = ModuleParameters(params=self.client.module.params)
+    def __init__(self, *args, **kwargs):
+        self.module = kwargs.get('module', None)
+        self.client = kwargs.get('client', None)
+        self.want = ModuleParameters(params=self.module.params)
         self.have = ApiParameters()
         self.changes = UsableChanges()
 
@@ -633,7 +612,7 @@ class ModuleManager(object):
                 else:
                     changed[k] = change
         if changed:
-            self.changes = UsableChanges(changed)
+            self.changes = UsableChanges(params=changed)
             return True
         return False
 
@@ -656,7 +635,7 @@ class ModuleManager(object):
         except iControlUnexpectedHTTPError as e:
             raise F5ModuleError(str(e))
 
-        reportable = ReportableChanges(self.changes.to_return())
+        reportable = ReportableChanges(params=self.changes.to_return())
         changes = reportable.to_return()
         result.update(**changes)
         result.update(dict(changed=changed))
@@ -666,7 +645,7 @@ class ModuleManager(object):
     def _announce_deprecations(self, result):
         warnings = result.pop('__warnings', [])
         for warning in warnings:
-            self.client.module.deprecate(
+            self.module.deprecate(
                 msg=warning['msg'],
                 version=warning['version']
             )
@@ -722,7 +701,7 @@ class ModuleManager(object):
         self.have = self.read_current_from_device()
         if not self.should_update():
             return False
-        if self.client.check_mode:
+        if self.module.check_mode:
             return True
         if self.draft_exists():
             redraft = True
@@ -735,7 +714,7 @@ class ModuleManager(object):
         return True
 
     def remove(self):
-        if self.client.check_mode:
+        if self.module.check_mode:
             return True
         if self.draft_exists():
             redraft = True
@@ -751,7 +730,7 @@ class ModuleManager(object):
 
     def create(self):
         self.should_update()
-        if self.client.check_mode:
+        if self.module.check_mode:
             return True
         if self.draft_exists():
             redraft = True
@@ -824,7 +803,7 @@ class ModuleManager(object):
 class ArgumentSpec(object):
     def __init__(self):
         self.supports_check_mode = True
-        self.argument_spec = dict(
+        argument_spec = dict(
             description=dict(),
             actions=dict(
                 type='list',
@@ -860,40 +839,39 @@ class ArgumentSpec(object):
             ),
             name=dict(required=True),
             policy=dict(required=True),
+            state=dict(
+                default='present',
+                choices=['absent', 'present']
+            ),
+            partition=dict(
+                default='Common',
+                fallback=(env_fallback, ['F5_PARTITION'])
+            )
         )
-        self.f5_product_name = 'bigip'
-
-
-def cleanup_tokens(client):
-    try:
-        resource = client.api.shared.authz.tokens_s.token.load(
-            name=client.api.icrs.token
-        )
-        resource.delete()
-    except Exception:
-        pass
+        self.argument_spec = {}
+        self.argument_spec.update(f5_argument_spec)
+        self.argument_spec.update(argument_spec)
 
 
 def main():
-    if not HAS_F5SDK:
-        raise F5ModuleError("The python f5-sdk module is required")
-
     spec = ArgumentSpec()
 
-    client = AnsibleF5Client(
+    module = AnsibleModule(
         argument_spec=spec.argument_spec,
-        supports_check_mode=spec.supports_check_mode,
-        f5_product_name=spec.f5_product_name
+        supports_check_mode=spec.supports_check_mode
     )
+    if not HAS_F5SDK:
+        module.fail_json(msg="The python f5-sdk module is required")
 
     try:
-        mm = ModuleManager(client)
+        client = F5Client(**module.params)
+        mm = ModuleManager(module=module, client=client)
         results = mm.exec_module()
         cleanup_tokens(client)
-        client.module.exit_json(**results)
-    except F5ModuleError as e:
+        module.exit_json(**results)
+    except F5ModuleError as ex:
         cleanup_tokens(client)
-        client.module.fail_json(msg=str(e))
+        module.fail_json(msg=str(ex))
 
 
 if __name__ == '__main__':

--- a/test/sanity/validate-modules/ignore.txt
+++ b/test/sanity/validate-modules/ignore.txt
@@ -41,9 +41,6 @@ lib/ansible/modules/net_tools/cloudflare_dns.py E317
 lib/ansible/modules/net_tools/haproxy.py E317
 lib/ansible/modules/net_tools/omapi_host.py E317
 lib/ansible/modules/network/cloudengine/ce_reboot.py E317
-lib/ansible/modules/network/f5/bigip_partition.py E321
-lib/ansible/modules/network/f5/bigip_policy.py E321
-lib/ansible/modules/network/f5/bigip_policy_rule.py E321
 lib/ansible/modules/network/f5/bigip_pool.py E321
 lib/ansible/modules/network/f5/bigip_profile_client_ssl.py E321
 lib/ansible/modules/network/f5/bigip_provision.py E321

--- a/test/units/modules/network/f5/test_bigip_monitor_http.py
+++ b/test/units/modules/network/f5/test_bigip_monitor_http.py
@@ -18,21 +18,22 @@ if sys.version_info < (2, 7):
 from ansible.compat.tests import unittest
 from ansible.compat.tests.mock import Mock
 from ansible.compat.tests.mock import patch
-from ansible.module_utils.f5_utils import AnsibleF5Client
-from ansible.module_utils.f5_utils import F5ModuleError
+from ansible.module_utils.basic import AnsibleModule
 
 try:
     from library.bigip_monitor_http import Parameters
     from library.bigip_monitor_http import ModuleManager
     from library.bigip_monitor_http import ArgumentSpec
-    from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
+    from library.module_utils.network.f5.common import F5ModuleError
+    from library.module_utils.network.f5.common import iControlUnexpectedHTTPError
     from test.unit.modules.utils import set_module_args
 except ImportError:
     try:
         from ansible.modules.network.f5.bigip_monitor_http import Parameters
         from ansible.modules.network.f5.bigip_monitor_http import ModuleManager
         from ansible.modules.network.f5.bigip_monitor_http import ArgumentSpec
-        from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
+        from ansible.module_utils.network.f5.common import F5ModuleError
+        from ansible.module_utils.network.f5.common import iControlUnexpectedHTTPError
         from units.modules.utils import set_module_args
     except ImportError:
         raise SkipTest("F5 Ansible modules require the f5-sdk Python library")
@@ -74,7 +75,7 @@ class TestParameters(unittest.TestCase):
             partition='Common'
         )
 
-        p = Parameters(args)
+        p = Parameters(params=args)
         assert p.name == 'foo'
         assert p.parent == '/Common/parent'
         assert p.send == 'this is a send string'
@@ -101,7 +102,7 @@ class TestParameters(unittest.TestCase):
             partition='Common'
         )
 
-        p = Parameters(args)
+        p = Parameters(params=args)
         assert p.name == 'foo'
         assert p.parent == '/Common/parent'
         assert p.send == 'this is a send string'
@@ -126,7 +127,7 @@ class TestParameters(unittest.TestCase):
             timeUntilUp=60
         )
 
-        p = Parameters(args)
+        p = Parameters(params=args)
         assert p.name == 'foo'
         assert p.parent == '/Common/parent'
         assert p.send == 'this is a send string'
@@ -140,8 +141,6 @@ class TestParameters(unittest.TestCase):
         assert p.time_until_up == 60
 
 
-@patch('ansible.module_utils.f5_utils.AnsibleF5Client._get_mgmt_root',
-       return_value=True)
 class TestManager(unittest.TestCase):
 
     def setUp(self):
@@ -164,14 +163,13 @@ class TestManager(unittest.TestCase):
             user='admin'
         ))
 
-        client = AnsibleF5Client(
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
 
         # Override methods in the specific type of manager
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.exists = Mock(side_effect=[False, True])
         mm.create_on_device = Mock(return_value=True)
 
@@ -197,15 +195,14 @@ class TestManager(unittest.TestCase):
             user='admin'
         ))
 
-        current = Parameters(load_fixture('load_ltm_monitor_http.json'))
-        client = AnsibleF5Client(
+        current = Parameters(params=load_fixture('load_ltm_monitor_http.json'))
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
 
         # Override methods in the specific type of manager
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.exists = Mock(return_value=True)
         mm.read_current_from_device = Mock(return_value=current)
 
@@ -223,15 +220,14 @@ class TestManager(unittest.TestCase):
             user='admin'
         ))
 
-        current = Parameters(load_fixture('load_ltm_monitor_http.json'))
-        client = AnsibleF5Client(
+        current = Parameters(params=load_fixture('load_ltm_monitor_http.json'))
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
 
         # Override methods in the specific type of manager
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.exists = Mock(return_value=True)
         mm.read_current_from_device = Mock(return_value=current)
         mm.update_on_device = Mock(return_value=True)
@@ -251,15 +247,14 @@ class TestManager(unittest.TestCase):
             user='admin'
         ))
 
-        current = Parameters(load_fixture('load_ltm_monitor_http.json'))
-        client = AnsibleF5Client(
+        current = Parameters(params=load_fixture('load_ltm_monitor_http.json'))
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
 
         # Override methods in the specific type of manager
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.exists = Mock(return_value=True)
         mm.read_current_from_device = Mock(return_value=current)
         mm.update_on_device = Mock(return_value=True)
@@ -279,15 +274,14 @@ class TestManager(unittest.TestCase):
             user='admin'
         ))
 
-        current = Parameters(load_fixture('load_ltm_monitor_http.json'))
-        client = AnsibleF5Client(
+        current = Parameters(params=load_fixture('load_ltm_monitor_http.json'))
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
 
         # Override methods in the specific type of manager
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.exists = Mock(return_value=True)
         mm.read_current_from_device = Mock(return_value=current)
         mm.update_on_device = Mock(return_value=True)
@@ -308,15 +302,14 @@ class TestManager(unittest.TestCase):
             user='admin'
         ))
 
-        current = Parameters(load_fixture('load_ltm_monitor_http.json'))
-        client = AnsibleF5Client(
+        current = Parameters(params=load_fixture('load_ltm_monitor_http.json'))
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
 
         # Override methods in the specific type of manager
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.exists = Mock(return_value=True)
         mm.read_current_from_device = Mock(return_value=current)
         mm.update_on_device = Mock(return_value=True)
@@ -336,15 +329,14 @@ class TestManager(unittest.TestCase):
             user='admin'
         ))
 
-        current = Parameters(load_fixture('load_ltm_monitor_http.json'))
-        client = AnsibleF5Client(
+        current = Parameters(params=load_fixture('load_ltm_monitor_http.json'))
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
 
         # Override methods in the specific type of manager
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.exists = Mock(return_value=True)
         mm.read_current_from_device = Mock(return_value=current)
         mm.update_on_device = Mock(return_value=True)
@@ -364,15 +356,14 @@ class TestManager(unittest.TestCase):
             user='admin'
         ))
 
-        current = Parameters(load_fixture('load_ltm_monitor_http.json'))
-        client = AnsibleF5Client(
+        current = Parameters(params=load_fixture('load_ltm_monitor_http.json'))
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
 
         # Override methods in the specific type of manager
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.exists = Mock(return_value=True)
         mm.read_current_from_device = Mock(return_value=current)
         mm.update_on_device = Mock(return_value=True)
@@ -392,15 +383,14 @@ class TestManager(unittest.TestCase):
             user='admin'
         ))
 
-        current = Parameters(load_fixture('load_ltm_monitor_http.json'))
-        client = AnsibleF5Client(
+        current = Parameters(params=load_fixture('load_ltm_monitor_http.json'))
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
 
         # Override methods in the specific type of manager
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.exists = Mock(return_value=True)
         mm.read_current_from_device = Mock(return_value=current)
         mm.update_on_device = Mock(return_value=True)
@@ -420,15 +410,14 @@ class TestManager(unittest.TestCase):
             user='admin'
         ))
 
-        current = Parameters(load_fixture('load_ltm_monitor_http.json'))
-        client = AnsibleF5Client(
+        current = Parameters(params=load_fixture('load_ltm_monitor_http.json'))
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
 
         # Override methods in the specific type of manager
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.exists = Mock(return_value=True)
         mm.read_current_from_device = Mock(return_value=current)
         mm.update_on_device = Mock(return_value=True)

--- a/test/units/modules/network/f5/test_bigip_monitor_https.py
+++ b/test/units/modules/network/f5/test_bigip_monitor_https.py
@@ -18,21 +18,22 @@ if sys.version_info < (2, 7):
 from ansible.compat.tests import unittest
 from ansible.compat.tests.mock import Mock
 from ansible.compat.tests.mock import patch
-from ansible.module_utils.f5_utils import AnsibleF5Client
-from ansible.module_utils.f5_utils import F5ModuleError
+from ansible.module_utils.basic import AnsibleModule
 
 try:
     from library.bigip_monitor_https import Parameters
     from library.bigip_monitor_https import ModuleManager
     from library.bigip_monitor_https import ArgumentSpec
-    from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
+    from library.module_utils.network.f5.common import F5ModuleError
+    from library.module_utils.network.f5.common import iControlUnexpectedHTTPError
     from test.unit.modules.utils import set_module_args
 except ImportError:
     try:
         from ansible.modules.network.f5.bigip_monitor_https import Parameters
         from ansible.modules.network.f5.bigip_monitor_https import ModuleManager
         from ansible.modules.network.f5.bigip_monitor_https import ArgumentSpec
-        from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
+        from ansible.module_utils.network.f5.common import F5ModuleError
+        from ansible.module_utils.network.f5.common import iControlUnexpectedHTTPError
         from units.modules.utils import set_module_args
     except ImportError:
         raise SkipTest("F5 Ansible modules require the f5-sdk Python library")
@@ -74,7 +75,7 @@ class TestParameters(unittest.TestCase):
             partition='Common'
         )
 
-        p = Parameters(args)
+        p = Parameters(params=args)
         assert p.name == 'foo'
         assert p.parent == '/Common/parent'
         assert p.send == 'this is a send string'
@@ -101,7 +102,7 @@ class TestParameters(unittest.TestCase):
             partition='Common'
         )
 
-        p = Parameters(args)
+        p = Parameters(params=args)
         assert p.name == 'foo'
         assert p.parent == '/Common/parent'
         assert p.send == 'this is a send string'
@@ -126,7 +127,7 @@ class TestParameters(unittest.TestCase):
             timeUntilUp=60
         )
 
-        p = Parameters(args)
+        p = Parameters(params=args)
         assert p.name == 'foo'
         assert p.parent == '/Common/parent'
         assert p.send == 'this is a send string'
@@ -140,8 +141,6 @@ class TestParameters(unittest.TestCase):
         assert p.time_until_up == 60
 
 
-@patch('ansible.module_utils.f5_utils.AnsibleF5Client._get_mgmt_root',
-       return_value=True)
 class TestManager(unittest.TestCase):
 
     def setUp(self):
@@ -164,14 +163,13 @@ class TestManager(unittest.TestCase):
             user='admin'
         ))
 
-        client = AnsibleF5Client(
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
 
         # Override methods in the specific type of manager
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.exists = Mock(side_effect=[False, True])
         mm.create_on_device = Mock(return_value=True)
 
@@ -197,15 +195,14 @@ class TestManager(unittest.TestCase):
             user='admin'
         ))
 
-        current = Parameters(load_fixture('load_ltm_monitor_https.json'))
-        client = AnsibleF5Client(
+        current = Parameters(params=load_fixture('load_ltm_monitor_https.json'))
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
 
         # Override methods in the specific type of manager
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.exists = Mock(return_value=True)
         mm.read_current_from_device = Mock(return_value=current)
 
@@ -223,15 +220,14 @@ class TestManager(unittest.TestCase):
             user='admin'
         ))
 
-        current = Parameters(load_fixture('load_ltm_monitor_https.json'))
-        client = AnsibleF5Client(
+        current = Parameters(params=load_fixture('load_ltm_monitor_https.json'))
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
 
         # Override methods in the specific type of manager
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.exists = Mock(return_value=True)
         mm.read_current_from_device = Mock(return_value=current)
         mm.update_on_device = Mock(return_value=True)
@@ -251,15 +247,14 @@ class TestManager(unittest.TestCase):
             user='admin'
         ))
 
-        current = Parameters(load_fixture('load_ltm_monitor_https.json'))
-        client = AnsibleF5Client(
+        current = Parameters(params=load_fixture('load_ltm_monitor_https.json'))
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
 
         # Override methods in the specific type of manager
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.exists = Mock(return_value=True)
         mm.read_current_from_device = Mock(return_value=current)
         mm.update_on_device = Mock(return_value=True)
@@ -279,15 +274,14 @@ class TestManager(unittest.TestCase):
             user='admin'
         ))
 
-        current = Parameters(load_fixture('load_ltm_monitor_https.json'))
-        client = AnsibleF5Client(
+        current = Parameters(params=load_fixture('load_ltm_monitor_https.json'))
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
 
         # Override methods in the specific type of manager
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.exists = Mock(return_value=True)
         mm.read_current_from_device = Mock(return_value=current)
         mm.update_on_device = Mock(return_value=True)
@@ -308,15 +302,14 @@ class TestManager(unittest.TestCase):
             user='admin'
         ))
 
-        current = Parameters(load_fixture('load_ltm_monitor_https.json'))
-        client = AnsibleF5Client(
+        current = Parameters(params=load_fixture('load_ltm_monitor_https.json'))
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
 
         # Override methods in the specific type of manager
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.exists = Mock(return_value=True)
         mm.read_current_from_device = Mock(return_value=current)
         mm.update_on_device = Mock(return_value=True)
@@ -336,15 +329,14 @@ class TestManager(unittest.TestCase):
             user='admin'
         ))
 
-        current = Parameters(load_fixture('load_ltm_monitor_https.json'))
-        client = AnsibleF5Client(
+        current = Parameters(params=load_fixture('load_ltm_monitor_https.json'))
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
 
         # Override methods in the specific type of manager
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.exists = Mock(return_value=True)
         mm.read_current_from_device = Mock(return_value=current)
         mm.update_on_device = Mock(return_value=True)
@@ -364,15 +356,14 @@ class TestManager(unittest.TestCase):
             user='admin'
         ))
 
-        current = Parameters(load_fixture('load_ltm_monitor_https.json'))
-        client = AnsibleF5Client(
+        current = Parameters(params=load_fixture('load_ltm_monitor_https.json'))
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
 
         # Override methods in the specific type of manager
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.exists = Mock(return_value=True)
         mm.read_current_from_device = Mock(return_value=current)
         mm.update_on_device = Mock(return_value=True)
@@ -392,15 +383,14 @@ class TestManager(unittest.TestCase):
             user='admin'
         ))
 
-        current = Parameters(load_fixture('load_ltm_monitor_https.json'))
-        client = AnsibleF5Client(
+        current = Parameters(params=load_fixture('load_ltm_monitor_https.json'))
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
 
         # Override methods in the specific type of manager
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.exists = Mock(return_value=True)
         mm.read_current_from_device = Mock(return_value=current)
         mm.update_on_device = Mock(return_value=True)
@@ -420,15 +410,14 @@ class TestManager(unittest.TestCase):
             user='admin'
         ))
 
-        current = Parameters(load_fixture('load_ltm_monitor_https.json'))
-        client = AnsibleF5Client(
+        current = Parameters(params=load_fixture('load_ltm_monitor_https.json'))
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
 
         # Override methods in the specific type of manager
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.exists = Mock(return_value=True)
         mm.read_current_from_device = Mock(return_value=current)
         mm.update_on_device = Mock(return_value=True)

--- a/test/units/modules/network/f5/test_bigip_monitor_snmp_dca.py
+++ b/test/units/modules/network/f5/test_bigip_monitor_snmp_dca.py
@@ -18,21 +18,22 @@ if sys.version_info < (2, 7):
 from ansible.compat.tests import unittest
 from ansible.compat.tests.mock import Mock
 from ansible.compat.tests.mock import patch
-from ansible.module_utils.f5_utils import AnsibleF5Client
-from ansible.module_utils.f5_utils import F5ModuleError
+from ansible.module_utils.basic import AnsibleModule
 
 try:
     from library.bigip_monitor_snmp_dca import Parameters
     from library.bigip_monitor_snmp_dca import ModuleManager
     from library.bigip_monitor_snmp_dca import ArgumentSpec
-    from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
+    from library.module_utils.network.f5.common import F5ModuleError
+    from library.module_utils.network.f5.common import iControlUnexpectedHTTPError
     from test.unit.modules.utils import set_module_args
 except ImportError:
     try:
         from ansible.modules.network.f5.bigip_monitor_snmp_dca import Parameters
         from ansible.modules.network.f5.bigip_monitor_snmp_dca import ModuleManager
         from ansible.modules.network.f5.bigip_monitor_snmp_dca import ArgumentSpec
-        from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
+        from ansible.module_utils.network.f5.common import F5ModuleError
+        from ansible.module_utils.network.f5.common import iControlUnexpectedHTTPError
         from units.modules.utils import set_module_args
     except ImportError:
         raise SkipTest("F5 Ansible modules require the f5-sdk Python library")
@@ -77,7 +78,7 @@ class TestParameters(unittest.TestCase):
             version='v1'
         )
 
-        p = Parameters(args)
+        p = Parameters(params=args)
         assert p.agent_type == 'UCD'
         assert p.community == 'public'
         assert p.cpu_coefficient == 1.5
@@ -115,7 +116,7 @@ class TestParameters(unittest.TestCase):
             version='v1'
         )
 
-        p = Parameters(args)
+        p = Parameters(params=args)
         assert p.agent_type == 'UCD'
         assert p.community == 'public'
         assert p.cpu_coefficient == 1.5
@@ -131,8 +132,6 @@ class TestParameters(unittest.TestCase):
         assert p.version == 'v1'
 
 
-@patch('ansible.module_utils.f5_utils.AnsibleF5Client._get_mgmt_root',
-       return_value=True)
 class TestManager(unittest.TestCase):
 
     def setUp(self):
@@ -159,14 +158,13 @@ class TestManager(unittest.TestCase):
             user='admin'
         ))
 
-        client = AnsibleF5Client(
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
 
         # Override methods in the specific type of manager
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.exists = Mock(side_effect=[False, True])
         mm.create_on_device = Mock(return_value=True)
 

--- a/test/units/modules/network/f5/test_bigip_monitor_tcp.py
+++ b/test/units/modules/network/f5/test_bigip_monitor_tcp.py
@@ -18,21 +18,22 @@ if sys.version_info < (2, 7):
 from ansible.compat.tests import unittest
 from ansible.compat.tests.mock import Mock
 from ansible.compat.tests.mock import patch
-from ansible.module_utils.f5_utils import AnsibleF5Client
-from ansible.module_utils.f5_utils import F5ModuleError
+from ansible.module_utils.basic import AnsibleModule
 
 try:
     from library.bigip_monitor_tcp import Parameters
     from library.bigip_monitor_tcp import ModuleManager
     from library.bigip_monitor_tcp import ArgumentSpec
-    from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
+    from library.module_utils.network.f5.common import F5ModuleError
+    from library.module_utils.network.f5.common import iControlUnexpectedHTTPError
     from test.unit.modules.utils import set_module_args
 except ImportError:
     try:
         from ansible.modules.network.f5.bigip_monitor_tcp import Parameters
         from ansible.modules.network.f5.bigip_monitor_tcp import ModuleManager
         from ansible.modules.network.f5.bigip_monitor_tcp import ArgumentSpec
-        from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
+        from ansible.module_utils.network.f5.common import F5ModuleError
+        from ansible.module_utils.network.f5.common import iControlUnexpectedHTTPError
         from units.modules.utils import set_module_args
     except ImportError:
         raise SkipTest("F5 Ansible modules require the f5-sdk Python library")
@@ -75,7 +76,7 @@ class TestParameters(unittest.TestCase):
             partition='Common'
         )
 
-        p = Parameters(args)
+        p = Parameters(params=args)
         assert p.name == 'foo'
         assert p.parent == '/Common/parent'
         assert p.send == 'this is a send string'
@@ -103,7 +104,7 @@ class TestParameters(unittest.TestCase):
             partition='Common'
         )
 
-        p = Parameters(args)
+        p = Parameters(params=args)
         assert p.name == 'foo'
         assert p.parent == '/Common/parent'
         assert p.send == 'this is a send string'
@@ -128,7 +129,7 @@ class TestParameters(unittest.TestCase):
             timeUntilUp=60
         )
 
-        p = Parameters(args)
+        p = Parameters(params=args)
         assert p.name == 'foo'
         assert p.parent == '/Common/parent'
         assert p.send == 'this is a send string'
@@ -142,8 +143,6 @@ class TestParameters(unittest.TestCase):
         assert p.time_until_up == 60
 
 
-@patch('ansible.module_utils.f5_utils.AnsibleF5Client._get_mgmt_root',
-       return_value=True)
 class TestManager(unittest.TestCase):
 
     def setUp(self):
@@ -166,14 +165,13 @@ class TestManager(unittest.TestCase):
             user='admin'
         ))
 
-        client = AnsibleF5Client(
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
 
         # Override methods to force specific logic in the module to happen
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.exists = Mock(side_effect=[False, True])
         mm.create_on_device = Mock(return_value=True)
 
@@ -199,15 +197,14 @@ class TestManager(unittest.TestCase):
             user='admin'
         ))
 
-        current = Parameters(load_fixture('load_ltm_monitor_tcp.json'))
-        client = AnsibleF5Client(
+        current = Parameters(params=load_fixture('load_ltm_monitor_tcp.json'))
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
 
         # Override methods in the specific type of manager
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.exists = Mock(return_value=True)
         mm.read_current_from_device = Mock(return_value=current)
 
@@ -225,15 +222,14 @@ class TestManager(unittest.TestCase):
             user='admin'
         ))
 
-        current = Parameters(load_fixture('load_ltm_monitor_tcp.json'))
-        client = AnsibleF5Client(
+        current = Parameters(params=load_fixture('load_ltm_monitor_tcp.json'))
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
 
         # Override methods in the specific type of manager
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.exists = Mock(return_value=True)
         mm.read_current_from_device = Mock(return_value=current)
         mm.update_on_device = Mock(return_value=True)
@@ -253,15 +249,14 @@ class TestManager(unittest.TestCase):
             user='admin'
         ))
 
-        current = Parameters(load_fixture('load_ltm_monitor_tcp.json'))
-        client = AnsibleF5Client(
+        current = Parameters(params=load_fixture('load_ltm_monitor_tcp.json'))
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
 
         # Override methods in the specific type of manager
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.exists = Mock(return_value=True)
         mm.read_current_from_device = Mock(return_value=current)
         mm.update_on_device = Mock(return_value=True)
@@ -281,15 +276,14 @@ class TestManager(unittest.TestCase):
             user='admin'
         ))
 
-        current = Parameters(load_fixture('load_ltm_monitor_tcp.json'))
-        client = AnsibleF5Client(
+        current = Parameters(params=load_fixture('load_ltm_monitor_tcp.json'))
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
 
         # Override methods in the specific type of manager
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.exists = Mock(return_value=True)
         mm.read_current_from_device = Mock(return_value=current)
         mm.update_on_device = Mock(return_value=True)
@@ -310,15 +304,14 @@ class TestManager(unittest.TestCase):
             user='admin'
         ))
 
-        current = Parameters(load_fixture('load_ltm_monitor_tcp.json'))
-        client = AnsibleF5Client(
+        current = Parameters(params=load_fixture('load_ltm_monitor_tcp.json'))
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
 
         # Override methods in the specific type of manager
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.exists = Mock(return_value=True)
         mm.read_current_from_device = Mock(return_value=current)
         mm.update_on_device = Mock(return_value=True)
@@ -338,15 +331,14 @@ class TestManager(unittest.TestCase):
             user='admin'
         ))
 
-        current = Parameters(load_fixture('load_ltm_monitor_tcp.json'))
-        client = AnsibleF5Client(
+        current = Parameters(params=load_fixture('load_ltm_monitor_tcp.json'))
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
 
         # Override methods in the specific type of manager
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.exists = Mock(return_value=True)
         mm.read_current_from_device = Mock(return_value=current)
         mm.update_on_device = Mock(return_value=True)
@@ -366,15 +358,14 @@ class TestManager(unittest.TestCase):
             user='admin'
         ))
 
-        current = Parameters(load_fixture('load_ltm_monitor_tcp.json'))
-        client = AnsibleF5Client(
+        current = Parameters(params=load_fixture('load_ltm_monitor_tcp.json'))
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
 
         # Override methods in the specific type of manager
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.exists = Mock(return_value=True)
         mm.read_current_from_device = Mock(return_value=current)
         mm.update_on_device = Mock(return_value=True)
@@ -394,15 +385,14 @@ class TestManager(unittest.TestCase):
             user='admin'
         ))
 
-        current = Parameters(load_fixture('load_ltm_monitor_tcp.json'))
-        client = AnsibleF5Client(
+        current = Parameters(params=load_fixture('load_ltm_monitor_tcp.json'))
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
 
         # Override methods in the specific type of manager
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.exists = Mock(return_value=True)
         mm.read_current_from_device = Mock(return_value=current)
         mm.update_on_device = Mock(return_value=True)
@@ -422,15 +412,14 @@ class TestManager(unittest.TestCase):
             user='admin'
         ))
 
-        current = Parameters(load_fixture('load_ltm_monitor_tcp.json'))
-        client = AnsibleF5Client(
+        current = Parameters(params=load_fixture('load_ltm_monitor_tcp.json'))
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
 
         # Override methods in the specific type of manager
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.exists = Mock(return_value=True)
         mm.read_current_from_device = Mock(return_value=current)
         mm.update_on_device = Mock(return_value=True)

--- a/test/units/modules/network/f5/test_bigip_monitor_tcp_echo.py
+++ b/test/units/modules/network/f5/test_bigip_monitor_tcp_echo.py
@@ -18,15 +18,15 @@ if sys.version_info < (2, 7):
 from ansible.compat.tests import unittest
 from ansible.compat.tests.mock import Mock
 from ansible.compat.tests.mock import patch
-from ansible.module_utils.f5_utils import AnsibleF5Client
-from ansible.module_utils.f5_utils import F5ModuleError
+from ansible.module_utils.basic import AnsibleModule
 
 try:
     from library.bigip_monitor_tcp_echo import Parameters
     from library.bigip_monitor_tcp_echo import ModuleManager
     from library.bigip_monitor_tcp_echo import ArgumentSpec
     from library.bigip_monitor_tcp_echo import HAS_F5SDK
-    from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
+    from library.module_utils.network.f5.common import F5ModuleError
+    from library.module_utils.network.f5.common import iControlUnexpectedHTTPError
     from test.unit.modules.utils import set_module_args
 except ImportError:
     try:
@@ -34,7 +34,8 @@ except ImportError:
         from ansible.modules.network.f5.bigip_monitor_tcp_echo import ModuleManager
         from ansible.modules.network.f5.bigip_monitor_tcp_echo import ArgumentSpec
         from ansible.modules.network.f5.bigip_monitor_tcp_echo import HAS_F5SDK
-        from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
+        from ansible.module_utils.network.f5.common import F5ModuleError
+        from ansible.module_utils.network.f5.common import iControlUnexpectedHTTPError
         from units.modules.utils import set_module_args
     except ImportError:
         raise SkipTest("F5 Ansible modules require the f5-sdk Python library")
@@ -73,7 +74,7 @@ class TestParameters(unittest.TestCase):
             partition='Common'
         )
 
-        p = Parameters(args)
+        p = Parameters(params=args)
         assert p.name == 'foo'
         assert p.parent == '/Common/parent'
         assert p.ip == '10.10.10.10'
@@ -94,7 +95,7 @@ class TestParameters(unittest.TestCase):
             partition='Common'
         )
 
-        p = Parameters(args)
+        p = Parameters(params=args)
         assert p.name == 'foo'
         assert p.parent == '/Common/parent'
         assert p.ip == '10.10.10.10'
@@ -114,7 +115,7 @@ class TestParameters(unittest.TestCase):
             timeUntilUp=60
         )
 
-        p = Parameters(args)
+        p = Parameters(params=args)
         assert p.name == 'foo'
         assert p.parent == '/Common/parent'
         assert p.ip == '10.10.10.10'
@@ -125,8 +126,6 @@ class TestParameters(unittest.TestCase):
         assert p.time_until_up == 60
 
 
-@patch('ansible.module_utils.f5_utils.AnsibleF5Client._get_mgmt_root',
-       return_value=True)
 class TestManagerEcho(unittest.TestCase):
 
     def setUp(self):
@@ -144,14 +143,13 @@ class TestManagerEcho(unittest.TestCase):
             user='admin'
         ))
 
-        client = AnsibleF5Client(
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
 
         # Override methods in the specific type of manager
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.exists = Mock(side_effect=[False, True])
         mm.create_on_device = Mock(return_value=True)
 
@@ -171,15 +169,14 @@ class TestManagerEcho(unittest.TestCase):
             user='admin'
         ))
 
-        current = Parameters(load_fixture('load_ltm_monitor_tcp_echo.json'))
-        client = AnsibleF5Client(
+        current = Parameters(params=load_fixture('load_ltm_monitor_tcp_echo.json'))
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
 
         # Override methods in the specific type of manager
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.exists = Mock(return_value=True)
         mm.read_current_from_device = Mock(return_value=current)
 
@@ -196,15 +193,14 @@ class TestManagerEcho(unittest.TestCase):
             user='admin'
         ))
 
-        current = Parameters(load_fixture('load_ltm_monitor_tcp_echo.json'))
-        client = AnsibleF5Client(
+        current = Parameters(params=load_fixture('load_ltm_monitor_tcp_echo.json'))
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
 
         # Override methods in the specific type of manager
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.exists = Mock(return_value=True)
         mm.read_current_from_device = Mock(return_value=current)
         mm.update_on_device = Mock(return_value=True)
@@ -223,15 +219,14 @@ class TestManagerEcho(unittest.TestCase):
             user='admin'
         ))
 
-        current = Parameters(load_fixture('load_ltm_monitor_tcp_echo.json'))
-        client = AnsibleF5Client(
+        current = Parameters(params=load_fixture('load_ltm_monitor_tcp_echo.json'))
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
 
         # Override methods in the specific type of manager
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.exists = Mock(return_value=True)
         mm.read_current_from_device = Mock(return_value=current)
         mm.update_on_device = Mock(return_value=True)
@@ -251,15 +246,14 @@ class TestManagerEcho(unittest.TestCase):
             user='admin'
         ))
 
-        current = Parameters(load_fixture('load_ltm_monitor_tcp_echo.json'))
-        client = AnsibleF5Client(
+        current = Parameters(params=load_fixture('load_ltm_monitor_tcp_echo.json'))
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
 
         # Override methods in the specific type of manager
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.exists = Mock(return_value=True)
         mm.read_current_from_device = Mock(return_value=current)
         mm.update_on_device = Mock(return_value=True)
@@ -278,15 +272,14 @@ class TestManagerEcho(unittest.TestCase):
             user='admin'
         ))
 
-        current = Parameters(load_fixture('load_ltm_monitor_tcp_echo.json'))
-        client = AnsibleF5Client(
+        current = Parameters(params=load_fixture('load_ltm_monitor_tcp_echo.json'))
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
 
         # Override methods in the specific type of manager
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.exists = Mock(return_value=True)
         mm.read_current_from_device = Mock(return_value=current)
         mm.update_on_device = Mock(return_value=True)
@@ -304,15 +297,14 @@ class TestManagerEcho(unittest.TestCase):
             user='admin'
         ))
 
-        current = Parameters(load_fixture('load_ltm_monitor_tcp_echo.json'))
-        client = AnsibleF5Client(
+        current = Parameters(params=load_fixture('load_ltm_monitor_tcp_echo.json'))
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
 
         # Override methods in the specific type of manager
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.exists = Mock(return_value=True)
         mm.read_current_from_device = Mock(return_value=current)
         mm.update_on_device = Mock(return_value=True)

--- a/test/units/modules/network/f5/test_bigip_monitor_tcp_half_open.py
+++ b/test/units/modules/network/f5/test_bigip_monitor_tcp_half_open.py
@@ -18,15 +18,15 @@ if sys.version_info < (2, 7):
 from ansible.compat.tests import unittest
 from ansible.compat.tests.mock import Mock
 from ansible.compat.tests.mock import patch
-from ansible.module_utils.f5_utils import AnsibleF5Client
-from ansible.module_utils.f5_utils import F5ModuleError
+from ansible.module_utils.basic import AnsibleModule
 
 try:
     from library.bigip_monitor_tcp_half_open import Parameters
     from library.bigip_monitor_tcp_half_open import ModuleManager
     from library.bigip_monitor_tcp_half_open import ArgumentSpec
     from library.bigip_monitor_tcp_half_open import HAS_F5SDK
-    from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
+    from library.module_utils.network.f5.common import F5ModuleError
+    from library.module_utils.network.f5.common import iControlUnexpectedHTTPError
     from test.unit.modules.utils import set_module_args
 except ImportError:
     try:
@@ -34,7 +34,8 @@ except ImportError:
         from ansible.modules.network.f5.bigip_monitor_tcp_half_open import ModuleManager
         from ansible.modules.network.f5.bigip_monitor_tcp_half_open import ArgumentSpec
         from ansible.modules.network.f5.bigip_monitor_tcp_half_open import HAS_F5SDK
-        from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
+        from ansible.module_utils.network.f5.common import F5ModuleError
+        from ansible.module_utils.network.f5.common import iControlUnexpectedHTTPError
         from units.modules.utils import set_module_args
     except ImportError:
         raise SkipTest("F5 Ansible modules require the f5-sdk Python library")
@@ -74,7 +75,7 @@ class TestParameters(unittest.TestCase):
             partition='Common'
         )
 
-        p = Parameters(args)
+        p = Parameters(params=args)
         assert p.name == 'foo'
         assert p.parent == '/Common/parent'
         assert p.ip == '10.10.10.10'
@@ -97,7 +98,7 @@ class TestParameters(unittest.TestCase):
             partition='Common'
         )
 
-        p = Parameters(args)
+        p = Parameters(params=args)
         assert p.name == 'foo'
         assert p.parent == '/Common/parent'
         assert p.ip == '10.10.10.10'
@@ -118,7 +119,7 @@ class TestParameters(unittest.TestCase):
             timeUntilUp=60
         )
 
-        p = Parameters(args)
+        p = Parameters(params=args)
         assert p.name == 'foo'
         assert p.parent == '/Common/parent'
         assert p.ip == '10.10.10.10'
@@ -130,8 +131,6 @@ class TestParameters(unittest.TestCase):
         assert p.time_until_up == 60
 
 
-@patch('ansible.module_utils.f5_utils.AnsibleF5Client._get_mgmt_root',
-       return_value=True)
 class TestManager(unittest.TestCase):
 
     def setUp(self):
@@ -150,14 +149,13 @@ class TestManager(unittest.TestCase):
             user='admin'
         ))
 
-        client = AnsibleF5Client(
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
 
         # Override methods in the specific type of manager
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.exists = Mock(side_effect=[False, True])
         mm.create_on_device = Mock(return_value=True)
 
@@ -178,15 +176,14 @@ class TestManager(unittest.TestCase):
             user='admin'
         ))
 
-        current = Parameters(load_fixture('load_ltm_monitor_tcp_half_open.json'))
-        client = AnsibleF5Client(
+        current = Parameters(params=load_fixture('load_ltm_monitor_tcp_half_open.json'))
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
 
         # Override methods in the specific type of manager
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.exists = Mock(return_value=True)
         mm.read_current_from_device = Mock(return_value=current)
 
@@ -203,15 +200,14 @@ class TestManager(unittest.TestCase):
             user='admin'
         ))
 
-        current = Parameters(load_fixture('load_ltm_monitor_tcp_half_open.json'))
-        client = AnsibleF5Client(
+        current = Parameters(params=load_fixture('load_ltm_monitor_tcp_half_open.json'))
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
 
         # Override methods in the specific type of manager
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.exists = Mock(return_value=True)
         mm.read_current_from_device = Mock(return_value=current)
         mm.update_on_device = Mock(return_value=True)
@@ -230,15 +226,14 @@ class TestManager(unittest.TestCase):
             user='admin'
         ))
 
-        current = Parameters(load_fixture('load_ltm_monitor_tcp_half_open.json'))
-        client = AnsibleF5Client(
+        current = Parameters(params=load_fixture('load_ltm_monitor_tcp_half_open.json'))
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
 
         # Override methods in the specific type of manager
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.exists = Mock(return_value=True)
         mm.read_current_from_device = Mock(return_value=current)
         mm.update_on_device = Mock(return_value=True)
@@ -258,15 +253,14 @@ class TestManager(unittest.TestCase):
             user='admin'
         ))
 
-        current = Parameters(load_fixture('load_ltm_monitor_tcp_half_open.json'))
-        client = AnsibleF5Client(
+        current = Parameters(params=load_fixture('load_ltm_monitor_tcp_half_open.json'))
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
 
         # Override methods in the specific type of manager
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.exists = Mock(return_value=True)
         mm.read_current_from_device = Mock(return_value=current)
         mm.update_on_device = Mock(return_value=True)
@@ -285,15 +279,14 @@ class TestManager(unittest.TestCase):
             user='admin'
         ))
 
-        current = Parameters(load_fixture('load_ltm_monitor_tcp_half_open.json'))
-        client = AnsibleF5Client(
+        current = Parameters(params=load_fixture('load_ltm_monitor_tcp_half_open.json'))
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
 
         # Override methods in the specific type of manager
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.exists = Mock(return_value=True)
         mm.read_current_from_device = Mock(return_value=current)
         mm.update_on_device = Mock(return_value=True)
@@ -311,15 +304,14 @@ class TestManager(unittest.TestCase):
             user='admin'
         ))
 
-        current = Parameters(load_fixture('load_ltm_monitor_tcp_half_open.json'))
-        client = AnsibleF5Client(
+        current = Parameters(params=load_fixture('load_ltm_monitor_tcp_half_open.json'))
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
 
         # Override methods in the specific type of manager
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.exists = Mock(return_value=True)
         mm.read_current_from_device = Mock(return_value=current)
         mm.update_on_device = Mock(return_value=True)

--- a/test/units/modules/network/f5/test_bigip_monitor_udp.py
+++ b/test/units/modules/network/f5/test_bigip_monitor_udp.py
@@ -18,21 +18,22 @@ if sys.version_info < (2, 7):
 from ansible.compat.tests import unittest
 from ansible.compat.tests.mock import Mock
 from ansible.compat.tests.mock import patch
-from ansible.module_utils.f5_utils import AnsibleF5Client
-from ansible.module_utils.f5_utils import F5ModuleError
+from ansible.module_utils.basic import AnsibleModule
 
 try:
     from library.bigip_monitor_udp import Parameters
     from library.bigip_monitor_udp import ModuleManager
     from library.bigip_monitor_udp import ArgumentSpec
-    from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
+    from library.module_utils.network.f5.common import F5ModuleError
+    from library.module_utils.network.f5.common import iControlUnexpectedHTTPError
     from test.unit.modules.utils import set_module_args
 except ImportError:
     try:
         from ansible.modules.network.f5.bigip_monitor_udp import Parameters
         from ansible.modules.network.f5.bigip_monitor_udp import ModuleManager
         from ansible.modules.network.f5.bigip_monitor_udp import ArgumentSpec
-        from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
+        from ansible.module_utils.network.f5.common import F5ModuleError
+        from ansible.module_utils.network.f5.common import iControlUnexpectedHTTPError
         from units.modules.utils import set_module_args
     except ImportError:
         raise SkipTest("F5 Ansible modules require the f5-sdk Python library")
@@ -74,7 +75,7 @@ class TestParameters(unittest.TestCase):
             partition='Common'
         )
 
-        p = Parameters(args)
+        p = Parameters(params=args)
         assert p.name == 'foo'
         assert p.parent == '/Common/parent'
         assert p.send == 'this is a send string'
@@ -101,7 +102,7 @@ class TestParameters(unittest.TestCase):
             partition='Common'
         )
 
-        p = Parameters(args)
+        p = Parameters(params=args)
         assert p.name == 'foo'
         assert p.parent == '/Common/parent'
         assert p.send == 'this is a send string'
@@ -126,7 +127,7 @@ class TestParameters(unittest.TestCase):
             timeUntilUp=60
         )
 
-        p = Parameters(args)
+        p = Parameters(params=args)
         assert p.name == 'foo'
         assert p.parent == '/Common/parent'
         assert p.send == 'this is a send string'
@@ -140,8 +141,6 @@ class TestParameters(unittest.TestCase):
         assert p.time_until_up == 60
 
 
-@patch('ansible.module_utils.f5_utils.AnsibleF5Client._get_mgmt_root',
-       return_value=True)
 class TestManager(unittest.TestCase):
 
     def setUp(self):
@@ -164,14 +163,13 @@ class TestManager(unittest.TestCase):
             user='admin'
         ))
 
-        client = AnsibleF5Client(
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
 
         # Override methods in the specific type of manager
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.exists = Mock(side_effect=[False, True])
         mm.create_on_device = Mock(return_value=True)
 
@@ -197,15 +195,14 @@ class TestManager(unittest.TestCase):
             user='admin'
         ))
 
-        current = Parameters(load_fixture('load_ltm_monitor_udp.json'))
-        client = AnsibleF5Client(
+        current = Parameters(params=load_fixture('load_ltm_monitor_udp.json'))
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
 
         # Override methods in the specific type of manager
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.exists = Mock(return_value=True)
         mm.read_current_from_device = Mock(return_value=current)
 
@@ -223,15 +220,14 @@ class TestManager(unittest.TestCase):
             user='admin'
         ))
 
-        current = Parameters(load_fixture('load_ltm_monitor_udp.json'))
-        client = AnsibleF5Client(
+        current = Parameters(params=load_fixture('load_ltm_monitor_udp.json'))
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
 
         # Override methods in the specific type of manager
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.exists = Mock(return_value=True)
         mm.read_current_from_device = Mock(return_value=current)
         mm.update_on_device = Mock(return_value=True)
@@ -251,15 +247,14 @@ class TestManager(unittest.TestCase):
             user='admin'
         ))
 
-        current = Parameters(load_fixture('load_ltm_monitor_udp.json'))
-        client = AnsibleF5Client(
+        current = Parameters(params=load_fixture('load_ltm_monitor_udp.json'))
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
 
         # Override methods in the specific type of manager
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.exists = Mock(return_value=True)
         mm.read_current_from_device = Mock(return_value=current)
         mm.update_on_device = Mock(return_value=True)
@@ -279,15 +274,14 @@ class TestManager(unittest.TestCase):
             user='admin'
         ))
 
-        current = Parameters(load_fixture('load_ltm_monitor_udp.json'))
-        client = AnsibleF5Client(
+        current = Parameters(params=load_fixture('load_ltm_monitor_udp.json'))
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
 
         # Override methods in the specific type of manager
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.exists = Mock(return_value=True)
         mm.read_current_from_device = Mock(return_value=current)
         mm.update_on_device = Mock(return_value=True)
@@ -308,15 +302,14 @@ class TestManager(unittest.TestCase):
             user='admin'
         ))
 
-        current = Parameters(load_fixture('load_ltm_monitor_udp.json'))
-        client = AnsibleF5Client(
+        current = Parameters(params=load_fixture('load_ltm_monitor_udp.json'))
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
 
         # Override methods in the specific type of manager
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.exists = Mock(return_value=True)
         mm.read_current_from_device = Mock(return_value=current)
         mm.update_on_device = Mock(return_value=True)
@@ -336,15 +329,14 @@ class TestManager(unittest.TestCase):
             user='admin'
         ))
 
-        current = Parameters(load_fixture('load_ltm_monitor_udp.json'))
-        client = AnsibleF5Client(
+        current = Parameters(params=load_fixture('load_ltm_monitor_udp.json'))
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
 
         # Override methods in the specific type of manager
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.exists = Mock(return_value=True)
         mm.read_current_from_device = Mock(return_value=current)
         mm.update_on_device = Mock(return_value=True)
@@ -364,15 +356,14 @@ class TestManager(unittest.TestCase):
             user='admin'
         ))
 
-        current = Parameters(load_fixture('load_ltm_monitor_udp.json'))
-        client = AnsibleF5Client(
+        current = Parameters(params=load_fixture('load_ltm_monitor_udp.json'))
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
 
         # Override methods in the specific type of manager
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.exists = Mock(return_value=True)
         mm.read_current_from_device = Mock(return_value=current)
         mm.update_on_device = Mock(return_value=True)
@@ -392,15 +383,14 @@ class TestManager(unittest.TestCase):
             user='admin'
         ))
 
-        current = Parameters(load_fixture('load_ltm_monitor_udp.json'))
-        client = AnsibleF5Client(
+        current = Parameters(params=load_fixture('load_ltm_monitor_udp.json'))
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
 
         # Override methods in the specific type of manager
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.exists = Mock(return_value=True)
         mm.read_current_from_device = Mock(return_value=current)
         mm.update_on_device = Mock(return_value=True)
@@ -420,15 +410,14 @@ class TestManager(unittest.TestCase):
             user='admin'
         ))
 
-        current = Parameters(load_fixture('load_ltm_monitor_udp.json'))
-        client = AnsibleF5Client(
+        current = Parameters(params=load_fixture('load_ltm_monitor_udp.json'))
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
 
         # Override methods in the specific type of manager
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.exists = Mock(return_value=True)
         mm.read_current_from_device = Mock(return_value=current)
         mm.update_on_device = Mock(return_value=True)

--- a/test/units/modules/network/f5/test_bigip_node.py
+++ b/test/units/modules/network/f5/test_bigip_node.py
@@ -17,20 +17,22 @@ if sys.version_info < (2, 7):
 from ansible.compat.tests import unittest
 from ansible.compat.tests.mock import Mock
 from ansible.compat.tests.mock import patch
-from ansible.module_utils.f5_utils import AnsibleF5Client
+from ansible.module_utils.basic import AnsibleModule
 
 try:
     from library.bigip_node import Parameters
     from library.bigip_node import ModuleManager
     from library.bigip_node import ArgumentSpec
-    from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
+    from library.module_utils.network.f5.common import F5ModuleError
+    from library.module_utils.network.f5.common import iControlUnexpectedHTTPError
     from test.unit.modules.utils import set_module_args
 except ImportError:
     try:
         from ansible.modules.network.f5.bigip_node import Parameters
         from ansible.modules.network.f5.bigip_node import ModuleManager
         from ansible.modules.network.f5.bigip_node import ArgumentSpec
-        from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
+        from ansible.module_utils.network.f5.common import F5ModuleError
+        from ansible.module_utils.network.f5.common import iControlUnexpectedHTTPError
         from units.modules.utils import set_module_args
     except ImportError:
         raise SkipTest("F5 Ansible modules require the f5-sdk Python library")
@@ -64,19 +66,17 @@ class TestParameters(unittest.TestCase):
             name='10.20.30.40'
         )
 
-        p = Parameters(args)
+        p = Parameters(params=args)
         assert p.host == '10.20.30.40'
         assert p.name == '10.20.30.40'
 
     def test_api_parameters(self):
         args = load_fixture('load_ltm_node_1.json')
 
-        p = Parameters(args)
+        p = Parameters(params=args)
         assert p.address == '1.2.3.4'
 
 
-@patch('ansible.module_utils.f5_utils.AnsibleF5Client._get_mgmt_root',
-       return_value=True)
 class TestManager(unittest.TestCase):
 
     def setUp(self):
@@ -96,12 +96,11 @@ class TestManager(unittest.TestCase):
             user='admin'
         ))
 
-        client = AnsibleF5Client(
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
 
         # Override methods to force specific logic in the module to happen
         mm.exists = Mock(side_effect=[False, True])
@@ -125,14 +124,13 @@ class TestManager(unittest.TestCase):
             user='admin'
         ))
 
-        current = Parameters(load_fixture('load_ltm_node_3.json'))
+        current = Parameters(params=load_fixture('load_ltm_node_3.json'))
 
-        client = AnsibleF5Client(
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
 
         # Override methods to force specific logic in the module to happen
         mm.exists = Mock(side_effect=[True, True])

--- a/test/units/modules/network/f5/test_bigip_partition.py
+++ b/test/units/modules/network/f5/test_bigip_partition.py
@@ -17,20 +17,22 @@ if sys.version_info < (2, 7):
 from ansible.compat.tests import unittest
 from ansible.compat.tests.mock import Mock
 from ansible.compat.tests.mock import patch
-from ansible.module_utils.f5_utils import AnsibleF5Client
+from ansible.module_utils.basic import AnsibleModule
 
 try:
     from library.bigip_partition import Parameters
     from library.bigip_partition import ModuleManager
     from library.bigip_partition import ArgumentSpec
-    from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
+    from library.module_utils.network.f5.common import F5ModuleError
+    from library.module_utils.network.f5.common import iControlUnexpectedHTTPError
     from test.unit.modules.utils import set_module_args
 except ImportError:
     try:
         from ansible.modules.network.f5.bigip_partition import Parameters
         from ansible.modules.network.f5.bigip_partition import ModuleManager
         from ansible.modules.network.f5.bigip_partition import ArgumentSpec
-        from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
+        from ansible.module_utils.network.f5.common import F5ModuleError
+        from ansible.module_utils.network.f5.common import iControlUnexpectedHTTPError
         from units.modules.utils import set_module_args
     except ImportError:
         raise SkipTest("F5 Ansible modules require the f5-sdk Python library")
@@ -65,7 +67,7 @@ class TestParameters(unittest.TestCase):
             route_domain=0
         )
 
-        p = Parameters(args)
+        p = Parameters(params=args)
         assert p.name == 'foo'
         assert p.description == 'my description'
         assert p.route_domain == 0
@@ -76,7 +78,7 @@ class TestParameters(unittest.TestCase):
             route_domain='0'
         )
 
-        p = Parameters(args)
+        p = Parameters(params=args)
         assert p.name == 'foo'
         assert p.route_domain == 0
 
@@ -87,14 +89,12 @@ class TestParameters(unittest.TestCase):
             defaultRouteDomain=1
         )
 
-        p = Parameters(args)
+        p = Parameters(params=args)
         assert p.name == 'foo'
         assert p.description == 'my description'
         assert p.route_domain == 1
 
 
-@patch('ansible.module_utils.f5_utils.AnsibleF5Client._get_mgmt_root',
-       return_value=True)
 class TestManagerEcho(unittest.TestCase):
 
     def setUp(self):
@@ -109,14 +109,13 @@ class TestManagerEcho(unittest.TestCase):
             user='admin'
         ))
 
-        client = AnsibleF5Client(
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
 
         # Override methods in the specific type of manager
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.exists = Mock(side_effect=[False, True])
         mm.create_on_device = Mock(return_value=True)
 
@@ -133,15 +132,14 @@ class TestManagerEcho(unittest.TestCase):
             user='admin'
         ))
 
-        current = Parameters(load_fixture('load_tm_auth_partition.json'))
-        client = AnsibleF5Client(
+        current = Parameters(params=load_fixture('load_tm_auth_partition.json'))
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
 
         # Override methods in the specific type of manager
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.exists = Mock(return_value=True)
         mm.read_current_from_device = Mock(return_value=current)
 
@@ -158,15 +156,14 @@ class TestManagerEcho(unittest.TestCase):
             user='admin'
         ))
 
-        current = Parameters(load_fixture('load_tm_auth_partition.json'))
-        client = AnsibleF5Client(
+        current = Parameters(params=load_fixture('load_tm_auth_partition.json'))
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
 
         # Override methods in the specific type of manager
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.exists = Mock(return_value=True)
         mm.read_current_from_device = Mock(return_value=current)
         mm.update_on_device = Mock(return_value=True)
@@ -185,15 +182,14 @@ class TestManagerEcho(unittest.TestCase):
             user='admin'
         ))
 
-        current = Parameters(load_fixture('load_tm_auth_partition.json'))
-        client = AnsibleF5Client(
+        current = Parameters(params=load_fixture('load_tm_auth_partition.json'))
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
 
         # Override methods in the specific type of manager
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.exists = Mock(return_value=True)
         mm.read_current_from_device = Mock(return_value=current)
         mm.update_on_device = Mock(return_value=True)

--- a/test/units/modules/network/f5/test_bigip_policy.py
+++ b/test/units/modules/network/f5/test_bigip_policy.py
@@ -17,7 +17,7 @@ if sys.version_info < (2, 7):
 from ansible.compat.tests import unittest
 from ansible.compat.tests.mock import Mock
 from ansible.compat.tests.mock import patch
-from ansible.module_utils.f5_utils import AnsibleF5Client
+from ansible.module_utils.basic import AnsibleModule
 
 try:
     from library.bigip_policy import Parameters
@@ -25,7 +25,8 @@ try:
     from library.bigip_policy import SimpleManager
     from library.bigip_policy import ComplexManager
     from library.bigip_policy import ArgumentSpec
-    from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
+    from library.module_utils.network.f5.common import F5ModuleError
+    from library.module_utils.network.f5.common import iControlUnexpectedHTTPError
     from test.unit.modules.utils import set_module_args
 except ImportError:
     try:
@@ -34,7 +35,8 @@ except ImportError:
         from ansible.modules.network.f5.bigip_policy import SimpleManager
         from ansible.modules.network.f5.bigip_policy import ComplexManager
         from ansible.modules.network.f5.bigip_policy import ArgumentSpec
-        from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
+        from ansible.module_utils.network.f5.common import F5ModuleError
+        from ansible.module_utils.network.f5.common import iControlUnexpectedHTTPError
         from units.modules.utils import set_module_args
     except ImportError:
         raise SkipTest("F5 Ansible modules require the f5-sdk Python library")
@@ -70,7 +72,7 @@ class TestParameters(unittest.TestCase):
             server='localhost',
             user='admin'
         )
-        p = Parameters(args)
+        p = Parameters(params=args)
         assert p.name == 'foo'
         assert p.description == 'asdf asdf asdf'
         assert p.strategy is None
@@ -85,7 +87,7 @@ class TestParameters(unittest.TestCase):
             user='admin',
             partition='Common'
         )
-        p = Parameters(args)
+        p = Parameters(params=args)
         assert p.name == 'foo'
         assert p.description == 'asdf asdf asdf'
         assert p.strategy == '/Common/foo'
@@ -100,7 +102,7 @@ class TestParameters(unittest.TestCase):
             user='admin',
             partition='Common'
         )
-        p = Parameters(args)
+        p = Parameters(params=args)
         assert p.name == 'foo'
         assert p.description == 'asdf asdf asdf'
         assert p.strategy == '/Common/foo'
@@ -115,7 +117,7 @@ class TestParameters(unittest.TestCase):
             user='admin',
             partition='Common'
         )
-        p = Parameters(args)
+        p = Parameters(params=args)
         assert p.name == 'foo'
         assert p.description == 'asdf asdf asdf'
         assert p.strategy == '/Foo/bar'
@@ -126,14 +128,12 @@ class TestParameters(unittest.TestCase):
             description='asdf asdf asdf',
             strategy='/Common/asdf'
         )
-        p = Parameters(args)
+        p = Parameters(params=args)
         assert p.name == 'foo'
         assert p.description == 'asdf asdf asdf'
         assert p.strategy == '/Common/asdf'
 
 
-@patch('ansible.module_utils.f5_utils.AnsibleF5Client._get_mgmt_root',
-       return_value=True)
 class TestSimpleTrafficPolicyManager(unittest.TestCase):
 
     def setUp(self):
@@ -149,19 +149,18 @@ class TestSimpleTrafficPolicyManager(unittest.TestCase):
             user='admin'
         ))
 
-        client = AnsibleF5Client(
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
 
         # Override methods in the specific type of manager
-        tm = SimpleManager(client)
+        tm = SimpleManager(module=module, params=module.params)
         tm.exists = Mock(return_value=False)
         tm.create_on_device = Mock(return_value=True)
 
         # Override methods to force specific logic in the module to happen
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.version_is_less_than_12 = Mock(return_value=True)
         mm.get_manager = Mock(return_value=tm)
 

--- a/test/units/modules/network/f5/test_bigip_policy_rule.py
+++ b/test/units/modules/network/f5/test_bigip_policy_rule.py
@@ -17,7 +17,7 @@ if sys.version_info < (2, 7):
 from ansible.compat.tests import unittest
 from ansible.compat.tests.mock import Mock
 from ansible.compat.tests.mock import patch
-from ansible.module_utils.f5_utils import AnsibleF5Client
+from ansible.module_utils.basic import AnsibleModule
 
 try:
     from library.bigip_policy_rule import Parameters
@@ -25,7 +25,8 @@ try:
     from library.bigip_policy_rule import ApiParameters
     from library.bigip_policy_rule import ModuleManager
     from library.bigip_policy_rule import ArgumentSpec
-    from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
+    from library.module_utils.network.f5.common import F5ModuleError
+    from library.module_utils.network.f5.common import iControlUnexpectedHTTPError
     from test.unit.modules.utils import set_module_args
 except ImportError:
     try:
@@ -34,7 +35,8 @@ except ImportError:
         from ansible.modules.network.f5.bigip_policy_rule import ApiParameters
         from ansible.modules.network.f5.bigip_policy_rule import ModuleManager
         from ansible.modules.network.f5.bigip_policy_rule import ArgumentSpec
-        from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
+        from ansible.module_utils.network.f5.common import F5ModuleError
+        from ansible.module_utils.network.f5.common import iControlUnexpectedHTTPError
         from units.modules.utils import set_module_args
     except ImportError:
         raise SkipTest("F5 Ansible modules require the f5-sdk Python library")
@@ -107,8 +109,6 @@ class TestParameters(unittest.TestCase):
         assert len(p.conditions) == 1
 
 
-@patch('ansible.module_utils.f5_utils.AnsibleF5Client._get_mgmt_root',
-       return_value=True)
 class TestManager(unittest.TestCase):
 
     def setUp(self):
@@ -136,14 +136,13 @@ class TestManager(unittest.TestCase):
             user='admin'
         ))
 
-        client = AnsibleF5Client(
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
 
         # Override methods to force specific logic in the module to happen
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.exists = Mock(return_value=False)
         mm.publish_on_device = Mock(return_value=True)
         mm.draft_exists = Mock(return_value=False)
@@ -176,15 +175,14 @@ class TestManager(unittest.TestCase):
             user='admin'
         ))
 
-        current = ApiParameters(load_fixture('load_ltm_policy_draft_rule_http-uri_forward.json'))
-        client = AnsibleF5Client(
+        current = ApiParameters(params=load_fixture('load_ltm_policy_draft_rule_http-uri_forward.json'))
+        module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            f5_product_name=self.spec.f5_product_name
+            supports_check_mode=self.spec.supports_check_mode
         )
 
         # Override methods to force specific logic in the module to happen
-        mm = ModuleManager(client)
+        mm = ModuleManager(module=module)
         mm.exists = Mock(return_value=True)
         mm.read_current_from_device = Mock(return_value=current)
         mm.draft_exists = Mock(return_value=False)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Primarily, this patch contains refactors to remove tracebacks that
are generated when libraries are missing. There is also,

* Removed re-def of cleanup_tokens.
* Changed parameter args to be keywords.
* Changed imports to include new module_util locations.
* Imports also include developing (sideband) module_util locations.
* Changed to using F5Client and plain AnsibleModule to prevent tracebacks caused by missing libraries.
* Removed init and update methods from most Parameter classes (optimization) as its now included in module_utils.
* Changed module and module param references to take into account the new self.module arg. Minor bug fixes made during this refactor.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
various f5 modules

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.14 (default, Dec 12 2017, 16:55:09) [GCC 4.9.2]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
