### PR TITLE
added support for --testcase flag in ansible-test

### DIFF
--- a/docs/docsite/rst/dev_guide/testing_integration.rst
+++ b/docs/docsite/rst/dev_guide/testing_integration.rst
@@ -219,6 +219,11 @@ To run integration tests for a specific module::
 
     ansible-test network-integration --inventory  /path/to/ansible/test/integration/inventory.networking vyos_vlan
 
+To run a single test case on a specific module::
+
+    # Only run vyos_vlan/tests/cli/basic.yaml
+    ansible-test network-integration --inventory  /path/to/ansible/test/integration/inventory.networking vyos_vlan --testcase basic
+
 To run integration tests for a specific transport::
 
     # Only run nxapi test

--- a/test/runner/lib/config.py
+++ b/test/runner/lib/config.py
@@ -193,6 +193,7 @@ class NetworkIntegrationConfig(IntegrationConfig):
 
         self.platform = args.platform  # type: list [str]
         self.inventory = args.inventory  # type: str
+        self.testcase = args.testcase  # type: str
 
 
 class UnitsConfig(TestConfig):

--- a/test/runner/lib/executor.py
+++ b/test/runner/lib/executor.py
@@ -943,6 +943,10 @@ def command_integration_role(args, target, start_at_task):
         if args.diff:
             cmd += ['--diff']
 
+        if isinstance(args, NetworkIntegrationConfig):
+            if args.testcase:
+                cmd += ['-e testcase=%s' % args.testcase]
+
         if args.verbosity:
             cmd.append('-' + ('v' * args.verbosity))
 

--- a/test/runner/lib/executor.py
+++ b/test/runner/lib/executor.py
@@ -945,7 +945,7 @@ def command_integration_role(args, target, start_at_task):
 
         if isinstance(args, NetworkIntegrationConfig):
             if args.testcase:
-                cmd += ['-e testcase=%s' % args.testcase]
+                cmd += ['-e', 'testcase=%s' % args.testcase]
 
         if args.verbosity:
             cmd.append('-' + ('v' * args.verbosity))

--- a/test/runner/test.py
+++ b/test/runner/test.py
@@ -264,6 +264,10 @@ def parse_args():
                                      metavar='PATH',
                                      help='path to inventory used for tests')
 
+    network_integration.add_argument('--testcase',
+                                     metavar='TESTCASE',
+                                     help='limit a test to a specified testcase')
+
     windows_integration = subparsers.add_parser('windows-integration',
                                                 parents=[integration],
                                                 help='windows integration tests')

--- a/test/runner/test.py
+++ b/test/runner/test.py
@@ -660,15 +660,19 @@ def complete_network_testcase(prefix, parsed_args, **_):
     """
     testcases = []
 
-    for platform in parsed_args.include:
-        test_dir = 'test/integration/targets/%s/tests' % platform
-        connections = os.listdir(test_dir)
+    # since testcases are module specific, don't autocomplete if more than one
+    # module is specidied
+    if len(parsed_args.include) != 1:
+        return []
 
-        for conn in connections:
-            if os.path.isdir(os.path.join(test_dir, conn)):
-                for testcase in os.listdir(os.path.join(test_dir, conn)):
-                    if testcase.startswith(prefix):
-                        testcases.append(testcase.split('.')[0])
+    test_dir = 'test/integration/targets/%s/tests' % parsed_args.include[0]
+    connections = os.listdir(test_dir)
+
+    for conn in connections:
+        if os.path.isdir(os.path.join(test_dir, conn)):
+            for testcase in os.listdir(os.path.join(test_dir, conn)):
+                if testcase.startswith(prefix):
+                    testcases.append(testcase.split('.')[0])
 
     return testcases
 

--- a/test/runner/test.py
+++ b/test/runner/test.py
@@ -67,6 +67,7 @@ from lib.cloud import (
 )
 
 import lib.cover
+import os
 
 
 def main():
@@ -266,7 +267,7 @@ def parse_args():
 
     network_integration.add_argument('--testcase',
                                      metavar='TESTCASE',
-                                     help='limit a test to a specified testcase')
+                                     help='limit a test to a specified testcase').completer = complete_network_testcase
 
     windows_integration = subparsers.add_parser('windows-integration',
                                                 parents=[integration],
@@ -651,6 +652,25 @@ def complete_network_platform(prefix, parsed_args, **_):
 
     return [i for i in images if i.startswith(prefix) and (not parsed_args.platform or i not in parsed_args.platform)]
 
+def complete_network_testcase(prefix, parsed_args, **_):
+    """
+    :type prefix: unicode
+    :type parsed_args: any
+    :rtype: list[str]
+    """
+    testcases = []
+
+    for platform in parsed_args.include:
+        test_dir = 'test/integration/targets/%s/tests' % platform
+        connections = os.listdir(test_dir)
+
+        for conn in connections:
+            if os.path.isdir(os.path.join(test_dir, conn)):
+                for testcase in os.listdir(os.path.join(test_dir, conn)):
+                    if testcase.startswith(prefix):
+                        testcases.append(testcase.split('.')[0])
+
+    return testcases
 
 def complete_sanity_test(prefix, parsed_args, **_):
     """

--- a/test/runner/test.py
+++ b/test/runner/test.py
@@ -67,7 +67,6 @@ from lib.cloud import (
 )
 
 import lib.cover
-import os
 
 
 def main():
@@ -652,6 +651,7 @@ def complete_network_platform(prefix, parsed_args, **_):
 
     return [i for i in images if i.startswith(prefix) and (not parsed_args.platform or i not in parsed_args.platform)]
 
+
 def complete_network_testcase(prefix, parsed_args, **_):
     """
     :type prefix: unicode
@@ -671,6 +671,7 @@ def complete_network_testcase(prefix, parsed_args, **_):
                         testcases.append(testcase.split('.')[0])
 
     return testcases
+
 
 def complete_sanity_test(prefix, parsed_args, **_):
     """


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
The `--testcase` flag allows users to limit network-integration tests to a specific test case

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
ansible-test

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0 (ansible_test_testcase 02a3a2bb96) last updated 2018/02/13 14:32:01 (GMT -400)
  config file = None
  configured module search path = ['/Users/david/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/david/code/ansible/lib/ansible
  executable location = /Users/david/code/ansible/bin/ansible
  python version = 3.6.4 (default, Jan  6 2018, 11:51:59) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
