### PR TITLE
Follow lookup conventions in vars lookup

### DIFF
--- a/lib/ansible/plugins/lookup/var.py
+++ b/lib/ansible/plugins/lookup/var.py
@@ -64,7 +64,7 @@ class LookupModule(LookupBase):
 
     def run(self, terms, variables=None, **kwargs):
 
-        ret = None
+        ret = []
         if variables is not None:
             self._templar.set_available_variables(variables)
         myvars = getattr(self._templar, '_available_variables', {})
@@ -91,10 +91,11 @@ class LookupModule(LookupBase):
                 value = myvars['hostvars'][term]
             else:
                 raise AnsibleUndefinedVariable('No variable found with this name: %s' % term)
-            ret = self._templar.template(value, fail_on_undefined=True)
+            ret = [self._templar.template(value, fail_on_undefined=True)]
         except AnsibleUndefinedVariable:
-            if default is None:
-                ret = default
+            if default is not None:
+                ret = [default]
             else:
                 raise
+
         return ret

--- a/lib/ansible/plugins/lookup/vars.py
+++ b/lib/ansible/plugins/lookup/vars.py
@@ -4,55 +4,57 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 DOCUMENTATION = """
-    lookup: var
+    lookup: vars
     author: Ansible Core
     version_added: "2.5"
-    short_description: Lookup templated value of variable
+    short_description: Lookup templated value of variables
     description:
       - Retrieves the value of an Ansible variable.
     options:
       _term:
-        description: The variable name to look up.
+        description: The variable names to look up.
         required: True
       default:
         description:
-            - What to return when the variable is undefined.
-            - If no default is set, it will result in an error if the variable is undefined.
+            - What to return if a variable is undefined.
+            - If no default is set, it will result in an error if any of the variables is undefined.
 """
 
 EXAMPLES = """
 - name: Show value of 'variablename'
-  debug: msg="{{ lookup('var', 'variabl' + myvar)}}"
+  debug: msg="{{ lookup('vars', 'variabl' + myvar)}}"
   vars:
     variablename: hello
     myvar: ename
 
 - name: Show default empty since i dont have 'variablnotename'
-  debug: msg="{{ lookup('var', 'variabl' + myvar, default='')}}"
+  debug: msg="{{ lookup('vars', 'variabl' + myvar, default='')}}"
   vars:
     variablename: hello
     myvar: notename
 
 - name: Produce an error since i dont have 'variablnotename'
-  debug: msg="{{ lookup('var', 'variabl' + myvar)}}"
+  debug: msg="{{ lookup('vars', 'variabl' + myvar)}}"
   ignore_errors: True
   vars:
     variablename: hello
     myvar: notename
 
-- name:  find some 'prefixed vars' in loop
-  debug: msg="{{ lookup('var', 'ansible_play_' + item) }}"
+- name: find several related variables:
+  debug: msg="{{ lookup('vars', 'ansible_play_hosts', 'ansible_play_batch', 'ansible_play_hosts_all') }}"
+
+- name: alternate way to find some 'prefixed vars' in loop
+  debug: msg="{{ lookup('vars', 'ansible_play_' + item) }}"
   loop:
     - hosts
     - batch
     - hosts_all
-
 """
 
 RETURN = """
 _value:
   description:
-    - valueof the variable requested
+    - valueof the variables requested.
 """
 
 from ansible.errors import AnsibleError, AnsibleUndefinedVariable

--- a/test/integration/targets/lookups/tasks/main.yml
+++ b/test/integration/targets/lookups/tasks/main.yml
@@ -286,3 +286,22 @@
 - assert:
     that:
       - "hello_world|trim == 'Hello world!'"
+
+# Vars lookups
+
+- name: Test that we can give it a single value and receive a single value
+  set_fact:
+    var_host: '{{ lookup("vars", "ansible_host") }}'
+
+- assert:
+    that:
+      - 'var_host == ansible_host'
+
+- name: Test that we can give a list of values to var and receive a list of values back
+  set_fact:
+    var_host_info: '{{ query("vars", "ansible_host", "ansible_user") }}'
+
+- assert:
+    that:
+      - 'var_host_info[0] == ansible_host'
+      - 'var_host_info[1] == ansible_user'


### PR DESCRIPTION
##### SUMMARY
* All of the lookups that we ship return a list.  Make var lookup do the same.
* Most of our lookups accept a list of terms.  Make var lookup do the same.
* Rename var to vars since it handles multiple variables.
* Test that the use case of scalar in and scalar out works just as well as list in, list out.
 
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
var lookup plugin

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5 (this lookup  is first in 2.5 so if we're going to change any of these, we should do it now).
```

