### PR TITLE
Include role:  serialization: (de)pickling support

### DIFF
--- a/lib/ansible/playbook/block.py
+++ b/lib/ansible/playbook/block.py
@@ -238,6 +238,7 @@ class Block(Base, Become, Conditional, Taggable):
         from ansible.playbook.task import Task
         from ansible.playbook.task_include import TaskInclude
         from ansible.playbook.handler_task_include import HandlerTaskInclude
+        from ansible.playbook.role_include import IncludeRole
 
         # we don't want the full set of attributes (the task lists), as that
         # would lead to a serialize/deserialize loop
@@ -264,6 +265,9 @@ class Block(Base, Become, Conditional, Taggable):
                 p = TaskInclude()
             elif parent_type == 'HandlerTaskInclude':
                 p = HandlerTaskInclude()
+            elif parent_type == 'IncludeRole':
+                p = IncludeRole()
+
             p.deserialize(parent_data)
             self._parent = p
             self._dep_chain = self._parent.get_dep_chain()

--- a/lib/ansible/playbook/role_include.py
+++ b/lib/ansible/playbook/role_include.py
@@ -63,6 +63,8 @@ class IncludeRole(TaskInclude):
         self._parent_role = role
         self._role_name = None
         self._role_path = None
+        self._play = None
+        self._role = None
 
     def get_block_list(self, play=None, variable_manager=None, loader=None):
 
@@ -81,6 +83,9 @@ class IncludeRole(TaskInclude):
 
         # save this for later use
         self._role_path = actual_role._role_path
+        self._role = actual_role
+        if myplay is not None:
+            self._play = myplay
 
         # compile role with parent roles as dependencies to ensure they inherit
         # variables
@@ -136,8 +141,15 @@ class IncludeRole(TaskInclude):
         new_me._parent_role = self._parent_role
         new_me._role_name = self._role_name
         new_me._role_path = self._role_path
+        new_me._role = self._role
+        new_me.private = self.private
+        new_me._play = self._play
 
         return new_me
+
+    @property
+    def is_loaded(self):
+        return self._role is not None
 
     def get_include_params(self):
         v = super(IncludeRole, self).get_include_params()

--- a/lib/ansible/playbook/role_include.py
+++ b/lib/ansible/playbook/role_include.py
@@ -135,7 +135,26 @@ class IncludeRole(TaskInclude):
 
     def copy(self, exclude_parent=False, exclude_tasks=False):
 
+        # save our attrs
+        role = self._role
+        parentrole = self._parent_role
+        parent = self._parent
+        play = self._play
+
+        # be smaller for parent methods to shallow copy
+        self._role = None
+        self._parent = None
+        self._parent_role = None
+        self._play = None
+
         new_me = super(IncludeRole, self).copy(exclude_parent=exclude_parent, exclude_tasks=exclude_tasks)
+
+        # restore our state
+        self._parent_role = parentrole
+        self._parent = parent
+        self._play = play
+        self._role = role
+
         new_me.statically_loaded = self.statically_loaded
         new_me._from_files = self._from_files.copy()
         new_me._parent_role = self._parent_role
@@ -156,3 +175,58 @@ class IncludeRole(TaskInclude):
         if self._parent_role:
             v.update(self._parent_role.get_role_params())
         return v
+
+    def serialize(self, no_play=False):
+        data = super(IncludeRole, self).serialize()
+        if not self._squashed and not self._finalized:
+            data['_irole_name'] = self._role_name
+            if self._parent_role:
+                data['_irole_prole'] = self._parent_role.serialize()
+            data['_irole_path'] = self._role_path
+            if self._role:
+                data['_irole_drole'] = self._role.serialize()
+            if self._play and not no_play:
+                # avoid deepcopy recurse errors
+                self._play.unregister_dynamic_role(self)
+                data['_irole_play'] = self._play.serialize(
+                    skip_dynamic_roles=True)
+                self._play.register_dynamic_role(self)
+        return data
+
+    def deserialize(self, data, play=None, include_deps=True):
+        from ansible.playbook.play import Play
+        from ansible.playbook.role import Role
+        self._role_name = data.get('_irole_name', '')
+        self._role_path = data.get('_irole_path', '')
+        if play is None and '_irole_play' in data:
+            play = Play()
+            play.deserialize(data['_irole_play'])
+            del data['_irole_play']
+        if play is not None:
+            setattr(self, '_play', play)
+        if '_irole_drole' in data:
+            r = Role()
+            r.deserialize(data['_irole_drole'])
+            setattr(self, '_role', r)
+            del data['_irole_drole']
+        if '_irole_prole' in data:
+            r = Role()
+            r.deserialize(data['_irole_prole'])
+            setattr(self, '_parent_role', r)
+            del data['_irole_prole']
+        if play is not None:
+            play.register_dynamic_role(self)
+        super(IncludeRole, self).deserialize(data)
+
+    def __setstate__(self, sr):
+        self.__init__()
+        self.deserialize(sr)
+
+    def __getstate__(self):
+        sr = self.serialize()
+        return sr
+
+    def __deepcopy__(self, memo):
+        ret = self.deserialize(self.serialize())
+        memo[id(self)] = ret
+        return ret


### PR DESCRIPTION
##### SUMMARY
The fixes that were introduced recently to avoid recursion errors (yes, already removed from 2.4 but still in 2.5)  are IMO more kind of workarounds that lead to the former bug not to happen again than fixes in themvelves.

This PR brings pickling/depickling support for include_role & fixes permanently the recursion error.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
includeçrole
##### ANSIBLE VERSION
```
2.4
devel
```


- This refs: #35065
- This fixes: #33922
- This fixes: #23609