### PR TITLE
Handle incorrect data type in list lookup plugin

### DIFF
--- a/lib/ansible/plugins/lookup/list.py
+++ b/lib/ansible/plugins/lookup/list.py
@@ -33,6 +33,7 @@ import collections
 from ansible.plugins.lookup import LookupBase
 from ansible.errors import AnsibleError
 
+
 class LookupModule(LookupBase):
 
     def run(self, terms, **kwargs):

--- a/lib/ansible/plugins/lookup/list.py
+++ b/lib/ansible/plugins/lookup/list.py
@@ -3,6 +3,7 @@
 
 # Make coding more python3-ish
 from __future__ import (absolute_import, division, print_function)
+
 __metaclass__ = type
 
 DOCUMENTATION = """
@@ -27,10 +28,14 @@ RETURN = """
   _list:
     description: basically the same as you fed in
 """
-from ansible.plugins.lookup import LookupBase
+import collections
 
+from ansible.plugins.lookup import LookupBase
+from ansible.errors import AnsibleError
 
 class LookupModule(LookupBase):
 
     def run(self, terms, **kwargs):
+        if not isinstance(terms, collections.Sequence):
+            raise AnsibleError("with_list expects a list")
         return terms

--- a/test/integration/targets/loops/tasks/main.yml
+++ b/test/integration/targets/loops/tasks/main.yml
@@ -214,7 +214,7 @@
   ignore_errors: True
 - assert:
     that:
-      - with_dict_passed_a_list|failed
+      - with_dict_passed_a_list is failed
 - debug:
     msg: "with_list passed a dict: {{item}}"
   with_list: "{{ a_dict }}"
@@ -222,4 +222,4 @@
   ignore_errors: True
 - assert:
     that:
-      - with_list_passed_a_dict|failed
+      - with_list_passed_a_dict is failed

--- a/test/integration/targets/loops/tasks/main.yml
+++ b/test/integration/targets/loops/tasks/main.yml
@@ -202,3 +202,24 @@
     that:
       - "output.results[0]['_ansible_item_label'] == 'looped_var foo_label'"
       - "output.results[1]['_ansible_item_label'] == 'looped_var bar_label'"
+
+# The following test cases are to ensure that we don't have a regression on
+# GitHub Issue https://github.com/ansible/ansible/issues/35481
+#
+# This should execute and not cause a RuntimeError
+- debug:
+    msg: "with_dict passed a list: {{item}}"
+  with_dict: "{{ a_list }}"
+  register: with_dict_passed_a_list
+  ignore_errors: True
+- assert:
+    that:
+      - with_dict_passed_a_list|failed
+- debug:
+    msg: "with_list passed a dict: {{item}}"
+  with_list: "{{ a_dict }}"
+  register: with_list_passed_a_dict
+  ignore_errors: True
+- assert:
+    that:
+      - with_list_passed_a_dict|failed


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #35481

Appropriately handle the scenario where someone passes an incorrect data type to `with_list` or otherwise to the `list` lookup plugin and gracefully fail the play instead of causing a `RuntimeError`.

Also added integration tests to ensure we don't have this happen again.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
lib/ansible/executor/task_executor.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (lookup 24bd56df65) last updated 2018/01/29 16:56:27 (GMT -500)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/admiller/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/admiller/src/dev/ansible/lib/ansible
  executable location = /home/admiller/.virtualenvs/ansible/bin/ansible
  python version = 2.7.14 (default, Jan 17 2018, 14:28:32) [GCC 7.2.1 20170915 (Red Hat 7.2.1-2)]
```



