### PR TITLE
Disable unstable azure_rm_containerinstance test.

### DIFF
--- a/test/integration/targets/azure_rm_containerinstance/aliases
+++ b/test/integration/targets/azure_rm_containerinstance/aliases
@@ -1,3 +1,2 @@
 cloud/azure
 destructive
-posix/ci/cloud/group2/azure


### PR DESCRIPTION
##### SUMMARY

Temporarily disable the unstable azure_rm_containerinstance test. The test fails periodically in CI:

https://app.shippable.com/github/ansible/ansible/runs/54351/2/tests

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

azure_rm_containerinstance integration test

##### ANSIBLE VERSION

```
ansible 2.6.0 (unstable-test f23f15e4e8) last updated 2018/02/09 22:44:37 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```
