### PR TITLE
Uninstall backports.lzma in archive test.

### DIFF
--- a/test/integration/targets/archive/tasks/main.yml
+++ b/test/integration/targets/archive/tasks/main.yml
@@ -62,6 +62,7 @@
 - name: Ensure backports.lzma is present to create test archive (pip)
   pip: name=backports.lzma state=latest
   when: ansible_python_version.split('.')[0] == '2'
+  register: backports_lzma_pip
 
 - name: prep our file
   copy: src={{ item }} dest={{output_dir}}/{{ item }}
@@ -328,3 +329,7 @@
 
 - name: remove nonascii test
   file: path="{{ output_dir }}/test-archive-nonascii-くらとみ.zip" state=absent
+
+- name: Remove backports.lzma if previously installed (pip)
+  pip: name=backports.lzma state=absent
+  when: backports_lzma_pip is changed


### PR DESCRIPTION
##### SUMMARY

Uninstall backports.lzma in archive test.

This avoids breaking other tests which depend on backports modules, since the backports.lzma module is currently incompatible with other backports modules.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

archive integration test

##### ANSIBLE VERSION

```
ansible 2.5.0 (archive-test-fix 6e8eb744ea) last updated 2018/01/22 11:38:12 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```
