### PR TITLE
import sanity test: remove yum_repository  from the exclusion list

### DIFF
--- a/test/sanity/import/skip.txt
+++ b/test/sanity/import/skip.txt
@@ -4,4 +4,3 @@ lib/ansible/modules/cloud/webfaction/webfaction_db.py
 lib/ansible/modules/cloud/webfaction/webfaction_domain.py
 lib/ansible/modules/cloud/webfaction/webfaction_mailbox.py
 lib/ansible/modules/cloud/webfaction/webfaction_site.py
-lib/ansible/modules/packaging/os/yum_repository.py


### PR DESCRIPTION
##### SUMMARY

`yum_repository` and import sanity test : Python 3.7 error have been fixed, remove this module from exclusion list.

See 232dc7110ca1fcaa0147bcce4773845220766869

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
test

##### ANSIBLE VERSION
```
ansible 2.5.0 (devel 2479b6d635) last updated 2018/02/01 19:45:42 (GMT +200)
```