### PR TITLE
Revised ELB association documentation

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_asg.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_asg.py
@@ -41,11 +41,11 @@ options:
     required: true
   load_balancers:
     description:
-      - List of ELB names to use for the group
+      - List of ELB names to use for the group. Use for classic load balancers.
     required: false
   target_group_arns:
     description:
-      - List of target group ARNs to use for the group
+      - List of target group ARNs to use for the group. Use for application load balancers.
     version_added: "2.4"
   availability_zones:
     description:


### PR DESCRIPTION
Specified when target_group_arns and load_balancers should be used.

##### SUMMARY
The documentation isn't clear that an application load balancer requires the target_group_arn property and a classic load balancer uses the load_balancers property.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
ec2_asg

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.2.0
  config file = /home/ubuntu/ansible/ansible.cfg
  configured module search path = [u'/home/ubuntu/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
No command output change. Documentation focused.
```
