### PR TITLE
Fix name param. Remove logging.

### DIFF
--- a/lib/ansible/module_utils/k8s/lookup.py
+++ b/lib/ansible/module_utils/k8s/lookup.py
@@ -64,7 +64,6 @@ class KubernetesLookup(object):
         self.connection = {}
 
     def run(self, terms, variables=None, **kwargs):
-        self.mylog('Here!')
         self.kind = kwargs.get('kind')
         self.name = kwargs.get('resource_name')
         self.namespace = kwargs.get('namespace')
@@ -100,14 +99,9 @@ class KubernetesLookup(object):
             )
 
         if self.name:
-            self.mylog("Calling get_object()")
             return self.get_object()
 
         return self.list_objects()
-
-    def mylog(self, msg):
-        with open('loggit.txt', 'a') as f:
-            f.write(msg + '\n')
 
     def get_helper(self, api_version, kind):
         try:
@@ -144,7 +138,6 @@ class KubernetesLookup(object):
             result = self.helper.get_object(self.name, self.namespace)
         except KubernetesException as exc:
             raise Exception('Failed to retrieve requested object: {0}'.format(exc.message))
-        self.mylog("Got restult")
         response = []
         if result is not None:
             # Convert Datetime objects to ISO format

--- a/lib/ansible/plugins/lookup/k8s.py
+++ b/lib/ansible/plugins/lookup/k8s.py
@@ -44,7 +44,7 @@ DOCUMENTATION = """
         - Use to specify an object model. If I(resource definition) is provided, the I(kind) from a
           I(resource_definition) will override this option.
         required: true
-      name:
+      resource_name:
         description:
         - Fetch a specific object by name. If I(resource definition) is provided, the I(metadata.name) value
           from the I(resource_definition) will override this option.


### PR DESCRIPTION
##### SUMMARY
Lookup plugin cleanup. 

- `name` parameter should be `resource_name`
- remove development logging

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/k8s/lookup.py

##### ANSIBLE VERSION
```
ansible 2.5.0 (feature/fix-lookup 50c38d0823) last updated 2018/01/14 12:08:32 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/Users/chouseknecht/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/chouseknecht/projects/ansible/lib/ansible
  executable location = /Users/chouseknecht/projects/ansible/bin/ansible
  python version = 2.7.14 (default, Nov 14 2017, 23:24:24) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.38)]
```
