### PR TITLE
Remove unused import from azure dyn inventory

### DIFF
--- a/contrib/inventory/azure_rm.py
+++ b/contrib/inventory/azure_rm.py
@@ -200,8 +200,6 @@ except ImportError:
     # python3
     import configparser as cp
 
-from packaging.version import Version
-
 from os.path import expanduser
 import ansible.module_utils.six.moves.urllib.parse as urlparse
 


### PR DESCRIPTION
##### SUMMARY

Remove unused import from azure_rm dynamic inventory

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

contrib/inventory/azure_rm.py

##### ADDITIONAL INFORMATION

The module is importing a package that is not used and not installed by default.
