### PR TITLE
Include licenses in the tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -11,6 +11,7 @@ recursive-include lib/ansible/module_utils/powershell *
 recursive-include lib/ansible/modules *
 recursive-include lib/ansible/galaxy/data *
 recursive-include docs *
+recursive-include licenses *
 recursive-include packaging *
 recursive-include test *
 include Makefile


### PR DESCRIPTION
##### SUMMARY
We were leaving this directory out of the tarball by mistake.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```
We only have this directory in 2.5 and above.
