### PR TITLE
(doc)fix: Changed command param to be required

### DIFF
--- a/lib/ansible/modules/cloud/misc/virt.py
+++ b/lib/ansible/modules/cloud/misc/virt.py
@@ -36,6 +36,7 @@ options:
     description:
       - In addition to state management, various non-idempotent commands are available.
     choices: [ create, define, destroy, freemem, get_xml, info, list_vms, nodeinfo, pause, shutdown, start, status, stop, undefine, unpause, virttype ]
+    required: true
   autostart:
     description:
       - start VM at host startup.


### PR DESCRIPTION
##### SUMMARY
Changed the `command` parameter to be required. If the command parameter is not set, ansible will fail with the following error:
`"msg": "expected state or command parameter to be specified"`

This could cause some confusion, because the [ansible module doc](http://docs.ansible.com/ansible/latest/virt_module.html) currently states that the `command` option is not required
##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME

virt module

##### ANSIBLE VERSION

```
ansible 2.4.2.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/etc/ansible/$ara_location/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.13 (default, Nov 24 2017, 17:33:09) [GCC 6.3.0 20170516]

```
