### PR TITLE
VMware: vmware_guest template find

### DIFF
--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -1000,6 +1000,37 @@ class PyVmomi(object):
             folder_name = '/' + folder_name
         return folder_name
 
+    def get_vm_or_template(self, template_name=None):
+        """
+        Function to find the virtual machine or virtual machine template using name
+        used for cloning purpose.
+        Args:
+            template_name: Name of virtual machine or virtual machine template
+
+        Returns: virtual machine or virtual machine template object
+
+        """
+        template_obj = None
+
+        if template_name:
+            objects = self.get_managed_objects_properties(vim_type=vim.VirtualMachine, properties=['name'])
+            templates = []
+
+            for temp_vm_object in objects:
+                if len(temp_vm_object.propSet) != 1:
+                    continue
+                for temp_vm_object_property in temp_vm_object.propSet:
+                    if temp_vm_object_property.val == template_name:
+                        templates.append(temp_vm_object.obj)
+                        break
+
+            if len(templates) > 1:
+                # We have found multiple virtual machine templates
+                self.module.fail_json(msg="Multiple virtual machines or templates with same name [%s] found." % template_name)
+            elif templates:
+                template_obj = templates[0]
+        return template_obj
+
     # Cluster related functions
     def find_cluster_by_name(self, cluster_name, datacenter_name=None):
         """

--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -1465,7 +1465,6 @@ class PyVmomiHelper(PyVmomi):
         # https://www.vmware.com/support/developer/vc-sdk/visdk41pubs/ApiReference/vim.vm.RelocateSpec.html
 
         # FIXME:
-        #   - multiple templates by the same name
         #   - static IPs
 
         self.folder = self.params.get('folder', None)
@@ -1515,8 +1514,7 @@ class PyVmomiHelper(PyVmomi):
         destfolder = f_obj
 
         if self.params['template']:
-            # FIXME: need to search for this in the same way as guests to ensure accuracy
-            vm_obj = find_obj(self.content, [vim.VirtualMachine], self.params['template'])
+            vm_obj = self.get_vm_or_template(template_name=self.params['template'])
             if vm_obj is None:
                 self.module.fail_json(msg="Could not find a template named %(template)s" % self.params)
         else:


### PR DESCRIPTION
##### SUMMARY
This fix adds logic to find unique virtual machine template using name.

Fixes: #26669

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/vmware.py
lib/ansible/modules/cloud/vmware/vmware_guest.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5devel
```