### PR TITLE
Fix junos_facts integration test failure

### DIFF
--- a/test/integration/targets/junos_facts/tests/netconf/facts.yaml
+++ b/test/integration/targets/junos_facts/tests/netconf/facts.yaml
@@ -62,7 +62,7 @@
 - assert:
     that:
       - "result.changed == false"
-      - "'set system host-name {{ inventory_hostname_short }}' in result['ansible_facts']['ansible_net_config']"
+      - "'set system services netconf ssh' in result['ansible_facts']['ansible_net_config']"
 
 - name: Collect config facts from device in xml format
   junos_facts:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Hostname is not always configured on remote host
Instead, add an assert statement to check if netconf
is configured for junos_facts.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Test Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
