### PR TITLE
remove new tmp var for localhost

### DIFF
--- a/lib/ansible/inventory/data.py
+++ b/lib/ansible/inventory/data.py
@@ -97,7 +97,6 @@ class InventoryData(object):
                                 'You can correct this by setting ansible_python_interpreter for localhost')
             new_host.set_variable("ansible_python_interpreter", py_interp)
             new_host.set_variable("ansible_connection", 'local')
-            new_host.set_variable("ansible_remote_tmp", C.DEFAULT_LOCAL_TMP)
 
             self.localhost = new_host
 


### PR DESCRIPTION
##### SUMMARY
this was causing issues with keep remote files as the 'local cleanup' would trump the setting.
it will revert back to using the 'remote path' setti.ng for 'localhost' actions.

fixes #35724


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
inventory

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```