### PR TITLE
NPM integration tests: use ansible-ci-files

### DIFF
--- a/test/integration/targets/npm/tasks/setup.yml
+++ b/test/integration/targets/npm/tasks/setup.yml
@@ -1,6 +1,6 @@
 - name: 'Download NPM'
   unarchive:
-    src: 'https://nodejs.org/dist/v{{ nodejs_version }}/{{ nodejs_path }}.tar.gz'
+    src: 'https://ansible-ci-files.s3.amazonaws.com/test/integration/targets/npm/{{ nodejs_path }}.tar.gz'
     dest: '{{ output_dir }}'
     remote_src: yes
     creates: '{{ output_dir }}/{{ nodejs_path }}.tar.gz'


### PR DESCRIPTION
##### SUMMARY

NPM integration tests: use `https://ansible-ci-files.s3.amazonaws.com` instead of `https://nodejs.org` in order to avoid network failure. This has been discussed at testing working group meeting ([2018-01-25](https://meetbot-raw.fedoraproject.org/ansible-meeting/2018-01-25/ansible_testing_working_group.2018-01-25-17.00.log.html#l-31)).

Network failure occurred there:
- https://github.com/ansible/ansible/pull/35167#issuecomment-359403713

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
npm

##### ANSIBLE VERSION
```
2.5.0
```