### PR TITLE
Added missing store regex pattern for prompt found after error

### DIFF
--- a/lib/ansible/plugins/connection/network_cli.py
+++ b/lib/ansible/plugins/connection/network_cli.py
@@ -487,6 +487,7 @@ class Connection(ConnectionBase):
                     match = regex.search(response)
                     if match:
                         errored_response = response
+                        self._matched_pattern = regex.pattern
                         self._matched_prompt = match.group()
                         break
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Minor change for noted missing store matched_pattern as repeated in the similar block of code below.

Note: Not sure if I mentioned this, but there appears to be a flow issue relative to errored_response block (where this change is) -- what if for some reason the next cli prompt is never matched, errored_response will never be set and it won't return a possible error message that may have been matched.   These changes came in https://github.com/ansible/ansible/pull/24600  I think I understand the reason why, but also wonder if some of the other changes around avoiding sending extra new lines to "wakeup the prompt" fixes some of this.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
network_cli

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```
