### PR TITLE
ovirt_disk: support sparse parameter (#34091)

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_disk.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_disk.py
@@ -87,10 +87,15 @@ options:
     format:
         description:
             - Specify format of the disk.
-            - If (cow) format is used, disk will by created as sparse, so space will be allocated for the volume as needed, also known as I(thin provision).
-            - If (raw) format is used, disk storage will be allocated right away, also known as I(preallocated).
             - Note that this option isn't idempotent as it's not currently possible to change format of the disk via API.
         choices: ['raw', 'cow']
+    sparse:
+        required: False
+        version_added: "2.5"
+        description:
+            - "I(True) if the disk should be sparse (also known as I(thin provision)).
+              If the parameter is omitted, cow disks will be created as sparse and raw disks as I(preallocated)"
+            - Note that this option isn't idempotent as it's not currently possible to change sparseness of the disk via API.
     storage_domain:
         description:
             - "Storage domain name where disk should be created. By default storage is chosen by oVirt/RHV engine."
@@ -438,7 +443,11 @@ class DisksModule(BaseModule):
             format=otypes.DiskFormat(
                 self._module.params.get('format')
             ) if self._module.params.get('format') else None,
-            sparse=self._module.params.get('format') != 'raw',
+            sparse=self._module.params.get(
+                'sparse'
+            ) if self._module.params.get(
+                'sparse'
+            ) is not None else self._module.params.get('format') != 'raw',
             openstack_volume_type=otypes.OpenStackVolumeType(
                 name=self.param('openstack_volume_type')
             ) if self.param('openstack_volume_type') else None,
@@ -563,6 +572,7 @@ def main():
         profile=dict(default=None),
         quota_id=dict(default=None),
         format=dict(default='cow', choices=['raw', 'cow']),
+        sparse=dict(default=None, type='bool'),
         bootable=dict(default=None, type='bool'),
         shareable=dict(default=None, type='bool'),
         logical_unit=dict(default=None, type='dict'),


### PR DESCRIPTION
Support sparse parameter as an explicit
value to allow creating raw-sparse disks.

This commit fixes #34091

##### SUMMARY
Introduce new sparse parameter and have old logic (cow=sparse, raw=preallocated) as default behavior if sparse parameter isn't found.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ovirt_disk

##### ANSIBLE VERSION
```
ansible 2.4.2.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /bin/ansible
  python version = 2.7.5 (default, Aug  4 2017, 00:39:18) [GCC 4.8.5 20150623 (Red Hat 4.8.5-16)]
```


##### ADDITIONAL INFORMATION
raw-sparse is a valid disk kind for oVirt engine