### PR TITLE
Add authorize and provider params to eos_l2_interface tests

### DIFF
--- a/test/integration/targets/eos_l2_interface/tests/cli/basic.yaml
+++ b/test/integration/targets/eos_l2_interface/tests/cli/basic.yaml
@@ -5,6 +5,8 @@
   eos_l2_interface:
     name: Ethernet1
     state: absent
+    authorize: yes
+    provider: "{{ cli }}"
   become: yes
 
 - name: Set switchport mode to access on vlan 4000


### PR DESCRIPTION
Otherwise this fail for connection local