### PR TITLE
Remove AnsibleUnicode special handling

### DIFF
--- a/lib/ansible/parsing/utils/yaml.py
+++ b/lib/ansible/parsing/utils/yaml.py
@@ -16,7 +16,7 @@ from ansible.errors.yaml_strings import YAML_SYNTAX_ERROR
 from ansible.module_utils.six import text_type
 from ansible.module_utils._text import to_native
 from ansible.parsing.yaml.loader import AnsibleLoader
-from ansible.parsing.yaml.objects import AnsibleBaseYAMLObject, AnsibleUnicode
+from ansible.parsing.yaml.objects import AnsibleBaseYAMLObject
 
 
 __all__ = ('from_yaml',)
@@ -61,31 +61,15 @@ def from_yaml(data, file_name='<string>', show_content=True, vault_secrets=None)
     '''
     new_data = None
 
-    if isinstance(data, AnsibleUnicode):
-        # The PyYAML's libyaml bindings use PyUnicode_CheckExact so
-        # they are unable to cope with our subclass.
-        # Unwrap and re-wrap the unicode so we can keep track of line
-        # numbers
-        # Note: Cannot use to_text() because AnsibleUnicode is a subclass of the text_type.
-        # Should not have to worry about tracebacks because python's text constructors (unicode() on
-        # python2 and str() on python3) can handle a subtype of themselves.
-        in_data = text_type(data)
-    else:
-        in_data = data
-
     try:
         # we first try to load this data as JSON.  Fixes issues with extra vars json strings not
         # being parsed correctly by the yaml parser
-        new_data = json.loads(in_data)
+        new_data = json.loads(data)
     except Exception:
         # must not be JSON, let the rest try
         try:
-            new_data = _safe_load(in_data, file_name=file_name, vault_secrets=vault_secrets)
+            new_data = _safe_load(data, file_name=file_name, vault_secrets=vault_secrets)
         except YAMLError as yaml_exc:
             _handle_error(yaml_exc, file_name, show_content)
-
-        if isinstance(data, AnsibleUnicode):
-            new_data = AnsibleUnicode(new_data)
-            new_data.ansible_pos = data.ansible_pos
 
     return new_data


### PR DESCRIPTION
##### SUMMARY
This is code that we're not sure is needed anymore.  Run it through our CI system to gather some preliminary information about whether it could be removed.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
dataloader

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
I think I wrote this code because we had a traceback at some point with pyyaml not able to handle our AnsibleUnicode type (the C library was doing an exact match to python's unicode type rather than testing with the object inheritance hierarchy.)   Neither jimi nor I are sure when AnsibleUnicode gets passed into this function, though, so we think it may be safe to remove this code now.