### PR TITLE
Make sure we don't try to inspect DOCUMENTATION if None

### DIFF
--- a/lib/ansible/plugins/loader.py
+++ b/lib/ansible/plugins/loader.py
@@ -214,7 +214,7 @@ class PluginLoader:
             if type_name in ('callback', 'connection', 'inventory', 'lookup', 'shell'):
                 dstring = get_docstring(path, fragment_loader, verbose=False, ignore_errors=True)[0]
 
-                if 'options' in dstring and isinstance(dstring['options'], dict):
+                if dstring and 'options' in dstring and isinstance(dstring['options'], dict):
                     C.config.initialize_plugin_configuration_definitions(type_name, name, dstring['options'])
                     display.debug('Loaded config def from plugin (%s/%s)' % (type_name, name))
 


### PR DESCRIPTION
##### SUMMARY

Guard against inspecting `DOCUMENTATION` in a plugin, that doesn't have `DOCUMENTATION`

Currently if you have a custom callback without `DOCUMENTATION` you would get a trace similar to the following:

```
Traceback (most recent call last):
  File "/home/travis/build/goodplay/goodplay/.tox/py27-ansibledevel/bin/ansible-playbook", line 118, in <module>
    exit_code = cli.run()
  File "/home/travis/build/goodplay/goodplay/.tox/py27-ansibledevel/lib/python2.7/site-packages/ansible/cli/playbook.py", line 122, in run
    results = pbex.run()
  File "/home/travis/build/goodplay/goodplay/.tox/py27-ansibledevel/lib/python2.7/site-packages/ansible/executor/playbook_executor.py", line 89, in run
    self._tqm.load_callbacks()
  File "/home/travis/build/goodplay/goodplay/.tox/py27-ansibledevel/lib/python2.7/site-packages/ansible/executor/task_queue_manager.py", line 190, in load_callbacks
    for callback_plugin in callback_loader.all(class_only=True):
  File "/home/travis/build/goodplay/goodplay/.tox/py27-ansibledevel/lib/python2.7/site-packages/ansible/plugins/loader.py", line 462, in all
    self._update_object(obj, name, path)
  File "/home/travis/build/goodplay/goodplay/.tox/py27-ansibledevel/lib/python2.7/site-packages/ansible/plugins/loader.py", line 346, in _update_object
    self._load_config_defs(name, path)
  File "/home/travis/build/goodplay/goodplay/.tox/py27-ansibledevel/lib/python2.7/site-packages/ansible/plugins/loader.py", line 217, in _load_config_defs
    if 'options' in dstring and isinstance(dstring['options'], dict):
TypeError: argument of type 'NoneType' is not iterable
```

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/loader.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```