### PR TITLE
Fix edit_config multiline commands on IOS

### DIFF
--- a/lib/ansible/plugins/cliconf/ios.py
+++ b/lib/ansible/plugins/cliconf/ios.py
@@ -71,7 +71,7 @@ class Cliconf(CliconfBase):
     def edit_config(self, command):
         for cmd in chain(['configure terminal'], to_list(command), ['end']):
             if cmd[0] == '{':
-                cmd = json.loads(cmd.replace('\'','"'))
+                cmd = json.loads(cmd.replace('\'', '"'))
                 command = cmd['command']
                 prompt = cmd['prompt']
                 answer = cmd['answer']

--- a/lib/ansible/plugins/cliconf/ios.py
+++ b/lib/ansible/plugins/cliconf/ios.py
@@ -70,13 +70,13 @@ class Cliconf(CliconfBase):
     @enable_mode
     def edit_config(self, command):
         for cmd in chain(['configure terminal'], to_list(command), ['end']):
-            try:
-                cmd = json.loads(cmd)
+            if cmd[0] == '{':
+                cmd = json.loads(cmd.replace('\'','"'))
                 command = cmd['command']
                 prompt = cmd['prompt']
                 answer = cmd['answer']
                 newline = cmd.get('newline', True)
-            except:
+            else:
                 command = cmd
                 prompt = None
                 answer = None

--- a/lib/ansible/plugins/cliconf/ios.py
+++ b/lib/ansible/plugins/cliconf/ios.py
@@ -19,6 +19,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+import ast
 import re
 import json
 
@@ -70,13 +71,13 @@ class Cliconf(CliconfBase):
     @enable_mode
     def edit_config(self, command):
         for cmd in chain(['configure terminal'], to_list(command), ['end']):
-            if cmd[0] == '{':
-                cmd = json.loads(cmd.replace('\'', '"'))
+            try:
+                cmd = ast.literal_eval(cmd)
                 command = cmd['command']
                 prompt = cmd['prompt']
                 answer = cmd['answer']
                 newline = cmd.get('newline', True)
-            else:
+            except:
                 command = cmd
                 prompt = None
                 answer = None


### PR DESCRIPTION
##### SUMMARY

The current code for multiline commands in IOS is broken: If you
pass a dict containing a command, prompt and answer it is seen
later as unicode string, but if you do a json.loads it fails
as the keys/values are enclosed in single quotes but JSON requires
double quotes.

Fixes #23539

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
ios

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (fix_edit_config_multiline_commands 77c4ba1782) last updated 2018/01/26 00:20:44 (GMT +200)

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
