### PR TITLE
VMware: re-enable vmware_guest_powerstate tests

### DIFF
--- a/test/integration/targets/vmware_guest_powerstate/tasks/main.yml
+++ b/test/integration/targets/vmware_guest_powerstate/tasks/main.yml
@@ -13,6 +13,5 @@
     vcsim: "{{ lookup('env', 'vcenter_host') }}"
 - debug: var=vcsim
 
-# Commenting following two is failing right now - 15 Dec 2017
-#- include: poweroff_d1_c1_f0.yml
-#- include: poweroff_d1_c1_f1.yml
+- include: poweroff_d1_c1_f0.yml
+- include: poweroff_d1_c1_f1.yml

--- a/test/integration/targets/vmware_guest_powerstate/tasks/poweroff_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest_powerstate/tasks/poweroff_d1_c1_f0.yml
@@ -48,4 +48,4 @@
 - name: make sure no changes were made
   assert:
     that:
-        - "poweroff_d1_c1_f0.results|map(attribute='changed')|unique|list == [True]"
+        - "poweroff_d1_c1_f0.results|map(attribute='changed')|unique|list == [False]"

--- a/test/integration/targets/vmware_guest_powerstate/tasks/poweroff_d1_c1_f1.yml
+++ b/test/integration/targets/vmware_guest_powerstate/tasks/poweroff_d1_c1_f1.yml
@@ -59,4 +59,4 @@
 - name: make sure no changes were made
   assert:
     that:
-        - "poweroff_d1_c1_f1.results|map(attribute='changed')|unique|list == [True]"
+        - "poweroff_d1_c1_f1.results|map(attribute='changed')|unique|list == [False]"


### PR DESCRIPTION
##### SUMMARY
Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
test/integration/targets/vmware_guest_powerstate/tasks/main.yml
test/integration/targets/vmware_guest_powerstate/tasks/poweroff_d1_c1_f0.yml
test/integration/targets/vmware_guest_powerstate/tasks/poweroff_d1_c1_f1.yml

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6devel
```