### PR TITLE
Fix loop/with typo in loops doc

### DIFF
--- a/docs/docsite/rst/playbooks_loops.rst
+++ b/docs/docsite/rst/playbooks_loops.rst
@@ -120,7 +120,7 @@ Using register with a loop
 
 After using ``register`` with a loop, the data structure placed in the variable will contain a ``results`` attribute that is a list of all responses from the module.
 
-Here is an example of using ``register`` with ``with_items``::
+Here is an example of using ``register`` with ``loop``::
 
     - shell: "echo {{ item }}"
       loop:


### PR DESCRIPTION
##### SUMMARY
small typo fix for loops

##### ISSUE TYPE

 - Docs Pull Request

##### COMPONENT NAME
docs

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```



