### PR TITLE
The roles-path option needs an '=' not a space.

### DIFF
--- a/docs/docsite/rst/galaxy.rst
+++ b/docs/docsite/rst/galaxy.rst
@@ -50,7 +50,7 @@ The following provides an example of using *--roles-path* to install the role in
 
 ::
 
-    $ ansible-galaxy install --roles-path . geerlingguy.apache
+    $ ansible-galaxy install --roles-path=. geerlingguy.apache
 
 .. seealso::
 


### PR DESCRIPTION
##### SUMMARY
Correct documentation, an example use of ansible-galaxy's --roles-path option.

##### ISSUE TYPE
 - Docs Pull Request


##### COMPONENT NAME
ansible-galaxy documentation

##### ANSIBLE VERSION
Online doc at this moment

