### PR TITLE
Secure letsencrypt account_key_content better

### DIFF
--- a/lib/ansible/modules/web_infrastructure/letsencrypt.py
+++ b/lib/ansible/modules/web_infrastructure/letsencrypt.py
@@ -55,6 +55,11 @@ options:
       - "Content of the Let's Encrypt account RSA or Elliptic Curve key."
       - "Mutually exclusive with C(account_key_src)."
       - "Required if C(account_key_src) is not used."
+      - "Warning: the content will be written into a temporary file, which will
+         be deleted by Ansible when the module completes. Since this is an
+         important private key — it can be used to change the account key,
+         or to revoke your certificates without knowing their private keys
+         —, this might not be acceptable."
     version_added: "2.5"
   account_email:
     description:

--- a/lib/ansible/modules/web_infrastructure/letsencrypt.py
+++ b/lib/ansible/modules/web_infrastructure/letsencrypt.py
@@ -367,6 +367,7 @@ class ACMEAccount(object):
         # Create a key file from content, key (path) and key content are mutually exclusive
         if self.key_content is not None:
             _, tmpsrc = tempfile.mkstemp()
+            module.add_cleanup_file(tmpsrc)  # Ansible will delete the file on exit
             f = open(tmpsrc, 'wb')
             try:
                 f.write(self.key_content)
@@ -914,10 +915,6 @@ class ACMEClient(object):
             if write_file(self.module, self.dest, pem_cert):
                 self.cert_days = get_cert_days(self.module, self.dest)
                 self.changed = True
-
-        # Clean up temporary account key file
-        if self.module.params['account_key_content'] is not None:
-            os.remove(self.account.key)
 
 
 def main():


### PR DESCRIPTION
##### SUMMARY
The `account_key_content` option added in #32948 does write the account's private key to disk, but does not take care to clean it up in several occasions (like when an error occurs, or when it is written to disk in the first round of the usual two round workflow). This PR uses Ansible's `module.add_cleanup_file()` to make sure Ansible cleans up the file no matter what happens, and adds a warning to the option's documentation that the key content will be written to disk (which might be what the user wanted to prevent).

##### ISSUE TYPE
Bugfix Pull Request

##### COMPONENT NAME
letsencrypt

##### ANSIBLE VERSION
devel

##### ADDITIONAL INFORMATION
The private account key can be used to issue new certificates in certain contexts, to revoke certificates issued by that account without knowing their private keys, or (with the ACME v2 endpoint) to change the private key of the account, which would allow to lock out the original owner of the key if it is stolen.
For that reason, the user should be informed that the key is written to disk, and care should be taken to make sure the temporary file is deleted.