### PR TITLE
added new IBM Power KVM guest recognisation

### DIFF
--- a/lib/ansible/module_utils/facts/virtual/linux.py
+++ b/lib/ansible/module_utils/facts/virtual/linux.py
@@ -160,6 +160,8 @@ class LinuxVirtual(Virtual):
                     virtual_facts['virtualization_type'] = 'uml'
                 elif re.match('^model name.*UML', line):
                     virtual_facts['virtualization_type'] = 'uml'
+                elif re.match('^machine.*CHRP IBM pSeries .emulated by qemu.', line):
+                    virtual_facts['virtualization_type'] = 'kvm'
                 elif re.match('^vendor_id.*PowerVM Lx86', line):
                     virtual_facts['virtualization_type'] = 'powervm_lx86'
                 elif re.match('^vendor_id.*IBM/S390', line):


### PR DESCRIPTION
##### SUMMARY
If you are running Ansible against a IBM OpenPower Based Linux machine it does not recognize the virtual machine technology.
This patch makes gives the correct value for the following facts
- 'ansible_virtualization_role' 
- 'ansible_virtualization_type'

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
fact gathering (setup)

##### ANSIBLE VERSION
```
ansible 2.5.0 (devel d0a257efad) last updated 2018/01/22 01:28:16 (GMT +200)
  config file = /home/ansible/.ansible.cfg
  configured module search path = [u'/home/ansible/ansible/library']
  ansible python module location = /home/ansible/ansible/lib/ansible
  executable location = /home/ansible/ansible/bin/ansible
  python version = 2.7.5 (default, May 16 2016, 12:54:51) [GCC 4.8.5 20150623 (PowerEL 4.8.5-10)]
```
