### PR TITLE
Use static password for win_owner test.

### DIFF
--- a/test/integration/targets/win_owner/tasks/main.yml
+++ b/test/integration/targets/win_owner/tasks/main.yml
@@ -172,7 +172,7 @@
 - name: create test user
   win_user:
     name: test win owner
-    password: TtPp!@#$%^ + {{ lookup('password', '/dev/null length=15') }}
+    password: E1K0-O8b1-c8M9-c6D5
 
 - name: set owner with space recurse
   win_owner:


### PR DESCRIPTION
##### SUMMARY

Use static password for win_owner test.

This will provide consistent results across test runs and should avoid previously seen issues with password complexity failures.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

win_owner integration tests

##### ANSIBLE VERSION

```
ansible 2.5.0 (win-owner-password 58920ee2a0) last updated 2018/01/29 14:41:53 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```
