### PR TITLE
Add aws_glacier_vault, AWS module to manager glacier vaults

### DIFF
--- a/lib/ansible/modules/cloud/amazon/aws_glacier_vault.py
+++ b/lib/ansible/modules/cloud/amazon/aws_glacier_vault.py
@@ -190,7 +190,7 @@ class GlacierVaultManager(object):
         except (botocore.exceptions.NoCredentialsError, botocore.exceptions.ClientError) as e:
             self.module.fail_json_aws(exception=e, msg="Failed to delete vault")
 
-        self.module.exit_json(vault=camel_dict_to_snake_dict(vault), tags=tags, changed=True)
+        self.module.exit_json(changed=True)
 
 
 def main():

--- a/lib/ansible/modules/cloud/amazon/aws_glacier_vault.py
+++ b/lib/ansible/modules/cloud/amazon/aws_glacier_vault.py
@@ -1,0 +1,165 @@
+#!/usr/bin/python
+#
+# This is a free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This Ansible library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this library.  If not, see <http://www.gnu.org/licenses/>.
+import botocore
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = '''
+---
+module: aws_glacier_vault
+short_description: Manage Glacier vaults in AWS
+description:
+    - Manage Glacier vaults in AWS
+version_added: "2.6"
+requirements: [ boto3 ]
+author: "Loic Blot <loic.blot@unix-experience.fr>"
+options:
+  name:
+    description:
+      - Name of the glacier vault
+    required: true
+    default: null
+  state:
+    description:
+      - Create or remove the glacier vault
+    required: false
+    default: present
+    choices: [ 'present', 'absent' ]
+extends_documentation_fragment:
+    - aws
+    - ec2
+'''
+
+EXAMPLES = '''
+# Note: These examples do not set authentication details, see the AWS Guide for details.
+
+# Create a simple glacier vault
+- aws_glacier_vault:
+    name: myglaciervault
+
+# Create a simple glacier vault in eu-west-3 region
+- aws_glacier_vault:
+    name: myglaciervault
+    region: eu-west-3
+
+# Remove an glacier vault
+- aws_glacier_vault:
+    name: myglaciervault
+    state: absent
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.ec2 import (ec2_argument_spec, boto3_conn, HAS_BOTO3, get_aws_connection_info,
+                                      boto3_tag_list_to_ansible_dict, ansible_dict_to_boto3_filter_list,
+                                      camel_dict_to_snake_dict)
+
+try:
+    from botocore.exceptions import ClientError
+except ImportError:
+    pass  # caught by imported HAS_BOTO3
+
+
+class GlacierVaultManager(object):
+    def __init__(self, connection, module):
+        self.connection = connection
+        self.module = module
+
+    def list(self):
+        vaults = self.connection.list_vaults()
+        if "VaultList" not in vaults:
+            self.module.fail_json(msg="Invalid response from Glacier: no VaultList found in response")
+
+        return vaults["VaultList"]
+
+    def exists(self, name):
+        for v in self.list():
+            if "VaultName" not in v:
+                self.module.fail_json(
+                    msg="Invalid response from Glacier: no VaultName found in vault object {}".format(v))
+
+            if v["VaultName"] == name:
+                return v
+
+        return None
+
+    def create_or_update(self):
+        name = self.module.params.get('name')
+        vault = self.exists(name)
+
+        if vault is None:
+            vault = self.connection.create_vault(vaultName=name)
+            self.module.exit_json(vault=vault, changed=True)
+
+        # Vault exists, no change to do
+        self.module.exit_json(vault=vault, changed=False)
+
+    def destroy(self):
+        name = self.module.params.get('name')
+        vault = self.exists(name)
+        if vault is None:
+            self.module.exit_json(changed=False)
+
+        self.connection.delete_vault(vaultName=name)
+        self.module.exit_json(vault=vault, changed=True)
+
+
+def main():
+    argument_spec = ec2_argument_spec()
+    argument_spec.update(
+        dict(
+            name=dict(required=True, type='str'),
+            state=dict(default='present', type='str', choices=['present', 'absent']),
+        )
+    )
+
+    module = AnsibleModule(argument_spec=argument_spec)
+
+    if not HAS_BOTO3:
+        module.fail_json(msg='boto3 required for this module')
+
+    region, ec2_url, aws_connect_params = get_aws_connection_info(module, boto3=True)
+
+    if region:
+        connection = boto3_conn(
+            module,
+            conn_type='client',
+            resource='glacier',
+            region=region,
+            endpoint=ec2_url,
+            **aws_connect_params
+        )
+    else:
+        module.fail_json(msg="region must be specified")
+
+    if connection is None:  # this should never happen
+        module.fail_json(msg='Unknown error, failed to create glacier connection, no information from boto.')
+
+    state = module.params.get("state")
+
+    try:
+        if state == 'present':
+            GlacierVaultManager(connection, module).create_or_update()
+        elif state == 'absent':
+            GlacierVaultManager(connection, module).destroy()
+    except botocore.exceptions.NoCredentialsError as e:
+        module.fail_json(msg="AWS credential error: {}".format(e))
+    except botocore.exceptions.ClientError as e:
+        module.fail_json(msg="AWS client error: {}".format(e))
+
+
+if __name__ == '__main__':
+    main()

--- a/test/integration/targets/aws_glacier_vault/aliases
+++ b/test/integration/targets/aws_glacier_vault/aliases
@@ -1,3 +1,2 @@
 cloud/aws
 posix/ci/cloud/group4/aws
-glacier

--- a/test/integration/targets/aws_glacier_vault/aliases
+++ b/test/integration/targets/aws_glacier_vault/aliases
@@ -1,0 +1,3 @@
+cloud/aws
+posix/ci/cloud/group4/aws
+glacier

--- a/test/integration/targets/aws_glacier_vault/defaults/main.yml
+++ b/test/integration/targets/aws_glacier_vault/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # defaults file for aws_lambda test
-glacier_vault_name: 'glacier_vault-{{ ansible_date_time.date }}'
+glacier_vault_name: '{{ resource_prefix }}-{{ ansible_date_time.date }}'
 glacier_vault_tags:
   Name: "{{ glacier_vault_name }}"
   Date: "{{ ansible_date_time.date }}"

--- a/test/integration/targets/aws_glacier_vault/defaults/main.yml
+++ b/test/integration/targets/aws_glacier_vault/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+# defaults file for aws_lambda test
+glacier_vault_name: 'glacier_vault-{{ ansible_date_time.date }}'
+glacier_vault_tags:
+  Name: "{{ glacier_vault_name }}"
+  Date: "{{ ansible_date_time.date }}"

--- a/test/integration/targets/aws_glacier_vault/meta/main.yml
+++ b/test/integration/targets/aws_glacier_vault/meta/main.yml
@@ -1,0 +1,3 @@
+dependencies:
+  - prepare_tests
+  - setup_ec2

--- a/test/integration/targets/aws_glacier_vault/tasks/main.yml
+++ b/test/integration/targets/aws_glacier_vault/tasks/main.yml
@@ -15,14 +15,20 @@
            - 'result.failed'
            - 'result.msg.startswith("missing required arguments: name")'
 
+    - name: set up aws connection info
+      set_fact:
+        aws_connection_info: &aws_connection_info
+          aws_access_key: "{{ aws_access_key }}"
+          aws_secret_key: "{{ aws_secret_key }}"
+          security_token: "{{ security_token }}"
+          region: "{{ aws_region }}"
+      no_log: yes
+
     # ============================================================
     - name: test state=present without tags (expect changed=True)
       aws_glacier_vault:
+        <<: *aws_connection_info
         name: '{{ glacier_vault_name }}'
-        ec2_region: '{{ ec2_region }}'
-        ec2_access_key: '{{ ec2_access_key }}'
-        ec2_secret_key: '{{ ec2_secret_key }}'
-        security_token: '{{ security_token }}'
         state: present
       register: result
 
@@ -35,12 +41,9 @@
     # ============================================================
     - name: test state=present with tags (expect changed=True)
       aws_glacier_vault:
+        <<: *aws_connection_info
         name: '{{ glacier_vault_name }}'
         tags: '{{ glacier_vault_tags }}'
-        ec2_region: '{{ ec2_region }}'
-        ec2_access_key: '{{ ec2_access_key }}'
-        ec2_secret_key: '{{ ec2_secret_key }}'
-        security_token: '{{ security_token }}'
         state: present
       register: result
 
@@ -53,12 +56,9 @@
     # ============================================================
     - name: test state=present drop tags (expect changed=True)
       aws_glacier_vault:
+        <<: *aws_connection_info
         name: '{{ glacier_vault_name }}'
         tags: {}
-        ec2_region: '{{ ec2_region }}'
-        ec2_access_key: '{{ ec2_access_key }}'
-        ec2_secret_key: '{{ ec2_secret_key }}'
-        security_token: '{{ security_token }}'
         state: present
       register: result
 
@@ -71,11 +71,8 @@
     # ============================================================
     - name: test state=absent (expect changed=False)
       aws_glacier_vault:
+        <<: *aws_connection_info
         name: "{{ glacier_vault_name }}"
-        ec2_region: '{{ ec2_region }}'
-        ec2_access_key: '{{ ec2_access_key }}'
-        ec2_secret_key: '{{ ec2_secret_key }}'
-        security_token: '{{ security_token }}'
         state: absent
       register: result
 
@@ -89,10 +86,7 @@
     # ============================================================
     - name: test state=absent (expect changed=False)
       aws_glacier_vault:
+        <<: *aws_connection_info
         name: "{{ glacier_vault_name }}"
-        ec2_region: '{{ ec2_region }}'
-        ec2_access_key: '{{ ec2_access_key }}'
-        ec2_secret_key: '{{ ec2_secret_key }}'
-        security_token: '{{ security_token }}'
         state: absent
       ignore_errors: yes

--- a/test/integration/targets/aws_glacier_vault/tasks/main.yml
+++ b/test/integration/targets/aws_glacier_vault/tasks/main.yml
@@ -1,7 +1,5 @@
 ---
-#
-#  Author: Michael De La Rue
-#  based on ec2_key.yml + lambda.py
+#  Author: Loïc BLOT
 
 - block:
 
@@ -20,12 +18,12 @@
     # ============================================================
     - name: test state=present without tags (expect changed=True)
       aws_glacier_vault:
-        name='{{glacier_vault_name}}'
-        ec2_region='{{ec2_region}}'
-        ec2_access_key='{{ec2_access_key}}'
-        ec2_secret_key='{{ec2_secret_key}}'
-        security_token='{{security_token}}'
-        state=present
+        name: '{{ glacier_vault_name }}'
+        ec2_region: '{{ ec2_region }}'
+        ec2_access_key: '{{ ec2_access_key }}'
+        ec2_secret_key: '{{ ec2_secret_key }}'
+        security_token: '{{ security_token }}'
+        state: present
       register: result
 
     - name: assert state=present
@@ -37,13 +35,13 @@
     # ============================================================
     - name: test state=present with tags (expect changed=True)
       aws_glacier_vault:
-        name='{{glacier_vault_name}}'
-        tags='{{glacier_vault_tags}}'
-        ec2_region='{{ec2_region}}'
-        ec2_access_key='{{ec2_access_key}}'
-        ec2_secret_key='{{ec2_secret_key}}'
-        security_token='{{security_token}}'
-        state=present
+        name: '{{ glacier_vault_name }}'
+        tags: '{{ glacier_vault_tags }}'
+        ec2_region: '{{ ec2_region }}'
+        ec2_access_key: '{{ ec2_access_key }}'
+        ec2_secret_key: '{{ ec2_secret_key }}'
+        security_token: '{{ security_token }}'
+        state: present
       register: result
 
     - name: assert state=present add tags
@@ -55,13 +53,13 @@
     # ============================================================
     - name: test state=present drop tags (expect changed=True)
       aws_glacier_vault:
-        name='{{glacier_vault_name}}'
-        tags={}
-        ec2_region='{{ec2_region}}'
-        ec2_access_key='{{ec2_access_key}}'
-        ec2_secret_key='{{ec2_secret_key}}'
-        security_token='{{security_token}}'
-        state=present
+        name: '{{ glacier_vault_name }}'
+        tags: {}
+        ec2_region: '{{ ec2_region }}'
+        ec2_access_key: '{{ ec2_access_key }}'
+        ec2_secret_key: '{{ ec2_secret_key }}'
+        security_token: '{{ security_token }}'
+        state: present
       register: result
 
     - name: assert state=present remove tags
@@ -73,12 +71,12 @@
     # ============================================================
     - name: test state=absent (expect changed=False)
       aws_glacier_vault:
-        name="{{glacier_vault_name}}"
-        ec2_region='{{ec2_region}}'
-        ec2_access_key='{{ec2_access_key}}'
-        ec2_secret_key='{{ec2_secret_key}}'
-        security_token='{{security_token}}'
-        state=absent
+        name: "{{ glacier_vault_name }}"
+        ec2_region: '{{ ec2_region }}'
+        ec2_access_key: '{{ ec2_access_key }}'
+        ec2_secret_key: '{{ ec2_secret_key }}'
+        security_token: '{{ security_token }}'
+        state: absent
       register: result
 
     - name: assert state=absent
@@ -91,16 +89,10 @@
     # ============================================================
     - name: test state=absent (expect changed=False)
       aws_glacier_vault:
-        name="{{glacier_vault_name}}"
-        ec2_region='{{ec2_region}}'
-        ec2_access_key='{{ec2_access_key}}'
-        ec2_secret_key='{{ec2_secret_key}}'
-        security_token='{{security_token}}'
-        state=absent
-      register: result
-
-    - name: assert state=absent
-      assert:
-        that:
-           - 'result is not failed'
-           - 'result.changed == False'
+        name: "{{ glacier_vault_name }}"
+        ec2_region: '{{ ec2_region }}'
+        ec2_access_key: '{{ ec2_access_key }}'
+        ec2_secret_key: '{{ ec2_secret_key }}'
+        security_token: '{{ security_token }}'
+        state: absent
+      ignore_errors: yes

--- a/test/integration/targets/aws_glacier_vault/tasks/main.yml
+++ b/test/integration/targets/aws_glacier_vault/tasks/main.yml
@@ -1,0 +1,106 @@
+---
+#
+#  Author: Michael De La Rue
+#  based on ec2_key.yml + lambda.py
+
+- block:
+
+    # ============================================================
+    - name: test with no parameters
+      aws_glacier_vault:
+      register: result
+      ignore_errors: true
+
+    - name: assert failure when called with no parameters
+      assert:
+        that:
+           - 'result.failed'
+           - 'result.msg.startswith("missing required arguments: name")'
+
+    # ============================================================
+    - name: test state=present without tags (expect changed=True)
+      aws_glacier_vault:
+        name='{{glacier_vault_name}}'
+        ec2_region='{{ec2_region}}'
+        ec2_access_key='{{ec2_access_key}}'
+        ec2_secret_key='{{ec2_secret_key}}'
+        security_token='{{security_token}}'
+        state=present
+      register: result
+
+    - name: assert state=present
+      assert:
+        that:
+           - 'result is not failed'
+           - 'result.changed == True'
+
+    # ============================================================
+    - name: test state=present with tags (expect changed=True)
+      aws_glacier_vault:
+        name='{{glacier_vault_name}}'
+        tags='{{glacier_vault_tags}}'
+        ec2_region='{{ec2_region}}'
+        ec2_access_key='{{ec2_access_key}}'
+        ec2_secret_key='{{ec2_secret_key}}'
+        security_token='{{security_token}}'
+        state=present
+      register: result
+
+    - name: assert state=present add tags
+      assert:
+        that:
+           - 'result is not failed'
+           - 'result.changed == True'
+
+    # ============================================================
+    - name: test state=present drop tags (expect changed=True)
+      aws_glacier_vault:
+        name='{{glacier_vault_name}}'
+        tags={}
+        ec2_region='{{ec2_region}}'
+        ec2_access_key='{{ec2_access_key}}'
+        ec2_secret_key='{{ec2_secret_key}}'
+        security_token='{{security_token}}'
+        state=present
+      register: result
+
+    - name: assert state=present remove tags
+      assert:
+        that:
+           - 'result is not failed'
+           - 'result.changed == True'
+
+    # ============================================================
+    - name: test state=absent (expect changed=False)
+      aws_glacier_vault:
+        name="{{glacier_vault_name}}"
+        ec2_region='{{ec2_region}}'
+        ec2_access_key='{{ec2_access_key}}'
+        ec2_secret_key='{{ec2_secret_key}}'
+        security_token='{{security_token}}'
+        state=absent
+      register: result
+
+    - name: assert state=absent
+      assert:
+        that:
+           - 'result is not failed'
+           - 'result.changed == True'
+  always:
+
+    # ============================================================
+    - name: test state=absent (expect changed=False)
+      aws_glacier_vault:
+        name="{{glacier_vault_name}}"
+        ec2_region='{{ec2_region}}'
+        ec2_access_key='{{ec2_access_key}}'
+        ec2_secret_key='{{ec2_secret_key}}'
+        security_token='{{security_token}}'
+        state=absent
+      register: result
+
+    - name: assert state=absent
+      assert:
+        that:
+           - 'result is not failed'
+           - 'result.changed == False'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
No glacier module currently exists for AWS

This module use Boto3 to manage Glacier bucket
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New Module Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
aws_glacier_bucket

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.4.3.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
ok: [localhost] => {
    "changed": false,
    "invocation": {
        "module_args": {
            "aws_access_key": null,
            "aws_secret_key": null,
            "ec2_url": null,
            "name": "mytestbucket",
            "profile": null,
            "region": "eu-west-3",
            "security_token": null,
            "state": "absent",
            "validate_certs": true
        }
    }
} (0.504275s)
```
