### PR TITLE
Include role honour allow duplicates

### DIFF
--- a/lib/ansible/executor/play_iterator.py
+++ b/lib/ansible/executor/play_iterator.py
@@ -423,7 +423,16 @@ class PlayIterator:
 
                             # we're advancing blocks, so if this was an end-of-role block we
                             # mark the current role complete
-                            if block._eor and host.name in block._role._had_task_run and not in_child and not peek:
+                            # unless we are the role or it allows_duplicates
+                            if (
+                                block._eor and
+                                host.name in block._role._had_task_run and (
+                                    (not in_child) or
+                                    (not (block._role._metadata and
+                                          block._role._metadata.allow_duplicates))
+                                ) and
+                                not peek
+                            ):
                                 block._role._completed[host.name] = True
                     else:
                         task = block.always[state.cur_always_task]

--- a/lib/ansible/playbook/role_include.py
+++ b/lib/ansible/playbook/role_include.py
@@ -63,6 +63,8 @@ class IncludeRole(TaskInclude):
         self._parent_role = role
         self._role_name = None
         self._role_path = None
+        self._play = None
+        self._role = None
 
     def get_block_list(self, play=None, variable_manager=None, loader=None):
 
@@ -81,6 +83,9 @@ class IncludeRole(TaskInclude):
 
         # save this for later use
         self._role_path = actual_role._role_path
+        self._role = actual_role
+        if myplay is not None:
+            self._play = myplay
 
         # compile role with parent roles as dependencies to ensure they inherit
         # variables
@@ -136,8 +141,15 @@ class IncludeRole(TaskInclude):
         new_me._parent_role = self._parent_role
         new_me._role_name = self._role_name
         new_me._role_path = self._role_path
+        new_me._role = self._role
+        new_me.private = self.private
+        new_me._play = self._play
 
         return new_me
+
+    @property
+    def is_loaded(self):
+        return self._role is not None
 
     def get_include_params(self):
         v = super(IncludeRole, self).get_include_params()

--- a/lib/ansible/playbook/role_include.py
+++ b/lib/ansible/playbook/role_include.py
@@ -52,7 +52,7 @@ class IncludeRole(TaskInclude):
     # ATTRIBUTES
 
     # private as this is a 'module options' vs a task property
-    _allow_duplicates = FieldAttribute(isa='bool', default=True, private=True)
+    _allow_duplicates = FieldAttribute(isa='bool', default=None, private=True)
     _private = FieldAttribute(isa='bool', default=None, private=True)
 
     def __init__(self, block=None, role=None, task_include=None):
@@ -79,7 +79,14 @@ class IncludeRole(TaskInclude):
 
         # build role
         actual_role = Role.load(ri, myplay, parent_role=self._parent_role, from_files=self._from_files)
-        actual_role._metadata.allow_duplicates = self.allow_duplicates
+        # proxy allow_duplicates attribute to role if explicitly set
+        if self.allow_duplicates is not None:
+            actual_role._metadata.allow_duplicates = self.allow_duplicates
+        # in any case sync allow_duplicates between the role and this include statement
+        # This is the side effect if we didnt explicitly setted the allow_duplicates attribute
+        # to fallback on the included role setting
+        if self.allow_duplicates is None and actual_role._metadata:
+            self.allow_duplicates = actual_role._metadata.allow_duplicates
 
         # save this for later use
         self._role_path = actual_role._role_path

--- a/lib/ansible/plugins/strategy/linear.py
+++ b/lib/ansible/plugins/strategy/linear.py
@@ -333,6 +333,13 @@ class StrategyModule(StrategyBase):
                                     variable_manager=self._variable_manager,
                                     loader=self._loader,
                                 )
+                                # Prevent included tasks to run if already done
+                                if new_ir._role and (
+                                    new_ir._role.has_run(host) and
+                                    (new_ir._role._metadata is None or (new_ir._role._metadata and not new_ir._role._metadata.allow_duplicates))
+                                ):
+                                    display.debug("'%s' skipped because role has already run" % new_ir)
+                                    new_blocks, handler_blocks = [], []
                                 self._tqm.update_handler_list([handler for handler_block in handler_blocks for handler in handler_block.block])
                             else:
                                 new_blocks = self._load_included_file(included_file, iterator=iterator)

--- a/test/integration/targets/include_role_honour_duplicates/aliases
+++ b/test/integration/targets/include_role_honour_duplicates/aliases
@@ -1,0 +1,3 @@
+posix/ci/group3
+include_role
+include_role_honour_allow_duplicates

--- a/test/integration/targets/include_role_honour_duplicates/roles/altinccounter/meta/main.yml
+++ b/test/integration/targets/include_role_honour_duplicates/roles/altinccounter/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/test/integration/targets/include_role_honour_duplicates/roles/altinccounter/tasks/main.yml
+++ b/test/integration/targets/include_role_honour_duplicates/roles/altinccounter/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+- set_fact:
+    cacheable: false
+    altcounter: "{{altcounter|int+1}}"

--- a/test/integration/targets/include_role_honour_duplicates/roles/inccounter/meta/main.yml
+++ b/test/integration/targets/include_role_honour_duplicates/roles/inccounter/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: false

--- a/test/integration/targets/include_role_honour_duplicates/roles/inccounter/tasks/main.yml
+++ b/test/integration/targets/include_role_honour_duplicates/roles/inccounter/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+- set_fact:
+    cacheable: false
+    counter: "{{counter|int+1}}"

--- a/test/integration/targets/include_role_honour_duplicates/roles/noinccounter/meta/main.yml
+++ b/test/integration/targets/include_role_honour_duplicates/roles/noinccounter/meta/main.yml
@@ -1,0 +1,2 @@
+---
+# allow_duplicates: <DEFAULT>

--- a/test/integration/targets/include_role_honour_duplicates/roles/noinccounter/tasks/main.yml
+++ b/test/integration/targets/include_role_honour_duplicates/roles/noinccounter/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+- set_fact:
+    cacheable: false
+    nocounter: "{{nocounter|int+1}}"

--- a/test/integration/targets/include_role_honour_duplicates/runme.sh
+++ b/test/integration/targets/include_role_honour_duplicates/runme.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+W=$(cd "$(dirname "$0")" && pwd)
+export ANSIBLE_ROLES_PATH="$W/roles"
+set -eux
+ansible-playbook -i../../inventory test.yml -v

--- a/test/integration/targets/include_role_honour_duplicates/test.yml
+++ b/test/integration/targets/include_role_honour_duplicates/test.yml
@@ -1,0 +1,37 @@
+---
+- hosts: testhost
+  tasks: [set_fact: {counter: 1, altcounter: 1, nocounter: 1, cacheable: False}]
+- name: >-
+    verify that allow_duplicates prevent include_role to run a role that
+    has already run only if if it does not allow it
+  hosts: testhost
+  strategy: linear
+  roles: [inccounter, altinccounter, noinccounter]
+  tasks:
+  - include_role: {name: inccounter}
+  - include_role: {name: altinccounter}
+  - include_role: {name: noinccounter}
+  - include_role: {name: inccounter}
+  - include_role: {name: altinccounter}
+  - include_role: {name: noinccounter}
+  - assert: {that: counter=='3', msg: counterfail}
+  - assert: {that: altcounter=='4', msg: altcounterfail}
+  - assert: {that: nocounter=='3', msg: nocounterfail}
+- hosts: testhost
+  tasks: [set_fact: {counter: 1, altcounter: 1, nocounter: 1, cacheable: False}]
+- name: >-
+    verify that allow_duplicates prevent include_role to run a role that
+    has already run only if if it does not allow it
+  hosts: testhost
+  strategy: free
+  roles: [inccounter, altinccounter, noinccounter]
+  tasks:
+  - include_role: {name: inccounter}
+  - include_role: {name: altinccounter}
+  - include_role: {name: noinccounter}
+  - include_role: {name: inccounter}
+  - include_role: {name: altinccounter}
+  - include_role: {name: noinccounter}
+  - assert: {that: counter=='3', msg: counterfail}
+  - assert: {that: altcounter=='4', msg: altcounterfail}
+  - assert: {that: nocounter=='3', msg: nocounterfail}


### PR DESCRIPTION
##### SUMMARY
include_role does not honour included role meta/main.yml allow_duplicates when not set on the include_role call and set it to True, which is pretty inintuitive

See associated test

This is part of the #32565 PR split.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
include_role

##### ANSIBLE VERSION
```
2.4
devel
```


##### ADDITIONAL INFORMATION
Pre (associatet PR test FAIL)

```
TASK [inccounter : set_fact] **************************************************************************************************************************************************************************************************************************************************
ok: [testhost] => {"ansible_facts": {"counter": "4"}, "changed": false}
 [WARNING]: Failure using method (v2_runner_on_ok) in callback plugin (<ansible.plugins.callback.junit.CallbackModule object at 0x7f719e940e10>):
/srv/corpusops/corpusops.bootstrap/venv/src/ansible/test/integration/targets/include_role_honour_duplicates/roles/inccounter/tasks/main.yml:2: verify that allow_duplicates prevent include_role to run a role that has already run only if if it does not allow it:
inccounter : set_fact cacheable=False, counter={{counter|int+1}}: duplicate host callback: testhost


TASK [include_role] ***********************************************************************************************************************************************************************************************************************************************************

TASK [altinccounter : set_fact] ***********************************************************************************************************************************************************************************************************************************************
ok: [testhost] => {"ansible_facts": {"altcounter": "4"}, "changed": false}
 [WARNING]: Failure using method (v2_runner_on_ok) in callback plugin (<ansible.plugins.callback.junit.CallbackModule object at 0x7f719e940e10>):
/srv/corpusops/corpusops.bootstrap/venv/src/ansible/test/integration/targets/include_role_honour_duplicates/roles/altinccounter/tasks/main.yml:2: verify that allow_duplicates prevent include_role to run a role that has already run only if if it does not allow it:
altinccounter : set_fact cacheable=False, altcounter={{altcounter|int+1}}: duplicate host callback: testhost


TASK [include_role] ***********************************************************************************************************************************************************************************************************************************************************

TASK [noinccounter : set_fact] ************************************************************************************************************************************************************************************************************************************************
ok: [testhost] => {"ansible_facts": {"nocounter": "4"}, "changed": false}
 [WARNING]: Failure using method (v2_runner_on_ok) in callback plugin (<ansible.plugins.callback.junit.CallbackModule object at 0x7f719e940e10>):
/srv/corpusops/corpusops.bootstrap/venv/src/ansible/test/integration/targets/include_role_honour_duplicates/roles/noinccounter/tasks/main.yml:2: verify that allow_duplicates prevent include_role to run a role that has already run only if if it does not allow it:
noinccounter : set_fact nocounter={{nocounter|int+1}}, cacheable=False: duplicate host callback: testhost


TASK [assert] *****************************************************************************************************************************************************************************************************************************************************************
fatal: [testhost]: FAILED! => {
    "assertion": "counter=='3'",
    "changed": false,
    "evaluated_to": false,
    "msg": "counterfail"
}
        to retry, use: --limit @/srv/corpusops/corpusops.bootstrap/venv/src/ansible/test/integration/targets/include_role_honour_duplicates/test.retry

PLAY RECAP ********************************************************************************************************************************************************************************************************************************************************************
testhost                   : ok=12   changed=0    unreachable=0    failed=1

NOTICE: To resume at this test target, use the option: --start-at include_role_honour_duplicates
ERROR: Command "./runme.sh -v" returned exit status 2.

```

Post (associatet PR test pass)
```
testhost                   : ok=26   changed=0    unreachable=0    failed=0

```