### PR TITLE
Changed os_server_facts example page

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_server_facts.py
+++ b/lib/ansible/modules/cloud/openstack/os_server_facts.py
@@ -51,6 +51,7 @@ EXAMPLES = '''
 - os_server_facts:
     cloud: rax-dfw
     server: web*
+    register: openstack_servers
 - debug:
     var: openstack_servers
 '''


### PR DESCRIPTION
##### SUMMARY
Changed os_server_facts example page, the example given is not working because the printed debug variable is not registered by os_server_facts.

##### ISSUE TYPE
 - Docs Pull Request