### PR TITLE
Fix lookup plugins documentation (nios, conjur_variable)

### DIFF
--- a/lib/ansible/plugins/lookup/conjur_variable.py
+++ b/lib/ansible/plugins/lookup/conjur_variable.py
@@ -13,9 +13,9 @@ DOCUMENTATION = """
     version_added: "2.5"
     short_description: Fetch credentials from CyberArk Conjur.
     description:
-      - Retrieves credentials from Conjur using the controlling host's Conjur identity. Conjur info: U(https://www.conjur.org/).
+      - "Retrieves credentials from Conjur using the controlling host's Conjur identity. Conjur info: U(https://www.conjur.org/)."
     requirements:
-      - The controlling host running Ansible has a Conjur identity. (More: U(https://developer.conjur.net/key_concepts/machine_identity.html))
+      - 'The controlling host running Ansible has a Conjur identity. (More: U(https://developer.conjur.net/key_concepts/machine_identity.html))'
     options:
       _term:
         description: Variable path

--- a/lib/ansible/plugins/lookup/nios.py
+++ b/lib/ansible/plugins/lookup/nios.py
@@ -45,7 +45,7 @@ options:
       required: False
       default: null
     extattrs:
-      descrpition: a dict object that is used to filter on extattrs
+      description: a dict object that is used to filter on extattrs
       required: false
       default: null
 """


### PR DESCRIPTION
##### SUMMARY
Fix lookup plugins documentation: `nios`, `conjur_variable`

Tested with:
> ./docs/bin/plugin_formatter.py -o /tmp/coin -P lookup -T docs/templates/ --module-dir lib/ansible/plugins/lookup -v 

Thanks to @mikedlr for pointing that.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
nios conjur_variable

##### ANSIBLE VERSION
```
ansible 2.5.0 (devel 54882d4715) last updated 2018/02/07 01:20:49 (GMT +200)
```