### PR TITLE
vault: add the faulty string parse_vaulttext output when error occurs

### DIFF
--- a/lib/ansible/parsing/vault/__init__.py
+++ b/lib/ansible/parsing/vault/__init__.py
@@ -275,7 +275,7 @@ def parse_vaulttext(b_vaulttext):
     except AnsibleVaultFormatError:
         raise
     except Exception as exc:
-        msg = "Vault vaulttext format error: %s" % exc
+        msg = "Vault vaulttext format error: %s. String was: %s" % (exc, b_vaulttext)
         raise AnsibleVaultFormatError(msg)
 
 


### PR DESCRIPTION
Show the errorneous string when the string was malformed

This permit to troubleshoot wrong vault-encrypted strings easily by searching through ansible inventory

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Be more explicit when ansible-vault string is wrong on decoding, permitting to find which string cause the problem in the inventory.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
vaults

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.4.2.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Here is the original output, it's not very useful especially when multiple users manipulate inventory (through a nice git repository), because we don't know where is the problem (and here the problem is in a map('extract', 'hostvars', 'blah') included in one of the following variable, then version far from the error).
```
fatal: [xxx8879]: FAILED! => {
    "changed": false,
    "msg": "AnsibleVaultFormatError: {{ haproxy_generic_backend + haproxy_custom_backend }}: {{ app_haproxy_custom_backend | default([]) }}: {{ env_haproxy_front_backend_profile | haproxy_backends(hostvars) }}: Vault vaulttext format error: need more than 1 value to unpack.
}
```

New output is more useful
```
fatal: [loadvlinf8417]: FAILED! => {
    "changed": false,
    "msg": "AnsibleVaultFormatError: {{ haproxy_generic_backend + haproxy_custom_backend }}: {{ app_haproxy_custom_backend | default([]) }}: {{ env_haproxy_front_backend_profile | haproxy_backends(hostvars) }}: Vault vaulttext format error: need more than 1 value to unpack. String was: 33386662663566663338656430386266663038653332386234343335323237663862303933653134643861366135320a3230383537333862353664333613132666333336238306535303063613134306366613339313364333261633434343762306561326133306234376338623037"
}
```
