### PR TITLE
Fix virt role detection for kvm if no other match

### DIFF
--- a/lib/ansible/module_utils/facts/virtual/linux.py
+++ b/lib/ansible/module_utils/facts/virtual/linux.py
@@ -209,7 +209,8 @@ class LinuxVirtual(Virtual):
 
                 else:
                     virtual_facts['virtualization_type'] = 'kvm'
-                virtual_facts['virtualization_role'] = 'host'
+                    virtual_facts['virtualization_role'] = 'host'
+
                 return virtual_facts
 
             if 'vboxdrv' in modules:


### PR DESCRIPTION
This fixes an indention bug introduced in
45a9f967749ec68e2077fe1d1d32dd37660ab376
(or maybe https://github.com/ansible/ansible/commit/b0dbc61d635d8c86fa7851c01f78719e175b16c2)

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Based on the issue mentioned in https://github.com/ansible/ansible/pull/21621
it seems that virt role detection for kvm guests systems can end up as 'host'
if none of the other kvm guest identification rules trigger.


<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
lib/ansible/module_utils/facts/virtual/linux.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (devel ea2b89c7ae) last updated 2018/01/26 12:57:30 (GMT -400)
  config file = /home/adrian/src/ansible/ansible.cfg
  configured module search path = [u'/home/adrian/ansible/my-modules']
  ansible python module location = /home/adrian/src/ansible/lib/ansible
  executable location = /home/adrian/src/ansible/bin/ansible
  python version = 2.7.14 (default, Jan 17 2018, 14:28:32) [GCC 7.2.1 20170915 (Red Hat 7.2.1-2)]


```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
