### PR TITLE
VMware: Check if VM is poweredoff before destroy

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -617,6 +617,10 @@ class PyVmomiHelper(PyVmomi):
 
     def remove_vm(self, vm):
         # https://www.vmware.com/support/developer/converter-sdk/conv60_apireference/vim.ManagedEntity.html#destroy
+        if vm.summary.runtime.powerState.lower() == 'poweredon':
+            self.module.fail_json(msg="Virtual machine %s found in 'powered on' state, "
+                                      "please use 'force' parameter to remove or poweroff VM "
+                                      "and try removing VM again." % vm.name)
         task = vm.Destroy()
         self.wait_for_task(task)
 

--- a/test/integration/targets/vmware_guest/tasks/delete_vm.yml
+++ b/test/integration/targets/vmware_guest/tasks/delete_vm.yml
@@ -1,0 +1,80 @@
+# Test code for the vmware_guest module.
+# Copyright: (c) 2018, Abhijeet Kasurde <akasurde@redhat.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Wait for Flask controller to come up online
+  wait_for:
+    host: "{{ vcsim }}"
+    port: 5000
+    state: started
+
+- name: kill vcsim
+  uri:
+    url: http://{{ vcsim }}:5000/killall
+- name: start vcsim with no folders
+  uri:
+    url: http://{{ vcsim }}:5000/spawn?datacenter=1&cluster=1&folder=0
+  register: vcsim_instance
+
+- name: Wait for Flask controller to come up online
+  wait_for:
+    host: "{{ vcsim }}"
+    port: 443
+    state: started
+
+- name: get a list of VMS from vcsim
+  uri:
+    url: http://{{ vcsim }}:5000/govc_find?filter=VM
+  register: vmlist
+
+- debug: var=vcsim_instance
+- debug: var=vmlist
+
+- name: get a guest
+  set_fact:
+    guest1: "{{ vmlist.json[0] }}"
+
+- vmware_vm_facts:
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    validate_certs: no
+  register: vm_details
+
+- name: store the vcenter container ip
+  set_fact:
+    vm_powerstate: "{{ vm_details.virtual_machines[guest1|basename]['power_state'] }}"
+
+- debug: var=vm_powerstate
+
+- vmware_guest:
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    validate_certs: no
+    name: "{{ guest1|basename }}"
+    state: poweredon
+  when: "vm_powerstate != 'poweredOn'"
+  register: vmware_guest_poweron_state
+
+- debug: var=vmware_guest_poweron_state
+
+- name: Delete VM
+  vmware_guest:
+    validate_certs: False
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    name: "{{ guest1|basename }}"
+    datacenter: "{{ (guest1|basename).split('_')[0] }}"
+    state: absent
+  register: delete_vm
+  ignore_errors: yes
+
+- debug: var=delete_vm
+
+- name: assert that changes were made
+  assert:
+    that:
+      - "not delete_vm.changed"
+      - "delete_vm.msg"

--- a/test/integration/targets/vmware_guest/tasks/main.yml
+++ b/test/integration/targets/vmware_guest/tasks/main.yml
@@ -24,4 +24,5 @@
 - include: mac_address_d1_c1_f0.yml
 - include: disk_type_d1_c1_f0.yml
 - include: create_nw_d1_c1_f0.yml
+- include: delete_vm.yml
 #- include: template_d1_c1_f0.yml


### PR DESCRIPTION

##### SUMMARY
This fix checks if VM is poweredoff before it can be destroyed.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/vmware/vmware_guest.py test/integration/targets/vmware_guest/tasks/delete_vm.yml test/integration/targets/vmware_guest/tasks/main.yml

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5devel
```