### PR TITLE
[WIP] initial cutover to API profiles - DO NOT MERGE

### DIFF
--- a/lib/ansible/utils/module_docs_fragments/azure.py
+++ b/lib/ansible/utils/module_docs_fragments/azure.py
@@ -90,6 +90,14 @@ options:
         - env
         default: auto
         version_added: 2.5
+    api_profile:
+        description:
+        - Selects an API profile to use when communicating with Azure services. Default value of C(latest) is appropriate for public clouds;
+          future values will allow use with Azure Stack.
+        choices:
+        - latest
+        default: latest
+        version_added: 2.5
 requirements:
     - "python >= 2.7"
     - "azure >= 2.0.0"

--- a/packaging/requirements/requirements-azure.txt
+++ b/packaging/requirements/requirements-azure.txt
@@ -16,4 +16,4 @@ azure-mgmt-web>=0.32.0,<0.33
 azure-mgmt-containerservice>=2.0.0,<3.0.0
 azure-mgmt-containerregistry>=1.0.1
 azure-mgmt-rdbms>=0.2.0rc1,<0.3.0
-azure-mgmt-containerinstance>=0.2.0,<0.3.0
+azure-mgmt-containerinstance>=0.3.1

--- a/test/runner/requirements/integration.cloud.azure.txt
+++ b/test/runner/requirements/integration.cloud.azure.txt
@@ -16,4 +16,4 @@ azure-mgmt-web>=0.32.0,<0.33
 azure-mgmt-containerservice>=2.0.0,<3.0.0
 azure-mgmt-containerregistry>=1.0.1
 azure-mgmt-rdbms>=0.2.0rc1,<0.3.0
-azure-mgmt-containerinstance>=0.2.0,<0.3.0
+azure-mgmt-containerinstance>=0.3.1


### PR DESCRIPTION
##### SUMMARY
* hardcoded API profiles in azure_rm_common
* changed azure_rm_securitygroup module to use api_profiles, dynamic models, kwargs on all SDK methods
* changed azure_rm_containerinstance module to use api_profiles, dynamic models, kwargs on all SDK methods
* fixed polling performance issue in azure_rm_securitygroup (default poll interval was 30s)

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
azure_rm_common.py

##### ANSIBLE VERSION
2.5.0

##### ADDITIONAL INFORMATION
