### PR TITLE
set_fact:  handle 'cacheable=value' form

### DIFF
--- a/lib/ansible/plugins/action/set_fact.py
+++ b/lib/ansible/plugins/action/set_fact.py
@@ -36,7 +36,7 @@ class ActionModule(ActionBase):
 
         facts = dict()
 
-        cacheable = bool(self._task.args.pop('cacheable', False))
+        cacheable = boolean(self._task.args.pop('cacheable', False))
 
         if self._task.args:
             for (k, v) in iteritems(self._task.args):

--- a/test/integration/targets/set_fact/set_fact_cached_1.yml
+++ b/test/integration/targets/set_fact/set_fact_cached_1.yml
@@ -33,6 +33,18 @@
         that:
           - ansible_foobar_not_cached == 'this_should_not_be_cached'
 
+    - name: set another non persistent fact that will not be cached
+      set_fact: "cacheable=no fact_not_cached='this_should_not_be_cached!'"
+
+    - name: show fact_not_cached fact after being set
+      debug:
+        var: fact_not_cached
+
+    - name: assert fact_not_cached is correct value
+      assert:
+        that:
+          - fact_not_cached == 'this_should_not_be_cached!'
+
 - name: the second play
   hosts: localhost
   tasks:

--- a/test/integration/targets/set_fact/set_fact_cached_2.yml
+++ b/test/integration/targets/set_fact/set_fact_cached_2.yml
@@ -19,3 +19,12 @@
       assert:
         that:
           - ansible_foobar_not_cached is undefined
+
+    - name: show fact_not_cached fact
+      debug:
+        var: fact_not_cached
+
+    - name: assert fact_not_cached is not cached
+      assert:
+        that:
+          - fact_not_cached is undefined


### PR DESCRIPTION
##### SUMMARY

If fact caching is enabled and `cacheable=value` form is used, then facts are always kept in cache.

Integration test provided.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
set_fact

##### ANSIBLE VERSION
```
ansible 2.5.0 (devel 191b934dbd) last updated 2018/01/15 11:56:12 (GMT +200)
```

##### ADDITIONAL INFORMATION
How to reproduce:
```
$ cat test.yml
- hosts: localhost
  gather_facts: no
  tasks:
  - set_fact: "cacheable=no fact_not_cached='this_should_not_be_cached!'"
$ mkdir /tmp/facts
$ ANSIBLE_CACHE_PLUGIN=jsonfile ANSIBLE_CACHE_PLUGIN_CONNECTION=/tmp/facts ansible-playbook -i localhost, test.yml
$ ls /tmp/facts/localhost && echo "ERROR"
```