### PR TITLE
Set `raw=True` when reading passwords from ConfigParser files.

### DIFF
--- a/contrib/inventory/cloudforms.py
+++ b/contrib/inventory/cloudforms.py
@@ -138,7 +138,7 @@ class CloudFormsInventory(object):
             warnings.warn("No username specified, you need to specify a CloudForms username.")
 
         if config.has_option('cloudforms', 'password'):
-            self.cloudforms_pw = config.get('cloudforms', 'password')
+            self.cloudforms_pw = config.get('cloudforms', 'password', raw=True)
         else:
             self.cloudforms_pw = None
 

--- a/contrib/inventory/foreman.py
+++ b/contrib/inventory/foreman.py
@@ -84,7 +84,7 @@ class ForemanInventory(object):
         try:
             self.foreman_url = config.get('foreman', 'url')
             self.foreman_user = config.get('foreman', 'user')
-            self.foreman_pw = config.get('foreman', 'password')
+            self.foreman_pw = config.get('foreman', 'password', raw=True)
             self.foreman_ssl_verify = config.getboolean('foreman', 'ssl_verify')
         except (ConfigParser.NoOptionError, ConfigParser.NoSectionError) as e:
             print("Error parsing configuration: %s" % e, file=sys.stderr)

--- a/contrib/inventory/ovirt4.py
+++ b/contrib/inventory/ovirt4.py
@@ -138,7 +138,7 @@ def create_connection():
     return sdk.Connection(
         url=config.get('ovirt', 'ovirt_url'),
         username=config.get('ovirt', 'ovirt_username'),
-        password=config.get('ovirt', 'ovirt_password'),
+        password=config.get('ovirt', 'ovirt_password', raw=True),
         ca_file=config.get('ovirt', 'ovirt_ca_file'),
         insecure=config.get('ovirt', 'ovirt_ca_file') is None,
     )

--- a/contrib/inventory/vmware_inventory.py
+++ b/contrib/inventory/vmware_inventory.py
@@ -268,7 +268,7 @@ class VMWareInventory(object):
         self.port = int(os.environ.get('VMWARE_PORT', config.get('vmware', 'port')))
         self.username = os.environ.get('VMWARE_USERNAME', config.get('vmware', 'username'))
         self.debugl('username is %s' % self.username)
-        self.password = os.environ.get('VMWARE_PASSWORD', config.get('vmware', 'password'))
+        self.password = os.environ.get('VMWARE_PASSWORD', config.get('vmware', 'password', raw=True))
         self.validate_certs = os.environ.get('VMWARE_VALIDATE_CERTS', config.get('vmware', 'validate_certs'))
         if self.validate_certs in ['no', 'false', 'False', False]:
             self.validate_certs = False


### PR DESCRIPTION

##### SUMMARY

Add `raw=True` for reading passwords from ConfigParser files for some inventory scripts.

The assumption is that no one is actually doing interpolation on the password value, even if they may for other configuration values, and passwords are far more likely to contain '%'.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME

contrib/inventory/cloudforms.py
contrib/inventory/foreman.py
contrib/inventory/ovirt4.py


##### ANSIBLE VERSION
```
ansible 2.4.2.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/notting/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.14 (default, Jan 17 2018, 14:28:32) [GCC 7.2.1 20170915 (Red Hat 7.2.1-2)]
```

##### ADDITIONAL INFORMATION

Hooray lack of defined standards.
