### PR TITLE
Fixes #35468: ADD max_results to the nios api

### DIFF
--- a/lib/ansible/module_utils/net_tools/nios/api.py
+++ b/lib/ansible/module_utils/net_tools/nios/api.py
@@ -50,7 +50,8 @@ nios_provider_spec = {
     'http_pool_connections': dict(type='int', default=10),
     'http_pool_maxsize': dict(type='int', default=10),
     'max_retries': dict(type='int', default=3),
-    'wapi_version': dict(default='1.4')
+    'wapi_version': dict(default='1.4'),
+    'max_results': dict(type='int', 1000)
 }
 
 

--- a/lib/ansible/module_utils/net_tools/nios/api.py
+++ b/lib/ansible/module_utils/net_tools/nios/api.py
@@ -51,7 +51,7 @@ nios_provider_spec = {
     'http_pool_maxsize': dict(type='int', default=10),
     'max_retries': dict(type='int', default=3),
     'wapi_version': dict(default='1.4'),
-    'max_results': dict(type='int', 1000)
+    'max_results': dict(type='int', default=1000)
 }
 
 

--- a/lib/ansible/utils/module_docs_fragments/nios.py
+++ b/lib/ansible/utils/module_docs_fragments/nios.py
@@ -76,6 +76,15 @@ options:
             variable.
         required: false
         default: 1.4
+      max_results:
+        description:
+          - Specifies the maximum number of objects to be returned,
+            if set to a negative number the appliance will return an error when the
+            number of returned objects would exceed the setting.
+          - Value can also be specified using C(INFOBLOX_MAX_RESULTS) environment
+            variable.
+        required: false
+        default: 1000
 notes:
   - "This module must be run locally, which can be achieved by specifying C(connection: local)."
 """

--- a/test/units/module_utils/net_tools/nios/test_api.py
+++ b/test/units/module_utils/net_tools/nios/test_api.py
@@ -32,7 +32,7 @@ class TestNiosApi(unittest.TestCase):
     def test_get_provider_spec(self):
         provider_options = ['host', 'username', 'password', 'ssl_verify', 'silent_ssl_warnings',
                             'http_request_timeout', 'http_pool_connections',
-                            'http_pool_maxsize', 'max_retries', 'wapi_version']
+                            'http_pool_maxsize', 'max_retries', 'wapi_version', 'max_results']
         res = api.WapiBase.provider_spec
         self.assertIsNotNone(res)
         self.assertIn('provider', res)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
By default, the number of results is limited to 1000, passing the "max_results" parameter, this would raise this limitation.
Alas nothing was planned to pass this parameter in the yaml configuration file.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
module_utils/net_tools/nios/api.py 
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

ansible 2.5.0 (devel_infoblox_max_results 627fa7c9cd) last updated 2018/01/29 19:32:55 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/clement/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/clement/Documents/PROJECTS/ansible_env_setup/ansible/lib/ansible
  executable location = /home/clement/Documents/PROJECTS/ansible_env_setup/ansible/bin/ansible
  python version = 3.6.3 (default, Oct  9 2017, 12:07:10) [GCC 7.2.1 20170915 (Red Hat 7.2.1-2)]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
 Add the max_results into the nios_provider_spec dict
- component: module_utils/net_tools/nios/api.py
- It would refer to '_max_results' option in WAPI
```yaml

---
# This file provides the configuration information for the Infoblox dynamic
# inventory script that is used to dynamically pull host information from NIOS.
# This file should be copied to /etc/ansible/infoblox.yaml in order for the
# dynamic script to find it.

# Sets the provider arguments for authenticating to the Infoblox server to
# retrieve inventory hosts.  Provider arguments can also be set using
# environment variables.  Supported environment variables all start with
# INFOBLOX_{{ name }}.  For instance, to set the host provider value, the
# environment variable would be INFOBLOX_HOST.
provider:
  host: XXXXXXXXXXX
  username: XXXXX
  password: XXXXX
  ssl_verify: False
  http_request_timeout: 120
  max_results: 10000 
# Filters allow the dynamic inventory script to restrict the set of hosts that
# are returned from the Infoblox server.
filters:
  # restrict returned hosts by extensible attributes
  extattrs: {"IN_DeviceType": "ACCESS", "IN_Country": "FR",  "IN_Service": "CAMPUS", "IN_Owner": "LAN" }


  # restrict returned hosts to a specified DNS view
  view: default
```
```python
nios_provider_spec = {
    'host': dict(),
    'username': dict(),
    'password': dict(no_log=True),
    'ssl_verify': dict(type='bool', default=False),
    'silent_ssl_warnings': dict(type='bool', default=True),
    'http_request_timeout': dict(type='int', default=10),
    'http_pool_connections': dict(type='int', default=10),
    'http_pool_maxsize': dict(type='int', default=10),
    'max_retries': dict(type='int', default=3),
    'wapi_version': dict(default='1.4'),
    'max_results': dict(type='int', default=1000)
}
```

