### PR TITLE
Add attachable parameter for Docker overlay networks

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_network.py
+++ b/lib/ansible/modules/cloud/docker/docker_network.py
@@ -66,7 +66,9 @@ options:
     description:
       - Specify if the network should allow manual attachment by individual containers.
         For overlay type networks only.
-    default: false
+    type: bool
+    default: 'no'
+    version_added: "2.7"
 
   ipam_driver:
     description:

--- a/lib/ansible/modules/cloud/docker/docker_network.py
+++ b/lib/ansible/modules/cloud/docker/docker_network.py
@@ -62,6 +62,12 @@ options:
     aliases:
       - incremental
 
+  attachable:
+    description:
+      - Specify if the network should allow manual attachment by individual containers.
+        For overlay type networks only.
+    default: false
+
   ipam_driver:
     description:
       - Specify an IPAM driver.
@@ -95,7 +101,7 @@ author:
 
 requirements:
     - "python >= 2.6"
-    - "docker-py >= 1.8.0"
+    - "docker >= 1.21.0"
     - "Please note that the L(docker-py,https://pypi.org/project/docker-py/) Python
        module has been superseded by L(docker,https://pypi.org/project/docker/)
        (see L(here,https://github.com/docker/docker-py/issues/1310) for details).
@@ -142,6 +148,12 @@ EXAMPLES = '''
       gateway: 172.3.26.1
       iprange: '192.168.1.0/24'
 
+- name: Create an attachable overlay-type network
+  docker_network:
+    name: network_three
+    driver: overlay
+    attachable: true
+
 - name: Delete a network, disconnecting all containers
   docker_network:
     name: network_one
@@ -180,6 +192,7 @@ class TaskParameters(DockerBaseClass):
         self.ipam_driver = None
         self.ipam_options = None
         self.appends = None
+        self.attachable = None
         self.force = None
         self.debug = None
 
@@ -269,6 +282,11 @@ class DockerNetworkManager(object):
                         # key has different value
                         different = True
                         differences.append('ipam_options.%s' % key)
+        if self.parameters.attachable:
+            if (not net.get('Attachable') or
+                    net['Attachable'] != self.parameters.attachable):
+                different = True
+                differences.append('attachable')
         return different, differences
 
     def create_network(self):
@@ -291,6 +309,7 @@ class DockerNetworkManager(object):
                 resp = self.client.create_network(self.parameters.network_name,
                                                   driver=self.parameters.driver,
                                                   options=self.parameters.driver_options,
+                                                  attachable=self.parameters.attachable,
                                                   ipam=ipam_config)
 
                 self.existing_network = self.client.inspect_network(resp['Id'])
@@ -378,6 +397,7 @@ def main():
         appends=dict(type='bool', default=False, aliases=['incremental']),
         ipam_driver=dict(type='str', default=None),
         ipam_options=dict(type='dict', default={}),
+        attachable=dict(type='bool', default=False),
         debug=dict(type='bool', default=False)
     )
 

--- a/lib/ansible/modules/cloud/docker/docker_network.py
+++ b/lib/ansible/modules/cloud/docker/docker_network.py
@@ -68,7 +68,7 @@ options:
         For overlay type networks only.
     type: bool
     default: 'no'
-    version_added: "2.7"
+    version_added: "2.8"
 
   ipam_driver:
     description:


### PR DESCRIPTION
##### SUMMARY
Added an extra parameter that is passed directly to `docker-py`'s `create_network()` method, allowing for the creation of overlay networks that are attachable by external containers.

Requires a bump of the recommended version of `docker-py` from 1.7.0 to 1.21.0.

Fixes #28380

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
`docker_network`

##### ANSIBLE VERSION
```
ansible 2.5.0 (feature/docker_network_attachable 0cc62b16fd) last updated 2018/01/24 10:02:28 (GMT -400)
  config file = /home/jcook/Projects/admiral/ansible.cfg
  configured module search path = [u'/home/jcook/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/jcook/Projects/ansible/lib/ansible
  executable location = env/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```

##### ADDITIONAL INFORMATION
See issue #28380
