### PR TITLE
Fix delegated {ansible,remote}_user var precedence

### DIFF
--- a/lib/ansible/playbook/play_context.py
+++ b/lib/ansible/playbook/play_context.py
@@ -350,11 +350,11 @@ class PlayContext(Base):
                     delegated_vars['ansible_port'] = C.DEFAULT_REMOTE_PORT
 
             # and likewise for the remote user
-            for user_var in ('ansible_%s_user' % delegated_transport,) + C.MAGIC_VARIABLE_MAPPING.get('remote_user'):
-                if user_var in delegated_vars and delegated_vars[user_var]:
-                    break
-            else:
-                delegated_vars['ansible_user'] = task.remote_user or self.remote_user
+            delegated_vars['ansible_user'] = task.remote_user or self.remote_user
+            if not delegated_vars['ansible_user']:
+                for user_var in ('ansible_%s_user' % delegated_transport,) + C.MAGIC_VARIABLE_MAPPING.get('remote_user'):
+                    if user_var in delegated_vars and delegated_vars[user_var]:
+                        break
         else:
             delegated_vars = dict()
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This fixes a bug in delegated `{ansible,remote}_user` var precedence where `remote_user` in `ansible.cfg` or in `inventory` was incorrectly used even though `remote_user` was declared either in `play` or in `task`.

Fixes https://github.com/ansible/ansible/issues/33516
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
delegate_to

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->