### PR TITLE
Fix sts_assume_role integration tests

### DIFF
--- a/lib/ansible/modules/cloud/amazon/iam_role.py
+++ b/lib/ansible/modules/cloud/amazon/iam_role.py
@@ -239,9 +239,11 @@ def create_or_update_role(connection, module):
             role = connection.create_role(**params)
             changed = True
         except ClientError as e:
-            module.fail_json(msg="Unable to create role", exception=traceback.format_exc(), **camel_dict_to_snake_dict(e.response))
+            module.fail_json(msg="Unable to create role: {0}".format(to_native(e)),
+                             exception=traceback.format_exc(), **camel_dict_to_snake_dict(e.response))
         except BotoCoreError as e:
-            module.fail_json(msg="Unable to create role", exception=traceback.format_exc())
+            module.fail_json(msg="Unable to create role: {0}".format(to_native(e)),
+                             exception=traceback.format_exc())
     else:
         # Check Assumed Policy document
         if not compare_assume_role_policy_doc(role['AssumeRolePolicyDocument'], params['AssumeRolePolicyDocument']):

--- a/test/integration/targets/sts_assume_role/aliases
+++ b/test/integration/targets/sts_assume_role/aliases
@@ -1,2 +1,3 @@
 cloud/aws
 posix/ci/cloud/group1/aws
+iam_role


### PR DESCRIPTION
##### SUMMARY
Fix sts_assume_role integration tests. Broken in 2c4f52d40494ea86c5a2250b1cc5a18fb6fee3a9 because I didn't add the exception to the fail_json msg.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/iam_role.py

##### ANSIBLE VERSION
```
2.5.0
```