### PR TITLE
Remove ssl_version parameter from hpilo_boot and hpilo_facts modules …

### DIFF
--- a/lib/ansible/modules/remote_management/hpilo/hpilo_boot.py
+++ b/lib/ansible/modules/remote_management/hpilo/hpilo_boot.py
@@ -65,12 +65,6 @@ options:
     - As a safeguard, without force, hpilo_boot will refuse to reboot a server that is already running.
     default: no
     choices: [ "yes", "no" ]
-  ssl_version:
-    description:
-      - Change the ssl_version used.
-    default: TLSv1
-    choices: [ "SSLv3", "SSLv23", "TLSv1", "TLSv1_1", "TLSv1_2" ]
-    version_added: '2.4'
 requirements:
 - hpilo
 notes:
@@ -130,7 +124,6 @@ def main():
             image=dict(type='str'),
             state=dict(type='str', default='boot_once', choices=['boot_always', 'boot_once', 'connect', 'disconnect', 'no_boot', 'poweroff']),
             force=dict(type='bool', default=False),
-            ssl_version=dict(type='str', default='TLSv1', choices=['SSLv3', 'SSLv23', 'TLSv1', 'TLSv1_1', 'TLSv1_2']),
         )
     )
 
@@ -144,9 +137,8 @@ def main():
     image = module.params['image']
     state = module.params['state']
     force = module.params['force']
-    ssl_version = getattr(hpilo.ssl, 'PROTOCOL_' + module.params.get('ssl_version').upper().replace('V', 'v'))
 
-    ilo = hpilo.Ilo(host, login=login, password=password, ssl_version=ssl_version)
+    ilo = hpilo.Ilo(host, login=login, password=password)
     changed = False
     status = {}
     power_status = 'UNKNOWN'

--- a/lib/ansible/modules/remote_management/hpilo/hpilo_facts.py
+++ b/lib/ansible/modules/remote_management/hpilo/hpilo_facts.py
@@ -37,12 +37,6 @@ options:
     description:
     - The password to authenticate to the HP iLO interface.
     default: admin
-  ssl_version:
-    description:
-      - Change the ssl_version used.
-    default: TLSv1
-    choices: [ "SSLv3", "SSLv23", "TLSv1", "TLSv1_1", "TLSv1_2" ]
-    version_added: '2.4'
 requirements:
 - hpilo
 notes:
@@ -155,7 +149,6 @@ def main():
             host=dict(type='str', required=True),
             login=dict(type='str', default='Administrator'),
             password=dict(type='str', default='admin', no_log=True),
-            ssl_version=dict(type='str', default='TLSv1', choices=['SSLv3', 'SSLv23', 'TLSv1', 'TLSv1_1', 'TLSv1_2']),
         ),
         supports_check_mode=True,
     )
@@ -166,9 +159,8 @@ def main():
     host = module.params['host']
     login = module.params['login']
     password = module.params['password']
-    ssl_version = getattr(hpilo.ssl, 'PROTOCOL_' + module.params.get('ssl_version').upper().replace('V', 'v'))
 
-    ilo = hpilo.Ilo(host, login=login, password=password, ssl_version=ssl_version)
+    ilo = hpilo.Ilo(host, login=login, password=password)
 
     facts = {
         'module_hw': True,


### PR DESCRIPTION
Remove ssl_version parameter from hpilo_boot and hpilo_facts modules due to incompatibility with the latest version of python-hpilo https://github.com/seveas/python-hpilo/commit/f602f27ef4bee073458bac862da9a46d741afae9#diff-9ccc70bd41ddf0398271050ebfd1be64

Before the change the error raised is clear.
```
TASK [Task to boot a system using an ISO from an HP iLO interface only if the system is an HP server] *************************************************************************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: TypeError: __init__() got an unexpected keyword argument 'ssl_version'
fatal: [localhost -> localhost]: FAILED! => {"changed": false, "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_eb9u8b/ansible_module_hpilo_boot.py\", line 208, in <module>\n    main()
\n  File \"/tmp/ansible_eb9u8b/ansible_module_hpilo_boot.py\", line 149, in main\n    ilo = hpilo.Ilo(host, login=login, password=password, ssl_version=ssl_version)\nTypeError: __init__() got an unexpected keywo
rd argument 'ssl_version'\n", "module_stdout": "", "msg": "MODULE FAILURE", "rc": 0}
```
