### PR TITLE
ovirt_storage_domains: docs: override_luns parameter is applicable also to fcp

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_storage_domains.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_storage_domains.py
@@ -113,6 +113,7 @@ options:
             - "C(address) - Address of the fibre channel storage server."
             - "C(port) - Port of the fibre channel storage server."
             - "C(lun_id) - LUN id."
+            - "C(override_luns) - If I(True) FCP storage domain luns will be overridden before adding."
             - "Note that these parameters are not idempotent."
     destroy:
         description:


### PR DESCRIPTION
##### SUMMARY
override_luns parameter is applicable also to fiber channel storage domains.
The module also act like that, but the docs is not mentioning the fcp support.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/ovirt/ovirt_storage_domains.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.2.0
```

