### PR TITLE
Enable hg test on Python 3.

### DIFF
--- a/test/integration/targets/hg/aliases
+++ b/test/integration/targets/hg/aliases
@@ -1,2 +1,1 @@
 posix/ci/group2
-skip/python3

--- a/test/integration/targets/hg/tasks/install.yml
+++ b/test/integration/targets/hg/tasks/install.yml
@@ -1,0 +1,78 @@
+- name: get the default python version
+  command: "{{ ansible_python_interpreter }} -V"
+  register: default_python_version
+
+- name: find the default python
+  command: which python
+  register: which_python
+
+- name: find the default pip
+  command: which pip
+  register: which_pip
+
+- name: preserve the default python
+  command: cp -av "{{ which_python.stdout }}" "{{ which_python.stdout }}.default"
+
+- name: preserve the default pip
+  command: cp -av "{{ which_pip.stdout }}" "{{ which_pip.stdout }}.default"
+
+# using the apt module prevents autoremove from working, so call apt-get via shell instead
+- name: install mercurial (apt)
+  shell: apt-get -y update && apt-get -y install mercurial
+  when: ansible_pkg_mgr == 'apt'
+
+- name: install mercurial (dnf)
+  dnf:
+    name: mercurial
+  when: ansible_pkg_mgr == 'dnf'
+
+- name: install mercurial (yum)
+  yum:
+    name: mercurial
+  when: ansible_pkg_mgr == 'yum'
+
+- name: install mercurial (pkgng)
+  pkgng:
+    name: mercurial
+  when: ansible_pkg_mgr == 'pkgng'
+
+- name: preserve the updated python
+  command: cp -av "{{ which_python.stdout }}" "{{ which_python.stdout }}.updated"
+
+- name: preserve the updated pip
+  command: cp -av "{{ which_pip.stdout }}" "{{ which_pip.stdout }}.updated"
+
+- name: locate mercurial
+  command: which hg
+  register: which_hg
+
+- name: get the mercurial interpreter
+  command: head -n 1 "{{ which_hg.stdout }}"
+  register: hg_interpreter
+
+- name: stat the mercurial interpreter
+  stat:
+    path: "{{ hg_interpreter.stdout[2:] }}"
+  register: stat_hg_interpreter
+
+- name: bypass the mercurial python interpreter symlink (if needed)
+  lineinfile:
+    path: "{{ which_hg.stdout }}"
+    regexp: "^#!.*$"
+    line: "#!{{ stat_hg_interpreter.stat.lnk_source }}"
+  when: stat_hg_interpreter.stat.islnk
+
+- name: restore the default python
+  command: cp -av "{{ which_python.stdout }}.default" "{{ which_python.stdout }}"
+
+- name: restore the default pip
+  command: cp -av "{{ which_pip.stdout }}.default" "{{ which_pip.stdout }}"
+
+- name: get the current python version
+  command: "{{ ansible_python_interpreter }} -V"
+  register: current_python_version
+
+- name: verify the python version has not changed
+  assert:
+    that:
+      - default_python_version.stdout == current_python_version.stdout

--- a/test/integration/targets/hg/tasks/main.yml
+++ b/test/integration/targets/hg/tasks/main.yml
@@ -16,6 +16,15 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
+- name: determine if mercurial is already installed
+  command: which hg
+  register: has_hg
+  ignore_errors: yes
+
+- name: install mercurial
+  include_tasks: install.yml
+  when: has_hg is failed
+
 - name: set where to extract the repo
   set_fact: checkout_dir={{ output_dir }}/epdb
 
@@ -84,3 +93,7 @@
       - hg_result3.msg
       - "'abort: HTTP Error 404: Not Found' in hg_result3.msg"
       - "not hg_result3.changed"
+
+- name: uninstall mercurial
+  include_tasks: uninstall.yml
+  when: has_hg is failed

--- a/test/integration/targets/hg/tasks/uninstall.yml
+++ b/test/integration/targets/hg/tasks/uninstall.yml
@@ -1,0 +1,42 @@
+- name: restore the updated python
+  command: mv "{{ which_python.stdout }}.updated" "{{ which_python.stdout }}"
+
+- name: restore the updated pip
+  command: mv "{{ which_pip.stdout }}.updated" "{{ which_pip.stdout }}"
+
+- name: restore the mercurial python interpreter symlink (if needed)
+  lineinfile:
+    path: "{{ which_hg.stdout }}"
+    regexp: "^#!.*$"
+    line: "#!{{ stat_hg_interpreter.stat.path }}"
+  when: stat_hg_interpreter.stat.islnk
+
+# using the apt module prevents autoremove from working, so call apt-get via shell instead
+- name: uninstall packages which were not originally installed (apt)
+  shell: apt-get -y remove mercurial && apt-get -y autoremove
+  when: ansible_pkg_mgr == 'apt'
+
+- name: uninstall packages which were not originally installed (dnf)
+  dnf:
+    name: mercurial
+    state: absent
+    autoremove: yes
+  when: ansible_pkg_mgr == 'dnf'
+
+# the yum module does not have an autoremove parameter
+- name: uninstall packages which were not originally installed (yum)
+  shell: yum -y autoremove mercurial
+  when: ansible_pkg_mgr == 'yum'
+
+- name: uninstall packages which were not originally installed (pkgng)
+  pkgng:
+    name: mercurial
+    state: absent
+    autoremove: yes
+  when: ansible_pkg_mgr == 'pkgng'
+
+- name: restore the default python
+  raw: mv "{{ which_python.stdout }}.default" "{{ which_python.stdout }}"
+
+- name: restore the default pip
+  raw: mv "{{ which_pip.stdout }}.default" "{{ which_pip.stdout }}"


### PR DESCRIPTION
##### SUMMARY

Enable hg test on Python 3.

The test will now install/uninstall mercurial as needed during the test. The default python and pip will be restored as needed during the test.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

hg integration test

##### ANSIBLE VERSION

```
ansible 2.5.0 (hg-test-fix 86072638cb) last updated 2018/02/07 21:59:30 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```
