### PR TITLE
add termination protection flag to ec2_asg module

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_asg.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_asg.py
@@ -146,7 +146,7 @@ options:
       - Protect newly created instances from being selected for termination during scale in
     required: false
     default: False
-    version_added: "2.5"
+    version_added: "2.6"
   termination_policies:
     description:
         - An ordered list of criteria used for selecting instances to be removed from the Auto Scaling group when reducing capacity.


### PR DESCRIPTION
##### SUMMARY
add module parameter 'new_instances_protected_from_scale_in' to ec2_asg to allow configuring the 'NewInstancesProtectedFromScaleIn' tunable in an AWS Scale Group.

False by default to preserve previous ec2_asg behavior.

Instance protection allows protecting instances in a scale group from being selected for termination during a scale down/in. Setting this to True means newly created instances will have instance protection enabled.

Fixes #29478 

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
ec2_asg

##### ANSIBLE VERSION
```
ansible 2.5.0 (ec2_asg_term_protect 73b1137f18) last updated 2018/02/05 20:38:21 (GMT +000)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/jdiaz/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/jdiaz/git/ansible/lib/ansible
  executable location = /home/jdiaz/git/ansible/bin/ansible
  python version = 2.7.5 (default, May  3 2017, 07:55:04) [GCC 4.8.5 20150623 (Red Hat 4.8.5-14)]
```


##### ADDITIONAL INFORMATION
You can go from an ec2_asg call that looked like this:
```
  - name: create test ASG
    ec2_asg:
      state: present
      region: us-east-2
      name: mytest-asg
      launch_config_name: test launch config
      min_size: 1
      max_size: 5
      desired_capacity: 2
      vpc_zone_identifier: vpc_subnet.id
```

To just adding `new_instances_protected_from_scale_in: True` and running/re-running the Ansible task.

Output before isn't interesting. Here's the output after the change.
```
TASK [create test ASG] ******************************************************************************************************************************************
Monday 05 February 2018  20:59:05 +0000 (0:00:00.037)       0:00:00.120 ******* 
changed: [localhost]

TASK [debug] ****************************************************************************************************************************************************
Monday 05 February 2018  20:59:47 +0000 (0:00:41.945)       0:00:42.065 ******* 
ok: [localhost] => {
    "failed": false, 
    "my_asg.new_instances_protected_from_scale_in": true
}
```
