### PR TITLE
Match recent Dockerfile change in httptester playbook file, to extend ca cert lifetime

### DIFF
--- a/test/utils/docker/httptester/httptester.yml
+++ b/test/utils/docker/httptester/httptester.yml
@@ -72,7 +72,7 @@
 
     - name: Generate ca key
       command: >
-        openssl req -new -x509 -nodes -extensions v3_ca -keyout /root/ca/private/cakey.pem -out /root/ca/cacert.pem
+        openssl req -new -x509 -days 3650 -nodes -extensions v3_ca -keyout /root/ca/private/cakey.pem -out /root/ca/cacert.pem
           -subj "/C=US/ST=North Carolina/L=Durham/O=Ansible/CN=ansible.http.tests"
 
     - name: Generate ansible.http.tests key


### PR DESCRIPTION
##### SUMMARY
Match recent Dockerfile change in httptester playbook file, to extend ca cert lifetime

cc @mattclay 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
test/utils/docker/httptester/httptester.yml

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```