### PR TITLE
[wip] Roles path unfrack cli

### DIFF
--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -335,8 +335,6 @@ class CLI(with_metaclass(ABCMeta, object)):
             if op.forks < 1:
                 self.parser.error("The number of processes (--forks) must be >= 1")
 
-        return op
-
     @abstractmethod
     def init_parser(self, usage="", desc=None, epilog=None):
         """

--- a/lib/ansible/cli/arguments/optparse_helpers.py
+++ b/lib/ansible/cli/arguments/optparse_helpers.py
@@ -77,17 +77,15 @@ class InvalidOptsParser(SortedOptParser):
 
 def unfrack_paths(option, opt, value, parser):
     """Turn an Option's value into a list of paths in Ansible locations"""
-    paths = getattr(parser.values, option.dest)
-    if paths is None:
-        paths = []
+    paths = getattr(parser.values, option.dest, None) or []
+    new_cli_paths = value
 
     if isinstance(value, string_types):
-        paths[:0] = [unfrackpath(x) for x in value.split(os.pathsep) if x]
-    elif isinstance(value, list):
-        paths[:0] = [unfrackpath(x) for x in value if x]
-    else:
-        pass  # FIXME: should we raise options error?
+        new_cli_paths = value.split(os.pathsep)
 
+    # add here to get a new paths instance containing the new ones
+    # This avoids clobbering the instance the Option default points to
+    paths = paths + [unfrackpath(x) for x in new_cli_paths if x]
     setattr(parser.values, option.dest, paths)
 
 

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -110,7 +110,7 @@ class GalaxyCLI(CLI):
         if self.action not in ("delete", "import", "init", "login", "setup"):
             # NOTE: while the option type=str, the default is a list, and the
             # callback will set the value to a list.
-            self.parser.add_option('-p', '--roles-path', dest='roles_path', action="callback", callback=opt_help.unfrack_paths, default=C.DEFAULT_ROLES_PATH,
+            self.parser.add_option('-p', '--roles-path', dest='roles_path', action="callback", callback=opt_help.unfrack_paths, default=[],
                                    help='The path to the directory containing your roles. The default is the roles_path configured in your ansible.cfg'
                                         ' file (/etc/ansible/roles if not configured)', type='str')
         if self.action in ("init", "install"):
@@ -261,7 +261,7 @@ class GalaxyCLI(CLI):
             # the user needs to specify a role
             raise AnsibleOptionsError("- you must specify a user/role name")
 
-        roles_path = context.CLIARGS['roles_path']
+        roles_path = context.CLIARGS['roles_path'] or C.DEFAULT_ROLES_PATH
 
         data = ''
         for role in context.CLIARGS['args']:
@@ -469,7 +469,7 @@ class GalaxyCLI(CLI):
                 display.display("- the role %s was not found" % name)
         else:
             # show all valid roles in the roles_path directory
-            roles_path = context.CLIARGS['roles_path']
+            roles_path = context.CLIARGS['roles_path'] or C.DEFAULT_ROLES_PATH
             path_found = False
             warnings = []
             for path in roles_path:

--- a/lib/ansible/galaxy/__init__.py
+++ b/lib/ansible/galaxy/__init__.py
@@ -26,6 +26,7 @@ __metaclass__ = type
 import os
 
 from ansible import context
+import ansible.constants as C
 from ansible.errors import AnsibleError
 from ansible.module_utils.six import string_types
 
@@ -39,7 +40,7 @@ class Galaxy(object):
     def __init__(self):
 
         # roles_path needs to be a list and will be by default
-        roles_path = context.CLIARGS.get('roles_path', tuple())
+        roles_path = context.CLIARGS.get('roles_path', None) or C.DEFAULT_ROLES_PATH
         # cli option handling is responsible for splitting roles_path
         self.roles_paths = roles_path
 


### PR DESCRIPTION
##### SUMMARY
Dont clobber Option default in unfrack_paths callback

one way to fix 'ansible-galaxy list -p some_path -p some_other_path' not overriding
config default

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
lib/ansible/cli/__init__.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (roles_path_unfrack_cli 61849bf902) last updated 2018/01/24 18:24:29 (GMT -400)
  config file = /home/adrian/src/ansible/ansible.cfg
  configured module search path = [u'/home/adrian/ansible/my-modules']
  ansible python module location = /home/adrian/src/ansible/lib/ansible
  executable location = /home/adrian/src/ansible/bin/ansible
  python version = 2.7.14 (default, Jan 17 2018, 14:28:32) [GCC 7.2.1 20170915 (Red Hat 7.2.1-2)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
