### PR TITLE
module for creating, managing Infoblox NIOS nameserver groups

### DIFF
--- a/lib/ansible/modules/net_tools/nios/nios_nsgroup.py
+++ b/lib/ansible/modules/net_tools/nios/nios_nsgroup.py
@@ -2,8 +2,8 @@
 
 
 from __future__ import absolute_import, division, print_function
-__metaclass__ = type
 
+__metaclass__ = type
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
@@ -12,8 +12,8 @@ ANSIBLE_METADATA = {'metadata_version': '1.0',
 DOCUMENTATION = '''
 ---
 module: nios_nsgroup
-short_description: manage InfoBlox DNS nameserver groups 
-extends_documentation_fragment: nios 
+short_description: manage InfoBlox DNS nameserver groups
+extends_documentation_fragment: nios
 author:
     - Erich Birngruber (@ebirn)
 version_added: "2.5"
@@ -23,7 +23,7 @@ description:
       WAPI interface over REST.
 requirements:
   - infoblox_client
-extends_documentation_fragment: nios 
+extends_documentation_fragment: nios
 options:
   external_primaries:
     description:
@@ -49,7 +49,7 @@ options:
     default: false
   use_external_primary:
     description:
-      - This flag controls whether the group is using an external primary. 
+      - This flag controls whether the group is using an external primary.
         Note that modification of this field requires passing values for C(grid_secondaries) and C(external_primaries).
     required: false
     default: false
@@ -72,30 +72,29 @@ options:
      default: present
 '''
 
-
 EXAMPLES = '''
 - name: create simple infoblox nameserver group
   nios_nsgroup:
     provider:
-      username: admin 
-      password: password 
+      username: admin
+      password: password
       host: infoblox-test.example.com
       wapi_version: 2.1
-    name: my-simple-group 
+    name: my-simple-group
     comment: "this is a simple nameserver group"
     grid_primary:
       - name: infoblox-test.example.com
   state: present
   connection: local
 
-- name: create infoblox nameserver group with external primaries 
+- name: create infoblox nameserver group with external primaries
   nios_nsgroup:
     provider:
       username: admin
-      password: password 
-      host: infoblox-test.examplecom
+      password: password
+      host: infoblox-test.example.com
       wapi_version: 2.1
-    name: my-example-group 
+    name: my-example-group
     use_external_primary: true
     comment: "this is my example nameserver group"
     external_primaries: "{{ ext_nameservers }}"
@@ -113,18 +112,20 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six import iteritems
 from ansible.module_utils.net_tools.nios.api import WapiModule
 
-## Fields List
-## Field		Type		Req	R/O	Base	Search
-## comment		String		N	N	Y	: = ~
-## extattrs		Extattr		N	N	N	ext
-## external_primaries	[struct]	N	N	N	N/A
-## external_secondaries	[struct]	N	N	N	N/A
-## grid_primary		[struct]	N	N	N	N/A
-## grid_secondaries	[struct]	N	N	N	N/A
-## is_grid_default	Bool		N	N	N	N/A
-## is_multimaster	Bool		N	Y	N	N/A
-## name			String		Y		N	Y	: = ~
-## use_external_primary	Bool		N	N	N	N/A
+
+# from infoblox documentation
+# Fields List
+# Field		Type		Req	R/O	Base	Search
+# comment		String		N	N	Y	: = ~
+# extattrs		Extattr		N	N	N	ext
+# external_primaries	[struct]	N	N	N	N/A
+# external_secondaries	[struct]	N	N	N	N/A
+# grid_primary		[struct]	N	N	N	N/A
+# grid_secondaries	[struct]	N	N	N	N/A
+# is_grid_default	Bool		N	N	N	N/A
+# is_multimaster	Bool		N	Y	N	N/A
+# name			String		Y		N	Y	: = ~
+# use_external_primary	Bool		N	N	N	N/A
 
 
 def main():
@@ -132,79 +133,82 @@ def main():
         provider=dict(required=True),
         state=dict(default='present', choices=['present', 'absent']),
     )
-    
-    # cleanup tsig fields 
+
+    # cleanup tsig fields
     def clean_tsig(ext):
-      if 'tsig_key' in ext and not ext['tsig_key']:
-        del ext['tsig_key'] 
-      if not 'tsig_key' in ext and 'tsig_key_name' in ext and not ext['tsig_key_name']:
-        del ext['tsig_key_name']
-      if 'tsig_key' not in ext and 'tsig_key_alg' in ext:
-        del ext['tsig_key_alg']
-      
+        if 'tsig_key' in ext and not ext['tsig_key']:
+            del ext['tsig_key']
+        if 'tsig_key' not in ext and 'tsig_key_name' in ext and not ext['tsig_key_name']:
+            del ext['tsig_key_name']
+        if 'tsig_key' not in ext and 'tsig_key_alg' in ext:
+            del ext['tsig_key_alg']
+
     def clean_grid_member(member):
-      if member['preferred_primaries']:
-        for ext in member['preferred_primaries']:
-          clean_tsig(ext)
-      if member['enable_preferred_primaries'] is False:
-        del member['enable_preferred_primaries']
-        del member['preferred_primaries']
-      if member['lead'] is False:
-        del member['lead']
-      if member['grid_replicate'] is False:
-        del  member['grid_replicate']
+        if member['preferred_primaries']:
+            for ext in member['preferred_primaries']:
+                clean_tsig(ext)
+        if member['enable_preferred_primaries'] is False:
+            del member['enable_preferred_primaries']
+            del member['preferred_primaries']
+        if member['lead'] is False:
+            del member['lead']
+        if member['grid_replicate'] is False:
+            del member['grid_replicate']
 
     def ext_primaries_transform(module):
-      if module.params['external_primaries']:
-        for ext in module.params['external_primaries']:
-          clean_tsig(ext)
-      return module.params['external_primaries']
-    
+        if module.params['external_primaries']:
+            for ext in module.params['external_primaries']:
+                clean_tsig(ext)
+        return module.params['external_primaries']
+
     def ext_secondaries_transform(module):
-      if module.params['external_secondaries']:
-        for ext in module.params['external_secondaries']:
-          clean_tsig(ext)
-      return module.params['external_secondaries']
-    
+        if module.params['external_secondaries']:
+            for ext in module.params['external_secondaries']:
+                clean_tsig(ext)
+        return module.params['external_secondaries']
+
     def grid_primary_preferred_transform(module):
-      for member in module.params['grid_primary']:
-        clean_grid_member(member)
-      return module.params['grid_primary']
+        for member in module.params['grid_primary']:
+            clean_grid_member(member)
+        return module.params['grid_primary']
 
     def grid_secondaries_preferred_primaries_transform(module):
-      for member in module.params['grid_secondaries']:
-        clean_grid_member(member)
-      return module.params['grid_secondaries']
-    
- 
+        for member in module.params['grid_secondaries']:
+            clean_grid_member(member)
+        return module.params['grid_secondaries']
+
     extserver_spec = dict(
-        address = dict(type='str', required=True, ib_req=True),
-        name = dict(type='str', required=True, ib_req=True),
-        stealth = dict(type='bool', default=False),
-        tsig_key = dict(type='str', default=''),
-        tsig_key_alg = dict(type='str', choices=['HMAC-MD5', 'HMAC-SHA256'], default='HMAC-MD5'),
-        tsig_key_name = dict(type='str', default='', )
+        address=dict(type='str', required=True, ib_req=True),
+        name=dict(type='str', required=True, ib_req=True),
+        stealth=dict(type='bool', default=False),
+        tsig_key=dict(type='str', default=''),
+        tsig_key_alg=dict(type='str', choices=['HMAC-MD5', 'HMAC-SHA256'], default='HMAC-MD5'),
+        tsig_key_name=dict(type='str', default='', )
     )
-    
+
     memberserver_spec = dict(
-        enable_preferred_primaries = dict(type='bool', default=False),
-        grid_replicate = dict(type='bool', default=False),
-        lead = dict(type='bool', default=False),
-        name = dict(type='str', required=True, ib_req=True),
-        preferred_primaries = dict(type='list', elements='dict', options=extserver_spec, default=[]),
-        stealth = dict(type='bool', default=False),
+        enable_preferred_primaries=dict(type='bool', default=False),
+        grid_replicate=dict(type='bool', default=False),
+        lead=dict(type='bool', default=False),
+        name=dict(type='str', required=True, ib_req=True),
+        preferred_primaries=dict(type='list', elements='dict', options=extserver_spec, default=[]),
+        stealth=dict(type='bool', default=False),
     )
- 
+
     ib_spec = dict(
         name=dict(type='str', required=True, ib_req=True),
-	grid_primary = dict(type='list', elements='dict', options=memberserver_spec, transform=grid_primary_preferred_transform),
-	grid_secondaries = dict(type='list', elements='dict', options=memberserver_spec, transform=grid_secondaries_preferred_primaries_transform, default=[]),
-	external_primaries = dict(type='list', elements='dict', options=extserver_spec, transform=ext_primaries_transform, default=[]),
-	external_secondaries = dict(type='list', elements='dict', options=extserver_spec, transform=ext_secondaries_transform, default=[]),
-        is_grid_default = dict(type='bool', default=False),
-        use_external_primary = dict(type='bool', default=False),
-        extattrs = dict(),
-        comment = dict(type='str', default=''),
+        grid_primary=dict(type='list', elements='dict', options=memberserver_spec,
+                          transform=grid_primary_preferred_transform),
+        grid_secondaries=dict(type='list', elements='dict', options=memberserver_spec,
+                              transform=grid_secondaries_preferred_primaries_transform, default=[]),
+        external_primaries=dict(type='list', elements='dict', options=extserver_spec, transform=ext_primaries_transform,
+                                default=[]),
+        external_secondaries=dict(type='list', elements='dict', options=extserver_spec,
+                                  transform=ext_secondaries_transform, default=[]),
+        is_grid_default=dict(type='bool', default=False),
+        use_external_primary=dict(type='bool', default=False),
+        extattrs=dict(),
+        comment=dict(type='str', default=''),
     )
 
     argument_spec.update(ib_spec)
@@ -220,5 +224,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-
-

--- a/lib/ansible/modules/net_tools/nios/nios_nsgroup.py
+++ b/lib/ansible/modules/net_tools/nios/nios_nsgroup.py
@@ -14,13 +14,13 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = '''
 ---
 module: nios_nsgroup
-short_description: manage InfoBlox DNS nameserver groups
+short_description: Configure InfoBlox DNS nameserver groups
 extends_documentation_fragment: nios
 author:
     - Erich Birngruber (@ebirn)
 version_added: "2.6"
 description:
-    - add or remove nameserver groups form Infoblox NIOS servers.
+    - Adds and/or removes nameserver groups form Infoblox NIOS servers.
       This module manages NIOS C(nsgroup) objects using the Infoblox
       WAPI interface over REST.
 requirements:
@@ -28,31 +28,35 @@ requirements:
 options:
   name:
     description:
-      - name of the nameserver group
+      - Specifies the name of the NIOS nameserver group to be managed.
     required: true
+  grid_primary:
+    description:
+      - This list of hosts is to be used as primary servers in this nameserver group. They must be grid members.
+        This option is required when setting I(use_external_primaries) to C(false).
+  grid_secondaries:
+    description:
+     - Configures the list of grid member hosts that act as secondary nameservers.
+       This option is required when setting I(use_external_primaries) to C(true). 
+  is_grid_default:
+    description:
+      - If set to C(True) this nsgroup will become the default nameserver group for new zones.
+    required: false
+    default: false
+  use_external_primary:
+    description:
+      - This flag controls whether the group is using an external primary nameserver.
+        Note that modification of this field requires passing values for I(grid_secondaries) and I(external_primaries).
+    required: false
+    default: false
   external_primaries:
     description:
-      - list of external primary nameservers
+      - Configures a list of external nameservers (non-members of the grid).
+        This option is required when setting I(use_external_primaries) to C(true).
     required: false
   external_secondaries:
     description:
-      - list of external secondary nameservers
-  grid_primary:
-    description:
-      - list of grid member primary nameservers
-  grid_secondaries:
-    description:
-     - list of grid member secondary nameservers
-  is_grid_default:
-    description:
-      - make this nameserver group the grid default
-    required: false
-  use_external_primary:
-    description:
-      - This flag controls whether the group is using an external primary.
-        Note that modification of this field requires passing values for C(grid_secondaries) and C(external_primaries).
-    required: false
-    default: false
+      - Allows to provide a list of external secondary nameservers, that are not members of the grid.
   extattrs:
     description:
       - Allows for the configuration of Extensible Attributes on the
@@ -67,7 +71,10 @@ options:
     required: false
   state:
     description:
-      - Should the resource be C(present) or C(absent).
+      - Configures the intended state of the instance of the object on
+        the NIOS server.  When this value is set to C(present), the object
+        is configured on the device and when this value is set to C(absent)
+        the value is removed (if necessary) from the device.
     choices: [present, absent]
     default: present
 '''

--- a/lib/ansible/modules/net_tools/nios/nios_nsgroup.py
+++ b/lib/ansible/modules/net_tools/nios/nios_nsgroup.py
@@ -25,7 +25,6 @@ description:
       WAPI interface over REST.
 requirements:
   - infoblox_client
-extends_documentation_fragment: nios
 options:
   external_primaries:
     description:
@@ -66,12 +65,12 @@ options:
       - Configures a text string comment to be associated with the instance
         of this object.  The provided text string will be configured on the
         object instance.
-   required: false
-   state:
-     description:
-       - Should the resource be C(present) or C(absent).
-     choices: [present, absent]
-     default: present
+    required: false
+  state:
+    description:
+      - Should the resource be C(present) or C(absent).
+    choices: [present, absent]
+    default: present
 '''
 
 EXAMPLES = '''
@@ -131,7 +130,7 @@ from ansible.module_utils.net_tools.nios.api import WapiModule
 
 
 def main():
-    ''' entrypoint for module execution'''
+    '''entrypoint for module execution.'''
     argument_spec = dict(
         provider=dict(required=True),
         state=dict(default='present', choices=['present', 'absent']),

--- a/lib/ansible/modules/net_tools/nios/nios_nsgroup.py
+++ b/lib/ansible/modules/net_tools/nios/nios_nsgroup.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-ANSIBLE_METADATA = {'metadata_version': '1.0',
+ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],
                     'supported_by': 'community'}
 
@@ -18,7 +18,7 @@ short_description: manage InfoBlox DNS nameserver groups
 extends_documentation_fragment: nios
 author:
     - Erich Birngruber (@ebirn)
-version_added: "2.5"
+version_added: "2.6"
 description:
     - add or remove nameserver groups form Infoblox NIOS servers.
       This module manages NIOS C(nsgroup) objects using the Infoblox

--- a/lib/ansible/modules/net_tools/nios/nios_nsgroup.py
+++ b/lib/ansible/modules/net_tools/nios/nios_nsgroup.py
@@ -1,5 +1,7 @@
 #!/usr/bin/python
+# -*- coding: utf-8 -*-
 
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
 
@@ -129,6 +131,7 @@ from ansible.module_utils.net_tools.nios.api import WapiModule
 
 
 def main():
+    ''' entrypoint for module execution'''
     argument_spec = dict(
         provider=dict(required=True),
         state=dict(default='present', choices=['present', 'absent']),

--- a/lib/ansible/modules/net_tools/nios/nios_nsgroup.py
+++ b/lib/ansible/modules/net_tools/nios/nios_nsgroup.py
@@ -32,31 +32,136 @@ options:
     required: true
   grid_primary:
     description:
-      - This list of hosts is to be used as primary servers in this nameserver group. They must be grid members.
+      - This host is to be used as primary server in this nameserver group. It must be a grid member.
         This option is required when setting I(use_external_primaries) to C(false).
+    suboptions:
+      name:
+        description:
+          - Provide the name of the grid member to identify the host.
+        required: true
+      enable_preferred_primaries:
+        description:
+          - This flag represents whether the preferred_primaries field values of this member are used (see Infoblox WAPI docs).
+        default: false
+        type: bool
+      grid_replicate:
+        description:
+          - Use DNS zone transfers if set to C(True) or ID Grid Replication if set to C(False)
+        type: bool
+        default: false
+      lead:
+        description:
+          - This flag controls if the grid lead secondary nameserver performs zone transfers to non lead secondaries.
+        type: bool
+        default: false
+      stealth:
+        description:
+          - Configure the external nameserver as stealth server (without NS record) in the zones.
+        type: bool
+        default: false
   grid_secondaries:
     description:
      - Configures the list of grid member hosts that act as secondary nameservers.
-       This option is required when setting I(use_external_primaries) to C(true). 
+       This option is required when setting I(use_external_primaries) to C(true).
+    suboptions:
+      name:
+        description:
+          - Provide the name of the grid member to identify the host.
+        required: true
+      enable_preferred_primaries:
+        description:
+          - This flag represents whether the preferred_primaries field values of this member are used (see Infoblox WAPI docs).
+        default: false
+        type: bool
+      grid_replicate:
+        description:
+          - Use DNS zone transfers if set to C(True) or ID Grid Replication if set to C(False)
+        type: bool
+        default: false
+      lead:
+        description:
+          - This flag controls if the grid lead secondary nameserver performs zone transfers to non lead secondaries.
+        type: bool
+        default: false
+      stealth:
+        description:
+          - Configure the external nameserver as stealth server (without NS record) in the zones.
+        type: bool
+        default: false
+      preferred_primaries:
+        description:
+          - Provide a list of elements like in I(external_primaries) to set the precedence of preferred primary nameservers.
   is_grid_default:
     description:
       - If set to C(True) this nsgroup will become the default nameserver group for new zones.
+    type: bool
     required: false
     default: false
   use_external_primary:
     description:
       - This flag controls whether the group is using an external primary nameserver.
         Note that modification of this field requires passing values for I(grid_secondaries) and I(external_primaries).
+    type: bool
     required: false
     default: false
   external_primaries:
     description:
       - Configures a list of external nameservers (non-members of the grid).
         This option is required when setting I(use_external_primaries) to C(true).
+    suboptions:
+      address:
+        description:
+          - Configures the IP address of the external nameserver
+        required: true
+      name:
+        description:
+          - Set a label for the external nameserver
+        required: true
+      stealth:
+        description:
+          - Configure the external nameserver as stealth server (without NS record) in the zones.
+        type: bool
+        default: false
+      tsig_key_name:
+        description:
+          - Sets a label for the I(tsig_key) value
+      tsig_key_alg:
+        description:
+          - Provides the algorithm used for the I(tsig_key) in use.
+        choices: ['HMAC-MD5', 'HMAC-SHA256']
+        default: 'HMAC-MD5'
+      tsig_key:
+        description:
+          - Set a DNS TSIG key for the nameserver to secure zone transfers (AFXRs).
     required: false
   external_secondaries:
     description:
       - Allows to provide a list of external secondary nameservers, that are not members of the grid.
+    suboptions:
+      address:
+        description:
+          - Configures the IP address of the external nameserver
+        required: true
+      name:
+        description:
+          - Set a label for the external nameserver
+        required: true
+      stealth:
+        description:
+          - Configure the external nameserver as stealth server (without NS record) in the zones.
+        type: bool
+        default: false
+      tsig_key_name:
+        description:
+          - Sets a label for the I(tsig_key) value
+      tsig_key_alg:
+        description:
+          - Provides the algorithm used for the I(tsig_key) in use.
+        choices: ['HMAC-MD5', 'HMAC-SHA256']
+        default: 'HMAC-MD5'
+      tsig_key:
+        description:
+          - Set a DNS TSIG key for the nameserver to secure zone transfers (AFXRs).
   extattrs:
     description:
       - Allows for the configuration of Extensible Attributes on the
@@ -189,16 +294,16 @@ def main():
         address=dict(type='str', required=True, ib_req=True),
         name=dict(type='str', required=True, ib_req=True),
         stealth=dict(type='bool', default=False),
-        tsig_key=dict(type='str', default=''),
+        tsig_key=dict(type='str'),
         tsig_key_alg=dict(type='str', choices=['HMAC-MD5', 'HMAC-SHA256'], default='HMAC-MD5'),
-        tsig_key_name=dict(type='str', default='', )
+        tsig_key_name=dict(type='str', required=True)
     )
 
     memberserver_spec = dict(
+        name=dict(type='str', required=True, ib_req=True),
         enable_preferred_primaries=dict(type='bool', default=False),
         grid_replicate=dict(type='bool', default=False),
         lead=dict(type='bool', default=False),
-        name=dict(type='str', required=True, ib_req=True),
         preferred_primaries=dict(type='list', elements='dict', options=extserver_spec, default=[]),
         stealth=dict(type='bool', default=False),
     )
@@ -208,15 +313,14 @@ def main():
         grid_primary=dict(type='list', elements='dict', options=memberserver_spec,
                           transform=grid_primary_preferred_transform),
         grid_secondaries=dict(type='list', elements='dict', options=memberserver_spec,
-                              transform=grid_secondaries_preferred_primaries_transform, default=[]),
-        external_primaries=dict(type='list', elements='dict', options=extserver_spec, transform=ext_primaries_transform,
-                                default=[]),
+                              transform=grid_secondaries_preferred_primaries_transform),
+        external_primaries=dict(type='list', elements='dict', options=extserver_spec, transform=ext_primaries_transform),
         external_secondaries=dict(type='list', elements='dict', options=extserver_spec,
-                                  transform=ext_secondaries_transform, default=[]),
+                                  transform=ext_secondaries_transform),
         is_grid_default=dict(type='bool', default=False),
         use_external_primary=dict(type='bool', default=False),
         extattrs=dict(),
-        comment=dict(type='str', default=''),
+        comment=dict(type='str'),
     )
 
     argument_spec.update(ib_spec)

--- a/lib/ansible/modules/net_tools/nios/nios_nsgroup.py
+++ b/lib/ansible/modules/net_tools/nios/nios_nsgroup.py
@@ -26,6 +26,10 @@ description:
 requirements:
   - infoblox_client
 options:
+  name:
+    description:
+      - name of the nameserver group
+    required: true
   external_primaries:
     description:
       - list of external primary nameservers
@@ -36,18 +40,13 @@ options:
   grid_primary:
     description:
       - list of grid member primary nameservers
-  grid_secondary:
+  grid_secondaries:
     description:
      - list of grid member secondary nameservers
-  grid_default:
+  is_grid_default:
     description:
       - make this nameserver group the grid default
     required: false
-  is_multimaster:
-    description:
-      - is the group a multi master group
-    required: false
-    default: false
   use_external_primary:
     description:
       - This flag controls whether the group is using an external primary.

--- a/lib/ansible/modules/net_tools/nios/nios_nsgroup.py
+++ b/lib/ansible/modules/net_tools/nios/nios_nsgroup.py
@@ -1,0 +1,211 @@
+#!/usr/bin/python
+
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.0',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = '''
+---
+module: nios_nsgroup
+short_description: manage InfoBlox DNS nameserver groups 
+extends_documentation_fragment: nios 
+author:
+    - Erich Birngruber (@ebirn)
+version_added: "2.5"
+description:
+    - add or remove nameserver groups form Infoblox NIOS servers.
+      This module manages NIOS C(nsgroup) objects using the Infoblox
+      WAPI interface over REST.
+requirements:
+  - infoblox_client
+extends_documentation_fragment: nios 
+options:
+  external_primaries:
+    description:
+      - list of external primary nameservers
+    required: false
+  external_secondaries:
+    description:
+      - list of external secondary nameservers
+  grid_primary:
+    description:
+      - list of grid member primary nameservers
+  grid_secondary:
+    description:
+     - list of grid member secondary nameservers
+  grid_default:
+    description:
+      - make this nameserver group the grid default
+    required: false
+  is_multimaster:
+    description:
+      - is the group a multi master group
+    required: false
+    default: false
+  use_external_primary:
+    description:
+      - This flag controls whether the group is using an external primary. 
+        Note that modification of this field requires passing values for C(grid_secondaries) and C(external_primaries).
+    required: false
+    default: false
+  extattrs:
+    description:
+      - Allows for the configuration of Extensible Attributes on the
+        instance of the object.  This argument accepts a set of key / value
+        pairs for configuration.
+    required: false
+  comment:
+    description:
+      - Configures a text string comment to be associated with the instance
+        of this object.  The provided text string will be configured on the
+        object instance.
+   required: false
+   state:
+     description:
+       - Should the resource be C(present) or C(absent).
+     choices: [present, absent]
+     default: present
+'''
+
+
+EXAMPLES = '''
+
+
+- name: create infoblox nameserver group with external primaries 
+  nios_nsgroup:
+    provider:
+      username: admin
+      password: password 
+      host: infoblox-test.examplecom
+      wapi_version: 2.2
+    name: my-example-group 
+    use_external_primary: true
+    comment: "this is my example nameserver group"
+    external_primaries: "{{ ext_nameservers }}"
+    grid_secondaries:
+      - name: infoblox-test.example.com
+        lead: True
+        preferred_primaries: "{{ ext_nameservers }}"
+  state: present
+'''
+
+RETURN = ''' # '''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.six import iteritems
+from ansible.module_utils.net_tools.nios.api import WapiModule
+
+## Fields List
+## Field		Type		Req	R/O	Base	Search
+## comment		String		N	N	Y	: = ~
+## extattrs		Extattr		N	N	N	ext
+## external_primaries	[struct]	N	N	N	N/A
+## external_secondaries	[struct]	N	N	N	N/A
+## grid_primary		[struct]	N	N	N	N/A
+## grid_secondaries	[struct]	N	N	N	N/A
+## is_grid_default	Bool		N	N	N	N/A
+## is_multimaster	Bool		N	Y	N	N/A
+## name			String		Y		N	Y	: = ~
+## use_external_primary	Bool		N	N	N	N/A
+
+
+def main():
+    argument_spec = dict(
+        provider=dict(required=True),
+        state=dict(default='present', choices=['present', 'absent']),
+    )
+    
+    # cleanup tsig fields 
+    def clean_tsig(ext):
+      if 'tsig_key' in ext and not ext['tsig_key']:
+        del ext['tsig_key'] 
+      if not 'tsig_key' in ext and 'tsig_key_name' in ext and not ext['tsig_key_name']:
+        del ext['tsig_key_name']
+      if 'tsig_key' not in ext and 'tsig_key_alg' in ext:
+        del ext['tsig_key_alg']
+      
+    def clean_grid_member(member):
+      if member['preferred_primaries']:
+        for ext in member['preferred_primaries']:
+          clean_tsig(ext)
+      if member['enable_preferred_primaries'] is False:
+        del member['enable_preferred_primaries']
+        del member['preferred_primaries']
+      if member['lead'] is False:
+        del member['lead']
+      if member['grid_replicate'] is False:
+        del  member['grid_replicate']
+
+    def ext_primaries_transform(module):
+      if module.params['external_primaries']:
+        for ext in module.params['external_primaries']:
+          clean_tsig(ext)
+      return module.params['external_primaries']
+    
+    def ext_secondaries_transform(module):
+      if module.params['external_secondaries']:
+        for ext in module.params['external_secondaries']:
+          clean_tsig(ext)
+      return module.params['external_secondaries']
+    
+    def grid_primary_preferred_transform(module):
+      for member in module.params['grid_primary']:
+        clean_grid_member(member)
+      return module.params['grid_primary']
+
+    def grid_secondaries_preferred_primaries_transform(module):
+      for member in module.params['grid_secondaries']:
+        clean_grid_member(member)
+      return module.params['grid_secondaries']
+    
+ 
+    extserver_spec = dict(
+        address = dict(type='str', required=True, ib_req=True),
+        name = dict(type='str', required=True, ib_req=True),
+        stealth = dict(type='bool', default=False),
+        tsig_key = dict(type='str', default=''),
+        tsig_key_alg = dict(type='str', choices=['HMAC-MD5', 'HMAC-SHA256'], default='HMAC-MD5'),
+        tsig_key_name = dict(type='str', default='', )
+    )
+    
+    memberserver_spec = dict(
+        enable_preferred_primaries = dict(type='bool', default=False),
+        grid_replicate = dict(type='bool', default=False),
+        lead = dict(type='bool', default=False),
+        name = dict(type='str', required=True, ib_req=True),
+        preferred_primaries = dict(type='list', elements='dict', options=extserver_spec, default=[]),
+        stealth = dict(type='bool', default=False),
+    )
+ 
+    ib_spec = dict(
+        name=dict(type='str', required=True, ib_req=True),
+	grid_primary = dict(type='list', elements='dict', options=memberserver_spec, transform=grid_primary_preferred_transform),
+	grid_secondaries = dict(type='list', elements='dict', options=memberserver_spec, transform=grid_secondaries_preferred_primaries_transform, default=[]),
+	external_primaries = dict(type='list', elements='dict', options=extserver_spec, transform=ext_primaries_transform, default=[]),
+	external_secondaries = dict(type='list', elements='dict', options=extserver_spec, transform=ext_secondaries_transform, default=[]),
+        is_grid_default = dict(type='bool', default=False),
+        use_external_primary = dict(type='bool', default=False),
+        extattrs = dict(),
+        comment = dict(type='str', default=''),
+    )
+
+    argument_spec.update(ib_spec)
+    argument_spec.update(WapiModule.provider_spec)
+
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
+
+    wapi = WapiModule(module)
+    result = wapi.run('nsgroup', ib_spec)
+
+    module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()
+
+

--- a/lib/ansible/modules/net_tools/nios/nios_nsgroup.py
+++ b/lib/ansible/modules/net_tools/nios/nios_nsgroup.py
@@ -74,7 +74,19 @@ options:
 
 
 EXAMPLES = '''
-
+- name: create simple infoblox nameserver group
+  nios_nsgroup:
+    provider:
+      username: admin 
+      password: password 
+      host: infoblox-test.example.com
+      wapi_version: 2.1
+    name: my-simple-group 
+    comment: "this is a simple nameserver group"
+    grid_primary:
+      - name: infoblox-test.example.com
+  state: present
+  connection: local
 
 - name: create infoblox nameserver group with external primaries 
   nios_nsgroup:
@@ -82,7 +94,7 @@ EXAMPLES = '''
       username: admin
       password: password 
       host: infoblox-test.examplecom
-      wapi_version: 2.2
+      wapi_version: 2.1
     name: my-example-group 
     use_external_primary: true
     comment: "this is my example nameserver group"
@@ -92,6 +104,7 @@ EXAMPLES = '''
         lead: True
         preferred_primaries: "{{ ext_nameservers }}"
   state: present
+  connection: local
 '''
 
 RETURN = ''' # '''

--- a/lib/ansible/modules/net_tools/nios/nios_nsgroup.py
+++ b/lib/ansible/modules/net_tools/nios/nios_nsgroup.py
@@ -116,17 +116,17 @@ from ansible.module_utils.net_tools.nios.api import WapiModule
 
 # from infoblox documentation
 # Fields List
-# Field		Type		Req	R/O	Base	Search
-# comment		String		N	N	Y	: = ~
-# extattrs		Extattr		N	N	N	ext
-# external_primaries	[struct]	N	N	N	N/A
-# external_secondaries	[struct]	N	N	N	N/A
-# grid_primary		[struct]	N	N	N	N/A
-# grid_secondaries	[struct]	N	N	N	N/A
-# is_grid_default	Bool		N	N	N	N/A
-# is_multimaster	Bool		N	Y	N	N/A
-# name			String		Y		N	Y	: = ~
-# use_external_primary	Bool		N	N	N	N/A
+# Field         Type            Req     R/O     Base    Search
+# comment               String          N       N       Y       : = ~
+# extattrs              Extattr         N       N       N       ext
+# external_primaries    [struct]        N       N       N       N/A
+# external_secondaries  [struct]        N       N       N       N/A
+# grid_primary          [struct]        N       N       N       N/A
+# grid_secondaries      [struct]        N       N       N       N/A
+# is_grid_default       Bool            N       N       N       N/A
+# is_multimaster        Bool            N       Y       N       N/A
+# name                  String          Y               N       Y       : = ~
+# use_external_primary  Bool            N       N       N       N/A
 
 
 def main():


### PR DESCRIPTION
##### SUMMARY
Module to create and manage Infoblox nameserver groups through the Wapi nsgroups objects.

##### ISSUE TYPE
 - New Module Pull Request

##### COMPONENT NAME
nios_nsgroup

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (nios_nsgroup 7cc47392f4) last updated 2018/02/08 18:37:52 (GMT +200)
  config file = None
  configured module search path = [u'/Users/erich.birngruber/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/erich.birngruber/projects/ansible_fork/lib/ansible
  executable location = /Users/erich.birngruber/projects/ansible_fork/bin/ansible
  python version = 2.7.10 (default, Feb  7 2017, 00:08:15) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.34)]
```


##### ADDITIONAL INFORMATION
