### PR TITLE
vultr: add api_endpoint param

### DIFF
--- a/lib/ansible/module_utils/vultr.py
+++ b/lib/ansible/module_utils/vultr.py
@@ -22,6 +22,7 @@ def vultr_argument_spec():
         api_timeout=dict(type='int', default=os.environ.get('VULTR_API_TIMEOUT')),
         api_retries=dict(type='int', default=os.environ.get('VULTR_API_RETRIES')),
         api_account=dict(default=os.environ.get('VULTR_API_ACCOUNT') or 'default'),
+        api_endpoint=dict(default=os.environ.get('VULTR_API_ENDPOINT')),
         validate_certs=dict(default=True, type='bool'),
     )
 
@@ -52,12 +53,15 @@ class Vultr:
             'api_key': self.module.params.get('api_key') or config.get('key'),
             'api_timeout': self.module.params.get('api_timeout') or config.get('timeout') or 60,
             'api_retries': self.module.params.get('api_retries') or config.get('retries') or 5,
+            'api_endpoint': self.module.params.get('api_endpoint') or config.get('endpoint') or VULTR_API_ENDPOINT,
         }
 
         # Common vultr returns
         self.result['vultr_api'] = {
             'api_account': self.module.params.get('api_account'),
             'api_timeout': self.api_config['api_timeout'],
+            'api_retries': self.api_config['api_retries'],
+            'api_endpoint': self.api_config['api_endpoint'],
         }
 
         # Headers to be passed to the API
@@ -70,7 +74,7 @@ class Vultr:
     def read_ini_config(self):
         ini_group = self.module.params.get('api_account')
 
-        keys = ['key', 'timeout', 'retries']
+        keys = ['key', 'timeout', 'retries', 'endpoint']
         env_conf = {}
         for key in keys:
             if 'VULTR_API_%s' % key.upper() not in os.environ:
@@ -122,7 +126,7 @@ class Vultr:
                 return "disable"
 
     def api_query(self, path="/", method="GET", data=None):
-        url = VULTR_API_ENDPOINT + path
+        url = self.api_config['api_endpoint'] + path
 
         if data:
             data_encoded = dict()

--- a/lib/ansible/modules/cloud/vultr/vr_account_facts.py
+++ b/lib/ansible/modules/cloud/vultr/vr_account_facts.py
@@ -49,6 +49,16 @@ vultr_api:
       returned: success
       type: int
       sample: 60
+    api_retries:
+      description: Amount of max retries for the API requests
+      returned: success
+      type: int
+      sample: 5
+    api_endpoint:
+      description: Endpoint used for the API requests
+      returned: success
+      type: string
+      sample: "https://api.vultr.com"
 vultr_account_facts:
   description: Response from Vultr API
   returned: success

--- a/lib/ansible/modules/cloud/vultr/vr_dns_domain.py
+++ b/lib/ansible/modules/cloud/vultr/vr_dns_domain.py
@@ -69,6 +69,16 @@ vultr_api:
       returned: success
       type: int
       sample: 60
+    api_retries:
+      description: Amount of max retries for the API requests
+      returned: success
+      type: int
+      sample: 5
+    api_endpoint:
+      description: Endpoint used for the API requests
+      returned: success
+      type: string
+      sample: "https://api.vultr.com"
 vultr_dns_domain:
   description: Response from Vultr API
   returned: success

--- a/lib/ansible/modules/cloud/vultr/vr_firewall_group.py
+++ b/lib/ansible/modules/cloud/vultr/vr_firewall_group.py
@@ -63,6 +63,16 @@ vultr_api:
       returned: success
       type: int
       sample: 60
+    api_retries:
+      description: Amount of max retries for the API requests
+      returned: success
+      type: int
+      sample: 5
+    api_endpoint:
+      description: Endpoint used for the API requests
+      returned: success
+      type: string
+      sample: "https://api.vultr.com"
 vultr_firewall_group:
   description: Response from Vultr API
   returned: success

--- a/lib/ansible/modules/cloud/vultr/vr_firewall_rule.py
+++ b/lib/ansible/modules/cloud/vultr/vr_firewall_rule.py
@@ -111,6 +111,16 @@ vultr_api:
       returned: success
       type: int
       sample: 60
+    api_retries:
+      description: Amount of max retries for the API requests
+      returned: success
+      type: int
+      sample: 5
+    api_endpoint:
+      description: Endpoint used for the API requests
+      returned: success
+      type: string
+      sample: "https://api.vultr.com"
 vultr_firewall_rule:
   description: Response from Vultr API
   returned: success

--- a/lib/ansible/modules/cloud/vultr/vr_server.py
+++ b/lib/ansible/modules/cloud/vultr/vr_server.py
@@ -155,6 +155,16 @@ vultr_api:
       returned: success
       type: int
       sample: 60
+    api_retries:
+      description: Amount of max retries for the API requests
+      returned: success
+      type: int
+      sample: 5
+    api_endpoint:
+      description: Endpoint used for the API requests
+      returned: success
+      type: string
+      sample: "https://api.vultr.com"
 vultr_server:
   description: Response from Vultr API with a few additions/modification
   returned: success

--- a/lib/ansible/modules/cloud/vultr/vr_ssh_key.py
+++ b/lib/ansible/modules/cloud/vultr/vr_ssh_key.py
@@ -68,6 +68,16 @@ vultr_api:
       returned: success
       type: int
       sample: 60
+    api_retries:
+      description: Amount of max retries for the API requests
+      returned: success
+      type: int
+      sample: 5
+    api_endpoint:
+      description: Endpoint used for the API requests
+      returned: success
+      type: string
+      sample: "https://api.vultr.com"
 vultr_ssh_key:
   description: Response from Vultr API
   returned: success

--- a/lib/ansible/modules/cloud/vultr/vr_startup_script.py
+++ b/lib/ansible/modules/cloud/vultr/vr_startup_script.py
@@ -80,6 +80,16 @@ vultr_api:
       returned: success
       type: int
       sample: 60
+    api_retries:
+      description: Amount of max retries for the API requests
+      returned: success
+      type: int
+      sample: 5
+    api_endpoint:
+      description: Endpoint used for the API requests
+      returned: success
+      type: string
+      sample: "https://api.vultr.com"
 vultr_startup_script:
   description: Response from Vultr API
   returned: success

--- a/lib/ansible/modules/cloud/vultr/vr_user.py
+++ b/lib/ansible/modules/cloud/vultr/vr_user.py
@@ -102,6 +102,16 @@ vultr_api:
       returned: success
       type: int
       sample: 60
+    api_retries:
+      description: Amount of max retries for the API requests
+      returned: success
+      type: int
+      sample: 5
+    api_endpoint:
+      description: Endpoint used for the API requests
+      returned: success
+      type: string
+      sample: "https://api.vultr.com"
 vultr_user:
   description: Response from Vultr API
   returned: success

--- a/lib/ansible/utils/module_docs_fragments/vultr.py
+++ b/lib/ansible/utils/module_docs_fragments/vultr.py
@@ -27,6 +27,11 @@ options:
       - Name of the ini section in the C(vultr.ini) file.
       - The ENV variable C(VULTR_API_ACCOUNT) is used as default, when defined.
     default: default
+  api_endpoint:
+    description:
+      - URL to API endpint (without trailing slash).
+      - The ENV variable C(VULTR_API_ENDPOINT) is used as default, when defined.
+    default: "https://api.vultr.com"
   validate_certs:
     description:
       - Validate SSL certs of the Vultr API.


### PR DESCRIPTION
##### SUMMARY
This allows to switch to a different API endpint, e.g. an API simulator.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
vultr

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
