### PR TITLE
ACI: Provide more debug output on failures

### DIFF
--- a/lib/ansible/module_utils/network/aci/aci.py
+++ b/lib/ansible/module_utils/network/aci/aci.py
@@ -918,7 +918,7 @@ class ACIModule(object):
             self.result['changed'] = True
             self.method = 'POST'
 
-    def exit_json(self):
+    def exit_json(self, **kwargs):
 
         if self.params['output_level'] in ('debug', 'info'):
             self.result['previous'] = self.existing
@@ -947,6 +947,7 @@ class ACIModule(object):
             self.result['sent'] = self.config
             self.result['proposed'] = self.proposed
 
+        self.result.update(**kwargs)
         self.module.exit_json(**self.result)
 
     def fail_json(self, msg, **kwargs):
@@ -954,6 +955,9 @@ class ACIModule(object):
         # Return error information, if we have it
         if self.error['code'] is not None and self.error['text'] is not None:
             self.result['error'] = self.error
+
+        if self.params['output_level'] in ('debug', 'info'):
+            self.result['previous'] = self.existing
 
         # Return the gory details when we need it
         if self.params['output_level'] == 'debug':
@@ -968,6 +972,10 @@ class ACIModule(object):
                 self.result['response'] = self.response
                 self.result['status'] = self.status
                 self.result['url'] = self.url
+
+        if self.params['output_level'] in ('debug', 'info'):
+            self.result['sent'] = self.config
+            self.result['proposed'] = self.proposed
 
         self.result.update(**kwargs)
         self.module.fail_json(msg=msg, **self.result)


### PR DESCRIPTION
##### SUMMARY
This PR includes:
- payload output on failure, when requested
- add additional kwargs to aci.exit_json()

We may want to enable some of this debug output by default on failure ?

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
aci modules

##### ANSIBLE VERSION
v2.5