### PR TITLE
Fixes commit a28eb94, which broke validate_certs = False for python <…

### DIFF
--- a/lib/ansible/modules/cloud/vmware/_vsphere_guest.py
+++ b/lib/ansible/modules/cloud/vmware/_vsphere_guest.py
@@ -1804,7 +1804,7 @@ def main():
         module.fail_json(msg='pysphere does not support verifying certificates with python < 2.7.9.  Either update python or set '
                              'validate_certs=False on the task')
 
-    if not validate_certs:
+    if not validate_certs and hasattr(ssl, 'SSLContext'):
         ssl._create_default_https_context = ssl._create_unverified_context
 
     try:


### PR DESCRIPTION
##### SUMMARY
Fixes commit a28eb94f1a37d0293e05e289b95835ea47832e73, which broke validate_certs = False for python < 2.7.9


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
vsphere_guest

##### ANSIBLE VERSION
```
ansible 2.5.0 (devel 3950f5b9ce) last updated 2018/01/15 16:55:05 (GMT +000)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /data01/ansible/lib/ansible
  executable location = /data01/ansible/bin/ansible
  python version = 2.6.6 (r266:84292, Aug  9 2016, 06:11:56) [GCC 4.4.7 20120313 (Red Hat 4.4.7-17)]
```


##### ADDITIONAL INFORMATION
If the vsphere_guest module is used with validate_certs = False and your python version is < 2.7.9.  The following line is evaluated in the module which results in the module failing. 
```
    if not validate_certs:
        ssl._create_default_https_context = ssl._create_unverified_context
```

**diff**
```diff
-    if not validate_certs:
+    if not validate_certs and sys.version_info > (2,7,9):
        ssl._create_default_https_context = ssl._create_unverified_context
```
