### PR TITLE
Aci access port to interface policy leaf profile

### DIFF
--- a/lib/ansible/modules/network/aci/aci_access_port_to_interface_policy_leaf_profile.py
+++ b/lib/ansible/modules/network/aci/aci_access_port_to_interface_policy_leaf_profile.py
@@ -33,11 +33,19 @@ options:
     -  The name of the Fabric access policy leaf interface profile access port selector.
     required: yes
     aliases: [ name, access_port_selector_name ]
+  description:
+    description:
+    - The description to assign to the C(access_port_selector)
+    required: no
   leaf_port_blk:
     description:
     - The name of the Fabric access policy leaf interface profile access port block.
     required: yes
     aliases: [ leaf_port_blk_name ]
+  leaf_port_blk_description:
+    description:
+    - The description to assign to the C(leaf_port_blk)
+    required: no
   from:
     description:
     - The beggining (from range) of the port range block for the leaf access port block.
@@ -119,7 +127,9 @@ def main():
     argument_spec.update({
         'leaf_interface_profile': dict(type='str', aliases=['leaf_interface_profile_name']),
         'access_port_selector': dict(type='str', aliases=['name', 'access_port_selector_name']),
+        'description': dict(typ='str'),
         'leaf_port_blk': dict(type='str', aliases=['leaf_port_blk_name']),
+        'leaf_port_blk_description': dict(type='str'),
         'from': dict(type='str', aliases=['fromPort', 'from_port_range']),
         'to': dict(type='str', aliases=['toPort', 'to_port_range']),
         'policy_group': dict(type='str', aliases=['policy_group_name']),
@@ -137,7 +147,9 @@ def main():
 
     leaf_interface_profile = module.params['leaf_interface_profile']
     access_port_selector = module.params['access_port_selector']
+    description = module.params['description']
     leaf_port_blk = module.params['leaf_port_blk']
+    leaf_port_blk_description = module.params['leaf_port_blk_description']
     from_ = module.params['from']
     to_ = module.params['to']
     policy_group = module.params['policy_group']
@@ -167,11 +179,27 @@ def main():
         aci.payload(
             aci_class='infraHPortS',
             class_config=dict(
+                descr=description,
                 name=access_port_selector,
             ),
             child_configs=[
-                dict(infraPortBlk=dict(attributes=dict(name=leaf_port_blk, fromPort=from_, toPort=to_))),
-                dict(infraRsAccBaseGrp=dict(attributes=dict(tDn='uni/infra/funcprof/accportgrp-{0}'.format(policy_group)))),
+                dict(
+                    infraPortBlk=dict(
+                        attributes=dict(
+                            descr=leaf_port_blk_description,
+                            name=leaf_port_blk,
+                            fromPort=from_,
+                            toPort=to_
+                        )
+                    )
+                ),
+                dict(
+                    infraRsAccBaseGrp=dict(
+                        attributes=dict(
+                            tDn='uni/infra/funcprof/accportgrp-{0}'.format(policy_group)
+                        )
+                    )
+                ),
             ],
         )
 

--- a/lib/ansible/modules/network/aci/aci_access_port_to_interface_policy_leaf_profile.py
+++ b/lib/ansible/modules/network/aci/aci_access_port_to_interface_policy_leaf_profile.py
@@ -189,14 +189,14 @@ def main():
                             descr=leaf_port_blk_description,
                             name=leaf_port_blk,
                             fromPort=from_,
-                            toPort=to_
+                            toPort=to_,
                         )
                     )
                 ),
                 dict(
                     infraRsAccBaseGrp=dict(
                         attributes=dict(
-                            tDn='uni/infra/funcprof/accportgrp-{0}'.format(policy_group)
+                            tDn='uni/infra/funcprof/accportgrp-{0}'.format(policy_group),
                         )
                     )
                 ),

--- a/lib/ansible/modules/network/aci/aci_access_port_to_interface_policy_leaf_profile.py
+++ b/lib/ansible/modules/network/aci/aci_access_port_to_interface_policy_leaf_profile.py
@@ -38,16 +38,16 @@ options:
     - The name of the Fabric access policy leaf interface profile access port block.
     required: yes
     aliases: [ leaf_port_blk_name ]
-  fromPort:
+  from:
     description:
     - The beggining (from range) of the port range block for the leaf access port block.
     required: yes
-    aliases: [ from_port_range ]
-  toPort:
+    aliases: [ fromPort, from_port_range ]
+  to:
     description:
     - The end (to range) of the port range block for the leaf access port block.
     required: yes
-    aliases: [ to_port_range ]
+    aliases: [ toPort, to_port_range ]
   policy_group:
     description:
     - The name of the fabric access policy group to be associated with the leaf interface profile interface selector.
@@ -70,8 +70,8 @@ EXAMPLES = r'''
     leaf_interface_profile: leafintprfname
     access_port_selector: accessportselectorname
     leaf_port_blk: leafportblkname
-    fromPort: 13
-    toPort: 16
+    from: 13
+    to: 16
     policy_group: policygroupname
     state: present
 
@@ -83,8 +83,8 @@ EXAMPLES = r'''
     leaf_interface_profile: leafintprfname
     access_port_selector: accessportselectorname
     leaf_port_blk: leafportblkname
-    fromPort: 13
-    toPort: 16
+    from: 13
+    to: 16
     state: present
 
 - name: Remove an interface access port selector associated with an Interface Policy Leaf Profile
@@ -116,15 +116,15 @@ from ansible.module_utils.basic import AnsibleModule
 
 def main():
     argument_spec = aci_argument_spec
-    argument_spec.update(
-        leaf_interface_profile=dict(type='str', aliases=['leaf_interface_profile_name']),
-        access_port_selector=dict(type='str', aliases=['name', 'access_port_selector_name']),
-        leaf_port_blk=dict(type='str', aliases=['leaf_port_blk_name']),
-        fromPort=dict(type='str', aliases=['from_port_range']),
-        toPort=dict(type='str', aliases=['to_port_range']),
-        policy_group=dict(type='str', aliases=['policy_group_name']),
-        state=dict(type='str', default='present', choices=['absent', 'present', 'query']),
-    )
+    argument_spec.update({
+        'leaf_interface_profile': dict(type='str', aliases=['leaf_interface_profile_name']),
+        'access_port_selector': dict(type='str', aliases=['name', 'access_port_selector_name']),
+        'leaf_port_blk': dict(type='str', aliases=['leaf_port_blk_name']),
+        'from': dict(type='str', aliases=['fromPort', 'from_port_range']),
+        'to': dict(type='str', aliases=['toPort', 'to_port_range']),
+        'policy_group': dict(type='str', aliases=['policy_group_name']),
+        'state': dict(type='str', default='present', choices=['absent', 'present', 'query']),
+    })
 
     module = AnsibleModule(
         argument_spec=argument_spec,
@@ -138,8 +138,8 @@ def main():
     leaf_interface_profile = module.params['leaf_interface_profile']
     access_port_selector = module.params['access_port_selector']
     leaf_port_blk = module.params['leaf_port_blk']
-    fromPort = module.params['fromPort']
-    toPort = module.params['toPort']
+    from_ = module.params['from']
+    to_ = module.params['to']
     policy_group = module.params['policy_group']
     state = module.params['state']
 
@@ -170,7 +170,7 @@ def main():
                 name=access_port_selector,
             ),
             child_configs=[
-                dict(infraPortBlk=dict(attributes=dict(name=leaf_port_blk, fromPort=fromPort, toPort=toPort))),
+                dict(infraPortBlk=dict(attributes=dict(name=leaf_port_blk, fromPort=from_, toPort=to_))),
                 dict(infraRsAccBaseGrp=dict(attributes=dict(tDn='uni/infra/funcprof/accportgrp-{0}'.format(policy_group)))),
             ],
         )


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
1) Change `to` and `from` options to use standard names
2) Add description parameter for updating description fields for the object.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
aci_access_port_to_interface_policy_leaf_profile
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.4.2
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
