### PR TITLE
Add instance check

### DIFF
--- a/.pytest_cache/v/cache/lastfailed
+++ b/.pytest_cache/v/cache/lastfailed
@@ -1,0 +1,3 @@
+{
+  "test/units/parsing/vault/test_vault.py::TestGetFileVaultSecret::test_file_not_found": true
+}

--- a/.pytest_cache/v/cache/lastfailed
+++ b/.pytest_cache/v/cache/lastfailed
@@ -1,3 +1,0 @@
-{
-  "test/units/parsing/vault/test_vault.py::TestGetFileVaultSecret::test_file_not_found": true
-}

--- a/lib/ansible/plugins/lookup/list.py
+++ b/lib/ansible/plugins/lookup/list.py
@@ -31,6 +31,7 @@ import collections
 from ansible.errors import AnsibleError
 from ansible.plugins.lookup import LookupBase
 
+
 class LookupModule(LookupBase):
 
     def run(self, terms, **kwargs):

--- a/lib/ansible/plugins/lookup/list.py
+++ b/lib/ansible/plugins/lookup/list.py
@@ -27,10 +27,13 @@ RETURN = """
   _list:
     description: basically the same as you fed in
 """
+from ansible.errors import AnsibleError
 from ansible.plugins.lookup import LookupBase
 
 
 class LookupModule(LookupBase):
 
     def run(self, terms, **kwargs):
+        if not isinstance(terms, list):
+            raise AnsibleError("with_list expects a list")
         return terms

--- a/lib/ansible/plugins/lookup/list.py
+++ b/lib/ansible/plugins/lookup/list.py
@@ -27,13 +27,13 @@ RETURN = """
   _list:
     description: basically the same as you fed in
 """
+import collections
 from ansible.errors import AnsibleError
 from ansible.plugins.lookup import LookupBase
-
 
 class LookupModule(LookupBase):
 
     def run(self, terms, **kwargs):
-        if not isinstance(terms, list):
+        if not isinstance(terms, collections.Sequence):
             raise AnsibleError("with_list expects a list")
         return terms

--- a/test/units/template/test_templar.py
+++ b/test/units/template/test_templar.py
@@ -29,6 +29,7 @@ from ansible.errors import AnsibleError, AnsibleUndefinedVariable
 from ansible.module_utils.six import string_types
 from ansible.template import Templar, AnsibleContext, AnsibleEnvironment
 from ansible.utils.unsafe_proxy import AnsibleUnsafe, wrap_var
+from ansible.plugins.lookup.list import LookupModule
 from units.mock.loader import DictDataLoader
 
 
@@ -340,6 +341,15 @@ class TestTemplarLookup(BaseTemplar, unittest.TestCase):
                                 self.templar._lookup,
                                 'dict',
                                 ['foo', 'bar'])
+
+    def test_lookup_jinja_list_dict_passed(self):
+        try:
+            module = LookupModule();
+            module.run({'foo': 'bar'})
+        except AnsibleError as e:
+            self.assertEqual("with_list expects a list", str(e))
+            return
+        raise AnsibleError("AnsibleError not raised")
 
     def test_lookup_jinja_kwargs(self):
         res = self.templar._lookup('list', 'blip', random_keyword='12345')

--- a/test/units/template/test_templar.py
+++ b/test/units/template/test_templar.py
@@ -340,12 +340,12 @@ class TestTemplarLookup(BaseTemplar, unittest.TestCase):
                                 "with_dict expects a dict",
                                 self.templar._lookup,
                                 'dict',
-                                ['FOO', 'BAR'])
+                                ['foo', 'bar'])
 
     def test_lookup_jinja_list_dict_passed(self):
         try:
             module = LookupModule()
-            module.run({'foo': 'bar'})
+            module.run({'FOO': 'BAR'})
         except AnsibleError as e:
             self.assertEqual("with_list expects a list", str(e))
             return

--- a/test/units/template/test_templar.py
+++ b/test/units/template/test_templar.py
@@ -340,7 +340,7 @@ class TestTemplarLookup(BaseTemplar, unittest.TestCase):
                                 "with_dict expects a dict",
                                 self.templar._lookup,
                                 'dict',
-                                ['foo', 'bar'])
+                                ['FOO', 'BAR'])
 
     def test_lookup_jinja_list_dict_passed(self):
         try:

--- a/test/units/template/test_templar.py
+++ b/test/units/template/test_templar.py
@@ -344,7 +344,7 @@ class TestTemplarLookup(BaseTemplar, unittest.TestCase):
 
     def test_lookup_jinja_list_dict_passed(self):
         try:
-            module = LookupModule();
+            module = LookupModule()
             module.run({'foo': 'bar'})
         except AnsibleError as e:
             self.assertEqual("with_list expects a list", str(e))


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fix #35481

I fixed the bug referring to the following file.
./lib/ansible/plugins/lookup/dict.py

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
./lib/ansible/plugins/lookup/list.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (devel f9e17877d9) last updated 2018/02/01 19:49:46 (GMT +900)
  config file = None
  configured module search path = [u'/home/vagrant/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/vagrant/ansible/lib/ansible
  executable location = /home/vagrant/ansible/bin/ansible
  python version = 2.7.5 (default, Aug  4 2017, 00:39:18) [GCC 4.8.5 20150623 (Red Hat 4.8.5-16)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->


<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
