### PR TITLE
Only delete key from redis in-memory cache if present

### DIFF
--- a/lib/ansible/plugins/cache/redis.py
+++ b/lib/ansible/plugins/cache/redis.py
@@ -116,7 +116,8 @@ class CacheModule(BaseCacheModule):
         return (self._db.zrank(self._keys_set, key) is not None)
 
     def delete(self, key):
-        del self._cache[key]
+        if key in self._cache:
+            del self._cache[key]
         self._db.delete(self._make_key(key))
         self._db.zrem(self._keys_set, key)
 


### PR DESCRIPTION
##### SUMMARY

Fixes #35120 : the redis cache plugin keeps key/value
entries in an in-memory cache to avoid hitting the
redis database each time.

The problem is that a cache entry is only set when
a value is get or set but it is always deleted when
trying to delete a value.

When the --flush-cache ansible-playbook option is used,
the redis cache plugin is first asked to remove every
entry corresponding to every hostname present in the inventory.
As no value as been set/get so far, it then tries to delete
an unexisting value from the cache and hence crashes with
a KeyError exception.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
- plugin/cache/redis

##### ANSIBLE VERSION
```
ansible 2.4.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/myuser/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Aug 29 2016, 10:12:21) [GCC 4.8.5 20150623 (Red Hat 4.8.5-4)]
```