### PR TITLE
Fix python3 interpreter issue (#34811)

### DIFF
--- a/lib/ansible/modules/net_tools/haproxy.py
+++ b/lib/ansible/modules/net_tools/haproxy.py
@@ -251,12 +251,15 @@ class HAProxy(object):
         """
         self.client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         self.client.connect(self.socket)
-        self.client.sendall('%s\n' % cmd)
+        try:
+            self.client.sendall('%s\n' % cmd)
+        except TypeError:
+            self.client.sendall((bytearray('%s\n', 'ASCII')) % cmd.encode())
         result = ''
         buf = ''
         buf = self.client.recv(RECV_SIZE)
         while buf:
-            result += buf
+            result += buf.decode('ASCII')
             buf = self.client.recv(RECV_SIZE)
         if capture_output:
             self.capture_command_output(cmd, result.strip())

--- a/lib/ansible/modules/net_tools/haproxy.py
+++ b/lib/ansible/modules/net_tools/haproxy.py
@@ -253,12 +253,15 @@ class HAProxy(object):
         self.client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         self.client.connect(self.socket)
         self.client.sendall(to_bytes('%s\n' % cmd))
-        result = ''
-        buf = ''
+
+        result = b''
+        buf = b''
         buf = self.client.recv(RECV_SIZE)
         while buf:
-            result += to_text(buf)
+            result += buf
             buf = self.client.recv(RECV_SIZE)
+        result = to_text(result, errors='surrogate_or_strict')
+
         if capture_output:
             self.capture_command_output(cmd, result.strip())
         self.client.close()

--- a/lib/ansible/modules/net_tools/haproxy.py
+++ b/lib/ansible/modules/net_tools/haproxy.py
@@ -202,6 +202,7 @@ import time
 from string import Template
 
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_bytes, to_text
 
 
 DEFAULT_SOCKET_LOCATION = "/var/run/haproxy.sock"
@@ -251,15 +252,12 @@ class HAProxy(object):
         """
         self.client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         self.client.connect(self.socket)
-        try:
-            self.client.sendall('%s\n' % cmd)
-        except TypeError:
-            self.client.sendall((bytearray('%s\n', 'ASCII')) % cmd.encode())
+        self.client.sendall(to_bytes('%s\n' % cmd))
         result = ''
         buf = ''
         buf = self.client.recv(RECV_SIZE)
         while buf:
-            result += buf.decode('ASCII')
+            result += to_text(buf)
             buf = self.client.recv(RECV_SIZE)
         if capture_output:
             self.capture_command_output(cmd, result.strip())


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
```When using python3 as ansible interpreter the haproxy fails while setting the backend to a specific state.```
* update python3 `Type` to fix this.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
HAProxy module

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
