### PR TITLE
Win lineinfile fix

### DIFF
--- a/lib/ansible/modules/windows/win_lineinfile.ps1
+++ b/lib/ansible/modules/windows/win_lineinfile.ps1
@@ -1,25 +1,9 @@
 #!powershell
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
-# WANT_JSON
-# POWERSHELL_COMMON
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+#Requires -Module Ansible.ModuleUtils.Legacy
 
-# Write lines to a file using the specified line separator and encoding,
-# performing validation if a validation command was specified.
 function WriteLines($outlines, $path, $linesep, $encodingobj, $validate, $check_mode) {
 	Try {
 		$temppath = [System.IO.Path]::GetTempFileName();
@@ -340,15 +324,6 @@ If (Test-Path -Path $path -PathType "container") {
 $linesep = "`r`n"
 If ($newline -eq "unix") {
 	$linesep = "`n";
-}
-
-# Fix any CR/LF literals in the line argument. PS will not recognize either backslash
-# or backtick literals in the incoming string argument without this bit of black magic.
-If ($line) {
-	$line = $line.Replace("\r", "`r");
-	$line = $line.Replace("\n", "`n");
-	$line = $line.Replace("``r", "`r");
-	$line = $line.Replace("``n", "`n");
 }
 
 # Figure out the proper encoding to use for reading / writing the target file.

--- a/lib/ansible/modules/windows/win_lineinfile.py
+++ b/lib/ansible/modules/windows/win_lineinfile.py
@@ -43,6 +43,8 @@ options:
     description:
       - Required for C(state=present). The line to insert/replace into the file. If C(backrefs) is set, may contain backreferences that will get
         expanded with the C(regexp) capture groups if the regexp matches.
+      - Be aware that the line is processed first on the controller and thus is dependent on yaml quoting rules. Any double quoted line
+        will have control characters, such as '\r\n', expanded. To print such characters literally, use single or no quotes.
   backrefs:
     required: false
     default: "no"
@@ -110,6 +112,11 @@ notes:
 
 EXAMPLES = r'''
 # Before 2.3, option 'dest', 'destfile' or 'name' was used instead of 'path'
+- name: insert path without converting \r\n
+  win_lineinfile:
+    path: c:\file.txt
+    line: c:\return\new
+
 - win_lineinfile:
     path: C:\temp\example.conf
     regexp: '^name='

--- a/lib/ansible/modules/windows/win_lineinfile.py
+++ b/lib/ansible/modules/windows/win_lineinfile.py
@@ -1,20 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible. If not, see <http://www.gnu.org/licenses/>.
+
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],

--- a/test/integration/targets/win_lineinfile/tasks/main.yml
+++ b/test/integration/targets/win_lineinfile/tasks/main.yml
@@ -696,8 +696,8 @@
 # c:\return\new
 # c:
 # eturn
-# ew
+# ew #or c:eturnew  on windows
 - name: assert that one line is literal and the other has breaks
   assert:
     that:
-    - result.stat.checksum == '3738b9874eb00778c276426c2f7a3f7d661f5f76'
+    - result.stat.checksum == 'd2dfd11bc70526ff13a91153c76a7ae5595a845b'

--- a/test/integration/targets/win_lineinfile/tasks/main.yml
+++ b/test/integration/targets/win_lineinfile/tasks/main.yml
@@ -653,6 +653,7 @@
     path: "{{win_output_dir}}/test_linebreak.txt"
   register: result
 
+# (Get-FileHash -path C:\ansible\test\integration\targets\win_lineinfile\files\test_linebreak.txt -Algorithm sha1).hash.tolower()
 - name: check win_stat file result
   assert:
     that:
@@ -666,17 +667,21 @@
   win_lineinfile:
     dest: "{{win_output_dir}}/test_linebreak.txt"
     line: c:\return\new
-  register: result
+  register: result_literal
 
-- debug:
-    var: result
-    verbosity: 1
+- name: insert path "c:\return\new" to test file, will cause line breaks
+  win_lineinfile:
+    dest: "{{win_output_dir}}/test_linebreak.txt"
+    line: "c:\return\new"
+  register: result_expand
 
-- name: assert that the line was inserted
+- name: assert that the lines were inserted
   assert:
     that:
-    - result.changed == true
-    - result.msg == 'line added'
+    - result_literal.changed == true
+    - result_literal.msg == 'line added'
+    - result_expand.changed == true
+    - result_expand.msg == 'line added'
 
 - name: stat the test file
   win_stat:
@@ -687,7 +692,12 @@
     var: result
     verbosity: 1
 
-- name: assert that the file path is inserted without line breaks
+# expect that the file looks like this:
+# c:\return\new
+# c:
+# eturn
+# ew
+- name: assert that one line is literal and the other has breaks
   assert:
     that:
-    - result.stat.checksum == 'bb952ff0904eddf71a5f44b68d499672d45cc61f'
+    - result.stat.checksum == '3738b9874eb00778c276426c2f7a3f7d661f5f76'

--- a/test/integration/targets/win_lineinfile/tasks/main.yml
+++ b/test/integration/targets/win_lineinfile/tasks/main.yml
@@ -638,3 +638,56 @@
   assert:
     that:
     - "result.stat.checksum == '66a72e71f42c4775f4326da95cfe82c8830e5022'"
+
+#########################################################################
+# issue #33858
+# \r\n causes line break instead of printing literally which breaks paths.
+
+- name: create testing file
+  win_copy:
+    src: test_linebreak.txt
+    dest: "{{win_output_dir}}/test_linebreak.txt"
+
+- name: stat the test file
+  win_stat:
+    path: "{{win_output_dir}}/test_linebreak.txt"
+  register: result
+
+- name: check win_stat file result
+  assert:
+    that:
+      - result.stat.exists
+      - not result.stat.isdir
+      - result.stat.checksum == 'da39a3ee5e6b4b0d3255bfef95601890afd80709'
+      - result is not failed
+      - result is not changed
+
+- name: insert path c:\return\new to test file
+  win_lineinfile:
+    dest: "{{win_output_dir}}/test_linebreak.txt"
+    line: c:\return\new
+  register: result
+
+- debug:
+    var: result
+    verbosity: 1
+
+- name: assert that the line was inserted
+  assert:
+    that:
+    - result.changed == true
+    - result.msg == 'line added'
+
+- name: stat the test file
+  win_stat:
+    path: "{{win_output_dir}}/test_linebreak.txt"
+  register: result
+
+- debug:
+    var: result
+    verbosity: 1
+
+- name: assert that the file path is inserted without line breaks
+  assert:
+    that:
+    - result.stat.checksum == 'bb952ff0904eddf71a5f44b68d499672d45cc61f'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #33858
Added test for this particular issue
Updated the copyright headers
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
win_lineinfile

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (win_lineinfile_fix d5a530a351) last updated 2018/01/19 16:34:00 (GMT +000)
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /opt/ansible/lib/ansible
  executable location = /opt/ansible/bin/ansible
  python version = 2.7.12 (default, Nov  2 2017, 19:20:38) [GCC 4.8.5 20150623 (Red Hat 4.8.5-11)]

```

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

win_lineinfile had a section which was converting `\r\n` to``` `r`n` ``` which is the PowerShell method of inserting line breaks. This was causing things like some windows paths (ex. c:\return\new) to be inserted incorrectly. 

After removing the section, if line breaks are desired they can still be done `path: "break\r\nhere"`. The quoting is important.

```
  - name: no line break
    win_lineinfile:
      path: c:\test.txt
      line: c:\return\new

  - name: no line break
    win_lineinfile:
      path: c:\test.txt
      line: 'c:\return\new'

  - name: line break occurs
    win_lineinfile:
      path: c:\test.txt
      line: "c:\return\new"
```

Any conversions are occurring in Ansible prior to being processed by PowerShell. So things like ```path: "break`r`nhere"``` are interpreted literally by powershell and no line break will occur.