### PR TITLE
aci_aaa_user_certificate: Rename user parameter to aaa_user

### DIFF
--- a/lib/ansible/modules/network/aci/aci_aaa_user_certificate.py
+++ b/lib/ansible/modules/network/aci/aci_aaa_user_certificate.py
@@ -23,12 +23,17 @@ author:
 - Dag Wieers (@dagwieers)
 version_added: '2.5'
 notes:
-- The C(user) must exist before using this module in your playbook.
-  The M(aci_user) module can be used for this.
+- The C(aaa_user) must exist before using this module in your playbook.
+  The M(aci_aaa_user) module can be used for this.
 options:
-  user:
+  aaa_user:
     description:
     - The name of the user to add a certificate to.
+  aaa_user_type:
+    description:
+    - Whether this is a normal user or an appuser.
+    choices: [ user, userapp ]
+    default: user
   certificate:
     description:
     - The PEM format public key extracted from the X.509 certificate.
@@ -37,11 +42,6 @@ options:
     description:
     - The name of the user certificate entry in ACI.
     aliases: [ cert_name ]
-  user_type:
-    description:
-    - Whether this is a normal user or an appuser.
-    choices: [ user, userapp ]
-    default: user
   state:
     description:
     - Use C(present) or C(absent) for adding or removing.
@@ -57,7 +57,7 @@ EXAMPLES = r'''
     host: apic
     username: admin
     password: SomeSecretPassword
-    user: admin
+    aaa_user: admin
     certificate_name: admin
     certificate_data: '{{ lookup("file", "pki/admin.crt") }}'
     state: present
@@ -67,7 +67,7 @@ EXAMPLES = r'''
     host: apic
     username: admin
     password: SomeSecretPassword
-    user: admin
+    aaa_user: admin
     certificate_name: admin
     state: absent
 
@@ -76,7 +76,7 @@ EXAMPLES = r'''
     host: apic
     username: admin
     password: SomeSecretPassword
-    user: admin
+    aaa_user: admin
     certificate_name: admin
     state: query
 
@@ -85,7 +85,7 @@ EXAMPLES = r'''
     host: apic
     username: admin
     password: SomeSecretPassword
-    user: admin
+    aaa_user: admin
     state: query
 '''
 
@@ -109,35 +109,35 @@ ACI_MAPPING = dict(
 def main():
     argument_spec = aci_argument_spec()
     argument_spec.update(
+        aaa_user=dict(type='str', required=True),
+        aaa_user_type=dict(type='str', default='user', choices=['appuser', 'user']),
         certificate=dict(type='str', aliases=['cert_data', 'certificate_data']),
         certificate_name=dict(type='str', aliases=['cert_name']),
         state=dict(type='str', default='present', choices=['absent', 'present', 'query']),
-        user=dict(type='str', required=True),
-        user_type=dict(type='str', default='user', choices=['appuser', 'user']),
     )
 
     module = AnsibleModule(
         argument_spec=argument_spec,
         supports_check_mode=True,
         required_if=[
-            ['state', 'absent', ['user', 'certificate_name']],
-            ['state', 'present', ['user', 'certificate', 'certificate_name']],
+            ['state', 'absent', ['aaa_user', 'certificate_name']],
+            ['state', 'present', ['aaa_user', 'certificate', 'certificate_name']],
         ],
     )
 
+    aaa_user = module.params['aaa_user']
+    aaa_user_type = module.params['aaa_user_type']
     certificate = module.params['certificate']
     certificate_name = module.params['certificate_name']
     state = module.params['state']
-    user = module.params['user']
-    user_type = module.params['user_type']
 
     aci = ACIModule(module)
     aci.construct_url(
         root_class=dict(
-            aci_class=ACI_MAPPING[user_type]['aci_class'],
-            aci_rn=ACI_MAPPING[user_type]['aci_mo'] + user,
-            filter_target='eq({0}.name, "{1}")'.format(ACI_MAPPING[user_type]['aci_class'], user),
-            module_object=user,
+            aci_class=ACI_MAPPING[aaa_user_type]['aci_class'],
+            aci_rn=ACI_MAPPING[aaa_user_type]['aci_mo'] + aaa_user,
+            filter_target='eq({0}.name, "{1}")'.format(ACI_MAPPING[aaa_user_type]['aci_class'], aaa_user),
+            module_object=aaa_user,
         ),
         subclass_1=dict(
             aci_class='aaaUserCert',

--- a/test/integration/targets/aci_aaa_user_certificate/tasks/main.yml
+++ b/test/integration/targets/aci_aaa_user_certificate/tasks/main.yml
@@ -18,7 +18,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
-    user: admin
+    aaa_user: admin
     certificate_name: admin
     state: absent
 
@@ -32,7 +32,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
-    user: admin
+    aaa_user: admin
     certificate_name: admin
     certificate: "{{ lookup('file', 'pki/admin.crt') }}"
     state: present
@@ -69,7 +69,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
-    user: admin
+    aaa_user: admin
     state: query
   check_mode: yes
   register: cm_query_all_certs


### PR DESCRIPTION
##### SUMMARY
Since `user` is an alias for `username` as well as the name of the user to manage, we need to make a clearer distinction. (Fortunately this conflict did work out fine, but it's better to avoid it).

So this PR removes any confusion.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
aci_aaa_user_certificate

##### ANSIBLE VERSION
v2.5