### PR TITLE
Use TEMP variable instead of hardcoded path

### DIFF
--- a/docs/docsite/rst/windows_setup.rst
+++ b/docs/docsite/rst/windows_setup.rst
@@ -35,7 +35,7 @@ This is an example of how to run this script from PowerShell:
 .. code-block:: powershell
 
     $url = "https://raw.githubusercontent.com/jborean93/ansible-windows/master/scripts/Upgrade-PowerShell.ps1"
-    $file = "$env:SystemDrive\temp\Upgrade-PowerShell.ps1"
+    $file = "$env:TEMP\Upgrade-PowerShell.ps1"
     $username = "Administrator"
     $password = "Password"
 


### PR DESCRIPTION
The script fails if a Temp directory is not present in the system drive (e.g. C:\Temp).
This can be solved by using the TEMP environment variable instead.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - New Module Pull Request
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
