### PR TITLE
Added warning when duplicated variables merged

### DIFF
--- a/lib/ansible/utils/vars.py
+++ b/lib/ansible/utils/vars.py
@@ -33,6 +33,11 @@ from ansible.module_utils.six import iteritems, string_types
 from ansible.module_utils._text import to_native, to_text
 from ansible.parsing.splitter import parse_kv
 
+try:
+    from __main__ import display
+except ImportError:
+    from ansible.utils.display import Display
+    display = Display()
 
 _MAXSIZE = 2 ** 32
 cur_id = 0
@@ -87,7 +92,10 @@ def combine_vars(a, b):
         # HASH_BEHAVIOUR == 'replace'
         _validate_mutable_mappings(a, b)
         result = a.copy()
-        result.update(b)
+        for key in b:
+            if key in result and result[key] != b[key]:
+                display.warning("Duplicate variable '%s' detected! The value will be overwritten!" % key)
+            result[key] = b[key]
         return result
 
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
I (and a lot of people in #9065) have spent many hours to debug the issue with variables merge.
I know that #9065 is closed by design, but I want to save a lot of my and other people's time in the future.

In this PR I've added a trivial warning message to save hours of debugging and straightly say "Hey, you have a duplicate, something can work wrong".

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.2.0
  config file = /home/art/.ansible.cfg
  configured module search path = [u'/home/art/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
