### PR TITLE
Adding "internal" option to "docker_network" module

### DIFF
--- a/changelogs/fragments/35370-add_support_for_docker_network_internal_flag.yaml
+++ b/changelogs/fragments/35370-add_support_for_docker_network_internal_flag.yaml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - "docker_network - ``internal`` is now used to set the ``Internal`` property of the docker network during creation."
+  - "docker_network - Minimum docker-py version increased from ``1.8.0`` to ``1.9.0``."

--- a/test/integration/targets/docker_network/tasks/tests/options.yml
+++ b/test/integration/targets/docker_network/tasks/tests/options.yml
@@ -1,0 +1,42 @@
+---
+- name: Registering network name
+  set_fact:
+    nname_1: "{{ name_prefix ~ '-network-1' }}"
+    nname_2: "{{ name_prefix ~ '-network-2' }}"
+- name: Registering network name
+  set_fact:
+    dnetworks: "{{ dnetworks }} + [nname_1, nname_2]"
+
+####################################################################
+## internal ########################################################
+####################################################################
+
+- name: internal
+  docker_network:
+    name: "{{ nname_1 }}"
+    internal: yes
+  register: internal_1
+
+- name: internal (idempotency)
+  docker_network:
+    name: "{{ nname_1 }}"
+    internal: yes
+  register: internal_2
+
+- name: internal (change)
+  docker_network:
+    name: "{{ nname_1 }}"
+    internal: no
+  register: internal_3
+
+- name: cleanup
+  docker_network:
+    name: "{{ nname_1 }}"
+    state: absent
+    force: yes
+
+- assert:
+    that:
+    - internal_1 is changed
+    - internal_2 is not changed
+    - internal_3 is changed


### PR DESCRIPTION
##### SUMMARY
This change adds support for the "internal" option to the "docker_network" module, allowing users to create internal Docker networks without having to resort to shell commands.

Fixes #27065

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
docker_network.py

##### ANSIBLE VERSION
```
ansible 2.5.0 (docker_network_internal 2cd60382d3) last updated 2018/01/25 13:23:38 (GMT -500)
  config file = None
  configured module search path = [u'/home/dbbendit/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/dbbendit/tmp/ansible/lib/ansible
  executable location = /home/dbbendit/tmp/ansible/bin/ansible
  python version = 2.7.12 (default, Nov 20 2017, 18:23:56) [GCC 5.4.0 20160609]

```