### PR TITLE
wait for {starting, stopping} units

### DIFF
--- a/lib/ansible/modules/system/systemd.py
+++ b/lib/ansible/modules/system/systemd.py
@@ -422,7 +422,7 @@ def main():
                     if service_state not in set(['inactive', 'failed']):
                         action = 'stop'
                     elif service_state == 'failed':
-                        result['state'] = 'failed' 
+                        result['state'] = 'failed'
                 elif module.params['state'] == 'reloaded':
                     # unlike restart, reload won't take effect on services in any state but 'active'
                     if service_state in set(['inactive', 'deactivating', 'failed']):
@@ -431,7 +431,7 @@ def main():
                         # wait for startup, then trigger the reload
                         if not module.check_mode:
                             if module.params['no_block']:
-                                module.fail_json(msg="Unable to reload service %s: %s" % (unit, "could not wait for service startup to complete with --no-block"))
+                                module.fail_json(msg="Unable to reload service %s: %s" % (unit, "cannot wait for service startup to complete with --no-block"))
                             (rc, out, err) = module.run_command("%s %s '%s'" % (systemctl, 'start', unit))
                             if rc != 0:
                                 module.fail_json(msg="Unable to reload service %s: service failed to start" % (unit))

--- a/lib/ansible/modules/system/systemd.py
+++ b/lib/ansible/modules/system/systemd.py
@@ -232,10 +232,6 @@ from ansible.module_utils.service import sysv_exists, sysv_is_enabled, fail_if_m
 from ansible.module_utils._text import to_native
 
 
-def is_running_service(service_status):
-    return service_status['ActiveState'] in set(['active', 'activating'])
-
-
 def request_was_ignored(out):
     return '=' not in out and 'ignoring request' in out
 
@@ -415,19 +411,37 @@ def main():
             result['state'] = module.params['state']
 
             # What is current service state?
-            if 'ActiveState' in result['status']:
+            service_status = result['status']
+            if 'ActiveState' in service_status:
                 action = None
+                service_state = service_status['ActiveState']
                 if module.params['state'] == 'started':
-                    if not is_running_service(result['status']):
+                    if service_state != 'active':
                         action = 'start'
                 elif module.params['state'] == 'stopped':
-                    if is_running_service(result['status']):
+                    if service_state not in set(['inactive', 'failed']):
                         action = 'stop'
-                else:
-                    if not is_running_service(result['status']):
+                    elif service_state == 'failed':
+                        result['state'] = 'failed' 
+                elif module.params['state'] == 'reloaded':
+                    # unlike restart, reload won't take effect on services in any state but 'active'
+                    if service_state in set(['inactive', 'deactivating', 'failed']):
                         action = 'start'
+                    elif service_state == 'activating':
+                        # wait for startup, then trigger the reload
+                        if not module.check_mode:
+                            if module.params['no_block']:
+                                module.fail_json(msg="Unable to reload service %s: %s" % (unit, "could not wait for service startup to complete with --no-block"))
+                            (rc, out, err) = module.run_command("%s %s '%s'" % (systemctl, 'start', unit))
+                            if rc != 0:
+                                module.fail_json(msg="Unable to reload service %s: service failed to start" % (unit))
+                        action = 'reload'
                     else:
-                        action = module.params['state'][:-2]  # remove 'ed' from restarted/reloaded
+                        action = 'reload'
+
+                    result['state'] = 'started'
+                else:
+                    action = module.params['state'][:-2]
                     result['state'] = 'started'
 
                 if action:


### PR DESCRIPTION
##### SUMMARY

When ansible runs `systemd: name=foo state=started` against a unit that is currently `activating` (starting up), it moves on immediately. For a unit that can take many seconds or minutes to start up, this causes some difficulty interacting with that unit later in the play. Further, a unit that was `deactivating` (stopping) would not await the ultimate shutdown of the unit.

This change waits for units that are `activating` when `state=started` is requested, and units that are `deactivating` when `state=stopped` is requested.

Additionally, some attempt has been made to rationalize the difference in semantics between `state=reloaded` and systemd's notion of "reload". In the latter, attempting to reload anything besides a fully running service is an error, and per b49aa70c29ce1b2e65641baee57d1556a100d947 the former makes an attempt to start any non-active service that's "reloaded." Systemd is nice to us here in that enqueuing a start job for any service that's failed or deactivating will (eventually) try to start it back up, which is considered to have the same rough effect as attempting a reload in Ansible, so we take that tack.

Unfortunately, still ambiguous is what to do when the unit is activating: does the unit have the latest configuration, or does it need to be reloaded? Here, we try to change the behavior of the systemd module to wait for the unit to start before issuing the requested reload (preferring too many reloads to too few), but truth be told I'm not sure the complexity that behavior adds to the implementation is a net positive, given the relative rarity of the case.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
systemd

##### ANSIBLE VERSION
```
ansible 2.3.2.0
  config file =
  configured module search path = Default w/o overrides
  python version = 2.7.14 (default, Sep 25 2017, 09:53:22) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.37)]
```


##### ADDITIONAL INFORMATION

Systemd reports units as being in one of five states: active, inactive, activating, deactivating, and failed. Combined with the four settings for the `state` parameter, produces 20 possible permutations. This change maps those 20 settings to systemd jobs in the following way:

state=started: active [ok], activating / deactivating / inactive / failed -> start 
state=stopped: inactive[ok], failed [ok], activating / deactivating / inactive -> stop
state=restarted: active, inactive, failed, activating, deactivating -> restart 
state=reloaded: active -> reload, inactive / deactivating / failed -> start, activating -> wait for startup, then reload