### PR TITLE
adding cli_default_profile

### DIFF
--- a/lib/ansible/utils/module_docs_fragments/azure.py
+++ b/lib/ansible/utils/module_docs_fragments/azure.py
@@ -61,6 +61,10 @@ options:
             - Azure tenant ID. Use when authenticating with a Service Principal.
         required: false
         default: null
+    cli_default_profile:
+        description:
+            - Use default Azure CLI security profile.
+        type: bool    
     cloud_environment:
         description:
             - For cloud environments other than the US public cloud, the environment name (as defined by Azure Python SDK, eg, C(AzureChinaCloud),

--- a/lib/ansible/utils/module_docs_fragments/azure.py
+++ b/lib/ansible/utils/module_docs_fragments/azure.py
@@ -64,7 +64,7 @@ options:
     cli_default_profile:
         description:
             - Use default Azure CLI security profile.
-        type: bool    
+        type: bool
     cloud_environment:
         description:
             - For cloud environments other than the US public cloud, the environment name (as defined by Azure Python SDK, eg, C(AzureChinaCloud),


### PR DESCRIPTION
##### SUMMARY
Added missing cli_default_profile to Azure documentation.
Apparently lack of this field causes sanity tests to fail when submitting new modules.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
Azure - all

##### ANSIBLE VERSION
2.4

##### ADDITIONAL INFORMATION

