### PR TITLE
template: change to pass along the correct template path

### DIFF
--- a/lib/ansible/plugins/action/assemble.py
+++ b/lib/ansible/plugins/action/assemble.py
@@ -85,8 +85,7 @@ class ActionModule(ActionBase):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
-        if not tmp:
-            tmp = self._connection._shell.tempdir
+        tmp = self._connection._shell.tempdir
 
         if task_vars is None:
             task_vars = dict()

--- a/lib/ansible/plugins/action/assemble.py
+++ b/lib/ansible/plugins/action/assemble.py
@@ -85,6 +85,9 @@ class ActionModule(ActionBase):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
+        if not tmp:
+            tmp = self._connection._shell.tempdir
+
         if task_vars is None:
             task_vars = dict()
 
@@ -146,11 +149,11 @@ class ActionModule(ActionBase):
                 if self._play_context.diff:
                     diff = self._get_diff_data(dest, path, task_vars)
 
-                remote_path = self._connection._shell.join_path(self._connection._shell.tempdir, 'src')
+                remote_path = self._connection._shell.join_path(tmp, 'src')
                 xfered = self._transfer_file(path, remote_path)
 
                 # fix file permissions when the copy is done as a different user
-                self._fixup_perms2((self._connection._shell.tempdir, remote_path))
+                self._fixup_perms2((tmp, remote_path))
 
                 new_module_args.update(dict(src=xfered,))
 
@@ -164,6 +167,6 @@ class ActionModule(ActionBase):
         except AnsibleAction as e:
             result.update(e.result)
         finally:
-            self._remove_tmp_path(self._connection._shell.tempdir)
+            self._remove_tmp_path(tmp)
 
         return result

--- a/lib/ansible/plugins/action/command.py
+++ b/lib/ansible/plugins/action/command.py
@@ -15,6 +15,9 @@ class ActionModule(ActionBase):
         self._supports_async = True
         results = super(ActionModule, self).run(tmp, task_vars)
 
+        if not tmp:
+            tmp = self._connection._shell.tempdir
+
         # Command module has a special config option to turn off the command nanny warnings
         if 'warn' not in self._task.args:
             self._task.args['warn'] = C.COMMAND_WARNINGS
@@ -24,6 +27,6 @@ class ActionModule(ActionBase):
 
         if not wrap_async:
             # remove a temporary path we created
-            self._remove_tmp_path(self._connection._shell.tempdir)
+            self._remove_tmp_path(tmp)
 
         return results

--- a/lib/ansible/plugins/action/command.py
+++ b/lib/ansible/plugins/action/command.py
@@ -15,8 +15,7 @@ class ActionModule(ActionBase):
         self._supports_async = True
         results = super(ActionModule, self).run(tmp, task_vars)
 
-        if not tmp:
-            tmp = self._connection._shell.tempdir
+        tmp = self._connection._shell.tempdir
 
         # Command module has a special config option to turn off the command nanny warnings
         if 'warn' not in self._task.args:

--- a/lib/ansible/plugins/action/copy.py
+++ b/lib/ansible/plugins/action/copy.py
@@ -389,8 +389,7 @@ class ActionModule(ActionBase):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
-        if tmp is None:
-            tmp = self._connection._shell.tempdir
+        tmp = self._connection._shell.tempdir
 
         source = self._task.args.get('src', None)
         content = self._task.args.get('content', None)

--- a/lib/ansible/plugins/action/copy.py
+++ b/lib/ansible/plugins/action/copy.py
@@ -258,7 +258,7 @@ class ActionModule(ActionBase):
                 return result
 
             # Define a remote directory that we will copy the file to.
-            tmp_src = self._connection._shell.join_path(self._connection._shell.tempdir, 'source')
+            tmp_src = self._connection._shell.join_path(tmp, 'source')
 
             remote_path = None
 
@@ -273,7 +273,7 @@ class ActionModule(ActionBase):
 
             # fix file permissions when the copy is done as a different user
             if remote_path:
-                self._fixup_perms2((self._connection._shell.tempdir, remote_path))
+                self._fixup_perms2((tmp, remote_path))
 
             if raw:
                 # Continue to next iteration if raw is defined.
@@ -548,6 +548,6 @@ class ActionModule(ActionBase):
             result.update(dict(dest=dest, src=source, changed=changed))
 
         # Delete tmp path
-        self._remove_tmp_path(self._connection._shell.tempdir)
+        self._remove_tmp_path(tmp)
 
         return result

--- a/lib/ansible/plugins/action/fetch.py
+++ b/lib/ansible/plugins/action/fetch.py
@@ -44,6 +44,9 @@ class ActionModule(ActionBase):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
+        if not tmp:
+            tmp = self._connection._shell.tempdir
+
         try:
             if self._play_context.check_mode:
                 result['skipped'] = True
@@ -212,6 +215,6 @@ class ActionModule(ActionBase):
                 result.update(dict(changed=False, md5sum=local_md5, file=source, dest=dest, checksum=local_checksum))
 
         finally:
-            self._remove_tmp_path(self._connection._shell.tempdir)
+            self._remove_tmp_path(tmp)
 
         return result

--- a/lib/ansible/plugins/action/fetch.py
+++ b/lib/ansible/plugins/action/fetch.py
@@ -44,8 +44,7 @@ class ActionModule(ActionBase):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
-        if not tmp:
-            tmp = self._connection._shell.tempdir
+        tmp = self._connection._shell.tempdir
 
         try:
             if self._play_context.check_mode:

--- a/lib/ansible/plugins/action/normal.py
+++ b/lib/ansible/plugins/action/normal.py
@@ -31,8 +31,7 @@ class ActionModule(ActionBase):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
-        if not tmp:
-            tmp = self._connection._shell.tempdir
+        tmp = self._connection._shell.tempdir
 
         if not result.get('skipped'):
 

--- a/lib/ansible/plugins/action/normal.py
+++ b/lib/ansible/plugins/action/normal.py
@@ -31,6 +31,9 @@ class ActionModule(ActionBase):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
+        if not tmp:
+            tmp = self._connection._shell.tempdir
+
         if not result.get('skipped'):
 
             if result.get('invocation', {}).get('module_args'):
@@ -51,6 +54,6 @@ class ActionModule(ActionBase):
 
         if not wrap_async:
             # remove a temporary path we created
-            self._remove_tmp_path(self._connection._shell.tempdir)
+            self._remove_tmp_path(tmp)
 
         return result

--- a/lib/ansible/plugins/action/package.py
+++ b/lib/ansible/plugins/action/package.py
@@ -39,6 +39,9 @@ class ActionModule(ActionBase):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
+        if not tmp:
+            tmp = self._connection._shell.tempdir
+
         module = self._task.args.get('use', 'auto')
 
         if module == 'auto':
@@ -76,6 +79,6 @@ class ActionModule(ActionBase):
         finally:
             if not self._task.async_val:
                 # remove a temporary path we created
-                self._remove_tmp_path(self._connection._shell.tempdir)
+                self._remove_tmp_path(tmp)
 
         return result

--- a/lib/ansible/plugins/action/package.py
+++ b/lib/ansible/plugins/action/package.py
@@ -39,8 +39,7 @@ class ActionModule(ActionBase):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
-        if not tmp:
-            tmp = self._connection._shell.tempdir
+        tmp = self._connection._shell.tempdir
 
         module = self._task.args.get('use', 'auto')
 

--- a/lib/ansible/plugins/action/patch.py
+++ b/lib/ansible/plugins/action/patch.py
@@ -36,8 +36,7 @@ class ActionModule(ActionBase):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
-        if not tmp:
-            tmp = self._connection._shell.tempdir
+        tmp = self._connection._shell.tempdir
 
         src = self._task.args.get('src', None)
         remote_src = boolean(self._task.args.get('remote_src', 'no'), strict=False)

--- a/lib/ansible/plugins/action/patch.py
+++ b/lib/ansible/plugins/action/patch.py
@@ -36,6 +36,9 @@ class ActionModule(ActionBase):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
+        if not tmp:
+            tmp = self._connection._shell.tempdir
+
         src = self._task.args.get('src', None)
         remote_src = boolean(self._task.args.get('remote_src', 'no'), strict=False)
 
@@ -52,7 +55,7 @@ class ActionModule(ActionBase):
             except AnsibleError as e:
                 raise AnsibleActionFail(to_native(e))
 
-            tmp_src = self._connection._shell.join_path(self._connection._shell.tempdir, os.path.basename(src))
+            tmp_src = self._connection._shell.join_path(tmp, os.path.basename(src))
             self._transfer_file(src, tmp_src)
             self._fixup_perms2((tmp_src,))
 
@@ -67,5 +70,5 @@ class ActionModule(ActionBase):
         except AnsibleAction as e:
             result.update(e.result)
         finally:
-            self._remove_tmp_path(self._connection._shell.tempdir)
+            self._remove_tmp_path(tmp)
         return result

--- a/lib/ansible/plugins/action/script.py
+++ b/lib/ansible/plugins/action/script.py
@@ -41,6 +41,9 @@ class ActionModule(ActionBase):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
+        if not tmp:
+            tmp = self._connection._shell.tempdir
+
         try:
             creates = self._task.args.get('creates')
             if creates:
@@ -87,7 +90,7 @@ class ActionModule(ActionBase):
 
             if not self._play_context.check_mode:
                 # transfer the file to a remote tmp location
-                tmp_src = self._connection._shell.join_path(self._connection._shell.tempdir, os.path.basename(source))
+                tmp_src = self._connection._shell.join_path(tmp, os.path.basename(source))
 
                 # Convert raw_params to text for the purpose of replacing the script since
                 # parts and tmp_src are both unicode strings and raw_params will be different
@@ -126,6 +129,6 @@ class ActionModule(ActionBase):
         except AnsibleAction as e:
             result.update(e.result)
         finally:
-            self._remove_tmp_path(self._connection._shell.tempdir)
+            self._remove_tmp_path(tmp)
 
         return result

--- a/lib/ansible/plugins/action/script.py
+++ b/lib/ansible/plugins/action/script.py
@@ -41,8 +41,7 @@ class ActionModule(ActionBase):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
-        if not tmp:
-            tmp = self._connection._shell.tempdir
+        tmp = self._connection._shell.tempdir
 
         try:
             creates = self._task.args.get('creates')

--- a/lib/ansible/plugins/action/service.py
+++ b/lib/ansible/plugins/action/service.py
@@ -38,8 +38,7 @@ class ActionModule(ActionBase):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
-        if not tmp:
-            tmp = self._connection._shell.tempdir
+        tmp = self._connection._shell.tempdir
 
         module = self._task.args.get('use', 'auto').lower()
 

--- a/lib/ansible/plugins/action/service.py
+++ b/lib/ansible/plugins/action/service.py
@@ -38,6 +38,9 @@ class ActionModule(ActionBase):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
+        if not tmp:
+            tmp = self._connection._shell.tempdir
+
         module = self._task.args.get('use', 'auto').lower()
 
         if module == 'auto':
@@ -84,6 +87,6 @@ class ActionModule(ActionBase):
             result.update(e.result)
         finally:
             if not self._task.async_val:
-                self._remove_tmp_path(self._connection._shell.tempdir)
+                self._remove_tmp_path(tmp)
 
         return result

--- a/lib/ansible/plugins/action/shell.py
+++ b/lib/ansible/plugins/action/shell.py
@@ -24,7 +24,4 @@ class ActionModule(ActionBase):
                                                                    shared_loader_obj=self._shared_loader_obj)
         result = command_action.run(task_vars=task_vars)
 
-        # remove a temporary path we created
-        self._remove_tmp_path(self._connection._shell.tempdir)
-
         return result

--- a/lib/ansible/plugins/action/template.py
+++ b/lib/ansible/plugins/action/template.py
@@ -41,6 +41,9 @@ class ActionModule(ActionBase):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
+        if not tmp:
+            tmp = self._connection._shell.tempdir
+
         source = self._task.args.get('src', None)
         dest = self._task.args.get('dest', None)
         force = boolean(self._task.args.get('force', True), strict=False)
@@ -151,12 +154,12 @@ class ActionModule(ActionBase):
                                                                         loader=self._loader,
                                                                         templar=self._templar,
                                                                         shared_loader_obj=self._shared_loader_obj)
-                result.update(copy_action.run(task_vars=task_vars))
+                result.update(copy_action.run(task_vars=task_vars, tmp=tmp))
             finally:
                 shutil.rmtree(tempdir)
         except AnsibleAction as e:
             result.update(e.result)
         finally:
-            self._remove_tmp_path(self._connection._shell.tempdir)
+            self._remove_tmp_path(tmp)
 
         return result

--- a/lib/ansible/plugins/action/template.py
+++ b/lib/ansible/plugins/action/template.py
@@ -41,8 +41,7 @@ class ActionModule(ActionBase):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
-        if not tmp:
-            tmp = self._connection._shell.tempdir
+        tmp = self._connection._shell.tempdir
 
         source = self._task.args.get('src', None)
         dest = self._task.args.get('dest', None)

--- a/lib/ansible/plugins/action/unarchive.py
+++ b/lib/ansible/plugins/action/unarchive.py
@@ -37,6 +37,9 @@ class ActionModule(ActionBase):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
+        if not tmp:
+            tmp = self._connection._shell.tempdir
+
         source = self._task.args.get('src', None)
         dest = self._task.args.get('dest', None)
         remote_src = boolean(self._task.args.get('remote_src', False), strict=False)
@@ -83,7 +86,7 @@ class ActionModule(ActionBase):
 
             if not remote_src:
                 # transfer the file to a remote tmp location
-                tmp_src = self._connection._shell.join_path(self._connection._shell.tempdir, 'source')
+                tmp_src = self._connection._shell.join_path(tmp, 'source')
                 self._transfer_file(source, tmp_src)
 
             # handle diff mode client side
@@ -91,7 +94,7 @@ class ActionModule(ActionBase):
 
             if not remote_src:
                 # fix file permissions when the copy is done as a different user
-                self._fixup_perms2((self._connection._shell.tempdir, tmp_src))
+                self._fixup_perms2((tmp, tmp_src))
                 # Build temporary module_args.
                 new_module_args = self._task.args.copy()
                 new_module_args.update(
@@ -119,5 +122,5 @@ class ActionModule(ActionBase):
         except AnsibleAction as e:
             result.update(e.result)
         finally:
-            self._remove_tmp_path(self._connection._shell.tempdir)
+            self._remove_tmp_path(tmp)
         return result

--- a/lib/ansible/plugins/action/unarchive.py
+++ b/lib/ansible/plugins/action/unarchive.py
@@ -37,8 +37,7 @@ class ActionModule(ActionBase):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
-        if not tmp:
-            tmp = self._connection._shell.tempdir
+        tmp = self._connection._shell.tempdir
 
         source = self._task.args.get('src', None)
         dest = self._task.args.get('dest', None)


### PR DESCRIPTION
##### SUMMARY
When running win_template it will give a warning saying it failed to delete a temporary directory. This change fixes

* Shares the same temp path with template and copy so that copy does not create an extra unneeded directory
* Fixes the cleanup in template to source the correct template path, for Windows this was trying to delete the new copy tmp path which no longer existed and left another one created by template initially (not sure about POSIX hosts)

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
template

##### ANSIBLE VERSION
```
2.5
```