### PR TITLE
Deprecate squash_actions

### DIFF
--- a/docs/docsite/rst/porting_guides/porting_guide_2.5.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.5.rst
@@ -132,32 +132,6 @@ See :ref:`playbooks_tests` for more information.
 
 Additionally, a script was created to assist in the conversion for tests using filter syntax to proper jinja test syntax. This script has been used to convert all of the Ansible integration tests to the correct format. There are a few limitations documented, and all changes made by this script should be evaluated for correctness before executing the modified playbooks. The script can be found at `https://github.com/ansible/ansible/blob/devel/hacking/fix_test_syntax.py <https://github.com/ansible/ansible/blob/devel/hacking/fix_test_syntax.py>`_.
 
-Using a loop on a package module via squash_actions
----------------------------------------------------
-
-The use of ``squash_actions`` to invoke a package module, such as "yum", to only invoke the module once is deprecated, and will be removed in Ansible 2.11.
-
-Instead of relying on implicit squashing, tasks should instead supply the list directly to the ``name``, ``pkg`` or ``package`` parameter of the module. This functionality has been supported in most modules since Ansible 2.3.
-
-**OLD** In Ansible 2.6 (and earlier) the following task would invoke the "yum" module only 1 time to install multiple packages
-
-.. code-block:: yaml
-
-    - name: Install packages
-      yum:
-        name: "{{ item }}"
-        state: present
-      with_items: "{{ packages }}"
-
-**NEW** In Ansible 2.7 it should be changed to look like this:
-
-.. code-block:: yaml
-
-    - name: Install packages
-      yum:
-        name: "{{ packages }}"
-        state: present
-
 Modules
 =======
 

--- a/docs/docsite/rst/porting_guides/porting_guide_2.5.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.5.rst
@@ -132,6 +132,32 @@ See :ref:`playbooks_tests` for more information.
 
 Additionally, a script was created to assist in the conversion for tests using filter syntax to proper jinja test syntax. This script has been used to convert all of the Ansible integration tests to the correct format. There are a few limitations documented, and all changes made by this script should be evaluated for correctness before executing the modified playbooks. The script can be found at `https://github.com/ansible/ansible/blob/devel/hacking/fix_test_syntax.py <https://github.com/ansible/ansible/blob/devel/hacking/fix_test_syntax.py>`_.
 
+Using a loop on a package module via squash_actions
+---------------------------------------------------
+
+The use of ``squash_actions`` to invoke a package module, such as "yum", to only invoke the module once is deprecated, and will be removed in Ansible 2.9.
+
+Instead of relying on implicit squashing, tasks should instead supply the list directly to the ``name``, ``pkg`` or ``package`` parameter of the module. This functionality has been supported in most modules since Ansible 2.3.
+
+**OLD** In Ansible 2.4 (and earlier) the following task would invoke the "yum" module only 1 time to install multiple packages
+
+.. code-block:: yaml
+
+    - name: Install packages
+      yum:
+        name: "{{ item }}"
+        state: present
+      with_items: "{{ packages }}"
+
+**NEW** In Ansible 2.5 it should be changed to look like this:
+
+.. code-block:: yaml
+
+    - name: Install packages
+      yum:
+        name: "{{ packages }}"
+        state: present
+
 Modules
 =======
 

--- a/docs/docsite/rst/porting_guides/porting_guide_2.5.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.5.rst
@@ -135,11 +135,11 @@ Additionally, a script was created to assist in the conversion for tests using f
 Using a loop on a package module via squash_actions
 ---------------------------------------------------
 
-The use of ``squash_actions`` to invoke a package module, such as "yum", to only invoke the module once is deprecated, and will be removed in Ansible 2.9.
+The use of ``squash_actions`` to invoke a package module, such as "yum", to only invoke the module once is deprecated, and will be removed in Ansible 2.11.
 
 Instead of relying on implicit squashing, tasks should instead supply the list directly to the ``name``, ``pkg`` or ``package`` parameter of the module. This functionality has been supported in most modules since Ansible 2.3.
 
-**OLD** In Ansible 2.4 (and earlier) the following task would invoke the "yum" module only 1 time to install multiple packages
+**OLD** In Ansible 2.6 (and earlier) the following task would invoke the "yum" module only 1 time to install multiple packages
 
 .. code-block:: yaml
 
@@ -149,7 +149,7 @@ Instead of relying on implicit squashing, tasks should instead supply the list d
         state: present
       with_items: "{{ packages }}"
 
-**NEW** In Ansible 2.5 it should be changed to look like this:
+**NEW** In Ansible 2.7 it should be changed to look like this:
 
 .. code-block:: yaml
 

--- a/docs/docsite/rst/porting_guides/porting_guide_2.7.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.7.rst
@@ -1,0 +1,89 @@
+.. _porting_2.7_guide:
+
+*************************
+Ansible 2.7 Porting Guide
+*************************
+
+This section discusses the behavioral changes between Ansible 2.6 and Ansible 2.7.
+
+It is intended to assist in updating your playbooks, plugins and other parts of your Ansible infrastructure so they will work with this version of Ansible.
+
+We suggest you read this page along with `Ansible Changelog <https://github.com/ansible/ansible/blob/devel/CHANGELOG.md#2.7>`_ to understand what updates you may need to make.
+
+This document is part of a collection on porting. The complete list of porting guides can be found at :ref:`porting guides <porting_guides>`.
+
+.. contents:: Topics
+
+Playbook
+========
+
+No notable changes.
+
+Deprecated
+==========
+
+Using a loop on a package module via squash_actions
+---------------------------------------------------
+
+The use of ``squash_actions`` to invoke a package module, such as "yum", to only invoke the module once is deprecated, and will be removed in Ansible 2.11.
+
+Instead of relying on implicit squashing, tasks should instead supply the list directly to the ``name``, ``pkg`` or ``package`` parameter of the module. This functionality has been supported in most modules since Ansible 2.3.
+
+**OLD** In Ansible 2.6 (and earlier) the following task would invoke the "yum" module only 1 time to install multiple packages
+
+.. code-block:: yaml
+
+    - name: Install packages
+      yum:
+        name: "{{ item }}"
+        state: present
+      with_items: "{{ packages }}"
+
+**NEW** In Ansible 2.7 it should be changed to look like this:
+
+.. code-block:: yaml
+
+    - name: Install packages
+      yum:
+        name: "{{ packages }}"
+        state: present
+
+
+Modules
+=======
+
+Major changes in popular modules are detailed here
+
+
+
+Modules removed
+---------------
+
+The following modules no longer exist:
+
+
+Deprecation notices
+-------------------
+
+The following modules will be removed in Ansible 2.10. Please update your playbooks accordingly.
+
+
+Noteworthy module changes
+-------------------------
+
+No notable changes.
+
+Plugins
+=======
+
+No notable changes.
+
+Porting custom scripts
+======================
+
+No notable changes.
+
+Networking
+==========
+
+No notable changes.

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -971,8 +971,9 @@ DEFAULT_SQUASH_ACTIONS:
   type: list
   version_added: "2.0"
   deprecated:
-    why: In favor of supplying a list directly to the name parameter
-    version: "2.9"
+    why: Loop squashing is deprecated and this configuration will no longer be used
+    version: "2.10"
+    alternatives: a list directly with the module argument
 DEFAULT_SSH_TRANSFER_METHOD:
   # TODO: move to ssh plugin
   default:

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -970,6 +970,9 @@ DEFAULT_SQUASH_ACTIONS:
   - {key: squash_actions, section: defaults}
   type: list
   version_added: "2.0"
+  deprecated:
+    why: In favor of supplying a list directly to the name parameter
+    version: "2.9"
 DEFAULT_SSH_TRANSFER_METHOD:
   # TODO: move to ssh plugin
   default:

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -972,7 +972,7 @@ DEFAULT_SQUASH_ACTIONS:
   version_added: "2.0"
   deprecated:
     why: Loop squashing is deprecated and this configuration will no longer be used
-    version: "2.10"
+    version: "2.11"
     alternatives: a list directly with the module argument
 DEFAULT_SSH_TRANSFER_METHOD:
   # TODO: move to ssh plugin

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -401,7 +401,7 @@ class TaskExecutor:
                         if template_no_item != template_with_item:
                             display.deprecated(
                                 'Invoking "%s" only once while using a loop via squash_actions is deprecated. '
-                                'Instead of using a loop to supply multiple packages and specifying `%s: %s`, '
+                                'Instead of using a loop to supply multiple items and specifying `%s: %s`, '
                                 'please use `%s: %r` and remove the loop' % (self._task.action, found, name, found, self._task.loop),
                                 version=2.9
                             )

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -403,7 +403,7 @@ class TaskExecutor:
                                 'Invoking "%s" only once while using a loop via squash_actions is deprecated. '
                                 'Instead of using a loop to supply multiple items and specifying `%s: %s`, '
                                 'please use `%s: %r` and remove the loop' % (self._task.action, found, name, found, self._task.loop),
-                                version='2.10'
+                                version='2.11'
                             )
                             for item in items:
                                 variables[loop_var] = item

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -403,7 +403,7 @@ class TaskExecutor:
                                 'Invoking "%s" only once while using a loop via squash_actions is deprecated. '
                                 'Instead of using a loop to supply multiple items and specifying `%s: %s`, '
                                 'please use `%s: %r` and remove the loop' % (self._task.action, found, name, found, self._task.loop),
-                                version=2.9
+                                version='2.10'
                             )
                             for item in items:
                                 variables[loop_var] = item

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -377,9 +377,11 @@ class TaskExecutor:
                 if all(isinstance(o, string_types) for o in items):
                     final_items = []
 
+                    found = None
                     for allowed in ['name', 'pkg', 'package']:
                         name = self._task.args.pop(allowed, None)
                         if name is not None:
+                            found = allowed
                             break
 
                     # This gets the information to check whether the name field
@@ -397,6 +399,12 @@ class TaskExecutor:
                         # name/pkg or the name/pkg field doesn't have any variables
                         # and thus the items can't be squashed
                         if template_no_item != template_with_item:
+                            display.deprecated(
+                                'Invoking "%s" only once while using a loop via squash_actions is deprecated. '
+                                'Instead of using a loop to supply multiple packages and specifying `%s: %s`, '
+                                'please use `%s: %r` and remove the loop' % (self._task.action, found, name, found, self._task.loop),
+                                version=2.9
+                            )
                             for item in items:
                                 variables[loop_var] = item
                                 if self._task.evaluate_conditional(templar, variables):


### PR DESCRIPTION
##### SUMMARY

squashing actions on a module is not a "best practice" to invoke the module only once time on a set of items.

Instead supplying the list directly to the `name`, `pkg`, or `package` argument is preferred.

##### ISSUE TYPE
 - Feature Pull Request?

##### COMPONENT NAME
lib/ansible/executor/task_executor.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```