### PR TITLE
Changes to enable network_cli and netconf on iosxr integration tests.

### DIFF
--- a/lib/ansible/module_utils/network/iosxr/iosxr.py
+++ b/lib/ansible/module_utils/network/iosxr/iosxr.py
@@ -359,6 +359,8 @@ def get_oper(module, filter=None):
 
     if filter is not None:
         response = conn.get(filter)
+    else:
+        return None
 
     return to_bytes(etree.tostring(response), errors='surrogate_then_replace').strip()
 

--- a/lib/ansible/modules/network/iosxr/iosxr_system.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_system.py
@@ -431,7 +431,7 @@ class NCConfiguration(ConfigBase):
             if self._want['name_servers']:
                 server_param = {}
                 server_param['vrf'] = self._want['vrf']
-                server_param['order'] = '1'
+                server_param['order'] = '0'
                 for server in self._want['name_servers']:
                     if server in sys_node['name_servers']:
                         server_param['name_servers'] = server
@@ -476,7 +476,7 @@ class NCConfiguration(ConfigBase):
                 server_adds, server_removes = diff_list(self._want['name_servers'], sys_node['name_servers'])
                 server_param = {}
                 server_param['vrf'] = self._want['vrf']
-                server_param['order'] = '1'
+                server_param['order'] = '0'
                 for domain in server_adds:
                     if domain not in sys_node['name_servers']:
                         server_param['name_servers'] = domain

--- a/test/integration/targets/iosxr_banner/tasks/cli.yaml
+++ b/test/integration/targets/iosxr_banner/tasks/cli.yaml
@@ -15,6 +15,8 @@
   loop_control:
     loop_var: test_case_to_run
 
+# Only one of the Testcase would be run to check if `connection: local`
+# is established. Full suite is run with `connection:network_cli` or `connection:netconf`
 - name: run test case (connection=local)
   include: "{{ test_case_to_run }} ansible_connection=local"
   with_first_found: "{{ test_items }}"

--- a/test/integration/targets/iosxr_banner/tasks/netconf.yaml
+++ b/test/integration/targets/iosxr_banner/tasks/netconf.yaml
@@ -15,6 +15,8 @@
   loop_control:
     loop_var: test_case_to_run
 
+# Only one of the Testcase would be run to check if `connection: local`
+# is established. Full suite is run with `connection:network_cli` or `connection:netconf`
 - name: run test case (connection=local)
   include: "{{ test_case_to_run }} ansible_connection=local"
   with_first_found: "{{ test_items }}"

--- a/test/integration/targets/iosxr_interface/tasks/cli.yaml
+++ b/test/integration/targets/iosxr_interface/tasks/cli.yaml
@@ -15,6 +15,8 @@
   loop_control:
     loop_var: test_case_to_run
 
+# Only one of the Testcase would be run to check if `connection: local`
+# is established. Full suite is run with `connection:network_cli` or `connection:netconf`
 - name: run test case (connection=local)
   include: "{{ test_case_to_run }} ansible_connection=local"
   with_first_found: "{{ test_items }}"

--- a/test/integration/targets/iosxr_interface/tasks/netconf.yaml
+++ b/test/integration/targets/iosxr_interface/tasks/netconf.yaml
@@ -15,6 +15,8 @@
   loop_control:
     loop_var: test_case_to_run
 
+# Only one of the Testcase would be run to check if `connection: local`
+# is established. Full suite is run with `connection:network_cli` or `connection:netconf`
 - name: run test case (connection=local)
   include: "{{ test_case_to_run }} ansible_connection=local"
   with_items: "{{ test_items }}"

--- a/test/integration/targets/iosxr_interface/tests/netconf/basic.yaml
+++ b/test/integration/targets/iosxr_interface/tests/netconf/basic.yaml
@@ -3,7 +3,9 @@
 
 - name: Setup interface
   iosxr_interface:
-    name: GigabitEthernet0/0/0/1
+    aggregate:
+      - name: GigabitEthernet0/0/0/0
+      - name: GigabitEthernet0/0/0/1
     state: absent
     provider: "{{ netconf }}"
   register: result

--- a/test/integration/targets/iosxr_logging/tasks/cli.yaml
+++ b/test/integration/targets/iosxr_logging/tasks/cli.yaml
@@ -15,6 +15,8 @@
   loop_control:
     loop_var: test_case_to_run
 
+# Only one of the Testcase would be run to check if `connection: local`
+# is established. Full suite is run with `connection:network_cli` or `connection:netconf`
 - name: run test case (connection=local)
   include: "{{ test_case_to_run }} ansible_connection=local"
   with_first_found: "{{ test_items }}"

--- a/test/integration/targets/iosxr_logging/tasks/cli.yaml
+++ b/test/integration/targets/iosxr_logging/tasks/cli.yaml
@@ -20,3 +20,6 @@
   with_first_found: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+
+- name: reset connection
+  meta: reset_connection

--- a/test/integration/targets/iosxr_logging/tasks/netconf.yaml
+++ b/test/integration/targets/iosxr_logging/tasks/netconf.yaml
@@ -15,6 +15,8 @@
   loop_control:
     loop_var: test_case_to_run
 
+# Only one of the Testcase would be run to check if `connection: local`
+# is established. Full suite is run with `connection:network_cli` or `connection:netconf`
 - name: run test case (connection=local)
   include: "{{ test_case_to_run }} ansible_connection=local"
   with_first_found: "{{ test_items }}"

--- a/test/integration/targets/iosxr_logging/tasks/netconf.yaml
+++ b/test/integration/targets/iosxr_logging/tasks/netconf.yaml
@@ -20,3 +20,6 @@
   with_first_found: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+
+- name: reset connection
+  meta: reset_connection

--- a/test/integration/targets/iosxr_logging/tests/netconf/basic.yaml
+++ b/test/integration/targets/iosxr_logging/tests/netconf/basic.yaml
@@ -93,6 +93,9 @@
     provider: "{{ netconf }}"
   register: result
 
+- debug:
+    msg: "{{ result }}"
+
 - assert: &true
     that:
       - 'result.changed == true'

--- a/test/integration/targets/iosxr_system/tasks/cli.yaml
+++ b/test/integration/targets/iosxr_system/tasks/cli.yaml
@@ -15,6 +15,8 @@
   loop_control:
     loop_var: test_case_to_run
 
+# Only one of the Testcase would be run to check if `connection: local`
+# is established. Full suite is run with `connection:network_cli` or `connection:netconf`
 - name: run test case (connection=local)
   include: "{{ test_case_to_run }} ansible_connection=local"
   with_first_found: "{{ test_items }}"

--- a/test/integration/targets/iosxr_system/tasks/cli.yaml
+++ b/test/integration/targets/iosxr_system/tasks/cli.yaml
@@ -20,3 +20,6 @@
   with_first_found: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+
+- name: reset connection
+  meta: reset_connection

--- a/test/integration/targets/iosxr_system/tasks/netconf.yaml
+++ b/test/integration/targets/iosxr_system/tasks/netconf.yaml
@@ -15,6 +15,8 @@
   loop_control:
     loop_var: test_case_to_run
 
+# Only one of the Testcase would be run to check if `connection: local`
+# is established. Full suite is run with `connection:network_cli` or `connection:netconf`
 - name: run test case (connection=local)
   include: "{{ test_case_to_run }} ansible_connection=local"
   with_first_found: "{{ test_items }}"

--- a/test/integration/targets/iosxr_system/tasks/netconf.yaml
+++ b/test/integration/targets/iosxr_system/tasks/netconf.yaml
@@ -9,14 +9,17 @@
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local"
+- name: run test case (connection=netconf)
+  include: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
 
-# - name: run test case (connection=netconf)
-#  include: "{{ test_case_to_run }} ansible_connection=netconf"
-#  with_items: "{{ test_items }}"
-#  loop_control:
-#    loop_var: test_case_to_run
+- name: run test case (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local"
+  with_first_found: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: reset connection
+  meta: reset_connection

--- a/test/integration/targets/iosxr_system/tests/cli/net_system.yaml
+++ b/test/integration/targets/iosxr_system/tests/cli/net_system.yaml
@@ -7,8 +7,8 @@
 - name: setup
   iosxr_config:
     lines:
-      - no ip domain-list ansible.com
-      - no ip domain-list redhat.com
+      - no domain list ansible.com
+      - no domain list redhat.com
     match: none
     provider: "{{ cli }}"
 
@@ -26,11 +26,11 @@
       - "'domain list ansible.com' in result.commands"
       - "'domain list redhat.com' in result.commands"
 
-- name: setup
+- name: teardown
   iosxr_config:
     lines:
-      - no ip domain-list ansible.com
-      - no ip domain-list redhat.com
+      - no domain list ansible.com
+      - no domain list redhat.com
     match: none
     provider: "{{ cli }}"
 

--- a/test/integration/targets/iosxr_system/tests/cli/set_domain_list.yaml
+++ b/test/integration/targets/iosxr_system/tests/cli/set_domain_list.yaml
@@ -4,8 +4,8 @@
 - name: setup
   iosxr_config:
     lines:
-      - no ip domain-list ansible.com
-      - no ip domain-list redhat.com
+      - no domain list ansible.com
+      - no domain list redhat.com
     match: none
     provider: "{{ cli }}"
 
@@ -114,7 +114,6 @@
   iosxr_config:
     lines:
       - no domain list ansible.com
-      - no domain list redhat.com
       - no domain list eng.ansible.com
     match: none
     provider: "{{ cli }}"

--- a/test/integration/targets/iosxr_system/tests/cli/set_lookup_source.yaml
+++ b/test/integration/targets/iosxr_system/tests/cli/set_lookup_source.yaml
@@ -3,9 +3,7 @@
 
 - name: setup
   iosxr_config:
-    lines:
-      - no domain lookup source-interface Loopback10
-#      - vrf ansible
+    lines: no domain lookup source-interface Loopback10
     match: none
     provider: "{{ cli }}"
 
@@ -30,36 +28,10 @@
     that:
       - result.changed == false
 
-#- name: change to vrf
-#  iosxr_system:
-#    lookup_source:
-#      - interface: Loopback10
-#        vrf: ansible
-#  register: result
-#
-#- assert:
-#    that:
-#      - result.changed == true
-#      - "'no ip domain lookup source-interface Management1' in result.commands"
-#      - "'ip domain lookup vrf ansible source-interface Management1' in result.commands"
-#      - result.commands|length == 2
-#
-#- name: verify change to vrf
-#  iosxr_system:
-#    lookup_source:
-#      - interface: Management1
-#        vrf: ansible
-#  register: result
-#
-#- assert:
-#    that:
-#      - result.changed == false
-
 - name: teardown
   iosxr_config:
     lines:
       - no domain lookup source-interface Loopback10
-      - no vrf ansible
     match: none
     provider: "{{ cli }}"
 

--- a/test/integration/targets/iosxr_system/tests/cli/set_name_servers.yaml
+++ b/test/integration/targets/iosxr_system/tests/cli/set_name_servers.yaml
@@ -40,33 +40,6 @@
     that:
       - result.changed == false
 
-#- name: change to vrf
-#  iosxr_system:
-#    name_servers:
-#      - 1.1.1.1
-#      - { server: 2.2.2.2, vrf: ansible }
-#      - 3.3.3.3
-#  register: result
-
-#- assert:
-#    that:
-#      - result.changed == true
-#      - result.commands|length == 2
-#      - "'no ip name-server 2.2.2.2' in result.commands"
-#      - "'ip name-server 2.2.2.2 vrf ansible' in result.commands"
-
-#- name: verify change to vrf
-#  iosxr_system:
-#    name_servers:
-#      - 1.1.1.1
-#      - { server: 2.2.2.2, vrf: ansible }
-#      - 3.3.3.3
-#  register: result
-#
-#- assert:
-#    that:
-#      - result.changed == false
-
 - name: remove one
   iosxr_system:
     name_servers:
@@ -86,7 +59,6 @@
     lines:
       - no ip name-server 1.1.1.1
       - no ip name-server 2.2.2.2
-      - no ip name-server 3.3.3.3
     match: none
     provider: "{{ cli }}"
 

--- a/test/integration/targets/iosxr_system/tests/netconf/set_domain_list.yaml
+++ b/test/integration/targets/iosxr_system/tests/netconf/set_domain_list.yaml
@@ -2,161 +2,176 @@
 - debug:
     msg: "START netconf/set_domain_search.yaml on connection={{ ansible_connection }}"
 
-- block:
-  - name: setup
-    iosxr_config:
-      lines:
-        - no domain list ansible.com
-        - no domain list redhat.com
-      match: none
-      provider: "{{ cli }}"
+- name: setup
+  iosxr_config:
+    lines:
+      - no domain list ansible.com
+      - no domain list redhat.com
+      - no domain list eng.ansible.com
+      - no domain vrf ansiblevrf list redhat.com
+      - no domain vrf ansiblevrf list ansible.com
+    match: none
+    provider: "{{ cli }}"
+  connection: network_cli
 
-  - name: configure domain_search
-    iosxr_system:
-      domain_search:
-        - ansible.com
-        - redhat.com
-      provider: "{{ netconf }}"
-    register: result
+- name: configure domain_search
+  iosxr_system:
+    domain_search:
+      - ansible.com
+      - redhat.com
+    provider: "{{ netconf }}"
+  connection: netconf
+  register: result
 
-  - assert:
-      that:
-        - result.changed == true
-        - "'ansible.com' in result.xml[0]"
-        - "'redhat.com' in result.xml[0]"
+- assert:
+    that:
+      - result.changed == true
+      - "'ansible.com' in result.xml[0]"
+      - "'redhat.com' in result.xml[0]"
 
-  - name: configure domain_search with vrf
-    iosxr_system: &domainvrf
-      vrf: ansiblevrf
-      domain_search:
-        - redhat.com
-        - ansible.com
-      provider: "{{ netconf }}"
-    register: result
+- name: configure domain_search with vrf
+  iosxr_system: &domainvrf
+    vrf: ansiblevrf
+    domain_search:
+      - redhat.com
+      - ansible.com
+    provider: "{{ netconf }}"
+  connection: netconf
+  register: result
 
-  - assert:
-      that:
-        - result.changed == true
-        - "'ansiblevrf' in result.xml[0]"
-        - "'ansible.com' in result.xml[0]"
-        - "'redhat.com' in result.xml[0]"
+- assert:
+    that:
+      - result.changed == true
+      - "'ansiblevrf' in result.xml[0]"
+      - "'ansible.com' in result.xml[0]"
+      - "'redhat.com' in result.xml[0]"
 
-  - name: verify domain_search with vrf
-    iosxr_system: *domainvrf
-    register: result
+- name: verify domain_search with vrf
+  iosxr_system: *domainvrf
+  connection: netconf
+  register: result
 
-  - assert:
-      that:
-        - result.changed == false
+- assert:
+    that:
+      - result.changed == false
 
-  - name: delete domain_search with vrf
-    iosxr_system: &deldomainvrf
-      vrf: ansiblevrf
-      domain_search:
-        - redhat.com
-      provider: "{{ netconf }}"
-    register: result
+- name: delete domain_search with vrf
+  iosxr_system: &deldomainvrf
+    vrf: ansiblevrf
+    domain_search:
+      - redhat.com
+    provider: "{{ netconf }}"
+  connection: netconf
+  register: result
 
-  - assert:
-      that:
-        - result.changed == true
-        - "'ansiblevrf' in result.xml[0]"
-        - "'ansible.com' in result.xml[0]"
+- assert:
+    that:
+      - result.changed == true
+      - "'ansiblevrf' in result.xml[0]"
+      - "'ansible.com' in result.xml[0]"
 
-  - name: verify delete domain_search with vrf
-    iosxr_system: *deldomainvrf
-    register: result
+- name: verify delete domain_search with vrf
+  iosxr_system: *deldomainvrf
+  connection: netconf
+  register: result
 
-  - assert:
-      that:
-        - result.changed == false
+- assert:
+    that:
+      - result.changed == false
 
-  - name: remove one entry
-    iosxr_system:
-      domain_search:
-        - ansible.com
-      provider: "{{ netconf }}"
-    register: result
+- name: remove one entry
+  iosxr_system:
+    domain_search:
+      - ansible.com
+    provider: "{{ netconf }}"
+  connection: netconf
+  register: result
 
-  - assert:
-      that:
-        - result.changed == true
-        - "'redhat.com' in result.xml[0]"
+- assert:
+    that:
+      - result.changed == true
+      - "'redhat.com' in result.xml[0]"
 
-  - name: verify remove one entry
-    iosxr_system:
-      domain_search:
-        - ansible.com
-      provider: "{{ netconf }}"
-    register: result
+- name: verify remove one entry
+  iosxr_system:
+    domain_search:
+      - ansible.com
+    provider: "{{ netconf }}"
+  connection: netconf
+  register: result
 
-  - assert:
-      that:
-        - result.changed == false
+- assert:
+    that:
+      - result.changed == false
 
-  - name: add one entry
-    iosxr_system:
-      domain_search:
-        - ansible.com
-        - redhat.com
-      provider: "{{ netconf }}"
-    register: result
+- name: add one entry
+  iosxr_system:
+    domain_search:
+      - ansible.com
+      - redhat.com
+    provider: "{{ netconf }}"
+  connection: netconf
+  register: result
 
-  - assert:
-      that:
-        - result.changed == true
-        - "'redhat.com' in result.xml[0]"
+- assert:
+    that:
+      - result.changed == true
+      - "'redhat.com' in result.xml[0]"
 
-  - name: verify add one entry
-    iosxr_system:
-      domain_search:
-        - ansible.com
-        - redhat.com
-      provider: "{{ netconf }}"
-    register: result
+- name: verify add one entry
+  iosxr_system:
+    domain_search:
+      - ansible.com
+      - redhat.com
+    provider: "{{ netconf }}"
+  connection: netconf
+  register: result
 
-  - assert:
-      that:
-        - result.changed == false
+- assert:
+    that:
+      - result.changed == false
 
-  - name: add and remove one entry
-    iosxr_system:
-      domain_search:
-        - ansible.com
-        - eng.ansible.com
-      provider: "{{ netconf }}"
-    register: result
+- name: add and remove one entry
+  iosxr_system:
+    domain_search:
+      - ansible.com
+      - eng.ansible.com
+    provider: "{{ netconf }}"
+  connection: netconf
+  register: result
 
-  - assert:
-      that:
-        - result.changed == true
-        - "'redhat.com' in result.xml[1]"
-        - "'eng.ansible.com' in result.xml[0]"
-        - result.xml|length == 2
+- assert:
+    that:
+      - result.changed == true
+      - "'redhat.com' in result.xml[1]"
+      - "'eng.ansible.com' in result.xml[0]"
+      - result.xml|length == 2
 
-  - name: verify add and remove one entry
-    iosxr_system:
-      domain_search:
-        - ansible.com
-        - eng.ansible.com
-      provider: "{{ netconf }}"
-    register: result
+- name: verify add and remove one entry
+  iosxr_system:
+    domain_search:
+      - ansible.com
+      - eng.ansible.com
+    provider: "{{ netconf }}"
+  connection: netconf
+  register: result
 
-  - assert:
-      that:
-        - result.changed == false
+- assert:
+    that:
+      - result.changed == false
 
-- always:
-  - name: teardown
-    iosxr_config:
-      lines:
-        - no domain list ansible.com
-        - no domain list redhat.com
-        - no domain list eng.ansible.com
-        - no domain vrf ansiblevrf list redhat.com
-        - no domain vrf ansiblevrf list ansible.com
-      match: none
-      provider: "{{ netconf }}"
+- name: teardown
+  iosxr_config:
+    lines:
+      - no domain list ansible.com
+      - no domain list redhat.com
+      - no domain list eng.ansible.com
+      - no domain vrf ansiblevrf list redhat.com
+      - no domain vrf ansiblevrf list ansible.com
+      - no domain vrf ansiblevrf list eng.ansible.com
+    match: none
+    provider: "{{ cli }}"
+  connection: network_cli
 
-  - debug:
-      msg: "END netconf/set_domain_search.yaml on connection={{ ansible_connection }}"
+- debug:
+    msg: "END netconf/set_domain_search.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/iosxr_system/tests/netconf/set_domain_name.yaml
+++ b/test/integration/targets/iosxr_system/tests/netconf/set_domain_name.yaml
@@ -1,79 +1,77 @@
 ---
 - debug:
     msg: "START netconf/set_domain_name.yaml on connection={{ ansible_connection }}"
-- block:
-  - name: setup
-    iosxr_config:
-      lines:
-        - no domain name
-        - no domain vrf ansiblevrf name
-      match: none
-      provider: "{{ cli }}"
 
-  - name: configure domain_name
-    iosxr_system: &domain
-      domain_name: eng.ansible.com
-      provider: "{{ netconf }}"
-    register: result
+- name: setup
+  iosxr_config:
+    lines:
+      - no domain name
+      - no domain vrf ansiblevrf name
+    match: none
+    provider: "{{ cli }}"
+  connection: network_cli
 
-  - assert:
-      that:
-        - "result.changed == true"
+- name: configure domain_name
+  iosxr_system: &domain
+    domain_name: eng.ansible.com
+    provider: "{{ netconf }}"
+  connection: netconf
+  register: result
 
-  - name: verify domain_name
-    iosxr_system: *domain
-    register: result
+- assert:
+    that:
+      - "result.changed == true"
 
-  - assert:
-      that:
-        - "result.changed == false"
+- name: verify domain_name
+  iosxr_system: *domain
+  connection: netconf
+  register: result
 
-  - name: configure domain_name
-    iosxr_system: &deldomain
-      domain_name: eng.ansible.com
-      provider: "{{ netconf }}"
-      state: absent
-    register: result
+- assert:
+    that:
+      - "result.changed == false"
 
-  - assert:
-      that:
-        - "result.changed == true"
+- name: configure domain_name
+  iosxr_system: &deldomain
+    domain_name: eng.ansible.com
+    provider: "{{ netconf }}"
+    state: absent
+  connection: netconf
+  register: result
 
-  - name: verify domain_name
-    iosxr_system: *deldomain
-    register: result
+- assert:
+    that:
+      - "result.changed == true"
 
-  - assert:
-      that:
-        - "result.changed == false"
+- name: verify domain_name
+  iosxr_system: *deldomain
+  connection: netconf
+  register: result
 
-  - name: configure domain_name with vrf
-    iosxr_system: &domainvrf
-      domain_name: eng.ansible.com
-      vrf: ansiblevrf
-      provider: "{{ netconf }}"
-    register: result
+- assert:
+    that:
+      - "result.changed == false"
 
-  - assert:
-      that:
-        - "result.changed == true"
+- name: configure domain_name with vrf
+  iosxr_system: &domainvrf
+    domain_name: eng.ansible.com
+    vrf: ansiblevrf
+    provider: "{{ netconf }}"
+  connection: netconf
+  register: result
 
-  - name: verify domain_name with vrf
-    iosxr_system: *domainvrf
-    register: result
+- assert:
+    that:
+      - "result.changed == true"
 
-  - assert:
-      that:
-        - "result.changed == false"
+- name: verify domain_name with vrf
+  iosxr_system: *domainvrf
+  connection: netconf
+  register: result
 
-- always:
-  - name: teardown
-    iosxr_config:
-      lines:
-        - no domain name
-        - no domain vrf ansiblevrf name
-      match: none
-      provider: "{{ cli }}"
+- assert:
+    that:
+      - "result.changed == false"
 
-  - debug:
-      msg: "END netconf/set_domain_name.yaml on connection={{ ansible_connection }}"
+- debug:
+    msg: "END netconf/set_domain_name.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/iosxr_system/tests/netconf/set_hostname.yaml
+++ b/test/integration/targets/iosxr_system/tests/netconf/set_hostname.yaml
@@ -8,11 +8,13 @@
       lines: hostname switch
       match: none
       provider: "{{ cli }}"
+    connection: network_cli
 
   - name: configure hostname
     iosxr_system:
       hostname: foo
       provider: "{{ netconf }}"
+    connection: netconf
     register: result
 
   - assert:
@@ -23,6 +25,7 @@
     iosxr_system:
       hostname: foo
       provider: "{{ netconf }}"
+    connection: netconf
     register: result
 
   - assert:
@@ -34,6 +37,7 @@
       lines: "hostname {{ inventory_hostname }}"
       match: none
       provider: "{{ cli }}"
+    connection: network_cli
 
 - debug:
     msg: "END netconf/set_hostname.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/iosxr_system/tests/netconf/set_lookup_source.yaml
+++ b/test/integration/targets/iosxr_system/tests/netconf/set_lookup_source.yaml
@@ -2,149 +2,159 @@
 - debug:
     msg: "START netconf/set_lookup_source.yaml on connection={{ ansible_connection }}"
 
-- block:
-  - name: setup
-    iosxr_config:
-      lines:
-        - no domain lookup source-interface Loopback10
-        - no domain vrf ansiblevrf lookup source-interface Loopback10
-        - no domain lookup disable
-        - no domain vrf ansiblevrf lookup disable
-      match: none
-      provider: "{{ cli }}"
+- name: setup
+  iosxr_config:
+    lines:
+      - no domain lookup source-interface Loopback10
+      - no domain vrf ansiblevrf lookup source-interface Loopback10
+      - no domain lookup disable
+      - no domain vrf ansiblevrf lookup disable
+    match: none
+    provider: "{{ cli }}"
+  connection: network_cli
 
-  - name: configure lookup_source
-    iosxr_system: &lookup
-      lookup_source: Loopback10
-      provider: "{{ netconf }}"
-    register: result
+- name: configure lookup_source
+  iosxr_system: &lookup
+    lookup_source: Loopback10
+    provider: "{{ netconf }}"
+  connection: netconf
+  register: result
 
-  - assert:
-      that:
-        - result.changed == true
-        - "'Loopback10' in result.xml[0]"
+- assert:
+    that:
+      - result.changed == true
+      - "'Loopback10' in result.xml[0]"
 
-  - name: verify lookup_source
-    iosxr_system: *lookup
-    register: result
+- name: verify lookup_source
+  iosxr_system: *lookup
+  connection: netconf
+  register: result
 
-  - assert:
-      that:
-        - result.changed == false
+- assert:
+    that:
+      - result.changed == false
 
-  - name: disable lookup
-    iosxr_system: &disable
-      lookup_enabled: False 
-      provider: "{{ netconf }}"
-    register: result
+- name: disable lookup
+  iosxr_system: &disable
+    lookup_enabled: False
+    provider: "{{ netconf }}"
+  connection: netconf
+  register: result
 
-  - assert:
-      that:
-        - result.changed == true
-        - "'lookup' in result.xml[0]"
+- assert:
+    that:
+      - result.changed == true
+      - "'lookup' in result.xml[0]"
 
-  - name: verify disable lookup
-    iosxr_system: *disable
-    register: result
+- name: verify disable lookup
+  iosxr_system: *disable
+  connection: netconf
+  register: result
 
-  - assert:
-      that:
-        - result.changed == false
+- assert:
+    that:
+      - result.changed == false
 
-  - name: delete lookup_source
-    iosxr_system: &dellookup
-      lookup_source: Loopback10
-      provider: "{{ netconf }}"
-      state: absent
-    register: result
+- name: delete lookup_source
+  iosxr_system: &dellookup
+    lookup_source: Loopback10
+    provider: "{{ netconf }}"
+    state: absent
+  connection: netconf
+  register: result
 
-  - assert:
-      that:
-        - result.changed == true
-        - "'Loopback10' in result.xml[0]"
+- assert:
+    that:
+      - result.changed == true
+      - "'Loopback10' in result.xml[0]"
 
-  - name: verify lookup_source
-    iosxr_system: *dellookup
-    register: result
+- name: verify lookup_source
+  iosxr_system: *dellookup
+  connection: netconf
+  register: result
 
-  - assert:
-      that:
-        - result.changed == false
+- assert:
+    that:
+      - result.changed == false
 
-  - name: configure lookup_source with vrf
-    iosxr_system: &lookupvrf
-      lookup_source: Loopback10
-      vrf: ansiblevrf
-      provider: "{{ netconf }}"
-    register: result
+- name: configure lookup_source with vrf
+  iosxr_system: &lookupvrf
+    lookup_source: Loopback10
+    vrf: ansiblevrf
+    provider: "{{ netconf }}"
+  connection: netconf
+  register: result
 
-  - assert:
-      that:
-        - result.changed == true
-        - "'Loopback10' in result.xml[0]"
-        - "'ansiblevrf' in result.xml[0]"
+- assert:
+    that:
+      - result.changed == true
+      - "'Loopback10' in result.xml[0]"
+      - "'ansiblevrf' in result.xml[0]"
 
-  - name: verify lookup_source
-    iosxr_system: *lookupvrf
-    register: result
+- name: verify lookup_source
+  iosxr_system: *lookupvrf
+  connection: netconf
+  register: result
 
-  - assert:
-      that:
-        - result.changed == false
+- assert:
+    that:
+      - result.changed == false
 
-  - name: disable lookup
-    iosxr_system: &disablevrf
-      lookup_enabled: False 
-      vrf: ansiblevrf
-      provider: "{{ netconf }}"
-    register: result
+- name: disable lookup
+  iosxr_system: &disablevrf
+    lookup_enabled: False
+    vrf: ansiblevrf
+    provider: "{{ netconf }}"
+  connection: netconf
+  register: result
 
-  - assert:
-      that:
-        - result.changed == true
-        - "'lookup' in result.xml[0]"
-        - "'ansiblevrf' in result.xml[0]"
+- assert:
+    that:
+      - result.changed == true
+      - "'lookup' in result.xml[0]"
+      - "'ansiblevrf' in result.xml[0]"
 
-  - name: verify disable lookup
-    iosxr_system: *disablevrf
-    register: result
+- name: verify disable lookup
+  iosxr_system: *disablevrf
+  connection: netconf
+  register: result
 
-  - assert:
-      that:
-        - result.changed == false
+- assert:
+    that:
+      - result.changed == false
 
-  - name: delete lookup_source
-    iosxr_system: &dellookupvrf
-      lookup_source: Loopback10
-      vrf: ansiblevrf
-      provider: "{{ netconf }}"
-      state: absent
-    register: result
+- name: delete lookup_source
+  iosxr_system: &dellookupvrf
+    lookup_source: Loopback10
+    vrf: ansiblevrf
+    provider: "{{ netconf }}"
+    state: absent
+  connection: netconf
+  register: result
 
-  - assert:
-      that:
-        - result.changed == true
-        - "'Loopback10' in result.xml[0]"
-        - "'ansiblevrf' in result.xml[0]"
+- assert:
+    that:
+      - result.changed == true
+      - "'Loopback10' in result.xml[0]"
+      - "'ansiblevrf' in result.xml[0]"
 
-  - name: verify lookup_source
-    iosxr_system: *dellookupvrf
-    register: result
+- name: verify lookup_source
+  iosxr_system: *dellookupvrf
+  connection: netconf
+  register: result
 
-  - assert:
-      that:
-        - result.changed == false
+- assert:
+    that:
+      - result.changed == false
 
-- always:
-  - name: teardown
-    iosxr_config:
-      lines:
-        - no domain lookup source-interface Loopback10
-        - no domain vrf ansiblevrf lookup source-interface Loopback10
-        - no domain lookup disable
-        - no domain vrf ansiblevrf lookup disable
-      match: none
-      provider: "{{ cli }}"
+- name: teardown
+  iosxr_config:
+    lines:
+      - no domain lookup disable
+      - no domain vrf ansiblevrf lookup disable
+    match: none
+    provider: "{{ cli }}"
+  connection: network_cli
 
-  - debug:
-      msg: "END netconf/set_lookup_source.yaml on connection={{ ansible_connection }}"
+- debug:
+    msg: "END netconf/set_lookup_source.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/iosxr_system/tests/netconf/set_name_servers.yaml
+++ b/test/integration/targets/iosxr_system/tests/netconf/set_name_servers.yaml
@@ -1,120 +1,137 @@
 ---
 - debug: 
     msg: "START netconf/set_name_servers.yaml on connection={{ ansible_connection }}"
-- block:
-  - name: configure name_servers
-    iosxr_system:
-      name_servers:
-        - 1.1.1.1
-        - 2.2.2.2
-        - 3.3.3.3
-      provider: "{{ netconf }}"
-    register: result
 
-  - assert:
-      that:
-        - result.changed == true
-        - result.xml|length == 1
-        - "'1.1.1.1' in result.xml[0]"
-        - "'2.2.2.2' in result.xml[0]"
-        - "'3.3.3.3' in result.xml[0]"
+- name: setup
+  iosxr_config:
+    lines:
+      - no domain name-server 1.1.1.1
+      - no domain name-server 2.2.2.2
+      - no domain name-server 3.3.3.3
+    match: none
+    provider: "{{ cli }}"
+  connection: network_cli
 
-  - name: verify name_servers
-    iosxr_system:
-      name_servers:
-        - 1.1.1.1
-        - 2.2.2.2
-        - 3.3.3.3
-      provider: "{{ netconf }}"
-    register: result
+- name: setup
+  iosxr_system:
+    vrf: ansible
+    name_servers:
+      - 1.1.1.1
+      - 2.2.2.2
+      - 3.3.3.3
+    provider: "{{ netconf }}"
+    state: absent
+  connection: netconf
+  ignore_errors: True
+  register: result
 
-  - assert:
-      that:
-        - result.changed == false
+- name: configure name_servers
+  iosxr_system:
+    name_servers:
+      - 1.1.1.1
+      - 2.2.2.2
+      - 3.3.3.3
+    provider: "{{ netconf }}"
+  connection: netconf
+  register: result
 
-  - name: add with to vrf
-    iosxr_system: &addvrf
-      vrf: ansible
-      name_servers:
-        - 1.1.1.1
-        - 2.2.2.2
-        - 3.3.3.3
-      provider: "{{ netconf }}"
-    register: result
+- assert:
+    that:
+      - result.changed == true
+      - result.xml|length == 1
+      - "'1.1.1.1' in result.xml[0]"
+      - "'2.2.2.2' in result.xml[0]"
+      - "'3.3.3.3' in result.xml[0]"
 
-  - assert:
-      that:
-        - result.changed == true
-        - result.xml|length == 1
-        - "'ansible' in result.xml[0]"
-        - "'1.1.1.1' in result.xml[0]"
-        - "'2.2.2.2' in result.xml[0]"
-        - "'3.3.3.3' in result.xml[0]"
+- name: verify name_servers
+  iosxr_system:
+    name_servers:
+      - 1.1.1.1
+      - 2.2.2.2
+      - 3.3.3.3
+    provider: "{{ netconf }}"
+  connection: netconf
+  register: result
 
-  - name: verify change to vrf
-    iosxr_system: *addvrf
-    register: result
+- assert:
+    that:
+      - result.changed == false
 
-  - assert:
-      that:
-        - result.changed == false
+- name: add name servers with vrf
+  iosxr_system: &addvrf
+    vrf: ansible
+    name_servers:
+      - 1.1.1.1
+      - 2.2.2.2
+      - 3.3.3.3
+    provider: "{{ netconf }}"
+  connection: netconf
+  register: result
 
-  - name: remove one
-    iosxr_system:
-      name_servers:
-        - 1.1.1.1
-        - 2.2.2.2
-      provider: "{{ netconf }}"
-    register: result
+- assert:
+    that:
+      - result.changed == true
+      - result.xml|length == 1
+      - "'ansible' in result.xml[0]"
+      - "'1.1.1.1' in result.xml[0]"
+      - "'2.2.2.2' in result.xml[0]"
+      - "'3.3.3.3' in result.xml[0]"
 
-  - assert:
-      that:
-        - result.changed == true
-        - result.xml|length == 1
-        - "'3.3.3.3' in result.xml[0]"
+- name: verify change to vrf
+  iosxr_system: *addvrf
+  connection: netconf
+  register: result
 
-## multiple name-servers deletion commands doesn't work in single 
-# config session (only the 1st one takes effect). May or may not be 
-# a VIRL software issue.
-- always:
-  - name: setup
-    iosxr_config:
-      lines: no domain name-server 1.1.1.1
-      match: none
-      provider: "{{ cli }}"
+- assert:
+    that:
+      - result.changed == false
 
-  - name: setup
-    iosxr_config:
-      lines: no domain name-server 2.2.2.2
-      match: none
-      provider: "{{ cli }}"
+- name: remove one
+  iosxr_system:
+    name_servers:
+      - 1.1.1.1
+      - 2.2.2.2
+    provider: "{{ netconf }}"
+  connection: netconf
+  register: result
 
-  - name: setup
-    iosxr_config:
-      lines: no domain name-server 3.3.3.3
-      match: none
-      provider: "{{ cli }}"
+- assert:
+    that:
+      - result.changed == true
+      - result.xml|length == 1
+      - "'3.3.3.3' in result.xml[0]"
 
-  - name: setup
-    iosxr_config:
-      lines: no domain vrf ansible name-server 1.1.1.1
-      match: none
-      provider: "{{ cli }}"
-    ignore_errors: true
+- name: remove one with vrf
+  iosxr_system:
+    vrf: ansible
+    name_servers:
+      - 1.1.1.1
+      - 2.2.2.2
+    provider: "{{ netconf }}"
+  connection: netconf
+  ignore_errors: True
+  register: result
 
-  - name: setup
-    iosxr_config:
-      lines: no domain vrf ansible name-server 2.2.2.2
-      match: none
-      provider: "{{ cli }}"
-    ignore_errors: true
+- name: teardown
+  iosxr_config:
+    lines:
+      - no domain name-server 1.1.1.1
+      - no domain name-server 2.2.2.2
+    match: none
+    provider: "{{ cli }}"
+  connection: network_cli
 
-  - name: setup
-    iosxr_config:
-      lines: no domain vrf ansible name-server 3.3.3.3
-      match: none
-      provider: "{{ cli }}"
-    ignore_errors: true
+- name: teardown
+  iosxr_system:
+    vrf: ansible
+    name_servers:
+      - 1.1.1.1
+      - 2.2.2.2
+    provider: "{{ netconf }}"
+    state: absent
+  connection: netconf
+  ignore_errors: True
+  register: result
 
-  - debug: 
-      msg: "END netconf/set_name_servers.yaml on connection={{ ansible_connection }}"
+- debug:
+    msg: "END netconf/set_name_servers.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/iosxr_user/tasks/cli.yaml
+++ b/test/integration/targets/iosxr_user/tasks/cli.yaml
@@ -26,6 +26,8 @@
   loop_control:
     loop_var: test_case_to_run
 
+# Only one of the Testcase would be run to check if `connection: local`
+# is established. Full suite is run with `connection:network_cli` or `connection:netconf`
 - name: run test case (connection=local)
   include: "{{ test_case_to_run }} ansible_connection=local"
   with_first_found: "{{ test_items }}"

--- a/test/integration/targets/iosxr_user/tasks/netconf.yaml
+++ b/test/integration/targets/iosxr_user/tasks/netconf.yaml
@@ -26,6 +26,8 @@
   loop_control:
     loop_var: test_case_to_run
 
+# Only one of the Testcase would be run to check if `connection: local`
+# is established. Full suite is run with `connection:network_cli` or `connection:netconf`
 - name: run test case (connection=local)
   include: "{{ test_case_to_run }} ansible_connection=local"
   with_first_found: "{{ test_items }}"

--- a/test/integration/targets/iosxr_user/tasks/netconf.yaml
+++ b/test/integration/targets/iosxr_user/tasks/netconf.yaml
@@ -20,14 +20,14 @@
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local"
+- name: run test case (connection=netconf)
+  include: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
 
-#- name: run test case (connection=netconf)
-  #include: "{{ test_case_to_run }} ansible_connection=network_cli"
-  #with_items: "{{ test_items }}"
-  #loop_control:
-  #  loop_var: test_case_to_run
+- name: run test case (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local"
+  with_first_found: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run

--- a/test/integration/targets/iosxr_user/tests/common/auth.yaml
+++ b/test/integration/targets/iosxr_user/tests/common/auth.yaml
@@ -6,12 +6,14 @@
       state: present
       configured_password: pass123
       provider: "{{ cli }}"
+    connection: network_cli
 
   - name: test login
     expect:
       command: "ssh auth_user@{{ ansible_ssh_host }} -p {{ ansible_ssh_port|default(22) }} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no show version"
       responses:
         (?i)password: "pass123"
+    connection: network_cli
 
   - name: test login with invalid password (should fail)
     expect:
@@ -19,6 +21,7 @@
       responses:
         (?i)password: "badpass"
     ignore_errors: yes
+    connection: network_cli
     register: results
 
   - name: check that attempt failed
@@ -32,18 +35,21 @@
       state: present
       public_key_contents: "{{ lookup('file', \"{{ role_path }}/files/public.pub\") }}"
       provider: "{{ cli }}"
+    connection: network_cli
 
   - name: test login with private key
     expect:
       command: "ssh auth_user@{{ ansible_ssh_host }} -p {{ ansible_ssh_port|default(22) }} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i {{ role_path }}/files/private show version"
       responses:
         (?i)password: 'pass123'
+    connection: network_cli
 
   - name: remove user and key
     iosxr_user:
       name: auth_user
       provider: "{{ cli }}"
       state: absent
+    connection: network_cli
 
   - name: test login with private key (should fail, no user)
     expect:
@@ -51,6 +57,7 @@
       responses:
         (?i)password: 'pass123'
     ignore_errors: yes
+    connection: network_cli
     register: results
 
   - name: create user with private key (path input)
@@ -59,6 +66,7 @@
       state: present
       public_key: "{{ role_path }}/files/public.pub"
       provider: "{{ cli }}"
+    connection: network_cli
 
   - name: test login with private key
     expect:
@@ -66,6 +74,7 @@
       responses:
         (?i)password: 'pass123'
     ignore_errors: yes
+    connection: network_cli
 
   - name: change private key for user
     iosxr_user:
@@ -73,6 +82,7 @@
       state: present
       public_key_contents: "{{ lookup('file', \"{{ role_path }}/files/public2.pub\") }}"
       provider: "{{ cli }}"
+    connection: network_cli
 
   # FIXME: pexpect fails with OSError: [Errno 5] Input/output error
   - name: test login with invalid private key (should fail)
@@ -81,6 +91,7 @@
       responses:
         (?i)password: "pass123"
     ignore_errors: yes
+    connection: network_cli
     register: results
 
   - name: check that attempt failed
@@ -94,4 +105,5 @@
       name: auth_user
       state: absent
       provider: "{{ cli }}"
+    connection: network_cli
     register: result

--- a/test/integration/targets/iosxr_user/tests/netconf/basic.yaml
+++ b/test/integration/targets/iosxr_user/tests/netconf/basic.yaml
@@ -6,6 +6,7 @@
       - no username ansible2
       - no username ansible3
     provider: "{{ cli }}"
+  connection: network_cli
 
 - name: Create user (SetUp)
   iosxr_user:
@@ -13,6 +14,7 @@
     configured_password: password
     state: present
     provider: "{{ netconf }}"
+  connection: netconf
   register: result
 
 - assert:
@@ -28,6 +30,7 @@
     update_password: always
     state: present
     provider: "{{ netconf }}"
+  connection: netconf
   register: result
 
 - assert:
@@ -43,6 +46,7 @@
     update_password: on_create
     state: present
     provider: "{{ netconf }}"
+  connection: netconf
   register: result
 
 - assert:
@@ -58,6 +62,7 @@
     group: sysadmin
     state: present
     provider: "{{ netconf }}"
+  connection: netconf
   register: result
 
 - assert:
@@ -74,6 +79,7 @@
     group: sysadmin
     state: present
     provider: "{{ netconf }}"
+  connection: netconf
   register: result
 
 - assert:
@@ -90,6 +96,7 @@
     state: present
     group: sysadmin
     provider: "{{ netconf }}"
+  connection: netconf
   register: result
 
 - assert:
@@ -111,6 +118,7 @@
     state: present
     group: sysadmin
     provider: "{{ netconf }}"
+  connection: netconf
   register: result
 
 - assert:
@@ -130,6 +138,7 @@
     state: present
     group: sysadmin
     provider: "{{ netconf }}"
+  connection: netconf
   register: result
 
 - assert:
@@ -145,6 +154,7 @@
       - name: ansible3
     state: absent
     provider: "{{ netconf }}"
+  connection: netconf
   register: result
 
 - assert:
@@ -162,6 +172,7 @@
       - name: ansible3
     state: absent
     provider: "{{ netconf }}"
+  connection: netconf
   register: result
 
 - assert:


### PR DESCRIPTION


##### SUMMARY
* Changes to enable network_cli and netconf on modules.
* limits connection local for single TC per playbook.


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request


##### COMPONENT NAME
iosxr_*

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5.0
```

