### PR TITLE
Change wording of Going Further section

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_modules_general.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_general.rst
@@ -291,13 +291,13 @@ test/units/modules/.../test/my_new_test_module.py``
 Going Further
 =============
 
-If you are planning on contributing back to the main Ansible repository
-by either a new feature or fixing a bug, `create a fork <https://help.github.com/articles/fork-a-repo/>`_
+If you would like to contribute to the main Ansible repository
+by by adding a new feature or fixing a bug, `create a fork <https://help.github.com/articles/fork-a-repo/>`_
 of the Ansible repository and develop against a new feature
 branch using the ``devel`` branch as a starting point.
 
-When you believe you have a good working code change,
-submit a pull request to the Ansible repository where you select
+When you you have a good working code change,
+submit a pull request to the Ansible repository by you selecting
 your feature branch as a source and the Ansible devel branch as
 a target.
 

--- a/docs/docsite/rst/dev_guide/developing_modules_general.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_general.rst
@@ -297,7 +297,7 @@ of the Ansible repository and develop against a new feature
 branch using the ``devel`` branch as a starting point.
 
 When you you have a good working code change,
-submit a pull request to the Ansible repository by you selecting
+submit a pull request to the Ansible repository by selecting
 your feature branch as a source and the Ansible devel branch as
 a target.
 

--- a/docs/docsite/rst/dev_guide/developing_modules_general.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_general.rst
@@ -292,7 +292,7 @@ Going Further
 =============
 
 If you would like to contribute to the main Ansible repository
-by by adding a new feature or fixing a bug, `create a fork <https://help.github.com/articles/fork-a-repo/>`_
+by adding a new feature or fixing a bug, `create a fork <https://help.github.com/articles/fork-a-repo/>`_
 of the Ansible repository and develop against a new feature
 branch using the ``devel`` branch as a starting point.
 

--- a/docs/docsite/rst/dev_guide/developing_modules_general.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_general.rst
@@ -291,15 +291,15 @@ test/units/modules/.../test/my_new_test_module.py``
 Going Further
 =============
 
-If you are starting new development or fixing a bug, create a new branch:
+If you are planning on contributing back to the main Ansible repository
+by either a new feature or fixing a bug, `create a fork <https://help.github.com/articles/fork-a-repo/>`_
+of the Ansible repository and develop against a new feature
+branch using the ``devel`` branch as a starting point.
 
-``$ git checkout -b my-new-branch``.
-
-If you are planning on contributing
-back to the main Ansible repository, fork the Ansible repository into
-your own GitHub account and develop against the new non-devel branch
-in your fork. When you believe you have a good working code change,
-submit a pull request to the Ansible repository.
+When you believe you have a good working code change,
+submit a pull request to the Ansible repository where you select
+your feature branch as a source and the Ansible devel branch as
+a target.
 
 If you want to submit a new module to the upstream Ansible repo, be sure
 to run through sanity checks first. For example:


### PR DESCRIPTION
The original wording was confusing with its non-devel branch part.
Made it much clearer for people to understand what to do.

Also removed the git command for creating branches, I believe a
develop should be aware of how basic git commands work.

##### ISSUE TYPE
 - Docs Pull Request