### PR TITLE
Have validate-modules error on non dict ANSIBLE_METADATA

### DIFF
--- a/docs/docsite/rst/dev_guide/testing_validate-modules.rst
+++ b/docs/docsite/rst/dev_guide/testing_validate-modules.rst
@@ -100,7 +100,7 @@ Errors
   312       No ``RETURN`` documentation provided
   313       ``RETURN`` is not valid YAML
   314       No ``ANSIBLE_METADATA`` provided
-  315       ``ANSIBLE_METADATA`` is not valid YAML
+  315       ``ANSIBLE_METADATA`` was not provided as a dict, YAML not supported
   316       Invalid ``ANSIBLE_METADATA`` schema
   317       option is marked as required but specifies a default.
             Arguments with a default should not be marked as required

--- a/test/sanity/validate-modules/main.py
+++ b/test/sanity/validate-modules/main.py
@@ -840,7 +840,7 @@ class ModuleValidator(Validator):
                             code=303,
                             msg='DOCUMENTATION fragment missing: %s' % fragment
                         )
-                    except Exception:
+                    except Exception as e:
                         self.reporter.trace(
                             path=self.object_path,
                             tracebk=traceback.format_exc()
@@ -848,7 +848,7 @@ class ModuleValidator(Validator):
                         self.reporter.error(
                             path=self.object_path,
                             code=304,
-                            msg='Unknown DOCUMENTATION error, see TRACE'
+                            msg='Unknown DOCUMENTATION error, see TRACE: %s' % e
                         )
 
                 if 'options' in doc and doc['options'] is None:
@@ -946,22 +946,32 @@ class ModuleValidator(Validator):
                     doc_info['ANSIBLE_METADATA']['value']
                 )
             else:
-                metadata, errors, traces = parse_yaml(
-                    doc_info['ANSIBLE_METADATA']['value'].s,
-                    doc_info['ANSIBLE_METADATA']['lineno'],
-                    self.name, 'ANSIBLE_METADATA'
+                # ANSIBLE_METADATA doesn't properly support YAML
+                # we should consider removing it from the spec
+                # Below code kept, incase we change our minds
+
+                # metadata, errors, traces = parse_yaml(
+                #     doc_info['ANSIBLE_METADATA']['value'].s,
+                #     doc_info['ANSIBLE_METADATA']['lineno'],
+                #     self.name, 'ANSIBLE_METADATA'
+                # )
+                # for error in errors:
+                #     self.reporter.error(
+                #         path=self.object_path,
+                #         code=315,
+                #         **error
+                #     )
+                # for trace in traces:
+                #     self.reporter.trace(
+                #         path=self.object_path,
+                #         tracebk=trace
+                #     )
+
+                self.reporter.error(
+                    path=self.object_path,
+                    code=315,
+                    msg='ANSIBLE_METADATA was not provided as a dict, YAML not supported'
                 )
-                for error in errors:
-                    self.reporter.error(
-                        path=self.object_path,
-                        code=315,
-                        **error
-                    )
-                for trace in traces:
-                    self.reporter.trace(
-                        path=self.object_path,
-                        tracebk=trace
-                    )
 
             if metadata:
                 self._validate_docs_schema(metadata, metadata_1_1_schema(deprecated),


### PR DESCRIPTION
##### SUMMARY
ANSIBLE_METADATA doesn't support YAML currently, change 315 to invalid data type

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
test/sanity/validate-modules/main.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```