### PR TITLE
fix Include role: exposed/shared vars

### DIFF
--- a/lib/ansible/playbook/helpers.py
+++ b/lib/ansible/playbook/helpers.py
@@ -343,7 +343,7 @@ def load_list_of_tasks(ds, play, block=None, role=None, task_include=None, use_h
                         ir._role_name = templar.template(ir._role_name)
 
                     # uses compiled list from object
-                    blocks, _ = ir.get_block_list(variable_manager=variable_manager, loader=loader)
+                    blocks, _ = ir.get_block_list(play, variable_manager=variable_manager, loader=loader)
                     task_list.extend(blocks)
                 else:
                     # passes task object itself for latter generation of list

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -91,6 +91,7 @@ class Play(Base, Taggable, Become):
         self._included_conditional = None
         self._included_path = None
         self._removed_hosts = []
+        self._dynamic_roles = []
         self.ROLE_CACHE = {}
 
     def __repr__(self):
@@ -294,6 +295,22 @@ class Play(Base, Taggable, Become):
     def get_roles(self):
         return self.roles[:]
 
+    def get_dynamic_roles(self):
+        return self._dynamic_roles[:]
+
+    def unregister_dynamic_role(self, drole):
+        try:
+            self._dynamic_roles.pop(self._dynamic_roles.index(drole))
+        except ValueError:
+            pass
+
+    def register_dynamic_role(self, drole):
+        if not getattr(drole, 'private', None):
+            try:
+                self._dynamic_roles.index(drole)
+            except ValueError:
+                self._dynamic_roles.append(drole)
+
     def get_tasks(self):
         tasklist = []
         for task in self.pre_tasks + self.tasks + self.post_tasks:
@@ -303,13 +320,26 @@ class Play(Base, Taggable, Become):
                 tasklist.append(task)
         return tasklist
 
-    def serialize(self):
+    def serialize(self, skip_dynamic_roles=False):
         data = super(Play, self).serialize()
 
+        if skip_dynamic_roles is None:
+            skip_dynamic_roles = []
+
         roles = []
+        dynamic_roles = []
         for role in self.get_roles():
             roles.append(role.serialize())
+
         data['roles'] = roles
+
+        if not skip_dynamic_roles:
+            for role in self.get_dynamic_roles():
+                rdata = role.serialize()
+                dynamic_roles.append(rdata)
+
+        data['dynamic_roles'] = dynamic_roles
+
         data['included_path'] = self._included_path
 
         return data
@@ -329,9 +359,22 @@ class Play(Base, Taggable, Become):
             setattr(self, 'roles', roles)
             del data['roles']
 
+        if 'dynamic_roles' in data:
+            role_data = data.get('dynamic_roles', [])
+            droles = []
+            for role in role_data:
+                r = Role()
+                role['_irole_play'] = self
+                r.deserialize(role)
+                droles.append(r)
+
+            setattr(self, 'dynamic_roles', droles)
+            del data['dynamic_roles']
+
     def copy(self):
         new_me = super(Play, self).copy()
         new_me.ROLE_CACHE = self.ROLE_CACHE.copy()
         new_me._included_conditional = self._included_conditional
         new_me._included_path = self._included_path
+        new_me._dynamic_roles = self._dynamic_roles[:]
         return new_me

--- a/lib/ansible/playbook/role_include.py
+++ b/lib/ansible/playbook/role_include.py
@@ -64,6 +64,8 @@ class IncludeRole(TaskInclude):
         self._parent_role = role
         self._role_name = None
         self._role_path = None
+        self._play = None
+        self._role = None
 
     def get_name(self):
         ''' return the name of the task '''
@@ -86,6 +88,9 @@ class IncludeRole(TaskInclude):
 
         # save this for later use
         self._role_path = actual_role._role_path
+        self._role = actual_role
+        if myplay is not None:
+            self._play = myplay
 
         # compile role with parent roles as dependencies to ensure they inherit
         # variables
@@ -166,8 +171,15 @@ class IncludeRole(TaskInclude):
         new_me._parent_role = self._parent_role
         new_me._role_name = self._role_name
         new_me._role_path = self._role_path
+        new_me._role = self._role
+        new_me.private = self.private
+        new_me._play = self._play
 
         return new_me
+
+    @property
+    def is_loaded(self):
+        return self._role is not None
 
     def get_include_params(self):
         v = super(IncludeRole, self).get_include_params()

--- a/lib/ansible/playbook/role_include.py
+++ b/lib/ansible/playbook/role_include.py
@@ -78,11 +78,24 @@ class IncludeRole(TaskInclude):
             myplay = self._parent._play
         else:
             myplay = play
+        if variable_manager is None or loader is None:
+            variable_manager = self.get_variable_manager()
+        if loader is None:
+            loader = variable_manager._loader
 
         ri = RoleInclude.load(self._role_name, play=myplay, variable_manager=variable_manager, loader=loader)
         ri.vars.update(self.vars)
 
         # build role
+        if self.vars:
+            v = self.vars.copy()
+            # bypass vars from include_role itself
+            for k in [
+                'name', 'private', 'allow_duplicates',
+                'defaults_from', 'tasks_from', 'vars_from'
+            ]:
+                v.pop(k, None)
+            ri.vars.update(v)
         actual_role = Role.load(ri, myplay, parent_role=self._parent_role, from_files=self._from_files)
         actual_role._metadata.allow_duplicates = self.allow_duplicates
 
@@ -91,6 +104,7 @@ class IncludeRole(TaskInclude):
         self._role = actual_role
         if myplay is not None:
             self._play = myplay
+            self._play.register_dynamic_role(self)
 
         # compile role with parent roles as dependencies to ensure they inherit
         # variables
@@ -186,3 +200,18 @@ class IncludeRole(TaskInclude):
         if self._parent_role:
             v.update(self._parent_role.get_role_params())
         return v
+
+    def get_default_vars(self, dep_chain=None):
+        if not self.is_loaded:
+            return dict()
+        if dep_chain is None:
+            dep_chain = self.get_dep_chain()
+        return self._role.get_default_vars(dep_chain=dep_chain)
+
+    def get_vars(self, include_params=True):
+        all_vars = TaskInclude.get_vars(self, include_params=include_params)
+        if self.is_loaded:  # not yet loaded skip
+            all_vars.update(
+                self._role.get_vars(include_params=include_params)
+            )
+        return all_vars

--- a/lib/ansible/playbook/task_include.py
+++ b/lib/ansible/playbook/task_include.py
@@ -93,7 +93,7 @@ class TaskInclude(Task):
         new_me.statically_loaded = self.statically_loaded
         return new_me
 
-    def get_vars(self):
+    def get_vars(self, include_params=True):
         '''
         We override the parent Task() classes get_vars here because
         we need to include the args of the include into the vars as
@@ -106,8 +106,9 @@ class TaskInclude(Task):
             if self._parent:
                 all_vars.update(self._parent.get_vars())
 
-            all_vars.update(self.vars)
-            all_vars.update(self.args)
+            if include_params:
+                all_vars.update(self.vars)
+                all_vars.update(self.args)
 
             if 'tags' in all_vars:
                 del all_vars['tags']

--- a/lib/ansible/vars/manager.py
+++ b/lib/ansible/vars/manager.py
@@ -185,10 +185,13 @@ class VariableManager:
         # default for all cases
         basedirs = [self._loader.get_basedir()]
 
+        # First compile vars that are coming from roles (defaults/main.yml)
+        # from within the play (both static and loaded dynamically)
+        # Of course for dynamic, we are only the ones which are
+        # already parsed yet through playbooks/role_include.py
+        # and not marked as private on the include statement.
         if play:
-            # first we compile any vars specified in defaults/main.yml
-            # for all roles within the specified play
-            for role in play.get_roles():
+            for role in play.get_roles() + play.get_dynamic_roles():
                 all_vars = combine_vars(all_vars, role.get_default_vars())
 
         if task:
@@ -374,7 +377,7 @@ class VariableManager:
             # By default, we now merge in all vars from all roles in the play,
             # unless the user has disabled this via a config option
             if not C.DEFAULT_PRIVATE_ROLE_VARS:
-                for role in play.get_roles():
+                for role in play.get_roles() + play.get_dynamic_roles():
                     all_vars = combine_vars(all_vars, role.get_vars(include_params=False))
 
         # next, we merge in the vars from the role, which will specifically

--- a/test/integration/targets/include_import/playbook/sharedvars.yml
+++ b/test/integration/targets/include_import/playbook/sharedvars.yml
@@ -1,0 +1,41 @@
+- name: verify that play can access vars after include role
+  hosts: testhost
+  tasks:
+    - shell: echo {{testinc_defvar1|default('notdefined')}}
+      register: test2
+    - assert:
+        that:
+          - test2.stdout == 'notdefined'
+    - include_role: {name: sharedvars_include_role}
+      register: testa
+    - shell: echo {{testinc_defvar1}}
+      register: test2
+    - shell: echo {{testinc_varvar1}}
+      register: test3
+    - assert:
+        that:
+          - testdep1.stdout == 'from deprole'
+          - test1.stdout == 'from role'
+          - test2.stdout == 'foobar'
+          - test3.stdout == 'muche'
+
+- name: verify that vars doesnt survive after play
+  hosts: testhost
+  tasks:
+    - shell: echo {{testinc_defvar1|default('notdefined')}}
+      register: test2
+    - assert:
+        that:
+          - test2.stdout == 'notdefined'
+
+- name: verify that we can play with default vars
+  hosts: testhost
+  tasks:
+    - include_role: {name: sharedvars_include_role}
+      vars:
+        testinc_defvar1: overriden
+    - shell: echo {{testinc_defvar1}}
+      register: test2
+    - assert:
+        that:
+          - test2.stdout == 'overriden'

--- a/test/integration/targets/include_import/roles/sharedvars_include_role/defaults/main.yml
+++ b/test/integration/targets/include_import/roles/sharedvars_include_role/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+testinc_defvar1: foobar
+testinc_varvar1: foobar

--- a/test/integration/targets/include_import/roles/sharedvars_include_role/meta/main.yml
+++ b/test/integration/targets/include_import/roles/sharedvars_include_role/meta/main.yml
@@ -1,0 +1,1 @@
+dependencies: [sharedvars_includedep_role]

--- a/test/integration/targets/include_import/roles/sharedvars_include_role/tasks/main.yml
+++ b/test/integration/targets/include_import/roles/sharedvars_include_role/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+- name: noop task
+  shell: echo from role
+  register: test1

--- a/test/integration/targets/include_import/roles/sharedvars_include_role/vars/main.yml
+++ b/test/integration/targets/include_import/roles/sharedvars_include_role/vars/main.yml
@@ -1,0 +1,2 @@
+---
+testinc_varvar1: muche

--- a/test/integration/targets/include_import/roles/sharedvars_includedep_role/defaults/main.yml
+++ b/test/integration/targets/include_import/roles/sharedvars_includedep_role/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+testdepinc_defvar1: foobar
+testdepinc_varvar1: foobar

--- a/test/integration/targets/include_import/roles/sharedvars_includedep_role/meta/main.yml
+++ b/test/integration/targets/include_import/roles/sharedvars_includedep_role/meta/main.yml
@@ -1,0 +1,1 @@
+dependencies: []

--- a/test/integration/targets/include_import/roles/sharedvars_includedep_role/tasks/main.yml
+++ b/test/integration/targets/include_import/roles/sharedvars_includedep_role/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+- name: noop task
+  shell: echo from deprole
+  register: testdep1

--- a/test/integration/targets/include_import/roles/sharedvars_includedep_role/vars/main.yml
+++ b/test/integration/targets/include_import/roles/sharedvars_includedep_role/vars/main.yml
@@ -1,0 +1,2 @@
+---
+testdepinc_varvar1: muche

--- a/test/integration/targets/include_import/runme.sh
+++ b/test/integration/targets/include_import/runme.sh
@@ -77,3 +77,9 @@ if [[ -z "$OUT" ]]; then
     echo "apply on import_tasks did not cause error"
     exit 1
 fi
+
+
+## shared vars
+# https://github.com/ansible/ansible/issues/21890
+ANSIBLE_STRATEGY='linear' ansible-playbook -i ../../inventory playbook/sharedvars.yml -v "$@" --skip-tags never
+ANSIBLE_STRATEGY='free' ansible-playbook -i ../../inventory playbook/sharedvars.yml -v "$@" --skip-tags never


### PR DESCRIPTION
##### SUMMARY
include_role included vars are totally losen from next tasks, roles play access making include_role pretty unusable to DRY code.
This PR fixes it; see #21890 and all linked bug.

This PR is a part of my initial PR #32565  which i splitted up.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
include_role

##### ANSIBLE VERSION
```
2.4
devel
```


##### ADDITIONAL INFORMATION
I added targets/include_role integration test to show the bug in action
expected test run
```
testhost                   : ok=16   changed=9    unreachable=0    failed=0
```
before the fix
```
TASK [test_include_role : noop task] ******************************************************************************************************************************************************************************************************************************************
changed: [testhost] => {"changed": true, "cmd": "echo from role", "delta": "0:00:00.099395", "end": "2018-01-20 17:32:41.982486", "rc": 0, "start": "2018-01-20 17:32:41.883091", "stderr": "", "stderr_lines": [], "stdout": "from role", "stdout_lines": ["from role"]}

TASK [command] ****************************************************************************************************************************************************************************************************************************************************************
fatal: [testhost]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'testinc_defvar1' is undefined\n\nThe error appears to have been in '/srv/corpusops/corpusops.bootstrap/venv/src/ansible/test/integration/targets/include_role/include_role.yml': line 11, column 7, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n      register: testa\n    - shell: echo {{testinc_defvar1}}\n      ^ here\nWe could be wrong, but this one looks like it might be an issue with\nmissing quotes.  Always quote template expression brackets when they\nstart a value. For instance:\n\n    with_items:\n      - {{ foo }}\n\nShould be written as:\n\n    with_items:\n      - \"{{ foo }}\"\n\nexception type: <class 'ansible.errors.AnsibleUndefinedVariable'>\nexception: 'testinc_defvar1' is undefined"}
        to retry, use: --limit @/srv/corpusops/corpusops.bootstrap/venv/src/ansible/test/integration/targets/include_role/include_role.retry

PLAY RECAP ********************************************************************************************************************************************************************************************************************************************************************
testhost                   : ok=5    changed=3    unreachable=0    failed=1

NOTICE: To resume at this test target, use the option: --start-at include_role
ERROR: Command "./runme.sh -v" returned exit status 2.
```


- related PRs: #35167 #35166 #35165 #35164 #35163
