### PR TITLE
Address missing extends_documentation_fragment

### DIFF
--- a/lib/ansible/modules/cloud/amazon/cloudfront_distribution.py
+++ b/lib/ansible/modules/cloud/amazon/cloudfront_distribution.py
@@ -26,6 +26,10 @@ author:
   - Willem van Ketwich (@wilvk)
   - Will Thames (@willthames)
 
+extends_documentation_fragment:
+  - aws
+  - ec2
+
 options:
 
     state:

--- a/lib/ansible/modules/cloud/amazon/cloudfront_distribution.py
+++ b/lib/ansible/modules/cloud/amazon/cloudfront_distribution.py
@@ -80,6 +80,13 @@ options:
         - A I(list[]) of domain name aliases (CNAMEs) as strings to be used for the distribution. Each alias must be unique across all distribution for the AWS
           account.
 
+    purge_aliases:
+      description:
+        - Specifies whether existing aliases will be removed before adding new aliases. When I(purge_aliases=yes), existing aliases are removed and I(aliases)
+          are added.
+      default: 'no'
+      choices: ['yes', 'no']
+
     default_root_object:
       description:
         - A config element that specifies the path to request when the user requests the origin. e.g. if specified as 'index.html', this maps to

--- a/test/sanity/validate-modules/ignore.txt
+++ b/test/sanity/validate-modules/ignore.txt
@@ -6,7 +6,6 @@ lib/ansible/modules/cloud/amazon/aws_api_gateway.py E322
 lib/ansible/modules/cloud/amazon/aws_application_scaling_policy.py E322
 lib/ansible/modules/cloud/amazon/aws_direct_connect_gateway.py E322
 lib/ansible/modules/cloud/amazon/aws_s3.py E322
-lib/ansible/modules/cloud/amazon/cloudfront_distribution.py E322
 lib/ansible/modules/cloud/amazon/cloudfront_facts.py E323
 lib/ansible/modules/cloud/amazon/data_pipeline.py E322
 lib/ansible/modules/cloud/amazon/ec2.py E322

--- a/test/sanity/validate-modules/ignore.txt
+++ b/test/sanity/validate-modules/ignore.txt
@@ -6,6 +6,7 @@ lib/ansible/modules/cloud/amazon/aws_api_gateway.py E322
 lib/ansible/modules/cloud/amazon/aws_application_scaling_policy.py E322
 lib/ansible/modules/cloud/amazon/aws_direct_connect_gateway.py E322
 lib/ansible/modules/cloud/amazon/aws_s3.py E322
+lib/ansible/modules/cloud/amazon/cloudfront_distribution.py E322
 lib/ansible/modules/cloud/amazon/cloudfront_facts.py E323
 lib/ansible/modules/cloud/amazon/data_pipeline.py E322
 lib/ansible/modules/cloud/amazon/ec2.py E322


### PR DESCRIPTION
##### SUMMARY

Due to the new argument spec validation, we have an error for a newly merged module (`cloudfront_distribution.py`)

It was missing `extends_documentation_fragment`, but is also missing another `purge_aliases` key in docs.

The ignore is there for `purge_aliases` which should be documented later and removed from the ignore list

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/cloudfront_distribution.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```