### PR TITLE
Revert "template: change to pass along the correct template path (#35…

### DIFF
--- a/lib/ansible/plugins/action/assemble.py
+++ b/lib/ansible/plugins/action/assemble.py
@@ -85,8 +85,6 @@ class ActionModule(ActionBase):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
-        tmp = self._connection._shell.tempdir
-
         if task_vars is None:
             task_vars = dict()
 
@@ -148,11 +146,11 @@ class ActionModule(ActionBase):
                 if self._play_context.diff:
                     diff = self._get_diff_data(dest, path, task_vars)
 
-                remote_path = self._connection._shell.join_path(tmp, 'src')
+                remote_path = self._connection._shell.join_path(self._connection._shell.tempdir, 'src')
                 xfered = self._transfer_file(path, remote_path)
 
                 # fix file permissions when the copy is done as a different user
-                self._fixup_perms2((tmp, remote_path))
+                self._fixup_perms2((self._connection._shell.tempdir, remote_path))
 
                 new_module_args.update(dict(src=xfered,))
 
@@ -166,6 +164,6 @@ class ActionModule(ActionBase):
         except AnsibleAction as e:
             result.update(e.result)
         finally:
-            self._remove_tmp_path(tmp)
+            self._remove_tmp_path(self._connection._shell.tempdir)
 
         return result

--- a/lib/ansible/plugins/action/command.py
+++ b/lib/ansible/plugins/action/command.py
@@ -15,8 +15,6 @@ class ActionModule(ActionBase):
         self._supports_async = True
         results = super(ActionModule, self).run(tmp, task_vars)
 
-        tmp = self._connection._shell.tempdir
-
         # Command module has a special config option to turn off the command nanny warnings
         if 'warn' not in self._task.args:
             self._task.args['warn'] = C.COMMAND_WARNINGS
@@ -26,6 +24,6 @@ class ActionModule(ActionBase):
 
         if not wrap_async:
             # remove a temporary path we created
-            self._remove_tmp_path(tmp)
+            self._remove_tmp_path(self._connection._shell.tempdir)
 
         return results

--- a/lib/ansible/plugins/action/copy.py
+++ b/lib/ansible/plugins/action/copy.py
@@ -258,7 +258,7 @@ class ActionModule(ActionBase):
                 return result
 
             # Define a remote directory that we will copy the file to.
-            tmp_src = self._connection._shell.join_path(tmp, 'source')
+            tmp_src = self._connection._shell.join_path(self._connection._shell.tempdir, 'source')
 
             remote_path = None
 
@@ -273,7 +273,7 @@ class ActionModule(ActionBase):
 
             # fix file permissions when the copy is done as a different user
             if remote_path:
-                self._fixup_perms2((tmp, remote_path))
+                self._fixup_perms2((self._connection._shell.tempdir, remote_path))
 
             if raw:
                 # Continue to next iteration if raw is defined.
@@ -392,7 +392,8 @@ class ActionModule(ActionBase):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
-        tmp = self._connection._shell.tempdir
+        if tmp is None:
+            tmp = self._connection._shell.tempdir
 
         source = self._task.args.get('src', None)
         content = self._task.args.get('content', None)
@@ -550,6 +551,6 @@ class ActionModule(ActionBase):
             result.update(dict(dest=dest, src=source, changed=changed))
 
         # Delete tmp path
-        self._remove_tmp_path(tmp)
+        self._remove_tmp_path(self._connection._shell.tempdir)
 
         return result

--- a/lib/ansible/plugins/action/fetch.py
+++ b/lib/ansible/plugins/action/fetch.py
@@ -44,8 +44,6 @@ class ActionModule(ActionBase):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
-        tmp = self._connection._shell.tempdir
-
         try:
             if self._play_context.check_mode:
                 result['skipped'] = True
@@ -214,6 +212,6 @@ class ActionModule(ActionBase):
                 result.update(dict(changed=False, md5sum=local_md5, file=source, dest=dest, checksum=local_checksum))
 
         finally:
-            self._remove_tmp_path(tmp)
+            self._remove_tmp_path(self._connection._shell.tempdir)
 
         return result

--- a/lib/ansible/plugins/action/normal.py
+++ b/lib/ansible/plugins/action/normal.py
@@ -31,8 +31,6 @@ class ActionModule(ActionBase):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
-        tmp = self._connection._shell.tempdir
-
         if not result.get('skipped'):
 
             if result.get('invocation', {}).get('module_args'):
@@ -53,6 +51,6 @@ class ActionModule(ActionBase):
 
         if not wrap_async:
             # remove a temporary path we created
-            self._remove_tmp_path(tmp)
+            self._remove_tmp_path(self._connection._shell.tempdir)
 
         return result

--- a/lib/ansible/plugins/action/package.py
+++ b/lib/ansible/plugins/action/package.py
@@ -39,8 +39,6 @@ class ActionModule(ActionBase):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
-        tmp = self._connection._shell.tempdir
-
         module = self._task.args.get('use', 'auto')
 
         if module == 'auto':
@@ -78,6 +76,6 @@ class ActionModule(ActionBase):
         finally:
             if not self._task.async_val:
                 # remove a temporary path we created
-                self._remove_tmp_path(tmp)
+                self._remove_tmp_path(self._connection._shell.tempdir)
 
         return result

--- a/lib/ansible/plugins/action/patch.py
+++ b/lib/ansible/plugins/action/patch.py
@@ -36,8 +36,6 @@ class ActionModule(ActionBase):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
-        tmp = self._connection._shell.tempdir
-
         src = self._task.args.get('src', None)
         remote_src = boolean(self._task.args.get('remote_src', 'no'), strict=False)
 
@@ -54,7 +52,7 @@ class ActionModule(ActionBase):
             except AnsibleError as e:
                 raise AnsibleActionFail(to_native(e))
 
-            tmp_src = self._connection._shell.join_path(tmp, os.path.basename(src))
+            tmp_src = self._connection._shell.join_path(self._connection._shell.tempdir, os.path.basename(src))
             self._transfer_file(src, tmp_src)
             self._fixup_perms2((tmp_src,))
 
@@ -69,5 +67,5 @@ class ActionModule(ActionBase):
         except AnsibleAction as e:
             result.update(e.result)
         finally:
-            self._remove_tmp_path(tmp)
+            self._remove_tmp_path(self._connection._shell.tempdir)
         return result

--- a/lib/ansible/plugins/action/script.py
+++ b/lib/ansible/plugins/action/script.py
@@ -42,8 +42,6 @@ class ActionModule(ActionBase):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
-        tmp = self._connection._shell.tempdir
-
         try:
             creates = self._task.args.get('creates')
             if creates:
@@ -90,7 +88,7 @@ class ActionModule(ActionBase):
 
             if not self._play_context.check_mode:
                 # transfer the file to a remote tmp location
-                tmp_src = self._connection._shell.join_path(tmp, os.path.basename(source))
+                tmp_src = self._connection._shell.join_path(self._connection._shell.tempdir, os.path.basename(source))
 
                 # Convert raw_params to text for the purpose of replacing the script since
                 # parts and tmp_src are both unicode strings and raw_params will be different
@@ -134,6 +132,6 @@ class ActionModule(ActionBase):
         except AnsibleAction as e:
             result.update(e.result)
         finally:
-            self._remove_tmp_path(tmp)
+            self._remove_tmp_path(self._connection._shell.tempdir)
 
         return result

--- a/lib/ansible/plugins/action/service.py
+++ b/lib/ansible/plugins/action/service.py
@@ -38,8 +38,6 @@ class ActionModule(ActionBase):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
-        tmp = self._connection._shell.tempdir
-
         module = self._task.args.get('use', 'auto').lower()
 
         if module == 'auto':
@@ -86,6 +84,6 @@ class ActionModule(ActionBase):
             result.update(e.result)
         finally:
             if not self._task.async_val:
-                self._remove_tmp_path(tmp)
+                self._remove_tmp_path(self._connection._shell.tempdir)
 
         return result

--- a/lib/ansible/plugins/action/shell.py
+++ b/lib/ansible/plugins/action/shell.py
@@ -24,4 +24,7 @@ class ActionModule(ActionBase):
                                                                    shared_loader_obj=self._shared_loader_obj)
         result = command_action.run(task_vars=task_vars)
 
+        # remove a temporary path we created
+        self._remove_tmp_path(self._connection._shell.tempdir)
+
         return result

--- a/lib/ansible/plugins/action/template.py
+++ b/lib/ansible/plugins/action/template.py
@@ -42,8 +42,6 @@ class ActionModule(ActionBase):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
-        tmp = self._connection._shell.tempdir
-
         source = self._task.args.get('src', None)
         dest = self._task.args.get('dest', None)
         force = boolean(self._task.args.get('force', True), strict=False)
@@ -154,12 +152,12 @@ class ActionModule(ActionBase):
                                                                         loader=self._loader,
                                                                         templar=self._templar,
                                                                         shared_loader_obj=self._shared_loader_obj)
-                result.update(copy_action.run(task_vars=task_vars, tmp=tmp))
+                result.update(copy_action.run(task_vars=task_vars))
             finally:
                 shutil.rmtree(tempdir)
         except AnsibleAction as e:
             result.update(e.result)
         finally:
-            self._remove_tmp_path(tmp)
+            self._remove_tmp_path(self._connection._shell.tempdir)
 
         return result

--- a/lib/ansible/plugins/action/unarchive.py
+++ b/lib/ansible/plugins/action/unarchive.py
@@ -37,8 +37,6 @@ class ActionModule(ActionBase):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
-        tmp = self._connection._shell.tempdir
-
         source = self._task.args.get('src', None)
         dest = self._task.args.get('dest', None)
         remote_src = boolean(self._task.args.get('remote_src', False), strict=False)
@@ -85,7 +83,7 @@ class ActionModule(ActionBase):
 
             if not remote_src:
                 # transfer the file to a remote tmp location
-                tmp_src = self._connection._shell.join_path(tmp, 'source')
+                tmp_src = self._connection._shell.join_path(self._connection._shell.tempdir, 'source')
                 self._transfer_file(source, tmp_src)
 
             # handle diff mode client side
@@ -93,7 +91,7 @@ class ActionModule(ActionBase):
 
             if not remote_src:
                 # fix file permissions when the copy is done as a different user
-                self._fixup_perms2((tmp, tmp_src))
+                self._fixup_perms2((self._connection._shell.tempdir, tmp_src))
                 # Build temporary module_args.
                 new_module_args = self._task.args.copy()
                 new_module_args.update(
@@ -121,5 +119,5 @@ class ActionModule(ActionBase):
         except AnsibleAction as e:
             result.update(e.result)
         finally:
-            self._remove_tmp_path(tmp)
+            self._remove_tmp_path(self._connection._shell.tempdir)
         return result


### PR DESCRIPTION
##### SUMMARY
This reverts commit 389f4ef1fb71629a3389306e6324ea5b118275ff.

which made it so only action plugins with 'transfer files == true' remove remote tmp files.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
action plugins

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```