### PR TITLE
Add minor conditional checks to nxos_bgp sanity test

### DIFF
--- a/test/integration/targets/nxos_bgp/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_bgp/tests/common/sanity.yaml
@@ -4,10 +4,13 @@
   when: ansible_connection == "local"
 
 - set_fact: neighbor_down_fib_accelerate="true"
-  when: not titanium
+  when: (not titanium) and (imagetag and ((imagetag | version_compare('N1', 'ne')) and (imagetag | version_compare('D1', 'ne'))))
 
 - set_fact: reconnect_interval="55"
-  when: not titanium
+  when: (not titanium) and (imagetag and ((imagetag | version_compare('N1', 'ne')) and (imagetag | version_compare('D1', 'ne'))))
+
+- set_fact: isolate="false"
+  when: not (platform | match("N35"))
 
 - name: "Enable feature BGP"
   nxos_feature:
@@ -77,7 +80,7 @@
       graceful_restart_helper: true
       graceful_restart_timers_restart: 130
       graceful_restart_timers_stalepath_time: 310
-      isolate: false
+      isolate: "{{isolate|default(omit)}}"
       log_neighbor_changes: true
       maxas_limit: 50
       neighbor_down_fib_accelerate: "{{neighbor_down_fib_accelerate|default(omit)}}"

--- a/test/integration/targets/nxos_bgp/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_bgp/tests/common/sanity.yaml
@@ -4,13 +4,13 @@
   when: ansible_connection == "local"
 
 - set_fact: neighbor_down_fib_accelerate="true"
-  when: (not titanium) and (imagetag and ((imagetag | version_compare('N1', 'ne')) and (imagetag | version_compare('D1', 'ne'))))
+  when: (not titanium) and ((imagetag != 'N1') and (imagetag != 'D1'))
 
 - set_fact: reconnect_interval="55"
-  when: (not titanium) and (imagetag and ((imagetag | version_compare('N1', 'ne')) and (imagetag | version_compare('D1', 'ne'))))
+  when: (not titanium) and ((imagetag != 'N1') and (imagetag != 'D1'))
 
 - set_fact: isolate="false"
-  when: not (platform | match("N35"))
+  when: platform is not match("N35")
 
 - name: "Enable feature BGP"
   nxos_feature:


### PR DESCRIPTION
##### SUMMARY
Add some minor conditional checks for nxos versions.
-->

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
nxos_bgp

##### ANSIBLE VERSION
```
ansible 2.5.0 (devel 942d98ed17) last updated 2018/01/29 14:54:55 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/Users/mwiebe/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mwiebe/Projects/nxos_ansible/fix_ansible/lib/ansible
  executable location = /Users/mwiebe/Projects/nxos_ansible/fix_ansible/bin/ansible
  python version = 2.7.13 (default, Apr  4 2017, 08:47:57) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.38)]
```


##### ADDITIONAL INFORMATION
Please cherry-pick into stable-2.4
