### PR TITLE
Add configurable blacklist filtering for python logger

### DIFF
--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -710,6 +710,14 @@ DEFAULT_LOG_PATH:
   ini:
   - {key: log_path, section: defaults}
   type: path
+DEFAULT_LOG_FILTER:
+  name: Name filters for python logger
+  default: []
+  description: List of logger names to filter out of the log file
+  env: [{name: ANSIBLE_LOG_FILTER}]
+  ini:
+    - {key: log_filter, section: defaults}
+  type: list
 DEFAULT_LOOKUP_PLUGIN_PATH:
   name: Lookup Plugins Path
   description: Colon separated paths in which Ansible will search for Lookup Plugins.

--- a/lib/ansible/utils/display.py
+++ b/lib/ansible/utils/display.py
@@ -47,6 +47,14 @@ except NameError:
     pass
 
 
+class FilterBlackList(logging.Filter):
+    def __init__(self, blacklist):
+        self.blacklist = [logging.Filter(name) for name in blacklist]
+
+    def filter(self, record):
+        return not any(f.filter(record) for f in self.blacklist)
+
+
 logger = None
 # TODO: make this a logging callback instead
 if C.DEFAULT_LOG_PATH:
@@ -56,6 +64,8 @@ if C.DEFAULT_LOG_PATH:
         mypid = str(os.getpid())
         user = getpass.getuser()
         logger = logging.getLogger("p=%s u=%s | " % (mypid, user))
+        for handler in logging.root.handlers:
+            handler.addFilter(FilterBlackList(C.DEFAULT_LOG_FILTER))
     else:
         print("[WARNING]: log file at %s is not writeable and we cannot create it, aborting\n" % path, file=sys.stderr)
 


### PR DESCRIPTION
##### SUMMARY
Add configurable blacklist filtering for python logger

Potential fix for #35532 

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
lib/ansible/utils/display.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.4
2.5
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```