### PR TITLE
Don't skip an inventory source just because it has a comma

### DIFF
--- a/lib/ansible/vars/manager.py
+++ b/lib/ansible/vars/manager.py
@@ -255,7 +255,7 @@ class VariableManager:
                 ''' merges all entities by inventory source '''
                 data = {}
                 for inventory_dir in self._inventory._sources:
-                    if ',' in inventory_dir:  # skip host lists
+                    if ',' in inventory_dir and not os.path.exists(inventory_dir):  # skip host lists
                         continue
                     elif not os.path.isdir(inventory_dir):  # always pass 'inventory directory'
                         inventory_dir = os.path.dirname(inventory_dir)

--- a/test/integration/targets/inventory_path_with_comma/aliases
+++ b/test/integration/targets/inventory_path_with_comma/aliases
@@ -1,0 +1,1 @@
+posix/ci/group3

--- a/test/integration/targets/inventory_path_with_comma/playbook.yml
+++ b/test/integration/targets/inventory_path_with_comma/playbook.yml
@@ -1,0 +1,9 @@
+---
+- hosts: all
+  gather_facts: false
+  tasks:
+    - name: Ensure we can see group_vars from path with comma
+      assert:
+        that:
+          - inventory_var_from_path_with_commas is defined
+          - inventory_var_from_path_with_commas == 'here'

--- a/test/integration/targets/inventory_path_with_comma/runme.sh
+++ b/test/integration/targets/inventory_path_with_comma/runme.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -ux
+
+ansible-playbook -i this,path,has,commas/hosts playbook.yml -v "$@"

--- a/test/integration/targets/inventory_path_with_comma/this,path,has,commas/group_vars/all.yml
+++ b/test/integration/targets/inventory_path_with_comma/this,path,has,commas/group_vars/all.yml
@@ -1,0 +1,1 @@
+inventory_var_from_path_with_commas: 'here'

--- a/test/integration/targets/inventory_path_with_comma/this,path,has,commas/hosts
+++ b/test/integration/targets/inventory_path_with_comma/this,path,has,commas/hosts
@@ -1,0 +1,1 @@
+localhost ansible_connect=local


### PR DESCRIPTION
##### SUMMARY
Don't skip an inventory source just because it has a comma, make sure it's also doesn't exist as a path. Fixes #34931

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/vars/manager.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
2.4
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```