### PR TITLE
Aws ssm multiple fixes

### DIFF
--- a/lib/ansible/modules/cloud/amazon/aws_ssm_parameter_store.py
+++ b/lib/ansible/modules/cloud/amazon/aws_ssm_parameter_store.py
@@ -60,7 +60,9 @@ options:
     description:
       - region.
     required: false
-author: Bill Wang (ozbillwang@gmail.com)
+author:
+  - Bill Wang (ozbillwang@gmail.com)
+  - Michael De La Rue (@mikedlr)
 extends_documentation_fragment: aws
 requirements: [ botocore, boto3 ]
 '''
@@ -107,13 +109,11 @@ delete_parameter:
     type: dictionary
 '''
 
-import traceback
 from ansible.module_utils.aws.core import AnsibleAWSModule
-from ansible.module_utils.ec2 import HAS_BOTO3, camel_dict_to_snake_dict
-from ansible.module_utils.ec2 import boto3_conn, ec2_argument_spec, get_aws_connection_info
+from ansible.module_utils.ec2 import boto3_conn, get_aws_connection_info
 
 try:
-    from botocore.exceptions import ClientError, NoCredentialsError
+    from botocore.exceptions import ClientError
 except ImportError:
     pass  # will be captured by imported HAS_BOTO3
 
@@ -145,7 +145,6 @@ def create_update_parameter(client, module):
 
 
 def delete_parameter(client, module):
-    changed = False
     response = {}
 
     try:
@@ -198,6 +197,7 @@ def main():
     }
     (changed, response) = invocations[state](client, module)
     module.exit_json(changed=changed, response=response)
+
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/cloud/amazon/aws_ssm_parameter_store.py
+++ b/lib/ansible/modules/cloud/amazon/aws_ssm_parameter_store.py
@@ -152,8 +152,8 @@ def delete_parameter(client, module):
             Name=module.params.get('name')
         )
     except ClientError as e:
-        if e.response['Error']['Code'] == 'ResourceNotFoundException':
-            return False, e.response
+        if e.response['Error']['Code'] == 'ParameterNotFound':
+            return False, {}
         module.fail_json_aws(e, msg="deleting parameter")
 
     return True, response
@@ -161,10 +161,7 @@ def delete_parameter(client, module):
 
 def setup_client(module):
     region, ec2_url, aws_connect_params = get_aws_connection_info(module, boto3=True)
-    if region:
-        connection = boto3_conn(module, conn_type='client', resource='ssm', region=region, endpoint=ec2_url, **aws_connect_params)
-    else:
-        module.fail_json(msg="region must be specified")
+    connection = boto3_conn(module, conn_type='client', resource='ssm', region=region, endpoint=ec2_url, **aws_connect_params)
     return connection
 
 

--- a/lib/ansible/plugins/lookup/aws_ssm.py
+++ b/lib/ansible/plugins/lookup/aws_ssm.py
@@ -1,6 +1,6 @@
 # (c) 2016, Bill Wang <ozbillwang(at)gmail.com>
 # (c) 2017, Marat Bakeev <hawara(at)gmail.com>
-# (c) 2018, Michael De La Rue <hawara(at)gmail.com>
+# (c) 2018, Michael De La Rue <siblemitcom.mddlr(at)spamgourmet.com>
 # (c) 2017 Ansible Project
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
@@ -72,12 +72,20 @@ EXAMPLES = '''
 '''
 # FIXME the last one is probably not true yet. 
 
-
+from ansible.utils.display import Display
 from ansible.module_utils.ec2 import HAS_BOTO3, boto3_tag_list_to_ansible_dict
 from ansible.errors import AnsibleError
 from ansible.plugins.lookup import LookupBase
 from ansible.module_utils.parsing.convert_bool import boolean
 import pdb
+
+from ansible.utils.display import Display
+
+try:
+    from __main__ import display
+except ImportError:
+    from ansible.utils.display import Display
+    display = Display()
 
 try:
     from botocore.exceptions import ClientError
@@ -145,7 +153,7 @@ class LookupModule(LookupBase):
         if bypath:
             for term in terms: 
                 ssm_dict["Path"] = term
-                #FIXME: display.debug("AWS_ssm lookup term: %s" % term)
+                display.vvv("AWS_ssm path lookup term: %s in region: %s" % (term, region))
                 try:
                     response = client.get_parameters_by_path(**ssm_dict)
                 except ClientError as e:
@@ -163,6 +171,7 @@ class LookupModule(LookupBase):
                     for x in paramlist:
                         x['Name'] = x['Name'][x['Name'].rfind('/') + 1:]
 
+                display.vvvv("AWS_ssm path lookup returned: %s" % str(paramlist))
                 if len(paramlist):
                     ret.append(boto3_tag_list_to_ansible_dict(paramlist,
                                                           tag_name_key_name="Name",
@@ -171,7 +180,7 @@ class LookupModule(LookupBase):
                     return None
             # Lookup by parameter name - always returns a list with one or no entry. 
         else:
-            #FIXME: display.debug("AWS_ssm lookup term: %s" % terms)
+            FIXME: display.vvv("AWS_ssm name lookup term: %s" % terms)
             ssm_dict["Names"] = terms
             try:
                 response = client.get_parameters(**ssm_dict)

--- a/lib/ansible/plugins/lookup/aws_ssm.py
+++ b/lib/ansible/plugins/lookup/aws_ssm.py
@@ -12,7 +12,7 @@ DOCUMENTATION = '''
     author:
       - Bill Wang <ozbillwang(at)gmail.com>
       - Marat Bakeev <hawara(at)gmail.com>
-      - Michael De La Rue <siblemitcom.mddlr@spamgourmet.com> 
+      - Michael De La Rue <siblemitcom.mddlr@spamgourmet.com>
     version_added: 2.5
     short_description: Get the value for a SSM parameter.
     description:
@@ -70,16 +70,11 @@ EXAMPLES = '''
   with_aws_ssm:
     - '/TEST/test-list region=ap-southeast-2, bypath'
 '''
-# FIXME the last one is probably not true yet. 
+# FIXME the last one is probably not true yet.
 
-from ansible.utils.display import Display
 from ansible.module_utils.ec2 import HAS_BOTO3, boto3_tag_list_to_ansible_dict
 from ansible.errors import AnsibleError
 from ansible.plugins.lookup import LookupBase
-from ansible.module_utils.parsing.convert_bool import boolean
-import pdb
-
-from ansible.utils.display import Display
 
 try:
     from __main__ import display
@@ -135,9 +130,7 @@ class LookupModule(LookupBase):
 
         ret = []
         response = {}
-        session = {}
         ssm_dict = {}
-        lparams = {}
 
         credentials = {}
         credentials['boto_profile'] = boto_profile
@@ -151,7 +144,7 @@ class LookupModule(LookupBase):
 
         # Lookup by path
         if bypath:
-            for term in terms: 
+            for term in terms:
                 ssm_dict["Path"] = term
                 display.vvv("AWS_ssm path lookup term: %s in region: %s" % (term, region))
                 try:
@@ -174,24 +167,21 @@ class LookupModule(LookupBase):
                 display.vvvv("AWS_ssm path lookup returned: %s" % str(paramlist))
                 if len(paramlist):
                     ret.append(boto3_tag_list_to_ansible_dict(paramlist,
-                                                          tag_name_key_name="Name",
-                                                          tag_value_key_name="Value"))
+                                                              tag_name_key_name="Name",
+                                                              tag_value_key_name="Value"))
                 else:
                     return None
-            # Lookup by parameter name - always returns a list with one or no entry. 
+            # Lookup by parameter name - always returns a list with one or no entry.
         else:
-            FIXME: display.vvv("AWS_ssm name lookup term: %s" % terms)
+            display.vvv("AWS_ssm name lookup term: %s" % terms)
             ssm_dict["Names"] = terms
             try:
                 response = client.get_parameters(**ssm_dict)
             except ClientError as e:
                 raise AnsibleError("SSM lookup exception: {0}".format(e))
-            # FIXME - hanle invaliod right
-            if len(response['Parameters']) > 0:
-                ret.append(response['Parameters'][0]['Value'])
+            if len(response['Parameters']) == len(terms):
+                ret = [p['Value'] for p in response['Parameters']]
             else:
-                raise AnsibleError('Undefined AWS SSM parameter: %s ' % terms[0])
+                raise AnsibleError('Undefined AWS SSM parameter: %s ' % str(response['InvalidParameters']))
 
         return ret
-
-

--- a/lib/ansible/plugins/lookup/aws_ssm.py
+++ b/lib/ansible/plugins/lookup/aws_ssm.py
@@ -120,7 +120,7 @@ def _boto3_conn(region, credentials):
 
 
 class LookupModule(LookupBase):
-    def run(self, terms, variables=None, boto_profile=None,
+    def run(self, terms, variables=None, boto_profile=None, aws_profile=None,
             aws_secret_key=None, aws_access_key=None, aws_security_token=None, region=None,
             bypath=False, shortnames=False, recursive=False, decrypt=True):
         '''
@@ -145,7 +145,10 @@ class LookupModule(LookupBase):
         ssm_dict = {}
 
         credentials = {}
-        credentials['boto_profile'] = boto_profile
+        if aws_profile:
+            credentials['boto_profile'] = aws_profile
+        else:
+            credentials['boto_profile'] = boto_profile
         credentials['aws_secret_access_key'] = aws_secret_key
         credentials['aws_access_key_id'] = aws_access_key
         credentials['aws_session_token'] = aws_security_token

--- a/lib/ansible/plugins/lookup/aws_ssm.py
+++ b/lib/ansible/plugins/lookup/aws_ssm.py
@@ -70,7 +70,7 @@ EXAMPLES = '''
     - 'bypath'
 '''
 
-from ansible.module_utils.ec2 import HAS_BOTO3
+from ansible.module_utils.ec2 import HAS_BOTO3, boto3_tag_list_to_ansible_dict
 from ansible.errors import AnsibleError
 from ansible.plugins.lookup import LookupBase
 from ansible.module_utils.parsing.convert_bool import boolean
@@ -158,7 +158,9 @@ class LookupModule(LookupBase):
                         x['Name'] = x['Name'][x['Name'].rfind('/') + 1:]
 
                 if len(paramlist):
-                    return paramlist
+                    return boto3_tag_list_to_ansible_dict(paramlist,
+                                                          tag_name_key_name="Name",
+                                                          tag_value_key_name="Value")
                 else:
                     return None
             # Lookup by parameter name

--- a/lib/ansible/plugins/lookup/aws_ssm.py
+++ b/lib/ansible/plugins/lookup/aws_ssm.py
@@ -17,8 +17,6 @@ version_added: 2.5
 requirements:
   - boto3
   - botocore
-extends_documentation_fragment:
-- aws_credentials
 short_description: Get the value for a SSM parameter or all parameters under a path.
 description:
   - Get the value for an Amazon Simple Systems Manager parameter or a heirarchy of parameters.

--- a/lib/ansible/plugins/lookup/aws_ssm.py
+++ b/lib/ansible/plugins/lookup/aws_ssm.py
@@ -8,40 +8,44 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 DOCUMENTATION = '''
-    lookup: aws_ssm
-    author:
-      - Bill Wang <ozbillwang(at)gmail.com>
-      - Marat Bakeev <hawara(at)gmail.com>
-      - Michael De La Rue <siblemitcom.mddlr@spamgourmet.com>
-    version_added: 2.5
-    short_description: Get the value for a SSM parameter or all parameters under a path.
-    description:
-      - Get the value for an Amazon Simple Systems Manager parameter or a heirarchy of parameters.
-        The first argument you pass the lookup can either be a parameter name or a hierarchy of
-        parameters. Hierarchies start with a forward slash and end with the parameter name. Up to
-        5 layers may be specified.
-      - When explicitly looking up a parameter by name the parameter being missing will be an error.
-      - When looking up a path for parameters under it a dictionary will be returned for each path.
-        If there is no parameter under that path then the return will be successful but the
-        dictionary will be empty.
-    options:
-      region:
-        description: The region to use. You may use environment variables ar the default profile's region as an alternative.
-      aws_profile:
-        description: The boto profile to use. You may use environment variables or the default profile as an alternative.
-
-      decrypt:
-        description: A boolean to indicate whether to decrypt the parameter.
-        default: false
-      bypath:
-        description: A boolean to indicate whether the parameter is provided as a hierarchy.
-        default: false
-      recursive:
-        description: A boolean to indicate whether to retrieve all parameters within a hierarchy.
-        default: false
-      shortnames:
-        description: Indicates whether to return the shortened name if using a parameter hierarchy.
-        default: false
+lookup: aws_ssm
+author:
+  - Bill Wang <ozbillwang(at)gmail.com>
+  - Marat Bakeev <hawara(at)gmail.com>
+  - Michael De La Rue <siblemitcom.mddlr@spamgourmet.com>
+version_added: 2.5
+requirements:
+  - boto3
+  - botocore
+extends_documentation_fragment:
+- aws_credentials
+short_description: Get the value for a SSM parameter or all parameters under a path.
+description:
+  - Get the value for an Amazon Simple Systems Manager parameter or a heirarchy of parameters.
+    The first argument you pass the lookup can either be a parameter name or a hierarchy of
+    parameters. Hierarchies start with a forward slash and end with the parameter name. Up to
+    5 layers may be specified.
+  - When explicitly looking up a parameter by name the parameter being missing will be an error.
+  - When looking up a path for parameters under it a dictionary will be returned for each path.
+    If there is no parameter under that path then the return will be successful but the
+    dictionary will be empty.
+options:
+  decrypt:
+    description: A boolean to indicate whether to decrypt the parameter.
+    default: false
+    type: boolean
+  bypath:
+    description: A boolean to indicate whether the parameter is provided as a hierarchy.
+    default: false
+    type: boolean
+  recursive:
+    description: A boolean to indicate whether to retrieve all parameters within a hierarchy.
+    default: false
+    type: boolean
+  shortnames:
+    description: Indicates whether to return the name only without path if using a parameter hierarchy.
+    default: false
+    type: boolean
 '''
 
 EXAMPLES = '''
@@ -126,6 +130,7 @@ class LookupModule(LookupBase):
             :kwarg aws_secret_key: identity of the AWS key to use
             :kwarg aws_access_key: AWS seret key (matching identity)
             :kwarg aws_security_token: AWS session key if using STS
+            :kwarg decrypt: Set to True to get decrypted parameters
             :kwarg region: AWS region in which to do the lookup
             :kwarg bypath: Set to True to do a lookup of variables under a path
             :kwarg recursive: Set to True to recurse below the path (requires bypath=True)

--- a/lib/ansible/plugins/lookup/aws_ssm.py
+++ b/lib/ansible/plugins/lookup/aws_ssm.py
@@ -88,7 +88,7 @@ class LookupModule(LookupBase):
             :param terms: a list of plugin options
                           e.g. ['parameter_name', 'region=us-east-1', 'aws_profile=profile', 'decrypt=false']
             :param variables: config variables
-            :return The value of the SSM parameter or None
+            :return A list containing one entry with the value of the SSM parameter or None
         '''
 
         ret = {}
@@ -168,7 +168,7 @@ class LookupModule(LookupBase):
                 if ret['Parameters']:
                     return [ret['Parameters'][0]['Value']]
                 else:
-                    return None
+                    raise AnsibleError('Undefined AWS SSM parameter: %s ' % terms[0])
 
         except ClientError as e:
             raise AnsibleError("SSM lookup exception: {0}".format(e))

--- a/test/integration/targets/aws_ssm_parameters/aliases
+++ b/test/integration/targets/aws_ssm_parameters/aliases
@@ -1,0 +1,2 @@
+cloud/aws
+posix/ci/cloud/group4/aws

--- a/test/integration/targets/aws_ssm_parameters/defaults/main.yml
+++ b/test/integration/targets/aws_ssm_parameters/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+# defaults file for aws_lambda test
+ssm_key_prefix: '{{resource_prefix}}'

--- a/test/integration/targets/aws_ssm_parameters/tasks/main.yml
+++ b/test/integration/targets/aws_ssm_parameters/tasks/main.yml
@@ -1,0 +1,34 @@
+---
+#
+#  Author: Michael De La Rue
+#  based on aws_lambda
+- block:
+
+     - name: Create or update key/value pair in aws parameter store
+       aws_ssm_parameter_store:
+         name: "/{{ssm_key_prefix}}/Hello"
+         description: "This is your first key"
+         value: "World"
+         ec2_access_key: '{{ec2_access_key}}'
+         ec2_secret_key: '{{ec2_secret_key}}'
+         security_token: '{{security_token}}'
+         region: '{{ec2_region}}'
+        
+     - name: Check that parameter was stored correctly
+       assert:
+        that:
+         - "{{lookup('aws_ssm', ssm_key_prefix ~ '/Hello', 'region=' ~ ec2_region )}} = 'World'"
+
+
+  always:
+
+     - name: Delete key/value pair in aws parameter store
+       aws_ssm_parameter_store:
+         name: "/{{ssm_key_prefix}}/Hello"
+         state: absent
+         ec2_access_key: '{{ec2_access_key}}'
+         ec2_secret_key: '{{ec2_secret_key}}'
+         security_token: '{{security_token}}'
+         region: '{{ec2_region}}'
+
+

--- a/test/integration/targets/aws_ssm_parameters/tasks/main.yml
+++ b/test/integration/targets/aws_ssm_parameters/tasks/main.yml
@@ -17,8 +17,46 @@
      - name: Check that parameter was stored correctly
        assert:
         that:
-         - "{{lookup('aws_ssm', ssm_key_prefix ~ '/Hello', 'region=' ~ ec2_region )}} = 'World'"
+         - "'{{lookup('aws_ssm', '/' ~ ssm_key_prefix ~ '/Hello', region=ec2_region, aws_access_key=ec2_access_key, aws_secret_key=ec2_secret_key, aws_security_token=security_token )}}' == 'World'"
 
+     - name: Create or update key/value pair in aws parameter store
+       aws_ssm_parameter_store:
+         name: "/{{ssm_key_prefix}}/path/wonvar"
+         description: "This is your first key"
+         value: "won value"
+         ec2_access_key: '{{ec2_access_key}}'
+         ec2_secret_key: '{{ec2_secret_key}}'
+         security_token: '{{security_token}}'
+         region: '{{ec2_region}}'
+        
+     - name: Create or update key/value pair in aws parameter store
+       aws_ssm_parameter_store:
+         name: "/{{ssm_key_prefix}}/path/toovar"
+         description: "This is your first key"
+         value: "too value"
+         ec2_access_key: '{{ec2_access_key}}'
+         ec2_secret_key: '{{ec2_secret_key}}'
+         security_token: '{{security_token}}'
+         region: '{{ec2_region}}'
+        
+     - name: Create or update key/value pair in aws parameter store
+       aws_ssm_parameter_store:
+         name: "/{{ssm_key_prefix}}/path/tree/treevar"
+         description: "This is your first key"
+         value: "tree value"
+         ec2_access_key: '{{ec2_access_key}}'
+         ec2_secret_key: '{{ec2_secret_key}}'
+         security_token: '{{security_token}}'
+         region: '{{ec2_region}}'
+        
+     - name: debug the lookup
+       debug:
+        msg: "{{lookup('aws_ssm', '/' ~ ssm_key_prefix ~ '/path', region=ec2_region, aws_access_key=ec2_access_key, aws_secret_key=ec2_secret_key, aws_security_token=security_token, bypath=True )}}'"
+
+     - name: Check that parameter path is stored and retrieved
+       assert:
+        that:
+         - "'{{lookup('aws_ssm', '/' ~ ssm_key_prefix ~ '/path', region=ec2_region, aws_access_key=ec2_access_key, aws_secret_key=ec2_secret_key, aws_security_token=security_token, bypath=True, shortnames=true ) | to_json }}' == '{\"toovar\": \"too value\", \"wonvar\": \"won value\"}'"
 
   always:
 
@@ -31,4 +69,16 @@
          security_token: '{{security_token}}'
          region: '{{ec2_region}}'
 
+     - name: Delete key/value pair in aws parameter store
+       aws_ssm_parameter_store:
+         name: "{{item}}"
+         state: absent
+         ec2_access_key: '{{ec2_access_key}}'
+         ec2_secret_key: '{{ec2_secret_key}}'
+         security_token: '{{security_token}}'
+         region: '{{ec2_region}}'
+       with_items:
+         - "/{{ssm_key_prefix}}/path/wonvar"
+         - "/{{ssm_key_prefix}}/path/toovar"
+         - "/{{ssm_key_prefix}}/path/tree/treevar"
 

--- a/test/integration/targets/aws_ssm_parameters/tasks/main.yml
+++ b/test/integration/targets/aws_ssm_parameters/tasks/main.yml
@@ -1,9 +1,10 @@
 ---
 #
 #  Author: Michael De La Rue
-#  based on aws_lambda
+#  based on aws_lambda test cases
 - block:
 
+     # ============================================================
      - name: Create or update key/value pair in aws parameter store
        aws_ssm_parameter_store:
          name: "/{{ssm_key_prefix}}/Hello"
@@ -13,12 +14,13 @@
          ec2_secret_key: '{{ec2_secret_key}}'
          security_token: '{{security_token}}'
          region: '{{ec2_region}}'
-        
+
      - name: Check that parameter was stored correctly
        assert:
         that:
          - "'{{lookup('aws_ssm', '/' ~ ssm_key_prefix ~ '/Hello', region=ec2_region, aws_access_key=ec2_access_key, aws_secret_key=ec2_secret_key, aws_security_token=security_token )}}' == 'World'"
 
+     # ============================================================
      - name: Create or update key/value pair in aws parameter store
        aws_ssm_parameter_store:
          name: "/{{ssm_key_prefix}}/path/wonvar"
@@ -28,7 +30,7 @@
          ec2_secret_key: '{{ec2_secret_key}}'
          security_token: '{{security_token}}'
          region: '{{ec2_region}}'
-        
+
      - name: Create or update key/value pair in aws parameter store
        aws_ssm_parameter_store:
          name: "/{{ssm_key_prefix}}/path/toovar"
@@ -38,7 +40,7 @@
          ec2_secret_key: '{{ec2_secret_key}}'
          security_token: '{{security_token}}'
          region: '{{ec2_region}}'
-        
+
      - name: Create or update key/value pair in aws parameter store
        aws_ssm_parameter_store:
          name: "/{{ssm_key_prefix}}/path/tree/treevar"
@@ -48,7 +50,7 @@
          ec2_secret_key: '{{ec2_secret_key}}'
          security_token: '{{security_token}}'
          region: '{{ec2_region}}'
-        
+
      - name: debug the lookup
        debug:
         msg: "{{lookup('aws_ssm', '/' ~ ssm_key_prefix ~ '/path', region=ec2_region, aws_access_key=ec2_access_key, aws_secret_key=ec2_secret_key, aws_security_token=security_token, bypath=True )}}'"
@@ -58,8 +60,23 @@
         that:
          - "'{{lookup('aws_ssm', '/' ~ ssm_key_prefix ~ '/path', region=ec2_region, aws_access_key=ec2_access_key, aws_secret_key=ec2_secret_key, aws_security_token=security_token, bypath=True, shortnames=true ) | to_json }}' == '{\"toovar\": \"too value\", \"wonvar\": \"won value\"}'"
 
+     # ============================================================
+     - name: Error in case we don't find the parameter
+       debug:
+        msg: "'{{lookup('aws_ssm', '/' ~ ssm_key_prefix ~ '/Goodbye', region=ec2_region, aws_access_key=ec2_access_key, aws_secret_key=ec2_secret_key, aws_security_token=security_token )}}' == 'World'"
+       register: result
+       ignore_errors: true
+
+     - name: assert failure from failure to find parameter
+       assert:
+         that:
+            - 'result.failed'
+            - "'Undefined AWS SSM parameter' in result.msg"
+
+
   always:
 
+     # ============================================================
      - name: Delete key/value pair in aws parameter store
        aws_ssm_parameter_store:
          name: "/{{ssm_key_prefix}}/Hello"
@@ -69,7 +86,8 @@
          security_token: '{{security_token}}'
          region: '{{ec2_region}}'
 
-     - name: Delete key/value pair in aws parameter store
+     # ============================================================
+     - name: Delete remaining key/value pairs in aws parameter store
        aws_ssm_parameter_store:
          name: "{{item}}"
          state: absent

--- a/test/integration/targets/aws_ssm_parameters/tasks/main.yml
+++ b/test/integration/targets/aws_ssm_parameters/tasks/main.yml
@@ -4,99 +4,133 @@
 #  based on aws_lambda test cases
 - block:
 
-     # ============================================================
-     - name: Create or update key/value pair in aws parameter store
-       aws_ssm_parameter_store:
-         name: "/{{ssm_key_prefix}}/Hello"
-         description: "This is your first key"
-         value: "World"
-         ec2_access_key: '{{ec2_access_key}}'
-         ec2_secret_key: '{{ec2_secret_key}}'
-         security_token: '{{security_token}}'
-         region: '{{ec2_region}}'
+    # ============================================================
+    - name: set up aws connection info
+      set_fact:
+        aws_connection_info: &aws_connection_info
+           aws_access_key: "{{ aws_access_key }}"
+           aws_secret_key: "{{ aws_secret_key }}"
+           security_token: "{{ security_token }}"
+           region: "{{ aws_region }}"
+      no_log: yes
+    # ============================================================
+    - name: Create or update key/value pair in aws parameter store
+      aws_ssm_parameter_store:
+        name: "/{{ssm_key_prefix}}/Hello"
+        description: "This is your first key"
+        value: "World"
+        <<: *aws_connection_info
 
-     - name: Check that parameter was stored correctly
-       assert:
+    - name: Check that parameter was stored correctly
+      assert:
+       that:
+        - "'{{lookup('aws_ssm', '/' ~ ssm_key_prefix ~ '/Hello', region=ec2_region, aws_access_key=ec2_access_key, aws_secret_key=ec2_secret_key, aws_security_token=security_token )}}' == 'World'"
+
+    # ============================================================
+    - name: Create or update key/value pair in aws parameter store
+      aws_ssm_parameter_store:
+        name: "/{{ssm_key_prefix}}/path/wonvar"
+        description: "This is your first key"
+        value: "won value"
+        <<: *aws_connection_info
+
+    - name: Create or update key/value pair in aws parameter store
+      aws_ssm_parameter_store:
+        name: "/{{ssm_key_prefix}}/path/toovar"
+        description: "This is your first key"
+        value: "too value"
+        <<: *aws_connection_info
+
+    - name: Create or update key/value pair in aws parameter store
+      aws_ssm_parameter_store:
+        name: "/{{ssm_key_prefix}}/path/tree/treevar"
+        description: "This is your first key"
+        value: "tree value"
+        <<: *aws_connection_info
+
+    # ============================================================
+    - name: Create or update key/value pair in aws parameter store
+      aws_ssm_parameter_store:
+        name: "/{{ssm_key_prefix}}/deeppath/wondir/samevar"
+        description: "This is your first key"
+        value: "won value"
+        <<: *aws_connection_info
+
+    - name: Create or update key/value pair in aws parameter store
+      aws_ssm_parameter_store:
+        name: "/{{ssm_key_prefix}}/deeppath/toodir/samevar"
+        description: "This is your first key"
+        value: "too value"
+        <<: *aws_connection_info
+
+    # ============================================================
+    - name: debug the lookup
+      debug:
+       msg: "{{lookup('aws_ssm', '/' ~ ssm_key_prefix ~ '/path', region=ec2_region, aws_access_key=ec2_access_key, aws_secret_key=ec2_secret_key, aws_security_token=security_token, bypath=True )}}'"
+
+    - name: Check that parameter path is stored and retrieved
+      assert:
+       that:
+        - "'{{lookup('aws_ssm', '/' ~ ssm_key_prefix ~ '/path', region=ec2_region, aws_access_key=ec2_access_key, aws_secret_key=ec2_secret_key, aws_security_token=security_token, bypath=True, shortnames=true ) | to_json }}' == '{\"toovar\": \"too value\", \"wonvar\": \"won value\"}'"
+
+    # ============================================================
+    - name: Error in case we don't find a named parameter
+      debug:
+       msg: "'{{lookup('aws_ssm', '/' ~ ssm_key_prefix ~ '/Goodbye', region=ec2_region, aws_access_key=ec2_access_key, aws_secret_key=ec2_secret_key, aws_security_token=security_token )}}' == 'World'"
+      register: result
+      ignore_errors: true
+
+    - name: assert failure from failure to find parameter
+      assert:
         that:
-         - "'{{lookup('aws_ssm', '/' ~ ssm_key_prefix ~ '/Hello', region=ec2_region, aws_access_key=ec2_access_key, aws_secret_key=ec2_secret_key, aws_security_token=security_token )}}' == 'World'"
+           - 'result.failed'
+           - "'Undefined AWS SSM parameter' in result.msg"
 
-     # ============================================================
-     - name: Create or update key/value pair in aws parameter store
-       aws_ssm_parameter_store:
-         name: "/{{ssm_key_prefix}}/path/wonvar"
-         description: "This is your first key"
-         value: "won value"
-         ec2_access_key: '{{ec2_access_key}}'
-         ec2_secret_key: '{{ec2_secret_key}}'
-         security_token: '{{security_token}}'
-         region: '{{ec2_region}}'
+    # ============================================================
+    - name: Handle multiple paths with one that doesn't exist - default to full names.
+      assert:
+       that:
+        - "'{{lookup('aws_ssm', '/' ~ ssm_key_prefix ~ '/path', '/' ~ ssm_key_prefix ~ '/dont_create_this_path_you_will_break_the_ansible_tests', region=ec2_region, aws_access_key=ec2_access_key, aws_secret_key=ec2_secret_key, aws_security_token=security_token, bypath=True ) | to_json }}' in ( '[{\"/' ~ ssm_key_prefix ~ '/path/toovar\": \"too value\", \"/' ~ ssm_key_prefix ~ '/path/wonvar\": \"won value\"}, {}]',  '[{\"/' ~ ssm_key_prefix ~ '/path/wonvar\": \"won value\", \"/' ~ ssm_key_prefix ~ '/path/toovar\": \"too value\"}, {}]' )"
 
-     - name: Create or update key/value pair in aws parameter store
-       aws_ssm_parameter_store:
-         name: "/{{ssm_key_prefix}}/path/toovar"
-         description: "This is your first key"
-         value: "too value"
-         ec2_access_key: '{{ec2_access_key}}'
-         ec2_secret_key: '{{ec2_secret_key}}'
-         security_token: '{{security_token}}'
-         region: '{{ec2_region}}'
 
-     - name: Create or update key/value pair in aws parameter store
-       aws_ssm_parameter_store:
-         name: "/{{ssm_key_prefix}}/path/tree/treevar"
-         description: "This is your first key"
-         value: "tree value"
-         ec2_access_key: '{{ec2_access_key}}'
-         ec2_secret_key: '{{ec2_secret_key}}'
-         security_token: '{{security_token}}'
-         region: '{{ec2_region}}'
+    # ============================================================
+    # this may be a bit of a nasty test case;  we should perhaps accept _either_ value that was stored
+    # in the two variables named 'samevar'
 
-     - name: debug the lookup
-       debug:
-        msg: "{{lookup('aws_ssm', '/' ~ ssm_key_prefix ~ '/path', region=ec2_region, aws_access_key=ec2_access_key, aws_secret_key=ec2_secret_key, aws_security_token=security_token, bypath=True )}}'"
+    - name: Handle multiple paths with one that doesn't exist - shortnames - including overlap.
+      assert:
+       that:
+        - "'{{lookup('aws_ssm', '/' ~ ssm_key_prefix ~ '/path', '/' ~ ssm_key_prefix ~ '/dont_create_this_path_you_will_break_the_ansible_tests', '/' ~ ssm_key_prefix ~ '/deeppath', region=ec2_region, aws_access_key=ec2_access_key, aws_secret_key=ec2_secret_key, aws_security_token=security_token, bypath=True, shortnames=true, recursive=true ) | to_json }}' == '[{\"toovar\": \"too value\", \"treevar\": \"tree value\", \"wonvar\": \"won value\"}, {}, {\"samevar\": \"won value\"}]'"
 
-     - name: Check that parameter path is stored and retrieved
-       assert:
+
+    # ============================================================
+    - name: Delete key/value pair in aws parameter store
+      aws_ssm_parameter_store:
+        name: "/{{ssm_key_prefix}}/Hello"
+        state: absent
+        <<: *aws_connection_info
+
+    # ============================================================
+    - name: Attempt delete key/value pair in aws parameter store again
+      aws_ssm_parameter_store:
+        name: "/{{ssm_key_prefix}}/Hello"
+        state: absent
+        <<: *aws_connection_info
+      register: result
+
+    - name: assert that changed is False since parameter should be deleted
+      assert:
         that:
-         - "'{{lookup('aws_ssm', '/' ~ ssm_key_prefix ~ '/path', region=ec2_region, aws_access_key=ec2_access_key, aws_secret_key=ec2_secret_key, aws_security_token=security_token, bypath=True, shortnames=true ) | to_json }}' == '{\"toovar\": \"too value\", \"wonvar\": \"won value\"}'"
-
-     # ============================================================
-     - name: Error in case we don't find the parameter
-       debug:
-        msg: "'{{lookup('aws_ssm', '/' ~ ssm_key_prefix ~ '/Goodbye', region=ec2_region, aws_access_key=ec2_access_key, aws_secret_key=ec2_secret_key, aws_security_token=security_token )}}' == 'World'"
-       register: result
-       ignore_errors: true
-
-     - name: assert failure from failure to find parameter
-       assert:
-         that:
-            - 'result.failed'
-            - "'Undefined AWS SSM parameter' in result.msg"
-
-
+          - result.changed == False
   always:
-
-     # ============================================================
-     - name: Delete key/value pair in aws parameter store
-       aws_ssm_parameter_store:
-         name: "/{{ssm_key_prefix}}/Hello"
-         state: absent
-         ec2_access_key: '{{ec2_access_key}}'
-         ec2_secret_key: '{{ec2_secret_key}}'
-         security_token: '{{security_token}}'
-         region: '{{ec2_region}}'
-
-     # ============================================================
-     - name: Delete remaining key/value pairs in aws parameter store
-       aws_ssm_parameter_store:
-         name: "{{item}}"
-         state: absent
-         ec2_access_key: '{{ec2_access_key}}'
-         ec2_secret_key: '{{ec2_secret_key}}'
-         security_token: '{{security_token}}'
-         region: '{{ec2_region}}'
-       with_items:
-         - "/{{ssm_key_prefix}}/path/wonvar"
-         - "/{{ssm_key_prefix}}/path/toovar"
-         - "/{{ssm_key_prefix}}/path/tree/treevar"
-
+    # ============================================================
+    - name: Delete remaining key/value pairs in aws parameter store
+      aws_ssm_parameter_store:
+        name: "{{item}}"
+        state: absent
+        <<: *aws_connection_info
+      with_items:
+        - "/{{ssm_key_prefix}}/Hello"
+        - "/{{ssm_key_prefix}}/path/wonvar"
+        - "/{{ssm_key_prefix}}/path/toovar"
+        - "/{{ssm_key_prefix}}/path/tree/treevar"

--- a/test/units/plugins/lookup/test_aws_ssm.py
+++ b/test/units/plugins/lookup/test_aws_ssm.py
@@ -22,8 +22,7 @@ from __future__ import (absolute_import, division, print_function)
 import pytest
 from copy import copy
 
-from ansible.compat.tests.mock import MagicMock, Mock, patch
-from units.modules.utils import set_module_args
+from ansible.compat.tests.mock import MagicMock, patch
 from ansible.errors import AnsibleError
 
 try:
@@ -35,20 +34,25 @@ except ImportError:
 
 
 simple_variable_success_response = {
-    'Parameters': [{'Name': 'simple_variable',
-                    'Type': 'String',
-                    'Value': 'simplevalue',
-                    'Version': 1
-    }],
+    'Parameters': [
+        {
+            'Name': 'simple_variable',
+            'Type': 'String',
+            'Value': 'simplevalue',
+            'Version': 1
+        }
+    ],
     'InvalidParameters': [],
-    'ResponseMetadata': { 'RequestId': '12121212-3434-5656-7878-9a9a9a9a9a9a',
-                          'HTTPStatusCode': 200,
-                          'HTTPHeaders': {'x-amzn-requestid': '12121212-3434-5656-7878-9a9a9a9a9a9a',
-                                          'content-type': 'application/x-amz-json-1.1',
-                                          'content-length': '116',
-                                          'date': 'Tue, 23 Jan 2018 11:04:27 GMT'
-                          },
-                          'RetryAttempts': 0
+    'ResponseMetadata': {
+        'RequestId': '12121212-3434-5656-7878-9a9a9a9a9a9a',
+        'HTTPStatusCode': 200,
+        'HTTPHeaders': {
+            'x-amzn-requestid': '12121212-3434-5656-7878-9a9a9a9a9a9a',
+            'content-type': 'application/x-amz-json-1.1',
+            'content-length': '116',
+            'date': 'Tue, 23 Jan 2018 11:04:27 GMT'
+        },
+        'RetryAttempts': 0
     }
 }
 
@@ -61,6 +65,7 @@ path_success_response['Parameters'] = [
 missing_variable_fail_response = copy(simple_variable_success_response)
 missing_variable_fail_response['Parameters'] = []
 missing_variable_fail_response['InvalidParameters'] = ['missing_variable']
+
 
 def test_lookup_variable():
     lookup = aws_ssm.LookupModule()
@@ -111,4 +116,3 @@ def test_warn_denied_variable():
     with pytest.raises(AnsibleError):
         with patch.object(boto3, 'client', boto3_client_double):
             lookup.run(["denied_variable"], {})
-    

--- a/test/units/plugins/lookup/test_aws_ssm.py
+++ b/test/units/plugins/lookup/test_aws_ssm.py
@@ -19,7 +19,6 @@
 # Make coding more python3-ish
 from __future__ import (absolute_import, division, print_function)
 
-import pdb
 import pytest
 from copy import copy
 

--- a/test/units/plugins/lookup/test_aws_ssm.py
+++ b/test/units/plugins/lookup/test_aws_ssm.py
@@ -1,0 +1,97 @@
+#
+# (c) 2017 Michael De La Rue
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+
+import pytest
+from copy import copy
+
+from ansible.compat.tests.mock import MagicMock, Mock, patch
+from units.modules.utils import set_module_args
+from ansible.errors import AnsibleError
+
+try:
+    import ansible.plugins.lookup.aws_ssm as aws_ssm
+    import boto3
+    from botocore.exceptions import ClientError
+except ImportError:
+    pytestmark = pytest.mark.skip("This test requires the boto3 and botocore Python libraries")
+
+
+simple_variable_success_response = {
+    'Parameters': [{'Name': 'simple_variable',
+                    'Type': 'String',
+                    'Value': 'simplevalue',
+                    'Version': 1
+    }],
+    'InvalidParameters': [],
+    'ResponseMetadata': { 'RequestId': '12121212-3434-5656-7878-9a9a9a9a9a9a',
+                          'HTTPStatusCode': 200,
+                          'HTTPHeaders': {'x-amzn-requestid': '12121212-3434-5656-7878-9a9a9a9a9a9a',
+                                          'content-type': 'application/x-amz-json-1.1',
+                                          'content-length': '116',
+                                          'date': 'Tue, 23 Jan 2018 11:04:27 GMT'
+                          },
+                          'RetryAttempts': 0
+    }
+}
+
+missing_variable_fail_response = copy(simple_variable_success_response)
+missing_variable_fail_response['Parameters'] = []
+missing_variable_fail_response['InvalidParameters'] = ['missing_variable']
+
+def test_lookup_variable():
+    lookup = aws_ssm.LookupModule()
+    
+    boto3_client_double = MagicMock()
+    # boto3_client_double.return_value.get_parameter_by_path.return_value = "simplevalue"
+    boto3_client_double.return_value.get_parameters.return_value = simple_variable_success_response
+
+    with patch.object(boto3, 'client', boto3_client_double):
+        retval = lookup.run(["simple_variable"], {})
+    assert(retval[0] == "simplevalue")
+
+
+def test_warn_missing_variable():
+    lookup = aws_ssm.LookupModule()
+
+    boto3_client_double = MagicMock()
+    # boto3_client_double.return_value.get_parameter_by_path.return_value = "simplevalue"
+    boto3_client_double.return_value.get_parameters.return_value = missing_variable_fail_response
+
+    with pytest.raises(AnsibleError):
+        with patch.object(boto3, 'client', boto3_client_double):
+            lookup.run(["missing_variable"], {})
+
+
+error_response = {'Error': {'Code': 'ResourceNotFoundException', 'Message': 'Fake Testing Error'}}
+operation_name = 'FakeOperation'
+
+
+def test_warn_denied_variable():
+    lookup = aws_ssm.LookupModule()
+
+    boto3_client_double = MagicMock()
+    # boto3_client_double.return_value.get_parameter_by_path.return_value = "simplevalue"
+    boto3_client_double.return_value.get_parameters.side_effect = ClientError(error_response, operation_name)
+
+    with pytest.raises(AnsibleError):
+        with patch.object(boto3, 'client', boto3_client_double):
+            lookup.run(["denied_variable"], {})
+    


### PR DESCRIPTION
##### SUMMARY

This is an aggressive set of fixes to the aws_ssm lookup and aws_ssm_parameter_store including new integration tests.   This should be primarily seen as a bugfix since it's in response to usage problems and limitations in the lookup and the minimum things needed to get the integration tests working but includes a user interface rewrite.  

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

aws_ssm lookup
aws_ssm_parameter_store module 

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (aws_ssm_multiple_fixes 8360a60cdc) last updated 2018/01/31 17:29:43 (GMT +100)
  config file = None
  configured module search path = [u'/home/mikedlr/dev/ansible/ansible-dev/library']
  ansible python module location = /home/mikedlr/dev/ansible/ansible-dev/lib/ansible
  executable location = /home/mikedlr/dev/ansible/ansible-dev/bin/ansible
  python version = 2.7.5 (default, Aug  4 2017, 00:39:18) [GCC 4.8.5 20150623 (Red Hat 4.8.5-16)]
```

##### ADDITIONAL INFORMATION

If accepted this PR should replace https://github.com/ansible/ansible/pull/35394 where the fixes included here are much wider and include the possibility to control the credentials used separately from the boto profile which may be critical.  

If needed, in order to avoid warnings about multiple components in one PR I will create a separate PR with only the lookup however it makes more sense to review this PR since only by fixing both can I put through the integration test.  