### PR TITLE
Fix Digital Ocean inventory script pagination handling

### DIFF
--- a/contrib/inventory/digital_ocean.py
+++ b/contrib/inventory/digital_ocean.py
@@ -191,7 +191,7 @@ class DoManager:
 
         except ValueError as e:
             sys.exit("Unable to parse result from %s: %s" % (url, e))
-        return json_resp
+        return resp_data
 
     def all_active_droplets(self):
         resp = self.send('droplets/')


### PR DESCRIPTION
##### SUMMARY
This fixes the pagination code in the Digital Ocean inventory script. It was fetching and combining pages correctly, but then returning the wrong dict to the caller.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
`contrib/inventory/digital_ocean.py`