### PR TITLE
modules/na_cdot_lun: properly compare LUN size

### DIFF
--- a/lib/ansible/modules/storage/netapp/na_cdot_lun.py
+++ b/lib/ansible/modules/storage/netapp/na_cdot_lun.py
@@ -331,7 +331,7 @@ class NetAppCDOTLUN(object):
                 property_changed = True
 
             elif self.state == 'present':
-                if not current_size == self.size:
+                if not int(current_size) == self.size:
                     size_changed = True
                     property_changed = True
 


### PR DESCRIPTION
##### SUMMARY
current_size is returned from the API as string, while self.size
(the requested size) is an integer. This caused the comparison
to always be False, and a resize request to always be sent.

Useless resize requests are fine if you have permissions to do a resize,
but when you don't it'll cause an error. It's best to avoid sending such request
if they're not needed.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
modules/storage/netapp/na_cdot_lun.py

##### ANSIBLE VERSION
```
ansible 2.4.2.0
```
