### PR TITLE
win_uri: fix creates/removes option

### DIFF
--- a/lib/ansible/modules/windows/win_uri.ps1
+++ b/lib/ansible/modules/windows/win_uri.ps1
@@ -37,6 +37,11 @@ $validate_certs = Get-AnsibleParam -obj $params -name "validate_certs" -type "bo
 $client_cert = Get-AnsibleParam -obj $params -name "client_cert" -type "path"
 $client_cert_password = Get-AnsibleParam -obj $params -name "client_cert_password" -type "str"
 
+$result = @{
+    changed = $false
+    url = $url
+}
+
 if ($creates -and (Test-AnsiblePath -Path $creates)) {
     $result.skipped = $true
     Exit-Json -obj $result -message "The 'creates' file or directory ($creates) already exists."
@@ -45,11 +50,6 @@ if ($creates -and (Test-AnsiblePath -Path $creates)) {
 if ($removes -and -not (Test-AnsiblePath -Path $removes)) {
     $result.skipped = $true
     Exit-Json -obj $result -message "The 'removes' file or directory ($removes) does not exist."
-}
-
-$result = @{
-    changed = $false
-    url = $url
 }
 
 if ($use_basic_parsing) {

--- a/test/integration/targets/win_uri/tasks/test.yml
+++ b/test/integration/targets/win_uri/tasks/test.yml
@@ -100,6 +100,30 @@
     that:
     - not get_request_with_dest_again.changed
 
+- name: test request with creates option should skip
+  win_uri:
+    url: http://{{httpbin_host}}/get
+    creates: '{{test_uri_path}}\get.json'
+  register: request_with_creates_skipped
+
+- name: assert test request with creates option should skip
+  assert:
+    that:
+    - not request_with_creates_skipped.changed
+    - request_with_creates_skipped.skipped
+
+- name: test request with creates option should not skip
+  win_uri:
+    url: http://{{httpbin_host}}/get
+    creates: '{{test_uri_path}}\fake.json'
+  register: request_with_creates_not_skipped
+
+- name: assert test request with creates option should not skip
+  assert:
+    that:
+    - not request_with_creates_not_skipped.changed
+    - request_with_creates_not_skipped.skipped is not defined
+
 - name: post request with return_content, dest and different content
   win_uri:
     url: http://{{httpbin_host}}/post


### PR DESCRIPTION
##### SUMMARY
The win_uri module tries to set `$result.skipped` before `$result` is actually defined. This just moves that definition to before the checks so it works properly.

This can possibly be cherry-picked back to 2.4 as well.

Fixes https://github.com/ansible/ansible/issues/35784

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
win_uri

##### ANSIBLE VERSION
```
2.5
```