### PR TITLE
Fixed snapshot module, Resource not found issue for persistent-disk-0

### DIFF
--- a/lib/ansible/modules/cloud/google/gce_snapshot.py
+++ b/lib/ansible/modules/cloud/google/gce_snapshot.py
@@ -192,9 +192,11 @@ def main():
 
     for instance_disk in instance_disks:
         disk_snapshot_name = snapshot_name
-        device_name = instance_disk['deviceName']
+        disk_info = gce._get_components_from_path(instance_disk['source'])
+        device_name = disk_info['name']
+        device_zone = disk_info['zone']
         if disks is None or device_name in disks:
-            volume_obj = gce.ex_get_volume(device_name)
+            volume_obj = gce.ex_get_volume(device_name, device_zone)
 
             # If we have more than one disk to snapshot, prepend the disk name
             if len(instance_disks) > 1:


### PR DESCRIPTION
##### SUMMARY
When gce_snapshot module calls gce.ex_get_node("instance_name", 'all') to collect instance info.
It returns the disks dict with deviceName as "persistent-disk-0" (Maybe a bug/expected behavior from google api response)
Actual disk name is not "persistent-disk-0", it is "test-disk-000" as seen in source link.
Check below google api response:
```
  "disks": [
    {
      "autoDelete": true,
      "boot": true,
      "deviceName": "persistent-disk-0",
      "index": 0,
      "interface": "SCSI",
      "kind": "compute#attachedDisk",
      "licenses": [
        "projects/centos-cloud/global/licenses/centos-7"
      ],
      "mode": "READ_WRITE",
      "source": "projects/cloud-sandbox-1162/zones/us-central1-a/disks/test-disk-000",
      "type": "PERSISTENT"
    }
  ]
```
gce_snapshot module was trying to take snapshot of deviceName i.e. "persistent-disk-0",
It failed with below issue as "persistent-disk-0" was not present in reality.
Hence now we take snapshot using source link device name. 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
gce_snapshot

##### ANSIBLE VERSION
```
ansible 2.4.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/centos/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Aug  4 2017, 00:39:18) [GCC 4.8.5 20150623 (Red Hat 4.8.5-16)]
```


##### ADDITIONAL INFORMATION
Reference issue: https://github.com/ansible/ansible/issues/35266