### PR TITLE
fix pep8 on os_security_group_rule.py

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_security_group_rule.py
+++ b/lib/ansible/modules/cloud/openstack/os_security_group_rule.py
@@ -240,16 +240,16 @@ def _find_matching_rule(module, secgroup, remotegroup):
     remote_group_id = remotegroup['id']
 
     for rule in secgroup['security_group_rules']:
-        if (protocol == rule['protocol']
-                and remote_ip_prefix == rule['remote_ip_prefix']
-                and ethertype == rule['ethertype']
-                and direction == rule['direction']
-                and remote_group_id == rule['remote_group_id']
-                and _ports_match(protocol,
-                                 module.params['port_range_min'],
-                                 module.params['port_range_max'],
-                                 rule['port_range_min'],
-                                 rule['port_range_max'])):
+        if (protocol == rule['protocol'] and
+                remote_ip_prefix == rule['remote_ip_prefix'] and
+                ethertype == rule['ethertype'] and
+                direction == rule['direction'] and
+                remote_group_id == rule['remote_group_id'] and
+                _ports_match(protocol,
+                             module.params['port_range_min'],
+                             module.params['port_range_max'],
+                             rule['port_range_min'],
+                             rule['port_range_max'])):
             return rule
     return None
 


### PR DESCRIPTION
##### SUMMARY
Fix following pep8 errors:
```
os_security_group_rule.py:244:17: W503 line break before binary operator
os_security_group_rule.py:245:17: W503 line break before binary operator
os_security_group_rule.py:246:17: W503 line break before binary operator
os_security_group_rule.py:247:17: W503 line break before binary operator
os_security_group_rule.py:248:17: W503 line break before binary operator
os_security_group_rule.py:249:34: E127 continuation line over-indented for visual indent
os_security_group_rule.py:250:34: E127 continuation line over-indented for visual indent
os_security_group_rule.py:251:34: E127 continuation line over-indented for visual indent
os_security_group_rule.py:252:34: E127 continuation line over-indented for visual indent
```

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
os_security_group_rule.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.2.0
  config file = None
  configured module search path = [u'/Users/buckleyd/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.14 (default, Jan  6 2018, 12:12:40) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]
```
