### PR TITLE
Removes a bogus key from fixtures

### DIFF
--- a/test/units/modules/network/f5/fixtures/load_regkey_license_key.json
+++ b/test/units/modules/network/f5/fixtures/load_regkey_license_key.json
@@ -20,7 +20,7 @@
         "evaluationEndDateTime": "2018-01-12T00:00:00-08:00",
         "licenseEndDateTime": "2018-01-12T00:00:00-08:00",
         "licenseStartDateTime": "2017-12-11T00:00:00-08:00",
-        "registrationKey": "J7217-42420-80195-30148-6427094",
+        "registrationKey": "XXXX-XXXX-XXXX-XXXX-XXXX",
         "dossier": "1a44262799bc",
         "authorization": "03fc41d1e8666",
         "usage": "F5 Internal Product Development",


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Removes a bogus key from fixtures

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
bigiq unit test fixtures

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (bugfix.remove-key 4cf2937c5a) last updated 2018/01/23 16:53:38 (GMT +000)
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /here/local/ansible/lib/ansible
  executable location = /here/local/ansible/bin/ansible
  python version = 2.7.14 (default, Dec 12 2017, 16:55:09) [GCC 4.9.2]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
