### PR TITLE
change testfiles for nxos_file_copy

### DIFF
--- a/test/integration/targets/nxos_file_copy/tests/cli/sanity.yaml
+++ b/test/integration/targets/nxos_file_copy/tests/cli/sanity.yaml
@@ -7,7 +7,7 @@
   nxos_command: &remove_file
     commands:
       - terminal dont-ask
-      - delete nxos.yaml
+      - delete network-integration.cfg
     provider: "{{ cli }}"
   ignore_errors: yes
 
@@ -18,9 +18,9 @@
     provider: "{{ cli }}"
 
 - block:
-  - name: "Copy nxos.yaml to bootflash"
+  - name: "Copy network-integration.cfg to bootflash"
     nxos_file_copy: &copy_file_same_name
-      local_file: "./nxos.yaml"
+      local_file: "./network-integration.cfg"
       file_system: "bootflash:"
       provider: "{{ cli }}"
       username: "{{ ansible_ssh_user }}"
@@ -33,7 +33,7 @@
       that:
         - "result.changed == true"
 
-  - name: "Check Idempotence - Copy nxos.yaml to bootflash"
+  - name: "Check Idempotence - Copy network-integration.cfg to bootflash"
     nxos_file_copy: *copy_file_same_name
     register: result
 
@@ -45,10 +45,10 @@
     nxos_command: *remove_file
     register: result
 
-  - name: "Copy ios.yaml to bootflash as another name"
+  - name: "Copy inventory.networking.template to bootflash as another name"
     nxos_file_copy: &copy_file_different_name
-      local_file: "./ios.yaml"
-      remote_file: "nxos.yaml"
+      local_file: "./inventory.networking.template"
+      remote_file: "network-integration.cfg"
       file_system: "bootflash:"
       provider: "{{ cli }}"
       username: "{{ ansible_ssh_user }}"
@@ -59,7 +59,7 @@
 
   - assert: *true
 
-  - name: "Check Idempotence - Copy ios.yaml to bootflash as another name"
+  - name: "Check Idempotence - Copy inventory.networking.template to bootflash as another name"
     nxos_file_copy: *copy_file_different_name
     register: result
 

--- a/test/integration/targets/nxos_file_copy/tests/nxapi/sanity.yaml
+++ b/test/integration/targets/nxos_file_copy/tests/nxapi/sanity.yaml
@@ -8,7 +8,7 @@
     commands:
       - command: terminal dont-ask
         output: text
-      - command: delete nxos.yaml
+      - command: delete network-integration.cfg
         output: text
     provider: "{{ nxapi }}"
   ignore_errors: yes
@@ -20,9 +20,9 @@
     provider: "{{ nxapi }}"
 
 - block:
-  - name: "Copy nxos.yaml to bootflash"
+  - name: "Copy network-integration.cfg to bootflash"
     nxos_file_copy: &copy_file_same_name
-      local_file: "./nxos.yaml"
+      local_file: "./network-integration.cfg"
       file_system: "bootflash:"
       provider: "{{ nxapi }}"
       username: "{{ ansible_ssh_user }}"
@@ -35,7 +35,7 @@
       that:
         - "result.changed == true"
 
-  - name: "Check Idempotence - Copy nxos.yaml to bootflash"
+  - name: "Check Idempotence - Copy network-integration.cfg to bootflash"
     nxos_file_copy: *copy_file_same_name
     register: result
 
@@ -48,10 +48,10 @@
     register: result
     ignore_errors: yes
 
-  - name: "Copy ios.yaml to bootflash as another name"
+  - name: "Copy inventory.networking.template to bootflash as another name"
     nxos_file_copy: &copy_file_different_name
-      local_file: "./ios.yaml"
-      remote_file: "nxos.yaml"
+      local_file: "./inventory.networking.template"
+      remote_file: "network-integration.cfg"
       file_system: "bootflash:"
       provider: "{{ nxapi }}"
       username: "{{ ansible_ssh_user }}"
@@ -62,7 +62,7 @@
 
   - assert: *true
 
-  - name: "Check Idempotence - Copy ios.yaml to bootflash as another name"
+  - name: "Check Idempotence - Copy inventory.networking.template to bootflash as another name"
     nxos_file_copy: *copy_file_different_name
     register: result
 


### PR DESCRIPTION
Signed-off-by: Trishna Guha <trishnaguha17@gmail.com>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Since nxos.yaml and ios.yaml are removed from test/integration dir, nxos_file_copy is failing because those files were used to test the module. Hence using other set of files here.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
test/integration/targets/nxos_file_copy/tests/{cli,nxapi}/sanity.yaml
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```