### PR TITLE
Fix modules index delimiter and improve readability

### DIFF
--- a/docs/templates/list_of_CATEGORY_modules.rst.j2
+++ b/docs/templates/list_of_CATEGORY_modules.rst.j2
@@ -9,7 +9,7 @@
 {% if category['_modules'] %}
 
 {% for module in category['_modules'] | sort %}
-  @{ module }@{% if module_info[module]['deprecated'] %} **(D)**{% endif%} - @{ module_info[module]['doc']['short_description'] }@ <@{ module }@_module>
+  `@{ module }@ <@{ module }@_module>`{% if module_info[module]['deprecated'] %} **(D)**{% endif%} - @{ module_info[module]['doc']['short_description'] }@
 {% endfor %}
 {% endif %}
 
@@ -21,7 +21,7 @@
 
 {% for module in info['_modules'] | sort %}
 {#  :ref:`@{ module }@`{% if module_info[module]['deprecated'] %} **(D)**{% endif%} @{ module_info[module]['doc']['short_description'] }@ #}
-    @{ module }@{% if module_info[module]['deprecated'] %} **(D)**{% endif%} @{ module_info[module]['doc']['short_description'] }@ <@{ module }@_module>
+    `@{ module }@ <@{ module }@_module>`{% if module_info[module]['deprecated'] %} **(D)**{% endif%} - @{ module_info[module]['doc']['short_description'] }@
 {% endfor %}
 
 {% endfor %}

--- a/docs/templates/list_of_CATEGORY_modules.rst.j2
+++ b/docs/templates/list_of_CATEGORY_modules.rst.j2
@@ -9,7 +9,7 @@
 {% if category['_modules'] %}
 
 {% for module in category['_modules'] | sort %}
-  `@{ module }@ <@{ module }@_module>`{% if module_info[module]['deprecated'] %} **(D)**{% endif%} - @{ module_info[module]['doc']['short_description'] }@
+  @{ module }@ <@{ module }@_module>{% if module_info[module]['deprecated'] %} **(D)**{% endif%} - @{ module_info[module]['doc']['short_description'] }@
 {% endfor %}
 {% endif %}
 
@@ -21,7 +21,7 @@
 
 {% for module in info['_modules'] | sort %}
 {#  :ref:`@{ module }@`{% if module_info[module]['deprecated'] %} **(D)**{% endif%} @{ module_info[module]['doc']['short_description'] }@ #}
-    `@{ module }@ <@{ module }@_module>`{% if module_info[module]['deprecated'] %} **(D)**{% endif%} - @{ module_info[module]['doc']['short_description'] }@
+    @{ module }@ <@{ module }@_module>{% if module_info[module]['deprecated'] %} **(D)**{% endif%} - @{ module_info[module]['doc']['short_description'] }@
 {% endfor %}
 
 {% endfor %}

--- a/docs/templates/list_of_CATEGORY_modules.rst.j2
+++ b/docs/templates/list_of_CATEGORY_modules.rst.j2
@@ -9,7 +9,7 @@
 {% if category['_modules'] %}
 
 {% for module in category['_modules'] | sort %}
-  @{ module }@ <@{ module }@_module>{% if module_info[module]['deprecated'] %} **(D)**{% endif%} - @{ module_info[module]['doc']['short_description'] }@
+  @{ module }@{% if module_info[module]['deprecated'] %} **(D)**{% endif%}  --  @{ module_info[module]['doc']['short_description'] }@ <@{ module }@_module>
 {% endfor %}
 {% endif %}
 
@@ -21,7 +21,7 @@
 
 {% for module in info['_modules'] | sort %}
 {#  :ref:`@{ module }@`{% if module_info[module]['deprecated'] %} **(D)**{% endif%} @{ module_info[module]['doc']['short_description'] }@ #}
-    @{ module }@ <@{ module }@_module>{% if module_info[module]['deprecated'] %} **(D)**{% endif%} - @{ module_info[module]['doc']['short_description'] }@
+    @{ module }@{% if module_info[module]['deprecated'] %} **(D)**{% endif%}  --  @{ module_info[module]['doc']['short_description'] }@ <@{ module }@_module>
 {% endfor %}
 
 {% endfor %}

--- a/docs/templates/list_of_CATEGORY_plugins.rst.j2
+++ b/docs/templates/list_of_CATEGORY_plugins.rst.j2
@@ -9,7 +9,7 @@
 {% if category['_modules'] %}
 
 {% for module in category['_modules'] | sort %}
-  `@{ module }@ <plugins/@{ module_info[module]['primary_category'] }@/@{ module }@>`{% if module_info[module]['deprecated'] %} **(D)**{% endif%}{% if module_info[module]['doc']['short_description'] %} - @{ module_info[module]['doc']['short_description'] }@{% endif %}
+  @{ module }@ <plugins/@{ module_info[module]['primary_category'] }@/@{ module }@>{% if module_info[module]['deprecated'] %} **(D)**{% endif%}{% if module_info[module]['doc']['short_description'] %} - @{ module_info[module]['doc']['short_description'] }@{% endif %}
 {% endfor %}
 {% endif %}
 

--- a/docs/templates/list_of_CATEGORY_plugins.rst.j2
+++ b/docs/templates/list_of_CATEGORY_plugins.rst.j2
@@ -9,7 +9,7 @@
 {% if category['_modules'] %}
 
 {% for module in category['_modules'] | sort %}
-  @{ module }@{% if module_info[module]['deprecated'] %} **(D)**{% endif%}{% if module_info[module]['doc']['short_description'] %} - @{ module_info[module]['doc']['short_description'] }@{% endif %} <plugins/@{ module_info[module]['primary_category'] }@/@{ module }@>
+  `@{ module }@ <plugins/@{ module_info[module]['primary_category'] }@/@{ module }@>`{% if module_info[module]['deprecated'] %} **(D)**{% endif%}{% if module_info[module]['doc']['short_description'] %} - @{ module_info[module]['doc']['short_description'] }@{% endif %}
 {% endfor %}
 {% endif %}
 

--- a/docs/templates/list_of_CATEGORY_plugins.rst.j2
+++ b/docs/templates/list_of_CATEGORY_plugins.rst.j2
@@ -9,7 +9,7 @@
 {% if category['_modules'] %}
 
 {% for module in category['_modules'] | sort %}
-  @{ module }@ <plugins/@{ module_info[module]['primary_category'] }@/@{ module }@>{% if module_info[module]['deprecated'] %} **(D)**{% endif%}{% if module_info[module]['doc']['short_description'] %} - @{ module_info[module]['doc']['short_description'] }@{% endif %}
+  @{ module }@{% if module_info[module]['deprecated'] %} **(D)**{% endif%}{% if module_info[module]['doc']['short_description'] %} -- @{ module_info[module]['doc']['short_description'] }@{% endif %} <plugins/@{ module_info[module]['primary_category'] }@/@{ module }@>
 {% endfor %}
 {% endif %}
 


### PR DESCRIPTION
##### SUMMARY
Looking at the modules index it's hard to read because it seems a large blob link:
http://docs.ansible.com/ansible/devel/module_docs/list_of_network_modules.html#aci

This PR changes the module index in 2 ways:
- It adds a delimiter between module name and short-description (as it was before)
- ~More importantly, it makes a visual distinction between module name and description by only making the module name a link (so the description is black on white)~

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
docs

##### ANSIBLE VERSION
v2.5