### PR TITLE
vultr: fix config ini params ignored

### DIFF
--- a/lib/ansible/module_utils/vultr.py
+++ b/lib/ansible/module_utils/vultr.py
@@ -19,8 +19,8 @@ VULTR_API_ENDPOINT = "https://api.vultr.com"
 def vultr_argument_spec():
     return dict(
         api_key=dict(default=os.environ.get('VULTR_API_KEY'), no_log=True),
-        api_timeout=dict(type='int', default=os.environ.get('VULTR_API_TIMEOUT') or 60),
-        api_retries=dict(type='int', default=os.environ.get('VULTR_API_RETRIES') or 5),
+        api_timeout=dict(type='int', default=os.environ.get('VULTR_API_TIMEOUT')),
+        api_retries=dict(type='int', default=os.environ.get('VULTR_API_RETRIES')),
         api_account=dict(default=os.environ.get('VULTR_API_ACCOUNT') or 'default'),
         validate_certs=dict(default=True, type='bool'),
     )
@@ -50,8 +50,8 @@ class Vultr:
 
         self.api_config = {
             'api_key': self.module.params.get('api_key') or config.get('key'),
-            'api_timeout': self.module.params.get('api_timeout') or config.get('timeout'),
-            'api_retries': self.module.params.get('api_retries') or config.get('retries'),
+            'api_timeout': self.module.params.get('api_timeout') or config.get('timeout') or 60,
+            'api_retries': self.module.params.get('api_retries') or config.get('retries') or 5,
         }
 
         # Common vultr returns

--- a/lib/ansible/utils/module_docs_fragments/vultr.py
+++ b/lib/ansible/utils/module_docs_fragments/vultr.py
@@ -16,12 +16,12 @@ options:
     description:
       - HTTP timeout to Vultr API.
       - The ENV variable C(VULTR_API_TIMEOUT) is used as default, when defined.
-    default: 10
+    default: 60
   api_retries:
     description:
       - Amount of retries in case of the Vultr API retuns an HTTP 503 code.
       - The ENV variable C(VULTR_API_RETRIES) is used as default, when defined.
-    default: 10
+    default: 5
   api_account:
     description:
       - Name of the ini section in the C(vultr.ini) file.
@@ -30,7 +30,7 @@ options:
   validate_certs:
     description:
       - Validate SSL certs of the Vultr API.
-    default: true
+    default: yes
     type: bool
 requirements:
   - "python >= 2.6"


### PR DESCRIPTION
##### SUMMARY
settings like timeout and retries read from config ini file vultr.ini. This commit fixes the precedence.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
vultr

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
