### PR TITLE
Allow empty hostnames for ECS task definition containers

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ecs_taskdefinition.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_taskdefinition.py
@@ -243,6 +243,10 @@ def main():
     for container in module.params.get('containers', []):
         for environment in container.get('environment', []):
             environment['value'] = to_text(environment['value'])
+        # Allow parameterization hostname with a way to not set it
+        for parameter in ['hostname', 'workingDirectory']:
+            if container.get(parameter) == "":
+                del(container[parameter])
 
     if module.params['state'] == 'present':
         if 'containers' not in module.params or not module.params['containers']:

--- a/test/integration/targets/ecs_cluster/defaults/main.yml
+++ b/test/integration/targets/ecs_cluster/defaults/main.yml
@@ -22,6 +22,7 @@ ecs_task_containers:
   - containerPort: "{{ ecs_task_container_port }}"
     hostPort: "{{ ecs_task_host_port|default(0) }}"
   mountPoints: "{{ ecs_task_mount_points|default([]) }}"
+  hostname: "{{ ecs_task_hostname|default() }}"
 ecs_service_deployment_configuration:
   minimum_healthy_percent: 0
   maximum_percent: 100

--- a/test/integration/targets/ecs_cluster/tasks/main.yml
+++ b/test/integration/targets/ecs_cluster/tasks/main.yml
@@ -264,6 +264,16 @@
         task_definition: "{{ ecs_task_name }}-vpc:{{ ecs_task_definition.taskdefinition.revision + 1}}"
         <<: *aws_connection_info
 
+    - name: create task definition with hostname
+      ecs_taskdefinition:
+        containers: "{{ ecs_task_containers }}"
+        family: "{{ ecs_task_name }}"
+        state: present
+        <<: *aws_connection_info
+      vars:
+        ecs_task_hostname: something.that.works
+      register: ecs_task_definition_with_hostname
+
   always:
 
     # TEAR DOWN: snapshot, ec2 instance, ec2 key pair, security group, vpc
@@ -304,9 +314,13 @@
       ecs_taskdefinition:
         containers: "{{ ecs_task_containers }}"
         family: "{{ ecs_task_name }}"
-        revision: "{{ ecs_task_definition.taskdefinition.revision }}"
+        revision: "{{ item.taskdefinition.revision }}"
         state: absent
         <<: *aws_connection_info
+      with_items:
+        - "{{ ecs_task_definition }}"
+        - "{{ ecs_task_definition_again }}"
+        - "{{ ecs_task_definition_with_hostname }}"
       ignore_errors: yes
 
     - name: remove load balancer


### PR DESCRIPTION
##### SUMMARY

To allow container hostnames to be set through a variable
but also not set if the variable is not set, something like
the below is needed:

```
  containers:
    hostname: "{{ var_hostname|default() }}"
```

To avoid

> hostname contains invalid characters, does not
> match pattern `^[a-zA-Z0-9-.]{0,253}[a-zA-Z0-9]$`

remove the `hostname` key from `containers` if it's empty.


<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
ecs_taskdefinition

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (devel 14f6b4d766) last updated 2018/02/09 08:26:38 (GMT +1000)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/will/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/will/src/ansible/lib/ansible
  executable location = /home/will/src/ansible/bin/ansible
  python version = 2.7.14 (default, Jan 17 2018, 14:28:32) [GCC 7.2.1 20170915 (Red Hat 7.2.1-2)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
