### PR TITLE
Include new module openssl_dhparam in changelog (#32620)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -185,6 +185,9 @@ See [Porting Guide](http://docs.ansible.com/ansible/devel/porting_guides.html) f
   * openshift_raw
   * openshift_scale
 
+#### Crypto
+  * openssl_dhparam
+
 #### Database
 - influxdb
   * influxdb_query


### PR DESCRIPTION
It's a new 2.5 module and I noticed it was missing.