### PR TITLE
Add aws_s3 action plugin to find source files as expected

### DIFF
--- a/hacking/aws_config/testing_policies/storage-policy.json
+++ b/hacking/aws_config/testing_policies/storage-policy.json
@@ -15,8 +15,8 @@
             ],
             "Effect": "Allow",
             "Resource": [
-                "arn:aws:s3:::ansible_test_*",
-                "arn:aws:s3:::ansible_test_*/*"
+                "arn:aws:s3:::ansible-test-*",
+                "arn:aws:s3:::ansible-test-*/*"
             ]
         }
     ]

--- a/lib/ansible/plugins/action/aws_s3.py
+++ b/lib/ansible/plugins/action/aws_s3.py
@@ -1,0 +1,55 @@
+# (c) 2012, Michael DeHaan <michael.dehaan@gmail.com>
+# (c) 2018, Will Thames <will@thames.id.au>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import os
+
+from ansible.errors import AnsibleError, AnsibleAction, AnsibleActionFail
+from ansible.module_utils._text import to_text
+from ansible.plugins.action import ActionBase
+
+
+class ActionModule(ActionBase):
+
+    TRANSFERS_FILES = True
+
+    def run(self, tmp=None, task_vars=None):
+        ''' handler for aws_s3 operations '''
+        if task_vars is None:
+            task_vars = dict()
+
+        result = super(ActionModule, self).run(tmp, task_vars)
+
+        source = self._task.args.get('src', None)
+
+        try:
+            new_module_args = self._task.args.copy()
+            if source:
+                source = os.path.expanduser(source)
+                try:
+                    source = self._loader.get_real_file(self._find_needle('files', source))
+                    new_module_args['src'] = source
+                except AnsibleError as e:
+                    raise AnsibleActionFail(to_text(e))
+
+            # execute the aws_s3 module now, with the updated args
+            result.update(self._execute_module(module_args=new_module_args, task_vars=task_vars))
+        except AnsibleAction as e:
+            result.update(e.result)
+        return result

--- a/test/integration/targets/aws_s3/files/hello.txt
+++ b/test/integration/targets/aws_s3/files/hello.txt
@@ -1,0 +1,1 @@
+Hello, World!

--- a/test/integration/targets/aws_s3/tasks/main.yml
+++ b/test/integration/targets/aws_s3/tasks/main.yml
@@ -65,6 +65,31 @@
       - result.changed == True
       - result.msg == "PUT operation complete"
 # ============================================================
+- name: check that roles file lookups work as expected
+  aws_s3:
+    bucket: "{{ bucket_name }}"
+    mode: put
+    src: hello.txt
+    object: hello.txt
+    <<: *aws_connection_info
+  retries: 3
+  delay: 3
+  register: result
+- name: assert object exists
+  assert:
+    that:
+      - result.changed == True
+      - result.msg == "PUT operation complete"
+- name: remove hello.txt (deletion tests are later)
+  aws_s3:
+    bucket: "{{ bucket_name }}"
+    mode: delobj
+    object: hello.txt
+    <<: *aws_connection_info
+  retries: 3
+  delay: 3
+  register: result
+# ============================================================
 - name: create a second temp file to download the object from the bucket
   tempfile:
   register: tmp2


### PR DESCRIPTION
##### SUMMARY
People expect to be able to upload files to s3 using standard
locations for files.

Providing an action plugin that effectively rewrites the `src`
key to the result of finding such a file is a great help.

Tests added, and IAM permissions corrected


##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
aws_s3

##### ANSIBLE VERSION
```
ansible 2.5.0 (devel 5a9562a101) last updated 2018/01/18 10:21:40 (GMT +1000)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/will/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/will/src/ansible/lib/ansible
  executable location = /home/will/src/ansible/bin/ansible
  python version = 2.7.14 (default, Dec 11 2017, 14:52:53) [GCC 7.2.1 20170915 (Red Hat 7.2.1-2)]
```

