### PR TITLE
service: Add support for DragonFly BSD

### DIFF
--- a/lib/ansible/modules/system/service.py
+++ b/lib/ansible/modules/system/service.py
@@ -1073,6 +1073,17 @@ class FreeBsdService(Service):
         return ret
 
 
+class DragonFlyBsdService(FreeBsdService):
+    """
+    This is the DragonFly BSD Service manipulation class - it uses the /etc/rc.conf
+    file for controlling services started at boot and the 'service' binary to
+    check status and perform direct service manipulation.
+    """
+
+    platform = 'DragonFly'
+    distribution = None
+
+
 class OpenBsdService(Service):
     """
     This is the OpenBSD Service manipulation class - it uses rcctl(8) or


### PR DESCRIPTION
For now create a subclass of the FreeBsd class

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Service module support for DragonFly BSD
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
system/service

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (devel_dfly 021d740d2b) last updated 2018/02/07 13:51:29 (GMT +200)
  config file = None
  configured module search path = [u'/home/antonioh/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/antonioh/s/ansible/lib/ansible
  executable location = /home/antonioh/s/ansible/bin/ansible
  python version = 2.7.14 (default, Nov 28 2017, 14:53:15) [GCC 5.4.1 [DragonFly] Release/2016-08-27]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
---

# file: site.yml

- hosts: all
  tasks:
    - name: Enable vknetd if not already enabled
      service:
        name: vknetd
        state: started
      become: yes
```

Before:
```
$ ansible-playbook site.yml -v -i inventory
No config file found; using defaults

PLAY [all] ***********************************************************************************************************

TASK [Gathering Facts] ***********************************************************************************************
ok: [localhost]

TASK [Enable vknetd if not already enabled] **************************************************************************
fatal: [localhost]: FAILED! => {"changed": false, "failed": true, "msg": "get_service_tools not implemented on target platform"}
        to retry, use: --limit @/home/antonioh/temp/testservice/site.retry

PLAY RECAP ***********************************************************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=1   
```

After:
```
$ ansible-playbook site.yml -v -i inventory
No config file found; using defaults

PLAY [all] ***********************************************************************************************************

TASK [Gathering Facts] ***********************************************************************************************
ok: [localhost]

TASK [Enable vknetd if not already enabled] **************************************************************************
changed: [localhost] => {"changed": true, "failed": false, "name": "vknetd", "state": "started"}

PLAY RECAP ***********************************************************************************************************
localhost                  : ok=2    changed=1    unreachable=0    failed=0   

```