### PR TITLE
Acquire `display`ed messages from forked process

### DIFF
--- a/bin/ansible-connection
+++ b/bin/ansible-connection
@@ -70,6 +70,7 @@ class ConnectionProcess(object):
             self.connection._connect()
             self.connection._socket_path = self.socket_path
             self.srv.register(self.connection)
+            messages.extend(sys.stdout.getvalue().splitlines())
             messages.append('connection to remote device started successfully')
 
             self.sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
@@ -189,6 +190,7 @@ def main():
 
         play_context = PlayContext()
         play_context.deserialize(pc_data)
+        display.verbosity = play_context.verbosity
 
     except Exception as e:
         rc = 1
@@ -277,6 +279,7 @@ def main():
         sys.stdout.write(json.dumps(result))
 
     sys.exit(rc)
+
 
 if __name__ == '__main__':
     display = Display()


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

Fixes #24721

Has the unfortunate side effect of passing text through `Display.display()` twice, so strings look like `<hostname> <hostname> text to be displayed`

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
ansible-connection

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```