### PR TITLE
changed to enable windows temp path override

### DIFF
--- a/lib/ansible/plugins/action/win_copy.py
+++ b/lib/ansible/plugins/action/win_copy.py
@@ -232,7 +232,7 @@ class ActionModule(ActionBase):
         return content_tempfile
 
     def _create_zip_tempfile(self, files, directories):
-        tmpdir = tempfile.mkdtemp()
+        tmpdir = tempfile.mkdtemp(dir=C.DEFAULT_LOCAL_TMP)
         zip_file_path = os.path.join(tmpdir, "win_copy.zip")
         zip_file = zipfile.ZipFile(zip_file_path, "w", zipfile.ZIP_STORED, True)
 
@@ -259,14 +259,13 @@ class ActionModule(ActionBase):
         if content is not None:
             os.remove(content_tempfile)
 
-    def _copy_single_file(self, local_file, dest, source_rel, task_vars):
+    def _copy_single_file(self, local_file, dest, source_rel, task_vars, tmp):
         if self._play_context.check_mode:
             module_return = dict(changed=True)
             return module_return
 
         # copy the file across to the server
-        tmp_path = self._make_tmp_path()
-        tmp_src = self._connection._shell.join_path(tmp_path, 'source')
+        tmp_src = self._connection._shell.join_path(tmp, 'source')
         self._transfer_file(local_file, tmp_src)
 
         copy_args = self._task.args.copy()
@@ -280,14 +279,20 @@ class ActionModule(ActionBase):
         )
         copy_args.pop('content', None)
 
-        copy_result = self._execute_module(module_name="copy", module_args=copy_args, task_vars=task_vars)
-        self._remove_tmp_path(tmp_path)
+        copy_result = self._execute_module(module_name="copy",
+                                           module_args=copy_args,
+                                           task_vars=task_vars,
+                                           tmp=tmp)
 
         return copy_result
 
-    def _copy_zip_file(self, dest, files, directories, task_vars):
+    def _copy_zip_file(self, dest, files, directories, task_vars, tmp):
         # create local zip file containing all the files and directories that
         # need to be copied to the server
+        if self._play_context.check_mode:
+            module_return = dict(changed=True)
+            return module_return
+
         try:
             zip_file = self._create_zip_tempfile(files, directories)
         except Exception as e:
@@ -301,15 +306,9 @@ class ActionModule(ActionBase):
 
         zip_path = self._loader.get_real_file(zip_file)
 
-        if self._play_context.check_mode:
-            module_return = dict(changed=True)
-            os.remove(zip_path)
-            os.removedirs(os.path.dirname(zip_path))
-            return module_return
-
-        # send zip file to remote, file must end in .zip so Com Shell.Application works
-        tmp_path = self._make_tmp_path()
-        tmp_src = self._connection._shell.join_path(tmp_path, 'source.zip')
+        # send zip file to remote, file must end in .zip so
+        # Com Shell.Application works
+        tmp_src = self._connection._shell.join_path(tmp, 'source.zip')
         self._transfer_file(zip_path, tmp_src)
 
         # run the explode operation of win_copy on remote
@@ -323,10 +322,12 @@ class ActionModule(ActionBase):
         )
         copy_args.pop('content', None)
         os.remove(zip_path)
-        os.removedirs(os.path.dirname(zip_path))
 
-        module_return = self._execute_module(module_args=copy_args, task_vars=task_vars)
-        self._remove_tmp_path(tmp_path)
+        module_return = self._execute_module(module_name='copy',
+                                             module_args=copy_args,
+                                             task_vars=task_vars,
+                                             tmp=tmp)
+        os.removedirs(os.path.dirname(zip_path))
         return module_return
 
     def run(self, tmp=None, task_vars=None):
@@ -480,17 +481,23 @@ class ActionModule(ActionBase):
         query_args.pop('src', None)
 
         query_args.pop('content', None)
-        query_return = self._execute_module(module_args=query_args, task_vars=task_vars)
+        query_return = self._execute_module(module_args=query_args,
+                                            task_vars=task_vars,
+                                            tmp=tmp)
 
         if query_return.get('failed') is True:
             result.update(query_return)
             return result
 
+        if len(query_return['files']) > 0 or len(query_return['directories']) > 0 and tmp is None:
+            tmp = self._make_tmp_path()
+
         if len(query_return['files']) == 1 and len(query_return['directories']) == 0:
             # we only need to copy 1 file, don't mess around with zips
             file_src = query_return['files'][0]['src']
             file_dest = query_return['files'][0]['dest']
-            copy_result = self._copy_single_file(file_src, dest, file_dest, task_vars)
+            copy_result = self._copy_single_file(file_src, dest, file_dest,
+                                                 task_vars, tmp)
 
             result['changed'] = True
             if copy_result.get('failed') is True:
@@ -500,13 +507,16 @@ class ActionModule(ActionBase):
             # either multiple files or directories need to be copied, compress
             # to a zip and 'explode' the zip on the server
             # TODO: handle symlinks
-            result.update(self._copy_zip_file(dest, source_files['files'], source_files['directories'], task_vars))
+            result.update(self._copy_zip_file(dest, source_files['files'],
+                                              source_files['directories'],
+                                              task_vars, tmp))
             result['changed'] = True
         else:
             # no operations need to occur
             result['failed'] = False
             result['changed'] = False
 
-        # remove the content temp file if it was created
+        # remove the content temp file and remote tmp file if it was created
         self._remove_tempfile_if_content_defined(content, content_tempfile)
+        self._remove_tmp_path(tmp)
         return result


### PR DESCRIPTION
##### SUMMARY
Some minor improvements to win_copy when it comes to dealing with tmp paths both local and remote.

Also changes the powershell plugin to honour the remote temp path value allowing people to specify a different tmp path. Supersedes https://github.com/ansible/ansible/pull/25795

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
windows
powershell
win_copy

##### ANSIBLE VERSION
```
2.5
```