### PR TITLE
* Fix DCI failure in net_* integration test of iosxr_logging

### DIFF
--- a/test/integration/targets/iosxr_logging/tests/cli/net_logging.yaml
+++ b/test/integration/targets/iosxr_logging/tests/cli/net_logging.yaml
@@ -6,14 +6,14 @@
 
 - name: Remove host logging - setup
   net_logging:
-    dest: hostnameprefix
+    dest: host
     name: 172.16.0.1
     state: absent
     provider: "{{ cli }}"
 
 - name: Set up host logging using platform agnostic module
   net_logging:
-    dest: hostnameprefix
+    dest: host
     name: 172.16.0.1
     state: present
     provider: "{{ cli }}"
@@ -22,11 +22,11 @@
 - assert:
     that:
       - 'result.changed == true'
-      - '"logging hostnameprefix 172.16.0.1" in result.commands'
+      - '"logging 172.16.0.1 vrf default severity info" in result.commands'
 
 - name: Remove host logging - teardown
   net_logging:
-    dest: hostnameprefix
+    dest: host
     name: 172.16.0.1
     state: absent
     provider: "{{ cli }}"


### PR DESCRIPTION
##### SUMMARY
Fix dci failure in net_logging.yaml of iosxr_logging module

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5.0
```

