### PR TITLE
win_domain_controller: optionally add -ReadOnlyReplica if true

### DIFF
--- a/lib/ansible/modules/windows/win_domain_controller.ps1
+++ b/lib/ansible/modules/windows/win_domain_controller.ps1
@@ -204,10 +204,15 @@ Try {
                 if ($sysvol_path) {
                     $install_params.SysvolPath = $sysvol_path
                 }
+                if ($read_only) {
+                    # while this is a switch value, if we set on $false site_name is required
+                    # https://github.com/ansible/ansible/issues/35858
+                    $install_params.ReadOnlyReplica = $true
+                }
                 if ($site_name) {
                     $install_params.SiteName = $site_name
                 }
-                $install_result = Install-ADDSDomainController -NoRebootOnCompletion -ReadOnlyReplica:$read_only -Force @install_params
+                $install_result = Install-ADDSDomainController -NoRebootOnCompletion -Force @install_params
 
                 Write-DebugLog "Installation completed, needs reboot..."
             }


### PR DESCRIPTION
##### SUMMARY
The `-ReadOnlyReplica` option being set requires the site name option where before it was not. This change updates the module to only set the read only option if it is true keeping it in line with the previous behaviour.

Fixes https://github.com/ansible/ansible/issues/35858.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
win_domain_controller

##### ANSIBLE VERSION
```
2.5
```