### PR TITLE
Detects errors in bigip_config

### DIFF
--- a/lib/ansible/modules/network/f5/bigip_config.py
+++ b/lib/ansible/modules/network/f5/bigip_config.py
@@ -211,11 +211,22 @@ class ModuleManager(object):
             response = self.save()
             responses.append(response)
 
+        self._detect_errors(responses)
         changes = {
             'stdout': responses,
             'stdout_lines': self._to_lines(responses)
         }
         self.changes = Parameters(params=changes)
+
+    def _detect_errors(self, stdout):
+        errors = [
+            'Unexpected Error:'
+        ]
+
+        msg = [x for x in stdout for y in errors if y in x]
+        if msg:
+            # Error only contains the lines that include the error
+            raise F5ModuleError(' '.join(msg))
 
     def reset(self):
         if self.module.check_mode:

--- a/test/units/modules/network/f5/test_bigip_config.py
+++ b/test/units/modules/network/f5/test_bigip_config.py
@@ -100,12 +100,12 @@ class TestManager(unittest.TestCase):
 
         # Override methods to force specific logic in the module to happen
         mm.exit_json = Mock(return_value=True)
-        mm.reset_device = Mock(return_value=True)
+        mm.reset_device = Mock(return_value='reset output')
         mm.upload_to_device = Mock(return_value=True)
         mm.move_on_device = Mock(return_value=True)
-        mm.merge_on_device = Mock(return_value=True)
+        mm.merge_on_device = Mock(return_value='merge output')
         mm.remove_temporary_file = Mock(return_value=True)
-        mm.save_on_device = Mock(return_value=True)
+        mm.save_on_device = Mock(return_value='save output')
 
         results = mm.exec_module()
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
There are changes that the merge config can fail, but the module
will still report success. This adds a blob of code to start
collecting those failures and bubbling up a module failure
accordingly.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
bigip_config.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0
  config file = /here/test/integration/ansible.cfg
  configured module search path = [u'/here/library']
  ansible python module location = /usr/local/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.14 (default, Dec 12 2017, 16:55:09) [GCC 4.9.2]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
