### PR TITLE
ios test changes

### DIFF
--- a/lib/ansible/modules/network/ios/ios_user.py
+++ b/lib/ansible/modules/network/ios/ios_user.py
@@ -181,12 +181,12 @@ def validate_privilege(value, module):
 
 
 def user_del_cmd(username):
-    return json.dumps({
+    return {
         'command': 'no username %s' % username,
         'prompt': 'This operation will remove all username related configurations with same name',
         'answer': 'y',
         'newline': False,
-    })
+    }
 
 
 def map_obj_to_commands(updates, module):

--- a/lib/ansible/plugins/cliconf/ios.py
+++ b/lib/ansible/plugins/cliconf/ios.py
@@ -19,7 +19,6 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-import ast
 import re
 import json
 
@@ -71,13 +70,12 @@ class Cliconf(CliconfBase):
     @enable_mode
     def edit_config(self, command):
         for cmd in chain(['configure terminal'], to_list(command), ['end']):
-            try:
-                cmd = ast.literal_eval(cmd)
+            if isinstance(cmd, dict):
                 command = cmd['command']
                 prompt = cmd['prompt']
                 answer = cmd['answer']
                 newline = cmd.get('newline', True)
-            except:
+            else:
                 command = cmd
                 prompt = None
                 answer = None

--- a/lib/ansible/plugins/cliconf/ios.py
+++ b/lib/ansible/plugins/cliconf/ios.py
@@ -58,9 +58,9 @@ class Cliconf(CliconfBase):
         if source not in ('running', 'startup'):
             return self.invalid_params("fetching configuration from %s is not supported" % source)
         if source == 'running':
-            cmd = b'show running-config all'
+            cmd = 'show running-config all'
         else:
-            cmd = b'show startup-config'
+            cmd = 'show startup-config'
 
         flags = [] if flags is None else flags
         cmd += ' '.join(flags)

--- a/test/integration/targets/ios_banner/tests/cli/basic-login.yaml
+++ b/test/integration/targets/ios_banner/tests/cli/basic-login.yaml
@@ -4,7 +4,7 @@
   ios_banner:
     banner: login
     state: absent
-    authorize: yes
+    provider: "{{ cli }}"
 
 
 - name: Set login
@@ -15,7 +15,7 @@
       that has a multiline
       string
     state: present
-    authorize: yes
+    provider: "{{ cli }}"
 
   register: result
 
@@ -35,7 +35,7 @@
       that has a multiline
       string
     state: present
-    authorize: yes
+    provider: "{{ cli }}"
 
   register: result
 

--- a/test/integration/targets/ios_banner/tests/cli/basic-motd.yaml
+++ b/test/integration/targets/ios_banner/tests/cli/basic-motd.yaml
@@ -4,7 +4,7 @@
   ios_banner:
     banner: motd
     state: absent
-    authorize: yes
+    provider: "{{ cli }}"
 
 
 - name: Set motd
@@ -15,7 +15,7 @@
       that has a multiline
       string
     state: present
-    authorize: yes
+    provider: "{{ cli }}"
 
   register: result
 
@@ -35,7 +35,7 @@
       that has a multiline
       string
     state: present
-    authorize: yes
+    provider: "{{ cli }}"
 
   register: result
 

--- a/test/integration/targets/ios_banner/tests/cli/basic-no-login.yaml
+++ b/test/integration/targets/ios_banner/tests/cli/basic-no-login.yaml
@@ -6,13 +6,13 @@
       Junk login banner
       over multiple lines
     state: present
-    authorize: yes
+    provider: "{{ cli }}"
 
 - name: remove login
   ios_banner:
     banner: login
     state: absent
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - debug:
@@ -27,7 +27,7 @@
   ios_banner:
     banner: login
     state: absent
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:

--- a/test/integration/targets/ios_command/tests/cli/bad_operator.yaml
+++ b/test/integration/targets/ios_command/tests/cli/bad_operator.yaml
@@ -6,7 +6,7 @@
     commands:
       - show version
       - show interfaces GigabitEthernet 0/0
-    authorize: yes
+    provider: "{{ cli }}"
     wait_for:
       - "result[0] contains 'Description: Foo'"
   register: result

--- a/test/integration/targets/ios_command/tests/cli/contains.yaml
+++ b/test/integration/targets/ios_command/tests/cli/contains.yaml
@@ -6,7 +6,7 @@
     commands:
       - show version
       - show interface loopback 888
-    authorize: yes
+    provider: "{{ cli }}"
     wait_for:
       - "result[0] contains Cisco"
       - "result[1] contains Loopback888"

--- a/test/integration/targets/ios_command/tests/cli/invalid.yaml
+++ b/test/integration/targets/ios_command/tests/cli/invalid.yaml
@@ -4,7 +4,7 @@
 - name: run invalid command
   ios_command:
     commands: show foo
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
   ignore_errors: yes
 
@@ -17,7 +17,7 @@
     commands:
       - show version
       - show foo
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
   ignore_errors: yes
 

--- a/test/integration/targets/ios_command/tests/cli/output.yaml
+++ b/test/integration/targets/ios_command/tests/cli/output.yaml
@@ -5,7 +5,7 @@
   ios_command:
     commands:
       - show version
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -18,7 +18,7 @@
     commands:
       - show version
       - show interfaces
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:

--- a/test/integration/targets/ios_command/tests/cli/timeout.yaml
+++ b/test/integration/targets/ios_command/tests/cli/timeout.yaml
@@ -5,7 +5,7 @@
   ios_command:
     commands:
       - show version
-    authorize: yes
+    provider: "{{ cli }}"
     wait_for:
       - "result[0] contains bad_value_string"
   register: result

--- a/test/integration/targets/ios_config/tests/cli/backup.yaml
+++ b/test/integration/targets/ios_config/tests/cli/backup.yaml
@@ -9,7 +9,7 @@
     parents:
       - interface Loopback999
     match: none
-    authorize: yes
+    provider: "{{ cli }}"
 
 - name: collect any backup files
   find:
@@ -28,7 +28,7 @@
   ios_config:
     src: basic/config.j2
     backup: yes
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:

--- a/test/integration/targets/ios_config/tests/cli/defaults.yaml
+++ b/test/integration/targets/ios_config/tests/cli/defaults.yaml
@@ -9,13 +9,13 @@
     parents:
       - interface Loopback999
     match: none
-    authorize: yes
+    provider: "{{ cli }}"
 
 - name: configure device with defaults included
   ios_config:
     src: defaults/config.j2
     defaults: yes
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - debug: var=result
@@ -30,7 +30,7 @@
   ios_config:
     src: defaults/config.j2
     defaults: yes
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - debug: var=result
@@ -44,14 +44,14 @@
   ios_config:
     lines:
         - mac-address-table notification mac-move
-    authorize: yes
+    provider: "{{ cli }}"
   ignore_errors: yes
 
 - name: show interfaces brief to ensure deivce goes to valid prompt
   ios_command:
     commands:
       - show interfaces
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:

--- a/test/integration/targets/ios_config/tests/cli/save.yaml
+++ b/test/integration/targets/ios_config/tests/cli/save.yaml
@@ -9,13 +9,13 @@
     parents:
       - interface Loopback999
     match: none
-    authorize: yes
+    provider: "{{ cli }}"
 
 
 - name: save config
   ios_config:
     save: true
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 # FIXME https://github.com/ansible/ansible-modules-core/issues/5008
   ignore_errors: true
@@ -29,7 +29,7 @@
 - name: save should always run
   ios_config:
     save: true
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 # FIXME https://github.com/ansible/ansible-modules-core/issues/5008
   ignore_errors: true
@@ -40,7 +40,7 @@
     lines:
       - "no ip http server"
     save_when: modified
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - name: save should always run
@@ -49,7 +49,7 @@
     lines:
       - "ip http server"
     save_when: modified
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -60,7 +60,7 @@
   ios_config:
     lines:
       - "no ip http server"
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - debug: msg="END cli/save.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/ios_config/tests/cli/src_basic.yaml
+++ b/test/integration/targets/ios_config/tests/cli/src_basic.yaml
@@ -9,12 +9,12 @@
     parents:
       - interface Loopback999
     match: none
-    authorize: yes
+    provider: "{{ cli }}"
 
 - name: configure device with config
   ios_config:
     src: basic/config.j2
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - name: debug, remove me
@@ -30,7 +30,7 @@
 - name: check device with config
   ios_config:
     src: basic/config.j2
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:

--- a/test/integration/targets/ios_config/tests/cli/src_invalid.yaml
+++ b/test/integration/targets/ios_config/tests/cli/src_invalid.yaml
@@ -6,7 +6,7 @@
 - name: configure with invalid src
   ios_config:
     src: basic/foobar.j2
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
   ignore_errors: yes
 

--- a/test/integration/targets/ios_config/tests/cli/src_match_none.yaml
+++ b/test/integration/targets/ios_config/tests/cli/src_match_none.yaml
@@ -9,13 +9,13 @@
     parents:
       - interface Loopback999
     match: none
-    authorize: yes
+    provider: "{{ cli }}"
 
 - name: configure device with config
   ios_config:
     src: basic/config.j2
     match: none
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -28,7 +28,7 @@
 - name: check device with config
   ios_config:
     src: basic/config.j2
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:

--- a/test/integration/targets/ios_config/tests/cli/sublevel.yaml
+++ b/test/integration/targets/ios_config/tests/cli/sublevel.yaml
@@ -7,13 +7,13 @@
       - 'no ip access-list extended test'
       - 'no ip access-list standard test'
     match: none
-    authorize: yes
+    provider: "{{ cli }}"
 
 - name: configure sub level command
   ios_config:
     lines: ['permit ip any any log']
     parents: ['ip access-list extended test']
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -26,7 +26,7 @@
   ios_config:
     lines: ['permit ip any any log']
     parents: ['ip access-list extended test']
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -38,6 +38,6 @@
     lines:
       - 'no ip access-list extended test'
     match: none
-    authorize: yes
+    provider: "{{ cli }}"
 
 - debug: msg="END cli/sublevel.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/ios_config/tests/cli/sublevel_block.yaml
+++ b/test/integration/targets/ios_config/tests/cli/sublevel_block.yaml
@@ -10,7 +10,7 @@
     parents: ['ip access-list extended test']
     before: ['no ip access-list extended test']
     after: ['exit']
-    authorize: yes
+    provider: "{{ cli }}"
     match: none
 
 - name: configure sub level command using block resplace
@@ -23,7 +23,7 @@
     parents: ['ip access-list extended test']
     replace: block
     after: ['exit']
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -45,7 +45,7 @@
     parents: ['ip access-list extended test']
     replace: block
     after: ['exit']
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -57,6 +57,6 @@
     lines:
       - no ip access-list extended test
     match: none
-    authorize: yes
+    provider: "{{ cli }}"
 
 - debug: msg="END cli/sublevel_block.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/ios_config/tests/cli/sublevel_exact.yaml
+++ b/test/integration/targets/ios_config/tests/cli/sublevel_exact.yaml
@@ -13,7 +13,7 @@
     before: no ip access-list extended test
     after: exit
     match: none
-    authorize: yes
+    provider: "{{ cli }}"
 
 - name: configure sub level command using exact match
   ios_config:
@@ -26,7 +26,7 @@
     before: no ip access-list extended test
     after: exit
     match: exact
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -48,7 +48,7 @@
       - permit ip host 4.4.4.4 any log
     parents: ip access-list extended test
     match: exact
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -60,6 +60,6 @@
     lines:
       - no ip access-list extended test
     match: none
-    authorize: yes
+    provider: "{{ cli }}"
 
 - debug: msg="END cli/sublevel_exact.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/ios_config/tests/cli/sublevel_strict.yaml
+++ b/test/integration/targets/ios_config/tests/cli/sublevel_strict.yaml
@@ -12,7 +12,7 @@
     parents: ip access-list extended test
     before: no ip access-list extended test
     match: none
-    authorize: yes
+    provider: "{{ cli }}"
 
 - name: configure sub level command using strict match
   ios_config:
@@ -23,7 +23,7 @@
       - permit ip host 4.4.4.4 any log
     parents: ip access-list extended test
     match: strict
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -39,7 +39,7 @@
     parents: ip access-list extended test
     after: exit
     match: strict
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -56,6 +56,6 @@
   ios_config:
     lines: no ip access-list extended test
     match: none
-    authorize: yes
+    provider: "{{ cli }}"
 
 - debug: msg="END cli/sublevel_strict.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/ios_config/tests/cli/toplevel.yaml
+++ b/test/integration/targets/ios_config/tests/cli/toplevel.yaml
@@ -5,12 +5,12 @@
   ios_config:
     lines: ['hostname {{ shorter_hostname }}']
     match: none
-    authorize: yes
+    provider: "{{ cli }}"
 
 - name: configure top level command
   ios_config:
     lines: ['hostname foo']
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -21,7 +21,7 @@
 - name: configure top level command idempotent check
   ios_config:
     lines: ['hostname foo']
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -32,6 +32,6 @@
   ios_config:
     lines: ['hostname {{ shorter_hostname }}']
     match: none
-    authorize: yes
+    provider: "{{ cli }}"
 
 - debug: msg="END cli/toplevel.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/ios_config/tests/cli/toplevel_after.yaml
+++ b/test/integration/targets/ios_config/tests/cli/toplevel_after.yaml
@@ -7,13 +7,13 @@
       - "snmp-server contact ansible"
       - "hostname {{ shorter_hostname }}"
     match: none
-    authorize: yes
+    provider: "{{ cli }}"
 
 - name: configure top level command with before
   ios_config:
     lines: ['hostname foo']
     after: ['snmp-server contact bar']
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -26,7 +26,7 @@
   ios_config:
     lines: ['hostname foo']
     after: ['snmp-server contact foo']
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -39,6 +39,6 @@
       - "no snmp-server contact"
       - "hostname {{ shorter_hostname }}"
     match: none
-    authorize: yes
+    provider: "{{ cli }}"
 
 - debug: msg="END cli/toplevel_after.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/ios_config/tests/cli/toplevel_before.yaml
+++ b/test/integration/targets/ios_config/tests/cli/toplevel_before.yaml
@@ -7,13 +7,13 @@
       - "snmp-server contact ansible"
       - "hostname {{ shorter_hostname }}"
     match: none
-    authorize: yes
+    provider: "{{ cli }}"
 
 - name: configure top level command with before
   ios_config:
     lines: ['hostname foo']
     before: ['snmp-server contact bar']
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -26,7 +26,7 @@
   ios_config:
     lines: ['hostname foo']
     before: ['snmp-server contact foo']
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -39,6 +39,6 @@
       - "no snmp-server contact"
       - "hostname {{ shorter_hostname }}"
     match: none
-    authorize: yes
+    provider: "{{ cli }}"
 
 - debug: msg="END cli/toplevel_before.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/ios_config/tests/cli/toplevel_nonidempotent.yaml
+++ b/test/integration/targets/ios_config/tests/cli/toplevel_nonidempotent.yaml
@@ -5,13 +5,13 @@
   ios_config:
     lines: ['hostname {{ shorter_hostname }}']
     match: none
-    authorize: yes
+    provider: "{{ cli }}"
 
 - name: configure top level command
   ios_config:
     lines: ['hostname foo']
     match: strict
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -23,7 +23,7 @@
   ios_config:
     lines: ['hostname foo']
     match: strict
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -34,6 +34,6 @@
   ios_config:
     lines: ['hostname {{ shorter_hostname }}']
     match: none
-    authorize: yes
+    provider: "{{ cli }}"
 
 - debug: msg="END cli/toplevel_nonidempotent.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/ios_facts/tests/cli/all_facts.yaml
+++ b/test/integration/targets/ios_facts/tests/cli/all_facts.yaml
@@ -6,7 +6,7 @@
   ios_facts:
     gather_subset:
       - all
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 

--- a/test/integration/targets/ios_facts/tests/cli/default_facts.yaml
+++ b/test/integration/targets/ios_facts/tests/cli/default_facts.yaml
@@ -4,7 +4,7 @@
 
 - name: test getting default facts
   ios_facts:
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:

--- a/test/integration/targets/ios_facts/tests/cli/invalid_subset.yaml
+++ b/test/integration/targets/ios_facts/tests/cli/invalid_subset.yaml
@@ -6,7 +6,7 @@
   ios_facts:
     gather_subset:
       - "foobar"
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
   ignore_errors: true
 
@@ -29,7 +29,7 @@
     gather_subset:
       - "!hardware"
       - "hardware"
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
   ignore_errors: true
 

--- a/test/integration/targets/ios_facts/tests/cli/not_hardware.yaml
+++ b/test/integration/targets/ios_facts/tests/cli/not_hardware.yaml
@@ -6,7 +6,7 @@
   ios_facts:
     gather_subset:
       - "!hardware"
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:

--- a/test/integration/targets/ios_interface/tests/cli/basic.yaml
+++ b/test/integration/targets/ios_interface/tests/cli/basic.yaml
@@ -8,7 +8,7 @@
     speed: 1000
     mtu: 1800
     state: present
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - name: Configure interface
@@ -16,7 +16,7 @@
     name: "{{ test_interface }}"
     description: test-interface-initial
     state: present
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -30,7 +30,7 @@
     name: "{{ test_interface }}"
     description: test-interface-initial
     state: present
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -43,7 +43,7 @@
     description: test-interface
     mtu: 2000
     state: present
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -59,7 +59,7 @@
     description: test-interface-1
     mtu: 1800
     state: present
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -73,7 +73,7 @@
   ios_interface:
     name: "{{ test_interface }}"
     enabled: False
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -86,7 +86,7 @@
   ios_interface:
     name: "{{ test_interface }}"
     enabled: True
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -102,7 +102,7 @@
     speed: 1000
     mtu: 1800
     state: present
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - name: Add interface aggregate
@@ -112,7 +112,7 @@
     - { name: "{{ test_interface2 }}", mtu: 2000, description: test-interface-2 }
     speed: 1000
     state: present
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -131,7 +131,7 @@
     - { name: "{{ test_interface2 }}", mtu: 2000, description: test-interface-2 }
     speed: 1000
     state: present
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -145,7 +145,7 @@
     - { name: "{{ test_interface2 }}" }
     enabled: False
     state: present
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -163,7 +163,7 @@
     - { name: "{{ test_interface2 }}" }
     enabled: True
     state: present
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -180,7 +180,7 @@
     - name: Loopback9
     - name: Loopback10
     state: absent
-    authorize: yes
+    provider: "{{ cli }}"
 
 - name: Create loopback interface aggregate
   ios_interface:
@@ -188,7 +188,7 @@
     - name: Loopback9
     - name: Loopback10
     state: present
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -203,7 +203,7 @@
     - name: Loopback9
     - name: Loopback10
     state: absent
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -218,7 +218,7 @@
     - name: Loopback9
     - name: Loopback10
     state: absent
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:

--- a/test/integration/targets/ios_interface/tests/cli/intent.yaml
+++ b/test/integration/targets/ios_interface/tests/cli/intent.yaml
@@ -7,7 +7,7 @@
     state: up
     tx_rate: ge(0)
     rx_rate: ge(0)
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -20,7 +20,7 @@
     state: down
     tx_rate: gt(0)
     rx_rate: lt(0)
-    authorize: yes
+    provider: "{{ cli }}"
   ignore_errors: yes
   register: result
 
@@ -36,7 +36,7 @@
     name: "{{ test_interface }}"
     enabled: False
     state: down
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -47,7 +47,7 @@
   ios_interface:
     name: "{{ test_interface }}"
     enabled: False
-    authorize: yes
+    provider: "{{ cli }}"
     state: up
   ignore_errors: yes
   register: result
@@ -61,7 +61,7 @@
   ios_command:
     commands:
       - show lldp neighbors
-    authorize: yes
+    provider: "{{ cli }}"
   register: show_lldp_neighbors_result
 
 - block:
@@ -71,7 +71,7 @@
         neighbors:
           - port: eth0
             host: netdev
-        authorize: yes
+        provider: "{{ cli }}"
       register: result
 
     - assert:
@@ -84,7 +84,7 @@
         neighbors:
           - port: dummy_port
             host: dummy_host
-        authorize: yes
+        provider: "{{ cli }}"
       ignore_errors: yes
       register: result
 
@@ -101,7 +101,7 @@
       - name: "{{ test_interface }}"
         enabled: True
         state: up
-    authorize: yes
+    provider: "{{ cli }}"
   ignore_errors: yes
   register: result
 
@@ -117,7 +117,7 @@
             neighbors:
               - port: eth0
                 host: netdev
-        authorize: yes
+        provider: "{{ cli }}"
       ignore_errors: yes
       register: result
 
@@ -134,7 +134,7 @@
             host: netdev
           - port: dummy_port
             host: dummy_host
-        authorize: yes
+        provider: "{{ cli }}"
       ignore_errors: yes
       register: result
 

--- a/test/integration/targets/ios_interface/tests/cli/net_interface.yaml
+++ b/test/integration/targets/ios_interface/tests/cli/net_interface.yaml
@@ -11,7 +11,7 @@
     speed: 1000
     mtu: 1800
     state: present
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - name: Configure interface using platform agnostic module
@@ -19,7 +19,7 @@
     name: "{{ test_interface }}"
     description: test-interface-initial
     state: present
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -34,7 +34,7 @@
     description: test-interface
     mtu: 2000
     state: present
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:

--- a/test/integration/targets/ios_l3_interface/tests/cli/basic.yaml
+++ b/test/integration/targets/ios_l3_interface/tests/cli/basic.yaml
@@ -5,7 +5,7 @@
   ios_l3_interface:
     name: "{{ test_interface }}"
     state: absent
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - name: Setup - Ensure interfaces are switchport
@@ -14,6 +14,7 @@
       - no shutdown
     parents:
       - "interface {{ item }}"
+    provider: "{{ cli }}"
   loop:
     - "{{ test_interface }}"
     - "{{ test_interface2 }}"
@@ -23,7 +24,7 @@
     name: "{{ test_interface }}"
     ipv4: 192.168.0.1/24
     state: present
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -37,7 +38,7 @@
     name: "{{ test_interface }}"
     ipv4: 192.168.0.1/24
     state: present
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -49,7 +50,7 @@
     name: "{{ test_interface2 }}"
     ipv4: 192.168.0.1/24
     state: present
-    authorize: yes
+    provider: "{{ cli }}"
   ignore_errors: yes
   register: result
 
@@ -63,7 +64,7 @@
     name: "{{ test_interface }}"
     ipv4: dhcp
     state: present
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -77,7 +78,7 @@
     name: "{{ test_interface }}"
     ipv6: fd5d:12c9:2201:1::1/64
     state: present
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -91,7 +92,7 @@
     name: "{{ test_interface }}"
     ipv6: fd5d:12c9:2201:1::1/64
     state: present
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -103,7 +104,7 @@
     name: "{{ test_interface2 }}"
     ipv6: fd5d:12c9:2201:1::1/64
     state: present
-    authorize: yes
+    provider: "{{ cli }}"
   ignore_errors: yes
   register: result
 
@@ -117,7 +118,7 @@
     name: "{{ test_interface }}"
     ipv6: dhcp
     state: present
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -130,7 +131,7 @@
   ios_l3_interface:
     name: "{{ test_interface }}"
     state: absent
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -144,14 +145,14 @@
   ios_l3_interface:
     name: "{{ test_interface }}"
     state: absent
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - name: Delete second interface ipv4 and ipv6 address (setup)
   ios_l3_interface:
     name: "{{ test_interface2 }}"
     state: absent
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - name: Configure ipv4 and ipv6 address using aggregate
@@ -159,7 +160,7 @@
     aggregate:
     - { name: "{{ test_interface }}", ipv4: 192.161.0.1/24, ipv6: "fd5d:12c9:2201:2::2/64" }
     - { name: "{{ test_interface2 }}", ipv4: 192.162.0.2/16, ipv6: "fd5e:12c9:2201:3::3/32" }
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -177,7 +178,7 @@
     aggregate:
     - { name: "{{ test_interface }}", ipv4: 192.161.0.1/24, ipv6: "fd5d:12c9:2201:2::2/64" }
     - { name: "{{ test_interface2 }}", ipv4: 192.162.0.2/16, ipv6: "fd5e:12c9:2201:3::3/32" }
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -189,7 +190,7 @@
     aggregate:
     - { name: "{{ test_interface }}", ipv4: 193.167.1.1/8, ipv6: "fd5a:12c9:2201:4::4/32" }
     - { name: "{{ test_interface2 }}", ipv4: 192.169.2.2/24, ipv6: "fd5b:12c9:2201:5::5/90" }
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -209,7 +210,7 @@
     - { name: "{{ test_interface }}" }
     - { name: "{{ test_interface2 }}" }
     state: absent
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -228,7 +229,7 @@
     - { name: "{{ test_interface }}" }
     - { name: "{{ test_interface2 }}" }
     state: absent
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:

--- a/test/integration/targets/ios_linkagg/tests/cli/basic.yaml
+++ b/test/integration/targets/ios_linkagg/tests/cli/basic.yaml
@@ -9,21 +9,21 @@
     ios_config:
       lines:
         - no interface port-channel 20
-      authorize: yes
+      provider: "{{ cli }}"
     ignore_errors: yes
 
   - name: setup - remove config used in test(part2)
     ios_config:
       lines:
         - no interface port-channel 5
-      authorize: yes
+      provider: "{{ cli }}"
     ignore_errors: yes
 
   - name: setup - remove config used in test(part3)
     ios_config:
       lines:
         - no channel-group 20 mode active
-      authorize: yes
+      provider: "{{ cli }}"
       parents: "{{ item }}"
     loop:
       - interface GigabitEthernet0/1
@@ -33,7 +33,7 @@
     ios_linkagg: &create
       group: 20
       state: present
-      authorize: yes
+      provider: "{{ cli }}"
     register: result
 
   - assert:
@@ -56,7 +56,7 @@
       members:
         - GigabitEthernet0/1
         - GigabitEthernet0/2
-      authorize: yes
+      provider: "{{ cli }}"
     register: result
 
   - assert:
@@ -81,7 +81,7 @@
       mode: active
       members:
         - GigabitEthernet0/2
-      authorize: yes
+      provider: "{{ cli }}"
     register: result
 
   - assert:
@@ -102,7 +102,7 @@
     ios_linkagg: &remove
       group: 20
       state: absent
-      authorize: yes
+      provider: "{{ cli }}"
     register: result
 
   - assert:
@@ -123,7 +123,7 @@
       aggregate:
         - { group: 5 }
         - { group: 20, mode: active, members: ['GigabitEthernet0/1'] }
-      authorize: yes
+      provider: "{{ cli }}"
     register: result
 
   - assert:
@@ -146,21 +146,21 @@
     ios_config:
       lines:
         - no interface port-channel 20
-      authorize: yes
+      provider: "{{ cli }}"
     ignore_errors: yes
 
   - name: teardown(part2)
     ios_config:
       lines:
         - no interface port-channel 5
-      authorize: yes
+      provider: "{{ cli }}"
     ignore_errors: yes
 
   - name: teardown(part3)
     ios_config:
       lines:
         - no channel-group 20 mode active
-      authorize: yes
+      provider: "{{ cli }}"
       parents: "{{ item }}"
     loop:
       - interface GigabitEthernet0/1

--- a/test/integration/targets/ios_lldp/tests/cli/basic.yaml
+++ b/test/integration/targets/ios_lldp/tests/cli/basic.yaml
@@ -4,12 +4,12 @@
 - name: Make sure LLDP is not running before tests
   ios_config:
     lines: no lldp run
-    authorize: yes
+    provider: "{{ cli }}"
 
 - name: Enable LLDP service
   ios_lldp:
     state: present
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -20,7 +20,7 @@
 - name: Enable LLDP service again (idempotent)
   ios_lldp:
     state: present
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -30,7 +30,7 @@
 - name: Disable LLDP service
   ios_lldp:
     state: absent
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -41,7 +41,7 @@
 - name: Disable LLDP service (idempotent)
   ios_lldp:
     state: absent
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:

--- a/test/integration/targets/ios_logging/tests/cli/basic.yaml
+++ b/test/integration/targets/ios_logging/tests/cli/basic.yaml
@@ -5,20 +5,20 @@
     dest: host
     name: 172.16.0.1
     state: absent
-    authorize: yes
+    provider: "{{ cli }}"
 
 - name: Remove console
   ios_logging:
     dest: console
     level: warnings
     state: absent
-    authorize: yes
+    provider: "{{ cli }}"
 
 - name: Remove buffer
   ios_logging:
     dest: buffered
     size: 8000
-    authorize: yes
+    provider: "{{ cli }}"
     state: absent
 
 # start tests
@@ -28,7 +28,7 @@
     name: 172.16.0.1
     facility: local7
     state: present
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -42,7 +42,7 @@
     dest: host
     name: 172.16.0.1
     state: present
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -54,7 +54,7 @@
     dest: host
     name: 172.16.0.1
     state: absent
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -67,7 +67,7 @@
     dest: host
     name: 172.16.0.1
     state: absent
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -79,7 +79,7 @@
     dest: console
     level: warnings
     state: present
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -91,7 +91,7 @@
   ios_logging:
     dest: buffered
     size: 8000
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -104,7 +104,7 @@
     aggregate:
       - { dest: console, level: notifications }
       - { dest: buffered, size: 9000 }
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -119,7 +119,7 @@
       - { dest: console, level: notifications }
       - { dest: buffered, size: 9000 }
     state: absent
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:

--- a/test/integration/targets/ios_logging/tests/cli/net_logging.yaml
+++ b/test/integration/targets/ios_logging/tests/cli/net_logging.yaml
@@ -9,7 +9,7 @@
     dest: host
     name: 172.16.0.1
     state: absent
-    authorize: yes
+    provider: "{{ cli }}"
 
 - name: Set up host logging using platform agnostic module
   net_logging:
@@ -17,7 +17,7 @@
     name: 172.16.0.1
     facility: local7
     state: present
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -31,6 +31,6 @@
     dest: host
     name: 172.16.0.1
     state: absent
-    authorize: yes
+    provider: "{{ cli }}"
 
 - debug: msg="END ios cli/net_logging.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/ios_ping/tests/cli/ping.yaml
+++ b/test/integration/targets/ios_ping/tests/cli/ping.yaml
@@ -3,7 +3,7 @@
 
 - ios_command:
     commands: show version
-    authorize: yes
+    provider: "{{ cli }}"
   register: show_version_result
 
 - set_fact: management_interface=GigabitEthernet0/0
@@ -16,7 +16,7 @@
   ios_command:
     commands:
       - "show ip interface {{ management_interface }} | include Internet address"
-    authorize: yes
+    provider: "{{ cli }}"
   register: show_ip_interface_result
 
 - name: Extract the IP address from registered output
@@ -25,14 +25,14 @@
 - name: expected successful ping
   ios_ping: &valid_ip
     dest: '{{ management_ip }}'
-    authorize: yes
+    provider: "{{ cli }}"
   register: esp
  
 - name: unexpected unsuccessful ping
   ios_ping: &invalid_ip
     dest: '10.255.255.250'
     timeout: 45
-    authorize: yes
+    provider: "{{ cli }}"
   register: uup
   ignore_errors: yes
 

--- a/test/integration/targets/ios_static_route/tests/cli/basic.yaml
+++ b/test/integration/targets/ios_static_route/tests/cli/basic.yaml
@@ -8,7 +8,7 @@
     next_hop: 10.0.0.8
     admin_distance: 1
     state: absent
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - name: create static route
@@ -17,7 +17,7 @@
     mask: 255.255.255.0
     next_hop: 10.0.0.8
     state: present
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -31,7 +31,7 @@
     mask: 255.255.255.0
     next_hop: 10.0.0.8
     state: present
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -45,7 +45,7 @@
     next_hop: 10.0.0.8
     admin_distance: 2
     state: present
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -60,7 +60,7 @@
     next_hop: 10.0.0.8
     admin_distance: 2
     state: present
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -74,7 +74,7 @@
     next_hop: 10.0.0.8
     admin_distance: 2
     state: absent
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -89,7 +89,7 @@
     next_hop: 10.0.0.8
     admin_distance: 2
     state: absent
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -102,7 +102,7 @@
       - { prefix: 172.16.32.0, mask: 255.255.255.0, next_hop: 10.0.0.8 }
       - { prefix: 172.16.33.0, mask: 255.255.255.0, next_hop: 10.0.0.8 }
     state: present
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -117,7 +117,7 @@
       - { prefix: 172.16.33.0, mask: 255.255.255.0, next_hop: 10.0.0.8, state: absent }
       - { prefix: 172.16.34.0, mask: 255.255.255.0, next_hop: 10.0.0.8 }
     state: present
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -132,7 +132,7 @@
       - { prefix: 172.16.33.0, mask: 255.255.255.0, next_hop: 10.0.0.8 }
       - { prefix: 172.16.34.0, mask: 255.255.255.0, next_hop: 10.0.0.8 }
     state: absent
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:

--- a/test/integration/targets/ios_static_route/tests/cli/net_static_route.yaml
+++ b/test/integration/targets/ios_static_route/tests/cli/net_static_route.yaml
@@ -11,7 +11,7 @@
     next_hop: 10.0.0.8
     admin_distance: 1
     state: absent
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - name: create static route using platform agnostic module
@@ -20,7 +20,7 @@
     mask: 255.255.255.0
     next_hop: 10.0.0.8
     state: present
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -35,7 +35,7 @@
     next_hop: 10.0.0.8
     admin_distance: 2
     state: absent
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - debug: msg="END ios cli/net_static_route.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/ios_system/tests/cli/net_system.yaml
+++ b/test/integration/targets/ios_system/tests/cli/net_system.yaml
@@ -10,14 +10,14 @@
       - no ip domain-list ansible.com
       - no ip domain-list redhat.com
     match: none
-    authorize: yes
+    provider: "{{ cli }}"
 
 - name: configure domain_search using platform agnostic module
   net_system:
     domain_search:
       - ansible.com
       - redhat.com
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -32,6 +32,6 @@
       - no ip domain-list ansible.com
       - no ip domain-list redhat.com
     match: none
-    authorize: yes
+    provider: "{{ cli }}"
 
 - debug: msg="END ios cli/net_system.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/ios_system/tests/cli/set_domain_list.yaml
+++ b/test/integration/targets/ios_system/tests/cli/set_domain_list.yaml
@@ -7,14 +7,14 @@
       - no ip domain-list ansible.com
       - no ip domain-list redhat.com
     match: none
-    authorize: yes
+    provider: "{{ cli }}"
 
 - name: configure domain_search
   ios_system:
     domain_search:
       - ansible.com
       - redhat.com
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -28,7 +28,7 @@
     domain_search:
       - ansible.com
       - redhat.com
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -39,7 +39,7 @@
   ios_system:
     domain_search:
       - ansible.com
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -51,7 +51,7 @@
   ios_system:
     domain_search:
       - ansible.com
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -63,7 +63,7 @@
     domain_search:
       - ansible.com
       - redhat.com
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -76,7 +76,7 @@
     domain_search:
       - ansible.com
       - redhat.com
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -88,7 +88,7 @@
     domain_search:
       - ansible.com
       - eng.ansible.com
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -103,7 +103,7 @@
     domain_search:
       - ansible.com
       - eng.ansible.com
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -117,6 +117,6 @@
       - no ip domain-list redhat.com
       - no ip domain-list eng.ansible.com
     match: none
-    authorize: yes
+    provider: "{{ cli }}"
 
 - debug: msg="END cli/set_domain_search.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/ios_system/tests/cli/set_domain_name.yaml
+++ b/test/integration/targets/ios_system/tests/cli/set_domain_name.yaml
@@ -5,12 +5,12 @@
   ios_config:
     lines: no ip domain-name
     match: none
-    authorize: yes
+    provider: "{{ cli }}"
 
 - name: configure domain_name
   ios_system:
     domain_name: eng.ansible.com
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -20,7 +20,7 @@
 - name: verify domain_name
   ios_system:
     domain_name: eng.ansible.com
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -31,6 +31,6 @@
   ios_config:
     lines: no ip domain-name
     match: none
-    authorize: yes
+    provider: "{{ cli }}"
 
 - debug: msg="END cli/set_domain_name.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/ios_system/tests/cli/set_hostname.yaml
+++ b/test/integration/targets/ios_system/tests/cli/set_hostname.yaml
@@ -5,12 +5,12 @@
   ios_config:
     lines: hostname switch
     match: none
-    authorize: yes
+    provider: "{{ cli }}"
 
 - name: configure hostname
   ios_system:
     hostname: foo
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -20,7 +20,7 @@
 - name: verify hostname
   ios_system:
     hostname: foo
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -31,6 +31,6 @@
   ios_config:
     lines: "hostname {{ inventory_hostname }}"
     match: none
-    authorize: yes
+    provider: "{{ cli }}"
 
 - debug: msg="END cli/set_hostname.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/ios_system/tests/cli/set_lookup_source.yaml
+++ b/test/integration/targets/ios_system/tests/cli/set_lookup_source.yaml
@@ -7,12 +7,12 @@
       - no ip domain lookup source-interface Loopback888
       - vrf definition ansible
     match: none
-    authorize: yes
+    provider: "{{ cli }}"
 
 - name: configure lookup_source
   ios_system:
     lookup_source: Loopback888
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -23,7 +23,7 @@
 - name: verify lookup_source
   ios_system:
     lookup_source: Loopback888
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -33,7 +33,7 @@
 - name: Disable lookup_source
   ios_system:
     lookup_enabled: False
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -44,7 +44,7 @@
 - name: Disable lookup_source
   ios_system:
     lookup_enabled: True
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -57,7 +57,7 @@
 #    lookup_source:
 #      - interface: Loopback10
 #        vrf: ansible
-#    authorize: yes
+#    provider: "{{ cli }}"
 #    provider: "{{ cli }}"
 #  register: result
 #
@@ -73,7 +73,7 @@
 #    lookup_source:
 #      - interface: Management1
 #        vrf: ansible
-#    authorize: yes
+#    provider: "{{ cli }}"
 #    provider: "{{ cli }}"
 #  register: result
 #
@@ -87,7 +87,7 @@
       - no ip domain lookup source-interface Loopback888
       - no vrf definition ansible
     match: none
-    authorize: yes
+    provider: "{{ cli }}"
   ignore_errors: yes
 # FIXME: Not sure why this is failing with msg": "no vrf definition ansible\r\n% IPv4 and IPv6 addresses from all interfaces in VRF ansible have been removed\r\nfoo(config)#", rc:1
 

--- a/test/integration/targets/ios_system/tests/cli/set_name_servers.yaml
+++ b/test/integration/targets/ios_system/tests/cli/set_name_servers.yaml
@@ -6,7 +6,7 @@
     lines:
       - no ip name-server
     match: none
-    authorize: yes
+    provider: "{{ cli }}"
 
 - name: configure name_servers
   ios_system:
@@ -14,7 +14,7 @@
       - 1.1.1.1
       - 2.2.2.2
       - 3.3.3.3
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -31,7 +31,7 @@
       - 1.1.1.1
       - 2.2.2.2
       - 3.3.3.3
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -72,7 +72,7 @@
     name_servers:
       - 1.1.1.1
       - 2.2.2.2
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -86,6 +86,6 @@
     lines:
       - no ip name-server
     match: none
-    authorize: yes
+    provider: "{{ cli }}"
 
 - debug: msg="END cli/set_name_servers.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/ios_user/tests/cli/auth.yaml
+++ b/test/integration/targets/ios_user/tests/cli/auth.yaml
@@ -6,7 +6,7 @@
       privilege: 15
       role: network-operator
       state: present
-      authorize: yes
+      provider: "{{ cli }}"
       configured_password: pass123
 
   - name: test login
@@ -33,7 +33,7 @@
     ios_user:
       name: auth_user
       state: absent
-      authorize: yes
+      provider: "{{ cli }}"
     register: result
 
   - name: reset connection

--- a/test/integration/targets/ios_user/tests/cli/basic.yaml
+++ b/test/integration/targets/ios_user/tests/cli/basic.yaml
@@ -79,6 +79,6 @@
 - assert:
     that:
       - 'result.changed == true'
-      - '"no username ansibletest1" in result.commands[0]'
-      - '"no username ansibletest2" in result.commands[1]'
-      - '"no username ansibletest3" in result.commands[2]'
+      - '"no username ansibletest1" in result.commands[0]["command"]'
+      - '"no username ansibletest2" in result.commands[1]["command"]'
+      - '"no username ansibletest3" in result.commands[2]["command"]'

--- a/test/integration/targets/ios_user/tests/cli/basic.yaml
+++ b/test/integration/targets/ios_user/tests/cli/basic.yaml
@@ -6,7 +6,7 @@
       - name: ansibletest2
       - name: ansibletest3
     state: absent
-    authorize: yes
+    provider: "{{ cli }}"
 
 - name: Create user (SetUp)
   ios_user:
@@ -14,7 +14,7 @@
     privilege: 15
     role: network-operator
     state: present
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -27,7 +27,7 @@
     aggregate:
       - name: ansibletest2
       - name: ansibletest3
-    authorize: yes
+    provider: "{{ cli }}"
     state: present
     view: network-admin
   register: result
@@ -43,7 +43,7 @@
     privilege: 15
     role: network-operator
     state: present
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -56,7 +56,7 @@
     aggregate:
       - name: ansibletest2
       - name: ansibletest3
-    authorize: yes
+    provider: "{{ cli }}"
     state: present
     view: network-admin
   register: result
@@ -73,7 +73,7 @@
       - name: ansibletest2
       - name: ansibletest3
     state: absent
-    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:

--- a/test/integration/targets/ios_vlan/tests/cli/basic.yaml
+++ b/test/integration/targets/ios_vlan/tests/cli/basic.yaml
@@ -11,14 +11,14 @@
         - no vlan 100
         - no vlan 200
         - no vlan 300
-      authorize: yes
+      provider: "{{ cli }}"
 
   - name: setup - remove switchport settings on interfaces used in test
     ios_config:
       lines:
         - switchport mode access
         - no switchport access vlan 100
-      authorize: yes
+      provider: "{{ cli }}"
       parents: "{{ item }}"
     loop:
       - interface GigabitEthernet0/1
@@ -28,7 +28,7 @@
     ios_vlan: &create
       vlan_id: 100
       name: test-vlan
-      authorize: yes
+      provider: "{{ cli }}"
     register: result
 
   - assert:
@@ -51,7 +51,7 @@
       interfaces:
         - GigabitEthernet0/1
         - GigabitEthernet0/2
-      authorize: yes
+      provider: "{{ cli }}"
     register: result
 
   - assert:
@@ -77,7 +77,7 @@
       vlan_id: 100
       interfaces:
         - GigabitEthernet0/1
-      authorize: yes
+      provider: "{{ cli }}"
     register: result
 
   - assert:
@@ -100,7 +100,7 @@
     ios_vlan:
       vlan_id: 100
       state: suspend
-      authorize: yes
+      provider: "{{ cli }}"
     register: result
 
   - assert:
@@ -113,7 +113,7 @@
     ios_vlan:
       vlan_id: 100
       state: active
-      authorize: yes
+      provider: "{{ cli }}"
     register: result
 
   - assert:
@@ -125,7 +125,7 @@
   - name: delete vlan
     ios_vlan: &delete
       vlan_id: 100
-      authorize: yes
+      provider: "{{ cli }}"
       state: absent
     register: result
 
@@ -147,7 +147,7 @@
       aggregate:
         - { vlan_id: 200, name: vlan-200 }
         - { vlan_id: 300, name: vlan-300 }
-      authorize: yes
+      provider: "{{ cli }}"
     register: result
 
   - assert:
@@ -172,7 +172,7 @@
         - { vlan_id: 200, name: vlan-200 }
         - { vlan_id: 300, name: vlan-300 }
       state: absent
-      authorize: yes
+      provider: "{{ cli }}"
     register: result
 
   - assert:
@@ -195,14 +195,14 @@
         - no vlan 100
         - no vlan 200
         - no vlan 300
-      authorize: yes
+      provider: "{{ cli }}"
 
   - name: teardown(part2)
     ios_config:
       lines:
         - switchport mode access
         - no switchport access vlan 100
-      authorize: yes
+      provider: "{{ cli }}"
       parents: "{{ item }}"
     loop:
       - interface GigabitEthernet0/1

--- a/test/units/modules/network/ios/test_ios_user.py
+++ b/test/units/modules/network/ios/test_ios_user.py
@@ -57,15 +57,14 @@ class TestIosUserModule(TestIosModule):
     def test_ios_user_delete(self):
         set_module_args(dict(name='ansible', state='absent'))
         result = self.execute_module(changed=True)
-        cmd = json.loads(
-            '{"answer": "y", "newline": false, ' +
-            '"prompt": "This operation will remove all username related ' +
-            'configurations with same name", "command": "no username ansible"}'
-        )
+        cmd = {
+            "command": "no username ansible", "answer": "y", "newline": False,
+            "prompt": "This operation will remove all username related configurations with same name",
+        }
 
         result_cmd = []
         for i in result['commands']:
-            result_cmd.append(json.loads(i))
+            result_cmd.append(i)
 
         self.assertEqual(result_cmd, [cmd])
 
@@ -86,15 +85,14 @@ class TestIosUserModule(TestIosModule):
     def test_ios_user_purge(self):
         set_module_args(dict(purge=True))
         result = self.execute_module(changed=True)
-        cmd = json.loads(
-            '{"answer": "y", "newline": false, ' +
-            '"prompt": "This operation will remove all username related ' +
-            'configurations with same name", "command": "no username ansible"}'
-        )
+        cmd = {
+            "command": "no username ansible", "answer": "y", "newline": False,
+            "prompt": "This operation will remove all username related configurations with same name",
+        }
 
         result_cmd = []
         for i in result['commands']:
-            result_cmd.append(json.loads(i))
+            result_cmd.append(i)
 
         self.assertEqual(result_cmd, [cmd])
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Mostly replaces `authorize: yes` with `provider: "{{ cli }}"` for `connection: local` tests that also need to provide an `auth_pass`

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
ios

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```

