### PR TITLE
[ec2_vpc_net_facts] Fix UnsupportedOperation for regions other than u…

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_net_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_net_facts.py
@@ -135,6 +135,7 @@ vpcs:
 '''
 
 import traceback
+from ansible.module_utils._text import to_native
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ec2 import (
     boto3_conn,
@@ -185,7 +186,11 @@ def describe_vpcs(connection, module):
     try:
         response = connection.describe_vpcs(VpcIds=vpc_ids, Filters=filters)
     except botocore.exceptions.ClientError as e:
-        module.fail_json(msg=e.message, exception=traceback.format_exc(), **camel_dict_to_snake_dict(e.response))
+        module.fail_json(msg="Unable to describe VPCs {0}: {1}".format(vpc_ids, to_native(e)),
+                         exception=traceback.format_exc(), **camel_dict_to_snake_dict(e.response))
+    except botocore.exceptions.BotoCoreError as e:
+        module.fail_json(msg="Unable to describe VPCs {0}: {1}".format(vpc_ids, to_native(e)),
+                         exception=traceback.format_exc())
 
     # Loop through results and create a list of VPC IDs
     for vpc in response['Vpcs']:
@@ -198,7 +203,11 @@ def describe_vpcs(connection, module):
         if e.response["Error"]["Message"] == "The functionality you requested is not available in this region.":
             cl_enabled = {'Vpcs': [{'VpcId': vpc_id, 'ClassicLinkEnabled': False} for vpc_id in vpc_list]}
         else:
-            module.fail_json(msg=e.message, exception=traceback.format_exc(), **camel_dict_to_snake_dict(e.response))
+            module.fail_json(msg="Unable to describe if ClassicLink is enabled: {0}".format(to_native(e)),
+                             exception=traceback.format_exc(), **camel_dict_to_snake_dict(e.response))
+    except botocore.exceptions.BotoCoreError as e:
+        module.fail_json(msg="Unable to describe if ClassicLink is enabled: {0}".format(to_native(e)),
+                         exception=traceback.format_exc())
 
     try:
         cl_dns_support = connection.describe_vpc_classic_link_dns_support(VpcIds=vpc_list)
@@ -206,20 +215,32 @@ def describe_vpcs(connection, module):
         if e.response["Error"]["Message"] == "The functionality you requested is not available in this region.":
             cl_dns_support = {'Vpcs': [{'VpcId': vpc_id, 'ClassicLinkDnsSupported': False} for vpc_id in vpc_list]}
         else:
-            module.fail_json(msg=e.message, exception=traceback.format_exc(), **camel_dict_to_snake_dict(e.response))
+            module.fail_json(msg="Unable to describe if ClassicLinkDns is supported: {0}".format(to_native(e)),
+                             exception=traceback.format_exc(), **camel_dict_to_snake_dict(e.response))
+    except botocore.exceptions.BotoCoreError as e:
+        module.fail_json(msg="Unable to describe if ClassicLinkDns is supported: {0}".format(to_native(e)),
+                         exception=traceback.format_exc())
 
     # Loop through the results and add the other VPC attributes we gathered
     for vpc in response['Vpcs']:
+        error_message = "Unable to describe VPC attribute {0}: {1}"
         # We have to make two separate calls per VPC to get these attributes.
         try:
             dns_support = describe_vpc_attr_with_backoff(connection, vpc['VpcId'], 'enableDnsSupport')
         except botocore.exceptions.ClientError as e:
-            module.fail_json(msg=e.message, exception=traceback.format_exc(), **camel_dict_to_snake_dict(e.response))
-
+            module.fail_json(msg=error_message.format('enableDnsSupport', to_native(e)),
+                             exception=traceback.format_exc(), **camel_dict_to_snake_dict(e.response))
+        except botocore.exceptions.BotoCoreError as e:
+            module.fail_json(msg=error_message.format('enableDnsSupport', to_native(e)),
+                             exception=traceback.format_exc())
         try:
             dns_hostnames = describe_vpc_attr_with_backoff(connection, vpc['VpcId'], 'enableDnsHostnames')
         except botocore.exceptions.ClientError as e:
-            module.fail_json(msg=e.message, exception=traceback.format_exc(), **camel_dict_to_snake_dict(e.response))
+            module.fail_json(msg=error_message.format('enableDnsHostnames', to_native(e)),
+                             exception=traceback.format_exc(), **camel_dict_to_snake_dict(e.response))
+        except botocore.exceptions.BotoCoreError as e:
+            module.fail_json(msg=error_message.format('enableDnsHostnames', to_native(e)),
+                             exception=traceback.format_exc())
 
         # loop through the ClassicLink Enabled results and add the value for the correct VPC
         for item in cl_enabled['Vpcs']:
@@ -256,14 +277,7 @@ def main():
         module.fail_json(msg='boto3 and botocore are required for this module')
 
     region, ec2_url, aws_connect_params = get_aws_connection_info(module, boto3=True)
-
-    if region:
-        try:
-            connection = boto3_conn(module, conn_type='client', resource='ec2', region=region, endpoint=ec2_url, **aws_connect_params)
-        except (botocore.exceptions.NoCredentialsError, botocore.exceptions.ProfileNotFound) as e:
-            module.fail_json(msg=e.message, exception=traceback.format_exc(), **camel_dict_to_snake_dict(e.response))
-    else:
-        module.fail_json(msg="region must be specified")
+    connection = boto3_conn(module, conn_type='client', resource='ec2', region=region, endpoint=ec2_url, **aws_connect_params)
 
     describe_vpcs(connection, module)
 

--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_net_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_net_facts.py
@@ -193,20 +193,20 @@ def describe_vpcs(connection, module):
 
     # We can get these results in bulk but still needs two separate calls to the API
     try:
-        if connection._client_config.region_name != 'us-east-1':
+        cl_enabled = connection.describe_vpc_classic_link(VpcIds=vpc_list)
+    except botocore.exceptions.ClientError as e:
+        if e.response["Error"]["Message"] == "The functionality you requested is not available in this region.":
             cl_enabled = {'Vpcs': [{'VpcId': vpc_id, 'ClassicLinkEnabled': False} for vpc_id in vpc_list]}
         else:
-            cl_enabled = connection.describe_vpc_classic_link(VpcIds=vpc_list)
-    except botocore.exceptions.ClientError as e:
-        module.fail_json(msg=e.message, exception=traceback.format_exc(), **camel_dict_to_snake_dict(e.response))
+            module.fail_json(msg=e.message, exception=traceback.format_exc(), **camel_dict_to_snake_dict(e.response))
 
     try:
-        if connection._client_config.region_name != 'us-east-1':
+        cl_dns_support = connection.describe_vpc_classic_link_dns_support(VpcIds=vpc_list)
+    except botocore.exceptions.ClientError as e:
+        if e.response["Error"]["Message"] == "The functionality you requested is not available in this region.":
             cl_dns_support = {'Vpcs': [{'VpcId': vpc_id, 'ClassicLinkDnsSupported': False} for vpc_id in vpc_list]}
         else:
-            cl_dns_support = connection.describe_vpc_classic_link_dns_support(VpcIds=vpc_list)
-    except botocore.exceptions.ClientError as e:
-        module.fail_json(msg=e.message, exception=traceback.format_exc(), **camel_dict_to_snake_dict(e.response))
+            module.fail_json(msg=e.message, exception=traceback.format_exc(), **camel_dict_to_snake_dict(e.response))
 
     # Loop through the results and add the other VPC attributes we gathered
     for vpc in response['Vpcs']:

--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_net_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_net_facts.py
@@ -193,12 +193,18 @@ def describe_vpcs(connection, module):
 
     # We can get these results in bulk but still needs two separate calls to the API
     try:
-        cl_enabled = connection.describe_vpc_classic_link(VpcIds=vpc_list)
+        if connection._client_config.region_name != 'us-east-1':
+            cl_enabled = {'Vpcs': [{'VpcId': vpc_id, 'ClassicLinkEnabled': False} for vpc_id in vpc_list]}
+        else:
+            cl_enabled = connection.describe_vpc_classic_link(VpcIds=vpc_list)
     except botocore.exceptions.ClientError as e:
         module.fail_json(msg=e.message, exception=traceback.format_exc(), **camel_dict_to_snake_dict(e.response))
 
     try:
-        cl_dns_support = connection.describe_vpc_classic_link_dns_support(VpcIds=vpc_list)
+        if connection._client_config.region_name != 'us-east-1':
+            cl_dns_support = {'Vpcs': [{'VpcId': vpc_id, 'ClassicLinkDnsSupported': False} for vpc_id in vpc_list]}
+        else:
+            cl_dns_support = connection.describe_vpc_classic_link_dns_support(VpcIds=vpc_list)
     except botocore.exceptions.ClientError as e:
         module.fail_json(msg=e.message, exception=traceback.format_exc(), **camel_dict_to_snake_dict(e.response))
 


### PR DESCRIPTION
…s-east-1

##### SUMMARY
Fixes 
```
  tasks:
    - name: test Frankfurt VPC
      ec2_vpc_net_facts:
        profile: shertel
        region: eu-central-1
        filters:
          "tag:Name": "AnsibleTest"
```
```
Traceback (most recent call last):
  File "/var/folders/by/k8_fbl593dlctgqmwq5wzl2c0000gn/T/ansible_2ycJ8S/ansible_module_ec2_vpc_net_facts.py", line 196, in describe_vpcs
    cl_enabled = connection.describe_vpc_classic_link(VpcIds=vpc_list)
  File "/Users/shertel/Workspace/ansible/venv/python2.7/lib/python2.7/site-packages/botocore/client.py", line 317, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/Users/shertel/Workspace/ansible/venv/python2.7/lib/python2.7/site-packages/botocore/client.py", line 615, in _make_api_call
    raise error_class(parsed_response, operation_name)
ClientError: An error occurred (UnsupportedOperation) when calling the DescribeVpcClassicLink operation: The functionality you requested is not available in this region.
```
After fix:
```
ok: [localhost] => {
    "attempts": 1,
    "changed": false,
    "failed": false,
    "invocation": {
        "module_args": {
            "aws_access_key": null,
            "aws_secret_key": null,
            "ec2_url": null,
            "filters": {
                "tag:Name": "AnsibleTest"
            },
            "profile": "shertel",
            "region": "eu-central-1",
            "security_token": null,
            "validate_certs": true,
            "vpc_ids": []
        }
    },
    "vpcs": [
        {
            "cidr_block": "10.0.0.0/16",
            "cidr_block_association_set": [
                {
                    "association_id": "vpc-cidr-assoc-40ca1928",
                    "cidr_block": "10.0.0.0/16",
                    "cidr_block_state": {
                        "state": "associated"
                    }
                }
            ],
            "classic_link_dns_supported": false,
            "classic_link_enabled": false,
            "dhcp_options_id": "dopt-d034d7b8",
            "enable_dns_hostnames": true,
            "enable_dns_support": true,
            "id": "vpc-7afb2811",
            "instance_tenancy": "default",
            "is_default": false,
            "state": "available",
            "tags": {
                "Name": "AnsibleTest"
            },
            "vpc_id": "vpc-7afb2811"
        }
    ]
}
META: ran handlers
META: ran handlers

PLAY RECAP ***********************************************************************************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=0
```

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/ec2_vpc_net_facts.py

##### ANSIBLE VERSION
```
2.5.0
```