### PR TITLE
Adds `redshift_cross_region_snapshots` module

### DIFF
--- a/lib/ansible/modules/cloud/amazon/redshift_cross_region_snapshots.py
+++ b/lib/ansible/modules/cloud/amazon/redshift_cross_region_snapshots.py
@@ -1,0 +1,214 @@
+#!/usr/bin/python
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'version': '1.0'}
+
+DOCUMENTATION = '''
+---
+module: redshift_cross_region_snapshots
+short_description: Manage Redshift Cross Region Snapshots
+description:
+  - Manage Redshift Cross Region Snapshots. Supports KMS-Encrypted Snapshots. For more information, see https://docs.aws.amazon.com/redshift/latest/mgmt/working-with-snapshots.html#cross-region-snapshot-copy
+version_added: "2.4"
+author: John Kerkstra (@captainkerk)
+options:
+  cluster_name:
+    description:
+      - The name of the cluster to configure cross-region snapshots for.
+    required: true
+    aliases: [ 'cluster' ]
+  state:
+    description:
+      - Create or remove the cross-region snapshot configuration.
+    required: true
+    choices: [ 'present', 'absent' ]
+  region:
+    description:
+      - The cluster's region
+    required: true
+    aliases: [ 'source' ]
+  destination_region:
+    description:
+      - The region to copy snapshots to
+    required: true
+    aliases: [ 'destination' ]
+  snapshot_copy_grant:
+    description:
+      - A grant for Amazon Redshift to use a master key in the destination region.
+      - See: http://boto3.readthedocs.io/en/latest/reference/services/redshift.html#Redshift.Client.create_snapshot_copy_grant
+    required: false
+    aliases: [ 'copy_grant' ]
+  snapshot_retention_period:
+    description:
+      - Keep cross-region snapshots for N number of days
+    required: true
+    aliases: [ 'retention_period' ]
+requirements: [ botocore, boto3 ]
+extends_documentation_fragment:
+  - aws
+'''
+
+EXAMPLES = '''
+
+# configure cross-region snapshot on cluster `johniscool`
+- redshift_cross_region_snapshots:
+    cluster_name: johniscool
+    state: present
+    region: us-east-1
+    destination_region: us-west-2
+    retention_period: 1
+
+# configure cross-region snapshot on kms-encrypted cluster
+- redshift_cross_region_snapshots:
+    cluster_name: whatever
+    state: present
+    source: us-east-1
+    destination: us-west-2
+    copy_grant: 'whatever-you-called-your-grant'
+    retention_period: 10
+
+# disable cross-region snapshots, necessary before most cluster modifications (rename, resize)
+- redshift_cross_region_snapshots:
+    cluster_name: whatever
+    state: absent
+    region: us-east-1
+    destination_region: us-west-2
+    retention_period: 10
+'''
+
+RETURN = ''' # '''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.ec2 import boto3_conn, get_aws_connection_info
+
+
+class SnapshotController(object):
+
+    def __init__(self, client, cluster_name):
+        self.client = client
+        self.cluster_name = cluster_name
+
+    def get_cluster_snapshot_copy_status(self):
+        response = self.client.describe_clusters(
+            ClusterIdentifier=self.cluster_name
+        )
+        return response['Clusters'][0].get('ClusterSnapshotCopyStatus')
+
+    def enable_snapshot_copy(self, destination_region, grant_name, retention_period):
+        if grant_name:
+            self.client.enable_snapshot_copy(
+                ClusterIdentifier=self.cluster_name,
+                DestinationRegion=destination_region,
+                RetentionPeriod=retention_period,
+                SnapshotCopyGrantName=grant_name,
+            )
+        else:
+            self.client.enable_snapshot_copy(
+                ClusterIdentifier=self.cluster_name,
+                DestinationRegion=destination_region,
+                RetentionPeriod=retention_period,
+            )
+
+    def disable_snapshot_copy(self):
+        self.client.disable_snapshot_copy(
+            ClusterIdentifier=self.cluster_name
+        )
+
+    def modify_snapshot_copy_retention_period(self, retention_period):
+        self.client.modify_snapshot_copy_retention_period(
+            ClusterIdentifier=self.cluster_name,
+            RetentionPeriod=retention_period
+        )
+
+
+def requesting_unsupported_modifications(actual, requested):
+    if (actual['SnapshotCopyGrantName'] != requested['snapshot_copy_grant'] or
+            actual['DestinationRegion'] != requested['destination_region']):
+        return True
+    return False
+
+
+def needs_update(actual, requested):
+    if actual['RetentionPeriod'] != requested['snapshot_retention_period']:
+        return True
+    return False
+
+
+def run_module():
+    module_args = dict(
+        cluster_name=dict(type='str', required=True, aliases=['cluster']),
+        state=dict(type='str', choices=['present', 'absent'], default='present'),
+        region=dict(type='str', required=True, aliases=['source']),
+        destination_region=dict(type='str', required=True, aliases=['destination']),
+        snapshot_copy_grant=dict(type='str', aliases=['copy_grant']),
+        snapshot_retention_period=dict(type='int', required=True, aliases=['retention_period']),
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True
+    )
+
+    result = dict(
+        changed=False,
+        message=''
+    )
+
+    region, ec2_url, aws_connect_params = get_aws_connection_info(module, boto3=True)
+    connection = boto3_conn(module, conn_type='client', resource='redshift',
+                            region=region, endpoint=ec2_url, **aws_connect_params)
+
+    snapshot_controller = SnapshotController(client=connection,
+                                             cluster_name=module.params.get('cluster_name'))
+
+    current_config = snapshot_controller.get_cluster_snapshot_copy_status()
+    if current_config is not None:
+        if module.params.get('state') == 'present':
+            if requesting_unsupported_modifications(current_config, module.params):
+                message = 'Cannot modify destination_region or grant_name. ' \
+                          'Please disable cross-region snapshots, and re-run.'
+                module.fail_json(msg=message, **result)
+            if needs_update(current_config, module.params):
+                result['changed'] = True
+                if module.check_mode:
+                    return result
+                snapshot_controller.modify_snapshot_copy_retention_period(
+                    module.params.get('snapshot_retention_period')
+                )
+        else:
+            result['changed'] = True
+            if module.check_mode:
+                return result
+            snapshot_controller.disable_snapshot_copy()
+    else:
+        if module.params.get('state') == 'present':
+            result['changed'] = True
+            if module.check_mode:
+                return result
+            snapshot_controller.enable_snapshot_copy(module.params.get('destination_region'),
+                                                     module.params.get('snapshot_copy_grant'),
+                                                     module.params.get('snapshot_retention_period'))
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/cloud/amazon/redshift_cross_region_snapshots.py
+++ b/lib/ansible/modules/cloud/amazon/redshift_cross_region_snapshots.py
@@ -16,7 +16,7 @@
 
 ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'community',
-                    'metadata_version': '1.0'}
+                    'metadata_version': '1.1'}
 
 DOCUMENTATION = '''
 ---
@@ -96,7 +96,7 @@ EXAMPLES = '''
 RETURN = ''' # '''
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.ec2 import boto3_conn, get_aws_connection_info
+from ansible.module_utils.ec2 import ec2_argument_spec, boto3_conn, get_aws_connection_info
 
 
 class SnapshotController(object):
@@ -152,17 +152,20 @@ def needs_update(actual, requested):
 
 
 def run_module():
-    module_args = dict(
-        cluster_name=dict(type='str', required=True, aliases=['cluster']),
-        state=dict(type='str', choices=['present', 'absent'], default='present'),
-        region=dict(type='str', required=True, aliases=['source']),
-        destination_region=dict(type='str', required=True, aliases=['destination']),
-        snapshot_copy_grant=dict(type='str', aliases=['copy_grant']),
-        snapshot_retention_period=dict(type='int', required=True, aliases=['retention_period']),
+    argument_spec = ec2_argument_spec()
+    argument_spec.update(
+        dict(
+            cluster_name=dict(type='str', required=True, aliases=['cluster']),
+            state=dict(type='str', choices=['present', 'absent'], default='present'),
+            region=dict(type='str', required=True, aliases=['source']),
+            destination_region=dict(type='str', required=True, aliases=['destination']),
+            snapshot_copy_grant=dict(type='str', aliases=['copy_grant']),
+            snapshot_retention_period=dict(type='int', required=True, aliases=['retention_period']),
+        )
     )
 
     module = AnsibleModule(
-        argument_spec=module_args,
+        argument_spec=argument_spec,
         supports_check_mode=True
     )
 

--- a/lib/ansible/modules/cloud/amazon/redshift_cross_region_snapshots.py
+++ b/lib/ansible/modules/cloud/amazon/redshift_cross_region_snapshots.py
@@ -66,31 +66,29 @@ extends_documentation_fragment:
 '''
 
 EXAMPLES = '''
-
-# configure cross-region snapshot on cluster `johniscool`
-- redshift_cross_region_snapshots:
+- name: configure cross-region snapshot on cluster `johniscool`
+  redshift_cross_region_snapshots:
     cluster_name: johniscool
     state: present
     region: us-east-1
     destination_region: us-west-2
     retention_period: 1
 
-# configure cross-region snapshot on kms-encrypted cluster
-- redshift_cross_region_snapshots:
+- name: configure cross-region snapshot on kms-encrypted cluster
+  redshift_cross_region_snapshots:
     cluster_name: whatever
     state: present
     source: us-east-1
     destination: us-west-2
-    copy_grant: 'whatever-you-called-your-grant'
+    copy_grant: 'my-grant-in-destination'
     retention_period: 10
 
-# disable cross-region snapshots, necessary before most cluster modifications (rename, resize)
-- redshift_cross_region_snapshots:
+- name: disable cross-region snapshots, necessary before most cluster modifications (rename, resize)
+  redshift_cross_region_snapshots:
     cluster_name: whatever
     state: absent
     region: us-east-1
     destination_region: us-west-2
-    retention_period: 10
 '''
 
 RETURN = ''' # '''

--- a/lib/ansible/modules/cloud/amazon/redshift_cross_region_snapshots.py
+++ b/lib/ansible/modules/cloud/amazon/redshift_cross_region_snapshots.py
@@ -16,50 +16,52 @@
 
 ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'community',
-                    'version': '1.0'}
+                    'metadata_version': '1.0'}
 
 DOCUMENTATION = '''
 ---
 module: redshift_cross_region_snapshots
 short_description: Manage Redshift Cross Region Snapshots
 description:
-  - Manage Redshift Cross Region Snapshots. Supports KMS-Encrypted Snapshots. For more information, see https://docs.aws.amazon.com/redshift/latest/mgmt/working-with-snapshots.html#cross-region-snapshot-copy
-version_added: "2.4"
+  - Manage Redshift Cross Region Snapshots. Supports KMS-Encrypted Snapshots.
+  - For more information, see https://docs.aws.amazon.com/redshift/latest/mgmt/working-with-snapshots.html#cross-region-snapshot-copy
+version_added: "2.5"
 author: John Kerkstra (@captainkerk)
 options:
   cluster_name:
     description:
       - The name of the cluster to configure cross-region snapshots for.
     required: true
-    aliases: [ 'cluster' ]
+    aliases: [ "cluster" ]
   state:
     description:
       - Create or remove the cross-region snapshot configuration.
     required: true
-    choices: [ 'present', 'absent' ]
+    choices: [ "present", "absent" ]
   region:
     description:
-      - The cluster's region
+      - The clusters region
     required: true
-    aliases: [ 'source' ]
+    aliases: [ "source" ]
   destination_region:
     description:
       - The region to copy snapshots to
     required: true
-    aliases: [ 'destination' ]
+    aliases: [ "destination" ]
   snapshot_copy_grant:
     description:
       - A grant for Amazon Redshift to use a master key in the destination region.
-      - See: http://boto3.readthedocs.io/en/latest/reference/services/redshift.html#Redshift.Client.create_snapshot_copy_grant
+      - See http://boto3.readthedocs.io/en/latest/reference/services/redshift.html#Redshift.Client.create_snapshot_copy_grant
     required: false
-    aliases: [ 'copy_grant' ]
+    aliases: [ "copy_grant" ]
   snapshot_retention_period:
     description:
       - Keep cross-region snapshots for N number of days
     required: true
-    aliases: [ 'retention_period' ]
-requirements: [ botocore, boto3 ]
+    aliases: [ "retention_period" ]
+requirements: [ "botocore", "boto3" ]
 extends_documentation_fragment:
+  - ec2
   - aws
 '''
 

--- a/lib/ansible/modules/cloud/amazon/redshift_cross_region_snapshots.py
+++ b/lib/ansible/modules/cloud/amazon/redshift_cross_region_snapshots.py
@@ -14,7 +14,7 @@ short_description: Manage Redshift Cross Region Snapshots
 description:
   - Manage Redshift Cross Region Snapshots. Supports KMS-Encrypted Snapshots.
   - For more information, see https://docs.aws.amazon.com/redshift/latest/mgmt/working-with-snapshots.html#cross-region-snapshot-copy
-version_added: "2.6"
+version_added: "2.7"
 author: JR Kerkstra (@captainkerk)
 options:
   cluster_name:
@@ -27,6 +27,7 @@ options:
       - Create or remove the cross-region snapshot configuration.
     required: true
     choices: [ "present", "absent" ]
+    default: present
   region:
     description:
       - The clusters region

--- a/lib/ansible/modules/cloud/amazon/redshift_cross_region_snapshots.py
+++ b/lib/ansible/modules/cloud/amazon/redshift_cross_region_snapshots.py
@@ -14,7 +14,7 @@ short_description: Manage Redshift Cross Region Snapshots
 description:
   - Manage Redshift Cross Region Snapshots. Supports KMS-Encrypted Snapshots.
   - For more information, see https://docs.aws.amazon.com/redshift/latest/mgmt/working-with-snapshots.html#cross-region-snapshot-copy
-version_added: "2.7"
+version_added: "2.8"
 author: JR Kerkstra (@captainkerk)
 options:
   cluster_name:

--- a/test/units/modules/cloud/amazon/test_redshift_cross_region_snapshots.py
+++ b/test/units/modules/cloud/amazon/test_redshift_cross_region_snapshots.py
@@ -1,0 +1,48 @@
+from ansible.modules.cloud.amazon import redshift_cross_region_snapshots as rcrs
+
+mock_status_enabled = {
+    'SnapshotCopyGrantName': 'snapshot-us-east-1-to-us-west-2',
+    'DestinationRegion': 'us-west-2',
+    'RetentionPeriod': 1,
+}
+
+mock_status_disabled = {}
+
+mock_request_illegal = {
+    'snapshot_copy_grant': 'changed',
+    'destination_region': 'us-west-2',
+    'snapshot_retention_period': 1
+}
+
+mock_request_update = {
+    'snapshot_copy_grant': 'snapshot-us-east-1-to-us-west-2',
+    'destination_region': 'us-west-2',
+    'snapshot_retention_period': 3
+}
+
+mock_request_no_update = {
+    'snapshot_copy_grant': 'snapshot-us-east-1-to-us-west-2',
+    'destination_region': 'us-west-2',
+    'snapshot_retention_period': 1
+}
+
+
+def test_fail_at_unsupported_operations():
+    response = rcrs.requesting_unsupported_modifications(
+        mock_status_enabled, mock_request_illegal
+    )
+    assert response is True
+
+
+def test_needs_update_true():
+    response = rcrs.needs_update(mock_status_enabled, mock_request_update)
+    assert response is True
+
+
+def test_no_change():
+    response = rcrs.requesting_unsupported_modifications(
+        mock_status_enabled, mock_request_no_update
+    )
+    needs_update_response = rcrs.needs_update(mock_status_enabled, mock_request_no_update)
+    assert response is False
+    assert needs_update_response is False


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
[AWS Redshift has the ability to copy automated snapshots to different regions](https://docs.aws.amazon.com/redshift/latest/mgmt/working-with-snapshots.html#cross-region-snapshot-copy)

I needed to manage snapshot copy configs on a few dozen redshift clusters. It goes without saying that I wanted a module that is idempotent. I also wanted it to understand the intricacies of this service, such as the fact you can only have one configuration at a time and that the only modification to this config is to change the retention period. 

I am currently using this module to manage a few dozen clusters in a production environment and across different AWS regions.


I felt that this copy config warranted its own module because:
* the existing redshift module is not idempotent
* its related to a cluster, but separate from a cluster configuration. You cannot set the snapshot copy configuration on a create_cluster or modify_cluster command.


<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New Module Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
redshift_cross_region_snapshots

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.1.0
  config file = /Users/employee/Projects/ansiblesite/ansible.cfg
  configured module search path = [u'/Users/employee/Projects/ansiblesite/playbooks/library']
  ansible python module location = /Users/employee/.pyenv/versions/2.7.13/lib/python2.7/site-packages/ansible
  executable location = /Users/employee/.pyenv/versions/2.7.13/bin/ansible
  python version = 2.7.13 (default, Sep  1 2017, 20:40:14) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```


##### ADDITIONAL INFORMATION


<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
