### PR TITLE
Fix backwards compatibility in letsencrypt module

### DIFF
--- a/lib/ansible/modules/web_infrastructure/letsencrypt.py
+++ b/lib/ansible/modules/web_infrastructure/letsencrypt.py
@@ -853,7 +853,7 @@ def main():
             challenge=dict(required=False, default='http-01', choices=['http-01', 'dns-01', 'tls-sni-02'], type='str'),
             csr=dict(required=True, aliases=['src'], type='path'),
             data=dict(required=False, no_log=True, default=None, type='dict'),
-            fullchain=dict(required=False, default=True, type='bool'),
+            fullchain=dict(required=False, default=False, type='bool'),
             dest=dict(required=True, aliases=['cert'], type='path'),
             remaining_days=dict(required=False, default=10, type='int'),
         ),


### PR DESCRIPTION
##### SUMMARY
PR #22074 contained a glitch where documentation and actual behavior of the new `fullchain` option differ: the documentation claims it defaults to `False`, while the code defaults it to `True`. The value `True` also breaks backwards compatibility.

##### ISSUE TYPE
Bugfix Pull Request

##### COMPONENT NAME
letsencrypt

##### ANSIBLE VERSION
```
devel
```


##### ADDITIONAL INFORMATION
Current `devel` branch contains:
``` .yaml
  fullchain:
    description: Include the full certificate chain in the destination file.
    default: false
    version_added: 2.5
```
and
``` .py
            fullchain=dict(required=False, default=True, type='bool'),
```