### PR TITLE
NSO: handle types for leaf-lists in nso_config (ValueBuilder)

### DIFF
--- a/lib/ansible/module_utils/network/nso/nso.py
+++ b/lib/ansible/module_utils/network/nso/nso.py
@@ -438,14 +438,20 @@ class ValueBuilder(object):
 
         schema = self._find_child(parent_path, parent_schema, key)
         if self._is_leaf(schema):
-            path_type = schema['type']
-            if path_type.get('primitive', False):
-                return path_type['name']
-            else:
-                path_type_key = '{0}:{1}'.format(
-                    path_type['namespace'], path_type['name'])
-                type_info = meta['types'][path_type_key]
-                return type_info[-1]['name']
+            def get_type(meta, curr_type):
+                if curr_type.get('primitive', False):
+                    return curr_type['name']
+                if 'namespace' in curr_type:
+                    curr_type_key = '{0}:{1}'.format(
+                        curr_type['namespace'], curr_type['name'])
+                    type_info = meta['types'][curr_type_key][-1]
+                    return get_type(meta, type_info)
+                if 'leaf_type' in curr_type:
+                    return get_type(meta, curr_type['leaf_type'][-1])
+                return curr_type['name']
+
+            return get_type(meta, schema['type'])
+
         return None
 
     def _ensure_schema_cached(self, path):

--- a/test/units/module_utils/network/nso/test_nso.py
+++ b/test/units/module_utils/network/nso/test_nso.py
@@ -152,7 +152,25 @@ SCHEMA_DATA = {
 ''',
     '/test:test': '''
 {
-    "meta": {},
+    "meta": {
+        "types": {
+            "http://example.com/test:t15": [
+               {
+                  "leaf_type":[
+                     {
+                        "name":"string"
+                     }
+                  ],
+                  "list_type":[
+                     {
+                        "name":"http://example.com/test:t15",
+                        "leaf-list":true
+                     }
+                  ]
+               }
+            ]
+        }
+    },
     "data": {
         "kind": "list",
         "name":"test",
@@ -206,6 +224,15 @@ SCHEMA_DATA = {
                         ]
                     }
                 ]
+            },
+            {
+               "kind":"leaf-list",
+               "name":"device-list",
+               "qname":"test:device-list",
+               "type": {
+                  "namespace":"http://example.com/test",
+                  "name":"t15"
+               }
             }
         ]
     }
@@ -334,6 +361,28 @@ class TestValueBuilder(unittest.TestCase):
         self.assertEquals('{0}{{nested}}/nested-child'.format(parent), value.path)
         self.assertEquals('set', value.state)
         self.assertEquals('nested-value', value.value)
+
+        self.assertEqual(0, len(calls))
+
+    @patch('ansible.module_utils.network.nso.nso.open_url')
+    def test_leaf_list_type(self, open_url_mock):
+        calls = [
+            MockResponse('new_trans', {}, 200, '{"result": {"th": 1}}'),
+            get_schema_response('/test:test')
+        ]
+        open_url_mock.side_effect = lambda *args, **kwargs: mock_call(calls, *args, **kwargs)
+
+        parent = "/test:test"
+        schema_data = json.loads(
+            SCHEMA_DATA['/test:test'])
+        schema = schema_data['data']
+
+        vb = nso.ValueBuilder(nso.JsonRpc('http://localhost:8080/jsonrpc'))
+        vb.build(parent, None, {'device-list': ['one', 'two']}, schema)
+        self.assertEquals(1, len(vb.values))
+        value = vb.values[0]
+        self.assertEquals('{0}/device-list'.format(parent), value.path)
+        self.assertEquals(['one', 'two'], value.value)
 
         self.assertEqual(0, len(calls))
 


### PR DESCRIPTION
Fixes: #34985

##### SUMMARY
This reads the type information for leaf-list elements from the appropriate part of the schema.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
nso_config

##### ANSIBLE VERSION
```
ansible 2.5.0 (nso_config_leaf-list_34985 e9efe8df5a) last updated 2018/01/17 13:25:10 (GMT +200)
  config file = None
  configured module search path = [u'/home/cnasten/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/cnasten/dev/ansible/lib/ansible
  executable location = /home/cnasten/dev/ansible/bin/ansible
  python version = 2.7.14+ (default, Dec  5 2017, 15:17:02) [GCC 7.2.0]
```


##### ADDITIONAL INFORMATION
See #34985 for details.