### PR TITLE
Add ios smoke tests

### DIFF
--- a/test/integration/targets/ios_smoke/defaults/main.yaml
+++ b/test/integration/targets/ios_smoke/defaults/main.yaml
@@ -1,0 +1,3 @@
+---
+testcase: "*"
+test_items: []

--- a/test/integration/targets/ios_smoke/meta/main.yaml
+++ b/test/integration/targets/ios_smoke/meta/main.yaml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_ios_tests

--- a/test/integration/targets/ios_smoke/tasks/cli.yaml
+++ b/test/integration/targets/ios_smoke/tasks/cli.yaml
@@ -1,0 +1,22 @@
+---
+- name: collect all cli test cases
+  find:
+    paths: "{{ role_path }}/tests/cli"
+    patterns: "{{ testcase }}.yaml"
+  register: test_cases
+  delegate_to: localhost
+
+- name: set test_items
+  set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
+
+- name: run test cases (connection=network_cli)
+  include: "{{ test_case_to_run }}"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test case (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local"
+  with_first_found: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run

--- a/test/integration/targets/ios_smoke/tasks/main.yaml
+++ b/test/integration/targets/ios_smoke/tasks/main.yaml
@@ -1,0 +1,2 @@
+---
+- { include: cli.yaml, tags: ['cli'] }

--- a/test/integration/targets/ios_smoke/templates/defaults/config.j2
+++ b/test/integration/targets/ios_smoke/templates/defaults/config.j2
@@ -1,0 +1,4 @@
+interface Loopback999
+ description this is a test
+ no shutdown
+

--- a/test/integration/targets/ios_smoke/tests/cli/common_config.yaml
+++ b/test/integration/targets/ios_smoke/tests/cli/common_config.yaml
@@ -1,2 +1,211 @@
 # ios_linkagg -> CustomNetworkConfig
 # ios_config -> dumps, NetworkConfig
+
+- debug: msg="START cli/common_config.yaml on connection={{ ansible_connection }}"
+
+- name: set hostname
+  ios_config:
+    lines: ['hostname ios-smoke']
+    match: none
+    provider: "{{ cli }}"
+
+- name: hit diff_ignore_lines
+  ios_config:
+    lines: ['hostname ios-smoke-diff']
+    diff_ignore_lines:
+      - hostname ios-smoke
+    save_when: modified
+    provider: "{{ cli }}"
+
+- name: return hostname
+  ios_config:
+    lines: ['hostname {{ shorter_hostname }}']
+    match: none
+    provider: "{{ cli }}"
+
+- name: hit items with parents
+  ios_config:
+    lines: ['permit ip any any log']
+    parents: ['ip access-list extended test']
+    provider: "{{ cli }}"
+    match: exact
+  register: result
+
+- name: teardown
+  ios_config:
+    lines:
+      - 'no ip access-list extended test'
+    match: none
+    provider: "{{ cli }}"
+
+- name: setup test NetworkConfig.difference, replace=block
+  ios_config:
+    lines:
+      - permit ip host 1.1.1.1 any log
+      - permit ip host 2.2.2.2 any log
+      - permit ip host 3.3.3.3 any log
+    parents: ['ip access-list extended test']
+    before: ['no ip access-list extended test']
+    after: ['exit']
+    provider: "{{ cli }}"
+    match: none
+
+- name: test NetworkConfig.difference, replace=block
+  ios_config:
+    lines:
+      - permit ip host 1.1.1.1 any log
+      - permit ip host 2.2.2.2 any log
+      - permit ip host 3.3.3.3 any log
+      - permit ip host 4.4.4.4 any log
+    parents: ['ip access-list extended test']
+    replace: block
+    after: ['exit']
+    provider: "{{ cli }}"
+  register: result
+
+- assert:
+    that:
+      - "result.changed == true"
+      - "'ip access-list extended test' in result.updates"
+      - "'permit ip host 1.1.1.1 any log' in result.updates"
+      - "'permit ip host 2.2.2.2 any log' in result.updates"
+      - "'permit ip host 3.3.3.3 any log' in result.updates"
+      - "'permit ip host 4.4.4.4 any log' in result.updates"
+
+- name: teardown- NetworkConfig.difference, replace=block
+  ios_config:
+    lines:
+      - no ip access-list extended test
+    match: none
+    provider: "{{ cli }}"
+
+# CustomNetworkConfig
+# currently gets skipped because switch_type != 'L2'
+- set_fact: switch_type="{{ switch_type }}"
+
+- block:
+
+  - name: setup - remove config used in test(part1)
+    ios_config:
+      lines:
+        - no interface port-channel 20
+      provider: "{{ cli }}"
+    ignore_errors: yes
+
+  - name: setup - remove config used in test(part2)
+    ios_config:
+      lines:
+        - no interface port-channel 5
+      provider: "{{ cli }}"
+    ignore_errors: yes
+
+  - name: setup - remove config used in test(part3)
+    ios_config:
+      lines:
+        - no channel-group 20 mode active
+      provider: "{{ cli }}"
+      parents: "{{ item }}"
+    loop:
+      - interface GigabitEthernet0/1
+      - interface GigabitEthernet0/2
+
+  - name: create linkagg
+    ios_linkagg: &create
+      group: 20
+      state: present
+      provider: "{{ cli }}"
+    register: result
+
+  - assert:
+      that:
+        - "result.changed == true"
+        - "'interface port-channel 20' in result.commands"
+
+  - name: set link aggregation group to members
+    ios_linkagg: &configure_member
+      group: 20
+      mode: active
+      members:
+        - GigabitEthernet0/1
+        - GigabitEthernet0/2
+      provider: "{{ cli }}"
+    register: result
+
+  - assert:
+      that:
+        - "result.changed == true"
+        - "'interface GigabitEthernet0/1' in result.commands"
+        - "'channel-group 20 mode active' in result.commands"
+        - "'interface GigabitEthernet0/2' in result.commands"
+        - "'channel-group 20 mode active' in result.commands"
+
+  - name: remove link aggregation group from member
+    ios_linkagg: &remove_member
+      group: 20
+      mode: active
+      members:
+        - GigabitEthernet0/2
+      provider: "{{ cli }}"
+    register: result
+
+  - assert:
+      that:
+        - "result.changed == true"
+        - "'interface GigabitEthernet0/1' in result.commands"
+        - "'no channel-group 20 mode active' in result.commands"
+
+  - name: remove linkagg
+    ios_linkagg: &remove
+      group: 20
+      state: absent
+      provider: "{{ cli }}"
+    register: result
+
+  - assert:
+      that:
+        - "result.changed == true"
+        - "'no interface port-channel 20' in result.commands"
+
+  - name: create aggregate of linkagg definitions
+    ios_linkagg: &create_agg
+      aggregate:
+        - { group: 5 }
+        - { group: 20, mode: active, members: ['GigabitEthernet0/1'] }
+      provider: "{{ cli }}"
+    register: result
+
+  - assert:
+      that:
+        - "result.changed == true"
+        - "'interface port-channel 5' in result.commands"
+        - "'interface port-channel 20' in result.commands"
+        - "'interface GigabitEthernet0/1' in result.commands"
+        - "'channel-group 20 mode active' in result.commands"
+
+  - name: teardown(part1)
+    ios_config:
+      lines:
+        - no interface port-channel 20
+      provider: "{{ cli }}"
+    ignore_errors: yes
+
+  - name: teardown(part2)
+    ios_config:
+      lines:
+        - no interface port-channel 5
+      provider: "{{ cli }}"
+    ignore_errors: yes
+
+  - name: teardown(part3)
+    ios_config:
+      lines:
+        - no channel-group 20 mode active
+      provider: "{{ cli }}"
+      parents: "{{ item }}"
+    loop:
+      - interface GigabitEthernet0/1
+      - interface GigabitEthernet0/2
+
+  when: switch_type == 'L2'
+
+- debug: msg="END cli/common_config.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/ios_smoke/tests/cli/common_config.yaml
+++ b/test/integration/targets/ios_smoke/tests/cli/common_config.yaml
@@ -3,6 +3,7 @@
 
 - debug: msg="START cli/common_config.yaml on connection={{ ansible_connection }}"
 
+# Hit NetworkConfig
 - name: set hostname
   ios_config:
     lines: ['hostname ios-smoke']

--- a/test/integration/targets/ios_smoke/tests/cli/common_config.yaml
+++ b/test/integration/targets/ios_smoke/tests/cli/common_config.yaml
@@ -1,0 +1,2 @@
+# ios_linkagg -> CustomNetworkConfig
+# ios_config -> dumps, NetworkConfig

--- a/test/integration/targets/ios_smoke/tests/cli/common_utils.py
+++ b/test/integration/targets/ios_smoke/tests/cli/common_utils.py
@@ -1,4 +1,0 @@
-# ios_command -> ComplexList
-# ios_interface -> conditional, remove_default_spec
-# ios_logging -> validate_ip_address
-# ios_l3_interface -> is_netmask, is_masklen, to_subnet, to_netmask, to_masklen

--- a/test/integration/targets/ios_smoke/tests/cli/common_utils.py
+++ b/test/integration/targets/ios_smoke/tests/cli/common_utils.py
@@ -1,0 +1,4 @@
+# ios_command -> ComplexList
+# ios_interface -> conditional, remove_default_spec
+# ios_logging -> validate_ip_address
+# ios_l3_interface -> is_netmask, is_masklen, to_subnet, to_netmask, to_masklen

--- a/test/integration/targets/ios_smoke/tests/cli/common_utils.yaml
+++ b/test/integration/targets/ios_smoke/tests/cli/common_utils.yaml
@@ -1,0 +1,160 @@
+---
+# ios_command -> ComplexList
+# ios_interface -> conditional, remove_default_spec
+# ios_logging -> validate_ip_address
+# ios_l3_interface -> is_netmask, is_masklen, to_subnet, to_netmask, to_masklen
+
+#ComplexList already covered
+
+- debug: msg="START ios_smoke cli/common_utils.yaml on connection={{ ansible_connection }}"
+
+# hit is_netmask(), is_masklen(), to_netmask(), to_masklen()
+- name: Delete interface ipv4 and ipv6 address(setup)
+  ios_l3_interface:
+    name: "{{ test_interface }}"
+    state: absent
+    provider: "{{ cli }}"
+  register: result
+
+- name: Setup - Ensure interfaces are switchport
+  ios_config:
+    lines:
+      - no shutdown
+    parents:
+      - "interface {{ item }}"
+    provider: "{{ cli }}"
+  loop:
+    - "{{ test_interface }}"
+    - "{{ test_interface2 }}"
+
+- name: Configure interface ipv4 address
+  ios_l3_interface:
+    name: "{{ test_interface }}"
+    ipv4: 192.168.0.1/24
+    state: present
+    provider: "{{ cli }}"
+  register: result
+
+- assert:
+    that:
+      - 'result.changed == true'
+      - '"interface {{ test_interface }}" in result.commands'
+      - '"ip address 192.168.0.1 255.255.255.0" in result.commands'
+
+- name: test invalid subnet
+  ios_l3_interface:
+    name: "{{ test_interface }}"
+    ipv4: 192.168.0.1/45
+    state: present
+    provider: "{{ cli }}"
+  register: result
+  ignore_errors: yes
+
+- debug: var=result
+
+- assert:
+    that:
+      - 'result.failed == true'
+
+- name:  Change ipv4 and ipv6 address using aggregate
+  ios_l3_interface:
+    aggregate:
+    - { name: "{{ test_interface }}", ipv4: 193.167.1.1/8, ipv6: "fd5a:12c9:2201:4::4/32" }
+    - { name: "{{ test_interface2 }}", ipv4: 192.169.2.2/24, ipv6: "fd5b:12c9:2201:5::5/90" }
+    provider: "{{ cli }}"
+  register: result
+
+- assert:
+    that:
+      - 'result.changed == true'
+      - '"interface {{ test_interface }}" in result.commands'
+      - '"ip address 193.167.1.1 255.0.0.0" in result.commands'
+      - '"ipv6 address fd5a:12c9:2201:4::4/32" in result.commands'
+      - '"interface {{ test_interface2 }}" in result.commands'
+      - '"ip address 192.169.2.2 255.255.255.0" in result.commands'
+      - '"ipv6 address fd5b:12c9:2201:5::5/90" in result.commands'
+
+- name:  Delete ipv4 and ipv6 address using aggregate
+  ios_l3_interface:
+    aggregate:
+    - { name: "{{ test_interface }}" }
+    - { name: "{{ test_interface2 }}" }
+    state: absent
+    provider: "{{ cli }}"
+  register: result
+
+# hit validate_ip_address()
+- name: Remove host logging - setup
+  net_logging:
+    dest: host
+    name: 172.16.0.1
+    state: absent
+    provider: "{{ cli }}"
+
+- name: Remove host logging - teardown
+  net_logging:
+    dest: host
+    name: 172.16.0.1
+    state: absent
+    provider: "{{ cli }}"
+
+# hit conditional(), remove_default_spec()
+- name: Check intent arguments
+  ios_interface:
+    name: "{{ test_interface }}"
+    state: up
+    tx_rate: ge(0)
+    rx_rate: ge(0)
+    provider: "{{ cli }}"
+  register: result
+
+- assert:
+    that:
+      - "result.failed == false"
+
+- name: Check intent arguments (failed condition)
+  ios_interface:
+    name: "{{ test_interface }}"
+    state: down
+    tx_rate: gt(0)
+    rx_rate: lt(0)
+    provider: "{{ cli }}"
+  ignore_errors: yes
+  register: result
+
+- assert:
+    that:
+      - "result.failed == true"
+      - "'state eq(down)' in result.failed_conditions"
+      - "'tx_rate gt(0)' in result.failed_conditions"
+      - "'rx_rate lt(0)' in result.failed_conditions"
+
+- name: Config + intent
+  ios_interface:
+    name: "{{ test_interface }}"
+    enabled: False
+    state: down
+    provider: "{{ cli }}"
+  register: result
+
+- assert:
+    that:
+      - "result.failed == false"
+
+- name: Config + intent (fail)
+  ios_interface:
+    name: "{{ test_interface }}"
+    enabled: False
+    provider: "{{ cli }}"
+    state: up
+  ignore_errors: yes
+  register: result
+
+- assert:
+    that:
+      - "result.failed == true"
+      - "'state eq(up)' in result.failed_conditions"
+
+
+
+- debug: msg="END ios_smoke cli/common_utils.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/ios_smoke/tests/cli/misc_tests.yaml
+++ b/test/integration/targets/ios_smoke/tests/cli/misc_tests.yaml
@@ -1,0 +1,22 @@
+---
+- debug: msg="START ios_smoke cli/misc_tests.yaml on connection={{ ansible_connection }}"
+
+# hit network.ios.ios- get_defaults_flag()
+- name: setup
+  ios_config:
+    commands:
+      - no description
+      - shutdown
+    parents:
+      - interface Loopback999
+    match: none
+    provider: "{{ cli }}"
+
+- name: configure device with defaults included
+  ios_config:
+    src: defaults/config.j2
+    defaults: yes
+    provider: "{{ cli }}"
+  register: result
+
+- debug: msg="END ios_smoke cli/misc_tests.yaml on connection={{ ansible_connection }}"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Adds smoke tests for ios in order to provide basic test coverage for code which is commonly used by ios modules.

Done:
- network.common.config
- network.common.utils
- network.ios.ios
- action.ios
- cliconf.ios
- terminal.ios

Coverage reports: https://newswangerd.github.io/ios/

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Test Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0 (ios_smoke 27e4507955) last updated 2018/02/09 12:25:40 (GMT -400)
  config file = None
  configured module search path = ['/Users/david/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/david/code/ansible/lib/ansible
  executable location = /Users/david/code/ansible/bin/ansible
  python version = 3.6.4 (default, Jan  6 2018, 11:51:59) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
