### PR TITLE
Add undocumented configuration parameter and explain in porting guide

### DIFF
--- a/docs/docsite/rst/porting_guides/porting_guide_2.5.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.5.rst
@@ -137,6 +137,20 @@ See :ref:`playbooks_tests` for more information.
 
 Additionally, a script was created to assist in the conversion for tests using filter syntax to proper jinja test syntax. This script has been used to convert all of the Ansible integration tests to the correct format. There are a few limitations documented, and all changes made by this script should be evaluated for correctness before executing the modified playbooks. The script can be found at `https://github.com/ansible/ansible/blob/devel/hacking/fix_test_syntax.py <https://github.com/ansible/ansible/blob/devel/hacking/fix_test_syntax.py>`_.
 
+Ansible fact namespacing
+------------------------
+Ansible facts, which have historically been written to names like 'ansible_*'
+in the main facts namespace, have been placed in their own new namespace,
+'ansible_facts.*' For example, the fact 'ansible_distribution' is now best
+queried through the variable structure 'ansible_facts.distribution'. 
+
+A new configuration variable, 'inject_facts_as_vars', has been added to
+ansible.cfg. Its default setting, 'True', keeps the 2.4 behavior of facts
+variables being set in the old 'ansible_*' locations (while also writing them
+to the new namespace). This variable is expected to be set to 'False' in a
+future release. When 'inject_facts_as_vars' is set to False, you must
+refer to ansible_facts through the new ansible_facts.* namespace.
+
 Modules
 =======
 

--- a/docs/docsite/rst/porting_guides/porting_guide_2.5.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.5.rst
@@ -139,17 +139,18 @@ Additionally, a script was created to assist in the conversion for tests using f
 
 Ansible fact namespacing
 ------------------------
-Ansible facts, which have historically been written to names like 'ansible_*'
-in the main facts namespace, have been placed in their own new namespace,
-'ansible_facts.*' For example, the fact 'ansible_distribution' is now best
-queried through the variable structure 'ansible_facts.distribution'. 
 
-A new configuration variable, 'inject_facts_as_vars', has been added to
+Ansible facts, which have historically been written to names like ``ansible_*``
+in the main facts namespace, have been placed in their own new namespace,
+``ansible_facts.*`` For example, the fact ``ansible_distribution`` is now best
+queried through the variable structure ``ansible_facts.distribution``. 
+
+A new configuration variable, ``inject_facts_as_vars``, has been added to
 ansible.cfg. Its default setting, 'True', keeps the 2.4 behavior of facts
-variables being set in the old 'ansible_*' locations (while also writing them
+variables being set in the old ``ansible_*`` locations (while also writing them
 to the new namespace). This variable is expected to be set to 'False' in a
-future release. When 'inject_facts_as_vars' is set to False, you must
-refer to ansible_facts through the new ansible_facts.* namespace.
+future release. When ``inject_facts_as_vars`` is set to False, you must
+refer to ansible_facts through the new ``ansible_facts.*`` namespace.
 
 Modules
 =======

--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -55,6 +55,15 @@
 # environment.
 # gather_timeout = 10
 
+# Ansible facts are available inside the ansible_facts.* dictionary
+# namespace. This setting maintains the behaviour which was the default prior
+# to 2.5, duplicating these variables into the main namespace, each with a
+# prefix of 'ansible_'.
+# This variable is set to True by default for backwards compatibility. It
+# will be changed to a default of 'False' in a future release.
+# ansible_facts.
+# inject_facts_as_vars = True
+
 # additional paths to search for roles in, colon separated
 #roles_path    = /etc/ansible/roles
 


### PR DESCRIPTION
##### SUMMARY

Changing the ansible_* facts to the ansible_facts.* namespace is described as a 'major change' in the 2.5 CHANGELOG entries, but its impact in the porting guide, nor the new configuration variable introduced by it in ansible.cfg are not actually described.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
docs/docsite/rst/porting_guide_2.5.rst

##### ANSIBLE VERSION
```
ansible 2.5.0b1 (detached HEAD a48cf0cb0d) last updated 2018/02/12 09:10:51 (GMT -700)
  config file = /Users/rsteinfeldt/Documents/discovery-ansible/ansible.cfg
  configured module search path = [u'/Users/rsteinfeldt/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/rsteinfeldt/Documents/ansible/src/ansible/lib/ansible
  executable location = /Users/rsteinfeldt/Documents/ansible/bin/ansible
  python version = 2.7.14 (default, Jan  6 2018, 12:16:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```

##### ADDITIONAL INFORMATION
