### PR TITLE
Use ansible-ci-files for rpm_key test downloads.

### DIFF
--- a/test/integration/targets/rpm_key/tasks/rpm_key.yaml
+++ b/test/integration/targets/rpm_key/tasks/rpm_key.yaml
@@ -21,17 +21,17 @@
 #
 - name: download EPEL GPG key
   get_url:
-    url: https://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7
+    url: https://ansible-ci-files.s3.amazonaws.com/test/integration/targets/rpm_key/RPM-GPG-KEY-EPEL-7
     dest: /tmp/RPM-GPG-KEY-EPEL-7
 
 - name: download sl rpm
   get_url:
-    url: https://download.fedoraproject.org/pub/epel/7/x86_64/Packages/s/sl-5.02-1.el7.x86_64.rpm
+    url: https://ansible-ci-files.s3.amazonaws.com/test/integration/targets/rpm_key/sl-5.02-1.el7.x86_64.rpm
     dest: /tmp/sl.rpm
 
 - name: download Mono key
   get_url:
-    url: http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
+    url: https://ansible-ci-files.s3.amazonaws.com/test/integration/targets/rpm_key/mono.gpg
     dest: /tmp/mono.gpg
 
 - name: remove EPEL GPG key from keyring
@@ -96,7 +96,7 @@
 - name: remove GPG key from url
   rpm_key:
     state: absent
-    key: https://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7
+    key: https://ansible-ci-files.s3.amazonaws.com/test/integration/targets/rpm_key/RPM-GPG-KEY-EPEL-7
 
 - name: Confirm key is missing
   shell: "rpm --checksig /tmp/sl.rpm"
@@ -112,7 +112,7 @@
 - name: add GPG key from url
   rpm_key:
     state: present
-    key: https://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7
+    key: https://ansible-ci-files.s3.amazonaws.com/test/integration/targets/rpm_key/RPM-GPG-KEY-EPEL-7
 
 - name: check GPG signature of sl. Should return okay
   shell: "rpm --checksig /tmp/sl.rpm"
@@ -128,7 +128,7 @@
 - name: add very first key on system
   rpm_key:
     state: present
-    key: https://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7
+    key: https://ansible-ci-files.s3.amazonaws.com/test/integration/targets/rpm_key/RPM-GPG-KEY-EPEL-7
 
 - name: check GPG signature of sl. Should return okay
   shell: "rpm --checksig /tmp/sl.rpm"


### PR DESCRIPTION
##### SUMMARY

Use ansible-ci-files for rpm_key test downloads.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

rpm_key integration test

##### ANSIBLE VERSION

```
ansible 2.5.0 (rpm-key-test b952c9d670) last updated 2018/01/25 21:03:43 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```
