### PR TITLE
fix when using vrf option

### DIFF
--- a/lib/ansible/modules/network/ios/ios_ping.py
+++ b/lib/ansible/modules/network/ios/ios_ping.py
@@ -176,7 +176,7 @@ def build_ping(dest, count=None, source=None, vrf=None):
     to execute. All args come from the module's unique params.
     """
     if vrf is not None:
-        cmd = "ping {0} {1}".format(vrf, dest)
+        cmd = "ping vrf {0} {1}".format(vrf, dest)
     else:
         cmd = "ping {0}".format(dest)
 


### PR DESCRIPTION
ping did not include "vrf" keyword in command and would fail.

##### SUMMARY
ping did not include "vrf" keyword in command and would fail.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ios_config, vrf option

##### ANSIBLE VERSION
ansible 2.4.2.0

```


##### ADDITIONAL INFORMATION
Task:
    - name: Test reachability to branch wan loopback IPs using mgmt vrf
      ios_ping:
        provider: "{{ ioscli }}"
        dest: '{{ item }}'
        vrf: mgmt
      with_items:
        - 172.16.1.201



Before Fix:
failed: [hq-wan-mpls] (item=172.16.1.201) => {
    "changed": false,
    "invocation": {
        "module_args": {
            "auth_pass": null,
            "authorize": null,
            "count": null,
            "dest": "172.16.1.201",
            "host": null,
            "password": null,
            "port": null,
            "provider": {
                "auth_pass": null,
                "authorize": null,
                "host": "hq-wan-mpls",
                "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
                "port": 22,
                "ssh_keyfile": null,
                "timeout": null,
                "username": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER"
            },
            "source": null,
            "ssh_keyfile": null,
            "state": "present",
            "timeout": null,
            "username": null,
            "vrf": "mgmt"
        }
    },
    "item": "172.16.1.201",
    "msg": "timeout trying to send command: ping mgmt 172.16.1.201",
    "rc": 1
}


After Fix:
ok: [hq-wan-mpls] => (item=172.16.1.201) => {
    "changed": false,
    "commands": [
        "ping vrf mgmt 172.16.1.201"
    ],
    "invocation": {
        "module_args": {
            "auth_pass": null,
            "authorize": null,
            "count": null,
            "dest": "172.16.1.201",
            "host": null,
            "password": null,
            "port": null,
            "provider": {
                "auth_pass": null,
                "authorize": null,
                "host": "hq-wan-mpls",
                "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
                "port": 22,
                "ssh_keyfile": null,
                "timeout": null,
                "username": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER"
            },
            "source": null,
            "ssh_keyfile": null,
            "state": "present",
            "timeout": null,
            "username": null,
            "vrf": "mgmt"
        }
    },
    "item": "172.16.1.201",
    "packet_loss": "0%",
    "packets_rx": 5,
    "packets_tx": 5,
    "rtt": {
        "avg": 1,
        "max": 2,
        "min": 1
    }
}
