### PR TITLE
Remove 'attempts' from non-looped tasks

### DIFF
--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -577,7 +577,7 @@ class TaskExecutor:
                     result['failed'] = False
 
             # Make attempts and retries available early to allow their use in changed/failed_when
-            if retries > 1:
+            if self._task.until:
                 result['attempts'] = attempt
 
             # set the changed property if it was missing.

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -577,7 +577,8 @@ class TaskExecutor:
                     result['failed'] = False
 
             # Make attempts and retries available early to allow their use in changed/failed_when
-            result['attempts'] = attempt
+            if retries > 1:
+                result['attempts'] = attempt
 
             # set the changed property if it was missing.
             if 'changed' not in result:

--- a/test/integration/targets/win_find/tasks/tests.yml
+++ b/test/integration/targets/win_find/tasks/tests.yml
@@ -25,7 +25,6 @@
 - name: set expected value for files in a single directory
   set_fact:
     expected:
-      attempts: 1
       changed: False
       examined: 5
       failed: False
@@ -109,7 +108,6 @@
 - name: set fact for hidden files
   set_fact:
     expected:
-      attempts: 1
       changed: False
       examined: 11
       failed: False
@@ -152,7 +150,6 @@
 - name: set fact for pattern files
   set_fact:
     expected:
-      attempts: 1
       changed: False
       examined: 5
       failed: False
@@ -191,7 +188,6 @@
 - name: set expected value for files in a nested directory
   set_fact:
     expected:
-      attempts: 1
       changed: False
       examined: 8
       failed: False
@@ -261,7 +257,6 @@
 - name: set expected value for files in a nested directory while following links
   set_fact:
     expected:
-      attempts: 1
       changed: False
       examined: 10
       failed: False
@@ -345,7 +340,6 @@
 - name: set expected fact for directories with recurse and follow
   set_fact:
     expected:
-      attempts: 1
       changed: False
       examined: 2
       failed: False
@@ -411,7 +405,6 @@
 - name: set expected fact for files by size
   set_fact:
     expected:
-      attempts: 1
       changed: False
       examined: 5
       failed: False
@@ -455,7 +448,6 @@
 - name: set expected fact for files by size (less than)
   set_fact:
     expected:
-      attempts: 1
       changed: False
       examined: 5
       failed: False

--- a/test/integration/targets/win_reg_stat/tasks/main.yml
+++ b/test/integration/targets/win_reg_stat/tasks/main.yml
@@ -50,7 +50,6 @@
 - name: set expected value for reg structure
   set_fact:
     expected:
-      attempts: 1
       changed: false
       exists: true
       failed: false
@@ -79,7 +78,6 @@
 - name: set expected value for reg key with no sub keys but some properties
   set_fact:
     expected:
-      attempts: 1
       changed: false
       exists: true
       failed: false
@@ -103,7 +101,6 @@
 - name: set expected value for reg key without sub keys or properties
   set_fact:
     expected:
-      attempts: 1
       changed: false
       exists: true
       failed: false
@@ -124,7 +121,6 @@
 - name: set expected value for non-existent reg key
   set_fact:
     expected:
-      attempts: 1
       changed: false
       exists: false
       failed: false
@@ -143,7 +139,6 @@
 - name: set expected string property
   set_fact:
     expected:
-      attempts: 1
       changed: false
       exists: true
       failed: false
@@ -165,7 +160,6 @@
 - name: set expected expand string property
   set_fact:
     expected:
-      attempts: 1
       changed: false
       exists: true
       failed: false
@@ -187,7 +181,6 @@
 - name: set expected multi string property
   set_fact:
     expected:
-      attempts: 1
       changed: false
       exists: true
       failed: false
@@ -209,7 +202,6 @@
 - name: set expected binary property
   set_fact:
     expected:
-      attempts: 1
       changed: false
       exists: true
       failed: false
@@ -231,7 +223,6 @@
 - name: set expected dword property
   set_fact:
     expected:
-      attempts: 1
       changed: false
       exists: true
       failed: false
@@ -253,7 +244,6 @@
 - name: set expected qword property
   set_fact:
     expected:
-      attempts: 1
       changed: false
       exists: true
       failed: false
@@ -275,7 +265,6 @@
 - name: set expected none property
   set_fact:
     expected:
-      attempts: 1
       changed: false
       exists: true
       failed: false
@@ -297,7 +286,6 @@
 - name: set expected none with value property
   set_fact:
     expected:
-      attempts: 1
       changed: false
       exists: true
       failed: false
@@ -319,7 +307,6 @@
 - name: set expected non-existence property
   set_fact:
     expected:
-      attempts: 1
       changed: false
       exists: false
       failed: false


### PR DESCRIPTION
##### SUMMARY
Without this change, every task will expose `attempts: 1` in the task results, even when not looping.

This was introduced in #34148

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
task_executor

##### ANSIBLE VERSION
v2.5

##### STEPS TO REPRODUCE
This is the output when running the ping module:
```
[dag@moria ansible.git]$ ansible -m ping -C localhost
localhost | SUCCESS => {
    "attempts": 1, 
    "changed": false, 
    "failed": false, 
    "ping": "pong"
}
```