### PR TITLE
New module: keycloak_group

### DIFF
--- a/lib/ansible/module_utils/keycloak.py
+++ b/lib/ansible/module_utils/keycloak.py
@@ -363,7 +363,7 @@ class KeycloakAPI(object):
 
         If the group does not exist, None is returned.
 
-        GID is a UUID provided by the Keycloak API
+        gid is a UUID provided by the Keycloak API
         :param gid: UUID of the group to be returned
         :param realm: Realm in which the group resides; default 'master'.
         """

--- a/lib/ansible/module_utils/keycloak.py
+++ b/lib/ansible/module_utils/keycloak.py
@@ -43,7 +43,8 @@ URL_REALM_ROLES = "{url}/admin/realms/{realm}/roles"
 
 URL_CLIENTTEMPLATE = "{url}/admin/realms/{realm}/client-templates/{id}"
 URL_CLIENTTEMPLATES = "{url}/admin/realms/{realm}/client-templates"
-
+URL_GROUPS = "{url}/admin/realms/{realm}/groups"
+URL_GROUP = "{url}/admin/realms/{realm}/groups/{groupid}"
 
 def keycloak_argument_spec():
     """
@@ -339,3 +340,135 @@ class KeycloakAPI(object):
         except Exception as e:
             self.module.fail_json(msg='Could not delete client template %s in realm %s: %s'
                                       % (id, realm, str(e)))
+
+    def get_groups(self, realm="master"):
+        """ Fetch the name and ID of all groups on the Keycloak server.
+
+        To fetch the full data of the group, make a subsequent call to
+        get_group_by_groupid, passing in the ID of the group you wish to return.
+
+        :param realm: Return the groups of this realm (default "master").
+        """
+        groups_url = URL_GROUPS.format(url=self.baseurl, realm=realm)
+        try:
+            return json.load(open_url(groups_url, method="GET", headers=self.restheaders,
+                                      validate_certs=self.validate_certs))
+        except Exception as e:
+            self.module.fail_json(msg="Could not fetch list of groups in realm {}: {}".format(
+                                        realm, str(e)))
+
+    def get_group_by_groupid(self, gid, realm="master"):
+        """ Fetch a keycloak group from the provided realm using the group's unique ID.
+
+        If the group does not exist, None is returned.
+
+        GID is a UUID provided by the Keycloak API
+        :param gid: UUID of the group to be returned
+        :param realm: Realm in which the group resides; default 'master'.
+        """
+        groups_url = URL_GROUP.format(url=self.baseurl, realm=realm, groupid=gid)
+        try:
+            return json.load(open_url( groups_url, method="GET", headers=self.restheaders,
+                                        validate_certs=self.validate_certs ))
+
+        except HTTPError as e:
+            if e.code == 404:
+                return None
+            else:
+                 self.module.fail_json(msg="Could not fetch group {} in realm {}: {}".format(
+                                            gid, realm, str(e)))
+        except Exception as e:
+            self.module.fail_json(msg="Could not fetch group {} in realm {}: {}".format(
+                                            gid, realm, str(e)))
+
+    def get_group_by_name(self, name, realm="master"):
+        """ Fetch a keycloak group within a realm based on its name.
+
+        The Keycloak API does not allow filtering of the Groups resource by name.
+        As a result, this method first retrieves the entire list of groups - name and ID -
+        then performs a second query to fetch the group.
+
+        If the group does not exist, None is returned.
+        :param name: Name of the group to fetch.
+        :param realm: Realm in which the group resides; default 'master'
+        """
+        groups_url = URL_GROUPS.format(url=self.baseurl, realm=realm)
+        try:
+            all_groups = self.get_groups(realm=realm)
+
+            for group in all_groups:
+                if group['name'] == name:
+                    return self.get_group_by_groupid(group['id'], realm=realm)
+
+            return None
+
+        except Exception as e:
+            self.module.fail_json(msg="Could not fetch group {} in realm {}: {}".format(
+                                            name, realm, str(e)))
+
+    def create_group(self, grouprep, realm="master"):
+        """ Create a Keycloak group.
+
+        :param grouprep: a GroupRepresentation of the group to be created. Must contain at minimum the field name.
+        :return: HTTPResponse object on success
+        """
+        groups_url = URL_GROUPS.format(url=self.baseurl, realm=realm)
+        try:
+            return open_url( groups_url, method='POST', headers=self.restheaders,
+                             data=json.dumps(grouprep), validate_certs=self.validate_certs )
+        except Exception as e:
+            self.module.fail_json(msg="Could not create group {} in realm {}: {}".format(
+                                            grouprep['name'], realm, str(e)))
+
+    def update_group(self, grouprep, realm="master"):
+        """ Update an existing group.
+
+        :param grouprep: A GroupRepresentation of the updated group.
+        :return HTTPResponse object on success
+        """
+        group_url = URL_GROUP.format(url=self.baseurl, realm=realm, groupid=grouprep['id'])
+
+        try:
+            return open_url(group_url, method='PUT', headers=self.restheaders,
+                            data=json.dumps(grouprep), validate_certs=self.validate_certs)
+        except Exception as e:
+            self.module.fail_json(msg='Could not update group %s in realm %s: %s'
+                                      % (grouprep['name'], realm, str(e)))
+
+    def delete_group(self, name=None, groupid=None, realm="master"):
+        """ Delete a group. One of name or groupid must be provided.
+
+        Providing the group ID is preferred as it avoids a second lookup to
+        convert a group name to an ID.
+
+        :param name: The name of the group. A lookup will be performed to retrieve the group ID.
+        :param groupid: The ID of the group (preferred to name).
+        :param realm: The realm in which this group resides, default "master".
+        """
+
+        if groupid is None and name is None:
+            # prefer an exception since this is almost certainly a programming error in the module itself.
+            raise Exception("Unable to delete group - one of group ID or name must be provided.")
+
+        # only lookup the name if groupid isn't provided.
+        # in the case that both are provided, prefer the ID, since it's one
+        # less lookup.
+        if groupid is None and name is not None:
+            for group in self.get_groups(realm=realm):
+                if group['name'] == name:
+                    groupid = group['id']
+                    break
+
+        # if the group doesn't exist - no problem, nothing to delete.
+        if groupid is None:
+            return None
+
+        # should have a good groupid by here.
+        group_url = URL_GROUP.format(realm=realm, groupid=groupid, url=self.baseurl)
+        try:
+            return open_url(group_url, method='DELETE', headers=self.restheaders,
+                            validate_certs=self.validate_certs)
+
+        except Exception as e:
+            module.fail_json(msg="Unable to delete group {}: {}".format(groupid, str(e)))
+

--- a/lib/ansible/module_utils/keycloak.py
+++ b/lib/ansible/module_utils/keycloak.py
@@ -46,6 +46,7 @@ URL_CLIENTTEMPLATES = "{url}/admin/realms/{realm}/client-templates"
 URL_GROUPS = "{url}/admin/realms/{realm}/groups"
 URL_GROUP = "{url}/admin/realms/{realm}/groups/{groupid}"
 
+
 def keycloak_argument_spec():
     """
     Returns argument_spec of options common to keycloak_*-modules
@@ -368,15 +369,15 @@ class KeycloakAPI(object):
         """
         groups_url = URL_GROUP.format(url=self.baseurl, realm=realm, groupid=gid)
         try:
-            return json.load(open_url( groups_url, method="GET", headers=self.restheaders,
-                                        validate_certs=self.validate_certs ))
+            return json.load(open_url(groups_url, method="GET", headers=self.restheaders,
+                                      validate_certs=self.validate_certs))
 
         except HTTPError as e:
             if e.code == 404:
                 return None
             else:
-                 self.module.fail_json(msg="Could not fetch group {} in realm {}: {}".format(
-                                            gid, realm, str(e)))
+                self.module.fail_json(msg="Could not fetch group {} in realm {}: {}".format(
+                                           gid, realm, str(e)))
         except Exception as e:
             self.module.fail_json(msg="Could not fetch group {} in realm {}: {}".format(
                                             gid, realm, str(e)))
@@ -414,8 +415,8 @@ class KeycloakAPI(object):
         """
         groups_url = URL_GROUPS.format(url=self.baseurl, realm=realm)
         try:
-            return open_url( groups_url, method='POST', headers=self.restheaders,
-                             data=json.dumps(grouprep), validate_certs=self.validate_certs )
+            return open_url(groups_url, method='POST', headers=self.restheaders,
+                            data=json.dumps(grouprep), validate_certs=self.validate_certs)
         except Exception as e:
             self.module.fail_json(msg="Could not create group {} in realm {}: {}".format(
                                             grouprep['name'], realm, str(e)))
@@ -471,4 +472,3 @@ class KeycloakAPI(object):
 
         except Exception as e:
             module.fail_json(msg="Unable to delete group {}: {}".format(groupid, str(e)))
-

--- a/lib/ansible/module_utils/keycloak.py
+++ b/lib/ansible/module_utils/keycloak.py
@@ -355,8 +355,8 @@ class KeycloakAPI(object):
             return json.load(open_url(groups_url, method="GET", headers=self.restheaders,
                                       validate_certs=self.validate_certs))
         except Exception as e:
-            self.module.fail_json(msg="Could not fetch list of groups in realm {}: {}".format(
-                                        realm, str(e)))
+            self.module.fail_json(msg="Could not fetch list of groups in realm %s: %s"
+                                      % (realm, str(e)))
 
     def get_group_by_groupid(self, gid, realm="master"):
         """ Fetch a keycloak group from the provided realm using the group's unique ID.
@@ -376,11 +376,11 @@ class KeycloakAPI(object):
             if e.code == 404:
                 return None
             else:
-                self.module.fail_json(msg="Could not fetch group {} in realm {}: {}".format(
-                                           gid, realm, str(e)))
+                self.module.fail_json(msg="Could not fetch group %s in realm %s: %s"
+                                          % (gid, realm, str(e)))
         except Exception as e:
-            self.module.fail_json(msg="Could not fetch group {} in realm {}: {}".format(
-                                            gid, realm, str(e)))
+            self.module.fail_json(msg="Could not fetch group %s in realm %s: %s"
+                                      % (gid, realm, str(e)))
 
     def get_group_by_name(self, name, realm="master"):
         """ Fetch a keycloak group within a realm based on its name.
@@ -404,8 +404,8 @@ class KeycloakAPI(object):
             return None
 
         except Exception as e:
-            self.module.fail_json(msg="Could not fetch group {} in realm {}: {}".format(
-                                            name, realm, str(e)))
+            self.module.fail_json(msg="Could not fetch group %s in realm %s: %s"
+                                      % (name, realm, str(e)))
 
     def create_group(self, grouprep, realm="master"):
         """ Create a Keycloak group.
@@ -418,8 +418,8 @@ class KeycloakAPI(object):
             return open_url(groups_url, method='POST', headers=self.restheaders,
                             data=json.dumps(grouprep), validate_certs=self.validate_certs)
         except Exception as e:
-            self.module.fail_json(msg="Could not create group {} in realm {}: {}".format(
-                                            grouprep['name'], realm, str(e)))
+            self.module.fail_json(msg="Could not create group %s in realm %s: %s"
+                                      % (grouprep['name'], realm, str(e)))
 
     def update_group(self, grouprep, realm="master"):
         """ Update an existing group.
@@ -471,4 +471,4 @@ class KeycloakAPI(object):
                             validate_certs=self.validate_certs)
 
         except Exception as e:
-            module.fail_json(msg="Unable to delete group {}: {}".format(groupid, str(e)))
+            self.module.fail_json(msg="Unable to delete group %s: %s" % (groupid, str(e)))

--- a/lib/ansible/modules/identity/keycloak/keycloak_group.py
+++ b/lib/ansible/modules/identity/keycloak/keycloak_group.py
@@ -75,6 +75,10 @@ options:
         required: false
         type: 'dict'
 
+notes:
+    - Presently, the I(realmRoles), I(clientRoles) and I(access) attributes returned by the Keycloak API
+      are read-only for groups. This limitation will be removed in a later version of this module.
+
 extends_documentation_fragment:
     - keycloak
 

--- a/lib/ansible/modules/identity/keycloak/keycloak_group.py
+++ b/lib/ansible/modules/identity/keycloak/keycloak_group.py
@@ -98,6 +98,7 @@ EXAMPLES = '''
     auth_realm: master
     auth_username: USERNAME
     auth_password: PASSWORD
+  delegate_to: localhost
 
 - name: Delete a keycloak group
   keycloak_group:
@@ -109,6 +110,7 @@ EXAMPLES = '''
     auth_realm: master
     auth_username: USERNAME
     auth_password: PASSWORD
+  delegate_to: localhost
 
 - name: Delete a Keycloak group based on name
   keycloak_group:
@@ -119,6 +121,7 @@ EXAMPLES = '''
     auth_realm: master
     auth_username: USERNAME
     auth_password: PASSWORD
+  delegate_to: localhost
 
 - name: Update the name of a Keycloak group
   keycloak_group:
@@ -130,6 +133,7 @@ EXAMPLES = '''
     auth_realm: master
     auth_username: USERNAME
     auth_password: PASSWORD
+  delegate_to: localhost
 
 - name: Create a keycloak group with some custom attributes
   keycloak_group:
@@ -148,6 +152,7 @@ EXAMPLES = '''
             - individual
             - list
             - items
+  delegate_to: localhost
 '''
 
 RETURN = '''

--- a/lib/ansible/modules/identity/keycloak/keycloak_group.py
+++ b/lib/ansible/modules/identity/keycloak/keycloak_group.py
@@ -46,6 +46,9 @@ options:
             - On C(absent), the group will be removed if it exists.
         required: true
         default: 'present'
+        choices:
+            - present
+            - absent
 
     name:
         description:
@@ -151,7 +154,7 @@ RETURN = '''
 msg:
   description: Message as to what action was taken
   returned: always
-  type: string
+  type: str
   sample: "Group my-new-sso-group has been created with ID '9d59aa76-2755-48c6-b1af-beb70a82c3cd'"
 
 group:
@@ -314,6 +317,7 @@ def main():
             module.exit_json(**result)
 
     module.exit_json(**result)
+
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/identity/keycloak/keycloak_group.py
+++ b/lib/ansible/modules/identity/keycloak/keycloak_group.py
@@ -1,0 +1,355 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2018, Adam Goossens <adam.goossens@gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: keycloak_group
+
+short_description: Allows administration of Keycloak groups via Keycloak API
+
+description:
+    - This module allows you to add, remove or modify Keycloak groups via the Keycloak REST API.
+      It requires access to the REST API via OpenID Connect; the user connecting and the client being
+      used must have the requisite access rights. In a default Keycloak installation, admin-cli
+      and an admin user would work, as would a separate client definition with the scope tailored
+      to your needs and a user having the expected roles.
+
+    - The names of module options are snake_cased versions of the camelCase ones found in the
+      Keycloak API and its documentation at U(http://www.keycloak.org/docs-api/3.3/rest-api/).
+
+    - The Keycloak API returns and expects group attribute values to be provided as lists. This
+      module will transparently convert any non-list attribute values into a list before providing it to the API.
+      When retrieving a group, expect the attribute values to be returned in a list.
+
+    - When updating a group, where possible provide the group ID to the module. This removes a lookup
+      to the API to translate the name into the group ID.
+
+options:
+    state:
+        description:
+            - State of the group.
+            - On C(present), the group will be created if it does not yet exist.
+            - On C(absent), the group will be removed if it exists.
+            - On C(updated), the group will be updated or created based on the parameters you provide.
+        required: true
+        default: 'present'
+
+    name:
+        description:
+            - Name of the group.
+            - This parameter is required only when creating or updating the group.
+        required: false
+        type: 'str'
+
+    realm:
+        description:
+            - They Keycloak realm under which this group resides.
+        required: false
+        type: 'str'
+        default: 'master'
+
+    id:
+        description:
+            - The unique identifier for this group. 
+            - This parameter is not required for updating or deleting a group but
+              providing it will reduce the number of API calls required.
+        required: false
+        type: 'str'
+
+    attributes:
+        description:
+            - A list of key/value pairs to set as custom attributes for the group.
+            - Values may be single values (e.g. a string) or a list of strings.
+        required: false
+        type: 'dict'
+
+extends_documentation_fragment:
+    - keycloak
+
+author:
+    - Adam Goossens (@adamgoossens)
+'''
+
+EXAMPLES = '''
+- name: Create a Keycloak group
+  local_action:
+    module: keycloak_group
+    name: my-new-kc-group
+    realm: MyCustomRealm
+    state: present
+    auth_client_id: admin-cli
+    auth_keycloak_url: https://auth.example.com/auth
+    auth_realm: master
+    auth_username: USERNAME
+    auth_password: PASSWORD
+  register: kc_group_id
+
+- name: Delete a keycloak group
+  local_action:
+    module: keycloak_group
+    id: '9d59aa76-2755-48c6-b1af-beb70a82c3cd'
+    state: absent
+    realm: MyCustomRealm
+    auth_client_id: admin-cli
+    auth_keycloak_url: https://auth.example.com/auth
+    auth_realm: master
+    auth_username: USERNAME
+    auth_password: PASSWORD
+
+- name: Delete a Keycloak group based on name
+  local_action:
+    module: keycloak_group
+    name: my-group-for-deletion
+    auth_client_id: admin-cli
+    auth_keycloak_url: https://auth.example.com/auth
+    auth_realm: master
+    auth_username: USERNAME
+    auth_password: PASSWORD
+
+- name: Update the name of a Keycloak group
+  local_action:
+    module: keycloak_group
+    id: '9d59aa76-2755-48c6-b1af-beb70a82c3cd'
+    name: an-updated-kc-group-name
+    state: present
+    auth_client_id: admin-cli
+    auth_keycloak_url: https://auth.example.com/auth
+    auth_realm: master
+    auth_username: USERNAME
+    auth_password: PASSWORD
+
+- name: Create a keycloak group with some custom attributes
+  local_action:
+    module: keycloak_group
+    auth_client_id: admin-cli
+    auth_keycloak_url: https://auth.example.com/auth
+    auth_realm: master
+    auth_username: USERNAME
+    auth_password: PASSWORD
+    name: my-new_group
+    attributes:
+        attrib1: value1
+        attrib2: value2
+        attrib3:
+            - with
+            - numerous
+            - individual
+            - list
+            - items
+'''
+
+RETURN = '''
+msg:
+  description: Message as to what action was taken
+  returned: always
+  type: string
+  sample: "Group my-new-sso-group has been created with ID '9d59aa76-2755-48c6-b1af-beb70a82c3cd'"
+
+proposed:
+  description: Group representation of proposed changes to group (sample is truncated)
+  returned: always
+  type: dict
+  sample: {
+    "attributes": {
+        "day_of_week": [
+            "friday"
+        ],
+        "expiry_date": [
+            "2018-01-01"
+        ]
+    },
+    "name": "new-name"
+}
+
+existing:
+  description: Group representation of the existing group, before modification or deletion. Sample is truncated.
+  returned: always
+  type: dict
+  sample: {
+    "name": "group-name",
+    "id": "2ac24fe7-cec6-4fc4-8c32-a17f79e3365e",
+    "path": "/group-name",
+    "realmRoles": []
+  }
+
+end_state:
+  description: Group representation of the group after module execution (sample is truncated).
+  returned: always
+  type: dict
+  sample: {
+    "name": "my-new-group",
+    "attributes": {
+       "weather": [ "sunny" ],
+       "cnames": [ "foo.bar.com", "bar.bar.com", "baz.bar.com" ]
+    }
+    "id": "1aedffb3-7501-4863-8dfc-f42951649aa9"
+  }
+'''
+
+from ansible.module_utils.keycloak import KeycloakAPI, camel, keycloak_argument_spec
+from ansible.module_utils.basic import AnsibleModule
+
+
+def main():
+    """
+    Module execution
+
+    :return:
+    """
+    argument_spec = keycloak_argument_spec()
+    meta_args = dict(
+        state=dict(default='present', choices=['present','absent']),
+        realm=dict(default='master'),
+
+        id=dict(type='str'),
+        name=dict(type='str'),
+        attributes=dict(type='dict')
+    )
+
+    argument_spec.update(meta_args)
+
+    module = AnsibleModule(argument_spec=argument_spec,
+                           supports_check_mode=True,
+                           required_one_of=([['id', 'name']]))
+
+    result = dict(changed=False, msg='', diff={}, group_id='')
+
+    # Obtain access token, initialize API
+    kc = KeycloakAPI(module)
+
+    realm = module.params.get('realm')
+    state = module.params.get('state')
+    gid = module.params.get('id')
+    name = module.params.get('name')
+    attributes = module.params.get('attributes')
+
+    before_group = None         # current state of the group, for merging.
+
+    # does the group already exist?
+    if gid is None:
+        before_group = kc.get_group_by_name(name, realm=realm)
+    else:
+        before_group = kc.get_group_by_groupid(gid, realm=realm)
+
+    before_group = {} if before_group is None else before_group
+
+    # attributes in Keycloak have their values returned as lists
+    # via the API. attributes is a dict, so we'll transparently convert
+    # the values to lists.
+    if attributes is not None:
+        for key,val in module.params['attributes'].iteritems():
+            module.params['attributes'][key] = [val] if type(val) != list else val
+
+    group_params = [x for x in module.params
+                    if x not in list(keycloak_argument_spec().keys()) + ['state', 'realm'] and
+                    module.params.get(x) is not None]
+
+    # build a changeset
+    changeset = {}
+    for param in group_params:
+        new_param_value = module.params.get(param)
+        old_value = before_group[param] if param in before_group else None
+        if new_param_value != old_value:
+            changeset[camel(param)] = new_param_value
+
+    # prepare the new group
+    updated_group = before_group.copy()
+    updated_group.update(changeset)
+
+    result['proposed'] = changeset if state != 'absent' else {}
+    result['existing'] = before_group
+
+    # if before_group is none, the group doesn't exist.
+    if before_group == {}:
+        if state == 'absent':
+            # nothing to do.
+            if module._diff:
+                result['diff'] = dict(before='', after='')
+            result['msg'] = 'Group does not exist; doing nothing.'
+            result['end_state'] = dict()
+            module.exit_json(**result)
+
+        # for 'present', create a new group.
+        result['changed'] = True
+        if name is None:
+            module.fail_json(msg='name must be specified when creating a new group')
+
+        if module._diff:
+            result['diff'] = dict(before='', after=after_group)
+
+        if module.check_mode:
+            module.exit_json(**result)
+
+        # do it for real!
+        kc.create_group(updated_group, realm=realm)
+        after_group = kc.get_group_by_name(name, realm)
+
+        result['end_state'] = after_group
+        result['msg'] = 'Group {} has been created with ID {}'.format(after_group['name'], after_group['id'])
+
+    else:
+        if state == 'present':
+            # no changes
+            if updated_group == before_group:
+                result['changed'] = False
+                result['end_state'] = updated_group
+                result['msg'] = "No changes required to group {}.".format(before_group['name'])
+                module.exit_json(**result)
+
+            # update the existing group
+            result['changed'] = True
+
+            if module._diff:
+                result['diff'] = dict(before=before_group, after=updated_group)
+
+            if module.check_mode:
+                module.exit_json(**result)
+
+            # do the update
+            kc.update_group(updated_group, realm=realm)
+
+            after_group = kc.get_group_by_groupid(updated_group['id'], realm=realm)
+
+            result['end_state'] = after_group
+            result['msg'] = "Group {} has been updated".format(after_group['id'])
+
+            module.exit_json(**result)
+
+        elif state == 'absent':
+            result['proposed'] = dict()
+            result['end_state'] = dict()
+
+            if module._diff:
+                result['diff'] = dict(before=before_group, after='')
+
+            if module.check_mode:
+                module.exit_json(**result)
+
+            # delete for real
+            gid = before_group['id']
+            kc.delete_group(groupid=gid, realm=realm)
+
+            result['changed'] = True
+            result['msg'] = "Group {} has been deleted".format(before_group['name'])
+
+            module.exit_json(**result)
+
+        else:
+            module.fail_json(msg='Unknown state {}'.format(state))
+
+    module.exit_json(**result)
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/identity/keycloak/keycloak_group.py
+++ b/lib/ansible/modules/identity/keycloak/keycloak_group.py
@@ -42,9 +42,8 @@ options:
     state:
         description:
             - State of the group.
-            - On C(present), the group will be created if it does not yet exist.
+            - On C(present), the group will be created if it does not yet exist, or updated with the parameters you provide.
             - On C(absent), the group will be removed if it exists.
-            - On C(updated), the group will be updated or created based on the parameters you provide.
         required: true
         default: 'present'
 
@@ -52,12 +51,10 @@ options:
         description:
             - Name of the group.
             - This parameter is required only when creating or updating the group.
-        required: false
 
     realm:
         description:
             - They Keycloak realm under which this group resides.
-        required: false
         default: 'master'
 
     id:
@@ -65,13 +62,11 @@ options:
             - The unique identifier for this group.
             - This parameter is not required for updating or deleting a group but
               providing it will reduce the number of API calls required.
-        required: false
 
     attributes:
         description:
             - A list of key/value pairs to set as custom attributes for the group.
             - Values may be single values (e.g. a string) or a list of strings.
-        required: false
 
 notes:
     - Presently, the I(realmRoles), I(clientRoles) and I(access) attributes returned by the Keycloak API
@@ -96,7 +91,6 @@ EXAMPLES = '''
     auth_realm: master
     auth_username: USERNAME
     auth_password: PASSWORD
-  register: kc_group_id
 
 - name: Delete a keycloak group
   local_action:
@@ -114,6 +108,7 @@ EXAMPLES = '''
   local_action:
     module: keycloak_group
     name: my-group-for-deletion
+    state: absent
     auth_client_id: admin-cli
     auth_keycloak_url: https://auth.example.com/auth
     auth_realm: master
@@ -289,7 +284,7 @@ def main():
             module.fail_json(msg='name must be specified when creating a new group')
 
         if module._diff:
-            result['diff'] = dict(before='', after=after_group)
+            result['diff'] = dict(before='', after=updated_group)
 
         if module.check_mode:
             module.exit_json(**result)
@@ -348,9 +343,6 @@ def main():
             result['msg'] = "Group {name} has been deleted".format(name=before_group['name'])
 
             module.exit_json(**result)
-
-        else:
-            module.fail_json(msg='Unknown state {state}'.format(state=state))
 
     module.exit_json(**result)
 


### PR DESCRIPTION
##### SUMMARY
This module (keycloak_group) allows using the Keycloak REST API (http://www.keycloak.org/docs-api/3.4/rest-api/index.html) to administrate Keycloak (http://www.keycloak.org) groups. It allows users to create, update and remove groups.

Keycloak is an Open Source Identity and Access Management system spearheaded by Red Hat. It provides OpenID Connect and SAML authentication/authorization services.

Two prior modules in this namespace have been merged (keycloak_client in #31716 and keycloak_clienttemplate in #33419). This module reuses and extends code introduced therein (from module_utils/keycloak.py).

##### ISSUE TYPE
New Module Pull Request

##### COMPONENT NAME
keycloak_group

##### ANSIBLE VERSION
2.8.0