### PR TITLE
Remove extra NuGet files from the default image.

### DIFF
--- a/test/runner/Dockerfile
+++ b/test/runner/Dockerfile
@@ -49,6 +49,9 @@ RUN ln -s python2.7 /usr/bin/python2
 RUN ln -s python3.6 /usr/bin/python3
 RUN ln -s python3   /usr/bin/python
 
+# Install dotnet core SDK, pwsh, and other PS/.NET sanity test tools.
+# For now, we need to manually purge XML docs and other items from a Nuget dir to vastly reduce the image size.
+# See https://github.com/dotnet/dotnet-docker/issues/237 for details.
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     apt-transport-https \
@@ -60,6 +63,8 @@ RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     dotnet-sdk-2.1.4 \
     powershell \
+    && \
+    find /usr/share/dotnet/sdk/NuGetFallbackFolder/ -name '*.xml' -type f -delete \
     && \
     apt-get clean
 RUN dotnet --version


### PR DESCRIPTION
##### SUMMARY

Remove extra NuGet files from the default image.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

default docker image for ansible-test

##### ANSIBLE VERSION

```
ansible 2.5.0 (optimize-default 33ad4108ba) last updated 2018/02/08 13:08:23 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```
