### PR TITLE
Explicitly provided CLI args should not inherit defaults

### DIFF
--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -396,7 +396,8 @@ class CLI(with_metaclass(ABCMeta, object)):
 
     @staticmethod
     def unfrack_paths(option, opt, value, parser):
-        paths = getattr(parser.values, option.dest)
+        # If this callback is executed, we've been given explicit values, ignore the default value
+        paths = [v for v in getattr(parser.values, option.dest) if v not in option.default]
         if paths is None:
             paths = []
 
@@ -407,7 +408,8 @@ class CLI(with_metaclass(ABCMeta, object)):
         else:
             pass  # FIXME: should we raise options error?
 
-        setattr(parser.values, option.dest, paths)
+        # We reverse the list to use the order provided on the CLI
+        setattr(parser.values, option.dest, paths[::-1])
 
     @staticmethod
     def unfrack_path(option, opt, value, parser):

--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -398,18 +398,25 @@ class CLI(with_metaclass(ABCMeta, object)):
     def unfrack_paths(option, opt, value, parser):
         # If this callback is executed, we've been given explicit values, ignore the default value
         paths = [v for v in getattr(parser.values, option.dest) if v not in option.default]
+
+        # If this is the first pass option.default is populated, ensure value is in paths and empty option.default
+        if option.default:
+            if value not in paths:
+                paths.append(value)
+            option.default[:] = []
+
         if paths is None:
             paths = []
 
+        # We reverse the lists to we end up with the order provided at the end
         if isinstance(value, string_types):
-            paths[:0] = [unfrackpath(x) for x in value.split(os.pathsep) if x]
+            paths.extend([unfrackpath(x) for x in value.split(os.pathsep) if x and unfrackpath(x) not in paths][::-1])
         elif isinstance(value, list):
-            paths[:0] = [unfrackpath(x) for x in value if x]
+            paths.extend([unfrackpath(x) for x in value if x and unfrackpath(x) not in paths][::-1])
         else:
             pass  # FIXME: should we raise options error?
 
-        # We reverse the list to use the order provided on the CLI
-        setattr(parser.values, option.dest, paths[::-1])
+        setattr(parser.values, option.dest, paths)
 
     @staticmethod
     def unfrack_path(option, opt, value, parser):


### PR DESCRIPTION
##### SUMMARY
Explicitly provided CLI args, that use the `CLI.unfrack_paths` callback, implicitly inherit the default values, which is unexpected.

Any explicitly provided values, should overwrite the defaults.

This PR aligns the behavior with standard CLI parsing expectations.

This is noticeable in the example of `-p` for `ansible-galaxy` where providing `-p ./roles` would effectively result in:

```
['./roles', '~/.ansible/roles', '/usr/share/ansible/roles', '/etc/ansible/roles']
```

Instead of just:

```
['./roles']
```

This PR adjusts that, and also allows any CLI arg using `CLI.unfrack_paths` to be used multiple times such as `-p ./roles -p /etc/ansible/roles` in addition to `-p ./roles:/etc/ansible/roles`

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/cli/__init__.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.4
2.5
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```