### PR TITLE
Modify the documentation of nmcli: conn_name

### DIFF
--- a/lib/ansible/modules/net_tools/nmcli.py
+++ b/lib/ansible/modules/net_tools/nmcli.py
@@ -42,6 +42,7 @@ options:
         description:
             - 'Where conn_name will be the name used to call the connection. when not provided a default name is generated: <type>[-<ifname>][-<num>]'
         required: True
+            - 'Where conn_name will be the name used to call the connection.'
     ifname:
         description:
             - Where IFNAME will be the what we call the interface name.


### PR DESCRIPTION
##### SUMMARY
Modify the documentation of nmcli: conn_name
Fixes: #29302

Signed-off-by: Amol Kahat <akahat@redhat.com>

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
nmcli

##### ANSIBLE VERSION
```
 $ ansible --version
ansible 2.5.0
  config file = None
  configured module search path = [u'/home/admin/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.14 (default, Jan 17 2018, 14:28:32) [GCC 7.2.1 20170915 (Red Hat 7.2.1-2)]
(ansible_venv) 
```


##### ADDITIONAL INFORMATION
