### PR TITLE
ACI: Fix integration tests after error message change

### DIFF
--- a/test/integration/targets/aci_aaa_user_certificate/tasks/main.yml
+++ b/test/integration/targets/aci_aaa_user_certificate/tasks/main.yml
@@ -15,7 +15,6 @@
     hostname: '{{ aci_hostname }}'
     username: '{{ aci_username }}'
     password: '{{ aci_password }}'
-    use_proxy: no
     validate_certs: no
     user: admin
     certificate_name: admin
@@ -28,7 +27,6 @@
     hostname: '{{ aci_hostname }}'
     username: '{{ aci_username }}'
     password: '{{ aci_password }}'
-    use_proxy: no
     validate_certs: no
     user: admin
     certificate_name: admin
@@ -64,7 +62,6 @@
     username: '{{ aci_username }}'
     #password: '{{ aci_password }}'
     private_key: '{{ role_path }}/pki/admin.key'
-    use_proxy: no
     validate_certs: no
     user: admin
     state: query

--- a/test/integration/targets/aci_access_port_to_interface_policy_leaf_profile/tasks/main.yml
+++ b/test/integration/targets/aci_access_port_to_interface_policy_leaf_profile/tasks/main.yml
@@ -15,8 +15,6 @@
     password: "{{ aci_password }}"
     leaf_interface_profile: leafintprftest
     validate_certs: no
-    use_ssl: no
-    use_proxy: no
     state: present
   register: leaf_profile_present
 

--- a/test/integration/targets/aci_ap/tasks/main.yml
+++ b/test/integration/targets/aci_ap/tasks/main.yml
@@ -67,7 +67,7 @@
       - ap_present_update.changed == true
       - 'ap_present_update.config.fvAp.attributes == {"descr": "Ansible Test Update"}'
       - ap_present_missing_param.failed == true
-      - 'ap_present_missing_param.msg == "state is present but the following are missing: ap"'
+      - 'ap_present_missing_param.msg == "state is present but all of the following are missing: ap"'
 
 - name: get ap - query specific ap
   aci_ap: &aci_ap_query
@@ -155,7 +155,7 @@
       - ap_delete_idempotent.changed == false
       - ap_delete_idempotent.existing == []
       - ap_delete_missing_param.failed == true
-      - 'ap_delete_missing_param.msg == "state is absent but the following are missing: tenant"'
+      - 'ap_delete_missing_param.msg == "state is absent but all of the following are missing: tenant"'
 
 - name: delete tenant - cleanup before ending tests
   aci_tenant:

--- a/test/integration/targets/aci_bd/tasks/main.yml
+++ b/test/integration/targets/aci_bd/tasks/main.yml
@@ -85,7 +85,7 @@
       - 'bd_present_2.config.fvBD.attributes == {"arpFlood": "yes", "descr": "Ansible Test", "ipLearning": "no", "multiDstPktAct": "drop", "name": "anstest2",
       "unicastRoute": "no", "unkMacUcastAct": "flood", "unkMcastAct": "opt-flood"}'
       - bd_present_missing_param.failed == true
-      - 'bd_present_missing_param.msg == "state is present but the following are missing: tenant"'
+      - 'bd_present_missing_param.msg == "state is present but all of the following are missing: tenant"'
 
 - name: get all bd
   aci_bd: &aci_query
@@ -175,7 +175,7 @@
       - bd_absent_idempotent.changed == false
       - bd_absent_idempotent.existing == []
       - bd_absent_missing_param.failed == true
-      - 'bd_absent_missing_param.msg == "state is absent but the following are missing: bd"'
+      - 'bd_absent_missing_param.msg == "state is absent but all of the following are missing: bd"'
 
 - name: delete vrf - cleanup before ending tests
   aci_vrf:

--- a/test/integration/targets/aci_bd_subnet/tasks/main.yml
+++ b/test/integration/targets/aci_bd_subnet/tasks/main.yml
@@ -108,7 +108,7 @@
       - create_bad_scope.failed == true
       - 'create_bad_scope.msg.startswith("value of scope must be one of")'
       - create_incomplete_data.failed == true
-      - 'create_incomplete_data.msg == "state is present but the following are missing: bd"'
+      - 'create_incomplete_data.msg == "state is present but all of the following are missing: bd"'
 
 - name: get all subnets
   aci_bd_subnet: &aci_query

--- a/test/integration/targets/aci_config_rollback/tasks/main.yml
+++ b/test/integration/targets/aci_config_rollback/tasks/main.yml
@@ -82,7 +82,7 @@
       - '"<fvTenant name=\"anstest\" rn=\"tn-anstest\" status=\"deleted\">" in rollback_preview.diff'
       - '"snapshots.diff.xml" in rollback_preview.url'
       - rollback_missing_param.failed == true
-      - 'rollback_missing_param.msg == "state is rollback but the following are missing: import_policy"'
+      - 'rollback_missing_param.msg == "state is rollback but all of the following are missing: import_policy"'
       - rollback_rollback.changed == true
       - '"ce2_" in rollback_rollback.config.configImportP.attributes.fileName'
       - '".tar.gz" in rollback_rollback.config.configImportP.attributes.fileName'

--- a/test/integration/targets/aci_config_snapshot/tasks/main.yml
+++ b/test/integration/targets/aci_config_snapshot/tasks/main.yml
@@ -54,7 +54,7 @@
       - invalid_max_count.failed == true
       - 'invalid_max_count.msg == "The \"max_count\" must be a number between 1 and 10"'
       - missing_param.failed == true
-      - 'missing_param.msg == "state is present but the following are missing: export_policy"'
+      - 'missing_param.msg == "state is present but all of the following are missing: export_policy"'
 
 - name: query with export_policy
   aci_config_snapshot: &query_snapshot
@@ -136,4 +136,4 @@
       - delete_idempotent.changed == false
       - delete_idempotent.existing == []
       - delete_missing_param.failed == true
-      - 'delete_missing_param.msg == "state is absent but the following are missing: snapshot"'
+      - 'delete_missing_param.msg == "state is absent but all of the following are missing: snapshot"'

--- a/test/integration/targets/aci_contract/tasks/main.yml
+++ b/test/integration/targets/aci_contract/tasks/main.yml
@@ -66,7 +66,7 @@
       - present_update.config != present_update.proposed
       - 'present_update.config.vzBrCP.attributes.scope == "application-profile"'
       - present_missing_param.failed == true
-      - 'present_missing_param.msg == "state is present but the following are missing: contract"'
+      - 'present_missing_param.msg == "state is present but all of the following are missing: contract"'
 
 - name: query contract
   aci_contract: &aci_contract_query
@@ -151,7 +151,7 @@
       - absent_idempotent.changed == false
       - absent_idempotent.existing == []
       - absent_missing_param.failed == true
-      - 'absent_missing_param.msg == "state is absent but the following are missing: tenant"'
+      - 'absent_missing_param.msg == "state is absent but all of the following are missing: tenant"'
 
 - name: cleanup tenant
   aci_tenant:

--- a/test/integration/targets/aci_contract_subject/tasks/main.yml
+++ b/test/integration/targets/aci_contract_subject/tasks/main.yml
@@ -82,7 +82,7 @@
       - subject_present_2.changed == true
       - 'subject_present_2.config.vzSubj.attributes == {"consMatchT": "All", "name": "anstest2", "prio": "level3", "revFltPorts": "no"}'
       - present_missing_param.failed == true
-      - 'present_missing_param.msg == "state is present but the following are missing: contract,subject"'
+      - 'present_missing_param.msg == "state is present but all of the following are missing: contract, subject"'
 
 - name: query tenant contract subject
   aci_contract_subject: &aci_query_subject
@@ -223,7 +223,7 @@
       - subject_absent_idempotent.changed == false
       - subject_absent_idempotent.existing == []
       - absent_missing_param.failed == true
-      - 'absent_missing_param.msg == "state is absent but the following are missing: subject"'
+      - 'absent_missing_param.msg == "state is absent but all of the following are missing: subject"'
 
 - name: cleanup contract
   aci_contract:

--- a/test/integration/targets/aci_contract_subject_to_filter/tasks/main.yml
+++ b/test/integration/targets/aci_contract_subject_to_filter/tasks/main.yml
@@ -93,7 +93,7 @@
       - subject_filter_update.changed == true
       - 'subject_filter_update.config.vzRsSubjFiltAtt.attributes == {"directives": ""}'
       - present_missing_param.failed == true
-      - 'present_missing_param.msg == "state is present but the following are missing: contract,filter,subject"'
+      - 'present_missing_param.msg == "state is present but all of the following are missing: contract, filter, subject"'
 
 - name: query all
   aci_contract_subject_to_filter:
@@ -157,7 +157,7 @@
       - subject_filter_absent_idempotent.changed == false
       - subject_filter_absent_idempotent.existing == []
       - absent_missing_param.failed == true
-      - 'absent_missing_param.msg == "state is absent but the following are missing: filter"'
+      - 'absent_missing_param.msg == "state is absent but all of the following are missing: filter"'
 
 - name: cleanup subject
   aci_contract_subject:

--- a/test/integration/targets/aci_encap_pool_range/tasks/vlan.yml
+++ b/test/integration/targets/aci_encap_pool_range/tasks/vlan.yml
@@ -182,7 +182,7 @@
   assert:
     that:
       - range_present_missing_param.failed == true
-      - 'range_present_missing_param.msg == "state is present but the following are missing: range_end,range_name,range_start"'
+      - 'range_present_missing_param.msg == "state is present but all of the following are missing: range_end, range_name, range_start"'
 
 - name: missing required param - error message works
   aci_encap_pool_range:

--- a/test/integration/targets/aci_epg/tasks/main.yml
+++ b/test/integration/targets/aci_epg/tasks/main.yml
@@ -81,7 +81,7 @@
       - epg_present_update.changed == true
       - 'epg_present_update.config == {"fvAEPg": {"attributes": {"descr": "Ansible Test Update"}}}'
       - epg_present_missing_param.failed == true
-      - 'epg_present_missing_param.msg == "state is present but the following are missing: ap"'
+      - 'epg_present_missing_param.msg == "state is present but all of the following are missing: ap"'
 
 - name: get specific epg
   aci_epg:
@@ -147,7 +147,7 @@
       - delete_epg_idempotent.changed == false
       - delete_epg_idempotent.existing == []
       - delete_epg_missing_param.failed == true
-      - 'delete_epg_missing_param.msg == "state is absent but the following are missing: tenant"'
+      - 'delete_epg_missing_param.msg == "state is absent but all of the following are missing: tenant"'
 
 - name: cleanup bd
   aci_bd:

--- a/test/integration/targets/aci_epg_to_contract/tasks/main.yml
+++ b/test/integration/targets/aci_epg_to_contract/tasks/main.yml
@@ -102,7 +102,7 @@
       - provide_present2.changed == true
       - provide_present2.existing == []
       - missing_param_present.failed == true
-      - 'missing_param_present.msg == "state is present but the following are missing: ap,contract,epg"'
+      - 'missing_param_present.msg == "state is present but all of the following are missing: ap, contract, epg"'
       - missing_required_present.failed == true
       - 'missing_required_present.msg == "missing required arguments: contract_type"'
       - incompatible_present.failed == true
@@ -205,7 +205,7 @@
       - consume_absent_idempotent.changed == false
       - consume_absent_idempotent.existing == []
       - missing_param_absent.failed == true
-      - 'missing_param_absent.msg == "state is absent but the following are missing: contract"'
+      - 'missing_param_absent.msg == "state is absent but all of the following are missing: contract"'
       - missing_required_absent.failed == true
       - 'missing_required_absent.msg == "missing required arguments: contract_type"'
 

--- a/test/integration/targets/aci_epg_to_domain/tasks/main.yml
+++ b/test/integration/targets/aci_epg_to_domain/tasks/main.yml
@@ -117,7 +117,7 @@
       - 'vmm_present.config == {"fvRsDomAtt": {"attributes": {"resImedcy": "pre-provision"}}}'
       - '"[uni/vmmp-VMware/dom-anstest].json" in vmm_present.url'
       - present_missing_params.failed == true
-      - 'present_missing_params.msg == "domain_type is vmm but the following are missing: vm_provider"'
+      - 'present_missing_params.msg == "domain_type is vmm but all of the following are missing: vm_provider"'
       - invalid_vlan.failed == true
       - 'invalid_vlan.msg == "Valid VLAN assigments are from 1 to 4096"'
       - incompatible_params.failed == true
@@ -178,7 +178,7 @@
       - idempotency_absent.changed == false
       - idempotency_absent.existing == []
       - absent_missing_param.failed == true
-      - 'absent_missing_param.msg == "state is absent but the following are missing: ap,domain,domain_type,epg"'
+      - 'absent_missing_param.msg == "state is absent but all of the following are missing: ap, domain, domain_type, epg"'
 
 - name: remove vmm domain - cleanup
   aci_rest:

--- a/test/integration/targets/aci_filter_entry/tasks/main.yml
+++ b/test/integration/targets/aci_filter_entry/tasks/main.yml
@@ -124,7 +124,7 @@
       - entry_present_4.changed == true
       - 'entry_present_4.config.vzEntry.attributes == {"dFromPort": "1000", "dToPort": "1000", "etherT": "ip", "name": "anstest4", "prot": "udp"}'
       - present_missing_param.failed == true
-      - 'present_missing_param.msg == "state is present but the following are missing: entry"'
+      - 'present_missing_param.msg == "state is present but all of the following are missing: entry"'
       - present_incompatible_params.failed == true
       - present_incompatible_params.msg.startswith("Parameter")
 
@@ -264,7 +264,7 @@
       - entry_absent_idempotent.changed == false
       - entry_absent_idempotent.existing == []
       - absent_missing_param.failed == true
-      - 'absent_missing_param.msg == "state is absent but the following are missing: entry,filter"'
+      - 'absent_missing_param.msg == "state is absent but all of the following are missing: entry, filter"'
 
 - name: cleanup filter
   aci_filter:

--- a/test/integration/targets/aci_interface_policy_leaf_profile/tasks/main.yml
+++ b/test/integration/targets/aci_interface_policy_leaf_profile/tasks/main.yml
@@ -16,7 +16,6 @@
     username: '{{ aci_username }}'
     password: '{{ aci_password }}'
     validate_certs: no
-    use_ssl: no
     leaf_interface_profile: ansible_test
     state: absent
 
@@ -28,7 +27,6 @@
     username: '{{ aci_username }}'
     password: '{{ aci_password }}'
     validate_certs: no
-    use_ssl: no
     leaf_interface_profile: ansible_test
     state: present
   check_mode: yes
@@ -111,7 +109,6 @@
     username: '{{ aci_username }}'
     password: '{{ aci_password }}'
     validate_certs: no
-    use_ssl: no
     state: query
   check_mode: yes
   register: cm_query_all_leaf_interface_profiles

--- a/test/integration/targets/aci_interface_selector_to_switch_policy_leaf_profile/tasks/main.yml
+++ b/test/integration/targets/aci_interface_selector_to_switch_policy_leaf_profile/tasks/main.yml
@@ -15,7 +15,6 @@
     password: "{{ aci_password }}"
     leaf_profile: swleafprftest
     validate_certs: no
-    use_ssl: no
     state: absent
 
 - name: delete Interface Policy Leaf profile for kick off
@@ -25,8 +24,6 @@
     password: "{{ aci_password }}"
     leaf_interface_profile: leafintprftest
     validate_certs: no
-    use_ssl: no
-    use_proxy: no
     state: absent
 
 - name: Ensuring Switch Policy Leaf profile exists for kick off
@@ -36,7 +33,6 @@
     password: "{{ aci_password }}"
     leaf_profile: swleafprftest
     validate_certs: no
-    use_ssl: no
     state: present
   register: leaf_profile_present
 
@@ -47,8 +43,6 @@
     password: "{{ aci_password }}"
     leaf_interface_profile: leafintprftest
     validate_certs: no
-    use_ssl: no
-    use_proxy: no
     state: present
   register: leaf_profile_present
 

--- a/test/integration/targets/aci_switch_leaf_policy_profile/tasks/main.yml
+++ b/test/integration/targets/aci_switch_leaf_policy_profile/tasks/main.yml
@@ -16,7 +16,6 @@
     username: '{{ aci_username }}'
     password: '{{ aci_password }}'
     validate_certs: no
-    use_ssl: no
     leaf_profile: ansible_test
     state: absent
 
@@ -28,7 +27,6 @@
     username: '{{ aci_username }}'
     password: '{{ aci_password }}'
     validate_certs: no
-    use_ssl: no
     leaf_profile: ansible_test
     state: present
   check_mode: yes
@@ -111,7 +109,6 @@
     username: '{{ aci_username }}'
     password: '{{ aci_password }}'
     validate_certs: no
-    use_ssl: no
     state: query
   check_mode: yes
   register: cm_query_all_switch_leaf_profiles

--- a/test/integration/targets/aci_switch_leaf_selector/tasks/main.yml
+++ b/test/integration/targets/aci_switch_leaf_selector/tasks/main.yml
@@ -15,8 +15,6 @@
     password: "{{ aci_password }}"
     leaf_profile: sw_name_test
     validate_certs: no
-    use_ssl: no
-    use_proxy: no
     state: absent
 
 - name: Ensuring Switch Policy Leaf profile exists for kick off
@@ -26,8 +24,6 @@
     password: "{{ aci_password }}"
     leaf_profile: sw_name_test
     validate_certs: no
-    use_ssl: no
-    use_proxy: no
     state: present
   register: leaf_profile_present
 

--- a/test/integration/targets/aci_vrf/tasks/main.yml
+++ b/test/integration/targets/aci_vrf/tasks/main.yml
@@ -73,7 +73,7 @@
       - 'vrf_update.config == {"fvCtx": {"attributes": {"descr": "Ansible Test Update", "pcEnfPref": "unenforced"}}}'
       - 'vrf_present_2.config.fvCtx.attributes == {"name": "anstest2", "pcEnfDir": "egress", "descr": "Ansible Test"}'
       - vrf_present_missing_param.failed == true
-      - 'vrf_present_missing_param.msg == "state is present but the following are missing: tenant"'
+      - 'vrf_present_missing_param.msg == "state is present but all of the following are missing: tenant"'
 
 - name: get all vrf
   aci_vrf: &aci_query
@@ -162,7 +162,7 @@
       - vrf_absent_idempotent.changed == false
       - vrf_absent_idempotent.existing == []
       - vrf_absent_missing_param.failed == true
-      - 'vrf_absent_missing_param.msg == "state is absent but the following are missing: vrf"'
+      - 'vrf_absent_missing_param.msg == "state is absent but all of the following are missing: vrf"'
 
 - name: delete tenant - cleanup before ending tests
   aci_tenant:


### PR DESCRIPTION
##### SUMMARY
This PR includes:
- Fixes to a standard error message we validate during integration tests
- Remove `use_ssl: no` and `use_proxy: no` from integration tests

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
aci modules

##### ANSIBLE VERSION
v2.5