### PR TITLE
Guard against assignments that are ast.Name in docs parsing

### DIFF
--- a/lib/ansible/parsing/metadata.py
+++ b/lib/ansible/parsing/metadata.py
@@ -191,7 +191,7 @@ def extract_metadata(module_ast=None, module_data=None, offsets=False):
     for root_idx, child in reversed(list(enumerate(module_ast.body))):
         if isinstance(child, ast.Assign):
             for target in child.targets:
-                if target.id == 'ANSIBLE_METADATA':
+                if isinstance(target, ast.Name) and target.id == 'ANSIBLE_METADATA':
                     metadata = ast.literal_eval(child.value)
                     if not offsets:
                         continue

--- a/test/sanity/validate-modules/main.py
+++ b/test/sanity/validate-modules/main.py
@@ -753,6 +753,9 @@ class ModuleValidator(Validator):
         for child in self.ast.body:
             if isinstance(child, ast.Assign):
                 for grandchild in child.targets:
+                    if not isinstance(grandchild, ast.Name):
+                        continue
+
                     if grandchild.id == 'DOCUMENTATION':
                         docs['DOCUMENTATION']['value'] = child.value.s
                         docs['DOCUMENTATION']['lineno'] = child.lineno


### PR DESCRIPTION
##### SUMMARY
In both validate-modules and in parsing for metadata, we need to guard against global assignments that aren't a `ast.Name`.

E.g.

```
URI_CONFIG_MAP["api/security/groups"] = True
```

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
lib/ansible/parsing/metadata.py
test/sanity/validate-modules/main.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```