### PR TITLE
added support for the --check flag for integration tests in ansible-test

### DIFF
--- a/test/runner/lib/config.py
+++ b/test/runner/lib/config.py
@@ -152,6 +152,7 @@ class IntegrationConfig(TestConfig):
         self.tags = args.tags
         self.skip_tags = args.skip_tags
         self.diff = args.diff
+        self.check = args.check
 
         if self.list_targets:
             self.explain = True

--- a/test/runner/lib/executor.py
+++ b/test/runner/lib/executor.py
@@ -943,6 +943,9 @@ def command_integration_role(args, target, start_at_task):
         if args.diff:
             cmd += ['--diff']
 
+        if args.check:
+            cmd += ['--check']
+
         if args.verbosity:
             cmd.append('-' + ('v' * args.verbosity))
 

--- a/test/runner/test.py
+++ b/test/runner/test.py
@@ -207,6 +207,10 @@ def parse_args():
                              action='store_true',
                              help='show diff output')
 
+    integration.add_argument('--check',
+                             action='store_true',
+                             help='runs integration tests in check mode')
+
     integration.add_argument('--allow-destructive',
                              action='store_true',
                              help='allow destructive tests (--local and --tox only)')


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
It would be nice to have support for the --check flag to make debugging issues related to check mode easier.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
- ansible-test

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (ansible-test-check-mode 9909474852) last updated 2018/02/01 13:28:27 (GMT -400)
  config file = None
  configured module search path = ['/Users/david/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/david/code/ansible/lib/ansible
  executable location = /Users/david/code/ansible/bin/ansible
  python version = 3.6.4 (default, Jan  6 2018, 11:51:59) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
