### PR TITLE
New Module for SmartOS: nictagadm

### DIFF
--- a/lib/ansible/modules/cloud/smartos/nictagadm.py
+++ b/lib/ansible/modules/cloud/smartos/nictagadm.py
@@ -25,35 +25,26 @@ options:
             - Name of the nic tag.
         required: true
     mac:
-        default: None
         description:
             - Specifies the I(mac) address to attach the nic tag to when not using an (I)etherstub. I(mac) and I(etherstub) are mutually exclusive.
         required: false
-        type: string
     etherstub:
         description:
             - Specifies that the nic tag will be attached to a created I(etherstub). I(etherstub) is mutually exclusive with both I(mtu), and mac.
-        default: false
         required: false
-        type: bool
     mtu:
-        default: None
         description:
             - Specifies the size of the I(mtu) of the desired nic tag. I(mtu) and I(etherstub) are mutually exclusive.
         required: false
-        type: int
     force:
-        default: false
         description:
             - When I(state) is absent set this switch will use the C(-f) parameter and delete the nic tag regardless of existing VMs.
-        type: bool
     state:
         choices: [ "present", "absent" ]
         default: "present"
         description:
             - Create or delete a SmartOS nic tag.
         required: false
-        type: string
 '''
 
 EXAMPLES = '''
@@ -71,25 +62,21 @@ name:
     type: string
     sample: storage0
 mac:
-    default: None
     description: MAC Address that the nic tag was attached to.
     returned: always
     type: string
     sample: 00:1b:21:a3:f5:4d
 etherstub:
-    default: false
     description: specifies if the nic tag will create and attach to an etherstub.
     returned: always
     type: boolean
     sample: False
 mtu:
-    default: None
     description: specifies which MTU size was passed during the nictagadm add command. mtu and etherstub are mutually exclusive.
     returned: always
     type: int
     sample: 1500
 force:
-    default: false
     description: Shows if -f was used during the deletion of a nic tag
     returned: always
     type: boolean

--- a/lib/ansible/modules/cloud/smartos/nictagadm.py
+++ b/lib/ansible/modules/cloud/smartos/nictagadm.py
@@ -25,30 +25,35 @@ options:
             - Name of the nic tag.
         required: true
     mac:
+        default: None
         description:
             - Specifies the I(mac) address to attach the nic tag to when not using an (I)etherstub. I(mac) and I(etherstub) are mutually exclusive.
         required: false
-        default: None
+        type: string
     etherstub:
         description:
             - Specifies that the nic tag will be attached to a created I(etherstub). I(etherstub) is mutually exclusive with both I(mtu), and mac.
-        required: false
         default: false
+        required: false
+        type: bool
     mtu:
+        default: None
         description:
             - Specifies the size of the I(mtu) of the desired nic tag. I(mtu) and I(etherstub) are mutually exclusive.
         required: false
-        default: None
+        type: int
     force:
+        default: false
         description:
             - When I(state) is absent set this switch will use the C(-f) parameter and delete the nic tag regardless of existing VMs.
-        default: false
+        type: bool
     state:
+        choices: [ "present", "absent" ]
+        default: "present"
         description:
             - Create or delete a SmartOS nic tag.
         required: false
-        default: "present"
-        choices: [ "present", "absent" ]
+        type: string
 '''
 
 EXAMPLES = '''
@@ -66,21 +71,25 @@ name:
     type: string
     sample: storage0
 mac:
+    default: None
     description: MAC Address that the nic tag was attached to.
     returned: always
     type: string
     sample: 00:1b:21:a3:f5:4d
 etherstub:
+    default: false
     description: specifies if the nic tag will create and attach to an etherstub.
     returned: always
     type: boolean
     sample: False
 mtu:
+    default: None
     description: specifies which MTU size was passed during the nictagadm add command. mtu and etherstub are mutually exclusive.
     returned: always
     type: int
     sample: 1500
 force:
+    default: false
     description: Shows if -f was used during the deletion of a nic tag
     returned: always
     type: boolean

--- a/lib/ansible/modules/cloud/smartos/nictagadm.py
+++ b/lib/ansible/modules/cloud/smartos/nictagadm.py
@@ -29,16 +29,20 @@ options:
             - Specifies the I(mac) address to attach the nic tag to when not using an (I)etherstub. I(mac) and I(etherstub) are mutually exclusive.
         required: false
     etherstub:
+        default: False
         description:
             - Specifies that the nic tag will be attached to a created I(etherstub). I(etherstub) is mutually exclusive with both I(mtu), and mac.
         required: false
+        type: bool
     mtu:
         description:
             - Specifies the size of the I(mtu) of the desired nic tag. I(mtu) and I(etherstub) are mutually exclusive.
         required: false
     force:
+        default: False
         description:
             - When I(state) is absent set this switch will use the C(-f) parameter and delete the nic tag regardless of existing VMs.
+        type: bool
     state:
         choices: [ "present", "absent" ]
         default: "present"

--- a/lib/ansible/modules/cloud/smartos/nictagadm.py
+++ b/lib/ansible/modules/cloud/smartos/nictagadm.py
@@ -17,7 +17,7 @@ module: nictagadm
 short_description: Manage nic tags on SmartOS systems.
 description:
   - Create of delete nic tags on SmartOS systems.
-version_added: "2.5"
+version_added: "2.6"
 author: Bruce Smith (@SmithX10)
 options:
     name:

--- a/lib/ansible/modules/cloud/smartos/nictagadm.py
+++ b/lib/ansible/modules/cloud/smartos/nictagadm.py
@@ -1,0 +1,216 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2018, Bruce Smith <Bruce.Smith.IT@gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = '''
+---
+module: nictagadm
+short_description: Manage NIC tags on Solaris/Illumos systems. 
+description:
+  - Create of delete NIC tags on Solaris/Illumos systems.
+version_added: "2.5"
+author: Bruce Smith (@SmithX10)
+options:
+    name:
+        description:
+            - NIC tag name.
+        required: true
+    mac:
+        description:
+            - MAC Address to attach the NIC tag to when not using an etherstub
+        required: false 
+        default: None
+    etherstub:
+        description:
+            - Specifies that the NIC tag will be attached to a created etherstub.  By specifying Etherstub as true MAC and MTU will be ignored and set to the value None. 
+        required: false
+        default: false
+    mtu:
+        description:
+            - MTU size of the NIC tag
+        required: false
+        default: 1500
+    force:
+        description:
+            - When State.Absent is set this switch will use the -f parameter and delete the NIC tag regardless of existing VMs
+        default: false
+    state:
+        description:
+            - Create or delete a Solaris/illumos NIC tag.
+        required: false
+        default: "present"
+        choices: [ "present", "absent" ]
+'''
+
+EXAMPLES = '''
+- name: Create 'strage0' on '00:1b:21:a3:f5:4d'
+  nictagadm: name=storage0 mac=00:1b:21:a3:f5:4d mtu=9000 state=present
+
+- name: Remove 'storage0' NIC tag 
+  nictagadm: name=storage0 state=absent force=false
+'''
+
+RETURN = '''
+name:
+    description: NIC tag name
+    returned: always
+    type: string
+    sample: storage0
+mac: 
+    description: MAC Address that the nic tag was attached to. (Ignored if etherstub is specified)
+    returned: always
+    type: string
+    sample: 00:1b:21:a3:f5:4d 
+etherstub:
+    description: specifies if the NIC tag will create and attach to an etherstub.
+    returned: always
+    type: boolean
+    sample: False
+mtu:
+    description: specifies which MTU size was passed during the nictagadm add command.  (Ignored if etherstub is specified)
+    returned: always
+    type: int
+    sample: 1500
+force:
+    description: Shows if -f was used during the deletion of a NIC tag
+    returned: always
+    type: boolean
+    sample: False
+state:
+    description: state of the target
+    returned: always
+    type: string
+    sample: present
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+
+class NICTAG(object):
+
+    def __init__(self, module):
+      self.module = module
+
+      self.name = module.params['name']
+      self.mac = module.params['mac']
+      self.etherstub = module.params['etherstub']
+      self.mtu = module.params['mtu']
+      self.force = module.params['force']
+      self.state = module.params['state']
+    
+    def nictag_exists(self):
+        cmd = [self.module.get_bin_path('nictagadm', True)]
+
+        cmd.append('exists')
+        cmd.append(self.name)
+
+        (rc, _, _) = self.module.run_command(cmd)
+
+        if rc == 0:
+            return True
+        else:
+            return False
+
+    def add_nictag(self):
+        cmd = [self.module.get_bin_path('nictagadm', True)]
+
+        cmd.append('-v')        
+        cmd.append('add')
+
+        if self.etherstub:
+            cmd.append('-l')
+            self.mac = None
+            self.mtu = None
+
+        if self.mtu:
+            cmd.append('-p')
+            cmd.append('mtu=' + str(self.mtu))
+
+        if self.mac:
+            cmd.append('-p')
+            cmd.append('mac=' + str(self.mac))
+        
+        cmd.append(self.name)
+
+        return self.module.run_command(cmd)
+    
+    def delete_nictag(self):
+        cmd = [self.module.get_bin_path('nictagadm', True)]
+        
+        cmd.append('-v')
+        cmd.append('delete')
+        
+        if self.force:
+            cmd.append('-f') 
+
+        cmd.append(self.name)
+
+        return self.module.run_command(cmd)
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            name=dict(required=True, type='str'),
+            mac=dict(default=None, type='str'),
+            etherstub=dict(default=False, type='bool'),
+            mtu=dict(default=1500, type='int'),
+            force=dict(default=False, type='bool'),
+            state=dict(default='present', choices=['absent', 'present']),
+        ),
+        required_if=[
+            ['etherstub', False, ['name', 'mac']],
+            ['state', 'absent', ['name', 'force']],
+        ],
+        supports_check_mode=True
+    )
+
+    nictag = NICTAG(module)
+    
+    rc = None
+    out = ''
+    err = ''
+    result = {}
+    result['name'] = nictag.name
+    result['mac'] = nictag.mac
+    result['etherstub'] = nictag.etherstub
+    result['mtu'] = nictag.mtu
+    result['force'] = nictag.force
+    result['state'] = nictag.state
+
+    if nictag.state == 'absent':
+        if nictag.nictag_exists():
+            if module.check_mode:
+                module.exit_json(changed=True)
+            (rc, out, err) = nictag.delete_nictag()
+            if rc != 0:
+                module.fail_json(name=nictag.name, msg=err, rc=rc)
+    elif nictag.state == 'present':
+        if not nictag.nictag_exists():
+            if module.check_mode:
+                module.exit_json(changed=True)
+            (rc, out, err) = nictag.add_nictag()
+            if rc is not None and rc != 0:
+                module.fail_json(name=nictag.name, msg=err, rc=rc)
+
+    if rc is None:
+        result['changed'] = False
+    else:
+        result['changed'] = True
+
+    if out:
+        result['stdout'] = out
+    if err:
+        result['stderr'] = err
+
+    module.exit_json(**result) 
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/cloud/smartos/nictagadm.py
+++ b/lib/ansible/modules/cloud/smartos/nictagadm.py
@@ -16,7 +16,7 @@ DOCUMENTATION = '''
 module: nictagadm
 short_description: Manage nic tags on SmartOS systems.
 description:
-  - Create of delete nic tags on SmartOS systems.
+  - Create or delete nic tags on SmartOS systems.
 version_added: "2.6"
 author: Bruce Smith (@SmithX10)
 options:

--- a/lib/ansible/modules/cloud/smartos/nictagadm.py
+++ b/lib/ansible/modules/cloud/smartos/nictagadm.py
@@ -4,10 +4,9 @@
 # (c) 2018, Bruce Smith <Bruce.Smith.IT@gmail.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-from __future__ import absolute_import, division, print_function 
+from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-import re
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],
@@ -16,7 +15,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = '''
 ---
 module: nictagadm
-short_description: Manage NIC tags on SmartOS systems. 
+short_description: Manage NIC tags on SmartOS systems.
 description:
   - Create of delete NIC tags on SmartOS systems.
 version_added: "2.5"
@@ -28,19 +27,19 @@ options:
         required: true
     mac:
         description:
-            - MAC Address to attach the NIC tag to when not using an etherstub
-        required: false 
+            - MAC Address to attach the NIC tag to when not using an etherstub. mac and etherstub are mutually exclusive.
+        required: false
         default: None
     etherstub:
         description:
-            - Specifies that the NIC tag will be attached to a created etherstub.  By specifying Etherstub as true MAC and MTU will be ignored and set to the value None. 
+            - Specifies that the NIC tag will be attached to a created etherstub. etherstub is mutually exclusive with both mtu, and mac.
         required: false
         default: false
     mtu:
         description:
-            - MTU size of the NIC tag
+            - MTU size of the NIC tag. mtu and etherstub are mutually exclusive.
         required: false
-        default: None 
+        default: None
     force:
         description:
             - When State.Absent is set this switch will use the -f parameter and delete the NIC tag regardless of existing VMs
@@ -57,7 +56,7 @@ EXAMPLES = '''
 - name: Create 'strage0' on '00:1b:21:a3:f5:4d'
   nictagadm: name=storage0 mac=00:1b:21:a3:f5:4d mtu=9000 state=present
 
-- name: Remove 'storage0' NIC tag 
+- name: Remove 'storage0' NIC tag
   nictagadm: name=storage0 state=absent force=false
 '''
 
@@ -67,13 +66,13 @@ name:
     returned: always
     type: string
     sample: storage0
-mac: 
-    description: MAC Address that the nic tag was attached to. mac and etherstub are mutually exclusive.
+mac:
+    description: MAC Address that the nic tag was attached to.
     returned: always
     type: string
-    sample: 00:1b:21:a3:f5:4d 
+    sample: 00:1b:21:a3:f5:4d
 etherstub:
-    description: specifies if the NIC tag will create and attach to an etherstub.  etherstub is mutually exclusive with both mac, and mtu.
+    description: specifies if the NIC tag will create and attach to an etherstub.
     returned: always
     type: boolean
     sample: False
@@ -94,19 +93,22 @@ state:
     sample: present
 '''
 
+import re
+
 from ansible.module_utils.basic import AnsibleModule
+
 
 class NICTAG(object):
 
     def __init__(self, module):
-      self.module = module
+        self.module = module
 
-      self.name = module.params['name']
-      self.mac = module.params['mac']
-      self.etherstub = module.params['etherstub']
-      self.mtu = module.params['mtu']
-      self.force = module.params['force']
-      self.state = module.params['state']
+        self.name = module.params['name']
+        self.mac = module.params['mac']
+        self.etherstub = module.params['etherstub']
+        self.mtu = module.params['mtu']
+        self.force = module.params['force']
+        self.state = module.params['state']
 
     def is_valid_mac(self):
         if re.match("[0-9a-f]{2}([:])[0-9a-f]{2}(\\1[0-9a-f]{2}){4}$", self.mac.lower()):
@@ -130,7 +132,7 @@ class NICTAG(object):
     def add_nictag(self):
         cmd = [self.module.get_bin_path('nictagadm', True)]
 
-        cmd.append('-v')        
+        cmd.append('-v')
         cmd.append('add')
 
         if self.etherstub:
@@ -143,23 +145,24 @@ class NICTAG(object):
         if self.mac:
             cmd.append('-p')
             cmd.append('mac=' + str(self.mac))
-        
+
         cmd.append(self.name)
 
         return self.module.run_command(cmd)
-    
+
     def delete_nictag(self):
         cmd = [self.module.get_bin_path('nictagadm', True)]
-        
+
         cmd.append('-v')
         cmd.append('delete')
-        
+
         if self.force:
-            cmd.append('-f') 
+            cmd.append('-f')
 
         cmd.append(self.name)
 
         return self.module.run_command(cmd)
+
 
 def main():
     module = AnsibleModule(
@@ -183,7 +186,7 @@ def main():
     )
 
     nictag = NICTAG(module)
-    
+
     rc = None
     out = ''
     err = ''
@@ -230,7 +233,7 @@ def main():
     if err:
         result['stderr'] = err
 
-    module.exit_json(**result) 
+    module.exit_json(**result)
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/cloud/smartos/nictagadm.py
+++ b/lib/ansible/modules/cloud/smartos/nictagadm.py
@@ -135,8 +135,6 @@ class NICTAG(object):
 
         if self.etherstub:
             cmd.append('-l')
-            # self.mac = None
-            # self.mtu = None
 
         if self.mtu:
             cmd.append('-p')

--- a/lib/ansible/modules/cloud/smartos/nictagadm.py
+++ b/lib/ansible/modules/cloud/smartos/nictagadm.py
@@ -7,7 +7,6 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],
                     'supported_by': 'community'}
@@ -93,9 +92,9 @@ state:
     sample: present
 '''
 
-import re
 
 from ansible.module_utils.basic import AnsibleModule
+import re
 
 
 class NICTAG(object):
@@ -122,7 +121,7 @@ class NICTAG(object):
         cmd.append('exists')
         cmd.append(self.name)
 
-        (rc, _, _) = self.module.run_command(cmd)
+        (rc, dummy, dummy) = self.module.run_command(cmd)
 
         if rc == 0:
             return True

--- a/lib/ansible/modules/cloud/smartos/nictagadm.py
+++ b/lib/ansible/modules/cloud/smartos/nictagadm.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# (c) 2018, Bruce Smith <Bruce.Smith.IT@gmail.com>
+# Copyright: (c) 2018, Bruce Smith <Bruce.Smith.IT@gmail.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
@@ -11,87 +11,96 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],
                     'supported_by': 'community'}
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: nictagadm
-short_description: Manage nic tags on SmartOS systems.
+short_description: Manage nic tags on SmartOS systems
 description:
   - Create or delete nic tags on SmartOS systems.
-version_added: "2.6"
-author: Bruce Smith (@SmithX10)
+version_added: '2.8'
+author:
+- Bruce Smith (@SmithX10)
 options:
-    name:
-        description:
-            - Name of the nic tag.
-        required: true
-    mac:
-        description:
-            - Specifies the I(mac) address to attach the nic tag to when not using an (I)etherstub. I(mac) and I(etherstub) are mutually exclusive.
-        required: false
-    etherstub:
-        default: False
-        description:
-            - Specifies that the nic tag will be attached to a created I(etherstub). I(etherstub) is mutually exclusive with both I(mtu), and mac.
-        required: false
-        type: bool
-    mtu:
-        description:
-            - Specifies the size of the I(mtu) of the desired nic tag. I(mtu) and I(etherstub) are mutually exclusive.
-        required: false
-    force:
-        default: False
-        description:
-            - When I(state) is absent set this switch will use the C(-f) parameter and delete the nic tag regardless of existing VMs.
-        type: bool
-    state:
-        choices: [ "present", "absent" ]
-        default: "present"
-        description:
-            - Create or delete a SmartOS nic tag.
-        required: false
+  name:
+    description:
+    - Name of the nic tag.
+    required: true
+    type: str
+  mac:
+    description:
+    - Specifies the I(mac) address to attach the nic tag to when not creating an I(etherstub).
+    - Parameters I(mac) and I(etherstub) are mutually exclusive.
+    type: str
+  etherstub:
+    description:
+    - Specifies that the nic tag will be attached to a created I(etherstub).
+    - Parameter I(etherstub) is mutually exclusive with both I(mtu), and I(mac).
+    type: bool
+    default: no
+  mtu:
+    description:
+    - Specifies the size of the I(mtu) of the desired nic tag.
+    - Parameters I(mtu) and I(etherstub) are mutually exclusive.
+    type: int
+  force:
+    description:
+    - When I(state) is absent set this switch will use the C(-f) parameter and delete the nic tag regardless of existing VMs.
+    type: bool
+    default: no
+  state:
+    description:
+    - Create or delete a SmartOS nic tag.
+    type: str
+    choices: [ absent, present ]
+    default: present
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 - name: Create 'storage0' on '00:1b:21:a3:f5:4d'
-  nictagadm: name=storage0 mac=00:1b:21:a3:f5:4d mtu=9000 state=present
+  nictagadm:
+    name: storage0
+    mac: 00:1b:21:a3:f5:4d
+    mtu: 9000
+    state: present
 
 - name: Remove 'storage0' nic tag
-  nictagadm: name=storage0 state=absent
+  nictagadm:
+    name: storage0
+    state: absent
 '''
 
-RETURN = '''
+RETURN = r'''
 name:
-    description: nic tag name
-    returned: always
-    type: string
-    sample: storage0
+  description: nic tag name
+  returned: always
+  type: str
+  sample: storage0
 mac:
-    description: MAC Address that the nic tag was attached to.
-    returned: always
-    type: string
-    sample: 00:1b:21:a3:f5:4d
+  description: MAC Address that the nic tag was attached to.
+  returned: always
+  type: str
+  sample: 00:1b:21:a3:f5:4d
 etherstub:
-    description: specifies if the nic tag will create and attach to an etherstub.
-    returned: always
-    type: boolean
-    sample: False
+  description: specifies if the nic tag will create and attach to an etherstub.
+  returned: always
+  type: bool
+  sample: False
 mtu:
-    description: specifies which MTU size was passed during the nictagadm add command. mtu and etherstub are mutually exclusive.
-    returned: always
-    type: int
-    sample: 1500
+  description: specifies which MTU size was passed during the nictagadm add command. mtu and etherstub are mutually exclusive.
+  returned: always
+  type: int
+  sample: 1500
 force:
-    description: Shows if -f was used during the deletion of a nic tag
-    returned: always
-    type: boolean
-    sample: False
+  description: Shows if -f was used during the deletion of a nic tag
+  returned: always
+  type: boolean
+  sample: False
 state:
-    description: state of the target
-    returned: always
-    type: string
-    sample: present
+  description: state of the target
+  returned: always
+  type: str
+  sample: present
 '''
-
 
 from ansible.module_utils.basic import AnsibleModule
 import re
@@ -114,8 +123,7 @@ class NicTag(object):
     def is_valid_mac(self):
         if re.match("[0-9a-f]{2}([:])[0-9a-f]{2}(\\1[0-9a-f]{2}){4}$", self.mac.lower()):
             return True
-        else:
-            return False
+        return False
 
     def nictag_exists(self):
         cmd = [self.nictagadm_bin]
@@ -165,12 +173,12 @@ class NicTag(object):
 def main():
     module = AnsibleModule(
         argument_spec=dict(
-            name=dict(required=True, type='str'),
-            mac=dict(default=None, type='str'),
-            etherstub=dict(default=False, type='bool'),
-            mtu=dict(default=None, type='int'),
-            force=dict(default=False, type='bool'),
-            state=dict(default='present', choices=['absent', 'present']),
+            name=dict(type='str', required=True),
+            mac=dict(type='str'),
+            etherstub=dict(type='bool', default=False),
+            mtu=dict(type='int'),
+            force=dict(type='bool', default=False),
+            state=dict(type='str', default='present', choices=['absent', 'present']),
         ),
         mutually_exclusive=[
             ['etherstub', 'mac'],
@@ -188,20 +196,21 @@ def main():
     rc = None
     out = ''
     err = ''
-    result = {}
-    result['name'] = nictag.name
-    result['mac'] = nictag.mac
-    result['etherstub'] = nictag.etherstub
-    result['mtu'] = nictag.mtu
-    result['force'] = nictag.force
-    result['state'] = nictag.state
+    result = dict(
+        changed=False,
+        etherstub=nictag.etherstub,
+        force=nictag.force,
+        name=nictag.name,
+        mac=nictag.mac,
+        mtu=nictag.mtu,
+        state=nictag.state,
+    )
 
     if not nictag.is_valid_mac():
         module.fail_json(msg='Invalid MAC Address Value',
                          name=nictag.name,
                          mac=nictag.mac,
                          etherstub=nictag.etherstub)
-    result['mac'] = nictag.mac
 
     if nictag.state == 'absent':
         if nictag.nictag_exists():
@@ -218,11 +227,8 @@ def main():
             if rc is not None and rc != 0:
                 module.fail_json(name=nictag.name, msg=err, rc=rc)
 
-    if rc is None:
-        result['changed'] = False
-    else:
+    if rc is not None:
         result['changed'] = True
-
     if out:
         result['stdout'] = out
     if err:

--- a/lib/ansible/modules/cloud/smartos/nictagadm.py
+++ b/lib/ansible/modules/cloud/smartos/nictagadm.py
@@ -93,7 +93,7 @@ mtu:
 force:
   description: Shows if -f was used during the deletion of a nic tag
   returned: always
-  type: boolean
+  type: bool
   sample: False
 state:
   description: state of the target
@@ -235,6 +235,7 @@ def main():
         result['stderr'] = err
 
     module.exit_json(**result)
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
##### SUMMARY
This change adds the ability to create and destroy nic_tags on SmartOS.

##### ISSUE TYPE
 - New Module Pull Request

##### COMPONENT NAME
Module Name: nictagadm

##### ANSIBLE VERSION
```
(venv) bruce.smith@Bruces-MacBook-Pro /g/m/n/ansible ❯❯❯ ansible --version                                                                                              devel ⬇ ◼
ansible 2.5.0 (devel 273a3d1d51) last updated 2018/02/08 17:32:54 (GMT +700)
  config file = None
  configured module search path = [u'/Users/bruce.smith/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /git/me/nictagadm/ansible/lib/ansible
  executable location = /git/me/nictagadm/ansible/bin/ansible
  python version = 2.7.14 (default, Jan  6 2018, 12:16:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```