### PR TITLE
Update archive.py (#34569)

### DIFF
--- a/lib/ansible/modules/files/archive.py
+++ b/lib/ansible/modules/files/archive.py
@@ -291,6 +291,7 @@ def main():
                     elif format == 'tar':
                         arcfile = tarfile.open(dest, 'w')
 
+                    realdest = os.path.realpath(os.path.expanduser(dest))
                     match_root = re.compile('^%s' % re.escape(arcroot))
                     for path in archive_paths:
                         if os.path.isdir(path):
@@ -316,7 +317,7 @@ def main():
                                     fullpath = dirpath + filename
                                     arcname = match_root.sub('', fullpath)
 
-                                    if not filecmp.cmp(fullpath, dest):
+                                    if not os.path.realpath(os.path.expanduser(fullpath)) == realdest:
                                         try:
                                             if format == 'zip':
                                                 arcfile.write(fullpath, arcname)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #34569 

"filecmp.cmp" does not work correctly if two files compared are both 0 byte.
Therefore, I revised the script to compare absolute file paths instead of using "filecmp.cmp".

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
lib/ansible/modules/files/archive.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (devel d05092bf8d) last updated 2018/01/13 17:30:27 (GMT +900)
  config file = None
  configured module search path = [u'/home/vagrant/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/vagrant/ansible/lib/ansible
  executable location = /home/vagrant/ansible/bin/ansible
  python version = 2.7.5 (default, Aug  4 2017, 00:39:18) [GCC 4.8.5 20150623 (Red Hat 4.8.5-16)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
