### PR TITLE
Fix problems with lookups when non-lists are returned.

### DIFF
--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -27,7 +27,7 @@ import pwd
 import re
 import time
 
-from collections import Sequence
+from collections import Iterable, Mapping
 from functools import wraps
 from io import StringIO
 from numbers import Number
@@ -45,7 +45,7 @@ from jinja2.utils import concat as j2_concat
 
 from ansible import constants as C
 from ansible.errors import AnsibleError, AnsibleFilterError, AnsibleUndefinedVariable, AnsibleAssertionError
-from ansible.module_utils.six import string_types, text_type
+from ansible.module_utils.six import string_types, text_type, binary_type
 from ansible.module_utils._text import to_native, to_text, to_bytes
 from ansible.plugins.loader import filter_loader, lookup_loader, test_loader
 from ansible.template.safe_eval import safe_eval
@@ -638,7 +638,7 @@ class Templar:
                 # output: "t.h.i.s. .s.t.r.i.n.g" and wantlist=True would have output the input
                 # terms instead of a list.  A single integer or float would have worked correctly,
                 # though.
-                if not isinstance(ran, Sequence) or isinstance(ran, (text_type, binary_type)):
+                if not isinstance(ran, Iterable) or isinstance(ran, (text_type, binary_type)) or isinstance(ran, Mapping):
                     ran = [ran]
 
                 if wantlist:


### PR DESCRIPTION
##### SUMMARY
If we decide that lookups should be able to return non-lists, then this is probably the PR that we want to apply.  Note, though, that although lookups could technically return some non-list output, that was very buggy previously:

* Strings did not work.  They ended up like "t,h,i,s, ,s,t,r,i,n,g"
* wantlist=true did not work.  It simply output the previous entry
* dicts would not have ended up list: "key1,key2,key3"

Only non-iterables would have worked before.  For instance, returning an integer or float.

So we might want to treat allowing non-lists as a bug and leave the conditional alone.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/template/__init__.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel/2.5
```


##### ADDITIONAL INFORMATION
Review/discussion needed from @sivel @bcoca 