### PR TITLE
Fix pip integration test.

### DIFF
--- a/test/integration/integration_config.yml
+++ b/test/integration/integration_config.yml
@@ -1,5 +1,3 @@
 ---
 win_output_dir: 'C:\ansible_testing'
 output_dir: ~/ansible_testing
-non_root_test_user: ansible
-pip_test_package: isort

--- a/test/integration/targets/pip/vars/main.yml
+++ b/test/integration/targets/pip/vars/main.yml
@@ -1,0 +1,1 @@
+pip_test_package: tex


### PR DESCRIPTION
##### SUMMARY

Fix pip integration test.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

pip integration test

##### ANSIBLE VERSION

```
ansible 2.5.0 (pip-test-fix 9d33696163) last updated 2018/01/31 22:55:44 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```
