### PR TITLE
ovirt_hosts: Add option to choose to reboot the host

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_hosts.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_hosts.py
@@ -129,6 +129,11 @@ options:
                action before executing upgrade action."
         default: True
         version_added: 2.4
+    reboot_after_upgrade:
+        description:
+            - "If I(true) and C(state) is I(upgraded) reboot host after successful upgrade."
+        default: True
+        version_added: 2.6
 extends_documentation_fragment: ovirt
 '''
 
@@ -412,6 +417,7 @@ def main():
         activate=dict(default=True, type='bool'),
         iscsi=dict(default=None, type='dict'),
         check_upgrade=dict(default=True, type='bool'),
+        reboot_after_upgrade=dict(default=True, type='bool'),
     )
     module = AnsibleModule(
         argument_spec=argument_spec,
@@ -497,6 +503,7 @@ def main():
                 wait_condition=lambda h: h.status == result_state,
                 post_action=lambda h: time.sleep(module.params['poll_interval']),
                 fail_condition=hosts_module.failed_state_after_reinstall,
+                reboot=module.params['reboot_after_upgrade'],
             )
         elif state == 'iscsidiscover':
             host_id = get_id_by_name(hosts_service, module.params['name'])


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This PR add new parameter `reboot_after_upgrade` to `ovirt_hosts` module to choose if host should be rebooted after upgrade.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
ovirt_hosts

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
