### PR TITLE
Test against a single transport (#35903)

### DIFF
--- a/docs/docsite/rst/dev_guide/testing_integration.rst
+++ b/docs/docsite/rst/dev_guide/testing_integration.rst
@@ -195,7 +195,7 @@ For guidance on writing network test see the `adding tests for Network modules g
 Running network integration tests locally
 -----------------------------------------
 
-Ansible uses Shippable to run an integration test suite on every PR, including new tests introduced by that PR. To find and fix problems in network modules, run the network integration test locally before you submit a PR. 
+Ansible uses Shippable to run an integration test suite on every PR, including new tests introduced by that PR. To find and fix problems in network modules, run the network integration test locally before you submit a PR.
 
 To run the network integration tests, use a command in the form::
 
@@ -219,6 +219,15 @@ To run integration tests for a specific module::
 
     ansible-test network-integration --inventory  /path/to/ansible/test/integration/inventory.networking vyos_vlan
 
+To run integration tests for a specific transport::
+
+    # Only run nxapi test
+    ansible-test network-integration --inventory  /path/to/ansible/test/integration/inventory.networking  --tags="nxapi" nxos_.*
+
+    # Skip any cli tests
+    ansible-test network-integration --inventory  /path/to/ansible/test/integration/inventory.networking  --skip-tags="cli" nxos_.*
+
+See `test/integration/targets/nxos_bgp/tasks/main.yaml <https://github.com/ansible/ansible/blob/devel/test/integration/targets/nxos_bgp/tasks/main.yaml>`_ for how this is implemented in the tests.
 
 For more options::
 


### PR DESCRIPTION
##### SUMMARY
Network integration tests can use tags to run only a specific transport
(cherry picked from commit c3523cdd60e8c03685d3cdf1857dbb89e3941392)
