### PR TITLE
Change documentation for path: in openssl_csr to match reality

### DIFF
--- a/lib/ansible/modules/crypto/openssl_csr.py
+++ b/lib/ansible/modules/crypto/openssl_csr.py
@@ -59,7 +59,7 @@ options:
     path:
         required: true
         description:
-            - Name of the folder in which the generated OpenSSL certificate signing request will be written
+            - Name of the file into which the generated OpenSSL certificate signing request will be written
     subject:
         required: false
         description:


### PR DESCRIPTION
##### SUMMARY
Using ansible 2.4.2.0 to create a CSR with the openssl_csr module, I did as the documentation said:
path: is documented as being the directory into which the csr will get written.

However, when running a playbook with path: /etc/ssl/, it errors out:
TASK [Create CSR] ***************************************************************************************************************************************************************************************************************************************************************************************************************************************************
fatal: [unifi.tigerstedt.net]: FAILED! => {"changed": false, "msg": "[Errno 21] Is a directory: '/etc/ssl/'"}
        to retry, use: --limit @/home/tiggi/hemma_ansible/lets-unifi.retry

Fix the documentation to show that dest: is a file, not a directory. This follows the model of openssl_privatekey where dest: is the private key file that gets generated. (and ultimately the letsencrypt module where dest: is the certificate file that gets issued.


##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
openssl_csr

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.2.0
  config file = /home/tiggi/hemma_ansible/ansible.cfg
  configured module search path = [u'/home/tiggi/hemma_ansible/library']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.14 (default, Sep 23 2017, 22:06:14) [GCC 7.2.0]
```
... but also present in current devel

##### ADDITIONAL INFORMATION

broken:
        - name: Create CSR
          openssl_csr:
                common_name: "{{ inventory_hostname }}"
                path: /etc/ssl/
                privatekey_path: /etc/ssl/hostkey.pem

working: 

        - name: Create CSR
          openssl_csr:
                common_name: "{{ inventory_hostname }}"
                path: /etc/ssl/hostcert.csr
                privatekey_path: /etc/ssl/hostkey.pem


<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
