### PR TITLE
Make template action respect local_tmp

### DIFF
--- a/lib/ansible/plugins/action/template.py
+++ b/lib/ansible/plugins/action/template.py
@@ -21,6 +21,7 @@ import os
 import shutil
 import tempfile
 
+from ansible import constants as C
 from ansible.errors import AnsibleError, AnsibleFileNotFound, AnsibleAction, AnsibleActionFail
 from ansible.module_utils._text import to_bytes, to_text
 from ansible.module_utils.parsing.convert_bool import boolean
@@ -132,7 +133,7 @@ class ActionModule(ActionBase):
             new_task.args.pop('variable_end_string', None)
             new_task.args.pop('trim_blocks', None)
             try:
-                tempdir = tempfile.mkdtemp()
+                tempdir = tempfile.mkdtemp(dir=C.DEFAULT_LOCAL_TMP)
                 result_file = os.path.join(tempdir, os.path.basename(source))
                 with open(result_file, 'wb') as f:
                     f.write(to_bytes(resultant, errors='surrogate_or_strict'))


### PR DESCRIPTION
##### SUMMARY
Make template action respect local_tmp. Fixes #34941

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/action/template.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```