### PR TITLE
Fix syntax error so route table tests always try to clean up

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_net.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_net.py
@@ -356,6 +356,11 @@ def main():
                 except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
                     module.fail_json_aws(e, "Failed to update enabled dns hostnames attribute")
 
+        try:
+            connection.get_waiter('vpc_available').wait(VpcIds=[vpc_id])
+        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+            module.fail_json_aws(e, msg="Unable to wait for VPC {0} to be available.".format(vpc_id))
+
         final_state = camel_dict_to_snake_dict(get_vpc(module, connection, vpc_id))
         final_state['tags'] = boto3_tag_list_to_ansible_dict(final_state.get('tags', []))
         final_state['id'] = final_state.pop('vpc_id')

--- a/test/integration/targets/ec2_vpc_route_table/tasks/main.yml
+++ b/test/integration/targets/ec2_vpc_route_table/tasks/main.yml
@@ -545,7 +545,7 @@
         - recreate_private_table.changed
         - recreate_private_table.route_table.id != create_public_table.route_table.id
 
-- always:
+  always:
   #############################################################################
   # TEAR DOWN STARTS HERE
   #############################################################################


### PR DESCRIPTION
##### SUMMARY
The always wasn't running after test failures. Also added a wait after creating a VPC to try to prevent
```
 ec2_vpc_route_table-jxp23s1l / /root/ansible/test/integration/targets/ec2_vpc_route_table/tasks/main.yml:12 / [localhost] amazon: ec2_vpc_route_table : create VPC aws_access_key={{ aws_access_key }}, aws_secret_key={{ aws_secret_key }}, security_token={{ security_token }}, region={{ aws_region }}, cidr_block=10.228.228.0/22, name={{ resource_prefix }}_vpc, state=present
 error: botocore.exceptions.ClientError: An error occurred (InvalidVpcID.NotFound) when calling the DescribeVpcs operation: The vpc ID 'vpc-ceb858b5' does not exist
                          Traceback (most recent call last):
  File "/tmp/ansible_w1d614e3/ansible_module_ec2_vpc_net.py", line 199, in get_vpc
    vpc_obj = connection.describe_vpcs(VpcIds=[vpc_id])['Vpcs'][0]
  File "/usr/local/lib/python3.6/dist-packages/botocore/client.py", line 317, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/usr/local/lib/python3.6/dist-packages/botocore/client.py", line 615, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.exceptions.ClientError: An error occurred (InvalidVpcID.NotFound) when calling the DescribeVpcs operation: The vpc ID 'vpc-ceb858b5' does not exist
```

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
test/integration/targets/ec2_vpc_route_table/tasks/main.yml

##### ANSIBLE VERSION
```
2.5.0
```