### PR TITLE
Fixing Bug for Embedded Switches in Parsing data

### DIFF
--- a/lib/ansible/modules/network/enos/enos_facts.py
+++ b/lib/ansible/modules/network/enos/enos_facts.py
@@ -208,7 +208,6 @@ class Default(FactsBase):
         return "NA"
 
     def parse_model(self, data):
-        # match = re.search(r'^Cisco (.+) \(revision', data, re.M)
         match = re.search(r'^Lenovo RackSwitch (\S+)', data, re.M | re.I)
         if match:
             return match.group(1)
@@ -221,7 +220,6 @@ class Default(FactsBase):
             return "Image2"
 
     def parse_serialnum(self, data):
-        # match = re.search(r'board ID (\S+)', data)
         match = re.search(r'^Switch Serial No:  (\S+)', data, re.M | re.I)
         if match:
             return match.group(1)
@@ -370,6 +368,11 @@ class Interfaces(FactsBase):
             innerData['speed'] = intfSplit[1].strip()
             innerData['duplex'] = intfSplit[2].strip()
             innerData['operstatus'] = intfSplit[5].strip()
+            if("up" not in intfSplit[5].strip()) and ("down" not in intfSplit[5].strip()):
+                innerData['description'] = intfSplit[7].strip()
+                innerData['macaddress'] = intfSplit[9].strip()
+                innerData['mtu'] = intfSplit[10].strip()
+                innerData['operstatus'] = intfSplit[6].strip()
             interfaces[intfSplit[0].strip()] = innerData
         return interfaces
 
@@ -381,6 +384,14 @@ class Interfaces(FactsBase):
             else:
                 line = line.strip()
                 match = re.match(r'^([0-9]+)', line)
+                if match:
+                    key = match.group(1)
+                    parsed.append(line)
+                match = re.match(r'^(INT+)', line)
+                if match:
+                    key = match.group(1)
+                    parsed.append(line)
+                match = re.match(r'^(EXT+)', line)
                 if match:
                     key = match.group(1)
                     parsed.append(line)
@@ -398,6 +409,14 @@ class Interfaces(FactsBase):
             else:
                 line = line.strip()
                 match = re.match(r'^([0-9]+)', line)
+                if match:
+                    key = match.group(1)
+                    parsed.append(line)
+                match = re.match(r'^(INT+)', line)
+                if match:
+                    key = match.group(1)
+                    parsed.append(line)
+                match = re.match(r'^(EXT+)', line)
                 if match:
                     key = match.group(1)
                     parsed.append(line)


### PR DESCRIPTION
##### SUMMARY
This a bug fix for parsing data gathered from embedded switches of Lenovo with respect to TOR switches. In Embedded switches like Tattooine , Compass FC etc, there is an extra column in the command "show interface status" which will result in parsing of data fails. It is mitigated here

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/network/enos/enos_facts.py

##### ANSIBLE VERSION
ansible 2.5.0
config file = /etc/ansible/ansible.cfg
configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible-2.5.0-py2.7.egg/ansible
executable location = /usr/local/bin/ansible
python version = 2.7.6 (default, Oct 26 2016, 20:30:19) [GCC 4.8.4]

##### ADDITIONAL INFORMATION
This is an effort to support Lenovo ENOS Embedded Switches also in Ansible