### PR TITLE
Add PSScriptAnalyzer to default container.

### DIFF
--- a/test/runner/Dockerfile
+++ b/test/runner/Dockerfile
@@ -49,5 +49,23 @@ RUN ln -s python2.7 /usr/bin/python2
 RUN ln -s python3.6 /usr/bin/python3
 RUN ln -s python3   /usr/bin/python
 
+RUN apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    apt-transport-https \
+    && \
+    apt-get clean
+ADD https://packages.microsoft.com/config/ubuntu/16.04/prod.list /etc/apt/sources.list.d/microsoft.list
+RUN curl --silent https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
+RUN apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    dotnet-sdk-2.1.4 \
+    powershell \
+    && \
+    apt-get clean
+RUN dotnet --version
+RUN pwsh --version
+COPY requirements/sanity.ps1 /tmp/
+RUN /tmp/sanity.ps1
+
 ENV container=docker
 CMD ["/sbin/init"]

--- a/test/runner/requirements/sanity.ps1
+++ b/test/runner/requirements/sanity.ps1
@@ -1,0 +1,8 @@
+#!/usr/bin/env pwsh
+#Requires -Version 6
+
+Set-StrictMode -Version 2.0
+$ErrorActionPreference = "Stop"
+
+Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
+Install-Module -Name PSScriptAnalyzer

--- a/test/sanity/code-smell/shebang.sh
+++ b/test/sanity/code-smell/shebang.sh
@@ -15,6 +15,7 @@ grep '^#!' -rIn . \
     -e ':#!/usr/bin/env python$' \
     -e ':#!/usr/bin/env bash$' \
     -e ':#!/usr/bin/env fish$' \
+    -e ':#!/usr/bin/env pwsh$' \
 
 if [ $? -ne 1 ]; then
     echo "One or more file(s) listed above have an unexpected shebang."


### PR DESCRIPTION
##### SUMMARY

Add PSScriptAnalyzer to default container.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

default ansible-test docker container

##### ANSIBLE VERSION

```
ansible 2.5.0 (docker-pssa 12151a053d) last updated 2018/01/23 14:26:49 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```
