### PR TITLE
Revert "Add identity_api_version opt in OpenStack modules (#26103)"

### DIFF
--- a/lib/ansible/module_utils/openstack.py
+++ b/lib/ansible/module_utils/openstack.py
@@ -90,9 +90,6 @@ def openstack_full_argument_spec(**kwargs):
         api_timeout=dict(default=None, type='int'),
         endpoint_type=dict(
             default='public', choices=['public', 'internal', 'admin']
-        ),
-        identity_api_version=dict(
-            default=None, choices=['2.0', '3']
         )
     )
     spec.update(kwargs)

--- a/lib/ansible/utils/module_docs_fragments/openstack.py
+++ b/lib/ansible/utils/module_docs_fragments/openstack.py
@@ -93,12 +93,6 @@ options:
     choices: [public, internal, admin]
     required: false
     default: public
-  identity_api_version:
-    description:
-        - The identity API version
-    choices: [2.0, 3]
-    required: false
-    default: None
 requirements:
   - python >= 2.7
   - shade


### PR DESCRIPTION
This reverts commit 346063795d5798f6722d5ca53103818db22c55b7.

There is a different solution prepped for this in #20974 that has just
been waiting for the integration tests to run.

Exposing just identity_api_version as a top-level option means we'd
ultimately wind up needing to do it for ALL of the services. By
introducing a more generalized cloud constructor that can take all of
the options you can otherwise pass, we solve several problems at once
without special-casing any of them.

Sorry for the delays in getting the other PR landed.