### PR TITLE
Update examples in modules/commands to use proper YAML syntax.

### DIFF
--- a/lib/ansible/modules/commands/command.py
+++ b/lib/ansible/modules/commands/command.py
@@ -74,7 +74,8 @@ EXAMPLES = '''
   register: mymotd
 
 - name: Run the command if the specified file does not exist.
-  command: /usr/bin/make_database.sh arg1 arg2 creates=/path/to/database
+  command: /usr/bin/make_database.sh arg1 arg2
+  creates: /path/to/database
 
 # You can also use the 'args' form to provide the options.
 - name: This command will change the working directory to somedir/ and will only run when /path/to/database doesn't exist.

--- a/lib/ansible/modules/commands/command.py
+++ b/lib/ansible/modules/commands/command.py
@@ -75,7 +75,8 @@ EXAMPLES = '''
 
 - name: Run the command if the specified file does not exist.
   command: /usr/bin/make_database.sh arg1 arg2
-  creates: /path/to/database
+  args:
+    creates: /path/to/database
 
 # You can also use the 'args' form to provide the options.
 - name: This command will change the working directory to somedir/ and will only run when /path/to/database doesn't exist.


### PR DESCRIPTION
##### SUMMARY
Update examples in the modules/commands/*.py files to use proper YAML syntax instead of item= syntax.

##### ISSUE TYPE

 - Docs Pull Request

##### COMPONENT NAME
commands/*



##### ADDITIONAL INFORMATION
I have created several similar PRs for the docs/docsite part of the tree.  If there is interest in similar changes to the examples for other modules let me know and I'll update those and submit PRs for eah module as well.