### PR TITLE
Accepting SANs marked as critical (fixes #32767).

### DIFF
--- a/lib/ansible/modules/web_infrastructure/letsencrypt.py
+++ b/lib/ansible/modules/web_infrastructure/letsencrypt.py
@@ -676,7 +676,9 @@ class ACMEClient(object):
         common_name = re.search(r"Subject:.*? CN\s?=\s?([^\s,;/]+)", to_text(out, errors='surrogate_or_strict'))
         if common_name is not None:
             domains.add(common_name.group(1))
-        subject_alt_names = re.search(r"X509v3 Subject Alternative Name: \n +([^\n]+)\n", to_text(out, errors='surrogate_or_strict'), re.MULTILINE | re.DOTALL)
+        subject_alt_names = re.search(
+            r"X509v3 Subject Alternative Name: (?:critical)?\n +([^\n]+)\n",
+            to_text(out, errors='surrogate_or_strict'), re.MULTILINE | re.DOTALL)
         if subject_alt_names is not None:
             for san in subject_alt_names.group(1).split(", "):
                 if san.startswith("DNS:"):


### PR DESCRIPTION
##### SUMMARY
If Subject Alternate Names are marked as critical, the regexp parsing the CSR output by OpenSSL doesn't match them and ignores them. This causes the problems in #32767 (`2**15 - 1` — yay! :) ).

##### ISSUE TYPE
Bugfix Pull Request

##### COMPONENT NAME
letsencrypt

##### ANSIBLE VERSION
```
2.4.0, devel
```

##### ADDITIONAL INFORMATION
Test output of `openssl req -in [cert].csr -noout -text` with critical SANs:
```
        Requested Extensions:
            X509v3 Subject Alternative Name: critical
                DNS:san.example.com, DNS:bla.example.org
```
Similar CSR without critical SANs:
```
        Requested Extensions:
            X509v3 Subject Alternative Name: 
                DNS:san.example.com, DNS:bla.example.org
```