### PR TITLE
Improved language around in_vpc parameter.

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_eip.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_eip.py
@@ -42,7 +42,7 @@ options:
     default: present
   in_vpc:
     description:
-      - allocate an EIP inside a VPC or not
+      - Allocate an EIP inside a VPC or not. Required if specifying an ENI.
     required: false
     default: false
     version_added: "1.4"


### PR DESCRIPTION
SUMMARY

Improved description of in_vpc parameter. It is required when using an Elastic IP but the documentation doesn't state this fact. Instead, it requires the user to experience an error which describes the problem.
ISSUE TYPE
COMPONENT NAME

ec2_eip
ANSIBLE VERSION

ansible 2.4.3.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/ubuntu/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]