### PR TITLE
Add ability to select to prefer IPv4 addresses for ansible_ssh_host

### DIFF
--- a/contrib/inventory/cloudforms.ini
+++ b/contrib/inventory/cloudforms.ini
@@ -31,6 +31,9 @@ nest_tags = False
 # Note: This suffix *must* include the leading '.' as it is appended to the hostname as is
 # suffix = .example.org
 
+# If true, will try and use an IPv4 address for the ansible_ssh_host rather than just the first IP address in the list
+prefer_ipv4 = False
+
 [cache]
 
 # Maximum time to trust the cache in seconds


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Currently Cloudforms can return a mix of IPv4 and IPv6 addresses in the
ipaddresses field and this mix comes in a "random" order (that is the
first entry may be IPv4 sometimes but IPv6 other times). If you wish to
always use IPv4 for the ansible_ssh_host value then this is problematic.

This change adds a new prefer_ipv4 flag which will look for the first
IPv4 address in the ipaddresses list and uses that instead of just the
first entry.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
Contrib/Inventory

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
N/A (cloudforms.py tested directly)
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
