### PR TITLE
Update lvol.py to better handle %PVS options when creating/resizing lvols.

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -1416,6 +1416,9 @@ class PyVmomiHelper(PyVmomi):
             resource_pool = cluster.resourcePool
         # fallback, pick any RP
         else:
+            resource_pool = self.select_resource_pool_by_name(self.params['resource_pool'])
+
+        if resource_pool is None:
             self.module.fail_json(msg='Unable to find resource pool, need esxi_hostname, resource_pool, or cluster')
 
         return resource_pool

--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -25,6 +25,7 @@ version_added: '2.2'
 author:
 - James Tanner (@jctanner) <tanner.jc@gmail.com>
 - Loic Blot (@nerzhul) <loic.blot@unix-experience.fr>
+- Philippe Dellaert (@pdellaert) <philippe@dellaert.org>
 notes:
 - Tested on vSphere 5.5 and 6.0
 requirements:
@@ -51,6 +52,7 @@ options:
     description:
     - UUID of the instance to manage if known, this is VMware's unique identifier.
     - This is required if name is not supplied.
+    - Please note that a supplied UUID will be ignored on VM creation, as VMware creates the UUID internally.
   template:
     description:
     - Template used to create VM.
@@ -64,7 +66,7 @@ options:
     version_added: '2.3'
   folder:
     description:
-    - Destination folder, absolute or relative path to find an existing guest or create the new guest.
+    - Destination folder, absolute path to find an existing guest or create the new guest.
     - The folder should include the datacenter. ESX's datacenter is ha-datacenter
     - 'Examples:'
     - '   folder: /ha-datacenter/vm'
@@ -76,16 +78,32 @@ options:
     - '   folder: /folder1/datacenter1/vm'
     - '   folder: folder1/datacenter1/vm'
     - '   folder: /folder1/datacenter1/vm/folder2'
-    - '   folder: vm/folder2'
-    - '   folder: folder2'
     default: /vm
   hardware:
     description:
     - Manage some VM hardware attributes.
     - 'Valid attributes are:'
+    - ' - C(hotadd_cpu) (boolean): Allow virtual CPUs to be added while the VM is running.'
+    - ' - C(hotremove_cpu) (boolean): Allow virtual CPUs to be removed while the VM is running. version_added: 2.5'
+    - ' - C(hotadd_memory) (boolean): Allow memory to be added while the VM is running.'
     - ' - C(memory_mb) (integer): Amount of memory in MB.'
+    - ' - C(nested_virt) (bool): Enable nested virtualization. version_added: 2.5'
     - ' - C(num_cpus) (integer): Number of CPUs.'
+    - ' - C(num_cpu_cores_per_socket) (integer): Number of Cores Per Socket. Value should be multiple of C(num_cpus).'
     - ' - C(scsi) (string): Valid values are C(buslogic), C(lsilogic), C(lsilogicsas) and C(paravirtual) (default).'
+    - ' - C(memory_reservation) (integer): Amount of memory in MB to set resource limits for memory. version_added: 2.5'
+    - " - C(memory_reservation_lock) (boolean): If set true, memory resource reservation for VM
+          will always be equal to the VM's memory size. version_added: 2.5"
+    - ' - C(max_connections) (integer): Maximum number of active remote display connections for the virtual machines. version_added: 2.5.'
+    - ' - C(mem_limit) (integer): The memory utilization of a virtual machine will not exceed this limit. Unit is MB.
+          version_added: 2.5'
+    - ' - C(mem_reservation) (integer): The amount of memory resource that is guaranteed available to the virtual
+          machine. Unit is MB. version_added: 2.5'
+    - ' - C(cpu_limit) (integer): The CPU utilization of a virtual machine will not exceed this limit. Unit is MHz.
+          version_added: 2.5'
+    - ' - C(cpu_reservation) (integer): The amount of CPU resource that is guaranteed available to the virtual machine.
+          Unit is MHz. version_added: 2.5'
+
   guest_id:
     description:
     - Set the guest ID (Debian, RHEL, Windows...).
@@ -99,9 +117,17 @@ options:
     - A list of disks to add.
     - 'Valid attributes are:'
     - ' - C(size_[tb,gb,mb,kb]) (integer): Disk storage size in specified unit.'
-    - ' - C(type) (string): Valid value is C(thin) (default: None).'
+    - ' - C(type) (string): Valid values are:'
+    - '   C(thin) thin disk, C(eagerzeroedthick) eagerzeroedthick disk, added in version 2.5, Default: C(None) thick disk, no eagerzero.'
     - ' - C(datastore) (string): Datastore to use for the disk. If C(autoselect_datastore) is enabled, filter datastore selection.'
     - ' - C(autoselect_datastore) (bool): select the less used datastore.'
+  cdrom:
+    description:
+    - A CD-ROM configuration for the VM.
+    - 'Valid attributes are:'
+    - ' - C(type) (string): The type of CD-ROM, valid options are C(none), C(client) or C(iso). With C(none) the CD-ROM will be disconnected but present.'
+    - ' - C(iso_path) (string): The datastore path to the ISO file to use, in the form of C([datastore1] path/to/file.iso). Required if type is iso.'
+    version_added: '2.5'
   resource_pool:
     description:
     - Affect machine to the given resource pool.
@@ -164,6 +190,9 @@ options:
     - ' - C(gateway) (string): Static gateway.'
     - ' - C(dns_servers) (string): DNS servers for this network interface (Windows).'
     - ' - C(domain) (string): Domain name for this network interface (Windows).'
+    - ' - C(wake_on_lan) (bool): Indicates if wake-on-LAN is enabled on this virtual network adapter. version_added: 2.5'
+    - ' - C(start_connected) (bool): Indicates that virtual network adapter starts with associated virtual machine powers on. version_added: 2.5'
+    - ' - C(allow_guest_control) (bool): Enables guest control over whether the connectable device is connected. version_added: 2.5'
     version_added: '2.3'
   customization:
     description:
@@ -207,8 +236,22 @@ EXAMPLES = r'''
       datastore: g73_datastore
     hardware:
       memory_mb: 512
-      num_cpus: 1
+      num_cpus: 6
+      num_cpu_cores_per_socket: 3
       scsi: paravirtual
+      memory_reservation: 512
+      memory_reservation_lock: True
+      mem_limit: 8096
+      mem_reservation: 4096
+      cpu_limit: 8096
+      cpu_reservation: 4096
+      max_connections: 5
+      hotadd_cpu: True
+      hotremove_cpu: True
+      hotadd_memory: False
+    cdrom:
+      type: iso
+      iso_path: "[datastore1] livecd.iso"
     networks:
     - name: VM Network
       mac: aa:bb:dd:aa:00:14
@@ -301,22 +344,23 @@ instance:
     sample: None
 '''
 
+import re
 import time
 
 HAS_PYVMOMI = False
 try:
     import pyVmomi
-    from pyVmomi import vim
+    from pyVmomi import vim, vmodl
 
     HAS_PYVMOMI = True
 except ImportError:
     pass
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_text
-from ansible.module_utils.vmware import (connect_to_api, find_obj, gather_vm_facts, get_all_objs,
-                                         compile_folder_path_for_object, serialize_spec, find_vm_by_id,
-                                         vmware_argument_spec)
+from ansible.module_utils._text import to_text, to_native
+from ansible.module_utils.vmware import (find_obj, gather_vm_facts, get_all_objs,
+                                         compile_folder_path_for_object, serialize_spec,
+                                         vmware_argument_spec, set_vm_power_state, PyVmomi)
 
 
 class PyVmomiDeviceHelper(object):
@@ -358,6 +402,52 @@ class PyVmomiDeviceHelper(object):
             isinstance(device, vim.vm.device.VirtualBusLogicController) or \
             isinstance(device, vim.vm.device.VirtualLsiLogicSASController)
 
+    @staticmethod
+    def create_ide_controller():
+        ide_ctl = vim.vm.device.VirtualDeviceSpec()
+        ide_ctl.operation = vim.vm.device.VirtualDeviceSpec.Operation.add
+        ide_ctl.device = vim.vm.device.VirtualIDEController()
+        ide_ctl.device.deviceInfo = vim.Description()
+        ide_ctl.device.busNumber = 0
+
+        return ide_ctl
+
+    @staticmethod
+    def create_cdrom(ide_ctl, cdrom_type, iso_path=None):
+        cdrom_spec = vim.vm.device.VirtualDeviceSpec()
+        cdrom_spec.operation = vim.vm.device.VirtualDeviceSpec.Operation.add
+        cdrom_spec.device = vim.vm.device.VirtualCdrom()
+        cdrom_spec.device.controllerKey = ide_ctl.device.key
+        cdrom_spec.device.key = -1
+        cdrom_spec.device.connectable = vim.vm.device.VirtualDevice.ConnectInfo()
+        cdrom_spec.device.connectable.allowGuestControl = True
+        cdrom_spec.device.connectable.startConnected = (cdrom_type != "none")
+        if cdrom_type in ["none", "client"]:
+            cdrom_spec.device.backing = vim.vm.device.VirtualCdrom.RemotePassthroughBackingInfo()
+        elif cdrom_type == "iso":
+            cdrom_spec.device.backing = vim.vm.device.VirtualCdrom.IsoBackingInfo(fileName=iso_path)
+
+        return cdrom_spec
+
+    @staticmethod
+    def is_equal_cdrom(vm_obj, cdrom_device, cdrom_type, iso_path):
+        if cdrom_type == "none":
+            return (isinstance(cdrom_device.backing, vim.vm.device.VirtualCdrom.RemotePassthroughBackingInfo) and
+                    cdrom_device.connectable.allowGuestControl and
+                    not cdrom_device.connectable.startConnected and
+                    (vm_obj.runtime.powerState != vim.VirtualMachinePowerState.poweredOn or not cdrom_device.connectable.connected))
+        elif cdrom_type == "client":
+            return (isinstance(cdrom_device.backing, vim.vm.device.VirtualCdrom.RemotePassthroughBackingInfo) and
+                    cdrom_device.connectable.allowGuestControl and
+                    cdrom_device.connectable.startConnected and
+                    (vm_obj.runtime.powerState != vim.VirtualMachinePowerState.poweredOn or cdrom_device.connectable.connected))
+        elif cdrom_type == "iso":
+            return (isinstance(cdrom_device.backing, vim.vm.device.VirtualCdrom.IsoBackingInfo) and
+                    cdrom_device.backing.fileName == iso_path and
+                    cdrom_device.connectable.allowGuestControl and
+                    cdrom_device.connectable.startConnected and
+                    (vm_obj.runtime.powerState != vim.VirtualMachinePowerState.poweredOn or cdrom_device.connectable.connected))
+
     def create_scsi_disk(self, scsi_ctl, disk_index=None):
         diskspec = vim.vm.device.VirtualDeviceSpec()
         diskspec.operation = vim.vm.device.VirtualDeviceSpec.Operation.add
@@ -367,8 +457,10 @@ class PyVmomiDeviceHelper(object):
         diskspec.device.backing.diskMode = 'persistent'
         diskspec.device.controllerKey = scsi_ctl.device.key
 
-        assert self.next_disk_unit_number != 7
-        assert disk_index != 7
+        if self.next_disk_unit_number == 7:
+            raise AssertionError()
+        if disk_index == 7:
+            raise AssertionError()
         """
         Configure disk unit number.
         """
@@ -402,25 +494,41 @@ class PyVmomiDeviceHelper(object):
         else:
             self.module.fail_json(msg='Invalid device_type "%s" for network "%s"' % (device_type, device_infos['name']))
 
-        nic.device.wakeOnLanEnabled = True
+        nic.device.wakeOnLanEnabled = bool(device_infos.get('wake_on_lan', True))
         nic.device.deviceInfo = vim.Description()
         nic.device.deviceInfo.label = device_label
         nic.device.deviceInfo.summary = device_infos['name']
         nic.device.connectable = vim.vm.device.VirtualDevice.ConnectInfo()
-        nic.device.connectable.startConnected = True
-        nic.device.connectable.allowGuestControl = True
+        nic.device.connectable.startConnected = bool(device_infos.get('start_connected', True))
+        nic.device.connectable.allowGuestControl = bool(device_infos.get('allow_guest_control', True))
         nic.device.connectable.connected = True
-        if 'mac' in device_infos:
-            nic.device.addressType = 'assigned'
+        if 'mac' in device_infos and self.is_valid_mac_addr(device_infos['mac']):
+            nic.device.addressType = 'manual'
             nic.device.macAddress = device_infos['mac']
         else:
             nic.device.addressType = 'generated'
 
         return nic
 
+    @staticmethod
+    def is_valid_mac_addr(mac_addr):
+        """
+        Function to validate MAC address for given string
+        Args:
+            mac_addr: string to validate as MAC address
+
+        Returns: (Boolean) True if string is valid MAC address, otherwise False
+        """
+        ret = False
+        mac_addr_regex = re.compile('[0-9a-f]{2}([-:])[0-9a-f]{2}(\\1[0-9a-f]{2}){4}$')
+        if mac_addr_regex.match(mac_addr):
+            ret = True
+        return ret
+
 
 class PyVmomiCache(object):
     """ This class caches references to objects which are requested multiples times but not modified """
+
     def __init__(self, content, dc_name=None):
         self.content = content
         self.dc_name = dc_name
@@ -447,10 +555,13 @@ class PyVmomiCache(object):
         if confine_to_datacenter:
             if hasattr(objects, 'items'):
                 # resource pools come back as a dictionary
+                # make a copy
+                tmpobjs = objects.copy()
                 for k, v in objects.items():
                     parent_dc = self.get_parent_datacenter(k)
                     if parent_dc.name != self.dc_name:
-                        objects.pop(k, None)
+                        tmpobjs.pop(k, None)
+                objects = tmpobjs
             else:
                 # everything else should be a list
                 objects = [x for x in objects if self.get_parent_datacenter(x).name == self.dc_name]
@@ -493,111 +604,14 @@ class PyVmomiCache(object):
         return datacenter
 
 
-class PyVmomiHelper(object):
+class PyVmomiHelper(PyVmomi):
     def __init__(self, module):
-        if not HAS_PYVMOMI:
-            module.fail_json(msg='pyvmomi module required')
-
-        self.module = module
+        super(PyVmomiHelper, self).__init__(module)
         self.device_helper = PyVmomiDeviceHelper(self.module)
-        self.params = module.params
-        self.si = None
-        self.content = connect_to_api(self.module)
         self.configspec = None
         self.change_detected = False
         self.customspec = None
-        self.current_vm_obj = None
         self.cache = PyVmomiCache(self.content, dc_name=self.params['datacenter'])
-
-    def getvm(self, name=None, uuid=None, folder=None):
-        vm = None
-        match_first = False
-        if uuid:
-            vm = find_vm_by_id(self.content, vm_id=uuid, vm_id_type="uuid")
-        elif folder and name:
-            if self.params['name_match'] == 'first':
-                match_first = True
-            vm = find_vm_by_id(self.content, vm_id=name, vm_id_type="inventory_path", folder=folder, match_first=match_first)
-        if vm:
-            self.current_vm_obj = vm
-
-        return vm
-
-    def set_powerstate(self, vm, state, force):
-        """
-        Set the power status for a VM determined by the current and
-        requested states. force is forceful
-        """
-        facts = self.gather_facts(vm)
-        expected_state = state.replace('_', '').lower()
-        current_state = facts['hw_power_status'].lower()
-        result = dict(
-            changed=False,
-            failed=False,
-        )
-
-        # Need Force
-        if not force and current_state not in ['poweredon', 'poweredoff']:
-            result['failed'] = True
-            result['msg'] = "VM is in %s power state. Force is required!" % current_state
-            return result
-
-        # State is not already true
-        if current_state != expected_state:
-            task = None
-            try:
-                if expected_state == 'poweredoff':
-                    task = vm.PowerOff()
-
-                elif expected_state == 'poweredon':
-                    task = vm.PowerOn()
-
-                elif expected_state == 'restarted':
-                    if current_state in ('poweredon', 'poweringon', 'resetting', 'poweredoff'):
-                        task = vm.Reset()
-                    else:
-                        result['failed'] = True
-                        result['msg'] = "Cannot restart VM in the current state %s" % current_state
-
-                elif expected_state == 'suspended':
-                    if current_state in ('poweredon', 'poweringon'):
-                        task = vm.Suspend()
-                    else:
-                        result['failed'] = True
-                        result['msg'] = 'Cannot suspend VM in the current state %s' % current_state
-
-                elif expected_state in ['shutdownguest', 'rebootguest']:
-                    if current_state == 'poweredon' and vm.guest.toolsRunningStatus == 'guestToolsRunning':
-                        if expected_state == 'shutdownguest':
-                            task = vm.ShutdownGuest()
-                        else:
-                            task = vm.RebootGuest()
-                        # Set result['changed'] immediately because
-                        # shutdown and reboot return None.
-                        result['changed'] = True
-                    else:
-                        result['failed'] = True
-                        result['msg'] = "VM %s must be in poweredon state & tools should be installed for guest shutdown/reboot" % vm.name
-
-            except Exception as e:
-                result['failed'] = True
-                result['msg'] = to_text(e)
-
-            if task:
-                self.wait_for_task(task)
-                if task.info.state == 'error':
-                    result['failed'] = True
-                    result['msg'] = str(task.info.error.msg)
-                else:
-                    result['changed'] = True
-
-        # need to get new metadata if changed
-        if result['changed']:
-            newvm = self.getvm(uuid=vm.config.uuid)
-            facts = self.gather_facts(newvm)
-            result['instance'] = facts
-
-        return result
 
     def gather_facts(self, vm):
         return gather_vm_facts(self.content, vm)
@@ -621,15 +635,87 @@ class PyVmomiHelper(object):
         if vm_creation and self.params['guest_id'] is None:
             self.module.fail_json(msg="guest_id attribute is mandatory for VM creation")
 
-        if vm_obj is None or self.params['guest_id'] != vm_obj.summary.config.guestId:
+        if self.params['guest_id'] and (vm_obj is None or self.params['guest_id'] != vm_obj.summary.config.guestId):
             self.change_detected = True
             self.configspec.guestId = self.params['guest_id']
+
+    def configure_resource_alloc_info(self, vm_obj):
+        """
+        Function to configure resource allocation information about virtual machine
+        :param vm_obj: VM object in case of reconfigure, None in case of deploy
+        :return: None
+        """
+        self.configspec.memoryAllocation = vim.ResourceAllocationInfo()
+        self.configspec.cpuAllocation = vim.ResourceAllocationInfo()
+
+        if 'hardware' in self.params:
+            if 'mem_limit' in self.params['hardware']:
+                mem_limit = None
+                try:
+                    mem_limit = int(self.params['hardware'].get('mem_limit'))
+                except ValueError as e:
+                    self.module.fail_json(msg="hardware.mem_limit attribute should be an integer value.")
+                self.configspec.memoryAllocation.limit = mem_limit
+                if vm_obj is None or self.configspec.memoryAllocation.limit != vm_obj.config.memoryAllocation.limit:
+                    self.change_detected = True
+
+            if 'mem_reservation' in self.params['hardware']:
+                mem_reservation = None
+                try:
+                    mem_reservation = int(self.params['hardware'].get('mem_reservation'))
+                except ValueError as e:
+                    self.module.fail_json(msg="hardware.mem_reservation should be an integer value.")
+
+                self.configspec.memoryAllocation.reservation = mem_reservation
+                if vm_obj is None or \
+                        self.configspec.memoryAllocation.reservation != vm_obj.config.memoryAllocation.reservation:
+                    self.change_detected = True
+
+            if 'cpu_limit' in self.params['hardware']:
+                cpu_limit = None
+                try:
+                    cpu_limit = int(self.params['hardware'].get('cpu_limit'))
+                except ValueError as e:
+                    self.module.fail_json(msg="hardware.cpu_limit attribute should be an integer value.")
+                self.configspec.cpuAllocation.limit = cpu_limit
+                if vm_obj is None or self.configspec.cpuAllocation.limit != vm_obj.config.cpuAllocation.limit:
+                    self.change_detected = True
+
+            if 'cpu_reservation' in self.params['hardware']:
+                cpu_reservation = None
+                try:
+                    cpu_reservation = int(self.params['hardware'].get('cpu_reservation'))
+                except ValueError as e:
+                    self.module.fail_json(msg="hardware.cpu_reservation should be an integer value.")
+                self.configspec.cpuAllocation.reservation = cpu_reservation
+                if vm_obj is None or \
+                        self.configspec.cpuAllocation.reservation != vm_obj.config.cpuAllocation.reservation:
+                    self.change_detected = True
 
     def configure_cpu_and_memory(self, vm_obj, vm_creation=False):
         # set cpu/memory/etc
         if 'hardware' in self.params:
             if 'num_cpus' in self.params['hardware']:
-                self.configspec.numCPUs = int(self.params['hardware']['num_cpus'])
+                try:
+                    num_cpus = int(self.params['hardware']['num_cpus'])
+                except ValueError as e:
+                    self.module.fail_json(msg="hardware.num_cpus attribute should be an integer value.")
+
+                if 'num_cpu_cores_per_socket' in self.params['hardware']:
+                    try:
+                        num_cpu_cores_per_socket = int(self.params['hardware']['num_cpu_cores_per_socket'])
+                    except ValueError as e:
+                        self.module.fail_json(msg="hardware.num_cpu_cores_per_socket attribute "
+                                                  "should be an integer value.")
+                    if num_cpus % num_cpu_cores_per_socket != 0:
+                        self.module.fail_json(msg="hardware.num_cpus attribute should be a multiple "
+                                                  "of hardware.num_cpu_cores_per_socket")
+
+                    self.configspec.numCoresPerSocket = num_cpu_cores_per_socket
+                    if vm_obj is None or self.configspec.numCoresPerSocket != vm_obj.config.hardware.numCoresPerSocket:
+                        self.change_detected = True
+
+                self.configspec.numCPUs = num_cpus
                 if vm_obj is None or self.configspec.numCPUs != vm_obj.config.hardware.numCPU:
                     self.change_detected = True
             # num_cpu is mandatory for VM creation
@@ -643,6 +729,128 @@ class PyVmomiHelper(object):
             # memory_mb is mandatory for VM creation
             elif vm_creation and not self.params['template']:
                 self.module.fail_json(msg="hardware.memory_mb attribute is mandatory for VM creation")
+
+            if 'hotadd_memory' in self.params['hardware']:
+                self.configspec.memoryHotAddEnabled = bool(self.params['hardware']['hotadd_memory'])
+                if vm_obj is None or self.configspec.memoryHotAddEnabled != vm_obj.config.memoryHotAddEnabled:
+                    self.change_detected = True
+
+            if 'hotadd_cpu' in self.params['hardware']:
+                self.configspec.cpuHotAddEnabled = bool(self.params['hardware']['hotadd_cpu'])
+                if vm_obj is None or self.configspec.cpuHotAddEnabled != vm_obj.config.cpuHotAddEnabled:
+                    self.change_detected = True
+
+            if 'hotremove_cpu' in self.params['hardware']:
+                self.configspec.cpuHotRemoveEnabled = bool(self.params['hardware']['hotremove_cpu'])
+                if vm_obj is None or self.configspec.cpuHotRemoveEnabled != vm_obj.config.cpuHotRemoveEnabled:
+                    self.change_detected = True
+
+            if 'memory_reservation' in self.params['hardware']:
+                memory_reservation_mb = 0
+                try:
+                    memory_reservation_mb = int(self.params['hardware']['memory_reservation'])
+                except ValueError as e:
+                    self.module.fail_json(msg="Failed to set memory_reservation value."
+                                              "Valid value for memory_reservation value in MB (integer): %s" % e)
+
+                mem_alloc = vim.ResourceAllocationInfo()
+                mem_alloc.reservation = memory_reservation_mb
+                self.configspec.memoryAllocation = mem_alloc
+                if vm_obj is None or self.configspec.memoryAllocation.reservation != vm_obj.config.memoryAllocation.reservation:
+                    self.change_detected = True
+
+            if 'memory_reservation_lock' in self.params['hardware']:
+                self.configspec.memoryReservationLockedToMax = bool(self.params['hardware']['memory_reservation_lock'])
+                if vm_obj is None or self.configspec.memoryReservationLockedToMax != vm_obj.config.memoryReservationLockedToMax:
+                    self.change_detected = True
+
+    def configure_cdrom(self, vm_obj):
+        # Configure the VM CD-ROM
+        if "cdrom" in self.params and self.params["cdrom"]:
+            if "type" not in self.params["cdrom"] or self.params["cdrom"]["type"] not in ["none", "client", "iso"]:
+                self.module.fail_json(msg="cdrom.type is mandatory")
+            if self.params["cdrom"]["type"] == "iso" and ("iso_path" not in self.params["cdrom"] or not self.params["cdrom"]["iso_path"]):
+                self.module.fail_json(msg="cdrom.iso_path is mandatory in case cdrom.type is iso")
+
+            if vm_obj and vm_obj.config.template:
+                # Changing CD-ROM settings on a template is not supported
+                return
+
+            cdrom_spec = None
+            cdrom_device = self.get_vm_cdrom_device(vm=vm_obj)
+            iso_path = self.params["cdrom"]["iso_path"] if "iso_path" in self.params["cdrom"] else None
+            if cdrom_device is None:
+                # Creating new CD-ROM
+                ide_device = self.get_vm_ide_device(vm=vm_obj)
+                if ide_device is None:
+                    # Creating new IDE device
+                    ide_device = self.device_helper.create_ide_controller()
+                    self.change_detected = True
+                    self.configspec.deviceChange.append(ide_device)
+                elif len(ide_device.device) > 3:
+                    self.module.fail_json(msg="hardware.cdrom specified for a VM or template which already has 4 IDE devices of which none are a cdrom")
+
+                cdrom_spec = self.device_helper.create_cdrom(ide_ctl=ide_device, cdrom_type=self.params["cdrom"]["type"], iso_path=iso_path)
+                if vm_obj and vm_obj.runtime.powerState == vim.VirtualMachinePowerState.poweredOn:
+                    cdrom_spec.device.connectable.connected = (self.params["cdrom"]["type"] != "none")
+
+            elif not self.device_helper.is_equal_cdrom(vm_obj=vm_obj, cdrom_device=cdrom_device, cdrom_type=self.params["cdrom"]["type"], iso_path=iso_path):
+                # Updating an existing CD-ROM
+                if self.params["cdrom"]["type"] in ["client", "none"]:
+                    cdrom_device.backing = vim.vm.device.VirtualCdrom.RemotePassthroughBackingInfo()
+                elif self.params["cdrom"]["type"] == "iso":
+                    cdrom_device.backing = vim.vm.device.VirtualCdrom.IsoBackingInfo(fileName=iso_path)
+                cdrom_device.connectable = vim.vm.device.VirtualDevice.ConnectInfo()
+                cdrom_device.connectable.allowGuestControl = True
+                cdrom_device.connectable.startConnected = (self.params["cdrom"]["type"] != "none")
+                if vm_obj and vm_obj.runtime.powerState == vim.VirtualMachinePowerState.poweredOn:
+                    cdrom_device.connectable.connected = (self.params["cdrom"]["type"] != "none")
+
+                cdrom_spec = vim.vm.device.VirtualDeviceSpec()
+                cdrom_spec.operation = vim.vm.device.VirtualDeviceSpec.Operation.edit
+                cdrom_spec.device = cdrom_device
+
+            if cdrom_spec:
+                self.change_detected = True
+                self.configspec.deviceChange.append(cdrom_spec)
+
+    def configure_hardware_params(self, vm_obj):
+        """
+        Function to configure hardware related configuration of virtual machine
+        Args:
+            vm_obj: virtual machine object
+        """
+        # maxMksConnections == max_connections
+        if 'hardware' in self.params:
+            if 'max_connections' in self.params['hardware']:
+                self.configspec.maxMksConnections = int(self.params['hardware']['max_connections'])
+                if vm_obj is None or self.configspec.maxMksConnections != vm_obj.config.hardware.maxMksConnections:
+                    self.change_detected = True
+
+            if 'nested_virt' in self.params['hardware']:
+                self.configspec.nestedHVEnabled = bool(self.params['hardware']['nested_virt'])
+                if vm_obj is None or self.configspec.nestedHVEnabled != bool(vm_obj.config.nestedHVEnabled):
+                    self.change_detected = True
+
+    def get_vm_cdrom_device(self, vm=None):
+        if vm is None:
+            return None
+
+        for device in vm.config.hardware.device:
+            if isinstance(device, vim.vm.device.VirtualCdrom):
+                return device
+
+        return None
+
+    def get_vm_ide_device(self, vm=None):
+        if vm is None:
+            return None
+
+        for device in vm.config.hardware.device:
+            if isinstance(device, vim.vm.device.VirtualIDEController):
+                return device
+
+        return None
 
     def get_vm_network_interfaces(self, vm=None):
         if vm is None:
@@ -714,6 +922,19 @@ class PyVmomiHelper(object):
                                               "The failing new MAC address is %s" % nic.device.macAddress)
 
                 nic.device = current_net_devices[key]
+                if ('wake_on_lan' in network_devices[key] and
+                        nic.device.wakeOnLanEnabled != network_devices[key].get('wake_on_lan')):
+                    nic.device.wakeOnLanEnabled = network_devices[key].get('wake_on_lan')
+                    nic_change_detected = True
+                if ('start_connected' in network_devices[key] and
+                        nic.device.connectable.startConnected != network_devices[key].get('start_connected')):
+                    nic.device.connectable.startConnected = network_devices[key].get('start_connected')
+                    nic_change_detected = True
+                if ('allow_guest_control' in network_devices[key] and
+                        nic.device.connectable.allowGuestControl != network_devices[key].get('allow_guest_control')):
+                    nic.device.connectable.allowGuestControl = network_devices[key].get('allow_guest_control')
+                    nic_change_detected = True
+
                 nic.device.deviceInfo = vim.Description()
             else:
                 nic.operation = vim.vm.device.VirtualDeviceSpec.Operation.add
@@ -723,17 +944,15 @@ class PyVmomiHelper(object):
                 # VDS switch
                 pg_obj = find_obj(self.content, [vim.dvs.DistributedVirtualPortgroup], network_devices[key]['name'])
 
-                if (nic.device.backing and
-                        (nic.device.backing.port.portgroupKey != pg_obj.key or
-                         nic.device.backing.port.switchUuid != pg_obj.config.distributedVirtualSwitch.uuid)):
+                if (nic.device.backing and not hasattr(nic.device.backing, 'port')) or \
+                   (nic.device.backing and (nic.device.backing.port.portgroupKey != pg_obj.key or
+                                            nic.device.backing.port.switchUuid != pg_obj.config.distributedVirtualSwitch.uuid)):
+                    dvs_port_connection = vim.dvs.PortConnection()
+                    dvs_port_connection.portgroupKey = pg_obj.key
+                    dvs_port_connection.switchUuid = pg_obj.config.distributedVirtualSwitch.uuid
+                    nic.device.backing = vim.vm.device.VirtualEthernetCard.DistributedVirtualPortBackingInfo()
+                    nic.device.backing.port = dvs_port_connection
                     nic_change_detected = True
-
-                dvs_port_connection = vim.dvs.PortConnection()
-                dvs_port_connection.portgroupKey = pg_obj.key
-                dvs_port_connection.switchUuid = pg_obj.config.distributedVirtualSwitch.uuid
-                nic.device.backing = vim.vm.device.VirtualEthernetCard.DistributedVirtualPortBackingInfo()
-                nic.device.backing.port = dvs_port_connection
-                nic_change_detected = True
             else:
                 # vSwitch
                 if not isinstance(nic.device.backing, vim.vm.device.VirtualEthernetCard.NetworkBackingInfo):
@@ -753,10 +972,14 @@ class PyVmomiHelper(object):
                 self.configspec.deviceChange.append(nic)
                 self.change_detected = True
 
-    def customize_customvalues(self, vm_obj):
+    def customize_customvalues(self, vm_obj, config_spec):
         if len(self.params['customvalues']) == 0:
             return
 
+        vm_custom_spec = config_spec
+        vm_custom_spec.extraConfig = []
+
+        changed = False
         facts = self.gather_facts(vm_obj)
         for kv in self.params['customvalues']:
             if 'key' not in kv or 'value' not in kv:
@@ -764,12 +987,15 @@ class PyVmomiHelper(object):
 
             # If kv is not kv fetched from facts, change it
             if kv['key'] not in facts['customvalues'] or facts['customvalues'][kv['key']] != kv['value']:
-                try:
-                    vm_obj.setCustomValue(key=kv['key'], value=kv['value'])
-                    self.change_detected = True
-                except Exception as e:
-                    self.module.fail_json(msg="Failed to set custom value for key='%s' and value='%s'. Error was: %s"
-                                          % (kv['key'], kv['value'], to_text(e)))
+                option = vim.option.OptionValue()
+                option.key = kv['key']
+                option.value = kv['value']
+
+                vm_custom_spec.extraConfig.append(option)
+                changed = True
+
+        if changed:
+            self.change_detected = True
 
     def customize_vm(self, vm_obj):
         # Network settings
@@ -925,7 +1151,7 @@ class PyVmomiHelper(object):
                 return expected * 1024 * 1024 * 1024
             elif unit == 'gb':
                 return expected * 1024 * 1024
-            elif unit == ' mb':
+            elif unit == 'mb':
                 return expected * 1024
             elif unit == 'kb':
                 return expected
@@ -972,8 +1198,11 @@ class PyVmomiHelper(object):
 
             # is it thin?
             if 'type' in expected_disk_spec:
-                if expected_disk_spec.get('type', '').lower() == 'thin':
+                disk_type = expected_disk_spec.get('type', '').lower()
+                if disk_type == 'thin':
                     diskspec.device.backing.thinProvisioned = True
+                elif disk_type == 'eagerzeroedthick':
+                    diskspec.device.backing.eagerlyScrub = True
 
             # which datastore?
             if expected_disk_spec.get('datastore'):
@@ -1084,12 +1313,18 @@ class PyVmomiHelper(object):
         return datastore, datastore_name
 
     def obj_has_parent(self, obj, parent):
-        assert obj is not None and parent is not None
+        if obj is None and parent is None:
+            raise AssertionError()
         current_parent = obj
 
         while True:
             if current_parent.name == parent.name:
                 return True
+
+            # Check if we have reached till root folder
+            moid = current_parent._moId
+            if moid in ['group-d1', 'ha-folder-root']:
+                return False
 
             current_parent = current_parent.parent
             if current_parent is None:
@@ -1166,6 +1401,25 @@ class PyVmomiHelper(object):
 
         return root
 
+    def get_resource_pool(self):
+        resource_pool = None
+        # highest priority, resource_pool given.
+        if self.params['resource_pool']:
+            resource_pool = self.select_resource_pool_by_name(self.params['resource_pool'])
+        # next priority, esxi hostname given.
+        elif self.params['esxi_hostname']:
+            host = self.select_host()
+            resource_pool = self.select_resource_pool_by_host(host)
+        # next priority, cluster given, take the root of the pool
+        elif self.params['cluster']:
+            cluster = self.cache.get_cluster(self.params['cluster'])
+            resource_pool = cluster.resourcePool
+        # fallback, pick any RP
+        else:
+            self.module.fail_json(msg='Unable to find resource pool, need esxi_hostname, resource_pool, or cluster')
+
+        return resource_pool
+
     def deploy_vm(self):
         # https://github.com/vmware/pyvmomi-community-samples/blob/master/samples/clone_vm.py
         # https://www.vmware.com/support/developer/vc-sdk/visdk25pubs/ReferenceGuide/vim.vm.CloneSpec.html
@@ -1188,12 +1442,17 @@ class PyVmomiHelper(object):
 
         dcpath = compile_folder_path_for_object(datacenter)
 
+        # Nested folder does not have trailing /
+        if not dcpath.endswith('/'):
+            dcpath += '/'
+
         # Check for full path first in case it was already supplied
-        if (self.params['folder'].startswith(dcpath + self.params['datacenter'] + '/vm')):
+        if (self.params['folder'].startswith(dcpath + self.params['datacenter'] + '/vm') or
+                self.params['folder'].startswith(dcpath + '/' + self.params['datacenter'] + '/vm')):
             fullpath = self.params['folder']
-        elif (self.params['folder'].startswith('/vm/') or self.params['folder'] == '/vm'):
+        elif self.params['folder'].startswith('/vm/') or self.params['folder'] == '/vm':
             fullpath = "%s%s%s" % (dcpath, self.params['datacenter'], self.params['folder'])
-        elif (self.params['folder'].startswith('/')):
+        elif self.params['folder'].startswith('/'):
             fullpath = "%s%s/vm%s" % (dcpath, self.params['datacenter'], self.params['folder'])
         else:
             fullpath = "%s%s/vm/%s" % (dcpath, self.params['datacenter'], self.params['folder'])
@@ -1202,7 +1461,16 @@ class PyVmomiHelper(object):
 
         # abort if no strategy was successful
         if f_obj is None:
-            self.module.fail_json(msg='No folder matched the path: %(folder)s' % self.params)
+            # Add some debugging values in failure.
+            details = {
+                'datacenter': datacenter.name,
+                'datacenter_path': dcpath,
+                'folder': self.params['folder'],
+                'full_search_path': fullpath,
+            }
+            self.module.fail_json(msg='No folder %s matched in the search path : %s' % (self.params['folder'], fullpath),
+                                  details=details)
+
         destfolder = f_obj
 
         if self.params['template']:
@@ -1214,26 +1482,21 @@ class PyVmomiHelper(object):
             vm_obj = None
 
         resource_pool = None
-        # need a resource pool if cloning from template
-        if self.params['resource_pool'] or self.params['template']:
-            if self.params['esxi_hostname']:
-                host = self.select_host()
-                resource_pool = self.select_resource_pool_by_host(host)
-            else:
-                resource_pool = self.select_resource_pool_by_name(self.params['resource_pool'])
-
-            if resource_pool is None:
-                self.module.fail_json(msg='Unable to find resource pool "%(resource_pool)s"' % self.params)
+        # always get a resource_pool
+        resource_pool = self.get_resource_pool()
 
         # set the destination datastore for VM & disks
         (datastore, datastore_name) = self.select_datastore(vm_obj)
 
-        self.configspec = vim.vm.ConfigSpec(cpuHotAddEnabled=True, memoryHotAddEnabled=True)
+        self.configspec = vim.vm.ConfigSpec()
         self.configspec.deviceChange = []
         self.configure_guestid(vm_obj=vm_obj, vm_creation=True)
         self.configure_cpu_and_memory(vm_obj=vm_obj, vm_creation=True)
+        self.configure_hardware_params(vm_obj=vm_obj)
+        self.configure_resource_alloc_info(vm_obj=vm_obj)
         self.configure_disks(vm_obj=vm_obj)
         self.configure_network(vm_obj=vm_obj)
+        self.configure_cdrom(vm_obj=vm_obj)
 
         # Find if we need network customizations (find keys in dictionary that requires customizations)
         network_changes = False
@@ -1251,15 +1514,12 @@ class PyVmomiHelper(object):
         clone_method = None
         try:
             if self.params['template']:
-                
                 # create the relocation spec
                 relospec = vim.vm.RelocateSpec()
 
                 # Only select specific host when ESXi hostname is provided
-                #if self.params['esxi_hostname']:
-                #    relospec.host = self.select_host()
-                relospec.host = self.select_host()
-                
+                if self.params['esxi_hostname']:
+                    relospec.host = self.select_host()
                 relospec.datastore = datastore
 
                 # https://www.vmware.com/support/developer/vc-sdk/visdk41pubs/ApiReference/vim.vm.RelocateSpec.html
@@ -1282,21 +1542,31 @@ class PyVmomiHelper(object):
 
                 clonespec.config = self.configspec
                 clone_method = 'Clone'
-                task = vm_obj.Clone(folder=destfolder, name=self.params['name'], spec=clonespec)
+                try:
+                    task = vm_obj.Clone(folder=destfolder, name=self.params['name'], spec=clonespec)
+                except vim.fault.NoPermission as e:
+                    self.module.fail_json(msg="Failed to clone virtual machine %s to folder %s "
+                                              "due to permission issue: %s" % (self.params['name'],
+                                                                               destfolder,
+                                                                               to_native(e.msg)))
                 self.change_detected = True
             else:
-                # If no pool specified by user, get it from host
-                if resource_pool is None:
-                    resource_pool = self.select_host().parent.resourcePool
                 # ConfigSpec require name for VM creation
                 self.configspec.name = self.params['name']
                 self.configspec.files = vim.vm.FileInfo(logDirectory=None,
                                                         snapshotDirectory=None,
                                                         suspendDirectory=None,
-                                                        vmPathName="[" + datastore_name + "] " + self.params["name"])
+                                                        vmPathName="[" + datastore_name + "]")
 
                 clone_method = 'CreateVM_Task'
-                task = destfolder.CreateVM_Task(config=self.configspec, pool=resource_pool)
+                try:
+                    task = destfolder.CreateVM_Task(config=self.configspec, pool=resource_pool)
+                except vmodl.fault.InvalidRequest as e:
+                    self.module.fail_json(msg="Failed to create virtual machine due to invalid configuration "
+                                              "parameter %s" % to_native(e.msg))
+                except vim.fault.RestrictedVersion as e:
+                    self.module.fail_json(msg="Failed to create virtual machine due to "
+                                              "product versioning restrictions: %s" % to_native(e.msg))
                 self.change_detected = True
             self.wait_for_task(task)
         except TypeError as e:
@@ -1328,10 +1598,14 @@ class PyVmomiHelper(object):
                 task = vm.ReconfigVM_Task(annotation_spec)
                 self.wait_for_task(task)
 
-            self.customize_customvalues(vm_obj=vm)
+            if self.params['customvalues']:
+                vm_custom_spec = vim.vm.ConfigSpec()
+                self.customize_customvalues(vm_obj=vm, config_spec=vm_custom_spec)
+                task = vm.ReconfigVM_Task(vm_custom_spec)
+                self.wait_for_task(task)
 
             if self.params['wait_for_ip_address'] or self.params['state'] in ['poweredon', 'restarted']:
-                self.set_powerstate(vm, 'poweredon', force=False)
+                set_vm_power_state(self.content, vm, 'poweredon', force=False)
 
                 if self.params['wait_for_ip_address']:
                     self.wait_for_vm_ip(vm)
@@ -1354,9 +1628,12 @@ class PyVmomiHelper(object):
 
         self.configure_guestid(vm_obj=self.current_vm_obj)
         self.configure_cpu_and_memory(vm_obj=self.current_vm_obj)
+        self.configure_hardware_params(vm_obj=self.current_vm_obj)
         self.configure_disks(vm_obj=self.current_vm_obj)
         self.configure_network(vm_obj=self.current_vm_obj)
-        self.customize_customvalues(vm_obj=self.current_vm_obj)
+        self.configure_cdrom(vm_obj=self.current_vm_obj)
+        self.customize_customvalues(vm_obj=self.current_vm_obj, config_spec=self.configspec)
+        self.configure_resource_alloc_info(vm_obj=self.current_vm_obj)
 
         if self.params['annotation'] and self.current_vm_obj.config.annotation != self.params['annotation']:
             self.configspec.annotation = str(self.params['annotation'])
@@ -1378,7 +1655,12 @@ class PyVmomiHelper(object):
 
         # Only send VMWare task if we see a modification
         if self.change_detected:
-            task = self.current_vm_obj.ReconfigVM_Task(spec=self.configspec)
+            task = None
+            try:
+                task = self.current_vm_obj.ReconfigVM_Task(spec=self.configspec)
+            except vim.fault.RestrictedVersion as e:
+                self.module.fail_json(msg="Failed to reconfigure virtual machine due to"
+                                          " product versioning restrictions: %s" % to_native(e.msg))
             self.wait_for_task(task)
             change_applied = True
 
@@ -1397,9 +1679,37 @@ class PyVmomiHelper(object):
                 return {'changed': change_applied, 'failed': True, 'msg': task.info.error.msg}
 
         # Mark VM as Template
-        if self.params['is_template']:
-            self.current_vm_obj.MarkAsTemplate()
+        if self.params['is_template'] and not self.current_vm_obj.config.template:
+            try:
+                self.current_vm_obj.MarkAsTemplate()
+            except vmodl.fault.NotSupported as e:
+                self.module.fail_json(msg="Failed to mark virtual machine [%s] "
+                                          "as template: %s" % (self.params['name'], e.msg))
             change_applied = True
+
+        # Mark Template as VM
+        elif not self.params['is_template'] and self.current_vm_obj.config.template:
+            if self.params['resource_pool']:
+                resource_pool = self.select_resource_pool_by_name(self.params['resource_pool'])
+
+                if resource_pool is None:
+                    self.module.fail_json(msg='Unable to find resource pool "%(resource_pool)s"' % self.params)
+
+                self.current_vm_obj.MarkAsVirtualMachine(pool=resource_pool)
+
+                # Automatically update VMWare UUID when converting template to VM.
+                # This avoids an interactive prompt during VM startup.
+                uuid_action = [x for x in self.current_vm_obj.config.extraConfig if x.key == "uuid.action"]
+                if not uuid_action:
+                    uuid_action_opt = vim.option.OptionValue()
+                    uuid_action_opt.key = "uuid.action"
+                    uuid_action_opt.value = "create"
+                    self.configspec.extraConfig.append(uuid_action_opt)
+                    self.change_detected = True
+
+                change_applied = True
+            else:
+                self.module.fail_json(msg="Resource pool must be specified when converting template to VM!")
 
         vm_facts = self.gather_facts(self.current_vm_obj)
         return {'changed': change_applied, 'failed': False, 'instance': vm_facts}
@@ -1417,7 +1727,7 @@ class PyVmomiHelper(object):
         facts = {}
         thispoll = 0
         while not ips and thispoll <= poll:
-            newvm = self.getvm(uuid=vm.config.uuid)
+            newvm = self.get_vm()
             facts = self.gather_facts(newvm)
             if facts['ipv4'] or facts['ipv6']:
                 ips = True
@@ -1443,6 +1753,7 @@ def main():
         folder=dict(type='str', default='/vm'),
         guest_id=dict(type='str'),
         disk=dict(type='list', default=[]),
+        cdrom=dict(type='dict', default={}),
         hardware=dict(type='dict', default={}),
         force=dict(type='bool', default=False),
         datacenter=dict(type='str', default='ha-datacenter'),
@@ -1472,7 +1783,7 @@ def main():
     pyv = PyVmomiHelper(module)
 
     # Check if the VM exists before continuing
-    vm = pyv.getvm(name=module.params['name'], folder=module.params['folder'], uuid=module.params['uuid'])
+    vm = pyv.get_vm()
 
     # VM already exists
     if vm:
@@ -1480,25 +1791,26 @@ def main():
             # destroy it
             if module.params['force']:
                 # has to be poweredoff first
-                pyv.set_powerstate(vm, 'poweredoff', module.params['force'])
+                set_vm_power_state(pyv.content, vm, 'poweredoff', module.params['force'])
             result = pyv.remove_vm(vm)
         elif module.params['state'] == 'present':
             result = pyv.reconfigure_vm()
         elif module.params['state'] in ['poweredon', 'poweredoff', 'restarted', 'suspended', 'shutdownguest', 'rebootguest']:
             # set powerstate
-            tmp_result = pyv.set_powerstate(vm, module.params['state'], module.params['force'])
+            tmp_result = set_vm_power_state(pyv.content, vm, module.params['state'], module.params['force'])
             if tmp_result['changed']:
                 result["changed"] = True
             if not tmp_result["failed"]:
                 result["failed"] = False
         else:
             # This should not happen
-            assert False
+            raise AssertionError()
     # VM doesn't exist
     else:
         if module.params['state'] in ['poweredon', 'poweredoff', 'present', 'restarted', 'suspended']:
-            # Create it ...
             result = pyv.deploy_vm()
+            if result['failed']:
+                module.fail_json(msg='Failed to create a virtual machine : %s' % result['msg'])
 
     if result['failed']:
         module.fail_json(**result)

--- a/lib/ansible/modules/system/lvol.py
+++ b/lib/ansible/modules/system/lvol.py
@@ -226,6 +226,7 @@ def parse_vgs(data):
         })
     return vgs
 
+
 def parse_pvs(data):
     pvs = []
     for line in data.splitlines():
@@ -237,6 +238,7 @@ def parse_pvs(data):
             'ext_size': int(decimal_point.match(parts[3]).group(1))
         })
     return pvs
+
 
 def get_lvm_version(module):
     ver_cmd = module.get_bin_path("lvm", required=True)
@@ -354,21 +356,21 @@ def main():
     this_vg = vgs[0]
 
     if pvs != "":
-      pvs_arr = pvs.split(" ")
-      this_pvs_total = 0
-      for onepv in pvs_arr:
-        pvs_cmd = module.get_bin_path("pvs", required=True)
-        rc, current_pvs, err = module.run_command(
-            "%s --noheadings -o pv_name,size,free,vg_extent_size --units %s --separator ';' %s" % (pvs_cmd, unit, onepv))
-    
-        if rc != 0:
-            if state == 'absent':
-                module.exit_json(changed=False, stdout="Physical volume %s does not exist." % onepv)
-            else:
-                module.fail_json(msg="Physical volume %s does not exist." % onepv, rc=rc, err=err)
-    
-        pvs_single = parse_pvs(current_pvs)
-        this_pvs_total += pvs_single[0]['size']
+        pvs_arr = pvs.split(" ")
+        this_pvs_total = 0
+        for onepv in pvs_arr:
+            pvs_cmd = module.get_bin_path("pvs", required=True)
+            rc, current_pvs, err = module.run_command(
+                "%s --noheadings -o pv_name,size,free,vg_extent_size --units %s --separator ';' %s" % (pvs_cmd, unit, onepv))
+
+            if rc != 0:
+                if state == 'absent':
+                    module.exit_json(changed=False, stdout="Physical volume %s does not exist." % onepv)
+                else:
+                    module.fail_json(msg="Physical volume %s does not exist." % onepv, rc=rc, err=err)
+
+            pvs_single = parse_pvs(current_pvs)
+            this_pvs_total += pvs_single[0]['size']
     # Get information on logical volume requested
     lvs_cmd = module.get_bin_path("lvs", required=True)
     rc, current_lvs, err = module.run_command(
@@ -436,9 +438,9 @@ def main():
                 size_requested = size_percent * this_vg['size'] / 100
             elif size_whole == 'PVS':
                 if 'this_pvs_total' in locals():
-                  size_requested = size_percent * this_pvs_total / 100
+                    size_requested = size_percent * this_pvs_total / 100
                 else:
-                  module.fail_json(msg="You must specify 'pvs' when using '%PVS' in 'size'.")
+                    module.fail_json(msg="You must specify 'pvs' when using '%PVS' in 'size'.")
             else:  # size_whole == 'FREE':
                 size_requested = size_percent * this_vg['free'] / 100
             if '+' in size:
@@ -528,4 +530,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-

--- a/lib/ansible/modules/system/lvol.py
+++ b/lib/ansible/modules/system/lvol.py
@@ -67,6 +67,7 @@ options:
   pvs:
     description:
     - Comma separated list of physical volumes (e.g. /dev/sda,/dev/sdb).
+      Must be specified if using '%PVS' in 'size'.
     version_added: "2.2"
   shrink:
     description:
@@ -225,6 +226,17 @@ def parse_vgs(data):
         })
     return vgs
 
+def parse_pvs(data):
+    pvs = []
+    for line in data.splitlines():
+        parts = line.strip().split(';')
+        pvs.append({
+            'name': parts[0],
+            'size': int(decimal_point.match(parts[1]).group(1)),
+            'free': int(decimal_point.match(parts[2]).group(1)),
+            'ext_size': int(decimal_point.match(parts[3]).group(1))
+        })
+    return pvs
 
 def get_lvm_version(module):
     ver_cmd = module.get_bin_path("lvm", required=True)
@@ -341,6 +353,22 @@ def main():
     vgs = parse_vgs(current_vgs)
     this_vg = vgs[0]
 
+    if pvs != "":
+      pvs_arr = pvs.split(" ")
+      this_pvs_total = 0
+      for onepv in pvs_arr:
+        pvs_cmd = module.get_bin_path("pvs", required=True)
+        rc, current_pvs, err = module.run_command(
+            "%s --noheadings -o pv_name,size,free,vg_extent_size --units %s --separator ';' %s" % (pvs_cmd, unit, onepv))
+    
+        if rc != 0:
+            if state == 'absent':
+                module.exit_json(changed=False, stdout="Physical volume %s does not exist." % onepv)
+            else:
+                module.fail_json(msg="Physical volume %s does not exist." % onepv, rc=rc, err=err)
+    
+        pvs_single = parse_pvs(current_pvs)
+        this_pvs_total += pvs_single[0]['size']
     # Get information on logical volume requested
     lvs_cmd = module.get_bin_path("lvs", required=True)
     rc, current_lvs, err = module.run_command(
@@ -404,8 +432,13 @@ def main():
             # Resize LV based on % value
             tool = None
             size_free = this_vg['free']
-            if size_whole == 'VG' or size_whole == 'PVS':
+            if size_whole == 'VG':
                 size_requested = size_percent * this_vg['size'] / 100
+            elif size_whole == 'PVS':
+                if 'this_pvs_total' in locals():
+                  size_requested = size_percent * this_pvs_total / 100
+                else:
+                  module.fail_json(msg="You must specify 'pvs' when using '%PVS' in 'size'.")
             else:  # size_whole == 'FREE':
                 size_requested = size_percent * this_vg['free'] / 100
             if '+' in size:
@@ -495,3 +528,4 @@ def main():
 
 if __name__ == '__main__':
     main()
+


### PR DESCRIPTION
##### SUMMARY
Updating lvol.py to better handle %PVS options when creating/resizing lvols.

- Adds idempotency when the module is called N+ times and %PVS is used in `size`.
- Making the module inline with LVM2 man pages (lvcreate/lvextend), specifically with the description of `-l|--extents` option and sentence 'The suffix %VG denotes the total size of the VG, the suffix %FREE the remaining free space in the VG, and the suffix %PVS the free space in the specified PVs'.
- This update makes `pvs` option mandatory when %PVS is used in `size`, because it calculates requested size by adding size of specified PVS in `pvs` (to be inline with the above point).
- Fixing errors like `"msg": "Unable to resize lv_var_cache_pulp to 100%PVS", "rc": 5)` when module is called N+ times, because it calculated size of VG and not only subset of PVS.


<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
- Feature Pull Request
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
lvol

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.1.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
Before applied changes same task 2 times:
- lvol: lv=lv_var_cache_pulp size=100%PVS pvs=/dev/sdc shrink=no state=present vg=vg_pulp
- lvol: lv=lv_var_cache_pulp size=100%PVS pvs=/dev/sdc shrink=no state=present vg=vg_pulp

will result in:
TASK [create_lvm : lvol] *****************************************************************************
ok: [server] => (item={'key': u'lv_var_cache_pulp', 'value': {u'path': u'/var/cache/pulp', u'pvs': u'/dev/sdc', u'mount': True, u'vg_name': u'vg_pulp', u'size': u'100%PVS'}})
TASK [create_lvm : lvol] *****************************************************************************
failed: [server] (item={'key': u'lv_var_cache_pulp', 'value': {u'path': u'/var/cache/pulp', u'pvs': u'/dev/sdc', u'mount': True, u'vg_name': u'vg_pulp', u'size': u'100%PVS'}}) => {"changed": false, "err": "  WARNING: No free extents on physical volume \"/dev/sdc\".\n  No specified PVs have space available.\n", "failed": true, "item": {"key": "lv_var_cache_pulp", "value": {"mount": true, "path": "/var/cache/pulp", "pvs": "/dev/sdc", "size": "100%PVS", "vg_name": "vg_pulp"}}, "msg": "Unable to resize lv_var_cache_pulp to 100%PVS", "rc": 5}
```
