### PR TITLE
Add boilderplate to remove a module but keep documentation.

### DIFF
--- a/lib/ansible/module_utils/common/removed.py
+++ b/lib/ansible/module_utils/common/removed.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2018, Ansible Project
+# Simplified BSD License (see licenses/simplified_bsd.txt or https://opensource.org/licenses/BSD-2-Clause)
+
+from ansible.module_utils._text import to_text
+
+
+def removed_module(msg=u'This module has been removed.  The module documentation may contain hints for porting'):
+    """
+    When a module is removed, we want the documentation available for a few releases to aid in
+    porting playbooks.  So leave the documentation but remove the actual code and instead have this
+    boilerplate::
+
+        from ansible.module_utils.common.removed import removed_module
+
+        if __name__ == '__main__':
+            removed_module()
+    """
+    # We may not have an AnsibleModule when this is called
+    msg = to_text(msg).translate({ord(u'"'): u'\\"'})
+    print('\n{{"msg": "{0}", "failed": true}}'.format(msg))


### PR DESCRIPTION

##### SUMMARY
As we start to deprecate and then remove modules we found out that we need a piece of boilerplate code to tell users that the module has been removed.  Pull this into a common function.

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME
module_utils

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
Ansible-2.5
```


##### ADDITIONAL INFORMATION
needing this so that we can non-intrusively update modules to give a good error message when a removed module is used in a playbook.