### PR TITLE
Update playbooks_best_practices.rst

### DIFF
--- a/docs/docsite/rst/playbooks_best_practices.rst
+++ b/docs/docsite/rst/playbooks_best_practices.rst
@@ -297,7 +297,7 @@ For just my webservers in Boston::
 
     ansible-playbook -i production webservers.yml --limit boston
 
-Forjust the first 10, and then the next 10::
+For just the first 10, and then the next 10::
    
     ansible-playbook -i production webservers.yml --limit boston[0:9]
     ansible-playbook -i production webservers.yml --limit boston[10:19]

--- a/docs/docsite/rst/playbooks_best_practices.rst
+++ b/docs/docsite/rst/playbooks_best_practices.rst
@@ -299,8 +299,8 @@ For just my webservers in Boston::
 
 Forjust the first 10, and then the next 10::
    
-    ansible-playbook -i production webservers.yml --limit boston[1:10]
-    ansible-playbook -i production webservers.yml --limit boston[11:20]
+    ansible-playbook -i production webservers.yml --limit boston[0:9]
+    ansible-playbook -i production webservers.yml --limit boston[10:19]
 
 And of course just basic ad-hoc stuff is also possible::
 


### PR DESCRIPTION
If deploying to the first 10 hosts in Boston it should be "-limit boston[0:9]" and the next 10 should be "-limit boston[10:19]". The doc as written would skip the first host (boston[0]) and try to deploy to a host that doesn't exist (boston[20])

##### SUMMARY
There appears to be a bug in the doc. See above

##### ISSUE TYPE
 - Docs Pull Request

##### ANSIBLE VERSION
ansible latest doc
