### PR TITLE
Skip coverage on routine CI runs.

### DIFF
--- a/test/utils/shippable/other.sh
+++ b/test/utils/shippable/other.sh
@@ -12,9 +12,9 @@ else
     base_branch=""
 fi
 # shellcheck disable=SC2086
-ansible-test compile --failure-ok --color -v --junit --coverage ${CHANGED:+"$CHANGED"} --docker default
+ansible-test compile --failure-ok --color -v --junit ${COVERAGE:+"$COVERAGE"} ${CHANGED:+"$CHANGED"} --docker default
 # shellcheck disable=SC2086
-ansible-test sanity  --failure-ok --color -v --junit --coverage ${CHANGED:+"$CHANGED"} --docker default --docker-keep-git --base-branch "${base_branch}"
+ansible-test sanity  --failure-ok --color -v --junit ${COVERAGE:+"$COVERAGE"} ${CHANGED:+"$CHANGED"} --docker default --docker-keep-git --base-branch "${base_branch}"
 
 rm test/results/bot/ansible-test-failure.json
 

--- a/test/utils/shippable/units.sh
+++ b/test/utils/shippable/units.sh
@@ -8,4 +8,4 @@ IFS='/:' read -ra args <<< "$1"
 version="${args[1]}"
 
 # shellcheck disable=SC2086
-ansible-test units --color -v --docker default --python "${version}" --coverage ${CHANGED:+"$CHANGED"} \
+ansible-test units --color -v --docker default --python "${version}" ${COVERAGE:+"$COVERAGE"} ${CHANGED:+"$CHANGED"} \


### PR DESCRIPTION
##### SUMMARY

Skip coverage on routine CI runs.

This will speed up compile, sanity and unit tests in CI.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

Shippable

##### ANSIBLE VERSION

```
ansible 2.5.0 (ci-coverage 9355a65a85) last updated 2018/01/23 10:01:06 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```
