### PR TITLE
Changing ENOS cliconf plugin license from BSD to GPL

### DIFF
--- a/lib/ansible/plugins/cliconf/enos.py
+++ b/lib/ansible/plugins/cliconf/enos.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2018 Lenovo, Inc.
+# Copyright (C) 2017 Lenovo, Inc.
 # All rights reserved.
 #
 # This file is part of Ansible

--- a/lib/ansible/plugins/cliconf/enos.py
+++ b/lib/ansible/plugins/cliconf/enos.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
-# Contains CLIConf Plugin methods for ENOS Module
+# Contains CLIConf Plugin methods for ENOS Modules
 # Lenovo Networking
 #
 from __future__ import (absolute_import, division, print_function)

--- a/lib/ansible/plugins/cliconf/enos.py
+++ b/lib/ansible/plugins/cliconf/enos.py
@@ -1,6 +1,5 @@
 #
-# Copyright (C) 2017 Lenovo, Inc.
-# All rights reserved.
+# (c) 2017 Red Hat Inc.
 #
 # This file is part of Ansible
 #

--- a/lib/ansible/plugins/cliconf/enos.py
+++ b/lib/ansible/plugins/cliconf/enos.py
@@ -1,34 +1,23 @@
-# This code is part of Ansible, but is an independent component.
-# This particular file snippet, and this file snippet only, is GPL licensed.
-# Modules you write using this snippet, which is embedded dynamically by
-# Ansible still belong to the author of the module, and may assign their own
-# license to the complete work.
 #
-# Copyright (C) 2017 Lenovo, Inc.
+# Copyright (C) 2018 Lenovo, Inc.
 # All rights reserved.
 #
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are met:
+# This file is part of Ansible
 #
-#  * Redistributions of source code must retain the above copyright
-#    notice, this list of conditions and the following disclaimer.
-#  * Redistributions in binary form must reproduce the above copyright notice,
-#    this list of conditions and the following disclaimer in the documentation
-#    and/or other materials provided with the distribution.
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 #
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-# POSSIBILITY OF SUCH DAMAGE.
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 #
-# Contains CLI Configuration Plugin methods for ENOS Modules
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Contains Action Plugin methods for ENOS Config Module
 # Lenovo Networking
 #
 from __future__ import (absolute_import, division, print_function)

--- a/lib/ansible/plugins/cliconf/enos.py
+++ b/lib/ansible/plugins/cliconf/enos.py
@@ -1,5 +1,5 @@
 # This code is part of Ansible, but is an independent component.
-# This particular file snippet, and this file snippet only, is BSD licensed.
+# This particular file snippet, and this file snippet only, is GPL licensed.
 # Modules you write using this snippet, which is embedded dynamically by
 # Ansible still belong to the author of the module, and may assign their own
 # license to the complete work.

--- a/lib/ansible/plugins/cliconf/enos.py
+++ b/lib/ansible/plugins/cliconf/enos.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
-# Contains CLIConf Plugin methods for ENOS Config Module
+# Contains CLIConf Plugin methods for ENOS Module
 # Lenovo Networking
 #
 from __future__ import (absolute_import, division, print_function)

--- a/lib/ansible/plugins/cliconf/enos.py
+++ b/lib/ansible/plugins/cliconf/enos.py
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
-# Contains Action Plugin methods for ENOS Config Module
+# Contains CLIConf Plugin methods for ENOS Config Module
 # Lenovo Networking
 #
 from __future__ import (absolute_import, division, print_function)


### PR DESCRIPTION
##### SUMMARY
Changing BSD to GPL for license as Suggested by John

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
lib/ansible/plugins/cliconf/enos.py

##### ANSIBLE VERSION
ansible 2.5.0
config file = /etc/ansible/ansible.cfg
configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible-2.5.0-py2.7.egg/ansible
executable location = /usr/local/bin/ansible
python version = 2.7.6 (default, Oct 26 2016, 20:30:19) [GCC 4.8.4]

ADDITIONAL INFORMATION
This is an effort to support Lenovo ENOS Switches in Ansible