### PR TITLE
name is not a required parameter

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_keystone_domain_facts.py
+++ b/lib/ansible/modules/cloud/openstack/os_keystone_domain_facts.py
@@ -27,7 +27,7 @@ options:
    name:
      description:
         - Name or ID of the domain
-     required: true
+     required: false
    filters:
      description:
         - A dictionary of meta data to use for further filtering.  Elements of


### PR DESCRIPTION
##### SUMMARY
Docs for `os_keystone_domain_facts` currently state that `name` is required, but then goes on to give an example where it is not specified. In reality, it is not required, and passing no name will return details of all domains defined in the cloud.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
os_keystone_domain_facts

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.2.0
  config file = None
  configured module search path = [u'/Users/buckleyd/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.14 (default, Jan  6 2018, 12:12:40) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]
```
