### PR TITLE
Detect OpenStack guests on RDO based installs, Newton and newer.

### DIFF
--- a/lib/ansible/module_utils/facts/virtual/linux.py
+++ b/lib/ansible/module_utils/facts/virtual/linux.py
@@ -97,7 +97,7 @@ class LinuxVirtual(Virtual):
             virtual_facts['virtualization_role'] = 'guest'
             return virtual_facts
 
-        if product_name == 'OpenStack Nova':
+        if product_name in ['OpenStack Compute', 'OpenStack Nova']:
             virtual_facts['virtualization_type'] = 'openstack'
             virtual_facts['virtualization_role'] = 'guest'
             return virtual_facts


### PR DESCRIPTION
##### SUMMARY
RDO is a fairly popular OpenStack distribution for RedHat (& co) based hosts. Between OpenStack versions Mitaka (Apr 2016) and Newton (Oct 2016), a change in the OpenStack Nova packaging configuration changed the product name from _OpenStack Nova_ to _OpenStack Compute_. This gets reflected in the DMI product name, /sys/devices/virtual/dmi/id/product_name on Linux.

The Setup module uses the DMI product name to figure out whether it's running in a KVM virtualized environment. The RDO change broke this detection, causing facts to return _ansible_virtualization_type_: _NA_ rather than the expected _openstack_.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
Setup module

##### ANSIBLE VERSION
```
ansible 2.5.0 (devel 61f17ad8c0) last updated 2018/01/29 12:19:28 (GMT +200)
  config file = None
  configured module search path = [u'/Users/kriss/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/kriss/Documents/development/upstream/ansible/lib/ansible
  executable location = /Users/kriss/Documents/development/upstream/ansible/bin/ansible
  python version = 2.7.10 (default, Jul 15 2017, 17:16:57) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.31)]
```


##### ADDITIONAL INFORMATION
[RDO packaging glue, Mitaka](https://github.com/rdo-packages/nova-distgit/blob/mitaka-rdo/openstack-nova.spec) (ansible_virtualization_type: openstack)
[RDO packaging glue, Newton](https://github.com/rdo-packages/nova-distgit/blob/newton-rdo/openstack-nova.spec) (ansible_virtualization_type: NA)

<!--- Paste verbatim command output below, e.g. before and after your change -->
Original output from a guest in an RDO/Ocata environment.
```
skunk01 | SUCCESS => {"ansible_facts": {"ansible_virtualization_type": "NA"}, "changed": false, "failed": false}
```

Output from a guest in an RDO/Ocata environment with the commit in this PR applied.
```
skunk01 | SUCCESS => {"ansible_facts": {"ansible_virtualization_type": "openstack"}, "changed": false, "failed": false}
```