### PR TITLE
ovirt_cluster: Fix documentation for gluster option

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_cluster.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_cluster.py
@@ -65,8 +65,9 @@ options:
     gluster:
         description:
             - "If I(True), hosts in this cluster will be used as Gluster Storage
-               server nodes, and not for running virtual machines."
-            - "By default the cluster is created for virtual machine hosts."
+               server nodes."
+            - "By default the cluster is created for virtual machine hosts only."
+            - "Note that you cannot add oVirt Node (RHV-H) to a Gluster-enabled cluster"
     threads_as_cores:
         description:
             - "If I(True) the exposed host threads would be treated as cores


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fix description of gluster option in ovirt_cluster module
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
ovirt_cluster.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4
```


##### ADDITIONAL INFORMATION
```
More info about gluster option when configuring the cluster can be found here, https://www.ovirt.org/documentation/admin-guide/chap-Clusters/
```
