### PR TITLE
win_security_policy: Add link to the win_user_right module

### DIFF
--- a/lib/ansible/modules/windows/win_security_policy.py
+++ b/lib/ansible/modules/windows/win_security_policy.py
@@ -39,6 +39,7 @@ notes:
   it if the value differs.
 - You can also run C(SecEdit.exe /export /cfg C:\temp\output.ini) to view the
   current policies set on your system.
+- When assigning user rights, use the M(win_user_right) module instead.
 options:
   section:
     description:


### PR DESCRIPTION
##### SUMMARY
Minor addition to the win_security_policy module docs. This adds a link to win_user_right and states it should be used to modify user rights.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
win_security_policy

##### ANSIBLE VERSION
```
2.5
```