### PR TITLE
[WIP] DO NOT MERGE - experiment - see what breaks in ci without pkg_resources

### DIFF
--- a/bin/ansible
+++ b/bin/ansible
@@ -22,15 +22,15 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 __requires__ = ['ansible']
-try:
-    import pkg_resources
-except Exception:
+#try:
+#    import pkg_resources
+#except Exception:
     # Use pkg_resources to find the correct versions of libraries and set
     # sys.path appropriately when there are multiversion installs.  But we
     # have code that better expresses the errors in the places where the code
     # is actually used (the deps are optional for many code paths) so we don't
     # want to fail here.
-    pass
+#    pass
 
 import os
 import shutil

--- a/bin/ansible
+++ b/bin/ansible
@@ -22,15 +22,6 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 __requires__ = ['ansible']
-#try:
-#    import pkg_resources
-#except Exception:
-    # Use pkg_resources to find the correct versions of libraries and set
-    # sys.path appropriately when there are multiversion installs.  But we
-    # have code that better expresses the errors in the places where the code
-    # is actually used (the deps are optional for many code paths) so we don't
-    # want to fail here.
-#    pass
 
 import os
 import shutil

--- a/bin/ansible-connection
+++ b/bin/ansible-connection
@@ -6,11 +6,6 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 __requires__ = ['ansible']
 
-#try:
-#    import pkg_resources
-#except Exception:
-#    pass
-
 import fcntl
 import os
 import shlex
@@ -321,6 +316,7 @@ def main():
         sys.stdout.write(json.dumps(result))
 
     sys.exit(rc)
+
 
 if __name__ == '__main__':
     display = Display()

--- a/bin/ansible-connection
+++ b/bin/ansible-connection
@@ -6,10 +6,10 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 __requires__ = ['ansible']
 
-try:
-    import pkg_resources
-except Exception:
-    pass
+#try:
+#    import pkg_resources
+#except Exception:
+#    pass
 
 import fcntl
 import os


### PR DESCRIPTION
##### SUMMARY
See what breaks in CI without pkg_resources

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
bin/ansible

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (no_pkg_resources_test c21651257c) last updated 2018/01/16 14:03:06 (GMT -400)
  config file = /home/adrian/src/ansible/ansible.cfg
  configured module search path = [u'/home/adrian/ansible/my-modules']
  ansible python module location = /home/adrian/src/ansible/lib/ansible
  executable location = /home/adrian/src/ansible/bin/ansible
  python version = 2.7.14 (default, Dec 11 2017, 14:52:53) [GCC 7.2.1 20170915 (Red Hat 7.2.1-2)]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
