### PR TITLE
eos_vlan: Modified logic to allow for more than 6 interfaces to be assigned to …

### DIFF
--- a/lib/ansible/modules/network/eos/eos_vlan.py
+++ b/lib/ansible/modules/network/eos/eos_vlan.py
@@ -199,24 +199,29 @@ def map_obj_to_commands(updates, module):
 
 def map_config_to_obj(module):
     objs = []
-    output = run_commands(module, ['show vlan'])
+    output = run_commands(module, ['show vlan conf'])
     lines = output[0].strip().splitlines()[2:]
 
     for l in lines:
         splitted_line = re.split(r'\s{2,}', l.strip())
-        obj = {}
-        obj['vlan_id'] = splitted_line[0]
-        obj['name'] = splitted_line[1]
-        obj['state'] = splitted_line[2]
-
-        if obj['state'] == 'suspended':
-            obj['state'] = 'suspend'
-
-        obj['interfaces'] = []
         if len(splitted_line) > 3:
+            obj = {}
+            obj['vlan_id'] = splitted_line[0]
+            obj['name'] = splitted_line[1]
+            obj['state'] = splitted_line[2]
+            obj['interfaces'] = []
 
             for i in splitted_line[3].split(','):
                 obj['interfaces'].append(i.strip().replace('Et', 'ethernet'))
+
+        elif len(splitted_line) < 3:
+            for i in splitted_line[0].split(','):
+                obj['interfaces'].append(i.strip().replace('Et', 'Ethernet'))
+        else:
+            # do nothing yet
+
+        if obj['state'] == 'suspended':
+            obj['state'] = 'suspend'
 
         objs.append(obj)
 

--- a/lib/ansible/modules/network/eos/eos_vlan.py
+++ b/lib/ansible/modules/network/eos/eos_vlan.py
@@ -199,26 +199,19 @@ def map_obj_to_commands(updates, module):
 
 def map_config_to_obj(module):
     objs = []
-    output = run_commands(module, ['show vlan conf'])
-    lines = output[0].strip().splitlines()[2:]
+    vlans = run_commands(module, ['show vlan conf | json'])
 
-    for l in lines:
-        splitted_line = re.split(r'\s{2,}', l.strip())
-        if len(splitted_line) > 3:
-            obj = {}
-            obj['vlan_id'] = splitted_line[0]
-            obj['name'] = splitted_line[1]
-            obj['state'] = splitted_line[2]
-            obj['interfaces'] = []
+    for vlan in vlans[0]['vlans']:
+        obj = {}
+        obj['vlan_id'] = vlan
+        obj['name'] = vlans[0]['vlans'][vlan]['name']
+        obj['state'] = vlans[0]['vlans'][vlan]['status']
+        obj['interfaces'] = []
 
-            for i in splitted_line[3].split(','):
-                obj['interfaces'].append(i.strip().replace('Et', 'ethernet'))
+        interfaces = vlans[0]['vlans'][vlan]
 
-        elif len(splitted_line) < 3:
-            for i in splitted_line[0].split(','):
-                obj['interfaces'].append(i.strip().replace('Et', 'Ethernet'))
-        else:
-            # do nothing yet
+        for interface in interfaces['interfaces']:
+            obj['interfaces'].append(interface)
 
         if obj['state'] == 'suspended':
             obj['state'] = 'suspend'


### PR DESCRIPTION

##### SUMMARY
Bug fix to allow more than 6 interfaces to be assigned to a vlan
Bug fix to properly show assigned interfaces to vlan when interface is not "hot"

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Fixes #35554
Fixes #35567

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
eos_vlan
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.2.0
  config file = None
  configured module search path = [u'/Users/jlee/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/Cellar/ansible/2.4.2.0_1/libexec/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.14 (default, Sep 25 2017, 09:53:22) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.37)]
```


##### ADDITIONAL INFORMATION

<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
