### PR TITLE
azure windows: changed pagefile to dynamically get the path

### DIFF
--- a/test/integration/targets/win_command/tasks/main.yml
+++ b/test/integration/targets/win_command/tasks/main.yml
@@ -77,17 +77,34 @@
     - cmdout is skipped
     - cmdout.msg is search('exists')
 
+- name: get path of pagefile
+  win_shell: |
+    $pagefile = $null
+    $cs = Get-CimInstance -ClassName Win32_ComputerSystem
+    if ($cs.AutomaticManagedPagefile) {
+        $pagefile = "$($env:SystemRoot.Substring(0, 1)):\pagefile.sys"
+    } else {
+        $pf = Get-CimInstance -ClassName Win32_PageFileSetting
+        if ($pf -ne $null) {
+            $pagefile = $pf[0].Name
+        }
+    }
+    $pagefile
+  register: pagefile_path
+
 - name: test creates with hidden system file, should skip
   win_command: echo no
   args:
-    creates: C:\pagefile.sys
+    creates: '{{pagefile_path.stdout_lines[0]}}'
   register: cmdout
+  when: pagefile_path.stdout_lines|count != 0
 
 - name: validate result
   assert:
     that:
     - cmdout is skipped
     - cmdout.msg is search('exists')
+  when: pagefile_path.stdout_lines|count != 0
 
 - name: ensure testfile is still present
   win_stat:

--- a/test/integration/targets/win_module_utils/library/file_util_test.ps1
+++ b/test/integration/targets/win_module_utils/library/file_util_test.ps1
@@ -17,9 +17,32 @@ Function Assert-Equals($actual, $expected) {
     }
 }
 
-# Test-AnsiblePath Hidden system file
-$actual = Test-AnsiblePath -Path C:\pagefile.sys
-Assert-Equals -actual $actual -expected $true
+Function Get-PagefilePath() {
+    $pagefile = $null
+    $cs = Get-CimInstance -ClassName Win32_ComputerSystem
+    if ($cs.AutomaticManagedPagefile) {
+        $pagefile = "$($env:SystemRoot.Substring(0, 1)):\pagefile.sys"
+    } else {
+        $pf = Get-CimInstance -ClassName Win32_PageFileSetting
+        if ($pf -ne $null) {
+            $pagefile = $pf[0].Name
+        }
+    }
+    return $pagefile
+}
+
+$pagefile = Get-PagefilePath
+if ($pagefile) {
+    # Test-AnsiblePath Hidden system file
+    $actual = Test-AnsiblePath -Path $pagefile
+    Assert-Equals -actual $actual -expected $true
+
+    # Get-AnsibleItem file
+    $actual = Get-AnsibleItem -Path $pagefile
+    Assert-Equals -actual $actual.FullName -expected $pagefile
+    Assert-Equals -actual $actual.Attributes.HasFlag([System.IO.FileAttributes]::Directory) -expected $false
+    Assert-Equals -actual $actual.Exists -expected $true
+}
 
 # Test-AnsiblePath File that doesn't exist
 $actual = Test-AnsiblePath -Path C:\fakefile
@@ -45,13 +68,6 @@ Assert-Equals -actual $failed -expected $true
 # Get-AnsibleItem doesn't exist with -ErrorAction SilentlyContinue param
 $actual = Get-AnsibleItem -Path C:\fakefile -ErrorAction SilentlyContinue
 Assert-Equals -actual $actual -expected $null
-
-
-# Get-AnsibleItem file
-$actual = Get-AnsibleItem -Path C:\pagefile.sys
-Assert-Equals -actual $actual.FullName -expected C:\pagefile.sys
-Assert-Equals -actual $actual.Attributes.HasFlag([System.IO.FileAttributes]::Directory) -expected $false
-Assert-Equals -actual $actual.Exists -expected $true
 
 # Get-AnsibleItem directory
 $actual = Get-AnsibleItem -Path C:\Windows

--- a/test/integration/targets/win_module_utils/library/file_util_test.ps1
+++ b/test/integration/targets/win_module_utils/library/file_util_test.ps1
@@ -24,7 +24,7 @@ Function Get-PagefilePath() {
         $pagefile = "$($env:SystemRoot.Substring(0, 1)):\pagefile.sys"
     } else {
         $pf = Get-CimInstance -ClassName Win32_PageFileSetting
-        if ($pf -ne $null) {
+        if ($null -ne $pf) {
             $pagefile = $pf[0].Name
         }
     }

--- a/test/integration/targets/win_shell/tasks/main.yml
+++ b/test/integration/targets/win_shell/tasks/main.yml
@@ -105,17 +105,34 @@
     - shellout is skipped
     - shellout.msg is search('exists')
 
+- name: get path of pagefile
+  win_shell: |
+    $pagefile = $null
+    $cs = Get-CimInstance -ClassName Win32_ComputerSystem
+    if ($cs.AutomaticManagedPagefile) {
+        $pagefile = "$($env:SystemRoot.Substring(0, 1)):\pagefile.sys"
+    } else {
+        $pf = Get-CimInstance -ClassName Win32_PageFileSetting
+        if ($pf -ne $null) {
+            $pagefile = $pf[0].Name
+        }
+    }
+    $pagefile
+  register: pagefile_path
+
 - name: test creates with hidden system file, should skip
   win_shell: echo test
   args:
-    creates: C:\pagefile.sys
+    creates: '{{pagefile_path.stdout_lines[0]}}'
   register: shellout
+  when: pagefile_path.stdout_lines|count != 0
 
 - name: validate result
   assert:
     that:
     - shellout is skipped
     - shellout.msg is search('exists')
+  when: pagefile_path.stdout_lines|count != 0
 
 - name: ensure testfile is still present
   win_stat:

--- a/test/integration/targets/win_stat/tasks/tests.yml
+++ b/test/integration/targets/win_stat/tasks/tests.yml
@@ -465,17 +465,34 @@
   failed_when: "win_stat_no_args.msg != 'Get-AnsibleParam: Missing required argument: path'"
 
 # https://github.com/ansible/ansible/issues/30258
+- name: get path of pagefile
+  win_shell: |
+    $pagefile = $null
+    $cs = Get-CimInstance -ClassName Win32_ComputerSystem
+    if ($cs.AutomaticManagedPagefile) {
+        $pagefile = "$($env:SystemRoot.Substring(0, 1)):\pagefile.sys"
+    } else {
+        $pf = Get-CimInstance -ClassName Win32_PageFileSetting
+        if ($pf -ne $null) {
+            $pagefile = $pf[0].Name
+        }
+    }
+    $pagefile
+  register: pagefile_path
+
 - name: get stat of pagefile
   win_stat:
-    path: C:\pagefile.sys
+    path: '{{pagefile_path.stdout_lines[0]}}'
     get_md5: no
     get_checksum: no
   register: pagefile_stat
+  when: pagefile_path.stdout_lines|count != 0
 
 - name: assert get stat of pagefile
   assert:
     that:
     - pagefile_stat.stat.exists == True
+  when: pagefile_path.stdout_lines|count != 0
 
 # Tests with normal user
 - set_fact:


### PR DESCRIPTION
##### SUMMARY
Azure doesn't store a pagefile for the C drive, this changes the tests to dynamically get the path

##### ISSUE TYPE
 - Test Pull Request

##### COMPONENT NAME
win_module_utils
win_shell
win_stat
win_command

##### ANSIBLE VERSION
```
2.5
```