### PR TITLE
[WIP] add s3ql support

### DIFF
--- a/lib/ansible/modules/system/filesystem.py
+++ b/lib/ansible/modules/system/filesystem.py
@@ -22,7 +22,7 @@ description:
 version_added: "1.2"
 options:
   fstype:
-    choices: [ btrfs, ext2, ext3, ext4, ext4dev, lvm, reiserfs, xfs ]
+    choices: [ btrfs, ext2, ext3, ext4, ext4dev, lvm, reiserfs, xfs, s3ql ]
     description:
     - Filesystem type to be created.
     - reiserfs support was added in 2.2.
@@ -227,6 +227,11 @@ class LVM(Filesystem):
         return block_count
 
 
+class S3QL(Filesystem):
+    MKSF = 'mkfs.s3ql --plain'
+    MKFS_FORCE_FLAGS = '--force'
+
+
 FILESYSTEMS = {
     'ext2': Ext2,
     'ext3': Ext3,
@@ -236,6 +241,7 @@ FILESYSTEMS = {
     'xfs': XFS,
     'btrfs': Btrfs,
     'LVM2_member': LVM,
+    's3ql': S3QL,
 }
 
 


### PR DESCRIPTION
##### SUMMARY
Add support for [S3QL](http://www.rath.org/s3ql-docs/mkfs.html), which is a file system that stores all its data online using storage services like Google Storage, Amazon S3, or OpenStack.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
Module FileSystem.

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0
  config file = /home/nicolas/Code/floss/ansible/ansible.cfg
  configured module search path = ['/home/nicolas/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/nicolas/Code/floss/ansible/venv/lib/python3.6/site-packages/ansible-2.5.0-py3.6.egg/ansible
  executable location = /home/nicolas/Code/floss/ansible/venv/bin/ansible
  python version = 3.6.4 (default, Jan 17 2018, 12:00:56) [GCC 7.2.1 20170915 (Red Hat 7.2.1-2)]
```


##### ADDITIONAL INFORMATION
The `--plain` argument is passed to `mkfs.s3ql` because without it, it
tries to create an encrypted file system and ask for the passphrase.
Since there is currently no way to specify the passphrase in an argument
(and explicitly does not take the one in config file), we can only create
unencrypted file system for the moment.
