### PR TITLE
Add support to create or terminate AWS Elastic Map Reduce

### DIFF
--- a/lib/ansible/modules/cloud/amazon/emr_cluster.py
+++ b/lib/ansible/modules/cloud/amazon/emr_cluster.py
@@ -3,9 +3,6 @@
 # Copyright: Ansible Project
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-from __future__ import absolute_import, division, print_function
-__metaclass__ = type
-
 ANSIBLE_METADATA = {
     'metadata_version': '1.1',
     'status': ['preview'],
@@ -15,127 +12,334 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = '''
 ---
 module: emr_cluster
-short_description:  Creating or Terminating EMR Clusters
-version_added: "2.6"
+short_description:  Creates and deletes EMR Clusters.
+version_added: "2.8"
 description:
-  - creating or terminating EMR Clusters
-  - steps (jobs spark for example) can be setup when Cluster is creating
-  - this module will check EMR name when state is present to check if cluster already exist
-    but EMR API don't have a unique field to ensure that behavior
-  - basically this module only receive args and send to boto3, so any argument supported
-    by method run_job_flow() can be used when state is create.
-    check http://boto3.readthedocs.io/en/latest/reference/services/emr.html#EMR.Client.run_job_flow
-    for more information
-  - it depends on boto3
+  - Creates and deletes EMR Clusters, you could set up EMR Steps
+    (spark jobs, for example) when it starts.
+requirements: [boto3]
 options:
-  region:
-    description:
-      - region where the module creating or terminating EMR Cluster
   name:
     description:
-      - name to be used when EMR is creating
-  instances:
-    description:
-      - specifications about EC2 instances
+      - The name of the Cluster. Required if C(state=present).
+    required: false
   log_uri:
     description:
-      - s3 path to store logs from EMR
-  release_label:
-    description:
-      - release label for the Amazon EMR
-      - default emr-5.11.0
-  steps:
-    description:
-      - list of steps will be run
-  bootstrap_actions:
-    description:
-      - list of action to run before Hadoop Starts
-  applications:
-    description:
-      - list of Applications that will be enabled on EMR
-  configurations:
-    description:
-      - dict of specific configuratins that will be pass for applications and Amazon EMR
-  service_role:
-    description:
-      - IAM role that will be assumed by the Amazon EMR
-      - default EMR_DefaultRole
-  job_flow_role:
-    description:
-      - IAM role that will be assumed by the Amazon EC2
-      - default EMR_EC2_DefaultRole
-  ebs_root_volume_size:
-    description:
-      - settings for EBS on root
-  ebs_optimized:
-    description:
-      - define if ebs is optimized
-  ebs_volumes:
-    description:
-      - list to create extra volumes see section EbsBlockDeviceConfigs in
-        http://boto3.readthedocs.io/en/latest/reference/services/emr.html#EMR.Client.run_job_flow
-  state:
-    description:
-      - ensure cluster is create or terminate
-      - default present
-  wait:
-    description:
-      - wait until EMR is RUNNING if state is create or present and TERMINATED if state is absent
-      - default false
-  wait_delay:
-    description:
-      - the amount of time in seconds to wait between attempts
-      - default 30
-  wait_max_attempts:
-    description:
-      - the number of attempts for cluster become to correct state
-      - default 60
-  cluster_id:
-    description:
-      - id from EMR that will be terminate
-      - this arg just only used by state terminate
+      - The bucket path to store logs.
+    required: false
   additional_info:
     description:
-      - a json string for selecting additiona features
+      - A JSON string for selecting additional features.
+    required: false
   ami_version:
     description:
-      - Amazon EMR AMI versions for 3.x and 2.x, EMR releases 4.0 and later this is defined by release_label
-  auto_scaling_role:
+      - Applies only to Amazon EMR AMI versions 3.x and 2.x. For EMR release 4.0 and later
+        I(release_label) is used. To specify a custom AMI, use I(custom_ami_id).
+    required: false
+  release_label:
     description:
-      - IAM Role for scaling policies, default is EMR_AutoScaling_DefaultRole
-  custom_ami_id:
+      - Determines what's the versions of the open source application packages installed
+        on the Cluster. See U(https://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-release-components.html).
+    required: false
+  instances:
     description:
-      - available only in Amazon EMR 5.7.0 and later
-  kerberos_attributes:
+      - Settings for specify the number and type of the Amazon EC2 instances. Required if I(state=present).
+    required: false
+    suboptions:
+      master_instance_type:
+        description:
+          - The EC2 instance type of the master node.
+      slave_instance_type:
+        description:
+          - The EC2 instance type of the core node.
+      instance_count:
+        description:
+          - The number of EC2 core node on the Cluster.
+      instance_groups:
+        description:
+          - A list to customize the number and the type of the instances in the Cluster for
+            MASTER, CORE and Task node. See U(https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-master-core-task-nodes.html)
+        suboptions:
+          name:
+            description:
+              - Friendly name given to the instance group.
+          market:
+            description:
+              - Define if the instance group will use ON_DEMAND or SPOT instances.
+            choices: ['ON_DEMAND', 'SPOT']
+          instance_role:
+            description:
+              - The role of the instance group in the cluster.
+            required: true
+            choices: ['MASTER', 'CORE', 'TASK']
+          instance_type:
+            description:
+              - The instance type for all instances in the group.
+            required: true
+          instance_count:
+            description:
+              - The number of instances for the instance group.
+            required: true
+          auto_scaling_policy:
+            description:
+              - An automatic scaling policy for a core or task instance group.
+                See U(https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/emr.html#EMR.Client.run_job_flow)
+      instance_fleets:
+        description:
+          - Using instance_fleets to specify target capacities for On-Demand and
+            Spot instances.
+        suboptions:
+          name:
+            description:
+              - A friendly name of the instance fleet.
+          instance_fleet_type:
+            description:
+              - The node type.
+            required: true
+            choices: ['MASTER', 'CORE', 'TASK']
+          target_on_demand_capacity:
+            description:
+              - How many On-Demand instances to provision.
+          target_spot_capacity:
+            description:
+              - How many Spot instances to provision.
+          instance_type_configs:
+            description:
+              - Define EC2 settings in the instance fleet.
+            suboptions:
+              instance_type:
+                description:
+                  - An EC2 instance type.
+                required: true
+              weighted_capacity:
+                description:
+                  - The number of units that a provisioned instance of this
+                    type provides toward fulfilling the target capacities.
+              bid_price:
+                description:
+                  - The bid price for each EC2 Spot instance
+              bid_price_as_percentage_of_on_demand_price:
+                description:
+                  - The bid price, as an percentage of On-Demand price.
+              launch_specifications:
+                description:
+                  - The launch specification, which determines the defined
+                    duration and provision timeout behavior.
+      ec2_key_name:
+        description:
+          - The name of the EC2 key pair.
+      placement:
+        description:
+          - The availability zone in which the cluster runs.
+      keep_job_flow_alive_when_no_steps:
+        description:
+          - Specifies if the cluster should be avaiable after completing all steps.
+        default: false
+      termination_protected:
+        description:
+          - Determines termination protection.
+      hadoop_version:
+        description:
+          - Applies only to Amazon EMR release versions earlier than 4.0. The Hadoop version for the cluster
+      ec2_subnet_id:
+        description:
+          - Applies to clusters that use the uniform instance group configuration.
+      ec2_subnet_ids:
+        description:
+          - Applies to clusters that use the instance fleets configuration.
+      emr_managed_master_security_group:
+        description:
+          - The identifier of the Amazon EC2 security group for the master node.
+      emr_managed_slave_security_group:
+        description:
+          - The identifier of the Amazon EC2 security group for the core and task nodes.
+      additional_master_security_groups:
+        description:
+          - A list of additional Amazon EC2 security group IDs for the master node
+      additional_slave_security_groups:
+        description:
+          - A list of additional Amazon EC2 security group IDs for the core and task nodes.
+  steps:
     description:
-      - attributes for Kerberos configuration. For more information see
-        https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-kerberos.html
-  new_supported_products:
+      - List of steps to run.
+    required: false
+    suboptions:
+      name:
+        description:
+          - The name of the step.
+        required: true
+      action_on_failure:
+        description:
+          - The action to take when step fails.
+        choices:
+          - TERMINATE_JOB_FLOW
+          - TERMINATE_CLUSTER
+          - CANCEL_AND_WAIT
+          - CONTINUE
+        default: TERMINATE_CLUSTER
+      hadoop_jar_step:
+        description:
+          - A dict with parameters to step.
+        suboptions:
+          properties:
+            description:
+              - A list of java properties that are set when the step runs.
+          jar:
+            description:
+              - A path to a JAR file run during the step.
+            required: true
+          main_class:
+            description:
+              - The name of the main class in the specified java file.
+          args:
+            description:
+              - A list of arguments passed to JAR.
+  bootstrap_actions:
     description:
-      - a list with third-party software to use, see boto3 documentation for more information.
-  repo_upgrade_on_boot:
-    description:
-      - applies when custom_ami_id is used, specified the types of udpates that are applied from the Amazon Linux
-  scale_down_behavior:
-    description:
-      - basically define if scale in occours based in INSTANCE_HOURS or TASK_COMPLETION
-  security_configuration:
-    description:
-      - name of security configuration
+      - A list of boostrap actions to run before cluster starts.
+    required: false
+    suboptions:
+      name:
+        description:
+          - A friendly name for the action.
+      script_path:
+        description:
+          - The s3 location of the script.
+      args:
+        description:
+          - Arguments pass to the script.
+            The script will access these arguments throughout $1, $2 and so on.
   supported_products:
     description:
-      - a list set by third-party when job is launched.
-  ec2_tags:
+      - For Amazon EMR releases 4.x and later, use I(Applications).
+        A list of strings that indicates third-party software to use
+    required: false
+  new_supported_products:
     description:
-      - a dict with tags that will be associate with a cluster
+      - For Amazon EMR releases 4.x and later, use I(Applications).
+        A list of strings that indicates third-party software to use with the job flow that accepts a user argument list.
+    required: false
+  applications:
+    description:
+      - Applies to Amazon EMR releases 4.0 and later.
+        A case-insensitive list of applications for Amazon EMR to install and configure when launching the cluster.
+    required: false
   visible_to_all_users:
     description:
-      - define if cluster will be visible to all IAM users, default is True
+      - Defines if the cluster will be avaiable for all users.
+    required: false
+    default: true
+  job_flow_role:
+    description:
+      - The IAM Role used by EC2 instances.
+    required: false
+    default: EMR_EC2_DefaultRole
+  service_role:
+    description:
+      - The IAM role that will be assumed by the Amazon EMR service.
+    required: false
+    default: EMR_DefaultRole
+  security_configuration:
+    description:
+      - The name of a security configuration to apply to the cluster.
+    required: false
+  auto_scaling_role:
+    description:
+      - An IAM role for automatic scaling policies
+    required: false
+  scale_down_behavior:
+    description:
+      - Specifies the way that individual Amazon EC2 instances terminate.
+    required: false
+  custom_ami_id:
+    description:
+      - The ID of a custom AMI. If specified, Amazon EMR uses this AMI when it launches cluster EC2 instances.
+        See U(https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-custom-ami.html).
+    required: false
+  ebs_root_volume_size:
+    description:
+      -  The size in GB of the root device.
+    required: false
+  repo_upgrade_on_boot:
+    description:
+      - Applies only when CustomAmiID is used. Specifies which updates from the Amazon Linux
+        AMI package repositories to apply automatically when the instance boots using the AMI.
+    required: false
+  kerberos_attributes:
+    description:
+      - Attributes for Kerberos configuration when Kerberos authentication is enabled using a security configuration
+    required: false
+  state:
+    description:
+      - Create or destroy the EMR.
+    choices: ['present', 'absent']
+    default: present
+  cluster_id:
+    description:
+      - The cluster_id used when state is absent. Required when C(state=absent).
+    required: false
+  tags:
+    description:
+      - A dict with tags that will be associate with EC2 instances.
+    required: false
+  wait:
+    description:
+      - Wait until the EMR state is RUNNING
+    required: false
+  wait_delay:
+    description:
+      - The amount of time in seconds to wait between attempts.
+    required: false
+    type: int
+    default: 30
+  wait_max_attempts:
+    description:
+      - The number of attempts to EMR state is RUNNING.
+    required: false
+    type: int
+    default: 60
+  configurations:
+    description:
+      - A dict with custom settings for applications installed
+        in the EMR. See U(https://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-configure-apps.html)
+    required: false
+  ebs_volumes:
+    description:
+      - A list to create extra volumes
+    required: false
+    suboptions:
+      type:
+        description:
+          - The volume type.
+        choices: ['gp2', 'io1', 'standard']
+        default: gp2
+      size:
+        description:
+          - The volume size in Gigabytes.
+      iops:
+        description;
+          - The number of I/O operations that the volume supports.
+      device:
+        description:
+          - The device name that is exposed to the instance.
+      volumes_per_instance:
+        description:
+          - Number of EBS volumes that will be associated with every instance in the group.
+  ebs_optimized:
+    description:
+      - Indicates whether a volume is EBS-optimized.
+    required: false
+    type: bool
+    default: false
 author:
   - Wellington Moreira Ramos (@wmaramos)
 extends_documentation_fragment:
   - aws
   - ec2
+notes:
+  - This module will get EMR name when the state is present to verify if the cluster already exist, but
+    the EMR API don't have a unique field to ensure that behavior, so could you've some cases that
+    exists more than one cluster with the same name. At this case you'll receive a warn.
 '''
 
 EXAMPLES = '''
@@ -148,7 +352,20 @@ EXAMPLES = '''
     ebs_volumes:
       - type: gp2
         size: 300
+    bootstrap_actions:
+      - name: bootstrap
+        script_bootstrap_action:
+          path: s3://bucket-name/path/to/script.sh
+          args:
+            - argv1
+            - argv2
     configurations:
+      core-site:
+        hadoop.security.groups.cache.secs: 250
+      mapred-site:
+        mapred.tasktracker.map.tasks.maximum: 2
+        mapreduce.map.sort.spill.percent: 0.90
+        mapreduce.tasktracker.reduce.tasks.maximum: 5
       spark:
         maximizeResourceAllocation: true
       hbase-site:
@@ -165,7 +382,7 @@ EXAMPLES = '''
           args:
             - "s3-dist-cp"
             - "--src=s3://bucket-name/events"
-            - "--dest=hdfs://aggregate"
+            - "--dest=hdfs:///aggregate"
             - "--groupBy=.*/[0-9]{4}/[0-9]{2}/.*gz"
             - "--targetSize=128"
             - "--outputCode=snappy"
@@ -190,61 +407,175 @@ EXAMPLES = '''
 '''
 
 RETURN = '''
-# For more information see http://boto3.readthedocs.io/en/latest/reference/services/emr.html#EMR.Client.describe_cluster
 ---
-cluster:
-  description: dictionary containing informations about EMR Cluster
-  returned: success
+applications:
+  description: The applications installed on this cluster.
+  returned: always
   type: complex
   contains:
-    id:
-      description: the unique id for the cluster
-      type: str
-      sample: j-2JNVMF38MZVHT
     name:
-      description: the name of the cluster
+      description: The name of the application.
+      returned: always
       type: str
-      sample: emr-jobs
-    status:
-      description: the current status defailts about the cluster
+    version:
+      description: The version of the application.
+      returned: always
+      type: str
+    args:
+      description: Arguments for EMR pass to application.
+      type: str
+    additional_info:
+      description: Meta information about third party applications.
+      type: str
+auto_terminate:
+  description: Specifies if the cluter should be terminate after completing all steps.
+  returned: always
+  type: bool
+changed:
+  description: Specifies if any settings was changed or not.
+  returned: always
+  type: bool
+configurations:
+  description: The list of configurations supplied to EMR cluster.
+  returned: always
+  type: complex
+  contains:
+    classification:
+      description: The classification whithin a configuration. See U(https://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-configure-apps.html)
+      type: str
+      sample: mapred-site
+    properties:
+      description: A dict with all settings applied to classification.
       type: dict
-    ec2_instaces_attributes:
-      description: provides information about ec2
-      type: dict
-    log_uri:
-      description: path for logs location in S3
+      sample:
+        mapred.tasktracker.map.tasks.maximum: 2
+        mapreduce.map.sort.spill.percent: 0.9
+        mapreduce.tasktracker.reduce.tasks.maximum: 5
+ec2_instance_attributes:
+    description: Provides information about EC2 settings.
+    returned: always
+    type: complex
+    contains:
+      ec2_key_name:
+        description: The EC2 key pair use to connect to hadoop user.
+        type: str
+        sample: emr-key-name
+      ec2_subnet_id:
+        description: The Amazon VPC subnet
+        type: str
+        sample: subnet-925a31cd
+      requested_ec2_subnet_ids:
+        description: Specifies one or more EC2 subnets. Applies only with instance_fleets.
+        type: list
+        sample:
+          - "subnet-923affd"
+      ec2_availability_zone:
+        description: The availability zone in which cluster runs.
+        type: str
+        sample: us-east-1a
+      requested_ec2_availability_zones:
+        description: Specified one or more availability zones. Applies only with instance_fleets.
+        type: list
+        sample:
+          - "us-east-1a"
+          - "us-east-1b"
+      iam_instance_profile:
+        description: The IAM role that was specified when cluster was launched.
+        type: str
+        sample: EMR_EC2_DefaultRole
+      emr_managed_master_security_group:
+        description: The indentifier of EC2 security group for the master node.
+        type: str
+        sample: sg-a9cd833a
+      emr_managed_slave_security_group:
+        description: The indentifier of EC2 security group for the core and task nodes.
+        type: str
+        sample: sg-a9cd833a
+      service_access_security_group:
+        description: The identifier of EC2 security group for the EMR service.
+        type: str
+        sample: sg-dab1ffab
+      additional_master_security_groups:
+        description: A list of additional EC2 security group for the master node.
+        type: list
+        sample:
+          - "sg-a9cd990a"
+          - "sg-dab1ffab"
+      additional_slave_security_groups:
+        description: A list of additional EC2 security group for the core and task node.
+        type: list
+        sample:
+          - "sg-a9cd990a"
+          - "sg-dab1ffab"
+id:
+  description: The unique id for the cluster.
+  type: str
+  sample: j-3130XEPLZZOH4
+instance_collection_type:
+  description: Then instance group configuration.
+  type: str
+  sample: INSTANCE_GROUP
+log_uri:
+  description: The path to S3 location where logs are stored.
+  type: str
+  sample: s3://path/to/s3/logs
+master_public_dns_name:
+  description: The DNS record point to master node.
+  type: str
+  sample: ip-172-16-0-81.ec2.internal
+name:
+  description: Friendly name to the cluster.
+  type: str
+  sample: emr-job
+normalized_instance_hours:
+  description: An approximation of the cost of the cluster, represented in m1.small/hours.
+  type: int
+  sample: 12
+release_label:
+  description: The EMR release label, which determines the version of applications.
+  type: str
+  sample: emr-5.15.0
+scale_down_behavior:
+  description: The way that individual EC2 instance terminate when automatic scale-in.
+  type: str
+  sample: TERMINATE_AT_TASK_COMPLETION
+service_role:
+  description: The IAM role that will be assumed by EMR Service.
+  type: str
+  sample: EMR_DefaultRole
+status:
+  description: The current status of the cluster.
+  type: str
+  sample: RUNNING
+tags:
+  description: EC2 tags used by cluster when was launched.
+  type: complex
+  contains:
+    key:
+      description: The name of key.
       type: str
-    release_label:
-      description: the release label for the Amazon EMR
+    value:
+      description: The value of the key.
       type: str
-    auto_terminate:
-      description: if true cluster should terminate after completing all step
-      type: boolean
-    applications:
-      description: list of the applications installed on this cluster
-      type: list
-    ec2_tags:
-      description: list of tags
-      type: dict
-    service_role:
-      description: IAM role that will be assumed by the Amazon AEMR service
-      type: str
-    master_public_dns_name:
-      description: the dns name of the master node
-      type: str
-    configurations:
-      description: the list of configurations supplied to EMR cluster
-      type: dict
+  sample:
+    - key: Name
+      value: emr-cluster
+termination_protected:
+  description: Specifies if termination protection is enable.
+  type: bool
+visible_to_all_users:
+  description: Specified if the cluster will be visible for all users.
+  type: bool
 '''
 
-from ansible.module_utils.aws.core import AnsibleAWSModule
+import re
 from ansible.module_utils.ec2 import (
     camel_dict_to_snake_dict,
     snake_dict_to_camel_dict,
     ansible_dict_to_boto3_tag_list
 )
 
-import re
+from ansible.module_utils.aws.core import AnsibleAWSModule
 
 try:
     from botocore.exceptions import BotoCoreError, ClientError, WaiterError
@@ -252,17 +583,18 @@ except ImportError:
     pass  # handled by AnsibleAWSModule
 
 
-class ElasticMapReduceError(Exception):
-    def __init__(self, msg, exception=None):
-        self.msg = msg
-        self.exception = exception
+def remove_none_object(obj):
+    if isinstance(obj, (list, tuple, set)):
+        return type(obj)(remove_none_object(x) for x in obj if x is not None)
+    elif isinstance(obj, dict):
+        return type(obj)((remove_none_object(k), remove_none_object(v))
+                         for k, v in obj.items() if k is not None and v is not None)
+    else:
+        return obj
 
 
 def check_emr_cluster(client, module):
     name = module.params.get('name')
-
-    if not name:
-        module.fail_json(msg='name is required')
 
     try:
         emr_clusters = client.list_clusters(ClusterStates=['STARTING',
@@ -272,21 +604,23 @@ def check_emr_cluster(client, module):
     except (ClientError, BotoCoreError) as e:
         module.fail_json_aws(e)
 
-    response = [emr for emr in emr_clusters['Clusters'] if re.compile(name).match(emr['Name'])]
+    response = [emr for emr in emr_clusters['Clusters']
+                if re.compile(name).match(emr['Name'])]
 
     if response:
         changed = False
 
         if len(response) > 1:
-            module.warn(warning='More than one Cluster match with name {} just only the first will be describe'.format(emr['Name']))
+            module.warn(
+                warning='More than one Cluster match with name {0} just only the first will be describe'.format(emr['Name']))
 
         try:
-            resource = client.describe_cluster(ClusterId=response[0]['Id'])
+            resource = client.describe_cluster(
+                ClusterId=response[0]['Id'])['Cluster']
         except (ClientError, BotoCoreError) as e:
             module.fail_json_aws(e)
 
         return changed, camel_dict_to_snake_dict(resource)
-
     else:
         return create_emr_cluster(client, module)
 
@@ -295,10 +629,16 @@ def terminate_emr_cluster(client, module):
     cluster_id = module.params.get('cluster_id')
     wait = module.params.get('wait')
 
-    if not cluster_id:
-        module.fail_json(msg='cluster_id required for state absent')
-
     try:
+        resource = client.describe_cluster(ClusterId=cluster_id)['Cluster']
+
+        if resource['Status']['State'] == 'TERMINATED':
+            changed = False
+            # Remove sensitive information
+            if 'KerberosAttributes' in resource:
+                del resource['KerberosAttributes']
+            return changed, camel_dict_to_snake_dict(resource)
+
         client.terminate_job_flows(JobFlowIds=[cluster_id])
         resource = client.describe_cluster(ClusterId=cluster_id)['Cluster']
     except (ClientError, BotoCoreError) as e:
@@ -310,46 +650,52 @@ def terminate_emr_cluster(client, module):
         wait_max_attempts = module.params.get('wait_max_attempts')
 
         try:
-            waiter.wait(ClusterId=job_flow_id, WaiterConfig={'Delay': wait_delay, 'MaxAttempts': wait_max_attempts})
-            resource = client.describe_cluster(ClusterId=job_flow_id)['Cluster']
+            waiter.wait(ClusterId=cluster_id, WaiterConfig={
+                        'Delay': wait_delay, 'MaxAttempts': wait_max_attempts})
+            resource = client.describe_cluster(
+                ClusterId=cluster_id)['Cluster']
         except (ClientError, BotoCoreError, WaiterError) as e:
             module.fail_json_aws(e)
 
     changed = True
+    # Remove sensitive information
+    if 'KerberosAttributes' in resource:
+        del resource['KerberosAttributes']
     return changed, camel_dict_to_snake_dict(resource)
 
 
 def create_emr_cluster(client, module):
-    params = {}
     wait = module.params.get('wait')
-    wait_timeout = module.params.get('wait_timeout')
 
-    for p in ['name', 'instances', 'log_uri', 'additional_info', 'ami_version', 'release_label',
-              'steps', 'bootstrap_actions', 'supported_products', 'new_supported_products',
-              'applications', 'visible_to_all_users', 'service_role', 'job_flow_role',
-              'security_configuration', 'auto_scaling_role', 'scale_down_behavior', 'custom_ami_id',
-              'repo_upgrade_on_boot', 'ebs_root_volume_size', 'cluster_id', 'kerberos_attributes']:
+    params = remove_none_object(module.params)
 
-        if p in module.params and module.params.get(p):
-            params[p] = module.params.get(p)
+    for param in params.keys():
+        if param not in emr_argument_spec():
+            del params[param]
 
-    if 'ec2_tags' in module.params and module.params.get('ec2_tags'):
-        params['tags'] = ansible_dict_to_boto3_tag_list(module.params.get('ec2_tags'))
-
-    if not params['name']:
-        module.fail_json(msg="name required for the state create")
+    if 'tags' in module.params and module.params.get('tags'):
+        params['tags'] = ansible_dict_to_boto3_tag_list(
+            module.params.get('tags'))
 
     params = snake_dict_to_camel_dict(params, capitalize_first=True)
 
     if 'configurations' in module.params and module.params.get('configurations'):
-        c = module.params.get('configurations')
+        configurations = module.params.get('configurations')
         params['Configurations'] = []
 
-        for k in c.keys():
-            params['Configurations'].append({'Classification': k, 'Properties': c[k]})
+        for key in configurations.keys():
+            properties = {}
+            for k, v in configurations[key].iteritems():
+                if isinstance(v, bool):
+                    properties[k] = str(v).lower()
+                else:
+                    properties[k] = str(v)
+
+            params['Configurations'].append(
+                {'Classification': key, 'Properties': properties})
 
     if 'ebs_volumes' in module.params and module.params.get('ebs_volumes'):
-        volumes = module.params.get('ebs_volumes')
+        volumes = remove_none_object(module.params.get('ebs_volumes'))
 
         device_configs = {'EbsBlockDeviceConfigs': []}
 
@@ -358,6 +704,12 @@ def create_emr_cluster(client, module):
 
             if 'iops' in v:
                 spec['VolumeSpecification']['Iops'] = v['iops']
+
+            if 'device' in v:
+                spec['Device'] = v['device']
+
+            if 'volumes_per_instance' in v:
+                spec['VolumesPerInstance'] = v['volumes_per_instance']
 
             spec['VolumeSpecification']['SizeInGB'] = v['size']
             spec['VolumeSpecification']['VolumeType'] = v['type']
@@ -369,7 +721,8 @@ def create_emr_cluster(client, module):
                 i['EbsConfiguration'] = device_configs
 
             if 'ebs_optimized' in module.params and module.params.get('ebs_volumes'):
-                i['EbsConfiguration']['EbsOptimized'] = module.params.get('ebs_optimized')
+                i['EbsConfiguration']['EbsOptimized'] = module.params.get(
+                    'ebs_optimized')
 
         elif 'InstanceFleets' in params['Instances']:
             for i in params['Instances']['InstanceFleets']:
@@ -377,7 +730,8 @@ def create_emr_cluster(client, module):
                     t['EbsConfiguration'] = device_configs
 
                     if 'ebs_optimized' in module.params and module.params.get('ebs_optimized'):
-                        t['EbsConfiguration']['EbsOptimized'] = module.params.get('ebs_optimized')
+                        t['EbsConfiguration']['EbsOptimized'] = module.params.get(
+                            'ebs_optimized')
 
     try:
         job_flow_id = client.run_job_flow(**params)['JobFlowId']
@@ -391,68 +745,164 @@ def create_emr_cluster(client, module):
         wait_max_attempts = module.params.get('wait_max_attempts')
 
         try:
-            waiter.wait(ClusterId=job_flow_id, WaiterConfig={'Delay': wait_delay, 'MaxAttempts': wait_max_attempts})
-            resource = client.describe_cluster(ClusterId=job_flow_id)['Cluster']
+            waiter.wait(ClusterId=job_flow_id, WaiterConfig={
+                        'Delay': wait_delay, 'MaxAttempts': wait_max_attempts})
+            resource = client.describe_cluster(
+                ClusterId=job_flow_id)['Cluster']
         except (ClientError, BotoCoreError, WaiterError) as e:
             module.fail_json_aws(e)
 
     changed = True
+    # Remove sensitive information
+    if 'KerberosAttributes' in resource:
+        del resource['KerberosAttributes']
     return changed, camel_dict_to_snake_dict(resource)
 
 
-def main():
-    argument_spec = dict(
+def emr_argument_spec():
+    spec = dict(
         dict(
-            name=dict(required=False),
-            instances=dict(required=False, type='dict'),
-            log_uri=dict(required=False),
-            additional_info=dict(required=False),
-            ami_version=dict(required=False),
-            release_label=dict(required=False, default='emr-5.11.0'),
-            steps=dict(required=False, type='list'),
-            bootstrap_actions=dict(required=False, type='list'),
-            supported_products=dict(required=False, type='list'),
-            new_supported_products=dict(required=False, type='list'),
-            applications=dict(required=False, type='list'),
-            configurations=dict(required=False, type='dict'),
-            visible_to_all_users=dict(required=False, type='bool', default=True),
-            service_role=dict(required=False, default='EMR_DefaultRole'),
-            job_flow_role=dict(required=False, default='EMR_EC2_DefaultRole'),
-            security_configuration=dict(required=False),
-            auto_scaling_role=dict(required=False),
-            scale_down_behavior=dict(required=False, choices=['instance_hour', 'task_completion']),
-            custom_ami_id=dict(required=False),
-            repo_upgrade_on_boot=dict(required=False),
-            ebs_root_volume_size=dict(required=False, type='int'),
-            state=dict(required=False, choices=['present', 'create', 'absent'], default='present'),
-            cluster_id=dict(required=False),
-            ec2_tags=dict(required=False, type='dict'),
-            kerberos_attributes=dict(required=False, type='dict'),
-            ebs_volumes=dict(required=False, type='list'),
-            ebs_optimized=dict(required=False, type='bool'),
-            wait=dict(required=False, type='bool', default=False),
-            wait_delay=dict(required=False, type='int', default=30),
-            wait_max_attempts=dict(required=False, type='int', default=60)
+            name=dict(type='str'),
+            log_uri=dict(type='str'),
+            additional_info=dict(type='str'),
+            ami_version=dict(type='str'),
+            release_label=dict(type='str'),
+            instances=dict(
+                type='dict',
+                options=dict(
+                    master_instance_type=dict(type='str'),
+                    slave_instance_type=dict(type='str'),
+                    instance_count=dict(type='int'),
+                    instance_groups=dict(
+                        type='list',
+                        elements='dict',
+                        options=dict(
+                            name=dict(type='str'),
+                            market=dict(type='str', choices=['ON_DEMAND', 'SPOT']),
+                            instance_role=dict(type='str', choices=['MASTER', 'CORE', 'TASK'], required=True),
+                            instance_type=dict(type='str', required=True),
+                            instance_count=dict(type='int', required=True),
+                            auto_scaling_policy=dict(type='dict')
+                        )
+                    ),
+                    instance_fleets=dict(
+                        type='list',
+                        elements='dict',
+                        options=dict(
+                            name=dict(type='str'),
+                            instance_fleet_type=dict(type='str', choices=['MASTER', 'CORE', 'TASK'], required=True),
+                            target_on_demand_capacity=dict(type='int'),
+                            target_spot_capacity=dict(type='int'),
+                            instance_type_configs=dict(
+                                type='list',
+                                elements='dict',
+                                options=dict(
+                                    instance_type=dict(type='str', required=True),
+                                    weighted_capacity=dict(type='int'),
+                                    bid_price=dict(type='str'),
+                                    bid_price_as_percentage_of_on_demand_price=dict(type='float'),
+                                    launch_specifications=dict(type='dict')
+                                )
+                            ),
+                            launch_specifications=dict(type='dict')
+                        )
+                    ),
+                    ec2_key_name=dict(type='str'),
+                    placement=dict(type='dict'),
+                    keep_job_flow_alive_when_no_steps=dict(type='bool', default=False),
+                    termination_protected=dict(type='bool', default=False),
+                    hadoop_version=dict(type='str'),
+                    ec2_subnet_id=dict(type='str'),
+                    ec2_subnets_ids=dict(type='list', elements='str'),
+                    emr_managed_master_security_group=dict(type='str'),
+                    emr_managed_slave_security_group=dict(type='str'),
+                    additional_master_security_groups=dict(type='list', elements='str'),
+                    additional_slave_security_groups=dict(type='list', elements='str')
+                )
+            ),
+            steps=dict(
+                type='list',
+                elements='dict',
+                options=dict(
+                    name=dict(type='str'),
+                    action_on_failure=dict(
+                        type='str',
+                        choices=[
+                            'TERMINATE_JOB_FLOW',
+                            'TERMINATE_CLUSTER',
+                            'CANCEL_AND_WAIT',
+                            'CONTINUE'
+                        ],
+                        default='TERMINATE_CLUSTER'
+                    ),
+                    hadoop_jar_step=dict(type='dict')
+                )
+            ),
+            bootstrap_actions=dict(type='list', elements='dict'),
+            supported_products=dict(type='list', elements='str'),
+            new_supported_products=dict(type='list', elements='dict'),
+            applications=dict(type='list', elements='dict'),
+            visible_to_all_users=dict(type='bool', default=True),
+            job_flow_role=dict(type='str', default='EMR_EC2_DefaultRole'),
+            service_role=dict(type='str', default='EMR_DefaultRole'),
+            security_configuration=dict(type='str'),
+            auto_scaling_role=dict(type='str'),
+            scale_down_behavior=dict(typ='str', choices=['TERMINATE_AT_INSTANCE_HOUR', 'TERMINATE_AT_TASK_COMPLETION']),
+            custom_ami_id=dict(type='str'),
+            ebs_root_volume_size=dict(type='int'),
+            repo_upgrade_on_boot=dict(type='str', choices=['SECURITY', 'NONE']),
+            kerberos_attributes=dict(type='dict', no_log=True)
+        )
+    )
+
+    return spec
+
+
+def main():
+    argument_spec = emr_argument_spec()
+    argument_spec.update(
+        dict(
+            state=dict(type='str', choices=['present', 'absent'], default='present'),
+            configurations=dict(type='dict'),
+            ebs_volumes=dict(
+                type='list',
+                elements='dict',
+                options=dict(
+                    type=dict(type='str', choices=['gp2', 'io1', 'standard'], default='gp2'),
+                    iops=dict(type='int'),
+                    size=dict(type='int'),
+                    device=dict(type='str'),
+                    volumes_per_instance=dict(type='int')
+                )
+            ),
+            ebs_optimized=dict(type='bool', default=False),
+            cluster_id=dict(type='str'),
+            tags=dict(type='dict'),
+            wait=dict(type='bool', default=False),
+            wait_delay=dict(type='int', default=30),
+            wait_max_attempts=dict(type='int', default=60)
         )
     )
 
     module = AnsibleAWSModule(argument_spec=argument_spec,
+                              required_if=[
+                                  ['state', 'present', ['name', 'instances', 'release_label']],
+                                  ['state', 'absent', ['cluster_id']]
+                              ],
                               supports_check_mode=True)
 
     case = {
         'present': check_emr_cluster,
-        'absent': terminate_emr_cluster,
-        'create': create_emr_cluster
+        'absent': terminate_emr_cluster
     }
 
     state = module.params.get('state')
-    try:
-        client = module.client('emr')
-        changed, response = case.get(state)(client, module)
-    except ElasticMapReduceError as e:
-        module.fail_json(e.exception, msg=e.msg)
+    client = module.client('emr')
+
+    changed, response = case.get(state)(client, module)
 
     module.exit_json(changed=changed, **response)
+
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/cloud/amazon/emr_cluster.py
+++ b/lib/ansible/modules/cloud/amazon/emr_cluster.py
@@ -1,0 +1,363 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Copyright: Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: emr_cluster
+short_description:  Creating or Terminating EMR Clusters
+version_added: "2.6"
+description:
+  - creating or terminating EMR Clusters
+  - steps (jobs spark for example) can be setup when Cluster is creating
+  - because the name is not a unique field in AWS this module can't ensure the state
+    from a cluster, so if you runs this module 10 times, 10 cluster will be created
+  - basically this module only receive args and send to boto3, so any argument supported
+    by method run_job_flow() can be used when state is create.
+    check http://boto3.readthedocs.io/en/latest/reference/services/emr.html#EMR.Client.run_job_flow
+    for more information
+  - it depends on boto3
+options:
+  region:
+    description:
+      - region where the module creating or terminating EMR Cluster
+  name:
+    description:
+      - name to be used when EMR is creating
+  instances:
+    description:
+      - specifications about EC2 instances
+  log_uri:
+    description:
+      - s3 path to store logs from EMR
+  release_label:
+    description:
+      - release label for the Amazon EMR
+      - default emr-5.11.0
+  steps:
+    description:
+      - list of steps will be run
+  bootstrap_actions:
+    description:
+      - list of action to run before Hadoop Starts
+  applications:
+    description:
+      - list of Applications that will be enabled on EMR
+  configurations:
+    description:
+      - list of specific configuratins that will be pass for applications and Amazon EMR
+  service_role:
+    description:
+      - IAM role that will be assumed by the Amazon EMR
+      - default EMR_DefaultRole
+  job_flow_role:
+    description:
+      - IAM role that will be assumed by the Amazon EC2
+      - default EMR_EC2_DefaultRole
+  ebs_root_volume_size:
+    description:
+      - settings for EBS on root
+  state:
+    description:
+      - ensure cluster is create or terminate
+      - default create
+  wait:
+    description:
+      - wait until EMR is RUNNING
+      - default false
+  wait_timeout:
+    description:
+      - how log before wait gives up, in seconds
+      - default 600
+  cluster_id:
+    description:
+      - id from EMR that will be terminate
+      - this arg just only used by state terminate
+  additional_info:
+    description:
+      - a json string for selecting additiona features
+  ami_version:
+    description:
+      - Amazon EMR AMI versions for 3.x and 2.x, EMR releases 4.0 and later this is defined by release_label
+  auto_scaling_role:
+    description:
+      - IAM Role for scaling policies, default is EMR_AutoScaling_DefaultRole
+  custom_ami_id:
+    description:
+      - available only in Amazon EMR 5.7.0 and later
+  kerberos_attributes:
+    description:
+      - attributes for Kerberos configuration. For more information see
+        https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-kerberos.html
+  new_supported_products:
+    description:
+      - a list with third-party software to use, see boto3 documentation for more information.
+  repo_upgrade_on_boot:
+    description:
+      - applies when custom_ami_id is used, specified the types of udpates that are applied from the Amazon Linux
+  scale_down_behavior:
+    description:
+      - basically define if scale in occours based in INSTANCE_HOURS or TASK_COMPLETION
+  security_configuration:
+    description:
+      - name of security configuration
+  supported_products:
+    description:
+      - a list set by third-party when job is launched.
+  tags:
+    description:
+      - a dict with tags that will be associate with a cluster
+  visible_to_all_users:
+    description:
+      - define if cluster will be visible to all IAM users, default is True
+author:
+  - Wellington Moreira Ramos (@wmaramos)
+extends_documentation_fragment:
+  - aws
+  - ec2
+'''
+
+EXAMPLES = '''
+- emr_cluster:
+    name: emr-jobs
+    region: us-east-1
+    log_uri: s3://bucket-name/logs/emr
+    wait: yes
+    applications:
+      - name: Hadoop
+      - name: Spark
+    steps:
+      - name: s3-dist-cp
+        hadoop_jar_step:
+          jar: command-runner.jar
+          action_on_failure: TERMINATE_CLUSTER
+          args:
+            - "s3-dist-cp"
+            - "--src=s3://bucket-name/events"
+            - "--dest=hdfs://aggregate"
+            - "--groupBy=.*/[0-9]{4}/[0-9]{2}/.*gz"
+            - "--targetSize=128"
+            - "--outputCode=snappy"
+    instances:
+      ec2_key_name: ec2_key
+      ec2_subnet_id: subnet-923a31db
+      configurations:
+        - classification: spark
+          properties:
+            maximizeResourceAllication: true
+      additional_slave_security_groups:
+        - sg-8eb2b1f1
+      additional_master_security_groups:
+        - sg-8eb2b1f1
+      instance_groups:
+        - name: master
+          instance_role: MASTER
+          instance_count: 1
+          instance_type: m3.xlarge
+          market: ON_DEMAND
+        - name: core
+          instance_role: CORE
+          instance_count: 4
+          instance_type: m3.xlarge
+          market: ON_DEMAND
+'''
+
+RETURN = '''
+# For more information see http://boto3.readthedocs.io/en/latest/reference/services/emr.html#EMR.Client.describe_cluster
+---
+cluster:
+  description: dictionary containing informations about EMR Cluster
+  returned: success
+  type: complex
+  contains:
+    id:
+      description: the unique id for the cluster
+      type: str
+      sample: j-2JNVMF38MZVHT
+    name:
+      description: the name of the cluster
+      type: str
+      sample: emr-jobs
+    status:
+      description: the current status defailts about the cluster
+      type: dict
+    ec2_instaces_attributes:
+      description: provides information about ec2
+      type: dict
+    log_uri:
+      description: path for logs location in S3
+      type: str
+    release_label:
+      description: the release label for the Amazon EMR
+      type: str
+    auto_terminate:
+      description: if true cluster should terminate after completing all step
+      type: boolean
+    applications:
+      description: list of the applications installed on this cluster
+      type: list
+    tags:
+      description: list of tags
+      type: dict
+    service_role:
+      description: IAM role that will be assumed by the Amazon AEMR service
+      type: str
+    master_public_dns_name:
+      description: the dns name of the master node
+      type: str
+    configurations:
+      description: the list of configurations supplied to EMR cluster
+      type: dict
+'''
+
+try:
+    from botocore.exception import ClientError
+except ImportError:
+    pass  # will be picked up from imported HAS_BOTO3
+
+import re
+import traceback
+import time
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.ec2 import ec2_argument_spec, boto3_conn, get_aws_connection_info
+from ansible.module_utils.ec2 import HAS_BOTO3, camel_dict_to_snake_dict, snake_dict_to_camel_dict, ansible_dict_to_boto3_tag_list
+
+
+def terminate_emr_cluster(client, module):
+    cluster_id = module.params.get('cluster_id')
+    wait = module.params.get('wait')
+    wait_timeout = module.params.get('wait_timeout')
+
+    if not cluster_id:
+        module.fail_json(msg='cluster_id required for state absent')
+
+    client.terminate_job_flows(JobFlowIds=[cluster_id])
+
+    resource = client.describe_cluster(ClusterId=cluster_id)['Cluster']
+
+    if wait:
+        wait_timeout = time.time() + wait_timeout
+        time.sleep(5)
+
+        while wait_timeout > time.time() and resource['Status']['State'] != 'TERMINATED':
+            time.sleep(5)
+
+            if wait_timeout <= time.time():
+                module.exit_json(msg="Timeout waiting for resource %s" % resource['Id'])
+
+            resource = client.describe_cluster(ClusterId=cluster_id)['Cluster']
+
+    return camel_dict_to_snake_dict(resource)
+
+
+def create_emr_cluster(client, module):
+    params = {}
+    wait = module.params.get('wait')
+    wait_timeout = module.params.get('wait_timeout')
+
+    for p in ['name', 'instances', 'log_uri', 'additional_info', 'ami_version', 'release_label',
+              'steps', 'bootstrap_actions', 'supported_products', 'new_supported_products',
+              'applications', 'configurations', 'visible_to_all_users', 'service_role', 'job_flow_role',
+              'security_configuration', 'auto_scaling_role', 'scale_down_behavior', 'custom_ami_id',
+              'repo_upgrade_on_boot', 'ebs_root_volume_size', 'cluster_id', 'kerberos_attributes']:
+
+        if p in module.params and module.params.get(p):
+            params[p] = module.params.get(p)
+
+    if 'tags' in module.params and module.params.get('tags'):
+        params['tags'] = ansible_dict_to_boto3_tag_list(module.params.get('tags'))
+
+    if not params['name']:
+        module.fail_json(msg="name required for the state create")
+
+    params = snake_dict_to_camel_dict(params, capitalize_first=True)
+
+    job_flow_id = client.run_job_flow(**params)['JobFlowId']
+
+    resource = client.describe_cluster(ClusterId=job_flow_id)['Cluster']
+
+    if wait:
+        wait_timeout = time.time() + wait_timeout
+        time.sleep(5)
+
+        while wait_timeout > time.time() and resource['Status']['State'] != 'RUNNING':
+            time.sleep(5)
+
+            if wait_timeout <= time.time():
+                module.exit_json(msg="Timeout waiting for resource %s" % resource['Id'])
+
+            resource = client.describe_cluster(ClusterId=job_flow_id)['Cluster']
+
+    return camel_dict_to_snake_dict(resource)
+
+
+def main():
+    argument_spec = ec2_argument_spec()
+    argument_spec.update(
+        dict(
+            name=dict(required=False),
+            instances=dict(required=False, type='dict'),
+            log_uri=dict(required=False),
+            additional_info=dict(required=False),
+            ami_version=dict(required=False),
+            release_label=dict(required=False, default='emr-5.11.0'),
+            steps=dict(required=False, type='list'),
+            bootstrap_actions=dict(required=False, type='list'),
+            supported_products=dict(required=False, type='list'),
+            new_supported_products=dict(required=False, type='list'),
+            applications=dict(required=False, type='list'),
+            configurations=dict(required=False, type='list'),
+            visible_to_all_users=dict(required=False, type='bool', default=True),
+            service_role=dict(required=False, default='EMR_DefaultRole'),
+            job_flow_role=dict(required=False, default='EMR_EC2_DefaultRole'),
+            security_configuration=dict(required=False),
+            auto_scaling_role=dict(required=False),
+            scale_down_behavior=dict(required=False, choices=['instance_hour', 'task_completion']),
+            custom_ami_id=dict(required=False),
+            repo_upgrade_on_boot=dict(required=False),
+            ebs_root_volume_size=dict(required=False, type='int'),
+            state=dict(required=False, choices=['create', 'absent'], default='create'),
+            wait=dict(required=False, type='bool', default=False),
+            cluster_id=dict(required=False),
+            tags=dict(required=False, type='dict'),
+            kerberos_attributes=dict(required=False, type='dict'),
+            wait_timeout=dict(required=False, type='int', default=600)
+        )
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True
+    )
+
+    state = module.params.get('state')
+
+    if not HAS_BOTO3:
+        module.fail_json(msg='boto3 required for this module')
+
+    try:
+        region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
+        client = boto3_conn(module, conn_type='client', resource='emr', region=region, endpoint=ec2_url, **aws_connect_kwargs)
+    except ClientError as e:
+        module.fail_json(msg=e.message, exception=traceback.format_exc(), **camel_dict_to_snake_dict(e.response))
+
+    if state == 'create':
+        cluster = create_emr_cluster(client, module)
+    elif state == 'absent':
+        cluster = terminate_emr_cluster(client, module)
+
+    module.exit_json(changed=True, cluster=cluster)
+
+if __name__ == '__main__':
+    main()

--- a/test/integration/targets/emr_cluster/aliases
+++ b/test/integration/targets/emr_cluster/aliases
@@ -1,0 +1,2 @@
+cloud/aws
+shippable/aws/group2

--- a/test/integration/targets/emr_cluster/defaults/main.yml
+++ b/test/integration/targets/emr_cluster/defaults/main.yml
@@ -1,0 +1,9 @@
+release_label: emr-5.21.0
+configurations:
+  core-site:
+    fs.s3a.attempts.maximum: 20
+  spark:
+    maximizeResourceAllocation: true
+applications:
+  - name: Hadoop
+  - name: Spark

--- a/test/integration/targets/emr_cluster/meta/main.yml
+++ b/test/integration/targets/emr_cluster/meta/main.yml
@@ -1,0 +1,3 @@
+dependencies:
+  - prepare_tests
+  - setup_ec2

--- a/test/integration/targets/emr_cluster/tasks/main.yml
+++ b/test/integration/targets/emr_cluster/tasks/main.yml
@@ -1,0 +1,192 @@
+---
+- module_defaults:
+  block:
+    - name: set up aws connection info
+      set_fact:
+        aws_connection_info: &aws_connection_info
+          aws_access_key: "{{ aws_access_key }}"
+          aws_secret_key: "{{ aws_secret_key }}"
+          security_token: "{{ security_token }}"
+          region: "{{ aws_region }}"
+      no_log: yes
+
+    - name: install aws cli
+      command: pip install awscli
+
+    - name: create default iam roles
+      command: aws emr create-default-roles
+      environment:
+        AWS_ACCESS_KEY_ID: "{{ aws_access_key }}"
+        AWS_SECRET_ACCESS_KEY: "{{ aws_secret_key }}"
+        AWS_SESSION_TOKEN: "{{ security_token }}"
+        AWS_DEFAULT_REGION: "{{ aws_region }}"
+
+    - name: create cluster using instance_fleets with custom applications
+      emr_cluster:
+        name: test_instance_fleets_with_custom_applications
+        release_label: "{{ release_label }}"
+        wait: true
+        configurations: "{{ configurations }}"
+        applications: "{{ applications }}"
+        instances:
+          keep_job_flow_alive_when_no_steps: true
+          instance_fleets:
+            - name: master
+              instance_fleet_type: MASTER
+              target_spot_capacity: 1
+              instance_type_configs:
+                - instance_type: m4.large
+                  bid_price_as_percentage_of_on_demand_price: 100
+        visible_to_all_users: true
+        <<: *aws_connection_info
+      check_mode: true
+      register: result
+
+    - name: assert that changed is True
+      assert:
+        that: result.changed
+
+    - name: assert that status is WAITING
+      assert:
+        that: >
+          result.status.state == 'WAITING'
+
+    - name: try create the same cluster
+      emr_cluster:
+        name: test_instance_fleets_with_custom_applications
+        release_label: "{{ release_label }}"
+        wait: true
+        configurations: "{{ configurations }}"
+        applications: "{{ applications }}"
+        instances:
+          keep_job_flow_alive_when_no_steps: true
+          instance_fleets:
+            - name: master
+              instance_fleet_type: MASTER
+              target_spot_capacity: 1
+              instance_type_configs:
+                - instance_type: m4.large
+                  bid_price_as_percentage_of_on_demand_price: 100
+        visible_to_all_users: true
+        <<: *aws_connection_info
+      check_mode: true
+      register: result
+
+    - name: assert that no changes would be made
+      assert:
+        that: not result.changed
+
+    - name: assert that applications was set up
+      assert:
+        that: >
+          result.applications | map(attribute='name') | list
+          ==
+          applications | map(attribute='name') | list
+
+    - name: defines classification list
+      set_fact:
+        classification: "{{ classification | default([]) | union([item.key]) }}"
+      loop: "{{ configurations | dict2items }}"
+
+    - name: assert that custom configurations was set up
+      assert:
+        that: >
+          result.configurations | map(attribute='classification') | list
+          ==
+          classification
+
+    - name: assert that instance_fleets was set up
+      assert:
+        that: >
+          result.instance_collection_type == 'INSTANCE_FLEET'
+
+    - name: cluster_id facts
+      set_fact:
+        cluster_ids: "{{ cluster_ids | default([]) | union([result.id]) }}"
+
+    - name: create cluster using instance_groups and job steps
+      emr_cluster:
+        name: test_instance_groups_with_steps
+        release_label: "{{ release_label }}"
+        wait: true
+        steps:
+          - name: s3-dist-cp
+            action_on_failure: TERMINATE_CLUSTER
+            hadoop_jar_step:
+              jar: command-runner.jar
+              args:
+                - s3-dist-cp
+                - --src=s3://{{ aws_region }}.elasticmapreduce/thirdparty/mapr/scripts/
+                - --dest=hdfs:///scripts
+        instances:
+          keep_job_flow_alive_when_no_steps: true
+          instance_groups:
+            - name: master
+              instance_role: MASTER
+              instance_count: 1
+              instance_type: m4.large
+              market: ON_DEMAND
+        visible_to_all_users: true
+        <<: *aws_connection_info
+      check_mode: true
+      register: result
+
+    - name: assert that changed is True
+      assert:
+        that: result.changed
+
+    - name: assert that status is RUNNING
+      assert:
+        that: >
+          result.status.state == 'RUNNING'
+
+    - name: assert that instance_group was set up
+      assert:
+        that: >
+          result.instance_collection_type == 'INSTANCE_GROUP'
+
+    - name: cluster_id facts
+      set_fact:
+        cluster_ids: "{{ cluster_ids | union([result.id]) }}"
+
+    - name: terminate clusters
+      emr_cluster:
+        cluster_id: "{{ item }}"
+        state: absent
+        wait: true
+        <<: *aws_connection_info
+      register: result
+      loop: "{{ cluster_ids }}"
+
+    - name: assert that changed is True
+      assert:
+        that: result.changed
+
+    - name: try terminate again
+      emr_cluster:
+        cluster_id: "{{ item }}"
+        state: absent
+        <<: *aws_connection_info
+      register: result
+      loop: "{{ cluster_ids }}"
+
+    - name: assert that no changes would be made
+      assert:
+        that: not result.changed
+
+  always:
+    - name: get active clusters
+      command: aws emr list-clusters --active
+      environment:
+        AWS_ACCESS_KEY_ID: "{{ aws_access_key }}"
+        AWS_SECRET_ACCESS_KEY: "{{ aws_secret_key }}"
+        AWS_SESSION_TOKEN: "{{ security_token }}"
+        AWS_DEFAULT_REGION: "{{ aws_region }}"
+      register: result
+
+    - name: tear down clusters
+      emr_cluster:
+        cluster_id: "{{ item }}"
+        state: absent
+        <<: *aws_connection_info
+      loop: "{{ result.stdout | from_json | json_query('Clusters[*].Id') }}"


### PR DESCRIPTION
##### SUMMARY
- create or terminating EMR Clusters
- steps (jobs spark for example) can be setup when Cluster is creating
- because the name is not a unique field in AWS this module can't ensure the state from a cluster, so if you runs this module 10 times, 10 cluster will be created
- basically this module only receive args and send to boto3, so any argument supported by method run_job_flow() can be used when state is create. Check http://boto3.readthedocs.io/en/latest/reference/services/emr.html#EMR.Client.run_job_flow for more information.
- it depends on boto3

##### ISSUE TYPE
 - New Module Pull Request

##### COMPONENT NAME
emr_cluster

##### ANSIBLE VERSION
```
ansible 2.8.0.dev0
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/wellington.ramos/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/wellington.ramos/git/ansible/lib/ansible
  executable location = /home/wellington.ramos/git/ansible/bin/ansible
  python version = 3.7.2 (default, Mar 17 2019, 16:39:09) [GCC 6.3.0 20170516]
```

