### PR TITLE
False matches the docs and intentions of the previous developer

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_service.py
@@ -686,7 +686,7 @@ class ContainerManager(DockerBaseClass):
 
         up_options = {
             u'--no-recreate': False,
-            u'--build': True,
+            u'--build': False,
             u'--no-build': False,
             u'--no-deps': False,
             u'--force-recreate': False,


### PR DESCRIPTION
##### SUMMARY
This changes the behaviour to match the docs and intentions of the previous developer. The cmd_build() function was added to give more control over the builds.  It should be off in the compose module when up() is called or it will build every time, and sometimes twice.  It looks like a typo.

I didn't seen an open issue for this, but I could have missed it.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
docker_service.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.3.0
  config file = /home/ubuntu/.ansible.cfg
  configured module search path = ['/home/ubuntu/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/ubuntu/ansible/venv/lib/python3.6/site-packages/ansible
  executable location = /home/ubuntu/ansible/venv/bin/ansible
  python version = 3.6.3 (default, Oct  3 2017, 21:45:48) [GCC 7.2.0]

```


##### ADDITIONAL INFORMATION
 - name: run thingy
      docker_service:
        project_src: .
        build: no
        state: present
        pull: yes
        stopped: no
        debug: yes

version: '3.4'
services:
  thingy:
    build:
      context: .
      dockerfile: Dockerfile
    image: ubuntu:rolling
    command: /bin/echo 'hello world'
    
Send this to an otherwise empty system and it will try to build on up().  Then it will die because it can't find the Dockerfile.  When the bool is swapped, it works as documented. 

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
Error starting project 500 Server Error: Internal Server Error (\"Cannot locate specified Dockerfile: Dockerfile\")

The full traceback is:
  File "/tmp/ansible_hcjykgrb/ansible_module_docker_service.py", line 746, in cmd_up
    timeout=self.timeout)
  File "/usr/local/lib/python3.6/dist-packages/compose/project.py", line 453, in up
    svc.ensure_image_exists(do_build=do_build)
  File "/usr/local/lib/python3.6/dist-packages/compose/service.py", line 308, in ensure_image_exists
    self.build()
  File "/usr/local/lib/python3.6/dist-packages/compose/service.py", line 972, in build
    all_events = stream_output(build_output, sys.stdout)
  File "/usr/local/lib/python3.6/dist-packages/compose/progress_stream.py", line 18, in stream_output
    for event in utils.json_stream(output):
  File "/usr/local/lib/python3.6/dist-packages/compose/utils.py", line 61, in split_buffer
    for data in stream_as_text(stream):
  File "/usr/local/lib/python3.6/dist-packages/compose/utils.py", line 37, in stream_as_text
    for data in stream:
  File "/usr/local/lib/python3.6/dist-packages/docker/api/client.py", line 313, in _stream_helper
    yield self._result(response, json=decode)
  File "/usr/local/lib/python3.6/dist-packages/docker/api/client.py", line 228, in _result
    self._raise_for_status(response)
  File "/usr/local/lib/python3.6/dist-packages/docker/api/client.py", line 224, in _raise_for_status
    raise create_api_error_from_http_exception(e)
  File "/usr/local/lib/python3.6/dist-packages/docker/errors.py", line 31, in create_api_error_from_http_exception
    raise cls(e, response=response, explanation=explanation)

```
