### PR TITLE
Remove potentially confusing `provider` from module documentation

### DIFF
--- a/lib/ansible/modules/network/ios/ios_ping.py
+++ b/lib/ansible/modules/network/ios/ios_ping.py
@@ -55,31 +55,22 @@ notes:
 '''
 
 EXAMPLES = r'''
-- provider:
-    host: "{{ ansible_host }}"
-    username: "{{ username }}"
-    password: "{{ password }}"
-
 - name: Test reachability to 10.10.10.10 using default vrf
   ios_ping:
-    provider: "{{ provider }}"
     dest: 10.10.10.10
 
 - name: Test reachability to 10.20.20.20 using prod vrf
   ios_ping:
-    provider: "{{ provider }}"
     dest: 10.20.20.20
     vrf: prod
 
 - name: Test unreachability to 10.30.30.30 using default vrf
   ios_ping:
-    provider: "{{ provider }}"
     dest: 10.30.30.30
     state: absent
 
 - name: Test reachability to 10.40.40.40 using prod vrf and setting count and source
   ios_ping:
-    provider: "{{ provider }}"
     dest: 10.40.40.40
     source: loopback0
     vrf: prod

--- a/lib/ansible/modules/network/junos/junos_config.py
+++ b/lib/ansible/modules/network/junos/junos_config.py
@@ -152,7 +152,6 @@ EXAMPLES = """
   junos_config:
     src: srx.cfg
     comment: update config
-    provider: "{{ netconf }}"
 
 - name: load configure lines into device
   junos_config:
@@ -160,22 +159,18 @@ EXAMPLES = """
       - set interfaces ge-0/0/1 unit 0 description "Test interface"
       - set vlans vlan01 description "Test vlan"
     comment: update config
-    provider: "{{ netconf }}"
 
 - name: rollback the configuration to id 10
   junos_config:
     rollback: 10
-    provider: "{{ netconf }}"
 
 - name: zero out the current configuration
   junos_config:
     zeroize: yes
-    provider: "{{ netconf }}"
 
 - name: confirm a previous commit
   junos_config:
     confirm_commit: yes
-    provider: "{{ netconf }}"
 """
 
 RETURN = """

--- a/lib/ansible/modules/network/nxos/nxos_acl.py
+++ b/lib/ansible/modules/network/nxos/nxos_acl.py
@@ -210,7 +210,6 @@ EXAMPLES = '''
     src: 1.1.1.1/24
     dest: any
     state: present
-    provider: "{{ nxos_provider }}"
 '''
 
 RETURN = '''

--- a/lib/ansible/modules/network/nxos/nxos_command.py
+++ b/lib/ansible/modules/network/nxos/nxos_command.py
@@ -26,11 +26,10 @@ description:
 options:
   commands:
     description:
-      - The commands to send to the remote NXOS device over the
-        configured provider.  The resulting output from the command
-        is returned.  If the I(wait_for) argument is provided, the
-        module is not returned until the condition is satisfied or
-        the number of retires as expired.
+      - The commands to send to the remote NXOS device.  The resulting
+        output from the command is returned.  If the I(wait_for)
+        argument is provided, the module is not returned until the
+        condition is satisfied or the number of retires as expired.
       - The I(commands) argument also accepts an alternative form
         that allows for complex values that specify the command
         to run and the output format to return.   This can be done
@@ -79,34 +78,21 @@ options:
 """
 
 EXAMPLES = """
-# Note: examples below use the following provider dict to handle
-#       transport and authentication to the node.
----
-vars:
-  cli:
-    host: "{{ inventory_hostname }}"
-    username: admin
-    password: admin
-    transport: cli
-
 ---
 - name: run show version on remote devices
   nxos_command:
     commands: show version
-    provider: "{{ cli }}"
 
 - name: run show version and check to see if output contains Cisco
   nxos_command:
     commands: show version
     wait_for: result[0] contains Cisco
-    provider: "{{ cli }}"
 
 - name: run multiple commands on remote nodes
   nxos_command:
     commands:
       - show version
       - show interfaces
-    provider: "{{ cli }}"
 
 - name: run multiple commands and evaluate the output
   nxos_command:
@@ -116,14 +102,12 @@ vars:
     wait_for:
       - result[0] contains Cisco
       - result[1] contains loopback0
-    provider: "{{ cli }}"
 
 - name: run commands and specify the output format
   nxos_command:
     commands:
       - command: show version
         output: json
-    provider: "{{ cli }}"
 """
 
 RETURN = """

--- a/lib/ansible/modules/network/system/net_ping.py
+++ b/lib/ansible/modules/network/system/net_ping.py
@@ -55,32 +55,22 @@ notes:
 
 
 EXAMPLES = r'''
-- provider:
-    host: "{{ ansible_host }}"
-    username: "{{ username }}"
-    password: "{{ password }}"
-    network_os: "{{ network_os }}"
-
 - name: Test reachability to 10.10.10.10 using default vrf
   net_ping:
-    provider: "{{ provider }}"
     dest: 10.10.10.10
 
 - name: Test reachability to 10.20.20.20 using prod vrf
   net_ping:
-    provider: "{{ provider }}"
     dest: 10.20.20.20
     vrf: prod
 
 - name: Test unreachability to 10.30.30.30 using default vrf
   net_ping:
-    provider: "{{ provider }}"
     dest: 10.30.30.30
     state: absent
 
 - name: Test reachability to 10.40.40.40 using prod vrf and setting count and source
   net_ping:
-    provider: "{{ provider }}"
     dest: 10.40.40.40
     source: loopback0
     vrf: prod


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
`provider` is unecessary (and not reccomended) in the vast majority of cases, so remove examples showing `provider`

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
network

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```