### PR TITLE
Fix inconsistent case of `Allocation_id` in NAT Gateway outputs

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_nat_gateway.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_nat_gateway.py
@@ -684,7 +684,7 @@ def create(client, subnet_id, allocation_id, client_token=None,
         else:
             result = DRY_RUN_GATEWAYS[0]
             result['create_time'] = datetime.datetime.utcnow()
-            result['nat_gateway_addresses'][0]['Allocation_id'] = allocation_id
+            result['nat_gateway_addresses'][0]['allocation_id'] = allocation_id
             result['subnet_id'] = subnet_id
 
         success = True


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

NAT Gateway module returns a capitalized version of the EIP allocation ID `"Allocation_id": "eipalloc-1d354233"` instead of the expected snake-style Ansible variable name, `allocation_id`. This PR fixes the case. 

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
ec2_vpc_nat_gateway

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
