### PR TITLE
VMware: Provide verbose message about non-existent VM

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -1343,6 +1343,11 @@ class PyVmomiHelper(PyVmomi):
                     datastore_name = datastore.name
 
         if not datastore:
+            if len(self.params['disk']) != 0 or self.params['template'] is None:
+                self.module.fail_json(msg="Unable to find the datastore with given parameters."
+                                          " This could mean, %s is a non-existent virtual machine and module tried to"
+                                          " deploy it as new virtual machine with no disk. Please specify disks parameter"
+                                          " or specify template to clone from." % self.params['name'])
             self.module.fail_json(msg="Failed to find a matching datastore")
 
         return datastore, datastore_name

--- a/test/integration/targets/vmware_guest/tasks/main.yml
+++ b/test/integration/targets/vmware_guest/tasks/main.yml
@@ -26,4 +26,5 @@
 - include: disk_type_d1_c1_f0.yml
 - include: create_nw_d1_c1_f0.yml
 - include: delete_vm.yml
+- include: non_existent_vm_ops.yml
 #- include: template_d1_c1_f0.yml

--- a/test/integration/targets/vmware_guest/tasks/non_existent_vm_ops.yml
+++ b/test/integration/targets/vmware_guest/tasks/non_existent_vm_ops.yml
@@ -1,0 +1,57 @@
+# Test code for the vmware_guest module.
+# Copyright: (c) 2018, Abhijeet Kasurde <akasurde@redhat.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Wait for Flask controller to come up online
+  wait_for:
+    host: "{{ vcsim }}"
+    port: 5000
+    state: started
+
+- name: kill vcsim
+  uri:
+    url: http://{{ vcsim }}:5000/killall
+- name: start vcsim with no folders
+  uri:
+    url: http://{{ vcsim }}:5000/spawn?datacenter=1&cluster=1&folder=0
+  register: vcsim_instance
+
+- name: Wait for Flask controller to come up online
+  wait_for:
+    host: "{{ vcsim }}"
+    port: 443
+    state: started
+
+- name: get a list of VMS from vcsim
+  uri:
+    url: http://{{ vcsim }}:5000/govc_find?filter=VM
+  register: vmlist
+
+- debug: var=vcsim_instance
+- debug: var=vmlist
+
+- name: get a guest
+  set_fact:
+    guest1: "{{ vmlist.json[0] }}"
+
+- name: Perform operation on non-existent VM
+  vmware_guest:
+    validate_certs: False
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    name: "non_existent_vm"
+    datacenter: "{{ (guest1|basename).split('_')[0] }}"
+    folder: "{{ guest1 | dirname }}"
+    state: poweredoff
+  register: non_existent_vm_ops
+  ignore_errors: yes
+
+- debug: var=non_existent_vm_ops
+
+- name: assert that changes were not made
+  assert:
+    that:
+      - not non_existent_vm_ops.changed
+      - non_existent_vm_ops.msg is defined
+      - "'Unable to find the datastore with given parameters' in non_existent_vm_ops.msg"


### PR DESCRIPTION
##### SUMMARY
This fix adds a verbose message about non-existent VM when specified
with operation, due to idempotency we can not detect correct state.

Fixes: #27384

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
lib/ansible/modules/cloud/vmware/vmware_guest.py
test/integration/targets/vmware_guest/tasks/main.yml
test/integration/targets/vmware_guest/tasks/non_existent_vm_ops.yml

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5devel
```