### PR TITLE
Clarify docs/examples of attribute removal

### DIFF
--- a/lib/ansible/modules/net_tools/ldap/ldap_attr.py
+++ b/lib/ansible/modules/net_tools/ldap/ldap_attr.py
@@ -84,7 +84,7 @@ options:
         values will be added if they're missing. If C(absent), all given
         values will be removed if present. If C(exact), the set of values
         will be forced to exactly those provided and no others. If
-        I(state=exact) and I(value) is empty, all values for this
+        I(state=exact) and I(value) is an empty list, all values for this
         attribute will be removed.
   values:
     required: true
@@ -152,7 +152,7 @@ EXAMPLES = """
   ldap_attr:
     dn: uid=jdoe,ou=people,dc=example,dc=com
     name: shadowExpire
-    values: ""
+    values: []
     state: exact
     server_uri: ldap://localhost/
     bind_dn: cn=admin,dc=example,dc=com
@@ -170,7 +170,7 @@ EXAMPLES = """
   ldap_attr:
     dn: uid=jdoe,ou=people,dc=example,dc=com
     name: shadowExpire
-    values: ""
+    values: []
     state: exact
     params: "{{ ldap_auth }}"
 """


### PR DESCRIPTION
##### SUMMARY
If `values="somestring"` is specified then the ldap_attr module normalizes it to 
`values=["somestring"]`. This means passing `name="foo", values="", state=exact` 
results in the ldap entry having an attribute called `foo` with the value `""`.

To delete all attributes "foo", regardless of their values, it is
necessary to pass name="foo", values=[], state="exact".


##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
ldap_attr

##### ANSIBLE VERSION
```
./bin/ansible --version
ansible 2.5.0 (ldap_attr-doc-delete-attr 3e2f7f7146) last updated 2018/02/07 22:25:37 (GMT +100)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/willmerae/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/willmerae/src/ansible/lib/ansible
  executable location = ./bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION

Using empty string:

```yaml
- hosts: localhost
  gather_facts: no
  vars:
    ldap_auth: 
      bind_dn: cn=admin,dc=zoldar,dc=net
      bind_pw: pass1
      server_uri: ldap://localhost:3333

  tasks:
    - ldap_attr:
        dn: dc=users,dc=zoldar,dc=net
        name: foo
        values:
          - bar
          - baz
        state: present
        params: "{{ ldap_auth }}"

    - ldap_attr:
        dn: dc=users,dc=zoldar,dc=net
        name: foo
        # Empty string results in a single attribute, with an empty value
        values: ""
        state: exact
        params: "{{ ldap_auth }}"
```

```
$ ./bin/ansible-playbook ldap.yml
[WARNING]: provided hosts list is empty, only localhost is available. Note
that the implicit localhost does not match 'all'


PLAY [localhost] ***************************************************************

TASK [ldap_attr] ***************************************************************
changed: [localhost]

TASK [ldap_attr] ***************************************************************
changed: [localhost]

PLAY RECAP *********************************************************************
localhost                  : ok=2    changed=2    unreachable=0    failed=0   

$ ldapsearch -H ldap://localhost:3333 -x -Dcn=admin,dc=zoldar,dc=net -wpass1 -b dc=users,dc=zoldar,dc=net -s base
# extended LDIF
#
# LDAPv3
# base <dc=users,dc=zoldar,dc=net> with scope baseObject
# filter: (objectclass=*)
# requesting: ALL
#

# users.zoldar.net
dn: dc=users,dc=zoldar,dc=net
objectClass: domain
dc: users
entryDN: dc=users,dc=zoldar,dc=net
entryUUID: 0ff8e431-16cb-47cd-8e57-1a89623a18ef
subschemaSubentry: cn=schema
creatorsName: cn=Internal Root User
createTimestamp: 20180207223911.318Z
modifiersName: cn=admin,dc=zoldar,dc=net
modifyTimestamp: 20180207223921.361Z
foo:

# search result
search: 2
result: 0 Success

# numResponses: 2
# numEntries: 1

```

Using empty list:

```yaml
- hosts: localhost
  gather_facts: no
  vars:
    ldap_auth: 
      bind_dn: cn=admin,dc=zoldar,dc=net
      bind_pw: pass1
      server_uri: ldap://localhost:3333

  tasks:
    - ldap_attr:
        dn: dc=users,dc=zoldar,dc=net
        name: foo
        values:
          - bar
          - baz
        state: present
        params: "{{ ldap_auth }}"

    - ldap_attr:
        dn: dc=users,dc=zoldar,dc=net
        name: foo
        # Empty list results in deletion of all attributes called foo
        values: []
        state: exact
        params: "{{ ldap_auth }}"
```

```
$ ./bin/ansible-playbook ldap.yml
[WARNING]: provided hosts list is empty, only localhost is available. Note
that the implicit localhost does not match 'all'


PLAY [localhost] ***************************************************************

TASK [ldap_attr] ***************************************************************
changed: [localhost]

TASK [ldap_attr] ***************************************************************
changed: [localhost]

PLAY RECAP *********************************************************************
localhost                  : ok=2    changed=2    unreachable=0    failed=0   

$ ldapsearch -H ldap://localhost:3333 -x -Dcn=admin,dc=zoldar,dc=net -wpass1 -b dc=users,dc=zoldar,dc=net -s base
# extended LDIF
#
# LDAPv3
# base <dc=users,dc=zoldar,dc=net> with scope baseObject
# filter: (objectclass=*)
# requesting: ALL
#

# users.zoldar.net
dn: dc=users,dc=zoldar,dc=net
objectClass: domain
dc: users
entryDN: dc=users,dc=zoldar,dc=net
entryUUID: 0ff8e431-16cb-47cd-8e57-1a89623a18ef
subschemaSubentry: cn=schema
creatorsName: cn=Internal Root User
createTimestamp: 20180207223911.318Z
modifiersName: cn=admin,dc=zoldar,dc=net
modifyTimestamp: 20180207224443.350Z

# search result
search: 2
result: 0 Success

# numResponses: 2
# numEntries: 1
```