### PR TITLE
Replace LooseVersion comparison with int/float comparison

### DIFF
--- a/lib/ansible/modules/system/hostname.py
+++ b/lib/ansible/modules/system/hostname.py
@@ -39,7 +39,6 @@ EXAMPLES = '''
 import os
 import socket
 import traceback
-from distutils.version import LooseVersion
 
 from ansible.module_utils.basic import (
     AnsibleModule,
@@ -567,10 +566,14 @@ class FedoraHostname(Hostname):
 class SLESHostname(Hostname):
     platform = 'Linux'
     distribution = 'Suse linux enterprise server '
-    distribution_version = get_distribution_version()
-    if distribution_version and LooseVersion("10") <= LooseVersion(distribution_version) <= LooseVersion("12"):
-        strategy_class = SLESStrategy
-    else:
+    try:
+        distribution_version = get_distribution_version()
+        # cast to float may raise ValueError on non SLES, we use float for a little more safety over int
+        if distribution_version and 10 <= float(distribution_version) <= 12:
+            strategy_class = SLESStrategy
+        else:
+            raise ValueError()
+    except ValueError:
         strategy_class = UnimplementedStrategy
 
 

--- a/test/sanity/import/skip.txt
+++ b/test/sanity/import/skip.txt
@@ -5,4 +5,3 @@ lib/ansible/modules/cloud/webfaction/webfaction_domain.py
 lib/ansible/modules/cloud/webfaction/webfaction_mailbox.py
 lib/ansible/modules/cloud/webfaction/webfaction_site.py
 lib/ansible/modules/packaging/os/yum_repository.py
-lib/ansible/modules/system/hostname.py


### PR DESCRIPTION
##### SUMMARY
Replace LooseVersion comparison with int/float for safer comparison on python3. Fixes #35435

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/system/hostname.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```