### PR TITLE
azure_rm_dnsrecordset: fix broken import and minor updates

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_dnsrecordset.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_dnsrecordset.py
@@ -58,8 +58,8 @@ options:
             - purge
     state:
         description:
-            - Assert the state of the record set. Use 'present' to create or update and
-              'absent' to delete.
+            - Assert the state of the record set. Use C(present) to create or update and
+              C(absent) to delete.
         default: present
         choices:
             - absent

--- a/lib/ansible/modules/cloud/azure/azure_rm_dnsrecordset.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_dnsrecordset.py
@@ -174,7 +174,7 @@ import sys
 
 from ansible.module_utils.basic import _load_params
 from ansible.module_utils.six import iteritems
-from ansible.module_utils.azure_rm_common import AzureRMModuleBase
+from ansible.module_utils.azure_rm_common import AzureRMModuleBase, HAS_AZURE
 
 try:
     from msrestazure.azure_exceptions import CloudError
@@ -229,7 +229,7 @@ RECORDSET_VALUE_MAP = dict(
     SRV=dict(attrname='srv_records', classobj=SrvRecord, is_list=True),
     TXT=dict(attrname='txt_records', classobj=TxtRecord, is_list=True),
     # FUTURE: add missing record types from https://github.com/Azure/azure-sdk-for-python/blob/master/azure-mgmt-dns/azure/mgmt/dns/models/record_set.py
-)
+) if HAS_AZURE else {}
 
 
 class AzureRMRecordSet(AzureRMModuleBase):

--- a/lib/ansible/modules/cloud/azure/azure_rm_dnsrecordset.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_dnsrecordset.py
@@ -183,9 +183,6 @@ except ImportError:
     # This is handled in azure_rm_common
     pass
 
-base_record = dict(
-    entry=dict(type='str', required=True)
-)
 
 RECORD_ARGSPECS = dict(
     A=dict(

--- a/test/sanity/import/skip.txt
+++ b/test/sanity/import/skip.txt
@@ -1,4 +1,3 @@
-lib/ansible/modules/cloud/azure/azure_rm_dnsrecordset.py
 lib/ansible/modules/cloud/dimensiondata/dimensiondata_network.py
 lib/ansible/modules/cloud/webfaction/webfaction_app.py
 lib/ansible/modules/cloud/webfaction/webfaction_db.py


### PR DESCRIPTION
##### SUMMARY
azure_rm_dnsrecordset:
- fix [broken import](https://github.com/ansible/community/wiki/Testing%3A-progress-tracker#list-of-things-that-need-unit-tests-eg-libraries-under-module_utils)
- doc: use formatting function
- remove unused dictionary

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
azure_rm_dnsrecordset

##### ANSIBLE VERSION
```
ansible 2.5.0 (devel 92b3d79283) last updated 2018/01/16 15:27:58 (GMT +200)
```