### PR TITLE
windows: standardise the powershell FileUtils

### DIFF
--- a/lib/ansible/module_utils/powershell/Ansible.ModuleUtils.FileUtil.psm1
+++ b/lib/ansible/module_utils/powershell/Ansible.ModuleUtils.FileUtil.psm1
@@ -9,33 +9,39 @@ as possible. They work by using Get-ChildItem with a filter and return the
 result from that.
 #>
 
-Function Test-FilePath($path) {
-    # Basic replacement for Test-Path that tests if the file/folder exists at the path
-    $directory = Split-Path -Path $path -Parent
-    $filename = Split-Path -Path $path -Leaf
-
-    $file = Get-ChildItem -Path $directory -Filter $filename -Force -ErrorAction SilentlyContinue
-    if ($file -ne $null) {
-        if ($file -is [Array] -and $file.Count -gt 1) {
-            throw "found multiple files at path '$path', make sure no wildcards are set in the path"
-        }
-        return $true
-    } else {
+Function Test-AnsiblePath {
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory=$true)][string]$Path
+    )
+    # Replacement for Test-Path
+    try {
+        $file_attributes = [System.IO.File]::GetAttributes($Path)
+    } catch [System.IO.FileNotFoundException] {
         return $false
     }
-}
 
-Function Get-FileItem($path) {
-    # Replacement for Get-Item
-    $directory = Split-Path -Path $path -Parent
-    $filename = Split-Path -Path $path -Leaf
-
-    $file = Get-ChildItem -Path $directory -Filter $filename -Force -ErrorAction SilentlyContinue
-    if ($file -is [Array] -and $file.Count -gt 1) {
-        throw "found multiple files at path '$path', make sure no wildcards are set in the path"
+    if ([Int32]$file_attributes -eq -1) {
+        return $false
+    } else {
+        return $true
     }
-
-    return $file
 }
 
-Export-ModuleMember -Function Test-FilePath, Get-FileItem
+Function Get-AnsibleItem {
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory=$true)][string]$Path
+    )
+    # Replacement for Get-Item
+    $file_attributes = [System.IO.File]::GetAttributes($Path)
+    if ([Int32]$file_attributes -eq -1) {
+        throw New-Object -TypeName System.Management.Automation.ItemNotFoundException -ArgumentList "Cannot find path '$Path' because it does not exist."
+    } elseif ($file_attributes.HasFlag([System.IO.FileAttributes]::Directory)) {
+        return New-Object -TypeName System.IO.DirectoryInfo -ArgumentList $Path
+    } else {
+        return New-Object -TypeName System.IO.FileInfo -ArgumentList $Path
+    }
+}
+
+Export-ModuleMember -Function Test-AnsiblePath, Get-AnsibleItem

--- a/lib/ansible/modules/windows/win_command.ps1
+++ b/lib/ansible/modules/windows/win_command.ps1
@@ -28,11 +28,11 @@ $result = @{
     cmd = $raw_command_line
 }
 
-if ($creates -and $(Test-FilePath -path $creates)) {
+if ($creates -and $(Test-AnsiblePath -Path $creates)) {
     Exit-Json @{msg="skipped, since $creates exists";cmd=$raw_command_line;changed=$false;skipped=$true;rc=0}
 }
 
-if ($removes -and -not $(Test-FilePath -path $removes)) {
+if ($removes -and -not $(Test-AnsiblePath -Path $removes)) {
     Exit-Json @{msg="skipped, since $removes does not exist";cmd=$raw_command_line;changed=$false;skipped=$true;rc=0}
 }
 

--- a/lib/ansible/modules/windows/win_shell.ps1
+++ b/lib/ansible/modules/windows/win_shell.ps1
@@ -56,11 +56,11 @@ $result = @{
     cmd = $raw_command_line
 }
 
-if ($creates -and $(Test-FilePath -path $creates)) {
+if ($creates -and $(Test-AnsiblePath -Path $creates)) {
     Exit-Json @{msg="skipped, since $creates exists";cmd=$raw_command_line;changed=$false;skipped=$true;rc=0}
 }
 
-if ($removes -and -not $(Test-FilePath -path $removes)) {
+if ($removes -and -not $(Test-AnsiblePath -Path $removes)) {
     Exit-Json @{msg="skipped, since $removes does not exist";cmd=$raw_command_line;changed=$false;skipped=$true;rc=0}
 }
 

--- a/lib/ansible/modules/windows/win_stat.ps1
+++ b/lib/ansible/modules/windows/win_stat.ps1
@@ -34,7 +34,7 @@ if (Get-Member -inputobject $params -name "get_md5") {
     Add-DepreactionWarning -obj $result -message "get_md5 has been deprecated along with the md5 return value, use get_checksum=True and checksum_algorithm=md5 instead" -version 2.9
 }
 
-$info = Get-FileItem -path $path
+$info = Get-AnsibleItem -Path $path -ErrorAction SilentlyContinue
 If ($info -ne $null) {
     $epoch_date = Get-Date -Date "01/01/1970"
     $attributes = @()
@@ -74,7 +74,7 @@ If ($info -ne $null) {
     $stat.owner = $info.GetAccessControl().Owner
 
     # values that are set according to the type of file
-    if ($info.PSIsContainer) {
+    if ($info.Attributes.HasFlag([System.IO.FileAttributes]::Directory)) {
         $stat.isdir = $true
         $share_info = Get-WmiObject -Class Win32_Share -Filter "Path='$($stat.path -replace '\\', '\\')'"
         if ($share_info -ne $null) {
@@ -82,11 +82,14 @@ If ($info -ne $null) {
             $stat.sharename = $share_info.Name
         }
 
-        $dir_files_sum = Get-ChildItem $stat.path -Recurse | Measure-Object -property length -sum
-        if ($dir_files_sum -eq $null) {
+        try {
+            $size = 0
+            foreach ($file in $info.EnumerateFiles("*", [System.IO.SearchOption]::AllDirectories)) {
+                $size += $file.Length
+            }
+            $stat.size = $size
+        } catch {
             $stat.size = 0
-        } else {
-            $stat.size = $dir_files_sum.Sum
         }
     } else {
         $stat.extension = $info.Extension

--- a/lib/ansible/modules/windows/win_wait_for.ps1
+++ b/lib/ansible/modules/windows/win_wait_for.ps1
@@ -119,7 +119,7 @@ if ($path -eq $null -and $port -eq $null -and $state -eq "drained") {
         $complete = $false
         while (((Get-Date) - $start_time).TotalSeconds -lt $timeout) {
             $attempts += 1
-            if (Test-FilePath -path $path) {
+            if (Test-AnsiblePath -Path $path) {
                 if ($search_regex -eq $null) {
                     $complete = $true
                     break
@@ -150,7 +150,7 @@ if ($path -eq $null -and $port -eq $null -and $state -eq "drained") {
         $complete = $false
         while (((Get-Date) - $start_time).TotalSeconds -lt $timeout) {
             $attempts += 1
-            if (Test-FilePath -path $path) {
+            if (Test-AnsiblePath -Path $path) {
                 if ($search_regex -ne $null) {
                     $file_contents = Get-Content -Path $path -Raw
                     if ($file_contents -notmatch $search_regex) {

--- a/test/integration/targets/win_stat/tasks/main.yml
+++ b/test/integration/targets/win_stat/tasks/main.yml
@@ -107,7 +107,7 @@
       name: '{{win_stat_user}}'
       state: absent
 
-  - name: ensure testy user profile is deleted
+  - name: ensure test user profile is deleted
     win_shell: rmdir /S /Q {{profile_dir_out.stdout_lines[0]}}
     args:
       executable: cmd.exe

--- a/test/integration/targets/win_stat/tasks/tests.yml
+++ b/test/integration/targets/win_stat/tasks/tests.yml
@@ -196,7 +196,7 @@
     - stat_directory.stat.nlink == 1
     - stat_directory.stat.owner == 'BUILTIN\Administrators'
     - stat_directory.stat.path == win_stat_dir + '\\nested'
-    - stat_directory.stat.size == 21
+    - stat_directory.stat.size == 24
 
 - name: test win_stat on empty directory
   win_stat:


### PR DESCRIPTION
##### SUMMARY
Standardises the cmdlet parameters and get's the FileUtil module_util ready for the mac path override.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
Ansible.ModuleUtils.FileUtil.psm1

##### ANSIBLE VERSION
```
2.5
```