### PR TITLE
Add exists module for checking file existence

### DIFF
--- a/lib/ansible/modules/files/exists.py
+++ b/lib/ansible/modules/files/exists.py
@@ -1,0 +1,120 @@
+#!/usr/bin/python
+# Copyright: (c) 2018, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['stableinterface'],
+                    'supported_by': 'core'}
+
+DOCUMENTATION = r'''
+---
+module: exists
+version_added: "2.5"
+short_description: Check to see if a file or directory exists
+description:
+  - Checks to see if a file exists, and if so if it is a directory or a link
+   similar to stat, but without calculating extra checksums.
+options:
+  path:
+    description:
+      - The full path of the file to check.
+    required: true
+  follow:
+    description:
+      - Whether to follow symlinks.
+    type: bool
+    default: 'no'
+notes:
+     - For Windows targets, use the M(win_stat) module instead.
+author: Monty Taylor (@e_monty)
+'''
+
+EXAMPLES = '''
+# Check if /etc/foo.conf exists.
+- exists:
+    path: /etc/foo.conf
+  register: foo_exists
+- fail:
+    msg: "Whoops! /etc/foo.conf does not exist"
+  when: not foo_exists.exists
+
+# Determine if a path exists and is a directory.
+- exists:
+    path: /path/to/something
+  register: p
+- debug:
+    msg: "Path exists and is a directory"
+  when: p.isdir
+'''
+
+RETURN = r'''
+exists:
+    description: If the destination path exists and can be read
+    returned: success
+    type: boolean
+    sample: True
+is_dir:
+    description: Tells you if the path is a directory
+    returned: success
+    type: boolean
+    sample: False
+is_link:
+    description: Tells you if the path is a symbolic link
+    returned: success
+    type: boolean
+    sample: False
+path:
+    description: The path to the file, or link target if follow is True
+    returned: success
+    type: string
+    sample: '/etc/foo'
+'''
+
+import errno
+import os
+import stat
+
+from ansible.module_utils.basic import AnsibleModule
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            path=dict(required=True, type='path'),
+            follow=dict(type='bool', default='no'),
+        ),
+        supports_check_mode=True,
+    )
+
+    path = module.params.get('path')
+    follow = module.params.get('follow')
+
+    results = dict(
+        changed=False, path=path,
+        exists=False, is_dir=False, is_link=False)
+
+    try:
+        if follow:
+            st = os.stat(b_path)
+        else:
+            st = os.lstat(b_path)
+    except OSError as e:
+        if e.errno == errno.ENOENT:
+            module.exit_json(**results)
+
+        module.fail_json(msg=e.strerror, **results)
+
+    results['exists'] = True
+    results['is_dir'] = stat.S_ISDIR(st.st_mode)
+    results['is_link'] = stat.S_ISLINK(st.st_mode)
+    if results['is_link'] and follow:
+        results['path'] = os.readlink(path)
+
+    module.exit_json(**results)
+
+
+if __name__ == '__main__':
+    main()

--- a/test/integration/targets/exists/aliases
+++ b/test/integration/targets/exists/aliases
@@ -1,0 +1,1 @@
+posix/ci/group2

--- a/test/integration/targets/exists/files/foo.txt
+++ b/test/integration/targets/exists/files/foo.txt
@@ -1,0 +1,1 @@
+templated_var_loaded

--- a/test/integration/targets/exists/meta/main.yml
+++ b/test/integration/targets/exists/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_tests

--- a/test/integration/targets/exists/tasks/main.yml
+++ b/test/integration/targets/exists/tasks/main.yml
@@ -1,0 +1,111 @@
+# test code for the exists module
+# (c) 2014, James Tanner <tanner.jc@gmail.com>
+
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+- name: make a new file
+  copy: dest={{output_dir}}/foo.txt mode=0644 content="hello world"
+
+- name: check if file exists
+  exists: path={{output_dir}}/foo.txt
+  register: foo_exists
+
+- debug: var=foo_exists
+
+- assert:
+    that:
+        - "'changed' in foo_exists"
+        - "foo_exists.changed == false"
+        - "'exists' in foo_exists"
+        - "foo_exists.exists == true"
+        - "'is_dir' in foo_exists"
+        - "foo_exists.is_dir == false"
+        - "'is_link' in foo_exists"
+        - "foo_exists.is_link == false"
+        - "'path' in foo_exists"
+        - "foo_exists.path == '{{ output_dir }}/foo.txt'"
+
+- name: make a symlink
+  file:
+    src: "{{ output_dir }}/foo.txt"
+    path: "{{ output_dir }}/foo-link"
+    state: link
+
+- name: check symlink exists with follow off
+  stat:
+    path: "{{ output_dir }}/foo-link"
+  register: symlink_exists
+
+- debug: var=symlink_exists
+
+- assert:
+    that:
+        - "'changed' in symlink_exists"
+        - "symlink_exists.changed == false"
+        - "'exists' in symlink_exists"
+        - "symlink_exists.exists == true"
+        - "'is_dir' in symlink_exists"
+        - "symlink_exists.is_dir == false"
+        - "'is_link' in symlink_exists"
+        - "symlink_exists.is_link == true"
+        - "'path' in symlink_exists"
+        - "symlink_exists.path == '{{ output_dir }}/foo.txt'"
+
+- name: check symlink exists with follow on
+  exists:
+    path: "{{ output_dir }}/foo-link"
+    follow: True
+  register: symlink_exists_follow
+
+- debug: var=symlink_exists_follow
+
+- assert:
+    that:
+        - "'changed' in symlink_exists_follow"
+        - "symlink_exists_follow.changed == false"
+        - "'exists' in symlink_exists_follow"
+        - "symlink_exists_follow.exists == true"
+        - "'is_dir' in symlink_exists_follow"
+        - "symlink_exists_follow.is_dir == false"
+        - "'is_link' in symlink_exists_follow"
+        - "symlink_exists_follow.is_link == true"
+        - "'path' in symlink_exists"
+        - "symlink_exists_follow.path == '{{ output_dir }}/foo-link'"
+
+- name: make a directory
+  file:
+    path: "{{ output_dir }}/bar"
+    state: directory
+
+- name: check directory exists
+  exists:
+    path: "{{ output_dir }}/foo-link"
+  register: bar_exists
+
+- debug: var=bar_exists
+
+- assert:
+    that:
+        - "'changed' in bar_exists"
+        - "bar_exists.changed == false"
+        - "'exists' in bar_exists"
+        - "bar_exists.exists == true"
+        - "'is_dir' in bar_exists"
+        - "bar_exists.is_dir == false"
+        - "'is_link' in bar_exists"
+        - "bar_exists.is_link == true"
+        - "'path' in bar_exists"
+        - "bar_exists.path == '{{ output_dir }}/bar'"


### PR DESCRIPTION
##### SUMMARY

It's a very common thing to want to do in playbooks to check if a file
exists or not. While the stat module can be used for this, it does a
bunch of checksum calculating and other stuff. While it can be turned
off, it winds up leaving people with playbooks that look like this:

```
  - name: Check for file
    stat:
       path: ".stestr/failing"
       get_checksum: false
       get_mime: false
       get_md5: false
     register: stestr_stat

  - name: Run command
    command: "{{ stestr_command }} last"
    when: stestr_stat.stat.exists
```
when they could just be this:
```
  - name: Check for stestr directory
    exists:
      path: "{{ zuul_work_dir }}/.stestr/failing"
    register: stestr_exists

  - name: Run command
    command: "{{ stestr_command }} last"
    when: stestr_exists.exists
```

##### ISSUE TYPE
 - New Module Pull Request

##### COMPONENT NAME
exists

##### ANSIBLE VERSION
2.4.3

##### ADDITIONAL INFORMATION
This would make @omgjlk happy. That should be justification enough.
