### PR TITLE
Fixes  #35034 - AWS RequestLimitExceeded error while calling DescribeVpcEndpoints

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_endpoint_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_endpoint_facts.py
@@ -118,13 +118,14 @@ except ImportError:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ec2 import (ec2_argument_spec, boto3_conn, get_aws_connection_info,
-                                      ansible_dict_to_boto3_filter_list, HAS_BOTO3, camel_dict_to_snake_dict)
+                                      ansible_dict_to_boto3_filter_list, HAS_BOTO3, camel_dict_to_snake_dict, AWSRetry)
 
 
 def date_handler(obj):
     return obj.isoformat() if hasattr(obj, 'isoformat') else obj
 
 
+@AWSRetry.exponential_backoff()
 def get_supported_services(client, module):
     results = list()
     params = dict()
@@ -138,6 +139,7 @@ def get_supported_services(client, module):
     return dict(service_names=results)
 
 
+@AWSRetry.exponential_backoff()
 def get_endpoints(client, module):
     results = list()
     params = dict()


### PR DESCRIPTION
SUMMARY
We observed the AWS RequestLimitExceeded error while using ec2_vpc_endpoint_facts ansible module. Please refer issue #35034 for details.

Added AWSRetry.exponential_backoff() for describe calls.

ISSUE TYPE
  - Bugfix Pull Request

COMPONENT NAME
ec2_vpc_endpoint_facts 

ANSIBLE VERSION
```
ansible 2.4.2.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Aug  4 2017, 00:39:18) [GCC 4.8.5 20150623 (Red Hat 4.8.5-16)]
```


ADDITIONAL INFORMATION