### PR TITLE
Reset network_cli command_timeout (alarm) on data recv'd

### DIFF
--- a/docs/docsite/rst/network/user_guide/network_debug_troubleshooting.rst
+++ b/docs/docsite/rst/network/user_guide/network_debug_troubleshooting.rst
@@ -432,6 +432,15 @@ To make this a permanent change, add the following to your ``ansible.cfg`` file:
    [persistent_connection]
    command_timeout = 30
 
+.. note::
+
+   ** Slow Connections or Device Response **
+
+   The ``command_timeout`` is now reset while the device is sending output.  As long as the device
+   is sending output within the ``command_timeout`` window, the timer will be extended to give the command
+   time to complete.  This means that setting ``command_timeout`` to excessively high values is less likely in
+   most cases.
+
 Option 2 (Per task command timeout setting):
 Increase command timeout per task basis. All network modules support a
 timeout value that can be set on a per task basis.

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1530,13 +1530,13 @@ PERSISTENT_CONNECT_RETRY_TIMEOUT:
   - {key: connect_retry_timeout, section: persistent_connection}
   type: integer
 PERSISTENT_COMMAND_TIMEOUT:
-  name: Persistence command timeout
+  name: Persistence command idle timeout
   default: 10
   description:
-    - This controls the amount of time to wait for response from remote device before timing out a persistent connection.
-    - Note that this timer is reset when the device is sending output, so commands that return slowly or slow network connections
-    - should not require this to be set to excessive values.  Commands that take a long time but do not print output however will
-    - often need this increased.
+    - This controls the amount of idle time to wait for a response from remote device before the command timeouts.
+    - The timer is reset when the device is sending output, so commands that trickle output or slow network connections
+    - should not require this to be set to excessive values.  Commands that take a long time but do not print any progressive
+    - output however will often need this increased.
   env: [{name: ANSIBLE_PERSISTENT_COMMAND_TIMEOUT}]
   ini:
   - {key: command_timeout, section: persistent_connection}

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1532,7 +1532,11 @@ PERSISTENT_CONNECT_RETRY_TIMEOUT:
 PERSISTENT_COMMAND_TIMEOUT:
   name: Persistence command timeout
   default: 10
-  description: This controls the amount of time to wait for response from remote device before timing out presistent connection.
+  description:
+    - This controls the amount of time to wait for response from remote device before timing out a persistent connection.
+    - Note that this timer is reset when the device is sending output, so commands that return slowly or slow network connections
+    - should not require this to be set to excessive values.  Commands that take a long time but do not print output however will
+    - often need this increased.
   env: [{name: ANSIBLE_PERSISTENT_COMMAND_TIMEOUT}]
   ini:
   - {key: command_timeout, section: persistent_connection}

--- a/lib/ansible/plugins/connection/network_cli.py
+++ b/lib/ansible/plugins/connection/network_cli.py
@@ -199,6 +199,7 @@ class Connection(NetworkConnectionBase):
         self._matched_prompt = None
         self._matched_cmd_prompt = None
         self._matched_pattern = None
+        self._first_matched_prompt = None
         self._last_response = None
         self._history = list()
 
@@ -361,7 +362,7 @@ class Connection(NetworkConnectionBase):
             if not data:
                 break
 
-            if signal_handler:
+            if signal_handler and self._first_matched_prompt:
                 display.debug("cli command_timeout extended on new data")
                 signal.alarm(self._play_context.timeout)
 
@@ -482,6 +483,8 @@ class Connection(NetworkConnectionBase):
                         errored_response = response
                         self._matched_pattern = regex.pattern
                         self._matched_prompt = match.group()
+                        if not self._first_matched_prompt:
+                            self._first_matched_prompt = self._matched_prompt
                         break
 
         if not is_error_message:
@@ -490,6 +493,8 @@ class Connection(NetworkConnectionBase):
                 if match:
                     self._matched_pattern = regex.pattern
                     self._matched_prompt = match.group()
+                    if not self._first_matched_prompt:
+                        self._first_matched_prompt = self._matched_prompt
                     if not errored_response:
                         return True
 

--- a/lib/ansible/plugins/connection/network_cli.py
+++ b/lib/ansible/plugins/connection/network_cli.py
@@ -351,7 +351,11 @@ class Connection(NetworkConnectionBase):
         self._matched_cmd_prompt = None
         matched_prompt_window = window_count = 0
 
-        command_timeout = self.get_option('persistent_command_timeout')
+        try:
+            command_timeout = self.get_option('persistent_command_timeout')
+        except:
+            command_timeout = None
+
         signal_handler = signal.getsignal(signal.SIGALRM)
         if signal_handler == signal.SIG_DFL:
             signal_handler = None
@@ -363,7 +367,7 @@ class Connection(NetworkConnectionBase):
             if not data:
                 break
 
-            if signal_handler and self._first_matched_prompt:
+            if command_timeout and signal_handler and self._first_matched_prompt:
                 display.debug("cli command_timeout extended on new data [%d]" % command_timeout)
                 signal.alarm(command_timeout)
 

--- a/lib/ansible/plugins/connection/network_cli.py
+++ b/lib/ansible/plugins/connection/network_cli.py
@@ -351,6 +351,7 @@ class Connection(NetworkConnectionBase):
         self._matched_cmd_prompt = None
         matched_prompt_window = window_count = 0
 
+        command_timeout = self.get_option('persistent_command_timeout')
         signal_handler = signal.getsignal(signal.SIGALRM)
         if signal_handler == signal.SIG_DFL:
             signal_handler = None
@@ -363,8 +364,8 @@ class Connection(NetworkConnectionBase):
                 break
 
             if signal_handler and self._first_matched_prompt:
-                display.debug("cli command_timeout extended on new data")
-                signal.alarm(self._play_context.timeout)
+                display.debug("cli command_timeout extended on new data [%d]" % command_timeout)
+                signal.alarm(command_timeout)
 
             recv.write(data)
             offset = recv.tell() - 256 if recv.tell() > 256 else 0

--- a/lib/ansible/plugins/connection/network_cli.py
+++ b/lib/ansible/plugins/connection/network_cli.py
@@ -146,9 +146,10 @@ options:
     type: int
     description:
       - Configures, in seconds, the amount of time to wait for a command to
-        return from the remote device.  If this timer is exceeded before the
-        command returns, the connection plugin will raise an exception and
-        close.
+        return from the remote device.  Once a valid prompt has been detected, the timer
+        will reset as the device prints new output.  Thus it acts as an idle timeout.
+        If this timer is exceeded before the command returns, the connection plugin
+        will raise an exception and close
     default: 10
     ini:
       - section: persistent_connection

--- a/lib/ansible/plugins/connection/paramiko_ssh.py
+++ b/lib/ansible/plugins/connection/paramiko_ssh.py
@@ -139,7 +139,6 @@ import re
 from termios import tcflush, TCIFLUSH
 from binascii import hexlify
 
-from ansible import constants as C
 from ansible.errors import AnsibleError, AnsibleConnectionFailure, AnsibleFileNotFound
 from ansible.module_utils.six import iteritems
 from ansible.module_utils.six.moves import input

--- a/test/units/plugins/connection/test_network_cli.py
+++ b/test/units/plugins/connection/test_network_cli.py
@@ -164,8 +164,8 @@ class TestConnectionClass(unittest.TestCase):
         signal.signal(signal.SIGALRM, timeout)
         pc = PlayContext()
         new_stdin = StringIO()
-        conn = network_cli.Connection(pc, new_stdin)
         pc.network_os = 'ios'
+        conn = connection_loader.get('network_cli', pc, new_stdin)
         timeout = 1
         conn.set_option('persistent_command_timeout', timeout)
 

--- a/test/units/plugins/connection/test_network_cli.py
+++ b/test/units/plugins/connection/test_network_cli.py
@@ -166,7 +166,8 @@ class TestConnectionClass(unittest.TestCase):
         new_stdin = StringIO()
         conn = network_cli.Connection(pc, new_stdin)
         pc.network_os = 'ios'
-        pc.timeout = 1
+        timeout = 1
+        conn.set_option('persistent_command_timeout', timeout)
 
         conn.ssh = MagicMock()
         mock__terminal = MagicMock()
@@ -180,7 +181,7 @@ class TestConnectionClass(unittest.TestCase):
 
         # test that trickled response data with overall duration over the timeout is ok
         # this works fine down to 1x, but 1.5x chosen as safer multiple
-        duration = 1.5 * pc.timeout
+        duration = 1.5 * timeout
         mock__shell.recv.side_effect = trickle(duration / len(response), response)
 
         try:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

network_cli currently depends on the command_timeout variable to set the length of time that it waits for a command to FULLY complete.  But it does not take into account if the device is actually sending output still.  

Why not instead reset this timer when data is received?


This PR proposes that the `alarm()` timer should simply be reset whenever data is received.  I did this in a simple way by seeing if the handler for `SIGALRM` was set.  

FYI, with this change, I was able to set `command_timeout=1` in the config and still run a number of long-winded test plays successfully including ones that previously failed with timeout set to 10 (due to the `show running all` that took 23 seconds on my DUT).

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
network_cli

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```

##### ADDITIONAL INFORMATION

Extending COMMAND_TIMEOUT is a oft recommended fix to these timeout issues, but setting it to some large value is impractical because it results in any non-responsive device taking that much extra time to abort the command.
