### PR TITLE
Single IPs should still return a network address

### DIFF
--- a/lib/ansible/plugins/filter/ipaddr.py
+++ b/lib/ansible/plugins/filter/ipaddr.py
@@ -247,8 +247,7 @@ def _netmask_query(v):
 
 def _network_query(v):
     '''Return the network of a given IP or subnet'''
-    if v.size > 1:
-        return str(v.network)
+    return str(v.network)
 
 
 def _network_id_query(v):


### PR DESCRIPTION
Related to: https://github.com/ansible/ansible/issues/12065
Netmask was fixed but network was not.

I would like this to behave in a sane way for various inputs.
Current output:
```
10.1.1.1/32 | ipaddr('network') => ''
10.2.2.0/24 | ipaddr('network') => '10.2.2.0'
```

I believe it should be:
```
10.1.1.1/32 | ipaddr('network') => '10.1.1.1'
10.2.2.0/24 | ipaddr('network') => '10.2.2.0'
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - New Module Pull Request
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
