### PR TITLE
Fixing name from aruba to ios.

### DIFF
--- a/test/units/modules/network/ios/test_ios_config.py
+++ b/test/units/modules/network/ios/test_ios_config.py
@@ -91,7 +91,7 @@ class TestIosConfigModule(TestIosModule):
         args = self.run_commands.call_args[0][1]
         self.assertIn('copy running-config startup-config\r', args)
 
-    def test_aruba_config_save_changed_false(self):
+    def test_ios_config_save_changed_false(self):
         set_module_args(dict(save_when='changed'))
         self.execute_module(changed=False)
         self.assertEqual(self.run_commands.call_count, 0)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Found a copy/paste error in the name of a function in an ios unit test.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
test_ios_config
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
$ ansible --version
ansible 2.5.0 (function_name_fix a185891d59) last updated 2018/02/01 14:42:42 (GMT -700)
  config file = None
  configured module search path = [u'/Users/james/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/james/Documents/git/ansible/lib/ansible
  executable location = /Users/james/Documents/git/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```

