### PR TITLE
Allow filtering of instances by tags in GCE dynamic inventory

### DIFF
--- a/contrib/inventory/gce.ini
+++ b/contrib/inventory/gce.ini
@@ -46,9 +46,13 @@ gce_service_account_pem_file_path =
 gce_project_id =
 gce_zone =
 
-# Filter inventory based on on state. Leave undefined to return instances regardless of state.
+# Filter inventory based on state. Leave undefined to return instances regardless of state.
 # example: Uncomment to only return inventory in the running or provisioning state
 #instance_states = RUNNING,PROVISIONING
+
+# Filter inventory based on instance tags. Leave undefined to return instances regardless of tags.
+# example: Uncomment to only return inventory with the http-server or https-server tag
+#instance_tags = http-server,https-server
 
 
 [inventory]

--- a/contrib/inventory/gce.py
+++ b/contrib/inventory/gce.py
@@ -253,8 +253,8 @@ class GceInventory(object):
         if self.args.instance_tags:
             self.instance_tags = self.args.instance_tags
         else:
-            self.instance_tags = os.environ.get('GCE_INSTANCE_TAGS',
-                    config.get('gce', 'instance_tags'))
+            self.instance_tags = os.environ.get(
+                'GCE_INSTANCE_TAGS', config.get('gce', 'instance_tags'))
         if self.instance_tags:
             self.instance_tags = self.instance_tags.split(',')
 

--- a/contrib/inventory/gce.py
+++ b/contrib/inventory/gce.py
@@ -222,6 +222,7 @@ class GceInventory(object):
             'gce_project_id': '',
             'gce_zone': '',
             'libcloud_secrets': '',
+            'instance_tags': '',
             'inventory_ip_type': '',
             'cache_path': '~/.ansible/tmp',
             'cache_max_age': '300'
@@ -247,19 +248,15 @@ class GceInventory(object):
             if states:
                 self.instance_states = states.split(',')
 
-        # Set the instance_tags filter
-        self.instance_tags = []
-        if config.has_option('gce', 'instance_tags'):
-            tags = config.get('gce', 'instance_tags')
-            # Ignore if instance_tags is an empty string.
-            if tags:
-                self.instance_tags = tags.split(',')
-        # Env var overrides config from file
-        if os.environ.get('GCE_INSTANCE_TAGS'):
-            self.instance_tags = os.environ.get('GCE_INSTANCE_TAGS').split(',')
-        # Cli param overrides both config and env var
+        # Set the instance_tags filter, env var overrides config from file
+        # and cli param overrides all
         if self.args.instance_tags:
-            self.instance_tags = self.args.instance_tags.split(',')
+            self.instance_tags = self.args.instance_tags
+        else:
+            self.instance_tags = os.environ.get('GCE_INSTANCE_TAGS',
+                    config.get('gce', 'instance_tags'))
+        if self.instance_tags:
+            self.instance_tags = self.instance_tags.split(',')
 
         # Caching
         cache_path = config.get('cache', 'cache_path')


### PR DESCRIPTION
##### SUMMARY
This enables to exclude instances in the project not relevant to the play, what benefits performance and can help to avoid mistakes.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
GCE dynamic inventory

##### ANSIBLE VERSION
```
ansible 2.4.2.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/pschiffe/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.14 (default, Jan 17 2018, 14:28:32) [GCC 7.2.1 20170915 (Red Hat 7.2.1-2)]
```

/cc @smarterclayton