### PR TITLE
Quote --rsh command options for rsync in syncrhonize module

### DIFF
--- a/lib/ansible/modules/files/synchronize.py
+++ b/lib/ansible/modules/files/synchronize.py
@@ -481,7 +481,7 @@ def main():
         ssh_cmd_str = ' '.join(shlex_quote(arg) for arg in ssh_cmd)
         if ssh_args:
             ssh_cmd_str += ' %s' % ssh_args
-        cmd.append('--rsh=%s' % ssh_cmd_str)
+        cmd.append('--rsh=\'%s\'' % ssh_cmd_str)
 
     if rsync_path:
         cmd.append('--rsync-path=%s' % rsync_path)


### PR DESCRIPTION
Signed-off-by: Adam Miller <admiller@redhat.com>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Currently the --rsh command arg being passed to rsync is not quoted,
but we're adding arguments to the ssh command and that causes rsync
to attempt to accept them as it's own, which is not the desired
outcome.

Fixes #35717


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
synchronize

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0 (synchronize 8ae2dc4721) last updated 2018/02/09 11:47:48 (GMT -500)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/admiller/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/admiller/src/dev/ansible/lib/ansible
  executable location = /home/admiller/src/dev/ansible/bin/ansible
  python version = 2.7.14 (default, Jan 17 2018, 14:28:32) [GCC 7.2.1 20170915 (Red Hat 7.2.1-2)]
```

