### PR TITLE
win_updates: fix regression when using string cat names

### DIFF
--- a/lib/ansible/plugins/action/win_updates.py
+++ b/lib/ansible/plugins/action/win_updates.py
@@ -6,6 +6,7 @@ import json
 from ansible.errors import AnsibleError
 from ansible.module_utils._text import to_text
 from ansible.module_utils.parsing.convert_bool import boolean
+from ansible.parsing.yaml.objects import AnsibleUnicode
 from ansible.plugins.action import ActionBase
 
 try:
@@ -140,6 +141,9 @@ class ActionModule(ActionBase):
             'SecurityUpdates',
             'UpdateRollups',
         ])
+        if isinstance(category_names, AnsibleUnicode):
+            category_names = [cat.strip() for cat in category_names.split(",")]
+
         state = self._task.args.get('state', 'installed')
         reboot = self._task.args.get('reboot', False)
         reboot_timeout = self._task.args.get('reboot_timeout',

--- a/test/integration/targets/win_updates/tasks/tests.yml
+++ b/test/integration/targets/win_updates/tasks/tests.yml
@@ -43,8 +43,7 @@
 - name: search for updates with log output (check)
   win_updates:
     state: searched
-    category_names:
-    - CriticalUpdates
+    category_names: CriticalUpdates
     log_path: '{{win_updates_dir}}/update.log'
   register: update_search_with_log_check
   check_mode: yes


### PR DESCRIPTION
##### SUMMARY
Fix to allow category names being set as a string. Also changed a test to cover this case.

Fixes https://github.com/ansible/ansible/issues/36014#issuecomment-364801205

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
win_updates

##### ANSIBLE VERSION
```
2.5
```