### PR TITLE
Document the multiline prompt/answer format for ios commands

### DIFF
--- a/lib/ansible/modules/network/ios/ios_command.py
+++ b/lib/ansible/modules/network/ios/ios_command.py
@@ -112,6 +112,12 @@ tasks:
       wait_for:
         - result[0] contains IOS
         - result[1] contains Loopback0
+  - name: run command that requires answering a prompt
+    ios_command:
+      commands:
+        - command: 'clear counters GigabitEthernet0/2'
+          prompt: 'Clear "show interface" counters on this interface [confirm]'
+          answer: c
 """
 
 RETURN = """

--- a/lib/ansible/modules/network/ios/ios_command.py
+++ b/lib/ansible/modules/network/ios/ios_command.py
@@ -37,6 +37,8 @@ description:
 extends_documentation_fragment: ios
 notes:
   - Tested against IOS 15.6
+  - If a command sent to the device requires answering a prompt, it is possible
+    to pass a dict containing I(command), I(answer) and I(prompt). See examples.
 options:
   commands:
     description:

--- a/lib/ansible/modules/network/vyos/vyos_command.py
+++ b/lib/ansible/modules/network/vyos/vyos_command.py
@@ -89,6 +89,8 @@ notes:
   - Tested against VYOS 1.1.7
   - Running C(show system boot-messages all) will cause the module to hang since
     VyOS is using a custom pager setting to display the output of that command.
+  - If a command sent to the device requires answering a prompt, it is possible
+    to pass a dict containing I(command), I(answer) and I(prompt). See examples.
 """
 
 EXAMPLES = """
@@ -108,6 +110,13 @@ tasks:
         - show hardware cpu
       wait_for:
         - "result[0] contains 'VyOS 1.1.7'"
+
+  - name: run command that requires answering a prompt
+    vyos_command:
+      commands:
+        - command: 'rollback 1'
+          prompt: 'Proceed with reboot? [confirm][y]'
+          answer: y
 """
 
 RETURN = """


### PR DESCRIPTION
##### SUMMARY

Document the multiline prompt/answer format for ios commands
Fixes #34468

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
ios_command

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (document_multiline_ios_command 7060e58e5c) last updated 2018/02/05 10:11:56 (GMT +200)

```
