### PR TITLE
Remove extraneous import on ios_l3_interface

### DIFF
--- a/lib/ansible/modules/network/ios/ios_l3_interface.py
+++ b/lib/ansible/modules/network/ios/ios_l3_interface.py
@@ -107,7 +107,7 @@ from ansible.module_utils.network.ios.ios import get_config, load_config
 from ansible.module_utils.network.ios.ios import ios_argument_spec
 from ansible.module_utils.network.common.config import NetworkConfig
 from ansible.module_utils.network.common.utils import conditional, remove_default_spec
-from ansible.module_utils.network.common.utils import is_netmask, is_masklen, to_subnet, to_netmask, to_masklen
+from ansible.module_utils.network.common.utils import is_netmask, is_masklen, to_netmask, to_masklen
 
 
 def validate_ipv4(value, module):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
removed to_subnet from list of imports on ios_l3_interface.py as it was not being used

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
ios_l3_interface

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0 (remove_to_subnet 96fa79269d) last updated 2018/02/09 11:06:41 (GMT -400)
  config file = None
  configured module search path = ['/Users/david/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/david/code/ansible/lib/ansible
  executable location = /Users/david/code/ansible/bin/ansible
  python version = 3.6.4 (default, Jan  6 2018, 11:51:59) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
