### PR TITLE
Improve convert_bool error message

### DIFF
--- a/lib/ansible/module_utils/parsing/convert_bool.py
+++ b/lib/ansible/module_utils/parsing/convert_bool.py
@@ -23,4 +23,4 @@ def boolean(value, strict=True):
     elif normalized_value in BOOLEANS_FALSE or not strict:
         return False
 
-    raise TypeError('%s is not a valid boolean.  Valid booleans include: %s' % (to_text(value), ', '.join(repr(i) for i in BOOLEANS)))
+    raise TypeError("The value '%s' is not a valid boolean.  Valid booleans include: %s" % (to_text(value), ', '.join(repr(i) for i in BOOLEANS)))


### PR DESCRIPTION
##### SUMMARY
The error message as it was confused me when the value was 'enabled' and
there was also a module parameter named 'enabled'.

    enabled is not a valid boolean.  Valid booleans include: yes, on, 1, true, ...

So by clearly describing it as a value, the confusion would have been
avoided.

    The value 'enabled' is not a valid boolean.  Valid booleans include: yes, on, 1, true, ...

##### ISSUE TYPE
 - Feature Pull Request
 - Docs Pull Request

##### COMPONENT NAME
core

##### ANSIBLE VERSION
v2.5