### PR TITLE
add support for configuring smtpport in callback_mail

### DIFF
--- a/lib/ansible/plugins/callback/mail.py
+++ b/lib/ansible/plugins/callback/mail.py
@@ -25,6 +25,13 @@ options:
           key: smtphost
           version_added: '2.5'
     default: localhost
+  mtaport:
+    description: Mail Transfer Agent Port, port at which server SMTP
+    ini:
+        - section: callback_mail
+          key: smtpport
+          version_added: '2.5'
+    default: 25
   to:
     description: Mail recipient
     ini:
@@ -76,6 +83,7 @@ class CallbackModule(CallbackBase):
         self.sender = None
         self.to = 'root'
         self.smtphost = os.getenv('SMTPHOST', 'localhost')
+        self.smtpport = 25
         self.cc = None
         self.bcc = None
 
@@ -86,6 +94,7 @@ class CallbackModule(CallbackBase):
         self.sender = self.get_option('sender')
         self.to = self.get_option('to')
         self.smtphost = self.get_option('mta')
+        self.smtpport = int(self.get_option('mtaport'))
         self.cc = self.get_option('cc')
         self.bcc = self.get_option('bcc')
 
@@ -93,7 +102,7 @@ class CallbackModule(CallbackBase):
         if body is None:
             body = subject
 
-        smtp = smtplib.SMTP(self.smtphost)
+        smtp = smtplib.SMTP(self.smtphost, port=self.smtpport)
 
         b_sender = to_bytes(self.sender)
         b_to = to_bytes(self.to)


### PR DESCRIPTION
##### SUMMARY
Add configuration option to [callback_mail] in ansible.cfg to set the port for mail
submission. Some environments must use port 587 (submission), rather than port 25 (smtp).

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
callback_mail

##### ANSIBLE VERSION
```
ansible 2.5.0 (dev/smtpport 14857e4929) last updated 2018/01/28 14:35:08 (GMT +000)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/usr/share/ansible']
  ansible python module location = /root/git/ansible/lib/ansible
  executable location = /root/git/ansible/bin/ansible
  python version = 2.7.13 (default, May 10 2017, 20:04:36) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]
```


##### ADDITIONAL INFORMATION
In my environment, SMTP servers are not accepting short addresses (e.g. <root> without domain)
and localhost is not usable as smtphost. I have it fixed with additional configuration items in
ansible.cfg for my version of ansible (v2.3). Found in devel this functionality is already there.
However, not all environments use port 25 (SMTP) for mail submissions, some use
port 587 (submission), this is not yet configurable in devel. Recoded my solution which includes
setting the port to fit the code already in devel.
