### PR TITLE
[Doc] Update Conditional Imports

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_conditionals.rst
+++ b/docs/docsite/rst/user_guide/playbooks_conditionals.rst
@@ -220,25 +220,15 @@ but it is easily handled with a minimum of syntax in an Ansible Playbook::
 As a reminder, the various YAML files contain just keys and values::
 
     ---
-    # for vars/CentOS.yml
+    # for vars/RedHat.yml
     apache: httpd
     somethingelse: 42
 
-How does this work?  If the operating system was 'CentOS', the first file Ansible would try to import
-would be 'vars/CentOS.yml', followed by '/vars/os_defaults.yml' if that file
+How does this work?  If the operating system was any RedHat derivate for example 'CentOS', the first file Ansible would try to import
+would be 'vars/RedHat.yml', followed by 'vars/os_defaults.yml' if that file
 did not exist.   If no files in the list were found, an error would be raised.
-On Debian, it would instead first look towards 'vars/Debian.yml' instead of 'vars/CentOS.yml', before
+On Debian, it would instead first look towards 'vars/Debian.yml' instead of 'vars/RedHat.yml', before
 falling back on 'vars/os_defaults.yml'. Pretty simple.
-
-To use this conditional import feature, you'll need facter or ohai installed prior to running the playbook, but
-you can of course push this out with Ansible if you like::
-
-    # for facter
-    ansible -m yum -a "pkg=facter state=present"
-    ansible -m yum -a "pkg=ruby-json state=present"
-
-    # for ohai
-    ansible -m yum -a "pkg=ohai state=present"
 
 Ansible's approach to configuration -- separating variables from tasks, keeps your playbooks
 from turning into arbitrary code with ugly nested ifs, conditionals, and so on - and results

--- a/docs/docsite/rst/user_guide/playbooks_conditionals.rst
+++ b/docs/docsite/rst/user_guide/playbooks_conditionals.rst
@@ -224,16 +224,15 @@ As a reminder, the various YAML files contain just keys and values::
     apache: httpd
     somethingelse: 42
 
-How does this work?  If the operating system was any RedHat derivate for example 'CentOS', the first file Ansible would try to import
-would be 'vars/RedHat.yml', followed by 'vars/os_defaults.yml' if that file
-did not exist.   If no files in the list were found, an error would be raised.
-On Debian, it would instead first look towards 'vars/Debian.yml' instead of 'vars/RedHat.yml', before
-falling back on 'vars/os_defaults.yml'. Pretty simple.
+How does this work?  For Red Hat operating systems ('CentOS', for example), the first file Ansible tries to import
+is 'vars/RedHat.yml'. If that file does not exist, Ansible attempts to load 'vars/os_defaults.yml'. If no files in 
+the list were found, an error is raised.
 
-Ansible's approach to configuration -- separating variables from tasks, keeps your playbooks
-from turning into arbitrary code with ugly nested ifs, conditionals, and so on - and results
-in more streamlined & auditable configuration rules -- especially because there are a
-minimum of decision points to track.
+On Debian, Ansible first looks for 'vars/Debian.yml' instead of 'vars/RedHat.yml', before
+falling back on 'vars/os_defaults.yml'.
+
+Ansible's approach to configuration -- separating variables from tasks, keeping your playbooks
+from turning into arbitrary code with nested conditionals - results in more streamlined and auditable configuration rules because there are fewer decision points to track.
 
 Selecting Files And Templates Based On Variables
 ````````````````````````````````````````````````


### PR DESCRIPTION
facter/ohai is not needed for the ansible internal facts

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
The docs say that the conditional imports need facter/ohai, this is not correct, they work fine with ansible 2.4 without facter/ohai

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
Docs

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, May  3 2017, 07:55:04) [GCC 4.8.5 20150623 (Red Hat 4.8.5-14)]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
