### PR TITLE
Stabilize ec2_vpc_route_table

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_route_table.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_route_table.py
@@ -685,8 +685,9 @@ def ensure_route_table_present(connection, module):
                                             purge_subnets=purge_subnets)
         changed = changed or result['changed']
 
-    # pause to allow route table routes/subnets/associations to be updated before exiting with final state
-    sleep(5)
+    if any(x is not None for x in [routes, subnets, propagating_vgw_ids]) or (not tags_valid and tags is not None):
+        # pause to allow route table routes/subnets/associations to be updated before exiting with final state
+        sleep(5)
     module.exit_json(changed=changed, route_table=get_route_table_info(connection, module, route_table))
 
 

--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_route_table.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_route_table.py
@@ -685,7 +685,7 @@ def ensure_route_table_present(connection, module):
                                             purge_subnets=purge_subnets)
         changed = changed or result['changed']
 
-    if any(x is not None for x in [routes, subnets, propagating_vgw_ids]) or (not tags_valid and tags is not None):
+    if changed:
         # pause to allow route table routes/subnets/associations to be updated before exiting with final state
         sleep(5)
     module.exit_json(changed=changed, route_table=get_route_table_info(connection, module, route_table))

--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_route_table.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_route_table.py
@@ -224,6 +224,7 @@ route_table:
 '''
 
 import re
+from time import sleep
 from ansible.module_utils.aws.core import AnsibleAWSModule
 from ansible.module_utils.ec2 import ec2_argument_spec, boto3_conn, get_aws_connection_info
 from ansible.module_utils.ec2 import ansible_dict_to_boto3_filter_list
@@ -647,6 +648,12 @@ def ensure_route_table_present(connection, module):
         if not module.check_mode:
             try:
                 route_table = connection.create_route_table(VpcId=vpc_id)['RouteTable']
+                # try to wait for route table to be present before moving on
+                for attempt in range(5):
+                    if not get_route_table_by_id(connection, module, route_table['RouteTableId']):
+                        sleep(2)
+                    else:
+                        break
             except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
                 module.fail_json_aws(e, msg="Error creating route table")
         else:
@@ -678,6 +685,8 @@ def ensure_route_table_present(connection, module):
                                             purge_subnets=purge_subnets)
         changed = changed or result['changed']
 
+    # pause to allow route table routes/subnets/associations to be updated before exiting with final state
+    sleep(5)
     module.exit_json(changed=changed, route_table=get_route_table_info(connection, module, route_table))
 
 


### PR DESCRIPTION
Wait for route table to be present before attempting to use it

Sleep before getting the final state of the route table in case modifications are incomplete

##### SUMMARY
ec2_vpc_route_table tests frequently fail in CI. This is an attempt to improve that. Running the tests locally, I experience various sporadic failures around 20-30% of the time. With this patch I have run the tests 20 times consecutively without failure.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/ec2_vpc_route_table.py

##### ANSIBLE VERSION
```
2.6.0
```
