### PR TITLE
Mount only | fixes #19820

### DIFF
--- a/lib/ansible/modules/system/mount.py
+++ b/lib/ansible/modules/system/mount.py
@@ -81,7 +81,6 @@ options:
         use this on OpenBSD with any state that operates on the live
         filesystem.
     default: /etc/fstab (/etc/vfstab on Solaris)
-    aliases: [ fstab ]
   boot:
     description:
       - Determines if the filesystem should be mounted on boot.
@@ -611,7 +610,7 @@ def main():
         argument_spec=dict(
             boot=dict(type='bool', default=True),
             dump=dict(type='str'),
-            fstab=dict(type='str', aliases=['fstab']),
+            fstab=dict(type='str'),
             fstype=dict(type='str'),
             path=dict(type='path', required=True, aliases=['name']),
             opts=dict(type='str'),

--- a/lib/ansible/modules/system/mount.py
+++ b/lib/ansible/modules/system/mount.py
@@ -736,11 +736,11 @@ def main():
 
         res = 0
 
-        # TODO: add a check to see if src have changed and remount if necessary
-
-        changed = True
-        if not module.check_mode:
-            res, msg = mount_raw(module, args)
+        if not os.path.ismount(name):
+            # TODO: add a check to see if src have changed and remount
+            if not module.check_mode:
+                res, msg = mount_raw(module, args)
+            changed = True
 
         if res:
             module.fail_json(msg="Error mounting %s: %s" % (name, msg))

--- a/lib/ansible/modules/system/mount.py
+++ b/lib/ansible/modules/system/mount.py
@@ -82,7 +82,6 @@ options:
         use this on OpenBSD with any state that operates on the live
         filesystem.
     default: /etc/fstab (/etc/vfstab on Solaris)
-    aliases: [ fstab ]
   boot:
     description:
       - Determines if the filesystem should be mounted on boot.
@@ -612,7 +611,7 @@ def main():
         argument_spec=dict(
             boot=dict(type='bool', default=True),
             dump=dict(type='str'),
-            fstab=dict(type='str', aliases=['fstab']),
+            fstab=dict(type='str'),
             fstype=dict(type='str'),
             path=dict(type='path', required=True, aliases=['name']),
             opts=dict(type='str'),

--- a/lib/ansible/modules/system/mount.py
+++ b/lib/ansible/modules/system/mount.py
@@ -58,17 +58,18 @@ options:
   state:
     description:
       - If C(mounted), the device will be actively mounted and appropriately
-        configured in I(fstab). If the mount point is not present, the mount
-        point will be created.
-      - If C(unmounted), the device will be unmounted without changing I(fstab).
+        configured in I(fstab_file). If the mount point is not present, the
+        mount point will be created.
+      - If C(unmounted), the device will be unmounted without changing
+        I(fstab_file).
       - C(present) only specifies that the device is to be configured in
-        I(fstab) and does not trigger or require a mount.
+        I(fstab_file) and does not trigger or require a mount.
       - C(absent) specifies that the device mount's entry will be removed from
-        I(fstab) and will also unmount the device and remove the mount
+        I(fstab_file) and will also unmount the device and remove the mount
         point.
     required: true
     choices: [ absent, mounted, present, unmounted ]
-  fstab:
+  fstab_file:
     description:
       - File to use instead of C(/etc/fstab). You shouldn't use this option
         unless you really know what you are doing. This might be useful if
@@ -77,6 +78,7 @@ options:
         use this on OpenBSD with any state that operates on the live
         filesystem.
     default: /etc/fstab (/etc/vfstab on Solaris)
+    aliases: [ fstab ]
   boot:
     description:
       - Determines if the filesystem should be mounted on boot.
@@ -189,7 +191,7 @@ def set_mount(module, args):
         new_line = (
             '%(src)s - %(name)s %(fstype)s %(passno)s %(boot)s %(opts)s\n')
 
-    for line in open(args['fstab'], 'r').readlines():
+    for line in open(args['fstab_file'], 'r').readlines():
         if not line.strip():
             to_write.append(line)
 
@@ -265,7 +267,7 @@ def set_mount(module, args):
         changed = True
 
     if changed and not module.check_mode:
-        write_fstab(module, to_write, args['fstab'])
+        write_fstab(module, to_write, args['fstab_file'])
 
     return (args['name'], changed)
 
@@ -277,7 +279,7 @@ def unset_mount(module, args):
     changed = False
     escaped_name = _escape_fstab(args['name'])
 
-    for line in open(args['fstab'], 'r').readlines():
+    for line in open(args['fstab_file'], 'r').readlines():
         if not line.strip():
             to_write.append(line)
 
@@ -333,7 +335,7 @@ def unset_mount(module, args):
         changed = True
 
     if changed and not module.check_mode:
-        write_fstab(module, to_write, args['fstab'])
+        write_fstab(module, to_write, args['fstab_file'])
 
     return (args['name'], changed)
 
@@ -363,15 +365,15 @@ def mount(module, args):
     cmd = [mount_bin]
 
     if get_platform().lower() == 'openbsd':
-        # Use module.params['fstab'] here as args['fstab'] has been set to the
-        # default value.
-        if module.params['fstab'] is not None:
+        # Use module.params['fstab_file'] here as args['fstab_file'] has been
+        # set to the default value.
+        if module.params['fstab_file'] is not None:
             module.fail_json(
                 msg=(
                     'OpenBSD does not support alternate fstab files. Do not '
-                    'specify the fstab parameter for OpenBSD hosts'))
+                    'specify the fstab_file parameter for OpenBSD hosts'))
     else:
-        cmd += _set_fstab_args(args['fstab'])
+        cmd += _set_fstab_args(args['fstab_file'])
 
     cmd += [name]
 
@@ -409,15 +411,15 @@ def remount(module, args):
         cmd += ['-o', 'remount']
 
     if get_platform().lower() == 'openbsd':
-        # Use module.params['fstab'] here as args['fstab'] has been set to the
-        # default value.
-        if module.params['fstab'] is not None:
+        # Use module.params['fstab_file'] here as args['fstab_file'] has been
+        # set to the default value.
+        if module.params['fstab_file'] is not None:
             module.fail_json(
                 msg=(
                     'OpenBSD does not support alternate fstab files. Do not '
                     'specify the fstab parameter for OpenBSD hosts'))
     else:
-        cmd += _set_fstab_args(args['fstab'])
+        cmd += _set_fstab_args(args['fstab_file'])
 
     cmd += [args['name']]
     out = err = ''
@@ -577,7 +579,7 @@ def main():
         argument_spec=dict(
             boot=dict(type='bool', default=True),
             dump=dict(type='str'),
-            fstab=dict(type='str'),
+            fstab_file=dict(type='str', aliases=['fstab']),
             fstype=dict(type='str'),
             path=dict(type='path', required=True, aliases=['name']),
             opts=dict(type='str'),
@@ -594,31 +596,31 @@ def main():
     )
 
     # solaris args:
-    #   name, src, fstype, opts, boot, passno, state, fstab=/etc/vfstab
+    #   name, src, fstype, opts, boot, passno, state, fstab_file=/etc/vfstab
     # linux args:
-    #   name, src, fstype, opts, dump, passno, state, fstab=/etc/fstab
-    # Note: Do not modify module.params['fstab'] as we need to know if the user
-    # explicitly specified it in mount() and remount()
+    #   name, src, fstype, opts, dump, passno, state, fstab_file=/etc/fstab
+    # Note: Do not modify module.params['fstab_file'] as we need to know if the
+    # user explicitly specified it in mount() and remount()
     if get_platform().lower() == 'sunos':
         args = dict(
             name=module.params['path'],
             opts='-',
             passno='-',
-            fstab=module.params['fstab'],
+            fstab_file=module.params['fstab_file'],
             boot='yes'
         )
-        if args['fstab'] is None:
-            args['fstab'] = '/etc/vfstab'
+        if args['fstab_file'] is None:
+            args['fstab_file'] = '/etc/vfstab'
     else:
         args = dict(
             name=module.params['path'],
             opts='defaults',
             dump='0',
             passno='0',
-            fstab=module.params['fstab']
+            fstab_file=module.params['fstab_file']
         )
-        if args['fstab'] is None:
-            args['fstab'] = '/etc/fstab'
+        if args['fstab_file'] is None:
+            args['fstab_file'] = '/etc/fstab'
 
         # FreeBSD doesn't have any 'default' so set 'rw' instead
         if get_platform() == 'FreeBSD':
@@ -637,17 +639,17 @@ def main():
                 'Bind mounts might be misinterpreted.')
 
     # Override defaults with user specified params
-    for key in ('src', 'fstype', 'passno', 'opts', 'dump', 'fstab'):
+    for key in ('src', 'fstype', 'passno', 'opts', 'dump', 'fstab_file'):
         if module.params[key] is not None:
             args[key] = module.params[key]
 
     # If fstab file does not exist, we first need to create it. This mainly
-    # happens when fstab option is passed to the module.
-    if not os.path.exists(args['fstab']):
-        if not os.path.exists(os.path.dirname(args['fstab'])):
-            os.makedirs(os.path.dirname(args['fstab']))
+    # happens when fstab_file option is passed to the module.
+    if not os.path.exists(args['fstab_file']):
+        if not os.path.exists(os.path.dirname(args['fstab_file'])):
+            os.makedirs(os.path.dirname(args['fstab_file']))
 
-        open(args['fstab'], 'a').close()
+        open(args['fstab_file'], 'a').close()
 
     # absent:
     #   Remove from fstab and unmounted.

--- a/lib/ansible/modules/system/mount.py
+++ b/lib/ansible/modules/system/mount.py
@@ -728,8 +728,7 @@ def main():
         if not os.path.exists(name) and not module.check_mode:
             try:
                 os.makedirs(name)
-            except (OSError, IOError):
-                e = get_exception()
+            except (OSError, IOError) as e:
                 module.fail_json(
                     msg="Error making dir %s: %s" % (name, str(e)))
 

--- a/lib/ansible/modules/system/mount.py
+++ b/lib/ansible/modules/system/mount.py
@@ -57,7 +57,7 @@ options:
     default: 0
   state:
     description:
-      - If C(mount), the device will be actively mounted without changing
+      - If C(mounted_raw), the device will be actively mounted without changing
         I(fstab). If the mount point is not present, the mount
         point will be created.
       - If C(mounted), the device will be actively mounted and appropriately
@@ -71,7 +71,7 @@ options:
         I(fstab) and will also unmount the device and remove the mount
         point.
     required: true
-    choices: [ absent, mounted, present, mount, unmounted ]
+    choices: [ absent, mounted, present, mounted_raw, unmounted ]
   fstab:
     description:
       - File to use instead of C(/etc/fstab). You shouldn't use this option
@@ -145,7 +145,7 @@ EXAMPLES = '''
     path: /mnt/data
     src: /dev/sb1
     fstype: ext4
-    state: mount
+    state: mounted_raw
 '''
 
 
@@ -618,7 +618,7 @@ def main():
             passno=dict(type='str'),
             src=dict(type='path'),
             backup=dict(default=False, type='bool'),
-            state=dict(type='str', required=True, choices=['absent', 'mounted', 'mount', 'present', 'unmounted']),
+            state=dict(type='str', required=True, choices=['absent', 'mounted', 'mounted_raw', 'present', 'unmounted']),
         ),
         supports_check_mode=True,
         required_if=(
@@ -689,7 +689,7 @@ def main():
     #   Do not change fstab state, but unmount.
     # present:
     #   Add to fstab, do not change mount state.
-    # mount:
+    # mounted_raw:
     #   Mount only, do not change fstab state.
     # mounted:
     #   Add to fstab if not there and make sure it is mounted. If it has
@@ -725,7 +725,7 @@ def main():
                         msg="Error unmounting %s: %s" % (name, msg))
 
             changed = True
-    elif state == 'mount':
+    elif state == 'mounted_raw':
         if not os.path.exists(name) and not module.check_mode:
             try:
                 os.makedirs(name)

--- a/lib/ansible/modules/system/mount.py
+++ b/lib/ansible/modules/system/mount.py
@@ -66,9 +66,9 @@ options:
       - If C(unmounted), the device will be unmounted without changing
         I(fstab).
       - C(present) only specifies that the device is to be configured in
-        I(fstab_file) and does not trigger or require a mount.
+        I(fstab) and does not trigger or require a mount.
       - C(absent) specifies that the device mount's entry will be removed from
-        I(fstab_file) and will also unmount the device and remove the mount
+        I(fstab) and will also unmount the device and remove the mount
         point.
     required: true
     choices: [ absent, mounted, present, mounted_raw, unmounted ]
@@ -202,7 +202,7 @@ def set_mount(module, args):
         new_line = (
             '%(src)s - %(name)s %(fstype)s %(passno)s %(boot)s %(opts)s\n')
 
-    for line in open(args['fstab_file'], 'r').readlines():
+    for line in open(args['fstab'], 'r').readlines():
         if not line.strip():
             to_write.append(line)
 
@@ -278,7 +278,7 @@ def set_mount(module, args):
         changed = True
 
     if changed and not module.check_mode:
-        write_fstab(module, to_write, args['fstab_file'])
+        write_fstab(module, to_write, args['fstab'])
 
     return (args['name'], changed)
 
@@ -290,7 +290,7 @@ def unset_mount(module, args):
     changed = False
     escaped_name = _escape_fstab(args['name'])
 
-    for line in open(args['fstab_file'], 'r').readlines():
+    for line in open(args['fstab'], 'r').readlines():
         if not line.strip():
             to_write.append(line)
 
@@ -346,7 +346,7 @@ def unset_mount(module, args):
         changed = True
 
     if changed and not module.check_mode:
-        write_fstab(module, to_write, args['fstab_file'])
+        write_fstab(module, to_write, args['fstab'])
 
     return (args['name'], changed)
 
@@ -382,9 +382,9 @@ def mount(module, args):
             module.fail_json(
                 msg=(
                     'OpenBSD does not support alternate fstab files. Do not '
-                    'specify the fstab_file parameter for OpenBSD hosts'))
+                    'specify the fstab parameter for OpenBSD hosts'))
     else:
-        cmd += _set_fstab_args(args['fstab_file'])
+        cmd += _set_fstab_args(args['fstab'])
 
     cmd += [name]
 
@@ -452,7 +452,7 @@ def remount(module, args):
                     'OpenBSD does not support alternate fstab files. Do not '
                     'specify the fstab parameter for OpenBSD hosts'))
     else:
-        cmd += _set_fstab_args(args['fstab_file'])
+        cmd += _set_fstab_args(args['fstab'])
 
     cmd += [args['name']]
     out = err = ''
@@ -612,7 +612,7 @@ def main():
         argument_spec=dict(
             boot=dict(type='bool', default=True),
             dump=dict(type='str'),
-            fstab_file=dict(type='str', aliases=['fstab']),
+            fstab=dict(type='str', aliases=['fstab']),
             fstype=dict(type='str'),
             path=dict(type='path', required=True, aliases=['name']),
             opts=dict(type='str'),
@@ -629,7 +629,7 @@ def main():
     )
 
     # solaris args:
-    #   name, src, fstype, opts, boot, passno, state, fstab_file=/etc/vfstab
+    #   name, src, fstype, opts, boot, passno, state, fstab=/etc/vfstab
     # linux args:
     #   name, src, fstype, opts, dump, passno, state, fstab=/etc/fstab
     # Note: Do not modify module.params['fstab'] as we need to know if the
@@ -639,21 +639,21 @@ def main():
             name=module.params['path'],
             opts='-',
             passno='-',
-            fstab_file=module.params['fstab_file'],
+            fstab=module.params['fstab'],
             boot='yes'
         )
-        if args['fstab_file'] is None:
-            args['fstab_file'] = '/etc/vfstab'
+        if args['fstab'] is None:
+            args['fstab'] = '/etc/vfstab'
     else:
         args = dict(
             name=module.params['path'],
             opts='defaults',
             dump='0',
             passno='0',
-            fstab_file=module.params['fstab_file']
+            fstab=module.params['fstab']
         )
-        if args['fstab_file'] is None:
-            args['fstab_file'] = '/etc/fstab'
+        if args['fstab'] is None:
+            args['fstab'] = '/etc/fstab'
 
         # FreeBSD doesn't have any 'default' so set 'rw' instead
         if get_platform() == 'FreeBSD':
@@ -672,17 +672,17 @@ def main():
                 'Bind mounts might be misinterpreted.')
 
     # Override defaults with user specified params
-    for key in ('src', 'fstype', 'passno', 'opts', 'dump', 'fstab_file'):
+    for key in ('src', 'fstype', 'passno', 'opts', 'dump', 'fstab'):
         if module.params[key] is not None:
             args[key] = module.params[key]
 
     # If fstab file does not exist, we first need to create it. This mainly
-    # happens when fstab_file option is passed to the module.
-    if not os.path.exists(args['fstab_file']):
-        if not os.path.exists(os.path.dirname(args['fstab_file'])):
-            os.makedirs(os.path.dirname(args['fstab_file']))
+    # happens when fstab option is passed to the module.
+    if not os.path.exists(args['fstab']):
+        if not os.path.exists(os.path.dirname(args['fstab'])):
+            os.makedirs(os.path.dirname(args['fstab']))
 
-        open(args['fstab_file'], 'a').close()
+        open(args['fstab'], 'a').close()
 
     # absent:
     #   Remove from fstab and unmounted.


### PR DESCRIPTION
##### SUMMARY
It add a new "mount" option that do not touch the fstab file.
It fixes #19820.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
Module `mount`

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0
  config file = /home/nicolas/Code/floss/ansible/ansible.cfg
  configured module search path = ['/home/nicolas/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/nicolas/Code/floss/ansible/venv/lib/python3.6/site-packages/ansible-2.5.0-py3.6.egg/ansible
  executable location = /home/nicolas/Code/floss/ansible/venv/bin/ansible
  python version = 3.6.4 (default, Jan 17 2018, 12:00:56) [GCC 7.2.1 20170915 (Red Hat 7.2.1-2)]
```