### PR TITLE
ovirt: Require Python SDK 4.2.4 for Ansible 2.5

### DIFF
--- a/lib/ansible/module_utils/ovirt.py
+++ b/lib/ansible/module_utils/ovirt.py
@@ -31,7 +31,7 @@ try:
     from enum import Enum  # enum is a ovirtsdk4 requirement
     import ovirtsdk4 as sdk
     import ovirtsdk4.version as sdk_version
-    HAS_SDK = LooseVersion(sdk_version.VERSION) >= LooseVersion('4.0.0')
+    HAS_SDK = LooseVersion(sdk_version.VERSION) >= LooseVersion('4.2.4')
 except ImportError:
     HAS_SDK = False
 
@@ -48,7 +48,7 @@ BYTES_MAP = {
 def check_sdk(module):
     if not HAS_SDK:
         module.fail_json(
-            msg='ovirtsdk4 version 4.0.0 or higher is required for this module'
+            msg='ovirtsdk4 version 4.2.4 or higher is required for this module'
         )
 
 

--- a/lib/ansible/utils/module_docs_fragments/ovirt.py
+++ b/lib/ansible/utils/module_docs_fragments/ovirt.py
@@ -68,7 +68,7 @@ options:
         default: 3
 requirements:
   - python >= 2.7
-  - ovirt-engine-sdk-python >= 4.0.0
+  - ovirt-engine-sdk-python >= 4.2.4
 notes:
   - "In order to use this module you have to install oVirt Python SDK.
      To ensure it's installed with correct version you can create the following task:

--- a/lib/ansible/utils/module_docs_fragments/ovirt_facts.py
+++ b/lib/ansible/utils/module_docs_fragments/ovirt_facts.py
@@ -56,7 +56,7 @@ options:
             - "C(headers) - Dictionary of HTTP headers to be added to each API call."
 requirements:
   - python >= 2.7
-  - ovirt-engine-sdk-python >= 4.0.0
+  - ovirt-engine-sdk-python >= 4.2.4
 notes:
   - "In order to use this module you have to install oVirt Python SDK.
      To ensure it's installed with correct version you can create the following task:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This PR update the check for oVirt modules to require Python SDK 4.2.4 for Ansible 2.5.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
ovirt

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5.x
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
