### PR TITLE
Add option tls_insecure to allow for insecure TLS

### DIFF
--- a/lib/ansible/modules/monitoring/grafana_dashboard.py
+++ b/lib/ansible/modules/monitoring/grafana_dashboard.py
@@ -100,6 +100,13 @@ options:
     default: 'yes'
     type: bool
     version_added: 2.7
+  tls_insecure:
+    description:
+      - Enable insecure TLS protocols.
+      - This should only be used with personally controlled devices (i.e. to support or upgrade older devices).
+    type: bool
+    default: no
+    version_added: '2.8'
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/monitoring/grafana_dashboard.py
+++ b/lib/ansible/modules/monitoring/grafana_dashboard.py
@@ -102,7 +102,7 @@ options:
     version_added: 2.7
   tls_insecure:
     description:
-      - Enable insecure TLS protocols.
+      - Enable insecure TLS/SSL protocols.
       - This should only be used with personally controlled devices (i.e. to support or upgrade older devices).
     type: bool
     default: no

--- a/lib/ansible/modules/monitoring/grafana_datasource.py
+++ b/lib/ansible/modules/monitoring/grafana_datasource.py
@@ -235,7 +235,7 @@ options:
     version_added: 2.8
   tls_insecure:
     description:
-      - Enable insecure TLS protocols.
+      - Enable insecure TLS/SSL protocols.
       - This should only be used with personally controlled devices (i.e. to support or upgrade older devices).
     type: bool
     default: no

--- a/lib/ansible/modules/monitoring/grafana_datasource.py
+++ b/lib/ansible/modules/monitoring/grafana_datasource.py
@@ -233,7 +233,13 @@ options:
     default: ''
     required: false
     version_added: 2.8
-
+  tls_insecure:
+    description:
+      - Enable insecure TLS protocols.
+      - This should only be used with personally controlled devices (i.e. to support or upgrade older devices).
+    type: bool
+    default: no
+    version_added: '2.8'
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/monitoring/icinga2_host.py
+++ b/lib/ansible/modules/monitoring/icinga2_host.py
@@ -96,6 +96,13 @@ options:
   variables:
     description:
       - List of variables.
+  tls_insecure:
+    description:
+      - Enable insecure TLS protocols.
+      - This should only be used with personally controlled devices (i.e. to support or upgrade older devices).
+    type: bool
+    default: no
+    version_added: '2.8'
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/monitoring/icinga2_host.py
+++ b/lib/ansible/modules/monitoring/icinga2_host.py
@@ -98,7 +98,7 @@ options:
       - List of variables.
   tls_insecure:
     description:
-      - Enable insecure TLS protocols.
+      - Enable insecure TLS/SSL protocols.
       - This should only be used with personally controlled devices (i.e. to support or upgrade older devices).
     type: bool
     default: no

--- a/lib/ansible/modules/net_tools/basics/get_url.py
+++ b/lib/ansible/modules/net_tools/basics/get_url.py
@@ -165,6 +165,13 @@ options:
       - Header to identify as, generally appears in web server logs.
     type: str
     default: ansible-httpget
+  tls_insecure:
+    description:
+      - Enable insecure TLS protocols.
+      - This should only be used with personally controlled devices (i.e. to support or upgrade older devices).
+    type: bool
+    default: no
+    version_added: '2.8'
 # informational: requirements for nodes
 extends_documentation_fragment:
     - files

--- a/lib/ansible/modules/net_tools/basics/get_url.py
+++ b/lib/ansible/modules/net_tools/basics/get_url.py
@@ -167,7 +167,7 @@ options:
     default: ansible-httpget
   tls_insecure:
     description:
-      - Enable insecure TLS protocols.
+      - Enable insecure TLS/SSL protocols.
       - This should only be used with personally controlled devices (i.e. to support or upgrade older devices).
     type: bool
     default: no

--- a/lib/ansible/modules/net_tools/basics/uri.py
+++ b/lib/ansible/modules/net_tools/basics/uri.py
@@ -182,6 +182,13 @@ options:
       - Header to identify as, generally appears in web server logs.
     type: str
     default: ansible-httpget
+  tls_insecure:
+    description:
+      - Enable insecure TLS/SSL protocols.
+      - This should only be used with personally controlled devices (i.e. to support or upgrade older devices).
+    type: bool
+    default: no
+    version_added: '2.8'
 notes:
   - The dependency on httplib2 was removed in Ansible 2.1.
   - The module returns all the HTTP headers in lower-case.

--- a/lib/ansible/modules/remote_management/imc/imc_rest.py
+++ b/lib/ansible/modules/remote_management/imc/imc_rest.py
@@ -1,11 +1,11 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
-# (c) 2017, Dag Wieers <dag@wieers.com>
+
+# Copyright: (c) 2017, Dag Wieers (@dagwieers) <dag@wieers.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
-
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],
@@ -75,7 +75,7 @@ options:
   tls_insecure:
     description:
     - Enable insecure TLS protocols.
-    - This may be required to support older devices.
+    - This should only be used with personally controlled devices (i.e. to support or upgrade older devices).
     type: bool
     default: no
     version_added: '2.8'
@@ -311,7 +311,7 @@ def imc_response(module, rawoutput, rawinput=''):
 def logout(module, url, cookie, timeout, tls_insecure=False):
     ''' Perform a logout, if needed '''
     data = '<aaaLogout cookie="%s" inCookie="%s"/>' % (cookie, cookie)
-    resp, auth = fetch_url(module, url, data=data, method="POST", timeout=timeout, tls_insecure=tls_insecure)
+    resp, auth = fetch_url(module, url, data=data, method="POST", timeout=timeout)
 
 
 def merge(one, two):
@@ -382,7 +382,7 @@ def main():
     # Perform login first
     url = '%s://%s/nuova' % (protocol, hostname)
     data = '<aaaLogin inName="%s" inPassword="%s"/>' % (username, password)
-    resp, auth = fetch_url(module, url, data=data, method='POST', timeout=timeout, tls_insecure=tls_insecure)
+    resp, auth = fetch_url(module, url, data=data, method='POST', timeout=timeout)
     if resp is None or auth['status'] != 200:
         result['elapsed'] = (datetime.datetime.utcnow() - start).seconds
         module.fail_json(msg='Task failed with error %(status)s: %(msg)s' % auth, **result)
@@ -416,7 +416,7 @@ def main():
         data = lxml.etree.tostring(xmldoc)
 
         # Perform actual request
-        resp, info = fetch_url(module, url, data=data, method='POST', timeout=timeout, tls_insecure=tls_insecure)
+        resp, info = fetch_url(module, url, data=data, method='POST', timeout=timeout)
         if resp is None or info['status'] != 200:
             result['elapsed'] = (datetime.datetime.utcnow() - start).seconds
             module.fail_json(msg='Task failed with error %(status)s: %(msg)s' % info, **result)

--- a/lib/ansible/modules/remote_management/imc/imc_rest.py
+++ b/lib/ansible/modules/remote_management/imc/imc_rest.py
@@ -74,8 +74,8 @@ options:
     default: 'yes'
   tls_insecure:
     description:
-    - Enable insecure TLS protocols.
-    - This should only be used with personally controlled devices (i.e. to support or upgrade older devices).
+      - Enable insecure TLS/SSL protocols.
+      - This should only be used with personally controlled devices (i.e. to support or upgrade older devices).
     type: bool
     default: no
     version_added: '2.8'

--- a/lib/ansible/plugins/doc_fragments/url.py
+++ b/lib/ansible/plugins/doc_fragments/url.py
@@ -60,4 +60,10 @@ options:
       - PEM formatted file that contains your private key to be used for SSL client authentication.
       - If C(client_cert) contains both the certificate and key, this option is not required.
     type: path
-'''
+  tls_insecure:
+    description:
+      - Enable insecure TLS protocols.
+      - This may be required to support older devices.
+    type: bool
+    default: no
+    version_added: '2.8'

--- a/lib/ansible/plugins/doc_fragments/url.py
+++ b/lib/ansible/plugins/doc_fragments/url.py
@@ -62,7 +62,7 @@ options:
     type: path
   tls_insecure:
     description:
-      - Enable insecure TLS protocols.
+      - Enable insecure TLS/SSL protocols.
       - This should only be used with personally controlled devices (i.e. to support or upgrade older devices).
     type: bool
     default: no

--- a/lib/ansible/plugins/doc_fragments/url.py
+++ b/lib/ansible/plugins/doc_fragments/url.py
@@ -63,7 +63,8 @@ options:
   tls_insecure:
     description:
       - Enable insecure TLS protocols.
-      - This may be required to support older devices.
+      - This should only be used with personally controlled devices (i.e. to support or upgrade older devices).
     type: bool
     default: no
     version_added: '2.8'
+'''

--- a/test/units/module_utils/urls/test_Request.py
+++ b/test/units/module_utils/urls/test_Request.py
@@ -448,4 +448,4 @@ def test_open_url(urlopen_mock, install_opener_mock, mocker):
                                      url_username=None, url_password=None, http_agent=None,
                                      force_basic_auth=False, follow_redirects='urllib2',
                                      client_cert=None, client_key=None, cookies=None, use_gssapi=False,
-                                     unix_socket=None)
+                                     unix_socket=None, tls_insecure=False)

--- a/test/units/module_utils/urls/test_Request.py
+++ b/test/units/module_utils/urls/test_Request.py
@@ -47,6 +47,7 @@ def test_Request_fallback(urlopen_mock, install_opener_mock, mocker):
         client_key='/tmp/client.key',
         cookies=cookies,
         unix_socket='/foo/bar/baz.sock',
+        tls_insecure=False,
     )
     fallback_mock = mocker.spy(request, '_fallback')
 
@@ -66,6 +67,7 @@ def test_Request_fallback(urlopen_mock, install_opener_mock, mocker):
         call(None, '/tmp/client.key'),  # client_key
         call(None, cookies),  # cookies
         call(None, '/foo/bar/baz.sock'),  # unix_socket
+        call(None, False),  # tls_insecure
     ]
     fallback_mock.assert_has_calls(calls)
 

--- a/test/units/module_utils/urls/test_Request.py
+++ b/test/units/module_utils/urls/test_Request.py
@@ -67,7 +67,6 @@ def test_Request_fallback(urlopen_mock, install_opener_mock, mocker):
         call(None, '/tmp/client.key'),  # client_key
         call(None, cookies),  # cookies
         call(None, '/foo/bar/baz.sock'),  # unix_socket
-        call(None, False),  # tls_insecure
     ]
     fallback_mock.assert_has_calls(calls)
 

--- a/test/units/module_utils/urls/test_fetch_url.py
+++ b/test/units/module_utils/urls/test_fetch_url.py
@@ -80,6 +80,7 @@ def test_fetch_url_params(open_url_mock, fake_ansible_module):
         'follow_redirects': 'all',
         'client_cert': 'client.pem',
         'client_key': 'client.key',
+        'tls_insecure': False,
     }
 
     r, info = fetch_url(fake_ansible_module, 'http://ansible.com/')

--- a/test/units/module_utils/urls/test_fetch_url.py
+++ b/test/units/module_utils/urls/test_fetch_url.py
@@ -67,7 +67,7 @@ def test_fetch_url(open_url_mock, fake_ansible_module):
     open_url_mock.assert_called_once_with('http://ansible.com/', client_cert=None, client_key=None, cookies=kwargs['cookies'], data=None,
                                           follow_redirects='urllib2', force=False, force_basic_auth='', headers=None,
                                           http_agent='ansible-httpget', last_mod_time=None, method=None, timeout=10, url_password='', url_username='',
-                                          use_proxy=True, validate_certs=True, use_gssapi=False, unix_socket=None)
+                                          use_proxy=True, validate_certs=True, use_gssapi=False, unix_socket=None, tls_insecure=False)
 
 
 def test_fetch_url_params(open_url_mock, fake_ansible_module):
@@ -90,7 +90,7 @@ def test_fetch_url_params(open_url_mock, fake_ansible_module):
     open_url_mock.assert_called_once_with('http://ansible.com/', client_cert='client.pem', client_key='client.key', cookies=kwargs['cookies'], data=None,
                                           follow_redirects='all', force=False, force_basic_auth=True, headers=None,
                                           http_agent='ansible-test', last_mod_time=None, method=None, timeout=10, url_password='passwd', url_username='user',
-                                          use_proxy=True, validate_certs=False, use_gssapi=False, unix_socket=None)
+                                          use_proxy=True, validate_certs=False, use_gssapi=False, unix_socket=None, tls_insecure=False)
 
 
 def test_fetch_url_cookies(mocker, fake_ansible_module):


### PR DESCRIPTION
##### SUMMARY
Some devices only support up to TLSv1.0, resulting now in TLSV1_ALERT_DECODE_ERROR.

Currently module_utils/urls.py already supports TLSv1.0 if the python version does not support anything newer or HAS_SSLCONTEXT is False. Also according to documentation PROTOCOL_SSLv23 should already support PROTOCOL_TLSv1, however that does not seem to be the case (in python 2.7.5 on RHEL7.4): https://docs.python.org/2/library/ssl.html#socket-creation

This PR includes TLSv1.0 support even if python supports newer TLSv1.1 and TLSv1.2, simply because otherwise Ansible cannot manage these older devices.

This could be backported.

PS If needed, we could add TLSv1 support also to other snippets that create an SSL context. In this PR I only considered the open_url() case.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
module_utils/urls.py

##### ANSIBLE VERSION
v2.5