### PR TITLE
* removes the console logging from cli run before netconf run

### DIFF
--- a/test/integration/targets/iosxr_logging/tests/netconf/basic.yaml
+++ b/test/integration/targets/iosxr_logging/tests/netconf/basic.yaml
@@ -10,6 +10,7 @@
 - name: remove console logging
   iosxr_logging:
     dest: console
+    level: warning
     state: absent
     provider: "{{ netconf }}"
   register: result
@@ -92,9 +93,6 @@
     state: absent
     provider: "{{ netconf }}"
   register: result
-
-- debug:
-    msg: "{{ result }}"
 
 - assert: &true
     that:


### PR DESCRIPTION


##### SUMMARY
Fixes a DCI failure in iosxr_logging, by correctly removing the console logging config

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
iosxr_logging

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5.0
```


