### PR TITLE
ovirt: Support to search entity with additional parameters

### DIFF
--- a/lib/ansible/module_utils/ovirt.py
+++ b/lib/ansible/module_utils/ovirt.py
@@ -218,20 +218,22 @@ def equal(param1, param2, ignore_case=False):
     return True
 
 
-def search_by_attributes(service, **kwargs):
+def search_by_attributes(service, list_params=None, **kwargs):
     """
     Search for the entity by attributes. Nested entities don't support search
     via REST, so in case using search for nested entity we return all entities
     and filter them by specified attributes.
     """
+    list_params = list_params or {}
     # Check if 'list' method support search(look for search parameter):
     if 'search' in inspect.getargspec(service.list)[0]:
         res = service.list(
-            search=' and '.join('{0}={1}'.format(k, v) for k, v in kwargs.items())
+            search=' and '.join('{0}={1}'.format(k, v) for k, v in kwargs.items()),
+            **list_params
         )
     else:
         res = [
-            e for e in service.list() if len([
+            e for e in service.list(**list_params) if len([
                 k for k, v in kwargs.items() if getattr(e, k, None) == v
             ]) == len(kwargs)
         ]
@@ -269,13 +271,16 @@ def search_by_name(service, name, **kwargs):
     return res[0]
 
 
-def get_entity(service):
+def get_entity(service, get_params=None):
     """
     Ignore SDK Error in case of getting an entity from service.
     """
     entity = None
     try:
-        entity = service.get()
+        if get_params is not None:
+            entity = service.get(**get_params)
+        else:
+            entity = service.get()
     except sdk.Error:
         # We can get here 404, we should ignore it, in case
         # of removing entity for example.
@@ -757,7 +762,7 @@ class BaseModule(object):
                     return entity
                 time.sleep(poll_interval)
 
-    def search_entity(self, search_params=None):
+    def search_entity(self, search_params=None, list_params=None):
         """
         Always first try to search by `ID`, if ID isn't specified,
         check if user constructed special search in `search_params`,
@@ -766,10 +771,10 @@ class BaseModule(object):
         entity = None
 
         if 'id' in self._module.params and self._module.params['id'] is not None:
-            entity = get_entity(self._service.service(self._module.params['id']))
+            entity = get_entity(self._service.service(self._module.params['id']), get_params=list_params)
         elif search_params is not None:
-            entity = search_by_attributes(self._service, **search_params)
+            entity = search_by_attributes(self._service, list_params=list_params, **search_params)
         elif self._module.params.get('name') is not None:
-            entity = search_by_attributes(self._service, name=self._module.params['name'])
+            entity = search_by_attributes(self._service, list_params=list_params, name=self._module.params['name'])
 
         return entity

--- a/lib/ansible/modules/cloud/ovirt/ovirt_vms.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_vms.py
@@ -1500,7 +1500,7 @@ def main():
             module=module,
             service=vms_service,
         )
-        vm = vms_module.search_entity()
+        vm = vms_module.search_entity(list_params={'all_content': True})
 
         control_state(vm, vms_service, module)
         if state in ('present', 'running', 'next_run'):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
To support for example `serial_console` parameter in `ovirt_vms` module, we need to pass `all_content` parameter to search attribute in Python SDK. This patch add a support for passing additional parameters to search.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
ovirt
ovirt_vms

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.4.2
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
