### PR TITLE
Add support for changing windows hostname

### DIFF
--- a/lib/ansible/modules/windows/win_hostname.ps1
+++ b/lib/ansible/modules/windows/win_hostname.ps1
@@ -35,9 +35,17 @@ if ($check_mode) {
 if (-not $check_mode) {
     if ($newComputerName -ne $currentComputerName) {
         $setResult = (Set-ComputerName($newComputerName))
-        $result.changed = $true
-        $result.rc = $setResult
-        Set-Attr $result "computer_name" $newComputerName
+        if ($setResult -eq 0) {         
+            $result.changed = $true
+            $result.rc = $setResult
+            Set-Attr $result "computer_name" $newComputerName
+        }
+        else {
+               $result.changed = $false
+               $result.rc = $setResult
+               Set-ComputerName($currentComputerName)
+               Set-Attr $result "computer_name" $currentComputerName
+            }    
     }   
    
 }

--- a/lib/ansible/modules/windows/win_hostname.ps1
+++ b/lib/ansible/modules/windows/win_hostname.ps1
@@ -32,16 +32,10 @@ $result = New-Object psobject @{
     changed = $false
 };
 
-If (-not $params.name.GetType)
-{
-    Fail-Json $result "missing required arguments: name"
-}
-
 $newComputerName = Get-Attr $params "name"
 $currentComputerName = (Get-ComputerName)
 
 if ($check_mode) {
-  # $result.msg = "Running in check mode - would change computer name to $newComputerName from $currentComputerName"  
   $result.msg = "Rename-computer $newComputerName -WhatIf" 
 }
 if (-not $check_mode) {
@@ -49,7 +43,6 @@ if (-not $check_mode) {
         $setResult = (Set-ComputerName($newComputerName))
         $result.changed = $true
         $result.rc = $setResult
-        # Set-Attr $result "user" $user_obj
         Set-Attr $result "computer_name" $newComputerName
     }   
    

--- a/lib/ansible/modules/windows/win_hostname.ps1
+++ b/lib/ansible/modules/windows/win_hostname.ps1
@@ -6,14 +6,8 @@
 
 ########
 
-function Get-ComputerName() {
-    Get-Content env:computername
-    return
-}
-
 function Set-ComputerName($newComputerName) {
-    $systemInfo = Get-WmiObject Win32_ComputerSystem
-    $cmdResult = $systemInfo.Rename($newComputerName)    
+    $cmdResult = Rename-computer $newComputerName    
     if ($cmdResult.ReturnValue -ne 0) {         
         Fail-Json $result "The computer name could not be set. Check that it is a valid name."                
     }
@@ -28,12 +22,12 @@ $check_mode = Get-AnsibleParam -obj $params -name "_ansible_check_mode" -type "b
 $diff_mode = Get-AnsibleParam -obj $params -name "_ansible_diff" -type "bool" -default $false
 
 
-$result = New-Object psobject @{
-    changed = $false
+$result = @{
+ changed = $false
 };
 
 $newComputerName = Get-Attr $params "name"
-$currentComputerName = (Get-ComputerName)
+$currentComputerName = $env:computername
 
 if ($check_mode) {
   $result.msg = "Rename-computer $newComputerName -WhatIf" 

--- a/lib/ansible/modules/windows/win_hostname.ps1
+++ b/lib/ansible/modules/windows/win_hostname.ps1
@@ -1,0 +1,54 @@
+#!powershell
+
+# WANT_JSON
+# POWERSHELL_COMMON
+
+########
+
+function Get-ComputerName() {
+    Get-Content env:computername
+    return
+}
+
+function Set-ComputerName($newComputerName) {
+    $systemInfo = Get-WmiObject Win32_ComputerSystem
+    $cmdResult = $systemInfo.Rename($newComputerName)    
+    if ($cmdResult.ReturnValue -ne 0) {         
+        Fail-Json $result "The computer name could not be set. Check that it is a valid name."                
+    }
+    return $cmdResult.ReturnValue
+}
+
+########
+
+$params = Parse-Args $args -supports_check_mode $true;
+$check_mode = Get-AnsibleParam -obj $params -name "_ansible_check_mode" -type "bool" -default $false
+$diff_mode = Get-AnsibleParam -obj $params -name "_ansible_diff" -type "bool" -default $false
+
+$result = New-Object psobject @{
+    changed = $false
+};
+
+If (-not $params.name.GetType)
+{
+    Fail-Json $result "missing required arguments: name"
+}
+
+$newComputerName = Get-Attr $params "name"
+$currentComputerName = (Get-ComputerName)
+
+if ($check_mode) {
+  $result.msg = "Running in check mode - would change computer name to $newComputerName from $currentComputerName"  
+}
+if (-not $check_mode) {
+    if ($newComputerName -ne $currentComputerName) {
+        $setResult = (Set-ComputerName($newComputerName))
+        $result.changed = $true
+        $result.rc = $setResult
+        # Set-Attr $result "user" $user_obj
+        Set-Attr $result "computer_name" $newComputerName
+    }   
+   
+}
+
+Exit-Json $result;

--- a/lib/ansible/modules/windows/win_hostname.ps1
+++ b/lib/ansible/modules/windows/win_hostname.ps1
@@ -1,7 +1,8 @@
 #!powershell
+# Copyright: (c) 2018, Ripon Banik (@riponbanik)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-# WANT_JSON
-# POWERSHELL_COMMON
+# Requires -Module Ansible.ModuleUtils.Legacy
 
 ########
 
@@ -22,8 +23,10 @@ function Set-ComputerName($newComputerName) {
 ########
 
 $params = Parse-Args $args -supports_check_mode $true;
+$name = Get-AnsibleParam -obj $params -name "name" -type "str" -failifempty $true
 $check_mode = Get-AnsibleParam -obj $params -name "_ansible_check_mode" -type "bool" -default $false
 $diff_mode = Get-AnsibleParam -obj $params -name "_ansible_diff" -type "bool" -default $false
+
 
 $result = New-Object psobject @{
     changed = $false

--- a/lib/ansible/modules/windows/win_hostname.ps1
+++ b/lib/ansible/modules/windows/win_hostname.ps1
@@ -41,7 +41,8 @@ $newComputerName = Get-Attr $params "name"
 $currentComputerName = (Get-ComputerName)
 
 if ($check_mode) {
-  $result.msg = "Running in check mode - would change computer name to $newComputerName from $currentComputerName"  
+  # $result.msg = "Running in check mode - would change computer name to $newComputerName from $currentComputerName"  
+  $result.msg = "Rename-computer $newComputerName -WhatIf" 
 }
 if (-not $check_mode) {
     if ($newComputerName -ne $currentComputerName) {

--- a/lib/ansible/modules/windows/win_hostname.py
+++ b/lib/ansible/modules/windows/win_hostname.py
@@ -11,7 +11,7 @@
 DOCUMENTATION = '''
 ---
 module: win_hostname
-version_added: "2.4"
+version_added: "2.6"
 short_description: Manages local Windows computer name
 description:
      - Manages local Windows computer name. 
@@ -19,18 +19,14 @@ description:
 options:
   name:
     description:
-      - Name of the computer
-    required: true
-    default: null
-    aliases: []
+      - Name of the computer.
+    required: true    
   author: Ripon Banik (@riponbanik)
 '''
 
 EXAMPLES = '''
-# Ad-hoc example
-ansible -i hosts -m win_hostname -a "name=myhost" windows
-# Playbook example
-- win_hostname: 
+- name: Change hostname with the new name
+  win_hostname: 
     name: myhost
 '''
 

--- a/lib/ansible/modules/windows/win_hostname.py
+++ b/lib/ansible/modules/windows/win_hostname.py
@@ -1,0 +1,31 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# this is a windows documentation stub.  actual code lives in the .ps1
+# file of the same name
+
+DOCUMENTATION = '''
+---
+module: win_hostname
+version_added: "2.4"
+short_description: Manages local Windows computer name
+description:
+     - Manages local Windows computer name. 
+     - A reboot is required for the computer name to take effect
+options:
+  name:
+    description:
+      - Name of the computer
+    required: true
+    default: null
+    aliases: []
+author: Ripon Banik
+'''
+
+EXAMPLES = '''
+# Ad-hoc example
+ansible -i hosts -m win_host -a "host_name=host ip_address=ip" windows
+# Playbook example
+- win_hostname: name=myhost
+'''
+

--- a/lib/ansible/modules/windows/win_hostname.py
+++ b/lib/ansible/modules/windows/win_hostname.py
@@ -4,6 +4,10 @@
 # this is a windows documentation stub.  actual code lives in the .ps1
 # file of the same name
 
+# Copyright: (c) 2018, Ripon Banik (@riponbanik)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+
 DOCUMENTATION = '''
 ---
 module: win_hostname
@@ -11,7 +15,7 @@ version_added: "2.4"
 short_description: Manages local Windows computer name
 description:
      - Manages local Windows computer name. 
-     - A reboot is required for the computer name to take effect
+     - A reboot is required for the computer name to take effect.
 options:
   name:
     description:
@@ -19,13 +23,14 @@ options:
     required: true
     default: null
     aliases: []
-author: Ripon Banik
+  author: Ripon Banik (@riponbanik)
 '''
 
 EXAMPLES = '''
 # Ad-hoc example
-ansible -i hosts -m win_host -a "host_name=host ip_address=ip" windows
+ansible -i hosts -m win_hostname -a "name=myhost" windows
 # Playbook example
-- win_hostname: name=myhost
+- win_hostname: 
+    name: myhost
 '''
 


### PR DESCRIPTION
##### SUMMARY
Add support for Windows Hostname

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
Windows

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.0.0
  config file = /home/rbanik/ansible/ansible.cfg
  python version = 2.7.13 (default, Nov 23 2017, 15:37:09) [GCC 6.3.0 20170406]
```

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
Tested with Windows 2012 R2
