### PR TITLE
Aws ssm return fixes

### DIFF
--- a/lib/ansible/plugins/lookup/aws_ssm.py
+++ b/lib/ansible/plugins/lookup/aws_ssm.py
@@ -70,7 +70,7 @@ EXAMPLES = '''
     - 'bypath'
 '''
 
-from ansible.module_utils.ec2 import HAS_BOTO3
+from ansible.module_utils.ec2 import HAS_BOTO3, boto3_tag_list_to_ansible_dict
 from ansible.errors import AnsibleError
 from ansible.plugins.lookup import LookupBase
 from ansible.module_utils.parsing.convert_bool import boolean
@@ -158,7 +158,9 @@ class LookupModule(LookupBase):
                         x['Name'] = x['Name'][x['Name'].rfind('/') + 1:]
 
                 if len(paramlist):
-                    return paramlist
+                    return boto3_tag_list_to_ansible_dict(paramlist,
+                                                          tag_name_key_name="Name",
+                                                          tag_value_key_name="Value")
                 else:
                     return None
             # Lookup by parameter name

--- a/lib/ansible/plugins/lookup/aws_ssm.py
+++ b/lib/ansible/plugins/lookup/aws_ssm.py
@@ -88,7 +88,7 @@ class LookupModule(LookupBase):
             :param terms: a list of plugin options
                           e.g. ['parameter_name', 'region=us-east-1', 'aws_profile=profile', 'decrypt=false']
             :param variables: config variables
-            :return The value of the SSM parameter or None
+            :return A list containing one entry with the value of the SSM parameter or None
         '''
 
         ret = {}
@@ -168,7 +168,7 @@ class LookupModule(LookupBase):
                 if ret['Parameters']:
                     return [ret['Parameters'][0]['Value']]
                 else:
-                    return None
+                    raise AnsibleError('Undefined AWS SSM parameter: %s ' % terms[0])
 
         except ClientError as e:
             raise AnsibleError("SSM lookup exception: {0}".format(e))

--- a/test/units/plugins/lookup/test_aws_ssm.py
+++ b/test/units/plugins/lookup/test_aws_ssm.py
@@ -22,8 +22,7 @@ from __future__ import (absolute_import, division, print_function)
 import pytest
 from copy import copy
 
-from ansible.compat.tests.mock import MagicMock, Mock, patch
-from units.modules.utils import set_module_args
+from ansible.compat.tests.mock import MagicMock, patch
 from ansible.errors import AnsibleError
 
 try:
@@ -35,20 +34,25 @@ except ImportError:
 
 
 simple_variable_success_response = {
-    'Parameters': [{'Name': 'simple_variable',
-                    'Type': 'String',
-                    'Value': 'simplevalue',
-                    'Version': 1
-    }],
+    'Parameters': [
+        {
+            'Name': 'simple_variable',
+            'Type': 'String',
+            'Value': 'simplevalue',
+            'Version': 1
+        }
+    ],
     'InvalidParameters': [],
-    'ResponseMetadata': { 'RequestId': '12121212-3434-5656-7878-9a9a9a9a9a9a',
-                          'HTTPStatusCode': 200,
-                          'HTTPHeaders': {'x-amzn-requestid': '12121212-3434-5656-7878-9a9a9a9a9a9a',
-                                          'content-type': 'application/x-amz-json-1.1',
-                                          'content-length': '116',
-                                          'date': 'Tue, 23 Jan 2018 11:04:27 GMT'
-                          },
-                          'RetryAttempts': 0
+    'ResponseMetadata': {
+        'RequestId': '12121212-3434-5656-7878-9a9a9a9a9a9a',
+        'HTTPStatusCode': 200,
+        'HTTPHeaders': {
+            'x-amzn-requestid': '12121212-3434-5656-7878-9a9a9a9a9a9a',
+            'content-type': 'application/x-amz-json-1.1',
+            'content-length': '116',
+            'date': 'Tue, 23 Jan 2018 11:04:27 GMT'
+        },
+        'RetryAttempts': 0
     }
 }
 
@@ -61,6 +65,7 @@ path_success_response['Parameters'] = [
 missing_variable_fail_response = copy(simple_variable_success_response)
 missing_variable_fail_response['Parameters'] = []
 missing_variable_fail_response['InvalidParameters'] = ['missing_variable']
+
 
 def test_lookup_variable():
     lookup = aws_ssm.LookupModule()
@@ -111,4 +116,3 @@ def test_warn_denied_variable():
     with pytest.raises(AnsibleError):
         with patch.object(boto3, 'client', boto3_client_double):
             lookup.run(["denied_variable"], {})
-    

--- a/test/units/plugins/lookup/test_aws_ssm.py
+++ b/test/units/plugins/lookup/test_aws_ssm.py
@@ -1,0 +1,97 @@
+#
+# (c) 2017 Michael De La Rue
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+
+import pytest
+from copy import copy
+
+from ansible.compat.tests.mock import MagicMock, Mock, patch
+from units.modules.utils import set_module_args
+from ansible.errors import AnsibleError
+
+try:
+    import ansible.plugins.lookup.aws_ssm as aws_ssm
+    import boto3
+    from botocore.exceptions import ClientError
+except ImportError:
+    pytestmark = pytest.mark.skip("This test requires the boto3 and botocore Python libraries")
+
+
+simple_variable_success_response = {
+    'Parameters': [{'Name': 'simple_variable',
+                    'Type': 'String',
+                    'Value': 'simplevalue',
+                    'Version': 1
+    }],
+    'InvalidParameters': [],
+    'ResponseMetadata': { 'RequestId': '12121212-3434-5656-7878-9a9a9a9a9a9a',
+                          'HTTPStatusCode': 200,
+                          'HTTPHeaders': {'x-amzn-requestid': '12121212-3434-5656-7878-9a9a9a9a9a9a',
+                                          'content-type': 'application/x-amz-json-1.1',
+                                          'content-length': '116',
+                                          'date': 'Tue, 23 Jan 2018 11:04:27 GMT'
+                          },
+                          'RetryAttempts': 0
+    }
+}
+
+missing_variable_fail_response = copy(simple_variable_success_response)
+missing_variable_fail_response['Parameters'] = []
+missing_variable_fail_response['InvalidParameters'] = ['missing_variable']
+
+def test_lookup_variable():
+    lookup = aws_ssm.LookupModule()
+    
+    boto3_client_double = MagicMock()
+    # boto3_client_double.return_value.get_parameter_by_path.return_value = "simplevalue"
+    boto3_client_double.return_value.get_parameters.return_value = simple_variable_success_response
+
+    with patch.object(boto3, 'client', boto3_client_double):
+        retval = lookup.run(["simple_variable"], {})
+    assert(retval[0] == "simplevalue")
+
+
+def test_warn_missing_variable():
+    lookup = aws_ssm.LookupModule()
+
+    boto3_client_double = MagicMock()
+    # boto3_client_double.return_value.get_parameter_by_path.return_value = "simplevalue"
+    boto3_client_double.return_value.get_parameters.return_value = missing_variable_fail_response
+
+    with pytest.raises(AnsibleError):
+        with patch.object(boto3, 'client', boto3_client_double):
+            lookup.run(["missing_variable"], {})
+
+
+error_response = {'Error': {'Code': 'ResourceNotFoundException', 'Message': 'Fake Testing Error'}}
+operation_name = 'FakeOperation'
+
+
+def test_warn_denied_variable():
+    lookup = aws_ssm.LookupModule()
+
+    boto3_client_double = MagicMock()
+    # boto3_client_double.return_value.get_parameter_by_path.return_value = "simplevalue"
+    boto3_client_double.return_value.get_parameters.side_effect = ClientError(error_response, operation_name)
+
+    with pytest.raises(AnsibleError):
+        with patch.object(boto3, 'client', boto3_client_double):
+            lookup.run(["denied_variable"], {})
+    


### PR DESCRIPTION
##### SUMMARY

This fixes returns from the aws_ssm parameter lookup plugin in both error cases and in the case of returns from a path. 

a) raise an Ansible Error exception if we fail to find the parameter we were told to find.
b) return a simple dictionary of parameter-path / value in the case we are told to search a path.  

This should be urgently merged before 2.5 to avoid having interface changes of the aws_ssm module after the public release. 

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

aws_ssm lookup plugin

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
  config file = None
  configured module search path = [u'/home/mikedlr/dev/ansible/ansible-dev/library']
  ansible python module location = /home/mikedlr/dev/ansible/ansible-dev/lib/ansible
  executable location = /home/mikedlr/dev/ansible/ansible-dev/bin/ansible
  python version = 2.7.5 (default, Aug  4 2017, 00:39:18) [GCC 4.8.5 20150623 (Red Hat 4.8.5-16)]
```

##### ADDITIONAL INFORMATION

This work has been paid for / supported by paddle.com - thanks / neat .  

