### PR TITLE
added force option to zabbix_hostmacro to allow control of overwriting 

### DIFF
--- a/lib/ansible/modules/monitoring/zabbix/zabbix_hostmacro.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_hostmacro.py
@@ -213,7 +213,7 @@ def main():
             # update host macro
             host_macro_class_obj.update_host_macro(host_macro_obj, macro_name, macro_value)
         else:
-            module.exit_json(changed=False, result="Host macro %s already exists and force set is to no" % macro_name)
+            module.exit_json(changed=False, result="Host macro %s already exists and force is set to no" % macro_name)
 
 
 

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_hostmacro.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_hostmacro.py
@@ -47,6 +47,12 @@ options:
         required: false
         choices: ['present', 'absent']
         default: "present"
+    force:
+        description:
+            - If C(yes) don't update an existing macro
+        required: false
+        default: 'yes'
+        choices: ['yes', 'no']
 
 extends_documentation_fragment:
     - zabbix
@@ -157,7 +163,8 @@ def main():
             macro_name=dict(type='str', required=True),
             macro_value=dict(type='str', required=True),
             state=dict(default="present", choices=['present', 'absent']),
-            timeout=dict(type='int', default=10)
+            timeout=dict(type='int', default=10),
+            force=dict(type='bool', default=True)
         ),
         supports_check_mode=True
     )
@@ -176,6 +183,7 @@ def main():
     macro_value = module.params['macro_value']
     state = module.params['state']
     timeout = module.params['timeout']
+    force = module.params['force']
 
     zbx = None
     # login to zabbix
@@ -202,9 +210,12 @@ def main():
         if not host_macro_obj:
             # create host macro
             host_macro_class_obj.create_host_macro(macro_name, macro_value, host_id)
-        else:
+        elif force:
             # update host macro
             host_macro_class_obj.update_host_macro(host_macro_obj, macro_name, macro_value)
+        else:
+            module.exit_json(changed=False, result="Host macro %s already exists and force set to no" % macro_name)
+
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_hostmacro.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_hostmacro.py
@@ -52,6 +52,7 @@ options:
             - Only updates an existing macro if set to C(yes).
         default: 'yes'
         choices: ['yes', 'no']
+        version_added: 2.5
 
 extends_documentation_fragment:
     - zabbix
@@ -214,7 +215,6 @@ def main():
             host_macro_class_obj.update_host_macro(host_macro_obj, macro_name, macro_value)
         else:
             module.exit_json(changed=False, result="Host macro %s already exists and force is set to no" % macro_name)
-
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_hostmacro.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_hostmacro.py
@@ -49,8 +49,7 @@ options:
         default: "present"
     force:
         description:
-            - If C(yes) don't update an existing macro
-        required: false
+            - Only updates an existing macro if set to C(yes).
         default: 'yes'
         choices: ['yes', 'no']
 
@@ -214,7 +213,7 @@ def main():
             # update host macro
             host_macro_class_obj.update_host_macro(host_macro_obj, macro_name, macro_value)
         else:
-            module.exit_json(changed=False, result="Host macro %s already exists and force set to no" % macro_name)
+            module.exit_json(changed=False, result="Host macro %s already exists and force set is to no" % macro_name)
 
 
 


### PR DESCRIPTION
##### SUMMARY
Added an extra option `force` which defaults to yes(to maintain existing behavior) this allows for situations where you might want to override macro's in zabbix frontend and not have ansible overwrite the change at next playbook execution


##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
zabbix_hostmacro

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (zabbix-hostmacro-fix c15f6657d4) last updated 2018/01/30 18:27:49 (GMT +100)
  config file = None
  configured module search path = [u'/home/a/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/a/Projects/forks/ansible/lib/ansible
  executable location = /home/a/Projects/forks/ansible/bin/ansible
  python version = 2.7.13 (default, Nov 24 2017, 17:33:09) [GCC 6.3.0 20170516]
