### PR TITLE
add DragonFlyBSD support to modules/system/{user,group}

### DIFF
--- a/lib/ansible/modules/system/group.py
+++ b/lib/ansible/modules/system/group.py
@@ -248,6 +248,15 @@ class FreeBsdGroup(Group):
         return (None, '', '')
 
 
+class DragonFlyBsdGroup(FreeBsdGroup):
+    """
+    This is a DragonFlyBSD Group manipulation class.
+    It inherits all behaviors from FreeBsdGroup class.
+    """
+
+    platform = 'DragonFly'
+
+
 # ===========================================
 
 class DarwinGroup(Group):

--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -119,7 +119,8 @@ options:
         default: "no"
     login_class:
         description:
-            - Optionally sets the user's login class for FreeBSD, OpenBSD and NetBSD systems.
+            - Optionally sets the user's login class for FreeBSD, DragonFlyBSD, OpenBSD and
+              NetBSD systems.
     remove:
         description:
             - When used with C(state=absent), behavior is as with C(userdel --remove).
@@ -170,7 +171,7 @@ options:
     expires:
         description:
             - An expiry time for the user in epoch, it will be ignored on platforms that do not support this.
-              Currently supported on Linux and FreeBSD.
+              Currently supported on Linux, FreeBSD, and DragonFlyBSD.
         version_added: "1.9"
     local:
         description:
@@ -927,6 +928,17 @@ class FreeBsdUser(User):
             return self.execute_command(cmd)
 
         return (rc, out, err)
+
+
+class DragonFlyBsdUser(FreeBsdUser):
+    """
+    This is a DragonFlyBSD User manipulation class - it inherits the
+    FreeBsdUser class behaviors, such as using the pw command to
+    manipulate the user database, followed by the chpass command
+    to change the password.
+    """
+
+    platform = 'DragonFly'
 
 
 class OpenBSDUser(User):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Subclass FreeBsdUser and FreeBsdGroup as DragonFlyBsdUser and DragonFlyBsdGroup, correctly setting platform name.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
modules/system/user, modules/system/group

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (devel 9c6d985733) last updated 2018/02/07 13:59:05 (GMT -400)
  config file = None
  configured module search path = ['/Users/jontow/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/jontow/GIT-external/ansible/lib/ansible
  executable location = /Users/jontow/GIT-external/ansible/bin/ansible
  python version = 3.6.4 (default, Jan  4 2018, 20:49:52) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
This is required on DragonFly, or it fails with an error like 'Failed to find required executable usermod' (DragonFly uses 'pw', like FreeBSD).

To trigger this bug, simply define a user that gets applied on a DragonFlyBSD host, like so:
```
---
- user:
    name: jontow
    comment: "jontow"
    groups: "{{ admin_groups }}"
    append: yes
    shell: "{{ zsh_path }}"
    update_password: on_create
    password: '...'
```

Before:
```
TASK [common : user] *********************************************************************************************************************************************
task path: /Users/jontow/GIT-je/ansible/roles/common/tasks/users/jontow.yml:2
fatal: [dbuild.je]: FAILED! => {"attempts": 1, "changed": false, "failed": true, "msg": "Failed to find required executable usermod in paths: /home/jontow/.rbenv/bin:/home/jontow/.cargo/bin:/sbin:/bin:/usr/sbin:/usr/bin:/usr/games:/usr/local/sbin:/usr/local/bin:/usr/pkg/sbin:/usr/pkg/bin:/home/jontow/bin:/sbin:/bin:/usr/sbin:/usr/bin:/usr/games:/usr/local/bin:/usr/local/sbin:/usr/pkg/bin:/usr/X11R6/bin:/home/argus/bin:/home/argus/sbin:/home/jontow/bin"}
```

After:
```
TASK [common : user] *********************************************************************************************************************************************
task path: /Users/jontow/GIT-je/ansible/roles/common/tasks/users/jontow.yml:2
ok: [dbuild.je] => {"append": true, "attempts": 1, "changed": false, "comment": "Jonathan Towne", "failed": false, "group": 1000, "groups": "wheel", "home": "/home/jontow", "move_home": false, "name": "jontow", "password": "NOT_LOGGING_PASSWORD", "shell": "/usr/local/bin/zsh", "state": "present", "uid": 1000}
```