### PR TITLE
[WIP] Block and playbook object copy/compare/identity unit tests

### DIFF
--- a/test/units/mock/compare_helpers.py
+++ b/test/units/mock/compare_helpers.py
@@ -119,24 +119,13 @@ class CopyCompare():
     def test_copy_eq(self):
         self.assertEqual(self.one, self.one_copy)
 
+
+class CopyParentCompare():
     def test_copy_parent_eq(self):
         self.assertEqual(self.one._parent, self.one_copy._parent)
 
 
-class CopyExcludeParentCompare():
-    def test_copy_eq(self):
-        self.assertEqual(self.one, self.one_copy_exclude_parent)
-
-    def test_copy_exclude_parent_eq(self):
-        self.assertFalse(self.one._parent == self.one_copy_exclude_parent._parent)
-
-    def test_copy_exclude_parent_ne(self):
-        self.assertNotEqual(self.one._parent, self.one_copy_exclude_parent._parent)
-
-
 class CopyExcludeTasksCompare():
-    def test_copy_eq(self):
-        self.assertEqual(self.one, self.one_copy_exclude_tasks)
 
     # FIXME: block compare is not currently based on taskslist. Should it be?
     def test_copy_exclude_tasks_eq(self):

--- a/test/units/mock/compare_helpers.py
+++ b/test/units/mock/compare_helpers.py
@@ -24,6 +24,17 @@ class EqualityCompare():
         self.assertFalse(self.one == self.different)
         self.assertTrue(self.one != self.different)
 
+    def test_eq_none(self):
+        # noqa since this compare is a bad idea, but can happen anyway
+        self.assertFalse(self.one == None)  # noqa
+        self.assertFalse(self.two == None)  # noqa
+        self.assertFalse(self.another_one == None)  # noqa
+
+    def test_ne_none(self):
+        self.assertNotEqual(self.one, None)
+        self.assertNotEqual(self.two, None)
+        self.assertNotEqual(self.another_one, None)
+
 
 class TotalOrdering():
     def test_lt(self):
@@ -79,3 +90,13 @@ class IdentityCompare():
         self.assertNotEqual(id(self.one), id(self.two))
         self.assertNotEqual(id(self.two), id(self.different))
         self.assertNotEqual(id(self.one), id(self.different))
+
+    def test_is_not_none(self):
+        self.assertTrue(self.one is not None)
+        self.assertTrue(self.two is not None)
+        self.assertTrue(self.another_one is not None)
+
+    def test_is_none(self):
+        self.assertFalse(self.one is None)
+        self.assertFalse(self.two is None)
+        self.assertFalse(self.another_one is None)

--- a/test/units/mock/compare_helpers.py
+++ b/test/units/mock/compare_helpers.py
@@ -92,6 +92,9 @@ class IdentityCompare():
         self.assertNotEqual(id(self.one), id(self.different))
 
     def test_is_not_none(self):
+        '''Override if you are actually testing None for some reason.
+
+        Or if your object has a legit reason to shared identity with None...'''
         self.assertTrue(self.one is not None)
         self.assertTrue(self.two is not None)
         self.assertTrue(self.another_one is not None)
@@ -100,3 +103,32 @@ class IdentityCompare():
         self.assertFalse(self.one is None)
         self.assertFalse(self.two is None)
         self.assertFalse(self.another_one is None)
+
+
+class UuidCompare():
+    def test_uuid_eq(self):
+        self.assertFalse(self.one._uuid == self.two._uuid)
+        # self.assertTrue(self.one._uuid == self.another_one._uuid)
+
+    def test_uuid_ne(self):
+        self.assertTrue(self.one._uuid != self.two._uuid)
+        # self.assertTrue(self.one._uuid != self.another_one._uuid)
+
+
+class CopyCompare():
+    def test_copy_eq(self):
+        self.assertEqual(self.one, self.one_copy)
+
+    def test_copy_parent_eq(self):
+        self.assertEqual(self.one._parent, self.one_copy._parent)
+
+
+class CopyExcludeParentCompare():
+    def test_copy_eq(self):
+        self.assertEqual(self.one, self.one_copy_exclude_parent)
+
+    def test_copy_parent_eq(self):
+        self.assertFalse(self.one._parent == self.one_copy_exclude_parent._parent)
+
+    def test_copy_parent_ne(self):
+        self.assertNotEqual(self.one._parent, self.one_copy_exclude_parent._parent)

--- a/test/units/mock/compare_helpers.py
+++ b/test/units/mock/compare_helpers.py
@@ -127,8 +127,20 @@ class CopyExcludeParentCompare():
     def test_copy_eq(self):
         self.assertEqual(self.one, self.one_copy_exclude_parent)
 
-    def test_copy_parent_eq(self):
+    def test_copy_exclude_parent_eq(self):
         self.assertFalse(self.one._parent == self.one_copy_exclude_parent._parent)
 
-    def test_copy_parent_ne(self):
+    def test_copy_exclude_parent_ne(self):
         self.assertNotEqual(self.one._parent, self.one_copy_exclude_parent._parent)
+
+
+class CopyExcludeTasksCompare():
+    def test_copy_eq(self):
+        self.assertEqual(self.one, self.one_copy_exclude_tasks)
+
+    # FIXME: block compare is not currently based on taskslist. Should it be?
+    def test_copy_exclude_tasks_eq(self):
+        self.assertEqual(self.one, self.one_copy_exclude_tasks)
+
+    def test_copy_exclude_tasks_ne(self):
+        self.assertTrue(self.one != self.one_copy_exclude_tasks)

--- a/test/units/mock/compare_helpers.py
+++ b/test/units/mock/compare_helpers.py
@@ -1,0 +1,81 @@
+# Copyright: (c) 2018, Ansible Project
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# mixin classes for testing object compare, total ordering and identity
+# (ie, __eq__, __gte__, hash, id)
+
+
+class DifferentType():
+    pass
+
+
+class EqualityCompare():
+
+    def test_eq(self):
+        self.assertTrue(self.one == self.one)
+        self.assertFalse(self.one == self.two)
+
+    def test_ne(self):
+        self.assertFalse(self.one != self.one)
+        self.assertTrue(self.one != self.two)
+
+    def test_eq_different(self):
+        self.assertFalse(self.one == self.different)
+        self.assertTrue(self.one != self.different)
+
+
+class TotalOrdering():
+    def test_lt(self):
+        self.assertFalse(self.one < self.one)
+        self.assertTrue(self.one < self.two)
+        self.assertFalse(self.two < self.one)
+
+    def test_gt(self):
+        self.assertFalse(self.one > self.one)
+        self.assertFalse(self.one > self.two)
+        self.assertTrue(self.two > self.one)
+
+    def test_le(self):
+        self.assertLessEqual(self.one, self.one)
+        self.assertTrue(self.one <= self.one)
+
+        self.assertLessEqual(self.one, self.two)
+        self.assertTrue(self.one <= self.two)
+
+        self.assertFalse(self.two <= self.one)
+
+    def test_ge(self):
+        self.assertGreaterEqual(self.one, self.one)
+        self.assertTrue(self.one >= self.one)
+
+        self.assertFalse(self.one >= self.two)
+
+        self.assertGreaterEqual(self.two, self.one)
+        self.assertTrue(self.two >= self.one)
+
+
+class HashCompare():
+    def test_hash_different(self):
+        self.assertNotEqual(hash(self.one), hash(self.different))
+
+    def test_hash(self):
+        self.assertNotEqual(hash(self.one), hash(self.two))
+
+
+class IdentityCompare():
+    def test_is(self):
+        self.assertFalse(self.one is self.two)
+        self.assertFalse(self.one is self.another_one)
+        self.assertFalse(self.one is self.different)
+
+    def test_not_is(self):
+        self.assertTrue(self.one is not self.two)
+        self.assertTrue(self.one is not self.another_one)
+        self.assertTrue(self.one is not self.different)
+
+    def test_id(self):
+        # the ids should never be the same
+        self.assertNotEqual(id(self.one), id(self.two))
+        self.assertNotEqual(id(self.two), id(self.different))
+        self.assertNotEqual(id(self.one), id(self.different))

--- a/test/units/playbook/test_attribute.py
+++ b/test/units/playbook/test_attribute.py
@@ -21,7 +21,7 @@ from ansible.compat.tests import unittest
 from ansible.playbook.attribute import Attribute
 
 
-class TestAttribute(unittest.TestCase, EqualityCompare, TotalOrdering, IdentityCompare, HashCompare):
+class TestAttributeCompare(unittest.TestCase, EqualityCompare, TotalOrdering, IdentityCompare, HashCompare):
 
     def setUp(self):
         self.one = Attribute(priority=100)

--- a/test/units/playbook/test_attribute.py
+++ b/test/units/playbook/test_attribute.py
@@ -15,40 +15,18 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
+from units.mock.compare_helpers import TotalOrdering, EqualityCompare, HashCompare, IdentityCompare, DifferentType
+
 from ansible.compat.tests import unittest
 from ansible.playbook.attribute import Attribute
 
 
-class TestAttribute(unittest.TestCase):
+class TestAttribute(unittest.TestCase, EqualityCompare, TotalOrdering, IdentityCompare, HashCompare):
 
     def setUp(self):
         self.one = Attribute(priority=100)
         self.two = Attribute(priority=0)
 
-    def test_eq(self):
-        self.assertTrue(self.one == self.one)
-        self.assertFalse(self.one == self.two)
+        self.another_one = Attribute(priority=100)
 
-    def test_ne(self):
-        self.assertFalse(self.one != self.one)
-        self.assertTrue(self.one != self.two)
-
-    def test_lt(self):
-        self.assertFalse(self.one < self.one)
-        self.assertTrue(self.one < self.two)
-        self.assertFalse(self.two < self.one)
-
-    def test_gt(self):
-        self.assertFalse(self.one > self.one)
-        self.assertFalse(self.one > self.two)
-        self.assertTrue(self.two > self.one)
-
-    def test_le(self):
-        self.assertTrue(self.one <= self.one)
-        self.assertTrue(self.one <= self.two)
-        self.assertFalse(self.two <= self.one)
-
-    def test_ge(self):
-        self.assertTrue(self.one >= self.one)
-        self.assertFalse(self.one >= self.two)
-        self.assertTrue(self.two >= self.one)
+        self.different = DifferentType()

--- a/test/units/playbook/test_base.py
+++ b/test/units/playbook/test_base.py
@@ -19,7 +19,9 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-from units.mock.compare_helpers import TotalOrdering, EqualityCompare, HashCompare, IdentityCompare, DifferentType
+from units.mock.compare_helpers import TotalOrdering, EqualityCompare, HashCompare
+from units.mock.compare_helpers import IdentityCompare, DifferentType, UuidCompare
+from units.mock.compare_helpers import CopyCompare
 
 from ansible.compat.tests import unittest
 
@@ -32,7 +34,7 @@ from ansible.playbook import base
 from units.mock.loader import DictDataLoader
 
 
-class TestBaseCompare(unittest.TestCase, EqualityCompare, TotalOrdering, IdentityCompare, HashCompare):
+class TestBaseCompare(unittest.TestCase, EqualityCompare, TotalOrdering, IdentityCompare, HashCompare, UuidCompare, CopyCompare):
     ClassUnderTest = base.Base
 
     def setUp(self):
@@ -47,6 +49,8 @@ class TestBaseCompare(unittest.TestCase, EqualityCompare, TotalOrdering, Identit
         self.two = two.load_data(two_ds, loader=fake_loader)
 
         self.another_one = one.copy()
+
+        self.one_copy = one.copy()
 
         self.different = DifferentType()
 
@@ -427,7 +431,7 @@ class BaseSubClass(base.Base):
         return value
 
 
-class TestBaseCompareSubBase(unittest.TestCase, EqualityCompare, TotalOrdering, IdentityCompare, HashCompare):
+class TestBaseCompareSubBase(unittest.TestCase, EqualityCompare, TotalOrdering, IdentityCompare, HashCompare, UuidCompare, CopyCompare):
     ClassUnderTest = BaseSubClass
 
     def setUp(self):
@@ -446,6 +450,7 @@ class TestBaseCompareSubBase(unittest.TestCase, EqualityCompare, TotalOrdering, 
         self.two = two.load_data(two_ds, loader=fake_loader)
 
         self.another_one = one.copy()
+        self.one_copy = one.copy()
 
         self.different = DifferentType()
 

--- a/test/units/playbook/test_base.py
+++ b/test/units/playbook/test_base.py
@@ -19,6 +19,8 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+from units.mock.compare_helpers import TotalOrdering, EqualityCompare, HashCompare, IdentityCompare, DifferentType
+
 from ansible.compat.tests import unittest
 
 from ansible.errors import AnsibleParserError
@@ -28,6 +30,25 @@ from ansible.template import Templar
 from ansible.playbook import base
 
 from units.mock.loader import DictDataLoader
+
+
+class TestBaseCompare(unittest.TestCase, EqualityCompare, TotalOrdering, IdentityCompare, HashCompare):
+    ClassUnderTest = base.Base
+
+    def setUp(self):
+        fake_loader = DictDataLoader({})
+
+        one_ds = {'name': 'base_one'}
+        one = self.ClassUnderTest()
+        self.one = one.load_data(one_ds, loader=fake_loader)
+
+        two_ds = {'name': 'base_two'}
+        two = self.ClassUnderTest()
+        self.two = two.load_data(two_ds, loader=fake_loader)
+
+        self.another_one = one.copy()
+
+        self.different = DifferentType()
 
 
 class TestBase(unittest.TestCase):
@@ -404,6 +425,29 @@ class BaseSubClass(base.Base):
             pass
 
         return value
+
+
+class TestBaseCompareSubBase(unittest.TestCase, EqualityCompare, TotalOrdering, IdentityCompare, HashCompare):
+    ClassUnderTest = BaseSubClass
+
+    def setUp(self):
+        fake_loader = DictDataLoader({})
+
+        one_ds = {'name': 'base_one',
+                  'test_attr_int': 1,
+                  'test_attr_float': 1.0}
+        one = self.ClassUnderTest()
+        self.one = one.load_data(one_ds, loader=fake_loader)
+
+        two_ds = {'name': 'base_two',
+                  'test_attr_int': 2,
+                  'test_attr_float': 2.0}
+        two = self.ClassUnderTest()
+        self.two = two.load_data(two_ds, loader=fake_loader)
+
+        self.another_one = one.copy()
+
+        self.different = DifferentType()
 
 
 # terrible name, but it is a TestBase subclass for testing subclasses of Base

--- a/test/units/playbook/test_base.py
+++ b/test/units/playbook/test_base.py
@@ -19,7 +19,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-from units.mock.compare_helpers import TotalOrdering, EqualityCompare, HashCompare
+from units.mock.compare_helpers import EqualityCompare, HashCompare
 from units.mock.compare_helpers import IdentityCompare, DifferentType, UuidCompare
 from units.mock.compare_helpers import CopyCompare
 
@@ -34,7 +34,12 @@ from ansible.playbook import base
 from units.mock.loader import DictDataLoader
 
 
-class TestBaseCompare(unittest.TestCase, EqualityCompare, TotalOrdering, IdentityCompare, HashCompare, UuidCompare, CopyCompare):
+class TestBaseCompare(unittest.TestCase,
+                      EqualityCompare,
+                      IdentityCompare,
+                      HashCompare,
+                      UuidCompare,
+                      CopyCompare):
     ClassUnderTest = base.Base
 
     def setUp(self):
@@ -431,7 +436,12 @@ class BaseSubClass(base.Base):
         return value
 
 
-class TestBaseCompareSubBase(unittest.TestCase, EqualityCompare, TotalOrdering, IdentityCompare, HashCompare, UuidCompare, CopyCompare):
+class TestBaseCompareSubBase(unittest.TestCase,
+                             EqualityCompare,
+                             IdentityCompare,
+                             HashCompare,
+                             UuidCompare,
+                             CopyCompare):
     ClassUnderTest = BaseSubClass
 
     def setUp(self):

--- a/test/units/playbook/test_block.py
+++ b/test/units/playbook/test_block.py
@@ -151,7 +151,7 @@ class TestBlock(unittest.TestCase):
 
 
 # FIXME: here to verify compare_helpers atm
-class IntTupleTotalOrdering(unittest.TestCase, TotalOrdering, EqualityCompare, HashCompare):
+class TestIntTupleTotalOrdering(unittest.TestCase, TotalOrdering, EqualityCompare, HashCompare):
     def setUp(self):
         self.one = (1,)
         self.two = (2,)
@@ -159,7 +159,7 @@ class IntTupleTotalOrdering(unittest.TestCase, TotalOrdering, EqualityCompare, H
         self.different = DifferentType()
 
 
-class IntTotalOrdering(unittest.TestCase, TotalOrdering, EqualityCompare):
+class TestIntTotalOrdering(unittest.TestCase, TotalOrdering, EqualityCompare):
     def setUp(self):
         self.one = 1
         self.two = 2
@@ -167,7 +167,7 @@ class IntTotalOrdering(unittest.TestCase, TotalOrdering, EqualityCompare):
         self.different = DifferentType()
 
 
-class BlockCompare(unittest.TestCase,  EqualityCompare, HashCompare):
+class TestBlockCompare(unittest.TestCase,  EqualityCompare, HashCompare):
     def setUp(self):
         block_ds = {'block': [],
                     'rescue': [],

--- a/test/units/playbook/test_block.py
+++ b/test/units/playbook/test_block.py
@@ -167,7 +167,7 @@ class IntTotalOrdering(unittest.TestCase, TotalOrdering, EqualityCompare):
         self.different = DifferentType()
 
 
-class BlockTotalOrdering(unittest.TestCase,  EqualityCompare, HashCompare):
+class BlockCompare(unittest.TestCase,  EqualityCompare, HashCompare):
     def setUp(self):
         block_ds = {'block': [],
                     'rescue': [],

--- a/test/units/playbook/test_block.py
+++ b/test/units/playbook/test_block.py
@@ -19,7 +19,9 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+from units.mock.loader import DictDataLoader
 from ansible.compat.tests import unittest
+
 from ansible.playbook.block import Block
 from ansible.playbook.task import Task
 
@@ -51,6 +53,60 @@ class TestBlock(unittest.TestCase):
         self.assertEqual(b.always, [])
         # not currently used
         # self.assertEqual(b.otherwise, [])
+
+    def test_copy(self):
+        block_ds = {'block': [],
+                    'rescue': [],
+                    'always': []
+                    }
+        block = Block()
+        fake_loader = DictDataLoader({})
+        loaded_block = block.load(block_ds, loader=fake_loader)
+
+        block_copy = loaded_block.copy()
+        self.assertEqual(loaded_block, block_copy)
+
+    def test_copy_exclude_parent(self):
+        block_ds = {'block': [],
+                    'rescue': [],
+                    'always': []
+                    }
+        block = Block()
+        fake_loader = DictDataLoader({})
+        loaded_block = block.load(block_ds, loader=fake_loader)
+
+        block_copy = loaded_block.copy(exclude_parent=True)
+        self.assertEqual(loaded_block, block_copy)
+
+    def test_copy_exclude_parent_exclude_tasks(self):
+        block_ds = {'block': [],
+                    'rescue': [],
+                    'always': []
+                    }
+        block = Block()
+        fake_loader = DictDataLoader({})
+        loaded_block = block.load(block_ds, loader=fake_loader)
+
+        block_copy = loaded_block.copy(exclude_parent=True, exclude_tasks=True)
+        self.assertEqual(loaded_block, block_copy)
+
+    def test_copy_parent(self):
+        block_ds = {'block': [],
+                    'rescue': [],
+                    'always': []
+                    }
+        block = Block()
+        fake_loader = DictDataLoader({})
+        loaded_block = block.load(block_ds, loader=fake_loader)
+
+        child_block_ds = {'block': [],
+                          'rescue': [],
+                          'always': []
+                          }
+        child_block = Block()
+        loaded_child_block = child_block.load(child_block_ds, loader=fake_loader)
+        block_copy = loaded_child_block.copy()
+        self.assertEqual(loaded_child_block, block_copy)
 
     def test_load_block_with_tasks(self):
         ds = dict(

--- a/test/units/playbook/test_block.py
+++ b/test/units/playbook/test_block.py
@@ -37,7 +37,7 @@ class TestBlock(unittest.TestCase):
 
     def test_construct_empty_block(self):
         b = Block()
-        self.assertIsInstance(Block, b)
+        self.assertIsInstance(b, Block)
 
     def test_construct_block_with_role(self):
         pass

--- a/test/units/playbook/test_block.py
+++ b/test/units/playbook/test_block.py
@@ -176,17 +176,30 @@ class TestBlockCompare(unittest.TestCase,
                        CopyCompare,
                        CopyExcludeTasksCompare):
     def setUp(self):
+        fake_loader = DictDataLoader({})
+
         _block_tasks = [{'action': 'block'}]
         _rescue_tasks = [{'action': 'rescue'}]
         _always_tasks = [{'action': 'always'}]
+
+        parent_block_ds = {'block': [],
+                           'rescue': [],
+                           'always': []
+                           }
+
+        raw_parent_block = Block()
+        parent_block = raw_parent_block.load(parent_block_ds,
+                                             loader=fake_loader)
+        self.parent_block = parent_block
 
         block_ds = {'block': _block_tasks,
                     'rescue': _rescue_tasks,
                     'always': _always_tasks,
                     }
-        raw_block_one = Block()
-        fake_loader = DictDataLoader({})
-        block_one = raw_block_one.load(block_ds, loader=fake_loader)
+        raw_block_one = Block(parent_block=parent_block)
+        block_one = raw_block_one.load(block_ds,
+                                       parent_block=parent_block,
+                                       loader=fake_loader)
         # object with value A
         self.one = block_one
 
@@ -220,11 +233,21 @@ class TestBlockCompare(unittest.TestCase,
         self.assertNotEqual(self.one.rescue, self.one_copy_exclude_tasks.rescue)
         self.assertNotEqual(self.one.always, self.one_copy_exclude_tasks.always)
 
-    def test_copy_exclude_eq(self):
+    def test_copy_exclude_parent_eq(self):
+        # print(self.one)
+        # print(self.one_copy_exclude_parent)
         self.assertEqual(self.one, self.one_copy_exclude_parent)
 
-    def test_copy_exclude_parent_eq(self):
-        self.assertFalse(self.one._parent == self.one_copy_exclude_parent._parent)
+    def test_copy_exclude_parent_compare_parent_eq(self):
+        # print(self.one)
+        # print(self.one._parent)
+        # print(self.one_copy_exclude_parent)
+        # print(self.one_copy_exclude_parent._parent)
+        self.assertFalse(self.one._parent == self.one_copy_exclude_parent._parent,
+                         'The parent of "%s" (%s) compares equally to parent of "%s" (%s) but should not' %
+                         (self.one, self.one._parent,
+                          self.one_copy_exclude_parent,
+                          self.one_copy_exclude_parent._parent))
 
     def test_copy_exclude_parent_ne(self):
         self.assertNotEqual(self.one._parent, self.one_copy_exclude_parent._parent)

--- a/test/units/playbook/test_block.py
+++ b/test/units/playbook/test_block.py
@@ -20,7 +20,9 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from units.mock.loader import DictDataLoader
-from units.mock.compare_helpers import TotalOrdering, EqualityCompare, HashCompare, DifferentType
+from units.mock.compare_helpers import TotalOrdering, EqualityCompare, HashCompare
+from units.mock.compare_helpers import DifferentType, UuidCompare, CopyCompare
+from units.mock.compare_helpers import CopyExcludeParentCompare
 from ansible.compat.tests import unittest
 
 from ansible.playbook.block import Block
@@ -167,7 +169,8 @@ class TestIntTotalOrdering(unittest.TestCase, TotalOrdering, EqualityCompare):
         self.different = DifferentType()
 
 
-class TestBlockCompare(unittest.TestCase,  EqualityCompare, HashCompare):
+class TestBlockCompare(unittest.TestCase,  EqualityCompare, HashCompare, UuidCompare,
+                       CopyCompare, CopyExcludeParentCompare):
     def setUp(self):
         block_ds = {'block': [],
                     'rescue': [],
@@ -190,6 +193,8 @@ class TestBlockCompare(unittest.TestCase,  EqualityCompare, HashCompare):
         self.two = block_two
 
         self.another_one = self.one.copy(exclude_parent=True, exclude_tasks=True)
+        self.one_copy = self.one.copy()
+        self.one_copy_exclude_parent = self.one.copy(exclude_parent=True)
 
         # A non-None object of a different type than one,two, or another_one
         self.different = DifferentType()

--- a/test/units/playbook/test_block.py
+++ b/test/units/playbook/test_block.py
@@ -22,7 +22,7 @@ __metaclass__ = type
 from units.mock.loader import DictDataLoader
 from units.mock.compare_helpers import TotalOrdering, EqualityCompare, HashCompare
 from units.mock.compare_helpers import DifferentType, UuidCompare, CopyCompare
-from units.mock.compare_helpers import CopyExcludeParentCompare, CopyExcludeTasksCompare
+from units.mock.compare_helpers import CopyExcludeTasksCompare
 from ansible.compat.tests import unittest
 
 from ansible.playbook.block import Block
@@ -169,8 +169,12 @@ class TestIntTotalOrdering(unittest.TestCase, TotalOrdering, EqualityCompare):
         self.different = DifferentType()
 
 
-class TestBlockCompare(unittest.TestCase,  EqualityCompare, HashCompare, UuidCompare,
-                       CopyCompare, CopyExcludeParentCompare, CopyExcludeTasksCompare):
+class TestBlockCompare(unittest.TestCase,
+                       EqualityCompare,
+                       HashCompare,
+                       UuidCompare,
+                       CopyCompare,
+                       CopyExcludeTasksCompare):
     def setUp(self):
         _block_tasks = [{'action': 'block'}]
         _rescue_tasks = [{'action': 'rescue'}]
@@ -215,3 +219,12 @@ class TestBlockCompare(unittest.TestCase,  EqualityCompare, HashCompare, UuidCom
         self.assertNotEqual(self.one.block, self.one_copy_exclude_tasks.block)
         self.assertNotEqual(self.one.rescue, self.one_copy_exclude_tasks.rescue)
         self.assertNotEqual(self.one.always, self.one_copy_exclude_tasks.always)
+
+    def test_copy_exclude_eq(self):
+        self.assertEqual(self.one, self.one_copy_exclude_parent)
+
+    def test_copy_exclude_parent_eq(self):
+        self.assertFalse(self.one._parent == self.one_copy_exclude_parent._parent)
+
+    def test_copy_exclude_parent_ne(self):
+        self.assertNotEqual(self.one._parent, self.one_copy_exclude_parent._parent)

--- a/test/units/playbook/test_conditional.py
+++ b/test/units/playbook/test_conditional.py
@@ -1,12 +1,34 @@
 
 from ansible.compat.tests import unittest
 from units.mock.loader import DictDataLoader
+from units.mock.compare_helpers import TotalOrdering, EqualityCompare, IdentityCompare, HashCompare, DifferentType
 
 from ansible.plugins.strategy import SharedPluginLoaderObj
 from ansible.template import Templar
 from ansible import errors
 
 from ansible.playbook import conditional
+
+
+class TestBaseCompare(unittest.TestCase, EqualityCompare, IdentityCompare, HashCompare):
+
+    def setUp(self):
+        fake_loader = DictDataLoader({})
+
+        one_ds = {'when': ["one"]}
+
+        self.one = conditional.Conditional(loader=fake_loader)
+        self.one.when = one_ds['when']
+
+        two_ds = {'when': ["two"]}
+
+        self.two = conditional.Conditional(loader=fake_loader)
+        self.two.when = two_ds['when']
+
+        self.another_one = conditional.Conditional(loader=fake_loader)
+        self.another_one.when = one_ds['when']
+
+        self.different = DifferentType()
 
 
 class TestConditional(unittest.TestCase):

--- a/test/units/playbook/test_included_file.py
+++ b/test/units/playbook/test_included_file.py
@@ -24,12 +24,32 @@ import os
 from ansible.compat.tests import unittest
 from ansible.compat.tests.mock import MagicMock
 from units.mock.loader import DictDataLoader
+from units.mock.compare_helpers import TotalOrdering, EqualityCompare, IdentityCompare, HashCompare, DifferentType
 
 from ansible.playbook.task import Task
 from ansible.playbook.task_include import TaskInclude
 from ansible.executor import task_result
 
 from ansible.playbook.included_file import IncludedFile
+
+
+class TestIncludedFileCompare(unittest.TestCase, EqualityCompare, TotalOrdering, IdentityCompare, HashCompare):
+    def setUp(self):
+        fake_loader = DictDataLoader({})
+
+        one_ds = {'name': 'one',
+                  'include': 'include_test_one.yml'}
+
+        self.one = TaskInclude.load(one_ds, loader=fake_loader)
+
+        two_ds = {'name': 'two',
+                  'include': 'include_test_two.yml'}
+
+        self.two = TaskInclude.load(two_ds, loader=fake_loader)
+
+        self.another_one = self.one.copy()
+
+        self.different = DifferentType()
 
 
 class TestIncludedFile(unittest.TestCase):

--- a/test/units/playbook/test_included_file.py
+++ b/test/units/playbook/test_included_file.py
@@ -24,7 +24,7 @@ import os
 from ansible.compat.tests import unittest
 from ansible.compat.tests.mock import MagicMock
 from units.mock.loader import DictDataLoader
-from units.mock.compare_helpers import TotalOrdering, EqualityCompare, IdentityCompare, HashCompare, DifferentType
+from units.mock.compare_helpers import EqualityCompare, IdentityCompare, HashCompare, DifferentType
 
 from ansible.playbook.task import Task
 from ansible.playbook.task_include import TaskInclude
@@ -33,7 +33,10 @@ from ansible.executor import task_result
 from ansible.playbook.included_file import IncludedFile
 
 
-class TestIncludedFileCompare(unittest.TestCase, EqualityCompare, TotalOrdering, IdentityCompare, HashCompare):
+class TestIncludedFileCompare(unittest.TestCase,
+                              EqualityCompare,
+                              IdentityCompare,
+                              HashCompare):
     def setUp(self):
         fake_loader = DictDataLoader({})
 

--- a/test/units/playbook/test_task.py
+++ b/test/units/playbook/test_task.py
@@ -22,6 +22,9 @@ __metaclass__ = type
 from ansible.compat.tests import unittest
 from ansible.playbook.task import Task
 
+from units.mock.compare_helpers import TotalOrdering, EqualityCompare, IdentityCompare, HashCompare, DifferentType
+from units.mock.loader import DictDataLoader
+
 
 basic_command_task = dict(
     name='Test Task',
@@ -31,6 +34,26 @@ basic_command_task = dict(
 kv_command_task = dict(
     action='command echo hi'
 )
+
+
+class TestBaseCompare(unittest.TestCase, EqualityCompare, TotalOrdering, IdentityCompare, HashCompare):
+
+    def setUp(self):
+        fake_loader = DictDataLoader({})
+
+        one_ds = {'name': 'base_one',
+                  'command': 'echo base_one'}
+
+        self.one = Task.load(one_ds, loader=fake_loader)
+
+        two_ds = {'name': 'base_two',
+                  'command': 'echo base_two'}
+
+        self.two = Task.load(two_ds, loader=fake_loader)
+
+        self.another_one = self.one.copy()
+
+        self.different = DifferentType()
 
 
 class TestTask(unittest.TestCase):

--- a/test/units/playbook/test_task.py
+++ b/test/units/playbook/test_task.py
@@ -38,7 +38,7 @@ kv_command_task = dict(
 )
 
 
-class TestTaskCompare(unittest.TestCase, EqualityCompare, TotalOrdering,
+class TestTaskCompare(unittest.TestCase, EqualityCompare,
                       IdentityCompare, HashCompare, UuidCompare,
                       CopyCompare, CopyExcludeParentCompare, CopyExcludeTasksCompare):
 

--- a/test/units/playbook/test_task.py
+++ b/test/units/playbook/test_task.py
@@ -23,6 +23,7 @@ from ansible.compat.tests import unittest
 from ansible.playbook.task import Task
 
 from units.mock.compare_helpers import TotalOrdering, EqualityCompare, IdentityCompare, HashCompare, DifferentType
+from units.mock.compare_helpers import UuidCompare, CopyCompare, CopyExcludeParentCompare
 from units.mock.loader import DictDataLoader
 
 
@@ -36,7 +37,9 @@ kv_command_task = dict(
 )
 
 
-class TestTaskCompare(unittest.TestCase, EqualityCompare, TotalOrdering, IdentityCompare, HashCompare):
+class TestTaskCompare(unittest.TestCase, EqualityCompare, TotalOrdering,
+                      IdentityCompare, HashCompare, UuidCompare,
+                      CopyCompare, CopyExcludeParentCompare):
 
     def setUp(self):
         fake_loader = DictDataLoader({})
@@ -52,6 +55,8 @@ class TestTaskCompare(unittest.TestCase, EqualityCompare, TotalOrdering, Identit
         self.two = Task.load(two_ds, loader=fake_loader)
 
         self.another_one = self.one.copy()
+        self.one_copy = self.one.copy()
+        self.one_copy_exclude_parent = self.one.copy(exclude_parent=True)
 
         self.different = DifferentType()
 

--- a/test/units/playbook/test_task.py
+++ b/test/units/playbook/test_task.py
@@ -24,6 +24,7 @@ from ansible.playbook.task import Task
 
 from units.mock.compare_helpers import TotalOrdering, EqualityCompare, IdentityCompare, HashCompare, DifferentType
 from units.mock.compare_helpers import UuidCompare, CopyCompare, CopyExcludeParentCompare
+from units.mock.compare_helpers import CopyExcludeTasksCompare
 from units.mock.loader import DictDataLoader
 
 
@@ -39,7 +40,7 @@ kv_command_task = dict(
 
 class TestTaskCompare(unittest.TestCase, EqualityCompare, TotalOrdering,
                       IdentityCompare, HashCompare, UuidCompare,
-                      CopyCompare, CopyExcludeParentCompare):
+                      CopyCompare, CopyExcludeParentCompare, CopyExcludeTasksCompare):
 
     def setUp(self):
         fake_loader = DictDataLoader({})
@@ -57,6 +58,7 @@ class TestTaskCompare(unittest.TestCase, EqualityCompare, TotalOrdering,
         self.another_one = self.one.copy()
         self.one_copy = self.one.copy()
         self.one_copy_exclude_parent = self.one.copy(exclude_parent=True)
+        self.one_copy_exclude_tasks = self.one.copy(exclude_tasks=True)
 
         self.different = DifferentType()
 

--- a/test/units/playbook/test_task.py
+++ b/test/units/playbook/test_task.py
@@ -36,7 +36,7 @@ kv_command_task = dict(
 )
 
 
-class TestBaseCompare(unittest.TestCase, EqualityCompare, TotalOrdering, IdentityCompare, HashCompare):
+class TestTaskCompare(unittest.TestCase, EqualityCompare, TotalOrdering, IdentityCompare, HashCompare):
 
     def setUp(self):
         fake_loader = DictDataLoader({})


### PR DESCRIPTION
##### SUMMARY
Test cases for testing comparison of some playbook objects (ie, their __eq__/__le__/__hash__ etc)

Possibly useful for https://github.com/ansible/ansible/pull/36075

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
 - Test Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
lib/ansible/playbook
test/units/playbook

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0 (block_copy_unit_test 272a99528b) last updated 2018/02/13 12:01:26 (GMT -400)
  config file = /home/adrian/src/ansible/ansible.cfg
  configured module search path = [u'/home/adrian/ansible/my-modules']
  ansible python module location = /home/adrian/src/ansible/lib/ansible
  executable location = /home/adrian/src/ansible/bin/ansible
  python version = 2.7.14 (default, Jan 17 2018, 14:28:32) [GCC 7.2.1 20170915 (Red Hat 7.2.1-2)]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
