### PR TITLE
influxdb_user module now does not require 'database_name'

### DIFF
--- a/lib/ansible/module_utils/influxdb.py
+++ b/lib/ansible/module_utils/influxdb.py
@@ -28,7 +28,7 @@ class InfluxDb():
         self.port = self.params['port']
         self.username = self.params['username']
         self.password = self.params['password']
-        self.database_name = self.params['database_name']
+        self.database_name = self.params.get('database_name')
 
     def check_lib(self):
         if not HAS_REQUESTS:
@@ -44,7 +44,6 @@ class InfluxDb():
             port=dict(default=8086, type='int'),
             username=dict(default='root', type='str', aliases=['login_username']),
             password=dict(default='root', type='str', no_log=True, aliases=['login_password']),
-            database_name=dict(default=None, type='str'),
             ssl=dict(default=False, type='bool'),
             validate_certs=dict(default=True, type='bool'),
             timeout=dict(type='int'),

--- a/lib/ansible/module_utils/influxdb.py
+++ b/lib/ansible/module_utils/influxdb.py
@@ -44,6 +44,7 @@ class InfluxDb():
             port=dict(default=8086, type='int'),
             username=dict(default='root', type='str', aliases=['login_username']),
             password=dict(default='root', type='str', no_log=True, aliases=['login_password']),
+            database_name=dict(default=None, type='str'),
             ssl=dict(default=False, type='bool'),
             validate_certs=dict(default=True, type='bool'),
             timeout=dict(type='int'),

--- a/lib/ansible/modules/database/influxdb/influxdb_user.py
+++ b/lib/ansible/modules/database/influxdb/influxdb_user.py
@@ -125,7 +125,6 @@ def main():
         user_name=dict(required=True, type='str'),
         user_password=dict(required=False, type='str', no_log=True),
         admin=dict(default='False', type='bool')
-
     )
     module = AnsibleModule(
         argument_spec=argument_spec,


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
influxdb_user module [does not require](https://docs.ansible.com/ansible/devel/module_docs/influxdb_user_module.html) 'database_name' parameter. But it fails for the task:
```yaml
- name: Create admin user
  influxdb_user:
    user_name: '{{ influxdb_admin_user }}'
    user_password: '{{ influxdb_admin_password }}'
    admin: yes
```
with "KeyError: 'database_name'" (issue #35279). It happens because of [this line](https://github.com/ar7z1/ansible/blob/1a2d9c88c2dbaf61ed3bc132c8946c86ef8f8fa8/lib/ansible/module_utils/influxdb.py#L31):
```python
class InfluxDb():
    def __init__(self, module):
        ...
        self.database_name = self.params['database_name']
```

In this PR I've fixed it: I've added [this line](https://github.com/ansible/ansible/pull/34021/files#diff-42741a013cc5628a7757ceac61d30298L47) into `influxdb_argument_spec`, but without `required=True`.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
influxdb_user

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (3237-change-rabbitmq-user-password-without-force 4cdda0d9a3) last updated 2018/01/23 21:56:35 (GMT +300)
  config file = /home/art/.ansible.cfg
  configured module search path = [u'/home/art/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/art/projects/github/ansible/lib/ansible
  executable location = /home/art/projects/github/ansible/bin/ansible
  python version = 2.7.12 (default, Nov 20 2017, 18:23:56) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
