### PR TITLE
runit: Logger-process is not considered for pid and state

### DIFF
--- a/lib/ansible/modules/system/runit.py
+++ b/lib/ansible/modules/system/runit.py
@@ -168,18 +168,22 @@ class Sv(object):
             self.full_state = self.state = err
         else:
             self.full_state = out
+            # full_state *may* contain information about the logger:
+            # "down: /etc/service/service-without-logger: 1s, normally up\n"
+            # "down: /etc/service/updater: 127s, normally up; run: log: (pid 364) 263439s\n"
+            full_state_no_logger = self.full_state.split("; ")[0]
 
-            m = re.search(r'\(pid (\d+)\)', out)
+            m = re.search(r'\(pid (\d+)\)', full_state_no_logger)
             if m:
                 self.pid = m.group(1)
 
-            m = re.search(r' (\d+)s', out)
+            m = re.search(r' (\d+)s', full_state_no_logger)
             if m:
                 self.duration = m.group(1)
 
-            if re.search('run:', out):
+            if re.search(r'^run:', full_state_no_logger):
                 self.state = 'started'
-            elif re.search('down:', out):
+            elif re.search(r'^down:', full_state_no_logger):
                 self.state = 'stopped'
             else:
                 self.state = 'unknown'


### PR DESCRIPTION
Fixes #34899

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
`sv status my-service` (`self.full_state`) may contain information about a logger-process, e.g.:
`"run: /etc/service/updater: (pid 18100) 1s; run: log: (pid 364) 266567s\n"`.
Currently it may occur that the `state` and `pid` of the logger-process are considered when determining the state/pid of the process being supervised.
This PR fixes this.


<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
 - Bugfix Pull Request


##### COMPONENT NAME
runit

##### ANSIBLE VERSION
```
ansible 2.4.2.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.13 (default, Jan 19 2017, 14:48:08) [GCC 6.3.0 20170124]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
