### PR TITLE
improved test coverage for vyos_config

### DIFF
--- a/test/integration/targets/vyos_config/tests/cli/check_config.yaml
+++ b/test/integration/targets/vyos_config/tests/cli/check_config.yaml
@@ -1,9 +1,33 @@
 ---
 - debug: msg="START cli/config_check.yaml on connection={{ ansible_connection }}"
 
-- name: setup
+- name: setup- ensure interface is not present
   vyos_config:
-    lines: set interfaces loopback lo description test
+    lines: delete interfaces loopback lo
+
+- name: setup- create interface
+  vyos_config:
+    lines:
+      - interfaces
+      - interfaces loopback lo
+      - interfaces loopback lo description test
+  register: result
+
+# note collapsing the duplicate lines doesn't work if
+# lines:
+#   - interfaces loopback lo description test
+#   - interfaces loopback lo
+#   - interfaces
+
+- name: Check that multiple duplicate lines collapse into a single commands
+  assert:
+    that:
+      - "{{ result.commands|length }} == 1"
+
+- name: Check that set is correctly prepended
+  assert:
+    that:
+      - "result.commands[0] == 'set interfaces loopback lo description test'"
 
 - name: configure config_check config command
   vyos_config:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Expands vyos_config integration test coverage to hit https://github.com/ansible/ansible/blob/devel/lib/ansible/modules/network/vyos/vyos_config.py#L150.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Test pull request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
- vyos_config

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (vyos_config_coverage 0d7af9461f) last updated 2018/01/24 12:02:09 (GMT -400)
  config file = None
  configured module search path = ['/Users/david/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/david/code/ansible/lib/ansible
  executable location = /Users/david/code/ansible/bin/ansible
  python version = 3.6.4 (default, Jan  6 2018, 11:51:59) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
