### PR TITLE
vsphere_guest: Explicit VM datastore

### DIFF
--- a/lib/ansible/modules/cloud/vmware/_vsphere_guest.py
+++ b/lib/ansible/modules/cloud/vmware/_vsphere_guest.py
@@ -59,6 +59,12 @@ options:
       - The name of the resource_pool to create the VM in.
     required: false
     default: None
+  datastore:
+    version_added: "2.6"
+    description:
+      - The name of the datastore to create the VM in.
+    required: true
+    default: null
   cluster:
     description:
       - The name of the cluster to create the VM in. By default this is derived from the host you tell the module to build the guest on.
@@ -1216,7 +1222,7 @@ def _get_folderid_for_path(vsphere_client, datacenter, path):
     return folder['id'] if folder else None
 
 
-def create_vm(vsphere_client, module, esxi, resource_pool, cluster_name, guest, vm_extra_config, vm_hardware, vm_disk, vm_nic, vm_hw_version, state):
+def create_vm(vsphere_client, module, esxi, resource_pool, datastore, cluster_name, guest, vm_extra_config, vm_hardware, vm_disk, vm_nic, vm_hw_version, state):
 
     datacenter = esxi['datacenter']
     esxi_hostname = esxi['hostname']
@@ -1339,7 +1345,7 @@ def create_vm(vsphere_client, module, esxi, resource_pool, cluster_name, guest, 
         config.set_element_version(vm_hw_version)
     vmfiles = config.new_files()
     datastore_name, ds = find_datastore(
-        module, vsphere_client, vm_disk['disk1']['datastore'], config_target)
+        module, vsphere_client, datastore, config_target)
     vmfiles.set_element_vmPathName(datastore_name)
     config.set_element_files(vmfiles)
     config.set_element_name(guest)
@@ -1748,6 +1754,7 @@ def main():
             vm_extra_config=dict(required=False, type='dict', default={}),
             vm_hw_version=dict(required=False, default=None, type='str'),
             resource_pool=dict(required=False, default=None, type='str'),
+            datastore=dict(required=True, type='str'),
             cluster=dict(required=False, default=None, type='str'),
             force=dict(required=False, type='bool', default=False),
             esxi=dict(required=False, type='dict', default={}),
@@ -1790,6 +1797,7 @@ def main():
     vm_hw_version = module.params['vm_hw_version']
     esxi = module.params['esxi']
     resource_pool = module.params['resource_pool']
+    datastore = module.params['datastore']
     cluster = module.params['cluster']
     template_src = module.params['template_src']
     from_template = module.params['from_template']
@@ -1918,6 +1926,7 @@ def main():
                 module=module,
                 esxi=esxi,
                 resource_pool=resource_pool,
+                datastore=datastore,
                 cluster_name=cluster,
                 guest=guest,
                 vm_extra_config=vm_extra_config,


### PR DESCRIPTION
##### SUMMARY
Adds the datastore parameter used to specify the location of the Virtual Machine files.

The current behavior was to use the datastore for disk ```disk1```. However, disks are optional and the expected disk key is not documented. The user should be able to create a diskless, cdrom bootable machine.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
cloud/vmware/vsphere_guest

##### ANSIBLE VERSION
```
ansible 2.4.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/vagrant/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.13 (default, Nov 24 2017, 17:33:09) [GCC 6.3.0 20170516]
```

##### ADDITIONAL INFORMATION
An ESXi or vSphere hypervisor is necessary. The hypervisor should have at least two datastores. One for the VM and one for the disk.

In fact, even if specifying disks is set to optional, the parameter validation code does not permit this. I have another fix for that. The testing must be done with a proper configuration including disk and network.

The change is breaking existing tasks. Adaptation for non-breaking can be done if requested.
