### PR TITLE
vsphere_guest: Full disk and network parameters check

### DIFF
--- a/lib/ansible/modules/cloud/vmware/_vsphere_guest.py
+++ b/lib/ansible/modules/cloud/vmware/_vsphere_guest.py
@@ -1339,7 +1339,7 @@ def create_vm(vsphere_client, module, esxi, resource_pool, cluster_name, guest, 
         config.set_element_version(vm_hw_version)
     vmfiles = config.new_files()
     datastore_name, ds = find_datastore(
-        module, vsphere_client, vm_disk['disk1']['datastore'], config_target)
+        module, vsphere_client, vm_disk[next(iter(vm_disk))]['datastore'], config_target)
     vmfiles.set_element_vmPathName(datastore_name)
     config.set_element_files(vmfiles)
     config.set_element_name(guest)
@@ -1692,19 +1692,15 @@ def main():
     }
 
     proto_vm_disk = {
-        'disk1': {
-            'datastore': string_types,
-            'size_gb': int,
-            'type': string_types
-        }
+        'datastore': string_types,
+        'size_gb': int,
+        'type': string_types
     }
 
     proto_vm_nic = {
-        'nic1': {
-            'type': string_types,
-            'network': string_types,
-            'network_type': string_types
-        }
+        'type': string_types,
+        'network': string_types,
+        'network_type': string_types
     }
 
     proto_esxi = {
@@ -1908,8 +1904,10 @@ def main():
         elif state in ['present', 'powered_off', 'powered_on']:
 
             # Check the guest_config
-            config_check("vm_disk", vm_disk, proto_vm_disk, module)
-            config_check("vm_nic", vm_nic, proto_vm_nic, module)
+            for disk in sorted(vm_disk):
+                config_check("vm_disk.%s" % disk, vm_disk[disk], proto_vm_disk, module)
+            for nic in sorted(vm_nic):
+                config_check("vm_nic.%s" % nic, vm_nic[nic], proto_vm_nic, module)
             config_check("vm_hardware", vm_hardware, proto_vm_hardware, module)
             config_check("esxi", esxi, proto_esxi, module)
 


### PR DESCRIPTION
##### SUMMARY
Makes the vsphere_guest module verify every disk and network specified for validity.

Past behavior was to only check the existence of disk1 and nic1. This was undocumented. The user should be able to specify any valid identifier for these parameters' keys.

This changes also allow empty arrays for disks and networks.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
cloud/vmware/vsphere_guest

##### ANSIBLE VERSION
```
ansible 2.4.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/vagrant/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.13 (default, Nov 24 2017, 17:33:09) [GCC 6.3.0 20170516]
```

##### ADDITIONAL INFORMATION
In the current state, specifying empty array in network and disk parameters will prevent the creation of the virtual machine. Without PR #35501 it will also not be possible to not use ```disk1``` and ```nic1``` names. However, the error message will specify the device key.

Testing should be done on ```disk1``` and another disk definition, for completeness. 

EDIT: I removed the need of applying PR #35501 before be choosing in the first defined disk key for machine datastore.