### PR TITLE
Fix win_regedit module and tests.

### DIFF
--- a/lib/ansible/modules/windows/win_regedit.ps1
+++ b/lib/ansible/modules/windows/win_regedit.ps1
@@ -448,7 +448,12 @@ try {
                 if (-not $check_mode) {
                     $reg_key = Get-Item -Path $path
                     try {
-                        $reg_key.OpenSubKey($null, [Microsoft.Win32.RegistryKeyPermissionCheck]::ReadWriteSubTree).SetValue($name, $data, $type)
+                        $sub_key = $reg_key.OpenSubKey($null, [Microsoft.Win32.RegistryKeyPermissionCheck]::ReadWriteSubTree)
+                        try {
+                            $sub_key.SetValue($name, $data, $type)
+                        } finally {
+                            $sub_key.Close()
+                        }
                     } catch {
                         Fail-Json $result "failed to change registry property '$name' at $($path): $($_.Exception.Message)"
                     } finally {
@@ -476,7 +481,12 @@ $key_prefix[$path]
             if (-not $check_mode) {
                 $reg_key = Get-Item -Path $path
                 try {
-                    $reg_key.OpenSubKey($null, [Microsoft.Win32.RegistryKeyPermissionCheck]::ReadWriteSubTree).SetValue($name, $data, $type)
+                    $sub_key = $reg_key.OpenSubKey($null, [Microsoft.Win32.RegistryKeyPermissionCheck]::ReadWriteSubTree)
+                    try {
+                        $sub_key.SetValue($name, $data, $type)
+                    } finally {
+                        $sub_key.Close()
+                    }
                 } catch {
                     Fail-Json $result "failed to change registry property '$name' at $($path): $($_.Exception.Message)"
                 } finally {
@@ -525,7 +535,12 @@ $key_prefix[$path]
                     if (-not $check_mode) {
                         $reg_key = Get-Item -Path $path
                         try {
-                            $reg_key.OpenSubKey($null, [Microsoft.Win32.RegistryKeyPermissionCheck]::ReadWriteSubTree).DeleteValue($name)
+                            $sub_key = $reg_key.OpenSubKey($null, [Microsoft.Win32.RegistryKeyPermissionCheck]::ReadWriteSubTree)
+                            try {
+                                $sub_key.DeleteValue($name)
+                            } finally {
+                                $sub_key.Close()
+                            }
                         } catch {
                             Fail-Json $result "failed to delete registry property '$name' at $($path): $($_.Exception.Message)"
                         } finally {

--- a/test/integration/targets/win_regedit/tasks/tests.yml
+++ b/test/integration/targets/win_regedit/tasks/tests.yml
@@ -469,12 +469,14 @@
 
 - name: get result of create new key in loaded hive (check mode)
   win_shell: |
+    $ErrorActionPreference = "Stop"
     &reg.exe load HKLM\ANSIBLE C:\Users\Default\NTUSER.dat > $null
     Test-Path -Path HKLM:\ANSIBLE\NewKey
+    [GC]::Collect()
+    [GC]::WaitForPendingFinalizers()
+    &reg.exe unload HKLM\ANSIBLE > $null
     exit 0
   register: new_key_in_hive_result_check
-
-- win_command: reg.exe unload HKLM\ANSIBLE
 
 - name: assert result of create new key in loaded hive (check mode)
   assert:
@@ -491,12 +493,14 @@
 
 - name: get result of create new key in loaded hive
   win_shell: |
+    $ErrorActionPreference = "Stop"
     &reg.exe load HKLM\ANSIBLE C:\Users\Default\NTUSER.dat > $null
     Test-Path -Path HKLM:\ANSIBLE\NewKey
+    [GC]::Collect()
+    [GC]::WaitForPendingFinalizers()
+    &reg.exe unload HKLM\ANSIBLE > $null
     exit 0
   register: new_key_in_hive_result
-
-- win_command: reg.exe unload HKLM\ANSIBLE
 
 - name: assert result of create new key in loaded hive
   assert:
@@ -533,11 +537,11 @@
     $prop = Get-ItemProperty -Path HKLM:\ANSIBLE\NewKey -Name TestProp -ErrorAction SilentlyContinue
     if ($prop) {
       $prop.TestProp
+      $prop.Close()
     }
+    &reg.exe unload HKLM\ANSIBLE > $null
     exit 0
   register: new_prop_in_hive_result_check
-
-- win_command: reg.exe unload HKLM\ANSIBLE
 
 - name: assert result of set hive key property (check mode)
   assert:
@@ -561,11 +565,11 @@
     $prop = Get-ItemProperty -Path HKLM:\ANSIBLE\NewKey -Name TestProp -ErrorAction SilentlyContinue
     if ($prop) {
       $prop.TestProp
+      $prop.Close()
     }
+    &reg.exe unload HKLM\ANSIBLE > $null
     exit 0
   register: new_prop_in_hive_result
-
-- win_command: reg.exe unload HKLM\ANSIBLE
 
 - name: assert result of set hive key property
   assert:
@@ -603,11 +607,11 @@
     $prop = Get-ItemProperty -Path HKLM:\ANSIBLE\NewKey -Name TestProp -ErrorAction SilentlyContinue
     if ($prop) {
       $prop.TestProp
+      $prop.Close()
     }
+    &reg.exe unload HKLM\ANSIBLE > $null
     exit 0
   register: remove_prop_in_hive_result_check
-
-- win_command: reg.exe unload HKLM\ANSIBLE
 
 - name: assert result of remove hive key property (check mode)
   assert:
@@ -629,11 +633,11 @@
     $prop = Get-ItemProperty -Path HKLM:\ANSIBLE\NewKey -Name TestProp -ErrorAction SilentlyContinue
     if ($prop) {
       $prop.TestProp
+      $prop.Close()
     }
+    &reg.exe unload HKLM\ANSIBLE > $null
     exit 0
   register: remove_prop_in_hive_result
-
-- win_command: reg.exe unload HKLM\ANSIBLE
 
 - name: assert result of remove hive key property
   assert:
@@ -665,12 +669,14 @@
 
 - name: get result of remove key in loaded hive (check mode)
   win_shell: |
+    $ErrorActionPreference = "Stop"
     &reg.exe load HKLM\ANSIBLE C:\Users\Default\NTUSER.dat > $null
     Test-Path -Path HKLM:\ANSIBLE\NewKey
+    [GC]::Collect()
+    [GC]::WaitForPendingFinalizers()
+    &reg.exe unload HKLM\ANSIBLE > $null
     exit 0
   register: remove_key_in_hive_result_check
-
-- win_command: reg.exe unload HKLM\ANSIBLE
 
 - name: assert result of removekey in loaded hive (check mode)
   assert:
@@ -688,12 +694,14 @@
 
 - name: get result of remove key in loaded hive
   win_shell: |
+    $ErrorActionPreference = "Stop"
     &reg.exe load HKLM\ANSIBLE C:\Users\Default\NTUSER.dat > $null
     Test-Path -Path HKLM:\ANSIBLE\NewKey
+    [GC]::Collect()
+    [GC]::WaitForPendingFinalizers()
+    &reg.exe unload HKLM\ANSIBLE > $null
     exit 0
   register: remove_key_in_hive_result
-
-- win_command: reg.exe unload HKLM\ANSIBLE
 
 - name: assert result of remove key in loaded hive
   assert:


### PR DESCRIPTION
##### SUMMARY

Fix win_regedit module and tests.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

win_regedit

##### ANSIBLE VERSION

```
ansible 2.5.0 (win-regedit-fixes 82d9091a1d) last updated 2018/01/29 13:38:06 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```
