### PR TITLE
Fix #31477: "dest" missing in copy result

### DIFF
--- a/lib/ansible/plugins/action/copy.py
+++ b/lib/ansible/plugins/action/copy.py
@@ -539,13 +539,13 @@ class ActionModule(ActionBase):
 
             changed = changed or module_return.get('changed', False)
 
-            # the file module returns the file path as 'path', but
-            # the copy module uses 'dest', so add it if it's not there
-            if 'path' in module_return and 'dest' not in module_return:
-                module_return['dest'] = module_return['path']
-
         if module_executed and len(source_files['files']) == 1:
             result.update(module_return)
+
+            # the file module returns the file path as 'path', but
+            # the copy module uses 'dest', so add it if it's not there
+            if 'path' in result and 'dest' not in result:
+                result['dest'] = result['path']
         else:
             result.update(dict(dest=dest, src=source, changed=changed))
 

--- a/test/integration/targets/copy/tasks/tests.yml
+++ b/test/integration/targets/copy/tasks/tests.yml
@@ -37,6 +37,7 @@
 
 - set_fact:
     remote_dir_expanded: '{{ echo.stdout }}'
+    remote_file_expanded: '{{ echo.stdout }}/foo.txt'
 
 - debug:
     var: copy_result
@@ -46,7 +47,7 @@
   assert:
     that:
       - "'changed' in copy_result"
-      - "'dest' in copy_result"
+      - copy_result.dest == remote_file_expanded
       - "'group' in copy_result"
       - "'gid' in copy_result"
       - "'md5sum' in copy_result"
@@ -110,6 +111,19 @@
   assert:
     that:
       - "copy_result2 is not changed"
+
+- name: Assert basic copy worked
+  assert:
+    that:
+      - "'changed' in copy_result2"
+      - copy_result2.dest == remote_file_expanded
+      - "'group' in copy_result2"
+      - "'gid' in copy_result2"
+      - "'checksum' in copy_result2"
+      - "'owner' in copy_result2"
+      - "'size' in copy_result2"
+      - "'state' in copy_result2"
+      - "'uid' in copy_result2"
 
 - name: Overwrite the file using the content system
   copy:


### PR DESCRIPTION
##### SUMMARY
When using the copy module `dest` was only added to the result if the file checksum changed.

Fixes #31477

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
copy

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (copy_dest a0f7715187) last updated 2018/02/04 13:03:50 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/tomek/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/tomek/ansible/lib/ansible
  executable location = /home/tomek/ansible/bin/ansible
  python version = 2.7.14 (default, Sep 23 2017, 22:06:14) [GCC 7.2.0]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
