### PR TITLE
Galaxy init fails to ignore paths matching 'role_skeleton_ignore' 

### DIFF
--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -233,7 +233,7 @@ class GalaxyCLI(CLI):
         for root, dirs, files in os.walk(role_skeleton, topdown=True):
             rel_root = os.path.relpath(root, role_skeleton)
             in_templates_dir = rel_root.split(os.sep, 1)[0] == 'templates'
-            dirs[:] = [d for d in dirs if not any(r.match(os.path.join(rel_root, d)) for r in skeleton_ignore_re)]
+            dirs[:] = [d for d in dirs if not any(r.match(d) for r in skeleton_ignore_re)]
 
             for f in files:
                 filename, ext = os.path.splitext(f)


### PR DESCRIPTION
##### SUMMARY

Fixes issue [Galaxy #315](https://github.com/ansible/galaxy/issues/315)

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/cli/galaxy.py

##### ANSIBLE VERSION
```
ansible 2.5.0 (bugfix/galaxy-skeleton-ignore 8f3eddb22e) last updated 2018/02/05 13:40:51 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/Users/chouseknecht/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/chouseknecht/projects/ansible/lib/ansible
  executable location = /Users/chouseknecht/projects/ansible/bin/ansible
  python version = 2.7.14 (default, Nov 14 2017, 23:24:24) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.38)]
```


##### ADDITIONAL INFORMATION
From the Galaxy issue:

Today I wanted to play around with custom skeletons as documented here: 
https://docs.ansible.com/ansible/latest/galaxy.html#using-a-custom-role-skeleton

## Actual Behaviour:

When running `ansible-galaxy init --role-skeleton=/path/to/skeleton role_name`:
- The directories and files from the custom skeleton are pulled in.
- variable "role_skeleton_ignore" seems to be ignored

## Expected Behaviour:

When running `ansible-galaxy init --role-skeleton=/path/to/skeleton role_name`:
- The directories and files from the custom skeleton are not pulled in as described in the docs (.git, .gitkeep).
- variable "role_skeleton_ignore" works as designed

## Steps to reproduce:

1. create a *skeleton* directory
2. cd in the *skeleton* directory
2. `git init`
3. `touch .gitkeep`
4. `ansible-galaxy init --role-skeleton=/path/to/skeleton role_name`
5.  `ls -la role_name`
6. .git still existing

## Information:

OS: Fedora 27
```
ansible --version
ansible 2.4.2.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/ds/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.14 (default, Jan 17 2018, 14:28:32) [GCC 7.2.1 20170915 (Red Hat 7.2.1-2)
```