### PR TITLE
Remove temporary files when not proxing inside urls utils

### DIFF
--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -618,6 +618,10 @@ class SSLValidationHandler(urllib_request.BaseHandler):
                             pass
 
         if not to_add:
+            try:
+                os.remove(to_add_path)
+            except OSError:
+                pass
             to_add_path = None
         return (tmp_path, to_add_path, paths_checked)
 
@@ -677,6 +681,16 @@ class SSLValidationHandler(urllib_request.BaseHandler):
 
         if not use_proxy:
             # ignore proxy settings for this host request
+            if tmp_ca_cert_path:
+                try:
+                    os.remove(tmp_ca_cert_path)
+                except OSError:
+                    pass
+            if to_add_ca_cert_path:
+                try:
+                    os.remove(to_add_ca_cert_path)
+                except OSError:
+                    pass
             return req
 
         try:


### PR DESCRIPTION
##### SUMMARY

This PR duplicates the fix in https://github.com/ansible/ansible/pull/22851 but makes the requested fix (from @jctanner) to add `try/except`s around the file removals. See that PR for the full summary.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME

module_utils/urls/fetch_url


##### ANSIBLE VERSION

2.5.0 0.0.devel


##### ADDITIONAL INFORMATION
See the original PR for additional information.