### PR TITLE
write() need bytes object on python 3

### DIFF
--- a/lib/ansible/modules/crypto/openssl_certificate.py
+++ b/lib/ansible/modules/crypto/openssl_certificate.py
@@ -756,7 +756,7 @@ class AcmeCertificate(Certificate):
                     '--acme-dir', self.challenge_path], stdout=subprocess.PIPE)
                 crt = p.communicate()[0]
                 with open(self.path, 'wb') as certfile:
-                    certfile.write(str(crt))
+                    certfile.write(to_bytes(crt))
             except OSError as exc:
                 raise CertificateError(exc)
 


### PR DESCRIPTION
##### SUMMARY

write() need bytes object on python 3.
Otherwise, it fail with:

    Traceback (most recent call last):
      File \"/tmp/ansible_c1zmq3i9/ansible_module_openssl_certificate.py\", line 808, in <module>
        main()
      File \"/tmp/ansible_c1zmq3i9/ansible_module_openssl_certificate.py\", line 787, in main
        certificate.generate(module)
      File \"/tmp/ansible_c1zmq3i9/ansible_module_openssl_certificate.py\", line 692, in generate
        certfile.write(str(crt))
    TypeError: a bytes-like object is required, not 'str'


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
openssl_certificate

##### ADDITIONAL INFORMATION
I didn't test yet the PR on python 2