### PR TITLE
Remove incorrect assumption on exception constructors

### DIFF
--- a/lib/ansible/template/vars.py
+++ b/lib/ansible/template/vars.py
@@ -23,6 +23,7 @@ from collections import Mapping
 
 from jinja2.utils import missing
 
+from ansible.errors import AnsibleError
 from ansible.module_utils.six import iteritems
 from ansible.module_utils._text import to_native
 
@@ -105,10 +106,10 @@ class AnsibleJ2Vars(Mapping):
             try:
                 value = self._templar.template(variable)
             except Exception as e:
-                try:
-                    raise type(e)(to_native(variable) + ': ' + e.message)
-                except AttributeError:
-                    raise type(e)(to_native(variable) + ': ' + to_native(e))
+                msg = getattr(e, 'message') or to_native(e)
+                raise AnsibleError("An unhandled exception occurred while templating '%s'. "
+                                   "Error was a %s, original message: %s" % (to_native(variable), type(e), msg))
+
             return value
 
     def add_locals(self, locals):


### PR DESCRIPTION
Do not assume that all exception constructors accept a single string
argument. For example UnicodeError's __init__ takes 5 parameters:
encoding, object, start, end, reason.

Also, if e.message is present but empty, fall back on stringifying
the exception occurrence.

Fixes #35270

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
core

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (topic/templating_reraise 4001d2ecb4) last updated 2018/01/24 10:40:49 (GMT +200)
  config file = None
  configured module search path = [u'/home/quinot/projects/ansible/lib/ansible/modules']
  ansible python module location = /home/quinot/projects/ansible/lib/ansible
  executable location = /home/quinot/projects/ansible/bin/ansible
  python version = 2.7.13 (default, Jan 19 2017, 14:48:08) [GCC 6.3.0 20170118]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
See issue #35270 

