### PR TITLE
Fix yum integration tests

### DIFF
--- a/test/integration/targets/yum/tasks/main.yml
+++ b/test/integration/targets/yum/tasks/main.yml
@@ -18,7 +18,32 @@
 
 # Note: We install the yum package onto Fedora so that this will work on dnf systems
 # We want to test that for people who don't want to upgrade their systems.
-- include: 'yum.yml'
+
+- block:
+  - include: 'yum.yml'
+  always:
+    - name: remove installed packages
+      yum:
+        name:
+          - bc
+          - sos
+        state: absent
+
+    # On CentOS 6 'yum groupremove "Development Tools"' fails when groupremove_leaf_only
+    # isn't enabled, that's why a package belonging to "Development Tools" (autoconf)
+    # is removed instead of the whole group.
+    - name: remove installed group
+      yum:
+        name: "@Development tools"
+        state: absent
+      when:
+        - (ansible_distribution in ['RedHat', 'CentOS', 'ScientificLinux'] and ansible_distribution_major_version|int > 6) or ansible_distribution in ['Fedora']
+    - name: remove a package from a group
+      yum:
+        name: 'autoconf'
+        state: absent
+      when:
+        - ansible_distribution in ['RedHat', 'CentOS', 'ScientificLinux'] and ansible_distribution_major_version|int <= 6
   when:
     - ansible_distribution in ['RedHat', 'CentOS', 'ScientificLinux', 'Fedora']
     - ansible_python.version.major == 2

--- a/test/integration/targets/yum/tasks/yum.yml
+++ b/test/integration/targets/yum/tasks/yum.yml
@@ -23,7 +23,7 @@
 - name: verify no change on re-uninstall in check mode
   assert:
     that:
-        - "not yum_result.changed"
+        - "not yum_result is changed"
 
 - name: uninstall sos again
   yum: name=sos state=removed
@@ -32,7 +32,7 @@
 - name: verify no change on re-uninstall
   assert:
     that:
-        - "not yum_result.changed"
+        - "not yum_result is changed"
 
 # INSTALL
 - name: install sos in check mode
@@ -43,7 +43,7 @@
 - name: verify installation of sos in check mode
   assert:
     that:
-        - "yum_result.changed"
+        - "yum_result is changed"
 
 - name: install sos
   yum: name=sos state=present
@@ -58,7 +58,7 @@
   assert:
     that:
         - "yum_result.rc == 0"
-        - "yum_result.changed"
+        - "yum_result is changed"
         - "rpm_result.rc == 0"
 
 - name: verify yum module outputs
@@ -77,7 +77,7 @@
 - name: verify no change on second install in check mode
   assert:
     that:
-        - "not yum_result.changed"
+        - "not yum_result is changed"
 
 - name: install sos again
   yum: name=sos state=present
@@ -85,7 +85,7 @@
 - name: verify no change on second install
   assert:
     that:
-        - "not yum_result.changed"
+        - "not yum_result is changed"
 
 # INSTALL AGAIN WITH LATEST
 - name: install sos again with state latest in check mode
@@ -95,7 +95,7 @@
 - name: verify install sos again with state latest in check mode
   assert:
     that:
-        - "not yum_result.changed"
+        - "not yum_result is changed"
 
 - name: install sos again with state latest idempotence
   yum: name=sos state=latest
@@ -103,7 +103,7 @@
 - name: verify install sos again with state latest idempotence
   assert:
     that:
-        - "not yum_result.changed"
+        - "not yum_result is changed"
 
 # INSTALL WITH LATEST
 - name: uninstall sos
@@ -121,7 +121,7 @@
 - name: verify install sos with state latest in check mode
   assert:
     that:
-        - "yum_result.changed"
+        - "yum_result is changed"
 
 - name: install sos with state latest
   yum: name=sos state=latest
@@ -129,7 +129,7 @@
 - name: verify install sos with state latest
   assert:
     that:
-        - "yum_result.changed"
+        - "yum_result is changed"
 
 - name: install sos with state latest idempotence
   yum: name=sos state=latest
@@ -137,7 +137,7 @@
 - name: verify install sos with state latest idempotence
   assert:
     that:
-        - "not yum_result.changed"
+        - "not yum_result is changed"
 
 # Multiple packages
 - name: uninstall sos and bc
@@ -178,7 +178,7 @@
   assert:
     that:
         - "yum_result.rc == 0"
-        - "yum_result.changed"
+        - "yum_result is changed"
         - "rpm_sos_result.rc == 0"
         - "rpm_bc_result.rc == 0"
 
@@ -208,7 +208,7 @@
   assert:
     that:
         - "yum_result.rc == 0"
-        - "yum_result.changed"
+        - "yum_result is changed"
         - "rpm_sos_result.rc == 0"
         - "rpm_bc_result.rc == 0"
 
@@ -236,7 +236,7 @@
   assert:
     that:
         - "yum_result.rc == 0"
-        - "yum_result.changed"
+        - "yum_result is changed"
         - "rpm_sos_result.rc == 0"
         - "rpm_bc_result.rc == 0"
 
@@ -269,7 +269,7 @@
   assert:
     that:
         - "yum_result.rc == 0"
-        - "yum_result.changed"
+        - "yum_result is changed"
         - "rpm_result.rc == 0"
 
 - name: verify yum module outputs
@@ -297,7 +297,7 @@
   assert:
     that:
         - "yum_result.rc == 0"
-        - "yum_result.changed"
+        - "yum_result is changed"
 
 - name: verify yum module outputs
   assert:
@@ -317,7 +317,7 @@
   assert:
     that:
         - "yum_result.rc == 0"
-        - "not yum_result.changed"
+        - "not yum_result is changed"
 
 - name: verify yum module outputs
   assert:
@@ -339,7 +339,7 @@
   assert:
     that:
         - "yum_result.rc == 0"
-        - "yum_result.changed"
+        - "yum_result is changed"
 
 - name: verify yum module outputs
   assert:
@@ -359,7 +359,7 @@
 - name: verify nothing changed
   assert:
     that:
-        - "not yum_result.changed"
+        - "not yum_result is changed"
 
 - name: verify yum module outputs
   assert:
@@ -379,7 +379,7 @@
   assert:
     that:
         - "yum_result.rc == 1"
-        - "not yum_result.changed"
+        - "not yum_result is changed"
         - "yum_result is failed"
 
 - name: verify yum module outputs
@@ -401,7 +401,7 @@
   assert:
     that:
         - "yum_result is failed"
-        - "not yum_result.changed"
+        - "not yum_result is changed"
 
 - name: verify yum module outputs
   assert:
@@ -420,7 +420,7 @@
   assert:
     that:
         - "yum_result is failed"
-        - "not yum_result.changed"
+        - "not yum_result is changed"
 
 - name: verify yum module outputs
   assert:
@@ -454,7 +454,7 @@
 - name: verify httpd not installed
   assert:
     that:
-      - "not yum_result.changed"
+      - "not yum_result is changed"
       - "'Packages providing httpd not installed due to update_only specified' in yum_result.results"
 
 - name: try to install not compatible arch rpm, should fail
@@ -468,7 +468,7 @@
   assert:
     that:
         - "yum_result.rc == 1"
-        - "not yum_result.changed"
+        - "not yum_result is changed"
         - "yum_result is failed"
 
 # setup for testing installing an RPM from url
@@ -500,7 +500,7 @@
   assert:
     that:
         - "yum_result.rc == 0"
-        - "yum_result.changed"
+        - "yum_result is changed"
         - "yum_result is not failed"
 
 - name: verify yum module outputs
@@ -521,7 +521,7 @@
   assert:
     that:
         - "yum_result.rc == 0"
-        - "not yum_result.changed"
+        - "not yum_result is changed"
         - "yum_result is not failed"
 
 - name: verify yum module outputs
@@ -547,7 +547,7 @@
   assert:
     that:
         - "yum_result.rc == 0"
-        - "yum_result.changed"
+        - "yum_result is changed"
         - "yum_result is not failed"
 
 - name: verify yum module outputs

--- a/test/integration/targets/yum/tasks/yum.yml
+++ b/test/integration/targets/yum/tasks/yum.yml
@@ -5,14 +5,14 @@
 
 - name: check sos with rpm
   shell: rpm -q sos
-  failed_when: False
+  ignore_errors: True
   register: rpm_result
 
 - name: verify uninstallation of sos
   assert:
     that:
-        - "yum_result.rc == 0"
-        - "rpm_result.rc == 1"
+        - "yum_result is success"
+        - "rpm_result is failed"
 
 # UNINSTALL AGAIN
 - name: uninstall sos again in check mode
@@ -49,25 +49,21 @@
   yum: name=sos state=present
   register: yum_result
 
-- name: check sos with rpm
-  shell: rpm -q sos
-  failed_when: False
-  register: rpm_result
-
 - name: verify installation of sos
   assert:
     that:
-        - "yum_result.rc == 0"
+        - "yum_result is success"
         - "yum_result is changed"
-        - "rpm_result.rc == 0"
 
 - name: verify yum module outputs
   assert:
     that:
         - "'changed' in yum_result"
         - "'msg' in yum_result"
-        - "'rc' in yum_result"
         - "'results' in yum_result"
+
+- name: check sos with rpm
+  shell: rpm -q sos
 
 # INSTALL AGAIN
 - name: install sos again in check mode
@@ -142,45 +138,38 @@
 # Multiple packages
 - name: uninstall sos and bc
   yum: name=sos,bc state=removed
-  register: yum_result
 
 - name: check sos with rpm
   shell: rpm -q sos
-  failed_when: False
+  ignore_errors: True
   register: rpm_sos_result
 
 - name: check bc with rpm
   shell: rpm -q bc
-  failed_when: False
+  ignore_errors: True
   register: rpm_bc_result
 
 - name: verify packages installed
   assert:
     that:
-        - "rpm_sos_result.rc != 0"
-        - "rpm_bc_result.rc != 0"
+        - "rpm_sos_result is failed"
+        - "rpm_bc_result is failed"
 
 - name: install sos and bc as comma separated
   yum: name=sos,bc state=present
   register: yum_result
 
-- name: check sos with rpm
-  shell: rpm -q sos
-  failed_when: False
-  register: rpm_sos_result
-
-- name: check bc with rpm
-  shell: rpm -q bc
-  failed_when: False
-  register: rpm_bc_result
-
 - name: verify packages installed
   assert:
     that:
-        - "yum_result.rc == 0"
+        - "yum_result is success"
         - "yum_result is changed"
-        - "rpm_sos_result.rc == 0"
-        - "rpm_bc_result.rc == 0"
+
+- name: check sos with rpm
+  shell: rpm -q sos
+
+- name: check bc with rpm
+  shell: rpm -q bc
 
 - name: uninstall sos and bc
   yum: name=sos,bc state=removed
@@ -194,23 +183,17 @@
     state: present
   register: yum_result
 
-- name: check sos with rpm
-  shell: rpm -q sos
-  failed_when: False
-  register: rpm_sos_result
-
-- name: check bc with rpm
-  shell: rpm -q bc
-  failed_when: False
-  register: rpm_bc_result
-
 - name: verify packages installed
   assert:
     that:
-        - "yum_result.rc == 0"
+        - "yum_result is success"
         - "yum_result is changed"
-        - "rpm_sos_result.rc == 0"
-        - "rpm_bc_result.rc == 0"
+
+- name: check sos with rpm
+  shell: rpm -q sos
+
+- name: check bc with rpm
+  shell: rpm -q bc
 
 - name: uninstall sos and bc
   yum: name=sos,bc state=removed
@@ -222,23 +205,17 @@
     state: present
   register: yum_result
 
-- name: check sos with rpm
-  shell: rpm -q sos
-  failed_when: False
-  register: rpm_sos_result
-
-- name: check sos with rpm
-  shell: rpm -q bc
-  failed_when: False
-  register: rpm_bc_result
-
 - name: verify packages installed
   assert:
     that:
-        - "yum_result.rc == 0"
+        - "yum_result is success"
         - "yum_result is changed"
-        - "rpm_sos_result.rc == 0"
-        - "rpm_bc_result.rc == 0"
+
+- name: check sos with rpm
+  shell: rpm -q sos
+
+- name: check sos with rpm
+  shell: rpm -q bc
 
 - name: uninstall sos and bc
   yum: name=sos,bc state=removed
@@ -260,25 +237,21 @@
   yum: name=sos state=present installroot='/'
   register: yum_result
 
-- name: check sos with rpm
-  shell: rpm -q sos --root=/
-  failed_when: False
-  register: rpm_result
-
 - name: verify installation of sos
   assert:
     that:
-        - "yum_result.rc == 0"
+        - "yum_result is success"
         - "yum_result is changed"
-        - "rpm_result.rc == 0"
 
 - name: verify yum module outputs
   assert:
     that:
         - "'changed' in yum_result"
         - "'msg' in yum_result"
-        - "'rc' in yum_result"
         - "'results' in yum_result"
+
+- name: check sos with rpm
+  shell: rpm -q sos --root=/
 
 - name: uninstall sos
   yum:
@@ -296,7 +269,7 @@
 - name: verify installation of the group
   assert:
     that:
-        - "yum_result.rc == 0"
+        - "yum_result is success"
         - "yum_result is changed"
 
 - name: verify yum module outputs
@@ -304,7 +277,6 @@
     that:
         - "'changed' in yum_result"
         - "'msg' in yum_result"
-        - "'rc' in yum_result"
         - "'results' in yum_result"
 
 - name: install the group again
@@ -316,7 +288,7 @@
 - name: verify nothing changed
   assert:
     that:
-        - "yum_result.rc == 0"
+        - "yum_result is success"
         - "not yum_result is changed"
 
 - name: verify yum module outputs
@@ -324,7 +296,6 @@
     that:
         - "'changed' in yum_result"
         - "'msg' in yum_result"
-        - "'rc' in yum_result"
         - "'results' in yum_result"
 
 - name: install the group again but also with a package that is not yet installed
@@ -338,7 +309,7 @@
 - name: verify sos is installed
   assert:
     that:
-        - "yum_result.rc == 0"
+        - "yum_result is success"
         - "yum_result is changed"
 
 - name: verify yum module outputs
@@ -346,7 +317,6 @@
     that:
         - "'changed' in yum_result"
         - "'msg' in yum_result"
-        - "'rc' in yum_result"
         - "'results' in yum_result"
 
 - name: try to install the group again, with --check to check 'changed'
@@ -378,7 +348,7 @@
 - name: verify installation of the non existing group failed
   assert:
     that:
-        - "yum_result.rc == 1"
+        - "yum_result is failed"
         - "not yum_result is changed"
         - "yum_result is failed"
 
@@ -387,7 +357,6 @@
     that:
         - "'changed' in yum_result"
         - "'msg' in yum_result"
-        - "'rc' in yum_result"
         - "'results' in yum_result"
 
 - name: try to install non existing file
@@ -467,7 +436,6 @@
 - name: verify that yum failed
   assert:
     that:
-        - "yum_result.rc == 1"
         - "not yum_result is changed"
         - "yum_result is failed"
 
@@ -499,7 +467,7 @@
 - name: verify installation
   assert:
     that:
-        - "yum_result.rc == 0"
+        - "yum_result is success"
         - "yum_result is changed"
         - "yum_result is not failed"
 
@@ -508,7 +476,6 @@
     that:
         - "'changed' in yum_result"
         - "'msg' in yum_result"
-        - "'rc' in yum_result"
         - "'results' in yum_result"
 
 - name: install the downloaded rpm again
@@ -520,7 +487,7 @@
 - name: verify installation
   assert:
     that:
-        - "yum_result.rc == 0"
+        - "yum_result is success"
         - "not yum_result is changed"
         - "yum_result is not failed"
 
@@ -529,7 +496,6 @@
     that:
         - "'changed' in yum_result"
         - "'msg' in yum_result"
-        - "'rc' in yum_result"
         - "'results' in yum_result"
 
 - name: clean up
@@ -546,7 +512,7 @@
 - name: verify installation
   assert:
     that:
-        - "yum_result.rc == 0"
+        - "yum_result is success"
         - "yum_result is changed"
         - "yum_result is not failed"
 
@@ -555,7 +521,6 @@
     that:
         - "'changed' in yum_result"
         - "'msg' in yum_result"
-        - "'rc' in yum_result"
         - "'results' in yum_result"
 
 - name: Create a temp RPM file which does not contain nevra information


### PR DESCRIPTION
##### SUMMARY
Fix `yum` integration tests:
- don't check `rc`:
  - `rc` isn't documented in `yum` module documentation
  - `rc` isn't always returned by `yum` module (and it would not make sense to always set `rc` in case of error):
    ```
    TASK [yum : try to install not compatible arch rpm, should fail] ***************
    fatal: [testhost]: FAILED! => {"attempts": 1, "changed": false, "failed": true, "msg": "Failure downloading http://download.fedoraproject.org/pub/epel/7/ppc64le/Packages/b/banner-1.3.4-3.el7.ppc64le.rpm, Request failed: <urlopen error timed out>"}
     ...ignoring
 
    TASK [yum : verify that yum failed] ********************************************
    fatal: [testhost]: FAILED! => {"failed": true, "msg": "The conditional check 'yum_result.rc == 1' failed. The error was: error while evaluating conditional (yum_result.rc == 1): 'dict object' has no attribute 'rc'"}
	to retry, use: --limit @/root/ansible/test/integration/yum-5zf9GA.retry
    ```
  - yum module uses `fail_json` method
- allow to execute integration tests twice in a row: always remove installed packages. Then the 2nd try doesn't report wrong error.
- use tests instead of filters

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
yum

##### ANSIBLE VERSION
```
ansible 2.5.0 (devel 8fdfda76e9) last updated 2018/01/22 12:19:38 (GMT +200)
```