### PR TITLE
Fixing syntax for mail callback doc

### DIFF
--- a/docs/docsite/rst/plugins/callback.rst
+++ b/docs/docsite/rst/plugins/callback.rst
@@ -14,7 +14,7 @@ Example Callback Plugins
 ++++++++++++++++++++++++
 
 The :doc:`log_plays <callback/log_plays>` callback is an example of how to record playbook events to a log file,
-and the :doc:`mail callback/mail` callback sends email on playbook failures.
+and the :doc:`mail <callback/mail>` callback sends email on playbook failures.
 
 The :doc:`osx_say <callback/oxs_say>` callback responds with computer synthesized speech on OS X in relation to playbook events.
 


### PR DESCRIPTION
##### SUMMARY
Fixing minor typo/formatting for documentation for callback plugin.


##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
callback plugin

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0
  config file = None
  configured module search path = [u'/home/mmercer/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = ./bin/ansible
  python version = 2.7.14 (default, Jan 17 2018, 14:28:32) [GCC 7.2.1 20170915 (Red Hat 7.2.1-2)]
```


##### ADDITIONAL INFORMATION
None
