### PR TITLE
openssl_certificate: Ensure issuer field is set

### DIFF
--- a/lib/ansible/modules/crypto/openssl_certificate.py
+++ b/lib/ansible/modules/crypto/openssl_certificate.py
@@ -449,6 +449,7 @@ class SelfSignedCertificate(Certificate):
                 # 10 years. 315360000 is 10 years in seconds.
                 cert.gmtime_adj_notAfter(315360000)
             cert.set_subject(self.csr.get_subject())
+            cert.set_issuer(self.csr.get_subject())
             cert.set_version(self.version - 1)
             cert.set_pubkey(self.csr.get_pubkey())
             cert.add_extensions(self.csr.get_extensions())

--- a/test/integration/targets/openssl_certificate/tests/validate.yml
+++ b/test/integration/targets/openssl_certificate/tests/validate.yml
@@ -6,6 +6,11 @@
   shell: 'openssl x509 -noout -modulus -in {{ output_dir }}/cert.pem'
   register: cert_modulus
 
+- name: Validate certificate (test - issuer value)
+  shell: 'openssl x509 -noout  -in {{ output_dir}}/cert.pem -text | grep "Issuer" | sed "s/.*: \(.*\)/\1/g"'
+  register: cert_issuer
+
+
 - name: Validate certificate (test - certficate version == default == 3)
   shell: 'openssl x509 -noout  -in {{ output_dir}}/cert.pem -text | grep "Version" | sed "s/.*: \(.*\) .*/\1/g"'
   register: cert_version
@@ -15,6 +20,7 @@
     that:
       - cert_modulus.stdout == privatekey_modulus.stdout
       - cert_version.stdout == '3'
+      - cert_issuer.stdout == 'CN=www.example.com'
 
 - name: Validate certificate idempotence
   assert:


### PR DESCRIPTION
##### SUMMARY

Ensure the Issuer field of the certificate is set when using the
selfsigned backend.

##### ISSUE TYPE

 - Bugfix Pull Request
 

##### COMPONENT NAME

  * openssl_certificate

##### ANSIBLE VERSION

 * master

##### ADDITIONAL INFORMATION

Fixes: https://github.com/ansible/ansible/issues/34963