### PR TITLE
nxos_facts: svi support ipv4

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_facts.py
+++ b/lib/ansible/modules/network/nxos/nxos_facts.py
@@ -30,7 +30,7 @@ short_description: Gets facts about NX-OS switches
 description:
   - Collects facts from Cisco Nexus devices running the NX-OS operating
     system.  Fact collection is supported over both Cli and Nxapi
-    transports.  This module prepends all of the base network fact keys
+    Transports.  This module prepends all of the base network fact keys
     with C(ansible_net_<fact>).  The facts module will always collect a
     base set of facts from the device and can enable or disable
     collection of additional facts.
@@ -334,7 +334,7 @@ class Interfaces(FactsBase):
             if 'type' in item:
                 intf.update(self.transform_dict(item, self.INTERFACE_SVI_MAP))
             else:
-                 intf.update(self.transform_dict(item, self.INTERFACE_MAP))
+                intf.update(self.transform_dict(item, self.INTERFACE_MAP))
 
             if 'eth_ip_addr' in item:
                 intf['ipv4'] = self.transform_dict(item, self.INTERFACE_IPV4_MAP)

--- a/lib/ansible/modules/network/nxos/nxos_facts.py
+++ b/lib/ansible/modules/network/nxos/nxos_facts.py
@@ -273,9 +273,25 @@ class Interfaces(FactsBase):
         ('eth_hw_desc', 'type')
     ])
 
+    INTERFACE_SVI_MAP = frozenset([
+        ('svi_line_proto', 'state'),
+        ('svi_bw', 'bandwidth'),
+        ('svi_mac', 'macaddress'),
+        ('eth_mtu', 'mtu'),
+        ('type', 'type'),
+    ])
+
     INTERFACE_IPV4_MAP = frozenset([
         ('eth_ip_addr', 'address'),
         ('eth_ip_mask', 'masklen')
+    ])
+
+    INTERFACE_SVI_MAP = frozenset([
+        ('svi_line_proto', 'state'),
+        ('svi_bw', 'bandwidth'),
+        ('svi_mac', 'macaddress'),
+        ('eth_mtu', 'mtu'),
+        ('type', 'type'),
     ])
 
     INTERFACE_IPV6_MAP = frozenset([
@@ -318,11 +334,19 @@ class Interfaces(FactsBase):
             name = item['interface']
 
             intf = dict()
-            intf.update(self.transform_dict(item, self.INTERFACE_MAP))
+            if 'type' in item:
+              intf.update(self.transform_dict(item, self.INTERFACE_SVI_MAP))
+            else:
+               intf.update(self.transform_dict(item, self.INTERFACE_MAP))
 
             if 'eth_ip_addr' in item:
                 intf['ipv4'] = self.transform_dict(item, self.INTERFACE_IPV4_MAP)
                 self.facts['all_ipv4_addresses'].append(item['eth_ip_addr'])
+
+            if 'svi_ip_addr' in item:
+                intf['ipv4'] = self.transform_dict(item, self.INTERFACE_SVI_IPV4_MAP)
+                self.facts['all_ipv4_addresses'].append(item['svi_ip_addr'])
+
 
             interfaces[name] = intf
 

--- a/lib/ansible/modules/network/nxos/nxos_facts.py
+++ b/lib/ansible/modules/network/nxos/nxos_facts.py
@@ -332,9 +332,9 @@ class Interfaces(FactsBase):
 
             intf = dict()
             if 'type' in item:
-              intf.update(self.transform_dict(item, self.INTERFACE_SVI_MAP))
+                intf.update(self.transform_dict(item, self.INTERFACE_SVI_MAP))
             else:
-               intf.update(self.transform_dict(item, self.INTERFACE_MAP))
+                 intf.update(self.transform_dict(item, self.INTERFACE_MAP))
 
             if 'eth_ip_addr' in item:
                 intf['ipv4'] = self.transform_dict(item, self.INTERFACE_IPV4_MAP)
@@ -343,7 +343,6 @@ class Interfaces(FactsBase):
             if 'svi_ip_addr' in item:
                 intf['ipv4'] = self.transform_dict(item, self.INTERFACE_SVI_IPV4_MAP)
                 self.facts['all_ipv4_addresses'].append(item['svi_ip_addr'])
-
 
             interfaces[name] = intf
 

--- a/lib/ansible/modules/network/nxos/nxos_facts.py
+++ b/lib/ansible/modules/network/nxos/nxos_facts.py
@@ -277,8 +277,8 @@ class Interfaces(FactsBase):
         ('svi_line_proto', 'state'),
         ('svi_bw', 'bandwidth'),
         ('svi_mac', 'macaddress'),
-        ('eth_mtu', 'mtu'),
-        ('type', 'type'),
+        ('svi_mtu', 'mtu'),
+        ('type', 'type')
     ])
 
     INTERFACE_IPV4_MAP = frozenset([
@@ -286,12 +286,9 @@ class Interfaces(FactsBase):
         ('eth_ip_mask', 'masklen')
     ])
 
-    INTERFACE_SVI_MAP = frozenset([
-        ('svi_line_proto', 'state'),
-        ('svi_bw', 'bandwidth'),
-        ('svi_mac', 'macaddress'),
-        ('eth_mtu', 'mtu'),
-        ('type', 'type'),
+    INTERFACE_SVI_IPV4_MAP = frozenset([
+        ('svi_ip_addr', 'address'),
+        ('svi_ip_mask', 'masklen')
     ])
 
     INTERFACE_IPV6_MAP = frozenset([

--- a/lib/ansible/modules/network/nxos/nxos_facts.py
+++ b/lib/ansible/modules/network/nxos/nxos_facts.py
@@ -30,7 +30,7 @@ short_description: Gets facts about NX-OS switches
 description:
   - Collects facts from Cisco Nexus devices running the NX-OS operating
     system.  Fact collection is supported over both Cli and Nxapi
-    Transports.  This module prepends all of the base network fact keys
+    transports.  This module prepends all of the base network fact keys
     with C(ansible_net_<fact>).  The facts module will always collect a
     base set of facts from the device and can enable or disable
     collection of additional facts.


### PR DESCRIPTION
##### SUMMARY
Adding Support for svi Interface Information

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
nxos

##### ANSIBLE VERSION
```
ansible 2.4.2.0
```


##### ADDITIONAL INFORMATION
NXOS output for show interface has diffrent keys for svi interface:
- svi_ip_addr
- svi_ip_mask
- svi_mac
- svi_line_proto or svi_admin_state
- type
- svi_mtu

Testet with N77k and N55k NXAPI only
