### PR TITLE
letsencrypt: fix account key detection for keys created by openssl_privatekey

### DIFF
--- a/lib/ansible/modules/web_infrastructure/letsencrypt.py
+++ b/lib/ansible/modules/web_infrastructure/letsencrypt.py
@@ -566,6 +566,12 @@ class ACMEAccount(object):
                 if m is not None:
                     account_key_type = m.group(1).lower()
                     break
+        if account_key_type is None:
+            # This happens for example if openssl_privatekey created this key
+            # (as opposed to the OpenSSL binary). For now, we assume this is
+            # an RSA key.
+            # FIXME: add some kind of auto-detection
+            account_key_type = "rsa"
         if account_key_type not in ("rsa", "ec"):
             return 'unknown key type "%s" % account_key_type', {}
 

--- a/lib/ansible/modules/web_infrastructure/letsencrypt.py
+++ b/lib/ansible/modules/web_infrastructure/letsencrypt.py
@@ -573,7 +573,7 @@ class ACMEAccount(object):
             # FIXME: add some kind of auto-detection
             account_key_type = "rsa"
         if account_key_type not in ("rsa", "ec"):
-            return 'unknown key type "%s" % account_key_type', {}
+            return 'unknown key type "%s"' % account_key_type, {}
 
         openssl_keydump_cmd = [self._openssl_bin, account_key_type, "-in", key, "-noout", "-text"]
         dummy, out, dummy = self.module.run_command(openssl_keydump_cmd, check_rc=True)


### PR DESCRIPTION
##### SUMMARY
Fix #35496

##### ISSUE TYPE
Bugfix Pull Request

##### COMPONENT NAME
letsencrypt

##### ANSIBLE VERSION
2.5.0

##### ADDITIONAL INFORMATION
A proper key type detection (based on the key's contents) would be better to implement. Since `openssl_privatekey` for now only supports RSA, this should at least fix the usecase where the two modules are combined.
