### PR TITLE
wait_for works with tcp6 disabled, fixes #23456

### DIFF
--- a/lib/ansible/modules/utilities/logic/wait_for.py
+++ b/lib/ansible/modules/utilities/logic/wait_for.py
@@ -316,6 +316,8 @@ class LinuxTCPConnectionInfo(TCPConnectionInfo):
     def get_active_connections_count(self):
         active_connections = 0
         for family in self.source_file.keys():
+            if not os.path.isfile(self.source_file[family]):
+                continue
             f = open(self.source_file[family])
             for tcp_connection in f.readlines():
                 tcp_connection = tcp_connection.strip().split()


### PR DESCRIPTION
##### SUMMARY
Fixes #23456. wait_for works with tcp6 disabled in drain mode.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
wait_for

##### ANSIBLE VERSION
```
ansible 2.5.0 (devel 347b5d1e50) last updated 2018/01/21 19:11:24 (GMT +200)
```


##### ADDITIONAL INFORMATION
Ignores missing file under /proc/net instead of throwing error. Error thrown was intercepted later, and was treated the same way as still existing connections.

```
# Provided tcp6 is disabled, so there is no /proc/net/tcp6 file. And there is nothing listening on port 80.
% ansible localhost -m wait_for -a 'state=drained port=80 sleep=2 timeout=10'
localhost | FAILED! => {
    "attempts": 1,
    "changed": false,
    "elapsed": 10,
    "failed": true,
    "msg": "Timeout when waiting for 127.0.0.1:80 to drain"
}
# after change:
% ansible localhost -m wait_for -a 'state=drained port=80 sleep=2 timeout=10'
localhost | SUCCESS => {
    "attempts": 1,
    "changed": false,
    "elapsed": 0,
    "failed": false,
    "path": null,
    "port": 80,
    "search_regex": null,
    "state": "drained"
}
```
