### PR TITLE
Ensure the MAC address uses colons instead of hyphens for later comparison

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -842,6 +842,10 @@ class TaskParameters(DockerBaseClass):
                 if network.get('links'):
                     network['links'] = self._parse_links(network['links'])
 
+        if self.mac_address:
+            # Ensure the MAC address uses colons instead of hyphens for later comparison
+            self.mac_address = self.mac_address.replace('-', ':')
+
         if self.entrypoint:
             # convert from list to str.
             self.entrypoint = ' '.join([str(x) for x in self.entrypoint])


### PR DESCRIPTION
##### SUMMARY
Ensure the MAC address uses colons instead of hyphens for later comparison. Fixes #35463

The Docker API seems to accept hyphens in the Mac address, but when returning the value of the mac address, the API uses colons.

If the user gives us hyphens, replace them with colons for proper comparison.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/docker/docker_container.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.4
2.5
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```