### PR TITLE
hostname parameter should be host_name

### DIFF
--- a/lib/ansible/modules/network/vyos/vyos_system.py
+++ b/lib/ansible/modules/network/vyos/vyos_system.py
@@ -72,7 +72,7 @@ commands:
 EXAMPLES = """
 - name: configure hostname and domain-name
   vyos_system:
-    hostname: vyos01
+    host_name: vyos01
     domain_name: test.example.com
 
 - name: remove all configuration


### PR DESCRIPTION
##### SUMMARY
the hostname parameter is wrong.  It will throw an error: "Unsupported parameters for (vyos_system) module: hostname Supported parameters include: domain_name, domain_search, host, host_name, name_server, password, port, provider, ssh_keyfile, state, timeout, username"  It is supposed to be host_name.  Only the example for documentation seems to be wrong in the module.
##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
vyos_system

##### ANSIBLE VERSION
```
ansible 2.5.0
  config file = /home/vagrant/.ansible.cfg
  configured module search path = [u'/home/vagrant/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Aug  4 2017, 00:39:18) [GCC 4.8.5 20150623 (Red Hat 4.8.5-16)]
```


##### ADDITIONAL INFORMATION
N/A
