### PR TITLE
move away from bad inline var defs

### DIFF
--- a/docs/docsite/rst/playbooks_reuse_includes.rst
+++ b/docs/docsite/rst/playbooks_reuse_includes.rst
@@ -55,9 +55,15 @@ You can then use ``import_tasks`` or ``include_tasks`` to include this file in y
 You can also pass variables into imports and includes::
 
     tasks:
-    - import_tasks: wordpress.yml wp_user=timmy
-    - import_tasks: wordpress.yml wp_user=alice
-    - import_tasks: wordpress.yml wp_user=bob
+    - import_tasks: wordpress.yml
+      vars:
+        wp_user: timmy
+    - import_tasks: wordpress.yml
+      vars:
+        wp_user: alice
+    - import_tasks: wordpress.yml
+      vars:
+        wp_user: bob
 
 Variables can also be passed to include files using an alternative syntax, which also supports structured variables like dictionaries and lists::
 


### PR DESCRIPTION
##### SUMMARY

partial fix for #35714

this was a hold over from `include` which did allow for inline vars.


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
import_tasks
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```