### PR TITLE
Exclude PSUseBOMForUnicodeEncodedFile error in pslint.ps1 test

### DIFF
--- a/test/sanity/pslint/pslint.ps1
+++ b/test/sanity/pslint/pslint.ps1
@@ -5,10 +5,13 @@
 Set-StrictMode -Version 2.0
 $ErrorActionPreference = "Stop"
 
+$ExcludedRules = PSUseBOMForUnicodeEncodedFile
 $Results = @()
 
 ForEach ($Path in $Args) {
-    $Results += Invoke-ScriptAnalyzer -Path $Path -Setting $PSScriptRoot/settings.psd1
+    $Results += Invoke-ScriptAnalyzer -Path $Path `
+      -Setting $PSScriptRoot/settings.psd1 `
+      -ExcludeRule $ExcludedRules
 }
 
 ConvertTo-Json -InputObject $Results


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes false positive in powershell files tests por UTF8 without BOM powershell scripts.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Fixes #35971
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
test/sanity/pslint/pslint.ps1
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
N/A


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
Added two parameters (`-ExcludeRule PSUseBOMForUnicodeEncodedFile`) to avoid false positive when the powershell is UTF8 encoded without BOM
<!--- Paste verbatim command output below, e.g. before and after your change -->

