### PR TITLE
Add transfer checksum verification in copy module

### DIFF
--- a/lib/ansible/modules/files/copy.py
+++ b/lib/ansible/modules/files/copy.py
@@ -87,6 +87,7 @@ options:
     description:
       - SHA1 checksum of the file being transferred. Used to valdiate that the copy of the file was successful.
       - If this is not provided, ansible will use the local calculated checksum of the src file.
+    version_added: '2.5'
 extends_documentation_fragment:
     - files
     - validate

--- a/lib/ansible/modules/files/copy.py
+++ b/lib/ansible/modules/files/copy.py
@@ -83,6 +83,10 @@ options:
     type: bool
     default: 'yes'
     version_added: "2.4"
+  checksum:
+    description:
+      - SHA1 checksum of the file being transferred. Used to valdiate that the copy of the file was successful.
+      - If this is not provided, ansible will use the local calculated checksum of the src file.
 extends_documentation_fragment:
     - files
     - validate
@@ -265,6 +269,7 @@ def main():
             directory_mode=dict(type='raw'),
             remote_src=dict(type='bool'),
             local_follow=dict(type='bool'),
+            checksum=dict(),
         ),
         add_file_common_args=True,
         supports_check_mode=True,
@@ -281,6 +286,7 @@ def main():
     follow = module.params['follow']
     mode = module.params['mode']
     remote_src = module.params['remote_src']
+    checksum = module.params['checksum']
 
     if not os.path.exists(b_src):
         module.fail_json(msg="Source %s not found" % (src))
@@ -298,6 +304,13 @@ def main():
         md5sum_src = None
 
     changed = False
+
+    if checksum_src != checksum:
+        module.fail_json(
+            msg='Copied file does not match the expected checksum. Transfer failed.',
+            checksum=checksum_src,
+            expected_checksum=checksum
+        )
 
     # Special handling for recursive copy - create intermediate dirs
     if original_basename and dest.endswith(os.sep):

--- a/lib/ansible/modules/files/copy.py
+++ b/lib/ansible/modules/files/copy.py
@@ -305,7 +305,7 @@ def main():
 
     changed = False
 
-    if checksum_src != checksum:
+    if checksum and checksum_src != checksum:
         module.fail_json(
             msg='Copied file does not match the expected checksum. Transfer failed.',
             checksum=checksum_src,

--- a/lib/ansible/plugins/action/copy.py
+++ b/lib/ansible/plugins/action/copy.py
@@ -291,6 +291,9 @@ class ActionModule(ActionBase):
                     original_basename=source_rel,
                 )
             )
+            if not self._task.args.get('checksum'):
+                new_module_args['checksum'] = local_checksum
+
             if lmode:
                 new_module_args['mode'] = lmode
 


### PR DESCRIPTION
##### SUMMARY
Add transfer checksum verification in copy module, to ensure that the file was transferred to the remote successfully. Fixes #35029

In a specific case described in #35029 the transferred file might not succeed, but all outward appearance will show that everything was successful.

This PR adds a new `checksum` argument to the `copy` module, that will be used to verify if the transferred file matches the expected checksum.

##### ISSUE TYPE
 - Feature Pull Request
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/files/copy.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.4
2.5
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```