### PR TITLE
Same bugfix as #30121

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_endpoint.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_endpoint.py
@@ -203,8 +203,7 @@ def wait_for_status(client, module, resource_id, status):
             else:
                 time.sleep(polling_increment_secs)
         except botocore.exceptions.ClientError as e:
-            module.fail_json(msg=str(e), exception=traceback.format_exc(),
-                             **camel_dict_to_snake_dict(e.response))
+            module.fail_json(msg=str(e), exception=traceback.format_exc())
 
     return status_achieved, resource
 
@@ -258,16 +257,14 @@ def create_vpc_endpoint(client, module):
         try:
             policy = json.loads(module.params.get('policy'))
         except ValueError as e:
-            module.fail_json(msg=str(e), exception=traceback.format_exc(),
-                             **camel_dict_to_snake_dict(e.response))
+            module.fail_json(msg=str(e), exception=traceback.format_exc())
 
     elif module.params.get('policy_file'):
         try:
             with open(module.params.get('policy_file'), 'r') as json_data:
                 policy = json.load(json_data)
         except Exception as e:
-            module.fail_json(msg=str(e), exception=traceback.format_exc(),
-                             **camel_dict_to_snake_dict(e.response))
+            module.fail_json(msg=str(e), exception=traceback.format_exc())
 
     if policy:
         params['PolicyDocument'] = json.dumps(policy)
@@ -290,11 +287,9 @@ def create_vpc_endpoint(client, module):
         elif "RouteAlreadyExists" in e.message:
             module.fail_json(msg="RouteAlreadyExists for one of the route tables - update is not allowed by the API")
         else:
-            module.fail_json(msg=str(e), exception=traceback.format_exc(),
-                             **camel_dict_to_snake_dict(e.response))
+            module.fail_json(msg=str(e), exception=traceback.format_exc())
     except Exception as e:
-        module.fail_json(msg=str(e), exception=traceback.format_exc(),
-                         **camel_dict_to_snake_dict(e.response))
+        module.fail_json(msg=str(e), exception=traceback.format_exc())
 
     return changed, result
 
@@ -316,11 +311,9 @@ def setup_removal(client, module):
             changed = True
             result = 'Would have deleted VPC Endpoint if not in check mode'
         else:
-            module.fail_json(msg=str(e), exception=traceback.format_exc(),
-                             **camel_dict_to_snake_dict(e.response))
+            module.fail_json(msg=str(e), exception=traceback.format_exc())
     except Exception as e:
-        module.fail_json(msg=str(e), exception=traceback.format_exc(),
-                         **camel_dict_to_snake_dict(e.response))
+        module.fail_json(msg=str(e), exception=traceback.format_exc())
     return changed, result
 
 
@@ -366,16 +359,14 @@ def main():
                 module.fail_json(msg="Error - no region provided")
         else:
             module.fail_json(msg="Can't retrieve connection information - " + str(e),
-                             exception=traceback.format_exc(),
-                             **camel_dict_to_snake_dict(e.response))
+                             exception=traceback.format_exc())
 
     try:
         region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
         ec2 = boto3_conn(module, conn_type='client', resource='ec2', region=region, endpoint=ec2_url, **aws_connect_kwargs)
     except botocore.exceptions.NoCredentialsError as e:
         module.fail_json(msg="Failed to connect to AWS due to wrong or missing credentials: %s" % str(e),
-                         exception=traceback.format_exc(),
-                         **camel_dict_to_snake_dict(e.response))
+                         exception=traceback.format_exc())
 
     # Ensure resource is present
     if state == 'present':


### PR DESCRIPTION
##### SUMMARY
Same issue as Fixes #30121

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
modules/cloud/amazon/ec2_vpc_endpoint.py

##### ANSIBLE VERSION
```
ansible 2.4.1.0
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible-2.4.1.0-py2.7.egg/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.13 (default, Jan 11 2017, 10:56:06) [GCC]
```
##### ADDITIONAL INFORMATION
An error was provoked. Instead of the expected error message, the output itself leads to an error. With the bugfix you get the desired error message.

```
Before:
The full traceback is:
Traceback (most recent call last):
  File "/tmp/ansible_i88LaE/ansible_module_ec2_vpc_endpoint.py", line 389, in <module>
    main()
  File "/tmp/ansible_i88LaE/ansible_module_ec2_vpc_endpoint.py", line 381, in main
    (changed, results) = setup_creation(ec2, module)
  File "/tmp/ansible_i88LaE/ansible_module_ec2_vpc_endpoint.py", line 234, in setup_creation
    changed, result = create_vpc_endpoint(client, module)
  File "/tmp/ansible_i88LaE/ansible_module_ec2_vpc_endpoint.py", line 296, in create_vpc_endpoint
    **camel_dict_to_snake_dict(e.response))
AttributeError: 'ParamValidationError' object has no attribute 'response'
```

```
After:
"Parameter validation failed:\nInvalid type for parameter RouteTableIds[0], value: {'failed': False, 'changed': False, 'route_table': {'routes': [{'gateway_id': 'local', 'instance_id': None, 'interface_id': None, 'vpc_peering_connection_id': None, 'state': 'active', 'destination_cidr_block': '10.0.0.0/16', 'origin': 'CreateRouteTable'}, {'gateway_id': 'igw-7335b114', 'instance_id': None, 'interface_id': None, 'vpc_peering_connection_id': None, 'state': 'active', 'destination_cidr_block': '0.0.0.0/0', 'origin': 'CreateRoute'}, {'gateway_id': 'vpce-cb8646a2', 'instance_id': None, 'interface_id': None, 'vpc_peering_connection_id': None, 'state': 'active', 'destination_cidr_block': None, 'origin': 'CreateRoute'}], 'vpc_id': 'vpc-0e1ac568', 'id': 'rtb-b733dece', 'tags': {'Environment': 'dev', 'Name': 'dev_private_rt', 'VPC': 'vpc-dev'}}}, type: <type 'dict'>, valid types: <type 'basestring'>\nInvalid type for parameter RouteTableIds[1], value: {'failed': False, 'changed': False, 'route_table': {'routes': [{'gateway_id': 'local', 'instance_id': None, 'interface_id': None, 'vpc_peering_connection_id': None, 'state': 'active', 'destination_cidr_block': '10.0.0.0/16', 'origin': 'CreateRouteTable'}, {'gateway_id': 'igw-7335b114', 'instance_id': None, 'interface_id': None, 'vpc_peering_connection_id': None, 'state': 'active', 'destination_cidr_block': '0.0.0.0/0', 'origin': 'CreateRoute'}, {'gateway_id': 'vpce-cb8646a2', 'instance_id': None, 'interface_id': None, 'vpc_peering_connection_id': None, 'state': 'active', 'destination_cidr_block': None, 'origin': 'CreateRoute'}], 'vpc_id': 'vpc-0e1ac568', 'id': 'rtb-170ce16e', 'tags': {'Environment': 'dev', 'Name': 'dev_public_rt', 'VPC': 'vpc-dev'}}}, type: <type 'dict'>, valid types: <type 'basestring'>"
```
