### PR TITLE
Update tags documentation to explain 2.5 behavior

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_tags.rst
+++ b/docs/docsite/rst/user_guide/playbooks_tags.rst
@@ -141,9 +141,9 @@ display all tags applied to the tasks with the ``--list-tags`` option.
 
     - hosts: all
       tasks:
-        - include_role:
-            name: myrole
-          tags: mytag  
+      - include_role:
+          name: myrole
+        tags: mytag  
     ...
 
     (role tasks file)

--- a/docs/docsite/rst/user_guide/playbooks_tags.rst
+++ b/docs/docsite/rst/user_guide/playbooks_tags.rst
@@ -137,6 +137,24 @@ display all tags applied to the tasks with the ``--list-tags`` option.
     ``block:`` may be used to tag more than one task at once. The include
     itself should also be tagged.
 
+    To include a role in a play, and execute it using the tag 'mytag':
+
+    - hosts: all
+      tasks:
+        - include_role:
+            name: myrole
+          tags: mytag  
+    ...
+
+    (role tasks file)
+    - block:
+        - name: First task to run
+          ...
+        - name: Second task to run
+          ...
+      tags:
+        - mytag
+
 
 .. _special_tags:
 

--- a/docs/docsite/rst/user_guide/playbooks_tags.rst
+++ b/docs/docsite/rst/user_guide/playbooks_tags.rst
@@ -1,22 +1,16 @@
 Tags
 ====
 
-If you have a large playbook it may become useful to be able to run a specific part of the configuration without running the whole playbook.
+If you have a large playbook, it may become useful to be able to run only
+a specific part of it rather than running *everything* in the playbook.
+Ansible supports a "tags:" attribute for this reason.
 
-Both plays and tasks support a "tags:" attribute for this reason.
-You can **ONLY** filter tasks based on tags from the command line with ``--tags`` or ``--skip-tags``.
-Adding ``tags:`` to a play, or to statically imported tasks and roles, adds
-those tags to the contained tasks.
+You can **ONLY** filter tasks based on tags from the command line with the 
+``--tags`` or ``--skip-tags`` options.
 
-Adding the tag ``bar`` to all tasks in a play::
-
-    - hosts: all
-      tags:
-        - bar
-      tasks:
-        ...
-
-Tagging indivdual tasks with different tags::
+Tags can be applied to *many* structures in Ansible (see "tag inheritance",
+below), but its simplest use is with indivdual tasks. Here is an example
+that tags two tasks with different tags::
 
     tasks:
         - yum:
@@ -38,9 +32,10 @@ If you wanted to just run the "configuration" and "packages" part of a very long
 
     ansible-playbook example.yml --tags "configuration,packages"
 
-On the other hand, if you want to run a playbook *without* certain tasks, you can use the ``--skip-tags`` command-line option::
+On the other hand, if you want to run a playbook *without* certain tagged
+tasks, you can use the ``--skip-tags`` command-line option::
 
-    ansible-playbook example.yml --skip-tags "notification"
+    ansible-playbook example.yml --skip-tags "packages"
 
 
 .. _tag_reuse:
@@ -50,7 +45,7 @@ Tag Reuse
 You can apply the same tag to more than one task. When a play is run using
 the ``--tags`` command-line option, all tasks with that tag name will be run.
 
-Example::
+This example tags several tasks with one tag, "ntp"::
 
     ---
     # file: roles/common/tasks/main.yml
@@ -81,11 +76,18 @@ Example::
 Tag Inheritance
 ```````````````
 
-When tagging items other than dynamic inclusions (see 'include_role' and
-'include_tasks'), you can apply ``tags:`` to structures above tasks. When
-Ansible processes these, ONLY the tasks they contain are tagged. Applying tags
-anywhere other than tasks is just a convenience so you don't have to tag all
-indivdual tasks. This example tags all tasks in a play::
+Adding ``tags:`` to a play, or to statically imported tasks and roles, adds
+those tags to all of the contained tasks. This is referred to as *tag
+inheritance*. Tag inheritance is *not* applicable to dynamic inclusions
+such as ``include_role`` and ``include_tasks``.
+
+When you apply ``tags:`` attributes to structures other than tasks,
+Ansible processes the tag attribute to apply ONLY to the tasks they contain.
+Applying tags anywhere other than tasks is just a convenience so you don't
+have to tag tasks indivdually.
+
+This example tags all tasks in the two plays. The first play has all its tasks
+tagged with 'bar', and the second has all its tasks tagged with 'foo'::
 
     - hosts: all
       tags:
@@ -117,13 +119,13 @@ All of these apply the specified tags to EACH task inside the play, imported
 file, or role, so that these tasks can be selectively run when the playbook
 is invoked with the corresponding tags.
 
-Tags are inherited *down* the dependency chain. In order for tags to be
-applied to a role and all its dependencies, the tag should be applied to the
-role, not to all the tasks within a role.
+Tags are applied *down* the dependency chain. In order for a tag to be
+inherited to a dependent role's tasks, the tag should be applied to the
+role declaration or static import, not to all the tasks within the role.
 
-You can see which tags are applied to tasks and imported tasks by running
-``ansible-playbook`` with the ``--list-tasks`` option. You can display all
-tags applied to the tasks with the ``--list-tags`` option.
+You can see which tags are applied to tasks, roles, and static imports 
+by running ``ansible-playbook`` with the ``--list-tasks`` option. You can
+display all tags applied to the tasks with the ``--list-tags`` option.
 
 .. note::
     The above information does not apply to `include_tasks`, `include_roles`,

--- a/docs/docsite/rst/user_guide/playbooks_tags.rst
+++ b/docs/docsite/rst/user_guide/playbooks_tags.rst
@@ -131,7 +131,8 @@ tags applied to the tasks with the ``--list-tags`` option.
 
     To use tags with tasks and roles intended for use as dynamic `include`s,
     all needed tasks should be explicitly tagged at the task level; or
-    ``block:`` may be used to tag more than one task at once.
+    ``block:`` may be used to tag more than one task at once. The include
+    itself should also be tagged.
 
 
 .. _special_tags:

--- a/docs/docsite/rst/user_guide/playbooks_tags.rst
+++ b/docs/docsite/rst/user_guide/playbooks_tags.rst
@@ -81,10 +81,11 @@ Example::
 Tag Inheritance
 ```````````````
 
-You can apply ``tags:`` to structures above tasks, but when Ansible processes
-them, ONLY the tasks they contain are tagged. Applying tags anywhere other than
-tasks is just a convenience so you don't have to tag all indivdual tasks. This
-example tags all tasks in a play::
+When tagging items other than dynamic inclusions (see 'include_role' and
+'include_tasks'), you can apply ``tags:`` to structures above tasks. When
+Ansible processes these, ONLY the tasks they contain are tagged. Applying tags
+anywhere other than tasks is just a convenience so you don't have to tag all
+indivdual tasks. This example tags all tasks in a play::
 
     - hosts: all
       tags:

--- a/docs/docsite/rst/user_guide/playbooks_tags.rst
+++ b/docs/docsite/rst/user_guide/playbooks_tags.rst
@@ -129,7 +129,7 @@ tags applied to the tasks with the ``--list-tags`` option.
     or other dynamic includes. Tags applied to either of these only tag the
     include itself.
 
-    To use tags with tasks and roles intended for use as dynamic `include`s,
+    To use tags with tasks and roles intended for dynamic inclusions,
     all needed tasks should be explicitly tagged at the task level; or
     ``block:`` may be used to tag more than one task at once. The include
     itself should also be tagged.


### PR DESCRIPTION
##### SUMMARY
With the identification of the issue fixed in #35732 , this PR does more to explain differences between static and dynamic includes as they exist in 2.5, and generally updates the document.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
docs/docsite/rst/playbooks_tags.rst

##### ANSIBLE VERSION
```
ansible 2.5.0a1 (detached HEAD 6cffa4959f) last updated 2018/02/02 11:05:58 (GMT -700)
  config file = /Users/rsteinfeldt/Documents/discovery-ansible/ansible.cfg
  configured module search path = [u'/Users/rsteinfeldt/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/rsteinfeldt/Documents/ansible/ansible/lib/ansible
  executable location = /Users/rsteinfeldt/Documents/ansible/bin/ansible
  python version = 2.7.14 (default, Jan  6 2018, 12:16:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```


##### ADDITIONAL INFORMATION
