### PR TITLE
Add etcd3 to botmeta

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -336,6 +336,7 @@ files:
   $modules/clustering/consul_acl.py: sgargan
   $modules/clustering/consul_kv.py: sgargan
   $modules/clustering/consul_session.py: sgargan
+  $modules/clustering/etcd3.py: evrardjp
   $modules/clustering/k8s: chouseknecht sdoran maxamillion fabianvf flaper87
   $modules/clustering/kubernetes.py: erjohnso supertom
   $modules/clustering/openshift: chouseknecht sdoran maxamillion fabianvf flaper87


### PR DESCRIPTION
The etcd3 module should have a corresponding entry in BOTMETA.

##### SUMMARY
Improve ansible botmeta

##### ISSUE TYPE
 - Bugfix Pull Request


##### COMPONENT NAME
etcd3

##### ANSIBLE VERSION
None


##### ADDITIONAL INFORMATION
BOTMETA should be updated to contain the maintainer information of the etcd3 module.
