### PR TITLE
Fix nxos_igmp_interface for diff nxos versions

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_igmp_interface.py
+++ b/lib/ansible/modules/network/nxos/nxos_igmp_interface.py
@@ -339,9 +339,9 @@ def get_igmp_interface(module, interface):
             igmp['report_llg'] = False
 
         immediate_leave = str(resource['ImmediateLeave']).lower()  # returns en or dis
-        if immediate_leave == 'en' or immediate_leave == 'true':
+        if re.search(r'^en|^true|^enabled', immediate_leave):
             igmp['immediate_leave'] = True
-        elif immediate_leave == 'dis' or immediate_leave == 'false':
+        elif re.search(r'^dis|^false|^disabled', immediate_leave):
             igmp['immediate_leave'] = False
 
     # the  next block of code is used to retrieve anything with:


### PR DESCRIPTION
##### SUMMARY
Fixes a problem where different versions of nxos return different key names for the `show igmp interface` command.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
nxos_igmp_interface

##### ANSIBLE VERSION
```
ansible 2.5.0 (rel250/fix_nxos_igmp_interface f7ae955248) last updated 2018/02/09 09:49:17 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/Users/mwiebe/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mwiebe/Projects/nxos_ansible/fix_ansible/lib/ansible
  executable location = /Users/mwiebe/Projects/nxos_ansible/fix_ansible/bin/ansible
  python version = 2.7.13 (default, Apr  4 2017, 08:47:57) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.38)]
```


##### ADDITIONAL INFORMATION
Failure before change
```
TASK [nxos_igmp_interface : Check Idempotence - Configure igmp interface with non-default values] ***************************************************************************************************
changed: [n9k.example.com]

TASK [nxos_igmp_interface : assert] *****************************************************************************************************************************************************************
fatal: [n9k.example.com]: FAILED! => {
    "assertion": "result.changed == false", 
    "changed": false, 
    "evaluated_to": false, 
    "failed": true
}

TASK [nxos_igmp_interface : Configure igmp interface with default value] ****************************************************************************************************************************
changed: [n9k.example.com]

TASK [nxos_igmp_interface : Put interface in default mode] ******************************************************************************************************************************************
changed: [n9k.example.com]

TASK [nxos_igmp_interface : Disable feature PIM] ****************************************************************************************************************************************************
changed: [n9k.example.com]

TASK [nxos_igmp_interface : debug] ******************************************************************************************************************************************************************
ok: [n9k.example.com] => {
    "failed": false, 
    "msg": "END connection=network_cli nxos_igmp_interface sanity test"
}
	to retry, use: --limit @/Users/mwiebe/Projects/nxos_ansible/fix_ansible/test/integration/nxos.retry

PLAY RECAP ******************************************************************************************************************************************************************************************
n9k.example.com  : ok=39   changed=7    unreachable=0    failed=1   
```

Success after change:
```
TASK [nxos_igmp_interface : Check Idempotence - Configure igmp interface with default value] ********************************************************************************************************
ok: [n9k.example.com]

TASK [nxos_igmp_interface : assert] *****************************************************************************************************************************************************************
ok: [n9k.example.com] => {
    "changed": false, 
    "failed": false, 
    "msg": "All assertions passed"
}

TASK [nxos_igmp_interface : Configure igmp interface with default value] ****************************************************************************************************************************
ok: [n9k.example.com]

TASK [nxos_igmp_interface : Put interface in default mode] ******************************************************************************************************************************************
changed: [n9k.example.com]

TASK [nxos_igmp_interface : Disable feature PIM] ****************************************************************************************************************************************************
changed: [n9k.example.com]

TASK [nxos_igmp_interface : debug] ******************************************************************************************************************************************************************
ok: [n9k.example.com] => {
    "failed": false, 
    "msg": "END connection=local nxos_igmp_interface sanity test"
}

PLAY RECAP ******************************************************************************************************************************************************************************************
n9k.example.com  : ok=84   changed=18   unreachable=0    failed=0   
```
