### PR TITLE
Clarify which ping module to use

### DIFF
--- a/lib/ansible/modules/network/ios/ios_ping.py
+++ b/lib/ansible/modules/network/ios/ios_ping.py
@@ -48,6 +48,10 @@ options:
     - The VRF to use for forwarding.
     required: false
     default: default
+notes:
+  - For a general purpose network module, see the M(net_ping) module.
+  - For Windows targets, use the M(win_ping) module instead.
+  - For targets running Python, use the M(ping) module instead.
 '''
 
 EXAMPLES = r'''

--- a/lib/ansible/modules/network/ios/ios_ping.py
+++ b/lib/ansible/modules/network/ios/ios_ping.py
@@ -13,9 +13,12 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = r'''
 ---
 module: ios_ping
-short_description: Tests reachability using ping from IOS switch
+short_description: Tests reachability using ping from Cisco IOS network devices
 description:
 - Tests reachability using ping from switch to a remote destination.
+- For a general purpose network module, see the M(net_ping) module.
+- For Windows targets, use the M(win_ping) module instead.
+- For targets running Python, use the M(ping) module instead.
 author:
 - Jacob McGill (@jmcgill298)
 version_added: '2.4'

--- a/lib/ansible/modules/network/nxos/nxos_ping.py
+++ b/lib/ansible/modules/network/nxos/nxos_ping.py
@@ -29,6 +29,9 @@ version_added: "2.1"
 short_description: Tests reachability using ping from Nexus switch.
 description:
     - Tests reachability using ping from switch to a remote destination.
+    - For a general purpose network module, see the M(net_ping) module.
+    - For Windows targets, use the M(win_ping) module instead.
+    - For targets running Python, use the M(ping) module instead.
 author:
     - Jason Edelman (@jedelman8)
     - Gabriele Gerbino (@GGabriele)
@@ -57,6 +60,10 @@ options:
             - Determines if the expected result is success or fail.
         choices: [ absent, present ]
         default: present
+notes:
+    - For a general purpose network module, see the M(net_ping) module.
+    - For Windows targets, use the M(win_ping) module instead.
+    - For targets running Python, use the M(ping) module instead.
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/network/system/net_ping.py
+++ b/lib/ansible/modules/network/system/net_ping.py
@@ -21,6 +21,8 @@ author: "Jacob McGill (@jmcgill298)"
 short_description: Tests reachability using ping from a network device
 description:
   - Tests reachability using ping from network device to a remote destination.
+  - For Windows targets, use the M(win_ping) module instead.
+  - For targets running Python, use the M(ping) module instead.
 options:
   count:
     description:

--- a/lib/ansible/modules/network/system/net_ping.py
+++ b/lib/ansible/modules/network/system/net_ping.py
@@ -48,6 +48,10 @@ options:
     - The VRF to use for forwarding.
     required: false
     default: default
+notes:
+  - For a general purpose network module, see the M(net_ping) module.
+  - For Windows targets, use the M(win_ping) module instead.
+  - For targets running Python, use the M(ping) module instead.
 '''
 
 

--- a/lib/ansible/modules/network/system/net_ping.py
+++ b/lib/ansible/modules/network/system/net_ping.py
@@ -49,7 +49,6 @@ options:
     required: false
     default: default
 notes:
-  - For a general purpose network module, see the M(net_ping) module.
   - For Windows targets, use the M(win_ping) module instead.
   - For targets running Python, use the M(ping) module instead.
 '''

--- a/lib/ansible/modules/system/ping.py
+++ b/lib/ansible/modules/system/ping.py
@@ -21,11 +21,13 @@ short_description: Try to connect to host, verify a usable python and return C(p
 description:
    - A trivial test module, this module always returns C(pong) on successful
      contact. It does not make sense in playbooks, but it is useful from
-     C(/usr/bin/ansible) to verify the ability to login and that a usable python is configured.
-   - This is NOT ICMP ping, this is just a trivial test module.
+     C(/usr/bin/ansible) to verify the ability to login and that a usable Python is configured.
+   - This is NOT ICMP ping, this is just a trivial test module that requires Python on the remote-node.
    - For Windows targets, use the M(win_ping) module instead.
+   - For Network targets, use the M(net_ping) module instead.
 notes:
    - For Windows targets, use the M(win_ping) module instead.
+   - For Network targets, use the M(net_ping) module instead.
 options:
   data:
     description:

--- a/lib/ansible/modules/windows/win_ping.py
+++ b/lib/ansible/modules/windows/win_ping.py
@@ -34,6 +34,7 @@ description:
   - Checks management connectivity of a windows host.
   - This is NOT ICMP ping, this is just a trivial test module.
   - For non-Windows targets, use the M(ping) module instead.
+  - For Network targets, use the M(net_ping) module instead.
 options:
   data:
     description:
@@ -42,6 +43,7 @@ options:
     default: pong
 notes:
   - For non-Windows targets, use the M(ping) module instead.
+  - For Network targets, use the M(net_ping) module instead.
 author:
 - Chris Church (@cchurch)
 '''


### PR DESCRIPTION
##### SUMMARY
Ensure each of the ping modules link to each other to hopefully remove some of the confusion about people running `ping` against devices without Python.

`ping` - Requires Python on remote-node
`ios_ping` - Only on Cisco IOS
`net_ping` - For network devices
`win_ping` - only for Windows

##### ISSUE TYPE
 - Docs Pull Request

