### PR TITLE
GitHub webhook modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ Ansible Changes By Release
 * ec2_ami_find has been deprecated, use ec2_ami_facts.
 * panos_security_policy: Use panos_security_rule - the old module uses deprecated API calls
 * vsphere_guest is deprecated in Ansible 2.5 and will be removed in Ansible-2.9. Use vmware_guest module instead.
+* github_hooks is deprecated in Ansible 2.5. Use github_webhooks and
+  github_webhook_facts instead.
 
 See [Porting Guide](http://docs.ansible.com/ansible/devel/porting_guides.html) for more information
 

--- a/lib/ansible/modules/source_control/_github_hooks.py
+++ b/lib/ansible/modules/source_control/_github_hooks.py
@@ -7,16 +7,20 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'community'}
-
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['deprecated'],
+    'supported_by': 'community'
+}
 
 DOCUMENTATION = '''
 ---
 module: github_hooks
 short_description: Manages GitHub service hooks.
+deprecated:
+  removed_in: "2.9"
+  why: Replaced by more granular modules
+  alternative: Use M(github_webhook) and M(github_webhook_facts) instead.
 description:
      - Adds service hooks and removes service hooks that have an error status.
 version_added: "1.4"
@@ -92,7 +96,8 @@ def request(module, url, user, oauthkey, data='', method='GET'):
     headers = {
         'Authorization': 'Basic %s' % auth,
     }
-    response, info = fetch_url(module, url, headers=headers, data=data, method=method)
+    response, info = fetch_url(
+        module, url, headers=headers, data=data, method=method)
     return response, info
 
 
@@ -138,7 +143,8 @@ def _create(module, hookurl, oauthkey, repo, user, content_type):
         }
     }
     data = json.dumps(values)
-    response, info = request(module, url, user, oauthkey, data=data, method='POST')
+    response, info = request(
+        module, url, user, oauthkey, data=data, method='POST')
     if info['status'] != 200:
         return 0, '[]'
     else:
@@ -152,17 +158,15 @@ def _delete(module, oauthkey, repo, user, hookid):
 
 
 def main():
-    module = AnsibleModule(
-        argument_spec=dict(
-            action=dict(required=True, choices=['list', 'clean504', 'cleanall', 'create']),
-            hookurl=dict(required=False),
-            oauthkey=dict(required=True, no_log=True),
-            repo=dict(required=True),
-            user=dict(required=True),
-            validate_certs=dict(default='yes', type='bool'),
-            content_type=dict(default='json', choices=['json', 'form']),
-        )
-    )
+    module = AnsibleModule(argument_spec=dict(
+        action=dict(
+            required=True, choices=['list', 'clean504', 'cleanall', 'create']),
+        hookurl=dict(required=False),
+        oauthkey=dict(required=True, no_log=True),
+        repo=dict(required=True),
+        user=dict(required=True),
+        validate_certs=dict(default='yes', type='bool'),
+        content_type=dict(default='json', choices=['json', 'form']), ))
 
     action = module.params['action']
     hookurl = module.params['hookurl']
@@ -181,7 +185,8 @@ def main():
         (rc, out) = _cleanall(module, oauthkey, repo, user)
 
     if action == "create":
-        (rc, out) = _create(module, hookurl, oauthkey, repo, user, content_type)
+        (rc, out) = _create(module, hookurl, oauthkey, repo, user,
+                            content_type)
 
     if rc != 0:
         module.fail_json(msg="failed", result=out)

--- a/lib/ansible/modules/source_control/github_webhook.py
+++ b/lib/ansible/modules/source_control/github_webhook.py
@@ -1,0 +1,244 @@
+#!/usr/bin/python
+#
+# Copyright: (c) Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: github_webhook
+short_description: Manage Github webhooks
+version_added: "2.5"
+description:
+  - "Create and delete Github webhooks"
+requirements:
+  - "PyGithub >= 1.3.5"
+options:
+  repository:
+    description:
+      - Full name of the repository to configure a hook for
+    required: true
+  url:
+    description:
+      - URL to which payloads will be delivered
+    required: true
+  content_type:
+    description:
+      - The media type used to serialize the payloads
+    required: false
+    choices: [ form, json ]
+    default: form
+  secret:
+    description:
+      - The shared secret between Github and the payload URL.
+    required: false
+  insecure_ssl:
+    description:
+      - Skip SSL verification
+    required: false
+    default: false
+  events:
+    description:
+      - >
+        A list of Github events the hook is triggered for. Events are listed at
+        U(https://developer.github.com/v3/activity/events/types/). Required
+        unless C(state) is C(absent)
+    required: false
+  active:
+    description:
+      - Whether or not the hook is active
+    required: false
+    default: true
+  state:
+    description:
+      - Whether the hook should be present or absent
+    required: false
+    choices: [ absent, present ]
+    default: present
+  user:
+    description:
+      - User to authenticate to Github as
+    required: true
+  password:
+    description:
+      - Password to authenticate to Github with
+    required: false
+  token:
+    description:
+      - Token to authenticate to Github with
+    required: false
+  github_url:
+    description:
+      - Base URL of the github api
+    required: false
+    default: https://api.github.com
+
+author:
+  - "Chris St. Pierre (@stpierre)"
+'''
+
+EXAMPLES = '''
+# create a new webhook that triggers on push (password auth)
+- github_webhook:
+    repository: ansible/ansible
+    url: https://www.example.com/hooks/
+    events:
+      - push
+    user: "{{ github_user }}"
+    password: "{{ github_password }}"
+
+# create a new webhook in a github enterprise installation with
+# multiple event triggers (token auth)
+- github_webhook:
+    repository: myorg/myrepo
+    url: https://jenkins.example.com/ghprbhook/
+    content_type: json
+    secret: "{{ github_shared_secret }}"
+    insecure_ssl: True
+    events:
+      - issue_comment
+      - pull_request
+    user: "{{ github_user }}"
+    token: "{{ github_user_api_token }}"
+    github_url: https://github.example.com
+
+# delete a webhook (password auth)
+- github_webhook:
+    repository: ansible/ansible
+    url: https://www.example.com/hooks/
+    state: absent
+    user: "{{ github_user }}"
+    password: "{{ github_password }}"
+'''
+
+RETURN = '''
+---
+hook_id:
+  description: The Github ID of the hook created/updated
+  returned: when state is 'present'
+  type: int
+  sample: 6206
+'''
+
+import traceback
+
+try:
+    import github
+    HAS_GITHUB = True
+except ImportError:
+    HAS_GITHUB = False
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_native
+
+
+def _create_hook_config(module):
+    return {
+        "url": module.params["url"],
+        "content_type": module.params["content_type"],
+        "secret": module.params.get("secret"),
+        "insecure_ssl": "1" if module.params["insecure_ssl"] else "0"
+    }
+
+
+def create_hook(repo, module):
+    config = _create_hook_config(module)
+    hook = repo.create_hook(
+        name="web",
+        config=config,
+        events=module.params["events"],
+        active=module.params["active"])
+
+    data = {"hook_id": hook.id}
+    return True, data
+
+
+def update_hook(repo, hook, module):
+    config = _create_hook_config(module)
+    hook.update()
+    hook.edit(
+        name="web",
+        config=config,
+        events=module.params["events"],
+        active=module.params["active"])
+
+    changed = hook.update()
+    data = {"hook_id": hook.id}
+    return changed, data
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            repository=dict(type='str', required=True),
+            url=dict(type='str', required=True),
+            content_type=dict(
+                type='str',
+                choices=('json', 'form'),
+                required=False,
+                default='form'),
+            secret=dict(type='str', required=False, no_log=True),
+            insecure_ssl=dict(type='bool', required=False, default=False),
+            events=dict(type='list', elements='str', required=False),
+            active=dict(type='bool', required=False, default=True),
+            state=dict(
+                type='str',
+                required=False,
+                choices=('absent', 'present'),
+                default='present'),
+            user=dict(type='str', required=True),
+            password=dict(type='str', required=False, no_log=True),
+            token=dict(type='str', required=False, no_log=True),
+            github_url=dict(
+                type='str', required=False, default="https://api.github.com")),
+        mutually_exclusive=(('password', 'token'), ))
+
+    if not HAS_GITHUB:
+        module.fail_json(msg="PyGithub required for this module")
+
+    if not module.params.get("password") and not module.params.get("token"):
+        module.fail_json(msg="You must specify either 'password' or 'token'")
+
+    if module.params["state"] == "present" and not module.params.get("events"):
+        module.fail_json(msg="'events' is required when state is 'present'")
+
+    github_conn = github.Github(
+        module.params["user"],
+        module.params.get("password") or module.params.get("token"),
+        base_url=module.params["github_url"])
+
+    repo = github_conn.get_repo(module.params["repository"])
+    hook = None
+    try:
+        for hook in repo.get_hooks():
+            if hook.url == module.params["url"]:
+                break
+    except github.GithubException as err:
+        module.fail_json(
+            msg="Unable to get hooks from repository %s: %s" % to_native(err),
+            exception=traceback.format_exc())
+
+    changed = False
+    data = {}
+    if hook is None and module.params["state"] == "present":
+        changed, data = create_hook(repo, module)
+    elif hook is not None and module.params["state"] == "absent":
+        hook.delete()
+        changed = True
+    elif hook is not None and module.params["state"] == "present":
+        changed, data = update_hook(repo, hook, module)
+    # else, there is no hook and we want there to be no hook
+
+    module.exit_json(changed=changed, **data)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/source_control/github_webhook_facts.py
+++ b/lib/ansible/modules/source_control/github_webhook_facts.py
@@ -1,0 +1,148 @@
+#!/usr/bin/python
+#
+# Copyright: (c) Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: github_webhook_facts
+short_description: Query information about Github webhooks
+version_added: "2.5"
+description:
+  - "Query information about Github webhooks"
+requirements:
+  - "PyGithub >= 1.3.5"
+options:
+  repository:
+    description:
+      - Full name of the repository to configure a hook for
+    required: true
+  user:
+    description:
+      - User to authenticate to Github as
+    required: true
+  password:
+    description:
+      - Password to authenticate to Github with
+    required: false
+  token:
+    description:
+      - Token to authenticate to Github with
+    required: false
+  github_url:
+    description:
+      - Base URL of the github api
+    required: false
+    default: https://api.github.com
+
+author:
+  - "Chris St. Pierre (@stpierre)"
+'''
+
+EXAMPLES = '''
+# list hooks for a repository (password auth)
+github_webhook_facts:
+  repository: ansible/ansible
+  user: "{{ github_user }}"
+  password: "{{ github_password }}"
+register: ansible_webhooks
+
+# list hooks for a repository on github enterprise (token auth)
+github_webhook_facts:
+  repository: myorg/myrepo
+  user: "{{ github_user }}"
+  token: "{{ github_user_api_token }}"
+  github_url: https://github.example.com/api/v3/
+register: myrepo_webhooks
+'''
+
+RETURN = '''
+---
+hooks:
+  description: A list of hooks that exist for the repo
+  returned: always
+  type: list
+  sample: >
+    [{"has_shared_secret": true,
+      "url": "https://jenkins.example.com/ghprbhook/",
+      "events": ["issue_comment", "pull_request"],
+      "insecure_ssl": "1",
+      "content_type": "json",
+      "active": true,
+      "id": 6206,
+      "last_response": {"status": "active", "message": "OK", "code": 200}}]
+'''
+
+import traceback
+
+try:
+    import github
+    HAS_GITHUB = True
+except ImportError:
+    HAS_GITHUB = False
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_native
+
+
+def _munge_hook(hook_obj):
+    retval = {
+        "active": hook_obj.active,
+        "events": hook_obj.events,
+        "id": hook_obj.id,
+        "url": hook_obj.url,
+    }
+    retval.update(hook_obj.config)
+    retval["has_shared_secret"] = "secret" in retval
+    if "secret" in retval:
+        del retval["secret"]
+
+    retval["last_response"] = hook_obj.last_response.raw_data
+    return retval
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            repository=dict(type='str', required=True),
+            user=dict(type='str', required=True),
+            password=dict(type='str', required=False, no_log=True),
+            token=dict(type='str', required=False, no_log=True),
+            github_url=dict(
+                type='str', required=False, default="https://api.github.com")),
+        mutually_exclusive=(('password', 'token'), ),
+        supports_check_mode=True)
+
+    if not HAS_GITHUB:
+        module.fail_json(msg="PyGithub required for this module")
+
+    if not module.params.get("password") and not module.params.get("token"):
+        module.fail_json(msg="You must specify either 'password' or 'token'")
+
+    github_conn = github.Github(
+        module.params["user"],
+        module.params.get("password") or module.params.get("token"),
+        base_url=module.params["github_url"])
+
+    repo = github_conn.get_repo(module.params["repository"])
+    try:
+        hooks = [_munge_hook(h) for h in repo.get_hooks()]
+    except github.GithubException as err:
+        module.fail_json(
+            msg="Unable to get hooks from repository %s: %s" % to_native(err),
+            exception=traceback.format_exc())
+
+    module.exit_json(changed=False, hooks=hooks)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
##### SUMMARY

This adds two new modules, `github_webhook` and `github_webhook_facts`, and deprecates the existing `github_hooks` module. The two modules provide much more predictable interfaces to querying and managing Github webhooks.

`github_hooks` lacks a number of important features: The ability to specify the events on which a webhook should fire; the ability to add a shared secret to a hook; the ability to create hooks that do not verify SSL against their target; and more. I considered merely updating that module to add the features needed, but the existing interface is pretty odd and would be difficult to update in a backwards-compatible way. For instance, it has a built-in feature for deleting all hooks whose last request returned 504 (`action: clean504`), but no way to update an existing hook, or delete a specific hook. It requires you to provide the API URL to a repository, rather than just the name of the repo (and optionally a Github API base), which requires a fair degree of familiarity with the Github API.

It has other issues that are easier to fix, but still weighed in on my decision to replace rather than upgrade: it rolls its own API client layer rather than using an existing library; it appears to support both password and API token auth, but only accepts a single "oauthkey" argument, which is a misnomer in both cases.

Rather than try to update it and fix all of the issues, I replaced it with two modules whose usage patterns are, I hope, much more intuitive.

##### ISSUE TYPE
 - New Module Pull Request

##### COMPONENT NAME
`github_webhook`, `github_webhook_facts`

##### ANSIBLE VERSION
```
ansible 2.5.0 (github-webhook-modules e161390b8b) last updated 2018/02/06 14:02:26 (GMT -500)
  config file = None
  configured module search path = [u'/home/stpierre/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/stpierre/devel/ansible/lib/ansible
  executable location = /home/stpierre/devel/ansible/bin/ansible
  python version = 2.7.14 (default, Jan 17 2018, 14:28:32) [GCC 7.2.1 20170915 (Red Hat 7.2.1-2)]
```
