### PR TITLE
Aws s3 kms

### DIFF
--- a/lib/ansible/modules/cloud/amazon/aws_s3.py
+++ b/lib/ansible/modules/cloud/amazon/aws_s3.py
@@ -148,7 +148,7 @@ options:
         GetObject permission but no other permissions. In this case using the option mode: get will fail without specifying
         ignore_nonexistent_bucket: True."
     version_added: "2.3"
-  kms_key_id:
+  encryption_kms_key_id:
     description:
       - KMS key id to use when encrypting objects using C(aws:kms) encryption. Ignored if encryption is not C(aws:kms)
     version_added: "2.7"
@@ -460,8 +460,8 @@ def create_dirkey(module, s3, bucket, obj, encrypt):
         params = {'Bucket': bucket, 'Key': obj, 'Body': b''}
         if encrypt:
             params['ServerSideEncryption'] = module.params['encryption_mode']
-        if module.params['kms_key_id'] and module.params['encryption_mode'] == 'aws:kms':
-            params['SSEKMSKeyId'] = module.params['kms_key_id']
+        if module.params['encryption_kms_key_id'] and module.params['encryption_mode'] == 'aws:kms':
+            params['SSEKMSKeyId'] = module.params['encryption_kms_key_id']
 
         s3.put_object(**params)
         for acl in module.params.get('permission'):
@@ -500,8 +500,8 @@ def upload_s3file(module, s3, bucket, obj, src, expiry, metadata, encrypt, heade
         extra = {}
         if encrypt:
             extra['ServerSideEncryption'] = module.params['encryption_mode']
-        if module.params['kms_key_id'] and module.params['encryption_mode'] == 'aws:kms':
-            extra['SSEKMSKeyId'] = module.params['kms_key_id']
+        if module.params['encryption_kms_key_id'] and module.params['encryption_mode'] == 'aws:kms':
+            extra['SSEKMSKeyId'] = module.params['encryption_kms_key_id']
         if metadata:
             extra['Metadata'] = {}
 
@@ -663,7 +663,7 @@ def main():
             rgw=dict(default='no', type='bool'),
             src=dict(),
             ignore_nonexistent_bucket=dict(default=False, type='bool'),
-            kms_key_id=dict()
+            encryption_kms_key_id=dict()
         ),
     )
     module = AnsibleModule(

--- a/lib/ansible/modules/cloud/amazon/aws_s3.py
+++ b/lib/ansible/modules/cloud/amazon/aws_s3.py
@@ -156,6 +156,7 @@ options:
   kms_key_id:
     description:
       - KMS key id to use when encrypting objects using C(aws:kms) encryption. Ignored if encryption is not C(aws:kms)
+    version_added: "2.6"
 
 requirements: [ "boto3", "botocore" ]
 author:

--- a/test/integration/targets/aws_s3/tasks/main.yml
+++ b/test/integration/targets/aws_s3/tasks/main.yml
@@ -286,7 +286,6 @@
         mode: get
         dest: "{{ tmp2.path }}"
         object: delete_encrypt_kms.txt
-        use_v4_signature: yes
         <<: *aws_connection_info
       retries: 3
       delay: 3

--- a/test/integration/targets/aws_s3/tasks/main.yml
+++ b/test/integration/targets/aws_s3/tasks/main.yml
@@ -279,6 +279,18 @@
       assert:
         that:
           - file1stat.stat.checksum == file2stat.stat.checksum
+      # FIXME - could use a test that checks uploaded file is *actually* aws:kms encrypted
+    - name: test get KMS encrypted object using v4 signature
+      aws_s3:
+        bucket: "{{ bucket_name }}"
+        mode: get
+        dest: "{{ tmp2.path }}"
+        object: delete_encrypt_kms.txt
+        use_v4_signature: yes
+        <<: *aws_connection_info
+      retries: 3
+      delay: 3
+      until: "result.msg == 'GET operation complete'"
     - name: delete KMS encrypted file
       aws_s3:
         bucket: "{{ bucket_name }}"
@@ -291,6 +303,10 @@
       file:
         path: "{{ tmp2.path }}"
         state: absent
+
+    # FIXME: could use a test that checks non standard KMS key
+    #        but that would require ability to create and remove such keys.
+    #        PRs exist for that, but propose deferring until after merge.
 
     - name: test creation of empty path
       aws_s3:
@@ -362,10 +378,6 @@
         that:
           - result.changed == False
 
-    - name: show ansible distribution
-      debug:
-        var: ansible_distribution
-
     - name: make tempfile 4 GB for OSX
       command:
         _raw_params: "dd if=/dev/zero of={{ tmp1.path }} bs=1m count=4096"
@@ -374,7 +386,7 @@
     - name: make tempfile 4 GB for linux
       command:
         _raw_params: "dd if=/dev/zero of={{ tmp1.path }} bs=1M count=4096"
-      when: ansible_distribution == 'Linux'
+      when: ansible_system == 'Linux'
 
     - name: test multipart download - platform specific
       block:
@@ -424,7 +436,7 @@
           assert:
             that:
               - not result.changed
-      when: ansible_distribution in ['MacOSX', 'Linux']
+      when: ansible_system == 'Linux' or ansible_distribution == 'MacOSX'
 
   always:
     ###### TEARDOWN STARTS HERE ######

--- a/test/integration/targets/aws_s3/tasks/main.yml
+++ b/test/integration/targets/aws_s3/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 # tasks file for test_s3
-# ============================================================
+
 - name: set up aws connection info
   set_fact:
     aws_connection_info: &aws_connection_info
@@ -9,333 +9,454 @@
       security_token: "{{ security_token }}"
       region: "{{ aws_region }}"
   no_log: yes
-# ============================================================
-- name: test create bucket
-  aws_s3:
-    bucket: "{{ bucket_name }}"
-    mode: create
-    <<: *aws_connection_info
-  register: result
-- name: assert changed is True
-  assert:
-    that:
-      - result.changed == True
-# ============================================================
-- name: trying to create a bucket name that already exists
-  aws_s3:
-    bucket: "{{ bucket_name }}"
-    mode: create
-    <<: *aws_connection_info
-  register: result
-- name: assert changed is False since the bucket already exists
-  assert:
-    that:
-      - result.changed == False
-# ============================================================
-- name: create temporary file object to put in a bucket
-  tempfile:
-  register: tmp1
-- name: make random contents
-  set_fact:
-      content: "{{ lookup('password', '/dev/null chars=ascii_letters,digits,hexdigits,punctuation') }}"
 
-- name: give temporary file data
-  copy:
-    content: "{{ content }}"
-    dest: "{{ tmp1.path }}"
-- name: get the stat of the file
-  stat:
-    path: "{{ tmp1.path }}"
-    get_checksum: yes
-  register: file1stat
-# ============================================================
-- name: test putting an object in the bucket
-  aws_s3:
-    bucket: "{{ bucket_name }}"
-    mode: put
-    src: "{{ tmp1.path }}"
-    object: delete.txt
-    <<: *aws_connection_info
-  retries: 3
-  delay: 3
-  register: result
-- name: assert object exists
-  assert:
-    that:
-      - result.changed == True
-      - result.msg == "PUT operation complete"
-# ============================================================
-- name: check that roles file lookups work as expected
-  aws_s3:
-    bucket: "{{ bucket_name }}"
-    mode: put
-    src: hello.txt
-    object: hello.txt
-    <<: *aws_connection_info
-  retries: 3
-  delay: 3
-  register: result
-- name: assert object exists
-  assert:
-    that:
-      - result.changed == True
-      - result.msg == "PUT operation complete"
-- name: remove hello.txt (deletion tests are later)
-  aws_s3:
-    bucket: "{{ bucket_name }}"
-    mode: delobj
-    object: hello.txt
-    <<: *aws_connection_info
-  retries: 3
-  delay: 3
-  register: result
-# ============================================================
-- name: create a second temp file to download the object from the bucket
-  tempfile:
-  register: tmp2
-- name: test get object
-  aws_s3:
-    bucket: "{{ bucket_name }}"
-    mode: get
-    dest: "{{ tmp2.path }}"
-    object: delete.txt
-    <<: *aws_connection_info
-  retries: 3
-  delay: 3
-  register: result
-  until: "result.msg == 'GET operation complete'"
-- name: get the stat of the file so we can compare the checksums
-  stat:
-    path: "{{ tmp2.path }}"
-    get_checksum: yes
-  register: file2stat
-- name: assert checksums are the same
-  assert:
-    that:
-      - file1stat.stat.checksum == file2stat.stat.checksum
-# ============================================================
-- name: test geturl of the object
-  aws_s3:
-    bucket: "{{ bucket_name }}"
-    mode: geturl
-    object: delete.txt
-    <<: *aws_connection_info
-  retries: 3
-  delay: 3
-  register: result
-  until: result.changed
-- name: assert we have the object's url
-  assert:
-    that:
-      - "'Download url:' in result.msg"
-      - result.changed == True
-# ============================================================
-- name: test getstr of the object
-  aws_s3:
-    bucket: "{{ bucket_name }}"
-    mode: getstr
-    object: delete.txt
-    <<: *aws_connection_info
-  retries: 3
-  delay: 3
-  register: result
-- name: assert that we have the object's contents
-  assert:
-    that:
-      - result.msg == "GET operation complete"
-      - result.contents == content
-# ============================================================
-- name: test list to get all objects in the bucket
-  aws_s3:
-    bucket: "{{ bucket_name }}"
-    mode: list
-    <<: *aws_connection_info
-  retries: 3
-  delay: 3
-  register: result
-- name: assert that the keys are correct
-  assert:
-    that:
-      - "'delete.txt' in result.s3_keys"
-      - result.msg == "LIST operation complete"
-# ============================================================
-- name: test delobj to just delete an object in the bucket
-  aws_s3:
-    bucket: "{{ bucket_name }}"
-    mode: delobj
-    object: delete.txt
-    <<: *aws_connection_info
-  retries: 3
-  delay: 3
-  register: result
-- name: assert that delete.txt is no longer an object in the bucket deleteme
-  assert:
-    that:
-      - "'Object deleted from bucket' in result.msg"
-      - result.changed == True
-- name: assert that delete.txt is no longer an object in the bucket deleteme
-  assert:
-    that:
-      - "'Object deleted from bucket' in result.msg"
-      - result.changed == True
-# ============================================================
-- name: test creation of empty path
-  aws_s3:
-    bucket: "{{ bucket_name }}"
-    mode: create
-    object: foo/bar/baz/
-    <<: *aws_connection_info
-  retries: 3
-  delay: 3
-  register: result
-- name: assert that empty path is created
-  assert:
-    that:
-      - "'Virtual directory foo/bar/baz/ created' in result.msg"
-      - result.changed == True
-- name: test deletion of empty path
-  aws_s3:
-    bucket: "{{ bucket_name }}"
-    mode: delobj
-    object: foo/bar/baz/
-    <<: *aws_connection_info
-  retries: 3
-  delay: 3
-# ============================================================
-- name: test delete bucket
-  aws_s3:
-    bucket: "{{ bucket_name }}"
-    mode: delete
-    <<: *aws_connection_info
-  register: result
-  retries: 3
-  delay: 3
-  until: result.changed
-- name: assert that changed is True
-  assert:
-    that:
-      - result.changed == True
-# ============================================================
-- name: delete temporary file 1
-  file:
-    state: absent
-    path: "{{ tmp1.path }}"
-- name: delete temporary file 2
-  file:
-    state: absent
-    path: "{{ tmp2.path }}"
-# ============================================================
-- name: test create a bucket with a dot in the name
-  aws_s3:
-    bucket: "{{ bucket_name + '.bucket' }}"
-    mode: create
-    <<: *aws_connection_info
-  register: result
-- name: assert that changed is True
-  assert:
-    that:
-      - result.changed == True
-# ============================================================
-- name: test delete a bucket with a dot in the name
-  aws_s3:
-    bucket: "{{ bucket_name + '.bucket' }}"
-    mode: delete
-    <<: *aws_connection_info
-  register: result
-- name: assert that changed is True
-  assert:
-    that:
-      - result.changed == True
-# ============================================================
-- name: test delete a nonexistent bucket
-  aws_s3:
-    bucket: "{{ bucket_name + '.bucket' }}"
-    mode: delete
-    <<: *aws_connection_info
-  register: result
-- name: assert that changed is False
-  assert:
-    that:
-      - result.changed == False
-# ============================================================
-- name: create a tempfile for the path
-  tempfile:
-  register: tmp1
-
-- name: make tempfile 4 GB for OSX
-  command:
-    _raw_params: "dd if=/dev/zero of={{ tmp1.path }} bs=1m count=4096"
-  when: ansible_distribution == 'MacOSX'
-
-- name: make tempfile 4 GB for linux
-  command:
-    _raw_params: "dd if=/dev/zero of={{ tmp1.path }} bs=1M count=4096"
-  when: ansible_distribution == 'Linux'
-
-- name: test multipart download - platform specific
-  block:
-    - name: make a bucket to upload the file
+- block:
+    - name: test create bucket
       aws_s3:
         bucket: "{{ bucket_name }}"
         mode: create
         <<: *aws_connection_info
+      register: result
+    - name: assert changed is True
+      assert:
+        that:
+          - result.changed == True
 
-    - name: upload the file to the bucket
+    - name: trying to create a bucket name that already exists
+      aws_s3:
+        bucket: "{{ bucket_name }}"
+        mode: create
+        <<: *aws_connection_info
+      register: result
+    - name: assert changed is False since the bucket already exists
+      assert:
+        that:
+          - result.changed == False
+
+    - name: create temporary file object to put in a bucket
+      tempfile:
+      register: tmp1
+    - name: make random contents
+      set_fact:
+          content: "{{ lookup('password', '/dev/null chars=ascii_letters,digits,hexdigits,punctuation') }}"
+
+    - name: give temporary file data
+      copy:
+        content: "{{ content }}"
+        dest: "{{ tmp1.path }}"
+    - name: get the stat of the file
+      stat:
+        path: "{{ tmp1.path }}"
+        get_checksum: yes
+      register: file1stat
+
+    - name: test putting an object in the bucket
       aws_s3:
         bucket: "{{ bucket_name }}"
         mode: put
         src: "{{ tmp1.path }}"
-        object: multipart.txt
-        <<: *aws_connection_info
-
-    - name: download file once
-      aws_s3:
-        bucket: "{{ bucket_name }}"
-        mode: get
-        dest: /tmp/multipart_download.txt
-        object: multipart.txt
-        overwrite: different
+        object: delete.txt
         <<: *aws_connection_info
       retries: 3
       delay: 3
-      until: "result.msg == 'GET operation complete'"
       register: result
-
-    - name: assert the file was downloaded once
+    - name: assert object exists
       assert:
         that:
-          - result.changed
+          - result.changed == True
+          - result.msg == "PUT operation complete"
 
-    - name: download file again
+    - name: check that roles file lookups work as expected
+      aws_s3:
+        bucket: "{{ bucket_name }}"
+        mode: put
+        src: hello.txt
+        object: hello.txt
+        <<: *aws_connection_info
+      retries: 3
+      delay: 3
+      register: result
+    - name: assert object exists
+      assert:
+        that:
+          - result.changed == True
+          - result.msg == "PUT operation complete"
+    - name: remove hello.txt (deletion tests are later)
+      aws_s3:
+        bucket: "{{ bucket_name }}"
+        mode: delobj
+        object: hello.txt
+        <<: *aws_connection_info
+      retries: 3
+      delay: 3
+      register: result
+
+    - name: create a second temp file to download the object from the bucket
+      tempfile:
+      register: tmp2
+
+    - name: test get object
       aws_s3:
         bucket: "{{ bucket_name }}"
         mode: get
-        dest: /tmp/multipart_download.txt
-        object: multipart.txt
-        overwrite: different
+        dest: "{{ tmp2.path }}"
+        object: delete.txt
         <<: *aws_connection_info
+      retries: 3
+      delay: 3
       register: result
-
-    - name: assert the file was not redownloaded
+      until: "result.msg == 'GET operation complete'"
+    - name: get the stat of the file so we can compare the checksums
+      stat:
+        path: "{{ tmp2.path }}"
+        get_checksum: yes
+      register: file2stat
+    - name: assert checksums are the same
       assert:
         that:
-          - not result.changed
+          - file1stat.stat.checksum == file2stat.stat.checksum
 
-    - name: delete file used for upload
+    - name: test geturl of the object
+      aws_s3:
+        bucket: "{{ bucket_name }}"
+        mode: geturl
+        object: delete.txt
+        <<: *aws_connection_info
+      retries: 3
+      delay: 3
+      register: result
+      until: result.changed
+    - name: assert we have the object's url
+      assert:
+        that:
+          - "'Download url:' in result.msg"
+          - result.changed == True
+
+    - name: test getstr of the object
+      aws_s3:
+        bucket: "{{ bucket_name }}"
+        mode: getstr
+        object: delete.txt
+        <<: *aws_connection_info
+      retries: 3
+      delay: 3
+      register: result
+    - name: assert that we have the object's contents
+      assert:
+        that:
+          - result.msg == "GET operation complete"
+          - result.contents == content
+
+    - name: test list to get all objects in the bucket
+      aws_s3:
+        bucket: "{{ bucket_name }}"
+        mode: list
+        <<: *aws_connection_info
+      retries: 3
+      delay: 3
+      register: result
+    - name: assert that the keys are correct
+      assert:
+        that:
+          - "'delete.txt' in result.s3_keys"
+          - result.msg == "LIST operation complete"
+
+    - name: test delobj to just delete an object in the bucket
+      aws_s3:
+        bucket: "{{ bucket_name }}"
+        mode: delobj
+        object: delete.txt
+        <<: *aws_connection_info
+      retries: 3
+      delay: 3
+      register: result
+    - name: assert that delete.txt is no longer an object in the bucket deleteme
+      assert:
+        that:
+          - "'Object deleted from bucket' in result.msg"
+          - result.changed == True
+    - name: assert that delete.txt is no longer an object in the bucket deleteme
+      assert:
+        that:
+          - "'Object deleted from bucket' in result.msg"
+          - result.changed == True
+    - name: clean up temp file
+      file:
+        path: "{{ tmp2.path }}"
+        state: absent
+
+    - name: test putting an encrypted object in the bucket
+      aws_s3:
+        bucket: "{{ bucket_name }}"
+        mode: put
+        src: "{{ tmp1.path }}"
+        encrypt: yes
+        object: delete_encrypt.txt
+        <<: *aws_connection_info
+      retries: 3
+      delay: 3
+      register: result
+    - name: assert object exists
+      assert:
+        that:
+          - result.changed == True
+          - result.msg == "PUT operation complete"
+
+    - name: create a second temp file to download the object from the bucket
+      tempfile:
+      register: tmp2
+    - name: test get encrypted object
+      aws_s3:
+        bucket: "{{ bucket_name }}"
+        mode: get
+        dest: "{{ tmp2.path }}"
+        object: delete_encrypt.txt
+        <<: *aws_connection_info
+      retries: 3
+      delay: 3
+      register: result
+      until: "result.msg == 'GET operation complete'"
+    - name: get the stat of the file so we can compare the checksums
+      stat:
+        path: "{{ tmp2.path }}"
+        get_checksum: yes
+      register: file2stat
+    - name: assert checksums are the same
+      assert:
+        that:
+          - file1stat.stat.checksum == file2stat.stat.checksum
+    - name: delete encrypted file
+      aws_s3:
+        bucket: "{{ bucket_name }}"
+        mode: delobj
+        object: delete_encrypt.txt
+        <<: *aws_connection_info
+      retries: 3
+      delay: 3
+    - name: clean up temp file
+      file:
+        path: "{{ tmp2.path }}"
+        state: absent
+
+    - name: test putting an aws:kms encrypted object in the bucket
+      aws_s3:
+        bucket: "{{ bucket_name }}"
+        mode: put
+        src: "{{ tmp1.path }}"
+        encrypt: yes
+        encryption_mode: aws:kms
+        object: delete_encrypt_kms.txt
+        <<: *aws_connection_info
+      retries: 3
+      delay: 3
+      register: result
+    - name: assert object exists
+      assert:
+        that:
+          - result.changed == True
+          - result.msg == "PUT operation complete"
+
+    - name: create a second temp file to download the object from the bucket
+      tempfile:
+      register: tmp2
+    - name: test get KMS encrypted object
+      aws_s3:
+        bucket: "{{ bucket_name }}"
+        mode: get
+        dest: "{{ tmp2.path }}"
+        object: delete_encrypt_kms.txt
+        <<: *aws_connection_info
+      retries: 3
+      delay: 3
+      register: result
+      until: "result.msg == 'GET operation complete'"
+    - name: get the stat of the file so we can compare the checksums
+      stat:
+        path: "{{ tmp2.path }}"
+        get_checksum: yes
+      register: file2stat
+    - name: assert checksums are the same
+      assert:
+        that:
+          - file1stat.stat.checksum == file2stat.stat.checksum
+    - name: delete KMS encrypted file
+      aws_s3:
+        bucket: "{{ bucket_name }}"
+        mode: delobj
+        object: delete_encrypt_kms.txt
+        <<: *aws_connection_info
+      retries: 3
+      delay: 3
+    - name: clean up temp file
+      file:
+        path: "{{ tmp2.path }}"
+        state: absent
+
+    - name: test creation of empty path
+      aws_s3:
+        bucket: "{{ bucket_name }}"
+        mode: create
+        object: foo/bar/baz/
+        <<: *aws_connection_info
+      retries: 3
+      delay: 3
+      register: result
+    - name: assert that empty path is created
+      assert:
+        that:
+          - "'Virtual directory foo/bar/baz/ created' in result.msg"
+          - result.changed == True
+    - name: test deletion of empty path
+      aws_s3:
+        bucket: "{{ bucket_name }}"
+        mode: delobj
+        object: foo/bar/baz/
+        <<: *aws_connection_info
+      retries: 3
+      delay: 3
+
+    - name: test delete bucket
+      aws_s3:
+        bucket: "{{ bucket_name }}"
+        mode: delete
+        <<: *aws_connection_info
+      register: result
+      retries: 3
+      delay: 3
+      until: result.changed
+    - name: assert that changed is True
+      assert:
+        that:
+          - result.changed == True
+
+    - name: test create a bucket with a dot in the name
+      aws_s3:
+        bucket: "{{ bucket_name + '.bucket' }}"
+        mode: create
+        <<: *aws_connection_info
+      register: result
+    - name: assert that changed is True
+      assert:
+        that:
+          - result.changed == True
+
+    - name: test delete a bucket with a dot in the name
+      aws_s3:
+        bucket: "{{ bucket_name + '.bucket' }}"
+        mode: delete
+        <<: *aws_connection_info
+      register: result
+    - name: assert that changed is True
+      assert:
+        that:
+          - result.changed == True
+
+    - name: test delete a nonexistent bucket
+      aws_s3:
+        bucket: "{{ bucket_name + '.bucket' }}"
+        mode: delete
+        <<: *aws_connection_info
+      register: result
+    - name: assert that changed is False
+      assert:
+        that:
+          - result.changed == False
+
+    - name: show ansible distribution
+      debug:
+        var: ansible_distribution
+
+    - name: make tempfile 4 GB for OSX
+      command:
+        _raw_params: "dd if=/dev/zero of={{ tmp1.path }} bs=1m count=4096"
+      when: ansible_distribution == 'MacOSX'
+
+    - name: make tempfile 4 GB for linux
+      command:
+        _raw_params: "dd if=/dev/zero of={{ tmp1.path }} bs=1M count=4096"
+      when: ansible_distribution == 'Linux'
+
+    - name: test multipart download - platform specific
+      block:
+        - name: make a bucket to upload the file
+          aws_s3:
+            bucket: "{{ bucket_name }}"
+            mode: create
+            <<: *aws_connection_info
+
+        - name: upload the file to the bucket
+          aws_s3:
+            bucket: "{{ bucket_name }}"
+            mode: put
+            src: "{{ tmp1.path }}"
+            object: multipart.txt
+            <<: *aws_connection_info
+
+        - name: download file once
+          aws_s3:
+            bucket: "{{ bucket_name }}"
+            mode: get
+            dest: "{{ tmp2.path }}"
+            object: multipart.txt
+            overwrite: different
+            <<: *aws_connection_info
+          retries: 3
+          delay: 3
+          until: "result.msg == 'GET operation complete'"
+          register: result
+
+        - name: assert the file was downloaded once
+          assert:
+            that:
+              - result.changed
+
+        - name: download file again
+          aws_s3:
+            bucket: "{{ bucket_name }}"
+            mode: get
+            dest: "{{ tmp2.path }}"
+            object: multipart.txt
+            overwrite: different
+            <<: *aws_connection_info
+          register: result
+
+        - name: assert the file was not redownloaded
+          assert:
+            that:
+              - not result.changed
+      when: ansible_distribution in ['MacOSX', 'Linux']
+
+  always:
+    ###### TEARDOWN STARTS HERE ######
+
+    - name: remove uploaded files
+      aws_s3:
+        bucket: "{{ bucket_name }}"
+        mode: delobj
+        object: "{{ item }}"
+        <<: *aws_connection_info
+      with_items:
+        - hello.txt
+        - delete.txt
+        - delete_encrypt.txt
+        - delete_encrypt_kms.txt
+      ignore_errors: yes
+
+    - name: delete temporary file 1
       file:
         state: absent
         path: "{{ tmp1.path }}"
+      ignore_errors: yes
 
-    - name: delete downloaded file
+    - name: delete temporary file 2
       file:
         state: absent
-        path: /tmp/multipart_download.txt
+        path: "{{ tmp2.path }}"
+      ignore_errors: yes
 
     - name: delete the bucket
       aws_s3:
         bucket: "{{ bucket_name }}"
         mode: delete
         <<: *aws_connection_info
-
-  when: ansible_distribution in ['MacOSX', 'Linux']
-# ============================================================
+      ignore_errors: yes


### PR DESCRIPTION
##### SUMMARY
Add S3 encryption improvements:

* Allow KMS to be used for SSE
* Allow non-standard KMS key to be used for SSE

Fixed skipped multipart tests, added various encryption tests (not as many as I'd like due to the lack of an aws_s3_object_facts module)

Reformatted the S3 test tasks file to look a lot more like all the others and hopefully more readable. If it's not more readable let me know and I can revert that bit of the change

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
aws_s3

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (devel 86c62e228d) last updated 2018/02/06 10:26:32 (GMT +1000)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/will/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/will/src/ansible/lib/ansible
  executable location = /home/will/src/ansible/bin/ansible
  python version = 2.7.14 (default, Jan 17 2018, 14:28:32) [GCC 7.2.1 20170915 (Red Hat 7.2.1-2)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
