### PR TITLE
New module: ezjail - manage FreeBSD jails with ezjail

### DIFF
--- a/lib/ansible/modules/system/ezjail.py
+++ b/lib/ansible/modules/system/ezjail.py
@@ -309,7 +309,7 @@ def create(module):
         if not module.check_mode:
             if (is_started and state == 'restarted') or state == 'stopped':
                 start_or_stop(module, 'stopped')
-            if state == 'started':
+            if state == 'started' or state == 'restarted':
                 start_or_stop(module, 'started')
 
     # set enabled / runnable state
@@ -356,7 +356,7 @@ def main():
     module = AnsibleModule(**MODULE_SPECS)
     state = module.params['state']
     try:
-        if state in ['stopped', 'started']:
+        if state in ['stopped', 'started', 'restarted']:
             result = create(module)
         elif state == 'absent':
             result = delete(module)

--- a/lib/ansible/modules/system/ezjail.py
+++ b/lib/ansible/modules/system/ezjail.py
@@ -18,7 +18,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = '''
 ---
 module: ezjail
-version_added: "2.5"
+version_added: "2.6"
 author:
   - Hans-Christian Halfbrodt (@hc42)
 short_description: Manage jails with Ezjail
@@ -46,13 +46,16 @@ options:
       - C(absent) will delete the jail if
         present (Caution This will also wipe the jailroot. Consider
         stopping and disabling the jail if you want to keep the jailroot.)
-    required: true
+    required: false
+    default: present
+    choices: ['stopped', 'started', 'restarted', 'absent']
   enabled:
     description:
       - Sets the runnable state of the jail (Does not stop the jail if
         set to false. I(state)=C(started) I(enabled)=C(no) is
         considered a valid combination.)
     required: false
+    default: true
   ip_addr:
     description:
       - Ip address string to use for the jail. The string will not be
@@ -63,6 +66,7 @@ options:
         (according to the jail config file) the ip will be updated and the
         jail will be restarted if I(state)=C(started) or I(state)=C(restarted).
     required: false
+    default: null
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/system/ezjail.py
+++ b/lib/ansible/modules/system/ezjail.py
@@ -1,0 +1,386 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2018, Hans-Christian Halfbrodt <ansible-hc at halfbrodt.org>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# see also https://github.com/hc42/ansible-ezjail
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+
+DOCUMENTATION = '''
+---
+module: ezjail
+version_added: "2.4"
+author:
+  - Hans-Christian Halfbrodt (@hc42)
+short_description: Manage jails with Ezjail
+description:
+  - The purpose of this module is to manage jails with Ezjail. Ezjail must
+    be installed and configured to use this module. There is currently no
+    support for provisioning. You can create jails, delete jails, change
+    the ip config, start and stop jail and set if jails are runnable.
+notes:
+  - Developed for FreeBSD jails creation. You have to setup and install the
+    basejail yourself with your own playbook. This way you can decide if
+    e.g. you want to use zfs or ufs.
+options:
+  name:
+    description: The jails name (used as identifier)
+    required: true
+  state:
+    description:
+      - The state the jail should have
+      - C(started) creates jail if not present and starts it.
+        C(stopped) creates a jail if not present and stops the jail
+        if running. C(restarted) also creates the jail if not present
+        and starts or restarts it. C(absent) will delete the jail if
+        present (Caution This will also wipe the jailroot. Consider
+        stopping and disbaling the jail if you want to keep the jailroot.)
+    required: true
+  enabled:
+    description:
+      - Sets the runnable state of the jail (Does not stop the jail if
+        set to false. I(state)=C(started) I(enabled)=C(no) is
+        considered a valid combination.)
+    required: false
+  ip_addr:
+    description:
+      - Ip address string to use for the jail. The string will not be
+        validated. An invalid valid value will result in an unstartable
+        jail. This parameter is technically only required on jail creation.
+        Nevertheless is it a good idea always provide it except for
+        I(state)=C(absent). If the current ip address of the jail differs
+        (according to the jail config file) the ip will be updated and the
+        jail will be restarted if I(state)=C(started) or I(state)=C(restarted).
+    required: false
+'''
+
+EXAMPLES = '''
+- name: www is created
+  ezjail:
+    name: www
+    state: started
+    ip_addr: em0|192.168.56.2
+
+- name: database is created
+  ezjail:
+    name: database
+    state: started
+    ip_addr: lo1|172.0.0.1
+
+- name: old gets deleted if present
+  ezjail:
+    name: oldjail
+    state: absent
+
+- name: test is running now but wont be after reboot
+  ezjail:
+    name: test
+    state: started
+    enabled: False
+
+- name: otherjail is stopped and not runnable
+  ezjail:
+    name: otherjail
+    state: stopped
+    enabled: no
+
+- name: lastjail is restarted
+  ezjail:
+    name: otherjail
+    state: stopped
+    enabled: no
+'''
+
+RETURN = '''
+changed:
+    description: if the jail has been modified or state has changed
+    type: bool
+    returned: success
+msg:
+    description: The performed action or error message
+    type: str
+    returned: always
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+import re
+import fileinput
+
+MODULE_SPECS = dict(
+    argument_spec=dict(
+        name=dict(required=True, type='str'),
+        state=dict(default='present', choices=['stopped', 'started', 'restarted', 'absent'], type='str'),
+        ip_addr=dict(required=False, type='str'),
+        enabled=dict(default=True, required=False, type='bool'),
+    ),
+    supports_check_mode=True
+)
+
+
+class FailedException(Exception):
+    ''' raised if any action fails '''
+
+    def __init__(self, msg):
+        self.msg = msg
+
+
+def ezjail_admin(module, *params):
+    ''' execute ezjail-admin command '''
+
+    cmd = module.get_bin_path('ezjail-admin', required=True)
+    return module.run_command(' '.join([cmd] + list(params)))
+
+
+def get_current_ip_addr(module):
+    name = module.params['name']
+    alphanumname = ''.join([c if c.isalnum() else '_' for c in name])
+    filename = '/usr/local/etc/ezjail/' + alphanumname
+    ip_addr = None
+    try:
+        conf_file = open(filename, 'r')
+        for line in conf_file:
+            if re.search(
+                    '^export jail_' + alphanumname + '_ip=".*"$',
+                    line) is not None:
+                ip_addr = re.sub(
+                    '^export jail_' + alphanumname + '_ip="(.*)"$',
+                    '\\1', line).rstrip()
+                break
+        conf_file.close()
+    except IOError:
+        raise FailedException(
+            'Could not open jail config file %s of jail %s'
+            % (filename, name))
+    if ip_addr is None:
+        raise FailedException('ip_addr for jail %s not found in file %s' % (name, filename))
+    return ip_addr
+
+
+def set_ip_addr(module):
+    name = module.params['name']
+    ip_addr = module.params['ip_addr']
+    alphanumname = ''.join([c if c.isalnum() else '_' for c in name])
+    filename = '/usr/local/etc/ezjail/' + alphanumname
+    try:
+        for line in fileinput.input(filename, inplace=True):
+            if re.search(
+                    '^export jail_' + alphanumname + '_ip=".*"$',
+                    line) is not None:
+                old_ip_addr = re.sub(
+                    '^export jail_' + alphanumname +
+                    '_ip="(.*)"$', '\\1', line).rstrip()
+                line = line.replace(
+                    '"' + old_ip_addr + '"',
+                    '"' + ip_addr + '"')
+            print(line)
+    except IOError:
+        raise FailedException(
+            'Could not write ip_addr %s into config file %s of jail %s'
+            % (ip_addr, filename, name))
+
+
+def is_enabled(module):
+    ''' is the jail enabled / runnable '''
+
+    name = module.params['name']
+    result = dict()
+    rc, out, err = ezjail_admin(module, 'config', '-r', 'test', name)
+    if rc != 0:
+        raise FailedException(
+            'Failed to get jail %s status: %s %s'
+            % (name, out, err))
+    return re.search('is not runnable', out) is None
+
+
+def setEnabled(module, enabled):
+    ''' set the jail enabled / runnable or not '''
+
+    name = module.params['name']
+    if enabled:
+        action = 'run'
+    else:
+        action = 'norun'
+    rc, out, err = ezjail_admin(module, 'config', '-r', action, name)
+    if rc != 0:
+        raise FailedException(
+            'Failed to set enabled state for jail %s status: %s %s'
+            % (name, out, err))
+
+
+def exists(module):
+    ''' is the jailname known to ezjail '''
+
+    name = module.params['name']
+    rc, out, err = ezjail_admin(module, 'config', '-r', 'test', name)
+    return rc == 0
+
+
+def started(module):
+    ''' is the jail started '''
+
+    name = module.params['name']
+    rc, out, err = ezjail_admin(module, 'list')
+    if rc != 0:
+        raise FailedException('Failed to get jail status for %s' % (name))
+
+    lines = out.strip().split('\n')
+    if len(lines) > 2:
+        # skip table headlines
+        # expexted table format:
+        expect_head = ['STA', 'JID', 'IP', 'Hostname', 'Root', 'Directory']
+        table_head = lines.pop(0).split()
+        if expect_head != table_head:
+            raise FailedException(
+                'Could not read jail list got %s expected %s'
+                % (' '.join(table_head), ' '.join(expect_head)))
+        del lines[0]
+        for line in lines:
+            values = line.split()
+            # test if name equals hostname
+            # and second letter of status is R for running
+            if len(values) >= 4 and values[3] == name:
+                return len(values[0]) > 1 and values[0][1] == 'R'
+    raise FailedException('Jail %s not found in ezjail-admin list' % (name))
+
+
+def start_or_stop(module, state):
+    ''' starts or stops the jail '''
+
+    name = module.params['name']
+    should_be_enabled = True
+
+    # enable to change run state
+    if not is_enabled(module):
+        should_be_enabled = False
+        setEnabled(module, True)
+
+    # change run state
+    if state == 'started':
+        action = 'start'
+    else:
+        action = 'stop'
+    rc, out, err = ezjail_admin(module, action, name)
+    if rc != 0:
+        raise FailedException(
+            'Could not %s jail %s: %s %s'
+            % (action, name, out, err))
+
+    # reset enabled state
+    if not should_be_enabled:
+        setEnabled(module, False)
+
+
+def create(module):
+    ''' creates the jail if required and starts/stops '''
+
+    name = module.params['name']
+    state = module.params['state']
+    enabled = module.params['enabled']
+
+    change_msgs = []
+    new_jail = not exists(module)
+
+    # create if not exists
+    if new_jail:
+        change_msgs.append('created')
+        if not module.check_mode:
+            if 'ip_addr' not in module.params or module.params['ip_addr'] is None:
+                raise FailedException('Missing required parameter ip_addr')
+            ip_addr = module.params['ip_addr']
+            rc, out, err = ezjail_admin(module, 'create', name, ip_addr)
+            if rc != 0:
+                raise FailedException(
+                    'Failed to create jail %s: %s %s'
+                    % (name, out, err))
+
+    is_started = started(module)
+
+    # update ip
+    if not new_jail and 'ip_addr' in module.params and module.params['ip_addr'] is not None:
+        ip_addr = module.params['ip_addr']
+        if ip_addr != get_current_ip_addr(module):
+            change_msgs.append('ip_addr updated')
+            if not module.check_mode:
+                set_ip_addr(module)
+                if state == 'started' and is_started:
+                    start_or_stop(module, 'stopped')
+                    start_or_stop(module, 'started')
+
+    # start or stop
+    sould_be_started = state == 'started'
+    if is_started != sould_be_started or state == 'restarted':
+        change_msgs.append(state)
+        if not module.check_mode:
+            if (is_started and state == 'restarted') or state == 'stopped':
+                start_or_stop(module, 'stopped')
+            if state == 'started':
+                start_or_stop(module, 'started')
+
+    # set enabled / runnable state
+    if enabled != is_enabled(module):
+        if enabled:
+            change_msgs.append('enabled')
+        else:
+            change_msgs.append('disabled')
+        if not module.check_mode:
+            setEnabled(module, enabled)
+
+    if module.check_mode:
+        msg = 'Jail %s would have been' % (name)
+        changed = False
+    else:
+        msg = 'Jail %s' % (name)
+        changed = True
+    msg = msg + ' ' + ' and '.join(change_msgs)
+
+    if len(change_msgs) == 0:
+        msg = 'Jail %s not changed' % (name)
+        changed = False
+
+    return dict(changed=changed, msg=msg)
+
+
+def delete(module):
+    ''' deletes the jail and wipes the jailroot '''
+
+    name = module.params['name']
+    if not exists(module):
+        return dict(changed=False, msg='Jail %s does not exist' % (name))
+    if module.check_mode:
+        return dict(changed=True, msg='Jail %s would habe been deleted' % (name))
+
+    rc, out, err = ezjail_admin(module, 'delete', '-f', '-w', name)
+    if rc != 0:
+        raise FailedException(
+            'Failed to delete jail %s: %s %s'
+            % (name, out, err))
+
+    return dict(changed=True, msg='Jail %s deleted' % (name))
+
+
+def main():
+    ''' execute module '''
+
+    module = AnsibleModule(**MODULE_SPECS)
+    state = module.params['state']
+    try:
+        if state in ['stopped', 'started']:
+            result = create(module)
+        elif state == 'absent':
+            result = delete(module)
+        module.exit_json(**result)
+    except FailedException as e:
+        module.fail_json(msg=e.msg)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/system/ezjail.py
+++ b/lib/ansible/modules/system/ezjail.py
@@ -56,6 +56,7 @@ options:
         considered a valid combination.)
     required: false
     default: true
+    type: bool
   ip_addr:
     description:
       - Ip address string to use for the jail. The string will not be

--- a/lib/ansible/modules/system/ezjail.py
+++ b/lib/ansible/modules/system/ezjail.py
@@ -18,7 +18,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = '''
 ---
 module: ezjail
-version_added: "2.4"
+version_added: "2.5"
 author:
   - Hans-Christian Halfbrodt (@hc42)
 short_description: Manage jails with Ezjail

--- a/test/integration/targets/ezjail/aliases
+++ b/test/integration/targets/ezjail/aliases
@@ -1,0 +1,6 @@
+destructive
+skip/osx
+skip/rhel
+skip/linux
+skip/windows
+freebsd

--- a/test/integration/targets/ezjail/aliases
+++ b/test/integration/targets/ezjail/aliases
@@ -1,2 +1,3 @@
+posix/ci/group3
 needs/root
 destructive

--- a/test/integration/targets/ezjail/aliases
+++ b/test/integration/targets/ezjail/aliases
@@ -1,6 +1,2 @@
+needs/root
 destructive
-skip/osx
-skip/rhel
-skip/linux
-skip/windows
-freebsd

--- a/test/integration/targets/ezjail/tasks/main.yml
+++ b/test/integration/targets/ezjail/tasks/main.yml
@@ -1,0 +1,13 @@
+- debug:
+    msg: '{{ role_name }}'
+- debug:
+    msg: '{{ role_path|basename }}'
+
+- name: only freebsd supported
+  when: ansible_os_family == "FreeBSD"
+  block:
+    - include_tasks: setup.yml
+    - include_tasks: test_jail1.yml
+    - include_tasks: test_jail2.yml
+    - include_tasks: test_jail3.yml
+    - include_tasks: test_jail4.yml

--- a/test/integration/targets/ezjail/tasks/main.yml
+++ b/test/integration/targets/ezjail/tasks/main.yml
@@ -4,7 +4,7 @@
     msg: '{{ role_path|basename }}'
 
 - name: only freebsd supported
-  when: ansible_system == "FreeBSD"
+  when: ansible_os_family == "FreeBSD"
   block:
     - include_tasks: setup.yml
     - include_tasks: test_jail1.yml

--- a/test/integration/targets/ezjail/tasks/main.yml
+++ b/test/integration/targets/ezjail/tasks/main.yml
@@ -4,7 +4,7 @@
     msg: '{{ role_path|basename }}'
 
 - name: only freebsd supported
-  when: ansible_os_family == "FreeBSD"
+  when: ansible_system == "FreeBSD"
   block:
     - include_tasks: setup.yml
     - include_tasks: test_jail1.yml

--- a/test/integration/targets/ezjail/tasks/setup.yml
+++ b/test/integration/targets/ezjail/tasks/setup.yml
@@ -1,0 +1,8 @@
+- name: install ezjail
+  pkgng: name=ezjail state=present
+
+- name: start ezjail
+  service: name=ezjail state=started enabled=yes
+
+- name: install basejail
+  raw: ls /usr/jails/basejail || ezjail-admin install

--- a/test/integration/targets/ezjail/tasks/setup.yml
+++ b/test/integration/targets/ezjail/tasks/setup.yml
@@ -1,3 +1,5 @@
+---
+
 - name: install ezjail
   pkgng: name=ezjail state=present
 

--- a/test/integration/targets/ezjail/tasks/test_jail1.yml
+++ b/test/integration/targets/ezjail/tasks/test_jail1.yml
@@ -2,12 +2,16 @@
   ezjail: name=test1 state=started ip_addr=lo0|127.0.0.1
   register: result
 
+- name: test1 check jail count
+  raw: ezjail-admin list|wc -l|tr -d ' '
+  register: jailcount
+
 - name: test1 check jail state
-  raw: ezjail-admin list
+  raw: ezjail-admin list|grep 'DR[ ]*[0-9]*[ ]*127.0.0.1[ ]*test1[ ]*/usr/jails/test1'
   register: state
 
 - name: test2 check jailroot deleted
-  raw: ls /usr/jails
+  raw: ls /usr/jails|grep 'test1'
   register: jailroot
 
 - name: test1 assert return values
@@ -15,26 +19,34 @@
     that:
       - "result.changed"
       - "'Jail test1 created and started' == result.msg"
-      - "state.stdout_lines|length == 3"
-      - "state.stdout_lines[2]|search('DR[ ]*[0-9]*[ ]*127.0.0.1[ ]*test1[ ]*/usr/jails/test1')"
-      - "jailroot.stdout|search('basejail[\\t]*flavours[\\t]*newjail[\\t]*test1\\r\\n')"
+      - "jailcount.stdout_lines[0] == '3'"
+      - "state.stdout != ''"
+      - "jailroot.stdout != ''"
 
 - name: test2 delete jail
   ezjail: name=test1 state=absent
   register: result
 
+- name: test2 check jail count
+  raw: ezjail-admin list|wc -l|tr -d ' '
+  register: jailcount
+  ignore_errors: yes
+
 - name: test2 check jail state
-  raw: ezjail-admin list
+  raw: ezjail-admin list|grep 'test1'
   register: state
+  ignore_errors: yes
 
 - name: test2 check jailroot deleted
-  raw: ls /usr/jails
+  raw: ls /usr/jails|grep 'test1'
   register: jailroot
+  ignore_errors: yes
 
 - name: test2 assert
   assert:
     that:
       - "result.changed"
       - "'Jail test1 deleted' == result.msg"
-      - "state.stdout_lines|length == 2"
-      - "jailroot.stdout|search('basejail[\\t]*flavours[\\t]*newjail\\r\\n')"
+      - "jailcount.stdout_lines[0] == '2'"
+      - "state.stdout == ''"
+      - "jailroot.stdout == ''"

--- a/test/integration/targets/ezjail/tasks/test_jail1.yml
+++ b/test/integration/targets/ezjail/tasks/test_jail1.yml
@@ -1,0 +1,40 @@
+- name: test1 create jail
+  ezjail: name=test1 state=started ip_addr=lo0|127.0.0.1
+  register: result
+
+- name: test1 check jail state
+  raw: ezjail-admin list
+  register: state
+
+- name: test2 check jailroot deleted
+  raw: ls /usr/jails
+  register: jailroot
+
+- name: test1 assert return values
+  assert:
+    that:
+      - "result.changed"
+      - "'Jail test1 created and started' == result.msg"
+      - "state.stdout_lines|length == 3"
+      - "state.stdout_lines[2]|search('DR[ ]*[0-9]*[ ]*127.0.0.1[ ]*test1[ ]*/usr/jails/test1')"
+      - "jailroot.stdout|search('basejail[\\t]*flavours[\\t]*newjail[\\t]*test1\\r\\n')"
+
+- name: test2 delete jail
+  ezjail: name=test1 state=absent
+  register: result
+
+- name: test2 check jail state
+  raw: ezjail-admin list
+  register: state
+
+- name: test2 check jailroot deleted
+  raw: ls /usr/jails
+  register: jailroot
+
+- name: test2 assert
+  assert:
+    that:
+      - "result.changed"
+      - "'Jail test1 deleted' == result.msg"
+      - "state.stdout_lines|length == 2"
+      - "jailroot.stdout|search('basejail[\\t]*flavours[\\t]*newjail\\r\\n')"

--- a/test/integration/targets/ezjail/tasks/test_jail1.yml
+++ b/test/integration/targets/ezjail/tasks/test_jail1.yml
@@ -1,3 +1,5 @@
+---
+
 - name: test1 create jail
   ezjail: name=test1 state=started ip_addr=lo0|127.0.0.1
   register: result

--- a/test/integration/targets/ezjail/tasks/test_jail2.yml
+++ b/test/integration/targets/ezjail/tasks/test_jail2.yml
@@ -1,13 +1,17 @@
-- name: test3 start jail 2
+- name: test3 start jail2
   ezjail: name=test2 state=stopped ip_addr=lo0|127.0.0.1
   register: result
 
+- name: test1 check jail count
+  raw: ezjail-admin list|wc -l|tr -d ' '
+  register: jailcount
+
 - name: test3 check jail state
-  raw: ezjail-admin list
+  raw: ezjail-admin list|grep 'DS[ ]*N\/A[ ]*127.0.0.1[ ]*test2[ ]*/usr/jails/test2'
   register: state
 
 - name: test3 check jailroot deleted
-  raw: ls /usr/jails
+  raw: ls /usr/jails|grep 'test2'
   register: jailroot
 
 - name: test3 assert
@@ -15,20 +19,24 @@
     that:
       - "result.changed"
       - "'Jail test2 created' == result.msg"
-      - "state.stdout_lines|length == 3"
-      - "state.stdout_lines[2]|search('D[ ]*[0-9]*[ ]*lo1|127.0.0.1[ ]*test2[ ]*/usr/jails/test2')"
-      - "jailroot.stdout|search('basejail[\\t]*flavours[\\t]*newjail[\\t]*test2\\r\\n')"
+      - "jailcount.stdout_lines[0] == '3'"
+      - "state.stdout != ''"
+      - "jailroot.stdout != ''"
 
-- name: test4 stop jail 2
+- name: test4 stop jail
   ezjail: name=test2 state=stopped
   register: result
 
+- name: test1 check jail count
+  raw: ezjail-admin list|wc -l|tr -d ' '
+  register: jailcount
+
 - name: test4 check jail state
-  raw: ezjail-admin list
+  raw: ezjail-admin list|grep 'DS[ ]*N\/A[ ]*127.0.0.1[ ]*test2[ ]*/usr/jails/test2'
   register: state
 
 - name: test4 check jailroot deleted
-  raw: ls /usr/jails
+  raw: ls /usr/jails|grep 'test2'
   register: jailroot
 
 - name: test4 assert
@@ -36,20 +44,24 @@
     that:
       - "not result.changed"
       - "'Jail test2 not changed' == result.msg"
-      - "state.stdout_lines|length == 3"
-      - "state.stdout_lines[2]|search('D[ ]*[0-9]*[ ]*lo1|127.0.0.1[ ]*test2[ ]*/usr/jails/test2')"
-      - "jailroot.stdout|search('basejail[\\t]*flavours[\\t]*newjail[\\t]*test2\\r\\n')"
+      - "jailcount.stdout_lines[0] == '3'"
+      - "state.stdout != ''"
+      - "jailroot.stdout != ''"
 
 - name: test5 start jail
   ezjail: name=test2 state=started
   register: result
 
+- name: test5 check jail count
+  raw: ezjail-admin list|wc -l|tr -d ' '
+  register: jailcount
+
 - name: test5 check jail state
-  raw: ezjail-admin list
+  raw: ezjail-admin list|grep 'DR[ ]*[0-9]*[ ]*127.0.0.1[ ]*test2[ ]*/usr/jails/test2'
   register: state
 
 - name: test5 check jailroot deleted
-  raw: ls /usr/jails
+  raw: ls /usr/jails|grep 'test2'
   register: jailroot
 
 - name: test5 assert
@@ -57,20 +69,24 @@
     that:
       - "result.changed"
       - "'Jail test2 started' == result.msg"
-      - "state.stdout_lines|length == 3"
-      - "state.stdout_lines[2]|search('DR[ ]*[0-9]*[ ]*lo1|127.0.0.1[ ]*test2[ ]*/usr/jails/test2')"
-      - "jailroot.stdout|search('basejail[\\t]*flavours[\\t]*newjail[\\t]*test2\\r\\n')"
+      - "jailcount.stdout_lines[0] == '3'"
+      - "state.stdout != ''"
+      - "jailroot.stdout != ''"
 
 - name: test6 start jail
   ezjail: name=test2 state=started ip_addr=lo0|127.0.0.2
   register: result
 
+- name: test6 check jail count
+  raw: ezjail-admin list|wc -l|tr -d ' '
+  register: jailcount
+
 - name: test6 check jail state
-  raw: ezjail-admin list
+  raw: ezjail-admin list|grep 'DR[ ]*[0-9]*[ ]*127.0.0.2[ ]*test2[ ]*/usr/jails/test2'
   register: state
 
 - name: test6 check jailroot deleted
-  raw: ls /usr/jails
+  raw: ls /usr/jails|grep 'test2'
   register: jailroot
 
 - name: test6 assert
@@ -78,20 +94,24 @@
     that:
       - "result.changed"
       - "'Jail test2 ip_addr updated' == result.msg"
-      - "state.stdout_lines|length == 3"
-      - "state.stdout_lines[2]|search('DR[ ]*[0-9]*[ ]*lo0|127.0.0.2[ ]*test2[ ]*/usr/jails/test2')"
-      - "jailroot.stdout|search('basejail[\\t]*flavours[\\t]*newjail[\\t]*test2\\r\\n')"
+      - "jailcount.stdout_lines[0] == '3'"
+      - "state.stdout != ''"
+      - "jailroot.stdout != ''"
 
 - name: test7 start jail 2
   ezjail: name=test2 state=started
   register: result
 
+- name: test7 check jail count
+  raw: ezjail-admin list|wc -l|tr -d ' '
+  register: jailcount
+
 - name: test7 check jail state
-  raw: ezjail-admin list
+  raw: ezjail-admin list|grep 'DR[ ]*[0-9]*[ ]*127.0.0.2[ ]*test2[ ]*/usr/jails/test2'
   register: state
 
 - name: test7 check jailroot deleted
-  raw: ls /usr/jails
+  raw: ls /usr/jails|grep 'test2'
   register: jailroot
 
 - name: test7 assert
@@ -99,20 +119,24 @@
     that:
       - "not result.changed"
       - "'Jail test2 not changed' == result.msg"
-      - "state.stdout_lines|length == 3"
-      - "state.stdout_lines[2]|search('DR[ ]*[0-9]*[ ]*lo0|127.0.0.2[ ]*test2[ ]*/usr/jails/test2')"
-      - "jailroot.stdout|search('basejail[\\t]*flavours[\\t]*newjail[\\t]*test2\\r\\n')"
+      - "jailcount.stdout_lines[0] == '3'"
+      - "state.stdout != ''"
+      - "jailroot.stdout != ''"
 
 - name: test8 start jail 2
   ezjail: name=test2 state=started enabled=no
   register: result
 
+- name: test8 check jail count
+  raw: ezjail-admin list|wc -l|tr -d ' '
+  register: jailcount
+
 - name: test8 check jail state
-  raw: ezjail-admin list
+  raw: ezjail-admin list|grep 'DRN[ ]*[0-9]*[ ]*127.0.0.2[ ]*test2[ ]*/usr/jails/test2'
   register: state
 
 - name: test8 check jailroot deleted
-  raw: ls /usr/jails
+  raw: ls /usr/jails|grep 'test2'
   register: jailroot
 
 - name: test8 assert
@@ -120,20 +144,24 @@
     that:
       - "result.changed"
       - "'Jail test2 disabled' == result.msg"
-      - "state.stdout_lines|length == 3"
-      - "state.stdout_lines[2]|search('DRN[ ]*[0-9]*[ ]*lo0|127.0.0.2[ ]*test2[ ]*/usr/jails/test2')"
-      - "jailroot.stdout|search('basejail[\\t]*flavours[\\t]*newjail[\\t]*test2\\r\\n')"
+      - "jailcount.stdout_lines[0] == '3'"
+      - "state.stdout != ''"
+      - "jailroot.stdout != ''"
 
 - name: test9 start jail 2
   ezjail: name=test2 state=stopped enabled=no
   register: result
 
+- name: test9 check jail count
+  raw: ezjail-admin list|wc -l|tr -d ' '
+  register: jailcount
+
 - name: test9 check jail state
-  raw: ezjail-admin list
+  raw: ezjail-admin list|grep 'DSN[ ]*N\/A[ ]*127.0.0.2[ ]*test2[ ]*/usr/jails/test2'
   register: state
 
 - name: test9 check jailroot deleted
-  raw: ls /usr/jails
+  raw: ls /usr/jails|grep 'test2'
   register: jailroot
 
 - name: test9 assert
@@ -141,26 +169,33 @@
     that:
       - "result.changed"
       - "'Jail test2 stopped' == result.msg"
-      - "state.stdout_lines|length == 3"
-      - "state.stdout_lines[2]|search('DN[ ]*[0-9]*[ ]*lo0|127.0.0.2[ ]*test2[ ]*/usr/jails/test2')"
-      - "jailroot.stdout|search('basejail[\\t]*flavours[\\t]*newjail[\\t]*test2\\r\\n')"
+      - "jailcount.stdout_lines[0] == '3'"
+      - "state.stdout != ''"
+      - "jailroot.stdout != ''"
 
 - name: test10 delete jail 2
   ezjail: name=test2 state=absent
   register: result
 
+- name: test10 check jail count
+  raw: ezjail-admin list|wc -l|tr -d ' '
+  register: jailcount
+
 - name: test10 check jail state
-  raw: ezjail-admin list
+  raw: ezjail-admin list|grep 'DRN[ ]*[0-9]*[ ]*127.0.0.2[ ]*test2[ ]*/usr/jails/test2'
   register: state
+  ignore_errors: true
 
 - name: test10 check jailroot deleted
-  raw: ls /usr/jails
+  raw: ls /usr/jails|grep 'test2'
   register: jailroot
+  ignore_errors: true
 
 - name: test10 assert
   assert:
     that:
       - "result.changed"
       - "'Jail test2 deleted' == result.msg"
-      - "state.stdout_lines|length == 2"
-      - "jailroot.stdout|search('basejail[\\t]*flavours[\\t]*newjail\\r\\n')"
+      - "jailcount.stdout_lines[0] == '2'"
+      - "state.stdout == ''"
+      - "jailroot.stdout == ''"

--- a/test/integration/targets/ezjail/tasks/test_jail2.yml
+++ b/test/integration/targets/ezjail/tasks/test_jail2.yml
@@ -1,3 +1,5 @@
+---
+
 - name: test3 start jail2
   ezjail: name=test2 state=stopped ip_addr=lo0|127.0.0.1
   register: result

--- a/test/integration/targets/ezjail/tasks/test_jail2.yml
+++ b/test/integration/targets/ezjail/tasks/test_jail2.yml
@@ -1,0 +1,166 @@
+- name: test3 start jail 2
+  ezjail: name=test2 state=stopped ip_addr=lo0|127.0.0.1
+  register: result
+
+- name: test3 check jail state
+  raw: ezjail-admin list
+  register: state
+
+- name: test3 check jailroot deleted
+  raw: ls /usr/jails
+  register: jailroot
+
+- name: test3 assert
+  assert:
+    that:
+      - "result.changed"
+      - "'Jail test2 created' == result.msg"
+      - "state.stdout_lines|length == 3"
+      - "state.stdout_lines[2]|search('D[ ]*[0-9]*[ ]*lo1|127.0.0.1[ ]*test2[ ]*/usr/jails/test2')"
+      - "jailroot.stdout|search('basejail[\\t]*flavours[\\t]*newjail[\\t]*test2\\r\\n')"
+
+- name: test4 stop jail 2
+  ezjail: name=test2 state=stopped
+  register: result
+
+- name: test4 check jail state
+  raw: ezjail-admin list
+  register: state
+
+- name: test4 check jailroot deleted
+  raw: ls /usr/jails
+  register: jailroot
+
+- name: test4 assert
+  assert:
+    that:
+      - "not result.changed"
+      - "'Jail test2 not changed' == result.msg"
+      - "state.stdout_lines|length == 3"
+      - "state.stdout_lines[2]|search('D[ ]*[0-9]*[ ]*lo1|127.0.0.1[ ]*test2[ ]*/usr/jails/test2')"
+      - "jailroot.stdout|search('basejail[\\t]*flavours[\\t]*newjail[\\t]*test2\\r\\n')"
+
+- name: test5 start jail
+  ezjail: name=test2 state=started
+  register: result
+
+- name: test5 check jail state
+  raw: ezjail-admin list
+  register: state
+
+- name: test5 check jailroot deleted
+  raw: ls /usr/jails
+  register: jailroot
+
+- name: test5 assert
+  assert:
+    that:
+      - "result.changed"
+      - "'Jail test2 started' == result.msg"
+      - "state.stdout_lines|length == 3"
+      - "state.stdout_lines[2]|search('DR[ ]*[0-9]*[ ]*lo1|127.0.0.1[ ]*test2[ ]*/usr/jails/test2')"
+      - "jailroot.stdout|search('basejail[\\t]*flavours[\\t]*newjail[\\t]*test2\\r\\n')"
+
+- name: test6 start jail
+  ezjail: name=test2 state=started ip_addr=lo0|127.0.0.2
+  register: result
+
+- name: test6 check jail state
+  raw: ezjail-admin list
+  register: state
+
+- name: test6 check jailroot deleted
+  raw: ls /usr/jails
+  register: jailroot
+
+- name: test6 assert
+  assert:
+    that:
+      - "result.changed"
+      - "'Jail test2 ip_addr updated' == result.msg"
+      - "state.stdout_lines|length == 3"
+      - "state.stdout_lines[2]|search('DR[ ]*[0-9]*[ ]*lo0|127.0.0.2[ ]*test2[ ]*/usr/jails/test2')"
+      - "jailroot.stdout|search('basejail[\\t]*flavours[\\t]*newjail[\\t]*test2\\r\\n')"
+
+- name: test7 start jail 2
+  ezjail: name=test2 state=started
+  register: result
+
+- name: test7 check jail state
+  raw: ezjail-admin list
+  register: state
+
+- name: test7 check jailroot deleted
+  raw: ls /usr/jails
+  register: jailroot
+
+- name: test7 assert
+  assert:
+    that:
+      - "not result.changed"
+      - "'Jail test2 not changed' == result.msg"
+      - "state.stdout_lines|length == 3"
+      - "state.stdout_lines[2]|search('DR[ ]*[0-9]*[ ]*lo0|127.0.0.2[ ]*test2[ ]*/usr/jails/test2')"
+      - "jailroot.stdout|search('basejail[\\t]*flavours[\\t]*newjail[\\t]*test2\\r\\n')"
+
+- name: test8 start jail 2
+  ezjail: name=test2 state=started enabled=no
+  register: result
+
+- name: test8 check jail state
+  raw: ezjail-admin list
+  register: state
+
+- name: test8 check jailroot deleted
+  raw: ls /usr/jails
+  register: jailroot
+
+- name: test8 assert
+  assert:
+    that:
+      - "result.changed"
+      - "'Jail test2 disabled' == result.msg"
+      - "state.stdout_lines|length == 3"
+      - "state.stdout_lines[2]|search('DRN[ ]*[0-9]*[ ]*lo0|127.0.0.2[ ]*test2[ ]*/usr/jails/test2')"
+      - "jailroot.stdout|search('basejail[\\t]*flavours[\\t]*newjail[\\t]*test2\\r\\n')"
+
+- name: test9 start jail 2
+  ezjail: name=test2 state=stopped enabled=no
+  register: result
+
+- name: test9 check jail state
+  raw: ezjail-admin list
+  register: state
+
+- name: test9 check jailroot deleted
+  raw: ls /usr/jails
+  register: jailroot
+
+- name: test9 assert
+  assert:
+    that:
+      - "result.changed"
+      - "'Jail test2 stopped' == result.msg"
+      - "state.stdout_lines|length == 3"
+      - "state.stdout_lines[2]|search('DN[ ]*[0-9]*[ ]*lo0|127.0.0.2[ ]*test2[ ]*/usr/jails/test2')"
+      - "jailroot.stdout|search('basejail[\\t]*flavours[\\t]*newjail[\\t]*test2\\r\\n')"
+
+- name: test10 delete jail 2
+  ezjail: name=test2 state=absent
+  register: result
+
+- name: test10 check jail state
+  raw: ezjail-admin list
+  register: state
+
+- name: test10 check jailroot deleted
+  raw: ls /usr/jails
+  register: jailroot
+
+- name: test10 assert
+  assert:
+    that:
+      - "result.changed"
+      - "'Jail test2 deleted' == result.msg"
+      - "state.stdout_lines|length == 2"
+      - "jailroot.stdout|search('basejail[\\t]*flavours[\\t]*newjail\\r\\n')"

--- a/test/integration/targets/ezjail/tasks/test_jail3.yml
+++ b/test/integration/targets/ezjail/tasks/test_jail3.yml
@@ -1,0 +1,61 @@
+- name: test11 create jail 3
+  ezjail: name=some-+crazy_.name state=started ip_addr=127.0.0.1
+  register: result
+
+- name: test11 check jail state
+  raw: ezjail-admin list
+  register: state
+
+- name: test11 check jailroot deleted
+  raw: ls /usr/jails
+  register: jailroot
+
+- name: test11 assert
+  assert:
+    that:
+      - "result.changed"
+      - "'Jail some-+crazy_.name created and started' == result.msg"
+      - "state.stdout_lines|length == 3"
+      - "state.stdout_lines[2]|search('DR[ ]*[0-9]*[ ]*127.0.0.1[ ]*some-\\+crazy_\\.name[ ]*/usr/jails/some-\\+crazy_\\.name')"
+      - "jailroot.stdout|search('basejail[\\t|\\r\\n]*newjail[\\t|\\r\\n]*flavours[\\t|\\r\\n]*some-\\+crazy_\\.name\\r\\n')"
+
+- name: test12 update jail 3
+  ezjail: name=some-+crazy_.name state=started ip_addr=127.0.0.2
+  register: result
+
+- name: test12 check jail state
+  raw: ezjail-admin list
+  register: state
+
+- name: test12 check jailroot deleted
+  raw: ls /usr/jails
+  register: jailroot
+
+- name: test12 assert
+  assert:
+    that:
+      - "result.changed"
+      - "'Jail some-+crazy_.name ip_addr updated' == result.msg"
+      - "state.stdout_lines|length == 3"
+      - "state.stdout_lines[2]|search('DR[ ]*[0-9]*[ ]*127.0.0.2[ ]*some-\\+crazy_\\.name[ ]*/usr/jails/some-\\+crazy_\\.name')"
+      - "jailroot.stdout|search('basejail[\\t|\\r\\n]*newjail[\\t|\\r\\n]*flavours[\\t|\\r\\n]*some-\\+crazy_\\.name\\r\\n')"
+
+- name: test13 delete jail 3
+  ezjail: name=some-+crazy_.name state=absent
+  register: result
+
+- name: test13 check jail state
+  raw: ezjail-admin list
+  register: state
+
+- name: test13 check jailroot
+  raw: ls /usr/jails
+  register: jailroot
+
+- name: test13 assert
+  assert:
+    that:
+      - "result.changed"
+      - "'Jail some-+crazy_.name deleted' == result.msg"
+      - "state.stdout_lines|length == 2"
+      - "jailroot.stdout|search('basejail[\\t]*flavours[\\t]*newjail\\r\\n')"

--- a/test/integration/targets/ezjail/tasks/test_jail3.yml
+++ b/test/integration/targets/ezjail/tasks/test_jail3.yml
@@ -2,12 +2,16 @@
   ezjail: name=some-+crazy_.name state=started ip_addr=127.0.0.1
   register: result
 
+- name: test11 check jail count
+  raw: ezjail-admin list|wc -l|tr -d ' '
+  register: jailcount
+
 - name: test11 check jail state
-  raw: ezjail-admin list
+  raw: ezjail-admin list|grep 'DR[ ]*[0-9]*[ ]*127.0.0.1[ ]*some-+crazy_.name[ ]*/usr/jails/some-+crazy_.name'
   register: state
 
 - name: test11 check jailroot deleted
-  raw: ls /usr/jails
+  raw: ls /usr/jails|grep 'some-+crazy_.name'
   register: jailroot
 
 - name: test11 assert
@@ -15,20 +19,24 @@
     that:
       - "result.changed"
       - "'Jail some-+crazy_.name created and started' == result.msg"
-      - "state.stdout_lines|length == 3"
-      - "state.stdout_lines[2]|search('DR[ ]*[0-9]*[ ]*127.0.0.1[ ]*some-\\+crazy_\\.name[ ]*/usr/jails/some-\\+crazy_\\.name')"
-      - "jailroot.stdout|search('basejail[\\t|\\r\\n]*newjail[\\t|\\r\\n]*flavours[\\t|\\r\\n]*some-\\+crazy_\\.name\\r\\n')"
+      - "jailcount.stdout_lines[0] == '3'"
+      - "state.stdout != ''"
+      - "jailroot.stdout != ''"
 
 - name: test12 update jail 3
   ezjail: name=some-+crazy_.name state=started ip_addr=127.0.0.2
   register: result
 
+- name: test12 check jail count
+  raw: ezjail-admin list|wc -l|tr -d ' '
+  register: jailcount
+
 - name: test12 check jail state
-  raw: ezjail-admin list
+  raw: ezjail-admin list|grep 'DR[ ]*[0-9]*[ ]*127.0.0.2[ ]*some-+crazy_.name[ ]*/usr/jails/some-+crazy_.name'
   register: state
 
 - name: test12 check jailroot deleted
-  raw: ls /usr/jails
+  raw: ls /usr/jails|grep 'some-+crazy_.name'
   register: jailroot
 
 - name: test12 assert
@@ -36,26 +44,33 @@
     that:
       - "result.changed"
       - "'Jail some-+crazy_.name ip_addr updated' == result.msg"
-      - "state.stdout_lines|length == 3"
-      - "state.stdout_lines[2]|search('DR[ ]*[0-9]*[ ]*127.0.0.2[ ]*some-\\+crazy_\\.name[ ]*/usr/jails/some-\\+crazy_\\.name')"
-      - "jailroot.stdout|search('basejail[\\t|\\r\\n]*newjail[\\t|\\r\\n]*flavours[\\t|\\r\\n]*some-\\+crazy_\\.name\\r\\n')"
+      - "jailcount.stdout_lines[0] == '3'"
+      - "state.stdout != ''"
+      - "jailroot.stdout != ''"
 
 - name: test13 delete jail 3
   ezjail: name=some-+crazy_.name state=absent
   register: result
 
-- name: test13 check jail state
-  raw: ezjail-admin list
-  register: state
+- name: test13 check jail count
+  raw: ezjail-admin list|wc -l|tr -d ' '
+  register: jailcount
 
-- name: test13 check jailroot
-  raw: ls /usr/jails
+- name: test13 check jail state
+  raw: ezjail-admin list|grep 'DR[ ]*[0-9]*[ ]*127.0.0.2[ ]*some-+crazy_.name[ ]*/usr/jails/some-+crazy_.name'
+  register: state
+  ignore_errors: yes
+
+- name: test13 check jailroot deleted
+  raw: ls /usr/jails|grep 'some-+crazy_.name'
   register: jailroot
+  ignore_errors: yes
 
 - name: test13 assert
   assert:
     that:
       - "result.changed"
       - "'Jail some-+crazy_.name deleted' == result.msg"
-      - "state.stdout_lines|length == 2"
-      - "jailroot.stdout|search('basejail[\\t]*flavours[\\t]*newjail\\r\\n')"
+      - "jailcount.stdout_lines[0] == '2'"
+      - "state.stdout == ''"
+      - "jailroot.stdout == ''"

--- a/test/integration/targets/ezjail/tasks/test_jail3.yml
+++ b/test/integration/targets/ezjail/tasks/test_jail3.yml
@@ -1,3 +1,5 @@
+---
+
 - name: test11 create jail 3
   ezjail: name=some-+crazy_.name state=started ip_addr=127.0.0.1
   register: result

--- a/test/integration/targets/ezjail/tasks/test_jail4.yml
+++ b/test/integration/targets/ezjail/tasks/test_jail4.yml
@@ -1,3 +1,5 @@
+---
+
 - name: test14 create check mode
   ezjail: name=test4 state=started ip_addr=127.0.0.1
   register: result

--- a/test/integration/targets/ezjail/tasks/test_jail4.yml
+++ b/test/integration/targets/ezjail/tasks/test_jail4.yml
@@ -3,21 +3,28 @@
   register: result
   check_mode: yes
 
-- name: test14 check jail state
-  raw: ezjail-admin list
-  register: state
+- name: test14 check jail count
+  raw: ezjail-admin list|wc -l|tr -d ' '
+  register: jailcount
 
-- name: test14 check jailroot
-  raw: ls /usr/jails
+- name: test14 check jail state
+  raw: ezjail-admin list|grep 'DR[ ]*[0-9]*[ ]*127.0.0.1[ ]*test4[ ]*/usr/jails/test4'
+  register: state
+  ignore_errors: yes
+
+- name: test14 check jailroot deleted
+  raw: ls /usr/jails|grep 'test4'
   register: jailroot
+  ignore_errors: yes
 
 - name: test14 assert
   assert:
     that:
       - "result.changed"
       - "'Jail test4 would have been created and started' == result.msg"
-      - "state.stdout_lines|length == 2"
-      - "jailroot.stdout|search('basejail[\\t]*flavours[\\t]*newjail\\r\\n')"
+      - "jailcount.stdout_lines[0] == '2'"
+      - "state.stdout == ''"
+      - "jailroot.stdout == ''"
 
 - name: test15 create jail for delete check mode
   ezjail: name=test4 state=started ip_addr=127.0.0.1
@@ -27,12 +34,16 @@
   register: result
   check_mode: yes
 
+- name: test15 check jail count
+  raw: ezjail-admin list|wc -l|tr -d ' '
+  register: jailcount
+
 - name: test15 check jail state
-  raw: ezjail-admin list
+  raw: ezjail-admin list|grep 'DR[ ]*[0-9]*[ ]*127.0.0.1[ ]*test4[ ]*/usr/jails/test4'
   register: state
 
-- name: test15 check jailroot
-  raw: ls /usr/jails
+- name: test13 check jailroot deleted
+  raw: ls /usr/jails|grep 'test4'
   register: jailroot
 
 - name: test15 assert
@@ -40,21 +51,25 @@
     that:
       - "result.changed"
       - "'Jail test4 would have been deleted' == result.msg"
-      - "state.stdout_lines|length == 3"
-      - "state.stdout_lines[2]|search('DR[ ]*[0-9]*[ ]*127.0.0.1[ ]*test4[ ]*/usr/jails/test4')"
-      - "jailroot.stdout|search('basejail[\\t]*flavours[\\t]*newjail[\\t]*test4\\r\\n')"
+      - "jailcount.stdout_lines[0] == '3'"
+      - "state.stdout != ''"
+      - "jailroot.stdout != ''"
 
 - name: test16 delete check mode
   ezjail: name=test4 state=stopped ip_addr=127.1.1.1 enabled=no
   register: result
   check_mode: yes
 
+- name: test16 check jail count
+  raw: ezjail-admin list|wc -l|tr -d ' '
+  register: jailcount
+
 - name: test16 check jail state
-  raw: ezjail-admin list
+  raw: ezjail-admin list|grep 'DR[ ]*[0-9]*[ ]*127.0.0.1[ ]*test4[ ]*/usr/jails/test4'
   register: state
 
-- name: test16 check jailroot
-  raw: ls /usr/jails
+- name: test16 check jailroot deleted
+  raw: ls /usr/jails|grep 'test4'
   register: jailroot
 
 - name: test16 assert
@@ -62,26 +77,33 @@
     that:
       - "result.changed"
       - "'Jail test4 would have been ip_addr updated and stopped and disabled' == result.msg"
-      - "state.stdout_lines|length == 3"
-      - "state.stdout_lines[2]|search('DR[ ]*[0-9]*[ ]*127.0.0.1[ ]*test4[ ]*/usr/jails/test4')"
-      - "jailroot.stdout|search('basejail[\\t]*flavours[\\t]*newjail[\\t]*test4\\r\\n')"
+      - "jailcount.stdout_lines[0] == '3'"
+      - "state.stdout != ''"
+      - "jailroot.stdout != ''"
 
 - name: test17 cleanup
   ezjail: name=test4 state=absent
   register: result
 
-- name: test17 check jail state
-  raw: ezjail-admin list
-  register: state
+- name: test17 check jail count
+  raw: ezjail-admin list|wc -l|tr -d ' '
+  register: jailcount
 
-- name: test17 check jailroot
-  raw: ls /usr/jails
+- name: test17 check jail state
+  raw: ezjail-admin list|grep 'DR[ ]*[0-9]*[ ]*127.0.0.1[ ]*test4[ ]*/usr/jails/test4'
+  register: state
+  ignore_errors: yes
+
+- name: test17 check jailroot deleted
+  raw: ls /usr/jails|grep 'test4'
   register: jailroot
+  ignore_errors: yes
 
 - name: test17 assert
   assert:
     that:
       - "result.changed"
       - "'Jail test4 deleted' == result.msg"
-      - "state.stdout_lines|length == 2"
-      - "jailroot.stdout|search('basejail[\\t]*flavours[\\t]*newjail\\r\\n')"
+      - "jailcount.stdout_lines[0] == '2'"
+      - "state.stdout == ''"
+      - "jailroot.stdout == ''"

--- a/test/integration/targets/ezjail/tasks/test_jail4.yml
+++ b/test/integration/targets/ezjail/tasks/test_jail4.yml
@@ -1,0 +1,87 @@
+- name: test14 create check mode
+  ezjail: name=test4 state=started ip_addr=127.0.0.1
+  register: result
+  check_mode: yes
+
+- name: test14 check jail state
+  raw: ezjail-admin list
+  register: state
+
+- name: test14 check jailroot
+  raw: ls /usr/jails
+  register: jailroot
+
+- name: test14 assert
+  assert:
+    that:
+      - "result.changed"
+      - "'Jail test4 would have been created and started' == result.msg"
+      - "state.stdout_lines|length == 2"
+      - "jailroot.stdout|search('basejail[\\t]*flavours[\\t]*newjail\\r\\n')"
+
+- name: test15 create jail for delete check mode
+  ezjail: name=test4 state=started ip_addr=127.0.0.1
+
+- name: test15 delete check mode
+  ezjail: name=test4 state=absent
+  register: result
+  check_mode: yes
+
+- name: test15 check jail state
+  raw: ezjail-admin list
+  register: state
+
+- name: test15 check jailroot
+  raw: ls /usr/jails
+  register: jailroot
+
+- name: test15 assert
+  assert:
+    that:
+      - "result.changed"
+      - "'Jail test4 would have been deleted' == result.msg"
+      - "state.stdout_lines|length == 3"
+      - "state.stdout_lines[2]|search('DR[ ]*[0-9]*[ ]*127.0.0.1[ ]*test4[ ]*/usr/jails/test4')"
+      - "jailroot.stdout|search('basejail[\\t]*flavours[\\t]*newjail[\\t]*test4\\r\\n')"
+
+- name: test16 delete check mode
+  ezjail: name=test4 state=stopped ip_addr=127.1.1.1 enabled=no
+  register: result
+  check_mode: yes
+
+- name: test16 check jail state
+  raw: ezjail-admin list
+  register: state
+
+- name: test16 check jailroot
+  raw: ls /usr/jails
+  register: jailroot
+
+- name: test16 assert
+  assert:
+    that:
+      - "result.changed"
+      - "'Jail test4 would have been ip_addr updated and stopped and disabled' == result.msg"
+      - "state.stdout_lines|length == 3"
+      - "state.stdout_lines[2]|search('DR[ ]*[0-9]*[ ]*127.0.0.1[ ]*test4[ ]*/usr/jails/test4')"
+      - "jailroot.stdout|search('basejail[\\t]*flavours[\\t]*newjail[\\t]*test4\\r\\n')"
+
+- name: test17 cleanup
+  ezjail: name=test4 state=absent
+  register: result
+
+- name: test17 check jail state
+  raw: ezjail-admin list
+  register: state
+
+- name: test17 check jailroot
+  raw: ls /usr/jails
+  register: jailroot
+
+- name: test17 assert
+  assert:
+    that:
+      - "result.changed"
+      - "'Jail test4 deleted' == result.msg"
+      - "state.stdout_lines|length == 2"
+      - "jailroot.stdout|search('basejail[\\t]*flavours[\\t]*newjail\\r\\n')"


### PR DESCRIPTION
##### SUMMARY
I created this module to be able to define the state of an FreeBSD jail, managed with Ezjail, in a playbook or role. The module should only do the minimal work of creating or deleting and starting or stopping a jail (similar to the service module). This enables me to quickly setup jails for applications. The installation and configuration of the jailhost should be done by in a playbook since this differs as different people have different preferences and different use cases. This module should be as general as possible.
See https://github.com/hc42/ansible-ezjail for a test playbook. There is also a vagrant file to setup a FreeBSD VM and test the playbook on it.

##### ISSUE TYPE
 - New Module Pull Request

##### COMPONENT NAME
new module: ezjail (system)

##### ANSIBLE VERSION
```
ansible 2.5.0 (devel 6b14eb2dec) last updated 2018/01/19 21:44:10 (GMT +200)
  config file = None
  configured module search path = ['~/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = ~/ansible-hc/lib/ansible
  executable location = ~/ansible-hc/bin/ansible
  python version = 3.6.4 (default, Jan 12 2018, 19:29:13) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```