### PR TITLE
Fixes issue #34956

### DIFF
--- a/lib/ansible/modules/windows/win_dns_client.ps1
+++ b/lib/ansible/modules/windows/win_dns_client.ps1
@@ -135,7 +135,11 @@ Function Get-DnsClientMatch {
 
     $current_dns_v4 = ($current_dns_all | Where-Object AddressFamily -eq 2 <# IPv4 #>).ServerAddresses
 
-    If ($current_dns_v4 -eq $null) {
+    If (($current_dns_v4 -eq $null) -and ($ipv4_addresses -eq $null)) {
+        $v4_match = $True
+    }
+
+    ElseIf (($current_dns_v4 -eq $null) -or ($ipv4_addresses -eq $null)) {
         $v4_match = $False
     }
 
@@ -166,10 +170,16 @@ Function Set-DnsClientAddresses
     )
 
     Write-DebugLog ("Setting DNS addresses for adapter {0} to ({1})" -f $adapter_name, ($ipv4_addresses -join ", "))
+    
+    If ($ipv4_addresses -eq $null) {
+        Set-DnsClientServerAddress -InterfaceAlias $adapter_name -ResetServerAddress
+    }
 
+    Else {
     # this silently ignores invalid IPs, so we validate parseability ourselves up front...
-    Set-DnsClientServerAddress -InterfaceAlias $adapter_name -ServerAddresses $ipv4_addresses
-
+        Set-DnsClientServerAddress -InterfaceAlias $adapter_name -ServerAddresses $ipv4_addresses
+    }
+    
     # TODO: implement IPv6
 }
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Should address issue #34956 -- logic was added to check to see if $ipv4_addresses is equal to $null and take appropriate actions to resolve the error mentioned in the issue and ensure that the DNS address is set to DHCP if $ipv4_addresses is null.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
win_dns_client

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.2.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Aug  4 2017, 00:39:18) [GCC 4.8.5 20150623 (Red Hat 4.8.5-16)]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
It seems like the issue was caused by the -CompareObject cmdlet's inability to compare objects if one or both of those objects were $null. I added logic to avoid the scenario. While doing so, I noticed that the task would not revert DNS settings to DHCP, so I made changes to the Set-DNSClientServerAddress cmdlet if $ipv4_addresses was $null.

Note the below before and after for the given playbook:

##### Playbook:
```
---
- name: Configure DNS to pull from DHCP
  hosts: windows
  tasks:
    - win_dns_client:
        adapter_names: "*"
        ipv4_addresses: []
```
<!--- Paste verbatim command output below, e.g. before and after your change -->
##### Before:
```
TASK [win_dns_client] ***********************************************************************************************************************************************************************************************************************
task path: /root/playbooks/win-dhcp.yml:9
Using module file /usr/lib/python2.7/site-packages/ansible/modules/windows/win_dns_client.ps1
<10.2.1.80> ESTABLISH WINRM CONNECTION FOR USER: administrator on PORT 5986 TO 10.2.1.80
EXEC (via pipeline wrapper)
fatal: [10.2.1.80]: FAILED! => {
    "changed": false,
    "module_stderr": "An error occurred while creating the pipeline.\r\n    + CategoryInfo          : NotSpecified: (:) [], ParentContainsErrorRecordException\r\n    + FullyQualifiedErrorId : RuntimeException\r\n \r\nCompare-Object : Cannot bind argument to parameter 'DifferenceObject' because it is null.\r\nAt line:143 char:54\r\n+ ...  $v4_match = @(Compare-Object $current_dns_v4 $ipv4_addresses).Count  ...\r\n+                                                   ~~~~~~~~~~~~~~~\r\n    + CategoryInfo          : InvalidData: (:) [Compare-Object], ParentContainsErrorRecordException\r\n    + FullyQualifiedErrorId : ParameterArgumentValidationErrorNullNotAllowed,Microsoft.PowerShell.Commands.CompareObje \r\n   ctCommand\r\n \r\n\r\n",
    "module_stdout": "",
    "msg": "MODULE FAILURE",
    "rc": 1
}
        to retry, use: --limit @/root/playbooks/win-dhcp.retry

```

##### After:
```
TASK [win_dns_client] ************************************************************************
task path: /etc/ansible/playbooks/dns2.yml:5
Using module file /usr/lib/python2.7/site-packages/ansible/modules/windows/win_dns_client.ps1
<192.168.187.140> ESTABLISH WINRM CONNECTION FOR USER: administrator on PORT 5986 TO 192.168.187.140
EXEC (via pipeline wrapper)
changed: [192.168.187.140] => {
    "changed": true,
    "failed": false
}
META: ran handlers
META: ran handlers
```

##### Other notes:
This is my first contribution to the open source community, so forgive me if I have done something a way that isn't the best ;)