### PR TITLE
Plumb newline param on cliconf

### DIFF
--- a/lib/ansible/plugins/cliconf/__init__.py
+++ b/lib/ansible/plugins/cliconf/__init__.py
@@ -94,13 +94,14 @@ class CliconfBase(with_metaclass(ABCMeta, object)):
         display.display('closing shell due to command timeout (%s seconds).' % self._connection._play_context.timeout, log_only=True)
         self.close()
 
-    def send_command(self, command, prompt=None, answer=None, sendonly=False):
+    def send_command(self, command, prompt=None, answer=None, sendonly=False, newline=True):
         """Executes a cli command and returns the results
         This method will execute the CLI command on the connection and return
         the results to the caller.  The command output will be returned as a
         string
         """
-        kwargs = {'command': to_bytes(command), 'sendonly': sendonly}
+        kwargs = {'command': to_bytes(command), 'sendonly': sendonly,
+                  'newline': newline}
         if prompt is not None:
             kwargs['prompt'] = to_bytes(prompt)
         if answer is not None:

--- a/lib/ansible/plugins/cliconf/ios.py
+++ b/lib/ansible/plugins/cliconf/ios.py
@@ -70,12 +70,15 @@ class Cliconf(CliconfBase):
                 command = cmd['command']
                 prompt = cmd['prompt']
                 answer = cmd['answer']
+                newline = cmd.get('newline', True)
             except:
                 command = cmd
                 prompt = None
                 answer = None
+                newline = True
 
-            self.send_command(to_bytes(command), to_bytes(prompt), to_bytes(answer))
+            self.send_command(to_bytes(command), to_bytes(prompt), to_bytes(answer),
+                              False, newline)
 
     def get(self, command, prompt=None, answer=None, sendonly=False):
         return self.send_command(to_bytes(command), prompt=to_bytes(prompt),


### PR DESCRIPTION
Change cb1b7052182d675d24bbf0f815587165f0cf6f0a introduced the newline
parameter on network_cli plugin, but that was never introduced on cliconf.
This causes ios_user to break, since the newline value is never plumbed thru
to network_cli