### PR TITLE
Prevent reparenting a block with itself

### DIFF
--- a/lib/ansible/playbook/base.py
+++ b/lib/ansible/playbook/base.py
@@ -197,10 +197,6 @@ class Base(with_metaclass(BaseMeta, object)):
         # and init vars, avoid using defaults in field declaration as it lives across plays
         self.vars = dict()
 
-    def __eq__(self, other):
-        '''object comparison based on _uuid'''
-        return self._uuid == other._uuid
-
     def dump_me(self, depth=0):
         ''' this is never called from production code, it is here to be used when debugging as a 'complex print' '''
         if depth == 0:

--- a/lib/ansible/playbook/base.py
+++ b/lib/ansible/playbook/base.py
@@ -197,6 +197,10 @@ class Base(with_metaclass(BaseMeta, object)):
         # and init vars, avoid using defaults in field declaration as it lives across plays
         self.vars = dict()
 
+    def __eq__(self, other):
+        '''object comparison based on _uuid'''
+        return self._uuid == other._uuid
+
     def dump_me(self, depth=0):
         ''' this is never called from production code, it is here to be used when debugging as a 'complex print' '''
         if depth == 0:

--- a/lib/ansible/playbook/block.py
+++ b/lib/ansible/playbook/block.py
@@ -174,8 +174,16 @@ class Block(Base, Become, Conditional, Taggable):
                     # block their parent
                     cur_obj = new_task
                     while cur_obj._parent:
+                        if cur_obj._parent:
+                            prev_obj = cur_obj
                         cur_obj = cur_obj._parent
-                    cur_obj._parent = new_block
+
+                    # Ensure that we don't make the new_block the parent of itself
+                    if cur_obj != new_block:
+                        cur_obj._parent = new_block
+                    else:
+                        # prev_obj._parent is cur_obj, to allow for mutability we need to use prev_obj
+                        prev_obj._parent = new_block
                 else:
                     new_task._parent = new_block
                 new_task_list.append(new_task)

--- a/lib/ansible/playbook/block.py
+++ b/lib/ansible/playbook/block.py
@@ -65,6 +65,10 @@ class Block(Base, Become, Conditional, Taggable):
     def __repr__(self):
         return "BLOCK(uuid=%s)(id=%s)(parent=%s)" % (self._uuid, id(self), self._parent)
 
+    def __eq__(self, other):
+        '''object comparison based on _uuid'''
+        return self._uuid == other._uuid
+
     def get_vars(self):
         '''
         Blocks do not store variables directly, however they may be a member


### PR DESCRIPTION
##### SUMMARY

We have been noticing that the parent tree for blocks is mutated and grows to large sizes. We have partially mitigated the problem in previous changes, but as a result the number of dynamic includes was limited in number due to recursion errors.

This change ensures that we never reparent a block with itself, causing a block explosion and recursion errors.

This also drastically speeds up dynamic task includes over time.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/playbook/base.py
lib/ansible/playbook/block.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.4
2.5
2.6
```


##### ADDITIONAL INFORMATION

Output of parent lineage from `Strategy._load_included_file` during a successive 100 `include_tasks`s in a flat playbook (reproducer from https://github.com/ansible/ansible/issues/36053):

Before this change (failing on the 42nd):

```
BLOCK(uuid=784f43a0-97cc-6ecb-df87-000000000009)(id=4781459104)
(parent=BLOCK(uuid=784f43a0-97cc-6ecb-df87-000000000009)(id=4781459160)
(parent=BLOCK(uuid=784f43a0-97cc-6ecb-df87-000000000009)(id=4781459216)
(parent=BLOCK(uuid=784f43a0-97cc-6ecb-df87-000000000009)(id=4781459272)
(parent=BLOCK(uuid=784f43a0-97cc-6ecb-df87-000000000009)(id=4781459328)
(parent=BLOCK(uuid=784f43a0-97cc-6ecb-df87-000000000009)(id=4781459384)
(parent=BLOCK(uuid=784f43a0-97cc-6ecb-df87-000000000009)(id=4781459440)
(parent=BLOCK(uuid=784f43a0-97cc-6ecb-df87-000000000009)(id=4781459496)
(parent=BLOCK(uuid=784f43a0-97cc-6ecb-df87-000000000009)(id=4781459552)
(parent=BLOCK(uuid=784f43a0-97cc-6ecb-df87-000000000009)(id=4781459608)
(parent=BLOCK(uuid=784f43a0-97cc-6ecb-df87-000000000009)(id=4781459664)
(parent=BLOCK(uuid=784f43a0-97cc-6ecb-df87-000000000009)(id=4781459720)
(parent=BLOCK(uuid=784f43a0-97cc-6ecb-df87-000000000009)(id=4781459776)
(parent=BLOCK(uuid=784f43a0-97cc-6ecb-df87-000000000009)(id=4781459832)
(parent=BLOCK(uuid=784f43a0-97cc-6ecb-df87-000000000009)(id=4781459888)
(parent=BLOCK(uuid=784f43a0-97cc-6ecb-df87-000000000009)(id=4781459944)
(parent=BLOCK(uuid=784f43a0-97cc-6ecb-df87-000000000009)(id=4781460000)
(parent=BLOCK(uuid=784f43a0-97cc-6ecb-df87-000000000009)(id=4781460056)
(parent=BLOCK(uuid=784f43a0-97cc-6ecb-df87-000000000009)(id=4781460112)
(parent=BLOCK(uuid=784f43a0-97cc-6ecb-df87-000000000009)(id=4781460168)
(parent=BLOCK(uuid=784f43a0-97cc-6ecb-df87-000000000009)(id=4781460224)
(parent=BLOCK(uuid=784f43a0-97cc-6ecb-df87-000000000009)(id=4781460280)
(parent=BLOCK(uuid=784f43a0-97cc-6ecb-df87-000000000009)(id=4781460336)
(parent=BLOCK(uuid=784f43a0-97cc-6ecb-df87-000000000009)(id=4781460392)
(parent=BLOCK(uuid=784f43a0-97cc-6ecb-df87-000000000009)(id=4781460448)
(parent=BLOCK(uuid=784f43a0-97cc-6ecb-df87-000000000009)(id=4781460504)
(parent=BLOCK(uuid=784f43a0-97cc-6ecb-df87-000000000009)(id=4781460560)
(parent=BLOCK(uuid=784f43a0-97cc-6ecb-df87-000000000009)(id=4781460616)
(parent=BLOCK(uuid=784f43a0-97cc-6ecb-df87-000000000009)(id=4781460672)
(parent=BLOCK(uuid=784f43a0-97cc-6ecb-df87-000000000009)(id=4781460728)
(parent=BLOCK(uuid=784f43a0-97cc-6ecb-df87-000000000009)(id=4781460784)
(parent=BLOCK(uuid=784f43a0-97cc-6ecb-df87-000000000009)(id=4781460840)
(parent=BLOCK(uuid=784f43a0-97cc-6ecb-df87-000000000009)(id=4781460896)
(parent=BLOCK(uuid=784f43a0-97cc-6ecb-df87-000000000009)(id=4781460952)
(parent=BLOCK(uuid=784f43a0-97cc-6ecb-df87-000000000009)(id=4781461008)
(parent=BLOCK(uuid=784f43a0-97cc-6ecb-df87-000000000009)(id=4781461064)
(parent=BLOCK(uuid=784f43a0-97cc-6ecb-df87-000000000009)(id=4781461120)
(parent=BLOCK(uuid=784f43a0-97cc-6ecb-df87-000000000009)(id=4781461176)
(parent=BLOCK(uuid=784f43a0-97cc-6ecb-df87-000000000009)(id=4781461232)
(parent=BLOCK(uuid=784f43a0-97cc-6ecb-df87-000000000009)(id=4781461288)
(parent=BLOCK(uuid=784f43a0-97cc-6ecb-df87-000000000009)(id=4781461344)
(parent=BLOCK(uuid=784f43a0-97cc-6ecb-df87-000000000009)(id=4781461400)
(parent=BLOCK(uuid=784f43a0-97cc-6ecb-df87-000000000009)(id=4645217000)
(parent=None)))))))))))))))))))))))))))))))))))))))))))
```

After this change (executes all 100 `include_task`s):

```
 BLOCK(uuid=784f43a0-97cc-6542-167b-000000000009)(id=4481635104)(parent=None))
```