### PR TITLE
Update some examples to use proper YAML syntax.

### DIFF
--- a/docs/docsite/rst/playbooks_blocks.rst
+++ b/docs/docsite/rst/playbooks_blocks.rst
@@ -45,7 +45,7 @@ Error Handling
 Blocks also introduce the ability to handle errors in a way similar to exceptions in most programming languages.
 
 .. code-block:: YAML
- :emphasize-lines: 3,7,11
+ :emphasize-lines: 3,9,15
  :caption: Block error handling example
 
 
@@ -76,21 +76,8 @@ error did or did not occur in the ``block`` and ``rescue`` sections. It should b
 Another example is how to run handlers after an error occurred :
 
 .. code-block:: YAML
- :emphasize-lines: 5,9
+ :emphasize-lines: 6,10
  :caption: Block run handlers in error handling
-
-
-.. seealso::
-
-   :doc:`playbooks`
-       An introduction to playbooks
-   :doc:`playbooks_reuse_roles`
-       Playbook organization by roles
-   `User Mailing List <http://groups.google.com/group/ansible-devel>`_
-       Have a question?  Stop by the google group!
-   `irc.freenode.net <http://irc.freenode.net>`_
-       #ansible IRC chat channel
-
 
 
   tasks:
@@ -107,3 +94,17 @@ Another example is how to run handlers after an error occurred :
      - name: run me even after an error
        debug:
          msg: 'this handler runs even on error'
+
+.. seealso::
+
+   :doc:`playbooks`
+       An introduction to playbooks
+   :doc:`playbooks_reuse_roles`
+       Playbook organization by roles
+   `User Mailing List <http://groups.google.com/group/ansible-devel>`_
+       Have a question?  Stop by the google group!
+   `irc.freenode.net <http://irc.freenode.net>`_
+       #ansible IRC chat channel
+
+
+

--- a/docs/docsite/rst/playbooks_blocks.rst
+++ b/docs/docsite/rst/playbooks_blocks.rst
@@ -8,19 +8,26 @@ Blocks allow for logical grouping of tasks and in play error handling. Most of w
  :emphasize-lines: 3
  :caption: Block example
 
-    tasks:
-      - name: Install Apache
-        block:
-          - yum: name={{ item }} state=installed
-            loop:
-              - httpd
-              - memcached
-          - template: src=templates/src.j2 dest=/etc/foo.conf
-          - service: name=bar state=started enabled=True
-        when: ansible_distribution == 'CentOS'
-        become: true
-        become_user: root
 
+  tasks:
+    - name: Install Apache
+      block:
+        - yum:
+            name: "{{ item }}"
+            state: installed
+          with_items:
+            - httpd
+            - memcached
+        - template:
+            src: templates/src.j2
+            dest: /etc/foo.conf
+        - service:
+            name: bar
+            state: started
+            enabled: True
+      when: ansible_distribution == 'CentOS'
+      become: true
+      become_user: root
 
 In the example above, each of the 3 tasks will be executed after appending the `when` condition from the block
 and evaluating it in the task's context. Also they inherit the privilege escalation directives enabling "become to root"
@@ -41,19 +48,24 @@ Blocks also introduce the ability to handle errors in a way similar to exception
  :emphasize-lines: 3,7,11
  :caption: Block error handling example
 
-   tasks:
-    - name: Attempt and gracefull roll back demo
-      block:
-        - debug: msg='I execute normally'
-        - command: /bin/false
-        - debug: msg='I never execute, due to the above task failing'
-      rescue:
-        - debug: msg='I caught an error'
-        - command: /bin/false
-        - debug: msg='I also never execute :-('
-      always:
-        - debug: msg="this always executes"
 
+  tasks:
+  - name: Attempt and gracefull roll back demo
+    block:
+      - debug:
+          msg: 'I execute normally'
+      - command: /bin/false
+      - debug:
+          msg: 'I never execute, due to the above task failing'
+    rescue:
+      - debug:
+          msg: 'I caught an error'
+      - command: /bin/false
+      - debug:
+          msg: 'I also never execute :-('
+    always:
+      - debug:
+          msg: "this always executes"
 
 The tasks in the ``block`` would execute normally, if there is any error the ``rescue`` section would get executed
 with whatever you need to do to recover from the previous error. The ``always`` section runs no matter what previous
@@ -67,18 +79,6 @@ Another example is how to run handlers after an error occurred :
  :emphasize-lines: 5,9
  :caption: Block run handlers in error handling
 
-  tasks:
-    - name: Attempt and gracefull roll back demo
-      block:
-        - debug: msg='I execute normally'
-          notify: run me even after an error
-        - command: /bin/false
-      rescue:
-        - name: make sure all handlers run
-          meta: flush_handlers
-   handlers:
-     - name: run me even after an error
-       debug: msg='this handler runs even on error'
 
 .. seealso::
 
@@ -93,3 +93,17 @@ Another example is how to run handlers after an error occurred :
 
 
 
+  tasks:
+    - name: Attempt and gracefull roll back demo
+      block:
+        - debug:
+            msg: 'I execute normally'
+          notify: run me even after an error
+        - command: /bin/false
+      rescue:
+        - name: make sure all handlers run
+          meta: flush_handlers
+  handlers:
+     - name: run me even after an error
+       debug:
+         msg: 'this handler runs even on error'


### PR DESCRIPTION
##### SUMMARY
Many of the examples in the ansible documentation use the name=value syntax instead of the proper YAML name: value syntax.  As I understand it there is now a preference for using the name: value syntax.  I have updated the examples in docs/docsite/rst/playbooks_blocks.rst to use this syntax and verified they all pass ansible-playbook --syntax-check when they are included in a playbook.

If this PR is well received I will work on updating the other examples.  I just wanted to get this published to gather feedback before updating other examples. 

 - Docs Pull Request

##### COMPONENT NAME
playbooks_blocks.rst
