### PR TITLE
vmware_guest: fix invalid backing on add nic

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -973,7 +973,8 @@ class PyVmomiHelper(PyVmomi):
                 # VDS switch
                 pg_obj = find_obj(self.content, [vim.dvs.DistributedVirtualPortgroup], network_devices[key]['name'])
 
-                if vm_obj is None or (nic.device.backing and not hasattr(nic.device.backing, 'port')) or \
+                if vm_obj is None or nic.device.backing is None or \
+                   (nic.device.backing and not hasattr(nic.device.backing, 'port')) or \
                    (nic.device.backing and (nic.device.backing.port.portgroupKey != pg_obj.key or
                                             nic.device.backing.port.switchUuid != pg_obj.config.distributedVirtualSwitch.uuid)):
                     dvs_port_connection = vim.dvs.PortConnection()


### PR DESCRIPTION
##### SUMMARY
Fixes #35946. Fix a non initialization of device backing when adding a new network adapter device to clone specifications.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
vmware_guest 

##### ANSIBLE VERSION
```
ansible 2.5.0 (devel 03c73e2bbb) last updated 2018/02/08 10:14:52 (GMT -500)
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/suser/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/suser/wd/ansible2/lib/ansible
  executable location = /home/suser/wd/ansible2/bin/ansible
  python version = 3.5.2 (default, Nov 23 2017, 16:37:01) [GCC 5.4.0 20160609]
```

##### ADDITIONAL INFORMATION
```

```