### PR TITLE
allow cert validation to be disabled for Azure modules

### DIFF
--- a/docs/docsite/rst/guide_azure.rst
+++ b/docs/docsite/rst/guide_azure.rst
@@ -404,3 +404,15 @@ You can execute the playbook with something like:
 .. code-block:: bash
 
     $ ansible-playbook -i ./ansible/contrib/inventory/azure_rm.py test_azure_inventory.yml
+
+
+Disabling certificate validation on Azure endpoints
+...................................................
+
+When an HTTPS proxy is present, or when using Azure Stack, it may be necessary to disable certificate validation for
+Azure endpoints in the Azure modules. This is not a recommended security practice, but may be necessary when the system
+CA store cannot be altered to include the necessary CA certificate. Certificate validation can be controlled by setting
+the "cert_validation_mode" value in a credential profile, via the "AZURE_CERT_VALIDATION_MODE" environment variable, or
+by passing the "cert_validation_mode" argument to any Azure module. The default value is "validate"; setting the value
+to "ignore" will prevent all certificate validation. The module argument takes precedence over a credential profile value,
+which takes precedence over the environment value.

--- a/lib/ansible/utils/module_docs_fragments/azure.py
+++ b/lib/ansible/utils/module_docs_fragments/azure.py
@@ -67,6 +67,15 @@ options:
               C(AzureUSGovernment)), or a metadata discovery endpoint URL (required for Azure Stack). Can also be set via credential file profile or
               the C(AZURE_CLOUD_ENVIRONMENT) environment variable.
         default: AzureCloud
+        version_added: 2.4
+    cert_validation_mode:
+        description:
+            - Controls the certificate validation behavior for Azure endpoints. By default, all modules will validate the server certificate, but
+              when an HTTPS proxy is in use, or against Azure Stack, it may be necessary to disable this behavior by passing C(ignore). Can also be
+              set via credential file profile or the C(AZURE_CERT_VALIDATION) environment variable.
+        choices: [validate, ignore]
+        default: null
+        version_added: 2.5
 requirements:
     - "python >= 2.7"
     - "azure >= 2.0.0"


### PR DESCRIPTION
##### SUMMARY
* `validate` or `ignore` values may be set by module, credential profile, or env. Module has highest precedence, followed by credential profile, then environment, and defaults to `validate` if not otherwise specified.
* fixes #33455

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
azure_rm_common

##### ANSIBLE VERSION
2.5.0

##### ADDITIONAL INFORMATION
