### PR TITLE
Verify that acme-tiny is present

### DIFF
--- a/lib/ansible/modules/crypto/openssl_certificate.py
+++ b/lib/ansible/modules/crypto/openssl_certificate.py
@@ -748,9 +748,11 @@ class AcmeCertificate(Certificate):
             )
 
         if not self.check(module, perms_required=False) or self.force:
+            acme_tiny_path = self.module.get_bin_path('acme-tiny', required=True)
+
             try:
                 p = subprocess.Popen([
-                    'acme-tiny',
+                    acme_tiny_path,
                     '--account-key', self.accountkey_path,
                     '--csr', self.csr_path,
                     '--acme-dir', self.challenge_path], stdout=subprocess.PIPE)

--- a/lib/ansible/modules/crypto/openssl_certificate.py
+++ b/lib/ansible/modules/crypto/openssl_certificate.py
@@ -340,7 +340,6 @@ filename:
 
 from random import randint
 import datetime
-import subprocess
 import os
 
 from ansible.module_utils import crypto as crypto_utils
@@ -751,12 +750,12 @@ class AcmeCertificate(Certificate):
             acme_tiny_path = self.module.get_bin_path('acme-tiny', required=True)
 
             try:
-                p = subprocess.Popen([
-                    acme_tiny_path,
-                    '--account-key', self.accountkey_path,
-                    '--csr', self.csr_path,
-                    '--acme-dir', self.challenge_path], stdout=subprocess.PIPE)
-                crt = p.communicate()[0]
+                crt = module.run_command("%s --account-key %s --csr %s"
+                                         "--acme-dir %s" % (acme_tiny_path,
+                                                            self.accountkey_path,
+                                                            self.csr_path,
+                                                            self.challenge_path),
+                                         check_rc=True)[1]
                 with open(self.path, 'wb') as certfile:
                     certfile.write(str(crt))
             except OSError as exc:


### PR DESCRIPTION
##### SUMMARY

Verify that acme-tiny is present. Otherwise, ansible will fail with a traceback instead of a cleaner error message. While on it, I also added the support for checking the return code and not showing stderr by default.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
openssl_certificate
