### PR TITLE
Tests symlinks

### DIFF
--- a/test/runner/lib/target.py
+++ b/test/runner/lib/target.py
@@ -291,14 +291,17 @@ def walk_test_targets(path=None, module_path=None, extensions=None, prefix=None,
     :type extra_dirs: tuple[str] | None
     :rtype: collections.Iterable[TestTarget]
     """
+
+    # track the pwd for short circuiting some of internal links
+    startpath = os.path.realpath('.') + '/'
+
     # walk and follow symlinks to allow testing external directories
     for root, _, file_names in os.walk(path or '.', topdown=False, followlinks=True):
 
-        # This is a workaround to ignore symmlinks pointing back at the checkout
+        # This is a workaround to ignore symlinks pointing back at the checkout
         if os.path.islink(root):
-            startpath = os.path.realpath('.')
             real = os.path.realpath(root)
-            if real.startswith(startpath + '/'):
+            if real.startswith(startpath):
                 continue
 
         if root.endswith('/__pycache__'):

--- a/test/runner/lib/target.py
+++ b/test/runner/lib/target.py
@@ -293,6 +293,14 @@ def walk_test_targets(path=None, module_path=None, extensions=None, prefix=None,
     """
     # walk and follow symlinks to allow testing external directories
     for root, _, file_names in os.walk(path or '.', topdown=False, followlinks=True):
+
+        # This is a workaround to ignore symmlinks pointing back at the checkout
+        if os.path.islink(root):
+            startpath = os.path.realpath('.')
+            real = os.path.realpath(root)
+            if real.startswith(startpath + '/'):
+                continue
+
         if root.endswith('/__pycache__'):
             continue
 

--- a/test/runner/lib/target.py
+++ b/test/runner/lib/target.py
@@ -291,6 +291,7 @@ def walk_test_targets(path=None, module_path=None, extensions=None, prefix=None,
     :type extra_dirs: tuple[str] | None
     :rtype: collections.Iterable[TestTarget]
     """
+    # walk and follow symlinks to allow testing external directories
     for root, _, file_names in os.walk(path or '.', topdown=False, followlinks=True):
         if root.endswith('/__pycache__'):
             continue

--- a/test/runner/lib/target.py
+++ b/test/runner/lib/target.py
@@ -291,7 +291,7 @@ def walk_test_targets(path=None, module_path=None, extensions=None, prefix=None,
     :type extra_dirs: tuple[str] | None
     :rtype: collections.Iterable[TestTarget]
     """
-    for root, _, file_names in os.walk(path or '.', topdown=False):
+    for root, _, file_names in os.walk(path or '.', topdown=False, followlinks=True):
         if root.endswith('/__pycache__'):
             continue
 


### PR DESCRIPTION
##### SUMMARY
A plugin or plugin tests author may want to develop content in a repo separate from ansible/ansible. With this patch, they could symlink from the `ansible/ansible/test/...` to the separate repo's checkout and ansible-test will find their test targets.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
ansible-test

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
