### PR TITLE
Add intg test to repro #36045 (add_host traceback)  [WILL FAIL CURRENTLY]

### DIFF
--- a/test/integration/targets/add_host/tasks/main.yml
+++ b/test/integration/targets/add_host/tasks/main.yml
@@ -16,6 +16,38 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
+# See https://github.com/ansible/ansible/issues/36045
+- set_fact:
+    inventory_data:
+      ansible_ssh_common_args: "-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no"
+      # ansible_ssh_host: "127.0.0.3"
+      ansible_host: "127.0.0.3"
+      ansible_ssh_pass: "foobar"
+      # ansible_ssh_port: "2222"
+      ansible_port: "2222"
+      ansible_ssh_private_key_file: "/tmp/inventory-cloudj9cGz5/identity"
+      ansible_ssh_user: "root"
+      hostname: "newdynamichost2"
+
+- name: Show inventory_data for 36045
+  debug:
+    msg: "{{ inventory_data }}"
+
+- name: Add host from dict 36045
+  add_host: "{{ inventory_data }}"
+
+- name: show newly added host
+  debug:
+    msg: "{{hostvars['newdynamichost2'].group_names}}"
+
+- name: ensure that dynamically-added newdynamichost2 is visible via hostvars, groups 36045
+  assert:
+    that:
+    - hostvars['newdynamichost2'] is defined
+    - hostvars['newdynamichost2'].group_names is defined
+
+#  end of https://github.com/ansible/ansible/issues/36045 related tests
+
 - name: add a host to the runtime inventory
   add_host:
     name: newdynamichost


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
an intg test for the repro in #36045 
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Tests Pull Request
 
##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
test/integration/targets/add_host/tasks/main.yml

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0 (intg_test_36045_repro 4096a9d688) last updated 2018/02/12 13:27:38 (GMT -400)
  config file = /home/adrian/src/ansible/ansible.cfg
  configured module search path = [u'/home/adrian/ansible/my-modules']
  ansible python module location = /home/adrian/src/ansible/lib/ansible
  executable location = /home/adrian/src/ansible/bin/ansible
  python version = 2.7.14 (default, Jan 17 2018, 14:28:32) [GCC 7.2.1 20170915 (Red Hat 7.2.1-2)]


```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
