### PR TITLE
Ensure that the become password is written on py3 in the ssh connection plugin

### DIFF
--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -780,6 +780,9 @@ class Connection(ConnectionBase):
                     if self._flags['become_prompt']:
                         display.debug('Sending become_pass in response to prompt')
                         stdin.write(to_bytes(self._play_context.become_pass) + b'\n')
+                        # On python3 stdin is a BufferedWriter, and we don't have a guarantee
+                        # that the write will happen without a flush
+                        stdin.flush()
                         self._flags['become_prompt'] = False
                         state += 1
                     elif self._flags['become_success']:

--- a/test/units/plugins/connection/test_ssh.py
+++ b/test/units/plugins/connection/test_ssh.py
@@ -459,6 +459,7 @@ class TestSSHConnectionRun(object):
         self.mock_selector.get_map.side_effect = lambda: True
 
         return_code, b_stdout, b_stderr = self.conn._run("ssh", "this is input data")
+        self.mock_popen_res.stdin.flush.assert_called_once_with()
         assert return_code == 0
         assert b_stdout == b'abc'
         assert b_stderr == b'123'


### PR DESCRIPTION
##### SUMMARY
Ensure that the become password is written on py3 in the ssh connection plugin. Fixes #34727

In python3, when `subprocess.Popen` is called, stdin is returned as a `io.BufferedWriter`.

Per the python docs for `io.BufferedWriter`:

> The buffer will be written out to the underlying RawIOBase object under various conditions, including:
> 
> * when the buffer gets too small for all pending data;
> * when flush() is called;
> * when a seek() is requested (for BufferedRandom objects);
> * when the BufferedWriter object is closed or destroyed.

As such we have no guarantee that the write ever happens, short of calling `flush`. This is specifically noticeable with pipelining enabled.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/connection/ssh.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.3
2.4
2.5
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```