### PR TITLE
contrib(inventory): fix Scaleway inventory used w/env variable token

### DIFF
--- a/contrib/inventory/scaleway.ini
+++ b/contrib/inventory/scaleway.ini
@@ -14,6 +14,9 @@ regions = par1
 # in order to generate inventory output.
 #
 [auth]
+# Token to authenticate with Scaleway's API.
+# If not defined will read the SCALEWAY_TOKEN environment variable
+#
 api_token = mysecrettoken
 
 

--- a/contrib/inventory/scaleway.py
+++ b/contrib/inventory/scaleway.py
@@ -152,8 +152,13 @@ def generate_inv_from_api(config):
     try:
         inventory['all'] = copy.deepcopy(EMPTY_GROUP)
 
-        auth_token = env_or_param(
-            'SCALEWAY_TOKEN', config.get('auth', 'api_token'))
+        if config.has_option('auth', 'api_token'):
+            auth_token = config.get('auth', 'api_token')
+        auth_token = env_or_param('SCALEWAY_TOKEN', param=auth_token)
+        if auth_token is None:
+            sys.stderr.write('ERROR: missing authentication token for Scaleway API')
+            sys.exit(1)
+
         if config.has_option('compute', 'regions'):
             regions = config.get('compute', 'regions')
             if regions == 'all':


### PR DESCRIPTION
##### SUMMARY

In order to authenticate with the Scaleway API for the contrib dynamic
inventory Scaleway the environment variable SCALEWAY_TOKEN was read
only if a value was set in the configuration .ini file.

This PR fixes that allowing to read only the environment variable
without needing to set a token in the configuration file.

Fixes #35693 

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

contrib/inventory/scaleway
