### PR TITLE
Fixes repeated calls to create an API object

### DIFF
--- a/lib/ansible/module_utils/network/f5/bigip.py
+++ b/lib/ansible/module_utils/network/f5/bigip.py
@@ -27,7 +27,8 @@ except ImportError:
 class F5Client(F5BaseClient):
     @property
     def api(self):
-        result = None
+        if self._client:
+            return self._client
         for x in range(0, 10):
             try:
                 result = ManagementRoot(
@@ -38,13 +39,11 @@ class F5Client(F5BaseClient):
                     verify=self.params['validate_certs'],
                     token='tmos'
                 )
-                break
+                self._client = result
+                return self._client
             except Exception:
                 time.sleep(3)
-        if result:
-            return result
-        else:
-            raise F5ModuleError(
-                'Unable to connect to {0} on port {1}. '
-                'Is "validate_certs" preventing this?'.format(self.params['server'], self.params['server_port'])
-            )
+        raise F5ModuleError(
+            'Unable to connect to {0} on port {1}. '
+            'Is "validate_certs" preventing this?'.format(self.params['server'], self.params['server_port'])
+        )

--- a/lib/ansible/module_utils/network/f5/bigiq.py
+++ b/lib/ansible/module_utils/network/f5/bigiq.py
@@ -27,7 +27,8 @@ except ImportError:
 class F5Client(F5BaseClient):
     @property
     def api(self):
-        result = None
+        if self._client:
+            return self._client
         for x in range(0, 10):
             try:
                 result = ManagementRoot(
@@ -38,13 +39,11 @@ class F5Client(F5BaseClient):
                     verify=self.params['validate_certs'],
                     token='local'
                 )
-                break
+                self._client = result
+                return self._client
             except Exception:
                 time.sleep(3)
-        if result:
-            return result
-        else:
-            raise F5ModuleError(
-                'Unable to connect to {0} on port {1}. '
-                'Is "validate_certs" preventing this?'.format(self.params['server'], self.params['server_port'])
-            )
+        raise F5ModuleError(
+            'Unable to connect to {0} on port {1}. '
+            'Is "validate_certs" preventing this?'.format(self.params['server'], self.params['server_port'])
+        )

--- a/lib/ansible/module_utils/network/f5/iworkflow.py
+++ b/lib/ansible/module_utils/network/f5/iworkflow.py
@@ -27,7 +27,8 @@ except ImportError:
 class F5Client(F5BaseClient):
     @property
     def api(self):
-        result = None
+        if self._client:
+            return self._client
         for x in range(0, 10):
             try:
                 result = ManagementRoot(
@@ -38,13 +39,11 @@ class F5Client(F5BaseClient):
                     verify=self.params['validate_certs'],
                     token='local'
                 )
-                break
+                self._client = result
+                return self._client
             except Exception:
                 time.sleep(3)
-        if result:
-            return result
-        else:
-            raise F5ModuleError(
-                'Unable to connect to {0} on port {1}. '
-                'Is "validate_certs" preventing this?'.format(self.params['server'], self.params['server_port'])
-            )
+        raise F5ModuleError(
+            'Unable to connect to {0} on port {1}. '
+            'Is "validate_certs" preventing this?'.format(self.params['server'], self.params['server_port'])
+        )


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
This patch fixes repeated attempts that the module would make to
re-create an API object. The change stores a copy for later lookup
instead. This prevents uncontrolled tokens from being created.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
f5 module utils

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.14 (default, Dec 12 2017, 16:55:09) [GCC 4.9.2]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
