### PR TITLE
Add missing storage domain properties

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_storage_domains.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_storage_domains.py
@@ -115,6 +115,18 @@ options:
             - "C(port) - Port of the fibre channel storage server."
             - "C(lun_id) - LUN id."
             - "Note that these parameters are not idempotent."
+    discard_after_delete:
+        description:
+            - "Boolean flag which indicates whether the storage domain should discard after delete."
+    wipe_after_delete:
+        description:
+            - "Boolean flag which indicates whether the storage domain should wipe the data after delete."
+    backup:
+        description:
+            - "Boolean flag which indicates whether the storage domain is configured as backup or not."
+    critical_space_action_blocker:
+        description:
+            - "Inidcates what is the minimum free space the storage domain should contain."
     destroy:
         description:
             - "Logical remove of the storage domain. If I(true) retains the storage domain's data for import."
@@ -174,6 +186,9 @@ EXAMPLES = '''
        - 1IET_000d0001
        - 1IET_000d0002
       address: 10.34.63.204
+    discard_after_delete: True
+    backup: False
+    critical_space_action_blocker: 5
 
 # Add data glusterfs storage domain
 -  ovirt_storage_domains:
@@ -193,6 +208,9 @@ EXAMPLES = '''
     nfs:
       address: 10.34.63.199
       path: /path/export
+    wipe_after_delete: False
+    backup: True
+    critical_space_action_blocker: 2
 
 # Import export NFS storage domain:
 - ovirt_storage_domains:
@@ -299,6 +317,11 @@ class StorageDomainModule(BaseModule):
             name=self._module.params['name'],
             description=self._module.params['description'],
             comment=self._module.params['comment'],
+            wipe_after_delete=self._module.params['wipe_after_delete'],
+            discard_after_delete=self._module.params['discard_after_delete'],
+            backup=self._module.params['backup'],
+            critical_space_action_blocker=self._module.params['critical_space_action_blocker']
+            if self._module.params['critical_space_action_blocker'] else None,
             import_=(
                 True
                 if self._module.params['state'] == 'imported' else None
@@ -545,6 +568,10 @@ def main():
         posixfs=dict(default=None, type='dict'),
         glusterfs=dict(default=None, type='dict'),
         fcp=dict(default=None, type='dict'),
+        discard_after_delete=dict(type='bool', default=False),
+        wipe_after_delete=dict(type='bool', default=False),
+        backup=dict(type='bool', default=False),
+        critical_space_action_blocker=dict(type='int'),
         destroy=dict(type='bool', default=False),
         format=dict(type='bool', default=False),
         discard_after_delete=dict(type='bool', default=True)

--- a/lib/ansible/modules/cloud/ovirt/ovirt_storage_domains.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_storage_domains.py
@@ -125,7 +125,7 @@ options:
         version_added: "2.5"
     critical_space_action_blocker:
         description:
-            - "Inidcates the minimal free space the storage domain should contain in GB percentages."
+            - "Inidcates the minimal free space the storage domain should contain in percentages."
         version_added: "2.5"
     warning_low_space:
         description:
@@ -574,7 +574,7 @@ def main():
         glusterfs=dict(default=None, type='dict'),
         fcp=dict(default=None, type='dict'),
         wipe_after_delete=dict(type='bool', default=None),
-        backup=dict(type='bool', default=False),
+        backup=dict(type='bool', default=None),
         critical_space_action_blocker=dict(type='int', default=None),
         warning_low_space=dict(type='int', default=None),
         destroy=dict(type='bool', default=False),

--- a/lib/ansible/modules/cloud/ovirt/ovirt_storage_domains.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_storage_domains.py
@@ -127,6 +127,9 @@ options:
     critical_space_action_blocker:
         description:
             - "Inidcates what is the minimum free space the storage domain should contain."
+    warning_low_space:
+        description:
+            - "Inidcates the minimum percentage of a free space in a storage domain to present a warning."
     destroy:
         description:
             - "Logical remove of the storage domain. If I(true) retains the storage domain's data for import."
@@ -189,6 +192,7 @@ EXAMPLES = '''
     discard_after_delete: True
     backup: False
     critical_space_action_blocker: 5
+    warning_low_space: 10
 
 # Add data glusterfs storage domain
 -  ovirt_storage_domains:
@@ -211,6 +215,7 @@ EXAMPLES = '''
     wipe_after_delete: False
     backup: True
     critical_space_action_blocker: 2
+    warning_low_space: 5
 
 # Import export NFS storage domain:
 - ovirt_storage_domains:
@@ -322,6 +327,8 @@ class StorageDomainModule(BaseModule):
             backup=self._module.params['backup'],
             critical_space_action_blocker=self._module.params['critical_space_action_blocker']
             if self._module.params['critical_space_action_blocker'] else None,
+            warning_low_space_indicator=self._module.params['warning_low_space']
+            if self._module.params['warning_low_space'] else None,
             import_=(
                 True
                 if self._module.params['state'] == 'imported' else None
@@ -572,6 +579,7 @@ def main():
         wipe_after_delete=dict(type='bool', default=False),
         backup=dict(type='bool', default=False),
         critical_space_action_blocker=dict(type='int'),
+        warning_low_space=dict(type='int'),
         destroy=dict(type='bool', default=False),
         format=dict(type='bool', default=False),
         discard_after_delete=dict(type='bool', default=True)

--- a/lib/ansible/modules/cloud/ovirt/ovirt_storage_domains.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_storage_domains.py
@@ -115,21 +115,22 @@ options:
             - "C(port) - Port of the fibre channel storage server."
             - "C(lun_id) - LUN id."
             - "Note that these parameters are not idempotent."
-    discard_after_delete:
-        description:
-            - "Boolean flag which indicates whether the storage domain should discard after delete."
     wipe_after_delete:
         description:
             - "Boolean flag which indicates whether the storage domain should wipe the data after delete."
+        version_added: "2.5"
     backup:
         description:
             - "Boolean flag which indicates whether the storage domain is configured as backup or not."
+        version_added: "2.5"
     critical_space_action_blocker:
         description:
-            - "Inidcates what is the minimum free space the storage domain should contain."
+            - "Inidcates the minimal free space the storage domain should contain in GB percentages."
+        version_added: "2.5"
     warning_low_space:
         description:
             - "Inidcates the minimum percentage of a free space in a storage domain to present a warning."
+        version_added: "2.5"
     destroy:
         description:
             - "Logical remove of the storage domain. If I(true) retains the storage domain's data for import."
@@ -323,12 +324,9 @@ class StorageDomainModule(BaseModule):
             description=self._module.params['description'],
             comment=self._module.params['comment'],
             wipe_after_delete=self._module.params['wipe_after_delete'],
-            discard_after_delete=self._module.params['discard_after_delete'],
             backup=self._module.params['backup'],
-            critical_space_action_blocker=self._module.params['critical_space_action_blocker']
-            if self._module.params['critical_space_action_blocker'] else None,
-            warning_low_space_indicator=self._module.params['warning_low_space']
-            if self._module.params['warning_low_space'] else None,
+            critical_space_action_blocker=self._module.params['critical_space_action_blocker'],
+            warning_low_space_indicator=self._module.params['warning_low_space'],
             import_=(
                 True
                 if self._module.params['state'] == 'imported' else None
@@ -575,11 +573,10 @@ def main():
         posixfs=dict(default=None, type='dict'),
         glusterfs=dict(default=None, type='dict'),
         fcp=dict(default=None, type='dict'),
-        discard_after_delete=dict(type='bool', default=False),
-        wipe_after_delete=dict(type='bool', default=False),
+        wipe_after_delete=dict(type='bool', default=None),
         backup=dict(type='bool', default=False),
-        critical_space_action_blocker=dict(type='int'),
-        warning_low_space=dict(type='int'),
+        critical_space_action_blocker=dict(type='int', default=None),
+        warning_low_space=dict(type='int', default=None),
         destroy=dict(type='bool', default=False),
         format=dict(type='bool', default=False),
         discard_after_delete=dict(type='bool', default=True)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Add additional attributes on adding/import storage domain to oVirt.
The properties are :
    wipe_after_delete - Boolean flag which indicates whether the storage domain should wipe the data after delete.
    backup - Boolean flag which indicates whether the storage domain is configured as backup or not.
    critical_space_action_blocker - Inidcates what is the minimum free space the storage domain should contain.
    warning_low_space - Inidcates the minimum percentage of a free space in a storage domain to present a warning.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - New Module Pull Request
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
