### PR TITLE
Update guide_azure.rst to include note about running ansible from within azure

### DIFF
--- a/docs/docsite/rst/guide_azure.rst
+++ b/docs/docsite/rst/guide_azure.rst
@@ -21,6 +21,8 @@ root directory of the Ansible repo.
 
     $ pip install .[azure]
 
+Or you can directly run Ansible in [Azure Cloud Shell](https://shell.azure.com) where Ansible is pre-installed.  
+
 Authenticating with Azure
 -------------------------
 

--- a/docs/docsite/rst/guide_azure.rst
+++ b/docs/docsite/rst/guide_azure.rst
@@ -21,7 +21,7 @@ root directory of the Ansible repo.
 
     $ pip install .[azure]
 
-Or you can directly run Ansible in [Azure Cloud Shell](https://shell.azure.com) where Ansible is pre-installed.  
+You can also directly run Ansible in [Azure Cloud Shell](https://shell.azure.com), where Ansible is pre-installed.  
 
 Authenticating with Azure
 -------------------------


### PR DESCRIPTION
Add one more option to run Ansible in Azure

##### SUMMARY
This is to add one more option to run Ansible in Azure through Azure Cloud Shell. 

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
Azure

##### ANSIBLE VERSION
Now 2.4.2 is supported by Azure Cloud Shell. 

$ ansible --version
ansible 2.4.2.0
  config file = None
  configured module search path = [u'/home/kylie/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /opt/ansible/local/lib/python2.7/site-packages/ansible
  executable location = /opt/ansible/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]

##### ADDITIONAL INFORMATION
Could you please have a review?
More information about Azure Cloud Shell: 
https://docs.microsoft.com/en-us/azure/cloud-shell/overview
https://docs.microsoft.com/en-us/azure/ansible/ansible-run-playbook-in-cloudshell
