### PR TITLE
Fix paramiko connections to hosts with uppercase characters

### DIFF
--- a/lib/ansible/plugins/connection/paramiko_ssh.py
+++ b/lib/ansible/plugins/connection/paramiko_ssh.py
@@ -324,7 +324,7 @@ class Connection(ConnectionBase):
                 key_filename = os.path.expanduser(self._play_context.private_key_file)
 
             ssh.connect(
-                self._play_context.remote_addr,
+                self._play_context.remote_addr.lower(),
                 username=self._play_context.remote_user,
                 allow_agent=allow_agent,
                 look_for_keys=self.get_option('look_for_keys'),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Fixes #32542. See also #26224.

Additionally see paramiko/paramiko#1161

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
paramiko_ssh

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```