### PR TITLE
make v2_playbook_on_notify method signatures consistent

### DIFF
--- a/lib/ansible/plugins/callback/__init__.py
+++ b/lib/ansible/plugins/callback/__init__.py
@@ -348,8 +348,7 @@ class CallbackBase(AnsiblePlugin):
     def v2_playbook_on_start(self, playbook):
         self.playbook_on_start()
 
-    def v2_playbook_on_notify(self, result, handler):
-        host = result._host.get_name()
+    def v2_playbook_on_notify(self, handler, host):
         self.playbook_on_notify(host, handler)
 
     def v2_playbook_on_no_hosts_matched(self):


### PR DESCRIPTION
Signed-off-by: Adam Miller <admiller@redhat.com>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This was causing an exception in the TaskQueueManager when a third
party handler plugin was processed that inherited or explicitly
called the callback method from super because the method signature
was incorrect in callback/__init__ and it processed the arguments as
incorrect data types as a side effect.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
lib/ansible/plugins/callback/__init__.py 

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (devel 1717444f18) last updated 2018/02/01 20:58:46 (GMT -500)
  config file = /home/admiller/src/dev/openshift-ansible/ansible.cfg
  configured module search path = [u'/home/admiller/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/admiller/src/dev/ansible/lib/ansible
  executable location = /home/admiller/src/dev/ansible/bin/ansible
  python version = 2.7.14 (default, Jan 17 2018, 14:28:32) [GCC 7.2.1 20170915 (Red Hat 7.2.1-2)]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
$ git clone https://github.com/openshift/openshift-ansible.git
$ cd openshift-ansible
$ cat > test.yml << EOF
# test.yml
---
- name: Test Playbook
  hosts: localhost
  connection: local
  gather_facts: no
  handlers:
  - name: my_handler
    debug:
      msg: "My Handler"
  roles:
    - lib_utils
  tasks:
  - name: my_task
    debug:
      msg: "My Task"
    changed_when: true
    notify: my_handler
EOF
```

Before change:
```
$ ansible-playbook test.yml           
 [WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit   
localhost does not match 'all'                  


PLAY [Test Playbook] ***************************************************************************

TASK [my_task] *********************************************************************************
Friday 02 February 2018  11:13:03 -0600 (0:00:00.069)       0:00:00.069 *******                 
 [WARNING]: Failure using method (v2_playbook_on_notify) in callback plugin                     
(<ansible.plugins.callback.aa_version_requirement.CallbackModule object at 0x7f4c9f83be50>):    
'Handler' object has no attribute '_host'       

 [WARNING]: Failure using method (v2_playbook_on_notify) in callback plugin                     
(<ansible.plugins.callback.profile_tasks.CallbackModule object at 0x7f4c9a7d59d0>): 'Handler'   
object has no attribute '_host'                 

changed: [localhost] => {                       
    "failed": false,    
    "msg": "My Task"    
}                       

RUNNING HANDLER [my_handler] *******************************************************************
Friday 02 February 2018  11:13:03 -0600 (0:00:00.055)       0:00:00.125 *******                 
ok: [localhost] => {    
    "failed": false,    
    "msg": "My Handler" 
}                       

PLAY RECAP *************************************************************************************
localhost                  : ok=2    changed=1    unreachable=0    failed=0                     

Friday 02 February 2018  11:13:03 -0600 (0:00:00.058)       0:00:00.184 *******                 
===============================================================================                 
my_handler ------------------------------------------------------------------------------ 0.06s 
my_task --------------------------------------------------------------------------------- 0.06s 
```

After change:
```
$ ansible-playbook test.yml           
 [WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit   
localhost does not match 'all'                  


PLAY [Test Playbook] ***************************************************************************

TASK [my_task] *********************************************************************************
Friday 02 February 2018  11:13:33 -0600 (0:00:00.072)       0:00:00.072 *******                 
changed: [localhost] => {                       
    "failed": false,    
    "msg": "My Task"    
}                       

RUNNING HANDLER [my_handler] *******************************************************************
Friday 02 February 2018  11:13:33 -0600 (0:00:00.055)       0:00:00.128 *******                 
ok: [localhost] => {    
    "failed": false,    
    "msg": "My Handler" 
}                       

PLAY RECAP *************************************************************************************
localhost                  : ok=2    changed=1    unreachable=0    failed=0                     

Friday 02 February 2018  11:13:33 -0600 (0:00:00.056)       0:00:00.185 *******                 
===============================================================================                 
my_handler ------------------------------------------------------------------------------ 0.06s 
my_task --------------------------------------------------------------------------------- 0.06s 
```