### PR TITLE
Add regex to catch ios error prompt

### DIFF
--- a/lib/ansible/modules/network/ios/ios_l3_interface.py
+++ b/lib/ansible/modules/network/ios/ios_l3_interface.py
@@ -301,12 +301,7 @@ def main():
 
     if commands:
         if not module.check_mode:
-            response = load_config(module, commands)
-            for item in response:
-                for cmd, rsp in iteritems(item):
-                    for err in ('Error:', 'overlaps with', 'Bad mask'):
-                        if err in rsp:
-                            module.fail_json(msg="command '%s' failed with error '%s'." % (cmd, rsp))
+            load_config(module, commands)
 
         result['changed'] = True
 

--- a/lib/ansible/plugins/terminal/ios.py
+++ b/lib/ansible/plugins/terminal/ios.py
@@ -43,6 +43,10 @@ class TerminalModule(TerminalBase):
         re.compile(br"connection timed out", re.I),
         re.compile(br"[^\r\n]+ not found"),
         re.compile(br"'[^']' +returned error code: ?\d+"),
+        re.compile(br"Bad mask", re.I),
+        re.compile(br"% ?(\S+) ?overlaps with ?(\S+)", re.I),
+        re.compile(br"[%\S] ?Error: ?[\s]+", re.I),
+        re.compile(br"[%\S] ?Informational: ?[\s]+", re.I)
     ]
 
     def on_open_shell(self):


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
*  Move the error checking from ios_l3_module
   to ios termianl plugin by adding additional
   regex to catch error prompt.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request
 
##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
ios_l3_interface
terminal/ios
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
