### PR TITLE
Allow inversion of uid_owner match in iptables module

### DIFF
--- a/lib/ansible/modules/system/iptables.py
+++ b/lib/ansible/modules/system/iptables.py
@@ -238,7 +238,9 @@ options:
     version_added: "2.1"
   uid_owner:
     description:
-      - Specifies the UID or username to use in match by owner rule.
+      - Specifies the UID or username to use in match by owner rule. From
+        Ansible 2.6 when the C(!) argument is prepended then the it inverts
+        the rule to apply instead to all users except that one specified.
     version_added: "2.1"
   reject_with:
     description:
@@ -437,6 +439,7 @@ def construct_rule(params):
     append_param(rule, params['limit'], '--limit', False)
     append_param(rule, params['limit_burst'], '--limit-burst', False)
     append_match(rule, params['uid_owner'], 'owner')
+    append_match_flag(rule, params['uid_owner'], '--uid-owner', True)
     append_param(rule, params['uid_owner'], '--uid-owner', False)
     if params['jump'] is None:
         append_jump(rule, params['reject_with'], 'REJECT')


### PR DESCRIPTION
##### SUMMARY
Allows one to invert the uid_owner match in an iptables rule.

##### ISSUE TYPE
Fixes #20747.

##### COMPONENT NAME
iptables

##### ANSIBLE VERSION
```
ansible 2.4.3.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/kevin/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.14+ (default, Feb  6 2018, 19:12:18) [GCC 7.3.0]
```
##### ADDITIONAL INFORMATION
There may be additional iptables parameters which may be inverted/negated which are not covered by the module, but I hadn't checked. This one is of high importance.

I tested this and it works great, just as expected. Please merge ASAP! @dagwieers @bcoca @jimi-c @maxamillion 