### PR TITLE
Remove TBD for Ansible 2.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1110,7 +1110,7 @@ See [Porting Guide](http://docs.ansible.com/ansible/devel/porting_guides.html) f
 
 <a id="2.3.3"></a>
 
-## 2.3.3 "Ramble On" - TBD
+## 2.3.3 "Ramble On"
 
 ### Bugfixes
 * Fix alternatives module handlling of non existing options


### PR DESCRIPTION
##### SUMMARY

I believe the TBD mention on 2.3.3 is incorrect and that it has already been shipped, according to https://pypi.python.org/pypi/ansible/2.3.3.0.

##### ISSUE TYPE

 - Docs Pull Request

##### COMPONENT NAME

Changelog