### PR TITLE
Fix nxos_bgp tests and prepare_nxos_tests refactor

### DIFF
--- a/test/integration/targets/nxos_bgp/tests/common/dis_policy.yaml
+++ b/test/integration/targets/nxos_bgp/tests/common/dis_policy.yaml
@@ -3,6 +3,12 @@
 - debug: msg="Using provider={{ connection.transport }}"
   when: ansible_connection == "local"
 
+- debug: msg="This bgp_disable_policy is not supported on {{ image_version }}"
+  when: imagetag is search("A8|D1")
+- set_fact: bgp_disable_policy="false"
+- set_fact: bgp_disable_policy="true"
+  when: imagetag is not search("A8|D1")
+
 - name: "Disable feature BGP"
   nxos_feature:
     feature: bgp
@@ -18,8 +24,6 @@
   ignore_errors: yes
 
 - block:
-  # these tasks will fail on N3k A8 code and n7k running helsinki
-  # due to no support
   - name: "set disable policy"
     nxos_bgp: &set1
       asn: 65535
@@ -28,18 +32,22 @@
       disable_policy_batching_ipv6_prefix_list: v6_p
       provider: "{{ connection }}"
     register: result
+    when: bgp_disable_policy
 
   - assert: &true
       that:
         - "result.changed == true"
+    when: bgp_disable_policy
 
   - name: "Check Idempotence"
     nxos_bgp: *set1
     register: result
+    when: bgp_disable_policy
 
   - assert: &false
       that:
         - "result.changed == false"
+    when: bgp_disable_policy
 
   - name: "reset disable policy"
     nxos_bgp: &reset1
@@ -49,14 +57,18 @@
       disable_policy_batching_ipv6_prefix_list: default
       provider: "{{ connection }}"
     register: result
+    when: bgp_disable_policy
 
   - assert: *true
+    when: bgp_disable_policy
 
   - name: "Check Idempotence"
     nxos_bgp: *reset1
     register: result
+    when: bgp_disable_policy
 
   - assert: *false
+    when: bgp_disable_policy
 
   rescue:
   - debug: msg="Tests can fail on A8 or helsinki images"

--- a/test/integration/targets/nxos_bgp/tests/common/hels.yaml
+++ b/test/integration/targets/nxos_bgp/tests/common/hels.yaml
@@ -3,12 +3,19 @@
 - debug: msg="Using provider={{ connection.transport }}"
   when: ansible_connection == "local"
 
+- debug: msg="This test is not supported on {{ image_version }}"
+  when: imagetag is search("D1")
+- set_fact: test_helsinki="false"
+- set_fact: test_helsinki="true"
+  when: imagetag is not search("D1")
+
 - name: "Disable feature BGP"
   nxos_feature:
     feature: bgp
     state: disabled
     provider: "{{ connection }}"
   ignore_errors: yes
+  when: test_helsinki
 
 - name: "Enable feature BGP"
   nxos_feature:
@@ -16,6 +23,7 @@
     state: enabled
     provider: "{{ connection }}"
   ignore_errors: yes
+  when: test_helsinki
 
 - block:
   # these tasks will fail on n7k running helsinki
@@ -33,19 +41,23 @@
       provider: "{{ connection }}"
     with_items: "{{ vrfs }}"
     register: result
+    when: test_helsinki
 
   - assert: &true
       that:
         - "result.changed == true"
+    when: test_helsinki
 
   - name: "Check Idempotence"
     nxos_bgp: *set1
     with_items: "{{ vrfs }}"
     register: result
+    when: test_helsinki
 
   - assert: &false
       that:
         - "result.changed == false"
+    when: test_helsinki
 
   - name: "reset helsinki"
     nxos_bgp: &reset1
@@ -61,15 +73,19 @@
       provider: "{{ connection }}"
     with_items: "{{ vrfs }}"
     register: result
+    when: test_helsinki
 
   - assert: *true
+    when: test_helsinki
 
   - name: "Check Idempotence"
     nxos_bgp: *reset1
     with_items: "{{ vrfs }}"
     register: result
+    when: test_helsinki
 
   - assert: *false
+    when: test_helsinki
 
   rescue:
   - debug: msg="Tests can fail on helsinki images"
@@ -81,5 +97,6 @@
       state: disabled
       provider: "{{ connection }}"
     ignore_errors: yes
+    when: test_helsinki
 
   - debug: msg="END connection={{ ansible_connection }} nxos_bgp parameter test"

--- a/test/integration/targets/nxos_bgp/tests/common/isolate.yaml
+++ b/test/integration/targets/nxos_bgp/tests/common/isolate.yaml
@@ -3,6 +3,13 @@
 - debug: msg="Using provider={{ connection.transport }}"
   when: ansible_connection == "local"
 
+
+- debug: msg="This bgp_isolate is not supported on {{ image_version }}"
+  when: imagetag is search("A8")
+- set_fact: bgp_isolate="false"
+- set_fact: bgp_isolate="true"
+  when: imagetag is not search("A8")
+
 - name: "Disable feature BGP"
   nxos_feature:
     feature: bgp
@@ -26,18 +33,22 @@
       isolate: false
       provider: "{{ connection }}"
     register: result
+    when: bgp_isolate
 
   - assert: &true
       that:
         - "result.changed == true"
+    when: bgp_isolate
 
   - name: "Check Idempotence"
     nxos_bgp: *set1
     register: result
+    when: bgp_isolate
 
   - assert: &false
       that:
         - "result.changed == false"
+    when: bgp_isolate
 
   - name: "reset isolate"
     nxos_bgp: &reset1
@@ -45,14 +56,18 @@
       isolate: true
       provider: "{{ connection }}"
     register: result
+    when: bgp_isolate
 
   - assert: *true
+    when: bgp_isolate
 
   - name: "Check Idempotence"
     nxos_bgp: *reset1
     register: result
+    when: bgp_isolate
 
   - assert: *false
+    when: bgp_isolate
 
   rescue:
   - debug: msg="Tests can fail on A8 images"

--- a/test/integration/targets/nxos_bgp/tests/common/supp_fib.yaml
+++ b/test/integration/targets/nxos_bgp/tests/common/supp_fib.yaml
@@ -3,6 +3,14 @@
 - debug: msg="Using provider={{ connection.transport }}"
   when: ansible_connection == "local"
 
+- set_fact: bgp_best_path_limit="false"
+- set_fact: bgp_best_path_limit="true"
+  when: imagetag is not search("I2")
+
+- set_fact: bgp_suppress_fib_supported="false"
+- set_fact: bgp_suppress_fib_supported="true"
+  when: imagetag is not search("A8|D1|I2|I4")
+
 - name: "Disable feature BGP"
   nxos_feature:
     feature: bgp
@@ -57,11 +65,13 @@
     nxos_bgp: *reset1
     with_items: "{{ vrfs }}"
     register: result
+    when: bgp_best_path_limit
 
   - assert: *false
+    when: bgp_best_path_limit
 
-  # this task will fail on n9k running I2 or I4
-  # due to no support
+  # Property does not nvgen on some images
+  # still try and set it but don't check idempotence
   - name: "set suppress fib"
     nxos_bgp: &set2
       asn: 65535
@@ -70,12 +80,15 @@
     register: result
 
   - assert: *true
+    when: bgp_suppress_fib_supported
 
   - name: "Check Idempotence"
     nxos_bgp: *set2
     register: result
+    when: bgp_suppress_fib_supported
 
   - assert: *false
+    when: bgp_suppress_fib_supported
 
   - name: "reset suppress fib"
     nxos_bgp: &reset2
@@ -85,12 +98,15 @@
     register: result
 
   - assert: *true
+    when: bgp_suppress_fib_supported
 
   - name: "Check Idempotence"
     nxos_bgp: *reset2
     register: result
+    when: bgp_suppress_fib_supported
 
   - assert: *false
+    when: bgp_suppress_fib_supported
 
   rescue:
   - debug: msg="Tests can fail on I2/I4/A8/Fretta or helsinki images"

--- a/test/integration/targets/prepare_nxos_tests/tasks/main.yml
+++ b/test/integration/targets/prepare_nxos_tests/tasks/main.yml
@@ -82,21 +82,26 @@
 # Create matrix of simple keys based on platform
 # and image version for use within test playbooks.
 - set_fact: imagetag=""
-- set_fact: imagetag="I2"
-  when: image_version is search("7.0\(3\)I2")
-- set_fact: imagetag="I3"
-  when: image_version is search("7.0\(3\)I3")
-- set_fact: imagetag="I4"
-  when: image_version is search("7.0\(3\)I4")
-- set_fact: imagetag="I5"
-  when: image_version is search("7.0\(3\)I5")
-- set_fact: imagetag="I6"
-  when: image_version is search("7.0\(3\)I6")
-- set_fact: imagetag="I7"
-  when: image_version is search("7.0\(3\)I7")
-- set_fact: imagetag="F1"
-  when: image_version is search("7.0\(3\)F1")
-- set_fact: imagetag="F2"
-  when: image_version is search("7.0\(3\)F2")
-- set_fact: imagetag="F3"
-  when: image_version is search("7.0\(3\)F3")
+- set_fact: imagemr=""
+
+# Examples
+# 8.0(1)
+# 7.3(0)D1(1)
+# 7.0(3)IHD8(1)
+- set_fact: imagetag="{{ image_version[0:3] }}"
+  when: image_version is search("\d\.\d\(\d\)")
+- set_fact: imagetag="{{ image_version[6:8] }}"
+  when: image_version is search("\d\.\d\(\d\)\S\S\(\d\)")
+- set_fact: imagetag="{{ image_version[6:10] }}"
+  when: image_version is search("\d\.\d\(\d\)\S\S\S\S\(\d\)")
+
+- set_fact: imagemr="{{ image_version[4:5] }}"
+  when: image_version is search("\d\.\d\(\d\)")
+- set_fact: imagemr="{{ image_version[9:10] }}"
+  when: image_version is search("\d\.\d\(\d\)\S\S\(\d\)")
+- set_fact: imagemr="{{ image_version[11:12] }}"
+  when: image_version is search("\d\.\d\(\d\)\S\S\S\S\(\d\)")
+
+- debug: msg="IMAGE VERSION {{ image_version }}"
+- debug: msg="IMAGE TAG {{ imagetag }}"
+- debug: msg="IMAGE MR {{ imagemr }}"


### PR DESCRIPTION
##### SUMMARY
* Refactors the version logic in `prepare_nxos_tests` to use regex patterns instead of hardcoded versions.  This logic is used to create both and image tag and image mr (maintenance release) number tag that can then be used to include or exclude tests for different Nexus versions.
* Add logic to skip tests that are not supported on a particular version of Nexus.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
nxos_bgp

##### ANSIBLE VERSION
```
ansible 2.5.0 (rel250/fix_nxos_bgp_test_failures 0c7fd46de0) last updated 2018/02/03 17:39:10 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/Users/mwiebe/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mwiebe/Projects/nxos_ansible/fix_ansible/lib/ansible
  executable location = /Users/mwiebe/Projects/nxos_ansible/fix_ansible/bin/ansible
  python version = 2.7.13 (default, Apr  4 2017, 08:47:57) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.38)]
```