### PR TITLE
Make xenserver_facts actually work

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -268,6 +268,7 @@ files:
   $modules/cloud/misc/virt_pool.py: drybjed
   $modules/cloud/misc/xenserver_facts.py:
     ignored: andyhky
+    maintainers: cheese
   $modules/cloud/opennebula/: ilicmilan kustodian
   $modules/cloud/openstack/: $team_openstack
   $modules/cloud/openstack/os_keystone_service.py: $team_openstack SamYaple

--- a/changelogs/fragments/xenserver-facts-fix.yaml
+++ b/changelogs/fragments/xenserver-facts-fix.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - xenserver_facts - ensure module works with newer versions of XenServer (https://github.com/ansible/ansible/pull/35821)

--- a/lib/ansible/modules/cloud/misc/xenserver_facts.py
+++ b/lib/ansible/modules/cloud/misc/xenserver_facts.py
@@ -22,12 +22,13 @@ description:
 author:
     - Andy Hill (@andyhky)
     - Tim Rupp
+    - Robin Lee (@cheese)
 options: {}
 '''
 
 EXAMPLES = '''
 - name: Gather facts from xenserver
-  xenserver:
+  xenserver_facts:
 
 - name: Print running VMs
   debug:
@@ -91,11 +92,8 @@ def get_xenapi_session():
 
 def get_networks(session):
     recs = session.xenapi.network.get_all_records()
-    xs_networks = {}
-    networks = change_keys(recs, key='uuid')
-    for network in networks.values():
-        xs_networks[network['name_label']] = network
-    return xs_networks
+    networks = change_keys(recs, key='name_label')
+    return networks
 
 
 def get_pifs(session):
@@ -132,6 +130,13 @@ def change_keys(recs, key='uuid', filter_func=None):
         if filter_func is not None and not filter_func(rec):
             continue
 
+        for param_name, param_value in rec.items():
+            # param_value may be of type xmlrpc.client.DateTime,
+            # which is not simply convertable to str.
+            # Use 'value' attr to get the str value,
+            # following an example in xmlrpc.client.DateTime document
+            if hasattr(param_value, "value"):
+                rec[param_name] = param_value.value
         new_recs[rec[key]] = rec
         new_recs[rec[key]]['ref'] = ref
 
@@ -146,26 +151,19 @@ def get_host(session):
 
 
 def get_vms(session):
-    xs_vms = {}
-    recs = session.xenapi.VM.get_all()
+    recs = session.xenapi.VM.get_all_records()
     if not recs:
         return None
-
-    vms = change_keys(recs, key='uuid')
-    for vm in vms.values():
-        xs_vms[vm['name_label']] = vm
-    return xs_vms
+    vms = change_keys(recs, key='name_label')
+    return vms
 
 
 def get_srs(session):
-    xs_srs = {}
-    recs = session.xenapi.SR.get_all()
+    recs = session.xenapi.SR.get_all_records()
     if not recs:
         return None
-    srs = change_keys(recs, key='uuid')
-    for sr in srs.values():
-        xs_srs[sr['name_label']] = sr
-    return xs_srs
+    srs = change_keys(recs, key='name_label')
+    return srs
 
 
 def main():
@@ -204,7 +202,7 @@ def main():
     if xs_srs:
         data['xs_srs'] = xs_srs
 
-    module.exit_json(ansible=data)
+    module.exit_json(ansible_facts=data)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
##### SUMMARY

Make xenserver_facts actually work.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
xenserver_facts

##### ANSIBLE VERSION
```
ansible 2.4.2.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/cheese/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.14 (default, Dec 11 2017, 16:08:01) [GCC 7.2.1 20170915 (Red Hat 7.2.1-2)]
```


##### ADDITIONAL INFORMATION
Tested with XenServer 7.1.

before:
```
$ ansible -m xenserver_facts -i hosts autohosts
192.168.209.75 | FAILED! => {
    "changed": false, 
    "module_stderr": "Shared connection to 192.168.209.75 closed.\r\n", 
    "module_stdout": "Traceback (most recent call last):\r\n  File \"/tmp/ansible_zG0vtS/ansible_module_xenserver_facts.py\", line 208, in <module>\r\n    main()\r\n  File \"/tmp/ansible_zG0vtS/ansible_module_xenserver_facts.py\", line 188, in main\r\n    xs_vms = get_vms(session)\r\n  File \"/tmp/ansible_zG0vtS/ansible_module_xenserver_facts.py\", line 152, in get_vms\r\n    vms = change_keys(recs, key='uuid')\r\n  File \"/tmp/ansible_zG0vtS/ansible_module_xenserver_facts.py\", line 131, in change_keys\r\n    for ref, rec in recs.items():\r\nAttributeError: 'list' object has no attribute 'items'\r\n", 
    "msg": "MODULE FAILURE", 
    "rc": 0
}
```

after:
(working as expected, output too large.)