### PR TITLE
Fix double prompt issue in network_cli

### DIFF
--- a/lib/ansible/plugins/terminal/__init__.py
+++ b/lib/ansible/plugins/terminal/__init__.py
@@ -69,11 +69,7 @@ class TerminalBase(with_metaclass(ABCMeta, object)):
 
         :returns: A byte string of the prompt
         """
-        # do not send '\n' here, exec_cli_command sends '\r' already,
-        # doing so causes double prompts.
-        self._exec_cli_command(b'')
-
-        return self._connection._matched_prompt
+        return self._connection.get_prompt()
 
     def on_open_shell(self):
         """Called after the SSH session is established


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #33993

In current implementation, while trying to fetch the
current cli prompt terminal plugin executes `\r` on the remote host.

If command execution results in a prompt for
example executing `enable` command results in `Password:` prompt.
This results in prompt and answer getting out of sync.

To fix it while fetching current prompt from terminal plugin use `get_prompt()`
api in network_cli that returns the latest matched cli prompt instead of executing `\r` on the remote host.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
network_cli

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
