### PR TITLE
fix new EC2 C5 instance virtualization_type identification

### DIFF
--- a/lib/ansible/module_utils/facts/virtual/linux.py
+++ b/lib/ansible/module_utils/facts/virtual/linux.py
@@ -119,7 +119,6 @@ class LinuxVirtual(Virtual):
             virtual_facts['virtualization_role'] = 'guest'
             return virtual_facts
 
-
         sys_vendor = get_file_content('/sys/devices/virtual/dmi/id/sys_vendor')
 
         # FIXME: This does also match hyperv

--- a/lib/ansible/module_utils/facts/virtual/linux.py
+++ b/lib/ansible/module_utils/facts/virtual/linux.py
@@ -114,6 +114,12 @@ class LinuxVirtual(Virtual):
             virtual_facts['virtualization_role'] = 'guest'
             return virtual_facts
 
+        if bios_vendor == 'Amazon EC2':
+            virtual_facts['virtualization_type'] = 'kvm'
+            virtual_facts['virtualization_role'] = 'guest'
+            return virtual_facts
+
+
         sys_vendor = get_file_content('/sys/devices/virtual/dmi/id/sys_vendor')
 
         # FIXME: This does also match hyperv
@@ -139,6 +145,11 @@ class LinuxVirtual(Virtual):
 
         if sys_vendor == 'OpenStack Foundation':
             virtual_facts['virtualization_type'] = 'openstack'
+            virtual_facts['virtualization_role'] = 'guest'
+            return virtual_facts
+
+        if sys_vendor == 'Amazon EC2':
+            virtual_facts['virtualization_type'] = 'kvm'
             virtual_facts['virtualization_role'] = 'guest'
             return virtual_facts
 


### PR DESCRIPTION
Fixes #35051

Signed-off-by: Adam Miller <admiller@redhat.com>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fix ansible_virtualization_type and ansible_virtualization_role not recognized for Amazon EC2 C5 Instances
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
lib/ansible/module_utils/facts/virtual/linux.py


##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
$ ansible --version
ansible 2.5.0 (facts/virtual/linux f56302b234) last updated 2018/01/18 14:50:29 (GMT -500)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/admiller/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/admiller/src/dev/ansible/lib/ansible
  executable location = /home/admiller/src/dev/ansible/bin/ansible
  python version = 2.7.14 (default, Dec 11 2017, 14:52:53) [GCC 7.2.1 20170915 (Red Hat 7.2.1-2)]

```


