### PR TITLE
grafana_plugin - expect default value of `version` param as None

### DIFF
--- a/lib/ansible/modules/monitoring/grafana_plugin.py
+++ b/lib/ansible/modules/monitoring/grafana_plugin.py
@@ -154,7 +154,7 @@ def grafana_plugin(module, params):
                             'changed': False,
                             'version': grafana_plugin_version}
                 else:
-                    if params['version'] == 'latest':
+                    if params['version'] == 'latest' or params['version'] is None:
                         cmd = '{} update {}'.format(grafana_cli, params['name'])
                     else:
                         cmd = '{} install {} {}'.format(grafana_cli, params['name'], params['version'])
@@ -164,7 +164,7 @@ def grafana_plugin(module, params):
                         'version': grafana_plugin_version}
         else:
             if 'version' in params:
-                if params['version'] == 'latest':
+                if params['version'] == 'latest' or params['version'] is None:
                     cmd = '{} install {}'.format(grafana_cli, params['name'])
                 else:
                     cmd = '{} install {} {}'.format(grafana_cli, params['name'], params['version'])


### PR DESCRIPTION
##### SUMMARY
Documentation says that `version` parameter isn't required however when not specified it causes a runtime error because it isn't checked for `None` value where needed. This resolves that problem.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
grafana_plugin

##### ANSIBLE VERSION
```
ansible 2.4.2.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/paulfantom/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.14 (default, Dec 11 2017, 16:08:01) [GCC 7.2.1 20170915 (Red Hat 7.2.1-2)]

```


##### ADDITIONAL INFORMATION
Step-by-step reproduction:
1. Run grafana_plugin with minimal config:
```
  grafana_plugin:
    name: "raintank-worldping-app"
    state: present
```
2. Ansible errors with:
```
{"changed": false, "item": "raintank-worldping-app", "msg": "'/usr/sbin/grafana-cli plugins install raintank-worldping-app None' execution returned an error : [1] \nError: ✗ Could not find the version your looking for\n\nNAME:\n   Grafana cli plugins install - install <plugin id> <plugin version (optional)>\n\nUSAGE:\n   Grafana cli plugins install [arguments...]\n "}
```

After this patch everything runs smoothly.