### PR TITLE
[2.4] cloudstack: fix timeout in ini config file is ignored

### DIFF
--- a/lib/ansible/module_utils/cloudstack.py
+++ b/lib/ansible/module_utils/cloudstack.py
@@ -60,8 +60,8 @@ def cs_argument_spec():
         api_key=dict(default=os.environ.get('CLOUDSTACK_KEY')),
         api_secret=dict(default=os.environ.get('CLOUDSTACK_SECRET'), no_log=True),
         api_url=dict(default=os.environ.get('CLOUDSTACK_ENDPOINT')),
-        api_http_method=dict(choices=['get', 'post'], default=os.environ.get('CLOUDSTACK_METHOD') or 'get'),
-        api_timeout=dict(type='int', default=os.environ.get('CLOUDSTACK_TIMEOUT') or 10),
+        api_http_method=dict(choices=['get', 'post'], default=os.environ.get('CLOUDSTACK_METHOD')),
+        api_timeout=dict(type='int', default=os.environ.get('CLOUDSTACK_TIMEOUT')),
         api_region=dict(default=os.environ.get('CLOUDSTACK_REGION') or 'cloudstack'),
     )
 
@@ -143,8 +143,8 @@ class AnsibleCloudStack(object):
             'endpoint': self.module.params.get('api_url') or config.get('endpoint'),
             'key': self.module.params.get('api_key') or config.get('key'),
             'secret': self.module.params.get('api_secret') or config.get('secret'),
-            'timeout': self.module.params.get('api_timeout') or config.get('timeout'),
-            'method': self.module.params.get('api_http_method') or config.get('method'),
+            'timeout': self.module.params.get('api_timeout') or config.get('timeout') or 10,
+            'method': self.module.params.get('api_http_method') or config.get('method') or 'get',
         }
         self.result.update({
             'api_region': api_region,


### PR DESCRIPTION
(partly cherry picked from commit 1c3bba0bdb8f030a382ece60efa3cd92e4df70fe)

##### SUMMARY
CHANGELOG: Fix regression, settings for timeout and method read from cloudstack.ini are ignored

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
cloudstack

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.4
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
