### PR TITLE
Fix inconsitencies between code assumptions and schema

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_mysqlserver.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_mysqlserver.py
@@ -102,13 +102,13 @@ id:
     sample: /subscriptions/12345678-1234-1234-1234-123412341234/testrg/providers/Microsoft.DBforMySQL/servers/mysqlsrv1b6dd89593
 version:
     description:
-        - Server version. Possible values include: C(5.6), C(5.7)
+        - 'Server version. Possible values include: C(5.6), C(5.7)'
     returned: always
     type: str
     sample: 5.6
 state:
     description:
-        - A state of a server that is visible to user. Possible values include: C(Ready), C(Dropping), C(Disabled)
+        - 'A state of a server that is visible to user. Possible values include: C(Ready), C(Dropping), C(Disabled)'
     returned: always
     type: str
     sample: Ready

--- a/lib/ansible/modules/cloud/azure/azure_rm_postgresqlserver.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_postgresqlserver.py
@@ -102,13 +102,13 @@ id:
     sample: /subscriptions/12345678-1234-1234-1234-123412341234/resourceGroups/samplerg/providers/Microsoft.DBforPostgreSQL/servers/mysqlsrv1b6dd89593
 version:
     description:
-        - Server version. Possible values include: C(9.5), C(9.6)
+        - 'Server version. Possible values include: C(9.5), C(9.6)'
     returned: always
     type: str
     sample: 9.6
 state:
     description:
-        - A state of a server that is visible to user. Possible values include: C(Ready), C(Dropping), C(Disabled)
+        - 'A state of a server that is visible to user. Possible values include: C(Ready), C(Dropping), C(Disabled)'
     returned: always
     type: str
     sample: Ready

--- a/test/sanity/validate-modules/main.py
+++ b/test/sanity/validate-modules/main.py
@@ -1041,7 +1041,7 @@ class ModuleValidator(Validator):
         for option, details in options.items():
             try:
                 names = [option] + details.get('aliases', [])
-            except AttributeError:
+            except (TypeError, AttributeError):
                 # Reporting of this syntax error will be handled by schema validation.
                 continue
 

--- a/test/sanity/validate-modules/schema.py
+++ b/test/sanity/validate-modules/schema.py
@@ -25,7 +25,7 @@ suboption_schema = Schema(
         Required('description'): Any(list_string_types, *string_types),
         'required': bool,
         'choices': list,
-        'aliases': Any(list, *string_types),
+        'aliases': Any(list_string_types),
         'version_added': Any(float, *string_types),
         'default': Any(None, float, int, bool, list, dict, *string_types),
         # Note: Types are strings, not literal bools, such as True or False
@@ -43,7 +43,7 @@ option_schema = Schema(
         Required('description'): Any(list_string_types, *string_types),
         'required': bool,
         'choices': list,
-        'aliases': Any(list, *string_types),
+        'aliases': Any(list_string_types),
         'version_added': Any(float, *string_types),
         'default': Any(None, float, int, bool, list, dict, *string_types),
         'suboptions': Any(None, *list_dict_suboption_schema),
@@ -61,7 +61,7 @@ list_dict_option_schema = [{str_type: option_schema} for str_type in string_type
 def return_schema(data):
 
     return_schema_dict = {
-        Required('description'): Any(list, *string_types),
+        Required('description'): Any(list_string_types, *string_types),
         Required('returned'): Any(*string_types),
         Required('type'): Any('string', 'list', 'boolean', 'dict', 'complex', 'bool', 'float', 'int', 'dictionary', 'str'),
         'version_added': Any(float, *string_types),


### PR DESCRIPTION
##### SUMMARY
The code of validate-modules assumed that some things were lists of strings, and the schema enforced either a list or a string type.

After investigation, the schema was found to be incorrect, they should have accepted `list_string_types` instead.

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME
test/sanity/validate-modules

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
