### PR TITLE
Register scalable target prior to creating/deleting a scaling policy

### DIFF
--- a/lib/ansible/modules/cloud/amazon/aws_application_scaling_policy.py
+++ b/lib/ansible/modules/cloud/amazon/aws_application_scaling_policy.py
@@ -469,7 +469,7 @@ def main():
     ))
 
     module = AnsibleAWSModule(argument_spec=argument_spec, supports_check_mode=True)
-    
+
     connection = module.client('application-autoscaling')
 
     if module.params.get("state") == 'present':

--- a/lib/ansible/modules/cloud/amazon/aws_application_scaling_policy.py
+++ b/lib/ansible/modules/cloud/amazon/aws_application_scaling_policy.py
@@ -56,11 +56,13 @@ options:
         description: A target tracking policy. This parameter is required if you are creating a new policy and the policy type is TargetTrackingScaling.
         required: no
     minimum_tasks:
-        description: The minimum value to scale to in response to a scale in event. This parameter is required if you are creating a first new policy for the specified service.
+        description: The minimum value to scale to in response to a scale in event.
+        This parameter is required if you are creating a first new policy for the specified service.
         required: no
     maximum_tasks:
-        description: The maximum value to scale to in response to a scale out event. This parameter is required if you are creating a first new policy for the specified service.
-        required: no    
+        description: The maximum value to scale to in response to a scale out event.
+        This parameter is required if you are creating a first new policy for the specified service.
+        required: no
 extends_documentation_fragment:
     - aws
     - ec2
@@ -179,6 +181,7 @@ def delete_scaling_policy(connection, module):
     result = {"changed": changed}
     return result
 
+
 def create_scalable_target(connection, module):
     changed = False
 
@@ -225,6 +228,7 @@ def create_scalable_target(connection, module):
 
     result = {"changed": changed, "response": snaked_response}
     return result
+
 
 def create_scaling_policy(connection, module):
     scaling_policy = connection.describe_scaling_policies(

--- a/lib/ansible/modules/cloud/amazon/aws_application_scaling_policy.py
+++ b/lib/ansible/modules/cloud/amazon/aws_application_scaling_policy.py
@@ -131,9 +131,18 @@ EXAMPLES = '''
 
 RETURN = '''
 alarms:
-    description: The CloudWatch alarms associated with the scaling policy
+    description: List of the CloudWatch alarms associated with the scaling policy
     returned: when state present
-    type: list of complex
+    type: complex
+    contains:
+        alarm_arn:
+            description: The Amazon Resource Name (ARN) of the alarm
+            returned: when state present
+            type: string
+        alarm_name
+            description: The name of the alarm
+            returned: when state present
+            type: string
 service_namespace:
     description: The namespace of the AWS service.
     returned: when state present

--- a/lib/ansible/modules/cloud/amazon/aws_application_scaling_policy.py
+++ b/lib/ansible/modules/cloud/amazon/aws_application_scaling_policy.py
@@ -228,9 +228,8 @@ def create_scaling_policy(connection, module):
 
         if not scalable_targets['ScalableTargets']:
             create_scalable_target(connection, module)
-        else:
-            if scalable_targets['ScalableTargets'][0]['MinCapacity'] != minimum_tasks or scalable_targets['ScalableTargets'][0]['MaxCapacity'] != max_capacity:
-                create_scalable_target(connection, module)
+        elif scalable_targets['ScalableTargets'][0]['MinCapacity'] != minimum_tasks or scalable_targets['ScalableTargets'][0]['MaxCapacity'] != max_capacity:
+            create_scalable_target(connection, module)
 
         scaling_policy = {
             'PolicyName': module.params.get('policy_name'),

--- a/lib/ansible/modules/cloud/amazon/aws_application_scaling_policy.py
+++ b/lib/ansible/modules/cloud/amazon/aws_application_scaling_policy.py
@@ -139,7 +139,7 @@ alarms:
             description: The Amazon Resource Name (ARN) of the alarm
             returned: when state present
             type: string
-        alarm_name
+        alarm_name:
             description: The name of the alarm
             returned: when state present
             type: string

--- a/lib/ansible/modules/cloud/amazon/aws_application_scaling_policy.py
+++ b/lib/ansible/modules/cloud/amazon/aws_application_scaling_policy.py
@@ -79,26 +79,44 @@ extends_documentation_fragment:
 EXAMPLES = '''
 # Note: These examples do not set authentication details, see the AWS Guide for details.
 
-# Create scaling policy for ECS Service
+# Create step scaling policy for ECS Service
 - name: scaling_policy
   aws_application_scaling_policy:
-  state: present
-  policy_name: test_policy
-  service_namespace: ecs
-  resource_id: service/poc-pricing/test-as
-  scalable_dimension: ecs:service:DesiredCount
-  policy_type: StepScaling
-  minimum_tasks: 1
-  maximum_tasks: 6
-  step_scaling_policy_configuration:
-    AdjustmentType: ChangeInCapacity
-    StepAdjustments:
-      - MetricIntervalUpperBound: 123
-        ScalingAdjustment: 2
-      - MetricIntervalLowerBound: 123
-        ScalingAdjustment: -2
-    Cooldown: 123
-    MetricAggregationType: Average
+    state: present
+    policy_name: test_policy
+    service_namespace: ecs
+    resource_id: service/poc-pricing/test-as
+    scalable_dimension: ecs:service:DesiredCount
+    policy_type: StepScaling
+    minimum_tasks: 1
+    maximum_tasks: 6
+    step_scaling_policy_configuration:
+      AdjustmentType: ChangeInCapacity
+      StepAdjustments:
+        - MetricIntervalUpperBound: 123
+          ScalingAdjustment: 2
+        - MetricIntervalLowerBound: 123
+          ScalingAdjustment: -2
+      Cooldown: 123
+      MetricAggregationType: Average
+
+# Create target tracking scaling policy for ECS Service
+- name: scaling_policy
+  aws_application_scaling_policy:
+    state: present
+    policy_name: test_policy
+    service_namespace: ecs
+    resource_id: service/poc-pricing/test-as
+    scalable_dimension: ecs:service:DesiredCount
+    policy_type: TargetTrackingScaling
+    minimum_tasks: 1
+    maximum_tasks: 6
+    target_tracking_scaling_policy_configuration:
+      TargetValue: 60
+      PredefinedMetricSpecification:
+        PredefinedMetricType: ECSServiceAverageCPUUtilization
+      ScaleOutCooldown: 60
+      ScaleInCooldown: 60
 
 # Remove scalable target for ECS Service
 - name: scaling_policy
@@ -116,7 +134,6 @@ alarms:
     description: The CloudWatch alarms associated with the scaling policy
     returned: when state present
     type: list of complex
-    sample: ecs
 service_namespace:
     description: The namespace of the AWS service.
     returned: when state present
@@ -163,10 +180,61 @@ step_scaling_policy_configuration:
     description: The step scaling policy.
     returned: when state present and the policy type is StepScaling
     type: complex
+    contains:
+        adjustment_type:
+            description: The adjustment type
+            returned: when state present and the policy type is StepScaling
+            type: string
+            sample: "ChangeInCapacity, PercentChangeInCapacity, ExactCapacity"
+        cooldown:
+            description: The amount of time, in seconds, after a scaling activity completes 
+                where previous trigger-related scaling activities can influence future scaling events
+            returned: when state present and the policy type is StepScaling
+            type: int
+            sample: 60
+        metric_aggregation_type:
+            description: The aggregation type for the CloudWatch metrics
+            returned: when state present and the policy type is StepScaling
+            type: string
+            sample: "Average, Minimum, Maximum"
+        step_adjustments:
+            description: A set of adjustments that enable you to scale based on the size of the alarm breach
+            returned: when state present and the policy type is StepScaling
+            type: list of complex
 target_tracking_scaling_policy_configuration:
     description: The target tracking policy.
     returned: when state present and the policy type is TargetTrackingScaling
     type: complex
+    contains:
+        predefined_metric_specification:
+            description: A predefined metric
+            returned: when state present and the policy type is TargetTrackingScaling
+            type: complex
+            contains:
+                predefined_metric_type:
+                    description: The metric type
+                    returned: when state present and the policy type is TargetTrackingScaling
+                    type: string
+                    sample: "ECSServiceAverageCPUUtilization, ECSServiceAverageMemoryUtilization"
+                resource_label:
+                    description: Identifies the resource associated with the metric type
+                    returned: when metric type is ALBRequestCountPerTarget
+                    type: string
+        scale_in_cooldown:
+            description: The amount of time, in seconds, after a scale in activity completes before another scale in activity can start
+            returned: when state present and the policy type is TargetTrackingScaling
+            type: int
+            sample: 60
+        scale_out_cooldown:
+            description: The amount of time, in seconds, after a scale out activity completes before another scale out activity can start
+            returned: when state present and the policy type is TargetTrackingScaling
+            type: int
+            sample: 60
+        target_value:
+            description: The target value for the metric
+            returned: when state present and the policy type is TargetTrackingScaling
+            type: int
+            sample: 70
 creation_time:
     description: The Unix timestamp for when the scalable target was created.
     returned: when state present

--- a/lib/ansible/modules/cloud/amazon/aws_application_scaling_policy.py
+++ b/lib/ansible/modules/cloud/amazon/aws_application_scaling_policy.py
@@ -57,11 +57,11 @@ options:
         required: no
     minimum_tasks:
         description: The minimum value to scale to in response to a scale in event.
-        This parameter is required if you are creating a first new policy for the specified service.
+            This parameter is required if you are creating a first new policy for the specified service.
         required: no
     maximum_tasks:
         description: The maximum value to scale to in response to a scale out event.
-        This parameter is required if you are creating a first new policy for the specified service.
+            This parameter is required if you are creating a first new policy for the specified service.
         required: no
 extends_documentation_fragment:
     - aws

--- a/lib/ansible/modules/cloud/amazon/aws_application_scaling_policy.py
+++ b/lib/ansible/modules/cloud/amazon/aws_application_scaling_policy.py
@@ -486,7 +486,6 @@ def main():
     except botocore.exceptions.ProfileNotFound as e:
         module.fail_json_aws(e, msg="AWS profile not found")
 
-
     if module.params.get("state") == 'present':
         # A scalable target must be registered prior to creating a scaling policy
         scalable_target_result = create_scalable_target(connection, module)


### PR DESCRIPTION
##### SUMMARY
Added essential step of creating scalable target registration before attempting to create (and delete)
a scaling policy.

up until now, this module has always failed with the following message (example message):
"An error occurred (ObjectNotFoundException) when calling the PutScalingPolicy operation: No scalable target registered for service namespace: ecs, resource ID: service/poc-pricing/test-as, scalable dimension: ecs:service:DesiredCount"

##### ISSUE TYPE

 - Bugfix Pull Request


##### COMPONENT NAME
aws_application_scaling_policy


```

```


##### ADDITIONAL INFORMATION
From boto3 documentation:
"
Registers or updates a scalable target. A scalable target is a resource that Application Auto Scaling can scale out or scale in. After you have registered a scalable target, you can use this operation to update the minimum and maximum values for its scalable dimension.

After you register a scalable target, you can create and apply scaling policies using PutScalingPolicy 
"

http://boto3.readthedocs.io/en/latest/reference/services/application-autoscaling.html#ApplicationAutoScaling.Client.register_scalable_target
```

```
