### PR TITLE
Sort arguments and return values in module docs

### DIFF
--- a/docs/templates/plugin.rst.j2
+++ b/docs/templates/plugin.rst.j2
@@ -98,7 +98,7 @@ Options
             {% endif %}
             <th class="head"><div class="cell-border">comments</div></th>
         </tr>
-        {% for key, value in options.items() recursive %}
+        {% for key, value in options|dictsort recursive %}
             <tr class="return-value-column">
                 {# parameter name with introduced label #}
                 <td>
@@ -221,7 +221,7 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
             <th class="head"><div class="cell-border">type</div></th>
             <th class="head"><div class="cell-border">sample</div></th>
         </tr>
-        {% for key, value in returndocs.items() recursive %}
+        {% for key, value in returndocs|dictsort recursive %}
             <tr class="return-value-column">
                 <td>
                     <div class="outer-elbow-container">


### PR DESCRIPTION
##### SUMMARY
Comparing the old module docs, with the devel docs the
options/arguments/parameters are no longer sorted.

Also, both in the old module docs and the devel docs the result values
are not sorted where they probably should.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
module docs

##### ANSIBLE VERSION
v2.5