### PR TITLE
Adding Redshift IAM Roles module + tests

### DIFF
--- a/lib/ansible/modules/cloud/amazon/redshift_iam_roles.py
+++ b/lib/ansible/modules/cloud/amazon/redshift_iam_roles.py
@@ -97,7 +97,7 @@ def main():
 
     region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
     conn = boto3_conn(module, conn_type='client', resource='redshift',
-                        region=region, endpoint=ec2_url, **aws_connect_params)
+                        region=region, endpoint=ec2_url, **aws_connect_kwargs)
 
     cluster_roles = conn.describe_clusters(ClusterIdentifier=target_cluster)['Clusters'][0]['IamRoles']
     current_roles = [x['IamRoleArn'] for x in cluster_roles]

--- a/lib/ansible/modules/cloud/amazon/redshift_iam_roles.py
+++ b/lib/ansible/modules/cloud/amazon/redshift_iam_roles.py
@@ -60,8 +60,7 @@ EXAMPLES = '''
 RETURN = ''' # '''
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.ec2 import boto3_conn, ec2_argument_spec, get_aws_connection_info
-from ansible.module_utils.ec2 import ec2_argument_spec, camel_dict_to_snake_dict, HAS_BOTO3
+from ansible.module_utils.ec2 import boto3_conn, ec2_argument_spec, get_aws_connection_info, camel_dict_to_snake_dict, HAS_BOTO3
 import traceback
 
 try:
@@ -74,9 +73,9 @@ def main():
     argument_spec = ec2_argument_spec()
     argument_spec.update(
         dict(
-            cluster=dict(type='str', required=True, aliases=['cluster_name']),
-            state=dict(type='str', required=True, choices=['present', 'absent'], default='present'),
-            roles=dict(type='list', required=True, default=[])
+            cluster=dict(type='str', required=True),
+            state=dict(type='str', required=True, choices=['present', 'absent']),
+            roles=dict(type='list', required=True)
         )
     )
 
@@ -98,7 +97,7 @@ def main():
 
     region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
     conn = boto3_conn(module, conn_type='client', resource='redshift',
-                            region=region, endpoint=ec2_url, **aws_connect_params)
+                        region=region, endpoint=ec2_url, **aws_connect_params)
 
     cluster_roles = conn.describe_clusters(ClusterIdentifier=target_cluster)['Clusters'][0]['IamRoles']
     current_roles = [x['IamRoleArn'] for x in cluster_roles]

--- a/lib/ansible/modules/cloud/amazon/redshift_iam_roles.py
+++ b/lib/ansible/modules/cloud/amazon/redshift_iam_roles.py
@@ -99,8 +99,7 @@ def main():
     }
 
     region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
-    conn = boto3_conn(module, conn_type='client', resource='redshift',
-                        region=region, endpoint=ec2_url, **aws_connect_kwargs)
+    conn = boto3_conn(module, conn_type='client', resource='redshift', region=region, endpoint=ec2_url, **aws_connect_kwargs)
 
     cluster_roles = conn.describe_clusters(ClusterIdentifier=target_cluster)['Clusters'][0]['IamRoles']
     current_roles = [x['IamRoleArn'] for x in cluster_roles]

--- a/lib/ansible/modules/cloud/amazon/redshift_iam_roles.py
+++ b/lib/ansible/modules/cloud/amazon/redshift_iam_roles.py
@@ -23,7 +23,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = '''
 module: redshift_iam_roles
 short_description: This module adds/removes IAM roles to/from Redshift clusters.
-version_added: 2.5
+version_added: 2.6
 author: Aaron Smith (@slapula)
 description:
     - "This module adds or removes a list of IAM roles to a give Redshift Cluster"
@@ -36,6 +36,7 @@ options:
         description:
             - "Desired state of the list of IAM roles on the give Redshift cluster"
         required: true
+        choices: ['present', 'absent']
     roles:
         description:
             - "This is a list of IAM roles (Full ARN) to add to the Redshift cluster. Roles attached to the cluster that are not on the list will be removed."

--- a/lib/ansible/modules/cloud/amazon/redshift_iam_roles.py
+++ b/lib/ansible/modules/cloud/amazon/redshift_iam_roles.py
@@ -1,0 +1,120 @@
+#!/usr/bin/python
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+module: redshift_iam_roles
+short_description: This module adds/removes IAM roles to/from Redshift clusters.
+version_added: 2.4
+description:
+    - "This module adds or removes a list of IAM roles to a give Redshift Cluster"
+options:
+    cluster:
+        description:
+            - "This is the cluster you'd like to modify"
+        required: true
+    state:
+        description:
+            - "Desired state of the list of IAM roles on the give Redshift cluster"
+        required: true
+    roles:
+        description:
+            - "This is a list of IAM roles (Full ARN) to add to a given Redshift cluster.  Roles attached to the cluster that are not on the list will be removed."
+        required: true
+'''
+
+EXAMPLES = '''
+- name: add IAM roles to a redshift cluster
+  redshift_iam_roles:
+    cluster: "staging"
+    state: present
+    roles:
+        - "arn:aws:iam::123456789012:role/superuser"
+        - "arn:aws:iam::123456789012:role/new_hotness"
+
+- name: remove all IAM roles from a redshift cluster
+  redshift_iam_roles:
+    cluster: "staging"
+    state: absent
+'''
+
+RETURN = ''' # '''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.ec2 import ec2_argument_spec, camel_dict_to_snake_dict, HAS_BOTO3
+import boto3
+import traceback
+
+try:
+    from botocore.exceptions import ClientError, BotoCoreError
+except ImportError:
+    pass  # will be detected by imported HAS_BOTO3
+
+def main():
+    client = boto3.client('redshift')
+
+    argument_spec = ec2_argument_spec()
+    argument_spec.update(
+        dict(
+            cluster=dict(type='str', required=True, aliases=['cluster_name']),
+            state=dict(type='str', required=True, choices=['present', 'absent'], default='present'),
+            roles=dict(type='list', required=True, default=[])
+        )
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True
+    )
+
+    if not HAS_BOTO3:
+        module.fail_json(msg='boto3 required for this module')
+
+    target_cluster = module.params.get('cluster')
+    desired_state = module.params.get('state')
+    target_roles = module.params.get('roles')
+
+    result = {
+        'changed': False
+    }
+
+    cluster_roles = client.describe_clusters(ClusterIdentifier=target_cluster)['Clusters'][0]['IamRoles']
+    current_roles = [x['IamRoleArn'] for x in cluster_roles]
+
+    if desired_state == 'present':
+        roles_to_add = list(set(target_roles) - set(current_roles))
+        roles_to_remove = list(set(current_roles) - set(target_roles))
+        if not definitive_roles:
+            module.exit_json(**result)
+        try:
+            response = client.modify_cluster_iam_roles(
+                ClusterIdentifier=target_cluster,
+                AddIamRoles=roles_to_add,
+                RemoveIamRoles=roles_to_remove
+            )
+            result['changed'] = True
+        except:
+            module.fail_json(msg="Unable to modify IAM role(s): {0}".format(e),
+                             exception=traceback.format_exc(), **camel_dict_to_snake_dict(e.response))
+
+    if desired_state == 'absent':
+        if not matching_roles:
+            module.exit_json(**result)
+        try:
+            response = client.modify_cluster_iam_roles(
+                ClusterIdentifier=target_cluster,
+                RemoveIamRoles=current_roles
+            )
+            result['changed'] = True
+        except:
+            module.fail_json(msg="Unable to modify IAM role(s): {0}".format(e),
+                             exception=traceback.format_exc(), **camel_dict_to_snake_dict(e.response))
+
+    module.exit_json(**result)
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/cloud/amazon/redshift_iam_roles.py
+++ b/lib/ansible/modules/cloud/amazon/redshift_iam_roles.py
@@ -40,6 +40,9 @@ options:
         description:
             - "This is a list of IAM roles (Full ARN) to add to the Redshift cluster. Roles attached to the cluster that are not on the list will be removed."
         required: true
+extends_documentation_fragment:
+    - ec2
+    - aws
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/cloud/amazon/redshift_iam_roles.py
+++ b/lib/ansible/modules/cloud/amazon/redshift_iam_roles.py
@@ -106,7 +106,7 @@ def main():
     if desired_state == 'present':
         roles_to_add = list(set(target_roles) - set(current_roles))
         roles_to_remove = list(set(current_roles) - set(target_roles))
-        if not definitive_roles:
+        if not roles_to_add:
             module.exit_json(**result)
         try:
             response = conn.modify_cluster_iam_roles(
@@ -115,12 +115,12 @@ def main():
                 RemoveIamRoles=roles_to_remove
             )
             result['changed'] = True
-        except:
+        except Exception as e:
             module.fail_json(msg="Unable to modify IAM role(s): {0}".format(e),
                              exception=traceback.format_exc(), **camel_dict_to_snake_dict(e.response))
 
     if desired_state == 'absent':
-        if not matching_roles:
+        if not current_roles:
             module.exit_json(**result)
         try:
             response = conn.modify_cluster_iam_roles(
@@ -128,7 +128,7 @@ def main():
                 RemoveIamRoles=current_roles
             )
             result['changed'] = True
-        except:
+        except Exception as e:
             module.fail_json(msg="Unable to modify IAM role(s): {0}".format(e),
                              exception=traceback.format_exc(), **camel_dict_to_snake_dict(e.response))
 

--- a/lib/ansible/modules/cloud/amazon/redshift_iam_roles.py
+++ b/lib/ansible/modules/cloud/amazon/redshift_iam_roles.py
@@ -65,7 +65,7 @@ EXAMPLES = '''
 
 RETURN = ''' # '''
 
-from ansible.module_utils.basic import AnsibleAWSModule
+from ansible.module_utils.aws.core import AnsibleAWSModule
 from ansible.module_utils.ec2 import boto3_conn, ec2_argument_spec, get_aws_connection_info, camel_dict_to_snake_dict, HAS_BOTO3
 import traceback
 
@@ -108,7 +108,7 @@ def main():
     cluster_roles = conn.describe_clusters(ClusterIdentifier=target_cluster)['Clusters'][0]['IamRoles']
     current_roles = [x['IamRoleArn'] for x in cluster_roles]
 
-    if purge_roles == True:
+    if module.params.get('purge_roles') is True:
         if desired_state or target_roles:
             module.fail_json_aws(msg="Unable to modify IAM role(s)")
         if not current_roles:

--- a/test/units/modules/cloud/amazon/test_redshift_iam_roles.py
+++ b/test/units/modules/cloud/amazon/test_redshift_iam_roles.py
@@ -9,6 +9,7 @@ from ansible.modules.cloud.amazon import redshift_iam_roles
 if not HAS_BOTO3:
     pytestmark = pytest.mark.skip("test_redshift_role.py requires the `boto3` and `botocore` modules")
 
+
 def test_warn_if_cluster_not_specified():
     set_module_args({
         "state": "present",
@@ -18,6 +19,7 @@ def test_warn_if_cluster_not_specified():
     })
     with pytest.raises(SystemExit):
         print(redshift_iam_roles.main())
+
 
 def test_warn_if_state_not_specified():
     set_module_args({
@@ -29,6 +31,7 @@ def test_warn_if_state_not_specified():
     with pytest.raises(SystemExit):
         print(redshift_iam_roles.main())
 
+
 def test_warn_if_roles_not_specified_during_add():
     set_module_args({
         "cluster": "foobaz",
@@ -36,6 +39,7 @@ def test_warn_if_roles_not_specified_during_add():
     })
     with pytest.raises(SystemExit):
         print(redshift_iam_roles.main())
+
 
 def test_warn_if_state_not_valid():
     set_module_args({

--- a/test/units/modules/cloud/amazon/test_redshift_iam_roles.py
+++ b/test/units/modules/cloud/amazon/test_redshift_iam_roles.py
@@ -1,0 +1,49 @@
+
+import boto3
+import pytest
+
+from units.modules.utils import set_module_args
+from ansible.module_utils.ec2 import HAS_BOTO3
+from ansible.modules.cloud.amazon import redshift_iam_roles
+
+if not HAS_BOTO3:
+    pytestmark = pytest.mark.skip("test_redshift_role.py requires the `boto3` and `botocore` modules")
+
+def test_warn_if_cluster_not_specified():
+    set_module_args({
+        "state": "present",
+        "roles": [
+            "arn:aws:iam::123456789012:role/superuser"
+        ],
+    })
+    with pytest.raises(SystemExit):
+        print(redshift_iam_roles.main())
+
+def test_warn_if_state_not_specified():
+    set_module_args({
+        "cluster": "foobaz",
+        "roles": [
+            "arn:aws:iam::123456789012:role/superuser"
+        ],
+    })
+    with pytest.raises(SystemExit):
+        print(redshift_iam_roles.main())
+
+def test_warn_if_roles_not_specified_during_add():
+    set_module_args({
+        "cluster": "foobaz",
+        "state": "present"
+    })
+    with pytest.raises(SystemExit):
+        print(redshift_iam_roles.main())
+
+def test_warn_if_state_not_valid():
+    set_module_args({
+        "cluster": "foobaz",
+        "state": "boofaz",
+        "roles": [
+            "arn:aws:iam::123456789012:role/superuser"
+        ],
+    })
+    with pytest.raises(SystemExit):
+        print(redshift_iam_roles.main())


### PR DESCRIPTION
##### SUMMARY
[Modifying Redshift IAM roles using the CLI is not optimal](https://docs.aws.amazon.com/cli/latest/reference/redshift/modify-cluster-iam-roles.html) and I found the standard `redshift` module to be a bit cumbersome for this task.

To make managing Redshift IAM roles easier, I created this module to declare an IAM role state for a given Redshift cluster and execute based on that desired state.  With this module, you can provide a list of IAM roles to assign and the module will add those roles to the cluster (removing any that are not on that list).  On the other side of the coin, you can use this module to remove all IAM roles from the cluster by simply setting `state` to `absent`.  I believe the documentation is clear on how to use this module so I'll refer you to that if you are interested in learning more.

Any feedback would be much appreciated 😄 

##### ISSUE TYPE
 - New Module Pull Request

##### COMPONENT NAME
redshift_iam_roles

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (redshift_iam_roles_module d1da6cc522) last updated 2018/02/06 11:11:39 (GMT -500)
  config file = None
  configured module search path = [u'/Users/slapula/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/slapula/Github/ansible/lib/ansible
  executable location = /Users/slapula/Github/ansible/bin/ansible
  python version = 2.7.13 (default, Sep  8 2017, 15:16:38) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
