### PR TITLE
Updating lvol.py to better handle %PVS options when creating/resizing lvols.

### DIFF
--- a/lib/ansible/modules/system/lvol.py
+++ b/lib/ansible/modules/system/lvol.py
@@ -226,6 +226,7 @@ def parse_vgs(data):
         })
     return vgs
 
+
 def parse_pvs(data):
     pvs = []
     for line in data.splitlines():
@@ -237,6 +238,7 @@ def parse_pvs(data):
             'ext_size': int(decimal_point.match(parts[3]).group(1))
         })
     return pvs
+
 
 def get_lvm_version(module):
     ver_cmd = module.get_bin_path("lvm", required=True)
@@ -354,21 +356,21 @@ def main():
     this_vg = vgs[0]
 
     if pvs != "":
-      pvs_arr = pvs.split(" ")
-      this_pvs_total = 0
-      for onepv in pvs_arr:
-        pvs_cmd = module.get_bin_path("pvs", required=True)
-        rc, current_pvs, err = module.run_command(
-            "%s --noheadings -o pv_name,size,free,vg_extent_size --units %s --separator ';' %s" % (pvs_cmd, unit, onepv))
-    
-        if rc != 0:
-            if state == 'absent':
-                module.exit_json(changed=False, stdout="Physical volume %s does not exist." % onepv)
-            else:
-                module.fail_json(msg="Physical volume %s does not exist." % onepv, rc=rc, err=err)
-    
-        pvs_single = parse_pvs(current_pvs)
-        this_pvs_total += pvs_single[0]['size']
+        pvs_arr = pvs.split(" ")
+        this_pvs_total = 0
+        for onepv in pvs_arr:
+            pvs_cmd = module.get_bin_path("pvs", required=True)
+            rc, current_pvs, err = module.run_command(
+                "%s --noheadings -o pv_name,size,free,vg_extent_size --units %s --separator ';' %s" % (pvs_cmd, unit, onepv))
+
+            if rc != 0:
+                if state == 'absent':
+                    module.exit_json(changed=False, stdout="Physical volume %s does not exist." % onepv)
+                else:
+                    module.fail_json(msg="Physical volume %s does not exist." % onepv, rc=rc, err=err)
+
+            pvs_single = parse_pvs(current_pvs)
+            this_pvs_total += pvs_single[0]['size']
     # Get information on logical volume requested
     lvs_cmd = module.get_bin_path("lvs", required=True)
     rc, current_lvs, err = module.run_command(
@@ -436,9 +438,9 @@ def main():
                 size_requested = size_percent * this_vg['size'] / 100
             elif size_whole == 'PVS':
                 if 'this_pvs_total' in locals():
-                  size_requested = size_percent * this_pvs_total / 100
+                    size_requested = size_percent * this_pvs_total / 100
                 else:
-                  module.fail_json(msg="You must specify 'pvs' when using '%PVS' in 'size'.")
+                    module.fail_json(msg="You must specify 'pvs' when using '%PVS' in 'size'.")
             else:  # size_whole == 'FREE':
                 size_requested = size_percent * this_vg['free'] / 100
             if '+' in size:
@@ -528,4 +530,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-

--- a/lib/ansible/modules/system/lvol.py
+++ b/lib/ansible/modules/system/lvol.py
@@ -67,6 +67,7 @@ options:
   pvs:
     description:
     - Comma separated list of physical volumes (e.g. /dev/sda,/dev/sdb).
+      Must be specified if using '%PVS' in 'size'.
     version_added: "2.2"
   shrink:
     description:
@@ -225,6 +226,17 @@ def parse_vgs(data):
         })
     return vgs
 
+def parse_pvs(data):
+    pvs = []
+    for line in data.splitlines():
+        parts = line.strip().split(';')
+        pvs.append({
+            'name': parts[0],
+            'size': int(decimal_point.match(parts[1]).group(1)),
+            'free': int(decimal_point.match(parts[2]).group(1)),
+            'ext_size': int(decimal_point.match(parts[3]).group(1))
+        })
+    return pvs
 
 def get_lvm_version(module):
     ver_cmd = module.get_bin_path("lvm", required=True)
@@ -341,6 +353,22 @@ def main():
     vgs = parse_vgs(current_vgs)
     this_vg = vgs[0]
 
+    if pvs != "":
+      pvs_arr = pvs.split(" ")
+      this_pvs_total = 0
+      for onepv in pvs_arr:
+        pvs_cmd = module.get_bin_path("pvs", required=True)
+        rc, current_pvs, err = module.run_command(
+            "%s --noheadings -o pv_name,size,free,vg_extent_size --units %s --separator ';' %s" % (pvs_cmd, unit, onepv))
+    
+        if rc != 0:
+            if state == 'absent':
+                module.exit_json(changed=False, stdout="Physical volume %s does not exist." % onepv)
+            else:
+                module.fail_json(msg="Physical volume %s does not exist." % onepv, rc=rc, err=err)
+    
+        pvs_single = parse_pvs(current_pvs)
+        this_pvs_total += pvs_single[0]['size']
     # Get information on logical volume requested
     lvs_cmd = module.get_bin_path("lvs", required=True)
     rc, current_lvs, err = module.run_command(
@@ -404,8 +432,13 @@ def main():
             # Resize LV based on % value
             tool = None
             size_free = this_vg['free']
-            if size_whole == 'VG' or size_whole == 'PVS':
+            if size_whole == 'VG':
                 size_requested = size_percent * this_vg['size'] / 100
+            elif size_whole == 'PVS':
+                if 'this_pvs_total' in locals():
+                  size_requested = size_percent * this_pvs_total / 100
+                else:
+                  module.fail_json(msg="You must specify 'pvs' when using '%PVS' in 'size'.")
             else:  # size_whole == 'FREE':
                 size_requested = size_percent * this_vg['free'] / 100
             if '+' in size:
@@ -495,3 +528,4 @@ def main():
 
 if __name__ == '__main__':
     main()
+


### PR DESCRIPTION
##### SUMMARY
Updating lvol.py to better handle %PVS options when creating/resizing lvols.

- Adds idempotency when the module is called N+ times and %PVS is used in `size`
- Making the module inline with LVM2 man pages (lvcreate/lvextend), specifically with the description of `-l|--extents` option and sentence `The suffix %VG denotes the total size of the VG, the suffix %FREE the remaining free space in the VG, and the suffix %PVS the free space in the specified PVs`.
- This update makes `pvs` option mandatory when %PVS is used in size, because it calculates requested size by adding size of specified PVS in `pvs` (to be inline with the above point).
- Fixing errors like `"msg": "Unable to resize lv_var_cache_pulp to 100%PVS", "rc": 5)` when module is called N+ times, because it calculated size of VG and not only subset of PVS.


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lvol

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.1.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
Before applied changes same task 2 times:
- lvol: lv=lv_var_cache_pulp size=100%PVS pvs=/dev/sdc shrink=no state=present vg=vg_pulp
- lvol: lv=lv_var_cache_pulp size=100%PVS pvs=/dev/sdc shrink=no state=present vg=vg_pulp

will result in:
TASK [create_lvm : lvol] *****************************************************************************
ok: [server] => (item={'key': u'lv_var_cache_pulp', 'value': {u'path': u'/var/cache/pulp', u'pvs': u'/dev/sdc', u'mount': True, u'vg_name': u'vg_pulp', u'size': u'100%PVS'}})
TASK [create_lvm : lvol] *****************************************************************************
failed: [server] (item={'key': u'lv_var_cache_pulp', 'value': {u'path': u'/var/cache/pulp', u'pvs': u'/dev/sdc', u'mount': True, u'vg_name': u'vg_pulp', u'size': u'100%PVS'}}) => {"changed": false, "err": "  WARNING: No free extents on physical volume \"/dev/sdc\".\n  No specified PVs have space available.\n", "failed": true, "item": {"key": "lv_var_cache_pulp", "value": {"mount": true, "path": "/var/cache/pulp", "pvs": "/dev/sdc", "size": "100%PVS", "vg_name": "vg_pulp"}}, "msg": "Unable to resize lv_var_cache_pulp to 100%PVS", "rc": 5}
```
