### PR TITLE
vsphere_guest reconfigure vm_floppy

### DIFF
--- a/lib/ansible/modules/cloud/vmware/_vsphere_guest.py
+++ b/lib/ansible/modules/cloud/vmware/_vsphere_guest.py
@@ -1010,6 +1010,49 @@ def reconfigure_vm(vsphere_client, vm, module, esxi, resource_pool, cluster_name
 
         changes['cdrom'] = vm_hardware['vm_cdrom']
 
+    # Change Floppy
+    if 'vm_floppy' in vm_hardware:
+        spec = spec_singleton(spec, request, vm)
+
+        floppy_type, floppy_image_path = get_floppy_params(module, vsphere_client, vm_hardware['vm_floppy'])
+
+        floppy = None
+        current_devices = vm.properties.config.hardware.device
+
+        for dev in current_devices:
+            if dev._type == 'VirtualFloppy':
+                floppy = dev._obj
+                break
+
+        if floppy_type == 'image':
+            image_location = floppy_image_path.split('/', 1)
+            datastore, ds = find_datastore(
+                module, vsphere_client, image_location[0], None)
+            image_path = image_location[1]
+            image = VI.ns0.VirtualFloppyImageBackingInfo_Def('image').pyclass()
+            image.set_element_fileName('%s %s' % (datastore, image_path))
+            floppy.set_element_backing(image)
+            floppy.Connectable.set_element_connected(True)
+            floppy.Connectable.set_element_startConnected(True)
+        elif floppy_type == 'client':
+            client = VI.ns0.VirtualFloppyRemoteDeviceBackingInfo_Def('client').pyclass()
+            client.set_element_deviceName('/dev/fd0')
+            floppy.set_element_backing(client)
+            floppy.Connectable.set_element_connected(True)
+            floppy.Connectable.set_element_startConnected(True)
+        else:
+            vsphere_client.disconnect()
+            module.fail_json(
+                msg="Error adding floppy of type %s to vm spec. "
+                " floppy type can either be image or client" % (floppy_type))
+
+        dev_change = spec.new_deviceChange()
+        dev_change.set_element_device(floppy)
+        dev_change.set_element_operation('edit')
+        devices.append(dev_change)
+
+        changes['floppy'] = vm_hardware['vm_floppy']
+
     # Resize hard drives
     if vm_disk:
         spec = spec_singleton(spec, request, vm)


### PR DESCRIPTION
##### SUMMARY
Allow user to reconfigure vm_floppy using vsphere_guest.

Current vm_floppy configuration is only at VM creation, this adds it to reconfigure as well.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
cloud/vmware/vsphere_guest (specifically reconfiguration)

##### ANSIBLE VERSION
```
ansible 2.5.0 (vsphere_guest_reconfigure_vm_floppy f3244d7b1e) last updated 2018/02/01 12:59:11 (GMT -400)
  config file = /Users/deric/.ansible.cfg
  configured module search path = [u'/Users/deric/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/deric/ansible/lib/ansible
  executable location = /Users/deric/ansible/bin/ansible
  python version = 2.7.14 (default, Sep 25 2017, 09:54:19) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.37)]
```

##### ADDITIONAL INFORMATION
```yaml
# before
- name: Reconfigure removable devices to 'client'
  vsphere_guest:
    vcenter_hostname: vcenter
    username: vcenter_username
    password: vcenter_password
    guest: inventory_hostname_short
    esxi:
      datacenter: datacenter
      hostname: esxi_host
    vm_hardware:
      vm_floppy:
        type: client
      vm_cdrom:
        type: client
    state: reconfigured
  delegate_to: localhost
# changed: [inventory_hostname_short -> localhost] => {"changed": true, "changes": {"cdrom": {"type": "client"}}, "failed": false}

# after
- name: Reconfigure removable devices to 'client'
  vsphere_guest:
    vcenter_hostname: vcenter
    username: vcenter_username
    password: vcenter_password
    guest: inventory_hostname_short
    esxi:
      datacenter: datacenter
      hostname: esxi_host
    vm_hardware:
      vm_floppy:
        type: client
      vm_cdrom:
        type: client
    state: reconfigured
  delegate_to: localhost
# changed: [inventory_hostname_short -> localhost] => {"changed": true, "changes": {"cdrom": {"type": "client"}, "floppy": {"type": "client"}}, "failed": false}
```