### PR TITLE
Use set_options for lookup plugins by default

### DIFF
--- a/lib/ansible/plugins/lookup/aws_account_attribute.py
+++ b/lib/ansible/plugins/lookup/aws_account_attribute.py
@@ -84,26 +84,17 @@ def _boto3_conn(region, credentials):
     return connection
 
 
-def _get_credentials(options):
-    credentials = {}
-    credentials['aws_profile'] = options['aws_profile']
-    credentials['aws_secret_access_key'] = options['aws_secret_key']
-    credentials['aws_access_key_id'] = options['aws_access_key']
-    credentials['aws_session_token'] = options['aws_security_token']
-
-    return credentials
-
-
 class LookupModule(LookupBase):
-    def run(self, terms, variables, **kwargs):
+    def run(self, terms, variables, attribute=None, region=None, aws_profile=None, aws_access_key=None, aws_secret_key=None, aws_security_token=None, **kwargs):
+        boto_credentials = {
+            'aws_profile': aws_profile,
+            'aws_secret_access_key': aws_secret_key,
+            'aws_access_key_id': aws_access_key,
+            'aws_session_token': aws_security_token
+        }
 
-        self.set_options(var_options=variables, direct=kwargs)
-        boto_credentials = _get_credentials(self._options)
-
-        region = self._options['region']
         client = _boto3_conn(region, boto_credentials)
 
-        attribute = kwargs.get('attribute')
         params = {'AttributeNames': []}
         check_ec2_classic = False
         if 'has-ec2-classic' == attribute:

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -621,7 +621,7 @@ class Templar:
             # safely catch run failures per #5059
             try:
                 instance.set_options(var_options=self._available_variables, direct=kwargs)
-                ran = instance.run(loop_terms, variables=self._available_variables, **kwargs)
+                ran = instance.run(loop_terms, variables=self._available_variables, **instance._options)
             except (AnsibleUndefinedVariable, UndefinedError) as e:
                 raise AnsibleUndefinedVariable(e)
             except Exception as e:

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -620,6 +620,7 @@ class Templar:
             loop_terms = listify_lookup_plugin_terms(terms=args, templar=self, loader=self._loader, fail_on_undefined=True, convert_bare=False)
             # safely catch run failures per #5059
             try:
+                instance.set_options(var_options=self._available_variables, direct=kwargs)
                 ran = instance.run(loop_terms, variables=self._available_variables, **kwargs)
             except (AnsibleUndefinedVariable, UndefinedError) as e:
                 raise AnsibleUndefinedVariable(e)

--- a/test/units/plugins/lookup/test_set_options.py
+++ b/test/units/plugins/lookup/test_set_options.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import pytest
+from ansible.plugins.loader import lookup_loader
+from ansible.template import Templar
+from units.mock.loader import DictDataLoader
+
+fake_loader = DictDataLoader()
+templar = Templar(loader=fake_loader, variables={})
+
+def test_env_var_overrides_omission(monkeypatch):
+    user_arguments = {'attribute': 'has-ec2-classic', 'region': 'us-east-1'}
+    instance = lookup_loader.get('aws_account_attribute', fake_loader, templar)
+    monkeypatch.setenv('AWS_PROFILE', 'env_test_profile')
+    instance.set_options(direct=user_arguments)
+
+    assert instance.get_option('aws_profile') == 'env_test_profile'
+    assert len(instance._options) == 6
+
+def test_env_var_precedence(monkeypatch):
+    user_arguments = {'attribute': 'has-ec2-classic', 'region': 'us-east-2'}
+    instance = lookup_loader.get('aws_account_attribute', fake_loader, templar)
+    monkeypatch.setenv('AWS_REGION', 'us-east-1')
+    instance.set_options(direct=user_arguments)
+
+    assert instance.get_option('region') == 'us-east-2'
+    assert len(instance._options) == 6
+
+def test_all_options_available(monkeypatch):
+    user_arguments = {}
+    instance = lookup_loader.get('aws_account_attribute', fake_loader, templar)
+    instance.set_options(direct=user_arguments)
+
+    assert instance._options == dict.fromkeys(['attribute', 'aws_profile', 'aws_access_key',
+                                               'aws_secret_key', 'aws_security_token', 'region'])


### PR DESCRIPTION
##### SUMMARY
Use set_options for lookup plugins by default. set_options uses the omission of kwargs to get fallback values (environment vars or in config). Setting key word arguments to default values in run() breaks it because it isn't clear if the user wanted an_option=None or False, or if that was the default. Since `LookupModule.run(terms, variables, **kwargs)` is being discouraged in lookup plugins, this allows the options to still use the fallback by calling set_options before run().

##### ISSUE TYPE
 - Feature Pull Request
 - New Module Pull Request
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
lib/ansible/template/__init__.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5.0
```
