### PR TITLE
ACI: Move to 'host' parameter instead of 'hostname'

### DIFF
--- a/lib/ansible/module_utils/network/aci/aci.py
+++ b/lib/ansible/module_utils/network/aci/aci.py
@@ -63,7 +63,7 @@ except ImportError:
 
 def aci_argument_spec():
     return dict(
-        hostname=dict(type='str', required=True, aliases=['host']),
+        host=dict(type='str', required=True, aliases=['hostname']),
         port=dict(type='int', required=False),
         username=dict(type='str', default='admin', aliases=['user']),
         password=dict(type='str', no_log=True),
@@ -216,9 +216,9 @@ class ACIModule(object):
 
         # Perform login request
         if 'port' in self.params and self.params['port'] is not None:
-            url = '%(protocol)s://%(hostname)s:%(port)s/api/aaaLogin.json' % self.params
+            url = '%(protocol)s://%(host)s:%(port)s/api/aaaLogin.json' % self.params
         else:
-            url = '%(protocol)s://%(hostname)s/api/aaaLogin.json' % self.params
+            url = '%(protocol)s://%(host)s/api/aaaLogin.json' % self.params
         payload = {'aaaUser': {'attributes': {'name': self.params['username'], 'pwd': self.params['password']}}}
         resp, auth = fetch_url(self.module, url,
                                data=json.dumps(payload),
@@ -281,9 +281,9 @@ class ACIModule(object):
         self.result['path'] = path
 
         if 'port' in self.params and self.params['port'] is not None:
-            self.result['url'] = '%(protocol)s://%(hostname)s:%(port)s/' % self.params + path.lstrip('/')
+            self.result['url'] = '%(protocol)s://%(host)s:%(port)s/' % self.params + path.lstrip('/')
         else:
-            self.result['url'] = '%(protocol)s://%(hostname)s/' % self.params + path.lstrip('/')
+            self.result['url'] = '%(protocol)s://%(host)s/' % self.params + path.lstrip('/')
 
         # Sign and encode request as to APIC's wishes
         if self.params['private_key'] is not None:
@@ -319,9 +319,9 @@ class ACIModule(object):
         self.result['path'] = path
 
         if 'port' in self.params and self.params['port'] is not None:
-            self.result['url'] = '%(protocol)s://%(hostname)s:%(port)s/' % self.params + path.lstrip('/')
+            self.result['url'] = '%(protocol)s://%(host)s:%(port)s/' % self.params + path.lstrip('/')
         else:
-            self.result['url'] = '%(protocol)s://%(hostname)s/' % self.params + path.lstrip('/')
+            self.result['url'] = '%(protocol)s://%(host)s/' % self.params + path.lstrip('/')
 
         # Sign and encode request as to APIC's wishes
         if self.params['private_key'] is not None:
@@ -395,9 +395,9 @@ class ACIModule(object):
 
         self.result['path'] = path
         if 'port' in self.params and self.params['port'] is not None:
-            self.result['url'] = '{0}://{1}:{2}/{3}'.format(self.module.params['protocol'], self.module.params['hostname'], self.module.params['port'], path)
+            self.result['url'] = '{0}://{1}:{2}/{3}'.format(self.module.params['protocol'], self.module.params['host'], self.module.params['port'], path)
         else:
-            self.result['url'] = '{0}://{1}/{2}'.format(self.module.params['protocol'], self.module.params['hostname'], path)
+            self.result['url'] = '{0}://{1}/{2}'.format(self.module.params['protocol'], self.module.params['host'], path)
         self.result['filter_string'] = filter_string
 
     def _construct_url_1(self, obj, child_includes):

--- a/lib/ansible/modules/network/aci/aci_aaa_user_certificate.py
+++ b/lib/ansible/modules/network/aci/aci_aaa_user_certificate.py
@@ -54,7 +54,7 @@ extends_documentation_fragment: aci
 EXAMPLES = r'''
 - name: Add a certificate to user
   aci_aaa_user_certificate:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     user: admin
@@ -64,7 +64,7 @@ EXAMPLES = r'''
 
 - name: Remove a certificate of a user
   aci_aaa_user_certificate:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     user: admin
@@ -73,7 +73,7 @@ EXAMPLES = r'''
 
 - name: Query a certificate of a user
   aci_aaa_user_certificate:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     user: admin
@@ -82,7 +82,7 @@ EXAMPLES = r'''
 
 - name: Query all certificates of a user
   aci_aaa_user_certificate:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     user: admin

--- a/lib/ansible/modules/network/aci/aci_access_port_to_interface_policy_leaf_profile.py
+++ b/lib/ansible/modules/network/aci/aci_access_port_to_interface_policy_leaf_profile.py
@@ -73,7 +73,7 @@ extends_documentation_fragment: aci
 EXAMPLES = r'''
 - name: Associate an Interface Access Port Selector to an Interface Policy Leaf Profile with a Policy Group
   aci_access_port_to_interface_policy_leaf_profile:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     leaf_interface_profile: leafintprfname
@@ -86,7 +86,7 @@ EXAMPLES = r'''
 
 - name: Associate an interface access port selector to an Interface Policy Leaf Profile (w/o policy group) (check if this works)
   aci_access_port_to_interface_policy_leaf_profile:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     leaf_interface_profile: leafintprfname
@@ -98,7 +98,7 @@ EXAMPLES = r'''
 
 - name: Remove an interface access port selector associated with an Interface Policy Leaf Profile
   aci_access_port_to_interface_policy_leaf_profile:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     leaf_interface_profile: leafintprfname
@@ -107,7 +107,7 @@ EXAMPLES = r'''
 
 - name: Query Specific access_port_selector under given leaf_interface_profile
   aci_access_port_to_interface_policy_leaf_profile:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     leaf_interface_profile: leafintprfname

--- a/lib/ansible/modules/network/aci/aci_aep.py
+++ b/lib/ansible/modules/network/aci/aci_aep.py
@@ -55,7 +55,7 @@ extends_documentation_fragment: aci
 EXAMPLES = r'''
 - name: Add a new AEP
   aci_aep:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     aep: ACI-AEP
@@ -64,7 +64,7 @@ EXAMPLES = r'''
 
 - name: Remove an existing AEP
   aci_aep:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     aep: ACI-AEP
@@ -72,7 +72,7 @@ EXAMPLES = r'''
 
 - name: Query an AEP
   aci_aep:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     aep: ACI-AEP
@@ -80,7 +80,7 @@ EXAMPLES = r'''
 
 - name: Query all AEPs
   aci_aep:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     state: query

--- a/lib/ansible/modules/network/aci/aci_ap.py
+++ b/lib/ansible/modules/network/aci/aci_ap.py
@@ -52,7 +52,7 @@ extends_documentation_fragment: aci
 EXAMPLES = r'''
 - name: Add a new AP
   aci_ap:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     tenant: production
@@ -62,7 +62,7 @@ EXAMPLES = r'''
 
 - name: Remove an AP
   aci_ap:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     tenant: production
@@ -71,7 +71,7 @@ EXAMPLES = r'''
 
 - name: Query an AP
   aci_ap:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     tenant: production
@@ -80,7 +80,7 @@ EXAMPLES = r'''
 
 - name: Query all APs
   aci_ap:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     state: query

--- a/lib/ansible/modules/network/aci/aci_bd_subnet.py
+++ b/lib/ansible/modules/network/aci/aci_bd_subnet.py
@@ -112,14 +112,14 @@ extends_documentation_fragment: aci
 EXAMPLES = r'''
 - name: create a tenant
   aci_tenant:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     tenant: production
 
 - name: create a bridge domain
   aci_bd:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     tenant: production
@@ -127,7 +127,7 @@ EXAMPLES = r'''
 
 - name: create a subnet
   aci_bd_subnet:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     tenant: production
@@ -137,7 +137,7 @@ EXAMPLES = r'''
 
 - name: create a subnet with options
   aci_bd_subnet:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     tenant: production
@@ -152,7 +152,7 @@ EXAMPLES = r'''
 
 - name: update a subnets scope to private and shared
   aci_bd_subnet:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     tenant: production
@@ -163,14 +163,14 @@ EXAMPLES = r'''
 
 - name: get all subnets
   aci_bd_subnet:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     state: query
 
 - name: get all subnets of specific gateway in specified tenant
   aci_bd_subnet:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     state: query
@@ -180,7 +180,7 @@ EXAMPLES = r'''
 
 - name: get specific subnet
   aci_bd_subnet:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     state: query
@@ -191,7 +191,7 @@ EXAMPLES = r'''
 
 - name: delete a subnet
   aci_bd_subnet:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     state: absent

--- a/lib/ansible/modules/network/aci/aci_config_rollback.py
+++ b/lib/ansible/modules/network/aci/aci_config_rollback.py
@@ -76,7 +76,7 @@ EXAMPLES = r'''
 ---
 - name: Create a Snapshot
   aci_config_snapshot:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     state: present
@@ -84,7 +84,7 @@ EXAMPLES = r'''
 
 - name: Query Existing Snapshots
   aci_config_snapshot:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     state: query
@@ -92,7 +92,7 @@ EXAMPLES = r'''
 
 - name: Compare Snapshot Files
   aci_config_rollback:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     state: preview
@@ -103,7 +103,7 @@ EXAMPLES = r'''
 
 - name: Rollback Configuration
   aci_config_rollback:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     state: rollback
@@ -113,7 +113,7 @@ EXAMPLES = r'''
 
 - name: Rollback Configuration
   aci_config_rollback:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     state: rollback
@@ -225,7 +225,7 @@ def main():
         aci.post_config()
 
     elif state == 'preview':
-        aci.result['url'] = '%(protocol)s://%(hostname)s/mqapi2/snapshots.diff.xml' % module.params
+        aci.result['url'] = '%(protocol)s://%(host)s/mqapi2/snapshots.diff.xml' % module.params
         aci.result['filter_string'] = (
             '?s1dn=uni/backupst/snapshots-[uni/fabric/configexp-%(export_policy)s]/snapshot-%(snapshot)s&'
             's2dn=uni/backupst/snapshots-[uni/fabric/configexp-%(compare_export_policy)s]/snapshot-%(compare_snapshot)s'

--- a/lib/ansible/modules/network/aci/aci_config_snapshot.py
+++ b/lib/ansible/modules/network/aci/aci_config_snapshot.py
@@ -69,7 +69,7 @@ extends_documentation_fragment: aci
 EXAMPLES = r'''
 - name: Create a Snapshot
   aci_config_snapshot:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     state: present
@@ -79,14 +79,14 @@ EXAMPLES = r'''
 
 - name: Query all Snapshots
   aci_config_snapshot:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     state: query
 
 - name: Query Snapshots associated with a particular Export Policy
   aci_config_snapshot:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     state: query
@@ -94,7 +94,7 @@ EXAMPLES = r'''
 
 - name: Delete a Snapshot
   aci_config_snapshot:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     state: absent

--- a/lib/ansible/modules/network/aci/aci_contract.py
+++ b/lib/ansible/modules/network/aci/aci_contract.py
@@ -69,7 +69,7 @@ extends_documentation_fragment: aci
 # FIXME: Add more, better examples
 EXAMPLES = r'''
 - aci_contract:
-    hostname: '{{ inventory_hostname }}'
+    host: '{{ inventory_hostname }}'
     username: '{{ username }}'
     password: '{{ password }}'
     contract: '{{ contract }}'

--- a/lib/ansible/modules/network/aci/aci_contract_subject.py
+++ b/lib/ansible/modules/network/aci/aci_contract_subject.py
@@ -86,7 +86,7 @@ extends_documentation_fragment: aci
 EXAMPLES = r'''
 - name: Add a new contract subject
   aci_contract_subject:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     tenant: production
@@ -100,7 +100,7 @@ EXAMPLES = r'''
 
 - name: Remove a contract subject
   aci_contract_subject:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     tenant: production
@@ -110,7 +110,7 @@ EXAMPLES = r'''
 
 - name: Query a contract subject
   aci_contract_subject:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     tenant: production
@@ -120,7 +120,7 @@ EXAMPLES = r'''
 
 - name: Query all contract subjects
   aci_contract_subject:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     state: query

--- a/lib/ansible/modules/network/aci/aci_contract_subject_to_filter.py
+++ b/lib/ansible/modules/network/aci/aci_contract_subject_to_filter.py
@@ -63,7 +63,7 @@ extends_documentation_fragment: aci
 # FIXME: Add more, better examples
 EXAMPLES = r'''
 - aci_subject_filter_binding:
-    hostname: '{{ inventory_hostname }}'
+    host: '{{ inventory_hostname }}'
     username: '{{ username }}'
     password: '{{ password }}'
     tenant: '{{ tenant }}'

--- a/lib/ansible/modules/network/aci/aci_domain.py
+++ b/lib/ansible/modules/network/aci/aci_domain.py
@@ -73,7 +73,7 @@ extends_documentation_fragment: aci
 EXAMPLES = r'''
 - name: Add a new physical domain
   aci_domain:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     domain: phys_dom
@@ -82,7 +82,7 @@ EXAMPLES = r'''
 
 - name: Remove a physical domain
   aci_domain:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     domain: phys_dom
@@ -91,7 +91,7 @@ EXAMPLES = r'''
 
 - name: Add a new VMM domain
   aci_domain:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     domain: hyperv_dom
@@ -101,7 +101,7 @@ EXAMPLES = r'''
 
 - name: Remove a VMM domain
   aci_domain:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     domain: hyperv_dom
@@ -111,7 +111,7 @@ EXAMPLES = r'''
 
 - name: Query a specific physical domain
   aci_domain:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     domain: phys_dom
@@ -120,7 +120,7 @@ EXAMPLES = r'''
 
 - name: Query all domains
   aci_domain:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     state: query

--- a/lib/ansible/modules/network/aci/aci_domain_to_vlan_pool.py
+++ b/lib/ansible/modules/network/aci/aci_domain_to_vlan_pool.py
@@ -62,7 +62,7 @@ extends_documentation_fragment: aci
 EXAMPLES = r'''
 - name: Bind a VMM domain to VLAN pool
   aci_domain_to_vlan_pool:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     domain: vmw_dom
@@ -74,7 +74,7 @@ EXAMPLES = r'''
 
 - name: Remove a VMM domain to VLAN pool binding
   aci_domain_to_vlan_pool:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     domain: vmw_dom
@@ -86,7 +86,7 @@ EXAMPLES = r'''
 
 - name: Bind a physical domain to VLAN pool
   aci_domain_to_vlan_pool:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     domain: phys_dom
@@ -97,7 +97,7 @@ EXAMPLES = r'''
 
 - name: Bind a physical domain to VLAN pool
   aci_domain_to_vlan_pool:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     domain: phys_dom
@@ -108,7 +108,7 @@ EXAMPLES = r'''
 
 - name: Query an domain to VLAN pool binding
   aci_domain_to_vlan_pool:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     domain: phys_dom
@@ -119,7 +119,7 @@ EXAMPLES = r'''
 
 - name: Query all domain to VLAN pool bindings
   aci_domain_to_vlan_pool:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     state: query

--- a/lib/ansible/modules/network/aci/aci_encap_pool.py
+++ b/lib/ansible/modules/network/aci/aci_encap_pool.py
@@ -55,7 +55,7 @@ extends_documentation_fragment: aci
 EXAMPLES = r'''
 - name: Add a new vlan pool
   aci_encap_pool:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     pool: production
@@ -65,7 +65,7 @@ EXAMPLES = r'''
 
 - name: Remove a vlan pool
   aci_encap_pool:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     pool: production
@@ -74,7 +74,7 @@ EXAMPLES = r'''
 
 - name: Query a vlan pool
   aci_encap_pool:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     pool: production
@@ -83,7 +83,7 @@ EXAMPLES = r'''
 
 - name: Query all vlan pools
   aci_encap_pool:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     pool_type: vlan

--- a/lib/ansible/modules/network/aci/aci_encap_pool_range.py
+++ b/lib/ansible/modules/network/aci/aci_encap_pool_range.py
@@ -74,7 +74,7 @@ extends_documentation_fragment: aci
 EXAMPLES = r'''
 - name: Add a new vlan range
   aci_vlan_pool_encap_block:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     pool: production
@@ -85,7 +85,7 @@ EXAMPLES = r'''
 
 - name: Remove a vlan range
   aci_vlan_pool_encap_block:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     pool: production
@@ -96,7 +96,7 @@ EXAMPLES = r'''
 
 - name: Query a vlan range
   aci_vlan_pool_encap_block:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     pool: production
@@ -107,7 +107,7 @@ EXAMPLES = r'''
 
 - name: Query a vlan pool for ranges
   aci_vlan_pool_encap_block:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     pool: production
@@ -116,7 +116,7 @@ EXAMPLES = r'''
 
 - name: Query all vlan ranges
   aci_vlan_pool_encap_block:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     pool_type: vlan

--- a/lib/ansible/modules/network/aci/aci_epg.py
+++ b/lib/ansible/modules/network/aci/aci_epg.py
@@ -76,7 +76,7 @@ extends_documentation_fragment: aci
 EXAMPLES = r'''
 - name: Add a new EPG
   aci_epg:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     tenant: production
@@ -86,7 +86,7 @@ EXAMPLES = r'''
     bd: prod_bd
 
 - aci_epg:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     tenant: production
@@ -105,7 +105,7 @@ EXAMPLES = r'''
 
 - name: Remove an EPG
   aci_epg:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     validate_certs: false
@@ -116,7 +116,7 @@ EXAMPLES = r'''
 
 - name: Query an EPG
   aci_epg:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     tenant: production
@@ -126,14 +126,14 @@ EXAMPLES = r'''
 
 - name: Query all EPGs
   aci_epg:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     state: query
 
 - name: Query all EPGs with a Specific Name
   aci_epg:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     validate_certs: false
@@ -142,7 +142,7 @@ EXAMPLES = r'''
 
 - name: Query all EPGs of an App Profile
   aci_epg:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     validate_certs: false

--- a/lib/ansible/modules/network/aci/aci_epg_monitoring_policy.py
+++ b/lib/ansible/modules/network/aci/aci_epg_monitoring_policy.py
@@ -53,7 +53,7 @@ extends_documentation_fragment: aci
 # FIXME: Add more, better examples
 EXAMPLES = r'''
 - aci_epg_monitoring_policy:
-    hostname: '{{ hostname }}'
+    host: '{{ hostname }}'
     username: '{{ username }}'
     password: '{{ password }}'
     monitoring_policy: '{{ monitoring_policy }}'

--- a/lib/ansible/modules/network/aci/aci_filter.py
+++ b/lib/ansible/modules/network/aci/aci_filter.py
@@ -52,7 +52,7 @@ extends_documentation_fragment: aci
 EXAMPLES = r'''
 - name: Add a new filter to a tenant
   aci_filter:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     filter: web_filter
@@ -62,7 +62,7 @@ EXAMPLES = r'''
 
 - name: Remove a filter for a tenant
   aci_filter:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     filter: web_filter
@@ -71,7 +71,7 @@ EXAMPLES = r'''
 
 - name: Query a filter of a tenant
   aci_filter:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     filter: web_filter
@@ -80,7 +80,7 @@ EXAMPLES = r'''
 
 - name: Query all filters for a tenant
   aci_filter:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     tenant: production

--- a/lib/ansible/modules/network/aci/aci_filter_entry.py
+++ b/lib/ansible/modules/network/aci/aci_filter_entry.py
@@ -102,17 +102,16 @@ extends_documentation_fragment: aci
 
 EXAMPLES = r'''
 - aci_filter_entry:
-    action: "{{ action }}"
+    host: "{{ inventory_hostname }}"
+    username: "{{ user }}"
+    password: "{{ pass }}"
+    state: "{{ state }}"
     entry: "{{ entry }}"
     tenant: "{{ tenant }}"
     ether_name: "{{  ether_name }}"
     icmp_msg_type: "{{ icmp_msg_type }}"
     filter: "{{ filter }}"
     descr: "{{ descr }}"
-    host: "{{ inventory_hostname }}"
-    username: "{{ user }}"
-    password: "{{ pass }}"
-    protocol: "{{ protocol }}"
 '''
 
 RETURN = ''' # '''

--- a/lib/ansible/modules/network/aci/aci_interface_policy_fc.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_fc.py
@@ -47,7 +47,7 @@ extends_documentation_fragment: aci
 
 EXAMPLES = r'''
 - aci_interface_policy_fc:
-    hostname: '{{ hostname }}'
+    host: '{{ hostname }}'
     username: '{{ username }}'
     password: '{{ password }}'
     fc_policy: '{{ fc_policy }}'

--- a/lib/ansible/modules/network/aci/aci_interface_policy_l2.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_l2.py
@@ -57,7 +57,7 @@ extends_documentation_fragment: aci
 
 EXAMPLES = r'''
 - aci_interface_policy_l2:
-    hostname: '{{ hostname }}'
+    host: '{{ hostname }}'
     username: '{{ username }}'
     password: '{{ password }}'
     l2_policy: '{{ l2_policy }}'

--- a/lib/ansible/modules/network/aci/aci_interface_policy_leaf_policy_group.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_leaf_policy_group.py
@@ -114,7 +114,7 @@ extends_documentation_fragment: aci
 EXAMPLES = r'''
 - name: creating a Port Channel (PC) Interface Policy Group
   aci_interface_policy_leaf_policy_group:
-    hostname: apic
+    host: apic
     username: yourusername
     password: yourpassword
     policy_group: policygroupname
@@ -126,7 +126,7 @@ EXAMPLES = r'''
 
 - name: creating a Virtual Port Channel (VPC) Interface Policy Group (no description)
   aci_interface_policy_leaf_policy_group:
-    hostname: apic
+    host: apic
     username: yourusername
     password: yourpassword
     policy_group: policygroupname
@@ -137,7 +137,7 @@ EXAMPLES = r'''
 
 - name: creating a Leaf Access Port Policy Group (no description)
   aci_interface_policy_leaf_policy_group:
-    hostname: apic
+    host: apic
     username: yourusername
     password: yourpassword
     policy_group: policygroupname
@@ -148,7 +148,7 @@ EXAMPLES = r'''
 
 - name: deleting an Interface policy Leaf Policy Group
   aci_interface_policy_leaf_policy_group:
-    hostname: apic
+    host: apic
     username: yourusername
     password: yourpassword
     policy_group: policygroupname

--- a/lib/ansible/modules/network/aci/aci_interface_policy_leaf_profile.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_leaf_profile.py
@@ -44,7 +44,7 @@ extends_documentation_fragment: aci
 EXAMPLES = r'''
 - name: Add a new leaf_interface_profile
   aci_interface_policy_leaf_profile:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     leaf_interface_profile: leafintprfname
@@ -53,7 +53,7 @@ EXAMPLES = r'''
 
 - name: Remove a leaf_interface_profile
   aci_interface_policy_leaf_profile:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     leaf_interface_profile: leafintprfname
@@ -61,14 +61,14 @@ EXAMPLES = r'''
 
 - name: Remove all leaf_interface_profiles
   aci_interface_policy_leaf_profile:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     state: absent
 
 - name: Query a leaf_interface_profile
   aci_interface_policy_leaf_profile:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     leaf_interface_profile: leafintprfname

--- a/lib/ansible/modules/network/aci/aci_interface_policy_lldp.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_lldp.py
@@ -55,7 +55,7 @@ extends_documentation_fragment: aci
 # FIXME: Add more, better examples
 EXAMPLES = r'''
 - aci_interface_policy_lldp:
-    hostname: '{{ hostname }}'
+    host: '{{ hostname }}'
     username: '{{ username }}'
     password: '{{ password }}'
     lldp_policy: '{{ lldp_policy }}'

--- a/lib/ansible/modules/network/aci/aci_interface_policy_mcp.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_mcp.py
@@ -48,7 +48,7 @@ extends_documentation_fragment: aci
 # FIXME: Add more, better examples
 EXAMPLES = r'''
 - aci_interface_policy_mcp:
-    hostname: '{{ hostname }}'
+    host: '{{ hostname }}'
     username: '{{ username }}'
     password: '{{ password }}'
     mcp: '{{ mcp }}'

--- a/lib/ansible/modules/network/aci/aci_interface_policy_port_channel.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_port_channel.py
@@ -101,7 +101,7 @@ extends_documentation_fragment: aci
 
 EXAMPLES = r'''
 - aci_interface_policy_port_channel:
-    hostname: '{{ inventory_hostname }}'
+    host: '{{ inventory_hostname }}'
     username: '{{ username }}'
     password: '{{ password }}'
     port_channel: '{{ port_channel }}'

--- a/lib/ansible/modules/network/aci/aci_interface_policy_port_security.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_port_security.py
@@ -47,7 +47,7 @@ extends_documentation_fragment: aci
 # FIXME: Add more, better examples
 EXAMPLES = r'''
 - aci_interface_policy_port_security:
-    hostname: '{{ inventory_hostname }}'
+    host: '{{ inventory_hostname }}'
     username: '{{ username }}'
     password: '{{ password }}'
     port_security: '{{ port_security }}'

--- a/lib/ansible/modules/network/aci/aci_interface_selector_to_switch_policy_leaf_profile.py
+++ b/lib/ansible/modules/network/aci/aci_interface_selector_to_switch_policy_leaf_profile.py
@@ -47,7 +47,7 @@ extends_documentation_fragment: aci
 EXAMPLES = r'''
 - name: Associating an interface selector profile to a switch policy leaf profile
   aci_interface_selector_to_switch_policy_leaf_profile:
-    hostname: apic
+    host: apic
     username: someusername
     password: somepassword
     leaf_profile: sw_name
@@ -56,7 +56,7 @@ EXAMPLES = r'''
 
 - name: Remove an interface selector profile associated with a switch policy leaf profile
   aci_interface_selector_to_switch_policy_leaf_profile:
-    hostname: apic
+    host: apic
     username: someusername
     password: somepassword
     leaf_profile: sw_name
@@ -65,7 +65,7 @@ EXAMPLES = r'''
 
 - name: Query an interface selector profile associated with a switch policy leaf profile
   aci_interface_selector_to_switch_policy_leaf_profile:
-    hostname: apic
+    host: apic
     username: someusername
     password: somepassword
     leaf_profile: sw_name

--- a/lib/ansible/modules/network/aci/aci_l3out_route_tag_policy.py
+++ b/lib/ansible/modules/network/aci/aci_l3out_route_tag_policy.py
@@ -55,7 +55,7 @@ extends_documentation_fragment: aci
 # FIXME: Add more, better examples
 EXAMPLES = r'''
 - aci_l3out_route_tag_policy:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     rtp: '{{ rtp_name }}'

--- a/lib/ansible/modules/network/aci/aci_rest.py
+++ b/lib/ansible/modules/network/aci/aci_rest.py
@@ -65,7 +65,7 @@ notes:
 EXAMPLES = r'''
 - name: Add a tenant using certifcate authentication
   aci_rest:
-    hostname: '{{ inventory_hostname }}'
+    host: '{{ inventory_hostname }}'
     username: '{{ aci_username }}'
     private_key: pki/admin.key
     method: post
@@ -75,7 +75,7 @@ EXAMPLES = r'''
 
 - name: Add a tenant using inline YAML
   aci_rest:
-    hostname: '{{ inventory_hostname }}'
+    host: '{{ inventory_hostname }}'
     username: '{{ aci_username }}'
     private_key: pki/admin.key
     validate_certs: no
@@ -90,7 +90,7 @@ EXAMPLES = r'''
 
 - name: Add a tenant using a JSON string
   aci_rest:
-    hostname: '{{ inventory_hostname }}'
+    host: '{{ inventory_hostname }}'
     username: '{{ aci_username }}'
     private_key: pki/admin.key
     validate_certs: no
@@ -109,7 +109,7 @@ EXAMPLES = r'''
 
 - name: Add a tenant using an XML string
   aci_rest:
-    hostname: '{{ inventory_hostname }}'
+    host: '{{ inventory_hostname }}'
     username: '{{ aci_username }}'
     private_key: pki/{{ aci_username}}.key
     validate_certs: no
@@ -120,7 +120,7 @@ EXAMPLES = r'''
 
 - name: Get tenants using password authentication
   aci_rest:
-    hostname: '{{ inventory_hostname }}'
+    host: '{{ inventory_hostname }}'
     username: '{{ aci_username }}'
     password: '{{ aci_password }}'
     method: get
@@ -129,7 +129,7 @@ EXAMPLES = r'''
 
 - name: Configure contracts
   aci_rest:
-    hostname: '{{ inventory_hostname }}'
+    host: '{{ inventory_hostname }}'
     username: '{{ aci_username }}'
     private_key: pki/admin.key
     method: post
@@ -139,7 +139,7 @@ EXAMPLES = r'''
 
 - name: Register leaves and spines
   aci_rest:
-    hostname: '{{ inventory_hostname }}'
+    host: '{{ inventory_hostname }}'
     username: '{{ aci_username }}'
     private_key: pki/admin.key
     validate_certs: no
@@ -155,7 +155,7 @@ EXAMPLES = r'''
 
 - name: Wait for all controllers to become ready
   aci_rest:
-    hostname: '{{ inventory_hostname }}'
+    host: '{{ inventory_hostname }}'
     username: '{{ aci_username }}'
     private_key: pki/admin.key
     validate_certs: no
@@ -370,7 +370,7 @@ def main():
                 module.fail_json(msg='Failed to parse provided XML payload: %s' % to_text(e), payload=payload)
 
     # Perform actual request using auth cookie (Same as aci_request, but also supports XML)
-    aci.result['url'] = '%(protocol)s://%(hostname)s/' % aci.params + path.lstrip('/')
+    aci.result['url'] = '%(protocol)s://%(host)s/' % aci.params + path.lstrip('/')
     if aci.params['method'] != 'get':
         path += '?rsp-subtree=modified'
         aci.result['url'] = update_qsl(aci.result['url'], {'rsp-subtree': 'modified'})

--- a/lib/ansible/modules/network/aci/aci_switch_leaf_selector.py
+++ b/lib/ansible/modules/network/aci/aci_switch_leaf_selector.py
@@ -68,7 +68,7 @@ extends_documentation_fragment: aci
 EXAMPLES = r'''
 - name: adding a switch policy leaf profile selector associated Node Block range (w/ policy group)
   aci_switch_leaf_selector:
-    hostname: apic
+    host: apic
     username: someusername
     password: somepassword
     leaf_profile: sw_name
@@ -81,7 +81,7 @@ EXAMPLES = r'''
 
 - name: adding a switch policy leaf profile selector associated Node Block range (w/o policy group)
   aci_switch_leaf_selector:
-    hostname: apic
+    host: apic
     username: someusername
     password: somepassword
     leaf_profile: sw_name
@@ -93,7 +93,7 @@ EXAMPLES = r'''
 
 - name: Removing a switch policy leaf profile selector
   aci_switch_leaf_selector:
-    hostname: apic
+    host: apic
     username: someusername
     password: somepassword
     leaf_profile: sw_name
@@ -102,7 +102,7 @@ EXAMPLES = r'''
 
 - name: Querying a switch policy leaf profile selector
   aci_switch_leaf_selector:
-    hostname: apic
+    host: apic
     username: someusername
     password: somepassword
     leaf_profile: sw_name

--- a/lib/ansible/modules/network/aci/aci_switch_policy_leaf_profile.py
+++ b/lib/ansible/modules/network/aci/aci_switch_policy_leaf_profile.py
@@ -43,7 +43,7 @@ extends_documentation_fragment: aci
 EXAMPLES = r'''
 - name: creating a Leaf Profile with description
   aci_switch_policy_leaf_profile:
-    hostname: apic
+    host: apic
     username: someusername
     password: somepassword
     leaf_profile: sw_name
@@ -52,7 +52,7 @@ EXAMPLES = r'''
 
 - name: Deleting a Leaf Profile
   aci_switch_policy_leaf_profile:
-    hostname: apic
+    host: apic
     username: someusername
     password: somepassword
     leaf_profile: sw_name
@@ -60,7 +60,7 @@ EXAMPLES = r'''
 
 - name: Query a Leaf Profile
   aci_switch_policy_leaf_profile:
-    hostname: apic
+    host: apic
     username: someusername
     password: somepassword
     leaf_profile: sw_name

--- a/lib/ansible/modules/network/aci/aci_taboo_contract.py
+++ b/lib/ansible/modules/network/aci/aci_taboo_contract.py
@@ -57,7 +57,7 @@ extends_documentation_fragment: aci
 # FIXME: Add more, better examples
 EXAMPLES = r'''
 - aci_taboo_contract:
-    hostname: '{{ inventory_hostname }}'
+    host: '{{ inventory_hostname }}'
     username: '{{ username }}'
     password: '{{ password }}'
     taboo_contract: '{{ taboo_contract }}'

--- a/lib/ansible/modules/network/aci/aci_tenant.py
+++ b/lib/ansible/modules/network/aci/aci_tenant.py
@@ -43,7 +43,7 @@ extends_documentation_fragment: aci
 EXAMPLES = r'''
 - name: Add a new tenant
   aci_tenant:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     tenant: production
@@ -52,7 +52,7 @@ EXAMPLES = r'''
 
 - name: Remove a tenant
   aci_tenant:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     tenant: production
@@ -60,7 +60,7 @@ EXAMPLES = r'''
 
 - name: Query a tenant
   aci_tenant:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     tenant: production
@@ -68,7 +68,7 @@ EXAMPLES = r'''
 
 - name: Query all tenants
   aci_tenant:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     state: query

--- a/lib/ansible/modules/network/aci/aci_tenant_action_rule_profile.py
+++ b/lib/ansible/modules/network/aci/aci_tenant_action_rule_profile.py
@@ -49,7 +49,7 @@ extends_documentation_fragment: aci
 # FIXME: Add more, better examples
 EXAMPLES = r'''
 - aci_tenant_action_rule_profile:
-    hostname: '{{ inventory_hostname }}'
+    host: '{{ inventory_hostname }}'
     username: '{{ username }}'
     password: '{{ password }}'
     action_rule: '{{ action_rule }}'

--- a/lib/ansible/modules/network/aci/aci_tenant_ep_retention_policy.py
+++ b/lib/ansible/modules/network/aci/aci_tenant_ep_retention_policy.py
@@ -78,7 +78,7 @@ extends_documentation_fragment: aci
 EXAMPLES = r'''
 - name: Add a new EPR policy
   aci_epr_policy:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     tenant: production
@@ -93,7 +93,7 @@ EXAMPLES = r'''
 
 - name: Remove an EPR policy
   aci_epr_policy:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     tenant: production
@@ -102,7 +102,7 @@ EXAMPLES = r'''
 
 - name: Query an EPR policy
   aci_epr_policy:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     tenant: production
@@ -111,7 +111,7 @@ EXAMPLES = r'''
 
 - name: Query all EPR policies
   aci_epr_policy:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     state: query

--- a/lib/ansible/modules/network/aci/aci_tenant_span_dst_group.py
+++ b/lib/ansible/modules/network/aci/aci_tenant_span_dst_group.py
@@ -51,7 +51,7 @@ extends_documentation_fragment: aci
 # FIXME: Add more, better examples
 EXAMPLES = r'''
 - aci_tenant_span_dst_group:
-    hostname: '{{ inventory_hostname }}'
+    host: '{{ inventory_hostname }}'
     username: '{{ username }}'
     password: '{{ password }}'
     dst_group: '{{ dst_group }}'

--- a/lib/ansible/modules/network/aci/aci_tenant_span_src_group.py
+++ b/lib/ansible/modules/network/aci/aci_tenant_span_src_group.py
@@ -56,14 +56,14 @@ extends_documentation_fragment: aci
 
 EXAMPLES = r'''
 - aci_tenant_span_src_group:
+    host:"{{ inventory_hostname }}"
+    username:"{{ username }}"
+    password:"{{ password }}"
     tenant:"{{ tenant }}"
     src_group:"{{ src_group }}"
     dst_group:"{{ dst_group }}"
     admin_state:"{{ admin_state }}"
     description:"{{ description }}"
-    host:"{{ inventory_hostname }}"
-    username:"{{ username }}"
-    password:"{{ password }}"
 '''
 
 RETURN = r'''

--- a/lib/ansible/modules/network/aci/aci_tenant_span_src_group_to_dst_group.py
+++ b/lib/ansible/modules/network/aci/aci_tenant_span_src_group_to_dst_group.py
@@ -50,13 +50,13 @@ extends_documentation_fragment: aci
 
 EXAMPLES = r'''
 - aci_tenant_span_src_group_to_dst_group:
+    host:"{{ inventory_hostname }}"
+    username:"{{ username }}"
+    password:"{{ password }}"
     tenant:"{{ tenant }}"
     src_group:"{{ src_group }}"
     dst_group:"{{ dst_group }}"
     description:"{{ description }}"
-    host:"{{ inventory_hostname }}"
-    username:"{{ username }}"
-    password:"{{ password }}"
 '''
 
 RETURN = r'''

--- a/lib/ansible/modules/network/aci/aci_vlan_pool.py
+++ b/lib/ansible/modules/network/aci/aci_vlan_pool.py
@@ -50,7 +50,7 @@ extends_documentation_fragment: aci
 EXAMPLES = r'''
 - name: Add a new VLAN pool
   aci_vlan_pool:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     pool: production
@@ -59,7 +59,7 @@ EXAMPLES = r'''
 
 - name: Remove a VLAN pool
   aci_vlan_pool:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     pool: production
@@ -67,7 +67,7 @@ EXAMPLES = r'''
 
 - name: Query a VLAN pool
   aci_vlan_pool:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     pool: production
@@ -75,7 +75,7 @@ EXAMPLES = r'''
 
 - name: Query all VLAN pools
   aci_vlan_pool:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     state: query

--- a/lib/ansible/modules/network/aci/aci_vlan_pool_encap_block.py
+++ b/lib/ansible/modules/network/aci/aci_vlan_pool_encap_block.py
@@ -69,7 +69,7 @@ extends_documentation_fragment: aci
 EXAMPLES = r'''
 - name: Add a new VLAN encap block
   aci_vlan_pool_encap_block:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     pool: production
@@ -79,7 +79,7 @@ EXAMPLES = r'''
 
 - name: Remove a VLAN encap block
   aci_vlan_pool_encap_block:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     pool: production
@@ -89,7 +89,7 @@ EXAMPLES = r'''
 
 - name: Query a VLAN encap block
   aci_vlan_pool_encap_block:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     pool: production
@@ -99,7 +99,7 @@ EXAMPLES = r'''
 
 - name: Query a VLAN pool for encap blocks
   aci_vlan_pool_encap_block:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     pool: production
@@ -107,7 +107,7 @@ EXAMPLES = r'''
 
 - name: Query all VLAN encap blocks
   aci_vlan_pool_encap_block:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     state: query

--- a/lib/ansible/modules/network/aci/aci_vrf.py
+++ b/lib/ansible/modules/network/aci/aci_vrf.py
@@ -58,7 +58,7 @@ extends_documentation_fragment: aci
 EXAMPLES = r'''
 - name: Add a new VRF to a tenant
   aci_vrf:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     vrf: vrf_lab
@@ -70,7 +70,7 @@ EXAMPLES = r'''
 
 - name: Remove a VRF for a tenant
   aci_vrf:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     vrf: vrf_lab
@@ -79,7 +79,7 @@ EXAMPLES = r'''
 
 - name: Query a VRF of a tenant
   aci_vrf:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     vrf: vrf_lab
@@ -88,7 +88,7 @@ EXAMPLES = r'''
 
 - name: Query all VRFs
   aci_vrf:
-    hostname: apic
+    host: apic
     username: admin
     password: SomeSecretPassword
     state: query

--- a/lib/ansible/utils/module_docs_fragments/aci.py
+++ b/lib/ansible/utils/module_docs_fragments/aci.py
@@ -23,11 +23,11 @@ class ModuleDocFragment(object):
     # Standard files documentation fragment
     DOCUMENTATION = '''
 options:
-  hostname:
+  host:
     description:
     - IP Address or hostname of APIC resolvable by Ansible control host.
     required: yes
-    aliases: [ host ]
+    aliases: [ hostname ]
   port:
     description:
     - Port number to be used for REST connection.

--- a/test/integration/targets/aci_aaa_user_certificate/tasks/main.yml
+++ b/test/integration/targets/aci_aaa_user_certificate/tasks/main.yml
@@ -12,7 +12,7 @@
 # CLEAN ENVIRONMENT
 - name: Remove any pre-existing certificate
   aci_aaa_user_certificate: &cert_absent
-    hostname: '{{ aci_hostname }}'
+    host: '{{ aci_hostname }}'
     username: '{{ aci_username }}'
     password: '{{ aci_password }}'
     validate_certs: '{{ aci_validate_certs | default(false) }}'
@@ -26,7 +26,7 @@
 # ADD USER CERTIFICATE
 - name: Add user certificate (check_mode)
   aci_aaa_user_certificate: &cert_present
-    hostname: '{{ aci_hostname }}'
+    host: '{{ aci_hostname }}'
     username: '{{ aci_username }}'
     password: '{{ aci_password }}'
     validate_certs: '{{ aci_validate_certs | default(false) }}'
@@ -62,7 +62,7 @@
 # QUERY ALL USER CERTIFICATES
 - name: Query all user certificates using signature-based authentication (check_mode)
   aci_aaa_user_certificate: &cert_query
-    hostname: '{{ aci_hostname }}'
+    host: '{{ aci_hostname }}'
     username: '{{ aci_username }}'
     #password: '{{ aci_password }}'
     private_key: '{{ role_path }}/pki/admin.key'

--- a/test/integration/targets/aci_config_rollback/tasks/main.yml
+++ b/test/integration/targets/aci_config_rollback/tasks/main.yml
@@ -10,7 +10,7 @@
 
 - name: ensure tenant does not exist for tests to kick off
   aci_tenant: &aci_tenant_absent
-    hostname: "{{ aci_hostname }}"
+    host: "{{ aci_hostname }}"
     username: "{{ aci_username }}"
     password: "{{ aci_password }}"
     validate_certs: '{{ aci_validate_certs | default(false) }}'

--- a/test/integration/targets/aci_config_snapshot/tasks/main.yml
+++ b/test/integration/targets/aci_config_snapshot/tasks/main.yml
@@ -10,7 +10,7 @@
 
 - name: create a snapshot - creation works
   aci_config_snapshot: &create_snapshot
-    hostname: "{{ aci_hostname }}"
+    host: "{{ aci_hostname }}"
     username: "{{ aci_username }}"
     password: "{{ aci_password }}"
     validate_certs: '{{ aci_validate_certs | default(false) }}'

--- a/test/integration/targets/aci_epg_to_domain/tasks/main.yml
+++ b/test/integration/targets/aci_epg_to_domain/tasks/main.yml
@@ -34,7 +34,7 @@
 
 - name: ensure phys domain exists for tests to kick off
   aci_rest: &aci_rest_phys_domain
-    hostname: "{{ aci_hostname }}"
+    host: "{{ aci_hostname }}"
     username: "{{ aci_username }}"
     password: "{{ aci_password }}"
     validate_certs: '{{ aci_validate_certs | default(false) }}'

--- a/test/integration/targets/aci_filter/tasks/main.yml
+++ b/test/integration/targets/aci_filter/tasks/main.yml
@@ -11,7 +11,7 @@
 # CLEAN ENVIRONMENT
 - name: Add tenant
   aci_tenant:
-    hostname: '{{ aci_hostname }}'
+    host: '{{ aci_hostname }}'
     username: '{{ aci_username }}'
     password: '{{ aci_password }}'
     validate_certs: '{{ aci_validate_certs | default(false) }}'
@@ -22,7 +22,7 @@
 
 - name: Remove filter
   aci_filter: &filter_absent
-    hostname: '{{ aci_hostname }}'
+    host: '{{ aci_hostname }}'
     username: '{{ aci_username }}'
     password: '{{ aci_password }}'
     validate_certs: '{{ aci_validate_certs | default(false) }}'
@@ -35,7 +35,7 @@
 # ADD FILTER
 - name: Add filter (check_mode)
   aci_filter: &filter_present
-    hostname: '{{ aci_hostname }}'
+    host: '{{ aci_hostname }}'
     username: '{{ aci_username }}'
     password: '{{ aci_password }}'
     validate_certs: '{{ aci_validate_certs | default(false) }}'
@@ -122,7 +122,7 @@
 # QUERY ALL FILTERS
 - name: Query all filters (check_mode)
   aci_filter: &filter_query
-    hostname: '{{ aci_hostname }}'
+    host: '{{ aci_hostname }}'
     username: '{{ aci_username }}'
     password: '{{ aci_password }}'
     validate_certs: '{{ aci_validate_certs | default(false) }}'

--- a/test/integration/targets/aci_interface_policy_leaf_profile/tasks/main.yml
+++ b/test/integration/targets/aci_interface_policy_leaf_profile/tasks/main.yml
@@ -12,7 +12,7 @@
 # CLEAN ENVIRONMENT
 - name: Remove leaf profile
   aci_interface_policy_leaf_profile: &interface_policy_leaf_profile_absent
-    hostname: '{{ aci_hostname }}'
+    host: '{{ aci_hostname }}'
     username: '{{ aci_username }}'
     password: '{{ aci_password }}'
     validate_certs: '{{ aci_validate_certs | default(false) }}'
@@ -25,7 +25,7 @@
 # ADD LEAF INTERFACE PROFILE
 - name: Add leaf interface profile (check_mode)
   aci_interface_policy_leaf_profile: &interface_policy_leaf_profile_present
-    hostname: '{{ aci_hostname }}'
+    host: '{{ aci_hostname }}'
     username: '{{ aci_username }}'
     password: '{{ aci_password }}'
     validate_certs: '{{ aci_validate_certs | default(false) }}'
@@ -109,7 +109,7 @@
 # QUERY ALL LEAF INTERFACE PROFILES
 - name: Query all interface profiles (check_mode)
   aci_interface_policy_leaf_profile: &interface_policy_leaf_profile_query
-    hostname: '{{ aci_hostname }}'
+    host: '{{ aci_hostname }}'
     username: '{{ aci_username }}'
     password: '{{ aci_password }}'
     validate_certs: '{{ aci_validate_certs | default(false) }}'

--- a/test/integration/targets/aci_rest/tasks/json_inline.yml
+++ b/test/integration/targets/aci_rest/tasks/json_inline.yml
@@ -11,7 +11,7 @@
 # CLEAN ENVIRONMENT
 - name: Remove tenant
   aci_rest: &tenant_absent
-    hostname: '{{ aci_hostname }}'
+    host: '{{ aci_hostname }}'
     username: '{{ aci_username }}'
     password: '{{ aci_password }}'
     validate_certs: '{{ aci_validate_certs | default(false) }}'
@@ -24,7 +24,7 @@
 # ADD TENANT
 - name: Add tenant (normal mode)
   aci_rest: &tenant_present
-    hostname: '{{ aci_hostname }}'
+    host: '{{ aci_hostname }}'
     username: '{{ aci_username }}'
     password: '{{ aci_password }}'
     validate_certs: '{{ aci_validate_certs | default(false) }}'
@@ -57,7 +57,7 @@
 # CHANGE TENANT
 - name: Change description of tenant (normal mode)
   aci_rest: &tenant_changed
-    hostname: '{{ aci_hostname }}'
+    host: '{{ aci_hostname }}'
     username: '{{ aci_username }}'
     password: '{{ aci_password }}'
     validate_certs: '{{ aci_validate_certs | default(false) }}'
@@ -102,7 +102,7 @@
 # QUERY ALL TENANTS
 - name: Query all tenants (normal mode)
   aci_rest: &tenant_query_all
-    hostname: '{{ aci_hostname }}'
+    host: '{{ aci_hostname }}'
     username: '{{ aci_username }}'
     password: '{{ aci_password }}'
     validate_certs: '{{ aci_validate_certs | default(false) }}'
@@ -121,7 +121,7 @@
 # QUERY A TENANT
 - name: Query our tenant
   aci_rest: &tenant_query
-    hostname: '{{ aci_hostname }}'
+    host: '{{ aci_hostname }}'
     username: '{{ aci_username }}'
     password: '{{ aci_password }}'
     validate_certs: '{{ aci_validate_certs | default(false) }}'

--- a/test/integration/targets/aci_rest/tasks/json_string.yml
+++ b/test/integration/targets/aci_rest/tasks/json_string.yml
@@ -11,7 +11,7 @@
 # CLEAN ENVIRONMENT
 - name: Remove tenant
   aci_rest: &tenant_absent
-    hostname: '{{ aci_hostname }}'
+    host: '{{ aci_hostname }}'
     username: '{{ aci_username }}'
     password: '{{ aci_password }}'
     validate_certs: '{{ aci_validate_certs | default(false) }}'
@@ -23,7 +23,7 @@
 # ADD TENANT
 - name: Add tenant (normal mode)
   aci_rest: &tenant_present
-    hostname: '{{ aci_hostname }}'
+    host: '{{ aci_hostname }}'
     username: '{{ aci_username }}'
     password: '{{ aci_password }}'
     validate_certs: '{{ aci_validate_certs | default(false) }}'
@@ -54,7 +54,7 @@
 # CHANGE TENANT
 - name: Change description of tenant (normal mode)
   aci_rest: &tenant_changed
-    hostname: '{{ aci_hostname }}'
+    host: '{{ aci_hostname }}'
     username: '{{ aci_username }}'
     password: '{{ aci_password }}'
     validate_certs: '{{ aci_validate_certs | default(false) }}'
@@ -96,7 +96,7 @@
 # QUERY ALL TENANTS
 - name: Query all tenants (normal mode)
   aci_rest: &tenant_query_all
-    hostname: '{{ aci_hostname }}'
+    host: '{{ aci_hostname }}'
     username: '{{ aci_username }}'
     password: '{{ aci_password }}'
     validate_certs: '{{ aci_validate_certs | default(false) }}'
@@ -114,7 +114,7 @@
 # QUERY A TENANT
 - name: Query our tenant
   aci_rest: &tenant_query
-    hostname: '{{ aci_hostname }}'
+    host: '{{ aci_hostname }}'
     username: '{{ aci_username }}'
     password: '{{ aci_password }}'
     validate_certs: '{{ aci_validate_certs | default(false) }}'

--- a/test/integration/targets/aci_rest/tasks/xml_string.yml
+++ b/test/integration/targets/aci_rest/tasks/xml_string.yml
@@ -11,7 +11,7 @@
 # CLEAN ENVIRONMENT
 - name: Remove tenant
   aci_rest: &tenant_absent
-    hostname: '{{ aci_hostname }}'
+    host: '{{ aci_hostname }}'
     username: '{{ aci_username }}'
     password: '{{ aci_password }}'
     validate_certs: '{{ aci_validate_certs | default(false) }}'
@@ -23,7 +23,7 @@
 # ADD TENANT
 - name: Add tenant (normal mode)
   aci_rest: &tenant_present
-    hostname: '{{ aci_hostname }}'
+    host: '{{ aci_hostname }}'
     username: '{{ aci_username }}'
     password: '{{ aci_password }}'
     validate_certs: '{{ aci_validate_certs | default(false) }}'
@@ -48,7 +48,7 @@
 # CHANGE TENANT
 - name: Change description of tenant (normal mode)
   aci_rest: &tenant_changed
-    hostname: '{{ aci_hostname }}'
+    host: '{{ aci_hostname }}'
     username: '{{ aci_username }}'
     password: '{{ aci_password }}'
     validate_certs: '{{ aci_validate_certs | default(false) }}'
@@ -83,7 +83,7 @@
 # QUERY ALL TENANTS
 - name: Query all tenants (normal mode)
   aci_rest: &tenant_query_all
-    hostname: '{{ aci_hostname }}'
+    host: '{{ aci_hostname }}'
     username: '{{ aci_username }}'
     password: '{{ aci_password }}'
     validate_certs: '{{ aci_validate_certs | default(false) }}'
@@ -101,7 +101,7 @@
 # QUERY A TENANT
 - name: Query our tenant
   aci_rest: &tenant_query
-    hostname: '{{ aci_hostname }}'
+    host: '{{ aci_hostname }}'
     username: '{{ aci_username }}'
     password: '{{ aci_password }}'
     validate_certs: '{{ aci_validate_certs | default(false) }}'

--- a/test/integration/targets/aci_rest/tasks/yaml_inline.yml
+++ b/test/integration/targets/aci_rest/tasks/yaml_inline.yml
@@ -11,7 +11,7 @@
 # CLEAN ENVIRONMENT
 - name: Remove tenant
   aci_rest: &tenant_absent
-    hostname: '{{ aci_hostname }}'
+    host: '{{ aci_hostname }}'
     username: '{{ aci_username }}'
     password: '{{ aci_password }}'
     validate_certs: '{{ aci_validate_certs | default(false) }}'
@@ -23,7 +23,7 @@
 # ADD TENANT
 - name: Add tenant (normal mode)
   aci_rest: &tenant_present
-    hostname: '{{ aci_hostname }}'
+    host: '{{ aci_hostname }}'
     username: '{{ aci_username }}'
     password: '{{ aci_password }}'
     validate_certs: '{{ aci_validate_certs | default(false) }}'
@@ -50,7 +50,7 @@
 # CHANGE TENANT
 - name: Change description of tenant (normal mode)
   aci_rest: &tenant_changed
-    hostname: '{{ aci_hostname }}'
+    host: '{{ aci_hostname }}'
     username: '{{ aci_username }}'
     password: '{{ aci_password }}'
     validate_certs: '{{ aci_validate_certs | default(false) }}'
@@ -88,7 +88,7 @@
 # QUERY ALL TENANTS
 - name: Query all tenants (normal mode)
   aci_rest: &tenant_query_all
-    hostname: '{{ aci_hostname }}'
+    host: '{{ aci_hostname }}'
     username: '{{ aci_username }}'
     password: '{{ aci_password }}'
     validate_certs: '{{ aci_validate_certs | default(false) }}'
@@ -106,7 +106,7 @@
 # QUERY A TENANT
 - name: Query our tenant
   aci_rest: &tenant_query
-    hostname: '{{ aci_hostname }}'
+    host: '{{ aci_hostname }}'
     username: '{{ aci_username }}'
     password: '{{ aci_password }}'
     validate_certs: '{{ aci_validate_certs | default(false) }}'

--- a/test/integration/targets/aci_rest/tasks/yaml_string.yml
+++ b/test/integration/targets/aci_rest/tasks/yaml_string.yml
@@ -11,7 +11,7 @@
 # CLEAN ENVIRONMENT
 - name: Remove tenant
   aci_rest: &tenant_absent
-    hostname: '{{ aci_hostname }}'
+    host: '{{ aci_hostname }}'
     username: '{{ aci_username }}'
     password: '{{ aci_password }}'
     validate_certs: '{{ aci_validate_certs | default(false) }}'
@@ -23,7 +23,7 @@
 # ADD TENANT
 - name: Add tenant (normal mode)
   aci_rest: &tenant_present
-    hostname: '{{ aci_hostname }}'
+    host: '{{ aci_hostname }}'
     username: '{{ aci_username }}'
     password: '{{ aci_password }}'
     validate_certs: '{{ aci_validate_certs | default(false) }}'
@@ -50,7 +50,7 @@
 # CHANGE TENANT
 - name: Change description of tenant (normal mode)
   aci_rest: &tenant_changed
-    hostname: '{{ aci_hostname }}'
+    host: '{{ aci_hostname }}'
     username: '{{ aci_username }}'
     password: '{{ aci_password }}'
     validate_certs: '{{ aci_validate_certs | default(false) }}'
@@ -88,7 +88,7 @@
 # QUERY ALL TENANTS
 - name: Query all tenants (normal mode)
   aci_rest: &tenant_query_all
-    hostname: '{{ aci_hostname }}'
+    host: '{{ aci_hostname }}'
     username: '{{ aci_username }}'
     password: '{{ aci_password }}'
     validate_certs: '{{ aci_validate_certs | default(false) }}'
@@ -106,7 +106,7 @@
 # QUERY A TENANT
 - name: Query our tenant
   aci_rest: &tenant_query
-    hostname: '{{ aci_hostname }}'
+    host: '{{ aci_hostname }}'
     username: '{{ aci_username }}'
     password: '{{ aci_password }}'
     validate_certs: '{{ aci_validate_certs | default(false) }}'

--- a/test/integration/targets/aci_switch_leaf_policy_profile/tasks/main.yml
+++ b/test/integration/targets/aci_switch_leaf_policy_profile/tasks/main.yml
@@ -12,7 +12,7 @@
 # CLEAN ENVIRONMENT
 - name: Remove leaf profile
   aci_switch_policy_leaf_profile: &aci_switch_policy_leaf_profile_absent
-    hostname: '{{ aci_hostname }}'
+    host: '{{ aci_hostname }}'
     username: '{{ aci_username }}'
     password: '{{ aci_password }}'
     validate_certs: '{{ aci_validate_certs | default(false) }}'
@@ -25,7 +25,7 @@
 # ADD LEAF PROFILE
 - name: Add switch policy leaf profile (check_mode)
   aci_switch_policy_leaf_profile: &aci_switch_policy_leaf_profile_present
-    hostname: '{{ aci_hostname }}'
+    host: '{{ aci_hostname }}'
     username: '{{ aci_username }}'
     password: '{{ aci_password }}'
     validate_certs: '{{ aci_validate_certs | default(false) }}'
@@ -109,7 +109,7 @@
 # QUERY ALL LEAF PROFILES
 - name: Query all profiles (check_mode)
   aci_switch_policy_leaf_profile: &aci_switch_policy_leaf_profile_query
-    hostname: '{{ aci_hostname }}'
+    host: '{{ aci_hostname }}'
     username: '{{ aci_username }}'
     password: '{{ aci_password }}'
     validate_certs: '{{ aci_validate_certs | default(false) }}'

--- a/test/integration/targets/aci_tenant/tasks/main.yml
+++ b/test/integration/targets/aci_tenant/tasks/main.yml
@@ -12,7 +12,7 @@
 # CLEAN ENVIRONMENT
 - name: Remove tenant
   aci_tenant: &tenant_absent
-    hostname: '{{ aci_hostname }}'
+    host: '{{ aci_hostname }}'
     username: '{{ aci_username }}'
     password: '{{ aci_password }}'
     validate_certs: '{{ aci_validate_certs | default(false) }}'
@@ -25,7 +25,7 @@
 # ADD TENANT
 - name: Add tenant (check_mode)
   aci_tenant: &tenant_present
-    hostname: '{{ aci_hostname }}'
+    host: '{{ aci_hostname }}'
     username: '{{ aci_username }}'
     password: '{{ aci_password }}'
     validate_certs: '{{ aci_validate_certs | default(false) }}'
@@ -109,7 +109,7 @@
 # QUERY ALL TENANTS
 - name: Query all tenants (check_mode)
   aci_tenant: &tenant_query
-    hostname: '{{ aci_hostname }}'
+    host: '{{ aci_hostname }}'
     username: '{{ aci_username }}'
     password: '{{ aci_password }}'
     validate_certs: '{{ aci_validate_certs | default(false) }}'


### PR DESCRIPTION
##### SUMMARY
Since most network-related modules are using 'host' instead of 'hostname', it's probably best to make this the default parameter and change all examples equally.

This could be the first step towards provider-support ?

##### ISSUE TYPE
 - Feature Pull Request
 - Docs Pull Request

##### COMPONENT NAME
aci modules

##### ANSIBLE VERSION
v2.5