### PR TITLE
Fixes #31693 Adds a "skipped" key if not present in task result

### DIFF
--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -141,6 +141,10 @@ class TaskExecutor:
             if 'changed' not in res:
                 res['changed'] = False
 
+            # make sure skipped is set in the result, if it's not present
+            if 'skipped' not in res:
+                res['skipped'] = False
+
             def _clean_res(res, errors='surrogate_or_strict'):
                 if isinstance(res, UnsafeProxy):
                     return res._obj

--- a/test/integration/targets/iterators/tasks/main.yml
+++ b/test/integration/targets/iterators/tasks/main.yml
@@ -176,7 +176,7 @@
 - name: verify with_subelements in subkeys results
   assert:
     that:
-        - _subelements_missing_subkeys.skipped is not defined
+        - _subelements_missing_subkeys.skipped == False
         - _subelements_missing_subkeys.results|length == 2
         - "_xk == 'k'"
         - "_xl == 'l'"


### PR DESCRIPTION
##### SUMMARY
Fixes #31693. Adds a 'skipped' key to the task result hash if not present already.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
task_executor.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0 (skipped_false f5b72b7478) last updated 2018/02/10 00:12:19 (GMT +200)
  config file = None
  configured module search path = ['/home/nikos/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/nikos/Projects/ansible/lib/ansible
  executable location = /home/nikos/Projects/ansible/bin/ansible
  python version = 3.6.4 (default, Jan  5 2018, 02:35:40) [GCC 7.2.1 20171224]
```

##### ADDITIONAL INFORMATION
Adds the `skipped` key similar to how `failed: false` is added. It is useful to not break tasks that check eg `when: result.skipped == True`. It also makes output more predictable without giving the impression that keys can popup depending on the circumstances.

A sample task that sets an fact, before the change would result into:
```
ok: [localhost -> localhost] => {
    "ansible_facts": {
        "local_user": "nikos"
    },
    "changed": true,
    "failed": false
}
```
and, after the PR is applied:
```
ok: [localhost -> localhost] => {
    "ansible_facts": {
        "local_user": "nikos"
    },
    "changed": false,
    "failed": false,
    "skipped": false
}
```