### PR TITLE
Fix copy for implicit relative paths

### DIFF
--- a/lib/ansible/modules/files/copy.py
+++ b/lib/ansible/modules/files/copy.py
@@ -213,6 +213,7 @@ state:
 '''
 
 import os
+import os.path
 import shutil
 import tempfile
 import traceback
@@ -273,6 +274,9 @@ def main():
     src = module.params['src']
     b_src = to_bytes(src, errors='surrogate_or_strict')
     dest = module.params['dest']
+    # Make sure we always have a directory component for later processing
+    if os.path.sep not in dest:
+        dest = '.{0}{1}'.format(os.path.sep, dest)
     b_dest = to_bytes(dest, errors='surrogate_or_strict')
     backup = module.params['backup']
     force = module.params['force']

--- a/test/integration/targets/copy/tasks/tests.yml
+++ b/test/integration/targets/copy/tasks/tests.yml
@@ -1262,6 +1262,60 @@
     - stat_circular_symlink_result.stat.exists
     - stat_circular_symlink_result.stat.islnk
 
+# Relative paths in dest:
+- name: Smoketest that copying content to an implicit relative path works
+  copy:
+    content: 'testing'
+    dest: 'ansible-testing.txt'
+  register: relative_results
+
+- name: Assert that copying to an implicit relative path reported changed
+  assert:
+    that:
+      - 'relative_results["changed"]'
+      - 'relative_results["checksum"] == "dc724af18fbdd4e59189f5fe768a5f8311527050"'
+
+- name: Test that copying the same content with an implicit relative path reports no change
+  copy:
+    content: 'testing'
+    dest: 'ansible-testing.txt'
+  register: relative_results
+
+- name: Assert that copying the same content with an implicit relative path reports no change
+  assert:
+    that:
+      - 'not relative_results["changed"]'
+      - 'relative_results["checksum"] == "dc724af18fbdd4e59189f5fe768a5f8311527050"'
+
+- name: Test that copying different content with an implicit relative path reports change
+  copy:
+    content: 'testing2'
+    dest: 'ansible-testing.txt'
+  register: relative_results
+
+- name: Assert that copying different content with an implicit relative path reports changed
+  assert:
+    that:
+      - 'relative_results["changed"]'
+      - 'relative_results["checksum"] == "596b29ec9afea9e461a20610d150939b9c399d93"'
+
+- name: Smoketest that explicit relative path works
+  copy:
+    content: 'testing'
+    dest: './ansible-testing.txt'
+  register: relative_results
+
+- name: Assert that explicit relative paths reports change
+  assert:
+    that:
+      - 'relative_results["changed"]'
+      - 'relative_results["checksum"] == "dc724af18fbdd4e59189f5fe768a5f8311527050"'
+
+- name: Cleanup relative path tests
+  file:
+    path: 'ansible-testing.txt'
+    state: absent
+
 # src is a file, dest is a non-existent directory (2 levels of directories):
 # checks that dest is created
 - include: dest_in_non_existent_directories.yml


### PR DESCRIPTION
##### SUMMARY
copy currently fails if you specify a destination without any directory
component.  This is because we take the dirname of the destination for
some processing and no dirname causes issues.

This corrects that by prepending "./" if there is no directory component
in dest.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/file/copy.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel and earlier
```


##### ADDITIONAL INFORMATION
This has been behaviour for a long time (at least as far back as 1.9).