### PR TITLE
get_url should accept headers as a dict, instead of only a complicated string

### DIFF
--- a/lib/ansible/modules/net_tools/basics/get_url.py
+++ b/lib/ansible/modules/net_tools/basics/get_url.py
@@ -114,7 +114,9 @@ options:
     version_added: '1.8'
   headers:
     description:
-        - Add custom HTTP headers to a request in hash/dict format. The C("key:value,key:value") string format is deprecated and will be removed in version 2.9.
+        - Add custom HTTP headers to a request in hash/dict format. The hash/dict format was added in 2.6.
+          Previous versions used a C("key:value,key:value") string format. The C("key:value,key:value") string
+          format is deprecated and will be removed in version 2.10.
     version_added: '2.0'
   url_username:
     description:
@@ -415,7 +417,7 @@ def main():
     elif module.params['headers']:
         try:
             headers = dict(item.split(':', 1) for item in module.params['headers'].split(','))
-            module.deprecate('Supplying `headers` as a string is deprecated. Please use dict/hash format for `headers`', version='2.9')
+            module.deprecate('Supplying `headers` as a string is deprecated. Please use dict/hash format for `headers`', version='2.10')
         except Exception:
             module.fail_json(msg="The string representation for the `headers` parameter requires a key:value,key:value syntax to be properly parsed.")
     else:

--- a/lib/ansible/modules/net_tools/basics/get_url.py
+++ b/lib/ansible/modules/net_tools/basics/get_url.py
@@ -387,7 +387,7 @@ def main():
         sha256sum=dict(type='str', default=''),
         checksum=dict(type='str', default=''),
         timeout=dict(type='int', default=10),
-        headers=dict(type='str'),
+        headers=dict(type='raw'),
         tmp_dest=dict(type='path'),
     )
 
@@ -410,11 +410,14 @@ def main():
     tmp_dest = module.params['tmp_dest']
 
     # Parse headers to dict
-    if module.params['headers']:
+    if isinstance(module.params['headers'], dict):
+        headers = module.params['headers']
+    elif module.params['headers']:
         try:
             headers = dict(item.split(':', 1) for item in module.params['headers'].split(','))
+            module.deprecate('Supplying `headers` as a string is deprecated. Please use dict/hash format for `headers`', version='2.9')
         except Exception:
-            module.fail_json(msg="The header parameter requires a key:value,key:value syntax to be properly parsed.")
+            module.fail_json(msg="The string representation for the `headers` parameter requires a key:value,key:value syntax to be properly parsed.")
     else:
         headers = None
 

--- a/lib/ansible/modules/net_tools/basics/get_url.py
+++ b/lib/ansible/modules/net_tools/basics/get_url.py
@@ -114,7 +114,7 @@ options:
     version_added: '1.8'
   headers:
     description:
-        - Add custom HTTP headers to a request in the format "key:value,key:value".
+        - Add custom HTTP headers to a request in hash/dict format. The C("key:value,key:value") string format is deprecated and will be removed in version 2.9.
     version_added: '2.0'
   url_username:
     description:

--- a/test/integration/targets/get_url/tasks/main.yml
+++ b/test/integration/targets/get_url/tasks/main.yml
@@ -230,10 +230,35 @@
 
 #https://github.com/ansible/ansible/issues/16191
 - name: Test url split with no filename
-  get_url: 
+  get_url:
     url: https://{{ httpbin_host }}
     dest: "{{ output_dir }}"
 
+- name: Test headers string
+  get_url:
+    url: https://{{ httpbin_host }}/headers
+    headers: Foo:bar,Baz:qux
+    dest: "{{ output_dir }}/headers_string.json"
+
+- name: Test headers string
+  assert:
+    that:
+      - (lookup('file', output_dir ~ '/headers_string.json')|from_json).headers.get('Foo') == 'bar'
+      - (lookup('file', output_dir ~ '/headers_string.json')|from_json).headers.get('Baz') == 'qux'
+
+- name: Test headers dict
+  get_url:
+    url: https://{{ httpbin_host }}/headers
+    headers:
+      Foo: bar
+      Baz: qux
+    dest: "{{ output_dir }}/headers_dict.json"
+
+- name: Test headers dict
+  assert:
+    that:
+      - (lookup('file', output_dir ~ '/headers_dict.json')|from_json).headers.get('Foo') == 'bar'
+      - (lookup('file', output_dir ~ '/headers_dict.json')|from_json).headers.get('Baz') == 'qux'
 
 - name: Test client cert auth, with certs
   get_url:

--- a/test/integration/targets/get_url/tasks/main.yml
+++ b/test/integration/targets/get_url/tasks/main.yml
@@ -246,6 +246,16 @@
       - (lookup('file', output_dir ~ '/headers_string.json')|from_json).headers.get('Foo') == 'bar'
       - (lookup('file', output_dir ~ '/headers_string.json')|from_json).headers.get('Baz') == 'qux'
 
+- name: Test headers string invalid format
+  get_url:
+    url: https://{{ httpbin_host }}/headers
+    headers: Foo
+    dest: "{{ output_dir }}/headers_string_invalid.json"
+  register: invalid_string_headers
+  failed_when:
+    - invalid_string_headers is successful
+    - invalid_string_headers.msg != "The string representation for the `headers` parameter requires a key:value,key:value syntax to be properly parsed."
+
 - name: Test headers dict
   get_url:
     url: https://{{ httpbin_host }}/headers


### PR DESCRIPTION
##### SUMMARY
get_url should accept headers as a dict, instead of only a complicated string

This also allows for headers that may use `,`s to separate values like:

```
Accept: application/tar+gzip, application/x-gzip, application/octet-stream
```

As of now, the above is impossible.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
lib/ansible/modules/net_tools/basics/get_url.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```