### PR TITLE
Integration tests for influxdb_user module

### DIFF
--- a/test/integration/targets/influxdb_user/aliases
+++ b/test/integration/targets/influxdb_user/aliases
@@ -1,0 +1,5 @@
+destructive
+posix/ci/group1
+skip/osx
+skip/freebsd
+skip/rhel

--- a/test/integration/targets/influxdb_user/meta/main.yml
+++ b/test/integration/targets/influxdb_user/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - setup_influxdb

--- a/test/integration/targets/influxdb_user/tasks/main.yml
+++ b/test/integration/targets/influxdb_user/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+
+- include: tests.yml
+  when: ansible_distribution == 'Ubuntu' and ansible_distribution_release == 'trusty'

--- a/test/integration/targets/influxdb_user/tasks/tests.yml
+++ b/test/integration/targets/influxdb_user/tasks/tests.yml
@@ -1,0 +1,48 @@
+---
+
+- name: Install influxdb python module
+  pip: name=influxdb
+
+- name: Check adding admin user
+  block:
+    - name: Add admin user
+      influxdb_user: user_name=admin user_password=admin admin=yes
+      register: add_admin_user
+
+    - name: Check that admin user adding succeeds with a change
+      assert:
+        that:
+          - add_admin_user.changed == true
+
+- name: Enable authentication and restart service
+  block:
+    - name: Enable authentication
+      lineinfile:
+        path: /etc/influxdb/influxdb.conf
+        regexp: 'auth-enabled ='
+        line: '  auth-enabled = true'
+
+    - name: Restart InfluxDB service
+      service: name=influxdb state=restarted
+
+- name: Check adding user when authentication enabled
+  block:
+    - name: Add user
+      influxdb_user: user_name=user user_password=user login_username=admin login_password=admin
+      register: add_user_with_auth_enabled
+
+    - name: Check that adding user with enabled authentication succeeds with a change
+      assert:
+        that:
+          - add_user_with_auth_enabled.changed == true
+
+- name: Check adding the same user
+  block:
+    - name: Add the same user
+      influxdb_user: user_name=user user_password=user login_username=admin login_password=admin
+      register: same_user
+
+    - name: Check that adding same user succeeds without a change
+      assert:
+        that:
+          - same_user.changed == false

--- a/test/integration/targets/influxdb_user/tasks/tests.yml
+++ b/test/integration/targets/influxdb_user/tasks/tests.yml
@@ -3,7 +3,19 @@
 - name: Install influxdb python module
   pip: name=influxdb
 
-- name: Check adding admin user
+- name: Test add admin user in check mode
+  block:
+    - name: Add admin user
+      influxdb_user: user_name=admin user_password=admin admin=yes
+      check_mode: true
+      register: add_admin_user
+
+    - name: Check that admin user adding succeeds with a change
+      assert:
+        that:
+          - add_admin_user.changed == true
+
+- name: Test add admin user
   block:
     - name: Add admin user
       influxdb_user: user_name=admin user_password=admin admin=yes
@@ -13,6 +25,17 @@
       assert:
         that:
           - add_admin_user.changed == true
+
+- name: Test add admin user idempotence
+  block:
+    - name: Add admin user
+      influxdb_user: user_name=admin user_password=admin admin=yes
+      register: add_admin_user
+
+    - name: Check that admin user adding succeeds without a change
+      assert:
+        that:
+          - add_admin_user.changed == false
 
 - name: Enable authentication and restart service
   block:
@@ -25,7 +48,19 @@
     - name: Restart InfluxDB service
       service: name=influxdb state=restarted
 
-- name: Check adding user when authentication enabled
+- name: Test add user in check mode when authentication enabled
+  block:
+    - name: Add user
+      influxdb_user: user_name=user user_password=user login_username=admin login_password=admin
+      check_mode: true
+      register: add_user_with_auth_enabled
+
+    - name: Check that adding user with enabled authentication succeeds with a change
+      assert:
+        that:
+          - add_user_with_auth_enabled.changed == true
+
+- name: Test add user when authentication enabled
   block:
     - name: Add user
       influxdb_user: user_name=user user_password=user login_username=admin login_password=admin
@@ -36,7 +71,7 @@
         that:
           - add_user_with_auth_enabled.changed == true
 
-- name: Check adding the same user
+- name: Test add user when authentication enabled idempotence
   block:
     - name: Add the same user
       influxdb_user: user_name=user user_password=user login_username=admin login_password=admin

--- a/test/integration/targets/setup_influxdb/tasks/main.yml
+++ b/test/integration/targets/setup_influxdb/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+
+- include: setup.yml
+  when: ansible_distribution == 'Ubuntu' and ansible_distribution_release == 'trusty'

--- a/test/integration/targets/setup_influxdb/tasks/setup.yml
+++ b/test/integration/targets/setup_influxdb/tasks/setup.yml
@@ -1,0 +1,26 @@
+---
+
+- name: Install https transport for apt and ca-certificates
+  apt: name={{ item }} state=latest force=yes
+  with_items:
+    - apt-transport-https
+    - ca-certificates
+
+- name: Install apt_key dependencies
+  pip: name={{ item }}
+  with_items:
+    - pyOpenSSL
+    - ndg-httpsclient
+    - pyasn1
+
+- name: Add InfluxDB public GPG key
+  apt_key: url=https://repos.influxdata.com/influxdb.key state=present
+
+- name: Add InfluxDB repository
+  apt_repository: repo='deb https://repos.influxdata.com/ubuntu trusty stable' filename='influxdb' state=present update_cache=yes
+
+- name: Install InfluxDB
+  apt: name=influxdb state=latest
+
+- name: Start InfluxDB service
+  service: name=influxdb state=started


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
In this PR I've added integration tests for influxdb_user module.
For simplicity, I run tests only on Ubuntu 14.04 (as [zabbix_host](https://github.com/ansible/ansible/blob/devel/test/integration/targets/zabbix_host/tasks/main.yml#L4) tests does).

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
influxdb_user

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (3237-change-rabbitmq-user-password-without-force 4cdda0d9a3) last updated 2018/01/23 21:56:35 (GMT +300)
  config file = /home/art/.ansible.cfg
  configured module search path = [u'/home/art/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/art/projects/github/ansible/lib/ansible
  executable location = /home/art/projects/github/ansible/bin/ansible
  python version = 2.7.12 (default, Nov 20 2017, 18:23:56) [GCC 5.4.0 20160609]
```

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```