### PR TITLE
Fix aws_account_attribute lookup credentials bug for access keys

### DIFF
--- a/lib/ansible/plugins/lookup/aws_account_attribute.py
+++ b/lib/ansible/plugins/lookup/aws_account_attribute.py
@@ -121,8 +121,8 @@ def _boto3_conn(region, credentials):
 def _get_credentials(options):
     credentials = {}
     credentials['boto_profile'] = options['boto_profile']
-    credentials['aws_secret_access_key'] = options['aws_access_key']
-    credentials['aws_access_key_id'] = options['aws_secret_key']
+    credentials['aws_secret_access_key'] = options['aws_secret_key']
+    credentials['aws_access_key_id'] = options['aws_access_key']
     credentials['aws_session_token'] = options['aws_security_token']
 
     return credentials


### PR DESCRIPTION
##### SUMMARY
Fix aws_account_attribute lookup credentials bug for access keys

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/lookup/aws_account_attribute.py

##### ANSIBLE VERSION
```
2.5.0
```