### PR TITLE
Fix dynamic inventory for vagrant does not work on python3

### DIFF
--- a/contrib/inventory/vagrant.py
+++ b/contrib/inventory/vagrant.py
@@ -38,13 +38,16 @@ import os.path
 import subprocess
 import re
 from paramiko import SSHConfig
-from cStringIO import StringIO
 from optparse import OptionParser
 from collections import defaultdict
 try:
     import json
 except:
     import simplejson as json
+try:
+    from cStringIO import StringIO
+except:
+    from io import StringIO
 
 _group = 'vagrant'  # a default group
 _ssh_to_ansible = [('user', 'ansible_ssh_user'),
@@ -74,7 +77,7 @@ def get_ssh_config():
 
 # list all the running boxes
 def list_running_boxes():
-    output = subprocess.check_output(["vagrant", "status"]).split('\n')
+    output = subprocess.check_output(["vagrant", "status"]).decode('utf-8').split('\n')
 
     boxes = []
 
@@ -90,7 +93,7 @@ def list_running_boxes():
 def get_a_ssh_config(box_name):
     """Gives back a map of all the machine's ssh configurations"""
 
-    output = subprocess.check_output(["vagrant", "ssh-config", box_name])
+    output = subprocess.check_output(["vagrant", "ssh-config", box_name]).decode('utf-8')
     config = SSHConfig()
     config.parse(StringIO(output))
     host_config = config.lookup(box_name)


### PR DESCRIPTION
##### SUMMARY

The dynamic inventory script for vagrant does not work on python3 with some errors

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

-  Dynamic inventory script for vagrant(contrib/inventory/vagrant.py)

##### ANSIBLE VERSION

```
$ ansble --version
ansible 2.5.0
  config file = /Users/hsaito/.ansible.cfg
  configured module search path = ['/Users/hsaito/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/hsaito/.virtualenvs/devel/lib/python3.6/site-packages/ansible-2.5.0-py3.6.egg/ansible
  executable location = /Users/hsaito/.virtualenvs/devel/bin/ansible
  python version = 3.6.3 (default, Nov  3 2017, 19:37:38) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.38)]
```

##### ADDITIONAL INFORMATION

When I tried to launch vagrant.py with --list option, the following error occurred on python3.6.3 runtime environment:

```
Traceback (most recent call last):
  File "/Users/hsaito/work/src/ansible/contrib/inventory/vagrant.py", line 41, in <module>
    from cStringIO import StringIO
ModuleNotFoundError: No module named 'cStringIO'
```

Even if I fixed above error, and then re-ran vagrant.py, I have different error as follows:

```
Traceback (most recent call last):
  File "./vagrant.py", line 113, in <module>
    ssh_config = get_ssh_config()
  File "./vagrant.py", line 75, in get_ssh_config
    return dict((k, get_a_ssh_config(k)) for k in list_running_boxes())
  File "./vagrant.py", line 80, in list_running_boxes
    output = subprocess.check_output(["vagrant", "status"]).split('\n')
TypeError: a bytes-like object is required, not 'str'
```