### PR TITLE
consul_kv: decodes kv values from Consul to utf-8

### DIFF
--- a/lib/ansible/modules/clustering/consul_kv.py
+++ b/lib/ansible/modules/clustering/consul_kv.py
@@ -132,6 +132,10 @@ except ImportError:
 from ansible.module_utils.basic import AnsibleModule
 
 
+# Note: `python-consul==0.7.2` kv `put` utf-8 encodes data - it cannot be configured
+_ENCODING = "utf-8"
+
+
 def execute(module):
 
     state = module.params.get('state')
@@ -159,7 +163,7 @@ def lock(module, state):
 
     index, existing = consul_api.kv.get(key)
 
-    changed = not existing or (existing and existing['Value'] != value)
+    changed = not existing or (existing and existing['Value'].decode(_ENCODING) != value)
     if changed and not module.check_mode:
         if state == 'acquire':
             changed = consul_api.kv.put(key, value,
@@ -186,7 +190,7 @@ def add_value(module):
 
     index, existing = consul_api.kv.get(key)
 
-    changed = not existing or (existing and existing['Value'] != value)
+    changed = not existing or (existing and existing['Value'].decode(_ENCODING) != value)
     if changed and not module.check_mode:
         changed = consul_api.kv.put(key, value,
                                     cas=module.params.get('cas'),

--- a/lib/ansible/modules/clustering/consul_kv.py
+++ b/lib/ansible/modules/clustering/consul_kv.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 #
 # (c) 2015, Steve Gargan <steve.gargan@gmail.com>
+# (c) 2017, 2018 Genome Research Ltd.
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
@@ -28,7 +29,8 @@ requirements:
   - requests
 version_added: "2.0"
 author:
-- Steve Gargan (@sgargan)
+  - Steve Gargan (@sgargan)
+  - Colin Nolan (@colin-nolan)
 options:
     state:
         description:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #35893 by decoding values from Consul as utf-8.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
consul_kv

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.2.0
  config file = None
  configured module search path = ['/root/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python3.6/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 3.6.2 (default, Sep 13 2017, 14:26:54) [GCC 4.9.2]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
N/A
