### PR TITLE
Fix network cli prompts to bind to the newline

### DIFF
--- a/lib/ansible/plugins/terminal/asa.py
+++ b/lib/ansible/plugins/terminal/asa.py
@@ -58,7 +58,7 @@ class TerminalModule(TerminalBase):
         if passwd:
             # Note: python-3.5 cannot combine u"" and r"" together.  Thus make
             # an r string and use to_text to ensure it's text on both py2 and py3.
-            cmd[u'prompt'] = to_text(r"[\r\n]?password: $", errors='surrogate_or_strict')
+            cmd[u'prompt'] = to_text(r"[\r\n]password: $", errors='surrogate_or_strict')
             cmd[u'answer'] = passwd
 
         try:

--- a/lib/ansible/plugins/terminal/asa.py
+++ b/lib/ansible/plugins/terminal/asa.py
@@ -30,7 +30,7 @@ from ansible.plugins.terminal import TerminalBase
 class TerminalModule(TerminalBase):
 
     terminal_stdout_re = [
-        re.compile(r"[\r\n]?[\w+\-\.:\/\[\]]+(?:\([^\)]+\)){,3}(?:>|#) ?$"),
+        re.compile(r"[\r\n][\w+\-\.:\/\[\]]+(?:\([^\)]+\)){,3}(?:>|#) ?$"),
         re.compile(r"\[\w+\@[\w\-\.]+(?: [^\]])\] ?[>#\$] ?$")
     ]
 

--- a/lib/ansible/plugins/terminal/dellos10.py
+++ b/lib/ansible/plugins/terminal/dellos10.py
@@ -59,7 +59,7 @@ class TerminalModule(TerminalBase):
 
         cmd = {u'command': u'enable'}
         if passwd:
-            cmd[u'prompt'] = to_text(r"[\r\n]?password: $", errors='surrogate_or_strict')
+            cmd[u'prompt'] = to_text(r"[\r\n]password: $", errors='surrogate_or_strict')
             cmd[u'answer'] = passwd
 
         try:

--- a/lib/ansible/plugins/terminal/dellos10.py
+++ b/lib/ansible/plugins/terminal/dellos10.py
@@ -32,7 +32,7 @@ from ansible.errors import AnsibleConnectionFailure
 class TerminalModule(TerminalBase):
 
     terminal_stdout_re = [
-        re.compile(br"[\r\n]?[\w+\-\.:\/\[\]]+(?:\([^\)]+\)){,3}(?:#) ?$"),
+        re.compile(br"[\r\n][\w+\-\.:\/\[\]]+(?:\([^\)]+\)){,3}(?:#) ?$"),
         re.compile(br"\[\w+\@[\w\-\.]+(?: [^\]])\] ?[>#\$] ?$")
     ]
 

--- a/lib/ansible/plugins/terminal/dellos6.py
+++ b/lib/ansible/plugins/terminal/dellos6.py
@@ -32,7 +32,7 @@ from ansible.errors import AnsibleConnectionFailure
 class TerminalModule(TerminalBase):
 
     terminal_stdout_re = [
-        re.compile(br"[\r\n]?[\w+\-\.:\/\[\]]+(?:\([^\)]+\)){,3}(?:>|#) ?$"),
+        re.compile(br"[\r\n][\w+\-\.:\/\[\]]+(?:\([^\)]+\)){,3}(?:>|#) ?$"),
         re.compile(br"\[\w+\@[\w\-\.]+(?: [^\]])\] ?[>#\$] ?$")
     ]
 

--- a/lib/ansible/plugins/terminal/dellos6.py
+++ b/lib/ansible/plugins/terminal/dellos6.py
@@ -58,7 +58,7 @@ class TerminalModule(TerminalBase):
 
         cmd = {u'command': u'enable'}
         if passwd:
-            cmd[u'prompt'] = to_text(r"[\r\n]?password:$", errors='surrogate_or_strict')
+            cmd[u'prompt'] = to_text(r"[\r\n]password:$", errors='surrogate_or_strict')
             cmd[u'answer'] = passwd
         try:
             self._exec_cli_command(to_bytes(json.dumps(cmd), errors='surrogate_or_strict'))

--- a/lib/ansible/plugins/terminal/dellos9.py
+++ b/lib/ansible/plugins/terminal/dellos9.py
@@ -57,7 +57,7 @@ class TerminalModule(TerminalBase):
 
         cmd = {u'command': u'enable'}
         if passwd:
-            cmd[u'prompt'] = to_text(r"[\r\n]?password: $", errors='surrogate_or_strict')
+            cmd[u'prompt'] = to_text(r"[\r\n]password: $", errors='surrogate_or_strict')
             cmd[u'answer'] = passwd
 
         try:

--- a/lib/ansible/plugins/terminal/dellos9.py
+++ b/lib/ansible/plugins/terminal/dellos9.py
@@ -32,7 +32,7 @@ from ansible.errors import AnsibleConnectionFailure
 class TerminalModule(TerminalBase):
 
     terminal_stdout_re = [
-        re.compile(br"[\r\n]?[\w+\-\.:\/\[\]]+(?:\([^\)]+\)){,3}(?:>|#) ?$"),
+        re.compile(br"[\r\n][\w+\-\.:\/\[\]]+(?:\([^\)]+\)){,3}(?:>|#) ?$"),
         re.compile(br"\[\w+\@[\w\-\.]+(?: [^\]])\] ?[>#\$] ?$")
     ]
 

--- a/lib/ansible/plugins/terminal/enos.py
+++ b/lib/ansible/plugins/terminal/enos.py
@@ -76,7 +76,7 @@ class TerminalModule(TerminalBase):
             # Note: python-3.5 cannot combine u"" and r"" together.  Thus make
             # an r string and use to_text to ensure it's text
             # on both py2 and py3.
-            cmd[u'prompt'] = to_text(r"[\r\n]?password: $",
+            cmd[u'prompt'] = to_text(r"[\r\n]password: $",
                                      errors='surrogate_or_strict')
             cmd[u'answer'] = passwd
 

--- a/lib/ansible/plugins/terminal/enos.py
+++ b/lib/ansible/plugins/terminal/enos.py
@@ -45,7 +45,7 @@ from ansible.plugins.terminal import TerminalBase
 class TerminalModule(TerminalBase):
 
     terminal_stdout_re = [
-        re.compile(br"[\r\n]?[\w+\-\.:\/\[\]]+(?:\([^\)]+\)){,3}(?:>|#) ?$"),
+        re.compile(br"[\r\n][\w+\-\.:\/\[\]]+(?:\([^\)]+\)){,3}(?:>|#) ?$"),
         re.compile(br"\[\w+\@[\w\-\.]+(?: [^\]])\] ?[>#\$] ?$"),
         re.compile(br">[\r\n]?")
     ]

--- a/lib/ansible/plugins/terminal/eos.py
+++ b/lib/ansible/plugins/terminal/eos.py
@@ -30,7 +30,7 @@ from ansible.module_utils._text import to_bytes, to_text
 class TerminalModule(TerminalBase):
 
     terminal_stdout_re = [
-        re.compile(br"[\r\n]?[\w+\-\.:\/\[\]]+(?:\([^\)]+\)){,3}(?:>|#) ?$"),
+        re.compile(br"[\r\n][\w+\-\.:\/\[\]]+(?:\([^\)]+\)){,3}(?:>|#) ?$"),
         re.compile(br"\[\w+\@[\w\-\.]+(?: [^\]])\] ?[>#\$] ?$")
     ]
 

--- a/lib/ansible/plugins/terminal/eos.py
+++ b/lib/ansible/plugins/terminal/eos.py
@@ -61,7 +61,7 @@ class TerminalModule(TerminalBase):
 
         cmd = {u'command': u'enable'}
         if passwd:
-            cmd[u'prompt'] = to_text(r"[\r\n]?password: $", errors='surrogate_or_strict')
+            cmd[u'prompt'] = to_text(r"[\r\n]password: $", errors='surrogate_or_strict')
             cmd[u'answer'] = passwd
 
         try:

--- a/lib/ansible/plugins/terminal/ironware.py
+++ b/lib/ansible/plugins/terminal/ironware.py
@@ -30,7 +30,7 @@ from ansible.plugins.terminal import TerminalBase
 class TerminalModule(TerminalBase):
 
     terminal_stdout_re = [
-        re.compile(r"[\r\n]?(?:\w+@)?[\w+\-\.:\/\[\]]+(?:\([^\)]+\)){,3}(?:>|#) ?$")
+        re.compile(r"[\r\n](?:\w+@)?[\w+\-\.:\/\[\]]+(?:\([^\)]+\)){,3}(?:>|#) ?$")
     ]
 
     terminal_stderr_re = [

--- a/lib/ansible/plugins/terminal/ironware.py
+++ b/lib/ansible/plugins/terminal/ironware.py
@@ -56,7 +56,7 @@ class TerminalModule(TerminalBase):
         if passwd:
             # Note: python-3.5 cannot combine u"" and r"" together.  Thus make
             # an r string and use to_text to ensure it's text on both py2 and py3.
-            cmd[u'prompt'] = to_text(r"[\r\n]?password: ?$", errors='surrogate_or_strict')
+            cmd[u'prompt'] = to_text(r"[\r\n]password: ?$", errors='surrogate_or_strict')
             cmd[u'answer'] = passwd
 
         try:

--- a/lib/ansible/plugins/terminal/onyx.py
+++ b/lib/ansible/plugins/terminal/onyx.py
@@ -55,7 +55,7 @@ class TerminalModule(TerminalBase):
             # Note: python-3.5 cannot combine u"" and r"" together.  Thus make
             # an r string and use to_text to ensure it's text on both py2 and
             # py3.
-            cmd[u'prompt'] = to_text(r"[\r\n]?password: $",
+            cmd[u'prompt'] = to_text(r"[\r\n]password: $",
                                      errors='surrogate_or_strict')
             cmd[u'answer'] = passwd
 


### PR DESCRIPTION
##### SUMMARY

This is a follow-on to #34585 where these other network_cli regexps should also be changed.  This PR changes the ones mentioned in https://github.com/ansible/ansible/pull/34585#issuecomment-356788884 for the password: prompts, and a second commit to this branch changes the normal CLI prompts as well.

Essentially all the prompt and password sub-prompts should be bound to the start of a newline.  Making it optional allows greater freedom in finding these in other content network devices can emit.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->

lib/ansible/plugins/terminal/enos.py
lib/ansible/plugins/terminal/eos.py
lib/ansible/plugins/terminal/dellos10.py
lib/ansible/plugins/terminal/asa.py
lib/ansible/plugins/terminal/ironware.py
lib/ansible/plugins/terminal/dellos9.py
lib/ansible/plugins/terminal/dellos6.py
lib/ansible/module_utils/network/dellos9/dellos9.py
lib/ansible/module_utils/network/dellos9/dellos9.py
lib/ansible/module_utils/network/dellos9/dellos9.py
lib/ansible/module_utils/network/dellos6/dellos6.py
lib/ansible/module_utils/network/dellos6/dellos6.py
lib/ansible/module_utils/network/dellos6/dellos6.py
lib/ansible/module_utils/network/dellos10/dellos10.py
lib/ansible/module_utils/network/dellos10/dellos10.py
lib/ansible/module_utils/network/dellos10/dellos10.py
lib/ansible/plugins/terminal/onyx.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```
