### PR TITLE
Temporary revert where world readable and module lang are set

### DIFF
--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1,6 +1,18 @@
 # Copyright (c) 2017 Ansible Project
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
+ALLOW_WORLD_READABLE_TMPFILES:
+  name: Allow world readable temporary files
+  default: False
+  description:
+    - This makes the temporary files created on the machine to be world readable and will issue a warning instead of failing the task.
+    - It is useful when becoming an unprivileged user.
+  env: []
+  ini:
+  - {key: allow_world_readable_tmpfiles, section: defaults}
+  type: boolean
+  yaml: {key: defaults.allow_world_readable_tmpfiles}
+  version_added: "2.1"
 ANSIBLE_COW_SELECTION:
   name: Cowsay filter selection
   default: default

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -744,6 +744,19 @@ DEFAULT_MODULE_COMPRESSION:
   - {key: module_compression, section: defaults}
 # vars:
 #   - name: ansible_module_compression
+DEFAULT_MODULE_LANG:
+  name: Target language environment
+  default: "{{ CONTROLLER_LANG }}"
+  description:
+    - "Language locale setting to use for modules when they execute on the target."
+    - "If empty it tries to set itself to the LANG environment variable on the controller."
+    - "This is only used if DEFAULT_MODULE_SET_LOCALE is set to true"
+  env: [{name: ANSIBLE_MODULE_LANG}]
+  ini:
+  - {key: module_lang, section: defaults}
+  deprecated:
+    why: Modules are coded to set their own locale if needed for screenscraping
+    version: "2.9"
 DEFAULT_MODULE_NAME:
   name: Default adhoc module
   default: command
@@ -759,6 +772,18 @@ DEFAULT_MODULE_PATH:
   ini:
   - {key: library, section: defaults}
   type: pathspec
+DEFAULT_MODULE_SET_LOCALE:
+  name: Target locale
+  default: False
+  description:
+    - Controls if we set locale for modules when executing on the target.
+  env: [{name: ANSIBLE_MODULE_SET_LOCALE}]
+  ini:
+  - {key: module_set_locale, section: defaults}
+  type: boolean
+  deprecated:
+    why: Modules are coded to set their own locale if needed for screenscraping
+    version: "2.9"
 DEFAULT_MODULE_UTILS_PATH:
   name: Module Utils Path
   description: Colon separated paths in which Ansible will search for Module utils files, which are shared by modules.

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -17,14 +17,14 @@ from ansible.module_utils.six import string_types
 from ansible.config.manager import ConfigManager, ensure_type, get_ini_config_value
 
 
-def _deprecated(msg):
+def _deprecated(msg, version='2.8'):
     ''' display is not guaranteed here, nor it being the full class, but try anyways, fallback to sys.stderr.write '''
     try:
         from __main__ import display
-        display.deprecated(msg, version='2.8')
+        display.deprecated(msg, version=version)
     except:
         import sys
-        sys.stderr.write('[DEPRECATED] %s, to be removed in 2.8' % msg)
+        sys.stderr.write('[DEPRECATED] %s, to be removed in %s' % (msg, version))
 
 
 def mk_boolean(value):

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -383,7 +383,7 @@ class ActionBase(with_metaclass(ABCMeta, object)):
         * If the chown fails we can set the file to be world readable so that
           the second unprivileged user can read the file.
           Since this could allow other users to get access to private
-          information we only do this ansible is configured with
+          information we only do this if ansible is configured with
           "allow_world_readable_tmpfiles" in the ansible.cfg
         """
         if remote_user is None:
@@ -431,7 +431,7 @@ class ActionBase(with_metaclass(ABCMeta, object)):
                     raise AnsibleError('Failed to change ownership of the temporary files Ansible needs to create despite connecting as a privileged user. '
                                        'Unprivileged become user would be unable to read the file.')
                 elif res['rc'] != 0:
-                    if self._connection._shell('allow_world_readable_temp'):
+                    if C.ALLOW_WORLD_READABLE_TMPFILES:
                         # chown and fs acls failed -- do things this insecure
                         # way only if the user opted in in the config file
                         display.warning('Using world-readable permissions for temporary files Ansible needs to create when becoming an unprivileged user. '

--- a/lib/ansible/plugins/shell/__init__.py
+++ b/lib/ansible/plugins/shell/__init__.py
@@ -23,6 +23,7 @@ import random
 import re
 import time
 
+import ansible.constants as C
 from ansible.module_utils.six import text_type
 from ansible.module_utils.six.moves import shlex_quote
 from ansible.plugins import AnsiblePlugin
@@ -36,21 +37,17 @@ class ShellBase(AnsiblePlugin):
         super(ShellBase, self).__init__()
 
         self.env = {}
+        if C.DEFAULT_MODULE_SET_LOCALE:
+            module_locale = C.DEFAULT_MODULE_LANG
+            self.env = {'LANG': module_locale,
+                        'LC_ALL': module_locale,
+                        'LC_MESSAGES': module_locale}
+
         self.tempdir = None
 
     def set_options(self, task_keys=None, var_options=None, direct=None):
 
         super(ShellBase, self).set_options(task_keys=task_keys, var_options=var_options, direct=direct)
-
-        # not all shell modules have this option
-        if self.get_option('set_module_language'):
-            self.env.update(
-                dict(
-                    LANG=self.get_option('module_language'),
-                    LC_ALL=self.get_option('module_language'),
-                    LC_MESSAGES=self.get_option('module_language'),
-                )
-            )
 
         # set env
         self.env.update(self.get_option('environment'))

--- a/lib/ansible/utils/module_docs_fragments/shell_common.py
+++ b/lib/ansible/utils/module_docs_fragments/shell_common.py
@@ -78,15 +78,4 @@ options:
         key: admin_users
     vars:
       - name: ansible_admin_users
-  allow_world_readable_temp:
-    type: boolean
-    description:
-        - This makes the temporary files created on the machine to be world readable and will issue a warning instead of failing the task.
-        - It is useful when becoming an unprivileged user.
-    ini:
-      - section: defaults
-        key: allow_world_readable_tmpfiles
-    vars:
-      - name: ansible_world_readable_tmpfiles
-    version_added: "2.1"
 """

--- a/lib/ansible/utils/module_docs_fragments/shell_common.py
+++ b/lib/ansible/utils/module_docs_fragments/shell_common.py
@@ -38,29 +38,6 @@ options:
         key: async_dir
     vars:
       - name: ansible_async_dir
-  set_module_language:
-    default: False
-    description: Controls if we set locale for modules when executing on the target.
-    env:
-      - name: ANSIBLE_MODULE_SET_LOCALE
-    ini:
-      - section: defaults
-        key: module_set_locale
-    type: boolean
-    vars:
-      - name: ansible_module_set_locale
-  module_language:
-    description:
-      - "If 'set_module_language' is true, this is the language language/locale setting to use for modules when they execute on the target."
-      - "Defaults to match the controller's settings."
-    default: "{{CONTROLLER_LANG}}"
-    env:
-      - name: ANSIBLE_MODULE_LANG
-    ini:
-      - section: defaults
-        key: module_lang
-    vars:
-      - name: ansible_module_lang
   environment:
     type: dict
     default: {}


### PR DESCRIPTION
##### SUMMARY
Move two types of settings from shell plugins back to ansible global.

* world_readable_temp_files: This setting belongs with its code.  that code is currently in action (fixup_perms2).  We can move this elsewhere once we've decided that fixup_perms2 can be moved as well (bcoca thinks that all of making temp directories should move into shell plugins).  (The rationale for moving is to make it settable per-host.  But if the code that makes use of it doesn't move, it means that we actually need a facility for setting things per-host without pushing them into the shell plugins.
* module_set_locale and module_lang: These are deprecated and we don't want new shell plugins to incorporate the options into their code.

##### ISSUE TYPE
 - Feature Pull Request


##### COMPONENT NAME
Changes to the temporary feature

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5.0
```