### PR TITLE
Fixes #35431 nxos_snmp_user  fixed removing encryption from user on subsequent runs of the task

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_snmp_user.py
+++ b/lib/ansible/modules/network/nxos/nxos_snmp_user.py
@@ -289,9 +289,6 @@ def main():
                 reset = True
                 proposed['encrypt'] = 'aes-128'
 
-            elif encrypt:
-                proposed['encrypt'] = 'aes-128'
-
             delta = dict(set(proposed.items()).difference(existing.items()))
 
             if delta.get('pwd'):
@@ -299,6 +296,9 @@ def main():
 
             if delta:
                 delta['group'] = group
+
+            if delta and encrypt:
+                delta['encrypt'] = 'aes-128'
 
             command = config_snmp_user(delta, user, reset, new)
             commands.append(command)


### PR DESCRIPTION
##### SUMMARY
Fixed the issue in #35431 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
nxos_snmp_user

##### ANSIBLE VERSION
```
ansible 2.5.0 (devel 857d0fd62e) last updated 2018/01/28 12:20:25 (GMT -400)
  config file = None
  configured module search path = ['/home/chip/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/chip/projects/gs/ansible/dev/ansible/lib/ansible
  executable location = /home/chip/projects/gs/ansible/dev/ansible/bin/ansible
  python version = 3.5.2 (default, Nov 23 2017, 16:37:01) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION
N/A

