### PR TITLE
Temporary pass temppath to modules

### DIFF
--- a/lib/ansible/errors/__init__.py
+++ b/lib/ansible/errors/__init__.py
@@ -254,6 +254,7 @@ class AnsibleFileNotFound(AnsibleRuntimeError):
 
 # These Exceptions are temporary, using them as flow control until we can get a better solution.
 # DO NOT USE as they will probably be removed soon.
+# We will port the action modules in our tree to use a context manager instead.
 class AnsibleAction(AnsibleRuntimeError):
     ''' Base Exception for Action plugin flow control '''
 
@@ -284,6 +285,6 @@ class AnsibleActionFail(AnsibleAction):
         self.result.update({'failed': True, 'msg': message})
 
 
-class AnsibleActionDone(AnsibleAction):
+class _AnsibleActionDone(AnsibleAction):
     ''' an action runtime early exit'''
     pass

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -47,6 +47,7 @@ PASS_VARS = {
     'shell_executable': '_shell',
     'socket': '_socket_path',
     'syslog_facility': '_syslog_facility',
+    'tempdir': 'tempdir',
     'verbosity': '_verbosity',
     'version': 'ansible_version',
 }
@@ -844,9 +845,6 @@ class AnsibleModule(object):
         self.aliases = {}
         self._legal_inputs = ['_ansible_%s' % k for k in PASS_VARS]
         self._options_context = list()
-
-        # set tempdir to remote tmp
-        self.tempdir = os.environ.get('ANSIBLE_REMOTE_TEMP', None)
 
         if add_file_common_args:
             for k, v in FILE_COMMON_ARGUMENTS.items():

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -631,6 +631,9 @@ class ActionBase(with_metaclass(ABCMeta, object)):
         # make sure all commands use the designated shell executable
         module_args['_ansible_shell_executable'] = self._play_context.executable
 
+        # make sure all commands use the designated temporary directory
+        module_args['_ansible_tempdir'] = self._connection._shell.tempdir
+
     def _update_connection_options(self, options, variables=None):
         ''' ensures connections have the appropriate information '''
         update = {}

--- a/lib/ansible/plugins/action/assemble.py
+++ b/lib/ansible/plugins/action/assemble.py
@@ -26,7 +26,7 @@ import re
 import tempfile
 
 from ansible import constants as C
-from ansible.errors import AnsibleError, AnsibleAction, AnsibleActionDone, AnsibleActionFail
+from ansible.errors import AnsibleError, AnsibleAction, _AnsibleActionDone, AnsibleActionFail
 from ansible.module_utils._text import to_native, to_text
 from ansible.module_utils.parsing.convert_bool import boolean
 from ansible.plugins.action import ActionBase
@@ -105,7 +105,7 @@ class ActionModule(ActionBase):
 
             if boolean(remote_src, strict=False):
                 result.update(self._execute_module(tmp=tmp, task_vars=task_vars))
-                raise AnsibleActionDone()
+                raise _AnsibleActionDone()
             else:
                 try:
                     src = self._find_needle('files', src)

--- a/lib/ansible/plugins/action/patch.py
+++ b/lib/ansible/plugins/action/patch.py
@@ -20,7 +20,7 @@ __metaclass__ = type
 
 import os
 
-from ansible.errors import AnsibleError, AnsibleAction, AnsibleActionDone, AnsibleActionFail
+from ansible.errors import AnsibleError, AnsibleAction, _AnsibleActionDone, AnsibleActionFail
 from ansible.module_utils._text import to_native
 from ansible.module_utils.parsing.convert_bool import boolean
 from ansible.plugins.action import ActionBase
@@ -47,7 +47,7 @@ class ActionModule(ActionBase):
             elif remote_src:
                 # everything is remote, so we just execute the module
                 # without changing any of the module arguments
-                raise AnsibleActionDone(result=self._execute_module(task_vars=task_vars))
+                raise _AnsibleActionDone(result=self._execute_module(task_vars=task_vars))
 
             try:
                 src = self._find_needle('files', src)

--- a/lib/ansible/plugins/action/script.py
+++ b/lib/ansible/plugins/action/script.py
@@ -21,7 +21,7 @@ import os
 import re
 import shlex
 
-from ansible.errors import AnsibleError, AnsibleAction, AnsibleActionDone, AnsibleActionFail, AnsibleActionSkip
+from ansible.errors import AnsibleError, AnsibleAction, _AnsibleActionDone, AnsibleActionFail, AnsibleActionSkip
 from ansible.module_utils._text import to_bytes, to_native, to_text
 from ansible.plugins.action import ActionBase
 from ansible.plugins.shell.powershell import exec_wrapper
@@ -112,7 +112,7 @@ class ActionModule(ActionBase):
                 script_cmd = ' '.join([env_string, target_command])
 
             if self._play_context.check_mode:
-                raise AnsibleActionDone()
+                raise _AnsibleActionDone()
 
             script_cmd = self._connection._shell.wrap_for_exec(script_cmd)
 

--- a/test/units/plugins/action/test_action.py
+++ b/test/units/plugins/action/test_action.py
@@ -419,6 +419,7 @@ class TestActionBase(unittest.TestCase):
         mock_connection.socket_path = None
         mock_connection._shell.get_remote_filename.return_value = 'copy.py'
         mock_connection._shell.join_path.side_effect = os.path.join
+        mock_connection._shell.tempdir = '/var/tmp/mytempdir'
 
         # we're using a real play context here
         play_context = PlayContext()


### PR DESCRIPTION
##### SUMMARY
* Pass temppath to modules via module arguments instead of an environment variable
* Also make AnsibleActionDone a private exception since we're going to get rid of this later.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5.0
```


##### ADDITIONAL INFORMATION
Followup to bcoca's temporary patchset.