### PR TITLE
Test behaviour of loop keyword plus lookup plugins

### DIFF
--- a/test/integration/targets/loops/files/data1.txt
+++ b/test/integration/targets/loops/files/data1.txt
@@ -1,0 +1,1 @@
+      Hello World

--- a/test/integration/targets/loops/files/data2.txt
+++ b/test/integration/targets/loops/files/data2.txt
@@ -1,0 +1,1 @@
+ Olá Mundo

--- a/test/integration/targets/loops/tasks/main.yml
+++ b/test/integration/targets/loops/tasks/main.yml
@@ -18,3 +18,131 @@
 - assert:
     that:
     - '(after.stdout |int) - (before.stdout|int) >= 4'
+
+#
+# Tests of loop syntax with args
+#
+
+- name: Test that with_list works with a list
+  ping:
+    data: '{{ item }}'
+  with_list:
+    - 'Hello World'
+    - 'Olá Mundo'
+  register: results
+
+- name: Assert that we ran the module twice with the correct strings
+  assert:
+    that:
+      - 'results["results"][0]["ping"] == "Hello World"'
+      - 'results["results"][1]["ping"] == "Olá Mundo"'
+
+- name: Test that with_list works with a list inside a variable
+  ping:
+    data: '{{ item }}'
+  with_list: '{{ phrases }}'
+  register: results2
+
+- name: Assert that we ran the module twice with the correct strings
+  assert:
+    that:
+      - 'results2["results"][0]["ping"] == "Hello World"'
+      - 'results2["results"][1]["ping"] == "Olá Mundo"'
+
+- name: Test that loop works with a manual list
+  ping:
+    data: '{{ item }}'
+  loop:
+    - 'Hello World'
+    - 'Olá Mundo'
+  register: results3
+
+- name: Assert that we ran the module twice with the correct strings
+  assert:
+    that:
+      - 'results3["results"][0]["ping"] == "Hello World"'
+      - 'results3["results"][1]["ping"] == "Olá Mundo"'
+
+- name: Test that loop works with a list in a variable
+  ping:
+    data: '{{ item }}'
+  loop: '{{ phrases }}'
+  register: results4
+
+- name: Assert that we ran the module twice with the correct strings
+  assert:
+    that:
+      - 'results4["results"][0]["ping"] == "Hello World"'
+      - 'results4["results"][1]["ping"] == "Olá Mundo"'
+
+- name: Test that loop works with a list via the list lookup
+  ping:
+    data: '{{ item }}'
+  loop: '{{ lookup("list", "Hello World", "Olá Mundo", wantlist=True) }}'
+  register: results5
+
+- name: Assert that we ran the module twice with the correct strings
+  assert:
+    that:
+      - 'results5["results"][0]["ping"] == "Hello World"'
+      - 'results5["results"][1]["ping"] == "Olá Mundo"'
+
+- name: Test that loop works with a list in a variable via the list lookup
+  ping:
+    data: '{{ item }}'
+  loop: '{{ lookup("list", wantlist=True, *phrases) }}'
+  register: results6
+
+- name: Assert that we ran the module twice with the correct strings
+  assert:
+    that:
+      - 'results6["results"][0]["ping"] == "Hello World"'
+      - 'results6["results"][1]["ping"] == "Olá Mundo"'
+
+- name: Test that loop works with a list via the query lookup
+  ping:
+    data: '{{ item }}'
+  loop: '{{ query("list", "Hello World", "Olá Mundo") }}'
+  register: results7
+
+- name: Assert that we ran the module twice with the correct strings
+  assert:
+    that:
+      - 'results7["results"][0]["ping"] == "Hello World"'
+      - 'results7["results"][1]["ping"] == "Olá Mundo"'
+
+- name: Test that loop works with a list in a variable via the query lookup
+  ping:
+    data: '{{ item }}'
+  loop: '{{ q("list", *phrases) }}'
+  register: results8
+
+- name: Assert that we ran the module twice with the correct strings
+  assert:
+    that:
+      - 'results8["results"][0]["ping"] == "Hello World"'
+      - 'results8["results"][1]["ping"] == "Olá Mundo"'
+
+- name: Test that loop works with a list and keyword args
+  ping:
+    data: '{{ item }}'
+  loop: '{{ q("file", "data1.txt", "data2.txt", lstrip=True) }}'
+  register: results9
+
+- name: Assert that we ran the module twice with the correct strings
+  assert:
+    that:
+      - 'results9["results"][0]["ping"] == "Hello World"'
+      - 'results9["results"][1]["ping"] == "Olá Mundo"'
+
+- name: Test that loop works with a list in variable and keyword args
+  ping:
+    data: '{{ item }}'
+  loop: '{{ q("file", lstrip=True, *filenames) }}'
+  register: results10
+
+- name: Assert that we ran the module twice with the correct strings
+  assert:
+    that:
+      - 'results10["results"][0]["ping"] == "Hello World"'
+      - 'results10["results"][1]["ping"] == "Olá Mundo"'

--- a/test/integration/targets/loops/vars/main.yml
+++ b/test/integration/targets/loops/vars/main.yml
@@ -1,0 +1,7 @@
+---
+phrases:
+  - 'Hello World'
+  - 'Olá Mundo'
+filenames:
+  - 'data1.txt'
+  - 'data2.txt'


### PR DESCRIPTION
We introduced the new loop keyword as a replacement for with without
adding tests that it behaved as we expected.  This test asserts that
behaviour.

Incidentally, it also shows how to use parameters with lookups and loops
now.

##### ISSUE TYPE

 - Test Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```
