### PR TITLE
Fix eos_vrf and eos_vlan interfaces param idempotent issue

### DIFF
--- a/lib/ansible/modules/network/eos/eos_interface.py
+++ b/lib/ansible/modules/network/eos/eos_interface.py
@@ -27,7 +27,8 @@ notes:
 options:
   name:
     description:
-      - Name of the Interface to be configured on remote device.
+      - Name of the Interface to be configured on remote device. The name of interface
+        should be in expanded format and not abbreviated.
     required: true
   description:
     description:

--- a/lib/ansible/modules/network/eos/eos_vlan.py
+++ b/lib/ansible/modules/network/eos/eos_vlan.py
@@ -45,7 +45,8 @@ options:
     required: true
   interfaces:
     description:
-      - List of interfaces that should be associated to the VLAN.
+      - List of interfaces that should be associated to the VLAN. The name of interface
+        should be in expanded format and not abbreviated.
   delay:
     description:
       - Delay the play should wait to check for declarative intent params values.
@@ -214,7 +215,7 @@ def map_config_to_obj(module):
         if len(splitted_line) > 3:
 
             for i in splitted_line[3].split(','):
-                obj['interfaces'].append(i.strip().replace('Et', 'Ethernet'))
+                obj['interfaces'].append(i.strip().replace('Et', 'ethernet'))
 
         objs.append(obj)
 
@@ -230,6 +231,9 @@ def map_params_to_obj(module):
                 if item.get(key) is None:
                     item[key] = module.params[key]
 
+            if item.get('interfaces'):
+                item['interfaces'] = [intf.replace(" ", "").lower() for intf in item.get('interfaces') if intf]
+
             d = item.copy()
             d['vlan_id'] = str(d['vlan_id'])
 
@@ -239,7 +243,7 @@ def map_params_to_obj(module):
             'vlan_id': str(module.params['vlan_id']),
             'name': module.params['name'],
             'state': module.params['state'],
-            'interfaces': module.params['interfaces']
+            'interfaces': [intf.replace(" ", "").lower() for intf in module.params['interfaces']] if module.params['interfaces'] else []
         })
 
     return obj
@@ -317,6 +321,7 @@ def main():
         check_declarative_intent_params(want, module)
 
     module.exit_json(**result)
+
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/network/eos/eos_vrf.py
+++ b/lib/ansible/modules/network/eos/eos_vrf.py
@@ -45,8 +45,10 @@ options:
       - Route distinguisher of the VRF
   interfaces:
     description:
-      - List of interfaces to check the VRF has been
-        configured correctly.
+      - Identifies the set of interfaces that
+        should be configured in the VRF. Interfaces must be routed
+        interfaces in order to be placed into a VRF. The name of interface
+        should be in expanded format and not abbreviated.
   aggregate:
     description: List of VRFs definitions
   purge:
@@ -195,13 +197,13 @@ def map_config_to_obj(module):
             obj = {}
             obj['name'] = splitted_line[0]
             obj['rd'] = splitted_line[1]
-            obj['interfaces'] = None
+            obj['interfaces'] = []
 
             if len(splitted_line) > 4:
                 obj['interfaces'] = []
 
                 for i in splitted_line[4].split(','):
-                    obj['interfaces'].append(i.strip())
+                    obj['interfaces'].append(i.strip().lower())
 
             objs.append(obj)
 
@@ -216,13 +218,17 @@ def map_params_to_obj(module):
             for key in item:
                 if item.get(key) is None:
                     item[key] = module.params[key]
+
+            if item.get('interfaces'):
+                item['interfaces'] = [intf.replace(" ", "").lower() for intf in item.get('interfaces') if intf]
+
             obj.append(item.copy())
     else:
         obj.append({
             'name': module.params['name'],
             'state': module.params['state'],
             'rd': module.params['rd'],
-            'interfaces': module.params['interfaces']
+            'interfaces': [intf.replace(" ", "").lower() for intf in module.params['interfaces']] if module.params['interfaces'] else []
         })
 
     return obj

--- a/test/integration/targets/eos_vlan/tests/cli/basic.yaml
+++ b/test/integration/targets/eos_vlan/tests/cli/basic.yaml
@@ -134,9 +134,9 @@
     that:
       - "result.changed == true"
       - "'vlan 4000' in result.commands"
-      - "'interface Ethernet1' in result.commands"
+      - "'interface ethernet1' in result.commands"
       - "'switchport access vlan 4000' in result.commands"
-      - "'interface Ethernet2' in result.commands"
+      - "'interface ethernet2' in result.commands"
       - "'switchport access vlan 4000' in result.commands"
       # Ensure sessions contains epoc. Will fail after 18th May 2033
       - "'ansible_1' in result.session_name"
@@ -146,8 +146,8 @@
     vlan_id: 4000
     state: present
     interfaces:
-      - Ethernet1
-      - Ethernet2
+      - ethernet 1   # interface name modified to test case insensitive and space scenario
+      - ethernet 2   # interface name modified to test case insensitive and space scenario
     authorize: yes
     provider: "{{ cli }}"
   become: yes
@@ -175,7 +175,7 @@
     that:
       - "result.changed == true"
       - "'vlan 4000' in result.commands"
-      - "'interface Ethernet2' in result.commands"
+      - "'interface ethernet2' in result.commands"
       - "'no switchport access vlan 4000' in result.commands"
       # Ensure sessions contains epoc. Will fail after 18th May 2033
       - "'ansible_1' in result.session_name"
@@ -185,7 +185,7 @@
     vlan_id: 4000
     state: present
     interfaces:
-      - Ethernet1
+      - ethernet 1 # interface name modified to handle case insensitive and space scenario
     authorize: yes
     provider: "{{ cli }}"
   become: yes

--- a/test/integration/targets/eos_vrf/tests/cli/basic.yaml
+++ b/test/integration/targets/eos_vrf/tests/cli/basic.yaml
@@ -109,7 +109,7 @@
 - assert:
     that:
       - "result.changed == true"
-      - "'interface Ethernet2' in result.commands"
+      - "'interface ethernet2' in result.commands"
       - "'vrf forwarding test' in result.commands"
       # Ensure sessions contains epoc. Will fail after 18th May 2033
       - "'ansible_1' in result.session_name"
@@ -121,7 +121,7 @@
     state: present
     authorize: yes
     interfaces:
-      - Ethernet2
+      - ethernet 2  # interface name modified to test case insensitive and space scenario
     provider: "{{ cli }}"
   become: yes
   register: result


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #34917

*  Remove spaces from in between interface name
*  Convert interface name to lower case as interface name
   is case insensitive wrt configuring on remote device.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
eos_vlan
eos_vrf
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
