### PR TITLE
Enable nxapi nxos_banner test

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_banner.py
+++ b/lib/ansible/modules/network/nxos/nxos_banner.py
@@ -117,9 +117,17 @@ def map_config_to_obj(module):
         module.fail_json(msg="banner: exec may not be supported on this platform.  Possible values are : exec | motd")
 
     if isinstance(output, dict):
-        output = list(output.values())[0]
+        output = list(output.values())
+        if output != []:
+            output = output[0]
+        else:
+            output = ''
         if isinstance(output, dict):
-            output = list(output.values())[0]
+            output = list(output.values())
+            if output != []:
+                output = output[0]
+            else:
+                output = ''
 
     obj = {'banner': module.params['banner'], 'state': 'absent'}
     if output:

--- a/test/integration/targets/nxos_banner/tasks/main.yaml
+++ b/test/integration/targets/nxos_banner/tasks/main.yaml
@@ -1,3 +1,3 @@
 ---
 - { include: cli.yaml, tags: ['cli'] }
-#- { include: nxapi.yaml, tags: ['nxapi'] }
+- { include: nxapi.yaml, tags: ['nxapi'] }

--- a/test/integration/targets/nxos_banner/tests/cli/basic-exec.yaml
+++ b/test/integration/targets/nxos_banner/tests/cli/basic-exec.yaml
@@ -1,12 +1,12 @@
 ---
-- debug: msg="START nxos_banner exec test"
+- debug: msg="START cli/nxos_banner exec test"
 
 - block:
     - name: setup - remove exec
-      nxos_banner:
+      nxos_banner: &remove
         banner: exec
         state: absent
-        provider: "{{ connection }}"
+        provider: "{{ cli }}"
 
     - name: Set exec
       nxos_banner: &exec
@@ -16,7 +16,7 @@
           that has a multiline
           string
         state: present
-        provider: "{{ connection }}"
+        provider: "{{ cli }}"
       register: result
 
     - assert:
@@ -33,10 +33,9 @@
           - "result.changed == false"
           - "result.commands | length == 0"
 
+    - name: teardown - remove exec
+      nxos_banner: *remove
+
   when: platform is match("N7K")
 
-- debug: msg="END nxos_banner exec test"
-
-# FIXME add in tests for everything defined in docs
-# FIXME Test state:absent + test:
-# FIXME Without powers ensure "privileged mode required"
+- debug: msg="END cli/nxos_banner exec test"

--- a/test/integration/targets/nxos_banner/tests/cli/basic-motd.yaml
+++ b/test/integration/targets/nxos_banner/tests/cli/basic-motd.yaml
@@ -1,9 +1,11 @@
 ---
+- debug: msg="START cli/nxos_banner motd test"
+
 - name: setup - remove motd
-  nxos_banner:
+  nxos_banner: &remove
     banner: motd
     state: absent
-    provider: "{{ connection }}"
+    provider: "{{ cli }}"
 
 - name: Set motd
   nxos_banner: &motd
@@ -13,7 +15,7 @@
       that has a multiline
       string
     state: present
-    provider: "{{ connection }}"
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -28,8 +30,8 @@
 - assert:
     that:
       - "result.changed == false"
-      - "result.commands | length == 0"
 
-# FIXME add in tests for everything defined in docs
-# FIXME Test state:absent + test:
-# FIXME Without powers ensure "privileged mode required"
+- name: teardown - remove motd
+  nxos_banner: *remove
+
+- debug: msg="END cli/nxos_banner motd test"

--- a/test/integration/targets/nxos_banner/tests/cli/basic-no-motd.yaml
+++ b/test/integration/targets/nxos_banner/tests/cli/basic-no-motd.yaml
@@ -1,4 +1,6 @@
 ---
+- debug: msg="START cli/nxos_banner no-motd test"
+
 - name: Setup
   nxos_banner:
     banner: motd
@@ -6,13 +8,13 @@
       Junk motd banner
       over multiple lines
     state: present
-    provider: "{{ connection }}"
+    provider: "{{ cli }}"
 
 - name: remove motd
   nxos_banner: &rm-motd
     banner: motd
     state: absent
-    provider: "{{ connection }}"
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -29,6 +31,4 @@
       - "result.changed == false"
       - "result.commands | length == 0"
 
-# FIXME add in tests for everything defined in docs
-# FIXME Test state:absent + test:
-# FIXME Without powers ensure "privileged mode required"
+- debug: msg="END cli/nxos_banner no-motd test"

--- a/test/integration/targets/nxos_banner/tests/nxapi/basic-exec.yaml
+++ b/test/integration/targets/nxos_banner/tests/nxapi/basic-exec.yaml
@@ -1,0 +1,32 @@
+---
+- debug: msg="START nxapi/nxos_banner exec test"
+
+- block:
+    - name: setup - remove exec
+      nxos_banner: &remove
+        banner: exec
+        state: absent
+        provider: "{{ nxapi }}"
+
+    - name: Set exec
+      nxos_banner: &exec
+        banner: exec
+        text: |
+          this is my exec banner
+          that has a multiline
+          string
+        state: present
+        provider: "{{ nxapi }}"
+      register: result
+
+    - assert:
+        that:
+          - "result.changed == true"
+          - "'banner exec @\nthis is my exec banner\nthat has a multiline\nstring\n@' in result.commands"
+
+    - name: teardown - remove exec
+      nxos_banner: *remove
+
+  when: platform is match("N7K")
+
+- debug: msg="END nxapi/nxos_banner exec test"

--- a/test/integration/targets/nxos_banner/tests/nxapi/basic-motd.yaml
+++ b/test/integration/targets/nxos_banner/tests/nxapi/basic-motd.yaml
@@ -1,0 +1,29 @@
+---
+- debug: msg="START nxapi/nxos_banner motd test"
+
+- name: setup - remove motd
+  nxos_banner: &remove
+    banner: motd
+    state: absent
+    provider: "{{ nxapi }}"
+
+- name: Set motd
+  nxos_banner: &motd
+    banner: motd
+    text: |
+      this is my motd banner
+      that has a multiline
+      string
+    state: present
+    provider: "{{ nxapi }}"
+  register: result
+
+- assert:
+    that:
+      - "result.changed == true"
+      - "'banner motd @\nthis is my motd banner\nthat has a multiline\nstring\n@' in result.commands"
+
+- name: teardown - remove motd
+  nxos_banner: *remove
+
+- debug: msg="END nxapi/nxos_banner motd test"

--- a/test/integration/targets/nxos_banner/tests/nxapi/basic-no-motd.yaml
+++ b/test/integration/targets/nxos_banner/tests/nxapi/basic-no-motd.yaml
@@ -1,0 +1,25 @@
+---
+- debug: msg="START nxapi/nxos_banner no-motd test"
+
+- name: Setup
+  nxos_banner:
+    banner: motd
+    text: |
+      Junk motd banner
+      over multiple lines
+    state: present
+    provider: "{{ nxapi }}"
+
+- name: remove motd
+  nxos_banner: &rm-motd
+    banner: motd
+    state: absent
+    provider: "{{ nxapi }}"
+  register: result
+
+- assert:
+    that:
+      - "result.changed == true"
+      - "'no banner motd' in result.commands"
+
+- debug: msg="END nxapi/nxos_banner no-motd test"


### PR DESCRIPTION
Signed-off-by: Trishna Guha <trishnaguha17@gmail.com>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
- Enable nxapi nxos_banner test
- Remove idempotent test for nxapi. Ref: https://github.com/ansible/ansible/pull/29088#issuecomment-356591170
- handle corner case for nxapi exec-banner
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
modules/network/nxos/nxos_banner
test/integration/targets/nxos_banner
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```