### PR TITLE
FreeIPA: Add Env variable as module parameter

### DIFF
--- a/lib/ansible/module_utils/ipa.py
+++ b/lib/ansible/module_utils/ipa.py
@@ -37,6 +37,7 @@ from ansible.module_utils._text import to_bytes, to_native, to_text
 from ansible.module_utils.six import PY3
 from ansible.module_utils.six.moves.urllib.parse import quote
 from ansible.module_utils.urls import fetch_url
+from ansible.module_utils.basic import env_fallback
 
 
 class IPAClient(object):
@@ -177,10 +178,10 @@ class IPAClient(object):
 
 def ipa_argument_spec():
     return dict(
-        ipa_prot=dict(type='str', default='https', choices=['http', 'https']),
-        ipa_host=dict(type='str', default='ipa.example.com'),
-        ipa_port=dict(type='int', default=443),
-        ipa_user=dict(type='str', default='admin'),
-        ipa_pass=dict(type='str', required=True, no_log=True),
+        ipa_prot=dict(type='str', default='https', choices=['http', 'https'], fallback=(env_fallback, ['IPA_PROT'])),
+        ipa_host=dict(type='str', default='ipa.example.com', fallback=(env_fallback, ['IPA_HOST'])),
+        ipa_port=dict(type='int', default=443, fallback=(env_fallback, ['IPA_PORT'])),
+        ipa_user=dict(type='str', default='admin', fallback=(env_fallback, ['IPA_USER'])),
+        ipa_pass=dict(type='str', required=True, no_log=True, fallback=(env_fallback, ['IPA_PASS'])),
         validate_certs=dict(type='bool', default=True),
     )

--- a/lib/ansible/utils/module_docs_fragments/ipa.py
+++ b/lib/ansible/utils/module_docs_fragments/ipa.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2017, Ansible Project
-# Copyright (c) 2017, Abhijeet Kasurde (akasurde@redhat.com)
+# Copyright (c) 2017-18, Ansible Project
+# Copyright (c) 2017-18, Abhijeet Kasurde (akasurde@redhat.com)
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 
@@ -8,19 +8,39 @@ class ModuleDocFragment(object):
     DOCUMENTATION = '''
 options:
   ipa_port:
-    description: Port of IPA server
+    description:
+    - Port of FreeIPA / IPA server.
+    - If the value is not specified in the task, the value of environment variable C(IPA_PORT) will be used instead.
+    - If both the environment variable C(IPA_PORT) and the value are not specified in the task, then default value is set.
+    - 'Environment variable fallback mechanism is added in version 2.5.'
     default: 443
   ipa_host:
-    description: IP or hostname of IPA server
+    description:
+    - IP or hostname of IPA server.
+    - If the value is not specified in the task, the value of environment variable C(IPA_HOST) will be used instead.
+    - If both the environment variable C(IPA_HOST) and the value are not specified in the task, then default value is set.
+    - 'Environment variable fallback mechanism is added in version 2.5.'
     default: ipa.example.com
   ipa_user:
-    description: Administrative account used on IPA server
+    description:
+    - Administrative account used on IPA server.
+    - If the value is not specified in the task, the value of environment variable C(IPA_USER) will be used instead.
+    - If both the environment variable C(IPA_USER) and the value are not specified in the task, then default value is set.
+    - 'Environment variable fallback mechanism is added in version 2.5.'
     default: admin
   ipa_pass:
-    description: Password of administrative user
+    description:
+    - Password of administrative user.
+    - If the value is not specified in the task, the value of environment variable C(IPA_PASS) will be used instead.
+    - If both the environment variable C(IPA_PASS) and the value are not specified in the task, then default value is set.
+    - 'Environment variable fallback mechanism is added in version 2.5.'
     required: true
   ipa_prot:
-    description: Protocol used by IPA server
+    description:
+    - Protocol used by IPA server.
+    - If the value is not specified in the task, the value of environment variable C(IPA_PROT) will be used instead.
+    - If both the environment variable C(IPA_PROT) and the value are not specified in the task, then default value is set.
+    - 'Environment variable fallback mechanism is added in version 2.5.'
     default: https
     choices: ["http", "https"]
   validate_certs:


### PR DESCRIPTION
##### SUMMARY
This fix adds environment variable fallback method to read
argument parameters if user has not specified.

Fixes: #35368

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
lib/ansible/module_utils/ipa.py
lib/ansible/utils/module_docs_fragments/ipa.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5devel
```