### PR TITLE
fix connection gets overridden by network_cli for transport nxapi,eapi net_* modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ Ansible Changes By Release
 * Fix traceback in winrm module when the ipaddress module is not installed
   https://github.com/ansible/ansible/pull/35723/files
 * Fix bug in `lineinfile` where the line would not be inserted when using `insertbefore` or `insertafter` if the pattern occured anywhere in the file. (https://github.com/ansible/ansible/issues/28721)
+* Fix connection local getting overridden by network_cli for transport nxapi,eapi for platform agnostic modules
+  (https://github.com/ansible/ansible/pull/35590)
+
 
 <a id="2.4.3"></a>
 

--- a/lib/ansible/plugins/action/eos.py
+++ b/lib/ansible/plugins/action/eos.py
@@ -84,37 +84,41 @@ class ActionModule(_ActionModule):
             task_vars['ansible_socket'] = socket_path
 
         else:
-            provider['transport'] = 'eapi'
-
-            if provider.get('host') is None:
-                provider['host'] = self._play_context.remote_addr
-
-            if provider.get('use_ssl') is None:
-                provider['use_ssl'] = ARGS_DEFAULT_VALUE['use_ssl']
-
-            if provider.get('port') is None:
-                default_port = 443 if provider['use_ssl'] else 80
-                provider['port'] = int(self._play_context.port or default_port)
-
-            if provider.get('timeout') is None:
-                provider['timeout'] = C.PERSISTENT_COMMAND_TIMEOUT
-
-            if provider.get('username') is None:
-                provider['username'] = self._play_context.connection_user
-
-            if provider.get('password') is None:
-                provider['password'] = self._play_context.password
-
-            if provider.get('authorize') is None:
-                provider['authorize'] = False
-
-            if provider.get('validate_certs') is None:
-                provider['validate_certs'] = ARGS_DEFAULT_VALUE['validate_certs']
-
-            self._task.args['provider'] = provider
+            self._task.args['provider'] = ActionModule.eapi_implementation(provider, self._play_context)
 
         result = super(ActionModule, self).run(tmp, task_vars)
         return result
+
+    @staticmethod
+    def eapi_implementation(provider, play_context):
+        provider['transport'] = 'eapi'
+
+        if provider.get('host') is None:
+            provider['host'] = play_context.remote_addr
+
+        if provider.get('use_ssl') is None:
+            provider['use_ssl'] = ARGS_DEFAULT_VALUE['use_ssl']
+
+        if provider.get('port') is None:
+            default_port = 443 if provider['use_ssl'] else 80
+            provider['port'] = int(play_context.port or default_port)
+
+        if provider.get('timeout') is None:
+            provider['timeout'] = C.PERSISTENT_COMMAND_TIMEOUT
+
+        if provider.get('username') is None:
+            provider['username'] = play_context.connection_user
+
+        if provider.get('password') is None:
+            provider['password'] = play_context.password
+
+        if provider.get('authorize') is None:
+            provider['authorize'] = False
+
+        if provider.get('validate_certs') is None:
+            provider['validate_certs'] = ARGS_DEFAULT_VALUE['validate_certs']
+
+        return provider
 
     def load_provider(self):
         provider = self._task.args.get('provider', {})

--- a/lib/ansible/plugins/action/net_base.py
+++ b/lib/ansible/plugins/action/net_base.py
@@ -74,7 +74,7 @@ class ActionModule(ActionBase):
         if self.provider.get('transport') == 'nxapi' and play_context.network_os == 'nxos':
             self._task.args['provider'] = _NxosActionModule.nxapi_implementation(self.provider, self._play_context)
         elif self.provider.get('transport') == 'eapi' and play_context.network_os == 'eos':
-             self._task.args['provider'] = _EosActionModule.eapi_implementation(self.provider, self._play_context)
+            self._task.args['provider'] = _EosActionModule.eapi_implementation(self.provider, self._play_context)
         else:
             socket_path = self._start_connection(play_context)
             task_vars['ansible_socket'] = socket_path

--- a/lib/ansible/plugins/action/net_base.py
+++ b/lib/ansible/plugins/action/net_base.py
@@ -23,6 +23,8 @@ import copy
 from ansible import constants as C
 from ansible.errors import AnsibleError
 from ansible.plugins.action import ActionBase
+from ansible.plugins.action.nxos import ActionModule as _NxosActionModule
+from ansible.plugins.action.eos import ActionModule as _EosActionModule
 from ansible.module_utils.basic import AnsibleFallbackNotFound
 from ansible.module_utils.six import iteritems
 
@@ -53,6 +55,9 @@ class ActionModule(ActionBase):
         if play_context.network_os == 'junos':
             play_context.connection = 'netconf'
             play_context.port = int(self.provider['port'] or self._play_context.port or 830)
+        elif self.provider.get('transport') in ('nxapi', 'eapi') and play_context.network_os in ('nxos', 'eos'):
+            play_context.connection = play_context.connection
+            play_context.port = int(self.provider['port'] or self._play_context.port or 22)
         else:
             play_context.connection = 'network_cli'
             play_context.port = int(self.provider['port'] or self._play_context.port or 22)
@@ -66,8 +71,13 @@ class ActionModule(ActionBase):
             play_context.become = self.provider['authorize'] or False
             play_context.become_pass = self.provider['auth_pass']
 
-        socket_path = self._start_connection(play_context)
-        task_vars['ansible_socket'] = socket_path
+        if self.provider.get('transport') == 'nxapi' and play_context.network_os == 'nxos':
+            self._task.args['provider'] = _NxosActionModule.nxapi_implementation(self.provider, self._play_context)
+        elif self.provider.get('transport') == 'eapi' and play_context.network_os == 'eos':
+             self._task.args['provider'] = _EosActionModule.eapi_implementation(self.provider, self._play_context)
+        else:
+            socket_path = self._start_connection(play_context)
+            task_vars['ansible_socket'] = socket_path
 
         if 'fail_on_missing_module' not in self._task.args:
             self._task.args['fail_on_missing_module'] = False

--- a/lib/ansible/plugins/action/nxos.py
+++ b/lib/ansible/plugins/action/nxos.py
@@ -81,38 +81,42 @@ class ActionModule(_ActionModule):
             task_vars['ansible_socket'] = socket_path
 
         else:
-            provider['transport'] = 'nxapi'
-            if provider.get('host') is None:
-                provider['host'] = self._play_context.remote_addr
-
-            if provider.get('port') is None:
-                if provider.get('use_ssl'):
-                    provider['port'] = 443
-                else:
-                    provider['port'] = 80
-
-            if provider.get('timeout') is None:
-                provider['timeout'] = C.PERSISTENT_COMMAND_TIMEOUT
-
-            if provider.get('username') is None:
-                provider['username'] = self._play_context.connection_user
-
-            if provider.get('password') is None:
-                provider['password'] = self._play_context.password
-
-            if provider.get('use_ssl') is None:
-                provider['use_ssl'] = False
-
-            if provider.get('validate_certs') is None:
-                provider['validate_certs'] = True
-
-            self._task.args['provider'] = provider
+            self._task.args['provider'] = ActionModule.nxapi_implementation(provider, self._play_context)
 
         # make sure a transport value is set in args
         self._task.args['transport'] = transport
 
         result = super(ActionModule, self).run(tmp, task_vars)
         return result
+
+    @staticmethod
+    def nxapi_implementation(provider, play_context):
+        provider['transport'] = 'nxapi'
+        if provider.get('host') is None:
+            provider['host'] = play_context.remote_addr
+
+        if provider.get('port') is None:
+            if provider.get('use_ssl'):
+                provider['port'] = 443
+            else:
+                provider['port'] = 80
+
+        if provider.get('timeout') is None:
+            provider['timeout'] = C.PERSISTENT_COMMAND_TIMEOUT
+
+        if provider.get('username') is None:
+            provider['username'] = play_context.connection_user
+
+        if provider.get('password') is None:
+            provider['password'] = play_context.password
+
+        if provider.get('use_ssl') is None:
+            provider['use_ssl'] = False
+
+        if provider.get('validate_certs') is None:
+            provider['validate_certs'] = True
+
+        return provider
 
     def load_provider(self):
         provider = self._task.args.get('provider', {})


### PR DESCRIPTION
Signed-off-by: Trishna Guha <trishnaguha17@gmail.com>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
- Fix connection getting overridden by `network_cli` for transport `nxapi`, `eapi` for `net_*` modules. Should be connection `local`.
- Define transport based provider functions in individual action plugins.

devel https://github.com/ansible/ansible/commit/48ecbb8fb90080b4d1056bbb1dc2bfaddcf2c847

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
plugins/action/net_base.py
plugins/action/eos.py
plugins/action/nxos.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
stable-2.4
```