### PR TITLE
allow user control of lookup error behaviour

### DIFF
--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -627,7 +627,8 @@ class Templar:
                 raise AnsibleUndefinedVariable(e)
             except Exception as e:
                 if self._fail_on_lookup_errors:
-                    msg = u"An unhandled exception occurred while running the lookup plugin '%s'. Error was a %s, original message: %s" % (name, type(e), to_text(e))
+                    msg = u"An unhandled exception occurred while running the lookup plugin '%s'. Error was a %s, original message: %s" % \
+                          (name, type(e), to_text(e))
                     if errors == 'warn':
                         display.warning(msg)
                     elif errors == 'ignore':

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -627,7 +627,7 @@ class Templar:
                 raise AnsibleUndefinedVariable(e)
             except Exception as e:
                 if self._fail_on_lookup_errors:
-                    msg = u"An unhandled exception occurred while running the lookup plugin '%s'. Error was a %s, original message: %s" % (name, type(e), e)
+                    msg = u"An unhandled exception occurred while running the lookup plugin '%s'. Error was a %s, original message: %s" % (name, type(e), to_text(e))
                     if errors == 'warn':
                         display.warning(msg)
                     elif errors == 'ignore':

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -627,7 +627,7 @@ class Templar:
                 raise AnsibleUndefinedVariable(e)
             except Exception as e:
                 if self._fail_on_lookup_errors:
-                    msg = "An unhandled exception occurred while running the lookup plugin '%s'. Error was a %s, original message: %s" % (name, type(e), e)
+                    msg = u"An unhandled exception occurred while running the lookup plugin '%s'. Error was a %s, original message: %s" % (name, type(e), e)
                     if errors == 'warn':
                         display.warning(msg)
                     elif errors == 'ignore':

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -616,6 +616,7 @@ class Templar:
         if instance is not None:
             wantlist = kwargs.pop('wantlist', False)
             allow_unsafe = kwargs.pop('allow_unsafe', C.DEFAULT_ALLOW_UNSAFE_LOOKUPS)
+            errors = kwargs.pop('errors', 'strict')
 
             from ansible.utils.listify import listify_lookup_plugin_terms
             loop_terms = listify_lookup_plugin_terms(terms=args, templar=self, loader=self._loader, fail_on_undefined=True, convert_bare=False)
@@ -626,8 +627,13 @@ class Templar:
                 raise AnsibleUndefinedVariable(e)
             except Exception as e:
                 if self._fail_on_lookup_errors:
-                    raise AnsibleError("An unhandled exception occurred while running the lookup plugin '%s'. Error was a %s, "
-                                       "original message: %s" % (name, type(e), e))
+                    msg = "An unhandled exception occurred while running the lookup plugin '%s'. Error was a %s, original message: %s" % (name, type(e), e)
+                    if errors == 'warn':
+                        display.warning(msg)
+                    elif errors == 'ignore':
+                        display.log(msg)
+                    else:
+                        raise AnsibleError(msg)
                 ran = None
 
             if ran and not allow_unsafe:

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -633,7 +633,7 @@ class Templar:
                     elif errors == 'ignore':
                         display.log(msg)
                     else:
-                        raise AnsibleError(msg)
+                        raise AnsibleError(to_native(msg))
                 ran = None
 
             if ran and not allow_unsafe:


### PR DESCRIPTION
##### SUMMARY

this does not affect undefined vars, only other exceptions raised by a lookup

i.e lookup('file' ..) not finding a file


<!--- Describe the change, including rationale and design decisions -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
lookups
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
future
```