### PR TITLE
Fixed Arista typo in docstring

### DIFF
--- a/lib/ansible/modules/network/eos/eos_l2_interface.py
+++ b/lib/ansible/modules/network/eos/eos_l2_interface.py
@@ -20,7 +20,7 @@ author: "Ricardo Carrillo Cruz (@rcarrillocruz)"
 short_description: Manage L2 interfaces on Arista EOS network devices.
 description:
   - This module provides declarative management of L2 interfaces
-    on Arist EOS network devices.
+    on Arista EOS network devices.
 notes:
   - Tested against EOS 4.15
 options:

--- a/lib/ansible/modules/network/eos/eos_l3_interface.py
+++ b/lib/ansible/modules/network/eos/eos_l3_interface.py
@@ -20,7 +20,7 @@ author: "Ganesh Nalawade (@ganeshrn)"
 short_description: Manage L3 interfaces on Arista EOS network devices.
 description:
   - This module provides declarative management of L3 interfaces
-    on Arist EOS network devices.
+    on Arista EOS network devices.
 notes:
   - Tested against EOS 4.15
 options:

--- a/lib/ansible/modules/network/eos/eos_linkagg.py
+++ b/lib/ansible/modules/network/eos/eos_linkagg.py
@@ -17,7 +17,7 @@ DOCUMENTATION = """
 module: eos_linkagg
 version_added: "2.5"
 author: "Trishna Guha (@trishnaguha)"
-short_description: Manage link aggregation groups on Arist EOS network devices
+short_description: Manage link aggregation groups on Arista EOS network devices
 description:
   - This module provides declarative management of link aggregation groups
     on Arista EOS network devices.

--- a/lib/ansible/modules/network/eos/eos_static_route.py
+++ b/lib/ansible/modules/network/eos/eos_static_route.py
@@ -17,7 +17,7 @@ DOCUMENTATION = """
 module: eos_static_route
 version_added: "2.5"
 author: "Trishna Guha (@trishnaguha)"
-short_description: Manage static IP routes on Arist EOS network devices
+short_description: Manage static IP routes on Arista EOS network devices
 description:
   - This module provides declarative management of static
     IP routes on Arista EOS network devices.


### PR DESCRIPTION
##### SUMMARY
Fixed typos in Arista network module docstrings

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
Arista network modules - eos_l2_interface, eos_l3_interface, eos_linkagg, eos_static_route

##### ANSIBLE VERSION
```
ansible 2.6.0 (slxos_command c3523cdd60) last updated 2018/02/09 10:38:23 (GMT -700)
  config file = /home/extreme/.ansible.cfg
  configured module search path = [u'/home/extreme/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/extreme/ansible/lib/ansible
  executable location = /home/extreme/ansible/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION
N/A