### PR TITLE
Include role honour allow duplicates

### DIFF
--- a/lib/ansible/executor/play_iterator.py
+++ b/lib/ansible/executor/play_iterator.py
@@ -426,7 +426,16 @@ class PlayIterator:
 
                             # we're advancing blocks, so if this was an end-of-role block we
                             # mark the current role complete
-                            if block._eor and host.name in block._role._had_task_run and not in_child and not peek:
+                            # unless we are the role or it allows_duplicates
+                            if (
+                                block._eor and
+                                host.name in block._role._had_task_run and (
+                                    (not in_child) or
+                                    (not (block._role._metadata and
+                                          block._role._metadata.allow_duplicates))
+                                ) and
+                                not peek
+                            ):
                                 block._role._completed[host.name] = True
                     else:
                         task = block.always[state.cur_always_task]

--- a/lib/ansible/playbook/role_include.py
+++ b/lib/ansible/playbook/role_include.py
@@ -64,6 +64,7 @@ class IncludeRole(TaskInclude):
         self._parent_role = role
         self._role_name = None
         self._role_path = None
+        self._role = None
 
     def get_name(self):
         ''' return the name of the task '''
@@ -90,6 +91,7 @@ class IncludeRole(TaskInclude):
 
         # save this for later use
         self._role_path = actual_role._role_path
+        self._role = actual_role
 
         # compile role with parent roles as dependencies to ensure they inherit
         # variables
@@ -158,6 +160,7 @@ class IncludeRole(TaskInclude):
         new_me._parent_role = self._parent_role
         new_me._role_name = self._role_name
         new_me._role_path = self._role_path
+        new_me._role = self._role
 
         return new_me
 

--- a/lib/ansible/playbook/role_include.py
+++ b/lib/ansible/playbook/role_include.py
@@ -84,7 +84,14 @@ class IncludeRole(TaskInclude):
         # build role
         actual_role = Role.load(ri, myplay, parent_role=self._parent_role, from_files=self._from_files,
                                 from_include=True)
-        actual_role._metadata.allow_duplicates = self.allow_duplicates
+        # proxy allow_duplicates attribute to role if explicitly set
+        if self.allow_duplicates is not None:
+            actual_role._metadata.allow_duplicates = self.allow_duplicates
+        # in any case sync allow_duplicates between the role and this include statement
+        # This is the side effect if we didnt explicitly setted the allow_duplicates attribute
+        # to fallback on the included role setting
+        if self.allow_duplicates is None and actual_role._metadata:
+            self.allow_duplicates = actual_role._metadata.allow_duplicates
 
         if self.statically_loaded or self.public:
             myplay.roles.append(actual_role)

--- a/lib/ansible/playbook/role_include.py
+++ b/lib/ansible/playbook/role_include.py
@@ -79,7 +79,9 @@ class IncludeRole(TaskInclude):
             myplay = play
 
         ri = RoleInclude.load(self._role_name, play=myplay, variable_manager=variable_manager, loader=loader)
-        ri.vars.update(self.vars)
+        rvars = {}
+        rvars.update(self.strip_vars(self.vars))
+        ri.vars.update(rvars)
 
         # build role
         actual_role = Role.load(ri, myplay, parent_role=self._parent_role, from_files=self._from_files,
@@ -176,3 +178,18 @@ class IncludeRole(TaskInclude):
         if self._parent_role:
             v.update(self._parent_role.get_role_params())
         return v
+
+    def strip_vars(self, all_vars):
+        # Remove the args configuring the role itself from arguments
+        stripped_args = frozenset(self.args.keys()).intersection(self.VALID_ARGS)
+        for k in stripped_args:
+            try:
+                del all_vars[k]
+            except KeyError:
+                pass
+        return all_vars
+
+    def get_vars(self):
+        all_vars = super(IncludeRole, self).get_vars()
+        all_vars = self.strip_vars(all_vars)
+        return all_vars

--- a/lib/ansible/plugins/strategy/free.py
+++ b/lib/ansible/plugins/strategy/free.py
@@ -229,6 +229,14 @@ class StrategyModule(StrategyBase):
                                 variable_manager=self._variable_manager,
                                 loader=self._loader,
                             )
+
+                            # Prevent included tasks to run if already done
+                            if new_ir._role and (
+                                new_ir._role.has_run(host) and
+                                (new_ir._role._metadata is None or (new_ir._role._metadata and not new_ir._role._metadata.allow_duplicates))
+                            ):
+                                display.debug("ir: '%s' skipped because role has already run" % new_ir)
+                                new_blocks, handler_blocks = [], []
                             self._tqm.update_handler_list([handler for handler_block in handler_blocks for handler in handler_block.block])
                         else:
                             new_blocks = self._load_included_file(included_file, iterator=iterator)

--- a/lib/ansible/plugins/strategy/linear.py
+++ b/lib/ansible/plugins/strategy/linear.py
@@ -359,6 +359,13 @@ class StrategyModule(StrategyBase):
                                     variable_manager=self._variable_manager,
                                     loader=self._loader,
                                 )
+                                # Prevent included tasks to run if already done
+                                if new_ir._role and (
+                                    new_ir._role.has_run(host) and
+                                    (new_ir._role._metadata is None or (new_ir._role._metadata and not new_ir._role._metadata.allow_duplicates))
+                                ):
+                                    display.debug("ir: '%s' skipped because role has already run" % new_ir)
+                                    new_blocks, handler_blocks = [], []
                                 self._tqm.update_handler_list([handler for handler_block in handler_blocks for handler in handler_block.block])
                             else:
                                 new_blocks = self._load_included_file(included_file, iterator=iterator)

--- a/test/integration/targets/include_import/playbook/honour_duplicates.yml
+++ b/test/integration/targets/include_import/playbook/honour_duplicates.yml
@@ -1,0 +1,37 @@
+---
+- name: >-
+    verify that allow_duplicates prevent include_role to run a role that
+    has already run only if if it does not allow it
+  hosts: testhost
+  pre_tasks: [set_fact: {counter: 0, altcounter: 0, nocounter: 0, cacheable: False}]
+  roles: [honour_duplicates/inccounter, honour_duplicates/altinccounter,
+          honour_duplicates/noinccounter]
+  tasks:
+  - include_role: {name: honour_duplicates/inccounter,    allow_duplicates: false}
+  - include_role: {name: honour_duplicates/altinccounter, allow_duplicates: false}
+  - include_role: {name: honour_duplicates/noinccounter,  allow_duplicates: false}
+  - assert: {that: counter=='1',    msg: "{{counter}} counterfail"}
+  - assert: {that: altcounter=='1', msg: "{{altcounter}} altcounterfail"}
+  - assert: {that: nocounter=='1',  msg: "{{nocounter}} nocounterfail"}
+  - include_role: {name: honour_duplicates/inccounter,    allow_duplicates: true}
+  - include_role: {name: honour_duplicates/altinccounter, allow_duplicates: true}
+  - include_role: {name: honour_duplicates/noinccounter,  allow_duplicates: true}
+  - assert: {that: counter=='2',    msg: "{{counter}} counterfail"}
+  - assert: {that: altcounter=='2', msg: "{{altcounter}} altcounterfail"}
+  - assert: {that: nocounter=='2',  msg: "{{nocounter}} nocounterfail"}
+  - include_role: {name: honour_duplicates/inccounter,    allow_duplicates: false}
+  - include_role: {name: honour_duplicates/altinccounter, allow_duplicates: false}
+  - include_role: {name: honour_duplicates/noinccounter,  allow_duplicates: false}
+  - assert: {that: counter=='2',    msg: "{{counter}} counterfail"}
+  - assert: {that: altcounter=='2', msg: "{{altcounter}} altcounterfail"}
+  - assert: {that: nocounter=='2',  msg: "{{nocounter}} nocounterfail"}
+- name: verify that with include_role, it works same way
+  hosts: testhost
+  pre_tasks:
+  - set_fact: {cacheable: false, counter: 0}
+  - include_role: {name: honour_duplicates/inccounter, allow_duplicates: false}
+  roles: [honour_duplicates/inccounter]
+  tasks:
+  - assert: {that: counter=='1', msg: "counterfailir1 {{counter}}"}
+  - include_role: {name: honour_duplicates/inccounter, allow_duplicates: true}
+  - assert: {that: counter=='2', msg: "counterfailir2 {{counter}}"}

--- a/test/integration/targets/include_import/roles/honour_duplicates/altinccounter/meta/main.yml
+++ b/test/integration/targets/include_import/roles/honour_duplicates/altinccounter/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/test/integration/targets/include_import/roles/honour_duplicates/altinccounter/tasks/main.yml
+++ b/test/integration/targets/include_import/roles/honour_duplicates/altinccounter/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+- set_fact:
+    cacheable: false
+    altcounter: "{{altcounter|int+1}}"

--- a/test/integration/targets/include_import/roles/honour_duplicates/inccounter/meta/main.yml
+++ b/test/integration/targets/include_import/roles/honour_duplicates/inccounter/meta/main.yml
@@ -1,0 +1,2 @@
+---
+# allow_duplicates: <DEFAULT>

--- a/test/integration/targets/include_import/roles/honour_duplicates/inccounter/tasks/main.yml
+++ b/test/integration/targets/include_import/roles/honour_duplicates/inccounter/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+- set_fact:
+    cacheable: false
+    counter: "{{counter|int+1}}"

--- a/test/integration/targets/include_import/roles/honour_duplicates/noinccounter/meta/main.yml
+++ b/test/integration/targets/include_import/roles/honour_duplicates/noinccounter/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: false

--- a/test/integration/targets/include_import/roles/honour_duplicates/noinccounter/tasks/main.yml
+++ b/test/integration/targets/include_import/roles/honour_duplicates/noinccounter/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+- set_fact:
+    cacheable: false
+    nocounter: "{{nocounter|int+1}}"

--- a/test/integration/targets/include_import/runme.sh
+++ b/test/integration/targets/include_import/runme.sh
@@ -81,3 +81,8 @@ ANSIBLE_STRATEGY='free' ansible-playbook tasks/test_include_dupe_loop.yml -i ../
 test "$(grep -c '"item=foo"' test_include_dupe_loop.out)" = 3
 
 ansible-playbook public_exposure/playbook.yml -i ../../inventory "$@"
+
+## Include role honour allow duplicates
+# https://github.com/ansible/ansible/pull/35164
+ANSIBLE_STRATEGY='linear' ansible-playbook playbook/honour_duplicates.yml -i ../../inventory "$@"
+ANSIBLE_STRATEGY='free' ansible-playbook playbook/honour_duplicates.yml -i ../../inventory "$@"


### PR DESCRIPTION
##### SUMMARY
include_role may re run roles that have allow_duplicates set to false in many cases, specially with 'imported' roles.
this pr brings consistency.
 
See associated test

This is part of the #32565 PR split.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
include_role

##### ANSIBLE VERSION
```
2.4
devel
```
testhost                   : ok=x   changed=0    unreachable=0    failed=x

```

Post (associatet PR test pass)
```
testhost                   : ok=x   changed=0    unreachable=0    failed=0

```

- related PRs: #35167 #35166 #35165 #35164 #35163
