### PR TITLE
[WIP] Fixed conflict between uri and setup_influxdb

### DIFF
--- a/test/integration/targets/influxdb_user/aliases
+++ b/test/integration/targets/influxdb_user/aliases
@@ -1,4 +1,5 @@
 destructive
+posix/ci/group1
 skip/osx
 skip/freebsd
 skip/rhel

--- a/test/integration/targets/uri/tasks/main.yml
+++ b/test/integration/targets/uri/tasks/main.yml
@@ -88,6 +88,13 @@
     - "{{fail_checksum.results}}"
     - "{{fail.results}}"
 
+- name: ensure python modules for Older Python SNI verification are absent
+  pip:
+    name: "{{ item }}"
+    state: absent
+  with_items:
+    - ndg-httpsclient
+
 - name: test https fetch to a site with mismatched hostname and certificate
   uri:
     url: "https://{{ badssl_host }}/"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
@mattclay [disabled](https://github.com/ansible/ansible/pull/35315#issuecomment-361455791) `influxdb_user` tests because it is conflicting with `uri` tests.

I've found the issue: the problem was in the `ndg-httpsclient` python module: `setup_influxdb` role [installs it](https://github.com/ansible/ansible/pull/35315/files#diff-a4d3134661df7dac2fc19e4e0412d037R13).

`uri` tests expects that `ndg-httpsclient` module is absent. That's why the test [test https fetch to a site with mismatched hostname and certificate](https://github.com/ansible/ansible/compare/devel...ar7z1:35315-fix-conflict-between-uri-and-setup_influxdb?expand=1#diff-5cea9f78e13e3973accb48c690dc9403L91) doesn't fail, although it expected.

In this PR I've added cleanup code to `uri` tests and enabled `influxdb_user` tests.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
influxdb_user, uri

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```