### PR TITLE
VMware: Additional check for RootSnapshot

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest_snapshot.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_snapshot.py
@@ -241,11 +241,13 @@ class PyVmomiHelper(PyVmomi):
         memory_dump = False
         quiesce = False
         # Check if there is a latest snapshot already present as specified by user
-        snap_obj = self.get_snapshots_by_name_recursively(vm.snapshot.rootSnapshotList,
-                                                          self.module.params["snapshot_name"])
-        if snap_obj:
-            # Snapshot already exists, do not anything.
-            self.module.exit_json(changed=False, msg="Snapshot named [%(snapshot_name)s] already exists." % self.module.params)
+        if vm.snapshot is not None:
+            snap_obj = self.get_snapshots_by_name_recursively(vm.snapshot.rootSnapshotList,
+                                                              self.module.params["snapshot_name"])
+            if snap_obj:
+                # Snapshot already exists, do not anything.
+                self.module.exit_json(changed=False,
+                                      msg="Snapshot named [%(snapshot_name)s] already exists and is current." % self.module.params)
         # Check if Virtual Machine provides capabilities for Quiesce and Memory Snapshots
         if vm.capability.quiescedSnapshotsSupported:
             quiesce = self.module.params['quiesce']


### PR DESCRIPTION
##### SUMMARY
This fix adds an additional check if there is no snapshot available
in VM. `rootSnapshotList` is None, if no snapshot is taken.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
lib/ansible/modules/cloud/vmware/vmware_guest_snapshot.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5devel
```