### PR TITLE
vsphere_guest: Allow configuration of manual mac address

### DIFF
--- a/lib/ansible/modules/cloud/vmware/_vsphere_guest.py
+++ b/lib/ansible/modules/cloud/vmware/_vsphere_guest.py
@@ -112,7 +112,7 @@ options:
     default: null
   vm_nic:
     description:
-      - A key, value list of nics, their types and what network to put them on.
+      - A key, value list of nics, their types and what network to put them on. Optionaly with their MAC address.
     required: false
     default: null
   vm_extra_config:
@@ -466,7 +466,7 @@ def add_floppy(module, s, config_target, config, devices, default_devs, type="im
     devices.append(floppy_spec)
 
 
-def add_nic(module, s, nfmor, config, devices, nic_type="vmxnet3", network_name="VM Network", network_type="standard"):
+def add_nic(module, s, nfmor, config, devices, nic_type="vmxnet3", network_name="VM Network", network_type="standard", mac_address=None):
     # add a NIC
     # Different network card types are: "VirtualE1000",
     # "VirtualE1000e","VirtualPCNet32", "VirtualVmxnet", "VirtualNmxnet2",
@@ -516,7 +516,11 @@ def add_nic(module, s, nfmor, config, devices, nic_type="vmxnet3", network_name=
             msg="Error adding nic backing to vm spec. No network type of:"
             " %s" % (network_type))
 
-    nic_ctlr.set_element_addressType("generated")
+    if mac_address:
+        nic_ctlr.set_element_addressType('manual')
+        nic_ctlr.set_element_macAddress(mac_address)
+    else:
+        nic_ctlr.set_element_addressType("generated")
     nic_ctlr.set_element_backing(nic_backing)
     nic_ctlr.set_element_key(4)
     nic_spec.set_element_device(nic_ctlr)
@@ -1447,9 +1451,10 @@ def create_vm(vsphere_client, module, esxi, resource_pool, cluster_name, guest, 
                 module.fail_json(
                     msg="Error on %s definition. network_type needs to be "
                     " specified." % nic)
+            mac_address = vm_nic[nic]['mac_address'] if 'mac_address' in vm_nic[nic] else None
             # Add the nic to the VM spec.
             add_nic(module, vsphere_client, nfmor, config, devices,
-                    nictype, network, network_type)
+                    nictype, network, network_type, mac_address)
 
     config.set_element_deviceChange(devices)
     create_vm_request.set_element_config(config)


### PR DESCRIPTION
##### SUMMARY
Allows user to explicitly specify the mac address of a virtual nic.

By default, ESXi or vSphere generate a MAC address for any virtual nic. However, in some circumstances, user will need to specify it. This change allows the user to manually specify the address.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
cloud/vmware/vsphere_guest

##### ANSIBLE VERSION
```
ansible 2.4.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/vagrant/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.13 (default, Nov 24 2017, 17:33:09) [GCC 6.3.0 20170516]
```

##### ADDITIONAL INFORMATION
