### PR TITLE
nso_config handle data.not_found in exists for nested lists

### DIFF
--- a/lib/ansible/module_utils/network/nso/nso.py
+++ b/lib/ansible/module_utils/network/nso/nso.py
@@ -140,8 +140,16 @@ class JsonRpc(object):
 
     def exists(self, path):
         payload = {'method': 'exists', 'params': {'path': path}}
-        resp, resp_json = self._read_call(payload)
-        return resp_json['result']['exists']
+        try:
+            resp, resp_json = self._read_call(payload)
+            return resp_json['result']['exists']
+        except NsoException as ex:
+            # calling exists on a sub-list when the parent list does
+            # not exists will cause data.not_found errors on recent
+            # NSO
+            if 'type' in ex.error and ex.error['type'] == 'data.not_found':
+                return False
+            raise
 
     def create(self, th, path):
         payload = {'method': 'create', 'params': {'th': th, 'path': path}}


### PR DESCRIPTION
Recent NSO can return data.not_found error on exists when parent list
entries does not exist. Handle this and return as false.

Fixes: #35264

##### SUMMARY
Handle data.not_found response from exists, happens on recent NSO when calling exists on nested lists where the parent list entry does not exist.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
nso_config

##### ANSIBLE VERSION
```
ansible 2.5.0 (nso_config_exists_35264 b7600b0ceb) last updated 2018/01/24 09:48:37 (GMT +200)
  config file = None
  configured module search path = [u'/home/cnasten/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/cnasten/dev/ansible/lib/ansible
  executable location = /home/cnasten/dev/ansible/bin/ansible
  python version = 2.7.14+ (default, Dec  5 2017, 15:17:02) [GCC 7.2.0]
```

##### ADDITIONAL INFORMATION
See #35264 for details.
