### PR TITLE
continue fact gathering even without dmidecode

### DIFF
--- a/lib/ansible/module_utils/facts/virtual/linux.py
+++ b/lib/ansible/module_utils/facts/virtual/linux.py
@@ -223,13 +223,15 @@ class LinuxVirtual(Virtual):
         # In older Linux Kernel versions, /sys filesystem is not available
         # dmidecode is the safest option to parse virtualization related values
         dmi_bin = self.module.get_bin_path('dmidecode')
-        (rc, out, err) = self.module.run_command('%s -s system-product-name' % dmi_bin)
-        if rc == 0:
-            # Strip out commented lines (specific dmidecode output)
-            vendor_name = ''.join([line.strip() for line in out.splitlines() if not line.startswith('#')])
-            if vendor_name in ['VMware Virtual Platform', 'VMware7,1']:
-                virtual_facts['virtualization_type'] = 'VMware'
-                virtual_facts['virtualization_role'] = 'guest'
+        # We still want to continue even if dmidecode is not available
+        if dmi_bin is not None:
+            (rc, out, err) = self.module.run_command('%s -s system-product-name' % dmi_bin)
+            if rc == 0:
+                # Strip out commented lines (specific dmidecode output)
+                vendor_name = ''.join([line.strip() for line in out.splitlines() if not line.startswith('#')])
+                if vendor_name in ['VMware Virtual Platform', 'VMware7,1']:
+                    virtual_facts['virtualization_type'] = 'VMware'
+                    virtual_facts['virtualization_role'] = 'guest'
 
         # If none of the above matches, return 'NA' for virtualization_type
         # and virtualization_role. This allows for proper grouping.

--- a/lib/ansible/module_utils/facts/virtual/linux.py
+++ b/lib/ansible/module_utils/facts/virtual/linux.py
@@ -229,7 +229,7 @@ class LinuxVirtual(Virtual):
             if rc == 0:
                 # Strip out commented lines (specific dmidecode output)
                 vendor_name = ''.join([line.strip() for line in out.splitlines() if not line.startswith('#')])
-                if vendor_name in ['VMware Virtual Platform', 'VMware7,1']:
+                if vendor_name.startwith('VMware'):
                     virtual_facts['virtualization_type'] = 'VMware'
                     virtual_facts['virtualization_role'] = 'guest'
 


### PR DESCRIPTION
##### SUMMARY
Bugfix Pull Request

If dmidecode is not available we still wan to continue with fact gathering.
On certain platforms dmidecode won't even be available

##### COMPONENT NAME
setup ( fact gathering )

##### ANSIBLE VERSION

```
ansible 2.5.0 (dmidecode-na 06a1ed6718) last updated 2018/01/16 12:49:32 (GMT +200)
  config file = /home/ansible/.ansible.cfg
  configured module search path = [u'/home/ansible/ansible/library']
  ansible python module location = /home/ansible/ansible/lib/ansible
  executable location = /home/ansible/ansible/bin/ansible
  python version = 2.7.5 (default, May 16 2016, 12:54:51) [GCC 4.8.5 20150623 (PowerEL 4.8.5-10)]
```
