### PR TITLE
Module DOCUMENTATION should match argspec

### DIFF
--- a/lib/ansible/modules/cloud/amazon/_ec2_ami_find.py
+++ b/lib/ansible/modules/cloud/amazon/_ec2_ami_find.py
@@ -158,6 +158,8 @@ options:
     choices: ['success', 'fail']
     default: 'success'
     required: false
+extends_documentation_fragment:
+    - aws
 requirements:
   - "python >= 2.6"
   - boto

--- a/lib/ansible/modules/cloud/amazon/aws_acm_facts.py
+++ b/lib/ansible/modules/cloud/amazon/aws_acm_facts.py
@@ -25,7 +25,9 @@ requirements:
   - boto3
 author:
   - Will Thames (@willthames)
-extends_documentation_fragment: aws
+extends_documentation_fragment:
+    - aws
+    - ec2
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/cloud/amazon/aws_api_gateway.py
+++ b/lib/ansible/modules/cloud/amazon/aws_api_gateway.py
@@ -63,6 +63,7 @@ author:
     - 'Michael De La Rue (@mikedlr)'
 extends_documentation_fragment:
     - aws
+    - ec2
 notes:
    - A future version of this module will probably use tags or another
      ID so that an API can be create only once.

--- a/lib/ansible/modules/cloud/amazon/aws_direct_connect_connection.py
+++ b/lib/ansible/modules/cloud/amazon/aws_direct_connect_connection.py
@@ -17,6 +17,9 @@ description:
     The connection may later be associated or disassociated with a link aggregation group.
 version_added: "2.4"
 author: "Sloane Hertel (@s-hertel)"
+extends_documentation_fragment:
+    - aws
+    - ec2
 requirements:
   - boto3
   - botocore
@@ -36,7 +39,7 @@ options:
     description:
       - The ID of the Direct Connect connection. I(name) or I(connection_id) is
         required to recreate or delete a connection. Modifying attributes of a
-        connection with I(force_update) will result in a new Direct Connect connection ID.
+        connection with I(forced_update) will result in a new Direct Connect connection ID.
   location:
     description:
       -  Where the Direct Connect connection is located. Required when I(state=present).
@@ -50,7 +53,7 @@ options:
     description:
       - The ID of the link aggregation group you want to associate with the connection.
         This is optional in case a stand-alone connection is desired.
-  force_update:
+  forced_update:
     description:
       - To modify bandwidth or location the connection will need to be deleted and recreated.
         By default this will not happen - this option must be set to True.
@@ -80,7 +83,7 @@ aws_direct_connect_connection:
   name: ansible-test-connection
   location: EqDC2
   bandwidth: 10Gbps
-  force_update: True
+  forced_update: True
 
 # delete the connection
 aws_direct_connect_connection:

--- a/lib/ansible/modules/cloud/amazon/aws_direct_connect_gateway.py
+++ b/lib/ansible/modules/cloud/amazon/aws_direct_connect_gateway.py
@@ -21,6 +21,9 @@ description:
   - Deletes AWS Direct Connect Gateway
   - Attaches Virtual Gateways to Direct Connect Gateway
   - Detaches Virtual Gateways to Direct Connect Gateway
+extends_documentation_fragment:
+    - aws
+    - ec2
 requirements: [ boto3 ]
 options:
   state:

--- a/lib/ansible/modules/cloud/amazon/aws_direct_connect_link_aggregation_group.py
+++ b/lib/ansible/modules/cloud/amazon/aws_direct_connect_link_aggregation_group.py
@@ -15,6 +15,9 @@ description:
   - Create, delete, or modify a Direct Connect link aggregation group.
 version_added: "2.4"
 author: "Sloane Hertel (@s-hertel)"
+extends_documentation_fragment:
+    - aws
+    - ec2
 requirements:
   - boto3
   - botocore

--- a/lib/ansible/modules/cloud/amazon/aws_s3.py
+++ b/lib/ansible/modules/cloud/amazon/aws_s3.py
@@ -143,7 +143,9 @@ requirements: [ "boto3", "botocore" ]
 author:
     - "Lester Wade (@lwade)"
     - "Sloane Hertel (@s-hertel)"
-extends_documentation_fragment: aws
+extends_documentation_fragment:
+    - aws
+    - ec2
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/cloud/amazon/aws_s3_cors.py
+++ b/lib/ansible/modules/cloud/amazon/aws_s3_cors.py
@@ -32,6 +32,7 @@ options:
     choices: [ 'present', 'absent' ]
 extends_documentation_fragment:
     - aws
+    - ec2
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/cloud/amazon/aws_waf_facts.py
+++ b/lib/ansible/modules/cloud/amazon/aws_waf_facts.py
@@ -21,7 +21,9 @@ options:
 author:
   - Mike Mochan (@mmochan)
   - Will Thames (@willthames)
-extends_documentation_fragment: aws
+extends_documentation_fragment:
+    - aws
+    - ec2
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
+++ b/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
@@ -93,7 +93,7 @@ options:
               I(domain_name_alias) to be specified.
         required: false
         default: false
-    streaming_distribution_configuration:
+    streaming_distribution_config:
         description:
             - Get the configuration information about a specified RTMP distribution.
               Requires I(distribution_id) or I(domain_name_alias) to be specified.
@@ -214,11 +214,11 @@ streaming_distribution:
       I(distribution_id) or I(domain_name_alias) to be specified.
     returned: only if I(streaming_distribution) is true
     type: dict
-streaming_distribution_configuration:
+streaming_distribution_config:
     description: >
       Describes the streaming configuration information for the distribution.
       Requires I(distribution_id) or I(domain_name_alias) to be specified.
-    returned: only if I(streaming_distribution_configuration) is true
+    returned: only if I(streaming_distribution_config) is true
     type: dict
 summary:
     description: Gives a summary of distributions, streaming distributions and origin access identities.

--- a/lib/ansible/modules/cloud/amazon/cloudwatchevent_rule.py
+++ b/lib/ansible/modules/cloud/amazon/cloudwatchevent_rule.py
@@ -20,6 +20,7 @@ description:
 version_added: "2.2"
 extends_documentation_fragment:
   - aws
+  - ec2
 author: "Jim Dalton (@jsdalton) <jim.dalton@gmail.com>"
 requirements:
   - python >= 2.6

--- a/lib/ansible/modules/cloud/amazon/ec2_key.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_key.py
@@ -55,6 +55,7 @@ options:
 
 extends_documentation_fragment:
   - aws
+  - ec2
 requirements: [ boto3 ]
 author:
   - "Vincent Viallet (@zbal)"

--- a/lib/ansible/modules/cloud/amazon/ec2_lc_find.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_lc_find.py
@@ -51,6 +51,8 @@ options:
 requirements:
   - "python >= 2.6"
   - boto3
+extends_documentation_fragment:
+    - aws
 """
 
 EXAMPLES = '''

--- a/lib/ansible/modules/cloud/amazon/ec2_metadata_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_metadata_facts.py
@@ -26,6 +26,8 @@ description:
       The module must be called from within the EC2 instance itself.
 notes:
     - Parameters to filter on ec2_metadata_facts may be added later.
+extends_documentation_fragment:
+    - url
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_dhcp_option.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_dhcp_option.py
@@ -108,7 +108,9 @@ options:
     default: present
     choices: [ 'absent', 'present' ]
     version_added: "2.1"
-extends_documentation_fragment: aws
+extends_documentation_fragment:
+    - aws
+    - ec2
 requirements:
     - boto
 """

--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_dhcp_option_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_dhcp_option_facts.py
@@ -33,7 +33,7 @@ options:
       - Provide this value as a list
     required: false
     default: None
-    aliases: ['DhcpOptionsIds']
+    aliases: ['DhcpOptionIds']
 extends_documentation_fragment:
     - aws
     - ec2

--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_endpoint_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_endpoint_facts.py
@@ -39,7 +39,9 @@ options:
     required: false
     default: None
 author: Karen Cheng(@Etherdaemon)
-extends_documentation_fragment: aws
+extends_documentation_fragment:
+    - aws
+    - ec2
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_nacl.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_nacl.py
@@ -63,7 +63,9 @@ options:
     choices: ['present', 'absent']
     default: present
 author: Mike Mochan(@mmochan)
-extends_documentation_fragment: aws
+extends_documentation_fragment:
+    - aws
+    - ec2
 requirements: [ botocore, boto3, json ]
 '''
 

--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_peer.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_peer.py
@@ -51,7 +51,9 @@ options:
     default: present
     choices: ['present', 'absent', 'accept', 'reject']
 author: Mike Mochan(@mmochan)
-extends_documentation_fragment: aws
+extends_documentation_fragment:
+    - aws
+    - ec2
 requirements: [ botocore, boto3, json ]
 '''
 

--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_peering_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_peering_facts.py
@@ -31,7 +31,9 @@ options:
     required: false
     default: None
 author: Karen Cheng(@Etherdaemon)
-extends_documentation_fragment: aws
+extends_documentation_fragment:
+  - aws
+  - ec2
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_subnet.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_subnet.py
@@ -87,7 +87,6 @@ options:
     version_added: "2.5"
 extends_documentation_fragment:
     - aws
-    - ec2
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_subnet.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_subnet.py
@@ -87,6 +87,7 @@ options:
     version_added: "2.5"
 extends_documentation_fragment:
     - aws
+    - ec2
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_vgw.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_vgw.py
@@ -59,7 +59,6 @@ options:
     aliases: [ "resource_tags" ]
 author: Nick Aslanidis (@naslanidis)
 extends_documentation_fragment:
-  - aws
   - ec2
 '''
 

--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_vpn.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_vpn.py
@@ -15,6 +15,9 @@ description:
   - This module creates, modifies, and deletes VPN connections. Idempotence is achieved by using the filters
     option or specifying the VPN connection identifier.
 version_added: "2.4"
+extends_documentation_fragment:
+ - ec2
+ - aws
 requirements: ['boto3', 'botocore']
 author: "Sloane Hertel (@s-hertel)"
 options:

--- a/lib/ansible/modules/cloud/amazon/ecs_ecr.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_ecr.py
@@ -52,7 +52,9 @@ options:
         default: 'present'
 author:
  - David M. Lee (@leedm777)
-extends_documentation_fragment: aws
+extends_documentation_fragment:
+  - aws
+  - ec2
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/cloud/amazon/efs_facts.py
+++ b/lib/ansible/modules/cloud/amazon/efs_facts.py
@@ -45,7 +45,8 @@ options:
         required: false
         default: None
 extends_documentation_fragment:
-    - aws
+  - aws
+  - ec2
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/cloud/amazon/elasticache_facts.py
+++ b/lib/ansible/modules/cloud/amazon/elasticache_facts.py
@@ -19,7 +19,9 @@ options:
 
 author:
   - Will Thames (@willthames)
-extends_documentation_fragment: aws
+extends_documentation_fragment:
+  - aws
+  - ec2
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/cloud/amazon/elasticache_parameter_group.py
+++ b/lib/ansible/modules/cloud/amazon/elasticache_parameter_group.py
@@ -28,6 +28,9 @@ description:
   - Returns information about the specified cache cluster.
 version_added: "2.3"
 author: "Sloane Hertel (@s-hertel)"
+extends_documentation_fragment:
+  - aws
+  - ec2
 requirements: [ boto3, botocore ]
 options:
   group_family:

--- a/lib/ansible/modules/cloud/amazon/elasticache_snapshot.py
+++ b/lib/ansible/modules/cloud/amazon/elasticache_snapshot.py
@@ -20,6 +20,9 @@ description:
   - Returns information about the specified snapshot.
 version_added: "2.3"
 author: "Sloane Hertel (@s-hertel)"
+extends_documentation_fragment:
+  - aws
+  - ec2
 requirements: [ boto3, botocore ]
 options:
   name:

--- a/lib/ansible/modules/cloud/amazon/execute_lambda.py
+++ b/lib/ansible/modules/cloud/amazon/execute_lambda.py
@@ -29,6 +29,7 @@ description:
 version_added: "2.2"
 extends_documentation_fragment:
   - aws
+  - ec2
 author: "Ryan Scott Brown (@ryansb) <ryansb@redhat.com>"
 requirements:
   - python >= 2.6

--- a/lib/ansible/modules/cloud/amazon/iam.py
+++ b/lib/ansible/modules/cloud/amazon/iam.py
@@ -99,7 +99,9 @@ notes:
 author:
     - "Jonathan I. Davila (@defionscode)"
     - "Paul Seiffert (@seiffert)"
-extends_documentation_fragment: aws
+extends_documentation_fragment:
+  - aws
+  - ec2
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/cloud/amazon/iam_group.py
+++ b/lib/ansible/modules/cloud/amazon/iam_group.py
@@ -57,6 +57,7 @@ options:
 requirements: [ botocore, boto3 ]
 extends_documentation_fragment:
   - aws
+  - ec2
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/cloud/amazon/iam_managed_policy.py
+++ b/lib/ansible/modules/cloud/amazon/iam_managed_policy.py
@@ -45,6 +45,9 @@ options:
     default: null
     choices: [ "present", "absent" ]
 author: "Dan Kozlowski (@dkhenry)"
+extends_documentation_fragment:
+  - aws
+  - ec2
 requirements:
     - boto3
     - botocore

--- a/lib/ansible/modules/cloud/amazon/iam_role.py
+++ b/lib/ansible/modules/cloud/amazon/iam_role.py
@@ -66,6 +66,7 @@ options:
 requirements: [ botocore, boto3 ]
 extends_documentation_fragment:
   - aws
+  - ec2
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/cloud/amazon/iam_role_facts.py
+++ b/lib/ansible/modules/cloud/amazon/iam_role_facts.py
@@ -37,7 +37,8 @@ options:
         required: false
         default: None
 extends_documentation_fragment:
-    - aws
+  - aws
+  - ec2
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/cloud/amazon/lambda_alias.py
+++ b/lib/ansible/modules/cloud/amazon/lambda_alias.py
@@ -52,9 +52,9 @@ options:
 requirements:
     - boto3
 extends_documentation_fragment:
-    - aws
-
-'''
+  - aws
+  - ec2
+ '''
 
 EXAMPLES = '''
 ---

--- a/lib/ansible/modules/cloud/amazon/lambda_alias.py
+++ b/lib/ansible/modules/cloud/amazon/lambda_alias.py
@@ -54,7 +54,7 @@ requirements:
 extends_documentation_fragment:
   - aws
   - ec2
- '''
+'''
 
 EXAMPLES = '''
 ---

--- a/lib/ansible/modules/cloud/amazon/lambda_event.py
+++ b/lib/ansible/modules/cloud/amazon/lambda_event.py
@@ -67,7 +67,6 @@ requirements:
 extends_documentation_fragment:
     - aws
     - ec2
-
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/cloud/amazon/lambda_event.py
+++ b/lib/ansible/modules/cloud/amazon/lambda_event.py
@@ -66,6 +66,7 @@ requirements:
     - boto3
 extends_documentation_fragment:
     - aws
+    - ec2
 
 '''
 

--- a/lib/ansible/modules/cloud/amazon/lambda_facts.py
+++ b/lib/ansible/modules/cloud/amazon/lambda_facts.py
@@ -54,7 +54,7 @@ requirements:
 extends_documentation_fragment:
   - aws
   - ec2
- '''
+'''
 
 EXAMPLES = '''
 ---

--- a/lib/ansible/modules/cloud/amazon/lambda_facts.py
+++ b/lib/ansible/modules/cloud/amazon/lambda_facts.py
@@ -52,9 +52,9 @@ author: Pierre Jodouin (@pjodouin)
 requirements:
     - boto3
 extends_documentation_fragment:
-    - aws
-
-'''
+  - aws
+  - ec2
+ '''
 
 EXAMPLES = '''
 ---

--- a/lib/ansible/modules/cloud/amazon/lambda_policy.py
+++ b/lib/ansible/modules/cloud/amazon/lambda_policy.py
@@ -93,7 +93,7 @@ requirements:
 extends_documentation_fragment:
   - aws
   - ec2
- '''
+'''
 
 EXAMPLES = '''
 ---

--- a/lib/ansible/modules/cloud/amazon/lambda_policy.py
+++ b/lib/ansible/modules/cloud/amazon/lambda_policy.py
@@ -91,9 +91,9 @@ options:
 requirements:
     - boto3
 extends_documentation_fragment:
-    - aws
-
-'''
+  - aws
+  - ec2
+ '''
 
 EXAMPLES = '''
 ---

--- a/lib/ansible/modules/cloud/amazon/lightsail.py
+++ b/lib/ansible/modules/cloud/amazon/lightsail.py
@@ -69,7 +69,9 @@ requirements:
   - "python >= 2.6"
   - boto3
 
-extends_documentation_fragment: aws
+extends_documentation_fragment:
+  - aws
+  - ec2
 '''
 
 

--- a/lib/ansible/modules/cloud/amazon/rds_param_group.py
+++ b/lib/ansible/modules/cloud/amazon/rds_param_group.py
@@ -82,6 +82,7 @@ options:
     description:
       - Map of parameter names and values. Numeric values may be represented as K for kilo (1024), M for mega (1024^2), G for giga (1024^3),
         or T for tera (1024^4), and these values will be expanded into the appropriate number before being set in the parameter group.
+    aliases: [parameters]
   tags:
     description:
       - Dictionary of tags to attach to the parameter group

--- a/lib/ansible/modules/cloud/amazon/redshift.py
+++ b/lib/ansible/modules/cloud/amazon/redshift.py
@@ -144,7 +144,9 @@ options:
       - how long before wait gives up, in seconds
     default: 300
 requirements: [ 'boto' ]
-extends_documentation_fragment: aws
+extends_documentation_fragment:
+  - aws
+  - ec2
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/cloud/amazon/redshift_subnet_group.py
+++ b/lib/ansible/modules/cloud/amazon/redshift_subnet_group.py
@@ -45,7 +45,9 @@ options:
     default: null
     aliases: ['subnets']
 requirements: [ 'boto' ]
-extends_documentation_fragment: aws
+extends_documentation_fragment:
+  - aws
+  - ec2
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/cloud/amazon/route53_facts.py
+++ b/lib/ansible/modules/cloud/amazon/route53_facts.py
@@ -111,7 +111,9 @@ options:
         ]
     default: 'list'
 author: Karen Cheng(@Etherdaemon)
-extends_documentation_fragment: aws
+extends_documentation_fragment:
+  - aws
+  - ec2
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/cloud/amazon/sns.py
+++ b/lib/ansible/modules/cloud/amazon/sns.py
@@ -84,7 +84,9 @@ options:
     required: true
     default: json
     choices: ['json', 'string']
-
+extends_documentation_fragment:
+ - ec2
+ - aws
 requirements:
     - "boto"
 """

--- a/lib/ansible/modules/cloud/amazon/sns_topic.py
+++ b/lib/ansible/modules/cloud/amazon/sns_topic.py
@@ -63,7 +63,9 @@ options:
         Blame Amazon."
     required: False
     default: True
-extends_documentation_fragment: aws
+extends_documentation_fragment:
+  - aws
+  - ec2
 requirements: [ "boto" ]
 """
 

--- a/lib/ansible/modules/cloud/cloudstack/cs_network_offering.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_network_offering.py
@@ -83,10 +83,11 @@ options:
   service_offering:
     description:
       - The service offering name or ID used by virtual router provider.
-  service_provider_list:
+  service_provider:
     description:
       - Provider to service mapping.
       - If not specified, the provider for the service will be mapped to the default provider on the physical network.
+    aliases: [service_provider]
   specify_ip_ranges:
     description:
       - Wheter the network offering supports specifying IP ranges.

--- a/lib/ansible/modules/cloud/digital_ocean/digital_ocean.py
+++ b/lib/ansible/modules/cloud/digital_ocean/digital_ocean.py
@@ -39,6 +39,7 @@ options:
   id:
     description:
      - Numeric, the droplet id you want to operate on.
+     aliases: ['droplet_id']
   name:
     description:
      - String, this is the name of the droplet - must be formatted by hostname rules, or the name of a SSH key.

--- a/lib/ansible/modules/cloud/digital_ocean/digital_ocean.py
+++ b/lib/ansible/modules/cloud/digital_ocean/digital_ocean.py
@@ -39,7 +39,7 @@ options:
   id:
     description:
      - Numeric, the droplet id you want to operate on.
-     aliases: ['droplet_id']
+    aliases: ['droplet_id']
   name:
     description:
      - String, this is the name of the droplet - must be formatted by hostname rules, or the name of a SSH key.

--- a/lib/ansible/modules/cloud/digital_ocean/digital_ocean_certificate.py
+++ b/lib/ansible/modules/cloud/digital_ocean/digital_ocean_certificate.py
@@ -43,6 +43,7 @@ options:
     description:
      - DigitalOcean OAuth token.
     required: true
+    aliases=['DO_API_TOKEN', 'DO_API_KEY', 'DO_OAUTH_TOKEN']
 
 notes:
   - Two environment variables can be used, DO_API_KEY, DO_OAUTH_TOKEN and DO_API_TOKEN.

--- a/lib/ansible/modules/cloud/digital_ocean/digital_ocean_certificate.py
+++ b/lib/ansible/modules/cloud/digital_ocean/digital_ocean_certificate.py
@@ -43,7 +43,7 @@ options:
     description:
      - DigitalOcean OAuth token.
     required: true
-    aliases=['DO_API_TOKEN', 'DO_API_KEY', 'DO_OAUTH_TOKEN']
+    aliases: ['DO_API_TOKEN', 'DO_API_KEY', 'DO_OAUTH_TOKEN']
 
 notes:
   - Two environment variables can be used, DO_API_KEY, DO_OAUTH_TOKEN and DO_API_TOKEN.

--- a/lib/ansible/modules/cloud/digital_ocean/digital_ocean_domain.py
+++ b/lib/ansible/modules/cloud/digital_ocean/digital_ocean_domain.py
@@ -31,11 +31,11 @@ options:
     description:
      - DigitalOcean api token.
     version_added: "1.9.5"
-    aliases: ['api_token']
+    aliases: ['API_TOKEN']
   id:
     description:
      - Numeric, the droplet id you want to operate on.
-     aliases: ['droplet_id']
+    aliases: ['droplet_id']
   name:
     description:
      - String, this is the name of the droplet - must be formatted by hostname rules, or the name of a SSH key, or the name of a domain.

--- a/lib/ansible/modules/cloud/digital_ocean/digital_ocean_domain.py
+++ b/lib/ansible/modules/cloud/digital_ocean/digital_ocean_domain.py
@@ -35,6 +35,7 @@ options:
   id:
     description:
      - Numeric, the droplet id you want to operate on.
+     aliases: ['droplet_id']
   name:
     description:
      - String, this is the name of the droplet - must be formatted by hostname rules, or the name of a SSH key, or the name of a domain.

--- a/lib/ansible/modules/cloud/digital_ocean/digital_ocean_sshkey.py
+++ b/lib/ansible/modules/cloud/digital_ocean/digital_ocean_sshkey.py
@@ -33,6 +33,7 @@ options:
     required: false
     default: None
     version_added: 2.4
+    aliases: ['id']
   name:
     description:
      - The name for the SSH key

--- a/lib/ansible/modules/cloud/digital_ocean/digital_ocean_tag.py
+++ b/lib/ansible/modules/cloud/digital_ocean/digital_ocean_tag.py
@@ -31,6 +31,7 @@ options:
     description:
     - The ID of the resource to operate on.
     - The data type of resource_id is changed from integer to string, from version 2.5.
+    aliases: ['droplet_id']
   resource_type:
     description:
     - The type of resource to operate on. Currently, only tagging of

--- a/lib/ansible/modules/cloud/packet/packet_device.py
+++ b/lib/ansible/modules/cloud/packet/packet_device.py
@@ -98,12 +98,6 @@ options:
     description:
       - Userdata blob made available to the machine
 
-  wait:
-    description:
-      - Whether to wait for the instance to be assigned IP address before returning.
-      - This option has been deprecated in favor of C(wait_for_public_IPv).
-    default: false
-
   wait_for_public_IPv:
     description:
       - Whether to wait for the instance to be assigned a public IPv4/IPv6 address.

--- a/lib/ansible/modules/cloud/rackspace/rax_cdb.py
+++ b/lib/ansible/modules/cloud/rackspace/rax_cdb.py
@@ -60,7 +60,9 @@ options:
       - how long before wait gives up, in seconds
     default: 300
 author: "Simon JAILLET (@jails)"
-extends_documentation_fragment: rackspace
+extends_documentation_fragment:
+  - rackspace
+  - rackspace.openstack
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/cloud/rackspace/rax_cdb_database.py
+++ b/lib/ansible/modules/cloud/rackspace/rax_cdb_database.py
@@ -40,7 +40,9 @@ options:
     choices: ['present', 'absent']
     default: present
 author: "Simon JAILLET (@jails)"
-extends_documentation_fragment: rackspace
+extends_documentation_fragment:
+  - rackspace
+  - rackspace.openstack
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/cloud/rackspace/rax_cdb_user.py
+++ b/lib/ansible/modules/cloud/rackspace/rax_cdb_user.py
@@ -47,7 +47,9 @@ options:
     choices: ['present', 'absent']
     default: present
 author: "Simon JAILLET (@jails)"
-extends_documentation_fragment: rackspace
+extends_documentation_fragment:
+  - rackspace
+  - rackspace.openstack
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/cloud/rackspace/rax_clb.py
+++ b/lib/ansible/modules/cloud/rackspace/rax_clb.py
@@ -101,7 +101,9 @@ options:
 author:
     - "Christopher H. Laco (@claco)"
     - "Matt Martz (@sivel)"
-extends_documentation_fragment: rackspace
+extends_documentation_fragment:
+  - rackspace
+  - rackspace.openstack
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/cloud/rackspace/rax_clb_nodes.py
+++ b/lib/ansible/modules/cloud/rackspace/rax_clb_nodes.py
@@ -77,7 +77,9 @@ options:
     description:
       - Weight of node
 author: "Lukasz Kawczynski (@neuroid)"
-extends_documentation_fragment: rackspace
+extends_documentation_fragment:
+  - rackspace
+  - rackspace.openstack
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/cloud/rackspace/rax_clb_ssl.py
+++ b/lib/ansible/modules/cloud/rackspace/rax_clb_ssl.py
@@ -67,7 +67,9 @@ options:
     - How long before "wait" gives up, in seconds.
     default: 300
 author: Ash Wilson
-extends_documentation_fragment: rackspace
+extends_documentation_fragment:
+  - rackspace
+  - rackspace.openstack
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/cloud/rackspace/rax_dns.py
+++ b/lib/ansible/modules/cloud/rackspace/rax_dns.py
@@ -44,7 +44,9 @@ notes:
     C(serial: 1) to avoid exceeding the API request limit imposed by
     the Rackspace CloudDNS API"
 author: "Matt Martz (@sivel)"
-extends_documentation_fragment: rackspace
+extends_documentation_fragment:
+  - rackspace
+  - rackspace.openstack
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/cloud/rackspace/rax_dns_record.py
+++ b/lib/ansible/modules/cloud/rackspace/rax_dns_record.py
@@ -87,7 +87,9 @@ notes:
   - As of version 1.7, the C(type) field is required and no longer defaults to an C(A) record.
   - C(PTR) record support was added in version 1.7
 author: "Matt Martz (@sivel)"
-extends_documentation_fragment: rackspace
+extends_documentation_fragment:
+  - rackspace
+  - rackspace.openstack
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/cloud/rackspace/rax_files.py
+++ b/lib/ansible/modules/cloud/rackspace/rax_files.py
@@ -70,7 +70,9 @@ options:
     description:
        - Sets an object to be presented as the HTTP index page when accessed by the CDN URL
 author: "Paul Durivage (@angstwad)"
-extends_documentation_fragment: rackspace
+extends_documentation_fragment:
+  - rackspace
+  - rackspace.openstack
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/cloud/rackspace/rax_files_objects.py
+++ b/lib/ansible/modules/cloud/rackspace/rax_files_objects.py
@@ -86,7 +86,9 @@ options:
       - meta
     default: file
 author: "Paul Durivage (@angstwad)"
-extends_documentation_fragment: rackspace
+extends_documentation_fragment:
+  - rackspace
+  - rackspace.openstack
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/cloud/rackspace/rax_queue.py
+++ b/lib/ansible/modules/cloud/rackspace/rax_queue.py
@@ -33,7 +33,9 @@ options:
 author:
     - "Christopher H. Laco (@claco)"
     - "Matt Martz (@sivel)"
-extends_documentation_fragment: rackspace
+extends_documentation_fragment:
+  - rackspace
+  - rackspace.openstack
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/cloud/rackspace/rax_scaling_group.py
+++ b/lib/ansible/modules/cloud/rackspace/rax_scaling_group.py
@@ -113,7 +113,9 @@ options:
       - how long before wait gives up, in seconds
     default: 300
 author: "Matt Martz (@sivel)"
-extends_documentation_fragment: rackspace
+extends_documentation_fragment:
+  - rackspace
+  - rackspace.openstack
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/cloud/rackspace/rax_scaling_policy.py
+++ b/lib/ansible/modules/cloud/rackspace/rax_scaling_policy.py
@@ -69,7 +69,9 @@ options:
       - absent
     default: present
 author: "Matt Martz (@sivel)"
-extends_documentation_fragment: rackspace
+extends_documentation_fragment:
+  - rackspace
+  - rackspace.openstack
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/cloud/spotinst/spotinst_aws_elastigroup.py
+++ b/lib/ansible/modules/cloud/spotinst/spotinst_aws_elastigroup.py
@@ -311,7 +311,7 @@ options:
         In case of update it will override the existing Security Group with the new given array
     required: true
 
-  shut_down_script:
+  shutdown_script:
     description:
       - (String) The Base64-encoded shutdown script that executes prior to instance termination.
         Encode before setting.

--- a/lib/ansible/modules/clustering/openshift/_oc.py
+++ b/lib/ansible/modules/clustering/openshift/_oc.py
@@ -40,6 +40,7 @@ options:
     description:
       - "The inline definition of the resource. This is mutually exclusive with name, namespace and kind."
     required: false
+    aliases: ['def', 'definition']
   kind:
     description: The kind of the resource upon which to take action.
     required: true
@@ -53,8 +54,15 @@ options:
     required: false
   token:
     description:
-      - "The token with which to authenticate agains the OpenShift cluster."
+      - "The token with which to authenticate against the OpenShift cluster."
     required: true
+  validate_certs:
+    description:
+      - If C(no), SSL certificates for the target url will not be validated.
+        This should only be used on personally controlled sites using
+        self-signed certificates.
+    type: bool
+    default: yes
   state:
     choices:
       - present

--- a/lib/ansible/modules/crypto/openssl_certificate.py
+++ b/lib/ansible/modules/crypto/openssl_certificate.py
@@ -94,7 +94,7 @@ options:
               If this value is not specified, certificate will stop being valid 10 years from now.
         aliases: [ selfsigned_notAfter ]
 
-    acme_accountkey:
+    acme_accountkey_path:
         description:
             - Path to the accountkey for the C(acme) provider
 
@@ -219,7 +219,7 @@ EXAMPLES = '''
     path: /etc/ssl/crt/ansible.com.crt
     csr_path: /etc/ssl/csr/ansible.com.csr
     provider: acme
-    acme_accountkey: /etc/ssl/private/ansible.com.pem
+    acme_accountkey_path: /etc/ssl/private/ansible.com.pem
     acme_challenge_path: /etc/ssl/challenges/ansible.com/
 
 - name: Force (re-)generate a new Let's Encrypt Certificate
@@ -227,7 +227,7 @@ EXAMPLES = '''
     path: /etc/ssl/crt/ansible.com.crt
     csr_path: /etc/ssl/csr/ansible.com.csr
     provider: acme
-    acme_accountkey: /etc/ssl/private/ansible.com.pem
+    acme_accountkey_path: /etc/ssl/private/ansible.com.pem
     acme_challenge_path: /etc/ssl/challenges/ansible.com/
     force: True
 

--- a/lib/ansible/modules/database/postgresql/postgresql_privs.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_privs.py
@@ -150,6 +150,8 @@ notes:
   - When revoking privileges, C(RESTRICT) is assumed (see PostgreSQL docs).
   - The ssl_rootcert parameter requires at least Postgres version 8.4 and I(psycopg2) version 2.4.3.
 requirements: [psycopg2]
+extends_documentation_fragment:
+  - postgres
 author: "Bernhard Weitzhofer (@b6d)"
 """
 

--- a/lib/ansible/modules/database/vertica/vertica_configuration.py
+++ b/lib/ansible/modules/database/vertica/vertica_configuration.py
@@ -24,6 +24,7 @@ options:
     description:
         - Name of the parameter to update.
     required: true
+    aliases: [parameter]
   value:
     description:
         - Value of the parameter to be set.

--- a/lib/ansible/modules/network/a10/a10_server.py
+++ b/lib/ansible/modules/network/a10/a10_server.py
@@ -25,7 +25,9 @@ description:
 author: "Eric Chou (@ericchou) 2016, Mischa Peters (@mischapeters) 2014"
 notes:
     - Requires A10 Networks aXAPI 2.1.
-extends_documentation_fragment: a10
+extends_documentation_fragment:
+  - a10
+  - url
 options:
   partition:
     version_added: "2.3"
@@ -59,6 +61,7 @@ options:
         required when C(state) is C(present).
     required: false
     default: null
+    aliases: ['port']
   state:
     description:
       - This is to specify the operation to create, update or remove SLB server.

--- a/lib/ansible/modules/network/a10/a10_server_axapi3.py
+++ b/lib/ansible/modules/network/a10/a10_server_axapi3.py
@@ -23,7 +23,9 @@ short_description: Manage A10 Networks AX/SoftAX/Thunder/vThunder devices
 description:
     - Manage SLB (Server Load Balancer) server objects on A10 Networks devices via aXAPIv3.
 author: "Eric Chou (@ericchou) based on previous work by Mischa Peters (@mischapeters)"
-extends_documentation_fragment: a10
+extends_documentation_fragment:
+  - a10
+  - url
 options:
   server_name:
     description:
@@ -48,6 +50,7 @@ options:
         and C(protocol:).
     required: false
     default: null
+    aliases: ['port']
   operation:
     description:
       - Create, Update or Remove SLB server. For create and update operation, we use the IP address and server

--- a/lib/ansible/modules/network/a10/a10_service_group.py
+++ b/lib/ansible/modules/network/a10/a10_service_group.py
@@ -26,8 +26,15 @@ author: "Eric Chou (@ericchou) 2016, Mischa Peters (@mischapeters) 2014"
 notes:
     - Requires A10 Networks aXAPI 2.1.
     - When a server doesn't exist and is added to the service-group the server will be created.
-extends_documentation_fragment: a10
+extends_documentation_fragment:
+  - a10
+  - url
 options:
+  state:
+    description:
+      - If the specified service group should exists.
+    default: present
+    choices: ['present', 'absent']
   partition:
     version_added: "2.3"
     description:
@@ -72,6 +79,7 @@ options:
         specify the C(status:). See the examples below for details.
     required: false
     default: null
+    aliases: ['server', 'member']
   validate_certs:
     description:
       - If C(no), SSL certificates will not be validated. This should only be used

--- a/lib/ansible/modules/network/a10/a10_virtual_server.py
+++ b/lib/ansible/modules/network/a10/a10_virtual_server.py
@@ -25,8 +25,15 @@ description:
 author: "Eric Chou (@ericchou) 2016, Mischa Peters (@mischapeters) 2014"
 notes:
     - Requires A10 Networks aXAPI 2.1.
-extends_documentation_fragment: a10
+extends_documentation_fragment:
+  - a10
+  - url
 options:
+  state:
+    description:
+      - If the specified virtual server should exist.
+    choices: ['present', 'absent']
+    default: present
   partition:
     version_added: "2.3"
     description:

--- a/lib/ansible/modules/network/asa/asa_acl.py
+++ b/lib/ansible/modules/network/asa/asa_acl.py
@@ -30,6 +30,7 @@ options:
         command syntax as some commands are automatically modified by the
         device config parser.
     required: true
+    aliases: [commands]
   before:
     description:
       - The ordered set of commands to push on to the command stack if

--- a/lib/ansible/modules/network/cloudengine/ce_aaa_server_host.py
+++ b/lib/ansible/modules/network/cloudengine/ce_aaa_server_host.py
@@ -201,7 +201,7 @@ EXAMPLES = '''
     ce_aaa_server_host:
       state: present
       radius_group_name: group1
-      raduis_server_type: Authentication
+      radius_server_type: Authentication
       radius_server_ip: 10.1.10.1
       radius_server_port: 2000
       radius_server_mode: Primary-server
@@ -212,7 +212,7 @@ EXAMPLES = '''
     ce_aaa_server_host:
       state: absent
       radius_group_name: group1
-      raduis_server_type: Authentication
+      radius_server_type: Authentication
       radius_server_ip: 10.1.10.1
       radius_server_port: 2000
       radius_server_mode: Primary-server
@@ -1059,7 +1059,7 @@ class AaaServerHost(object):
 
         module = kwargs["module"]
         radius_group_name = module.params['radius_group_name']
-        raduis_server_type = module.params['raduis_server_type']
+        radius_server_type = module.params['radius_server_type']
         radius_server_ip = module.params['radius_server_ip']
         radius_server_port = module.params['radius_server_port']
         radius_server_mode = module.params['radius_server_mode']
@@ -1099,10 +1099,10 @@ class AaaServerHost(object):
                 for tmp in result["radius_server_ip_v4"]:
                     if "serverType" in tmp.keys():
                         if state == "present":
-                            if tmp["serverType"] != raduis_server_type:
+                            if tmp["serverType"] != radius_server_type:
                                 need_cfg = True
                         else:
-                            if tmp["serverType"] == raduis_server_type:
+                            if tmp["serverType"] == radius_server_type:
                                 need_cfg = True
                     if "serverIPAddress" in tmp.keys():
                         if state == "present":
@@ -1141,14 +1141,14 @@ class AaaServerHost(object):
 
         module = kwargs["module"]
         radius_group_name = module.params['radius_group_name']
-        raduis_server_type = module.params['raduis_server_type']
+        radius_server_type = module.params['radius_server_type']
         radius_server_ip = module.params['radius_server_ip']
         radius_server_port = module.params['radius_server_port']
         radius_server_mode = module.params['radius_server_mode']
         radius_vpn_name = module.params['radius_vpn_name']
 
         conf_str = CE_MERGE_RADIUS_SERVER_CFG_IPV4 % (
-            radius_group_name, raduis_server_type,
+            radius_group_name, radius_server_type,
             radius_server_ip, radius_server_port,
             radius_server_mode, radius_vpn_name)
 
@@ -1163,7 +1163,7 @@ class AaaServerHost(object):
         cmd = "radius server group %s" % radius_group_name
         cmds.append(cmd)
 
-        if raduis_server_type == "Authentication":
+        if radius_server_type == "Authentication":
             cmd = "radius server authentication %s %s" % (
                 radius_server_ip, radius_server_port)
 
@@ -1190,14 +1190,14 @@ class AaaServerHost(object):
 
         module = kwargs["module"]
         radius_group_name = module.params['radius_group_name']
-        raduis_server_type = module.params['raduis_server_type']
+        radius_server_type = module.params['radius_server_type']
         radius_server_ip = module.params['radius_server_ip']
         radius_server_port = module.params['radius_server_port']
         radius_server_mode = module.params['radius_server_mode']
         radius_vpn_name = module.params['radius_vpn_name']
 
         conf_str = CE_DELETE_RADIUS_SERVER_CFG_IPV4 % (
-            radius_group_name, raduis_server_type,
+            radius_group_name, radius_server_type,
             radius_server_ip, radius_server_port,
             radius_server_mode, radius_vpn_name)
 
@@ -1212,7 +1212,7 @@ class AaaServerHost(object):
         cmd = "radius server group %s" % radius_group_name
         cmds.append(cmd)
 
-        if raduis_server_type == "Authentication":
+        if radius_server_type == "Authentication":
             cmd = "undo radius server authentication %s %s" % (
                 radius_server_ip, radius_server_port)
 
@@ -1239,7 +1239,7 @@ class AaaServerHost(object):
 
         module = kwargs["module"]
         radius_group_name = module.params['radius_group_name']
-        raduis_server_type = module.params['raduis_server_type']
+        radius_server_type = module.params['radius_server_type']
         radius_server_ipv6 = module.params['radius_server_ipv6']
         radius_server_port = module.params['radius_server_port']
         radius_server_mode = module.params['radius_server_mode']
@@ -1278,10 +1278,10 @@ class AaaServerHost(object):
                 for tmp in result["radius_server_ip_v6"]:
                     if "serverType" in tmp.keys():
                         if state == "present":
-                            if tmp["serverType"] != raduis_server_type:
+                            if tmp["serverType"] != radius_server_type:
                                 need_cfg = True
                         else:
-                            if tmp["serverType"] == raduis_server_type:
+                            if tmp["serverType"] == radius_server_type:
                                 need_cfg = True
                     if "serverIPAddress" in tmp.keys():
                         if state == "present":
@@ -1313,13 +1313,13 @@ class AaaServerHost(object):
 
         module = kwargs["module"]
         radius_group_name = module.params['radius_group_name']
-        raduis_server_type = module.params['raduis_server_type']
+        radius_server_type = module.params['radius_server_type']
         radius_server_ipv6 = module.params['radius_server_ipv6']
         radius_server_port = module.params['radius_server_port']
         radius_server_mode = module.params['radius_server_mode']
 
         conf_str = CE_MERGE_RADIUS_SERVER_CFG_IPV6 % (
-            radius_group_name, raduis_server_type,
+            radius_group_name, radius_server_type,
             radius_server_ipv6, radius_server_port,
             radius_server_mode)
 
@@ -1334,7 +1334,7 @@ class AaaServerHost(object):
         cmd = "radius server group %s" % radius_group_name
         cmds.append(cmd)
 
-        if raduis_server_type == "Authentication":
+        if radius_server_type == "Authentication":
             cmd = "radius server authentication %s %s" % (
                 radius_server_ipv6, radius_server_port)
 
@@ -1355,13 +1355,13 @@ class AaaServerHost(object):
 
         module = kwargs["module"]
         radius_group_name = module.params['radius_group_name']
-        raduis_server_type = module.params['raduis_server_type']
+        radius_server_type = module.params['radius_server_type']
         radius_server_ipv6 = module.params['radius_server_ipv6']
         radius_server_port = module.params['radius_server_port']
         radius_server_mode = module.params['radius_server_mode']
 
         conf_str = CE_DELETE_RADIUS_SERVER_CFG_IPV6 % (
-            radius_group_name, raduis_server_type,
+            radius_group_name, radius_server_type,
             radius_server_ipv6, radius_server_port,
             radius_server_mode)
 
@@ -1376,7 +1376,7 @@ class AaaServerHost(object):
         cmd = "radius server group %s" % radius_group_name
         cmds.append(cmd)
 
-        if raduis_server_type == "Authentication":
+        if radius_server_type == "Authentication":
             cmd = "undo radius server authentication %s %s" % (
                 radius_server_ipv6, radius_server_port)
 
@@ -1397,7 +1397,7 @@ class AaaServerHost(object):
 
         module = kwargs["module"]
         radius_group_name = module.params['radius_group_name']
-        raduis_server_type = module.params['raduis_server_type']
+        radius_server_type = module.params['radius_server_type']
         radius_server_name = module.params['radius_server_name']
         radius_server_port = module.params['radius_server_port']
         radius_server_mode = module.params['radius_server_mode']
@@ -1437,10 +1437,10 @@ class AaaServerHost(object):
                 for tmp in result["radius_server_name_cfg"]:
                     if "serverType" in tmp.keys():
                         if state == "present":
-                            if tmp["serverType"] != raduis_server_type:
+                            if tmp["serverType"] != radius_server_type:
                                 need_cfg = True
                         else:
-                            if tmp["serverType"] == raduis_server_type:
+                            if tmp["serverType"] == radius_server_type:
                                 need_cfg = True
                     if "serverName" in tmp.keys():
                         if state == "present":
@@ -1479,14 +1479,14 @@ class AaaServerHost(object):
 
         module = kwargs["module"]
         radius_group_name = module.params['radius_group_name']
-        raduis_server_type = module.params['raduis_server_type']
+        radius_server_type = module.params['radius_server_type']
         radius_server_name = module.params['radius_server_name']
         radius_server_port = module.params['radius_server_port']
         radius_server_mode = module.params['radius_server_mode']
         radius_vpn_name = module.params['radius_vpn_name']
 
         conf_str = CE_MERGE_RADIUS_SERVER_NAME % (
-            radius_group_name, raduis_server_type,
+            radius_group_name, radius_server_type,
             radius_server_name, radius_server_port,
             radius_server_mode, radius_vpn_name)
 
@@ -1500,7 +1500,7 @@ class AaaServerHost(object):
         cmd = "radius server group %s" % radius_group_name
         cmds.append(cmd)
 
-        if raduis_server_type == "Authentication":
+        if radius_server_type == "Authentication":
             cmd = "radius server authentication hostname %s %s" % (
                 radius_server_name, radius_server_port)
 
@@ -1527,14 +1527,14 @@ class AaaServerHost(object):
 
         module = kwargs["module"]
         radius_group_name = module.params['radius_group_name']
-        raduis_server_type = module.params['raduis_server_type']
+        radius_server_type = module.params['radius_server_type']
         radius_server_name = module.params['radius_server_name']
         radius_server_port = module.params['radius_server_port']
         radius_server_mode = module.params['radius_server_mode']
         radius_vpn_name = module.params['radius_vpn_name']
 
         conf_str = CE_DELETE_RADIUS_SERVER_NAME % (
-            radius_group_name, raduis_server_type,
+            radius_group_name, radius_server_type,
             radius_server_name, radius_server_port,
             radius_server_mode, radius_vpn_name)
 
@@ -1548,7 +1548,7 @@ class AaaServerHost(object):
         cmd = "radius server group %s" % radius_group_name
         cmds.append(cmd)
 
-        if raduis_server_type == "Authentication":
+        if radius_server_type == "Authentication":
             cmd = "undo radius server authentication hostname %s %s" % (
                 radius_server_name, radius_server_port)
 
@@ -2319,7 +2319,7 @@ def main():
         local_user_level=dict(type='str'),
         local_user_group=dict(type='str'),
         radius_group_name=dict(type='str'),
-        raduis_server_type=dict(choices=['Authentication', 'Accounting']),
+        radius_server_type=dict(choices=['Authentication', 'Accounting']),
         radius_server_ip=dict(type='str'),
         radius_server_ipv6=dict(type='str'),
         radius_server_port=dict(type='str'),
@@ -2366,7 +2366,7 @@ def main():
 
     # radius para
     radius_group_name = module.params['radius_group_name']
-    raduis_server_type = module.params['raduis_server_type']
+    radius_server_type = module.params['radius_server_type']
     radius_server_ip = module.params['radius_server_ip']
     radius_server_ipv6 = module.params['radius_server_ipv6']
     radius_server_port = module.params['radius_server_port']
@@ -2406,8 +2406,8 @@ def main():
         proposed["local_user_group"] = local_user_group
     if radius_group_name:
         proposed["radius_group_name"] = radius_group_name
-    if raduis_server_type:
-        proposed["raduis_server_type"] = raduis_server_type
+    if radius_server_type:
+        proposed["radius_server_type"] = radius_server_type
     if radius_server_ip:
         proposed["radius_server_ip"] = radius_server_ip
     if radius_server_ipv6:
@@ -2480,9 +2480,9 @@ def main():
             module.fail_json(
                 msg='Error: Please do not input radius_server_ip and radius_server_ipv6 at the same time.')
 
-        if not raduis_server_type or not radius_server_port or not radius_server_mode or not radius_vpn_name:
+        if not radius_server_type or not radius_server_port or not radius_server_mode or not radius_vpn_name:
             module.fail_json(
-                msg='Error: Please input raduis_server_type radius_server_port radius_server_mode radius_vpn_name.')
+                msg='Error: Please input radius_server_type radius_server_port radius_server_mode radius_vpn_name.')
 
         if radius_server_ip:
             rds_server_ipv4_result = ce_aaa_server_host.get_radius_server_cfg_ipv4(

--- a/lib/ansible/modules/network/dellos10/dellos10_command.py
+++ b/lib/ansible/modules/network/dellos10/dellos10_command.py
@@ -173,7 +173,7 @@ def main():
         # { command: <str>, prompt: <str>, response: <str> }
         commands=dict(type='list', required=True),
 
-        wait_for=dict(type='list', aliases=['waitfor']),
+        wait_for=dict(type='list'),
         match=dict(default='all', choices=['all', 'any']),
 
         retries=dict(default=10, type='int'),

--- a/lib/ansible/modules/network/dellos6/dellos6_command.py
+++ b/lib/ansible/modules/network/dellos6/dellos6_command.py
@@ -174,7 +174,7 @@ def main():
         # { command: <str>, prompt: <str>, response: <str> }
         commands=dict(type='list', required=True),
 
-        wait_for=dict(type='list', aliases=['waitfor']),
+        wait_for=dict(type='list'),
         match=dict(default='all', choices=['all', 'any']),
 
         retries=dict(default=10, type='int'),

--- a/lib/ansible/modules/network/dellos9/dellos9_command.py
+++ b/lib/ansible/modules/network/dellos9/dellos9_command.py
@@ -178,7 +178,7 @@ def main():
         # { command: <str>, prompt: <str>, response: <str> }
         commands=dict(type='list', required=True),
 
-        wait_for=dict(type='list', aliases=['waitfor']),
+        wait_for=dict(type='list'),
         match=dict(default='all', choices=['all', 'any']),
 
         retries=dict(default=10, type='int'),

--- a/lib/ansible/modules/network/eos/eos_config.py
+++ b/lib/ansible/modules/network/eos/eos_config.py
@@ -45,6 +45,7 @@ options:
         command syntax as some commands are automatically modified by the
         device config parser.
     required: false
+    aliases: ['commands']
     default: null
   parents:
     description:

--- a/lib/ansible/modules/network/eos/eos_system.py
+++ b/lib/ansible/modules/network/eos/eos_system.py
@@ -52,6 +52,7 @@ options:
         append to the hostname for the purpose of doing name resolution.
         This argument accepts a list of names and will be reconciled
         with the current active configuration on the running node.
+    aliases: ['domain_list']
   lookup_source:
     description:
       - Provides one or more source

--- a/lib/ansible/modules/network/eos/eos_user.py
+++ b/lib/ansible/modules/network/eos/eos_user.py
@@ -42,7 +42,8 @@ options:
       - The set of username objects to be configured on the remote
         Arista EOS device.  The list entries can either be the username
         or a hash of username and properties.  This argument is mutually
-        exclusive with the C(username) argument. alias C(users).
+        exclusive with the C(username) argument.
+    aliases: ['users', 'collection']
     version_added: "2.4"
   name:
     description:

--- a/lib/ansible/modules/network/illumos/dladm_iptun.py
+++ b/lib/ansible/modules/network/illumos/dladm_iptun.py
@@ -26,7 +26,6 @@ options:
         description:
             - IP tunnel interface name.
         required: true
-        aliases: [ "tunnel", "link" ]
     temporary:
         description:
             - Specifies that the IP tunnel interface is temporary. Temporary IP tunnel
@@ -39,6 +38,7 @@ options:
         required: false
         default: "ipv4"
         choices: [ "ipv4", "ipv6", "6to4" ]
+        aliases: ['tunnel_type']
     local_address:
         description:
             - Literat IP address or hostname corresponding to the tunnel source.

--- a/lib/ansible/modules/network/illumos/flowadm.py
+++ b/lib/ansible/modules/network/illumos/flowadm.py
@@ -36,7 +36,7 @@ options:
         description:
             - Identifies a network flow by the local IP address.
         required: false
-    remove_ip:
+    remote_ip:
         description:
             - Identifies a network flow by the remote IP address.
         required: false

--- a/lib/ansible/modules/network/illumos/ipadm_addrprop.py
+++ b/lib/ansible/modules/network/illumos/ipadm_addrprop.py
@@ -191,7 +191,7 @@ class AddrProp(object):
 def main():
     module = AnsibleModule(
         argument_spec=dict(
-            addrobj=dict(required=True, default=None, aliases=['nic, interface']),
+            addrobj=dict(required=True, default=None, aliases=['nic', 'interface']),
             property=dict(required=True, aliases=['name']),
             value=dict(required=False),
             temporary=dict(default=False, type='bool'),

--- a/lib/ansible/modules/network/ios/ios_user.py
+++ b/lib/ansible/modules/network/ios/ios_user.py
@@ -43,7 +43,8 @@ options:
       - The set of username objects to be configured on the remote
         Cisco IOS device. The list entries can either be the username
         or a hash of username and properties. This argument is mutually
-        exclusive with the C(name) argument. alias C(users).
+        exclusive with the C(name) argument.
+    aliases: ['users']
   name:
     description:
       - The username to be configured on the Cisco IOS device.
@@ -76,6 +77,7 @@ options:
         device running configuration. The argument accepts a string value
         defining the view name. This argument does not check if the view
         has been configured on the device.
+    aliases: ['role']
   nopassword:
     description:
       - Defines the username without assigning

--- a/lib/ansible/modules/network/iosxr/iosxr_user.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_user.py
@@ -35,7 +35,8 @@ options:
       - The set of username objects to be configured on the remote
         Cisco IOS XR device. The list entries can either be the username
         or a hash of username and properties. This argument is mutually
-        exclusive with the C(name) argument, alias C(users).
+        exclusive with the C(name) argument.
+    aliases: ['users', 'collection']
   name:
     description:
       - The username to be configured on the Cisco IOS XR device.
@@ -62,7 +63,8 @@ options:
       - Configures the group for the username in the
         device running configuration. The argument accepts a string value
         defining the group name. This argument does not check if the group
-        has been configured on the device, alias C(role).
+        has been configured on the device.
+    aliases: ['role']
   groups:
     version_added: "2.5"
     description:

--- a/lib/ansible/modules/network/junos/junos_lldp.py
+++ b/lib/ansible/modules/network/junos/junos_lldp.py
@@ -35,12 +35,6 @@ options:
       - Specify the number of seconds that LLDP information is held before it is
         discarded. The multiplier value is used in combination with the
         C(interval) value.
-  enable:
-    description:
-      - If value is C(True) it enable LLDP protocol on remote device, if value
-        is C(False) it disables LLDP protocol.
-    default: present
-    choices: [True, False]
   state:
     description:
       - Value of C(present) ensures given LLDP configuration

--- a/lib/ansible/modules/network/junos/junos_user.py
+++ b/lib/ansible/modules/network/junos/junos_user.py
@@ -32,10 +32,11 @@ options:
         on the remote device.  The list of users will be compared against
         the current users and only changes will be added or removed from
         the device configuration.  This argument is mutually exclusive with
-        the name argument. alias C(users).
+        the name argument.
     version_added: "2.4"
     required: False
     default: null
+    aliases: ['users', 'collection']
   name:
     description:
       - The C(name) argument defines the username of the user to be created

--- a/lib/ansible/modules/network/nxos/_nxos_ip_interface.py
+++ b/lib/ansible/modules/network/nxos/_nxos_ip_interface.py
@@ -73,6 +73,11 @@ options:
         required: false
         default: false
         version_added: "2.4"
+    include_defaults:
+        description:
+            - Specify if the complete running configuration for module operations should be used.
+        default: true
+        type: bool
     state:
         description:
             - Specify desired state of the resource.

--- a/lib/ansible/modules/network/nxos/_nxos_portchannel.py
+++ b/lib/ansible/modules/network/nxos/_nxos_portchannel.py
@@ -68,6 +68,11 @@ options:
     required: false
     choices: ['true', 'false']
     default: false
+  include_defaults:
+    description:
+      - Specify if the complete running configuration for module operations should be used.
+    default: false
+    type: bool
   state:
     description:
       - Manage the state of the resource.

--- a/lib/ansible/modules/network/nxos/nxos_acl.py
+++ b/lib/ansible/modules/network/nxos/nxos_acl.py
@@ -172,7 +172,7 @@ options:
     required: false
     default: null
     choices: ['enable']
-  time-range:
+  time_range:
     description:
       - Name of time-range to apply.
     required: false
@@ -192,6 +192,11 @@ options:
     choices: ['af11', 'af12', 'af13', 'af21', 'af22', 'af23','af31','af32',
               'af33', 'af41', 'af42', 'af43', 'cs1', 'cs2', 'cs3', 'cs4',
               'cs5', 'cs6', 'cs7', 'default', 'ef']
+  include_defaults:
+    description:
+      - Specify if the complete running configuration for module operations should be used.
+    default: false
+    type: bool
   state:
     description:
       - Specify desired state of the resource.

--- a/lib/ansible/modules/network/nxos/nxos_evpn_vni.py
+++ b/lib/ansible/modules/network/nxos/nxos_evpn_vni.py
@@ -74,6 +74,11 @@ options:
       - Sets the route-target 'import' extended communities.
     required: false
     default: null
+  include_defaults:
+    description:
+      - Specify if the complete running configuration for module operations should be used.
+    default: true
+    type: bool
   state:
     description:
       - Determines whether the config should be present or not

--- a/lib/ansible/modules/network/nxos/nxos_igmp.py
+++ b/lib/ansible/modules/network/nxos/nxos_igmp.py
@@ -59,6 +59,11 @@ options:
         required: false
         default: null
         choices: ['true', 'false']
+    include_defaults:
+        description:
+            - Specify if the complete running configuration for module operations should be used.
+        default: false
+        type: bool
     state:
         description:
             - Manages desired state of the resource.

--- a/lib/ansible/modules/network/nxos/nxos_igmp_interface.py
+++ b/lib/ansible/modules/network/nxos/nxos_igmp_interface.py
@@ -159,6 +159,11 @@ options:
         required: false
         choices: ['true', 'false']
         default: null
+    include_defaults:
+        description:
+            - Specify if the complete running configuration for module operations should be used.
+        default: true
+        type: bool
     state:
         description:
             - Manages desired state of the resource.

--- a/lib/ansible/modules/network/nxos/nxos_interface_ospf.py
+++ b/lib/ansible/modules/network/nxos/nxos_interface_ospf.py
@@ -111,6 +111,11 @@ options:
       - Specifies the message_digest password. Valid value is a string.
     required: false
     default: null
+  include_defaults:
+    description:
+      - Specify if the complete running configuration for module operations should be used.
+    default: true
+    type: bool
   state:
     description:
       - Determines whether the config should be present or not

--- a/lib/ansible/modules/network/nxos/nxos_ospf.py
+++ b/lib/ansible/modules/network/nxos/nxos_ospf.py
@@ -41,6 +41,11 @@ options:
     required: false
     default: present
     choices: ['present','absent']
+  include_defaults:
+    description:
+      - Specify if the complete running configuration for module operations should be used.
+    default: true
+    type: bool
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/network/nxos/nxos_ospf_vrf.py
+++ b/lib/ansible/modules/network/nxos/nxos_ospf_vrf.py
@@ -120,6 +120,11 @@ options:
     required: false
     choices: ['true','false']
     default: null
+  include_defaults:
+    description:
+      - Specify if the complete running configuration for module operations should be used.
+    default: true
+    type: bool
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/network/nxos/nxos_rollback.py
+++ b/lib/ansible/modules/network/nxos/nxos_rollback.py
@@ -50,6 +50,11 @@ options:
               with checkpoint_file.
         required: false
         default: null
+    include_defaults:
+        description:
+            - Specify if the complete running configuration for module operations should be used.
+        default: false
+        type: bool
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/network/nxos/nxos_user.py
+++ b/lib/ansible/modules/network/nxos/nxos_user.py
@@ -40,14 +40,15 @@ options:
       - The set of username objects to be configured on the remote
         Cisco Nexus device.  The list entries can either be the username
         or a hash of username and properties.  This argument is mutually
-        exclusive with the C(name) argument. alias C(users).
+        exclusive with the C(name) argument.
+    aliases: ['users', 'collection']
     version_added: "2.4"
     required: false
     default: null
   name:
     description:
       - The username to be configured on the remote Cisco Nexus
-        device.  This argument accepts a stringv value and is mutually
+        device.  This argument accepts a string value and is mutually
         exclusive with the C(aggregate) argument.
     required: false
     default: null
@@ -76,6 +77,7 @@ options:
         has been configured on the device.
     required: false
     default: null
+    aliases: ['roles']
   sshkey:
     description:
       - The C(sshkey) argument defines the SSH public key to configure

--- a/lib/ansible/modules/network/nxos/nxos_vrrp.py
+++ b/lib/ansible/modules/network/nxos/nxos_vrrp.py
@@ -71,6 +71,11 @@ options:
         choices: ['shutdown', 'no shutdown']
         default: no shutdown
         version_added: "2.2"
+    include_defaults:
+        description:
+            - Specify if the complete running configuration for module operations should be used.
+        default: false
+        type: bool
     state:
         description:
             - Specify desired state of the resource.

--- a/lib/ansible/modules/network/ordnance/ordnance_config.py
+++ b/lib/ansible/modules/network/ordnance/ordnance_config.py
@@ -24,7 +24,7 @@ description:
     an implementation for working with these configuration sections in
     a deterministic way.
 options:
-  commands:
+  lines:
     description:
       - The ordered set of commands that should be configured in the
         section.  The commands must be the exact same commands as found

--- a/lib/ansible/modules/network/ovs/openvswitch_db.py
+++ b/lib/ansible/modules/network/ovs/openvswitch_db.py
@@ -43,7 +43,7 @@ options:
         required: true
         description:
             - Identifies the recoard in the table.
-    column:
+    col:
         required: true
         description:
             - Identifies the column in the record.

--- a/lib/ansible/modules/network/vyos/vyos_system.py
+++ b/lib/ansible/modules/network/vyos/vyos_system.py
@@ -36,7 +36,7 @@ extends_documentation_fragment: vyos
 notes:
   - Tested against VYOS 1.1.7
 options:
-  hostname:
+  host_name:
     description:
       - Configure the device hostname parameter. This option takes an ASCII string value.
   domain_name:

--- a/lib/ansible/modules/network/vyos/vyos_user.py
+++ b/lib/ansible/modules/network/vyos/vyos_user.py
@@ -43,7 +43,8 @@ options:
       - The set of username objects to be configured on the remote
         VyOS device. The list entries can either be the username or
         a hash of username and properties. This argument is mutually
-        exclusive with the C(name) argument. alias C(users).
+        exclusive with the C(name) argument.
+    aliases: ['users', 'collection']
   name:
     description:
       - The username to be configured on the VyOS device.
@@ -74,6 +75,7 @@ options:
     description:
       - The C(level) argument configures the level of the user when logged
         into the system. This argument accepts string values admin or operator.
+    aliases: ['role']
   purge:
     description:
       - Instructs the module to consider the

--- a/lib/ansible/modules/notification/mail.py
+++ b/lib/ansible/modules/notification/mail.py
@@ -42,6 +42,7 @@ options:
     - The email-address(es) the mail is being sent to.
     - This is a list, which may contain address and phrase portions.
     default: root
+    aliases: ['recipients']
   cc:
     description:
     - The email-address(es) the mail is being copied to.

--- a/lib/ansible/modules/notification/nexmo.py
+++ b/lib/ansible/modules/notification/nexmo.py
@@ -51,6 +51,8 @@ options:
     choices:
       - 'yes'
       - 'no'
+extends_documentation_fragment:
+  - url
 """
 
 EXAMPLES = """

--- a/lib/ansible/modules/packaging/language/composer.py
+++ b/lib/ansible/modules/packaging/language/composer.py
@@ -83,7 +83,7 @@ options:
             - Disables all plugins ( see --no-plugins ).
         default: false
         choices: [ true, false]
-        aliases: [ no-plugin ]
+        aliases: [ no-plugins ]
     optimize_autoloader:
         description:
             - Optimize autoloader during autoloader dump (see --optimize-autoloader).

--- a/lib/ansible/modules/packaging/os/apt.py
+++ b/lib/ansible/modules/packaging/os/apt.py
@@ -55,6 +55,7 @@ options:
     description:
       - Corresponds to the C(--no-install-recommends) option for I(apt). C(yes) installs recommended packages.  C(no) does not install
         recommended packages. By default, Ansible will use the same defaults as the operating system. Suggested packages are never installed.
+    aliases: ['install-recommends']
     type: bool
   force:
     description:

--- a/lib/ansible/modules/packaging/os/pulp_repo.py
+++ b/lib/ansible/modules/packaging/os/pulp_repo.py
@@ -22,7 +22,6 @@ short_description: Add or remove Pulp repos from a remote host.
 description:
   - Add or remove Pulp repos from a remote host.
 version_added: "2.3"
-requirements: []
 options:
   add_export_distributor:
     description:
@@ -144,6 +143,8 @@ options:
 notes:
   - This module can currently only create distributors and importers on rpm
     repositories. Contributions to support other repo types are welcome.
+extends_documentation_fragment:
+  - url
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/packaging/os/urpmi.py
+++ b/lib/ansible/modules/packaging/os/urpmi.py
@@ -41,6 +41,7 @@ options:
       - Corresponds to the C(--no-recommends) option for I(urpmi).
     type: bool
     default: 'yes'
+    aliases@ ['no-recommends']
   force:
     description:
       - Assume "yes" is the answer to any question urpmi has to ask.

--- a/lib/ansible/modules/packaging/os/urpmi.py
+++ b/lib/ansible/modules/packaging/os/urpmi.py
@@ -41,7 +41,7 @@ options:
       - Corresponds to the C(--no-recommends) option for I(urpmi).
     type: bool
     default: 'yes'
-    aliases@ ['no-recommends']
+    aliases: ['no-recommends']
   force:
     description:
       - Assume "yes" is the answer to any question urpmi has to ask.

--- a/lib/ansible/modules/remote_management/imc/imc_rest.py
+++ b/lib/ansible/modules/remote_management/imc/imc_rest.py
@@ -46,7 +46,7 @@ options:
     - Name of the absolute path of the filename that includes the body
       of the http request being sent to the Cisco IMC REST API.
     - Parameter C(path) is mutual exclusive with parameter C(content).
-    aliases: [ src ]
+    aliases: [ 'src', 'config_file' ]
   content:
     description:
     - When used instead of C(path), sets the content of the API requests directly.

--- a/lib/ansible/modules/remote_management/ucs/ucs_wwn_pool.py
+++ b/lib/ansible/modules/remote_management/ucs/ucs_wwn_pool.py
@@ -38,7 +38,7 @@ options:
     - Optional if state is absent.
     choices: [node, port]
     required: yes
-  descrption:
+  description:
     description:
     - A description of the WWNN or WWPN pool.
     - Enter up to 256 characters.

--- a/lib/ansible/modules/source_control/github_deploy_key.py
+++ b/lib/ansible/modules/source_control/github_deploy_key.py
@@ -82,6 +82,7 @@ options:
       - The 6 digit One Time Password for 2-Factor Authentication. Required together with I(username) and I(password).
     required: false
     default: null
+    aliases: ['2fa_token']
 requirements:
    - python-requests
 notes:

--- a/lib/ansible/modules/storage/netapp/netapp_e_hostgroup.py
+++ b/lib/ansible/modules/storage/netapp/netapp_e_hostgroup.py
@@ -60,7 +60,7 @@ options:
     required: false
     description:
     - The id number of the host group to manage. Either this or C(name) must be supplied.
-  hosts::
+  hosts:
     required: false
     description:
     - a list of host names/labels to add to the group

--- a/lib/ansible/modules/system/gluster_volume.py
+++ b/lib/ansible/modules/system/gluster_volume.py
@@ -37,7 +37,7 @@ options:
   replicas:
     description:
       - Replica count for volume.
-  arbiter:
+  arbiters:
     description:
       - Arbiter count for volume.
     version_added: '2.3'

--- a/lib/ansible/modules/system/selinux.py
+++ b/lib/ansible/modules/system/selinux.py
@@ -39,6 +39,7 @@ options:
       - path to the SELinux configuration file, if non-standard
     required: false
     default: "/etc/selinux/config"
+    aliases: ['configfile', 'file']
 notes:
    - Not tested on any debian based system
 requirements: [ libselinux-python ]

--- a/lib/ansible/modules/web_infrastructure/django_manage.py
+++ b/lib/ansible/modules/web_infrastructure/django_manage.py
@@ -45,7 +45,7 @@ options:
   virtualenv:
     description:
       - An optional path to a I(virtualenv) installation to use while running the manage application.
-    required: false
+    aliases: [virtualenv]
   apps:
     description:
       - A list of space-delimited apps to target. Used by the 'test' command.

--- a/lib/ansible/modules/web_infrastructure/jenkins_plugin.py
+++ b/lib/ansible/modules/web_infrastructure/jenkins_plugin.py
@@ -114,6 +114,8 @@ notes:
     host where Jenkins runs as it needs direct access to the plugin files.
   - "The C(params) option was removed in Ansible 2.5 due to circumventing Ansible's
     option handling"
+extends_documentation_fragment:
+  - url
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/web_infrastructure/jira.py
+++ b/lib/ansible/modules/web_infrastructure/jira.py
@@ -46,7 +46,6 @@ options:
       - The password to log-in with.
 
   project:
-    aliases: [ prj ]
     required: false
     description:
       - The project for this operation. Required for issue creation.

--- a/lib/ansible/utils/module_docs_fragments/f5.py
+++ b/lib/ansible/utils/module_docs_fragments/f5.py
@@ -26,6 +26,7 @@ options:
         You can omit this option if the environment variable C(F5_PASSWORD)
         is set.
     required: true
+    aliases: ['pass', 'pwd']
   server:
     description:
       - The BIG-IP host. You can omit this option if the environment

--- a/lib/ansible/utils/module_docs_fragments/netapp.py
+++ b/lib/ansible/utils/module_docs_fragments/netapp.py
@@ -40,10 +40,12 @@ options:
       description:
       - This can be a Cluster-scoped or SVM-scoped account, depending on whether a Cluster-level or SVM-level API is required.
         For more information, please read the documentation U(https://goo.gl/BRu78Z).
+      aliases: ['user']
   password:
       required: true
       description:
       - Password for the specified user.
+      aliases: ['pass']
 
 requirements:
   - A physical or virtual clustered Data ONTAP system. The modules were developed with Clustered Data ONTAP 8.3

--- a/lib/ansible/utils/module_docs_fragments/url.py
+++ b/lib/ansible/utils/module_docs_fragments/url.py
@@ -1,0 +1,72 @@
+# (c) 2018, John Barker<gundalow@redhat.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+
+class ModuleDocFragment(object):
+
+    # Standard files documentation fragment
+    DOCUMENTATION = """
+options:
+  url:
+    description:
+      - HTTP, HTTPS, or FTP URL in the form (http|https|ftp)://[user[:pass]]@host.domain[:port]/path
+  force:
+    description:
+      - If C(yes) do not get a cached copy.
+    aliases:
+      - thirsty
+    type: bool
+    default: no
+  http_agent:
+    description:
+      - Header to identify as, generally appears in web server logs.
+    default: ansible-httpget
+  use_proxy:
+    description:
+      - If C(no), it will not use a proxy, even if one is defined in an environment variable on the target hosts.
+    type: bool
+    default: yes
+  validate_certs:
+    description:
+      - If C(no), SSL certificates will not be validated. This should only be used
+        on personally controlled sites using self-signed certificates.
+    default: yes
+    type: bool
+  url_username:
+    description:
+      - The username for use in HTTP basic authentication.
+      - This parameter can be used without I(url_password) for sites that allow empty passwords
+  url_password:
+    description:
+      - The password for use in HTTP basic authentication.
+      - If the I(url_username) parameter is not specified, the I(url_password) parameter will not be used.
+  force_basic_auth:
+    description:
+      - Credentials specified with I(url_username) and I(url_password) should be passed in HTTP Header.
+    default: no
+    type: bool
+  client_cert:
+    description:
+      - PEM formatted certificate chain file to be used for SSL client
+        authentication. This file can also include the key as well, and if
+        the key is included, C(client_key) is not required.
+  client_key:
+    description:
+      - PEM formatted file that contains your private key to be used for SSL
+        client authentication. If C(client_cert) contains both the certificate
+        and key, this option is not required.
+"""

--- a/lib/ansible/utils/module_docs_fragments/vca.py
+++ b/lib/ansible/utils/module_docs_fragments/vca.py
@@ -31,7 +31,7 @@ options:
         - The vca password, if not set the environment variable C(VCA_PASS) is checked for the password.
       required: false
       default: None
-      aliases: ['pass', 'pwd']
+      aliases: ['pass', 'passwd']
     org:
       description:
         - The org to login to for creating vapp. This option is required when the C(service_type) is I(vdc).


### PR DESCRIPTION
##### SUMMARY
Large update of many modules so that DOCUMENTATION option name and
aliases match those defined in the argspec.
    
Issues identified by https://github.com/ansible/ansible/pull/34809
    
In addition to many typos and missing aliases, the following notable
changes were made:
    
* Create`module_docs_fragments/url.py` for `url_argument_spec`
*` dellos*_command` shouldn't have ever had `waitfor` (incorrectly copied deprecated aliases)
* `ce_aaa_server_host.py` `s/raduis_server_type/radius_server_type/g`
* `junos_lldp` enable should be part of `state`.


##### ISSUE TYPE
 - Docs Pull Request
