### PR TITLE
Update documentation for package.py to address use with apt

### DIFF
--- a/lib/ansible/modules/packaging/os/package.py
+++ b/lib/ansible/modules/packaging/os/package.py
@@ -27,7 +27,7 @@ description:
 options:
   name:
     description:
-      - "Package name, or package specifier with version, like C(name-1.0)."
+      - "Package name, or package specifier with version, like C(name-1.0). Systems using 'apt' require and equal sign instead of a dash, i.e. C(name=1.0)."
       - "Be aware that packages are not always named the same and this module will not 'translate' them per distro."
     required: true
   state:
@@ -57,4 +57,12 @@ EXAMPLES = '''
   package:
     name: "{{ apache }}"
     state: absent
+
+- name: install at version 3.1.10 on yum systems
+  package:
+    name: at-3.1.10
+
+- name: install at version 3.1.16-1 on apt systems
+  package:
+    name: at=3.1.16-1
 '''


### PR DESCRIPTION
apt uses "=" instead of "-". Explaining in DOCUMENTATION and added two EXAMPLES.

This issue has been described in #29705. This pull request does not fix the behaviour, it just explains it.

##### SUMMARY
Updating the documentation will help other users.

Does not fix, but hopefully helps users suffering issue #29705.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
package

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible --version
ansible 2.4.2.0
  config file = /Users/username/Documents/ansible/ansible.cfg
  configured module search path = [u'/Users/username/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/site-packages/ansible
  executable location = /Users/username/Library/Python/2.7/bin/ansible
  python version = 2.7.14 (default, Sep 25 2017, 09:53:22) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.37)]
```

##### ADDITIONAL INFORMATION
According to the (current) documentation, a dash ("-") should work, but it does not:
```
ansible -m package -a "name=libsemanage-common-2.3-1" reference-debian-8
reference-debian-8 | FAILED! => {
    "changed": false, 
    "msg": "No package matching 'libsemanage-common-2.3-1' is available"
}
```

What does work is an equal ("=") sign:
```
ansible -m package -a "name=libsemanage-common=2.3-1" reference-debian-8
reference-debian-8 | SUCCESS => {
    "cache_update_time": 1516107446, 
    "cache_updated": false, 
    "changed": false
}
```
