### PR TITLE
nxos_vlan ValueError fix

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_vlan.py
+++ b/lib/ansible/modules/network/nxos/nxos_vlan.py
@@ -404,7 +404,7 @@ def parse_interfaces(module, vlan):
     interfaces = vlan.get('vlanshowplist-ifidx')
     if interfaces:
         for i in interfaces.split(','):
-            if '-' in i:
+            if 'eth' in i.lower() and '-' in i:
                 int_range = i.split('-')
                 stop = int((int_range)[1])
                 start = int(int_range[0].split('/')[1])


### PR DESCRIPTION
Signed-off-by: Trishna Guha <trishnaguha17@gmail.com>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
fixes https://github.com/ansible/ansible/issues/35517
The existing code breaks when `port-channel` is found to be the value of the iterator.
The logic is to append interfaces when it finds Ethernet with range, for example `Ethernet1/2-5`.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
modules/network/nxos/nxos_vlan
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```