### PR TITLE
Adds better error handling to f5 api connections

### DIFF
--- a/lib/ansible/module_utils/network/f5/bigip.py
+++ b/lib/ansible/module_utils/network/f5/bigip.py
@@ -16,19 +16,27 @@ except ImportError:
 
 try:
     from library.module_utils.network.f5.common import F5BaseClient
+    from library.module_utils.network.f5.common import F5ModuleError
 except ImportError:
     from ansible.module_utils.network.f5.common import F5BaseClient
+    from ansible.module_utils.network.f5.common import F5ModuleError
 
 
 class F5Client(F5BaseClient):
     @property
     def api(self):
-        result = ManagementRoot(
-            self.params['server'],
-            self.params['user'],
-            self.params['password'],
-            port=self.params['server_port'],
-            verify=self.params['validate_certs'],
-            token='tmos'
-        )
+        try:
+            result = ManagementRoot(
+                self.params['server'],
+                self.params['user'],
+                self.params['password'],
+                port=self.params['server_port'],
+                verify=self.params['validate_certs'],
+                token='tmos'
+            )
+        except Exception:
+            raise F5ModuleError(
+                'Unable to connect to {0} on port {1}. '
+                'Is "validate_certs" preventing this?'.format(self.params['server'], self.params['server_port'])
+            )
         return result

--- a/lib/ansible/module_utils/network/f5/bigiq.py
+++ b/lib/ansible/module_utils/network/f5/bigiq.py
@@ -14,18 +14,29 @@ try:
 except ImportError:
     HAS_F5SDK = False
 
-from ansible.module_utils.network.f5.common import F5BaseClient
+try:
+    from library.module_utils.network.f5.common import F5BaseClient
+    from library.module_utils.network.f5.common import F5ModuleError
+except ImportError:
+    from ansible.module_utils.network.f5.common import F5BaseClient
+    from ansible.module_utils.network.f5.common import F5ModuleError
 
 
 class F5Client(F5BaseClient):
     @property
     def api(self):
-        result = ManagementRoot(
-            self.params['server'],
-            self.params['user'],
-            self.params['password'],
-            port=self.params['server_port'],
-            verify=self.params['validate_certs'],
-            token='local'
-        )
+        try:
+            result = ManagementRoot(
+                self.params['server'],
+                self.params['user'],
+                self.params['password'],
+                port=self.params['server_port'],
+                verify=self.params['validate_certs'],
+                token='local'
+            )
+        except Exception:
+            raise F5ModuleError(
+                'Unable to connect to {0} on port {1}. '
+                'Is "validate_certs" preventing this?'.format(self.params['server'], self.params['server_port'])
+            )
         return result

--- a/lib/ansible/module_utils/network/f5/iworkflow.py
+++ b/lib/ansible/module_utils/network/f5/iworkflow.py
@@ -14,18 +14,29 @@ try:
 except ImportError:
     HAS_F5SDK = False
 
-from ansible.module_utils.network.f5.common import F5BaseClient
+try:
+    from library.module_utils.network.f5.common import F5BaseClient
+    from library.module_utils.network.f5.common import F5ModuleError
+except ImportError:
+    from ansible.module_utils.network.f5.common import F5BaseClient
+    from ansible.module_utils.network.f5.common import F5ModuleError
 
 
 class F5Client(F5BaseClient):
     @property
     def api(self):
-        result = ManagementRoot(
-            self.params['server'],
-            self.params['user'],
-            self.params['password'],
-            port=self.params['server_port'],
-            verify=self.params['validate_certs'],
-            token='local'
-        )
+        try:
+            result = ManagementRoot(
+                self.params['server'],
+                self.params['user'],
+                self.params['password'],
+                port=self.params['server_port'],
+                verify=self.params['validate_certs'],
+                token='local'
+            )
+        except Exception:
+            raise F5ModuleError(
+                'Unable to connect to {0} on port {1}. '
+                'Is "validate_certs" preventing this?'.format(self.params['server'], self.params['server_port'])
+            )
         return result


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Previously, the failure of the API connection would result
in a stack trace. This patch makes the failure capable of exiting
with fail_json

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
various f5 module utils

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.14 (default, Dec 12 2017, 16:55:09) [GCC 4.9.2]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
