### PR TITLE
Freeipa dns ttl : fixes #33969

### DIFF
--- a/lib/ansible/modules/identity/ipa/ipa_dnsrecord.py
+++ b/lib/ansible/modules/identity/ipa/ipa_dnsrecord.py
@@ -46,11 +46,16 @@ options:
     - In the case of 'PTR' record type, this will be the hostname.
     - In the case of 'TXT' record type, this will be a text.
     required: true
+  record_ttl: 
+    description: 
+    - Set the TTL for the record if the record_value is new, changes its value, or if state is set to force.
+    - If the record exists and state is set to present the TTL is not updated even the option differs from what is set in IPA.  
+    version_added: "2.5"
   state:
     description: State to ensure
     required: false
     default: present
-    choices: ["present", "absent"]
+    choices: ["present", "force", "absent"]
 extends_documentation_fragment: ipa.documentation
 version_added: "2.4"
 '''
@@ -96,6 +101,18 @@ EXAMPLES = '''
     ipa_user: admin
     ipa_pass: topsecret
     state: absent
+
+# Ensure that dns record exists with a TTL
+- ipa_dnsrecord:
+    name: host01
+    zone_name: example.com
+    record_type: 'AAAA'
+    record_value: '::1'
+    record_ttl: 300
+    ipa_host: ipa.example.com
+    ipa_user: admin
+    ipa_pass: topsecret
+    state: force
 '''
 
 RETURN = '''
@@ -119,7 +136,7 @@ class DNSRecordIPAClient(IPAClient):
     def dnsrecord_find(self, zone_name, record_name):
         return self._post_json(method='dnsrecord_find', name=zone_name, item={'idnsname': record_name})
 
-    def dnsrecord_add(self, zone_name=None, record_name=None, details=None):
+    def dnsrecord_add(self, zone_name=None, record_name=None, record_ttl=None, details=None):
         item = dict(idnsname=record_name)
         if details['record_type'] == 'A':
             item.update(a_part_ip_address=details['record_value'])
@@ -136,11 +153,16 @@ class DNSRecordIPAClient(IPAClient):
         elif details['record_type'] == 'TXT':
             item.update(txtrecord=details['record_value'])
 
+        if record_ttl: 
+            item.update(dnsttl=record_ttl)
+
         return self._post_json(method='dnsrecord_add', name=zone_name, item=item)
 
-    def dnsrecord_mod(self, zone_name=None, record_name=None, details=None):
+    def dnsrecord_mod(self, zone_name=None, record_name=None, record_ttl=None, details=None):
         item = get_dnsrecord_dict(details)
         item.update(idnsname=record_name)
+        if record_ttl: 
+            item.update(dnsttl=record_ttl)
         return self._post_json(method='dnsrecord_mod', name=zone_name, item=item)
 
     def dnsrecord_del(self, zone_name=None, record_name=None, details=None):
@@ -176,6 +198,7 @@ def get_dnsrecord_diff(client, ipa_dnsrecord, module_dnsrecord):
 def ensure(module, client):
     zone_name = module.params['zone_name']
     record_name = module.params['record_name']
+    record_ttl = module.params['record_ttl']
     state = module.params['state']
 
     ipa_dnsrecord = client.dnsrecord_find(zone_name, record_name)
@@ -189,6 +212,7 @@ def ensure(module, client):
             if not module.check_mode:
                 client.dnsrecord_add(zone_name=zone_name,
                                      record_name=record_name,
+                                     record_ttl=record_ttl,
                                      details=module_dnsrecord)
         else:
             diff = get_dnsrecord_diff(client, ipa_dnsrecord, module_dnsrecord)
@@ -197,7 +221,17 @@ def ensure(module, client):
                 if not module.check_mode:
                     client.dnsrecord_mod(zone_name=zone_name,
                                          record_name=record_name,
+                                         record_ttl=record_ttl,
                                          details=module_dnsrecord)
+
+    elif state == 'force':
+        changed = True
+        if not module.check_mode:
+            client.dnsrecord_add(zone_name=zone_name,
+                                 record_name=record_name,
+                                 record_ttl=record_ttl,
+                                 details=module_dnsrecord)
+
     else:
         if ipa_dnsrecord:
             changed = True
@@ -216,7 +250,8 @@ def main():
                          record_name=dict(type='str', aliases=['name'], required=True),
                          record_type=dict(type='str', default='A', choices=record_types),
                          record_value=dict(type='str', required=True),
-                         state=dict(type='str', default='present', choices=['present', 'absent']),
+                         record_ttl=dict(type='int', required=False),
+                         state=dict(type='str', default='present', choices=['present', 'absent', 'force']),
                          )
 
     module = AnsibleModule(argument_spec=argument_spec,

--- a/lib/ansible/modules/identity/ipa/ipa_dnsrecord.py
+++ b/lib/ansible/modules/identity/ipa/ipa_dnsrecord.py
@@ -46,10 +46,10 @@ options:
     - In the case of 'PTR' record type, this will be the hostname.
     - In the case of 'TXT' record type, this will be a text.
     required: true
-  record_ttl: 
-    description: 
+  record_ttl:
+    description:
     - Set the TTL for the record if the record_value is new, changes its value, or if state is set to force.
-    - If the record exists and state is set to present the TTL is not updated even the option differs from what is set in IPA.  
+    - If the record exists and state is set to present the TTL is not updated even the option differs from what is set in IPA.
     version_added: "2.5"
   state:
     description: State to ensure
@@ -153,7 +153,7 @@ class DNSRecordIPAClient(IPAClient):
         elif details['record_type'] == 'TXT':
             item.update(txtrecord=details['record_value'])
 
-        if record_ttl: 
+        if record_ttl:
             item.update(dnsttl=record_ttl)
 
         return self._post_json(method='dnsrecord_add', name=zone_name, item=item)
@@ -161,7 +161,7 @@ class DNSRecordIPAClient(IPAClient):
     def dnsrecord_mod(self, zone_name=None, record_name=None, record_ttl=None, details=None):
         item = get_dnsrecord_dict(details)
         item.update(idnsname=record_name)
-        if record_ttl: 
+        if record_ttl:
             item.update(dnsttl=record_ttl)
         return self._post_json(method='dnsrecord_mod', name=zone_name, item=item)
 

--- a/lib/ansible/modules/identity/ipa/ipa_dnsrecord.py
+++ b/lib/ansible/modules/identity/ipa/ipa_dnsrecord.py
@@ -226,11 +226,19 @@ def ensure(module, client):
 
     elif state == 'force':
         changed = True
-        if not module.check_mode:
-            client.dnsrecord_add(zone_name=zone_name,
-                                 record_name=record_name,
-                                 record_ttl=record_ttl,
-                                 details=module_dnsrecord)
+        if not ipa_dnsrecord:
+            if not module.check_mode:
+                client.dnsrecord_add(zone_name=zone_name,
+                                     record_name=record_name,
+                                     record_ttl=record_ttl,
+                                     details=module_dnsrecord)
+
+        else:
+            if not module.check_mode:
+                client.dnsrecord_mod(zone_name=zone_name,
+                                     record_name=record_name,
+                                     record_ttl=record_ttl,
+                                     details=module_dnsrecord)
 
     else:
         if ipa_dnsrecord:


### PR DESCRIPTION
##### SUMMARY
Allow TTL values to be for dns records created in IPA.  

Note.  The IPA API does not return the TTL associated with records when queried so the TTL value is only set when the record_value is new, is changed or the new state is forced.   

Fixes #33969

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
- ipa_dnsrecord.py

##### ANSIBLE VERSION
```
ansible 2.5.0 (freeipa_dns_ttl e999bc5abe) last updated 2018/01/29 11:20:30 (GMT +100)
  config file = /Users/lee/.ansible.cfg
  configured module search path = [u'/Users/lee/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/lee/projects/python/ansible/lib/ansible
  executable location = /Users/lee/projects/python/ansible/bin/ansible
  python version = 2.7.14 (default, Sep 25 2017, 09:54:19) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.37)]
```

##### ADDITIONAL INFORMATION
Added a new option record_ttl which allows the dns TTL to set for a specific record.   The record_ttl is passed to the dnsrecord_add and dnsrecord_mod functions when invoked with state=present.   A new state=forced option is added which ensures dnsrecord_mod is called even if the record_value already exists and would not otherwise be changed.   Using state=forced always returns changed.
