### PR TITLE
FIX: multiple nested tasks include levels

### DIFF
--- a/lib/ansible/playbook/included_file.py
+++ b/lib/ansible/playbook/included_file.py
@@ -115,7 +115,16 @@ class IncludedFile:
                                     include_target = templar.template(include_result['include'])
                                     if original_task._role:
                                         new_basedir = os.path.join(original_task._role._role_path, 'tasks', cumulative_path)
-                                        include_file = loader.path_dwim_relative(new_basedir, 'tasks', include_target)
+                                        candidates = [loader.path_dwim_relative(original_task._role._role_path, 'tasks', include_target),
+                                                      loader.path_dwim_relative(new_basedir, 'tasks', include_target)]
+                                        for include_file in candidates:
+                                            try:
+                                                # may throw OSError
+                                                os.stat(include_file)
+                                                # or select the task file if it exists
+                                                break
+                                            except OSError:
+                                                pass
                                     else:
                                         include_file = loader.path_dwim_relative(loader.get_basedir(), cumulative_path, include_target)
 

--- a/test/integration/targets/include_role_nested/aliases
+++ b/test/integration/targets/include_role_nested/aliases
@@ -1,0 +1,2 @@
+posix/ci/group3
+include_role

--- a/test/integration/targets/include_role_nested/nested.yml
+++ b/test/integration/targets/include_role_nested/nested.yml
@@ -1,0 +1,6 @@
+- name: >-
+    verify that multiple level of nested statements and 
+    include+meta doesnt mess included files mecanisms
+  hosts: testhost
+  tasks:
+  - include_tasks: ./tasks/nested/nested.yml

--- a/test/integration/targets/include_role_nested/nested/nested/nested/test_nested_dep_role2/defaults/main.yml
+++ b/test/integration/targets/include_role_nested/nested/nested/nested/test_nested_dep_role2/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+testnesteddep2_defvar1: foobar
+testnesteddep2_varvar1: foobar

--- a/test/integration/targets/include_role_nested/nested/nested/nested/test_nested_dep_role2/meta/main.yml
+++ b/test/integration/targets/include_role_nested/nested/nested/nested/test_nested_dep_role2/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+- role: nested/nested/test_nested_dep_role2a

--- a/test/integration/targets/include_role_nested/nested/nested/nested/test_nested_dep_role2/tasks/main.yml
+++ b/test/integration/targets/include_role_nested/nested/nested/nested/test_nested_dep_role2/tasks/main.yml
@@ -1,0 +1,2 @@
+---
+- include_tasks: ./rund.yml

--- a/test/integration/targets/include_role_nested/nested/nested/nested/test_nested_dep_role2/tasks/rund.yml
+++ b/test/integration/targets/include_role_nested/nested/nested/nested/test_nested_dep_role2/tasks/rund.yml
@@ -1,0 +1,2 @@
+---
+- shell: echo from deprole2a

--- a/test/integration/targets/include_role_nested/nested/nested/nested/test_nested_dep_role2/vars/main.yml
+++ b/test/integration/targets/include_role_nested/nested/nested/nested/test_nested_dep_role2/vars/main.yml
@@ -1,0 +1,2 @@
+---
+testnesteddep2_varvar1: muche

--- a/test/integration/targets/include_role_nested/nested/nested/nested/test_nested_dep_role2a/defaults/main.yml
+++ b/test/integration/targets/include_role_nested/nested/nested/nested/test_nested_dep_role2a/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+testnesteddep2_defvar1: foobar
+testnesteddep2_varvar1: foobar

--- a/test/integration/targets/include_role_nested/nested/nested/nested/test_nested_dep_role2a/meta/main.yml
+++ b/test/integration/targets/include_role_nested/nested/nested/nested/test_nested_dep_role2a/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+- role: nested/nested/test_nested_dep_role2b

--- a/test/integration/targets/include_role_nested/nested/nested/nested/test_nested_dep_role2a/tasks/main.yml
+++ b/test/integration/targets/include_role_nested/nested/nested/nested/test_nested_dep_role2a/tasks/main.yml
@@ -1,0 +1,2 @@
+---
+- include_tasks: ./rune.yml

--- a/test/integration/targets/include_role_nested/nested/nested/nested/test_nested_dep_role2a/tasks/rune.yml
+++ b/test/integration/targets/include_role_nested/nested/nested/nested/test_nested_dep_role2a/tasks/rune.yml
@@ -1,0 +1,2 @@
+---
+- shell: echo from deprole2

--- a/test/integration/targets/include_role_nested/nested/nested/nested/test_nested_dep_role2a/vars/main.yml
+++ b/test/integration/targets/include_role_nested/nested/nested/nested/test_nested_dep_role2a/vars/main.yml
@@ -1,0 +1,2 @@
+---
+testnesteddep2_varvar1: muche

--- a/test/integration/targets/include_role_nested/nested/nested/nested/test_nested_dep_role2b/defaults/main.yml
+++ b/test/integration/targets/include_role_nested/nested/nested/nested/test_nested_dep_role2b/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+testnesteddep2_defvar1: foobar
+testnesteddep2_varvar1: foobar

--- a/test/integration/targets/include_role_nested/nested/nested/nested/test_nested_dep_role2b/meta/main.yml
+++ b/test/integration/targets/include_role_nested/nested/nested/nested/test_nested_dep_role2b/meta/main.yml
@@ -1,0 +1,1 @@
+dependencies: []

--- a/test/integration/targets/include_role_nested/nested/nested/nested/test_nested_dep_role2b/tasks/main.yml
+++ b/test/integration/targets/include_role_nested/nested/nested/nested/test_nested_dep_role2b/tasks/main.yml
@@ -1,0 +1,2 @@
+---
+- include_tasks: ./runf.yml

--- a/test/integration/targets/include_role_nested/nested/nested/nested/test_nested_dep_role2b/tasks/runf.yml
+++ b/test/integration/targets/include_role_nested/nested/nested/nested/test_nested_dep_role2b/tasks/runf.yml
@@ -1,0 +1,2 @@
+---
+- shell: echo from deprole2b

--- a/test/integration/targets/include_role_nested/nested/nested/nested/test_nested_dep_role2b/vars/main.yml
+++ b/test/integration/targets/include_role_nested/nested/nested/nested/test_nested_dep_role2b/vars/main.yml
@@ -1,0 +1,2 @@
+---
+testnesteddep2_varvar1: muche

--- a/test/integration/targets/include_role_nested/nested/nested/test_nested_dep_role/defaults/main.yml
+++ b/test/integration/targets/include_role_nested/nested/nested/test_nested_dep_role/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+testnesteddep_defvar1: foobar
+testnesteddep_varvar1: foobar

--- a/test/integration/targets/include_role_nested/nested/nested/test_nested_dep_role/meta/main.yml
+++ b/test/integration/targets/include_role_nested/nested/nested/test_nested_dep_role/meta/main.yml
@@ -1,0 +1,2 @@
+---
+dependencies: []

--- a/test/integration/targets/include_role_nested/nested/nested/test_nested_dep_role/tasks/main.yml
+++ b/test/integration/targets/include_role_nested/nested/nested/test_nested_dep_role/tasks/main.yml
@@ -1,0 +1,2 @@
+---
+- include_tasks: ./runc.yml

--- a/test/integration/targets/include_role_nested/nested/nested/test_nested_dep_role/tasks/runc.yml
+++ b/test/integration/targets/include_role_nested/nested/nested/test_nested_dep_role/tasks/runc.yml
@@ -1,0 +1,4 @@
+---
+- debug:
+    msg: from test_nested_dep_role
+- include_role: {name: nested/nested/test_nested_dep_role2}

--- a/test/integration/targets/include_role_nested/nested/nested/test_nested_dep_role/vars/main.yml
+++ b/test/integration/targets/include_role_nested/nested/nested/test_nested_dep_role/vars/main.yml
@@ -1,0 +1,2 @@
+---
+testnesteddep_varvar1: muche

--- a/test/integration/targets/include_role_nested/nestedtasks/nested/nested.yml
+++ b/test/integration/targets/include_role_nested/nestedtasks/nested/nested.yml
@@ -1,0 +1,2 @@
+---
+- include_role: {name: test_nested_include_task}

--- a/test/integration/targets/include_role_nested/roles/test_nested_include_task/meta/main.yml
+++ b/test/integration/targets/include_role_nested/roles/test_nested_include_task/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+- role: nested/test_nested_dep_role

--- a/test/integration/targets/include_role_nested/roles/test_nested_include_task/tasks/main.yml
+++ b/test/integration/targets/include_role_nested/roles/test_nested_include_task/tasks/main.yml
@@ -1,0 +1,2 @@
+---
+- include_tasks: ./runa.yml

--- a/test/integration/targets/include_role_nested/roles/test_nested_include_task/tasks/runa.yml
+++ b/test/integration/targets/include_role_nested/roles/test_nested_include_task/tasks/runa.yml
@@ -1,0 +1,3 @@
+---
+- debug: 
+    msg: from test_nested_include_task

--- a/test/integration/targets/include_role_nested/runme.sh
+++ b/test/integration/targets/include_role_nested/runme.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+W=$(cd "$(dirname "$0")" && pwd)
+export ANSIBLE_ROLES_PATH="$W/nested:$W/roles"
+set -eux
+ansible-playbook -i../../inventory nested.yml -v

--- a/test/integration/targets/include_role_nested/tasks/nested/nested.yml
+++ b/test/integration/targets/include_role_nested/tasks/nested/nested.yml
@@ -1,0 +1,2 @@
+---
+- include_tasks: ../../nestedtasks/nested/nested.yml


### PR DESCRIPTION
I'm splitting the #32565 PR on multiple more isolated PR as it may be easier to accept/check in in core.


##### ISSUE TYPE
 - Bug Report
##### COMPONENT NAME
include_tasks

##### ANSIBLE VERSION
```
2.4
devel
```

##### CONFIGURATION
standard

##### OS / ENVIRONMENT
ubuntu lts

##### SUMMARY
See 4f97013cabc79cba669090b9a7d2a13bdbf34453

##### STEPS TO REPRODUCE
See 4f97013cabc79cba669090b9a7d2a13bdbf34453

##### EXPECTED RESULTS
included tasks find file
```

Running include_role_nested integration test script
Run command: ./runme.sh -v
+ ansible-playbook -i../../inventory nested.yml -v
Using /srv/corpusops/corpusops.bootstrap/venv/src/ansible/test/integration/integration.cfg as config file

PLAY [verify that multiple level of nested statements and  include+meta doesnt mess included files mecanisms] *****************************************************************************************************************************************************************

TASK [Gathering Facts] ********************************************************************************************************************************************************************************************************************************************************
ok: [testhost]

TASK [include_tasks] **********************************************************************************************************************************************************************************************************************************************************
included: /srv/corpusops/corpusops.bootstrap/venv/src/ansible/test/integration/targets/include_role_nested/tasks/nested/nested.yml for testhost

TASK [include_tasks] **********************************************************************************************************************************************************************************************************************************************************
included: /srv/corpusops/corpusops.bootstrap/venv/src/ansible/test/integration/targets/include_role_nested/./tasks/nested/../../nestedtasks/nested/nested.yml for testhost

TASK [include_role] ***********************************************************************************************************************************************************************************************************************************************************

TASK [nested/test_nested_dep_role : include_tasks] ****************************************************************************************************************************************************************************************************************************
included: /srv/corpusops/corpusops.bootstrap/venv/src/ansible/test/integration/targets/include_role_nested/nested/nested/test_nested_dep_role/tasks/./runc.yml for testhost

TASK [nested/test_nested_dep_role : debug] ************************************************************************************************************************************************************************************************************************************
ok: [testhost] => {
    "msg": "from test_nested_dep_role"
}

TASK [nested/test_nested_dep_role : include_role] *****************************************************************************************************************************************************************************************************************************

TASK [nested/nested/test_nested_dep_role2b : include_tasks] *******************************************************************************************************************************************************************************************************************
included: /srv/corpusops/corpusops.bootstrap/venv/src/ansible/test/integration/targets/include_role_nested/nested/nested/nested/test_nested_dep_role2b/tasks/./runf.yml for testhost

TASK [nested/nested/test_nested_dep_role2b : command] *************************************************************************************************************************************************************************************************************************
changed: [testhost] => {"changed": true, "cmd": "echo from deprole2b", "delta": "0:00:00.100271", "end": "2018-01-19 21:28:28.678150", "rc": 0, "start": "2018-01-19 21:28:28.577879", "stderr": "", "stderr_lines": [], "stdout": "from deprole2b", "stdout_lines": ["from deprole2b"]}

TASK [nested/nested/test_nested_dep_role2a : include_tasks] *******************************************************************************************************************************************************************************************************************
included: /srv/corpusops/corpusops.bootstrap/venv/src/ansible/test/integration/targets/include_role_nested/nested/nested/nested/test_nested_dep_role2a/tasks/./rune.yml for testhost

TASK [nested/nested/test_nested_dep_role2a : command] *************************************************************************************************************************************************************************************************************************
changed: [testhost] => {"changed": true, "cmd": "echo from deprole2", "delta": "0:00:00.098868", "end": "2018-01-19 21:28:28.972384", "rc": 0, "start": "2018-01-19 21:28:28.873516", "stderr": "", "stderr_lines": [], "stdout": "from deprole2", "stdout_lines": ["from deprole2"]}

TASK [nested/nested/test_nested_dep_role2 : include_tasks] ********************************************************************************************************************************************************************************************************************
included: /srv/corpusops/corpusops.bootstrap/venv/src/ansible/test/integration/targets/include_role_nested/nested/nested/nested/test_nested_dep_role2/tasks/./rund.yml for testhost

TASK [nested/nested/test_nested_dep_role2 : command] **************************************************************************************************************************************************************************************************************************
changed: [testhost] => {"changed": true, "cmd": "echo from deprole2a", "delta": "0:00:00.110779", "end": "2018-01-19 21:28:29.281009", "rc": 0, "start": "2018-01-19 21:28:29.170230", "stderr": "", "stderr_lines": [], "stdout": "from deprole2a", "stdout_lines": ["from deprole2a"]}

TASK [test_nested_include_task : include_tasks] *******************************************************************************************************************************************************************************************************************************
included: /srv/corpusops/corpusops.bootstrap/venv/src/ansible/test/integration/targets/include_role_nested/roles/test_nested_include_task/tasks/./runa.yml for testhost

TASK [test_nested_include_task : debug] ***************************************************************************************************************************************************************************************************************************************
ok: [testhost] => {
    "msg": "from test_nested_include_task"
}

PLAY RECAP ********************************************************************************************************************************************************************************************************************************************************************
testhost                   : ok=13   changed=3    unreachable=0    failed=0
```


##### ACTUAL RESULTS
included tasks doesnt find file
```
Running include_role_nested integration test script
Run command: ./runme.sh -v
+ ansible-playbook -i../../inventory nested.yml -v
Using /srv/corpusops/corpusops.bootstrap/venv/src/ansible/test/integration/integration.cfg as config file

PLAY [verify that multiple level of nested statements and  include+meta doesnt mess included files mecanisms] *****************************************************************************************************************************************************************

TASK [Gathering Facts] ********************************************************************************************************************************************************************************************************************************************************
ok: [testhost]

TASK [include_tasks] **********************************************************************************************************************************************************************************************************************************************************
included: /srv/corpusops/corpusops.bootstrap/venv/src/ansible/test/integration/targets/include_role_nested/tasks/nested/nested.yml for testhost

TASK [include_tasks] **********************************************************************************************************************************************************************************************************************************************************
included: /srv/corpusops/corpusops.bootstrap/venv/src/ansible/test/integration/targets/include_role_nested/./tasks/nested/../../nestedtasks/nested/nested.yml for testhost

TASK [include_role] ***********************************************************************************************************************************************************************************************************************************************************

TASK [nested/test_nested_dep_role : include_tasks] ****************************************************************************************************************************************************************************************************************************
fatal: [testhost]: FAILED! => {"reason": "Unable to retrieve file contents\nCould not find or access '/srv/corpusops/corpusops.bootstrap/venv/src/ansible/test/integration/targets/include_role_nested/runc.yml'"}
 [WARNING]: Failure using method (v2_runner_on_failed) in callback plugin (<ansible.plugins.callback.junit.CallbackModule object at 0x7f9e22175e10>):
/srv/corpusops/corpusops.bootstrap/venv/src/ansible/test/integration/targets/include_role_nested/nested/nested/test_nested_dep_role/tasks/main.yml:2: verify that multiple level of nested statements and  include+meta doesnt mess included files mecanisms:
nested/test_nested_dep_role : include_tasks _raw_params=./runc.yml: duplicate host callback: testhost

        to retry, use: --limit @/srv/corpusops/corpusops.bootstrap/venv/src/ansible/test/integration/targets/include_role_nested/nested.retry

PLAY RECAP ********************************************************************************************************************************************************************************************************************************************************************
testhost                   : ok=3    changed=0    unreachable=0    failed=1

NOTICE: To resume at this test target, use the option: --start-at include_role_nested
ERROR: Command "./runme.sh -v" returned exit status 2.
```