### PR TITLE
Fix inability for mysql login user to grant privileges

### DIFF
--- a/lib/ansible/modules/database/mysql/mysql_user.py
+++ b/lib/ansible/modules/database/mysql/mysql_user.py
@@ -407,7 +407,7 @@ def user_mod(cursor, user, host, host_all, password, encrypted, new_priv, append
                     try:
                         privileges_grant(cursor, user, host, db_table, new_priv[db_table])
                     except Exception as e:
-                        module.fail_json(msg="Revoking privs failed: %s" % to_native(e), exception=traceback.format_exc())
+                        module.fail_json(msg="Granting privs failed: %s" % to_native(e), exception=traceback.format_exc())
                     changed = True
 
     return changed


### PR DESCRIPTION
##### SUMMARY

This PR fixes #35552, an issue when non-root, non-super `login_user` was not able to grant privileges, even if she had proper mysql GRANT for doing so.

The original module determines whether user exists by doing COUNT(*) on `mysql.user`. In case `login_user` lacks privileges on `mysql.user`, it would fail. This PR just silently assumes the user does exist (and if not, it would fail later, instead of creating it).

The `login_user` might lack access to `mysql` database itself. This PR changes the behaviour of the module, when it initially connects to no database, and in case of manipulating tables in that db, directly refers the `mysql` DB.

Fixes #35552 

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME

mysql_user module

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0
  config file = /home/ubuntu/.ansible.cfg
  configured module search path = [u'/home/ubuntu/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/ubuntu/misko-ansible/local/lib/python2.7/site-packages/ansible
  executable location = /home/ubuntu/misko-ansible/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```
