### PR TITLE
Set play context on stdout callback plugin

### DIFF
--- a/lib/ansible/executor/task_queue_manager.py
+++ b/lib/ansible/executor/task_queue_manager.py
@@ -243,6 +243,10 @@ class TaskQueueManager:
         )
 
         play_context = PlayContext(new_play, self._options, self.passwords, self._connection_lockfile.fileno())
+        if (self._stdout_callback and
+                hasattr(self._stdout_callback, 'set_play_context')):
+            self._stdout_callback.set_play_context(play_context)
+
         for callback_plugin in self._callback_plugins:
             if hasattr(callback_plugin, 'set_play_context'):
                 callback_plugin.set_play_context(play_context)


### PR DESCRIPTION
##### SUMMARY
The loop on self._callback_plugins does not include the stdout callback,
so the stdout_callback never has set_play_context called.

##### ISSUE TYPE
 - Bugfix Pull Request