### PR TITLE
ACI: Change RETURN output as discussed

### DIFF
--- a/lib/ansible/module_utils/network/aci/aci.py
+++ b/lib/ansible/module_utils/network/aci/aci.py
@@ -69,7 +69,7 @@ def aci_argument_spec():
         password=dict(type='str', no_log=True),
         private_key=dict(type='path', aliases=['cert_key']),  # Beware, this is not the same as client_key !
         certificate_name=dict(type='str', aliases=['cert_name']),  # Beware, this is not the same as client_cert !
-        output_level=dict(type='str', aliases=['default', 'normal', 'info', 'debug']),
+        output_level=dict(type='str', choices=['debug', 'info', 'normal']),
         timeout=dict(type='int', default=30),
         use_proxy=dict(type='bool', default=True),
         use_ssl=dict(type='bool', default=True),
@@ -879,6 +879,7 @@ class ACIModule(object):
 
         if self.params['output_level'] in ('debug', 'info'):
             self.result['original'] = self.existing
+
         if self.params['output_level'] == 'debug':
             self.result['method'] = self.method
             self.result['path'] = self.path

--- a/lib/ansible/module_utils/network/aci/aci.py
+++ b/lib/ansible/module_utils/network/aci/aci.py
@@ -131,9 +131,9 @@ class ACIModule(object):
         self.existing = None
 
         # info output
-        self.config = None
+        self.config = dict()
         self.original = None
-        self.proposed = None
+        self.proposed = dict()
 
         # debug output
         self.filter_string = ''

--- a/lib/ansible/module_utils/network/aci/aci.py
+++ b/lib/ansible/module_utils/network/aci/aci.py
@@ -914,8 +914,8 @@ class ACIModule(object):
 
         if self.module._diff and self.original != self.existing:
             self.result['diff'] = dict(
-                before=self.original,
-                after=self.existing,
+                before=json.dumps(self.original, sort_keys=True, indent=4),
+                after=json.dumps(self.existing, sort_keys=True, indent=4),
             )
 
         if self.params['output_level'] in ('debug', 'info'):

--- a/lib/ansible/module_utils/network/aci/aci.py
+++ b/lib/ansible/module_utils/network/aci/aci.py
@@ -267,8 +267,8 @@ class ACIModule(object):
             jsondata = json.loads(rawoutput)
         except Exception as e:
             # Expose RAW output for troubleshooting
-            # self.error = dict(code=-1, text="Unable to parse output as JSON, see 'raw' output. %s" % e)
-            self.error = dict(code=str(self.status), text="Request failed: %s (see 'raw' output" % self.response)
+            self.error = dict(code=-1, text="Unable to parse output as JSON, see 'raw' output. %s" % e)
+            # self.error = dict(code=str(self.status), text="Request failed: %s (see 'raw' output)" % self.response)
             self.result['raw'] = rawoutput
             return
 
@@ -291,8 +291,8 @@ class ACIModule(object):
             xmldata = cobra.data(xml)
         except Exception as e:
             # Expose RAW output for troubleshooting
-            # self.error = dict(code=-1, text="Unable to parse output as XML, see 'raw' output. %s" % e)
-            self.error = dict(code=str(self.status), text="Request failed: %s (see 'raw' output)" % self.response)
+            self.error = dict(code=-1, text="Unable to parse output as XML, see 'raw' output. %s" % e)
+            # self.error = dict(code=str(self.status), text="Request failed: %s (see 'raw' output)" % self.response)
             self.result['raw'] = rawoutput
             return
 

--- a/lib/ansible/module_utils/network/aci/aci.py
+++ b/lib/ansible/module_utils/network/aci/aci.py
@@ -308,7 +308,7 @@ class ACIModule(object):
         ''' Set error information when found '''
 
         # Handle possible APIC error information
-        if self.totalCount != 0:
+        if self.totalCount != '0':
             try:
                 self.error = self.imdata[0]['error']['attributes']
             except (KeyError, IndexError):

--- a/lib/ansible/module_utils/network/aci/aci.py
+++ b/lib/ansible/module_utils/network/aci/aci.py
@@ -884,7 +884,7 @@ class ACIModule(object):
         if self.params['output_level'] == 'debug':
             self.result['filter_string'] = self.filter_string
             self.result['method'] = self.method
-            #self.result['path'] = self.path
+            # self.result['path'] = self.path  # Adding 'path' in result causes state: absent in output
             self.result['response'] = self.response
             self.result['status'] = self.status
             self.result['url'] = self.url

--- a/lib/ansible/module_utils/network/aci/aci.py
+++ b/lib/ansible/module_utils/network/aci/aci.py
@@ -922,7 +922,7 @@ class ACIModule(object):
         #     )
 
         if self.params['output_level'] in ('debug', 'info'):
-            self.result['config'] = self.config
+            self.result['sent'] = self.config
             self.result['proposed'] = self.proposed
 
         self.module.exit_json(**self.result)

--- a/lib/ansible/module_utils/network/aci/aci.py
+++ b/lib/ansible/module_utils/network/aci/aci.py
@@ -267,7 +267,7 @@ class ACIModule(object):
             jsondata = json.loads(rawoutput)
         except Exception as e:
             # Expose RAW output for troubleshooting
-            #self.error = dict(code=-1, text="Unable to parse output as JSON, see 'raw' output. %s" % e)
+            # self.error = dict(code=-1, text="Unable to parse output as JSON, see 'raw' output. %s" % e)
             self.error = dict(code=str(self.status), text="Request failed: %s (see 'raw' output" % self.response)
             self.result['raw'] = rawoutput
             return
@@ -291,7 +291,7 @@ class ACIModule(object):
             xmldata = cobra.data(xml)
         except Exception as e:
             # Expose RAW output for troubleshooting
-            #self.error = dict(code=-1, text="Unable to parse output as XML, see 'raw' output. %s" % e)
+            # self.error = dict(code=-1, text="Unable to parse output as XML, see 'raw' output. %s" % e)
             self.error = dict(code=str(self.status), text="Request failed: %s (see 'raw' output)" % self.response)
             self.result['raw'] = rawoutput
             return
@@ -949,4 +949,3 @@ class ACIModule(object):
 
         self.result.update(**kwargs)
         self.module.fail_json(msg=msg, **self.result)
-

--- a/lib/ansible/module_utils/network/aci/aci.py
+++ b/lib/ansible/module_utils/network/aci/aci.py
@@ -189,6 +189,10 @@ class ACIModule(object):
         # Ensure protocol is set
         self.define_protocol()
 
+        if self.module._debug:
+            self.module.warn('Enable debug output because ANSIBLE_DEBUG was set.')
+            self.params['output_level'] = 'debug'
+
         if self.params['private_key']:
             # Perform signature-based authentication, no need to log on separately
             if not HAS_OPENSSL:

--- a/lib/ansible/module_utils/network/aci/aci.py
+++ b/lib/ansible/module_utils/network/aci/aci.py
@@ -174,6 +174,7 @@ class ACIModule(object):
         self.result = dict(changed=False)
         self.headers = dict()
 
+        self.filter_string = None
         self.method = None
         self.path = None
         self.response = None
@@ -881,10 +882,12 @@ class ACIModule(object):
             self.result['original'] = self.existing
 
         if self.params['output_level'] == 'debug':
+            self.result['filter_string'] = self.filter_string
             self.result['method'] = self.method
-            self.result['path'] = self.path
+            #self.result['path'] = self.path
             self.result['response'] = self.response
             self.result['status'] = self.status
+            self.result['url'] = self.url
 
         if self.params['state'] in ('absent', 'present'):
             self.get_existing()

--- a/lib/ansible/modules/network/aci/aci_aaa_user.py
+++ b/lib/ansible/modules/network/aci/aci_aaa_user.py
@@ -153,7 +153,7 @@ error:
         "code": "122",
         "text": "unknown managed object class foo"
     }
-config:
+sent:
   description: The actual/minimal configuration pushed to the APIC
   returned: info
   type: list
@@ -185,7 +185,7 @@ previous: The original configuration from the APIC before the module has started
         }
     ]
 proposed:
-  description: The assembled configuration the user proposed before reducing
+  description: The assembled configuration from the user-provided parameters
   returned: info
   type: dict
   sample:

--- a/lib/ansible/modules/network/aci/aci_aaa_user.py
+++ b/lib/ansible/modules/network/aci/aci_aaa_user.py
@@ -153,6 +153,11 @@ error:
         "code": "122",
         "text": "unknown managed object class foo"
     }
+raw:
+  description: The raw output returned by the APIC REST API (xml or json)
+  returned: parse error
+  type: string
+  sample: '<?xml version="1.0" encoding="UTF-8"?><imdata totalCount="1"><error code="122" text="unknown managed object class foo"/></imdata>'
 sent:
   description: The actual/minimal configuration pushed to the APIC
   returned: info

--- a/lib/ansible/modules/network/aci/aci_aaa_user.py
+++ b/lib/ansible/modules/network/aci/aci_aaa_user.py
@@ -249,7 +249,7 @@ def main():
     elif state == 'absent':
         aci.delete_config()
 
-    module.exit_json(**aci.result)
+    aci.exit_json()
 
 
 if __name__ == "__main__":

--- a/lib/ansible/modules/network/aci/aci_aaa_user.py
+++ b/lib/ansible/modules/network/aci/aci_aaa_user.py
@@ -124,7 +124,105 @@ EXAMPLES = r'''
     state: query
 '''
 
-RETURN = r''' # '''
+RETURN = r'''
+current:
+  description: The existing configuration from the APIC after the module has finished
+  returned: success
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production environment",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+error:
+  description: The error information as returned from the APIC
+  returned: failure
+  type: dict
+  sample:
+    {
+        "code": "122",
+        "text": "unknown managed object class foo"
+    }
+config:
+  description: The actual/minimal configuration pushed to the APIC
+  returned: info
+  type: list
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment"
+            }
+        }
+    }
+previous: The original configuration from the APIC before the module has started
+  description:
+  returned: info
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+proposed:
+  description: The assembled configuration the user proposed before reducing
+  returned: info
+  type: dict
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment",
+                "name": "production"
+            }
+        }
+    }
+filter_string:
+  description: The filter string used for the request
+  returned: failure or debug
+  type: string
+  sample: ?rsp-prop-include=config-only
+method:
+  description: The HTTP method used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: POST
+response
+  description: The HTTP response from the APIC
+  returned: failure or debug
+  type: string
+  sample: OK (30 bytes)
+status:
+  description: The HTTP status from the APIC
+  returned: failure or debug
+  type: int
+  sample: 200
+url:
+  description: The HTTP url used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: https://10.11.12.13/api/mo/uni/tn-production.json
+'''
 
 from ansible.module_utils.network.aci.aci import ACIModule, aci_argument_spec
 from ansible.module_utils.basic import AnsibleModule

--- a/lib/ansible/modules/network/aci/aci_aaa_user.py
+++ b/lib/ansible/modules/network/aci/aci_aaa_user.py
@@ -170,8 +170,8 @@ sent:
             }
         }
     }
-previous: The original configuration from the APIC before the module has started
-  description:
+previous:
+  description: The original configuration from the APIC before the module has started
   returned: info
   type: list
   sample:
@@ -206,13 +206,13 @@ filter_string:
   description: The filter string used for the request
   returned: failure or debug
   type: string
-  sample: ?rsp-prop-include=config-only
+  sample: '?rsp-prop-include=config-only'
 method:
   description: The HTTP method used for the request to the APIC
   returned: failure or debug
   type: string
   sample: POST
-response
+response:
   description: The HTTP response from the APIC
   returned: failure or debug
   type: string

--- a/lib/ansible/modules/network/aci/aci_aaa_user_certificate.py
+++ b/lib/ansible/modules/network/aci/aci_aaa_user_certificate.py
@@ -118,6 +118,11 @@ error:
         "code": "122",
         "text": "unknown managed object class foo"
     }
+raw:
+  description: The raw output returned by the APIC REST API (xml or json)
+  returned: parse error
+  type: string
+  sample: '<?xml version="1.0" encoding="UTF-8"?><imdata totalCount="1"><error code="122" text="unknown managed object class foo"/></imdata>'
 sent:
   description: The actual/minimal configuration pushed to the APIC
   returned: info

--- a/lib/ansible/modules/network/aci/aci_aaa_user_certificate.py
+++ b/lib/ansible/modules/network/aci/aci_aaa_user_certificate.py
@@ -167,7 +167,7 @@ def main():
     elif state == 'absent':
         aci.delete_config()
 
-    module.exit_json(**aci.result)
+    aci.exit_json()
 
 
 if __name__ == "__main__":

--- a/lib/ansible/modules/network/aci/aci_aaa_user_certificate.py
+++ b/lib/ansible/modules/network/aci/aci_aaa_user_certificate.py
@@ -135,8 +135,8 @@ sent:
             }
         }
     }
-previous: The original configuration from the APIC before the module has started
-  description:
+previous:
+  description: The original configuration from the APIC before the module has started
   returned: info
   type: list
   sample:
@@ -177,7 +177,7 @@ method:
   returned: failure or debug
   type: string
   sample: POST
-response
+response:
   description: The HTTP response from the APIC
   returned: failure or debug
   type: string

--- a/lib/ansible/modules/network/aci/aci_aaa_user_certificate.py
+++ b/lib/ansible/modules/network/aci/aci_aaa_user_certificate.py
@@ -89,7 +89,105 @@ EXAMPLES = r'''
     state: query
 '''
 
-RETURN = r''' # '''
+RETURN = r'''
+current:
+  description: The existing configuration from the APIC after the module has finished
+  returned: success
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production environment",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+error:
+  description: The error information as returned from the APIC
+  returned: failure
+  type: dict
+  sample:
+    {
+        "code": "122",
+        "text": "unknown managed object class foo"
+    }
+sent:
+  description: The actual/minimal configuration pushed to the APIC
+  returned: info
+  type: list
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment"
+            }
+        }
+    }
+previous: The original configuration from the APIC before the module has started
+  description:
+  returned: info
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+proposed:
+  description: The assembled configuration from the user-provided parameters
+  returned: info
+  type: dict
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment",
+                "name": "production"
+            }
+        }
+    }
+filter_string:
+  description: The filter string used for the request
+  returned: failure or debug
+  type: string
+  sample: ?rsp-prop-include=config-only
+method:
+  description: The HTTP method used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: POST
+response
+  description: The HTTP response from the APIC
+  returned: failure or debug
+  type: string
+  sample: OK (30 bytes)
+status:
+  description: The HTTP status from the APIC
+  returned: failure or debug
+  type: int
+  sample: 200
+url:
+  description: The HTTP url used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: https://10.11.12.13/api/mo/uni/tn-production.json
+'''
 
 from ansible.module_utils.network.aci.aci import ACIModule, aci_argument_spec
 from ansible.module_utils.basic import AnsibleModule

--- a/lib/ansible/modules/network/aci/aci_access_port_to_interface_policy_leaf_profile.py
+++ b/lib/ansible/modules/network/aci/aci_access_port_to_interface_policy_leaf_profile.py
@@ -116,7 +116,103 @@ EXAMPLES = r'''
 '''
 
 RETURN = r'''
-#
+current:
+  description: The existing configuration from the APIC after the module has finished
+  returned: success
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production environment",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+error:
+  description: The error information as returned from the APIC
+  returned: failure
+  type: dict
+  sample:
+    {
+        "code": "122",
+        "text": "unknown managed object class foo"
+    }
+sent:
+  description: The actual/minimal configuration pushed to the APIC
+  returned: info
+  type: list
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment"
+            }
+        }
+    }
+previous: The original configuration from the APIC before the module has started
+  description:
+  returned: info
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+proposed:
+  description: The assembled configuration from the user-provided parameters
+  returned: info
+  type: dict
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment",
+                "name": "production"
+            }
+        }
+    }
+filter_string:
+  description: The filter string used for the request
+  returned: failure or debug
+  type: string
+  sample: ?rsp-prop-include=config-only
+method:
+  description: The HTTP method used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: POST
+response
+  description: The HTTP response from the APIC
+  returned: failure or debug
+  type: string
+  sample: OK (30 bytes)
+status:
+  description: The HTTP status from the APIC
+  returned: failure or debug
+  type: int
+  sample: 200
+url:
+  description: The HTTP url used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: https://10.11.12.13/api/mo/uni/tn-production.json
 '''
 
 from ansible.module_utils.network.aci.aci import ACIModule, aci_argument_spec

--- a/lib/ansible/modules/network/aci/aci_access_port_to_interface_policy_leaf_profile.py
+++ b/lib/ansible/modules/network/aci/aci_access_port_to_interface_policy_leaf_profile.py
@@ -213,7 +213,7 @@ def main():
     elif state == 'absent':
         aci.delete_config()
 
-    module.exit_json(**aci.result)
+    aci.exit_json()
 
 
 if __name__ == "__main__":

--- a/lib/ansible/modules/network/aci/aci_access_port_to_interface_policy_leaf_profile.py
+++ b/lib/ansible/modules/network/aci/aci_access_port_to_interface_policy_leaf_profile.py
@@ -144,6 +144,11 @@ error:
         "code": "122",
         "text": "unknown managed object class foo"
     }
+raw:
+  description: The raw output returned by the APIC REST API (xml or json)
+  returned: parse error
+  type: string
+  sample: '<?xml version="1.0" encoding="UTF-8"?><imdata totalCount="1"><error code="122" text="unknown managed object class foo"/></imdata>'
 sent:
   description: The actual/minimal configuration pushed to the APIC
   returned: info

--- a/lib/ansible/modules/network/aci/aci_access_port_to_interface_policy_leaf_profile.py
+++ b/lib/ansible/modules/network/aci/aci_access_port_to_interface_policy_leaf_profile.py
@@ -161,8 +161,8 @@ sent:
             }
         }
     }
-previous: The original configuration from the APIC before the module has started
-  description:
+previous:
+  description: The original configuration from the APIC before the module has started
   returned: info
   type: list
   sample:
@@ -203,7 +203,7 @@ method:
   returned: failure or debug
   type: string
   sample: POST
-response
+response:
   description: The HTTP response from the APIC
   returned: failure or debug
   type: string

--- a/lib/ansible/modules/network/aci/aci_aep.py
+++ b/lib/ansible/modules/network/aci/aci_aep.py
@@ -87,7 +87,103 @@ EXAMPLES = r'''
 '''
 
 RETURN = r'''
-#
+current:
+  description: The existing configuration from the APIC after the module has finished
+  returned: success
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production environment",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+error:
+  description: The error information as returned from the APIC
+  returned: failure
+  type: dict
+  sample:
+    {
+        "code": "122",
+        "text": "unknown managed object class foo"
+    }
+sent:
+  description: The actual/minimal configuration pushed to the APIC
+  returned: info
+  type: list
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment"
+            }
+        }
+    }
+previous: The original configuration from the APIC before the module has started
+  description:
+  returned: info
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+proposed:
+  description: The assembled configuration from the user-provided parameters
+  returned: info
+  type: dict
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment",
+                "name": "production"
+            }
+        }
+    }
+filter_string:
+  description: The filter string used for the request
+  returned: failure or debug
+  type: string
+  sample: ?rsp-prop-include=config-only
+method:
+  description: The HTTP method used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: POST
+response
+  description: The HTTP response from the APIC
+  returned: failure or debug
+  type: string
+  sample: OK (30 bytes)
+status:
+  description: The HTTP status from the APIC
+  returned: failure or debug
+  type: int
+  sample: 200
+url:
+  description: The HTTP url used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: https://10.11.12.13/api/mo/uni/tn-production.json
 '''
 
 from ansible.module_utils.network.aci.aci import ACIModule, aci_argument_spec

--- a/lib/ansible/modules/network/aci/aci_aep.py
+++ b/lib/ansible/modules/network/aci/aci_aep.py
@@ -155,7 +155,7 @@ def main():
     elif state == 'absent':
         aci.delete_config()
 
-    module.exit_json(**aci.result)
+    aci.exit_json()
 
 if __name__ == "__main__":
     main()

--- a/lib/ansible/modules/network/aci/aci_aep.py
+++ b/lib/ansible/modules/network/aci/aci_aep.py
@@ -115,6 +115,11 @@ error:
         "code": "122",
         "text": "unknown managed object class foo"
     }
+raw:
+  description: The raw output returned by the APIC REST API (xml or json)
+  returned: parse error
+  type: string
+  sample: '<?xml version="1.0" encoding="UTF-8"?><imdata totalCount="1"><error code="122" text="unknown managed object class foo"/></imdata>'
 sent:
   description: The actual/minimal configuration pushed to the APIC
   returned: info

--- a/lib/ansible/modules/network/aci/aci_aep.py
+++ b/lib/ansible/modules/network/aci/aci_aep.py
@@ -132,8 +132,8 @@ sent:
             }
         }
     }
-previous: The original configuration from the APIC before the module has started
-  description:
+previous:
+  description: The original configuration from the APIC before the module has started
   returned: info
   type: list
   sample:
@@ -174,7 +174,7 @@ method:
   returned: failure or debug
   type: string
   sample: POST
-response
+response:
   description: The HTTP response from the APIC
   returned: failure or debug
   type: string

--- a/lib/ansible/modules/network/aci/aci_aep_to_domain.py
+++ b/lib/ansible/modules/network/aci/aci_aep_to_domain.py
@@ -102,8 +102,8 @@ sent:
             }
         }
     }
-previous: The original configuration from the APIC before the module has started
-  description:
+previous:
+  description: The original configuration from the APIC before the module has started
   returned: info
   type: list
   sample:
@@ -144,7 +144,7 @@ method:
   returned: failure or debug
   type: string
   sample: POST
-response
+response:
   description: The HTTP response from the APIC
   returned: failure or debug
   type: string

--- a/lib/ansible/modules/network/aci/aci_aep_to_domain.py
+++ b/lib/ansible/modules/network/aci/aci_aep_to_domain.py
@@ -56,7 +56,105 @@ extends_documentation_fragment: aci
 
 EXAMPLES = r''' # '''
 
-RETURN = ''' # '''
+RETURN = r'''
+current:
+  description: The existing configuration from the APIC after the module has finished
+  returned: success
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production environment",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+error:
+  description: The error information as returned from the APIC
+  returned: failure
+  type: dict
+  sample:
+    {
+        "code": "122",
+        "text": "unknown managed object class foo"
+    }
+sent:
+  description: The actual/minimal configuration pushed to the APIC
+  returned: info
+  type: list
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment"
+            }
+        }
+    }
+previous: The original configuration from the APIC before the module has started
+  description:
+  returned: info
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+proposed:
+  description: The assembled configuration from the user-provided parameters
+  returned: info
+  type: dict
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment",
+                "name": "production"
+            }
+        }
+    }
+filter_string:
+  description: The filter string used for the request
+  returned: failure or debug
+  type: string
+  sample: ?rsp-prop-include=config-only
+method:
+  description: The HTTP method used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: POST
+response
+  description: The HTTP response from the APIC
+  returned: failure or debug
+  type: string
+  sample: OK (30 bytes)
+status:
+  description: The HTTP status from the APIC
+  returned: failure or debug
+  type: int
+  sample: 200
+url:
+  description: The HTTP url used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: https://10.11.12.13/api/mo/uni/tn-production.json
+'''
 
 from ansible.module_utils.network.aci.aci import ACIModule, aci_argument_spec
 from ansible.module_utils.basic import AnsibleModule

--- a/lib/ansible/modules/network/aci/aci_aep_to_domain.py
+++ b/lib/ansible/modules/network/aci/aci_aep_to_domain.py
@@ -85,6 +85,11 @@ error:
         "code": "122",
         "text": "unknown managed object class foo"
     }
+raw:
+  description: The raw output returned by the APIC REST API (xml or json)
+  returned: parse error
+  type: string
+  sample: '<?xml version="1.0" encoding="UTF-8"?><imdata totalCount="1"><error code="122" text="unknown managed object class foo"/></imdata>'
 sent:
   description: The actual/minimal configuration pushed to the APIC
   returned: info

--- a/lib/ansible/modules/network/aci/aci_aep_to_domain.py
+++ b/lib/ansible/modules/network/aci/aci_aep_to_domain.py
@@ -150,7 +150,7 @@ def main():
     elif state == 'absent':
         aci.delete_config()
 
-    module.exit_json(**aci.result)
+    aci.exit_json()
 
 
 if __name__ == "__main__":

--- a/lib/ansible/modules/network/aci/aci_ap.py
+++ b/lib/ansible/modules/network/aci/aci_ap.py
@@ -157,7 +157,7 @@ def main():
     elif state == 'absent':
         aci.delete_config()
 
-    module.exit_json(**aci.result)
+    aci.exit_json()
 
 
 if __name__ == "__main__":

--- a/lib/ansible/modules/network/aci/aci_ap.py
+++ b/lib/ansible/modules/network/aci/aci_ap.py
@@ -87,7 +87,103 @@ EXAMPLES = r'''
 '''
 
 RETURN = r'''
-#
+current:
+  description: The existing configuration from the APIC after the module has finished
+  returned: success
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production environment",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+error:
+  description: The error information as returned from the APIC
+  returned: failure
+  type: dict
+  sample:
+    {
+        "code": "122",
+        "text": "unknown managed object class foo"
+    }
+sent:
+  description: The actual/minimal configuration pushed to the APIC
+  returned: info
+  type: list
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment"
+            }
+        }
+    }
+previous: The original configuration from the APIC before the module has started
+  description:
+  returned: info
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+proposed:
+  description: The assembled configuration from the user-provided parameters
+  returned: info
+  type: dict
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment",
+                "name": "production"
+            }
+        }
+    }
+filter_string:
+  description: The filter string used for the request
+  returned: failure or debug
+  type: string
+  sample: ?rsp-prop-include=config-only
+method:
+  description: The HTTP method used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: POST
+response
+  description: The HTTP response from the APIC
+  returned: failure or debug
+  type: string
+  sample: OK (30 bytes)
+status:
+  description: The HTTP status from the APIC
+  returned: failure or debug
+  type: int
+  sample: 200
+url:
+  description: The HTTP url used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: https://10.11.12.13/api/mo/uni/tn-production.json
 '''
 
 from ansible.module_utils.network.aci.aci import ACIModule, aci_argument_spec

--- a/lib/ansible/modules/network/aci/aci_ap.py
+++ b/lib/ansible/modules/network/aci/aci_ap.py
@@ -115,6 +115,11 @@ error:
         "code": "122",
         "text": "unknown managed object class foo"
     }
+raw:
+  description: The raw output returned by the APIC REST API (xml or json)
+  returned: parse error
+  type: string
+  sample: '<?xml version="1.0" encoding="UTF-8"?><imdata totalCount="1"><error code="122" text="unknown managed object class foo"/></imdata>'
 sent:
   description: The actual/minimal configuration pushed to the APIC
   returned: info

--- a/lib/ansible/modules/network/aci/aci_ap.py
+++ b/lib/ansible/modules/network/aci/aci_ap.py
@@ -132,8 +132,8 @@ sent:
             }
         }
     }
-previous: The original configuration from the APIC before the module has started
-  description:
+previous:
+  description: The original configuration from the APIC before the module has started
   returned: info
   type: list
   sample:
@@ -174,7 +174,7 @@ method:
   returned: failure or debug
   type: string
   sample: POST
-response
+response:
   description: The HTTP response from the APIC
   returned: failure or debug
   type: string

--- a/lib/ansible/modules/network/aci/aci_bd.py
+++ b/lib/ansible/modules/network/aci/aci_bd.py
@@ -341,7 +341,7 @@ def main():
     elif state == 'absent':
         aci.delete_config()
 
-    module.exit_json(**aci.result)
+    aci.exit_json()
 
 
 if __name__ == "__main__":

--- a/lib/ansible/modules/network/aci/aci_bd.py
+++ b/lib/ansible/modules/network/aci/aci_bd.py
@@ -252,8 +252,8 @@ sent:
             }
         }
     }
-previous: The original configuration from the APIC before the module has started
-  description:
+previous:
+  description: The original configuration from the APIC before the module has started
   returned: info
   type: list
   sample:
@@ -294,7 +294,7 @@ method:
   returned: failure or debug
   type: string
   sample: POST
-response
+response:
   description: The HTTP response from the APIC
   returned: failure or debug
   type: string

--- a/lib/ansible/modules/network/aci/aci_bd.py
+++ b/lib/ansible/modules/network/aci/aci_bd.py
@@ -206,7 +206,105 @@ EXAMPLES = r'''
     bd: web_servers
 '''
 
-RETURN = r''' # '''
+RETURN = r'''
+current:
+  description: The existing configuration from the APIC after the module has finished
+  returned: success
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production environment",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+error:
+  description: The error information as returned from the APIC
+  returned: failure
+  type: dict
+  sample:
+    {
+        "code": "122",
+        "text": "unknown managed object class foo"
+    }
+sent:
+  description: The actual/minimal configuration pushed to the APIC
+  returned: info
+  type: list
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment"
+            }
+        }
+    }
+previous: The original configuration from the APIC before the module has started
+  description:
+  returned: info
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+proposed:
+  description: The assembled configuration from the user-provided parameters
+  returned: info
+  type: dict
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment",
+                "name": "production"
+            }
+        }
+    }
+filter_string:
+  description: The filter string used for the request
+  returned: failure or debug
+  type: string
+  sample: ?rsp-prop-include=config-only
+method:
+  description: The HTTP method used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: POST
+response
+  description: The HTTP response from the APIC
+  returned: failure or debug
+  type: string
+  sample: OK (30 bytes)
+status:
+  description: The HTTP status from the APIC
+  returned: failure or debug
+  type: int
+  sample: 200
+url:
+  description: The HTTP url used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: https://10.11.12.13/api/mo/uni/tn-production.json
+'''
 
 from ansible.module_utils.network.aci.aci import ACIModule, aci_argument_spec
 from ansible.module_utils.basic import AnsibleModule

--- a/lib/ansible/modules/network/aci/aci_bd.py
+++ b/lib/ansible/modules/network/aci/aci_bd.py
@@ -235,6 +235,11 @@ error:
         "code": "122",
         "text": "unknown managed object class foo"
     }
+raw:
+  description: The raw output returned by the APIC REST API (xml or json)
+  returned: parse error
+  type: string
+  sample: '<?xml version="1.0" encoding="UTF-8"?><imdata totalCount="1"><error code="122" text="unknown managed object class foo"/></imdata>'
 sent:
   description: The actual/minimal configuration pushed to the APIC
   returned: info

--- a/lib/ansible/modules/network/aci/aci_bd_subnet.py
+++ b/lib/ansible/modules/network/aci/aci_bd_subnet.py
@@ -230,6 +230,11 @@ error:
         "code": "122",
         "text": "unknown managed object class foo"
     }
+raw:
+  description: The raw output returned by the APIC REST API (xml or json)
+  returned: parse error
+  type: string
+  sample: '<?xml version="1.0" encoding="UTF-8"?><imdata totalCount="1"><error code="122" text="unknown managed object class foo"/></imdata>'
 sent:
   description: The actual/minimal configuration pushed to the APIC
   returned: info

--- a/lib/ansible/modules/network/aci/aci_bd_subnet.py
+++ b/lib/ansible/modules/network/aci/aci_bd_subnet.py
@@ -247,8 +247,8 @@ sent:
             }
         }
     }
-previous: The original configuration from the APIC before the module has started
-  description:
+previous:
+  description: The original configuration from the APIC before the module has started
   returned: info
   type: list
   sample:
@@ -289,7 +289,7 @@ method:
   returned: failure or debug
   type: string
   sample: POST
-response
+response:
   description: The HTTP response from the APIC
   returned: failure or debug
   type: string

--- a/lib/ansible/modules/network/aci/aci_bd_subnet.py
+++ b/lib/ansible/modules/network/aci/aci_bd_subnet.py
@@ -326,7 +326,7 @@ def main():
     elif state == 'absent':
         aci.delete_config()
 
-    module.exit_json(**aci.result)
+    aci.exit_json()
 
 
 if __name__ == "__main__":

--- a/lib/ansible/modules/network/aci/aci_bd_subnet.py
+++ b/lib/ansible/modules/network/aci/aci_bd_subnet.py
@@ -201,7 +201,105 @@ EXAMPLES = r'''
     mask: 24
 '''
 
-RETURN = r''' # '''
+RETURN = r'''
+current:
+  description: The existing configuration from the APIC after the module has finished
+  returned: success
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production environment",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+error:
+  description: The error information as returned from the APIC
+  returned: failure
+  type: dict
+  sample:
+    {
+        "code": "122",
+        "text": "unknown managed object class foo"
+    }
+sent:
+  description: The actual/minimal configuration pushed to the APIC
+  returned: info
+  type: list
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment"
+            }
+        }
+    }
+previous: The original configuration from the APIC before the module has started
+  description:
+  returned: info
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+proposed:
+  description: The assembled configuration from the user-provided parameters
+  returned: info
+  type: dict
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment",
+                "name": "production"
+            }
+        }
+    }
+filter_string:
+  description: The filter string used for the request
+  returned: failure or debug
+  type: string
+  sample: ?rsp-prop-include=config-only
+method:
+  description: The HTTP method used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: POST
+response
+  description: The HTTP response from the APIC
+  returned: failure or debug
+  type: string
+  sample: OK (30 bytes)
+status:
+  description: The HTTP status from the APIC
+  returned: failure or debug
+  type: int
+  sample: 200
+url:
+  description: The HTTP url used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: https://10.11.12.13/api/mo/uni/tn-production.json
+'''
 
 SUBNET_CONTROL_MAPPING = dict(nd_ra='nd', no_gw='no-default-gateway', querier_ip='querier', unspecified='')
 

--- a/lib/ansible/modules/network/aci/aci_bd_to_l3out.py
+++ b/lib/ansible/modules/network/aci/aci_bd_to_l3out.py
@@ -76,6 +76,11 @@ error:
         "code": "122",
         "text": "unknown managed object class foo"
     }
+raw:
+  description: The raw output returned by the APIC REST API (xml or json)
+  returned: parse error
+  type: string
+  sample: '<?xml version="1.0" encoding="UTF-8"?><imdata totalCount="1"><error code="122" text="unknown managed object class foo"/></imdata>'
 sent:
   description: The actual/minimal configuration pushed to the APIC
   returned: info

--- a/lib/ansible/modules/network/aci/aci_bd_to_l3out.py
+++ b/lib/ansible/modules/network/aci/aci_bd_to_l3out.py
@@ -122,7 +122,7 @@ def main():
     elif state == 'absent':
         aci.delete_config()
 
-    module.exit_json(**aci.result)
+    aci.exit_json()
 
 
 if __name__ == "__main__":

--- a/lib/ansible/modules/network/aci/aci_bd_to_l3out.py
+++ b/lib/ansible/modules/network/aci/aci_bd_to_l3out.py
@@ -93,8 +93,8 @@ sent:
             }
         }
     }
-previous: The original configuration from the APIC before the module has started
-  description:
+previous:
+  description: The original configuration from the APIC before the module has started
   returned: info
   type: list
   sample:
@@ -135,7 +135,7 @@ method:
   returned: failure or debug
   type: string
   sample: POST
-response
+response:
   description: The HTTP response from the APIC
   returned: failure or debug
   type: string

--- a/lib/ansible/modules/network/aci/aci_bd_to_l3out.py
+++ b/lib/ansible/modules/network/aci/aci_bd_to_l3out.py
@@ -47,7 +47,105 @@ extends_documentation_fragment: aci
 
 EXAMPLES = r''' # '''
 
-RETURN = ''' # '''
+RETURN = r'''
+current:
+  description: The existing configuration from the APIC after the module has finished
+  returned: success
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production environment",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+error:
+  description: The error information as returned from the APIC
+  returned: failure
+  type: dict
+  sample:
+    {
+        "code": "122",
+        "text": "unknown managed object class foo"
+    }
+sent:
+  description: The actual/minimal configuration pushed to the APIC
+  returned: info
+  type: list
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment"
+            }
+        }
+    }
+previous: The original configuration from the APIC before the module has started
+  description:
+  returned: info
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+proposed:
+  description: The assembled configuration from the user-provided parameters
+  returned: info
+  type: dict
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment",
+                "name": "production"
+            }
+        }
+    }
+filter_string:
+  description: The filter string used for the request
+  returned: failure or debug
+  type: string
+  sample: ?rsp-prop-include=config-only
+method:
+  description: The HTTP method used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: POST
+response
+  description: The HTTP response from the APIC
+  returned: failure or debug
+  type: string
+  sample: OK (30 bytes)
+status:
+  description: The HTTP status from the APIC
+  returned: failure or debug
+  type: int
+  sample: 200
+url:
+  description: The HTTP url used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: https://10.11.12.13/api/mo/uni/tn-production.json
+'''
 
 SUBNET_CONTROL_MAPPING = dict(nd_ra='nd', no_gw='no-default-gateway', querier_ip='querier', unspecified='')
 

--- a/lib/ansible/modules/network/aci/aci_config_rollback.py
+++ b/lib/ansible/modules/network/aci/aci_config_rollback.py
@@ -234,7 +234,7 @@ def main():
         # Generate rollback comparison
         get_preview(aci)
 
-    module.exit_json(**aci.result)
+    aci.exit_json()
 
 
 def get_preview(aci):

--- a/lib/ansible/modules/network/aci/aci_config_rollback.py
+++ b/lib/ansible/modules/network/aci/aci_config_rollback.py
@@ -127,7 +127,103 @@ EXAMPLES = r'''
 '''
 
 RETURN = r'''
-#
+current:
+  description: The existing configuration from the APIC after the module has finished
+  returned: success
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production environment",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+error:
+  description: The error information as returned from the APIC
+  returned: failure
+  type: dict
+  sample:
+    {
+        "code": "122",
+        "text": "unknown managed object class foo"
+    }
+sent:
+  description: The actual/minimal configuration pushed to the APIC
+  returned: info
+  type: list
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment"
+            }
+        }
+    }
+previous: The original configuration from the APIC before the module has started
+  description:
+  returned: info
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+proposed:
+  description: The assembled configuration from the user-provided parameters
+  returned: info
+  type: dict
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment",
+                "name": "production"
+            }
+        }
+    }
+filter_string:
+  description: The filter string used for the request
+  returned: failure or debug
+  type: string
+  sample: ?rsp-prop-include=config-only
+method:
+  description: The HTTP method used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: POST
+response
+  description: The HTTP response from the APIC
+  returned: failure or debug
+  type: string
+  sample: OK (30 bytes)
+status:
+  description: The HTTP status from the APIC
+  returned: failure or debug
+  type: int
+  sample: 200
+url:
+  description: The HTTP url used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: https://10.11.12.13/api/mo/uni/tn-production.json
 '''
 
 from ansible.module_utils.network.aci.aci import ACIModule, aci_argument_spec

--- a/lib/ansible/modules/network/aci/aci_config_rollback.py
+++ b/lib/ansible/modules/network/aci/aci_config_rollback.py
@@ -274,7 +274,7 @@ def main():
         ) % module.params
 
         # Generate rollback comparison
-        aci.get_preview()
+        get_preview(aci)
 
     aci.exit_json()
 

--- a/lib/ansible/modules/network/aci/aci_config_rollback.py
+++ b/lib/ansible/modules/network/aci/aci_config_rollback.py
@@ -129,7 +129,7 @@ EXAMPLES = r'''
 RETURN = r'''
 preview:
   description: A preview between two snapshots
-  returned:
+  returned: when state is preview
   type: string
 error:
   description: The error information as returned from the APIC
@@ -155,7 +155,7 @@ method:
   returned: failure or debug
   type: string
   sample: POST
-response
+response:
   description: The HTTP response from the APIC
   returned: failure or debug
   type: string

--- a/lib/ansible/modules/network/aci/aci_config_rollback.py
+++ b/lib/ansible/modules/network/aci/aci_config_rollback.py
@@ -348,7 +348,7 @@ def get_preview(aci):
         xml_to_json(aci, resp.read())
     else:
         aci.result['apic_response'] = resp.read()
-        aci.module.fail_json(msg='Request failed: %(error_code)s %(error_text)s' % aci.result, **aci.result)
+        aci.fail_json(msg='Request failed: %(code)s %(text)s' % aci.error)
 
 
 def xml_to_json(aci, response_data):

--- a/lib/ansible/modules/network/aci/aci_config_snapshot.py
+++ b/lib/ansible/modules/network/aci/aci_config_snapshot.py
@@ -209,7 +209,7 @@ def main():
                 ),
             )
 
-            if aci.result['existing']:
+            if aci.existing:
                 aci.get_diff('configSnapshot')
 
                 # Mark Snapshot for Deletion

--- a/lib/ansible/modules/network/aci/aci_config_snapshot.py
+++ b/lib/ansible/modules/network/aci/aci_config_snapshot.py
@@ -215,7 +215,7 @@ def main():
                 # Mark Snapshot for Deletion
                 aci.post_config()
 
-    module.exit_json(**aci.result)
+    aci.exit_json()
 
 
 if __name__ == "__main__":

--- a/lib/ansible/modules/network/aci/aci_config_snapshot.py
+++ b/lib/ansible/modules/network/aci/aci_config_snapshot.py
@@ -131,6 +131,11 @@ error:
         "code": "122",
         "text": "unknown managed object class foo"
     }
+raw:
+  description: The raw output returned by the APIC REST API (xml or json)
+  returned: parse error
+  type: string
+  sample: '<?xml version="1.0" encoding="UTF-8"?><imdata totalCount="1"><error code="122" text="unknown managed object class foo"/></imdata>'
 sent:
   description: The actual/minimal configuration pushed to the APIC
   returned: info

--- a/lib/ansible/modules/network/aci/aci_config_snapshot.py
+++ b/lib/ansible/modules/network/aci/aci_config_snapshot.py
@@ -236,7 +236,7 @@ def main():
         if max_count in range(1, 11):
             max_count = str(max_count)
         else:
-            module.fail_json(msg='The "max_count" must be a number between 1 and 10')
+            module.fail_json(msg="Parameter 'max_count' must be a number between 1 and 10")
     snapshot = module.params['snapshot']
     if snapshot is not None and not snapshot.startswith('run-'):
         snapshot = 'run-' + snapshot

--- a/lib/ansible/modules/network/aci/aci_config_snapshot.py
+++ b/lib/ansible/modules/network/aci/aci_config_snapshot.py
@@ -102,7 +102,105 @@ EXAMPLES = r'''
     snapshot: run-2017-08-24T17-20-05
 '''
 
-RETURN = r''' # '''
+RETURN = r'''
+current:
+  description: The existing configuration from the APIC after the module has finished
+  returned: success
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production environment",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+error:
+  description: The error information as returned from the APIC
+  returned: failure
+  type: dict
+  sample:
+    {
+        "code": "122",
+        "text": "unknown managed object class foo"
+    }
+sent:
+  description: The actual/minimal configuration pushed to the APIC
+  returned: info
+  type: list
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment"
+            }
+        }
+    }
+previous: The original configuration from the APIC before the module has started
+  description:
+  returned: info
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+proposed:
+  description: The assembled configuration from the user-provided parameters
+  returned: info
+  type: dict
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment",
+                "name": "production"
+            }
+        }
+    }
+filter_string:
+  description: The filter string used for the request
+  returned: failure or debug
+  type: string
+  sample: ?rsp-prop-include=config-only
+method:
+  description: The HTTP method used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: POST
+response
+  description: The HTTP response from the APIC
+  returned: failure or debug
+  type: string
+  sample: OK (30 bytes)
+status:
+  description: The HTTP status from the APIC
+  returned: failure or debug
+  type: int
+  sample: 200
+url:
+  description: The HTTP url used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: https://10.11.12.13/api/mo/uni/tn-production.json
+'''
 
 from ansible.module_utils.network.aci.aci import ACIModule, aci_argument_spec
 from ansible.module_utils.basic import AnsibleModule

--- a/lib/ansible/modules/network/aci/aci_config_snapshot.py
+++ b/lib/ansible/modules/network/aci/aci_config_snapshot.py
@@ -148,8 +148,8 @@ sent:
             }
         }
     }
-previous: The original configuration from the APIC before the module has started
-  description:
+previous:
+  description: The original configuration from the APIC before the module has started
   returned: info
   type: list
   sample:
@@ -190,7 +190,7 @@ method:
   returned: failure or debug
   type: string
   sample: POST
-response
+response:
   description: The HTTP response from the APIC
   returned: failure or debug
   type: string

--- a/lib/ansible/modules/network/aci/aci_contract.py
+++ b/lib/ansible/modules/network/aci/aci_contract.py
@@ -81,7 +81,103 @@ EXAMPLES = r'''
 '''
 
 RETURN = r'''
-#
+current:
+  description: The existing configuration from the APIC after the module has finished
+  returned: success
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production environment",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+error:
+  description: The error information as returned from the APIC
+  returned: failure
+  type: dict
+  sample:
+    {
+        "code": "122",
+        "text": "unknown managed object class foo"
+    }
+sent:
+  description: The actual/minimal configuration pushed to the APIC
+  returned: info
+  type: list
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment"
+            }
+        }
+    }
+previous: The original configuration from the APIC before the module has started
+  description:
+  returned: info
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+proposed:
+  description: The assembled configuration from the user-provided parameters
+  returned: info
+  type: dict
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment",
+                "name": "production"
+            }
+        }
+    }
+filter_string:
+  description: The filter string used for the request
+  returned: failure or debug
+  type: string
+  sample: ?rsp-prop-include=config-only
+method:
+  description: The HTTP method used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: POST
+response
+  description: The HTTP response from the APIC
+  returned: failure or debug
+  type: string
+  sample: OK (30 bytes)
+status:
+  description: The HTTP status from the APIC
+  returned: failure or debug
+  type: int
+  sample: 200
+url:
+  description: The HTTP url used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: https://10.11.12.13/api/mo/uni/tn-production.json
 '''
 
 from ansible.module_utils.network.aci.aci import ACIModule, aci_argument_spec

--- a/lib/ansible/modules/network/aci/aci_contract.py
+++ b/lib/ansible/modules/network/aci/aci_contract.py
@@ -109,6 +109,11 @@ error:
         "code": "122",
         "text": "unknown managed object class foo"
     }
+raw:
+  description: The raw output returned by the APIC REST API (xml or json)
+  returned: parse error
+  type: string
+  sample: '<?xml version="1.0" encoding="UTF-8"?><imdata totalCount="1"><error code="122" text="unknown managed object class foo"/></imdata>'
 sent:
   description: The actual/minimal configuration pushed to the APIC
   returned: info

--- a/lib/ansible/modules/network/aci/aci_contract.py
+++ b/lib/ansible/modules/network/aci/aci_contract.py
@@ -162,7 +162,7 @@ def main():
     elif state == 'absent':
         aci.delete_config()
 
-    module.exit_json(**aci.result)
+    aci.exit_json()
 
 
 if __name__ == "__main__":

--- a/lib/ansible/modules/network/aci/aci_contract.py
+++ b/lib/ansible/modules/network/aci/aci_contract.py
@@ -126,8 +126,8 @@ sent:
             }
         }
     }
-previous: The original configuration from the APIC before the module has started
-  description:
+previous:
+  description: The original configuration from the APIC before the module has started
   returned: info
   type: list
   sample:
@@ -168,7 +168,7 @@ method:
   returned: failure or debug
   type: string
   sample: POST
-response
+response:
   description: The HTTP response from the APIC
   returned: failure or debug
   type: string

--- a/lib/ansible/modules/network/aci/aci_contract_subject.py
+++ b/lib/ansible/modules/network/aci/aci_contract_subject.py
@@ -127,7 +127,103 @@ EXAMPLES = r'''
 '''
 
 RETURN = r'''
-#
+current:
+  description: The existing configuration from the APIC after the module has finished
+  returned: success
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production environment",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+error:
+  description: The error information as returned from the APIC
+  returned: failure
+  type: dict
+  sample:
+    {
+        "code": "122",
+        "text": "unknown managed object class foo"
+    }
+sent:
+  description: The actual/minimal configuration pushed to the APIC
+  returned: info
+  type: list
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment"
+            }
+        }
+    }
+previous: The original configuration from the APIC before the module has started
+  description:
+  returned: info
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+proposed:
+  description: The assembled configuration from the user-provided parameters
+  returned: info
+  type: dict
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment",
+                "name": "production"
+            }
+        }
+    }
+filter_string:
+  description: The filter string used for the request
+  returned: failure or debug
+  type: string
+  sample: ?rsp-prop-include=config-only
+method:
+  description: The HTTP method used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: POST
+response
+  description: The HTTP response from the APIC
+  returned: failure or debug
+  type: string
+  sample: OK (30 bytes)
+status:
+  description: The HTTP status from the APIC
+  returned: failure or debug
+  type: int
+  sample: 200
+url:
+  description: The HTTP url used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: https://10.11.12.13/api/mo/uni/tn-production.json
 '''
 
 from ansible.module_utils.network.aci.aci import ACIModule, aci_argument_spec

--- a/lib/ansible/modules/network/aci/aci_contract_subject.py
+++ b/lib/ansible/modules/network/aci/aci_contract_subject.py
@@ -172,8 +172,8 @@ sent:
             }
         }
     }
-previous: The original configuration from the APIC before the module has started
-  description:
+previous:
+  description: The original configuration from the APIC before the module has started
   returned: info
   type: list
   sample:
@@ -214,7 +214,7 @@ method:
   returned: failure or debug
   type: string
   sample: POST
-response
+response:
   description: The HTTP response from the APIC
   returned: failure or debug
   type: string

--- a/lib/ansible/modules/network/aci/aci_contract_subject.py
+++ b/lib/ansible/modules/network/aci/aci_contract_subject.py
@@ -155,6 +155,11 @@ error:
         "code": "122",
         "text": "unknown managed object class foo"
     }
+raw:
+  description: The raw output returned by the APIC REST API (xml or json)
+  returned: parse error
+  type: string
+  sample: '<?xml version="1.0" encoding="UTF-8"?><imdata totalCount="1"><error code="122" text="unknown managed object class foo"/></imdata>'
 sent:
   description: The actual/minimal configuration pushed to the APIC
   returned: info

--- a/lib/ansible/modules/network/aci/aci_contract_subject.py
+++ b/lib/ansible/modules/network/aci/aci_contract_subject.py
@@ -232,7 +232,7 @@ def main():
     elif state == 'absent':
         aci.delete_config()
 
-    module.exit_json(**aci.result)
+    aci.exit_json()
 
 if __name__ == "__main__":
     main()

--- a/lib/ansible/modules/network/aci/aci_contract_subject_to_filter.py
+++ b/lib/ansible/modules/network/aci/aci_contract_subject_to_filter.py
@@ -74,7 +74,103 @@ EXAMPLES = r'''
 '''
 
 RETURN = r'''
-#
+current:
+  description: The existing configuration from the APIC after the module has finished
+  returned: success
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production environment",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+error:
+  description: The error information as returned from the APIC
+  returned: failure
+  type: dict
+  sample:
+    {
+        "code": "122",
+        "text": "unknown managed object class foo"
+    }
+sent:
+  description: The actual/minimal configuration pushed to the APIC
+  returned: info
+  type: list
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment"
+            }
+        }
+    }
+previous: The original configuration from the APIC before the module has started
+  description:
+  returned: info
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+proposed:
+  description: The assembled configuration from the user-provided parameters
+  returned: info
+  type: dict
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment",
+                "name": "production"
+            }
+        }
+    }
+filter_string:
+  description: The filter string used for the request
+  returned: failure or debug
+  type: string
+  sample: ?rsp-prop-include=config-only
+method:
+  description: The HTTP method used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: POST
+response
+  description: The HTTP response from the APIC
+  returned: failure or debug
+  type: string
+  sample: OK (30 bytes)
+status:
+  description: The HTTP status from the APIC
+  returned: failure or debug
+  type: int
+  sample: 200
+url:
+  description: The HTTP url used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: https://10.11.12.13/api/mo/uni/tn-production.json
 '''
 
 from ansible.module_utils.network.aci.aci import ACIModule, aci_argument_spec

--- a/lib/ansible/modules/network/aci/aci_contract_subject_to_filter.py
+++ b/lib/ansible/modules/network/aci/aci_contract_subject_to_filter.py
@@ -169,7 +169,7 @@ def main():
     # Remove subject_filter used to build URL from module.params
     module.params.pop('subject_filter')
 
-    module.exit_json(**aci.result)
+    aci.exit_json()
 
 
 if __name__ == "__main__":

--- a/lib/ansible/modules/network/aci/aci_contract_subject_to_filter.py
+++ b/lib/ansible/modules/network/aci/aci_contract_subject_to_filter.py
@@ -102,6 +102,11 @@ error:
         "code": "122",
         "text": "unknown managed object class foo"
     }
+raw:
+  description: The raw output returned by the APIC REST API (xml or json)
+  returned: parse error
+  type: string
+  sample: '<?xml version="1.0" encoding="UTF-8"?><imdata totalCount="1"><error code="122" text="unknown managed object class foo"/></imdata>'
 sent:
   description: The actual/minimal configuration pushed to the APIC
   returned: info

--- a/lib/ansible/modules/network/aci/aci_contract_subject_to_filter.py
+++ b/lib/ansible/modules/network/aci/aci_contract_subject_to_filter.py
@@ -119,8 +119,8 @@ sent:
             }
         }
     }
-previous: The original configuration from the APIC before the module has started
-  description:
+previous:
+  description: The original configuration from the APIC before the module has started
   returned: info
   type: list
   sample:
@@ -161,7 +161,7 @@ method:
   returned: failure or debug
   type: string
   sample: POST
-response
+response:
   description: The HTTP response from the APIC
   returned: failure or debug
   type: string

--- a/lib/ansible/modules/network/aci/aci_domain.py
+++ b/lib/ansible/modules/network/aci/aci_domain.py
@@ -172,8 +172,8 @@ sent:
             }
         }
     }
-previous: The original configuration from the APIC before the module has started
-  description:
+previous:
+  description: The original configuration from the APIC before the module has started
   returned: info
   type: list
   sample:
@@ -214,7 +214,7 @@ method:
   returned: failure or debug
   type: string
   sample: POST
-response
+response:
   description: The HTTP response from the APIC
   returned: failure or debug
   type: string

--- a/lib/ansible/modules/network/aci/aci_domain.py
+++ b/lib/ansible/modules/network/aci/aci_domain.py
@@ -155,6 +155,11 @@ error:
         "code": "122",
         "text": "unknown managed object class foo"
     }
+raw:
+  description: The raw output returned by the APIC REST API (xml or json)
+  returned: parse error
+  type: string
+  sample: '<?xml version="1.0" encoding="UTF-8"?><imdata totalCount="1"><error code="122" text="unknown managed object class foo"/></imdata>'
 sent:
   description: The actual/minimal configuration pushed to the APIC
   returned: info

--- a/lib/ansible/modules/network/aci/aci_domain.py
+++ b/lib/ansible/modules/network/aci/aci_domain.py
@@ -254,7 +254,7 @@ def main():
     elif state == 'absent':
         aci.delete_config()
 
-    module.exit_json(**aci.result)
+    aci.exit_json()
 
 
 if __name__ == "__main__":

--- a/lib/ansible/modules/network/aci/aci_domain.py
+++ b/lib/ansible/modules/network/aci/aci_domain.py
@@ -126,7 +126,105 @@ EXAMPLES = r'''
     state: query
 '''
 
-RETURN = r''' # '''
+RETURN = r'''
+current:
+  description: The existing configuration from the APIC after the module has finished
+  returned: success
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production environment",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+error:
+  description: The error information as returned from the APIC
+  returned: failure
+  type: dict
+  sample:
+    {
+        "code": "122",
+        "text": "unknown managed object class foo"
+    }
+sent:
+  description: The actual/minimal configuration pushed to the APIC
+  returned: info
+  type: list
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment"
+            }
+        }
+    }
+previous: The original configuration from the APIC before the module has started
+  description:
+  returned: info
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+proposed:
+  description: The assembled configuration from the user-provided parameters
+  returned: info
+  type: dict
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment",
+                "name": "production"
+            }
+        }
+    }
+filter_string:
+  description: The filter string used for the request
+  returned: failure or debug
+  type: string
+  sample: ?rsp-prop-include=config-only
+method:
+  description: The HTTP method used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: POST
+response
+  description: The HTTP response from the APIC
+  returned: failure or debug
+  type: string
+  sample: OK (30 bytes)
+status:
+  description: The HTTP status from the APIC
+  returned: failure or debug
+  type: int
+  sample: 200
+url:
+  description: The HTTP url used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: https://10.11.12.13/api/mo/uni/tn-production.json
+'''
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.network.aci.aci import ACIModule, aci_argument_spec

--- a/lib/ansible/modules/network/aci/aci_domain_to_encap_pool.py
+++ b/lib/ansible/modules/network/aci/aci_domain_to_encap_pool.py
@@ -66,7 +66,105 @@ extends_documentation_fragment: aci
 
 EXAMPLES = r''' # '''
 
-RETURN = ''' # '''
+RETURN = r'''
+current:
+  description: The existing configuration from the APIC after the module has finished
+  returned: success
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production environment",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+error:
+  description: The error information as returned from the APIC
+  returned: failure
+  type: dict
+  sample:
+    {
+        "code": "122",
+        "text": "unknown managed object class foo"
+    }
+sent:
+  description: The actual/minimal configuration pushed to the APIC
+  returned: info
+  type: list
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment"
+            }
+        }
+    }
+previous: The original configuration from the APIC before the module has started
+  description:
+  returned: info
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+proposed:
+  description: The assembled configuration from the user-provided parameters
+  returned: info
+  type: dict
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment",
+                "name": "production"
+            }
+        }
+    }
+filter_string:
+  description: The filter string used for the request
+  returned: failure or debug
+  type: string
+  sample: ?rsp-prop-include=config-only
+method:
+  description: The HTTP method used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: POST
+response
+  description: The HTTP response from the APIC
+  returned: failure or debug
+  type: string
+  sample: OK (30 bytes)
+status:
+  description: The HTTP status from the APIC
+  returned: failure or debug
+  type: int
+  sample: 200
+url:
+  description: The HTTP url used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: https://10.11.12.13/api/mo/uni/tn-production.json
+'''
 
 from ansible.module_utils.network.aci.aci import ACIModule, aci_argument_spec
 from ansible.module_utils.basic import AnsibleModule

--- a/lib/ansible/modules/network/aci/aci_domain_to_encap_pool.py
+++ b/lib/ansible/modules/network/aci/aci_domain_to_encap_pool.py
@@ -112,8 +112,8 @@ sent:
             }
         }
     }
-previous: The original configuration from the APIC before the module has started
-  description:
+previous:
+  description: The original configuration from the APIC before the module has started
   returned: info
   type: list
   sample:
@@ -154,7 +154,7 @@ method:
   returned: failure or debug
   type: string
   sample: POST
-response
+response:
   description: The HTTP response from the APIC
   returned: failure or debug
   type: string

--- a/lib/ansible/modules/network/aci/aci_domain_to_encap_pool.py
+++ b/lib/ansible/modules/network/aci/aci_domain_to_encap_pool.py
@@ -95,6 +95,11 @@ error:
         "code": "122",
         "text": "unknown managed object class foo"
     }
+raw:
+  description: The raw output returned by the APIC REST API (xml or json)
+  returned: parse error
+  type: string
+  sample: '<?xml version="1.0" encoding="UTF-8"?><imdata totalCount="1"><error code="122" text="unknown managed object class foo"/></imdata>'
 sent:
   description: The actual/minimal configuration pushed to the APIC
   returned: info

--- a/lib/ansible/modules/network/aci/aci_domain_to_encap_pool.py
+++ b/lib/ansible/modules/network/aci/aci_domain_to_encap_pool.py
@@ -196,7 +196,7 @@ def main():
     elif state == 'absent':
         aci.delete_config()
 
-    module.exit_json(**aci.result)
+    aci.exit_json()
 
 
 if __name__ == "__main__":

--- a/lib/ansible/modules/network/aci/aci_domain_to_vlan_pool.py
+++ b/lib/ansible/modules/network/aci/aci_domain_to_vlan_pool.py
@@ -231,7 +231,7 @@ def main():
     elif state == 'absent':
         aci.delete_config()
 
-    module.exit_json(**aci.result)
+    aci.exit_json()
 
 
 if __name__ == "__main__":

--- a/lib/ansible/modules/network/aci/aci_domain_to_vlan_pool.py
+++ b/lib/ansible/modules/network/aci/aci_domain_to_vlan_pool.py
@@ -125,7 +125,105 @@ EXAMPLES = r'''
     state: query
 '''
 
-RETURN = ''' # '''
+RETURN = r'''
+current:
+  description: The existing configuration from the APIC after the module has finished
+  returned: success
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production environment",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+error:
+  description: The error information as returned from the APIC
+  returned: failure
+  type: dict
+  sample:
+    {
+        "code": "122",
+        "text": "unknown managed object class foo"
+    }
+sent:
+  description: The actual/minimal configuration pushed to the APIC
+  returned: info
+  type: list
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment"
+            }
+        }
+    }
+previous: The original configuration from the APIC before the module has started
+  description:
+  returned: info
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+proposed:
+  description: The assembled configuration from the user-provided parameters
+  returned: info
+  type: dict
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment",
+                "name": "production"
+            }
+        }
+    }
+filter_string:
+  description: The filter string used for the request
+  returned: failure or debug
+  type: string
+  sample: ?rsp-prop-include=config-only
+method:
+  description: The HTTP method used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: POST
+response
+  description: The HTTP response from the APIC
+  returned: failure or debug
+  type: string
+  sample: OK (30 bytes)
+status:
+  description: The HTTP status from the APIC
+  returned: failure or debug
+  type: int
+  sample: 200
+url:
+  description: The HTTP url used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: https://10.11.12.13/api/mo/uni/tn-production.json
+'''
 
 from ansible.module_utils.network.aci.aci import ACIModule, aci_argument_spec
 from ansible.module_utils.basic import AnsibleModule

--- a/lib/ansible/modules/network/aci/aci_domain_to_vlan_pool.py
+++ b/lib/ansible/modules/network/aci/aci_domain_to_vlan_pool.py
@@ -154,6 +154,11 @@ error:
         "code": "122",
         "text": "unknown managed object class foo"
     }
+raw:
+  description: The raw output returned by the APIC REST API (xml or json)
+  returned: parse error
+  type: string
+  sample: '<?xml version="1.0" encoding="UTF-8"?><imdata totalCount="1"><error code="122" text="unknown managed object class foo"/></imdata>'
 sent:
   description: The actual/minimal configuration pushed to the APIC
   returned: info

--- a/lib/ansible/modules/network/aci/aci_domain_to_vlan_pool.py
+++ b/lib/ansible/modules/network/aci/aci_domain_to_vlan_pool.py
@@ -171,8 +171,8 @@ sent:
             }
         }
     }
-previous: The original configuration from the APIC before the module has started
-  description:
+previous:
+  description: The original configuration from the APIC before the module has started
   returned: info
   type: list
   sample:
@@ -213,7 +213,7 @@ method:
   returned: failure or debug
   type: string
   sample: POST
-response
+response:
   description: The HTTP response from the APIC
   returned: failure or debug
   type: string

--- a/lib/ansible/modules/network/aci/aci_encap_pool.py
+++ b/lib/ansible/modules/network/aci/aci_encap_pool.py
@@ -185,7 +185,7 @@ def main():
     elif state == 'absent':
         aci.delete_config()
 
-    module.exit_json(**aci.result)
+    aci.exit_json()
 
 
 if __name__ == "__main__":

--- a/lib/ansible/modules/network/aci/aci_encap_pool.py
+++ b/lib/ansible/modules/network/aci/aci_encap_pool.py
@@ -91,7 +91,108 @@ EXAMPLES = r'''
 '''
 
 RETURN = r'''
-#
+current:
+  description: The existing configuration from the APIC after the module has finished
+  returned: success
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production environment",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+error:
+  description: The error information as returned from the APIC
+  returned: failure
+  type: dict
+  sample:
+    {
+        "code": "122",
+        "text": "unknown managed object class foo"
+    }
+raw:
+  description: The raw output returned by the APIC REST API (xml or json)
+  returned: parse error
+  type: string
+  sample: '<?xml version="1.0" encoding="UTF-8"?><imdata totalCount="1"><error code="122" text="unknown managed object class foo"/></imdata>'
+sent:
+  description: The actual/minimal configuration pushed to the APIC
+  returned: info
+  type: list
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment"
+            }
+        }
+    }
+previous: The original configuration from the APIC before the module has started
+  description:
+  returned: info
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+proposed:
+  description: The assembled configuration from the user-provided parameters
+  returned: info
+  type: dict
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment",
+                "name": "production"
+            }
+        }
+    }
+filter_string:
+  description: The filter string used for the request
+  returned: failure or debug
+  type: string
+  sample: ?rsp-prop-include=config-only
+method:
+  description: The HTTP method used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: POST
+response
+  description: The HTTP response from the APIC
+  returned: failure or debug
+  type: string
+  sample: OK (30 bytes)
+status:
+  description: The HTTP status from the APIC
+  returned: failure or debug
+  type: int
+  sample: 200
+url:
+  description: The HTTP url used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: https://10.11.12.13/api/mo/uni/tn-production.json
 '''
 
 from ansible.module_utils.network.aci.aci import ACIModule, aci_argument_spec

--- a/lib/ansible/modules/network/aci/aci_encap_pool.py
+++ b/lib/ansible/modules/network/aci/aci_encap_pool.py
@@ -136,8 +136,8 @@ sent:
             }
         }
     }
-previous: The original configuration from the APIC before the module has started
-  description:
+previous:
+  description: The original configuration from the APIC before the module has started
   returned: info
   type: list
   sample:
@@ -178,7 +178,7 @@ method:
   returned: failure or debug
   type: string
   sample: POST
-response
+response:
   description: The HTTP response from the APIC
   returned: failure or debug
   type: string

--- a/lib/ansible/modules/network/aci/aci_encap_pool_range.py
+++ b/lib/ansible/modules/network/aci/aci_encap_pool_range.py
@@ -124,7 +124,103 @@ EXAMPLES = r'''
 '''
 
 RETURN = r'''
-#
+current:
+  description: The existing configuration from the APIC after the module has finished
+  returned: success
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production environment",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+error:
+  description: The error information as returned from the APIC
+  returned: failure
+  type: dict
+  sample:
+    {
+        "code": "122",
+        "text": "unknown managed object class foo"
+    }
+sent:
+  description: The actual/minimal configuration pushed to the APIC
+  returned: info
+  type: list
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment"
+            }
+        }
+    }
+previous: The original configuration from the APIC before the module has started
+  description:
+  returned: info
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+proposed:
+  description: The assembled configuration from the user-provided parameters
+  returned: info
+  type: dict
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment",
+                "name": "production"
+            }
+        }
+    }
+filter_string:
+  description: The filter string used for the request
+  returned: failure or debug
+  type: string
+  sample: ?rsp-prop-include=config-only
+method:
+  description: The HTTP method used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: POST
+response
+  description: The HTTP response from the APIC
+  returned: failure or debug
+  type: string
+  sample: OK (30 bytes)
+status:
+  description: The HTTP status from the APIC
+  returned: failure or debug
+  type: int
+  sample: 200
+url:
+  description: The HTTP url used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: https://10.11.12.13/api/mo/uni/tn-production.json
 '''
 
 from ansible.module_utils.network.aci.aci import ACIModule, aci_argument_spec

--- a/lib/ansible/modules/network/aci/aci_encap_pool_range.py
+++ b/lib/ansible/modules/network/aci/aci_encap_pool_range.py
@@ -303,7 +303,7 @@ def main():
     elif state == 'absent':
         aci.delete_config()
 
-    module.exit_json(**aci.result)
+    aci.exit_json()
 
 
 if __name__ == "__main__":

--- a/lib/ansible/modules/network/aci/aci_encap_pool_range.py
+++ b/lib/ansible/modules/network/aci/aci_encap_pool_range.py
@@ -169,8 +169,8 @@ sent:
             }
         }
     }
-previous: The original configuration from the APIC before the module has started
-  description:
+previous:
+  description: The original configuration from the APIC before the module has started
   returned: info
   type: list
   sample:
@@ -211,7 +211,7 @@ method:
   returned: failure or debug
   type: string
   sample: POST
-response
+response:
   description: The HTTP response from the APIC
   returned: failure or debug
   type: string

--- a/lib/ansible/modules/network/aci/aci_encap_pool_range.py
+++ b/lib/ansible/modules/network/aci/aci_encap_pool_range.py
@@ -152,6 +152,11 @@ error:
         "code": "122",
         "text": "unknown managed object class foo"
     }
+raw:
+  description: The raw output returned by the APIC REST API (xml or json)
+  returned: parse error
+  type: string
+  sample: '<?xml version="1.0" encoding="UTF-8"?><imdata totalCount="1"><error code="122" text="unknown managed object class foo"/></imdata>'
 sent:
   description: The actual/minimal configuration pushed to the APIC
   returned: info

--- a/lib/ansible/modules/network/aci/aci_epg.py
+++ b/lib/ansible/modules/network/aci/aci_epg.py
@@ -196,8 +196,8 @@ sent:
             }
         }
     }
-previous: The original configuration from the APIC before the module has started
-  description:
+previous:
+  description: The original configuration from the APIC before the module has started
   returned: info
   type: list
   sample:
@@ -238,7 +238,7 @@ method:
   returned: failure or debug
   type: string
   sample: POST
-response
+response:
   description: The HTTP response from the APIC
   returned: failure or debug
   type: string

--- a/lib/ansible/modules/network/aci/aci_epg.py
+++ b/lib/ansible/modules/network/aci/aci_epg.py
@@ -179,6 +179,11 @@ error:
         "code": "122",
         "text": "unknown managed object class foo"
     }
+raw:
+  description: The raw output returned by the APIC REST API (xml or json)
+  returned: parse error
+  type: string
+  sample: '<?xml version="1.0" encoding="UTF-8"?><imdata totalCount="1"><error code="122" text="unknown managed object class foo"/></imdata>'
 sent:
   description: The actual/minimal configuration pushed to the APIC
   returned: info

--- a/lib/ansible/modules/network/aci/aci_epg.py
+++ b/lib/ansible/modules/network/aci/aci_epg.py
@@ -151,7 +151,103 @@ EXAMPLES = r'''
 '''
 
 RETURN = r'''
-#
+current:
+  description: The existing configuration from the APIC after the module has finished
+  returned: success
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production environment",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+error:
+  description: The error information as returned from the APIC
+  returned: failure
+  type: dict
+  sample:
+    {
+        "code": "122",
+        "text": "unknown managed object class foo"
+    }
+sent:
+  description: The actual/minimal configuration pushed to the APIC
+  returned: info
+  type: list
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment"
+            }
+        }
+    }
+previous: The original configuration from the APIC before the module has started
+  description:
+  returned: info
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+proposed:
+  description: The assembled configuration from the user-provided parameters
+  returned: info
+  type: dict
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment",
+                "name": "production"
+            }
+        }
+    }
+filter_string:
+  description: The filter string used for the request
+  returned: failure or debug
+  type: string
+  sample: ?rsp-prop-include=config-only
+method:
+  description: The HTTP method used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: POST
+response
+  description: The HTTP response from the APIC
+  returned: failure or debug
+  type: string
+  sample: OK (30 bytes)
+status:
+  description: The HTTP status from the APIC
+  returned: failure or debug
+  type: int
+  sample: 200
+url:
+  description: The HTTP url used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: https://10.11.12.13/api/mo/uni/tn-production.json
 '''
 
 from ansible.module_utils.network.aci.aci import ACIModule, aci_argument_spec

--- a/lib/ansible/modules/network/aci/aci_epg.py
+++ b/lib/ansible/modules/network/aci/aci_epg.py
@@ -243,7 +243,7 @@ def main():
     elif state == 'absent':
         aci.delete_config()
 
-    module.exit_json(**aci.result)
+    aci.exit_json()
 
 
 if __name__ == "__main__":

--- a/lib/ansible/modules/network/aci/aci_epg_monitoring_policy.py
+++ b/lib/ansible/modules/network/aci/aci_epg_monitoring_policy.py
@@ -131,7 +131,7 @@ def main():
     elif state == 'absent':
         aci.delete_config()
 
-    module.exit_json(**aci.result)
+    aci.exit_json()
 
 
 if __name__ == "__main__":

--- a/lib/ansible/modules/network/aci/aci_epg_monitoring_policy.py
+++ b/lib/ansible/modules/network/aci/aci_epg_monitoring_policy.py
@@ -62,7 +62,103 @@ EXAMPLES = r'''
 '''
 
 RETURN = r'''
-#
+current:
+  description: The existing configuration from the APIC after the module has finished
+  returned: success
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production environment",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+error:
+  description: The error information as returned from the APIC
+  returned: failure
+  type: dict
+  sample:
+    {
+        "code": "122",
+        "text": "unknown managed object class foo"
+    }
+sent:
+  description: The actual/minimal configuration pushed to the APIC
+  returned: info
+  type: list
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment"
+            }
+        }
+    }
+previous: The original configuration from the APIC before the module has started
+  description:
+  returned: info
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+proposed:
+  description: The assembled configuration from the user-provided parameters
+  returned: info
+  type: dict
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment",
+                "name": "production"
+            }
+        }
+    }
+filter_string:
+  description: The filter string used for the request
+  returned: failure or debug
+  type: string
+  sample: ?rsp-prop-include=config-only
+method:
+  description: The HTTP method used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: POST
+response
+  description: The HTTP response from the APIC
+  returned: failure or debug
+  type: string
+  sample: OK (30 bytes)
+status:
+  description: The HTTP status from the APIC
+  returned: failure or debug
+  type: int
+  sample: 200
+url:
+  description: The HTTP url used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: https://10.11.12.13/api/mo/uni/tn-production.json
 '''
 
 from ansible.module_utils.network.aci.aci import ACIModule, aci_argument_spec

--- a/lib/ansible/modules/network/aci/aci_epg_monitoring_policy.py
+++ b/lib/ansible/modules/network/aci/aci_epg_monitoring_policy.py
@@ -90,6 +90,11 @@ error:
         "code": "122",
         "text": "unknown managed object class foo"
     }
+raw:
+  description: The raw output returned by the APIC REST API (xml or json)
+  returned: parse error
+  type: string
+  sample: '<?xml version="1.0" encoding="UTF-8"?><imdata totalCount="1"><error code="122" text="unknown managed object class foo"/></imdata>'
 sent:
   description: The actual/minimal configuration pushed to the APIC
   returned: info

--- a/lib/ansible/modules/network/aci/aci_epg_monitoring_policy.py
+++ b/lib/ansible/modules/network/aci/aci_epg_monitoring_policy.py
@@ -107,8 +107,8 @@ sent:
             }
         }
     }
-previous: The original configuration from the APIC before the module has started
-  description:
+previous:
+  description: The original configuration from the APIC before the module has started
   returned: info
   type: list
   sample:
@@ -149,7 +149,7 @@ method:
   returned: failure or debug
   type: string
   sample: POST
-response
+response:
   description: The HTTP response from the APIC
   returned: failure or debug
   type: string

--- a/lib/ansible/modules/network/aci/aci_epg_to_contract.py
+++ b/lib/ansible/modules/network/aci/aci_epg_to_contract.py
@@ -69,7 +69,105 @@ extends_documentation_fragment: aci
 
 EXAMPLES = r''' # '''
 
-RETURN = r''' # '''
+RETURN = r'''
+current:
+  description: The existing configuration from the APIC after the module has finished
+  returned: success
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production environment",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+error:
+  description: The error information as returned from the APIC
+  returned: failure
+  type: dict
+  sample:
+    {
+        "code": "122",
+        "text": "unknown managed object class foo"
+    }
+sent:
+  description: The actual/minimal configuration pushed to the APIC
+  returned: info
+  type: list
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment"
+            }
+        }
+    }
+previous: The original configuration from the APIC before the module has started
+  description:
+  returned: info
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+proposed:
+  description: The assembled configuration from the user-provided parameters
+  returned: info
+  type: dict
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment",
+                "name": "production"
+            }
+        }
+    }
+filter_string:
+  description: The filter string used for the request
+  returned: failure or debug
+  type: string
+  sample: ?rsp-prop-include=config-only
+method:
+  description: The HTTP method used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: POST
+response
+  description: The HTTP response from the APIC
+  returned: failure or debug
+  type: string
+  sample: OK (30 bytes)
+status:
+  description: The HTTP status from the APIC
+  returned: failure or debug
+  type: int
+  sample: 200
+url:
+  description: The HTTP url used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: https://10.11.12.13/api/mo/uni/tn-production.json
+'''
 
 from ansible.module_utils.network.aci.aci import ACIModule, aci_argument_spec
 from ansible.module_utils.basic import AnsibleModule

--- a/lib/ansible/modules/network/aci/aci_epg_to_contract.py
+++ b/lib/ansible/modules/network/aci/aci_epg_to_contract.py
@@ -169,7 +169,7 @@ def main():
     elif state == 'absent':
         aci.delete_config()
 
-    module.exit_json(**aci.result)
+    aci.exit_json()
 
 
 if __name__ == "__main__":

--- a/lib/ansible/modules/network/aci/aci_epg_to_contract.py
+++ b/lib/ansible/modules/network/aci/aci_epg_to_contract.py
@@ -115,8 +115,8 @@ sent:
             }
         }
     }
-previous: The original configuration from the APIC before the module has started
-  description:
+previous:
+  description: The original configuration from the APIC before the module has started
   returned: info
   type: list
   sample:
@@ -157,7 +157,7 @@ method:
   returned: failure or debug
   type: string
   sample: POST
-response
+response:
   description: The HTTP response from the APIC
   returned: failure or debug
   type: string

--- a/lib/ansible/modules/network/aci/aci_epg_to_contract.py
+++ b/lib/ansible/modules/network/aci/aci_epg_to_contract.py
@@ -98,6 +98,11 @@ error:
         "code": "122",
         "text": "unknown managed object class foo"
     }
+raw:
+  description: The raw output returned by the APIC REST API (xml or json)
+  returned: parse error
+  type: string
+  sample: '<?xml version="1.0" encoding="UTF-8"?><imdata totalCount="1"><error code="122" text="unknown managed object class foo"/></imdata>'
 sent:
   description: The actual/minimal configuration pushed to the APIC
   returned: info

--- a/lib/ansible/modules/network/aci/aci_epg_to_domain.py
+++ b/lib/ansible/modules/network/aci/aci_epg_to_domain.py
@@ -131,6 +131,11 @@ error:
         "code": "122",
         "text": "unknown managed object class foo"
     }
+raw:
+  description: The raw output returned by the APIC REST API (xml or json)
+  returned: parse error
+  type: string
+  sample: '<?xml version="1.0" encoding="UTF-8"?><imdata totalCount="1"><error code="122" text="unknown managed object class foo"/></imdata>'
 sent:
   description: The actual/minimal configuration pushed to the APIC
   returned: info

--- a/lib/ansible/modules/network/aci/aci_epg_to_domain.py
+++ b/lib/ansible/modules/network/aci/aci_epg_to_domain.py
@@ -102,7 +102,105 @@ extends_documentation_fragment: aci
 
 EXAMPLES = r''' # '''
 
-RETURN = r''' # '''
+RETURN = r'''
+current:
+  description: The existing configuration from the APIC after the module has finished
+  returned: success
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production environment",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+error:
+  description: The error information as returned from the APIC
+  returned: failure
+  type: dict
+  sample:
+    {
+        "code": "122",
+        "text": "unknown managed object class foo"
+    }
+sent:
+  description: The actual/minimal configuration pushed to the APIC
+  returned: info
+  type: list
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment"
+            }
+        }
+    }
+previous: The original configuration from the APIC before the module has started
+  description:
+  returned: info
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+proposed:
+  description: The assembled configuration from the user-provided parameters
+  returned: info
+  type: dict
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment",
+                "name": "production"
+            }
+        }
+    }
+filter_string:
+  description: The filter string used for the request
+  returned: failure or debug
+  type: string
+  sample: ?rsp-prop-include=config-only
+method:
+  description: The HTTP method used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: POST
+response
+  description: The HTTP response from the APIC
+  returned: failure or debug
+  type: string
+  sample: OK (30 bytes)
+status:
+  description: The HTTP status from the APIC
+  returned: failure or debug
+  type: int
+  sample: 200
+url:
+  description: The HTTP url used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: https://10.11.12.13/api/mo/uni/tn-production.json
+'''
 
 from ansible.module_utils.network.aci.aci import ACIModule, aci_argument_spec
 from ansible.module_utils.basic import AnsibleModule

--- a/lib/ansible/modules/network/aci/aci_epg_to_domain.py
+++ b/lib/ansible/modules/network/aci/aci_epg_to_domain.py
@@ -239,7 +239,7 @@ def main():
     elif state == 'absent':
         aci.delete_config()
 
-    module.exit_json(**aci.result)
+    aci.exit_json()
 
 
 if __name__ == "__main__":

--- a/lib/ansible/modules/network/aci/aci_epg_to_domain.py
+++ b/lib/ansible/modules/network/aci/aci_epg_to_domain.py
@@ -148,8 +148,8 @@ sent:
             }
         }
     }
-previous: The original configuration from the APIC before the module has started
-  description:
+previous:
+  description: The original configuration from the APIC before the module has started
   returned: info
   type: list
   sample:
@@ -190,7 +190,7 @@ method:
   returned: failure or debug
   type: string
   sample: POST
-response
+response:
   description: The HTTP response from the APIC
   returned: failure or debug
   type: string

--- a/lib/ansible/modules/network/aci/aci_filter.py
+++ b/lib/ansible/modules/network/aci/aci_filter.py
@@ -88,7 +88,103 @@ EXAMPLES = r'''
 '''
 
 RETURN = r'''
-#
+current:
+  description: The existing configuration from the APIC after the module has finished
+  returned: success
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production environment",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+error:
+  description: The error information as returned from the APIC
+  returned: failure
+  type: dict
+  sample:
+    {
+        "code": "122",
+        "text": "unknown managed object class foo"
+    }
+sent:
+  description: The actual/minimal configuration pushed to the APIC
+  returned: info
+  type: list
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment"
+            }
+        }
+    }
+previous: The original configuration from the APIC before the module has started
+  description:
+  returned: info
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+proposed:
+  description: The assembled configuration from the user-provided parameters
+  returned: info
+  type: dict
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment",
+                "name": "production"
+            }
+        }
+    }
+filter_string:
+  description: The filter string used for the request
+  returned: failure or debug
+  type: string
+  sample: ?rsp-prop-include=config-only
+method:
+  description: The HTTP method used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: POST
+response
+  description: The HTTP response from the APIC
+  returned: failure or debug
+  type: string
+  sample: OK (30 bytes)
+status:
+  description: The HTTP status from the APIC
+  returned: failure or debug
+  type: int
+  sample: 200
+url:
+  description: The HTTP url used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: https://10.11.12.13/api/mo/uni/tn-production.json
 '''
 
 from ansible.module_utils.network.aci.aci import ACIModule, aci_argument_spec

--- a/lib/ansible/modules/network/aci/aci_filter.py
+++ b/lib/ansible/modules/network/aci/aci_filter.py
@@ -157,7 +157,7 @@ def main():
     elif state == 'absent':
         aci.delete_config()
 
-    module.exit_json(**aci.result)
+    aci.exit_json()
 
 
 if __name__ == "__main__":

--- a/lib/ansible/modules/network/aci/aci_filter.py
+++ b/lib/ansible/modules/network/aci/aci_filter.py
@@ -133,8 +133,8 @@ sent:
             }
         }
     }
-previous: The original configuration from the APIC before the module has started
-  description:
+previous:
+  description: The original configuration from the APIC before the module has started
   returned: info
   type: list
   sample:
@@ -175,7 +175,7 @@ method:
   returned: failure or debug
   type: string
   sample: POST
-response
+response:
   description: The HTTP response from the APIC
   returned: failure or debug
   type: string

--- a/lib/ansible/modules/network/aci/aci_filter.py
+++ b/lib/ansible/modules/network/aci/aci_filter.py
@@ -116,6 +116,11 @@ error:
         "code": "122",
         "text": "unknown managed object class foo"
     }
+raw:
+  description: The raw output returned by the APIC REST API (xml or json)
+  returned: parse error
+  type: string
+  sample: '<?xml version="1.0" encoding="UTF-8"?><imdata totalCount="1"><error code="122" text="unknown managed object class foo"/></imdata>'
 sent:
   description: The actual/minimal configuration pushed to the APIC
   returned: info

--- a/lib/ansible/modules/network/aci/aci_filter_entry.py
+++ b/lib/ansible/modules/network/aci/aci_filter_entry.py
@@ -160,8 +160,8 @@ sent:
             }
         }
     }
-previous: The original configuration from the APIC before the module has started
-  description:
+previous:
+  description: The original configuration from the APIC before the module has started
   returned: info
   type: list
   sample:
@@ -202,7 +202,7 @@ method:
   returned: failure or debug
   type: string
   sample: POST
-response
+response:
   description: The HTTP response from the APIC
   returned: failure or debug
   type: string

--- a/lib/ansible/modules/network/aci/aci_filter_entry.py
+++ b/lib/ansible/modules/network/aci/aci_filter_entry.py
@@ -249,7 +249,7 @@ def main():
     elif state == 'absent':
         aci.delete_config()
 
-    module.exit_json(**aci.result)
+    aci.exit_json()
 
 
 if __name__ == "__main__":

--- a/lib/ansible/modules/network/aci/aci_filter_entry.py
+++ b/lib/ansible/modules/network/aci/aci_filter_entry.py
@@ -114,7 +114,105 @@ EXAMPLES = r'''
     descr: "{{ descr }}"
 '''
 
-RETURN = ''' # '''
+RETURN = r'''
+current:
+  description: The existing configuration from the APIC after the module has finished
+  returned: success
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production environment",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+error:
+  description: The error information as returned from the APIC
+  returned: failure
+  type: dict
+  sample:
+    {
+        "code": "122",
+        "text": "unknown managed object class foo"
+    }
+sent:
+  description: The actual/minimal configuration pushed to the APIC
+  returned: info
+  type: list
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment"
+            }
+        }
+    }
+previous: The original configuration from the APIC before the module has started
+  description:
+  returned: info
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+proposed:
+  description: The assembled configuration from the user-provided parameters
+  returned: info
+  type: dict
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment",
+                "name": "production"
+            }
+        }
+    }
+filter_string:
+  description: The filter string used for the request
+  returned: failure or debug
+  type: string
+  sample: ?rsp-prop-include=config-only
+method:
+  description: The HTTP method used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: POST
+response
+  description: The HTTP response from the APIC
+  returned: failure or debug
+  type: string
+  sample: OK (30 bytes)
+status:
+  description: The HTTP status from the APIC
+  returned: failure or debug
+  type: int
+  sample: 200
+url:
+  description: The HTTP url used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: https://10.11.12.13/api/mo/uni/tn-production.json
+'''
 
 from ansible.module_utils.network.aci.aci import ACIModule, aci_argument_spec
 from ansible.module_utils.basic import AnsibleModule

--- a/lib/ansible/modules/network/aci/aci_filter_entry.py
+++ b/lib/ansible/modules/network/aci/aci_filter_entry.py
@@ -143,6 +143,11 @@ error:
         "code": "122",
         "text": "unknown managed object class foo"
     }
+raw:
+  description: The raw output returned by the APIC REST API (xml or json)
+  returned: parse error
+  type: string
+  sample: '<?xml version="1.0" encoding="UTF-8"?><imdata totalCount="1"><error code="122" text="unknown managed object class foo"/></imdata>'
 sent:
   description: The actual/minimal configuration pushed to the APIC
   returned: info

--- a/lib/ansible/modules/network/aci/aci_firmware_source.py
+++ b/lib/ansible/modules/network/aci/aci_firmware_source.py
@@ -60,7 +60,103 @@ EXAMPLES = r'''
 '''
 
 RETURN = r'''
-#
+current:
+  description: The existing configuration from the APIC after the module has finished
+  returned: success
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production environment",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+error:
+  description: The error information as returned from the APIC
+  returned: failure
+  type: dict
+  sample:
+    {
+        "code": "122",
+        "text": "unknown managed object class foo"
+    }
+sent:
+  description: The actual/minimal configuration pushed to the APIC
+  returned: info
+  type: list
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment"
+            }
+        }
+    }
+previous: The original configuration from the APIC before the module has started
+  description:
+  returned: info
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+proposed:
+  description: The assembled configuration from the user-provided parameters
+  returned: info
+  type: dict
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment",
+                "name": "production"
+            }
+        }
+    }
+filter_string:
+  description: The filter string used for the request
+  returned: failure or debug
+  type: string
+  sample: ?rsp-prop-include=config-only
+method:
+  description: The HTTP method used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: POST
+response
+  description: The HTTP response from the APIC
+  returned: failure or debug
+  type: string
+  sample: OK (30 bytes)
+status:
+  description: The HTTP status from the APIC
+  returned: failure or debug
+  type: int
+  sample: 200
+url:
+  description: The HTTP url used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: https://10.11.12.13/api/mo/uni/tn-production.json
 '''
 
 

--- a/lib/ansible/modules/network/aci/aci_firmware_source.py
+++ b/lib/ansible/modules/network/aci/aci_firmware_source.py
@@ -131,7 +131,7 @@ def main():
     elif state == 'absent':
         aci.delete_config()
 
-    module.exit_json(**aci.result)
+    aci.exit_json()
 
 
 if __name__ == "__main__":

--- a/lib/ansible/modules/network/aci/aci_firmware_source.py
+++ b/lib/ansible/modules/network/aci/aci_firmware_source.py
@@ -88,6 +88,11 @@ error:
         "code": "122",
         "text": "unknown managed object class foo"
     }
+raw:
+  description: The raw output returned by the APIC REST API (xml or json)
+  returned: parse error
+  type: string
+  sample: '<?xml version="1.0" encoding="UTF-8"?><imdata totalCount="1"><error code="122" text="unknown managed object class foo"/></imdata>'
 sent:
   description: The actual/minimal configuration pushed to the APIC
   returned: info

--- a/lib/ansible/modules/network/aci/aci_firmware_source.py
+++ b/lib/ansible/modules/network/aci/aci_firmware_source.py
@@ -105,8 +105,8 @@ sent:
             }
         }
     }
-previous: The original configuration from the APIC before the module has started
-  description:
+previous:
+  description: The original configuration from the APIC before the module has started
   returned: info
   type: list
   sample:
@@ -147,7 +147,7 @@ method:
   returned: failure or debug
   type: string
   sample: POST
-response
+response:
   description: The HTTP response from the APIC
   returned: failure or debug
   type: string

--- a/lib/ansible/modules/network/aci/aci_interface_policy_fc.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_fc.py
@@ -102,8 +102,8 @@ sent:
             }
         }
     }
-previous: The original configuration from the APIC before the module has started
-  description:
+previous:
+  description: The original configuration from the APIC before the module has started
   returned: info
   type: list
   sample:
@@ -144,7 +144,7 @@ method:
   returned: failure or debug
   type: string
   sample: POST
-response
+response:
   description: The HTTP response from the APIC
   returned: failure or debug
   type: string

--- a/lib/ansible/modules/network/aci/aci_interface_policy_fc.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_fc.py
@@ -57,7 +57,103 @@ EXAMPLES = r'''
 '''
 
 RETURN = r'''
-#
+current:
+  description: The existing configuration from the APIC after the module has finished
+  returned: success
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production environment",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+error:
+  description: The error information as returned from the APIC
+  returned: failure
+  type: dict
+  sample:
+    {
+        "code": "122",
+        "text": "unknown managed object class foo"
+    }
+sent:
+  description: The actual/minimal configuration pushed to the APIC
+  returned: info
+  type: list
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment"
+            }
+        }
+    }
+previous: The original configuration from the APIC before the module has started
+  description:
+  returned: info
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+proposed:
+  description: The assembled configuration from the user-provided parameters
+  returned: info
+  type: dict
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment",
+                "name": "production"
+            }
+        }
+    }
+filter_string:
+  description: The filter string used for the request
+  returned: failure or debug
+  type: string
+  sample: ?rsp-prop-include=config-only
+method:
+  description: The HTTP method used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: POST
+response
+  description: The HTTP response from the APIC
+  returned: failure or debug
+  type: string
+  sample: OK (30 bytes)
+status:
+  description: The HTTP status from the APIC
+  returned: failure or debug
+  type: int
+  sample: 200
+url:
+  description: The HTTP url used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: https://10.11.12.13/api/mo/uni/tn-production.json
 '''
 
 from ansible.module_utils.network.aci.aci import ACIModule, aci_argument_spec

--- a/lib/ansible/modules/network/aci/aci_interface_policy_fc.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_fc.py
@@ -85,6 +85,11 @@ error:
         "code": "122",
         "text": "unknown managed object class foo"
     }
+raw:
+  description: The raw output returned by the APIC REST API (xml or json)
+  returned: parse error
+  type: string
+  sample: '<?xml version="1.0" encoding="UTF-8"?><imdata totalCount="1"><error code="122" text="unknown managed object class foo"/></imdata>'
 sent:
   description: The actual/minimal configuration pushed to the APIC
   returned: info

--- a/lib/ansible/modules/network/aci/aci_interface_policy_fc.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_fc.py
@@ -121,7 +121,7 @@ def main():
     elif state == 'absent':
         aci.delete_config()
 
-    module.exit_json(**aci.result)
+    aci.exit_json()
 
 
 if __name__ == "__main__":

--- a/lib/ansible/modules/network/aci/aci_interface_policy_l2.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_l2.py
@@ -140,7 +140,7 @@ def main():
     elif state == 'absent':
         aci.delete_config()
 
-    module.exit_json(**aci.result)
+    aci.exit_json()
 
 
 if __name__ == "__main__":

--- a/lib/ansible/modules/network/aci/aci_interface_policy_l2.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_l2.py
@@ -111,8 +111,8 @@ sent:
             }
         }
     }
-previous: The original configuration from the APIC before the module has started
-  description:
+previous:
+  description: The original configuration from the APIC before the module has started
   returned: info
   type: list
   sample:
@@ -153,7 +153,7 @@ method:
   returned: failure or debug
   type: string
   sample: POST
-response
+response:
   description: The HTTP response from the APIC
   returned: failure or debug
   type: string

--- a/lib/ansible/modules/network/aci/aci_interface_policy_l2.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_l2.py
@@ -94,6 +94,11 @@ error:
         "code": "122",
         "text": "unknown managed object class foo"
     }
+raw:
+  description: The raw output returned by the APIC REST API (xml or json)
+  returned: parse error
+  type: string
+  sample: '<?xml version="1.0" encoding="UTF-8"?><imdata totalCount="1"><error code="122" text="unknown managed object class foo"/></imdata>'
 sent:
   description: The actual/minimal configuration pushed to the APIC
   returned: info

--- a/lib/ansible/modules/network/aci/aci_interface_policy_l2.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_l2.py
@@ -66,7 +66,103 @@ EXAMPLES = r'''
 '''
 
 RETURN = r'''
-#
+current:
+  description: The existing configuration from the APIC after the module has finished
+  returned: success
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production environment",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+error:
+  description: The error information as returned from the APIC
+  returned: failure
+  type: dict
+  sample:
+    {
+        "code": "122",
+        "text": "unknown managed object class foo"
+    }
+sent:
+  description: The actual/minimal configuration pushed to the APIC
+  returned: info
+  type: list
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment"
+            }
+        }
+    }
+previous: The original configuration from the APIC before the module has started
+  description:
+  returned: info
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+proposed:
+  description: The assembled configuration from the user-provided parameters
+  returned: info
+  type: dict
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment",
+                "name": "production"
+            }
+        }
+    }
+filter_string:
+  description: The filter string used for the request
+  returned: failure or debug
+  type: string
+  sample: ?rsp-prop-include=config-only
+method:
+  description: The HTTP method used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: POST
+response
+  description: The HTTP response from the APIC
+  returned: failure or debug
+  type: string
+  sample: OK (30 bytes)
+status:
+  description: The HTTP status from the APIC
+  returned: failure or debug
+  type: int
+  sample: 200
+url:
+  description: The HTTP url used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: https://10.11.12.13/api/mo/uni/tn-production.json
 '''
 
 from ansible.module_utils.network.aci.aci import ACIModule, aci_argument_spec

--- a/lib/ansible/modules/network/aci/aci_interface_policy_leaf_policy_group.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_leaf_policy_group.py
@@ -185,6 +185,11 @@ error:
         "code": "122",
         "text": "unknown managed object class foo"
     }
+raw:
+  description: The raw output returned by the APIC REST API (xml or json)
+  returned: parse error
+  type: string
+  sample: '<?xml version="1.0" encoding="UTF-8"?><imdata totalCount="1"><error code="122" text="unknown managed object class foo"/></imdata>'
 sent:
   description: The actual/minimal configuration pushed to the APIC
   returned: info

--- a/lib/ansible/modules/network/aci/aci_interface_policy_leaf_policy_group.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_leaf_policy_group.py
@@ -389,7 +389,7 @@ def main():
     elif state == 'absent':
         aci.delete_config()
 
-    module.exit_json(**aci.result)
+    aci.exit_json()
 
 
 if __name__ == "__main__":

--- a/lib/ansible/modules/network/aci/aci_interface_policy_leaf_policy_group.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_leaf_policy_group.py
@@ -156,7 +156,105 @@ EXAMPLES = r'''
     state: absent
 '''
 
-RETURN = ''' # '''
+RETURN = '''
+current:
+  description: The existing configuration from the APIC after the module has finished
+  returned: success
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production environment",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+error:
+  description: The error information as returned from the APIC
+  returned: failure
+  type: dict
+  sample:
+    {
+        "code": "122",
+        "text": "unknown managed object class foo"
+    }
+sent:
+  description: The actual/minimal configuration pushed to the APIC
+  returned: info
+  type: list
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment"
+            }
+        }
+    }
+previous: The original configuration from the APIC before the module has started
+  description:
+  returned: info
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+proposed:
+  description: The assembled configuration from the user-provided parameters
+  returned: info
+  type: dict
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment",
+                "name": "production"
+            }
+        }
+    }
+filter_string:
+  description: The filter string used for the request
+  returned: failure or debug
+  type: string
+  sample: ?rsp-prop-include=config-only
+method:
+  description: The HTTP method used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: POST
+response
+  description: The HTTP response from the APIC
+  returned: failure or debug
+  type: string
+  sample: OK (30 bytes)
+status:
+  description: The HTTP status from the APIC
+  returned: failure or debug
+  type: int
+  sample: 200
+url:
+  description: The HTTP url used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: https://10.11.12.13/api/mo/uni/tn-production.json
+'''
 
 from ansible.module_utils.network.aci.aci import ACIModule, aci_argument_spec
 from ansible.module_utils.basic import AnsibleModule

--- a/lib/ansible/modules/network/aci/aci_interface_policy_leaf_policy_group.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_leaf_policy_group.py
@@ -202,8 +202,8 @@ sent:
             }
         }
     }
-previous: The original configuration from the APIC before the module has started
-  description:
+previous:
+  description: The original configuration from the APIC before the module has started
   returned: info
   type: list
   sample:
@@ -244,7 +244,7 @@ method:
   returned: failure or debug
   type: string
   sample: POST
-response
+response:
   description: The HTTP response from the APIC
   returned: failure or debug
   type: string

--- a/lib/ansible/modules/network/aci/aci_interface_policy_leaf_profile.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_leaf_profile.py
@@ -104,6 +104,11 @@ error:
         "code": "122",
         "text": "unknown managed object class foo"
     }
+raw:
+  description: The raw output returned by the APIC REST API (xml or json)
+  returned: parse error
+  type: string
+  sample: '<?xml version="1.0" encoding="UTF-8"?><imdata totalCount="1"><error code="122" text="unknown managed object class foo"/></imdata>'
 sent:
   description: The actual/minimal configuration pushed to the APIC
   returned: info

--- a/lib/ansible/modules/network/aci/aci_interface_policy_leaf_profile.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_leaf_profile.py
@@ -134,7 +134,7 @@ def main():
     elif state == 'absent':
         aci.delete_config()
 
-    module.exit_json(**aci.result)
+    aci.exit_json()
 
 
 if __name__ == "__main__":

--- a/lib/ansible/modules/network/aci/aci_interface_policy_leaf_profile.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_leaf_profile.py
@@ -76,7 +76,103 @@ EXAMPLES = r'''
 '''
 
 RETURN = r'''
-#
+current:
+  description: The existing configuration from the APIC after the module has finished
+  returned: success
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production environment",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+error:
+  description: The error information as returned from the APIC
+  returned: failure
+  type: dict
+  sample:
+    {
+        "code": "122",
+        "text": "unknown managed object class foo"
+    }
+sent:
+  description: The actual/minimal configuration pushed to the APIC
+  returned: info
+  type: list
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment"
+            }
+        }
+    }
+previous: The original configuration from the APIC before the module has started
+  description:
+  returned: info
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+proposed:
+  description: The assembled configuration from the user-provided parameters
+  returned: info
+  type: dict
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment",
+                "name": "production"
+            }
+        }
+    }
+filter_string:
+  description: The filter string used for the request
+  returned: failure or debug
+  type: string
+  sample: ?rsp-prop-include=config-only
+method:
+  description: The HTTP method used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: POST
+response
+  description: The HTTP response from the APIC
+  returned: failure or debug
+  type: string
+  sample: OK (30 bytes)
+status:
+  description: The HTTP status from the APIC
+  returned: failure or debug
+  type: int
+  sample: 200
+url:
+  description: The HTTP url used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: https://10.11.12.13/api/mo/uni/tn-production.json
 '''
 
 from ansible.module_utils.network.aci.aci import ACIModule, aci_argument_spec

--- a/lib/ansible/modules/network/aci/aci_interface_policy_leaf_profile.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_leaf_profile.py
@@ -121,8 +121,8 @@ sent:
             }
         }
     }
-previous: The original configuration from the APIC before the module has started
-  description:
+previous:
+  description: The original configuration from the APIC before the module has started
   returned: info
   type: list
   sample:
@@ -163,7 +163,7 @@ method:
   returned: failure or debug
   type: string
   sample: POST
-response
+response:
   description: The HTTP response from the APIC
   returned: failure or debug
   type: string

--- a/lib/ansible/modules/network/aci/aci_interface_policy_lldp.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_lldp.py
@@ -65,7 +65,103 @@ EXAMPLES = r'''
 '''
 
 RETURN = r'''
-#
+current:
+  description: The existing configuration from the APIC after the module has finished
+  returned: success
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production environment",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+error:
+  description: The error information as returned from the APIC
+  returned: failure
+  type: dict
+  sample:
+    {
+        "code": "122",
+        "text": "unknown managed object class foo"
+    }
+sent:
+  description: The actual/minimal configuration pushed to the APIC
+  returned: info
+  type: list
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment"
+            }
+        }
+    }
+previous: The original configuration from the APIC before the module has started
+  description:
+  returned: info
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+proposed:
+  description: The assembled configuration from the user-provided parameters
+  returned: info
+  type: dict
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment",
+                "name": "production"
+            }
+        }
+    }
+filter_string:
+  description: The filter string used for the request
+  returned: failure or debug
+  type: string
+  sample: ?rsp-prop-include=config-only
+method:
+  description: The HTTP method used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: POST
+response
+  description: The HTTP response from the APIC
+  returned: failure or debug
+  type: string
+  sample: OK (30 bytes)
+status:
+  description: The HTTP status from the APIC
+  returned: failure or debug
+  type: int
+  sample: 200
+url:
+  description: The HTTP url used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: https://10.11.12.13/api/mo/uni/tn-production.json
 '''
 
 from ansible.module_utils.network.aci.aci import ACIModule, aci_argument_spec

--- a/lib/ansible/modules/network/aci/aci_interface_policy_lldp.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_lldp.py
@@ -132,7 +132,7 @@ def main():
     elif state == 'absent':
         aci.delete_config()
 
-    module.exit_json(**aci.result)
+    aci.exit_json()
 
 
 if __name__ == "__main__":

--- a/lib/ansible/modules/network/aci/aci_interface_policy_lldp.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_lldp.py
@@ -93,6 +93,11 @@ error:
         "code": "122",
         "text": "unknown managed object class foo"
     }
+raw:
+  description: The raw output returned by the APIC REST API (xml or json)
+  returned: parse error
+  type: string
+  sample: '<?xml version="1.0" encoding="UTF-8"?><imdata totalCount="1"><error code="122" text="unknown managed object class foo"/></imdata>'
 sent:
   description: The actual/minimal configuration pushed to the APIC
   returned: info

--- a/lib/ansible/modules/network/aci/aci_interface_policy_lldp.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_lldp.py
@@ -110,8 +110,8 @@ sent:
             }
         }
     }
-previous: The original configuration from the APIC before the module has started
-  description:
+previous:
+  description: The original configuration from the APIC before the module has started
   returned: info
   type: list
   sample:
@@ -152,7 +152,7 @@ method:
   returned: failure or debug
   type: string
   sample: POST
-response
+response:
   description: The HTTP response from the APIC
   returned: failure or debug
   type: string

--- a/lib/ansible/modules/network/aci/aci_interface_policy_mcp.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_mcp.py
@@ -102,8 +102,8 @@ sent:
             }
         }
     }
-previous: The original configuration from the APIC before the module has started
-  description:
+previous:
+  description: The original configuration from the APIC before the module has started
   returned: info
   type: list
   sample:
@@ -144,7 +144,7 @@ method:
   returned: failure or debug
   type: string
   sample: POST
-response
+response:
   description: The HTTP response from the APIC
   returned: failure or debug
   type: string

--- a/lib/ansible/modules/network/aci/aci_interface_policy_mcp.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_mcp.py
@@ -57,7 +57,103 @@ EXAMPLES = r'''
 '''
 
 RETURN = r'''
-#
+current:
+  description: The existing configuration from the APIC after the module has finished
+  returned: success
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production environment",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+error:
+  description: The error information as returned from the APIC
+  returned: failure
+  type: dict
+  sample:
+    {
+        "code": "122",
+        "text": "unknown managed object class foo"
+    }
+sent:
+  description: The actual/minimal configuration pushed to the APIC
+  returned: info
+  type: list
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment"
+            }
+        }
+    }
+previous: The original configuration from the APIC before the module has started
+  description:
+  returned: info
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+proposed:
+  description: The assembled configuration from the user-provided parameters
+  returned: info
+  type: dict
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment",
+                "name": "production"
+            }
+        }
+    }
+filter_string:
+  description: The filter string used for the request
+  returned: failure or debug
+  type: string
+  sample: ?rsp-prop-include=config-only
+method:
+  description: The HTTP method used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: POST
+response
+  description: The HTTP response from the APIC
+  returned: failure or debug
+  type: string
+  sample: OK (30 bytes)
+status:
+  description: The HTTP status from the APIC
+  returned: failure or debug
+  type: int
+  sample: 200
+url:
+  description: The HTTP url used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: https://10.11.12.13/api/mo/uni/tn-production.json
 '''
 
 from ansible.module_utils.network.aci.aci import ACIModule, aci_argument_spec

--- a/lib/ansible/modules/network/aci/aci_interface_policy_mcp.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_mcp.py
@@ -85,6 +85,11 @@ error:
         "code": "122",
         "text": "unknown managed object class foo"
     }
+raw:
+  description: The raw output returned by the APIC REST API (xml or json)
+  returned: parse error
+  type: string
+  sample: '<?xml version="1.0" encoding="UTF-8"?><imdata totalCount="1"><error code="122" text="unknown managed object class foo"/></imdata>'
 sent:
   description: The actual/minimal configuration pushed to the APIC
   returned: info

--- a/lib/ansible/modules/network/aci/aci_interface_policy_mcp.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_mcp.py
@@ -121,7 +121,7 @@ def main():
     elif state == 'absent':
         aci.delete_config()
 
-    module.exit_json(**aci.result)
+    aci.exit_json()
 
 
 if __name__ == "__main__":

--- a/lib/ansible/modules/network/aci/aci_interface_policy_port_channel.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_port_channel.py
@@ -112,7 +112,103 @@ EXAMPLES = r'''
 '''
 
 RETURN = r'''
-#
+current:
+  description: The existing configuration from the APIC after the module has finished
+  returned: success
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production environment",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+error:
+  description: The error information as returned from the APIC
+  returned: failure
+  type: dict
+  sample:
+    {
+        "code": "122",
+        "text": "unknown managed object class foo"
+    }
+sent:
+  description: The actual/minimal configuration pushed to the APIC
+  returned: info
+  type: list
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment"
+            }
+        }
+    }
+previous: The original configuration from the APIC before the module has started
+  description:
+  returned: info
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+proposed:
+  description: The assembled configuration from the user-provided parameters
+  returned: info
+  type: dict
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment",
+                "name": "production"
+            }
+        }
+    }
+filter_string:
+  description: The filter string used for the request
+  returned: failure or debug
+  type: string
+  sample: ?rsp-prop-include=config-only
+method:
+  description: The HTTP method used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: POST
+response
+  description: The HTTP response from the APIC
+  returned: failure or debug
+  type: string
+  sample: OK (30 bytes)
+status:
+  description: The HTTP status from the APIC
+  returned: failure or debug
+  type: int
+  sample: 200
+url:
+  description: The HTTP url used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: https://10.11.12.13/api/mo/uni/tn-production.json
 '''
 
 from ansible.module_utils.network.aci.aci import ACIModule, aci_argument_spec

--- a/lib/ansible/modules/network/aci/aci_interface_policy_port_channel.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_port_channel.py
@@ -140,6 +140,11 @@ error:
         "code": "122",
         "text": "unknown managed object class foo"
     }
+raw:
+  description: The raw output returned by the APIC REST API (xml or json)
+  returned: parse error
+  type: string
+  sample: '<?xml version="1.0" encoding="UTF-8"?><imdata totalCount="1"><error code="122" text="unknown managed object class foo"/></imdata>'
 sent:
   description: The actual/minimal configuration pushed to the APIC
   returned: info

--- a/lib/ansible/modules/network/aci/aci_interface_policy_port_channel.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_port_channel.py
@@ -157,8 +157,8 @@ sent:
             }
         }
     }
-previous: The original configuration from the APIC before the module has started
-  description:
+previous:
+  description: The original configuration from the APIC before the module has started
   returned: info
   type: list
   sample:
@@ -199,7 +199,7 @@ method:
   returned: failure or debug
   type: string
   sample: POST
-response
+response:
   description: The HTTP response from the APIC
   returned: failure or debug
   type: string

--- a/lib/ansible/modules/network/aci/aci_interface_policy_port_channel.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_port_channel.py
@@ -209,7 +209,7 @@ def main():
     elif state == 'absent':
         aci.delete_config()
 
-    module.exit_json(**aci.result)
+    aci.exit_json()
 
 
 if __name__ == "__main__":

--- a/lib/ansible/modules/network/aci/aci_interface_policy_port_security.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_port_security.py
@@ -56,7 +56,103 @@ EXAMPLES = r'''
 '''
 
 RETURN = r'''
-#
+current:
+  description: The existing configuration from the APIC after the module has finished
+  returned: success
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production environment",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+error:
+  description: The error information as returned from the APIC
+  returned: failure
+  type: dict
+  sample:
+    {
+        "code": "122",
+        "text": "unknown managed object class foo"
+    }
+sent:
+  description: The actual/minimal configuration pushed to the APIC
+  returned: info
+  type: list
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment"
+            }
+        }
+    }
+previous: The original configuration from the APIC before the module has started
+  description:
+  returned: info
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+proposed:
+  description: The assembled configuration from the user-provided parameters
+  returned: info
+  type: dict
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment",
+                "name": "production"
+            }
+        }
+    }
+filter_string:
+  description: The filter string used for the request
+  returned: failure or debug
+  type: string
+  sample: ?rsp-prop-include=config-only
+method:
+  description: The HTTP method used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: POST
+response
+  description: The HTTP response from the APIC
+  returned: failure or debug
+  type: string
+  sample: OK (30 bytes)
+status:
+  description: The HTTP status from the APIC
+  returned: failure or debug
+  type: int
+  sample: 200
+url:
+  description: The HTTP url used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: https://10.11.12.13/api/mo/uni/tn-production.json
 '''
 
 from ansible.module_utils.network.aci.aci import ACIModule, aci_argument_spec

--- a/lib/ansible/modules/network/aci/aci_interface_policy_port_security.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_port_security.py
@@ -122,7 +122,7 @@ def main():
     elif state == 'absent':
         aci.delete_config()
 
-    module.exit_json(**aci.result)
+    aci.exit_json()
 
 
 if __name__ == "__main__":

--- a/lib/ansible/modules/network/aci/aci_interface_policy_port_security.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_port_security.py
@@ -84,6 +84,11 @@ error:
         "code": "122",
         "text": "unknown managed object class foo"
     }
+raw:
+  description: The raw output returned by the APIC REST API (xml or json)
+  returned: parse error
+  type: string
+  sample: '<?xml version="1.0" encoding="UTF-8"?><imdata totalCount="1"><error code="122" text="unknown managed object class foo"/></imdata>'
 sent:
   description: The actual/minimal configuration pushed to the APIC
   returned: info

--- a/lib/ansible/modules/network/aci/aci_interface_policy_port_security.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_port_security.py
@@ -101,8 +101,8 @@ sent:
             }
         }
     }
-previous: The original configuration from the APIC before the module has started
-  description:
+previous:
+  description: The original configuration from the APIC before the module has started
   returned: info
   type: list
   sample:
@@ -143,7 +143,7 @@ method:
   returned: failure or debug
   type: string
   sample: POST
-response
+response:
   description: The HTTP response from the APIC
   returned: failure or debug
   type: string

--- a/lib/ansible/modules/network/aci/aci_interface_selector_to_switch_policy_leaf_profile.py
+++ b/lib/ansible/modules/network/aci/aci_interface_selector_to_switch_policy_leaf_profile.py
@@ -138,7 +138,7 @@ def main():
     elif state == 'absent':
         aci.delete_config()
 
-    module.exit_json(**aci.result)
+    aci.exit_json()
 
 
 if __name__ == "__main__":

--- a/lib/ansible/modules/network/aci/aci_interface_selector_to_switch_policy_leaf_profile.py
+++ b/lib/ansible/modules/network/aci/aci_interface_selector_to_switch_policy_leaf_profile.py
@@ -73,7 +73,105 @@ EXAMPLES = r'''
     state: query
 '''
 
-RETURN = ''' # '''
+RETURN = r'''
+current:
+  description: The existing configuration from the APIC after the module has finished
+  returned: success
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production environment",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+error:
+  description: The error information as returned from the APIC
+  returned: failure
+  type: dict
+  sample:
+    {
+        "code": "122",
+        "text": "unknown managed object class foo"
+    }
+sent:
+  description: The actual/minimal configuration pushed to the APIC
+  returned: info
+  type: list
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment"
+            }
+        }
+    }
+previous: The original configuration from the APIC before the module has started
+  description:
+  returned: info
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+proposed:
+  description: The assembled configuration from the user-provided parameters
+  returned: info
+  type: dict
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment",
+                "name": "production"
+            }
+        }
+    }
+filter_string:
+  description: The filter string used for the request
+  returned: failure or debug
+  type: string
+  sample: ?rsp-prop-include=config-only
+method:
+  description: The HTTP method used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: POST
+response
+  description: The HTTP response from the APIC
+  returned: failure or debug
+  type: string
+  sample: OK (30 bytes)
+status:
+  description: The HTTP status from the APIC
+  returned: failure or debug
+  type: int
+  sample: 200
+url:
+  description: The HTTP url used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: https://10.11.12.13/api/mo/uni/tn-production.json
+'''
 
 from ansible.module_utils.network.aci.aci import ACIModule, aci_argument_spec
 from ansible.module_utils.basic import AnsibleModule

--- a/lib/ansible/modules/network/aci/aci_interface_selector_to_switch_policy_leaf_profile.py
+++ b/lib/ansible/modules/network/aci/aci_interface_selector_to_switch_policy_leaf_profile.py
@@ -102,6 +102,11 @@ error:
         "code": "122",
         "text": "unknown managed object class foo"
     }
+raw:
+  description: The raw output returned by the APIC REST API (xml or json)
+  returned: parse error
+  type: string
+  sample: '<?xml version="1.0" encoding="UTF-8"?><imdata totalCount="1"><error code="122" text="unknown managed object class foo"/></imdata>'
 sent:
   description: The actual/minimal configuration pushed to the APIC
   returned: info

--- a/lib/ansible/modules/network/aci/aci_interface_selector_to_switch_policy_leaf_profile.py
+++ b/lib/ansible/modules/network/aci/aci_interface_selector_to_switch_policy_leaf_profile.py
@@ -119,8 +119,8 @@ sent:
             }
         }
     }
-previous: The original configuration from the APIC before the module has started
-  description:
+previous:
+  description: The original configuration from the APIC before the module has started
   returned: info
   type: list
   sample:
@@ -161,7 +161,7 @@ method:
   returned: failure or debug
   type: string
   sample: POST
-response
+response:
   description: The HTTP response from the APIC
   returned: failure or debug
   type: string

--- a/lib/ansible/modules/network/aci/aci_l3out_route_tag_policy.py
+++ b/lib/ansible/modules/network/aci/aci_l3out_route_tag_policy.py
@@ -65,7 +65,103 @@ EXAMPLES = r'''
 '''
 
 RETURN = r'''
-#
+current:
+  description: The existing configuration from the APIC after the module has finished
+  returned: success
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production environment",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+error:
+  description: The error information as returned from the APIC
+  returned: failure
+  type: dict
+  sample:
+    {
+        "code": "122",
+        "text": "unknown managed object class foo"
+    }
+sent:
+  description: The actual/minimal configuration pushed to the APIC
+  returned: info
+  type: list
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment"
+            }
+        }
+    }
+previous: The original configuration from the APIC before the module has started
+  description:
+  returned: info
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+proposed:
+  description: The assembled configuration from the user-provided parameters
+  returned: info
+  type: dict
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment",
+                "name": "production"
+            }
+        }
+    }
+filter_string:
+  description: The filter string used for the request
+  returned: failure or debug
+  type: string
+  sample: ?rsp-prop-include=config-only
+method:
+  description: The HTTP method used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: POST
+response
+  description: The HTTP response from the APIC
+  returned: failure or debug
+  type: string
+  sample: OK (30 bytes)
+status:
+  description: The HTTP status from the APIC
+  returned: failure or debug
+  type: int
+  sample: 200
+url:
+  description: The HTTP url used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: https://10.11.12.13/api/mo/uni/tn-production.json
 '''
 
 from ansible.module_utils.network.aci.aci import ACIModule, aci_argument_spec

--- a/lib/ansible/modules/network/aci/aci_l3out_route_tag_policy.py
+++ b/lib/ansible/modules/network/aci/aci_l3out_route_tag_policy.py
@@ -93,6 +93,11 @@ error:
         "code": "122",
         "text": "unknown managed object class foo"
     }
+raw:
+  description: The raw output returned by the APIC REST API (xml or json)
+  returned: parse error
+  type: string
+  sample: '<?xml version="1.0" encoding="UTF-8"?><imdata totalCount="1"><error code="122" text="unknown managed object class foo"/></imdata>'
 sent:
   description: The actual/minimal configuration pushed to the APIC
   returned: info

--- a/lib/ansible/modules/network/aci/aci_l3out_route_tag_policy.py
+++ b/lib/ansible/modules/network/aci/aci_l3out_route_tag_policy.py
@@ -136,7 +136,7 @@ def main():
     elif state == 'absent':
         aci.delete_config()
 
-    module.exit_json(**aci.result)
+    aci.exit_json()
 
 
 if __name__ == "__main__":

--- a/lib/ansible/modules/network/aci/aci_l3out_route_tag_policy.py
+++ b/lib/ansible/modules/network/aci/aci_l3out_route_tag_policy.py
@@ -110,8 +110,8 @@ sent:
             }
         }
     }
-previous: The original configuration from the APIC before the module has started
-  description:
+previous:
+  description: The original configuration from the APIC before the module has started
   returned: info
   type: list
   sample:
@@ -152,7 +152,7 @@ method:
   returned: failure or debug
   type: string
   sample: POST
-response
+response:
   description: The HTTP response from the APIC
   returned: failure or debug
   type: string

--- a/lib/ansible/modules/network/aci/aci_rest.py
+++ b/lib/ansible/modules/network/aci/aci_rest.py
@@ -388,7 +388,7 @@ def main():
                            use_proxy=aci.params['use_proxy'])
 
     aci.result['method'] = aci.params['method'].upper()
-    #aci.result['path'] = aci.path
+    # aci.result['path'] = aci.path  # Adding 'path' in result causes state: absent in output
     aci.result['response'] = info['msg']
     aci.result['status'] = info['status']
     aci.result['url'] = aci.url

--- a/lib/ansible/modules/network/aci/aci_rest.py
+++ b/lib/ansible/modules/network/aci/aci_rest.py
@@ -370,25 +370,28 @@ def main():
                 module.fail_json(msg='Failed to parse provided XML payload: %s' % to_text(e), payload=payload)
 
     # Perform actual request using auth cookie (Same as aci_request, but also supports XML)
-    aci.result['url'] = '%(protocol)s://%(host)s/' % aci.params + path.lstrip('/')
+    aci.url = '%(protocol)s://%(host)s/' % aci.params + path.lstrip('/')
     if aci.params['method'] != 'get':
         path += '?rsp-subtree=modified'
-        aci.result['url'] = update_qsl(aci.result['url'], {'rsp-subtree': 'modified'})
+        aci.url = update_qsl(aci.url, {'rsp-subtree': 'modified'})
 
     # Sign and encode request as to APIC's wishes
     if aci.params['private_key'] is not None:
         aci.cert_auth(path=path, payload=payload)
 
     # Perform request
-    resp, info = fetch_url(module, aci.result['url'],
+    resp, info = fetch_url(module, aci.url,
                            data=payload,
                            headers=aci.headers,
                            method=aci.params['method'].upper(),
                            timeout=aci.params['timeout'],
                            use_proxy=aci.params['use_proxy'])
 
+    aci.result['method'] = aci.params['method'].upper()
+    #aci.result['path'] = aci.path
     aci.result['response'] = info['msg']
     aci.result['status'] = info['status']
+    aci.result['url'] = aci.url
 
     # Report failure
     if info['status'] != 200:

--- a/lib/ansible/modules/network/aci/aci_rest.py
+++ b/lib/ansible/modules/network/aci/aci_rest.py
@@ -388,22 +388,23 @@ def main():
                            timeout=aci.params['timeout'],
                            use_proxy=aci.params['use_proxy'])
 
-    aci.result['filter_string'] = aci.filter_string
-    aci.result['method'] = aci.params['method'].upper()
-    # aci.result['path'] = aci.path  # Adding 'path' in result causes state: absent in output
-    aci.result['response'] = info['msg']
-    aci.result['status'] = info['status']
-    aci.result['url'] = aci.url
+    if aci.params['output_level'] == 'debug':
+        aci.result['filter_string'] = aci.filter_string
+        aci.result['method'] = aci.params['method'].upper()
+        # aci.result['path'] = aci.path  # Adding 'path' in result causes state: absent in output
+        aci.result['response'] = info['msg']
+        aci.result['status'] = info['status']
+        aci.result['url'] = aci.url
 
     # Report failure
     if info['status'] != 200:
         try:
             # APIC error
             aci.response(info['body'], rest_type)
-            module.fail_json(msg='Request failed: %(error_code)s %(error_text)s' % aci.result, **aci.result)
+            aci.fail_json(msg='Request failed: %(code)s %(text)s' % aci.error)
         except KeyError:
             # Connection error
-            module.fail_json(msg='Request failed for %(url)s. %(msg)s' % info, **aci.result)
+            aci.fail_json(msg='Request connection failed for %(url)s. %(msg)s' % info)
 
     aci.response_any(resp.read(), rest_type)
 

--- a/lib/ansible/modules/network/aci/aci_switch_leaf_selector.py
+++ b/lib/ansible/modules/network/aci/aci_switch_leaf_selector.py
@@ -139,6 +139,11 @@ error:
         "code": "122",
         "text": "unknown managed object class foo"
     }
+raw:
+  description: The raw output returned by the APIC REST API (xml or json)
+  returned: parse error
+  type: string
+  sample: '<?xml version="1.0" encoding="UTF-8"?><imdata totalCount="1"><error code="122" text="unknown managed object class foo"/></imdata>'
 sent:
   description: The actual/minimal configuration pushed to the APIC
   returned: info

--- a/lib/ansible/modules/network/aci/aci_switch_leaf_selector.py
+++ b/lib/ansible/modules/network/aci/aci_switch_leaf_selector.py
@@ -156,8 +156,8 @@ sent:
             }
         }
     }
-previous: The original configuration from the APIC before the module has started
-  description:
+previous:
+  description: The original configuration from the APIC before the module has started
   returned: info
   type: list
   sample:
@@ -198,7 +198,7 @@ method:
   returned: failure or debug
   type: string
   sample: POST
-response
+response:
   description: The HTTP response from the APIC
   returned: failure or debug
   type: string

--- a/lib/ansible/modules/network/aci/aci_switch_leaf_selector.py
+++ b/lib/ansible/modules/network/aci/aci_switch_leaf_selector.py
@@ -209,7 +209,7 @@ def main():
     elif state == 'absent':
         aci.delete_config()
 
-    module.exit_json(**aci.result)
+    aci.exit_json()
 
 
 if __name__ == "__main__":

--- a/lib/ansible/modules/network/aci/aci_switch_leaf_selector.py
+++ b/lib/ansible/modules/network/aci/aci_switch_leaf_selector.py
@@ -110,7 +110,105 @@ EXAMPLES = r'''
     state: query
 '''
 
-RETURN = ''' # '''
+RETURN = r'''
+current:
+  description: The existing configuration from the APIC after the module has finished
+  returned: success
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production environment",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+error:
+  description: The error information as returned from the APIC
+  returned: failure
+  type: dict
+  sample:
+    {
+        "code": "122",
+        "text": "unknown managed object class foo"
+    }
+sent:
+  description: The actual/minimal configuration pushed to the APIC
+  returned: info
+  type: list
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment"
+            }
+        }
+    }
+previous: The original configuration from the APIC before the module has started
+  description:
+  returned: info
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+proposed:
+  description: The assembled configuration from the user-provided parameters
+  returned: info
+  type: dict
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment",
+                "name": "production"
+            }
+        }
+    }
+filter_string:
+  description: The filter string used for the request
+  returned: failure or debug
+  type: string
+  sample: ?rsp-prop-include=config-only
+method:
+  description: The HTTP method used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: POST
+response
+  description: The HTTP response from the APIC
+  returned: failure or debug
+  type: string
+  sample: OK (30 bytes)
+status:
+  description: The HTTP status from the APIC
+  returned: failure or debug
+  type: int
+  sample: 200
+url:
+  description: The HTTP url used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: https://10.11.12.13/api/mo/uni/tn-production.json
+'''
 
 from ansible.module_utils.network.aci.aci import ACIModule, aci_argument_spec
 from ansible.module_utils.basic import AnsibleModule

--- a/lib/ansible/modules/network/aci/aci_switch_policy_leaf_profile.py
+++ b/lib/ansible/modules/network/aci/aci_switch_policy_leaf_profile.py
@@ -113,8 +113,8 @@ sent:
             }
         }
     }
-previous: The original configuration from the APIC before the module has started
-  description:
+previous:
+  description: The original configuration from the APIC before the module has started
   returned: info
   type: list
   sample:
@@ -155,7 +155,7 @@ method:
   returned: failure or debug
   type: string
   sample: POST
-response
+response:
   description: The HTTP response from the APIC
   returned: failure or debug
   type: string

--- a/lib/ansible/modules/network/aci/aci_switch_policy_leaf_profile.py
+++ b/lib/ansible/modules/network/aci/aci_switch_policy_leaf_profile.py
@@ -96,6 +96,11 @@ error:
         "code": "122",
         "text": "unknown managed object class foo"
     }
+raw:
+  description: The raw output returned by the APIC REST API (xml or json)
+  returned: parse error
+  type: string
+  sample: '<?xml version="1.0" encoding="UTF-8"?><imdata totalCount="1"><error code="122" text="unknown managed object class foo"/></imdata>'
 sent:
   description: The actual/minimal configuration pushed to the APIC
   returned: info

--- a/lib/ansible/modules/network/aci/aci_switch_policy_leaf_profile.py
+++ b/lib/ansible/modules/network/aci/aci_switch_policy_leaf_profile.py
@@ -68,7 +68,103 @@ EXAMPLES = r'''
 '''
 
 RETURN = r'''
-#
+current:
+  description: The existing configuration from the APIC after the module has finished
+  returned: success
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production environment",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+error:
+  description: The error information as returned from the APIC
+  returned: failure
+  type: dict
+  sample:
+    {
+        "code": "122",
+        "text": "unknown managed object class foo"
+    }
+sent:
+  description: The actual/minimal configuration pushed to the APIC
+  returned: info
+  type: list
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment"
+            }
+        }
+    }
+previous: The original configuration from the APIC before the module has started
+  description:
+  returned: info
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+proposed:
+  description: The assembled configuration from the user-provided parameters
+  returned: info
+  type: dict
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment",
+                "name": "production"
+            }
+        }
+    }
+filter_string:
+  description: The filter string used for the request
+  returned: failure or debug
+  type: string
+  sample: ?rsp-prop-include=config-only
+method:
+  description: The HTTP method used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: POST
+response
+  description: The HTTP response from the APIC
+  returned: failure or debug
+  type: string
+  sample: OK (30 bytes)
+status:
+  description: The HTTP status from the APIC
+  returned: failure or debug
+  type: int
+  sample: 200
+url:
+  description: The HTTP url used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: https://10.11.12.13/api/mo/uni/tn-production.json
 '''
 
 from ansible.module_utils.network.aci.aci import ACIModule, aci_argument_spec

--- a/lib/ansible/modules/network/aci/aci_switch_policy_leaf_profile.py
+++ b/lib/ansible/modules/network/aci/aci_switch_policy_leaf_profile.py
@@ -127,7 +127,7 @@ def main():
     elif state == 'absent':
         aci.delete_config()
 
-    module.exit_json(**aci.result)
+    aci.exit_json()
 
 
 if __name__ == "__main__":

--- a/lib/ansible/modules/network/aci/aci_taboo_contract.py
+++ b/lib/ansible/modules/network/aci/aci_taboo_contract.py
@@ -111,8 +111,8 @@ sent:
             }
         }
     }
-previous: The original configuration from the APIC before the module has started
-  description:
+previous:
+  description: The original configuration from the APIC before the module has started
   returned: info
   type: list
   sample:
@@ -153,7 +153,7 @@ method:
   returned: failure or debug
   type: string
   sample: POST
-response
+response:
   description: The HTTP response from the APIC
   returned: failure or debug
   type: string

--- a/lib/ansible/modules/network/aci/aci_taboo_contract.py
+++ b/lib/ansible/modules/network/aci/aci_taboo_contract.py
@@ -94,6 +94,11 @@ error:
         "code": "122",
         "text": "unknown managed object class foo"
     }
+raw:
+  description: The raw output returned by the APIC REST API (xml or json)
+  returned: parse error
+  type: string
+  sample: '<?xml version="1.0" encoding="UTF-8"?><imdata totalCount="1"><error code="122" text="unknown managed object class foo"/></imdata>'
 sent:
   description: The actual/minimal configuration pushed to the APIC
   returned: info

--- a/lib/ansible/modules/network/aci/aci_taboo_contract.py
+++ b/lib/ansible/modules/network/aci/aci_taboo_contract.py
@@ -66,7 +66,103 @@ EXAMPLES = r'''
 '''
 
 RETURN = r'''
-#
+current:
+  description: The existing configuration from the APIC after the module has finished
+  returned: success
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production environment",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+error:
+  description: The error information as returned from the APIC
+  returned: failure
+  type: dict
+  sample:
+    {
+        "code": "122",
+        "text": "unknown managed object class foo"
+    }
+sent:
+  description: The actual/minimal configuration pushed to the APIC
+  returned: info
+  type: list
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment"
+            }
+        }
+    }
+previous: The original configuration from the APIC before the module has started
+  description:
+  returned: info
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+proposed:
+  description: The assembled configuration from the user-provided parameters
+  returned: info
+  type: dict
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment",
+                "name": "production"
+            }
+        }
+    }
+filter_string:
+  description: The filter string used for the request
+  returned: failure or debug
+  type: string
+  sample: ?rsp-prop-include=config-only
+method:
+  description: The HTTP method used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: POST
+response
+  description: The HTTP response from the APIC
+  returned: failure or debug
+  type: string
+  sample: OK (30 bytes)
+status:
+  description: The HTTP status from the APIC
+  returned: failure or debug
+  type: int
+  sample: 200
+url:
+  description: The HTTP url used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: https://10.11.12.13/api/mo/uni/tn-production.json
 '''
 
 from ansible.module_utils.network.aci.aci import ACIModule, aci_argument_spec

--- a/lib/ansible/modules/network/aci/aci_taboo_contract.py
+++ b/lib/ansible/modules/network/aci/aci_taboo_contract.py
@@ -137,7 +137,7 @@ def main():
     elif state == 'absent':
         aci.delete_config()
 
-    module.exit_json(**aci.result)
+    aci.exit_json()
 
 
 if __name__ == "__main__":

--- a/lib/ansible/modules/network/aci/aci_tenant.py
+++ b/lib/ansible/modules/network/aci/aci_tenant.py
@@ -103,6 +103,11 @@ error:
         "code": "122",
         "text": "unknown managed object class foo"
     }
+raw:
+  description: The raw output returned by the APIC REST API (xml or json)
+  returned: parse error
+  type: string
+  sample: '<?xml version="1.0" encoding="UTF-8"?><imdata totalCount="1"><error code="122" text="unknown managed object class foo"/></imdata>'
 sent:
   description: The actual/minimal configuration pushed to the APIC
   returned: info

--- a/lib/ansible/modules/network/aci/aci_tenant.py
+++ b/lib/ansible/modules/network/aci/aci_tenant.py
@@ -135,7 +135,7 @@ def main():
     elif state == 'absent':
         aci.delete_config()
 
-    module.exit_json(**aci.result)
+    aci.exit_json()
 
 
 if __name__ == "__main__":

--- a/lib/ansible/modules/network/aci/aci_tenant.py
+++ b/lib/ansible/modules/network/aci/aci_tenant.py
@@ -75,7 +75,103 @@ EXAMPLES = r'''
 '''
 
 RETURN = r'''
-#
+current:
+  description: The existing configuration from the APIC after the module has finished
+  returned: success
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production environment",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+error:
+  description: The error information as returned from the APIC
+  returned: failure
+  type: dict
+  sample:
+    {
+        "code": "122",
+        "text": "unknown managed object class foo"
+    }
+sent:
+  description: The actual/minimal configuration pushed to the APIC
+  returned: info
+  type: list
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment"
+            }
+        }
+    }
+previous: The original configuration from the APIC before the module has started
+  description:
+  returned: info
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+proposed:
+  description: The assembled configuration from the user-provided parameters
+  returned: info
+  type: dict
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment",
+                "name": "production"
+            }
+        }
+    }
+filter_string:
+  description: The filter string used for the request
+  returned: failure or debug
+  type: string
+  sample: ?rsp-prop-include=config-only
+method:
+  description: The HTTP method used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: POST
+response
+  description: The HTTP response from the APIC
+  returned: failure or debug
+  type: string
+  sample: OK (30 bytes)
+status:
+  description: The HTTP status from the APIC
+  returned: failure or debug
+  type: int
+  sample: 200
+url:
+  description: The HTTP url used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: https://10.11.12.13/api/mo/uni/tn-production.json
 '''
 
 from ansible.module_utils.network.aci.aci import ACIModule, aci_argument_spec

--- a/lib/ansible/modules/network/aci/aci_tenant.py
+++ b/lib/ansible/modules/network/aci/aci_tenant.py
@@ -120,8 +120,8 @@ sent:
             }
         }
     }
-previous: The original configuration from the APIC before the module has started
-  description:
+previous:
+  description: The original configuration from the APIC before the module has started
   returned: info
   type: list
   sample:
@@ -162,7 +162,7 @@ method:
   returned: failure or debug
   type: string
   sample: POST
-response
+response:
   description: The HTTP response from the APIC
   returned: failure or debug
   type: string

--- a/lib/ansible/modules/network/aci/aci_tenant_action_rule_profile.py
+++ b/lib/ansible/modules/network/aci/aci_tenant_action_rule_profile.py
@@ -86,6 +86,11 @@ error:
         "code": "122",
         "text": "unknown managed object class foo"
     }
+raw:
+  description: The raw output returned by the APIC REST API (xml or json)
+  returned: parse error
+  type: string
+  sample: '<?xml version="1.0" encoding="UTF-8"?><imdata totalCount="1"><error code="122" text="unknown managed object class foo"/></imdata>'
 sent:
   description: The actual/minimal configuration pushed to the APIC
   returned: info

--- a/lib/ansible/modules/network/aci/aci_tenant_action_rule_profile.py
+++ b/lib/ansible/modules/network/aci/aci_tenant_action_rule_profile.py
@@ -58,7 +58,103 @@ EXAMPLES = r'''
 '''
 
 RETURN = r'''
-#
+current:
+  description: The existing configuration from the APIC after the module has finished
+  returned: success
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production environment",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+error:
+  description: The error information as returned from the APIC
+  returned: failure
+  type: dict
+  sample:
+    {
+        "code": "122",
+        "text": "unknown managed object class foo"
+    }
+sent:
+  description: The actual/minimal configuration pushed to the APIC
+  returned: info
+  type: list
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment"
+            }
+        }
+    }
+previous: The original configuration from the APIC before the module has started
+  description:
+  returned: info
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+proposed:
+  description: The assembled configuration from the user-provided parameters
+  returned: info
+  type: dict
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment",
+                "name": "production"
+            }
+        }
+    }
+filter_string:
+  description: The filter string used for the request
+  returned: failure or debug
+  type: string
+  sample: ?rsp-prop-include=config-only
+method:
+  description: The HTTP method used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: POST
+response
+  description: The HTTP response from the APIC
+  returned: failure or debug
+  type: string
+  sample: OK (30 bytes)
+status:
+  description: The HTTP status from the APIC
+  returned: failure or debug
+  type: int
+  sample: 200
+url:
+  description: The HTTP url used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: https://10.11.12.13/api/mo/uni/tn-production.json
 '''
 
 from ansible.module_utils.network.aci.aci import ACIModule, aci_argument_spec

--- a/lib/ansible/modules/network/aci/aci_tenant_action_rule_profile.py
+++ b/lib/ansible/modules/network/aci/aci_tenant_action_rule_profile.py
@@ -103,8 +103,8 @@ sent:
             }
         }
     }
-previous: The original configuration from the APIC before the module has started
-  description:
+previous:
+  description: The original configuration from the APIC before the module has started
   returned: info
   type: list
   sample:
@@ -145,7 +145,7 @@ method:
   returned: failure or debug
   type: string
   sample: POST
-response
+response:
   description: The HTTP response from the APIC
   returned: failure or debug
   type: string

--- a/lib/ansible/modules/network/aci/aci_tenant_action_rule_profile.py
+++ b/lib/ansible/modules/network/aci/aci_tenant_action_rule_profile.py
@@ -128,7 +128,7 @@ def main():
     elif state == 'absent':
         aci.delete_config()
 
-    module.exit_json(**aci.result)
+    aci.exit_json()
 
 
 if __name__ == "__main__":

--- a/lib/ansible/modules/network/aci/aci_tenant_ep_retention_policy.py
+++ b/lib/ansible/modules/network/aci/aci_tenant_ep_retention_policy.py
@@ -163,8 +163,8 @@ sent:
             }
         }
     }
-previous: The original configuration from the APIC before the module has started
-  description:
+previous:
+  description: The original configuration from the APIC before the module has started
   returned: info
   type: list
   sample:
@@ -205,7 +205,7 @@ method:
   returned: failure or debug
   type: string
   sample: POST
-response
+response:
   description: The HTTP response from the APIC
   returned: failure or debug
   type: string

--- a/lib/ansible/modules/network/aci/aci_tenant_ep_retention_policy.py
+++ b/lib/ansible/modules/network/aci/aci_tenant_ep_retention_policy.py
@@ -146,6 +146,11 @@ error:
         "code": "122",
         "text": "unknown managed object class foo"
     }
+raw:
+  description: The raw output returned by the APIC REST API (xml or json)
+  returned: parse error
+  type: string
+  sample: '<?xml version="1.0" encoding="UTF-8"?><imdata totalCount="1"><error code="122" text="unknown managed object class foo"/></imdata>'
 sent:
   description: The actual/minimal configuration pushed to the APIC
   returned: info

--- a/lib/ansible/modules/network/aci/aci_tenant_ep_retention_policy.py
+++ b/lib/ansible/modules/network/aci/aci_tenant_ep_retention_policy.py
@@ -118,7 +118,103 @@ EXAMPLES = r'''
 '''
 
 RETURN = r'''
-#
+current:
+  description: The existing configuration from the APIC after the module has finished
+  returned: success
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production environment",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+error:
+  description: The error information as returned from the APIC
+  returned: failure
+  type: dict
+  sample:
+    {
+        "code": "122",
+        "text": "unknown managed object class foo"
+    }
+sent:
+  description: The actual/minimal configuration pushed to the APIC
+  returned: info
+  type: list
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment"
+            }
+        }
+    }
+previous: The original configuration from the APIC before the module has started
+  description:
+  returned: info
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+proposed:
+  description: The assembled configuration from the user-provided parameters
+  returned: info
+  type: dict
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment",
+                "name": "production"
+            }
+        }
+    }
+filter_string:
+  description: The filter string used for the request
+  returned: failure or debug
+  type: string
+  sample: ?rsp-prop-include=config-only
+method:
+  description: The HTTP method used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: POST
+response
+  description: The HTTP response from the APIC
+  returned: failure or debug
+  type: string
+  sample: OK (30 bytes)
+status:
+  description: The HTTP status from the APIC
+  returned: failure or debug
+  type: int
+  sample: 200
+url:
+  description: The HTTP url used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: https://10.11.12.13/api/mo/uni/tn-production.json
 '''
 
 from ansible.module_utils.network.aci.aci import ACIModule, aci_argument_spec

--- a/lib/ansible/modules/network/aci/aci_tenant_ep_retention_policy.py
+++ b/lib/ansible/modules/network/aci/aci_tenant_ep_retention_policy.py
@@ -227,7 +227,7 @@ def main():
     elif state == 'absent':
         aci.delete_config()
 
-    module.exit_json(**aci.result)
+    aci.exit_json()
 
 
 if __name__ == "__main__":

--- a/lib/ansible/modules/network/aci/aci_tenant_span_dst_group.py
+++ b/lib/ansible/modules/network/aci/aci_tenant_span_dst_group.py
@@ -88,6 +88,11 @@ error:
         "code": "122",
         "text": "unknown managed object class foo"
     }
+raw:
+  description: The raw output returned by the APIC REST API (xml or json)
+  returned: parse error
+  type: string
+  sample: '<?xml version="1.0" encoding="UTF-8"?><imdata totalCount="1"><error code="122" text="unknown managed object class foo"/></imdata>'
 sent:
   description: The actual/minimal configuration pushed to the APIC
   returned: info

--- a/lib/ansible/modules/network/aci/aci_tenant_span_dst_group.py
+++ b/lib/ansible/modules/network/aci/aci_tenant_span_dst_group.py
@@ -129,7 +129,7 @@ def main():
     elif state == 'absent':
         aci.delete_config()
 
-    module.exit_json(**aci.result)
+    aci.exit_json()
 
 
 if __name__ == "__main__":

--- a/lib/ansible/modules/network/aci/aci_tenant_span_dst_group.py
+++ b/lib/ansible/modules/network/aci/aci_tenant_span_dst_group.py
@@ -105,8 +105,8 @@ sent:
             }
         }
     }
-previous: The original configuration from the APIC before the module has started
-  description:
+previous:
+  description: The original configuration from the APIC before the module has started
   returned: info
   type: list
   sample:
@@ -147,7 +147,7 @@ method:
   returned: failure or debug
   type: string
   sample: POST
-response
+response:
   description: The HTTP response from the APIC
   returned: failure or debug
   type: string

--- a/lib/ansible/modules/network/aci/aci_tenant_span_dst_group.py
+++ b/lib/ansible/modules/network/aci/aci_tenant_span_dst_group.py
@@ -60,7 +60,103 @@ EXAMPLES = r'''
 '''
 
 RETURN = r'''
-#
+current:
+  description: The existing configuration from the APIC after the module has finished
+  returned: success
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production environment",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+error:
+  description: The error information as returned from the APIC
+  returned: failure
+  type: dict
+  sample:
+    {
+        "code": "122",
+        "text": "unknown managed object class foo"
+    }
+sent:
+  description: The actual/minimal configuration pushed to the APIC
+  returned: info
+  type: list
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment"
+            }
+        }
+    }
+previous: The original configuration from the APIC before the module has started
+  description:
+  returned: info
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+proposed:
+  description: The assembled configuration from the user-provided parameters
+  returned: info
+  type: dict
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment",
+                "name": "production"
+            }
+        }
+    }
+filter_string:
+  description: The filter string used for the request
+  returned: failure or debug
+  type: string
+  sample: ?rsp-prop-include=config-only
+method:
+  description: The HTTP method used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: POST
+response
+  description: The HTTP response from the APIC
+  returned: failure or debug
+  type: string
+  sample: OK (30 bytes)
+status:
+  description: The HTTP status from the APIC
+  returned: failure or debug
+  type: int
+  sample: 200
+url:
+  description: The HTTP url used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: https://10.11.12.13/api/mo/uni/tn-production.json
 '''
 
 from ansible.module_utils.network.aci.aci import ACIModule, aci_argument_spec

--- a/lib/ansible/modules/network/aci/aci_tenant_span_src_group.py
+++ b/lib/ansible/modules/network/aci/aci_tenant_span_src_group.py
@@ -67,7 +67,103 @@ EXAMPLES = r'''
 '''
 
 RETURN = r'''
-#
+current:
+  description: The existing configuration from the APIC after the module has finished
+  returned: success
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production environment",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+error:
+  description: The error information as returned from the APIC
+  returned: failure
+  type: dict
+  sample:
+    {
+        "code": "122",
+        "text": "unknown managed object class foo"
+    }
+sent:
+  description: The actual/minimal configuration pushed to the APIC
+  returned: info
+  type: list
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment"
+            }
+        }
+    }
+previous: The original configuration from the APIC before the module has started
+  description:
+  returned: info
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+proposed:
+  description: The assembled configuration from the user-provided parameters
+  returned: info
+  type: dict
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment",
+                "name": "production"
+            }
+        }
+    }
+filter_string:
+  description: The filter string used for the request
+  returned: failure or debug
+  type: string
+  sample: ?rsp-prop-include=config-only
+method:
+  description: The HTTP method used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: POST
+response
+  description: The HTTP response from the APIC
+  returned: failure or debug
+  type: string
+  sample: OK (30 bytes)
+status:
+  description: The HTTP status from the APIC
+  returned: failure or debug
+  type: int
+  sample: 200
+url:
+  description: The HTTP url used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: https://10.11.12.13/api/mo/uni/tn-production.json
 '''
 
 from ansible.module_utils.network.aci.aci import ACIModule, aci_argument_spec

--- a/lib/ansible/modules/network/aci/aci_tenant_span_src_group.py
+++ b/lib/ansible/modules/network/aci/aci_tenant_span_src_group.py
@@ -112,8 +112,8 @@ sent:
             }
         }
     }
-previous: The original configuration from the APIC before the module has started
-  description:
+previous:
+  description: The original configuration from the APIC before the module has started
   returned: info
   type: list
   sample:
@@ -154,7 +154,7 @@ method:
   returned: failure or debug
   type: string
   sample: POST
-response
+response:
   description: The HTTP response from the APIC
   returned: failure or debug
   type: string

--- a/lib/ansible/modules/network/aci/aci_tenant_span_src_group.py
+++ b/lib/ansible/modules/network/aci/aci_tenant_span_src_group.py
@@ -143,7 +143,7 @@ def main():
     elif state == 'absent':
         aci.delete_config()
 
-    module.exit_json(**aci.result)
+    aci.exit_json()
 
 
 if __name__ == "__main__":

--- a/lib/ansible/modules/network/aci/aci_tenant_span_src_group.py
+++ b/lib/ansible/modules/network/aci/aci_tenant_span_src_group.py
@@ -95,6 +95,11 @@ error:
         "code": "122",
         "text": "unknown managed object class foo"
     }
+raw:
+  description: The raw output returned by the APIC REST API (xml or json)
+  returned: parse error
+  type: string
+  sample: '<?xml version="1.0" encoding="UTF-8"?><imdata totalCount="1"><error code="122" text="unknown managed object class foo"/></imdata>'
 sent:
   description: The actual/minimal configuration pushed to the APIC
   returned: info

--- a/lib/ansible/modules/network/aci/aci_tenant_span_src_group_to_dst_group.py
+++ b/lib/ansible/modules/network/aci/aci_tenant_span_src_group_to_dst_group.py
@@ -88,6 +88,11 @@ error:
         "code": "122",
         "text": "unknown managed object class foo"
     }
+raw:
+  description: The raw output returned by the APIC REST API (xml or json)
+  returned: parse error
+  type: string
+  sample: '<?xml version="1.0" encoding="UTF-8"?><imdata totalCount="1"><error code="122" text="unknown managed object class foo"/></imdata>'
 sent:
   description: The actual/minimal configuration pushed to the APIC
   returned: info

--- a/lib/ansible/modules/network/aci/aci_tenant_span_src_group_to_dst_group.py
+++ b/lib/ansible/modules/network/aci/aci_tenant_span_src_group_to_dst_group.py
@@ -105,8 +105,8 @@ sent:
             }
         }
     }
-previous: The original configuration from the APIC before the module has started
-  description:
+previous:
+  description: The original configuration from the APIC before the module has started
   returned: info
   type: list
   sample:
@@ -147,7 +147,7 @@ method:
   returned: failure or debug
   type: string
   sample: POST
-response
+response:
   description: The HTTP response from the APIC
   returned: failure or debug
   type: string

--- a/lib/ansible/modules/network/aci/aci_tenant_span_src_group_to_dst_group.py
+++ b/lib/ansible/modules/network/aci/aci_tenant_span_src_group_to_dst_group.py
@@ -137,7 +137,7 @@ def main():
     elif state == 'absent':
         aci.delete_config()
 
-    module.exit_json(**aci.result)
+    aci.exit_json()
 
 
 if __name__ == "__main__":

--- a/lib/ansible/modules/network/aci/aci_tenant_span_src_group_to_dst_group.py
+++ b/lib/ansible/modules/network/aci/aci_tenant_span_src_group_to_dst_group.py
@@ -60,7 +60,103 @@ EXAMPLES = r'''
 '''
 
 RETURN = r'''
-#
+current:
+  description: The existing configuration from the APIC after the module has finished
+  returned: success
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production environment",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+error:
+  description: The error information as returned from the APIC
+  returned: failure
+  type: dict
+  sample:
+    {
+        "code": "122",
+        "text": "unknown managed object class foo"
+    }
+sent:
+  description: The actual/minimal configuration pushed to the APIC
+  returned: info
+  type: list
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment"
+            }
+        }
+    }
+previous: The original configuration from the APIC before the module has started
+  description:
+  returned: info
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+proposed:
+  description: The assembled configuration from the user-provided parameters
+  returned: info
+  type: dict
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment",
+                "name": "production"
+            }
+        }
+    }
+filter_string:
+  description: The filter string used for the request
+  returned: failure or debug
+  type: string
+  sample: ?rsp-prop-include=config-only
+method:
+  description: The HTTP method used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: POST
+response
+  description: The HTTP response from the APIC
+  returned: failure or debug
+  type: string
+  sample: OK (30 bytes)
+status:
+  description: The HTTP status from the APIC
+  returned: failure or debug
+  type: int
+  sample: 200
+url:
+  description: The HTTP url used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: https://10.11.12.13/api/mo/uni/tn-production.json
 '''
 
 from ansible.module_utils.network.aci.aci import ACIModule, aci_argument_spec

--- a/lib/ansible/modules/network/aci/aci_vlan_pool.py
+++ b/lib/ansible/modules/network/aci/aci_vlan_pool.py
@@ -127,8 +127,8 @@ sent:
             }
         }
     }
-previous: The original configuration from the APIC before the module has started
-  description:
+previous:
+  description: The original configuration from the APIC before the module has started
   returned: info
   type: list
   sample:
@@ -169,7 +169,7 @@ method:
   returned: failure or debug
   type: string
   sample: POST
-response
+response:
   description: The HTTP response from the APIC
   returned: failure or debug
   type: string

--- a/lib/ansible/modules/network/aci/aci_vlan_pool.py
+++ b/lib/ansible/modules/network/aci/aci_vlan_pool.py
@@ -82,7 +82,103 @@ EXAMPLES = r'''
 '''
 
 RETURN = r'''
-#
+current:
+  description: The existing configuration from the APIC after the module has finished
+  returned: success
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production environment",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+error:
+  description: The error information as returned from the APIC
+  returned: failure
+  type: dict
+  sample:
+    {
+        "code": "122",
+        "text": "unknown managed object class foo"
+    }
+sent:
+  description: The actual/minimal configuration pushed to the APIC
+  returned: info
+  type: list
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment"
+            }
+        }
+    }
+previous: The original configuration from the APIC before the module has started
+  description:
+  returned: info
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+proposed:
+  description: The assembled configuration from the user-provided parameters
+  returned: info
+  type: dict
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment",
+                "name": "production"
+            }
+        }
+    }
+filter_string:
+  description: The filter string used for the request
+  returned: failure or debug
+  type: string
+  sample: ?rsp-prop-include=config-only
+method:
+  description: The HTTP method used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: POST
+response
+  description: The HTTP response from the APIC
+  returned: failure or debug
+  type: string
+  sample: OK (30 bytes)
+status:
+  description: The HTTP status from the APIC
+  returned: failure or debug
+  type: int
+  sample: 200
+url:
+  description: The HTTP url used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: https://10.11.12.13/api/mo/uni/tn-production.json
 '''
 
 from ansible.module_utils.network.aci.aci import ACIModule, aci_argument_spec

--- a/lib/ansible/modules/network/aci/aci_vlan_pool.py
+++ b/lib/ansible/modules/network/aci/aci_vlan_pool.py
@@ -110,6 +110,11 @@ error:
         "code": "122",
         "text": "unknown managed object class foo"
     }
+raw:
+  description: The raw output returned by the APIC REST API (xml or json)
+  returned: parse error
+  type: string
+  sample: '<?xml version="1.0" encoding="UTF-8"?><imdata totalCount="1"><error code="122" text="unknown managed object class foo"/></imdata>'
 sent:
   description: The actual/minimal configuration pushed to the APIC
   returned: info

--- a/lib/ansible/modules/network/aci/aci_vlan_pool.py
+++ b/lib/ansible/modules/network/aci/aci_vlan_pool.py
@@ -153,7 +153,7 @@ def main():
     elif state == 'absent':
         aci.delete_config()
 
-    module.exit_json(**aci.result)
+    aci.exit_json()
 
 
 if __name__ == "__main__":

--- a/lib/ansible/modules/network/aci/aci_vlan_pool_encap_block.py
+++ b/lib/ansible/modules/network/aci/aci_vlan_pool_encap_block.py
@@ -114,7 +114,103 @@ EXAMPLES = r'''
 '''
 
 RETURN = r'''
-#
+current:
+  description: The existing configuration from the APIC after the module has finished
+  returned: success
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production environment",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+error:
+  description: The error information as returned from the APIC
+  returned: failure
+  type: dict
+  sample:
+    {
+        "code": "122",
+        "text": "unknown managed object class foo"
+    }
+sent:
+  description: The actual/minimal configuration pushed to the APIC
+  returned: info
+  type: list
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment"
+            }
+        }
+    }
+previous: The original configuration from the APIC before the module has started
+  description:
+  returned: info
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+proposed:
+  description: The assembled configuration from the user-provided parameters
+  returned: info
+  type: dict
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment",
+                "name": "production"
+            }
+        }
+    }
+filter_string:
+  description: The filter string used for the request
+  returned: failure or debug
+  type: string
+  sample: ?rsp-prop-include=config-only
+method:
+  description: The HTTP method used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: POST
+response
+  description: The HTTP response from the APIC
+  returned: failure or debug
+  type: string
+  sample: OK (30 bytes)
+status:
+  description: The HTTP status from the APIC
+  returned: failure or debug
+  type: int
+  sample: 200
+url:
+  description: The HTTP url used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: https://10.11.12.13/api/mo/uni/tn-production.json
 '''
 
 from ansible.module_utils.network.aci.aci import ACIModule, aci_argument_spec

--- a/lib/ansible/modules/network/aci/aci_vlan_pool_encap_block.py
+++ b/lib/ansible/modules/network/aci/aci_vlan_pool_encap_block.py
@@ -159,8 +159,8 @@ sent:
             }
         }
     }
-previous: The original configuration from the APIC before the module has started
-  description:
+previous:
+  description: The original configuration from the APIC before the module has started
   returned: info
   type: list
   sample:
@@ -201,7 +201,7 @@ method:
   returned: failure or debug
   type: string
   sample: POST
-response
+response:
   description: The HTTP response from the APIC
   returned: failure or debug
   type: string

--- a/lib/ansible/modules/network/aci/aci_vlan_pool_encap_block.py
+++ b/lib/ansible/modules/network/aci/aci_vlan_pool_encap_block.py
@@ -142,6 +142,11 @@ error:
         "code": "122",
         "text": "unknown managed object class foo"
     }
+raw:
+  description: The raw output returned by the APIC REST API (xml or json)
+  returned: parse error
+  type: string
+  sample: '<?xml version="1.0" encoding="UTF-8"?><imdata totalCount="1"><error code="122" text="unknown managed object class foo"/></imdata>'
 sent:
   description: The actual/minimal configuration pushed to the APIC
   returned: info

--- a/lib/ansible/modules/network/aci/aci_vlan_pool_encap_block.py
+++ b/lib/ansible/modules/network/aci/aci_vlan_pool_encap_block.py
@@ -247,7 +247,7 @@ def main():
     elif state == 'absent':
         aci.delete_config()
 
-    module.exit_json(**aci.result)
+    aci.exit_json()
 
 
 if __name__ == "__main__":

--- a/lib/ansible/modules/network/aci/aci_vrf.py
+++ b/lib/ansible/modules/network/aci/aci_vrf.py
@@ -123,6 +123,11 @@ error:
         "code": "122",
         "text": "unknown managed object class foo"
     }
+raw:
+  description: The raw output returned by the APIC REST API (xml or json)
+  returned: parse error
+  type: string
+  sample: '<?xml version="1.0" encoding="UTF-8"?><imdata totalCount="1"><error code="122" text="unknown managed object class foo"/></imdata>'
 sent:
   description: The actual/minimal configuration pushed to the APIC
   returned: info

--- a/lib/ansible/modules/network/aci/aci_vrf.py
+++ b/lib/ansible/modules/network/aci/aci_vrf.py
@@ -94,7 +94,105 @@ EXAMPLES = r'''
     state: query
 '''
 
-RETURN = r''' # '''
+RETURN = r'''
+current:
+  description: The existing configuration from the APIC after the module has finished
+  returned: success
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production environment",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+error:
+  description: The error information as returned from the APIC
+  returned: failure
+  type: dict
+  sample:
+    {
+        "code": "122",
+        "text": "unknown managed object class foo"
+    }
+sent:
+  description: The actual/minimal configuration pushed to the APIC
+  returned: info
+  type: list
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment"
+            }
+        }
+    }
+previous: The original configuration from the APIC before the module has started
+  description:
+  returned: info
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+proposed:
+  description: The assembled configuration from the user-provided parameters
+  returned: info
+  type: dict
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment",
+                "name": "production"
+            }
+        }
+    }
+filter_string:
+  description: The filter string used for the request
+  returned: failure or debug
+  type: string
+  sample: ?rsp-prop-include=config-only
+method:
+  description: The HTTP method used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: POST
+response
+  description: The HTTP response from the APIC
+  returned: failure or debug
+  type: string
+  sample: OK (30 bytes)
+status:
+  description: The HTTP status from the APIC
+  returned: failure or debug
+  type: int
+  sample: 200
+url:
+  description: The HTTP url used for the request to the APIC
+  returned: failure or debug
+  type: string
+  sample: https://10.11.12.13/api/mo/uni/tn-production.json
+'''
 
 from ansible.module_utils.network.aci.aci import ACIModule, aci_argument_spec
 from ansible.module_utils.basic import AnsibleModule

--- a/lib/ansible/modules/network/aci/aci_vrf.py
+++ b/lib/ansible/modules/network/aci/aci_vrf.py
@@ -167,7 +167,7 @@ def main():
     elif state == 'absent':
         aci.delete_config()
 
-    module.exit_json(**aci.result)
+    aci.exit_json()
 
 
 if __name__ == "__main__":

--- a/lib/ansible/modules/network/aci/aci_vrf.py
+++ b/lib/ansible/modules/network/aci/aci_vrf.py
@@ -140,8 +140,8 @@ sent:
             }
         }
     }
-previous: The original configuration from the APIC before the module has started
-  description:
+previous:
+  description: The original configuration from the APIC before the module has started
   returned: info
   type: list
   sample:
@@ -182,7 +182,7 @@ method:
   returned: failure or debug
   type: string
   sample: POST
-response
+response:
   description: The HTTP response from the APIC
   returned: failure or debug
   type: string

--- a/lib/ansible/utils/module_docs_fragments/aci.py
+++ b/lib/ansible/utils/module_docs_fragments/aci.py
@@ -45,22 +45,22 @@ options:
     required: yes
   private_key:
     description:
-    - PEM formatted file that contains your private key to be used for client certificate authentication.
+    - PEM formatted file that contains your private key to be used for signature-based authentication.
     - The name of the key (without extension) is used as the certificate name in ACI, unless C(certificate_name) is specified.
     aliases: [ cert_key ]
   certificate_name:
     description:
-    - The X.509 certificate name attached to the APIC AAA user.
+    - The X.509 certificate name attached to the APIC AAA user used for signature-based authentication.
     - It defaults to the C(private_key) basename, without extension.
     aliases: [ cert_name ]
     default: C(private_key) basename
   output_level:
     description:
     - Influence the output of the ACI module.
-    - C(default) means the normal output, incl. C(existing) dict
+    - C(normal) means the standard output, incl. C(existing) dict
     - C(info) means informational output, incl. C(original), C(config) and C(proposed) dicts
-    - C(debug) means debugging output, incl. C(method), C(response), C(status) and C(url)
-    choices: [normal, info, debug]
+    - C(debug) means debugging output, incl. C(filter_string), C(method), C(response), C(status) and C(url)
+    choices: [ debug, info, normal ]
     default: normal
   timeout:
     description:
@@ -69,8 +69,8 @@ options:
   use_proxy:
     description:
       - If C(no), it will not use a proxy, even if one is defined in an environment variable on the target hosts.
-    default: 'yes'
     type: bool
+    default: 'yes'
   use_ssl:
     description:
     - If C(no), an HTTP connection will be used instead of the default HTTPS connection.

--- a/lib/ansible/utils/module_docs_fragments/aci.py
+++ b/lib/ansible/utils/module_docs_fragments/aci.py
@@ -58,7 +58,7 @@ options:
     description:
     - Influence the output of this ACI module.
     - C(normal) means the standard output, incl. C(current) dict
-    - C(info) means informational output, incl. C(previous), C(config) and C(proposed) dicts
+    - C(info) means informational output, incl. C(previous), C(proposed) and C(sent) dicts
     - C(debug) means debugging output, incl. C(filter_string), C(method), C(response), C(status) and C(url) information
     choices: [ debug, info, normal ]
     default: normal

--- a/lib/ansible/utils/module_docs_fragments/aci.py
+++ b/lib/ansible/utils/module_docs_fragments/aci.py
@@ -54,6 +54,14 @@ options:
     - It defaults to the C(private_key) basename, without extension.
     aliases: [ cert_name ]
     default: C(private_key) basename
+  output_level:
+    description:
+    - Influence the output of the ACI module.
+    - C(default) means the normal output, incl. C(existing) dict
+    - C(info) means informational output, incl. C(original), C(config) an C(proposed)
+    - C(debug) means debugging output, incl. C(method), C(path), C(status), C(url)
+    choices: [normal, info, debug]
+    default: normal
   timeout:
     description:
     - The socket level timeout in seconds.

--- a/lib/ansible/utils/module_docs_fragments/aci.py
+++ b/lib/ansible/utils/module_docs_fragments/aci.py
@@ -56,10 +56,10 @@ options:
     default: C(private_key) basename
   output_level:
     description:
-    - Influence the output of the ACI module.
-    - C(normal) means the standard output, incl. C(existing) dict
-    - C(info) means informational output, incl. C(original), C(config) and C(proposed) dicts
-    - C(debug) means debugging output, incl. C(filter_string), C(method), C(response), C(status) and C(url)
+    - Influence the output of this ACI module.
+    - C(normal) means the standard output, incl. C(current) dict
+    - C(info) means informational output, incl. C(previous), C(config) and C(proposed) dicts
+    - C(debug) means debugging output, incl. C(filter_string), C(method), C(response), C(status) and C(url) information
     choices: [ debug, info, normal ]
     default: normal
   timeout:

--- a/lib/ansible/utils/module_docs_fragments/aci.py
+++ b/lib/ansible/utils/module_docs_fragments/aci.py
@@ -58,8 +58,8 @@ options:
     description:
     - Influence the output of the ACI module.
     - C(default) means the normal output, incl. C(existing) dict
-    - C(info) means informational output, incl. C(original), C(config) an C(proposed)
-    - C(debug) means debugging output, incl. C(method), C(path), C(status), C(url)
+    - C(info) means informational output, incl. C(original), C(config) and C(proposed) dicts
+    - C(debug) means debugging output, incl. C(method), C(response), C(status) and C(url)
     choices: [normal, info, debug]
     default: normal
   timeout:

--- a/test/integration/targets/aci_access_port_to_interface_policy_leaf_profile/tasks/main.yml
+++ b/test/integration/targets/aci_access_port_to_interface_policy_leaf_profile/tasks/main.yml
@@ -56,11 +56,11 @@
     - accessport_to_intf_check_mode_present.changed == true
     - accessport_to_intf_present.changed == true
     - accessport_to_intf_present.previous == []
-    - 'accessport_to_intf_present.config == {"infraHPortS": {"attributes": {"name": "anstest_accessportselector"}, "children": [{"infraPortBlk": {"attributes": {"fromPort": "13", "name": "anstest_leafportblkname", "toPort": "16"}}}, {"infraRsAccBaseGrp": {"attributes": {"tDn": "uni/infra/funcprof/accportgrp-None"}}}]}}'
+    - 'accessport_to_intf_present.sent == {"infraHPortS": {"attributes": {"name": "anstest_accessportselector"}, "children": [{"infraPortBlk": {"attributes": {"fromPort": "13", "name": "anstest_leafportblkname", "toPort": "16"}}}, {"infraRsAccBaseGrp": {"attributes": {"tDn": "uni/infra/funcprof/accportgrp-None"}}}]}}'
     - accessport_to_intf_idempotent.changed == false
-    - accessport_to_intf_idempotent.config == {}
+    - accessport_to_intf_idempotent.sent == {}
     - accessport_to_intf_update.changed == true
-    - 'accessport_to_intf_update.config == {"infraHPortS": {"attributes": {},"children": [{"infraRsAccBaseGrp": {"attributes": {"tDn": "uni/infra/funcprof/accportgrp-anstest_policygroupname"}}}]}}'
+    - 'accessport_to_intf_update.sent == {"infraHPortS": {"attributes": {},"children": [{"infraRsAccBaseGrp": {"attributes": {"tDn": "uni/infra/funcprof/accportgrp-anstest_policygroupname"}}}]}}'
 
 - name: Query Specific access_port_selector and leaf_interface_profile binding
   aci_access_port_to_interface_policy_leaf_profile:

--- a/test/integration/targets/aci_access_port_to_interface_policy_leaf_profile/tasks/main.yml
+++ b/test/integration/targets/aci_access_port_to_interface_policy_leaf_profile/tasks/main.yml
@@ -16,7 +16,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
-    output_level: info
+    output_level: debug
     state: present
     leaf_interface_profile: leafintprftest
   register: leaf_profile_present

--- a/test/integration/targets/aci_access_port_to_interface_policy_leaf_profile/tasks/main.yml
+++ b/test/integration/targets/aci_access_port_to_interface_policy_leaf_profile/tasks/main.yml
@@ -55,7 +55,7 @@
     that:
     - accessport_to_intf_check_mode_present.changed == true
     - accessport_to_intf_present.changed == true
-    - accessport_to_intf_present.original == []
+    - accessport_to_intf_present.previous == []
     - 'accessport_to_intf_present.config == {"infraHPortS": {"attributes": {"name": "anstest_accessportselector"}, "children": [{"infraPortBlk": {"attributes": {"fromPort": "13", "name": "anstest_leafportblkname", "toPort": "16"}}}, {"infraRsAccBaseGrp": {"attributes": {"tDn": "uni/infra/funcprof/accportgrp-None"}}}]}}'
     - accessport_to_intf_idempotent.changed == false
     - accessport_to_intf_idempotent.config == {}
@@ -73,7 +73,7 @@
   assert:
     that:
       - binding_query.changed == false
-      - binding_query.original | length >= 1
+      - binding_query.previous | length >= 1
       - '"api/mo/uni/infra/accportprof-leafintprftest/hports-anstest_accessportselector-typ-range.json" in binding_query.url'
 
 - name: Remove binding of interface access port selector and Interface Policy Leaf Profile - check mode
@@ -106,11 +106,11 @@
   assert:
     that:
       - accessport_to_intf_check_mode_absent.changed == true
-      - accessport_to_intf_check_mode_absent.original != []
+      - accessport_to_intf_check_mode_absent.previous != []
       - accessport_to_intf_absent.changed == true
-      - accessport_to_intf_absent.original == accessport_to_intf_check_mode_absent.original
+      - accessport_to_intf_absent.previous == accessport_to_intf_check_mode_absent.previous
       - accessport_to_intf_absent_idempotent.changed == false
-      - accessport_to_intf_absent_idempotent.original == []
+      - accessport_to_intf_absent_idempotent.previous == []
       - accessport_to_intf_absent_missing_param.failed == true
       - 'accessport_to_intf_absent_missing_param.msg == "state is absent but all of the following are missing: access_port_selector"'
 

--- a/test/integration/targets/aci_access_port_to_interface_policy_leaf_profile/tasks/main.yml
+++ b/test/integration/targets/aci_access_port_to_interface_policy_leaf_profile/tasks/main.yml
@@ -16,6 +16,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: info
     state: present
     leaf_interface_profile: leafintprftest
   register: leaf_profile_present
@@ -54,7 +55,7 @@
     that:
     - accessport_to_intf_check_mode_present.changed == true
     - accessport_to_intf_present.changed == true
-    - accessport_to_intf_present.existing == []
+    - accessport_to_intf_present.original == []
     - 'accessport_to_intf_present.config == {"infraHPortS": {"attributes": {"name": "anstest_accessportselector"}, "children": [{"infraPortBlk": {"attributes": {"fromPort": "13", "name": "anstest_leafportblkname", "toPort": "16"}}}, {"infraRsAccBaseGrp": {"attributes": {"tDn": "uni/infra/funcprof/accportgrp-None"}}}]}}'
     - accessport_to_intf_idempotent.changed == false
     - accessport_to_intf_idempotent.config == {}
@@ -72,7 +73,7 @@
   assert:
     that:
       - binding_query.changed == false
-      - binding_query.existing | length >= 1
+      - binding_query.original | length >= 1
       - '"api/mo/uni/infra/accportprof-leafintprftest/hports-anstest_accessportselector-typ-range.json" in binding_query.url'
 
 - name: Remove binding of interface access port selector and Interface Policy Leaf Profile - check mode
@@ -105,11 +106,11 @@
   assert:
     that:
       - accessport_to_intf_check_mode_absent.changed == true
-      - accessport_to_intf_check_mode_absent.existing != []
+      - accessport_to_intf_check_mode_absent.original != []
       - accessport_to_intf_absent.changed == true
-      - accessport_to_intf_absent.existing == accessport_to_intf_check_mode_absent.existing
+      - accessport_to_intf_absent.original == accessport_to_intf_check_mode_absent.original
       - accessport_to_intf_absent_idempotent.changed == false
-      - accessport_to_intf_absent_idempotent.existing == []
+      - accessport_to_intf_absent_idempotent.original == []
       - accessport_to_intf_absent_missing_param.failed == true
       - 'accessport_to_intf_absent_missing_param.msg == "state is absent but all of the following are missing: access_port_selector"'
 

--- a/test/integration/targets/aci_ap/tasks/main.yml
+++ b/test/integration/targets/aci_ap/tasks/main.yml
@@ -16,6 +16,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: info
     state: present
     tenant: anstest
   register: tenant_present
@@ -60,11 +61,11 @@
     that:
       - ap_present_check_mode.changed == true
       - ap_present.changed == true
-      - ap_present.existing == []
+      - ap_present.original == []
       - ap_present.config == ap_present_check_mode.config
       - 'ap_present.config == {"fvAp": {"attributes": {"descr": "Ansible Test", "name": "anstest"}}}'
       - ap_present_idempotent.changed == false
-      - ap_present_idempotent.existing != []
+      - ap_present_idempotent.original != []
       - ap_present_idempotent.config == {}
       - ap_present_update.changed == true
       - 'ap_present_update.config.fvAp.attributes == {"descr": "Ansible Test Update"}'
@@ -100,21 +101,21 @@
   assert:
     that:
       - query_ap.changed == false
-      - query_ap.existing | length == 1
-      - 'query_ap.existing.0.fvAp.attributes.name == "anstest"'
+      - query_ap.original | length == 1
+      - 'query_ap.original.0.fvAp.attributes.name == "anstest"'
       - '"tn-anstest/ap-anstest.json" in query_ap.url'
       - query_ap_tenant.changed == false
-      - query_ap_tenant.existing | length == 1
-      - query_ap_tenant.existing.0.fvTenant.children | length == 2
+      - query_ap_tenant.original | length == 1
+      - query_ap_tenant.original.0.fvTenant.children | length == 2
       - '"rsp-subtree-class=fvAp" in query_ap_tenant.filter_string'
       - '"tn-anstest.json" in query_ap_tenant.url'
       - query_ap_ap.changed == false
-      - query_ap_ap.existing != []
-      - query_ap_ap.existing.0.fvAp is defined
+      - query_ap_ap.original != []
+      - query_ap_ap.original.0.fvAp is defined
       - '"query-target-filter=eq(fvAp.name, \"anstest\")" in query_ap_ap.filter_string'
       - '"class/fvAp.json" in query_ap_ap.url'
       - query_all.changed == false
-      - query_all.existing | length > 1
+      - query_all.original | length > 1
       - '"class/fvAp.json" in query_all.url'
 
 - name: delete ap - check_mode works
@@ -150,12 +151,12 @@
   assert:
     that:
       - ap_delete_check_mode.changed == true
-      - ap_delete_check_mode.existing != []
+      - ap_delete_check_mode.original != []
       - '"tn-anstest/ap-anstest.json" in ap_delete_check_mode.url'
       - ap_delete.changed == true
-      - ap_delete.existing == ap_delete_check_mode.existing
+      - ap_delete.original == ap_delete_check_mode.original
       - ap_delete_idempotent.changed == false
-      - ap_delete_idempotent.existing == []
+      - ap_delete_idempotent.original == []
       - ap_delete_missing_param.failed == true
       - 'ap_delete_missing_param.msg == "state is absent but all of the following are missing: tenant"'
 

--- a/test/integration/targets/aci_ap/tasks/main.yml
+++ b/test/integration/targets/aci_ap/tasks/main.yml
@@ -16,7 +16,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
-    output_level: info
+    output_level: debug
     state: present
     tenant: anstest
   register: tenant_present

--- a/test/integration/targets/aci_ap/tasks/main.yml
+++ b/test/integration/targets/aci_ap/tasks/main.yml
@@ -61,11 +61,11 @@
     that:
       - ap_present_check_mode.changed == true
       - ap_present.changed == true
-      - ap_present.original == []
+      - ap_present.previous == []
       - ap_present.config == ap_present_check_mode.config
       - 'ap_present.config == {"fvAp": {"attributes": {"descr": "Ansible Test", "name": "anstest"}}}'
       - ap_present_idempotent.changed == false
-      - ap_present_idempotent.original != []
+      - ap_present_idempotent.previous != []
       - ap_present_idempotent.config == {}
       - ap_present_update.changed == true
       - 'ap_present_update.config.fvAp.attributes == {"descr": "Ansible Test Update"}'
@@ -101,21 +101,21 @@
   assert:
     that:
       - query_ap.changed == false
-      - query_ap.original | length == 1
-      - 'query_ap.original.0.fvAp.attributes.name == "anstest"'
+      - query_ap.previous | length == 1
+      - 'query_ap.previous.0.fvAp.attributes.name == "anstest"'
       - '"tn-anstest/ap-anstest.json" in query_ap.url'
       - query_ap_tenant.changed == false
-      - query_ap_tenant.original | length == 1
-      - query_ap_tenant.original.0.fvTenant.children | length == 2
+      - query_ap_tenant.previous | length == 1
+      - query_ap_tenant.previous.0.fvTenant.children | length == 2
       - '"rsp-subtree-class=fvAp" in query_ap_tenant.filter_string'
       - '"tn-anstest.json" in query_ap_tenant.url'
       - query_ap_ap.changed == false
-      - query_ap_ap.original != []
-      - query_ap_ap.original.0.fvAp is defined
+      - query_ap_ap.previous != []
+      - query_ap_ap.previous.0.fvAp is defined
       - '"query-target-filter=eq(fvAp.name, \"anstest\")" in query_ap_ap.filter_string'
       - '"class/fvAp.json" in query_ap_ap.url'
       - query_all.changed == false
-      - query_all.original | length > 1
+      - query_all.previous | length > 1
       - '"class/fvAp.json" in query_all.url'
 
 - name: delete ap - check_mode works
@@ -151,12 +151,12 @@
   assert:
     that:
       - ap_delete_check_mode.changed == true
-      - ap_delete_check_mode.original != []
+      - ap_delete_check_mode.previous != []
       - '"tn-anstest/ap-anstest.json" in ap_delete_check_mode.url'
       - ap_delete.changed == true
-      - ap_delete.original == ap_delete_check_mode.original
+      - ap_delete.previous == ap_delete_check_mode.previous
       - ap_delete_idempotent.changed == false
-      - ap_delete_idempotent.original == []
+      - ap_delete_idempotent.previous == []
       - ap_delete_missing_param.failed == true
       - 'ap_delete_missing_param.msg == "state is absent but all of the following are missing: tenant"'
 

--- a/test/integration/targets/aci_ap/tasks/main.yml
+++ b/test/integration/targets/aci_ap/tasks/main.yml
@@ -62,13 +62,13 @@
       - ap_present_check_mode.changed == true
       - ap_present.changed == true
       - ap_present.previous == []
-      - ap_present.config == ap_present_check_mode.config
-      - 'ap_present.config == {"fvAp": {"attributes": {"descr": "Ansible Test", "name": "anstest"}}}'
+      - ap_present.sent == ap_present_check_mode.sent
+      - 'ap_present.sent == {"fvAp": {"attributes": {"descr": "Ansible Test", "name": "anstest"}}}'
       - ap_present_idempotent.changed == false
       - ap_present_idempotent.previous != []
-      - ap_present_idempotent.config == {}
+      - ap_present_idempotent.sent == {}
       - ap_present_update.changed == true
-      - 'ap_present_update.config.fvAp.attributes == {"descr": "Ansible Test Update"}'
+      - 'ap_present_update.sent.fvAp.attributes == {"descr": "Ansible Test Update"}'
       - ap_present_missing_param.failed == true
       - 'ap_present_missing_param.msg == "state is present but all of the following are missing: ap"'
 

--- a/test/integration/targets/aci_bd/tasks/main.yml
+++ b/test/integration/targets/aci_bd/tasks/main.yml
@@ -75,7 +75,7 @@
   assert:
     that:
       - bd_present_check_mode.changed == true
-      - 'bd_present_check_mode.config == {"fvBD": {"attributes": {"descr": "Ansible Test"}}}'
+      - 'bd_present_check_mode.config == {"fvBD": {"attributes": {"descr": "Ansible Test", "name": "anstest"}}}'
       - bd_present.changed == true
       - bd_present.config == bd_present_check_mode.config
       - bd_present.original == []

--- a/test/integration/targets/aci_bd/tasks/main.yml
+++ b/test/integration/targets/aci_bd/tasks/main.yml
@@ -78,11 +78,11 @@
       - 'bd_present_check_mode.config == {"fvBD": {"attributes": {"descr": "Ansible Test", "name": "anstest"}}}'
       - bd_present.changed == true
       - bd_present.config == bd_present_check_mode.config
-      - bd_present.original == []
+      - bd_present.previous == []
       - bd_present_idempotent.changed == false
-      - bd_present_idempotent.original != []
+      - bd_present_idempotent.previous != []
       - bd_update.changed == true
-      - bd_update.original != []
+      - bd_update.previous != []
       - bd_update.changed != bd_update.proposed
       - 'bd_update.config == {"fvBD": {"attributes": {"descr": "Ansible Test Update"}, "children": [{"fvRsCtx": {"attributes": {"tnFvCtxName": "anstest"}}}]}}'
       - 'bd_present_2.config.fvBD.attributes == {"arpFlood": "yes", "descr": "Ansible Test", "ipLearning": "no", "multiDstPktAct": "drop", "name": "anstest2",
@@ -119,23 +119,23 @@
   assert:
     that:
       - query_all.changed == false
-      - query_all.original | length > 1
-      - query_all.original.0.fvBD is defined
+      - query_all.previous | length > 1
+      - query_all.previous.0.fvBD is defined
       - '"rsp-subtree-class=fvRsCtx,fvRsIgmpsn,fvRsBDToNdP,fvRsBdToEpRet" in query_all.filter_string'
       - '"class/fvBD.json" in query_all.url'
       - query_tenant.changed == false
-      - query_tenant.original | length == 1
-      - query_tenant.original.0.fvTenant.children | length == 2
+      - query_tenant.previous | length == 1
+      - query_tenant.previous.0.fvTenant.children | length == 2
       - '"rsp-subtree-class=fvRsCtx,fvRsIgmpsn,fvRsBDToNdP,fvRsBdToEpRet,fvBD" in query_tenant.filter_string'
       - '"tn-anstest.json" in query_tenant.url'
       - query_bd_bd.changed == false
-      - query_bd_bd.original != []
+      - query_bd_bd.previous != []
       - '"query-target-filter=eq(fvBD.name, \"anstest\")" in query_bd_bd.filter_string'
       - '"rsp-subtree=full&rsp-subtree-class=fvRsCtx,fvRsIgmpsn,fvRsBDToNdP,fvRsBdToEpRet" in query_bd_bd.filter_string'
       - '"class/fvBD.json" in query_bd_bd.url'
       - query_bd.changed == false
-      - query_bd.original | length == 1
-      - 'query_bd.original.0.fvBD.attributes.name == "anstest"'
+      - query_bd.previous | length == 1
+      - 'query_bd.previous.0.fvBD.attributes.name == "anstest"'
       - '"rsp-subtree-class=fvRsCtx,fvRsIgmpsn,fvRsBDToNdP,fvRsBdToEpRet" in query_bd.filter_string'
       - '"tn-anstest/BD-anstest.json" in query_bd.url'
 
@@ -174,9 +174,9 @@
       - bd_absent_check_mode.changed == true
       - bd_absent_check_mode.proposed == {}
       - bd_absent.changed == true
-      - bd_absent.original != []
+      - bd_absent.previous != []
       - bd_absent_idempotent.changed == false
-      - bd_absent_idempotent.original == []
+      - bd_absent_idempotent.previous == []
       - bd_absent_missing_param.failed == true
       - 'bd_absent_missing_param.msg == "state is absent but all of the following are missing: bd"'
 

--- a/test/integration/targets/aci_bd/tasks/main.yml
+++ b/test/integration/targets/aci_bd/tasks/main.yml
@@ -16,6 +16,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: info
     state: present
     tenant: anstest
   register: tenant_present
@@ -77,11 +78,11 @@
       - 'bd_present_check_mode.config == {"fvBD": {"attributes": {"descr": "Ansible Test", "name": "anstest"}}}'
       - bd_present.changed == true
       - bd_present.config == bd_present_check_mode.config
-      - bd_present.existing == []
+      - bd_present.original == []
       - bd_present_idempotent.changed == false
-      - bd_present_idempotent.existing != []
+      - bd_present_idempotent.original != []
       - bd_update.changed == true
-      - bd_update.existing != []
+      - bd_update.original != []
       - bd_update.changed != bd_update.proposed
       - 'bd_update.config == {"fvBD": {"attributes": {"descr": "Ansible Test Update"}, "children": [{"fvRsCtx": {"attributes": {"tnFvCtxName": "anstest"}}}]}}'
       - 'bd_present_2.config.fvBD.attributes == {"arpFlood": "yes", "descr": "Ansible Test", "ipLearning": "no", "multiDstPktAct": "drop", "name": "anstest2",
@@ -118,23 +119,23 @@
   assert:
     that:
       - query_all.changed == false
-      - query_all.existing | length > 1
-      - query_all.existing.0.fvBD is defined
+      - query_all.original | length > 1
+      - query_all.original.0.fvBD is defined
       - '"rsp-subtree-class=fvRsCtx,fvRsIgmpsn,fvRsBDToNdP,fvRsBdToEpRet" in query_all.filter_string'
       - '"class/fvBD.json" in query_all.url'
       - query_tenant.changed == false
-      - query_tenant.existing | length == 1
-      - query_tenant.existing.0.fvTenant.children | length == 2
+      - query_tenant.original | length == 1
+      - query_tenant.original.0.fvTenant.children | length == 2
       - '"rsp-subtree-class=fvRsCtx,fvRsIgmpsn,fvRsBDToNdP,fvRsBdToEpRet,fvBD" in query_tenant.filter_string'
       - '"tn-anstest.json" in query_tenant.url'
       - query_bd_bd.changed == false
-      - query_bd_bd.existing != []
+      - query_bd_bd.original != []
       - '"query-target-filter=eq(fvBD.name, \"anstest\")" in query_bd_bd.filter_string'
       - '"rsp-subtree=full&rsp-subtree-class=fvRsCtx,fvRsIgmpsn,fvRsBDToNdP,fvRsBdToEpRet" in query_bd_bd.filter_string'
       - '"class/fvBD.json" in query_bd_bd.url'
       - query_bd.changed == false
-      - query_bd.existing | length == 1
-      - 'query_bd.existing.0.fvBD.attributes.name == "anstest"'
+      - query_bd.original | length == 1
+      - 'query_bd.original.0.fvBD.attributes.name == "anstest"'
       - '"rsp-subtree-class=fvRsCtx,fvRsIgmpsn,fvRsBDToNdP,fvRsBdToEpRet" in query_bd.filter_string'
       - '"tn-anstest/BD-anstest.json" in query_bd.url'
 
@@ -173,9 +174,9 @@
       - bd_absent_check_mode.changed == true
       - bd_absent_check_mode.proposed == {}
       - bd_absent.changed == true
-      - bd_absent.existing != []
+      - bd_absent.original != []
       - bd_absent_idempotent.changed == false
-      - bd_absent_idempotent.existing == []
+      - bd_absent_idempotent.original == []
       - bd_absent_missing_param.failed == true
       - 'bd_absent_missing_param.msg == "state is absent but all of the following are missing: bd"'
 

--- a/test/integration/targets/aci_bd/tasks/main.yml
+++ b/test/integration/targets/aci_bd/tasks/main.yml
@@ -16,7 +16,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
-    output_level: info
+    output_level: debug
     state: present
     tenant: anstest
   register: tenant_present

--- a/test/integration/targets/aci_bd/tasks/main.yml
+++ b/test/integration/targets/aci_bd/tasks/main.yml
@@ -75,7 +75,7 @@
   assert:
     that:
       - bd_present_check_mode.changed == true
-      - 'bd_present_check_mode.config == {"fvBD": {"attributes": {"descr": "Ansible Test", "name": "anstest"}}}'
+      - 'bd_present_check_mode.config == {"fvBD": {"attributes": {"descr": "Ansible Test"}}}'
       - bd_present.changed == true
       - bd_present.config == bd_present_check_mode.config
       - bd_present.original == []

--- a/test/integration/targets/aci_bd/tasks/main.yml
+++ b/test/integration/targets/aci_bd/tasks/main.yml
@@ -75,17 +75,17 @@
   assert:
     that:
       - bd_present_check_mode.changed == true
-      - 'bd_present_check_mode.config == {"fvBD": {"attributes": {"descr": "Ansible Test", "name": "anstest"}}}'
+      - 'bd_present_check_mode.sent == {"fvBD": {"attributes": {"descr": "Ansible Test", "name": "anstest"}}}'
       - bd_present.changed == true
-      - bd_present.config == bd_present_check_mode.config
+      - bd_present.sent == bd_present_check_mode.sent
       - bd_present.previous == []
       - bd_present_idempotent.changed == false
       - bd_present_idempotent.previous != []
       - bd_update.changed == true
       - bd_update.previous != []
       - bd_update.changed != bd_update.proposed
-      - 'bd_update.config == {"fvBD": {"attributes": {"descr": "Ansible Test Update"}, "children": [{"fvRsCtx": {"attributes": {"tnFvCtxName": "anstest"}}}]}}'
-      - 'bd_present_2.config.fvBD.attributes == {"arpFlood": "yes", "descr": "Ansible Test", "ipLearning": "no", "multiDstPktAct": "drop", "name": "anstest2",
+      - 'bd_update.sent == {"fvBD": {"attributes": {"descr": "Ansible Test Update"}, "children": [{"fvRsCtx": {"attributes": {"tnFvCtxName": "anstest"}}}]}}'
+      - 'bd_present_2.sent.fvBD.attributes == {"arpFlood": "yes", "descr": "Ansible Test", "ipLearning": "no", "multiDstPktAct": "drop", "name": "anstest2",
       "unicastRoute": "no", "unkMacUcastAct": "flood", "unkMcastAct": "opt-flood"}'
       - bd_present_missing_param.failed == true
       - 'bd_present_missing_param.msg == "state is present but all of the following are missing: tenant"'

--- a/test/integration/targets/aci_bd_subnet/tasks/main.yml
+++ b/test/integration/targets/aci_bd_subnet/tasks/main.yml
@@ -94,20 +94,20 @@
   assert:
     that:
       - create_check_mode.changed == true
-      - 'create_check_mode.config == {"fvSubnet": {"attributes": {"descr": "Ansible Test", "ip": "10.100.100.1/24", "name": "anstest"}}}'
+      - 'create_check_mode.sent == {"fvSubnet": {"attributes": {"descr": "Ansible Test", "ip": "10.100.100.1/24", "name": "anstest"}}}'
       - create_subnet.changed == true
-      - 'create_subnet.config == {"fvSubnet": {"attributes": {"descr": "Ansible Test", "ip": "10.100.100.1/24", "name": "anstest"}}}'
+      - 'create_subnet.sent == {"fvSubnet": {"attributes": {"descr": "Ansible Test", "ip": "10.100.100.1/24", "name": "anstest"}}}'
       - 'create_subnet.previous == []'
       - create_subnet2.changed == true
-      - create_subnet2.config == create_subnet2.proposed
-      - 'create_subnet2.config.fvSubnet.attributes.scope == "private,shared"'
-      - 'create_subnet2.config.fvSubnet.children.0.fvRsBDSubnetToProfile.attributes == {"tnL3extOutName": "default", "tnRtctrlProfileName": "default"}'
+      - create_subnet2.sent == create_subnet2.proposed
+      - 'create_subnet2.sent.fvSubnet.attributes.scope == "private,shared"'
+      - 'create_subnet2.sent.fvSubnet.children.0.fvRsBDSubnetToProfile.attributes == {"tnL3extOutName": "default", "tnRtctrlProfileName": "default"}'
       - create_idempotency.changed == false
       - create_idempotency.previous != []
       - modify_subnet.changed == true
       - modify_subnet.previous != []
       - modify_subnet.changed != modify_subnet.proposed
-      - 'modify_subnet.config == {"fvSubnet": {"attributes": {"ctrl": "querier", "scope": "public,shared"}}}'
+      - 'modify_subnet.sent == {"fvSubnet": {"attributes": {"ctrl": "querier", "scope": "public,shared"}}}'
       - create_bad_scope.failed == true
       - 'create_bad_scope.msg.startswith("value of scope must be one of")'
       - create_incomplete_data.failed == true

--- a/test/integration/targets/aci_bd_subnet/tasks/main.yml
+++ b/test/integration/targets/aci_bd_subnet/tasks/main.yml
@@ -97,15 +97,15 @@
       - 'create_check_mode.config == {"fvSubnet": {"attributes": {"descr": "Ansible Test", "ip": "10.100.100.1/24", "name": "anstest"}}}'
       - create_subnet.changed == true
       - 'create_subnet.config == {"fvSubnet": {"attributes": {"descr": "Ansible Test", "ip": "10.100.100.1/24", "name": "anstest"}}}'
-      - 'create_subnet.original == []'
+      - 'create_subnet.previous == []'
       - create_subnet2.changed == true
       - create_subnet2.config == create_subnet2.proposed
       - 'create_subnet2.config.fvSubnet.attributes.scope == "private,shared"'
       - 'create_subnet2.config.fvSubnet.children.0.fvRsBDSubnetToProfile.attributes == {"tnL3extOutName": "default", "tnRtctrlProfileName": "default"}'
       - create_idempotency.changed == false
-      - create_idempotency.original != []
+      - create_idempotency.previous != []
       - modify_subnet.changed == true
-      - modify_subnet.original != []
+      - modify_subnet.previous != []
       - modify_subnet.changed != modify_subnet.proposed
       - 'modify_subnet.config == {"fvSubnet": {"attributes": {"ctrl": "querier", "scope": "public,shared"}}}'
       - create_bad_scope.failed == true
@@ -170,7 +170,7 @@
   assert:
     that:
       - get_all.changed == false
-      - get_all.original | length > 1
+      - get_all.previous | length > 1
       - get_all_tenant.changed == false
       - '"tn-anstest.json" in get_all_tenant.url'
       - get_all_bd.changed == false
@@ -178,7 +178,7 @@
       - '"class/fvBD.json" in get_all_bd.url'
       - get_all_tenant_bd.changed == false
       - '"tn-anstest/BD-anstest.json" in get_all_tenant_bd.url'
-      - get_all_tenant_bd.original.0.fvBD.children | length > 1
+      - get_all_tenant_bd.previous.0.fvBD.children | length > 1
       - get_subnet_tenant.changed == false
       - '"rsp-subtree-filter=eq(fvSubnet.ip, \"10.100.100.1/24\")" in get_subnet_tenant.filter_string'
       - '"tn-anstest.json" in get_subnet_tenant.url'
@@ -186,7 +186,7 @@
       - '"query-target-filter=eq(fvBD.name, \"anstest\")" and "rsp-subtree-filter=eq(fvSubnet.ip, \"10.100.100.1/24\")" in get_subnet_bd.filter_string'
       - '"class/fvBD.json" in get_subnet_bd.url'
       - get_subnet.changed == false
-      - get_subnet.original | length == 1
+      - get_subnet.previous | length == 1
       - '"tn-anstest/BD-anstest/subnet-[10.100.100.1/24].json" in get_subnet.url'
       - get_subnets_gateway.changed == false
       - '"query-target-filter=eq(fvSubnet.ip, \"10.100.100.1/24\")" in get_subnets_gateway.filter_string'
@@ -218,10 +218,10 @@
       - delete_check_mode.changed == true
       - delete_check_mode.proposed == {}
       - delete_subnet.changed == true
-      - delete_subnet.original != []
+      - delete_subnet.previous != []
       - 'delete_subnet.method == "DELETE"'
       - delete_idempotency.changed == false
-      - delete_idempotency.original == []
+      - delete_idempotency.previous == []
 
 - name: delete bd - cleanup before ending tests
   aci_bd:

--- a/test/integration/targets/aci_bd_subnet/tasks/main.yml
+++ b/test/integration/targets/aci_bd_subnet/tasks/main.yml
@@ -16,7 +16,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
-    output_level: info
+    output_level: debug
     state: present
     tenant: anstest
   register: tenant_present

--- a/test/integration/targets/aci_bd_subnet/tasks/main.yml
+++ b/test/integration/targets/aci_bd_subnet/tasks/main.yml
@@ -16,6 +16,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: info
     state: present
     tenant: anstest
   register: tenant_present
@@ -96,15 +97,15 @@
       - 'create_check_mode.config == {"fvSubnet": {"attributes": {"descr": "Ansible Test", "ip": "10.100.100.1/24", "name": "anstest"}}}'
       - create_subnet.changed == true
       - 'create_subnet.config == {"fvSubnet": {"attributes": {"descr": "Ansible Test", "ip": "10.100.100.1/24", "name": "anstest"}}}'
-      - 'create_subnet.existing == []'
+      - 'create_subnet.original == []'
       - create_subnet2.changed == true
       - create_subnet2.config == create_subnet2.proposed
       - 'create_subnet2.config.fvSubnet.attributes.scope == "private,shared"'
       - 'create_subnet2.config.fvSubnet.children.0.fvRsBDSubnetToProfile.attributes == {"tnL3extOutName": "default", "tnRtctrlProfileName": "default"}'
       - create_idempotency.changed == false
-      - create_idempotency.existing != []
+      - create_idempotency.original != []
       - modify_subnet.changed == true
-      - modify_subnet.existing != []
+      - modify_subnet.original != []
       - modify_subnet.changed != modify_subnet.proposed
       - 'modify_subnet.config == {"fvSubnet": {"attributes": {"ctrl": "querier", "scope": "public,shared"}}}'
       - create_bad_scope.failed == true
@@ -169,7 +170,7 @@
   assert:
     that:
       - get_all.changed == false
-      - get_all.existing | length > 1
+      - get_all.original | length > 1
       - get_all_tenant.changed == false
       - '"tn-anstest.json" in get_all_tenant.url'
       - get_all_bd.changed == false
@@ -177,7 +178,7 @@
       - '"class/fvBD.json" in get_all_bd.url'
       - get_all_tenant_bd.changed == false
       - '"tn-anstest/BD-anstest.json" in get_all_tenant_bd.url'
-      - get_all_tenant_bd.existing.0.fvBD.children | length > 1
+      - get_all_tenant_bd.original.0.fvBD.children | length > 1
       - get_subnet_tenant.changed == false
       - '"rsp-subtree-filter=eq(fvSubnet.ip, \"10.100.100.1/24\")" in get_subnet_tenant.filter_string'
       - '"tn-anstest.json" in get_subnet_tenant.url'
@@ -185,7 +186,7 @@
       - '"query-target-filter=eq(fvBD.name, \"anstest\")" and "rsp-subtree-filter=eq(fvSubnet.ip, \"10.100.100.1/24\")" in get_subnet_bd.filter_string'
       - '"class/fvBD.json" in get_subnet_bd.url'
       - get_subnet.changed == false
-      - get_subnet.existing | length == 1
+      - get_subnet.original | length == 1
       - '"tn-anstest/BD-anstest/subnet-[10.100.100.1/24].json" in get_subnet.url'
       - get_subnets_gateway.changed == false
       - '"query-target-filter=eq(fvSubnet.ip, \"10.100.100.1/24\")" in get_subnets_gateway.filter_string'
@@ -217,10 +218,10 @@
       - delete_check_mode.changed == true
       - delete_check_mode.proposed == {}
       - delete_subnet.changed == true
-      - delete_subnet.existing != []
+      - delete_subnet.original != []
       - 'delete_subnet.method == "DELETE"'
       - delete_idempotency.changed == false
-      - delete_idempotency.existing == []
+      - delete_idempotency.original == []
 
 - name: delete bd - cleanup before ending tests
   aci_bd:

--- a/test/integration/targets/aci_config_rollback/tasks/main.yml
+++ b/test/integration/targets/aci_config_rollback/tasks/main.yml
@@ -49,15 +49,15 @@
     <<: *create_snapshot
     state: preview
     compare_export_policy: anstest
-    compare_snapshot: "{{ snapshots.previous.0.configSnapshotCont.children[-1].configSnapshot.attributes.name }}"
-    snapshot: "{{ snapshots.previous.0.configSnapshotCont.children[-2].configSnapshot.attributes.name }}"
+    compare_snapshot: "{{ snapshots.previous.0.sentSnapshotCont.children[-1].sentSnapshot.attributes.name }}"
+    snapshot: "{{ snapshots.previous.0.sentSnapshotCont.children[-2].sentSnapshot.attributes.name }}"
   register: rollback_preview
 
 - name: rollback to snapshot
   aci_config_rollback: &aci_rollback
     <<: *create_snapshot
     state: rollback
-    snapshot: "{{ snapshots.previous.0.configSnapshotCont.children[-1].configSnapshot.attributes.name }}"
+    snapshot: "{{ snapshots.previous.0.sentSnapshotCont.children[-1].sentSnapshot.attributes.name }}"
   ignore_errors: yes
   register: rollback_missing_param
 
@@ -87,8 +87,8 @@
       - rollback_missing_param.failed == true
       - 'rollback_missing_param.msg == "state is rollback but all of the following are missing: import_policy"'
       - rollback_rollback.changed == true
-      - '"ce2_" in rollback_rollback.config.configImportP.attributes.fileName'
-      - '".tar.gz" in rollback_rollback.config.configImportP.attributes.fileName'
+      - '"ce2_" in rollback_rollback.sent.sentImportP.attributes.fileName'
+      - '".tar.gz" in rollback_rollback.sent.sentImportP.attributes.fileName'
       - '"fabric/configimp-anstest.json" in rollback_rollback.url'
       - tenant_removed.changed == false
       - tenant_removed.previous == []

--- a/test/integration/targets/aci_config_rollback/tasks/main.yml
+++ b/test/integration/targets/aci_config_rollback/tasks/main.yml
@@ -49,15 +49,15 @@
     <<: *create_snapshot
     state: preview
     compare_export_policy: anstest
-    compare_snapshot: "{{ snapshots.previous.0.sentSnapshotCont.children[-1].sentSnapshot.attributes.name }}"
-    snapshot: "{{ snapshots.previous.0.sentSnapshotCont.children[-2].sentSnapshot.attributes.name }}"
+    compare_snapshot: "{{ snapshots.previous.0.configSnapshotCont.children[-1].configSnapshot.attributes.name }}"
+    snapshot: "{{ snapshots.previous.0.configSnapshotCont.children[-2].configSnapshot.attributes.name }}"
   register: rollback_preview
 
 - name: rollback to snapshot
   aci_config_rollback: &aci_rollback
     <<: *create_snapshot
     state: rollback
-    snapshot: "{{ snapshots.previous.0.sentSnapshotCont.children[-1].sentSnapshot.attributes.name }}"
+    snapshot: "{{ snapshots.previous.0.configSnapshotCont.children[-1].configSnapshot.attributes.name }}"
   ignore_errors: yes
   register: rollback_missing_param
 
@@ -87,8 +87,8 @@
       - rollback_missing_param.failed == true
       - 'rollback_missing_param.msg == "state is rollback but all of the following are missing: import_policy"'
       - rollback_rollback.changed == true
-      - '"ce2_" in rollback_rollback.sent.sentImportP.attributes.fileName'
-      - '".tar.gz" in rollback_rollback.sent.sentImportP.attributes.fileName'
+      - '"ce2_" in rollback_rollback.sent.configImportP.attributes.fileName'
+      - '".tar.gz" in rollback_rollback.sent.configImportP.attributes.fileName'
       - '"fabric/configimp-anstest.json" in rollback_rollback.url'
       - tenant_removed.changed == false
       - tenant_removed.previous == []

--- a/test/integration/targets/aci_config_rollback/tasks/main.yml
+++ b/test/integration/targets/aci_config_rollback/tasks/main.yml
@@ -16,6 +16,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: info
     state: absent
     tenant: anstest
 
@@ -48,15 +49,15 @@
     <<: *create_snapshot
     state: preview
     compare_export_policy: anstest
-    compare_snapshot: "{{ snapshots.existing.0.configSnapshotCont.children[-1].configSnapshot.attributes.name }}"
-    snapshot: "{{ snapshots.existing.0.configSnapshotCont.children[-2].configSnapshot.attributes.name }}"
+    compare_snapshot: "{{ snapshots.original.0.configSnapshotCont.children[-1].configSnapshot.attributes.name }}"
+    snapshot: "{{ snapshots.original.0.configSnapshotCont.children[-2].configSnapshot.attributes.name }}"
   register: rollback_preview
 
 - name: rollback to snapshot
   aci_config_rollback: &aci_rollback
     <<: *create_snapshot
     state: rollback
-    snapshot: "{{ snapshots.existing.0.configSnapshotCont.children[-1].configSnapshot.attributes.name }}"
+    snapshot: "{{ snapshots.original.0.configSnapshotCont.children[-1].configSnapshot.attributes.name }}"
   ignore_errors: yes
   register: rollback_missing_param
 
@@ -90,4 +91,4 @@
       - '".tar.gz" in rollback_rollback.config.configImportP.attributes.fileName'
       - '"fabric/configimp-anstest.json" in rollback_rollback.url'
       - tenant_removed.changed == false
-      - tenant_removed.existing == []
+      - tenant_removed.original == []

--- a/test/integration/targets/aci_config_rollback/tasks/main.yml
+++ b/test/integration/targets/aci_config_rollback/tasks/main.yml
@@ -16,7 +16,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
-    output_level: info
+    output_level: debug
     state: absent
     tenant: anstest
 

--- a/test/integration/targets/aci_config_rollback/tasks/main.yml
+++ b/test/integration/targets/aci_config_rollback/tasks/main.yml
@@ -49,15 +49,15 @@
     <<: *create_snapshot
     state: preview
     compare_export_policy: anstest
-    compare_snapshot: "{{ snapshots.original.0.configSnapshotCont.children[-1].configSnapshot.attributes.name }}"
-    snapshot: "{{ snapshots.original.0.configSnapshotCont.children[-2].configSnapshot.attributes.name }}"
+    compare_snapshot: "{{ snapshots.previous.0.configSnapshotCont.children[-1].configSnapshot.attributes.name }}"
+    snapshot: "{{ snapshots.previous.0.configSnapshotCont.children[-2].configSnapshot.attributes.name }}"
   register: rollback_preview
 
 - name: rollback to snapshot
   aci_config_rollback: &aci_rollback
     <<: *create_snapshot
     state: rollback
-    snapshot: "{{ snapshots.original.0.configSnapshotCont.children[-1].configSnapshot.attributes.name }}"
+    snapshot: "{{ snapshots.previous.0.configSnapshotCont.children[-1].configSnapshot.attributes.name }}"
   ignore_errors: yes
   register: rollback_missing_param
 
@@ -91,4 +91,4 @@
       - '".tar.gz" in rollback_rollback.config.configImportP.attributes.fileName'
       - '"fabric/configimp-anstest.json" in rollback_rollback.url'
       - tenant_removed.changed == false
-      - tenant_removed.original == []
+      - tenant_removed.previous == []

--- a/test/integration/targets/aci_config_snapshot/tasks/main.yml
+++ b/test/integration/targets/aci_config_snapshot/tasks/main.yml
@@ -16,6 +16,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: info
     export_policy: anstest
     max_count: 10
     include_secure: no
@@ -66,7 +67,7 @@
 
 - name: generate snapshot name
   set_fact:
-    test_snapshot: "{{ query_export.existing.0.configSnapshotCont.children.0.configSnapshot.attributes.rn.strip('snapshot-') }}"
+    test_snapshot: "{{ query_export.original.0.configSnapshotCont.children.0.configSnapshot.attributes.rn.strip('snapshot-') }}"
 
 - name: query with export_policy and snapshot
   aci_config_snapshot: &query_both
@@ -93,12 +94,12 @@
       - query_export.failed == false
       - query_export.changed == false
       - '"snapshots-[uni/fabric/configexp-anstest].json" in query_export.url'
-      - 'query_export.existing.0.configSnapshotCont.attributes.name == "anstest"'
-      - query_export.existing.0.configSnapshotCont.children | length > 1
+      - 'query_export.original.0.configSnapshotCont.attributes.name == "anstest"'
+      - query_export.original.0.configSnapshotCont.children | length > 1
       - query_export_snapshot.failed == false
       - query_export_snapshot.changed == false
       - '"snapshots-[uni/fabric/configexp-anstest]/snapshot-{{ test_snapshot }}.json" in query_export_snapshot.url'
-      - query_export_snapshot.existing | length == 1
+      - query_export_snapshot.original | length == 1
       - query_snapshot.failed == false
       - query_snapshot.changed == false
       - '"class/configSnapshot.json" in query_snapshot.url'
@@ -106,7 +107,7 @@
       - query_all.failed == false
       - query_all.changed == false
       - '"class/configSnapshot.json" in query_all.url'
-      - query_all.existing | length > 1
+      - query_all.original | length > 1
 
 - name: delete works
   aci_config_snapshot: &delete
@@ -132,10 +133,10 @@
       - delete_snapshot.failed == false
       - delete_snapshot.changed == true
       - 'delete_snapshot.config == {"configSnapshot": {"attributes": {"retire": "yes"}}}'
-      - delete_snapshot.existing != []
-      - delete_snapshot.existing.0.configSnapshot.attributes.name == test_snapshot
+      - delete_snapshot.original != []
+      - delete_snapshot.original.0.configSnapshot.attributes.name == test_snapshot
       - delete_idempotent.failed == false
       - delete_idempotent.changed == false
-      - delete_idempotent.existing == []
+      - delete_idempotent.original == []
       - delete_missing_param.failed == true
       - 'delete_missing_param.msg == "state is absent but all of the following are missing: snapshot"'

--- a/test/integration/targets/aci_config_snapshot/tasks/main.yml
+++ b/test/integration/targets/aci_config_snapshot/tasks/main.yml
@@ -67,7 +67,7 @@
 
 - name: generate snapshot name
   set_fact:
-    test_snapshot: "{{ query_export.original.0.configSnapshotCont.children.0.configSnapshot.attributes.rn.strip('snapshot-') }}"
+    test_snapshot: "{{ query_export.previous.0.configSnapshotCont.children.0.configSnapshot.attributes.rn.strip('snapshot-') }}"
 
 - name: query with export_policy and snapshot
   aci_config_snapshot: &query_both
@@ -94,12 +94,12 @@
       - query_export.failed == false
       - query_export.changed == false
       - '"snapshots-[uni/fabric/configexp-anstest].json" in query_export.url'
-      - 'query_export.original.0.configSnapshotCont.attributes.name == "anstest"'
-      - query_export.original.0.configSnapshotCont.children | length > 1
+      - 'query_export.previous.0.configSnapshotCont.attributes.name == "anstest"'
+      - query_export.previous.0.configSnapshotCont.children | length > 1
       - query_export_snapshot.failed == false
       - query_export_snapshot.changed == false
       - '"snapshots-[uni/fabric/configexp-anstest]/snapshot-{{ test_snapshot }}.json" in query_export_snapshot.url'
-      - query_export_snapshot.original | length == 1
+      - query_export_snapshot.previous | length == 1
       - query_snapshot.failed == false
       - query_snapshot.changed == false
       - '"class/configSnapshot.json" in query_snapshot.url'
@@ -107,7 +107,7 @@
       - query_all.failed == false
       - query_all.changed == false
       - '"class/configSnapshot.json" in query_all.url'
-      - query_all.original | length > 1
+      - query_all.previous | length > 1
 
 - name: delete works
   aci_config_snapshot: &delete
@@ -133,10 +133,10 @@
       - delete_snapshot.failed == false
       - delete_snapshot.changed == true
       - 'delete_snapshot.config == {"configSnapshot": {"attributes": {"retire": "yes"}}}'
-      - delete_snapshot.original != []
-      - delete_snapshot.original.0.configSnapshot.attributes.name == test_snapshot
+      - delete_snapshot.previous != []
+      - delete_snapshot.previous.0.configSnapshot.attributes.name == test_snapshot
       - delete_idempotent.failed == false
       - delete_idempotent.changed == false
-      - delete_idempotent.original == []
+      - delete_idempotent.previous == []
       - delete_missing_param.failed == true
       - 'delete_missing_param.msg == "state is absent but all of the following are missing: snapshot"'

--- a/test/integration/targets/aci_config_snapshot/tasks/main.yml
+++ b/test/integration/targets/aci_config_snapshot/tasks/main.yml
@@ -27,7 +27,7 @@
 - name: update snapshot to include secure and use xml - update works
   aci_config_snapshot:
     <<: *create_snapshot
-    include_secure: "yes"
+    include_secure: yes
     format: xml
   register: create_update
 

--- a/test/integration/targets/aci_config_snapshot/tasks/main.yml
+++ b/test/integration/targets/aci_config_snapshot/tasks/main.yml
@@ -16,7 +16,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
-    output_level: info
+    output_level: debug
     export_policy: anstest
     max_count: 10
     include_secure: no

--- a/test/integration/targets/aci_config_snapshot/tasks/main.yml
+++ b/test/integration/targets/aci_config_snapshot/tasks/main.yml
@@ -50,12 +50,12 @@
     that:
       - create.failed == false
       - create.changed == true
-      - 'create.sent.sentExportP.attributes.adminSt == "triggered"'
+      - 'create.sent.configExportP.attributes.adminSt == "triggered"'
       - create_update.failed == false
       - create_update.changed == true
       - 'create_update.sent == {"configExportP": {"attributes": {"adminSt": "triggered", "format": "xml", "includeSecureFields": "yes"}}}'
       - invalid_max_count.failed == true
-      - 'invalid_max_count.msg == "The \"max_count\" must be a number between 1 and 10"'
+      - invalid_max_count.msg == "Parameter 'max_count' must be a number between 1 and 10"
       - missing_param.failed == true
       - 'missing_param.msg == "state is present but all of the following are missing: export_policy"'
 
@@ -67,7 +67,7 @@
 
 - name: generate snapshot name
   set_fact:
-    test_snapshot: "{{ query_export.previous.0.sentSnapshotCont.children.0.sentSnapshot.attributes.rn.strip('snapshot-') }}"
+    test_snapshot: "{{ query_export.previous.0.configSnapshotCont.children.0.configSnapshot.attributes.rn.strip('snapshot-') }}"
 
 - name: query with export_policy and snapshot
   aci_config_snapshot: &query_both
@@ -94,8 +94,8 @@
       - query_export.failed == false
       - query_export.changed == false
       - '"snapshots-[uni/fabric/configexp-anstest].json" in query_export.url'
-      - 'query_export.previous.0.sentSnapshotCont.attributes.name == "anstest"'
-      - query_export.previous.0.sentSnapshotCont.children | length > 1
+      - query_export.previous.0.configSnapshotCont.attributes.name == "anstest"
+      - query_export.previous.0.configSnapshotCont.children | length > 1
       - query_export_snapshot.failed == false
       - query_export_snapshot.changed == false
       - '"snapshots-[uni/fabric/configexp-anstest]/snapshot-{{ test_snapshot }}.json" in query_export_snapshot.url'
@@ -134,7 +134,7 @@
       - delete_snapshot.changed == true
       - 'delete_snapshot.sent == {"configSnapshot": {"attributes": {"retire": "yes"}}}'
       - delete_snapshot.previous != []
-      - delete_snapshot.previous.0.sentSnapshot.attributes.name == test_snapshot
+      - delete_snapshot.previous.0.configSnapshot.attributes.name == test_snapshot
       - delete_idempotent.failed == false
       - delete_idempotent.changed == false
       - delete_idempotent.previous == []

--- a/test/integration/targets/aci_config_snapshot/tasks/main.yml
+++ b/test/integration/targets/aci_config_snapshot/tasks/main.yml
@@ -50,10 +50,10 @@
     that:
       - create.failed == false
       - create.changed == true
-      - 'create.config.configExportP.attributes.adminSt == "triggered"'
+      - 'create.sent.sentExportP.attributes.adminSt == "triggered"'
       - create_update.failed == false
       - create_update.changed == true
-      - 'create_update.config == {"configExportP": {"attributes": {"adminSt": "triggered", "format": "xml", "includeSecureFields": "yes"}}}'
+      - 'create_update.sent == {"configExportP": {"attributes": {"adminSt": "triggered", "format": "xml", "includeSecureFields": "yes"}}}'
       - invalid_max_count.failed == true
       - 'invalid_max_count.msg == "The \"max_count\" must be a number between 1 and 10"'
       - missing_param.failed == true
@@ -67,7 +67,7 @@
 
 - name: generate snapshot name
   set_fact:
-    test_snapshot: "{{ query_export.previous.0.configSnapshotCont.children.0.configSnapshot.attributes.rn.strip('snapshot-') }}"
+    test_snapshot: "{{ query_export.previous.0.sentSnapshotCont.children.0.sentSnapshot.attributes.rn.strip('snapshot-') }}"
 
 - name: query with export_policy and snapshot
   aci_config_snapshot: &query_both
@@ -94,8 +94,8 @@
       - query_export.failed == false
       - query_export.changed == false
       - '"snapshots-[uni/fabric/configexp-anstest].json" in query_export.url'
-      - 'query_export.previous.0.configSnapshotCont.attributes.name == "anstest"'
-      - query_export.previous.0.configSnapshotCont.children | length > 1
+      - 'query_export.previous.0.sentSnapshotCont.attributes.name == "anstest"'
+      - query_export.previous.0.sentSnapshotCont.children | length > 1
       - query_export_snapshot.failed == false
       - query_export_snapshot.changed == false
       - '"snapshots-[uni/fabric/configexp-anstest]/snapshot-{{ test_snapshot }}.json" in query_export_snapshot.url'
@@ -132,9 +132,9 @@
     that:
       - delete_snapshot.failed == false
       - delete_snapshot.changed == true
-      - 'delete_snapshot.config == {"configSnapshot": {"attributes": {"retire": "yes"}}}'
+      - 'delete_snapshot.sent == {"configSnapshot": {"attributes": {"retire": "yes"}}}'
       - delete_snapshot.previous != []
-      - delete_snapshot.previous.0.configSnapshot.attributes.name == test_snapshot
+      - delete_snapshot.previous.0.sentSnapshot.attributes.name == test_snapshot
       - delete_idempotent.failed == false
       - delete_idempotent.changed == false
       - delete_idempotent.previous == []

--- a/test/integration/targets/aci_contract/tasks/main.yml
+++ b/test/integration/targets/aci_contract/tasks/main.yml
@@ -61,13 +61,13 @@
     that:
       - present_check_mode.changed == true
       - present_check_mode.previous == []
-      - 'present_check_mode.config == {"vzBrCP": {"attributes": {"name": "anstest", "descr": "Ansible Test"}}}'
+      - 'present_check_mode.sent == {"vzBrCP": {"attributes": {"name": "anstest", "descr": "Ansible Test"}}}'
       - contract_present.changed == true
-      - contract_present.config == present_check_mode.config
+      - contract_present.sent == present_check_mode.sent
       - present_idempotent.changed == false
       - present_update.changed == true
-      - present_update.config != present_update.proposed
-      - 'present_update.config.vzBrCP.attributes.scope == "application-profile"'
+      - present_update.sent != present_update.proposed
+      - 'present_update.sent.vzBrCP.attributes.scope == "application-profile"'
       - present_missing_param.failed == true
       - 'present_missing_param.msg == "state is present but all of the following are missing: contract"'
 

--- a/test/integration/targets/aci_contract/tasks/main.yml
+++ b/test/integration/targets/aci_contract/tasks/main.yml
@@ -60,7 +60,7 @@
   assert:
     that:
       - present_check_mode.changed == true
-      - present_check_mode.original == []
+      - present_check_mode.previous == []
       - 'present_check_mode.config == {"vzBrCP": {"attributes": {"name": "anstest", "descr": "Ansible Test"}}}'
       - contract_present.changed == true
       - contract_present.config == present_check_mode.config
@@ -100,19 +100,19 @@
   assert:
     that:
       - query_contract.changed == false
-      - query_contract.original | length == 1
+      - query_contract.previous | length == 1
       - '"tn-anstest/brc-anstest.json" in query_contract.url'
       - query_tenant.changed == false
-      - query_tenant.original | length == 1
-      - query_tenant.original.0.fvTenant.children | length > 1
+      - query_tenant.previous | length == 1
+      - query_tenant.previous.0.fvTenant.children | length > 1
       - '"rsp-subtree-class=vzBrCP" in query_tenant.filter_string'
       - '"tn-anstest.json" in query_tenant.url'
       - query_name.changed == false
-      - query_name.original != []
+      - query_name.previous != []
       - '"query-target-filter=eq(vzBrCP.name, \"anstest\")" in query_name.filter_string'
       - '"class/vzBrCP.json" in query_name.url'
       - query_all.changed == false
-      - query_all.original | length > 1
+      - query_all.previous | length > 1
       - '"class/vzBrCP.json" in query_all.url'
 
 - name: delete contract - check mode works
@@ -148,11 +148,11 @@
   assert:
     that:
       - absent_check_mode.changed == true
-      - absent_check_mode.original != []
+      - absent_check_mode.previous != []
       - contract_absent.changed == true
-      - contract_absent.original == absent_check_mode.original
+      - contract_absent.previous == absent_check_mode.previous
       - absent_idempotent.changed == false
-      - absent_idempotent.original == []
+      - absent_idempotent.previous == []
       - absent_missing_param.failed == true
       - 'absent_missing_param.msg == "state is absent but all of the following are missing: tenant"'
 

--- a/test/integration/targets/aci_contract/tasks/main.yml
+++ b/test/integration/targets/aci_contract/tasks/main.yml
@@ -16,6 +16,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: info
     state: present
     tenant: anstest
   register: tenant_present
@@ -59,7 +60,7 @@
   assert:
     that:
       - present_check_mode.changed == true
-      - present_check_mode.existing == []
+      - present_check_mode.original == []
       - 'present_check_mode.config == {"vzBrCP": {"attributes": {"name": "anstest", "descr": "Ansible Test"}}}'
       - contract_present.changed == true
       - contract_present.config == present_check_mode.config
@@ -99,19 +100,19 @@
   assert:
     that:
       - query_contract.changed == false
-      - query_contract.existing | length == 1
+      - query_contract.original | length == 1
       - '"tn-anstest/brc-anstest.json" in query_contract.url'
       - query_tenant.changed == false
-      - query_tenant.existing | length == 1
-      - query_tenant.existing.0.fvTenant.children | length > 1
+      - query_tenant.original | length == 1
+      - query_tenant.original.0.fvTenant.children | length > 1
       - '"rsp-subtree-class=vzBrCP" in query_tenant.filter_string'
       - '"tn-anstest.json" in query_tenant.url'
       - query_name.changed == false
-      - query_name.existing != []
+      - query_name.original != []
       - '"query-target-filter=eq(vzBrCP.name, \"anstest\")" in query_name.filter_string'
       - '"class/vzBrCP.json" in query_name.url'
       - query_all.changed == false
-      - query_all.existing | length > 1
+      - query_all.original | length > 1
       - '"class/vzBrCP.json" in query_all.url'
 
 - name: delete contract - check mode works
@@ -147,11 +148,11 @@
   assert:
     that:
       - absent_check_mode.changed == true
-      - absent_check_mode.existing != []
+      - absent_check_mode.original != []
       - contract_absent.changed == true
-      - contract_absent.existing == absent_check_mode.existing
+      - contract_absent.original == absent_check_mode.original
       - absent_idempotent.changed == false
-      - absent_idempotent.existing == []
+      - absent_idempotent.original == []
       - absent_missing_param.failed == true
       - 'absent_missing_param.msg == "state is absent but all of the following are missing: tenant"'
 

--- a/test/integration/targets/aci_contract/tasks/main.yml
+++ b/test/integration/targets/aci_contract/tasks/main.yml
@@ -16,7 +16,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
-    output_level: info
+    output_level: debug
     state: present
     tenant: anstest
   register: tenant_present

--- a/test/integration/targets/aci_contract_subject/tasks/main.yml
+++ b/test/integration/targets/aci_contract_subject/tasks/main.yml
@@ -73,17 +73,17 @@
   assert:
     that:
       - subject_present_check_mode.changed == true
-      - 'subject_present_check_mode.config == {"vzSubj": {"attributes": {"descr": "Ansible Test", "name": "anstest"}}}'
+      - 'subject_present_check_mode.sent == {"vzSubj": {"attributes": {"descr": "Ansible Test", "name": "anstest"}}}'
       - subject_present.changed == true
       - subject_present.previous == []
-      - subject_present.config == subject_present_check_mode.config
+      - subject_present.sent == subject_present_check_mode.sent
       - subject_present_idempotent.changed == false
       - subject_present_idempotent.previous != []
       - subject_update.changed == true
-      - subject_update.config != subject_update.proposed
-      - 'subject_update.config.vzSubj.attributes == {"prio": "level2", "provMatchT": "AtmostOne"}'
+      - subject_update.sent != subject_update.proposed
+      - 'subject_update.sent.vzSubj.attributes == {"prio": "level2", "provMatchT": "AtmostOne"}'
       - subject_present_2.changed == true
-      - 'subject_present_2.config.vzSubj.attributes == {"consMatchT": "All", "name": "anstest2", "prio": "level3", "revFltPorts": "no"}'
+      - 'subject_present_2.sent.vzSubj.attributes == {"consMatchT": "All", "name": "anstest2", "prio": "level3", "revFltPorts": "no"}'
       - present_missing_param.failed == true
       - 'present_missing_param.msg == "state is present but all of the following are missing: contract, subject"'
 

--- a/test/integration/targets/aci_contract_subject/tasks/main.yml
+++ b/test/integration/targets/aci_contract_subject/tasks/main.yml
@@ -16,6 +16,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: info
     state: present
     tenant: anstest
   register: tenant_present
@@ -74,10 +75,10 @@
       - subject_present_check_mode.changed == true
       - 'subject_present_check_mode.config == {"vzSubj": {"attributes": {"descr": "Ansible Test", "name": "anstest"}}}'
       - subject_present.changed == true
-      - subject_present.existing == []
+      - subject_present.original == []
       - subject_present.config == subject_present_check_mode.config
       - subject_present_idempotent.changed == false
-      - subject_present_idempotent.existing != []
+      - subject_present_idempotent.original != []
       - subject_update.changed == true
       - subject_update.config != subject_update.proposed
       - 'subject_update.config.vzSubj.attributes == {"prio": "level2", "provMatchT": "AtmostOne"}'
@@ -141,48 +142,48 @@
   assert:
     that:
       - query_tenant_contract_subject.changed == false
-      - query_tenant_contract_subject.existing | length == 1
-      - 'query_tenant_contract_subject.existing.0.vzSubj.attributes.name == "anstest"'
+      - query_tenant_contract_subject.original | length == 1
+      - 'query_tenant_contract_subject.original.0.vzSubj.attributes.name == "anstest"'
       - '"tn-anstest/brc-anstest/subj-anstest.json" in query_tenant_contract_subject.url'
       - query_tenant_contract.changed == false
-      - query_tenant_contract.existing | length == 1
-      - 'query_tenant_contract.existing.0.vzBrCP.attributes.name == "anstest"'
-      - query_tenant_contract.existing.0.vzBrCP.children | length == 2
+      - query_tenant_contract.original | length == 1
+      - 'query_tenant_contract.original.0.vzBrCP.attributes.name == "anstest"'
+      - query_tenant_contract.original.0.vzBrCP.children | length == 2
       - '"rsp-subtree-class=vzSubj" in query_tenant_contract.filter_string'
       - '"tn-anstest/brc-anstest.json" in query_tenant_contract.url'
       - query_tenant_subject.changed == false
-      - query_tenant_subject.existing | length == 1
-      - 'query_tenant_subject.existing.0.fvTenant.attributes.name == "anstest"'
-      - query_tenant_subject.existing.0.fvTenant.children.0.vzBrCP.children | length == 1
-      - 'query_tenant_subject.existing.0.fvTenant.children.0.vzBrCP.children.0.vzSubj.attributes.name == "anstest"'
+      - query_tenant_subject.original | length == 1
+      - 'query_tenant_subject.original.0.fvTenant.attributes.name == "anstest"'
+      - query_tenant_subject.original.0.fvTenant.children.0.vzBrCP.children | length == 1
+      - 'query_tenant_subject.original.0.fvTenant.children.0.vzBrCP.children.0.vzSubj.attributes.name == "anstest"'
       - '"rsp-subtree-filter=eq(vzSubj.name, \"anstest\")" in query_tenant_subject.filter_string'
       - '"rsp-subtree-class=vzSubj" in query_tenant_subject.filter_string'
       - '"tn-anstest.json" in query_tenant_subject.url'
       - query_contract_subject.changed == false
-      - 'query_contract_subject.existing.0.vzBrCP.attributes.name == "anstest"'
-      - query_contract_subject.existing.0.vzBrCP.children | length == 1
-      - 'query_contract_subject.existing.0.vzBrCP.children.0.vzSubj.attributes.name == "anstest"'
+      - 'query_contract_subject.original.0.vzBrCP.attributes.name == "anstest"'
+      - query_contract_subject.original.0.vzBrCP.children | length == 1
+      - 'query_contract_subject.original.0.vzBrCP.children.0.vzSubj.attributes.name == "anstest"'
       - '"query-target-filter=eq(vzBrCP.name, \"anstest\")" in query_contract_subject.filter_string'
       - '"rsp-subtree-filter=eq(vzSubj.name, \"anstest\")" in query_contract_subject.filter_string'
       - '"rsp-subtree-class=vzSubj" in query_contract_subject.filter_string'
       - '"class/vzBrCP.json" in query_contract_subject.url'
       - query_tenant.changed == false
-      - query_tenant.existing | length == 1
-      - 'query_tenant.existing.0.fvTenant.attributes.name == "anstest"'
+      - query_tenant.original | length == 1
+      - 'query_tenant.original.0.fvTenant.attributes.name == "anstest"'
       - '"rsp-subtree-class=vzBrCP,vzSubj" in query_tenant.filter_string'
       - '"tn-anstest.json" in query_tenant.url'
       - query_contract.changed == false
-      - 'query_contract.existing.0.vzBrCP.attributes.name == "anstest"'
+      - 'query_contract.original.0.vzBrCP.attributes.name == "anstest"'
       - '"query-target-filter=eq(vzBrCP.name, \"anstest\")" in query_contract.filter_string'
       - '"rsp-subtree-class=vzSubj" in query_contract.filter_string'
       - '"class/vzBrCP.json" in query_contract.url'
       - query_subject.changed == false
-      - 'query_subject.existing.0.vzSubj.attributes.name == "anstest"'
+      - 'query_subject.original.0.vzSubj.attributes.name == "anstest"'
       - '"query-target-filter=eq(vzSubj.name, \"anstest\")" in query_subject.filter_string'
       - '"class/vzSubj.json" in query_subject.url'
       - query_all.changed == false
-      - query_all.existing > 1
-      - query_all.existing.0.vzSubj is defined
+      - query_all.original > 1
+      - query_all.original.0.vzSubj is defined
       - '"class/vzSubj.json" in query_all.url'
 
 - name: delete subject - check mode works
@@ -218,12 +219,12 @@
   assert:
     that:
       - subject_absent_check_mode.changed == true
-      - subject_absent_check_mode.existing != []
+      - subject_absent_check_mode.original != []
       - subject_absent_check_mode.proposed == {}
       - subject_absent.changed == true
-      - subject_absent.existing == subject_absent_check_mode.existing
+      - subject_absent.original == subject_absent_check_mode.original
       - subject_absent_idempotent.changed == false
-      - subject_absent_idempotent.existing == []
+      - subject_absent_idempotent.original == []
       - absent_missing_param.failed == true
       - 'absent_missing_param.msg == "state is absent but all of the following are missing: subject"'
 

--- a/test/integration/targets/aci_contract_subject/tasks/main.yml
+++ b/test/integration/targets/aci_contract_subject/tasks/main.yml
@@ -75,10 +75,10 @@
       - subject_present_check_mode.changed == true
       - 'subject_present_check_mode.config == {"vzSubj": {"attributes": {"descr": "Ansible Test", "name": "anstest"}}}'
       - subject_present.changed == true
-      - subject_present.original == []
+      - subject_present.previous == []
       - subject_present.config == subject_present_check_mode.config
       - subject_present_idempotent.changed == false
-      - subject_present_idempotent.original != []
+      - subject_present_idempotent.previous != []
       - subject_update.changed == true
       - subject_update.config != subject_update.proposed
       - 'subject_update.config.vzSubj.attributes == {"prio": "level2", "provMatchT": "AtmostOne"}'
@@ -142,48 +142,48 @@
   assert:
     that:
       - query_tenant_contract_subject.changed == false
-      - query_tenant_contract_subject.original | length == 1
-      - 'query_tenant_contract_subject.original.0.vzSubj.attributes.name == "anstest"'
+      - query_tenant_contract_subject.previous | length == 1
+      - 'query_tenant_contract_subject.previous.0.vzSubj.attributes.name == "anstest"'
       - '"tn-anstest/brc-anstest/subj-anstest.json" in query_tenant_contract_subject.url'
       - query_tenant_contract.changed == false
-      - query_tenant_contract.original | length == 1
-      - 'query_tenant_contract.original.0.vzBrCP.attributes.name == "anstest"'
-      - query_tenant_contract.original.0.vzBrCP.children | length == 2
+      - query_tenant_contract.previous | length == 1
+      - 'query_tenant_contract.previous.0.vzBrCP.attributes.name == "anstest"'
+      - query_tenant_contract.previous.0.vzBrCP.children | length == 2
       - '"rsp-subtree-class=vzSubj" in query_tenant_contract.filter_string'
       - '"tn-anstest/brc-anstest.json" in query_tenant_contract.url'
       - query_tenant_subject.changed == false
-      - query_tenant_subject.original | length == 1
-      - 'query_tenant_subject.original.0.fvTenant.attributes.name == "anstest"'
-      - query_tenant_subject.original.0.fvTenant.children.0.vzBrCP.children | length == 1
-      - 'query_tenant_subject.original.0.fvTenant.children.0.vzBrCP.children.0.vzSubj.attributes.name == "anstest"'
+      - query_tenant_subject.previous | length == 1
+      - 'query_tenant_subject.previous.0.fvTenant.attributes.name == "anstest"'
+      - query_tenant_subject.previous.0.fvTenant.children.0.vzBrCP.children | length == 1
+      - 'query_tenant_subject.previous.0.fvTenant.children.0.vzBrCP.children.0.vzSubj.attributes.name == "anstest"'
       - '"rsp-subtree-filter=eq(vzSubj.name, \"anstest\")" in query_tenant_subject.filter_string'
       - '"rsp-subtree-class=vzSubj" in query_tenant_subject.filter_string'
       - '"tn-anstest.json" in query_tenant_subject.url'
       - query_contract_subject.changed == false
-      - 'query_contract_subject.original.0.vzBrCP.attributes.name == "anstest"'
-      - query_contract_subject.original.0.vzBrCP.children | length == 1
-      - 'query_contract_subject.original.0.vzBrCP.children.0.vzSubj.attributes.name == "anstest"'
+      - 'query_contract_subject.previous.0.vzBrCP.attributes.name == "anstest"'
+      - query_contract_subject.previous.0.vzBrCP.children | length == 1
+      - 'query_contract_subject.previous.0.vzBrCP.children.0.vzSubj.attributes.name == "anstest"'
       - '"query-target-filter=eq(vzBrCP.name, \"anstest\")" in query_contract_subject.filter_string'
       - '"rsp-subtree-filter=eq(vzSubj.name, \"anstest\")" in query_contract_subject.filter_string'
       - '"rsp-subtree-class=vzSubj" in query_contract_subject.filter_string'
       - '"class/vzBrCP.json" in query_contract_subject.url'
       - query_tenant.changed == false
-      - query_tenant.original | length == 1
-      - 'query_tenant.original.0.fvTenant.attributes.name == "anstest"'
+      - query_tenant.previous | length == 1
+      - 'query_tenant.previous.0.fvTenant.attributes.name == "anstest"'
       - '"rsp-subtree-class=vzBrCP,vzSubj" in query_tenant.filter_string'
       - '"tn-anstest.json" in query_tenant.url'
       - query_contract.changed == false
-      - 'query_contract.original.0.vzBrCP.attributes.name == "anstest"'
+      - 'query_contract.previous.0.vzBrCP.attributes.name == "anstest"'
       - '"query-target-filter=eq(vzBrCP.name, \"anstest\")" in query_contract.filter_string'
       - '"rsp-subtree-class=vzSubj" in query_contract.filter_string'
       - '"class/vzBrCP.json" in query_contract.url'
       - query_subject.changed == false
-      - 'query_subject.original.0.vzSubj.attributes.name == "anstest"'
+      - 'query_subject.previous.0.vzSubj.attributes.name == "anstest"'
       - '"query-target-filter=eq(vzSubj.name, \"anstest\")" in query_subject.filter_string'
       - '"class/vzSubj.json" in query_subject.url'
       - query_all.changed == false
-      - query_all.original > 1
-      - query_all.original.0.vzSubj is defined
+      - query_all.previous > 1
+      - query_all.previous.0.vzSubj is defined
       - '"class/vzSubj.json" in query_all.url'
 
 - name: delete subject - check mode works
@@ -219,12 +219,12 @@
   assert:
     that:
       - subject_absent_check_mode.changed == true
-      - subject_absent_check_mode.original != []
+      - subject_absent_check_mode.previous != []
       - subject_absent_check_mode.proposed == {}
       - subject_absent.changed == true
-      - subject_absent.original == subject_absent_check_mode.original
+      - subject_absent.previous == subject_absent_check_mode.previous
       - subject_absent_idempotent.changed == false
-      - subject_absent_idempotent.original == []
+      - subject_absent_idempotent.previous == []
       - absent_missing_param.failed == true
       - 'absent_missing_param.msg == "state is absent but all of the following are missing: subject"'
 

--- a/test/integration/targets/aci_contract_subject/tasks/main.yml
+++ b/test/integration/targets/aci_contract_subject/tasks/main.yml
@@ -16,7 +16,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
-    output_level: info
+    output_level: debug
     state: present
     tenant: anstest
   register: tenant_present

--- a/test/integration/targets/aci_contract_subject_to_filter/tasks/main.yml
+++ b/test/integration/targets/aci_contract_subject_to_filter/tasks/main.yml
@@ -16,6 +16,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: info
     state: present
     tenant: anstest
   register: tenant_present
@@ -84,14 +85,14 @@
   assert:
     that:
       - subject_filter_present_check_mode.changed == true
-      - subject_filter_present_check_mode.existing == []
+      - subject_filter_present_check_mode.original == []
       - 'subject_filter_present_check_mode.config == {"vzRsSubjFiltAtt": {"attributes": {"directives": "log", "tnVzFilterName": "anstest"}}}'
       - subject_filter_present.changed == true
-      - subject_filter_present.existing == []
+      - subject_filter_present.original == []
       - subject_filter_present.config == subject_filter_present_check_mode.config
       - subject_filter_present_2.changed == true
       - subject_filter_present_idempotent.changed == false
-      - subject_filter_present_idempotent.existing != []
+      - subject_filter_present_idempotent.original != []
       - subject_filter_update.changed == true
       - 'subject_filter_update.config.vzRsSubjFiltAtt.attributes == {"directives": ""}'
       - present_missing_param.failed == true
@@ -114,10 +115,10 @@
   assert:
     that:
       - query_all.changed == false
-      - query_all.existing | length > 1
-      - query_all.existing.0.vzRsSubjFiltAtt is defined
+      - query_all.original | length > 1
+      - query_all.original.0.vzRsSubjFiltAtt is defined
       - query_binding.changed == false
-      - query_binding.existing != []
+      - query_binding.original != []
 
 - name: delete subject filter binding - check mode works
   aci_contract_subject_to_filter: &aci_subject_filter_absent
@@ -153,11 +154,11 @@
     that:
       - subject_filter_absent_check_mode.changed == true
       - subject_filter_absent_check_mode.proposed == {}
-      - subject_filter_absent_check_mode.existing != []
+      - subject_filter_absent_check_mode.original != []
       - subject_filter_absent.changed == true
-      - subject_filter_absent.existing != []
+      - subject_filter_absent.original != []
       - subject_filter_absent_idempotent.changed == false
-      - subject_filter_absent_idempotent.existing == []
+      - subject_filter_absent_idempotent.original == []
       - absent_missing_param.failed == true
       - 'absent_missing_param.msg == "state is absent but all of the following are missing: filter"'
 

--- a/test/integration/targets/aci_contract_subject_to_filter/tasks/main.yml
+++ b/test/integration/targets/aci_contract_subject_to_filter/tasks/main.yml
@@ -86,15 +86,15 @@
     that:
       - subject_filter_present_check_mode.changed == true
       - subject_filter_present_check_mode.previous == []
-      - 'subject_filter_present_check_mode.config == {"vzRsSubjFiltAtt": {"attributes": {"directives": "log", "tnVzFilterName": "anstest"}}}'
+      - 'subject_filter_present_check_mode.sent == {"vzRsSubjFiltAtt": {"attributes": {"directives": "log", "tnVzFilterName": "anstest"}}}'
       - subject_filter_present.changed == true
       - subject_filter_present.previous == []
-      - subject_filter_present.config == subject_filter_present_check_mode.config
+      - subject_filter_present.sent == subject_filter_present_check_mode.sent
       - subject_filter_present_2.changed == true
       - subject_filter_present_idempotent.changed == false
       - subject_filter_present_idempotent.previous != []
       - subject_filter_update.changed == true
-      - 'subject_filter_update.config.vzRsSubjFiltAtt.attributes == {"directives": ""}'
+      - 'subject_filter_update.sent.vzRsSubjFiltAtt.attributes == {"directives": ""}'
       - present_missing_param.failed == true
       - 'present_missing_param.msg == "state is present but all of the following are missing: contract, filter, subject"'
 

--- a/test/integration/targets/aci_contract_subject_to_filter/tasks/main.yml
+++ b/test/integration/targets/aci_contract_subject_to_filter/tasks/main.yml
@@ -85,14 +85,14 @@
   assert:
     that:
       - subject_filter_present_check_mode.changed == true
-      - subject_filter_present_check_mode.original == []
+      - subject_filter_present_check_mode.previous == []
       - 'subject_filter_present_check_mode.config == {"vzRsSubjFiltAtt": {"attributes": {"directives": "log", "tnVzFilterName": "anstest"}}}'
       - subject_filter_present.changed == true
-      - subject_filter_present.original == []
+      - subject_filter_present.previous == []
       - subject_filter_present.config == subject_filter_present_check_mode.config
       - subject_filter_present_2.changed == true
       - subject_filter_present_idempotent.changed == false
-      - subject_filter_present_idempotent.original != []
+      - subject_filter_present_idempotent.previous != []
       - subject_filter_update.changed == true
       - 'subject_filter_update.config.vzRsSubjFiltAtt.attributes == {"directives": ""}'
       - present_missing_param.failed == true
@@ -115,10 +115,10 @@
   assert:
     that:
       - query_all.changed == false
-      - query_all.original | length > 1
-      - query_all.original.0.vzRsSubjFiltAtt is defined
+      - query_all.previous | length > 1
+      - query_all.previous.0.vzRsSubjFiltAtt is defined
       - query_binding.changed == false
-      - query_binding.original != []
+      - query_binding.previous != []
 
 - name: delete subject filter binding - check mode works
   aci_contract_subject_to_filter: &aci_subject_filter_absent
@@ -154,11 +154,11 @@
     that:
       - subject_filter_absent_check_mode.changed == true
       - subject_filter_absent_check_mode.proposed == {}
-      - subject_filter_absent_check_mode.original != []
+      - subject_filter_absent_check_mode.previous != []
       - subject_filter_absent.changed == true
-      - subject_filter_absent.original != []
+      - subject_filter_absent.previous != []
       - subject_filter_absent_idempotent.changed == false
-      - subject_filter_absent_idempotent.original == []
+      - subject_filter_absent_idempotent.previous == []
       - absent_missing_param.failed == true
       - 'absent_missing_param.msg == "state is absent but all of the following are missing: filter"'
 

--- a/test/integration/targets/aci_encap_pool/tasks/vlan.yml
+++ b/test/integration/targets/aci_encap_pool/tasks/vlan.yml
@@ -78,7 +78,7 @@
   assert:
     that:
       - idempotent_dynamic.changed == false
-      - 'idempotent_dynamic.existing == [{"fvnsVlanInstP": {"attributes": {"allocMode": "dynamic", "descr": "Ansible Test", "dn": "uni/infra/vlanns-[anstest]-dynamic", "name": "anstest", "nameAlias": "", "ownerKey": "", "ownerTag": ""}}}]'
+      - 'idempotent_dynamic.original == [{"fvnsVlanInstP": {"attributes": {"allocMode": "dynamic", "descr": "Ansible Test", "dn": "uni/infra/vlanns-[anstest]-dynamic", "name": "anstest", "nameAlias": "", "ownerKey": "", "ownerTag": ""}}}]'
       - idempotent_dynamic.config == {}
  
 - name: update static vlan pool - update works
@@ -157,7 +157,7 @@
     that:
       - get_all_pools.changed == false
       - get_all_pools.method == "GET"
-      - get_all_pools.existing | length > 1
+      - get_all_pools.original | length > 1
 
 - name: get created static vlan pool - get mo works
   aci_encap_pool:
@@ -170,7 +170,7 @@
     that:
       - get_static_pool.changed == false
       - get_static_pool.method == "GET"
-      - get_static_pool.existing | length == 1
+      - get_static_pool.original | length == 1
       - get_static_pool.original.0.fvnsVlanInstP.attributes.allocMode == "static"
       - get_static_pool.original.0.fvnsVlanInstP.attributes.name == "anstest"
 
@@ -185,7 +185,7 @@
     that:
       - get_dynamic_pool.changed == false
       - get_dynamic_pool.method == "GET"
-      - get_dynamic_pool.existing | length == 1
+      - get_dynamic_pool.original | length == 1
       - get_dynamic_pool.original.0.fvnsVlanInstP.attributes.allocMode == "dynamic"
       - get_dynamic_pool.original.0.fvnsVlanInstP.attributes.name == "anstest"
 
@@ -249,7 +249,7 @@
   assert:
     that:
       - idempotent_delete_static.changed == false
-      - idempotent_delete_static.existing == []
+      - idempotent_delete_static.original == []
 
 - name: delete dynamic vlan pool again - idempotency works
   aci_encap_pool:
@@ -260,4 +260,4 @@
   assert:
     that:
       - idempotent_delete_dynamic.changed == false
-      - idempotent_delete_dynamic.existing == []
+      - idempotent_delete_dynamic.original == []

--- a/test/integration/targets/aci_encap_pool/tasks/vlan.yml
+++ b/test/integration/targets/aci_encap_pool/tasks/vlan.yml
@@ -40,7 +40,7 @@
   assert:
     that:
       - create_static.changed == true
-      - create_static.existing == []
+      - create_static.original == []
       - create_static.config == create_check_mode.config
 
 - name: create dynamic vlan pool - creation works
@@ -54,7 +54,7 @@
   assert:
     that:
       - create_dynamic.changed == true
-      - create_dynamic.existing == []
+      - create_dynamic.original == []
       - 'create_dynamic.config == {"fvnsVlanInstP": {"attributes": {"allocMode": "dynamic", "descr": "Ansible Test", "name": "anstest"}}}'
 
 - name: create static vlan pool again - idempotency works
@@ -66,7 +66,7 @@
   assert:
     that:
       - idempotent_static.changed == false
-      - 'idempotent_static.existing == [{"fvnsVlanInstP": {"attributes": {"allocMode": "static", "descr": "Ansible Test", "dn": "uni/infra/vlanns-[anstest]-static", "name": "anstest", "nameAlias": "", "ownerKey": "", "ownerTag": ""}}}]'
+      - 'idempotent_static.original == [{"fvnsVlanInstP": {"attributes": {"allocMode": "static", "descr": "Ansible Test", "dn": "uni/infra/vlanns-[anstest]-static", "name": "anstest", "nameAlias": "", "ownerKey": "", "ownerTag": ""}}}]'
       - idempotent_static.config == {}
 
 - name: create dynamic vlan pool again - idempotency works
@@ -171,8 +171,8 @@
       - get_static_pool.changed == false
       - get_static_pool.method == "GET"
       - get_static_pool.existing | length == 1
-      - get_static_pool.existing.0.fvnsVlanInstP.attributes.allocMode == "static"
-      - get_static_pool.existing.0.fvnsVlanInstP.attributes.name == "anstest"
+      - get_static_pool.original.0.fvnsVlanInstP.attributes.allocMode == "static"
+      - get_static_pool.original.0.fvnsVlanInstP.attributes.name == "anstest"
 
 - name: get created dynamic vlan pool - get mo works
   aci_encap_pool:
@@ -186,8 +186,8 @@
       - get_dynamic_pool.changed == false
       - get_dynamic_pool.method == "GET"
       - get_dynamic_pool.existing | length == 1
-      - get_dynamic_pool.existing.0.fvnsVlanInstP.attributes.allocMode == "dynamic"
-      - get_dynamic_pool.existing.0.fvnsVlanInstP.attributes.name == "anstest"
+      - get_dynamic_pool.original.0.fvnsVlanInstP.attributes.allocMode == "dynamic"
+      - get_dynamic_pool.original.0.fvnsVlanInstP.attributes.name == "anstest"
 
 - name: get created dynamic vlan pool - get mo works
   aci_encap_pool:
@@ -213,8 +213,8 @@
     that:
       - delete_static.changed == true
       - delete_static.method == "DELETE"
-      - delete_static.existing.0.fvnsVlanInstP.attributes.allocMode == "static"
-      - delete_static.existing.0.fvnsVlanInstP.attributes.name == "anstest"
+      - delete_static.original.0.fvnsVlanInstP.attributes.allocMode == "static"
+      - delete_static.original.0.fvnsVlanInstP.attributes.name == "anstest"
 
 - name: delete dynamic vlan pool - check mode works
   aci_encap_pool:
@@ -237,8 +237,8 @@
     that:
       - delete_dynamic.changed == true
       - delete_dynamic.method == "DELETE"
-      - delete_dynamic.existing.0.fvnsVlanInstP.attributes.allocMode == "dynamic"
-      - delete_dynamic.existing.0.fvnsVlanInstP.attributes.name == "anstest"
+      - delete_dynamic.original.0.fvnsVlanInstP.attributes.allocMode == "dynamic"
+      - delete_dynamic.original.0.fvnsVlanInstP.attributes.name == "anstest"
 
 - name: delete static vlan pool again - idempotency works
   aci_encap_pool:

--- a/test/integration/targets/aci_encap_pool/tasks/vlan.yml
+++ b/test/integration/targets/aci_encap_pool/tasks/vlan.yml
@@ -30,7 +30,7 @@
   assert:
     that:
       - create_check_mode.changed == true
-      - 'create_check_mode.config == {"fvnsVlanInstP": {"attributes": {"allocMode": "static", "descr": "Ansible Test", "name": "anstest"}}}'
+      - 'create_check_mode.sent == {"fvnsVlanInstP": {"attributes": {"allocMode": "static", "descr": "Ansible Test", "name": "anstest"}}}'
 
 - name: create static vlan pool - creation works
   aci_encap_pool:
@@ -42,7 +42,7 @@
     that:
       - create_static.changed == true
       - create_static.previous == []
-      - create_static.config == create_check_mode.config
+      - create_static.sent == create_check_mode.sent
 
 - name: create dynamic vlan pool - creation works
   aci_encap_pool: &aci_pool_present_dynamic
@@ -56,7 +56,7 @@
     that:
       - create_dynamic.changed == true
       - create_dynamic.previous == []
-      - 'create_dynamic.config == {"fvnsVlanInstP": {"attributes": {"allocMode": "dynamic", "descr": "Ansible Test", "name": "anstest"}}}'
+      - 'create_dynamic.sent == {"fvnsVlanInstP": {"attributes": {"allocMode": "dynamic", "descr": "Ansible Test", "name": "anstest"}}}'
 
 - name: create static vlan pool again - idempotency works
   aci_encap_pool:
@@ -68,7 +68,7 @@
     that:
       - idempotent_static.changed == false
       - 'idempotent_static.previous == [{"fvnsVlanInstP": {"attributes": {"allocMode": "static", "descr": "Ansible Test", "dn": "uni/infra/vlanns-[anstest]-static", "name": "anstest", "nameAlias": "", "ownerKey": "", "ownerTag": ""}}}]'
-      - idempotent_static.config == {}
+      - idempotent_static.sent == {}
 
 - name: create dynamic vlan pool again - idempotency works
   aci_encap_pool:
@@ -80,7 +80,7 @@
     that:
       - idempotent_dynamic.changed == false
       - 'idempotent_dynamic.previous == [{"fvnsVlanInstP": {"attributes": {"allocMode": "dynamic", "descr": "Ansible Test", "dn": "uni/infra/vlanns-[anstest]-dynamic", "name": "anstest", "nameAlias": "", "ownerKey": "", "ownerTag": ""}}}]'
-      - idempotent_dynamic.config == {}
+      - idempotent_dynamic.sent == {}
  
 - name: update static vlan pool - update works
   aci_encap_pool:
@@ -92,7 +92,7 @@
   assert:
     that:
       - update_static.changed == true
-      - 'update_static.config == {"fvnsVlanInstP": {"attributes": {"descr": "Ansible Test Change"}}}'
+      - 'update_static.sent == {"fvnsVlanInstP": {"attributes": {"descr": "Ansible Test Change"}}}'
 
 - name: update dynamic vlan pool - update works
   aci_encap_pool:
@@ -104,7 +104,7 @@
   assert:
     that:
       - update_dynamic.changed == true
-      - 'update_dynamic.config == {"fvnsVlanInstP": {"attributes": {"descr": "Ansible Test Change"}}}'
+      - 'update_dynamic.sent == {"fvnsVlanInstP": {"attributes": {"descr": "Ansible Test Change"}}}'
 
 - name: missing param - failure message works
   aci_encap_pool:

--- a/test/integration/targets/aci_encap_pool/tasks/vlan.yml
+++ b/test/integration/targets/aci_encap_pool/tasks/vlan.yml
@@ -41,7 +41,7 @@
   assert:
     that:
       - create_static.changed == true
-      - create_static.original == []
+      - create_static.previous == []
       - create_static.config == create_check_mode.config
 
 - name: create dynamic vlan pool - creation works
@@ -55,7 +55,7 @@
   assert:
     that:
       - create_dynamic.changed == true
-      - create_dynamic.original == []
+      - create_dynamic.previous == []
       - 'create_dynamic.config == {"fvnsVlanInstP": {"attributes": {"allocMode": "dynamic", "descr": "Ansible Test", "name": "anstest"}}}'
 
 - name: create static vlan pool again - idempotency works
@@ -67,7 +67,7 @@
   assert:
     that:
       - idempotent_static.changed == false
-      - 'idempotent_static.original == [{"fvnsVlanInstP": {"attributes": {"allocMode": "static", "descr": "Ansible Test", "dn": "uni/infra/vlanns-[anstest]-static", "name": "anstest", "nameAlias": "", "ownerKey": "", "ownerTag": ""}}}]'
+      - 'idempotent_static.previous == [{"fvnsVlanInstP": {"attributes": {"allocMode": "static", "descr": "Ansible Test", "dn": "uni/infra/vlanns-[anstest]-static", "name": "anstest", "nameAlias": "", "ownerKey": "", "ownerTag": ""}}}]'
       - idempotent_static.config == {}
 
 - name: create dynamic vlan pool again - idempotency works
@@ -79,7 +79,7 @@
   assert:
     that:
       - idempotent_dynamic.changed == false
-      - 'idempotent_dynamic.original == [{"fvnsVlanInstP": {"attributes": {"allocMode": "dynamic", "descr": "Ansible Test", "dn": "uni/infra/vlanns-[anstest]-dynamic", "name": "anstest", "nameAlias": "", "ownerKey": "", "ownerTag": ""}}}]'
+      - 'idempotent_dynamic.previous == [{"fvnsVlanInstP": {"attributes": {"allocMode": "dynamic", "descr": "Ansible Test", "dn": "uni/infra/vlanns-[anstest]-dynamic", "name": "anstest", "nameAlias": "", "ownerKey": "", "ownerTag": ""}}}]'
       - idempotent_dynamic.config == {}
  
 - name: update static vlan pool - update works
@@ -158,7 +158,7 @@
     that:
       - get_all_pools.changed == false
       - get_all_pools.method == "GET"
-      - get_all_pools.original | length > 1
+      - get_all_pools.previous | length > 1
 
 - name: get created static vlan pool - get mo works
   aci_encap_pool:
@@ -171,9 +171,9 @@
     that:
       - get_static_pool.changed == false
       - get_static_pool.method == "GET"
-      - get_static_pool.original | length == 1
-      - get_static_pool.original.0.fvnsVlanInstP.attributes.allocMode == "static"
-      - get_static_pool.original.0.fvnsVlanInstP.attributes.name == "anstest"
+      - get_static_pool.previous | length == 1
+      - get_static_pool.previous.0.fvnsVlanInstP.attributes.allocMode == "static"
+      - get_static_pool.previous.0.fvnsVlanInstP.attributes.name == "anstest"
 
 - name: get created dynamic vlan pool - get mo works
   aci_encap_pool:
@@ -186,9 +186,9 @@
     that:
       - get_dynamic_pool.changed == false
       - get_dynamic_pool.method == "GET"
-      - get_dynamic_pool.original | length == 1
-      - get_dynamic_pool.original.0.fvnsVlanInstP.attributes.allocMode == "dynamic"
-      - get_dynamic_pool.original.0.fvnsVlanInstP.attributes.name == "anstest"
+      - get_dynamic_pool.previous | length == 1
+      - get_dynamic_pool.previous.0.fvnsVlanInstP.attributes.allocMode == "dynamic"
+      - get_dynamic_pool.previous.0.fvnsVlanInstP.attributes.name == "anstest"
 
 - name: get created dynamic vlan pool - get mo works
   aci_encap_pool:
@@ -214,8 +214,8 @@
     that:
       - delete_static.changed == true
       - delete_static.method == "DELETE"
-      - delete_static.original.0.fvnsVlanInstP.attributes.allocMode == "static"
-      - delete_static.original.0.fvnsVlanInstP.attributes.name == "anstest"
+      - delete_static.previous.0.fvnsVlanInstP.attributes.allocMode == "static"
+      - delete_static.previous.0.fvnsVlanInstP.attributes.name == "anstest"
 
 - name: delete dynamic vlan pool - check mode works
   aci_encap_pool:
@@ -238,8 +238,8 @@
     that:
       - delete_dynamic.changed == true
       - delete_dynamic.method == "DELETE"
-      - delete_dynamic.original.0.fvnsVlanInstP.attributes.allocMode == "dynamic"
-      - delete_dynamic.original.0.fvnsVlanInstP.attributes.name == "anstest"
+      - delete_dynamic.previous.0.fvnsVlanInstP.attributes.allocMode == "dynamic"
+      - delete_dynamic.previous.0.fvnsVlanInstP.attributes.name == "anstest"
 
 - name: delete static vlan pool again - idempotency works
   aci_encap_pool:
@@ -250,7 +250,7 @@
   assert:
     that:
       - idempotent_delete_static.changed == false
-      - idempotent_delete_static.original == []
+      - idempotent_delete_static.previous == []
 
 - name: delete dynamic vlan pool again - idempotency works
   aci_encap_pool:
@@ -261,4 +261,4 @@
   assert:
     that:
       - idempotent_delete_dynamic.changed == false
-      - idempotent_delete_dynamic.original == []
+      - idempotent_delete_dynamic.previous == []

--- a/test/integration/targets/aci_encap_pool/tasks/vlan.yml
+++ b/test/integration/targets/aci_encap_pool/tasks/vlan.yml
@@ -7,6 +7,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: debug
     state: absent
     pool: anstest
     pool_type: vlan

--- a/test/integration/targets/aci_encap_pool/tasks/vxlan.yml
+++ b/test/integration/targets/aci_encap_pool/tasks/vxlan.yml
@@ -35,7 +35,7 @@
   assert:
     that:
       - create_vxlan.changed == true
-      - create_vxlan.original == []
+      - create_vxlan.previous == []
       - create_vxlan.config == create_vxlan_check_mode.config
 
 - name: create vxlan pool again - idempotency works
@@ -47,7 +47,7 @@
   assert:
     that:
       - idempotent_vxlan.changed == false
-      - 'idempotent_vxlan.original.0.fvnsVxlanInstP.attributes.name == "anstest"'
+      - 'idempotent_vxlan.previous.0.fvnsVxlanInstP.attributes.name == "anstest"'
       - idempotent_vxlan.config == {}
 
 - name: update vxlan pool - update works
@@ -97,7 +97,7 @@
   assert:
     that:
       - query_vxlan.changed == false
-      - query_vxlan.original | length == 1
+      - query_vxlan.previous | length == 1
       - '"infra/vxlanns-anstest.json" in query_vxlan.url'
 
 - name: get created static vlan pool - get class works
@@ -110,7 +110,7 @@
   assert:
     that:
       - query_vxlan_all.changed == false
-      - query_vxlan_all.original | length > 1
+      - query_vxlan_all.previous | length > 1
       - '"class/fvnsVxlanInstP.json" in query_vxlan_all.url'
 
 - name: delete vxlan pool - check mode works
@@ -123,7 +123,7 @@
   assert:
     that:
       - delete_vxlan_check_mode.changed == true
-      - delete_vxlan_check_mode.original != []
+      - delete_vxlan_check_mode.previous != []
 
 - name: delete vxlan pool - deletion works
   aci_encap_pool:
@@ -134,8 +134,8 @@
   assert:
     that:
       - delete_vxlan.changed == true
-      - delete_vxlan.original == delete_vxlan_check_mode.original
-      - delete_vxlan.original.0.fvnsVxlanInstP.attributes.name == "anstest"
+      - delete_vxlan.previous == delete_vxlan_check_mode.previous
+      - delete_vxlan.previous.0.fvnsVxlanInstP.attributes.name == "anstest"
 
 - name: delete vxlan pool again - idempotency works
   aci_encap_pool:
@@ -153,7 +153,7 @@
   assert:
     that:
       - delete_vxlan_idempotent.changed == false
-      - delete_vxlan_idempotent.original == []
+      - delete_vxlan_idempotent.previous == []
 
 - name: delete vxlan pool - cleanup
   aci_encap_pool:

--- a/test/integration/targets/aci_encap_pool/tasks/vxlan.yml
+++ b/test/integration/targets/aci_encap_pool/tasks/vxlan.yml
@@ -7,6 +7,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: debug
     state: absent
     pool: anstest
     pool_type: vxlan

--- a/test/integration/targets/aci_encap_pool/tasks/vxlan.yml
+++ b/test/integration/targets/aci_encap_pool/tasks/vxlan.yml
@@ -34,7 +34,7 @@
   assert:
     that:
       - create_vxlan.changed == true
-      - create_vxlan.existing == []
+      - create_vxlan.original == []
       - create_vxlan.config == create_vxlan_check_mode.config
 
 - name: create vxlan pool again - idempotency works
@@ -46,7 +46,7 @@
   assert:
     that:
       - idempotent_vxlan.changed == false
-      - 'idempotent_vxlan.existing.0.fvnsVxlanInstP.attributes.name == "anstest"'
+      - 'idempotent_vxlan.original.0.fvnsVxlanInstP.attributes.name == "anstest"'
       - idempotent_vxlan.config == {}
 
 - name: update vxlan pool - update works
@@ -96,7 +96,7 @@
   assert:
     that:
       - query_vxlan.changed == false
-      - query_vxlan.existing | length == 1
+      - query_vxlan.original | length == 1
       - '"infra/vxlanns-anstest.json" in query_vxlan.url'
 
 - name: get created static vlan pool - get class works
@@ -109,7 +109,7 @@
   assert:
     that:
       - query_vxlan_all.changed == false
-      - query_vxlan_all.existing | length > 1
+      - query_vxlan_all.original | length > 1
       - '"class/fvnsVxlanInstP.json" in query_vxlan_all.url'
 
 - name: delete vxlan pool - check mode works
@@ -122,7 +122,7 @@
   assert:
     that:
       - delete_vxlan_check_mode.changed == true
-      - delete_vxlan_check_mode.existing != []
+      - delete_vxlan_check_mode.original != []
 
 - name: delete vxlan pool - deletion works
   aci_encap_pool:
@@ -133,8 +133,8 @@
   assert:
     that:
       - delete_vxlan.changed == true
-      - delete_vxlan.existing == delete_vxlan_check_mode.existing
-      - delete_vxlan.existing.0.fvnsVxlanInstP.attributes.name == "anstest"
+      - delete_vxlan.original == delete_vxlan_check_mode.original
+      - delete_vxlan.original.0.fvnsVxlanInstP.attributes.name == "anstest"
 
 - name: delete vxlan pool again - idempotency works
   aci_encap_pool:
@@ -152,7 +152,7 @@
   assert:
     that:
       - delete_vxlan_idempotent.changed == false
-      - delete_vxlan_idempotent.existing == []
+      - delete_vxlan_idempotent.original == []
 
 - name: delete vxlan pool - cleanup
   aci_encap_pool:

--- a/test/integration/targets/aci_encap_pool/tasks/vxlan.yml
+++ b/test/integration/targets/aci_encap_pool/tasks/vxlan.yml
@@ -24,7 +24,7 @@
   assert:
     that:
       - create_vxlan_check_mode.changed == true
-      - 'create_vxlan_check_mode.config == {"fvnsVxlanInstP": {"attributes": {"descr": "Ansible Test", "name": "anstest"}}}'
+      - 'create_vxlan_check_mode.sent == {"fvnsVxlanInstP": {"attributes": {"descr": "Ansible Test", "name": "anstest"}}}'
 
 - name: create vxlan pool - creation works
   aci_encap_pool:
@@ -36,7 +36,7 @@
     that:
       - create_vxlan.changed == true
       - create_vxlan.previous == []
-      - create_vxlan.config == create_vxlan_check_mode.config
+      - create_vxlan.sent == create_vxlan_check_mode.sent
 
 - name: create vxlan pool again - idempotency works
   aci_encap_pool:
@@ -48,7 +48,7 @@
     that:
       - idempotent_vxlan.changed == false
       - 'idempotent_vxlan.previous.0.fvnsVxlanInstP.attributes.name == "anstest"'
-      - idempotent_vxlan.config == {}
+      - idempotent_vxlan.sent == {}
 
 - name: update vxlan pool - update works
   aci_encap_pool:
@@ -60,7 +60,7 @@
   assert:
     that:
       - update_vxlan.changed == true
-      - 'update_vxlan.config == {"fvnsVxlanInstP": {"attributes": {"descr": "Ansible Test Change"}}}'
+      - 'update_vxlan.sent == {"fvnsVxlanInstP": {"attributes": {"descr": "Ansible Test Change"}}}'
 
 - name: create vxlan pool - used for query
   aci_encap_pool:

--- a/test/integration/targets/aci_encap_pool_range/tasks/vlan.yml
+++ b/test/integration/targets/aci_encap_pool_range/tasks/vlan.yml
@@ -56,7 +56,7 @@
   assert:
     that:
       - range_present.changed == true
-      - range_present.original == []
+      - range_present.previous == []
       - range_present.config == range_present_check_mode.config
       - range_present.config == range_present.proposed
 
@@ -69,7 +69,7 @@
   assert:
     that:
       - range_present_idempotent.changed == false
-      - 'range_present_idempotent.original.0.fvnsEncapBlk.attributes.name == "anstest"'
+      - 'range_present_idempotent.previous.0.fvnsEncapBlk.attributes.name == "anstest"'
 
 - name: update vlan pool range - update works
   aci_encap_pool_range:
@@ -82,7 +82,7 @@
   assert:
     that:
       - range_present_update.changed == true
-      - range_present_update.original != []
+      - range_present_update.previous != []
       - range_present_update.config != range_present.config
 
 - name: create vlan pool range - used for query
@@ -97,7 +97,7 @@
   assert:
     that:
       - range_present_2.changed == true
-      - range_present_2.original == []
+      - range_present_2.previous == []
 
 - name: invalid range_start - error message works
   aci_encap_pool_range:
@@ -213,8 +213,8 @@
     that:
       - range_query.changed == false
       - range_query.url.endswith("infra/vlanns-[anstest]-static/from-[vlan-20]-to-[vlan-40].json")
-      - range_query.original | length == 1
-      - 'range_query.original.0.fvnsEncapBlk.attributes.name == "anstest"'
+      - range_query.previous | length == 1
+      - 'range_query.previous.0.fvnsEncapBlk.attributes.name == "anstest"'
 
 - name: query vlan pool range - from, to, and name are filtered
   aci_encap_pool_range: &aci_range_query_filter
@@ -228,9 +228,9 @@
       - range_query_from_to_name.changed == false
       - 'range_query_from_to_name.url.endswith("class/fvnsEncapBlk.json")'
       - '"query-target-filter=and(eq(fvnsEncapBlk.from, \"vlan-20\"),eq(fvnsEncapBlk.to, \"vlan-40\"),eq(fvnsEncapBlk.name, \"anstest\"))" in range_query_from_to_name.filter_string'
-      - 'range_query_from_to_name.original.0.fvnsEncapBlk.attributes.name == "anstest"'
-      - 'range_query_from_to_name.original.0.fvnsEncapBlk.attributes.from == "vlan-20"'
-      - 'range_query_from_to_name.original.0.fvnsEncapBlk.attributes.to == "vlan-40"'
+      - 'range_query_from_to_name.previous.0.fvnsEncapBlk.attributes.name == "anstest"'
+      - 'range_query_from_to_name.previous.0.fvnsEncapBlk.attributes.from == "vlan-20"'
+      - 'range_query_from_to_name.previous.0.fvnsEncapBlk.attributes.to == "vlan-40"'
 
 - name: query vlan pool range - from and name are filtered
   aci_encap_pool_range:
@@ -244,8 +244,8 @@
       - range_query_from_name.changed == false
       - 'range_query_from_name.url.endswith("class/fvnsEncapBlk.json")'
       - '"query-target-filter=and(eq(fvnsEncapBlk.from, \"vlan-20\"),eq(fvnsEncapBlk.name, \"anstest\"))" in range_query_from_name.filter_string'
-      - 'range_query_from_name.original.0.fvnsEncapBlk.attributes.name == "anstest"'
-      - 'range_query_from_name.original.0.fvnsEncapBlk.attributes.from == "vlan-20"'
+      - 'range_query_from_name.previous.0.fvnsEncapBlk.attributes.name == "anstest"'
+      - 'range_query_from_name.previous.0.fvnsEncapBlk.attributes.from == "vlan-20"'
 
 - name: query vlan pool range - to and name are filtered
   aci_encap_pool_range:
@@ -259,8 +259,8 @@
       - range_query_to_name.changed == false
       - 'range_query_to_name.url.endswith("class/fvnsEncapBlk.json")'
       - '"query-target-filter=and(eq(fvnsEncapBlk.to, \"vlan-40\"),eq(fvnsEncapBlk.name, \"anstest\"))" in range_query_to_name.filter_string'
-      - 'range_query_to_name.original.0.fvnsEncapBlk.attributes.name == "anstest"'
-      - 'range_query_to_name.original.0.fvnsEncapBlk.attributes.to == "vlan-40"'
+      - 'range_query_to_name.previous.0.fvnsEncapBlk.attributes.name == "anstest"'
+      - 'range_query_to_name.previous.0.fvnsEncapBlk.attributes.to == "vlan-40"'
 
 - name: query vlan pool range - name is filtered
   aci_encap_pool_range:
@@ -275,7 +275,7 @@
       - range_query_name.changed == false
       - 'range_query_name.url.endswith("class/fvnsEncapBlk.json")'
       - '"query-target-filter=eq(fvnsEncapBlk.name, \"anstest\")" in range_query_name.filter_string'
-      - 'range_query_name.original.0.fvnsEncapBlk.attributes.name == "anstest"'
+      - 'range_query_name.previous.0.fvnsEncapBlk.attributes.name == "anstest"'
 
 - name: query vlan pool range - from and to are filtered
   aci_encap_pool_range:
@@ -289,8 +289,8 @@
       - range_query_from_to.changed == false
       - 'range_query_from_to.url.endswith("class/fvnsEncapBlk.json")'
       - '"query-target-filter=and(eq(fvnsEncapBlk.from, \"vlan-20\"),eq(fvnsEncapBlk.to, \"vlan-40\"))" in range_query_from_to.filter_string'
-      - 'range_query_from_to.original.0.fvnsEncapBlk.attributes.from == "vlan-20"'
-      - 'range_query_from_to.original.0.fvnsEncapBlk.attributes.to == "vlan-40"'
+      - 'range_query_from_to.previous.0.fvnsEncapBlk.attributes.from == "vlan-20"'
+      - 'range_query_from_to.previous.0.fvnsEncapBlk.attributes.to == "vlan-40"'
 
 - name: query all ranges in a vlan pool
   aci_encap_pool_range:
@@ -302,9 +302,9 @@
 - name: query assertions
   assert:
     that:
-      - range_query_pool.original | length == 1
-      - 'range_query_pool.original.0.fvnsVlanInstP.attributes.name == "anstest"'
-      - range_query_pool.original.0.fvnsVlanInstP.children | length > 1
+      - range_query_pool.previous | length == 1
+      - 'range_query_pool.previous.0.fvnsVlanInstP.attributes.name == "anstest"'
+      - range_query_pool.previous.0.fvnsVlanInstP.children | length > 1
       - 'range_query_pool.url.endswith("infra/vlanns-[anstest]-static.json")'
 
 - name: query all ranges
@@ -318,8 +318,8 @@
   assert:
     that:
       - range_query_all.changed == false
-      - range_query_all.original | length > 1
-      - range_query_all.original.0.fvnsEncapBlk is defined
+      - range_query_all.previous | length > 1
+      - range_query_all.previous.0.fvnsEncapBlk is defined
       - 'range_query_all.url.endswith("class/fvnsEncapBlk.json")'
 
 - name: delete vlan pool range - deletion works
@@ -333,7 +333,7 @@
     that:
       - delete_range.changed == true
       - delete_range.proposed == {}
-      - 'delete_range.original.0.fvnsEncapBlk.attributes.name == "anstest"'
+      - 'delete_range.previous.0.fvnsEncapBlk.attributes.name == "anstest"'
 
 - name: delete vlan pool range - check mode works
   aci_encap_pool_range: &aci_range_absent
@@ -346,7 +346,7 @@
   assert:
     that:
       - delete_check_mode.changed == true
-      - delete_check_mode.original != []
+      - delete_check_mode.previous != []
 
 - name: delete vlan pool range - deletion works
   aci_encap_pool_range:
@@ -357,7 +357,7 @@
   assert:
     that:
       - delete_range_2.changed == true
-      - delete_range_2.original == delete_check_mode.original
+      - delete_range_2.previous == delete_check_mode.previous
 
 - name: delete vlan pool range again - idempotency works
   aci_encap_pool_range:
@@ -368,7 +368,7 @@
   assert:
     that:
       - delete_idempotent.changed == false
-      - delete_idempotent.original == []
+      - delete_idempotent.previous == []
 
 - name: cleanup vlan pool
   aci_encap_pool:

--- a/test/integration/targets/aci_encap_pool_range/tasks/vlan.yml
+++ b/test/integration/targets/aci_encap_pool_range/tasks/vlan.yml
@@ -20,6 +20,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: debug
     state: present
     pool: anstest
     pool_type: vlan

--- a/test/integration/targets/aci_encap_pool_range/tasks/vlan.yml
+++ b/test/integration/targets/aci_encap_pool_range/tasks/vlan.yml
@@ -45,7 +45,7 @@
   assert:
     that:
       - range_present_check_mode.changed == true
-      - 'range_present_check_mode.config == {"fvnsEncapBlk": {"attributes": {"allocMode": "inherit", "descr": "Ansible Test", "from": "vlan-20", "name": "anstest", "to": "vlan-40"}}}'
+      - 'range_present_check_mode.sent == {"fvnsEncapBlk": {"attributes": {"allocMode": "inherit", "descr": "Ansible Test", "from": "vlan-20", "name": "anstest", "to": "vlan-40"}}}'
 
 - name: create vlan pool range - creation works
   aci_encap_pool_range:
@@ -57,8 +57,8 @@
     that:
       - range_present.changed == true
       - range_present.previous == []
-      - range_present.config == range_present_check_mode.config
-      - range_present.config == range_present.proposed
+      - range_present.sent == range_present_check_mode.sent
+      - range_present.sent == range_present.proposed
 
 - name: create vlan pool range - idempotency works
   aci_encap_pool_range:
@@ -83,7 +83,7 @@
     that:
       - range_present_update.changed == true
       - range_present_update.previous != []
-      - range_present_update.config != range_present.config
+      - range_present_update.sent != range_present.sent
 
 - name: create vlan pool range - used for query
   aci_encap_pool_range: &aci_range_present_2

--- a/test/integration/targets/aci_encap_pool_range/tasks/vlan.yml
+++ b/test/integration/targets/aci_encap_pool_range/tasks/vlan.yml
@@ -55,7 +55,7 @@
   assert:
     that:
       - range_present.changed == true
-      - range_present.existing == []
+      - range_present.original == []
       - range_present.config == range_present_check_mode.config
       - range_present.config == range_present.proposed
 
@@ -68,7 +68,7 @@
   assert:
     that:
       - range_present_idempotent.changed == false
-      - 'range_present_idempotent.existing.0.fvnsEncapBlk.attributes.name == "anstest"'
+      - 'range_present_idempotent.original.0.fvnsEncapBlk.attributes.name == "anstest"'
 
 - name: update vlan pool range - update works
   aci_encap_pool_range:
@@ -81,7 +81,7 @@
   assert:
     that:
       - range_present_update.changed == true
-      - range_present_update.existing != []
+      - range_present_update.original != []
       - range_present_update.config != range_present.config
 
 - name: create vlan pool range - used for query
@@ -96,7 +96,7 @@
   assert:
     that:
       - range_present_2.changed == true
-      - range_present_2.existing == []
+      - range_present_2.original == []
 
 - name: invalid range_start - error message works
   aci_encap_pool_range:
@@ -212,8 +212,8 @@
     that:
       - range_query.changed == false
       - range_query.url.endswith("infra/vlanns-[anstest]-static/from-[vlan-20]-to-[vlan-40].json")
-      - range_query.existing | length == 1
-      - 'range_query.existing.0.fvnsEncapBlk.attributes.name == "anstest"'
+      - range_query.original | length == 1
+      - 'range_query.original.0.fvnsEncapBlk.attributes.name == "anstest"'
 
 - name: query vlan pool range - from, to, and name are filtered
   aci_encap_pool_range: &aci_range_query_filter
@@ -227,9 +227,9 @@
       - range_query_from_to_name.changed == false
       - 'range_query_from_to_name.url.endswith("class/fvnsEncapBlk.json")'
       - '"query-target-filter=and(eq(fvnsEncapBlk.from, \"vlan-20\"),eq(fvnsEncapBlk.to, \"vlan-40\"),eq(fvnsEncapBlk.name, \"anstest\"))" in range_query_from_to_name.filter_string'
-      - 'range_query_from_to_name.existing.0.fvnsEncapBlk.attributes.name == "anstest"'
-      - 'range_query_from_to_name.existing.0.fvnsEncapBlk.attributes.from == "vlan-20"'
-      - 'range_query_from_to_name.existing.0.fvnsEncapBlk.attributes.to == "vlan-40"'
+      - 'range_query_from_to_name.original.0.fvnsEncapBlk.attributes.name == "anstest"'
+      - 'range_query_from_to_name.original.0.fvnsEncapBlk.attributes.from == "vlan-20"'
+      - 'range_query_from_to_name.original.0.fvnsEncapBlk.attributes.to == "vlan-40"'
 
 - name: query vlan pool range - from and name are filtered
   aci_encap_pool_range:
@@ -243,8 +243,8 @@
       - range_query_from_name.changed == false
       - 'range_query_from_name.url.endswith("class/fvnsEncapBlk.json")'
       - '"query-target-filter=and(eq(fvnsEncapBlk.from, \"vlan-20\"),eq(fvnsEncapBlk.name, \"anstest\"))" in range_query_from_name.filter_string'
-      - 'range_query_from_name.existing.0.fvnsEncapBlk.attributes.name == "anstest"'
-      - 'range_query_from_name.existing.0.fvnsEncapBlk.attributes.from == "vlan-20"'
+      - 'range_query_from_name.original.0.fvnsEncapBlk.attributes.name == "anstest"'
+      - 'range_query_from_name.original.0.fvnsEncapBlk.attributes.from == "vlan-20"'
 
 - name: query vlan pool range - to and name are filtered
   aci_encap_pool_range:
@@ -258,8 +258,8 @@
       - range_query_to_name.changed == false
       - 'range_query_to_name.url.endswith("class/fvnsEncapBlk.json")'
       - '"query-target-filter=and(eq(fvnsEncapBlk.to, \"vlan-40\"),eq(fvnsEncapBlk.name, \"anstest\"))" in range_query_to_name.filter_string'
-      - 'range_query_to_name.existing.0.fvnsEncapBlk.attributes.name == "anstest"'
-      - 'range_query_to_name.existing.0.fvnsEncapBlk.attributes.to == "vlan-40"'
+      - 'range_query_to_name.original.0.fvnsEncapBlk.attributes.name == "anstest"'
+      - 'range_query_to_name.original.0.fvnsEncapBlk.attributes.to == "vlan-40"'
 
 - name: query vlan pool range - name is filtered
   aci_encap_pool_range:
@@ -274,7 +274,7 @@
       - range_query_name.changed == false
       - 'range_query_name.url.endswith("class/fvnsEncapBlk.json")'
       - '"query-target-filter=eq(fvnsEncapBlk.name, \"anstest\")" in range_query_name.filter_string'
-      - 'range_query_name.existing.0.fvnsEncapBlk.attributes.name == "anstest"'
+      - 'range_query_name.original.0.fvnsEncapBlk.attributes.name == "anstest"'
 
 - name: query vlan pool range - from and to are filtered
   aci_encap_pool_range:
@@ -288,8 +288,8 @@
       - range_query_from_to.changed == false
       - 'range_query_from_to.url.endswith("class/fvnsEncapBlk.json")'
       - '"query-target-filter=and(eq(fvnsEncapBlk.from, \"vlan-20\"),eq(fvnsEncapBlk.to, \"vlan-40\"))" in range_query_from_to.filter_string'
-      - 'range_query_from_to.existing.0.fvnsEncapBlk.attributes.from == "vlan-20"'
-      - 'range_query_from_to.existing.0.fvnsEncapBlk.attributes.to == "vlan-40"'
+      - 'range_query_from_to.original.0.fvnsEncapBlk.attributes.from == "vlan-20"'
+      - 'range_query_from_to.original.0.fvnsEncapBlk.attributes.to == "vlan-40"'
 
 - name: query all ranges in a vlan pool
   aci_encap_pool_range:
@@ -301,9 +301,9 @@
 - name: query assertions
   assert:
     that:
-      - range_query_pool.existing | length == 1
-      - 'range_query_pool.existing.0.fvnsVlanInstP.attributes.name == "anstest"'
-      - range_query_pool.existing.0.fvnsVlanInstP.children | length > 1
+      - range_query_pool.original | length == 1
+      - 'range_query_pool.original.0.fvnsVlanInstP.attributes.name == "anstest"'
+      - range_query_pool.original.0.fvnsVlanInstP.children | length > 1
       - 'range_query_pool.url.endswith("infra/vlanns-[anstest]-static.json")'
 
 - name: query all ranges
@@ -317,8 +317,8 @@
   assert:
     that:
       - range_query_all.changed == false
-      - range_query_all.existing | length > 1
-      - range_query_all.existing.0.fvnsEncapBlk is defined
+      - range_query_all.original | length > 1
+      - range_query_all.original.0.fvnsEncapBlk is defined
       - 'range_query_all.url.endswith("class/fvnsEncapBlk.json")'
 
 - name: delete vlan pool range - deletion works
@@ -332,7 +332,7 @@
     that:
       - delete_range.changed == true
       - delete_range.proposed == {}
-      - 'delete_range.existing.0.fvnsEncapBlk.attributes.name == "anstest"'
+      - 'delete_range.original.0.fvnsEncapBlk.attributes.name == "anstest"'
 
 - name: delete vlan pool range - check mode works
   aci_encap_pool_range: &aci_range_absent
@@ -345,7 +345,7 @@
   assert:
     that:
       - delete_check_mode.changed == true
-      - delete_check_mode.existing != []
+      - delete_check_mode.original != []
 
 - name: delete vlan pool range - deletion works
   aci_encap_pool_range:
@@ -356,7 +356,7 @@
   assert:
     that:
       - delete_range_2.changed == true
-      - delete_range_2.existing == delete_check_mode.existing
+      - delete_range_2.original == delete_check_mode.original
 
 - name: delete vlan pool range again - idempotency works
   aci_encap_pool_range:
@@ -367,7 +367,7 @@
   assert:
     that:
       - delete_idempotent.changed == false
-      - delete_idempotent.existing == []
+      - delete_idempotent.original == []
 
 - name: cleanup vlan pool
   aci_encap_pool:

--- a/test/integration/targets/aci_epg/tasks/main.yml
+++ b/test/integration/targets/aci_epg/tasks/main.yml
@@ -74,7 +74,7 @@
   assert:
     that:
       - epg_present_check_mode.changed == true
-      - epg_present_check_mode.original == []
+      - epg_present_check_mode.previous == []
       - epg_present_check_mode.config.fvAEPg.attributes != {}
       - 'epg_present_check_mode.config.fvAEPg.children.0.fvRsBd.attributes.tnFvBDName == "anstest"'
       - epg_present.changed == true
@@ -103,11 +103,11 @@
   assert:
     that:
       - epg_query.changed == false
-      - epg_query.original | length == 1
-      - 'epg_query.original.0.fvAEPg.attributes.name == "anstest"'
+      - epg_query.previous | length == 1
+      - 'epg_query.previous.0.fvAEPg.attributes.name == "anstest"'
       - '"tn-anstest/ap-anstest/epg-anstest.json" in epg_query.url'
       - epg_query_all.changed == false
-      - epg_query_all.original | length > 1
+      - epg_query_all.previous | length > 1
       - '"rsp-subtree-class=fvRsBd" in epg_query_all.filter_string'
       - '"class/fvAEPg.json" in epg_query_all.url'
 
@@ -144,11 +144,11 @@
   assert:
     that:
       - delete_epg_check_mode.changed == true
-      - delete_epg_check_mode.original != []
+      - delete_epg_check_mode.previous != []
       - delete_epg.changed == true
-      - delete_epg.original == delete_epg_check_mode.original
+      - delete_epg.previous == delete_epg_check_mode.previous
       - delete_epg_idempotent.changed == false
-      - delete_epg_idempotent.original == []
+      - delete_epg_idempotent.previous == []
       - delete_epg_missing_param.failed == true
       - 'delete_epg_missing_param.msg == "state is absent but all of the following are missing: tenant"'
 
@@ -156,16 +156,16 @@
   aci_bd:
     <<: *aci_bd_present
     state: absent
-  when: bd_present.original == []
+  when: bd_present.previous == []
 
 - name: cleanup ap
   aci_ap:
     <<: *aci_ap_present
     state: absent
-  when: ap_present.original == []
+  when: ap_present.previous == []
 
 - name: cleanup tenant
   aci_tenant:
     <<: *aci_tenant_present
     state: absent
-  when: tenant_present.original == []
+  when: tenant_present.previous == []

--- a/test/integration/targets/aci_epg/tasks/main.yml
+++ b/test/integration/targets/aci_epg/tasks/main.yml
@@ -16,6 +16,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: info
     state: present
     tenant: anstest
   register: tenant_present
@@ -73,7 +74,7 @@
   assert:
     that:
       - epg_present_check_mode.changed == true
-      - epg_present_check_mode.existing == []
+      - epg_present_check_mode.original == []
       - epg_present_check_mode.config.fvAEPg.attributes != {}
       - 'epg_present_check_mode.config.fvAEPg.children.0.fvRsBd.attributes.tnFvBDName == "anstest"'
       - epg_present.changed == true
@@ -102,11 +103,11 @@
   assert:
     that:
       - epg_query.changed == false
-      - epg_query.existing | length == 1
-      - 'epg_query.existing.0.fvAEPg.attributes.name == "anstest"'
+      - epg_query.original | length == 1
+      - 'epg_query.original.0.fvAEPg.attributes.name == "anstest"'
       - '"tn-anstest/ap-anstest/epg-anstest.json" in epg_query.url'
       - epg_query_all.changed == false
-      - epg_query_all.existing | length > 1
+      - epg_query_all.original | length > 1
       - '"rsp-subtree-class=fvRsBd" in epg_query_all.filter_string'
       - '"class/fvAEPg.json" in epg_query_all.url'
 
@@ -143,11 +144,11 @@
   assert:
     that:
       - delete_epg_check_mode.changed == true
-      - delete_epg_check_mode.existing != []
+      - delete_epg_check_mode.original != []
       - delete_epg.changed == true
-      - delete_epg.existing == delete_epg_check_mode.existing
+      - delete_epg.original == delete_epg_check_mode.original
       - delete_epg_idempotent.changed == false
-      - delete_epg_idempotent.existing == []
+      - delete_epg_idempotent.original == []
       - delete_epg_missing_param.failed == true
       - 'delete_epg_missing_param.msg == "state is absent but all of the following are missing: tenant"'
 
@@ -155,16 +156,16 @@
   aci_bd:
     <<: *aci_bd_present
     state: absent
-  when: bd_present.existing == []
+  when: bd_present.original == []
 
 - name: cleanup ap
   aci_ap:
     <<: *aci_ap_present
     state: absent
-  when: ap_present.existing == []
+  when: ap_present.original == []
 
 - name: cleanup tenant
   aci_tenant:
     <<: *aci_tenant_present
     state: absent
-  when: tenant_present.existing == []
+  when: tenant_present.original == []

--- a/test/integration/targets/aci_epg/tasks/main.yml
+++ b/test/integration/targets/aci_epg/tasks/main.yml
@@ -75,14 +75,14 @@
     that:
       - epg_present_check_mode.changed == true
       - epg_present_check_mode.previous == []
-      - epg_present_check_mode.config.fvAEPg.attributes != {}
-      - 'epg_present_check_mode.config.fvAEPg.children.0.fvRsBd.attributes.tnFvBDName == "anstest"'
+      - epg_present_check_mode.sent.fvAEPg.attributes != {}
+      - 'epg_present_check_mode.sent.fvAEPg.children.0.fvRsBd.attributes.tnFvBDName == "anstest"'
       - epg_present.changed == true
-      - epg_present.config == epg_present_check_mode.config
+      - epg_present.sent == epg_present_check_mode.sent
       - epg_present_idempotent.changed == false
-      - epg_present_idempotent.config == {}
+      - epg_present_idempotent.sent == {}
       - epg_present_update.changed == true
-      - 'epg_present_update.config == {"fvAEPg": {"attributes": {"descr": "Ansible Test Update"}}}'
+      - 'epg_present_update.sent == {"fvAEPg": {"attributes": {"descr": "Ansible Test Update"}}}'
       - epg_present_missing_param.failed == true
       - 'epg_present_missing_param.msg == "state is present but all of the following are missing: ap"'
 

--- a/test/integration/targets/aci_epg/tasks/main.yml
+++ b/test/integration/targets/aci_epg/tasks/main.yml
@@ -16,7 +16,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
-    output_level: info
+    output_level: debug
     state: present
     tenant: anstest
   register: tenant_present

--- a/test/integration/targets/aci_epg_to_contract/tasks/main.yml
+++ b/test/integration/targets/aci_epg_to_contract/tasks/main.yml
@@ -16,6 +16,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: info
     state: present
     tenant: anstest
   register: tenant_present
@@ -97,12 +98,12 @@
       - 'provide_present_check_mode.config == {"fvRsProv": {"attributes": {"tnVzBrCPName": "anstest_http"}}}'
       - provide_present.changed == true
       - provide_present.config == provide_present_check_mode.config
-      - provide_present.existing == []
+      - provide_present.original == []
       - consume_present.changed == true
-      - consume_present.existing == []
+      - consume_present.original == []
       - 'consume_present.config == {"fvRsCons": {"attributes": {"tnVzBrCPName": "anstest_db"}}}'
       - provide_present2.changed == true
-      - provide_present2.existing == []
+      - provide_present2.original == []
       - missing_param_present.failed == true
       - 'missing_param_present.msg == "state is present but all of the following are missing: ap, contract, epg"'
       - missing_required_present.failed == true
@@ -141,10 +142,10 @@
   assert:
     that:
       - query_provide_contract.changed == false
-      - query_provide_contract.existing != []
+      - query_provide_contract.original != []
       - '"class/fvRsProv.json" in query_provide_contract.url'
       - query_consume_contract.changed == false
-      - query_consume_contract.existing != []
+      - query_consume_contract.original != []
       - '"class/fvRsCons.json" in query_consume_contract.url'
       - query_all.changed == false
       - '"class/fvRsProv.json" in query_all.url'
@@ -198,14 +199,14 @@
   assert:
     that:
       - consume_absent_check_mode.changed == true
-      - consume_absent_check_mode.existing.0.fvRsCons is defined
+      - consume_absent_check_mode.original.0.fvRsCons is defined
       - consume_absent.changed == true
-      - consume_absent.existing == consume_absent_check_mode.existing
+      - consume_absent.original == consume_absent_check_mode.original
       - provide_absent.changed == true
-      - provide_absent.existing.0.fvRsProv is defined
+      - provide_absent.original.0.fvRsProv is defined
       - provide_absent2.changed == true
       - consume_absent_idempotent.changed == false
-      - consume_absent_idempotent.existing == []
+      - consume_absent_idempotent.original == []
       - missing_param_absent.failed == true
       - 'missing_param_absent.msg == "state is absent but all of the following are missing: contract"'
       - missing_required_absent.failed == true

--- a/test/integration/targets/aci_epg_to_contract/tasks/main.yml
+++ b/test/integration/targets/aci_epg_to_contract/tasks/main.yml
@@ -98,12 +98,12 @@
       - 'provide_present_check_mode.config == {"fvRsProv": {"attributes": {"tnVzBrCPName": "anstest_http"}}}'
       - provide_present.changed == true
       - provide_present.config == provide_present_check_mode.config
-      - provide_present.original == []
+      - provide_present.previous == []
       - consume_present.changed == true
-      - consume_present.original == []
+      - consume_present.previous == []
       - 'consume_present.config == {"fvRsCons": {"attributes": {"tnVzBrCPName": "anstest_db"}}}'
       - provide_present2.changed == true
-      - provide_present2.original == []
+      - provide_present2.previous == []
       - missing_param_present.failed == true
       - 'missing_param_present.msg == "state is present but all of the following are missing: ap, contract, epg"'
       - missing_required_present.failed == true
@@ -142,10 +142,10 @@
   assert:
     that:
       - query_provide_contract.changed == false
-      - query_provide_contract.original != []
+      - query_provide_contract.previous != []
       - '"class/fvRsProv.json" in query_provide_contract.url'
       - query_consume_contract.changed == false
-      - query_consume_contract.original != []
+      - query_consume_contract.previous != []
       - '"class/fvRsCons.json" in query_consume_contract.url'
       - query_all.changed == false
       - '"class/fvRsProv.json" in query_all.url'
@@ -199,14 +199,14 @@
   assert:
     that:
       - consume_absent_check_mode.changed == true
-      - consume_absent_check_mode.original.0.fvRsCons is defined
+      - consume_absent_check_mode.previous.0.fvRsCons is defined
       - consume_absent.changed == true
-      - consume_absent.original == consume_absent_check_mode.original
+      - consume_absent.previous == consume_absent_check_mode.previous
       - provide_absent.changed == true
-      - provide_absent.original.0.fvRsProv is defined
+      - provide_absent.previous.0.fvRsProv is defined
       - provide_absent2.changed == true
       - consume_absent_idempotent.changed == false
-      - consume_absent_idempotent.original == []
+      - consume_absent_idempotent.previous == []
       - missing_param_absent.failed == true
       - 'missing_param_absent.msg == "state is absent but all of the following are missing: contract"'
       - missing_required_absent.failed == true

--- a/test/integration/targets/aci_epg_to_contract/tasks/main.yml
+++ b/test/integration/targets/aci_epg_to_contract/tasks/main.yml
@@ -16,7 +16,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
-    output_level: info
+    output_level: debug
     state: present
     tenant: anstest
   register: tenant_present

--- a/test/integration/targets/aci_epg_to_contract/tasks/main.yml
+++ b/test/integration/targets/aci_epg_to_contract/tasks/main.yml
@@ -95,13 +95,13 @@
   assert:
     that:
       - provide_present_check_mode.changed == true
-      - 'provide_present_check_mode.config == {"fvRsProv": {"attributes": {"tnVzBrCPName": "anstest_http"}}}'
+      - 'provide_present_check_mode.sent == {"fvRsProv": {"attributes": {"tnVzBrCPName": "anstest_http"}}}'
       - provide_present.changed == true
-      - provide_present.config == provide_present_check_mode.config
+      - provide_present.sent == provide_present_check_mode.sent
       - provide_present.previous == []
       - consume_present.changed == true
       - consume_present.previous == []
-      - 'consume_present.config == {"fvRsCons": {"attributes": {"tnVzBrCPName": "anstest_db"}}}'
+      - 'consume_present.sent == {"fvRsCons": {"attributes": {"tnVzBrCPName": "anstest_db"}}}'
       - provide_present2.changed == true
       - provide_present2.previous == []
       - missing_param_present.failed == true

--- a/test/integration/targets/aci_epg_to_domain/tasks/main.yml
+++ b/test/integration/targets/aci_epg_to_domain/tasks/main.yml
@@ -111,7 +111,7 @@
     that:
       - phys_check_mode_present.changed == true
       - phys_present.changed == true
-      - phys_present.original == []
+      - phys_present.previous == []
       - 'phys_present.config == {"fvRsDomAtt": {"attributes": {}}}'
       - '"[uni/phys-anstest].json" in phys_present.url'
       - phys_idempotent.changed == false
@@ -139,7 +139,7 @@
   assert:
     that:
       - binding_query.changed == false
-      - binding_query.original | length > 1
+      - binding_query.previous | length > 1
       - '"class/fvRsDomAtt.json" in binding_query.url'
 
 - name: delete domain epg binding - check mode
@@ -176,12 +176,12 @@
   assert:
     that:
       - epg_domain_check_mode_absent.changed == true
-      - epg_domain_check_mode_absent.original != []
+      - epg_domain_check_mode_absent.previous != []
       - epg_domain_absent.changed == true
-      - epg_domain_absent.original == epg_domain_check_mode_absent.original
+      - epg_domain_absent.previous == epg_domain_check_mode_absent.previous
       - epg_vmm_domain_absent.changed == true
       - idempotency_absent.changed == false
-      - idempotency_absent.original == []
+      - idempotency_absent.previous == []
       - absent_missing_param.failed == true
       - 'absent_missing_param.msg == "state is absent but all of the following are missing: ap, domain, domain_type, epg"'
 

--- a/test/integration/targets/aci_epg_to_domain/tasks/main.yml
+++ b/test/integration/targets/aci_epg_to_domain/tasks/main.yml
@@ -16,6 +16,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: info
     state: present
     tenant: anstest
   register: tenant_present
@@ -110,7 +111,7 @@
     that:
       - phys_check_mode_present.changed == true
       - phys_present.changed == true
-      - phys_present.existing == []
+      - phys_present.original == []
       - 'phys_present.config == {"fvRsDomAtt": {"attributes": {}}}'
       - '"[uni/phys-anstest].json" in phys_present.url'
       - phys_idempotent.changed == false
@@ -138,7 +139,7 @@
   assert:
     that:
       - binding_query.changed == false
-      - binding_query.existing | length > 1
+      - binding_query.original | length > 1
       - '"class/fvRsDomAtt.json" in binding_query.url'
 
 - name: delete domain epg binding - check mode
@@ -175,12 +176,12 @@
   assert:
     that:
       - epg_domain_check_mode_absent.changed == true
-      - epg_domain_check_mode_absent.existing != []
+      - epg_domain_check_mode_absent.original != []
       - epg_domain_absent.changed == true
-      - epg_domain_absent.existing == epg_domain_check_mode_absent.existing
+      - epg_domain_absent.original == epg_domain_check_mode_absent.original
       - epg_vmm_domain_absent.changed == true
       - idempotency_absent.changed == false
-      - idempotency_absent.existing == []
+      - idempotency_absent.original == []
       - absent_missing_param.failed == true
       - 'absent_missing_param.msg == "state is absent but all of the following are missing: ap, domain, domain_type, epg"'
 

--- a/test/integration/targets/aci_epg_to_domain/tasks/main.yml
+++ b/test/integration/targets/aci_epg_to_domain/tasks/main.yml
@@ -16,7 +16,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
-    output_level: info
+    output_level: debug
     state: present
     tenant: anstest
   register: tenant_present

--- a/test/integration/targets/aci_epg_to_domain/tasks/main.yml
+++ b/test/integration/targets/aci_epg_to_domain/tasks/main.yml
@@ -112,14 +112,14 @@
       - phys_check_mode_present.changed == true
       - phys_present.changed == true
       - phys_present.previous == []
-      - 'phys_present.config == {"fvRsDomAtt": {"attributes": {}}}'
+      - 'phys_present.sent == {"fvRsDomAtt": {"attributes": {}}}'
       - '"[uni/phys-anstest].json" in phys_present.url'
       - phys_idempotent.changed == false
-      - phys_idempotent.config == {}
+      - phys_idempotent.sent == {}
       - phys_update.changed == true
-      - 'phys_update.config == {"fvRsDomAtt": {"attributes": {"instrImedcy": "immediate"}}}'
+      - 'phys_update.sent == {"fvRsDomAtt": {"attributes": {"instrImedcy": "immediate"}}}'
       - vmm_present.changed == true
-      - 'vmm_present.config == {"fvRsDomAtt": {"attributes": {"resImedcy": "pre-provision"}}}'
+      - 'vmm_present.sent == {"fvRsDomAtt": {"attributes": {"resImedcy": "pre-provision"}}}'
       - '"[uni/vmmp-VMware/dom-anstest].json" in vmm_present.url'
       - present_missing_params.failed == true
       - 'present_missing_params.msg == "domain_type is vmm but all of the following are missing: vm_provider"'

--- a/test/integration/targets/aci_filter_entry/tasks/main.yml
+++ b/test/integration/targets/aci_filter_entry/tasks/main.yml
@@ -111,16 +111,16 @@
   assert:
     that:
       - entry_present_check_mode.changed == true
-      - entry_present_check_mode.original == []
+      - entry_present_check_mode.previous == []
       - 'entry_present_check_mode.config == {"vzEntry": {"attributes": {"dFromPort": "http","dToPort": "88","descr": "Ansible Test","etherT": "ip","name": "anstest","prot": "tcp"}}}'
       - entry_present.changed == true
-      - entry_present.original == []
+      - entry_present.previous == []
       - entry_present.config == entry_present_check_mode.config
       - entry_present_idempotent.changed == false
-      - entry_present_idempotent.original != []
+      - entry_present_idempotent.previous != []
       - entry_present_idempotent.config == {}
       - entry_present_update.changed == true
-      - entry_present_update.original != []
+      - entry_present_update.previous != []
       - entry_present_update.config != entry_present_update.proposed
       - entry_present_2.changed == true
       - 'entry_present_2.config.vzEntry.attributes == {"arpOpc": "reply",  "etherT": "arp", "name": "anstest2"}'
@@ -188,44 +188,44 @@
   assert:
     that:
       - query_tenant_filter_entry.changed == false
-      - query_tenant_filter_entry.original | length == 1
-      - 'query_tenant_filter_entry.original.0.vzEntry.attributes.name == "anstest"'
+      - query_tenant_filter_entry.previous | length == 1
+      - 'query_tenant_filter_entry.previous.0.vzEntry.attributes.name == "anstest"'
       - '"tn-anstest/flt-anstest/e-anstest.json" in query_tenant_filter_entry.url'
       - query_filter_entry.changed == false
-      - 'query_filter_entry.original.0.vzFilter.attributes.name == "anstest"'
-      - query_filter_entry.original.0.vzFilter.children | length == 1
+      - 'query_filter_entry.previous.0.vzFilter.attributes.name == "anstest"'
+      - query_filter_entry.previous.0.vzFilter.children | length == 1
       - '"query-target-filter=eq(vzFilter.name, \"anstest\")" in query_filter_entry.filter_string'
       - '"rsp-subtree-filter=eq(vzEntry.name, \"anstest\")" in query_filter_entry.filter_string'
       - '"class/vzFilter.json" in query_filter_entry.url'
       - query_tenant_entry.changed == false
-      - query_tenant_entry.original | length == 1
-      - 'query_tenant_entry.original.0.fvTenant.attributes.name == "anstest"'
+      - query_tenant_entry.previous | length == 1
+      - 'query_tenant_entry.previous.0.fvTenant.attributes.name == "anstest"'
       - '"rsp-subtree-filter=eq(vzEntry.name, \"anstest\")" in query_tenant_entry.filter_string'
       - '"rsp-subtree-class=vzEntry" in query_tenant_entry.filter_string'
       - '"tn-anstest.json" in query_tenant_entry.url'
       - query_tenant_filter.changed == false
-      - query_tenant_filter.original | length == 1
-      - 'query_tenant_filter.original.0.vzFilter.attributes.name == "anstest"'
-      - query_tenant_filter.original.0.vzFilter.children | length == 4
+      - query_tenant_filter.previous | length == 1
+      - 'query_tenant_filter.previous.0.vzFilter.attributes.name == "anstest"'
+      - query_tenant_filter.previous.0.vzFilter.children | length == 4
       - '"rsp-subtree-class=vzEntry" in query_tenant_filter.filter_string'
       - '"tn-anstest/flt-anstest.json" in query_tenant_filter.url'
       - query_entry.changed == false
-      - 'query_entry.original.0.vzEntry.attributes.name == "anstest"'
+      - 'query_entry.previous.0.vzEntry.attributes.name == "anstest"'
       - '"query-target-filter=eq(vzEntry.name, \"anstest\")" in query_entry.filter_string'
       - '"class/vzEntry.json" in query_entry.url'
       - query_filter.changed == false
-      - 'query_filter.original.0.vzFilter.attributes.name == "anstest"'
+      - 'query_filter.previous.0.vzFilter.attributes.name == "anstest"'
       - '"query-target-filter=eq(vzFilter.name, \"anstest\")" in query_filter.filter_string'
       - '"rsp-subtree-class=vzEntry" in query_filter.filter_string'
       - '"class/vzFilter.json" in query_filter.url'
       - query_tenant.changed == false
-      - query_tenant.original | length == 1
-      - 'query_tenant.original.0.fvTenant.attributes.name == "anstest"'
+      - query_tenant.previous | length == 1
+      - 'query_tenant.previous.0.fvTenant.attributes.name == "anstest"'
       - '"rsp-subtree-class=vzFilter,vzEntry" in query_tenant.filter_string'
       - '"tn-anstest.json" in query_tenant.url'
       - query_all.changed == false
-      - query_all.original | length > 1
-      - query_all.original.0.vzEntry is defined
+      - query_all.previous | length > 1
+      - query_all.previous.0.vzEntry is defined
       - '"class/vzEntry.json" in query_all.url'
 
 - name: delete entry - check mode works
@@ -262,12 +262,12 @@
   assert:
     that:
       - entry_absent_check_mode.changed == true
-      - entry_absent_check_mode.original != []
+      - entry_absent_check_mode.previous != []
       - entry_absent.changed == true
-      - entry_absent.original == entry_absent_check_mode.original
+      - entry_absent.previous == entry_absent_check_mode.previous
       - entry_absent.proposed == {}
       - entry_absent_idempotent.changed == false
-      - entry_absent_idempotent.original == []
+      - entry_absent_idempotent.previous == []
       - absent_missing_param.failed == true
       - 'absent_missing_param.msg == "state is absent but all of the following are missing: entry, filter"'
 

--- a/test/integration/targets/aci_filter_entry/tasks/main.yml
+++ b/test/integration/targets/aci_filter_entry/tasks/main.yml
@@ -16,7 +16,6 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
-    output_level: info
     state: absent
     tenant: anstest
 
@@ -28,7 +27,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
-    output_level: info
+    output_level: debug
     state: present
     tenant: anstest
   register: tenant_present

--- a/test/integration/targets/aci_filter_entry/tasks/main.yml
+++ b/test/integration/targets/aci_filter_entry/tasks/main.yml
@@ -16,6 +16,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: info
     state: absent
     tenant: anstest
 
@@ -27,6 +28,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: info
     state: present
     tenant: anstest
   register: tenant_present
@@ -110,16 +112,16 @@
   assert:
     that:
       - entry_present_check_mode.changed == true
-      - entry_present_check_mode.existing == []
+      - entry_present_check_mode.original == []
       - 'entry_present_check_mode.config == {"vzEntry": {"attributes": {"dFromPort": "http","dToPort": "88","descr": "Ansible Test","etherT": "ip","name": "anstest","prot": "tcp"}}}'
       - entry_present.changed == true
-      - entry_present.existing == []
+      - entry_present.original == []
       - entry_present.config == entry_present_check_mode.config
       - entry_present_idempotent.changed == false
-      - entry_present_idempotent.existing != []
+      - entry_present_idempotent.original != []
       - entry_present_idempotent.config == {}
       - entry_present_update.changed == true
-      - entry_present_update.existing != []
+      - entry_present_update.original != []
       - entry_present_update.config != entry_present_update.proposed
       - entry_present_2.changed == true
       - 'entry_present_2.config.vzEntry.attributes == {"arpOpc": "reply",  "etherT": "arp", "name": "anstest2"}'
@@ -187,44 +189,44 @@
   assert:
     that:
       - query_tenant_filter_entry.changed == false
-      - query_tenant_filter_entry.existing | length == 1
-      - 'query_tenant_filter_entry.existing.0.vzEntry.attributes.name == "anstest"'
+      - query_tenant_filter_entry.original | length == 1
+      - 'query_tenant_filter_entry.original.0.vzEntry.attributes.name == "anstest"'
       - '"tn-anstest/flt-anstest/e-anstest.json" in query_tenant_filter_entry.url'
       - query_filter_entry.changed == false
-      - 'query_filter_entry.existing.0.vzFilter.attributes.name == "anstest"'
-      - query_filter_entry.existing.0.vzFilter.children | length == 1
+      - 'query_filter_entry.original.0.vzFilter.attributes.name == "anstest"'
+      - query_filter_entry.original.0.vzFilter.children | length == 1
       - '"query-target-filter=eq(vzFilter.name, \"anstest\")" in query_filter_entry.filter_string'
       - '"rsp-subtree-filter=eq(vzEntry.name, \"anstest\")" in query_filter_entry.filter_string'
       - '"class/vzFilter.json" in query_filter_entry.url'
       - query_tenant_entry.changed == false
-      - query_tenant_entry.existing | length == 1
-      - 'query_tenant_entry.existing.0.fvTenant.attributes.name == "anstest"'
+      - query_tenant_entry.original | length == 1
+      - 'query_tenant_entry.original.0.fvTenant.attributes.name == "anstest"'
       - '"rsp-subtree-filter=eq(vzEntry.name, \"anstest\")" in query_tenant_entry.filter_string'
       - '"rsp-subtree-class=vzEntry" in query_tenant_entry.filter_string'
       - '"tn-anstest.json" in query_tenant_entry.url'
       - query_tenant_filter.changed == false
-      - query_tenant_filter.existing | length == 1
-      - 'query_tenant_filter.existing.0.vzFilter.attributes.name == "anstest"'
-      - query_tenant_filter.existing.0.vzFilter.children | length == 4
+      - query_tenant_filter.original | length == 1
+      - 'query_tenant_filter.original.0.vzFilter.attributes.name == "anstest"'
+      - query_tenant_filter.original.0.vzFilter.children | length == 4
       - '"rsp-subtree-class=vzEntry" in query_tenant_filter.filter_string'
       - '"tn-anstest/flt-anstest.json" in query_tenant_filter.url'
       - query_entry.changed == false
-      - 'query_entry.existing.0.vzEntry.attributes.name == "anstest"'
+      - 'query_entry.original.0.vzEntry.attributes.name == "anstest"'
       - '"query-target-filter=eq(vzEntry.name, \"anstest\")" in query_entry.filter_string'
       - '"class/vzEntry.json" in query_entry.url'
       - query_filter.changed == false
-      - 'query_filter.existing.0.vzFilter.attributes.name == "anstest"'
+      - 'query_filter.original.0.vzFilter.attributes.name == "anstest"'
       - '"query-target-filter=eq(vzFilter.name, \"anstest\")" in query_filter.filter_string'
       - '"rsp-subtree-class=vzEntry" in query_filter.filter_string'
       - '"class/vzFilter.json" in query_filter.url'
       - query_tenant.changed == false
-      - query_tenant.existing | length == 1
-      - 'query_tenant.existing.0.fvTenant.attributes.name == "anstest"'
+      - query_tenant.original | length == 1
+      - 'query_tenant.original.0.fvTenant.attributes.name == "anstest"'
       - '"rsp-subtree-class=vzFilter,vzEntry" in query_tenant.filter_string'
       - '"tn-anstest.json" in query_tenant.url'
       - query_all.changed == false
-      - query_all.existing | length > 1
-      - query_all.existing.0.vzEntry is defined
+      - query_all.original | length > 1
+      - query_all.original.0.vzEntry is defined
       - '"class/vzEntry.json" in query_all.url'
 
 - name: delete entry - check mode works
@@ -261,12 +263,12 @@
   assert:
     that:
       - entry_absent_check_mode.changed == true
-      - entry_absent_check_mode.existing != []
+      - entry_absent_check_mode.original != []
       - entry_absent.changed == true
-      - entry_absent.existing == entry_absent_check_mode.existing
+      - entry_absent.original == entry_absent_check_mode.original
       - entry_absent.proposed == {}
       - entry_absent_idempotent.changed == false
-      - entry_absent_idempotent.existing == []
+      - entry_absent_idempotent.original == []
       - absent_missing_param.failed == true
       - 'absent_missing_param.msg == "state is absent but all of the following are missing: entry, filter"'
 

--- a/test/integration/targets/aci_filter_entry/tasks/main.yml
+++ b/test/integration/targets/aci_filter_entry/tasks/main.yml
@@ -112,22 +112,22 @@
     that:
       - entry_present_check_mode.changed == true
       - entry_present_check_mode.previous == []
-      - 'entry_present_check_mode.config == {"vzEntry": {"attributes": {"dFromPort": "http","dToPort": "88","descr": "Ansible Test","etherT": "ip","name": "anstest","prot": "tcp"}}}'
+      - 'entry_present_check_mode.sent == {"vzEntry": {"attributes": {"dFromPort": "http","dToPort": "88","descr": "Ansible Test","etherT": "ip","name": "anstest","prot": "tcp"}}}'
       - entry_present.changed == true
       - entry_present.previous == []
-      - entry_present.config == entry_present_check_mode.config
+      - entry_present.sent == entry_present_check_mode.sent
       - entry_present_idempotent.changed == false
       - entry_present_idempotent.previous != []
-      - entry_present_idempotent.config == {}
+      - entry_present_idempotent.sent == {}
       - entry_present_update.changed == true
       - entry_present_update.previous != []
-      - entry_present_update.config != entry_present_update.proposed
+      - entry_present_update.sent != entry_present_update.proposed
       - entry_present_2.changed == true
-      - 'entry_present_2.config.vzEntry.attributes == {"arpOpc": "reply",  "etherT": "arp", "name": "anstest2"}'
+      - 'entry_present_2.sent.vzEntry.attributes == {"arpOpc": "reply",  "etherT": "arp", "name": "anstest2"}'
       - entry_present_3.changed == true
-      - 'entry_present_3.config.vzEntry.attributes == {"etherT": "ip", "icmpv4T": "echo", "name": "anstest3", "prot": "icmp"}'
+      - 'entry_present_3.sent.vzEntry.attributes == {"etherT": "ip", "icmpv4T": "echo", "name": "anstest3", "prot": "icmp"}'
       - entry_present_4.changed == true
-      - 'entry_present_4.config.vzEntry.attributes == {"dFromPort": "1000", "dToPort": "1000", "etherT": "ip", "name": "anstest4", "prot": "udp"}'
+      - 'entry_present_4.sent.vzEntry.attributes == {"dFromPort": "1000", "dToPort": "1000", "etherT": "ip", "name": "anstest4", "prot": "udp"}'
       - present_missing_param.failed == true
       - 'present_missing_param.msg == "state is present but all of the following are missing: entry"'
       - present_incompatible_params.failed == true

--- a/test/integration/targets/aci_interface_selector_to_switch_policy_leaf_profile/tasks/main.yml
+++ b/test/integration/targets/aci_interface_selector_to_switch_policy_leaf_profile/tasks/main.yml
@@ -79,7 +79,7 @@
     that:
     - intftoleaf_check_mode_present.changed == true
     - intftoleaf_present.changed == true
-    - intftoleaf_present.original == []
+    - intftoleaf_present.previous == []
     - 'intftoleaf_present.config == {"infraRsAccPortP": {"attributes": {"tDn": "uni/infra/accportprof-leafintprftest"}}}'
     - intftoleaf_idempotent.changed == false
     - intftoleaf_idempotent.config == {}
@@ -95,7 +95,7 @@
   assert:
     that:
       - binding_query.changed == false
-      - binding_query.original | length >= 1
+      - binding_query.previous | length >= 1
       - '"api/mo/uni/infra/nprof-swleafprftest/rsaccPortP-[uni/infra/accportprof-leafintprftest].json" in binding_query.url'
 
 - name: Remove binding of interface access port selector and Interface Policy Leaf Profile - check mode
@@ -127,11 +127,11 @@
   assert:
     that:
       - intftoleaf_check_mode_absent.changed == true
-      - intftoleaf_check_mode_absent.original != []
+      - intftoleaf_check_mode_absent.previous != []
       - intftoleaf_absent.changed == true
-      - intftoleaf_absent.original == intftoleaf_check_mode_absent.original
+      - intftoleaf_absent.previous == intftoleaf_check_mode_absent.previous
       - intftoleaf_absent_idempotent.changed == false
-      - intftoleaf_absent_idempotent.original == []
+      - intftoleaf_absent_idempotent.previous == []
       - intftoleaf_absent_missing_param.failed == true
       - 'intftoleaf_absent_missing_param.msg == "state is absent but all of the following are missing: interface_selector"'
 

--- a/test/integration/targets/aci_interface_selector_to_switch_policy_leaf_profile/tasks/main.yml
+++ b/test/integration/targets/aci_interface_selector_to_switch_policy_leaf_profile/tasks/main.yml
@@ -16,6 +16,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: info
     leaf_profile: swleafprftest
     state: absent
 
@@ -27,6 +28,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: info
     leaf_interface_profile: leafintprftest
     state: absent
 
@@ -38,6 +40,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: info
     leaf_profile: swleafprftest
     state: present
   register: leaf_profile_present
@@ -50,6 +53,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: info
     leaf_interface_profile: leafintprftest
     state: present
   register: leaf_profile_present
@@ -77,7 +81,7 @@
     that:
     - intftoleaf_check_mode_present.changed == true
     - intftoleaf_present.changed == true
-    - intftoleaf_present.existing == []
+    - intftoleaf_present.original == []
     - 'intftoleaf_present.config == {"infraRsAccPortP": {"attributes": {"tDn": "uni/infra/accportprof-leafintprftest"}}}'
     - intftoleaf_idempotent.changed == false
     - intftoleaf_idempotent.config == {}
@@ -93,7 +97,7 @@
   assert:
     that:
       - binding_query.changed == false
-      - binding_query.existing | length >= 1
+      - binding_query.original | length >= 1
       - '"api/mo/uni/infra/nprof-swleafprftest/rsaccPortP-[uni/infra/accportprof-leafintprftest].json" in binding_query.url'
 
 - name: Remove binding of interface access port selector and Interface Policy Leaf Profile - check mode
@@ -125,11 +129,11 @@
   assert:
     that:
       - intftoleaf_check_mode_absent.changed == true
-      - intftoleaf_check_mode_absent.existing != []
+      - intftoleaf_check_mode_absent.original != []
       - intftoleaf_absent.changed == true
-      - intftoleaf_absent.existing == intftoleaf_check_mode_absent.existing
+      - intftoleaf_absent.original == intftoleaf_check_mode_absent.original
       - intftoleaf_absent_idempotent.changed == false
-      - intftoleaf_absent_idempotent.existing == []
+      - intftoleaf_absent_idempotent.original == []
       - intftoleaf_absent_missing_param.failed == true
       - 'intftoleaf_absent_missing_param.msg == "state is absent but all of the following are missing: interface_selector"'
 

--- a/test/integration/targets/aci_interface_selector_to_switch_policy_leaf_profile/tasks/main.yml
+++ b/test/integration/targets/aci_interface_selector_to_switch_policy_leaf_profile/tasks/main.yml
@@ -16,7 +16,6 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
-    output_level: info
     leaf_profile: swleafprftest
     state: absent
 
@@ -28,7 +27,6 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
-    output_level: info
     leaf_interface_profile: leafintprftest
     state: absent
 
@@ -40,7 +38,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
-    output_level: info
+    output_level: debug
     leaf_profile: swleafprftest
     state: present
   register: leaf_profile_present

--- a/test/integration/targets/aci_interface_selector_to_switch_policy_leaf_profile/tasks/main.yml
+++ b/test/integration/targets/aci_interface_selector_to_switch_policy_leaf_profile/tasks/main.yml
@@ -80,9 +80,9 @@
     - intftoleaf_check_mode_present.changed == true
     - intftoleaf_present.changed == true
     - intftoleaf_present.previous == []
-    - 'intftoleaf_present.config == {"infraRsAccPortP": {"attributes": {"tDn": "uni/infra/accportprof-leafintprftest"}}}'
+    - 'intftoleaf_present.sent == {"infraRsAccPortP": {"attributes": {"tDn": "uni/infra/accportprof-leafintprftest"}}}'
     - intftoleaf_idempotent.changed == false
-    - intftoleaf_idempotent.config == {}
+    - intftoleaf_idempotent.sent == {}
 
 - name: Query an interface selector profile associated with a switch policy leaf profile
   aci_interface_selector_to_switch_policy_leaf_profile:

--- a/test/integration/targets/aci_switch_leaf_selector/tasks/main.yml
+++ b/test/integration/targets/aci_switch_leaf_selector/tasks/main.yml
@@ -16,6 +16,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: info
     leaf_profile: sw_name_test
     state: absent
 
@@ -27,6 +28,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: info
     leaf_profile: sw_name_test
     state: present
   register: leaf_profile_present
@@ -65,7 +67,7 @@
     that:
     - sw_leaf_selec_check_mode_present.changed == true
     - sw_leaf_selec_present.changed == true
-    - sw_leaf_selec_present.existing == []
+    - sw_leaf_selec_present.original == []
     - 'sw_leaf_selec_present.config ==  {"infraLeafS": {"attributes": {"name": "leaf_selector_name"}, "children": [{"infraNodeBlk": {"attributes": {"from_": "1011", "name": "node_blk_name", "to_": "1011"}}},{"infraRsAccNodePGrp": {"attributes": {"tDn": "uni/infra/funcprof/accnodepgrp-None"}}}]}}'
     - sw_leaf_selec_idempotent.changed == false
     - sw_leaf_selec_idempotent.config == {}
@@ -83,7 +85,7 @@
   assert:
     that:
       - binding_query.changed == false
-      - binding_query.existing | length >= 1
+      - binding_query.original | length >= 1
       - '"api/mo/uni/infra/nprof-sw_name_test/leaves-leaf_selector_name-typ-range.json" in binding_query.url'
 
 - name: Remove binding of interface access port selector and Interface Policy Leaf Profile - check mode
@@ -116,11 +118,11 @@
   assert:
     that:
       - sw_leaf_selec_check_mode_absent.changed == true
-      - sw_leaf_selec_check_mode_absent.existing != []
+      - sw_leaf_selec_check_mode_absent.original != []
       - sw_leaf_selec_absent.changed == true
-      - sw_leaf_selec_absent.existing == sw_leaf_selec_check_mode_absent.existing
+      - sw_leaf_selec_absent.original == sw_leaf_selec_check_mode_absent.original
       - sw_leaf_selec_absent_idempotent.changed == false
-      - sw_leaf_selec_absent_idempotent.existing == []
+      - sw_leaf_selec_absent_idempotent.original == []
       - sw_leaf_selec_absent_missing_param.failed == true
       - 'sw_leaf_selec_absent_missing_param.msg == "state is absent but all of the following are missing: leaf"'
 

--- a/test/integration/targets/aci_switch_leaf_selector/tasks/main.yml
+++ b/test/integration/targets/aci_switch_leaf_selector/tasks/main.yml
@@ -66,7 +66,7 @@
     that:
     - sw_leaf_selec_check_mode_present.changed == true
     - sw_leaf_selec_present.changed == true
-    - sw_leaf_selec_present.original == []
+    - sw_leaf_selec_present.previous == []
     - 'sw_leaf_selec_present.config ==  {"infraLeafS": {"attributes": {"name": "leaf_selector_name"}, "children": [{"infraNodeBlk": {"attributes": {"from_": "1011", "name": "node_blk_name", "to_": "1011"}}},{"infraRsAccNodePGrp": {"attributes": {"tDn": "uni/infra/funcprof/accnodepgrp-None"}}}]}}'
     - sw_leaf_selec_idempotent.changed == false
     - sw_leaf_selec_idempotent.config == {}
@@ -84,7 +84,7 @@
   assert:
     that:
       - binding_query.changed == false
-      - binding_query.original | length >= 1
+      - binding_query.previous | length >= 1
       - '"api/mo/uni/infra/nprof-sw_name_test/leaves-leaf_selector_name-typ-range.json" in binding_query.url'
 
 - name: Remove binding of interface access port selector and Interface Policy Leaf Profile - check mode
@@ -117,11 +117,11 @@
   assert:
     that:
       - sw_leaf_selec_check_mode_absent.changed == true
-      - sw_leaf_selec_check_mode_absent.original != []
+      - sw_leaf_selec_check_mode_absent.previous != []
       - sw_leaf_selec_absent.changed == true
-      - sw_leaf_selec_absent.original == sw_leaf_selec_check_mode_absent.original
+      - sw_leaf_selec_absent.previous == sw_leaf_selec_check_mode_absent.previous
       - sw_leaf_selec_absent_idempotent.changed == false
-      - sw_leaf_selec_absent_idempotent.original == []
+      - sw_leaf_selec_absent_idempotent.previous == []
       - sw_leaf_selec_absent_missing_param.failed == true
       - 'sw_leaf_selec_absent_missing_param.msg == "state is absent but all of the following are missing: leaf"'
 

--- a/test/integration/targets/aci_switch_leaf_selector/tasks/main.yml
+++ b/test/integration/targets/aci_switch_leaf_selector/tasks/main.yml
@@ -16,7 +16,6 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
-    output_level: info
     leaf_profile: sw_name_test
     state: absent
 
@@ -28,7 +27,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
-    output_level: info
+    output_level: debug
     leaf_profile: sw_name_test
     state: present
   register: leaf_profile_present

--- a/test/integration/targets/aci_switch_leaf_selector/tasks/main.yml
+++ b/test/integration/targets/aci_switch_leaf_selector/tasks/main.yml
@@ -67,11 +67,11 @@
     - sw_leaf_selec_check_mode_present.changed == true
     - sw_leaf_selec_present.changed == true
     - sw_leaf_selec_present.previous == []
-    - 'sw_leaf_selec_present.config ==  {"infraLeafS": {"attributes": {"name": "leaf_selector_name"}, "children": [{"infraNodeBlk": {"attributes": {"from_": "1011", "name": "node_blk_name", "to_": "1011"}}},{"infraRsAccNodePGrp": {"attributes": {"tDn": "uni/infra/funcprof/accnodepgrp-None"}}}]}}'
+    - 'sw_leaf_selec_present.sent ==  {"infraLeafS": {"attributes": {"name": "leaf_selector_name"}, "children": [{"infraNodeBlk": {"attributes": {"from_": "1011", "name": "node_blk_name", "to_": "1011"}}},{"infraRsAccNodePGrp": {"attributes": {"tDn": "uni/infra/funcprof/accnodepgrp-None"}}}]}}'
     - sw_leaf_selec_idempotent.changed == false
-    - sw_leaf_selec_idempotent.config == {}
+    - sw_leaf_selec_idempotent.sent == {}
     - sw_leaf_selec_update.changed == true
-    - 'sw_leaf_selec_update.config == {"infraLeafS": {"attributes": {},"children": [{"infraRsAccNodePGrp": {"attributes": {"tDn": "uni/infra/funcprof/accnodepgrp-anstest_policygroupname"}}}]}}'
+    - 'sw_leaf_selec_update.sent == {"infraLeafS": {"attributes": {},"children": [{"infraRsAccNodePGrp": {"attributes": {"tDn": "uni/infra/funcprof/accnodepgrp-anstest_policygroupname"}}}]}}'
 
 - name: Query Specific switch policy leaf profile selector
   aci_switch_leaf_selector:

--- a/test/integration/targets/aci_vlan_pool/tasks/main.yml
+++ b/test/integration/targets/aci_vlan_pool/tasks/main.yml
@@ -64,7 +64,7 @@
   assert:
     that:
       - create_dynamic.changed == true
-      - create_dynamic.existing == []
+      - create_dynamic.original == []
       - 'create_dynamic.config == {"fvnsVlanInstP": {"attributes": {"allocMode": "dynamic", "descr": "Ansible Test", "name": "anstest"}}}'
 
 - name: Create static vlan pool again - idempotency works
@@ -76,7 +76,7 @@
   assert:
     that:
       - idempotent_static.changed == false
-      - 'idempotent_static.existing == [{"fvnsVlanInstP": {"attributes": {"allocMode": "static", "descr": "Ansible Test", "dn": "uni/infra/vlanns-[anstest]-static", "name": "anstest", "nameAlias": "", "ownerKey": "", "ownerTag": ""}}}]'
+      - 'idempotent_static.original == [{"fvnsVlanInstP": {"attributes": {"allocMode": "static", "descr": "Ansible Test", "dn": "uni/infra/vlanns-[anstest]-static", "name": "anstest", "nameAlias": "", "ownerKey": "", "ownerTag": ""}}}]'
       - idempotent_static.config == {}
 
 - name: Create dynamic vlan pool again - idempotency works
@@ -88,7 +88,7 @@
   assert:
     that:
       - idempotent_dynamic.changed == false
-      - 'idempotent_dynamic.existing == [{"fvnsVlanInstP": {"attributes": {"allocMode": "dynamic", "descr": "Ansible Test", "dn": "uni/infra/vlanns-[anstest]-dynamic", "name": "anstest", "nameAlias": "", "ownerKey": "", "ownerTag": ""}}}]'
+      - 'idempotent_dynamic.original == [{"fvnsVlanInstP": {"attributes": {"allocMode": "dynamic", "descr": "Ansible Test", "dn": "uni/infra/vlanns-[anstest]-dynamic", "name": "anstest", "nameAlias": "", "ownerKey": "", "ownerTag": ""}}}]'
       - idempotent_dynamic.config == {}
  
 - name: Update static vlan pool - update works
@@ -154,7 +154,7 @@
     that:
       - get_all_pools.changed == false
       - get_all_pools.method == "GET"
-      - get_all_pools.existing | length > 1
+      - get_all_pools.original | length > 1
 
 - name: Get created static vlan pool - get mo works
   aci_vlan_pool:
@@ -167,9 +167,9 @@
     that:
       - get_static_pool.changed == false
       - get_static_pool.method == "GET"
-      - get_static_pool.existing | length == 1
-      - get_static_pool.existing.0.fvnsVlanInstP.attributes.allocMode == "static"
-      - get_static_pool.existing.0.fvnsVlanInstP.attributes.name == "anstest"
+      - get_static_pool.original | length == 1
+      - get_static_pool.original.0.fvnsVlanInstP.attributes.allocMode == "static"
+      - get_static_pool.original.0.fvnsVlanInstP.attributes.name == "anstest"
 
 - name: Get created dynamic vlan pool - get mo works
   aci_vlan_pool:
@@ -182,9 +182,9 @@
     that:
       - get_dynamic_pool.changed == false
       - get_dynamic_pool.method == "GET"
-      - get_dynamic_pool.existing | length == 1
-      - get_dynamic_pool.existing.0.fvnsVlanInstP.attributes.allocMode == "dynamic"
-      - get_dynamic_pool.existing.0.fvnsVlanInstP.attributes.name == "anstest"
+      - get_dynamic_pool.original | length == 1
+      - get_dynamic_pool.original.0.fvnsVlanInstP.attributes.allocMode == "dynamic"
+      - get_dynamic_pool.original.0.fvnsVlanInstP.attributes.name == "anstest"
 
 - name: Delete static vlan pool - deletion works
   aci_vlan_pool:
@@ -196,8 +196,8 @@
     that:
       - delete_static.changed == true
       - delete_static.method == "DELETE"
-      - delete_static.existing.0.fvnsVlanInstP.attributes.allocMode == "static"
-      - delete_static.existing.0.fvnsVlanInstP.attributes.name == "anstest"
+      - delete_static.original.0.fvnsVlanInstP.attributes.allocMode == "static"
+      - delete_static.original.0.fvnsVlanInstP.attributes.name == "anstest"
 
 - name: Delete dynamic vlan pool - check mode works
   aci_vlan_pool:
@@ -220,8 +220,8 @@
     that:
       - delete_dynamic.changed == true
       - delete_dynamic.method == "DELETE"
-      - delete_dynamic.existing.0.fvnsVlanInstP.attributes.allocMode == "dynamic"
-      - delete_dynamic.existing.0.fvnsVlanInstP.attributes.name == "anstest"
+      - delete_dynamic.original.0.fvnsVlanInstP.attributes.allocMode == "dynamic"
+      - delete_dynamic.original.0.fvnsVlanInstP.attributes.name == "anstest"
 
 - name: Delete static vlan pool again - idempotency works
   aci_vlan_pool:
@@ -232,7 +232,7 @@
   assert:
     that:
       - idempotent_delete_static.changed == false
-      - idempotent_delete_static.existing == []
+      - idempotent_delete_static.original == []
 
 - name: Delete dynamic vlan pool again - idempotency works
   aci_vlan_pool:
@@ -243,4 +243,4 @@
   assert:
     that:
       - idempotent_delete_dynamic.changed == false
-      - idempotent_delete_dynamic.existing == []
+      - idempotent_delete_dynamic.original == []

--- a/test/integration/targets/aci_vlan_pool/tasks/main.yml
+++ b/test/integration/targets/aci_vlan_pool/tasks/main.yml
@@ -17,7 +17,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
-    output_level: info
+    output_level: debug
     state: absent
     pool: anstest
     allocation_mode: static

--- a/test/integration/targets/aci_vlan_pool/tasks/main.yml
+++ b/test/integration/targets/aci_vlan_pool/tasks/main.yml
@@ -17,6 +17,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: info
     state: absent
     pool: anstest
     allocation_mode: static

--- a/test/integration/targets/aci_vlan_pool/tasks/main.yml
+++ b/test/integration/targets/aci_vlan_pool/tasks/main.yml
@@ -39,7 +39,7 @@
   assert:
     that:
       - create_check_mode.changed == true
-      - 'create_check_mode.config == {"fvnsVlanInstP": {"attributes": {"allocMode": "static", "descr": "Ansible Test", "name": "anstest"}}}'
+      - 'create_check_mode.sent == {"fvnsVlanInstP": {"attributes": {"allocMode": "static", "descr": "Ansible Test", "name": "anstest"}}}'
 
 - name: Create static vlan pool - creation works
   aci_vlan_pool:
@@ -51,7 +51,7 @@
     that:
       - create_static.changed == true
       - create_static.previous == []
-      - create_static.config == create_check_mode.config
+      - create_static.sent == create_check_mode.sent
 
 - name: Create dynamic vlan pool - creation works
   aci_vlan_pool: &aci_pool_present_dynamic
@@ -65,7 +65,7 @@
     that:
       - create_dynamic.changed == true
       - create_dynamic.previous == []
-      - 'create_dynamic.config == {"fvnsVlanInstP": {"attributes": {"allocMode": "dynamic", "descr": "Ansible Test", "name": "anstest"}}}'
+      - 'create_dynamic.sent == {"fvnsVlanInstP": {"attributes": {"allocMode": "dynamic", "descr": "Ansible Test", "name": "anstest"}}}'
 
 - name: Create static vlan pool again - idempotency works
   aci_vlan_pool:
@@ -77,7 +77,7 @@
     that:
       - idempotent_static.changed == false
       - 'idempotent_static.previous == [{"fvnsVlanInstP": {"attributes": {"allocMode": "static", "descr": "Ansible Test", "dn": "uni/infra/vlanns-[anstest]-static", "name": "anstest", "nameAlias": "", "ownerKey": "", "ownerTag": ""}}}]'
-      - idempotent_static.config == {}
+      - idempotent_static.sent == {}
 
 - name: Create dynamic vlan pool again - idempotency works
   aci_vlan_pool:
@@ -89,7 +89,7 @@
     that:
       - idempotent_dynamic.changed == false
       - 'idempotent_dynamic.previous == [{"fvnsVlanInstP": {"attributes": {"allocMode": "dynamic", "descr": "Ansible Test", "dn": "uni/infra/vlanns-[anstest]-dynamic", "name": "anstest", "nameAlias": "", "ownerKey": "", "ownerTag": ""}}}]'
-      - idempotent_dynamic.config == {}
+      - idempotent_dynamic.sent == {}
  
 - name: Update static vlan pool - update works
   aci_vlan_pool:
@@ -101,7 +101,7 @@
   assert:
     that:
       - update_static.changed == true
-      - 'update_static.config == {"fvnsVlanInstP": {"attributes": {"descr": "Ansible Test Change"}}}'
+      - 'update_static.sent == {"fvnsVlanInstP": {"attributes": {"descr": "Ansible Test Change"}}}'
 
 - name: Update dynamic vlan pool - update works
   aci_vlan_pool:
@@ -113,7 +113,7 @@
   assert:
     that:
       - update_dynamic.changed == true
-      - 'update_dynamic.config == {"fvnsVlanInstP": {"attributes": {"descr": "Ansible Test Change"}}}'
+      - 'update_dynamic.sent == {"fvnsVlanInstP": {"attributes": {"descr": "Ansible Test Change"}}}'
 
 - name: Missing param - failure message works
   aci_vlan_pool:

--- a/test/integration/targets/aci_vlan_pool/tasks/main.yml
+++ b/test/integration/targets/aci_vlan_pool/tasks/main.yml
@@ -50,7 +50,7 @@
   assert:
     that:
       - create_static.changed == true
-      - create_static.existing == []
+      - create_static.original == []
       - create_static.config == create_check_mode.config
 
 - name: Create dynamic vlan pool - creation works

--- a/test/integration/targets/aci_vlan_pool/tasks/main.yml
+++ b/test/integration/targets/aci_vlan_pool/tasks/main.yml
@@ -50,7 +50,7 @@
   assert:
     that:
       - create_static.changed == true
-      - create_static.original == []
+      - create_static.previous == []
       - create_static.config == create_check_mode.config
 
 - name: Create dynamic vlan pool - creation works
@@ -64,7 +64,7 @@
   assert:
     that:
       - create_dynamic.changed == true
-      - create_dynamic.original == []
+      - create_dynamic.previous == []
       - 'create_dynamic.config == {"fvnsVlanInstP": {"attributes": {"allocMode": "dynamic", "descr": "Ansible Test", "name": "anstest"}}}'
 
 - name: Create static vlan pool again - idempotency works
@@ -76,7 +76,7 @@
   assert:
     that:
       - idempotent_static.changed == false
-      - 'idempotent_static.original == [{"fvnsVlanInstP": {"attributes": {"allocMode": "static", "descr": "Ansible Test", "dn": "uni/infra/vlanns-[anstest]-static", "name": "anstest", "nameAlias": "", "ownerKey": "", "ownerTag": ""}}}]'
+      - 'idempotent_static.previous == [{"fvnsVlanInstP": {"attributes": {"allocMode": "static", "descr": "Ansible Test", "dn": "uni/infra/vlanns-[anstest]-static", "name": "anstest", "nameAlias": "", "ownerKey": "", "ownerTag": ""}}}]'
       - idempotent_static.config == {}
 
 - name: Create dynamic vlan pool again - idempotency works
@@ -88,7 +88,7 @@
   assert:
     that:
       - idempotent_dynamic.changed == false
-      - 'idempotent_dynamic.original == [{"fvnsVlanInstP": {"attributes": {"allocMode": "dynamic", "descr": "Ansible Test", "dn": "uni/infra/vlanns-[anstest]-dynamic", "name": "anstest", "nameAlias": "", "ownerKey": "", "ownerTag": ""}}}]'
+      - 'idempotent_dynamic.previous == [{"fvnsVlanInstP": {"attributes": {"allocMode": "dynamic", "descr": "Ansible Test", "dn": "uni/infra/vlanns-[anstest]-dynamic", "name": "anstest", "nameAlias": "", "ownerKey": "", "ownerTag": ""}}}]'
       - idempotent_dynamic.config == {}
  
 - name: Update static vlan pool - update works
@@ -154,7 +154,7 @@
     that:
       - get_all_pools.changed == false
       - get_all_pools.method == "GET"
-      - get_all_pools.original | length > 1
+      - get_all_pools.previous | length > 1
 
 - name: Get created static vlan pool - get mo works
   aci_vlan_pool:
@@ -167,9 +167,9 @@
     that:
       - get_static_pool.changed == false
       - get_static_pool.method == "GET"
-      - get_static_pool.original | length == 1
-      - get_static_pool.original.0.fvnsVlanInstP.attributes.allocMode == "static"
-      - get_static_pool.original.0.fvnsVlanInstP.attributes.name == "anstest"
+      - get_static_pool.previous | length == 1
+      - get_static_pool.previous.0.fvnsVlanInstP.attributes.allocMode == "static"
+      - get_static_pool.previous.0.fvnsVlanInstP.attributes.name == "anstest"
 
 - name: Get created dynamic vlan pool - get mo works
   aci_vlan_pool:
@@ -182,9 +182,9 @@
     that:
       - get_dynamic_pool.changed == false
       - get_dynamic_pool.method == "GET"
-      - get_dynamic_pool.original | length == 1
-      - get_dynamic_pool.original.0.fvnsVlanInstP.attributes.allocMode == "dynamic"
-      - get_dynamic_pool.original.0.fvnsVlanInstP.attributes.name == "anstest"
+      - get_dynamic_pool.previous | length == 1
+      - get_dynamic_pool.previous.0.fvnsVlanInstP.attributes.allocMode == "dynamic"
+      - get_dynamic_pool.previous.0.fvnsVlanInstP.attributes.name == "anstest"
 
 - name: Delete static vlan pool - deletion works
   aci_vlan_pool:
@@ -196,8 +196,8 @@
     that:
       - delete_static.changed == true
       - delete_static.method == "DELETE"
-      - delete_static.original.0.fvnsVlanInstP.attributes.allocMode == "static"
-      - delete_static.original.0.fvnsVlanInstP.attributes.name == "anstest"
+      - delete_static.previous.0.fvnsVlanInstP.attributes.allocMode == "static"
+      - delete_static.previous.0.fvnsVlanInstP.attributes.name == "anstest"
 
 - name: Delete dynamic vlan pool - check mode works
   aci_vlan_pool:
@@ -220,8 +220,8 @@
     that:
       - delete_dynamic.changed == true
       - delete_dynamic.method == "DELETE"
-      - delete_dynamic.original.0.fvnsVlanInstP.attributes.allocMode == "dynamic"
-      - delete_dynamic.original.0.fvnsVlanInstP.attributes.name == "anstest"
+      - delete_dynamic.previous.0.fvnsVlanInstP.attributes.allocMode == "dynamic"
+      - delete_dynamic.previous.0.fvnsVlanInstP.attributes.name == "anstest"
 
 - name: Delete static vlan pool again - idempotency works
   aci_vlan_pool:
@@ -232,7 +232,7 @@
   assert:
     that:
       - idempotent_delete_static.changed == false
-      - idempotent_delete_static.original == []
+      - idempotent_delete_static.previous == []
 
 - name: Delete dynamic vlan pool again - idempotency works
   aci_vlan_pool:
@@ -243,4 +243,4 @@
   assert:
     that:
       - idempotent_delete_dynamic.changed == false
-      - idempotent_delete_dynamic.original == []
+      - idempotent_delete_dynamic.previous == []

--- a/test/integration/targets/aci_vlan_pool_encap_block/tasks/main.yml
+++ b/test/integration/targets/aci_vlan_pool_encap_block/tasks/main.yml
@@ -17,7 +17,6 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
-    output_level: info
     state: absent
     pool: anstest
     allocation_mode: static
@@ -31,7 +30,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
-    output_level: info
+    output_level: debug
     state: present
     pool: anstest
     allocation_mode: static

--- a/test/integration/targets/aci_vlan_pool_encap_block/tasks/main.yml
+++ b/test/integration/targets/aci_vlan_pool_encap_block/tasks/main.yml
@@ -65,7 +65,7 @@
   assert:
     that:
       - encap_block_present.changed == true
-      - encap_block_present.original == []
+      - encap_block_present.previous == []
       - encap_block_present.config == encap_block_present_check_mode.config
       - encap_block_present.config == encap_block_present.proposed
 
@@ -78,7 +78,7 @@
   assert:
     that:
       - encap_block_present_idempotent.changed == false
-      - 'encap_block_present_idempotent.original.0.fvnsEncapBlk.attributes.name == "anstest"'
+      - 'encap_block_present_idempotent.previous.0.fvnsEncapBlk.attributes.name == "anstest"'
 
 - name: Update vlan pool range - update works
   aci_vlan_pool_encap_block:
@@ -91,7 +91,7 @@
   assert:
     that:
       - encap_block_present_update.changed == true
-      - encap_block_present_update.original != []
+      - encap_block_present_update.previous != []
       - encap_block_present_update.config != encap_block_present.config
 
 - name: Create vlan pool range - used for query
@@ -106,7 +106,7 @@
   assert:
     that:
       - encap_block_present_2.changed == true
-      - encap_block_present_2.original == []
+      - encap_block_present_2.previous == []
 
 - name: Invalid encap_block_start - error message works
   aci_vlan_pool_encap_block:
@@ -209,8 +209,8 @@
     that:
       - encap_block_query.changed == false
       - encap_block_query.url.endswith("infra/vlanns-[anstest]-static/from-[vlan-20]-to-[vlan-40].json")
-      - encap_block_query.original | length == 1
-      - encap_block_query.original.0.fvnsEncapBlk.attributes.name == "anstest"
+      - encap_block_query.previous | length == 1
+      - encap_block_query.previous.0.fvnsEncapBlk.attributes.name == "anstest"
 
 - name: Query vlan pool range - from, to, and name are filtered
   aci_vlan_pool_encap_block: &aci_encap_block_query_filter
@@ -224,9 +224,9 @@
       - encap_block_query_from_to_name.changed == false
       - encap_block_query_from_to_name.url.endswith("class/fvnsEncapBlk.json")
       - '"query-target-filter=and(eq(fvnsEncapBlk.from, \"vlan-20\"),eq(fvnsEncapBlk.to, \"vlan-40\"),eq(fvnsEncapBlk.name, \"anstest\"))" in encap_block_query_from_to_name.filter_string'
-      - encap_block_query_from_to_name.original.0.fvnsEncapBlk.attributes.name == "anstest"
-      - encap_block_query_from_to_name.original.0.fvnsEncapBlk.attributes.from == "vlan-20"
-      - encap_block_query_from_to_name.original.0.fvnsEncapBlk.attributes.to == "vlan-40"
+      - encap_block_query_from_to_name.previous.0.fvnsEncapBlk.attributes.name == "anstest"
+      - encap_block_query_from_to_name.previous.0.fvnsEncapBlk.attributes.from == "vlan-20"
+      - encap_block_query_from_to_name.previous.0.fvnsEncapBlk.attributes.to == "vlan-40"
 
 - name: Query vlan pool range - from and name are filtered
   aci_vlan_pool_encap_block:
@@ -240,8 +240,8 @@
       - encap_block_query_from_name.changed == false
       - encap_block_query_from_name.url.endswith("class/fvnsEncapBlk.json")
       - '"query-target-filter=and(eq(fvnsEncapBlk.from, \"vlan-20\"),eq(fvnsEncapBlk.name, \"anstest\"))" in encap_block_query_from_name.filter_string'
-      - encap_block_query_from_name.original.0.fvnsEncapBlk.attributes.name == "anstest"
-      - encap_block_query_from_name.original.0.fvnsEncapBlk.attributes.from == "vlan-20"
+      - encap_block_query_from_name.previous.0.fvnsEncapBlk.attributes.name == "anstest"
+      - encap_block_query_from_name.previous.0.fvnsEncapBlk.attributes.from == "vlan-20"
 
 - name: Query vlan pool range - to and name are filtered
   aci_vlan_pool_encap_block:
@@ -255,8 +255,8 @@
       - encap_block_query_to_name.changed == false
       - encap_block_query_to_name.url.endswith("class/fvnsEncapBlk.json")
       - '"query-target-filter=and(eq(fvnsEncapBlk.to, \"vlan-40\"),eq(fvnsEncapBlk.name, \"anstest\"))" in encap_block_query_to_name.filter_string'
-      - encap_block_query_to_name.original.0.fvnsEncapBlk.attributes.name == "anstest"
-      - encap_block_query_to_name.original.0.fvnsEncapBlk.attributes.to == "vlan-40"
+      - encap_block_query_to_name.previous.0.fvnsEncapBlk.attributes.name == "anstest"
+      - encap_block_query_to_name.previous.0.fvnsEncapBlk.attributes.to == "vlan-40"
 
 - name: Query vlan pool range - name is filtered
   aci_vlan_pool_encap_block:
@@ -271,7 +271,7 @@
       - encap_block_query_name.changed == false
       - encap_block_query_name.url.endswith("class/fvnsEncapBlk.json")
       - '"query-target-filter=eq(fvnsEncapBlk.name, \"anstest\")" in encap_block_query_name.filter_string'
-      - encap_block_query_name.original.0.fvnsEncapBlk.attributes.name == "anstest"
+      - encap_block_query_name.previous.0.fvnsEncapBlk.attributes.name == "anstest"
 
 - name: Query vlan pool range - from and to are filtered
   aci_vlan_pool_encap_block:
@@ -285,8 +285,8 @@
       - encap_block_query_from_to.changed == false
       - encap_block_query_from_to.url.endswith("class/fvnsEncapBlk.json")
       - '"query-target-filter=and(eq(fvnsEncapBlk.from, \"vlan-20\"),eq(fvnsEncapBlk.to, \"vlan-40\"))" in encap_block_query_from_to.filter_string'
-      - encap_block_query_from_to.original.0.fvnsEncapBlk.attributes.from == "vlan-20"
-      - encap_block_query_from_to.original.0.fvnsEncapBlk.attributes.to == "vlan-40"
+      - encap_block_query_from_to.previous.0.fvnsEncapBlk.attributes.from == "vlan-20"
+      - encap_block_query_from_to.previous.0.fvnsEncapBlk.attributes.to == "vlan-40"
 
 - name: Query all ranges in a vlan pool
   aci_vlan_pool_encap_block:
@@ -298,9 +298,9 @@
 - name: Query assertions
   assert:
     that:
-      - encap_block_query_pool.original | length == 1
-      - encap_block_query_pool.original.0.fvnsVlanInstP.attributes.name == "anstest"
-      - encap_block_query_pool.original.0.fvnsVlanInstP.children | length > 1
+      - encap_block_query_pool.previous | length == 1
+      - encap_block_query_pool.previous.0.fvnsVlanInstP.attributes.name == "anstest"
+      - encap_block_query_pool.previous.0.fvnsVlanInstP.children | length > 1
       - encap_block_query_pool.url.endswith("infra/vlanns-[anstest]-static.json")
 
 - name: Query all ranges
@@ -314,8 +314,8 @@
   assert:
     that:
       - encap_block_query_all.changed == false
-      - encap_block_query_all.original | length > 1
-      - encap_block_query_all.original.0.fvnsEncapBlk is defined
+      - encap_block_query_all.previous | length > 1
+      - encap_block_query_all.previous.0.fvnsEncapBlk is defined
       - encap_block_query_all.url.endswith("class/fvnsEncapBlk.json")
 
 - name: Delete vlan pool range - deletion works
@@ -329,7 +329,7 @@
     that:
       - delete_range.changed == true
       - delete_range.proposed == {}
-      - delete_range.original.0.fvnsEncapBlk.attributes.name == "anstest"
+      - delete_range.previous.0.fvnsEncapBlk.attributes.name == "anstest"
 
 - name: Delete vlan pool range - check mode works
   aci_vlan_pool_encap_block: &aci_encap_block_absent
@@ -342,7 +342,7 @@
   assert:
     that:
       - delete_check_mode.changed == true
-      - delete_check_mode.original != []
+      - delete_check_mode.previous != []
 
 - name: Delete vlan pool range - deletion works
   aci_vlan_pool_encap_block:
@@ -353,7 +353,7 @@
   assert:
     that:
       - delete_encap_block_2.changed == true
-      - delete_encap_block_2.original == delete_check_mode.original
+      - delete_encap_block_2.previous == delete_check_mode.previous
 
 - name: Delete vlan pool range again - idempotency works
   aci_vlan_pool_encap_block:
@@ -364,7 +364,7 @@
   assert:
     that:
       - delete_idempotent.changed == false
-      - delete_idempotent.original == []
+      - delete_idempotent.previous == []
 
 - name: Cleanup vlan pool
   aci_vlan_pool:

--- a/test/integration/targets/aci_vlan_pool_encap_block/tasks/main.yml
+++ b/test/integration/targets/aci_vlan_pool_encap_block/tasks/main.yml
@@ -17,6 +17,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: info
     state: absent
     pool: anstest
     allocation_mode: static
@@ -30,6 +31,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: info
     state: present
     pool: anstest
     allocation_mode: static
@@ -64,7 +66,7 @@
   assert:
     that:
       - encap_block_present.changed == true
-      - encap_block_present.existing == []
+      - encap_block_present.original == []
       - encap_block_present.config == encap_block_present_check_mode.config
       - encap_block_present.config == encap_block_present.proposed
 
@@ -77,7 +79,7 @@
   assert:
     that:
       - encap_block_present_idempotent.changed == false
-      - 'encap_block_present_idempotent.existing.0.fvnsEncapBlk.attributes.name == "anstest"'
+      - 'encap_block_present_idempotent.original.0.fvnsEncapBlk.attributes.name == "anstest"'
 
 - name: Update vlan pool range - update works
   aci_vlan_pool_encap_block:
@@ -90,7 +92,7 @@
   assert:
     that:
       - encap_block_present_update.changed == true
-      - encap_block_present_update.existing != []
+      - encap_block_present_update.original != []
       - encap_block_present_update.config != encap_block_present.config
 
 - name: Create vlan pool range - used for query
@@ -105,7 +107,7 @@
   assert:
     that:
       - encap_block_present_2.changed == true
-      - encap_block_present_2.existing == []
+      - encap_block_present_2.original == []
 
 - name: Invalid encap_block_start - error message works
   aci_vlan_pool_encap_block:
@@ -208,8 +210,8 @@
     that:
       - encap_block_query.changed == false
       - encap_block_query.url.endswith("infra/vlanns-[anstest]-static/from-[vlan-20]-to-[vlan-40].json")
-      - encap_block_query.existing | length == 1
-      - encap_block_query.existing.0.fvnsEncapBlk.attributes.name == "anstest"
+      - encap_block_query.original | length == 1
+      - encap_block_query.original.0.fvnsEncapBlk.attributes.name == "anstest"
 
 - name: Query vlan pool range - from, to, and name are filtered
   aci_vlan_pool_encap_block: &aci_encap_block_query_filter
@@ -223,9 +225,9 @@
       - encap_block_query_from_to_name.changed == false
       - encap_block_query_from_to_name.url.endswith("class/fvnsEncapBlk.json")
       - '"query-target-filter=and(eq(fvnsEncapBlk.from, \"vlan-20\"),eq(fvnsEncapBlk.to, \"vlan-40\"),eq(fvnsEncapBlk.name, \"anstest\"))" in encap_block_query_from_to_name.filter_string'
-      - encap_block_query_from_to_name.existing.0.fvnsEncapBlk.attributes.name == "anstest"
-      - encap_block_query_from_to_name.existing.0.fvnsEncapBlk.attributes.from == "vlan-20"
-      - encap_block_query_from_to_name.existing.0.fvnsEncapBlk.attributes.to == "vlan-40"
+      - encap_block_query_from_to_name.original.0.fvnsEncapBlk.attributes.name == "anstest"
+      - encap_block_query_from_to_name.original.0.fvnsEncapBlk.attributes.from == "vlan-20"
+      - encap_block_query_from_to_name.original.0.fvnsEncapBlk.attributes.to == "vlan-40"
 
 - name: Query vlan pool range - from and name are filtered
   aci_vlan_pool_encap_block:
@@ -239,8 +241,8 @@
       - encap_block_query_from_name.changed == false
       - encap_block_query_from_name.url.endswith("class/fvnsEncapBlk.json")
       - '"query-target-filter=and(eq(fvnsEncapBlk.from, \"vlan-20\"),eq(fvnsEncapBlk.name, \"anstest\"))" in encap_block_query_from_name.filter_string'
-      - encap_block_query_from_name.existing.0.fvnsEncapBlk.attributes.name == "anstest"
-      - encap_block_query_from_name.existing.0.fvnsEncapBlk.attributes.from == "vlan-20"
+      - encap_block_query_from_name.original.0.fvnsEncapBlk.attributes.name == "anstest"
+      - encap_block_query_from_name.original.0.fvnsEncapBlk.attributes.from == "vlan-20"
 
 - name: Query vlan pool range - to and name are filtered
   aci_vlan_pool_encap_block:
@@ -254,8 +256,8 @@
       - encap_block_query_to_name.changed == false
       - encap_block_query_to_name.url.endswith("class/fvnsEncapBlk.json")
       - '"query-target-filter=and(eq(fvnsEncapBlk.to, \"vlan-40\"),eq(fvnsEncapBlk.name, \"anstest\"))" in encap_block_query_to_name.filter_string'
-      - encap_block_query_to_name.existing.0.fvnsEncapBlk.attributes.name == "anstest"
-      - encap_block_query_to_name.existing.0.fvnsEncapBlk.attributes.to == "vlan-40"
+      - encap_block_query_to_name.original.0.fvnsEncapBlk.attributes.name == "anstest"
+      - encap_block_query_to_name.original.0.fvnsEncapBlk.attributes.to == "vlan-40"
 
 - name: Query vlan pool range - name is filtered
   aci_vlan_pool_encap_block:
@@ -270,7 +272,7 @@
       - encap_block_query_name.changed == false
       - encap_block_query_name.url.endswith("class/fvnsEncapBlk.json")
       - '"query-target-filter=eq(fvnsEncapBlk.name, \"anstest\")" in encap_block_query_name.filter_string'
-      - encap_block_query_name.existing.0.fvnsEncapBlk.attributes.name == "anstest"
+      - encap_block_query_name.original.0.fvnsEncapBlk.attributes.name == "anstest"
 
 - name: Query vlan pool range - from and to are filtered
   aci_vlan_pool_encap_block:
@@ -284,8 +286,8 @@
       - encap_block_query_from_to.changed == false
       - encap_block_query_from_to.url.endswith("class/fvnsEncapBlk.json")
       - '"query-target-filter=and(eq(fvnsEncapBlk.from, \"vlan-20\"),eq(fvnsEncapBlk.to, \"vlan-40\"))" in encap_block_query_from_to.filter_string'
-      - encap_block_query_from_to.existing.0.fvnsEncapBlk.attributes.from == "vlan-20"
-      - encap_block_query_from_to.existing.0.fvnsEncapBlk.attributes.to == "vlan-40"
+      - encap_block_query_from_to.original.0.fvnsEncapBlk.attributes.from == "vlan-20"
+      - encap_block_query_from_to.original.0.fvnsEncapBlk.attributes.to == "vlan-40"
 
 - name: Query all ranges in a vlan pool
   aci_vlan_pool_encap_block:
@@ -297,9 +299,9 @@
 - name: Query assertions
   assert:
     that:
-      - encap_block_query_pool.existing | length == 1
-      - encap_block_query_pool.existing.0.fvnsVlanInstP.attributes.name == "anstest"
-      - encap_block_query_pool.existing.0.fvnsVlanInstP.children | length > 1
+      - encap_block_query_pool.original | length == 1
+      - encap_block_query_pool.original.0.fvnsVlanInstP.attributes.name == "anstest"
+      - encap_block_query_pool.original.0.fvnsVlanInstP.children | length > 1
       - encap_block_query_pool.url.endswith("infra/vlanns-[anstest]-static.json")
 
 - name: Query all ranges
@@ -313,8 +315,8 @@
   assert:
     that:
       - encap_block_query_all.changed == false
-      - encap_block_query_all.existing | length > 1
-      - encap_block_query_all.existing.0.fvnsEncapBlk is defined
+      - encap_block_query_all.original | length > 1
+      - encap_block_query_all.original.0.fvnsEncapBlk is defined
       - encap_block_query_all.url.endswith("class/fvnsEncapBlk.json")
 
 - name: Delete vlan pool range - deletion works
@@ -328,7 +330,7 @@
     that:
       - delete_range.changed == true
       - delete_range.proposed == {}
-      - delete_range.existing.0.fvnsEncapBlk.attributes.name == "anstest"
+      - delete_range.original.0.fvnsEncapBlk.attributes.name == "anstest"
 
 - name: Delete vlan pool range - check mode works
   aci_vlan_pool_encap_block: &aci_encap_block_absent
@@ -341,7 +343,7 @@
   assert:
     that:
       - delete_check_mode.changed == true
-      - delete_check_mode.existing != []
+      - delete_check_mode.original != []
 
 - name: Delete vlan pool range - deletion works
   aci_vlan_pool_encap_block:
@@ -352,7 +354,7 @@
   assert:
     that:
       - delete_encap_block_2.changed == true
-      - delete_encap_block_2.existing == delete_check_mode.existing
+      - delete_encap_block_2.original == delete_check_mode.original
 
 - name: Delete vlan pool range again - idempotency works
   aci_vlan_pool_encap_block:
@@ -363,7 +365,7 @@
   assert:
     that:
       - delete_idempotent.changed == false
-      - delete_idempotent.existing == []
+      - delete_idempotent.original == []
 
 - name: Cleanup vlan pool
   aci_vlan_pool:

--- a/test/integration/targets/aci_vlan_pool_encap_block/tasks/main.yml
+++ b/test/integration/targets/aci_vlan_pool_encap_block/tasks/main.yml
@@ -54,7 +54,7 @@
   assert:
     that:
       - encap_block_present_check_mode.changed == true
-      - 'encap_block_present_check_mode.config == {"fvnsEncapBlk": {"attributes": {"allocMode": "inherit", "descr": "Ansible Test", "from": "vlan-20", "name": "anstest", "to": "vlan-40"}}}'
+      - 'encap_block_present_check_mode.sent == {"fvnsEncapBlk": {"attributes": {"allocMode": "inherit", "descr": "Ansible Test", "from": "vlan-20", "name": "anstest", "to": "vlan-40"}}}'
 
 - name: Create vlan pool encap_block - creation works
   aci_vlan_pool_encap_block:
@@ -66,8 +66,8 @@
     that:
       - encap_block_present.changed == true
       - encap_block_present.previous == []
-      - encap_block_present.config == encap_block_present_check_mode.config
-      - encap_block_present.config == encap_block_present.proposed
+      - encap_block_present.sent == encap_block_present_check_mode.sent
+      - encap_block_present.sent == encap_block_present.proposed
 
 - name: Create vlan pool range - idempotency works
   aci_vlan_pool_encap_block:
@@ -92,7 +92,7 @@
     that:
       - encap_block_present_update.changed == true
       - encap_block_present_update.previous != []
-      - encap_block_present_update.config != encap_block_present.config
+      - encap_block_present_update.sent != encap_block_present.sent
 
 - name: Create vlan pool range - used for query
   aci_vlan_pool_encap_block: &aci_encap_block_present_2

--- a/test/integration/targets/aci_vrf/tasks/main.yml
+++ b/test/integration/targets/aci_vrf/tasks/main.yml
@@ -64,17 +64,17 @@
   assert:
     that:
       - vrf_present_check_mode.changed == true
-      - 'vrf_present_check_mode.config == {"fvCtx": {"attributes": {"descr": "Ansible Test", "name": "anstest"}}}'
+      - 'vrf_present_check_mode.sent == {"fvCtx": {"attributes": {"descr": "Ansible Test", "name": "anstest"}}}'
       - vrf_present.changed == true
-      - vrf_present.config == vrf_present_check_mode.config
+      - vrf_present.sent == vrf_present_check_mode.sent
       - vrf_present.previous == []
       - vrf_present_idempotent.changed == false
       - vrf_present_idempotent.previous != []
       - vrf_update.changed == true
       - vrf_update.previous != []
       - vrf_update.changed != vrf_update.proposed
-      - 'vrf_update.config == {"fvCtx": {"attributes": {"descr": "Ansible Test Update", "pcEnfPref": "unenforced"}}}'
-      - 'vrf_present_2.config.fvCtx.attributes == {"name": "anstest2", "pcEnfDir": "egress", "descr": "Ansible Test"}'
+      - 'vrf_update.sent == {"fvCtx": {"attributes": {"descr": "Ansible Test Update", "pcEnfPref": "unenforced"}}}'
+      - 'vrf_present_2.sent.fvCtx.attributes == {"name": "anstest2", "pcEnfDir": "egress", "descr": "Ansible Test"}'
       - vrf_present_missing_param.failed == true
       - 'vrf_present_missing_param.msg == "state is present but all of the following are missing: tenant"'
 

--- a/test/integration/targets/aci_vrf/tasks/main.yml
+++ b/test/integration/targets/aci_vrf/tasks/main.yml
@@ -67,11 +67,11 @@
       - 'vrf_present_check_mode.config == {"fvCtx": {"attributes": {"descr": "Ansible Test", "name": "anstest"}}}'
       - vrf_present.changed == true
       - vrf_present.config == vrf_present_check_mode.config
-      - vrf_present.original == []
+      - vrf_present.previous == []
       - vrf_present_idempotent.changed == false
-      - vrf_present_idempotent.original != []
+      - vrf_present_idempotent.previous != []
       - vrf_update.changed == true
-      - vrf_update.original != []
+      - vrf_update.previous != []
       - vrf_update.changed != vrf_update.proposed
       - 'vrf_update.config == {"fvCtx": {"attributes": {"descr": "Ansible Test Update", "pcEnfPref": "unenforced"}}}'
       - 'vrf_present_2.config.fvCtx.attributes == {"name": "anstest2", "pcEnfDir": "egress", "descr": "Ansible Test"}'
@@ -107,22 +107,22 @@
   assert:
     that:
       - query_all.changed == false
-      - query_all.original | length > 1
-      - query_all.original.0.fvCtx is defined
+      - query_all.previous | length > 1
+      - query_all.previous.0.fvCtx is defined
       - '"class/fvCtx.json" in query_all.url'
       - query_tenant.changed == false
-      - query_tenant.original | length == 1
-      - query_tenant.original.0.fvTenant.children | length == 2
-      - 'query_tenant.original.0.fvTenant.attributes.name == "anstest"'
+      - query_tenant.previous | length == 1
+      - query_tenant.previous.0.fvTenant.children | length == 2
+      - 'query_tenant.previous.0.fvTenant.attributes.name == "anstest"'
       - '"rsp-subtree-class=fvCtx" in query_tenant.filter_string'
       - '"tn-anstest.json" in query_tenant.url'
       - query_vrf_vrf.changed == false
-      - query_vrf_vrf.original != []
-      - 'query_vrf_vrf.original.0.fvCtx.attributes.name == "anstest"'
+      - query_vrf_vrf.previous != []
+      - 'query_vrf_vrf.previous.0.fvCtx.attributes.name == "anstest"'
       - '"query-target-filter=eq(fvCtx.name, \"anstest\")" in query_vrf_vrf.filter_string'
       - '"class/fvCtx.json" in query_vrf_vrf.url'
       - query_vrf.changed == false
-      - query_vrf.original | length == 1
+      - query_vrf.previous | length == 1
       - '"tn-anstest/ctx-anstest.json" in query_vrf.url'
 
 - name: delete vrf - check mode works
@@ -158,12 +158,12 @@
   assert:
     that:
       - vrf_absent_check_mode.changed == true
-      - vrf_absent_check_mode.original != []
+      - vrf_absent_check_mode.previous != []
       - vrf_absent_check_mode.proposed == {}
       - vrf_absent.changed == true
-      - vrf_absent.original == vrf_absent_check_mode.original
+      - vrf_absent.previous == vrf_absent_check_mode.previous
       - vrf_absent_idempotent.changed == false
-      - vrf_absent_idempotent.original == []
+      - vrf_absent_idempotent.previous == []
       - vrf_absent_missing_param.failed == true
       - 'vrf_absent_missing_param.msg == "state is absent but all of the following are missing: vrf"'
 

--- a/test/integration/targets/aci_vrf/tasks/main.yml
+++ b/test/integration/targets/aci_vrf/tasks/main.yml
@@ -16,6 +16,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: info
     state: present
     tenant: anstest
   register: tenant_present
@@ -66,11 +67,11 @@
       - 'vrf_present_check_mode.config == {"fvCtx": {"attributes": {"descr": "Ansible Test", "name": "anstest"}}}'
       - vrf_present.changed == true
       - vrf_present.config == vrf_present_check_mode.config
-      - vrf_present.existing == []
+      - vrf_present.original == []
       - vrf_present_idempotent.changed == false
-      - vrf_present_idempotent.existing != []
+      - vrf_present_idempotent.original != []
       - vrf_update.changed == true
-      - vrf_update.existing != []
+      - vrf_update.original != []
       - vrf_update.changed != vrf_update.proposed
       - 'vrf_update.config == {"fvCtx": {"attributes": {"descr": "Ansible Test Update", "pcEnfPref": "unenforced"}}}'
       - 'vrf_present_2.config.fvCtx.attributes == {"name": "anstest2", "pcEnfDir": "egress", "descr": "Ansible Test"}'
@@ -106,22 +107,22 @@
   assert:
     that:
       - query_all.changed == false
-      - query_all.existing | length > 1
-      - query_all.existing.0.fvCtx is defined
+      - query_all.original | length > 1
+      - query_all.original.0.fvCtx is defined
       - '"class/fvCtx.json" in query_all.url'
       - query_tenant.changed == false
-      - query_tenant.existing | length == 1
-      - query_tenant.existing.0.fvTenant.children | length == 2
-      - 'query_tenant.existing.0.fvTenant.attributes.name == "anstest"'
+      - query_tenant.original | length == 1
+      - query_tenant.original.0.fvTenant.children | length == 2
+      - 'query_tenant.original.0.fvTenant.attributes.name == "anstest"'
       - '"rsp-subtree-class=fvCtx" in query_tenant.filter_string'
       - '"tn-anstest.json" in query_tenant.url'
       - query_vrf_vrf.changed == false
-      - query_vrf_vrf.existing != []
-      - 'query_vrf_vrf.existing.0.fvCtx.attributes.name == "anstest"'
+      - query_vrf_vrf.original != []
+      - 'query_vrf_vrf.original.0.fvCtx.attributes.name == "anstest"'
       - '"query-target-filter=eq(fvCtx.name, \"anstest\")" in query_vrf_vrf.filter_string'
       - '"class/fvCtx.json" in query_vrf_vrf.url'
       - query_vrf.changed == false
-      - query_vrf.existing | length == 1
+      - query_vrf.original | length == 1
       - '"tn-anstest/ctx-anstest.json" in query_vrf.url'
 
 - name: delete vrf - check mode works
@@ -157,12 +158,12 @@
   assert:
     that:
       - vrf_absent_check_mode.changed == true
-      - vrf_absent_check_mode.existing != []
+      - vrf_absent_check_mode.original != []
       - vrf_absent_check_mode.proposed == {}
       - vrf_absent.changed == true
-      - vrf_absent.existing == vrf_absent_check_mode.existing
+      - vrf_absent.original == vrf_absent_check_mode.original
       - vrf_absent_idempotent.changed == false
-      - vrf_absent_idempotent.existing == []
+      - vrf_absent_idempotent.original == []
       - vrf_absent_missing_param.failed == true
       - 'vrf_absent_missing_param.msg == "state is absent but all of the following are missing: vrf"'
 

--- a/test/integration/targets/aci_vrf/tasks/main.yml
+++ b/test/integration/targets/aci_vrf/tasks/main.yml
@@ -16,7 +16,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
-    output_level: info
+    output_level: debug
     state: present
     tenant: anstest
   register: tenant_present

--- a/test/units/module_utils/network/aci/test_aci.py
+++ b/test/units/module_utils/network/aci/test_aci.py
@@ -21,11 +21,30 @@
 import sys
 
 from ansible.compat.tests import unittest
-from ansible.module_utils.network.aci.aci import aci_response_json, aci_response_xml
+from ansible.module_utils.network.aci.aci import ACIModule
 from ansible.module_utils.six import PY2, PY3
 from ansible.module_utils._text import to_native
 
 from nose.plugins.skip import SkipTest
+
+
+class AltModule():
+    params = dict(
+        hostname='dummy',
+        port=123,
+        protocol='https',
+        state='present',
+    )
+
+
+class AltACIModule(ACIModule):
+    def __init__(self):
+        self.result = dict(changed=False)
+        self.module = AltModule
+        self.params = self.module.params
+
+aci = AltACIModule()
+
 
 try:
     from lxml import etree
@@ -40,24 +59,28 @@ class AciRest(unittest.TestCase):
     def test_invalid_aci_login(self):
         self.maxDiff = None
 
-        expected_result = {
-            'error_code': '401',
-            'error_text': 'Username or password is incorrect - FAILED local authentication',
-            'imdata': [{
-                'error': {
-                    'attributes': {
-                        'code': '401',
-                        'text': 'Username or password is incorrect - FAILED local authentication',
-                    },
+        error = dict(
+            code='401',
+            text='Username or password is incorrect - FAILED local authentication',
+        )
+
+        imdata = [{
+            'error': {
+                'attributes': {
+                    'code': '401',
+                    'text': 'Username or password is incorrect - FAILED local authentication',
                 },
-            }],
-            'totalCount': '1',
-        }
+            },
+        }]
+
+        totalCount = 1
 
         json_response = '{"totalCount":"1","imdata":[{"error":{"attributes":{"code":"401","text":"Username or password is incorrect - FAILED local authentication"}}}]}'  # NOQA
         json_result = dict()
-        aci_response_json(json_result, json_response)
-        self.assertEqual(expected_result, json_result)
+        aci.response_json(json_response)
+        self.assertEqual(aci.error, error)
+        self.assertEqual(aci.imdata, imdata)
+        self.assertEqual(aci.totalCount, totalCount)
 
         # Python 2.7+ is needed for xmljson
         if sys.version_info < (2, 7):
@@ -68,94 +91,94 @@ class AciRest(unittest.TestCase):
         </imdata>
         '''
         xml_result = dict()
-        aci_response_xml(xml_result, xml_response)
-        self.assertEqual(json_result, xml_result)
+        aci.response_xml(xml_response)
+        self.assertEqual(aci.error, error)
+        self.assertEqual(aci.imdata, imdata)
+        self.assertEqual(aci.totalCount, totalCount)
 
     def test_valid_aci_login(self):
         self.maxDiff = None
 
-        expected_result = {
-            'error_code': 0,
-            'error_text': 'Success',
-            'imdata': [{
-                'aaaLogin': {
-                    'attributes': {
-                        'token': 'ZldYAsoO9d0FfAQM8xaEVWvQPSOYwpnqzhwpIC1r4MaToknJjlIuAt9+TvXqrZ8lWYIGPj6VnZkWiS8nJfaiaX/AyrdD35jsSxiP3zydh+849xym7ALCw/fFNsc7b5ik1HaMuSUtdrN8fmCEUy7Pq/QNpGEqkE8m7HaxAuHpmvXgtdW1bA+KKJu2zY1c/tem',  # NOQA
-                        'siteFingerprint': 'NdxD72K/uXaUK0wn',
-                        'refreshTimeoutSeconds': '600',
-                        'maximumLifetimeSeconds': '86400',
-                        'guiIdleTimeoutSeconds': '1200',
-                        'restTimeoutSeconds': '90',
-                        'creationTime': '1500134817',
-                        'firstLoginTime': '1500134817',
-                        'userName': 'admin',
-                        'remoteUser': 'false',
-                        'unixUserId': '15374',
-                        'sessionId': 'o7hObsqNTfCmDGcZI5c4ng==',
-                        'lastName': '',
-                        'firstName': '',
-                        'version': '2.0(2f)',
-                        'buildTime': 'Sat Aug 20 23:07:07 PDT 2016',
-                        'node': 'topology/pod-1/node-1',
-                    },
-                    'children': [{
-                        'aaaUserDomain': {
-                            'attributes': {
-                                'name': 'all',
-                                'rolesR': 'admin',
-                                'rolesW': 'admin',
-                            },
-                            'children': [{
-                                'aaaReadRoles': {
-                                    'attributes': {},
-                                },
-                            }, {
-                                'aaaWriteRoles': {
-                                    'attributes': {},
-                                    'children': [{
-                                        'role': {
-                                            'attributes': {
-                                                'name': 'admin',
-                                            },
-                                        },
-                                    }],
-                                },
-                            }],
-                        },
-                    }, {
-                        'DnDomainMapEntry': {
-                            'attributes': {
-                                'dn': 'uni/tn-common',
-                                'readPrivileges': 'admin',
-                                'writePrivileges': 'admin',
-                            },
-                        },
-                    }, {
-                        'DnDomainMapEntry': {
-                            'attributes': {
-                                'dn': 'uni/tn-infra',
-                                'readPrivileges': 'admin',
-                                'writePrivileges': 'admin',
-                            },
-                        },
-                    }, {
-                        'DnDomainMapEntry': {
-                            'attributes': {
-                                'dn': 'uni/tn-mgmt',
-                                'readPrivileges': 'admin',
-                                'writePrivileges': 'admin',
-                            },
-                        },
-                    }],
+        imdata = [{
+            'aaaLogin': {
+                'attributes': {
+                    'token': 'ZldYAsoO9d0FfAQM8xaEVWvQPSOYwpnqzhwpIC1r4MaToknJjlIuAt9+TvXqrZ8lWYIGPj6VnZkWiS8nJfaiaX/AyrdD35jsSxiP3zydh+849xym7ALCw/fFNsc7b5ik1HaMuSUtdrN8fmCEUy7Pq/QNpGEqkE8m7HaxAuHpmvXgtdW1bA+KKJu2zY1c/tem',  # NOQA
+                    'siteFingerprint': 'NdxD72K/uXaUK0wn',
+                    'refreshTimeoutSeconds': '600',
+                    'maximumLifetimeSeconds': '86400',
+                    'guiIdleTimeoutSeconds': '1200',
+                    'restTimeoutSeconds': '90',
+                    'creationTime': '1500134817',
+                    'firstLoginTime': '1500134817',
+                    'userName': 'admin',
+                    'remoteUser': 'false',
+                    'unixUserId': '15374',
+                    'sessionId': 'o7hObsqNTfCmDGcZI5c4ng==',
+                    'lastName': '',
+                    'firstName': '',
+                    'version': '2.0(2f)',
+                    'buildTime': 'Sat Aug 20 23:07:07 PDT 2016',
+                    'node': 'topology/pod-1/node-1',
                 },
-            }],
-            'totalCount': '1',
-        }
+                'children': [{
+                    'aaaUserDomain': {
+                        'attributes': {
+                            'name': 'all',
+                            'rolesR': 'admin',
+                            'rolesW': 'admin',
+                        },
+                        'children': [{
+                            'aaaReadRoles': {
+                                'attributes': {},
+                            },
+                        }, {
+                            'aaaWriteRoles': {
+                                'attributes': {},
+                                'children': [{
+                                    'role': {
+                                        'attributes': {
+                                            'name': 'admin',
+                                        },
+                                    },
+                                }],
+                            },
+                        }],
+                    },
+                }, {
+                    'DnDomainMapEntry': {
+                        'attributes': {
+                            'dn': 'uni/tn-common',
+                            'readPrivileges': 'admin',
+                            'writePrivileges': 'admin',
+                        },
+                    },
+                }, {
+                    'DnDomainMapEntry': {
+                        'attributes': {
+                            'dn': 'uni/tn-infra',
+                            'readPrivileges': 'admin',
+                             'writePrivileges': 'admin',
+                        },
+                    },
+                }, {
+                    'DnDomainMapEntry': {
+                        'attributes': {
+                            'dn': 'uni/tn-mgmt',
+                            'readPrivileges': 'admin',
+                            'writePrivileges': 'admin',
+                        },
+                    },
+                }],
+            },
+        }]
+
+        totalCount = 1
 
         json_response = '{"totalCount":"1","imdata":[{"aaaLogin":{"attributes":{"token":"ZldYAsoO9d0FfAQM8xaEVWvQPSOYwpnqzhwpIC1r4MaToknJjlIuAt9+TvXqrZ8lWYIGPj6VnZkWiS8nJfaiaX/AyrdD35jsSxiP3zydh+849xym7ALCw/fFNsc7b5ik1HaMuSUtdrN8fmCEUy7Pq/QNpGEqkE8m7HaxAuHpmvXgtdW1bA+KKJu2zY1c/tem","siteFingerprint":"NdxD72K/uXaUK0wn","refreshTimeoutSeconds":"600","maximumLifetimeSeconds":"86400","guiIdleTimeoutSeconds":"1200","restTimeoutSeconds":"90","creationTime":"1500134817","firstLoginTime":"1500134817","userName":"admin","remoteUser":"false","unixUserId":"15374","sessionId":"o7hObsqNTfCmDGcZI5c4ng==","lastName":"","firstName":"","version":"2.0(2f)","buildTime":"Sat Aug 20 23:07:07 PDT 2016","node":"topology/pod-1/node-1"},"children":[{"aaaUserDomain":{"attributes":{"name":"all","rolesR":"admin","rolesW":"admin"},"children":[{"aaaReadRoles":{"attributes":{}}},{"aaaWriteRoles":{"attributes":{},"children":[{"role":{"attributes":{"name":"admin"}}}]}}]}},{"DnDomainMapEntry":{"attributes":{"dn":"uni/tn-common","readPrivileges":"admin","writePrivileges":"admin"}}},{"DnDomainMapEntry":{"attributes":{"dn":"uni/tn-infra","readPrivileges":"admin","writePrivileges":"admin"}}},{"DnDomainMapEntry":{"attributes":{"dn":"uni/tn-mgmt","readPrivileges":"admin","writePrivileges":"admin"}}}]}}]}'  # NOQA
         json_result = dict()
-        aci_response_json(json_result, json_response)
-        self.assertEqual(expected_result, json_result)
+        aci.response_json(json_response)
+        self.assertEqual(aci.imdata, imdata)
+        self.assertEqual(aci.totalCount, totalCount)
 
         # Python 2.7+ is needed for xmljson
         if sys.version_info < (2, 7):
@@ -163,30 +186,35 @@ class AciRest(unittest.TestCase):
 
         xml_response = '<?xml version="1.0" encoding="UTF-8"?><imdata totalCount="1">\n<aaaLogin token="ZldYAsoO9d0FfAQM8xaEVWvQPSOYwpnqzhwpIC1r4MaToknJjlIuAt9+TvXqrZ8lWYIGPj6VnZkWiS8nJfaiaX/AyrdD35jsSxiP3zydh+849xym7ALCw/fFNsc7b5ik1HaMuSUtdrN8fmCEUy7Pq/QNpGEqkE8m7HaxAuHpmvXgtdW1bA+KKJu2zY1c/tem" siteFingerprint="NdxD72K/uXaUK0wn" refreshTimeoutSeconds="600" maximumLifetimeSeconds="86400" guiIdleTimeoutSeconds="1200" restTimeoutSeconds="90" creationTime="1500134817" firstLoginTime="1500134817" userName="admin" remoteUser="false" unixUserId="15374" sessionId="o7hObsqNTfCmDGcZI5c4ng==" lastName="" firstName="" version="2.0(2f)" buildTime="Sat Aug 20 23:07:07 PDT 2016" node="topology/pod-1/node-1">\n<aaaUserDomain name="all" rolesR="admin" rolesW="admin">\n<aaaReadRoles/>\n<aaaWriteRoles>\n<role name="admin"/>\n</aaaWriteRoles>\n</aaaUserDomain>\n<DnDomainMapEntry dn="uni/tn-common" readPrivileges="admin" writePrivileges="admin"/>\n<DnDomainMapEntry dn="uni/tn-infra" readPrivileges="admin" writePrivileges="admin"/>\n<DnDomainMapEntry dn="uni/tn-mgmt" readPrivileges="admin" writePrivileges="admin"/>\n</aaaLogin></imdata>\n'''  # NOQA
         xml_result = dict()
-        aci_response_xml(xml_result, xml_response)
-        self.assertEqual(json_result, xml_result)
+        aci.response_xml(xml_response)
+        self.assertEqual(aci.imdata, imdata)
+        self.assertEqual(aci.totalCount, totalCount)
 
     def test_invalid_input(self):
         self.maxDiff = None
 
-        expected_result = {
-            'error_code': '401',
-            'error_text': 'Username or password is incorrect - FAILED local authentication',
-            'imdata': [{
-                'error': {
-                    'attributes': {
-                        'code': '401',
-                        'text': 'Username or password is incorrect - FAILED local authentication',
-                    },
+        error = dict(
+            code='401',
+            text='Username or password is incorrect - FAILED local authentication',
+        )
+
+        imdata = [{
+            'error': {
+                'attributes': {
+                    'code': '401',
+                    'text': 'Username or password is incorrect - FAILED local authentication',
                 },
-            }],
-            'totalCount': '1',
-        }
+            },
+        }]
+
+        totalCount = 1
 
         json_response = '{"totalCount":"1","imdata":[{"error":{"attributes":{"code":"401","text":"Username or password is incorrect - FAILED local authentication"}}}]}'  # NOQA
         json_result = dict()
-        aci_response_json(json_result, json_response)
-        self.assertEqual(expected_result, json_result)
+        aci.response_json(json_response)
+        self.assertEqual(aci.error, error)
+        self.assertEqual(aci.imdata, imdata)
+        self.assertEqual(aci.totalCount, totalCount)
 
         # Python 2.7+ is needed for xmljson
         if sys.version_info < (2, 7):
@@ -197,8 +225,10 @@ class AciRest(unittest.TestCase):
         </imdata>
         '''
         xml_result = dict()
-        aci_response_xml(xml_result, xml_response)
-        self.assertEqual(json_result, xml_result)
+        aci.response_xml(xml_response)
+        self.assertEqual(aci.error, error)
+        self.assertEqual(aci.imdata, imdata)
+        self.assertEqual(aci.totalCount, totalCount)
 
     def test_empty_response(self):
         self.maxDiffi = None
@@ -208,16 +238,17 @@ class AciRest(unittest.TestCase):
         else:
             error_text = "Unable to parse output as JSON, see 'raw' output. Expecting value: line 1 column 1 (char 0)"
 
-        expected_json_result = {
-            'error_code': -1,
-            'error_text': error_text,
-            'raw': '',
-        }
+        error = dict(
+            code=-1,
+            text=error_text,
+        )
+        raw = ''
 
         json_response = ''
         json_result = dict()
-        aci_response_json(json_result, json_response)
-        self.assertEqual(expected_json_result, json_result)
+        aci.response_json(json_response)
+        self.assertEqual(aci.error, error)
+        self.assertEqual(aci.result['raw'], raw)
 
         # Python 2.7+ is needed for xmljson
         if sys.version_info < (2, 7):
@@ -234,16 +265,18 @@ class AciRest(unittest.TestCase):
         else:
             error_text = "Unable to parse output as XML, see 'raw' output. Document is empty, line 1, column 1 (<string>, line 1)"
 
-        expected_xml_result = {
-            'error_code': -1,
-            'error_text': error_text,
-            'raw': '',
-        }
+        error = dict(
+            code=-1,
+            text=error_text,
+        )
+
+        raw = ''
 
         xml_response = ''
         xml_result = dict()
-        aci_response_xml(xml_result, xml_response)
-        self.assertEqual(expected_xml_result, xml_result)
+        aci.response_xml(xml_response)
+        self.assertEqual(aci.error, error)
+        self.assertEqual(aci.result['raw'], raw)
 
     def test_invalid_response(self):
         self.maxDiff = None
@@ -255,16 +288,18 @@ class AciRest(unittest.TestCase):
         else:
             error_text = "Unable to parse output as JSON, see 'raw' output. Expecting value: line 1 column 9 (char 8)"
 
-        expected_json_result = {
-            'error_code': -1,
-            'error_text': error_text,
-            'raw': '{ "aaa":',
-        }
+        error = dict(
+            code=-1,
+            text=error_text,
+        )
+
+        raw = '{ "aaa":'
 
         json_response = '{ "aaa":'
         json_result = dict()
-        aci_response_json(json_result, json_response)
-        self.assertEqual(expected_json_result, json_result)
+        aci.response_json(json_response)
+        self.assertEqual(aci.error, error)
+        self.assertEqual(aci.result['raw'], raw)
 
         # Python 2.7+ is needed for xmljson
         if sys.version_info < (2, 7):
@@ -279,13 +314,15 @@ class AciRest(unittest.TestCase):
         else:
             error_text = "Unable to parse output as XML, see 'raw' output. Couldn't find end of Start Tag aaa line 1, line 1, column 6 (<string>, line 1)"  # NOQA
 
-        expected_xml_result = {
-            'error_code': -1,
-            'error_text': error_text,
-            'raw': '<aaa ',
-        }
+        error = dict(
+            code=-1,
+            text=error_text,
+        )
+
+        raw = '<aaa '
 
         xml_response = '<aaa '
         xml_result = dict()
-        aci_response_xml(xml_result, xml_response)
-        self.assertEqual(expected_xml_result, xml_result)
+        aci.response_xml(xml_response)
+        self.assertEqual(aci.error, error)
+        self.assertEqual(aci.result['raw'], raw)


### PR DESCRIPTION
##### SUMMARY
This PR includes:
- A cleanup of RETURN values for all ACI modules
- Add parameter `output_level` to influence RETURN detail
- Support ANSIBLE_DEBUG or `--debug` option
- Remove path information from output (to avoid magic `state: absent` result)
- Add RETURN documentation to all modules

This fixes #35304  

##### ISSUE TYPE
 - Feature Pull Request
 - Docs Pull Request

##### COMPONENT NAME
aci modules

##### ANSIBLE VERSION
v2.5