### PR TITLE
Minor updates to nxos_nxapi tests

### DIFF
--- a/test/integration/targets/nxos_nxapi/tasks/platform/n5k/assert_changes.yaml
+++ b/test/integration/targets/nxos_nxapi/tasks/platform/n5k/assert_changes.yaml
@@ -1,0 +1,6 @@
+---
+- name: Assert configuration changes
+  assert:
+    that:
+      - result.stdout[0].http_port is not defined
+      - result.stdout[0].https_port|string is search("9443")

--- a/test/integration/targets/nxos_nxapi/tests/cli/configure.yaml
+++ b/test/integration/targets/nxos_nxapi/tests/cli/configure.yaml
@@ -31,8 +31,6 @@
   when: platform | match('N5K')
 
 - include: targets/nxos_nxapi/tasks/platform/default/assert_changes.yaml
-  when: not ( platform is search('N7K'))
-
   when: not ( platform is search('N7K')) and not (platform is search('N5K')) and not (platform is search('N35'))
 
 - name: Configure NXAPI again

--- a/test/integration/targets/nxos_nxapi/tests/cli/configure.yaml
+++ b/test/integration/targets/nxos_nxapi/tests/cli/configure.yaml
@@ -27,8 +27,13 @@
 - include: targets/nxos_nxapi/tasks/platform/n7k/assert_changes.yaml
   when: platform is match('N7K')
 
+- include: targets/nxos_nxapi/tasks/platform/n5k/assert_changes.yaml
+  when: platform | match('N5K')
+
 - include: targets/nxos_nxapi/tasks/platform/default/assert_changes.yaml
   when: not ( platform is search('N7K'))
+
+  when: not ( platform is search('N7K')) and not (platform is search('N5K')) and not (platform is search('N35'))
 
 - name: Configure NXAPI again
   nxos_nxapi:

--- a/test/integration/targets/nxos_nxapi/tests/cli/configure.yaml
+++ b/test/integration/targets/nxos_nxapi/tests/cli/configure.yaml
@@ -28,7 +28,7 @@
   when: platform is match('N7K')
 
 - include: targets/nxos_nxapi/tasks/platform/n5k/assert_changes.yaml
-  when: platform | match('N5K')
+  when: platform is match('N5K')
 
 - include: targets/nxos_nxapi/tasks/platform/default/assert_changes.yaml
   when: not ( platform is search('N7K')) and not (platform is search('N5K')) and not (platform is search('N35'))


### PR DESCRIPTION
##### SUMMARY
* Adds Nexus 5k support for nxos_nxapi tests
* Adds a few platform checks in the tests

##### ISSUE TYPE
 - Integration Tests Pull Request

##### COMPONENT NAME
nxos_nxapi

##### ANSIBLE VERSION
```
ansible 2.5.0 (rel250/fix_nxos_nxapi_tests adeb48d2da) last updated 2018/02/05 15:19:53 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/Users/mwiebe/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mwiebe/Projects/nxos_ansible/fix_ansible/lib/ansible
  executable location = /Users/mwiebe/Projects/nxos_ansible/fix_ansible/bin/ansible
  python version = 2.7.13 (default, Apr  4 2017, 08:47:57) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.38)]
```
