### PR TITLE
Adds the oVirt High Performance (high_performance) VM type.

### DIFF
--- a/lib/ansible/modules/cloud/misc/ovirt.py
+++ b/lib/ansible/modules/cloud/misc/ovirt.py
@@ -72,8 +72,8 @@ options:
     aliases: [ vmmem ]
   instance_type:
     description:
-     - Define whether the instance is a server or desktop.
-    choices: [ desktop, server ]
+     - Define whether the instance is a server, desktop or high_performance.
+    choices: [ desktop, server, high_performance ]
     default: server
     aliases: [ vmtype ]
   disk_alloc:
@@ -368,7 +368,7 @@ def main():
             instance_nic=dict(type='str', aliases=['vmnic']),
             instance_network=dict(type='str', default='rhevm', aliases=['vmnetwork']),
             instance_mem=dict(type='str', aliases=['vmmem']),
-            instance_type=dict(type='str', default='server', aliases=['vmtype'], choices=['desktop', 'server']),
+            instance_type=dict(type='str', default='server', aliases=['vmtype'], choices=['desktop', 'server', 'high_performance']),
             disk_alloc=dict(type='str', default='thin', choices=['preallocated', 'thin']),
             disk_int=dict(type='str', default='virtio', choices=['ide', 'virtio']),
             instance_os=dict(type='str', aliases=['vmos']),
@@ -405,7 +405,7 @@ def main():
     vmdisk_alloc = module.params['disk_alloc']  # thin, preallocated
     vmdisk_int = module.params['disk_int']  # disk interface virtio or ide
     vmos = module.params['instance_os']  # Operating System
-    vmtype = module.params['instance_type']  # server or desktop
+    vmtype = module.params['instance_type']  # server, desktop or high_performance
     vmcores = module.params['instance_cores']  # number of cores
     sdomain = module.params['sdomain']  # storage domain to store disk on
     region = module.params['region']  # oVirt Datacenter

--- a/lib/ansible/modules/cloud/ovirt/ovirt_vms.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_vms.py
@@ -165,7 +165,7 @@ options:
         description:
             - Type of the Virtual Machine.
             - Default value is set by oVirt/RHV engine.
-        choices: [ desktop, server ]
+        choices: [ desktop, server, high_performance ]
     operating_system:
         description:
             - Operating system of the Virtual Machine.
@@ -1425,7 +1425,7 @@ def main():
         cpu_sockets=dict(type='int'),
         cpu_cores=dict(type='int'),
         cpu_shares=dict(type='int'),
-        type=dict(type='str', choices=['server', 'desktop']),
+        type=dict(type='str', choices=['server', 'desktop', 'high_performance']),
         operating_system=dict(type='str',
                               choices=[
                                   'rhel_6_ppc64', 'other', 'freebsd', 'windows_2003x64', 'windows_10',


### PR DESCRIPTION
##### SUMMARY
Adds the high performance VM type to oVirt.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
oVirt

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.2.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/ykaul/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.14 (default, Jan 17 2018, 14:28:32) [GCC 7.2.1 20170915 (Red Hat 7.2.1-2)]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
