### PR TITLE
Work-around for empty changesets with status FAILED being created

### DIFF
--- a/lib/ansible/modules/cloud/amazon/cloudformation.py
+++ b/lib/ansible/modules/cloud/amazon/cloudformation.py
@@ -346,21 +346,25 @@ def create_changeset(module, stack_params, cfn):
             result = dict(changed=False, output='ChangeSet %s already exists.' % changeset_name, warnings=[warning])
         else:
             cs = cfn.create_change_set(**stack_params)
-            while True:
+            # Make sure we don't enter an infinite loop
+            time_end = time.time() + 600
+            while time.time() < time_end:
                 try:
                     newcs = cfn.describe_change_set(ChangeSetName=cs['Id'])
-                except Exception as err:
+                except botocore.exceptions.BotoCoreError as err:
                     error_msg = boto_exception(err)
                     module.fail_json(msg=error_msg)
                 if newcs['Status'] == 'CREATE_PENDING' or newcs['Status'] == 'CREATE_IN_PROGRESS':
                     time.sleep(1)
-                elif 'FAILED' == newcs['Status'] and "The submitted information didn't contain changes" in newcs['StatusReason']:
+                elif newcs['Status'] == 'FAILED' and "The submitted information didn't contain changes" in newcs['StatusReason']:
                     cfn.delete_change_set(ChangeSetName=cs['Id'])
                     result = dict(changed=False,
-                                  output='Stack is already up-to-date, ChangeSet refused to create due to lack of changes.')
+                                  output='Stack is already up-to-date, Change Set refused to create due to lack of changes.')
                     module.exit_json(**result)
                 else:
                     break
+                # Lets not hog the cpu/spam the AWS API
+                time.sleep(1)
             result = stack_operation(cfn, stack_params['StackName'], 'CREATE_CHANGESET')
             result['warnings'] = ['Created changeset named %s for stack %s' % (changeset_name, stack_params['StackName']),
                                   'You can execute it using: aws cloudformation execute-change-set --change-set-name %s' % cs['Id'],

--- a/lib/ansible/modules/cloud/amazon/cloudformation.py
+++ b/lib/ansible/modules/cloud/amazon/cloudformation.py
@@ -346,6 +346,21 @@ def create_changeset(module, stack_params, cfn):
             result = dict(changed=False, output='ChangeSet %s already exists.' % changeset_name, warnings=[warning])
         else:
             cs = cfn.create_change_set(**stack_params)
+            while True:
+                try:
+                    newcs = cfn.describe_change_set(ChangeSetName=cs['Id'])
+                except Exception as err:
+                    error_msg = boto_exception(err)
+                    module.fail_json(msg=error_msg)
+                if newcs['Status'] == 'CREATE_PENDING' or newcs['Status'] == 'CREATE_IN_PROGRESS':
+                    time.sleep(1)
+                elif 'FAILED' == newcs['Status'] and "The submitted information didn't contain changes" in newcs['StatusReason']:
+                    cfn.delete_change_set(ChangeSetName=cs['Id'])
+                    result = dict(changed=False,
+                                  output='Stack is already up-to-date, ChangeSet refused to create due to lack of changes.')
+                    module.exit_json(**result)
+                else:
+                    break
             result = stack_operation(cfn, stack_params['StackName'], 'CREATE_CHANGESET')
             result['warnings'] = ['Created changeset named %s for stack %s' % (changeset_name, stack_params['StackName']),
                                   'You can execute it using: aws cloudformation execute-change-set --change-set-name %s' % cs['Id'],


### PR DESCRIPTION
##### SUMMARY
When you try to update a cloudformation stack with a changeset without making actual changes, the changeset will fail with the following message:
````
FAILED - The submitted information didn't contain changes. Submit different information to create a change set.
````
This is not an issue with cloudformation but is by design. I have put in a feature request with AWS to stop the changeset from being created when it has no changes.

In the mean time, you only want ansible to create changesets when there are actually changes for this stack. This is why I have added a way around this. This change checks the changeset after it has been created. If it failed due to having no changes, the changeset will be removed by ansible and the task result will be set to changed=False. If it does not fail with that specific message, it will continue with the rest of the code like it did before.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
modules/cloud/amazon/cloudformation

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
$ ansible --version
ansible 2.4.2.0
python version = 2.7.14 (default, Sep 20 2017, 01:25:59) [GCC 7.2.0]
```


##### ADDITIONAL INFORMATION
**Before**:
```
TASK [cloudformation (no changes)] ********
 [WARNING]: Created changeset named [changeset] for stack [stackname]
 [WARNING]: You can execute it using: aws cloudformation execute-change-set --change-set-name arn:aws:cloudformation:[region]:[account]:changeSet/[changeset]
changed: [localhost]
```
Changeset:
```
Status: FAILED - The submitted information didn't contain changes. Submit different information to create a change set.
```
**After**:
```
TASK [cloudformation (no changes)] ********
ok: [localhost]
```