### PR TITLE
Include role:  serialization: (de)pickling support

### DIFF
--- a/lib/ansible/playbook/block.py
+++ b/lib/ansible/playbook/block.py
@@ -248,6 +248,7 @@ class Block(Base, Become, Conditional, Taggable):
         # import is here to avoid import loops
         from ansible.playbook.task_include import TaskInclude
         from ansible.playbook.handler_task_include import HandlerTaskInclude
+        from ansible.playbook.role_include import IncludeRole
 
         # we don't want the full set of attributes (the task lists), as that
         # would lead to a serialize/deserialize loop
@@ -274,6 +275,9 @@ class Block(Base, Become, Conditional, Taggable):
                 p = TaskInclude()
             elif parent_type == 'HandlerTaskInclude':
                 p = HandlerTaskInclude()
+            elif parent_type == 'IncludeRole':
+                p = IncludeRole()
+
             p.deserialize(parent_data)
             self._parent = p
             self._dep_chain = self._parent.get_dep_chain()

--- a/lib/ansible/playbook/helpers.py
+++ b/lib/ansible/playbook/helpers.py
@@ -332,7 +332,7 @@ def load_list_of_tasks(ds, play, block=None, role=None, task_include=None, use_h
                         ir._role_name = templar.template(ir._role_name)
 
                     # uses compiled list from object
-                    blocks, _ = ir.get_block_list(variable_manager=variable_manager, loader=loader)
+                    blocks, _ = ir.get_block_list(play, variable_manager=variable_manager, loader=loader)
                     t = task_list.extend(blocks)
                 else:
                     # passes task object itself for latter generation of list

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -91,6 +91,7 @@ class Play(Base, Taggable, Become):
         self._included_conditional = None
         self._included_path = None
         self._removed_hosts = []
+        self._dynamic_roles = []
         self.ROLE_CACHE = {}
 
     def __repr__(self):
@@ -288,6 +289,22 @@ class Play(Base, Taggable, Become):
     def get_roles(self):
         return self.roles[:]
 
+    def get_dynamic_roles(self):
+        return self._dynamic_roles[:]
+
+    def unregister_dynamic_role(self, drole):
+        try:
+            self._dynamic_roles.pop(self._dynamic_roles.index(drole))
+        except ValueError:
+            pass
+
+    def register_dynamic_role(self, drole):
+        if not getattr(drole, 'private', None):
+            try:
+                self._dynamic_roles.index(drole)
+            except ValueError:
+                self._dynamic_roles.append(drole)
+
     def get_tasks(self):
         tasklist = []
         for task in self.pre_tasks + self.tasks + self.post_tasks:
@@ -297,13 +314,26 @@ class Play(Base, Taggable, Become):
                 tasklist.append(task)
         return tasklist
 
-    def serialize(self):
+    def serialize(self, skip_dynamic_roles=False):
         data = super(Play, self).serialize()
 
+        if skip_dynamic_roles is None:
+            skip_dynamic_roles = []
+
         roles = []
+        dynamic_roles = []
         for role in self.get_roles():
             roles.append(role.serialize())
+
         data['roles'] = roles
+
+        if not skip_dynamic_roles:
+            for role in self.get_dynamic_roles():
+                rdata = role.serialize(no_play=True)
+                dynamic_roles.append(rdata)
+
+        data['dynamic_roles'] = dynamic_roles
+
         data['included_path'] = self._included_path
 
         return data
@@ -323,9 +353,22 @@ class Play(Base, Taggable, Become):
             setattr(self, 'roles', roles)
             del data['roles']
 
+        if 'dynamic_roles' in data:
+            role_data = data.get('dynamic_roles', [])
+            droles = []
+            for role in role_data:
+                r = Role()
+                role['_irole_play'] = self
+                r.deserialize(role)
+                droles.append(r)
+
+            setattr(self, 'dynamic_roles', droles)
+            del data['dynamic_roles']
+
     def copy(self):
         new_me = super(Play, self).copy()
         new_me.ROLE_CACHE = self.ROLE_CACHE.copy()
         new_me._included_conditional = self._included_conditional
         new_me._included_path = self._included_path
+        new_me._dynamic_roles = self._dynamic_roles[:]
         return new_me

--- a/lib/ansible/playbook/role_include.py
+++ b/lib/ansible/playbook/role_include.py
@@ -75,11 +75,24 @@ class IncludeRole(TaskInclude):
             myplay = self._parent._play
         else:
             myplay = play
+        if variable_manager is None or loader is None:
+            variable_manager = self.get_variable_manager()
+        if loader is None:
+            loader = variable_manager._loader
 
         ri = RoleInclude.load(self._role_name, play=myplay, variable_manager=variable_manager, loader=loader)
         ri.vars.update(self.vars)
 
         # build role
+        if self.vars:
+            v = self.vars.copy()
+            # bypass vars from include_role itself
+            for k in [
+                'name', 'private', 'allow_duplicates',
+                'defaults_from', 'tasks_from', 'vars_from'
+            ]:
+                v.pop(k, None)
+            ri.vars.update(v)
         actual_role = Role.load(ri, myplay, parent_role=self._parent_role, from_files=self._from_files)
         actual_role._metadata.allow_duplicates = self.allow_duplicates
 
@@ -88,6 +101,7 @@ class IncludeRole(TaskInclude):
         self._role = actual_role
         if myplay is not None:
             self._play = myplay
+            self._play.register_dynamic_role(self)
 
         # compile role with parent roles as dependencies to ensure they inherit
         # variables
@@ -158,3 +172,18 @@ class IncludeRole(TaskInclude):
         if self._parent_role:
             v.update(self._parent_role.get_role_params())
         return v
+
+    def get_default_vars(self, dep_chain=None):
+        if not self.is_loaded:
+            return dict()
+        if dep_chain is None:
+            dep_chain = self.get_dep_chain()
+        return self._role.get_default_vars(dep_chain=dep_chain)
+
+    def get_vars(self, include_params=True):
+        all_vars = TaskInclude.get_vars(self, include_params=include_params)
+        if self.is_loaded:  # not yet loaded skip
+            all_vars.update(
+                self._role.get_vars(include_params=include_params)
+            )
+        return all_vars

--- a/lib/ansible/playbook/role_include.py
+++ b/lib/ansible/playbook/role_include.py
@@ -65,6 +65,8 @@ class IncludeRole(TaskInclude):
         self._parent_role = role
         self._role_name = None
         self._role_path = None
+        self._play = None
+        self._role = None
 
     def get_block_list(self, play=None, variable_manager=None, loader=None):
 
@@ -83,6 +85,9 @@ class IncludeRole(TaskInclude):
 
         # save this for later use
         self._role_path = actual_role._role_path
+        self._role = actual_role
+        if myplay is not None:
+            self._play = myplay
 
         # compile role with parent roles as dependencies to ensure they inherit
         # variables
@@ -138,8 +143,15 @@ class IncludeRole(TaskInclude):
         new_me._parent_role = self._parent_role
         new_me._role_name = self._role_name
         new_me._role_path = self._role_path
+        new_me._role = self._role
+        new_me.private = self.private
+        new_me._play = self._play
 
         return new_me
+
+    @property
+    def is_loaded(self):
+        return self._role is not None
 
     def get_include_params(self):
         v = super(IncludeRole, self).get_include_params()

--- a/lib/ansible/playbook/role_include.py
+++ b/lib/ansible/playbook/role_include.py
@@ -151,7 +151,26 @@ class IncludeRole(TaskInclude):
 
     def copy(self, exclude_parent=False, exclude_tasks=False):
 
+        # save our attrs
+        role = self._role
+        parentrole = self._parent_role
+        parent = self._parent
+        play = self._play
+
+        # be smaller for parent methods to shallow copy
+        self._role = None
+        self._parent = None
+        self._parent_role = None
+        self._play = None
+
         new_me = super(IncludeRole, self).copy(exclude_parent=exclude_parent, exclude_tasks=exclude_tasks)
+
+        # restore our state
+        self._parent_role = parentrole
+        self._parent = parent
+        self._play = play
+        self._role = role
+
         new_me.statically_loaded = self.statically_loaded
         new_me._from_files = self._from_files.copy()
         new_me._parent_role = self._parent_role
@@ -187,3 +206,58 @@ class IncludeRole(TaskInclude):
                 self._role.get_vars(include_params=include_params)
             )
         return all_vars
+
+    def serialize(self, no_play=False):
+        data = super(IncludeRole, self).serialize()
+        if not self._squashed and not self._finalized:
+            data['_irole_name'] = self._role_name
+            if self._parent_role:
+                data['_irole_prole'] = self._parent_role.serialize()
+            data['_irole_path'] = self._role_path
+            if self._role:
+                data['_irole_drole'] = self._role.serialize()
+            if self._play and not no_play:
+                # avoid deepcopy recurse errors
+                self._play.unregister_dynamic_role(self)
+                data['_irole_play'] = self._play.serialize(
+                    skip_dynamic_roles=True)
+                self._play.register_dynamic_role(self)
+        return data
+
+    def deserialize(self, data, play=None, include_deps=True):
+        from ansible.playbook.play import Play
+        from ansible.playbook.role import Role
+        self._role_name = data.get('_irole_name', '')
+        self._role_path = data.get('_irole_path', '')
+        if play is None and '_irole_play' in data:
+            play = Play()
+            play.deserialize(data['_irole_play'])
+            del data['_irole_play']
+        if play is not None:
+            setattr(self, '_play', play)
+        if '_irole_drole' in data:
+            r = Role()
+            r.deserialize(data['_irole_drole'])
+            setattr(self, '_role', r)
+            del data['_irole_drole']
+        if '_irole_prole' in data:
+            r = Role()
+            r.deserialize(data['_irole_prole'])
+            setattr(self, '_parent_role', r)
+            del data['_irole_prole']
+        if play is not None:
+            play.register_dynamic_role(self)
+        super(IncludeRole, self).deserialize(data)
+
+    def __setstate__(self, sr):
+        self.__init__()
+        self.deserialize(sr)
+
+    def __getstate__(self):
+        sr = self.serialize()
+        return sr
+
+    def __deepcopy__(self, memo):
+        ret = self.deserialize(self.serialize())
+        memo[id(self)] = ret
+        return ret

--- a/lib/ansible/playbook/task_include.py
+++ b/lib/ansible/playbook/task_include.py
@@ -59,7 +59,7 @@ class TaskInclude(Task):
         new_me.statically_loaded = self.statically_loaded
         return new_me
 
-    def get_vars(self):
+    def get_vars(self, include_params=True):
         '''
         We override the parent Task() classes get_vars here because
         we need to include the args of the include into the vars as
@@ -72,8 +72,9 @@ class TaskInclude(Task):
             if self._parent:
                 all_vars.update(self._parent.get_vars())
 
-            all_vars.update(self.vars)
-            all_vars.update(self.args)
+            if include_params:
+                all_vars.update(self.vars)
+                all_vars.update(self.args)
 
             if 'tags' in all_vars:
                 del all_vars['tags']

--- a/lib/ansible/vars/manager.py
+++ b/lib/ansible/vars/manager.py
@@ -185,10 +185,13 @@ class VariableManager:
         # default for all cases
         basedirs = [self._loader.get_basedir()]
 
+        # First compile vars that are coming from roles (defaults/main.yml)
+        # from within the play (both static and loaded dynamically)
+        # Of course for dynamic, we are only the ones which are
+        # already parsed yet through playbooks/role_include.py
+        # and not marked as private on the include statement.
         if play:
-            # first we compile any vars specified in defaults/main.yml
-            # for all roles within the specified play
-            for role in play.get_roles():
+            for role in play.get_roles() + play.get_dynamic_roles():
                 all_vars = combine_vars(all_vars, role.get_default_vars())
 
         if task:
@@ -372,7 +375,7 @@ class VariableManager:
             # By default, we now merge in all vars from all roles in the play,
             # unless the user has disabled this via a config option
             if not C.DEFAULT_PRIVATE_ROLE_VARS:
-                for role in play.get_roles():
+                for role in play.get_roles() + play.get_dynamic_roles():
                     all_vars = combine_vars(all_vars, role.get_vars(include_params=False))
 
         # next, we merge in the vars from the role, which will specifically

--- a/test/integration/targets/include_import/playbook/sharedvars.yml
+++ b/test/integration/targets/include_import/playbook/sharedvars.yml
@@ -1,0 +1,41 @@
+- name: verify that play can access vars after include role
+  hosts: testhost
+  tasks:
+    - shell: echo {{testinc_defvar1|default('notdefined')}}
+      register: test2
+    - assert:
+        that:
+          - test2.stdout == 'notdefined'
+    - include_role: {name: sharedvars_include_role}
+      register: testa
+    - shell: echo {{testinc_defvar1}}
+      register: test2
+    - shell: echo {{testinc_varvar1}}
+      register: test3
+    - assert:
+        that:
+          - testdep1.stdout == 'from deprole'
+          - test1.stdout == 'from role'
+          - test2.stdout == 'foobar'
+          - test3.stdout == 'muche'
+
+- name: verify that vars doesnt survive after play
+  hosts: testhost
+  tasks:
+    - shell: echo {{testinc_defvar1|default('notdefined')}}
+      register: test2
+    - assert:
+        that:
+          - test2.stdout == 'notdefined'
+
+- name: verify that we can play with default vars
+  hosts: testhost
+  tasks:
+    - include_role: {name: sharedvars_include_role}
+      vars:
+        testinc_defvar1: overriden
+    - shell: echo {{testinc_defvar1}}
+      register: test2
+    - assert:
+        that:
+          - test2.stdout == 'overriden'

--- a/test/integration/targets/include_import/roles/sharedvars_include_role/defaults/main.yml
+++ b/test/integration/targets/include_import/roles/sharedvars_include_role/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+testinc_defvar1: foobar
+testinc_varvar1: foobar

--- a/test/integration/targets/include_import/roles/sharedvars_include_role/meta/main.yml
+++ b/test/integration/targets/include_import/roles/sharedvars_include_role/meta/main.yml
@@ -1,0 +1,1 @@
+dependencies: [sharedvars_includedep_role]

--- a/test/integration/targets/include_import/roles/sharedvars_include_role/tasks/main.yml
+++ b/test/integration/targets/include_import/roles/sharedvars_include_role/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+- name: noop task
+  shell: echo from role
+  register: test1

--- a/test/integration/targets/include_import/roles/sharedvars_include_role/vars/main.yml
+++ b/test/integration/targets/include_import/roles/sharedvars_include_role/vars/main.yml
@@ -1,0 +1,2 @@
+---
+testinc_varvar1: muche

--- a/test/integration/targets/include_import/roles/sharedvars_includedep_role/defaults/main.yml
+++ b/test/integration/targets/include_import/roles/sharedvars_includedep_role/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+testdepinc_defvar1: foobar
+testdepinc_varvar1: foobar

--- a/test/integration/targets/include_import/roles/sharedvars_includedep_role/meta/main.yml
+++ b/test/integration/targets/include_import/roles/sharedvars_includedep_role/meta/main.yml
@@ -1,0 +1,1 @@
+dependencies: []

--- a/test/integration/targets/include_import/roles/sharedvars_includedep_role/tasks/main.yml
+++ b/test/integration/targets/include_import/roles/sharedvars_includedep_role/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+- name: noop task
+  shell: echo from deprole
+  register: testdep1

--- a/test/integration/targets/include_import/roles/sharedvars_includedep_role/vars/main.yml
+++ b/test/integration/targets/include_import/roles/sharedvars_includedep_role/vars/main.yml
@@ -1,0 +1,2 @@
+---
+testdepinc_varvar1: muche

--- a/test/integration/targets/include_import/runme.sh
+++ b/test/integration/targets/include_import/runme.sh
@@ -37,7 +37,14 @@ ANSIBLE_STRATEGY='free' ansible-playbook role/test_include_role.yml -i ../../inv
 # https://github.com/ansible/ansible/issues/23609
 ANSIBLE_STRATEGY='linear' ansible-playbook test_recursion.yml -i ../../inventory "$@" --skip-tags never
 
+
 ## Nested tasks
 # https://github.com/ansible/ansible/issues/34782
 ANSIBLE_STRATEGY='linear' ansible-playbook nested.yml  -i ../../inventory "$@" --skip-tags never
 ANSIBLE_STRATEGY='free' ansible-playbook nested.yml  -i ../../inventory "$@" --skip-tags never
+
+
+## shared vars
+# https://github.com/ansible/ansible/issues/21890
+ANSIBLE_STRATEGY='linear' ansible-playbook -i ../../inventory playbook/sharedvars.yml -v "$@" --skip-tags never
+ANSIBLE_STRATEGY='free' ansible-playbook -i ../../inventory playbook/sharedvars.yml -v "$@" --skip-tags never

--- a/test/integration/targets/include_import/runme.sh
+++ b/test/integration/targets/include_import/runme.sh
@@ -38,13 +38,13 @@ ANSIBLE_STRATEGY='free' ansible-playbook role/test_include_role.yml -i ../../inv
 ANSIBLE_STRATEGY='linear' ansible-playbook test_recursion.yml -i ../../inventory "$@" --skip-tags never
 
 
-## Nested tasks
-# https://github.com/ansible/ansible/issues/34782
-ANSIBLE_STRATEGY='linear' ansible-playbook nested.yml  -i ../../inventory "$@" --skip-tags never
-ANSIBLE_STRATEGY='free' ansible-playbook nested.yml  -i ../../inventory "$@" --skip-tags never
-
-
 ## shared vars
 # https://github.com/ansible/ansible/issues/21890
 ANSIBLE_STRATEGY='linear' ansible-playbook -i ../../inventory playbook/sharedvars.yml -v "$@" --skip-tags never
 ANSIBLE_STRATEGY='free' ansible-playbook -i ../../inventory playbook/sharedvars.yml -v "$@" --skip-tags never
+
+
+## Nested tasks
+# https://github.com/ansible/ansible/issues/34782
+ANSIBLE_STRATEGY='linear' ansible-playbook nested.yml  -i ../../inventory "$@" --skip-tags never
+ANSIBLE_STRATEGY='free' ansible-playbook nested.yml  -i ../../inventory "$@" --skip-tags never


### PR DESCRIPTION
##### SUMMARY
The fixes that were introduced recently to avoid recursion errors (yes, already removed from 2.4 but still in 2.5)  are IMO more kind of workarounds that lead to the former bug not to happen again than fixes in themvelves.

This PR brings pickling/depickling support for include_role & fixes permanently the recursion error.

This PR is for the moment dependant of #35167 (the only real commit is 82ca34bfa721923a69456c17fda4dd53b8286054)
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
include_role
##### ANSIBLE VERSION
```
2.4
devel
```


- This refs: #35065
- This fixes: #33922
- This fixes: #23609

- related PRs: #35167 #35166 #35165 #35164 #35163
