### PR TITLE
Test Windows 2012+ using Azure by default.

### DIFF
--- a/test/runner/lib/core_ci.py
+++ b/test/runner/lib/core_ci.py
@@ -73,6 +73,9 @@ class AnsibleCoreCI(object):
             azure=(
                 'azure',
                 'rhel',
+                'windows/2012',
+                'windows/2012-R2',
+                'windows/2016',
             ),
             parallels=(
                 'osx',
@@ -86,6 +89,11 @@ class AnsibleCoreCI(object):
             for candidate in providers:
                 if platform in providers[candidate]:
                     # assign default provider based on platform
+                    self.provider = candidate
+                    break
+            for candidate in providers:
+                if '%s/%s' % (platform, version) in providers[candidate]:
+                    # assign default provider based on platform and version
                     self.provider = candidate
                     break
 


### PR DESCRIPTION
##### SUMMARY

Test Windows 2012+ using Azure by default.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.5.0 (at-azure ace12a12d7) last updated 2018/01/29 16:04:22 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```
