### PR TITLE
Leading dot in efs_facts.mountpoint

### DIFF
--- a/lib/ansible/modules/cloud/amazon/efs.py
+++ b/lib/ansible/modules/cloud/amazon/efs.py
@@ -150,7 +150,12 @@ life_cycle_state:
     type: string
     sample: "creating, available, deleting, deleted"
 mount_point:
-    description: url of file system
+    description: url of file system with leading dot from the time when AWS EFS required to add a region suffix to the address
+    returned: always
+    type: string
+    sample: ".fs-xxxxxxxx.efs.us-west-2.amazonaws.com:/"
+filesystem_address:
+    description: url of file system valid for use with mount
     returned: always
     type: string
     sample: "fs-xxxxxxxx.efs.us-west-2.amazonaws.com:/"
@@ -267,10 +272,14 @@ class EFSConnection(object):
             item['Name'] = item['CreationToken']
             item['CreationTime'] = str(item['CreationTime'])
             """
-            Suffix of network path to be used as NFS device for mount. More detail here:
+            In the time when MountPoint was introduced there was a need to add a suffix of network path before one could use it
+            AWS updated it and now there is no need to add a suffix. MountPoint is left for back-compatibility purpose
+            And new FilesystemAddress variable is introduced for direct use with other modules (e.g. mount)
+            AWS documentation is available here:
             http://docs.aws.amazon.com/efs/latest/ug/gs-step-three-connect-to-ec2-instance.html
             """
-            item['MountPoint'] = '%s.efs.%s.amazonaws.com:/' % (item['FileSystemId'], self.region)
+            item['MountPoint'] = '.%s.efs.%s.amazonaws.com:/' % (item['FileSystemId'], self.region)
+            item['FilesystemAddress'] = '%s.efs.%s.amazonaws.com:/' % (item['FileSystemId'], self.region)
             if 'Timestamp' in item['SizeInBytes']:
                 item['SizeInBytes']['Timestamp'] = str(item['SizeInBytes']['Timestamp'])
             if item['LifeCycleState'] == self.STATE_AVAILABLE:

--- a/lib/ansible/modules/cloud/amazon/efs.py
+++ b/lib/ansible/modules/cloud/amazon/efs.py
@@ -153,7 +153,7 @@ mount_point:
     description: url of file system
     returned: always
     type: string
-    sample: ".fs-xxxxxxxx.efs.us-west-2.amazonaws.com:/"
+    sample: "fs-xxxxxxxx.efs.us-west-2.amazonaws.com:/"
 mount_targets:
     description: list of mount targets
     returned: always
@@ -270,7 +270,7 @@ class EFSConnection(object):
             Suffix of network path to be used as NFS device for mount. More detail here:
             http://docs.aws.amazon.com/efs/latest/ug/gs-step-three-connect-to-ec2-instance.html
             """
-            item['MountPoint'] = '.%s.efs.%s.amazonaws.com:/' % (item['FileSystemId'], self.region)
+            item['MountPoint'] = '%s.efs.%s.amazonaws.com:/' % (item['FileSystemId'], self.region)
             if 'Timestamp' in item['SizeInBytes']:
                 item['SizeInBytes']['Timestamp'] = str(item['SizeInBytes']['Timestamp'])
             if item['LifeCycleState'] == self.STATE_AVAILABLE:

--- a/lib/ansible/modules/cloud/amazon/efs_facts.py
+++ b/lib/ansible/modules/cloud/amazon/efs_facts.py
@@ -91,6 +91,11 @@ life_cycle_state:
     type: str
     sample: creating, available, deleting, deleted
 mount_point:
+    description: url of file system with leading dot from the time AWS EFS required to add network suffix to EFS address
+    returned: always
+    type: str
+    sample: .fs-xxxxxxxx.efs.us-west-2.amazonaws.com:/
+filesystem_address:
     description: url of file system
     returned: always
     type: str
@@ -232,10 +237,15 @@ class EFSConnection(object):
         for item in file_systems:
             item['CreationTime'] = str(item['CreationTime'])
             """
-            Suffix of network path to be used as NFS device for mount. More detail here:
+            In the time when MountPoint was introduced there was a need to add a suffix of network path before one could use it
+            AWS updated it and now there is no need to add a suffix. MountPoint is left for back-compatibility purpose
+            And new FilesystemAddress variable is introduced for direct use with other modules (e.g. mount)
+            AWS documentation is available here:
             http://docs.aws.amazon.com/efs/latest/ug/gs-step-three-connect-to-ec2-instance.html
             """
-            item['MountPoint'] = '%s.efs.%s.amazonaws.com:/' % (item['FileSystemId'], self.region)
+            item['MountPoint'] = '.%s.efs.%s.amazonaws.com:/' % (item['FileSystemId'], self.region)
+            item['FilesystemAddress'] = '%s.efs.%s.amazonaws.com:/' % (item['FileSystemId'], self.region)
+
             if 'Timestamp' in item['SizeInBytes']:
                 item['SizeInBytes']['Timestamp'] = str(item['SizeInBytes']['Timestamp'])
             if item['LifeCycleState'] == self.STATE_AVAILABLE:

--- a/lib/ansible/modules/cloud/amazon/efs_facts.py
+++ b/lib/ansible/modules/cloud/amazon/efs_facts.py
@@ -94,7 +94,7 @@ mount_point:
     description: url of file system
     returned: always
     type: str
-    sample: .fs-xxxxxxxx.efs.us-west-2.amazonaws.com:/
+    sample: fs-xxxxxxxx.efs.us-west-2.amazonaws.com:/
 mount_targets:
     description: list of mount targets
     returned: always

--- a/lib/ansible/modules/cloud/amazon/efs_facts.py
+++ b/lib/ansible/modules/cloud/amazon/efs_facts.py
@@ -235,7 +235,7 @@ class EFSConnection(object):
             Suffix of network path to be used as NFS device for mount. More detail here:
             http://docs.aws.amazon.com/efs/latest/ug/gs-step-three-connect-to-ec2-instance.html
             """
-            item['MountPoint'] = '.%s.efs.%s.amazonaws.com:/' % (item['FileSystemId'], self.region)
+            item['MountPoint'] = '%s.efs.%s.amazonaws.com:/' % (item['FileSystemId'], self.region)
             if 'Timestamp' in item['SizeInBytes']:
                 item['SizeInBytes']['Timestamp'] = str(item['SizeInBytes']['Timestamp'])
             if item['LifeCycleState'] == self.STATE_AVAILABLE:


### PR DESCRIPTION
##### SUMMARY
efs_facts module returns efs_facts.mount_point value with leading dot in the address.
It is impossible to pass the value to e.g. mount ansible module or use it other way without removing the dot in advance.
Didn't find any hint in the code on why the dot should be there.

##### ISSUE TYPE
 - Bugfix Pull Request (there was no ticket for it)

##### COMPONENT NAME
efs_facts
efs

##### ANSIBLE VERSION
```
ansible 2.4.3.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/user/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.14+ (default, Dec  5 2017, 15:17:02) [GCC 7.2.0]
```

##### ADDITIONAL INFORMATION
Actual return information:
mount_point | .fs-xxxxxxxx.efs.us-west-2.amazonaws.com:/

Expected return information:
mount_point | fs-xxxxxxxx.efs.us-west-2.amazonaws.com:/

If the dot should be there, we need to add an explanation on why it is there and how one can live with it.