### PR TITLE
ini children order callout

### DIFF
--- a/docs/docsite/rst/intro_inventory.rst
+++ b/docs/docsite/rst/intro_inventory.rst
@@ -179,6 +179,10 @@ Groups of Groups, and Group Variables
 It is also possible to make groups of groups using the ``:children`` suffix in INI or the ``children:`` entry in YAML.
 You can apply variables using ``:vars`` or ``vars:``:
 
+The order that the groups are in is important for the ini file format.
+You need to specify the child group then the parent group.
+The example below shows atlanta and raleigh then the southeast:children group they are in.
+If you specify the southeast:children then atlanta and raleigh it will fail parsing.
 
 .. code-block:: ini
 


### PR DESCRIPTION
If you don't get the order correct for child:parent then it will parse as yml and fail.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - New Module Pull Request
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
