### PR TITLE
Fix 'repomd.xml signature could not be verified'

### DIFF
--- a/lib/ansible/modules/packaging/os/yum.py
+++ b/lib/ansible/modules/packaging/os/yum.py
@@ -523,7 +523,7 @@ def is_update(module, repoq, pkgspec, conf_file, qf=def_qf, en_repos=None, dis_r
     return set()
 
 
-def what_provides(module, repoq, req_spec, conf_file, qf=def_qf, en_repos=None, dis_repos=None, installroot='/'):
+def what_provides(module, repoq, yum_basecmd, req_spec, conf_file, qf=def_qf, en_repos=None, dis_repos=None, installroot='/'):
     if en_repos is None:
         en_repos = []
     if dis_repos is None:
@@ -539,7 +539,19 @@ def what_provides(module, repoq, req_spec, conf_file, qf=def_qf, en_repos=None, 
             for rid in en_repos:
                 my.repos.enableRepo(rid)
 
-            pkgs = my.returnPackagesByDep(req_spec) + my.returnInstalledPackagesByDep(req_spec)
+            try:
+                pkgs = my.returnPackagesByDep(req_spec) + my.returnInstalledPackagesByDep(req_spec)
+            except Exception as e:
+                # If a repo with `repo_gpgcheck=1` is added and the repo GPG
+                # key was never accepted, quering this repo will throw an
+                # error: 'repomd.xml signature could not be verified'. In that
+                # situation we need to run `yum -y makecache` which will accept
+                # the key and try again.
+                if 'repomd.xml signature could not be verified' in to_native(e):
+                    module.run_command(yum_basecmd + ['makecache'])
+                    pkgs = my.returnPackagesByDep(req_spec) + my.returnInstalledPackagesByDep(req_spec)
+                else:
+                    raise
             if not pkgs:
                 e, m, _ = my.pkgSack.matchPackageNames([req_spec])
                 pkgs.extend(e)
@@ -824,7 +836,7 @@ def install(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos, i
                     continue
 
             # look up what pkgs provide this
-            pkglist = what_provides(module, repoq, spec, conf_file, en_repos=en_repos, dis_repos=dis_repos, installroot=installroot)
+            pkglist = what_provides(module, repoq, yum_basecmd, spec, conf_file, en_repos=en_repos, dis_repos=dis_repos, installroot=installroot)
             if not pkglist:
                 res['msg'] += "No package matching '%s' found available, installed or updated" % spec
                 res['results'].append("No package matching '%s' found available, installed or updated" % spec)
@@ -1088,7 +1100,7 @@ def latest(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos, up
                     pkgs['update'].append(spec)
                 else:
                     pkgs['install'].append(spec)
-            pkglist = what_provides(module, repoq, spec, conf_file, en_repos=en_repos, dis_repos=dis_repos, installroot=installroot)
+            pkglist = what_provides(module, repoq, yum_basecmd, spec, conf_file, en_repos=en_repos, dis_repos=dis_repos, installroot=installroot)
             # FIXME..? may not be desirable to throw an exception here if a single package is missing
             if not pkglist:
                 res['msg'] += "No package matching '%s' found available, installed or updated" % spec


### PR DESCRIPTION


##### SUMMARY
If a repo with `repo_gpgcheck=1` is added and the repo GPG key was never accepted, quering this repo would throw an error `repomd.xml signature could not be verified` and the module would fail. If that happens now `yum -y makecache` will be run which will fetch the new repo data and accept the repo GPG key.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
yum module

##### ANSIBLE VERSION
```
ansible 2.6.0 (fix-signature-could-not-be-verified 3908fc7a96) last updated 2018/02/09 23:11:13 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/kustodian/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/kustodian/git/github/ansible/lib/ansible
  executable location = /home/kustodian/git/github/ansible/bin/ansible
  python version = 2.7.14 (default, Sep 23 2017, 22:06:14) [GCC 7.2.0]
```

##### ADDITIONAL INFORMATION
This should also resolve issue #20711 which was reported about a year ago and it was closed without a proper resolution (only a workaround was suggested).