### PR TITLE
DUPLICATE Update ios_ping.py to allow for count > 70.

### DIFF
--- a/lib/ansible/modules/network/ios/ios_ping.py
+++ b/lib/ansible/modules/network/ios/ios_ping.py
@@ -143,7 +143,7 @@ def main():
     ping_results = run_commands(module, commands=results["commands"])
     ping_results_list = ping_results[0].split("\n")
 
-    success, rx, tx, rtt = parse_ping(ping_results_list[3])
+    success, rx, tx, rtt = parse_ping(ping_results_list[len(ping_results_list)-1])
     loss = abs(100 - int(success))
     results["packet_loss"] = str(loss) + "%"
     results["packets_rx"] = int(rx)


### PR DESCRIPTION
##### SUMMARY
Modified ios_ping.py to allow for count >70.


##### ISSUE TYPE
Bugfix Pull Request

##### COMPONENT NAME
ios_ping module

##### ANSIBLE VERSION
```
**ansible 2.4.3.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/nick/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.14 (default, Sep 23 2017, 22:06:14) [GCC 7.2.0]
**
```


##### ADDITIONAL INFORMATION
Playbook:
```
- hosts: CSR1
  gather_facts: true
  connection: local

  tasks:
    - name: Test reachability to 8.8.8.8 using default vrf
      ios_ping:
        provider:
          host: "{{ ansible_host }}"
          username: "nick"
          password: "cisco"
        dest: 10.1.1.1
        count: 71
      register: result
    - name: Show Output
      debug:
        msg: "{{ result }}"
    - name: Save Output
      copy:
        content: "{{ result }}"
        dest: "/opt/ansible/backups/ping_{{ inventory_hostname }}.txt"

```

Before:
```
root@ansible:/opt/ansible/playbooks# ansible-playbook ping_google.yaml 

PLAY [CSR1] *******************************************************************************************************************************

TASK [Gathering Facts] ********************************************************************************************************************
ok: [CSR1]

TASK [Test reachability to 8.8.8.8 using default vrf] *************************************************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: AttributeError: 'NoneType' object has no attribute 'group'
fatal: [CSR1]: FAILED! => {"changed": false, "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_fo1_C_/ansible_module_ios_ping.py\", line 213, in <module>\n    main()\n  File \"/tmp/ansible_fo1_C_/ansible_module_ios_ping.py\", line 149, in main\n    success, rx, tx, rtt = parse_ping(ping_results_list[3])\n  File \"/tmp/ansible_fo1_C_/ansible_module_ios_ping.py\", line 198, in parse_ping\n    return rate.group(\"pct\"), rate.group(\"rx\"), rate.group(\"tx\"), rtt.groupdict()\nAttributeError: 'NoneType' object has no attribute 'group'\n", "module_stdout": "", "msg": "MODULE FAILURE", "rc": 0}
	to retry, use: --limit @/opt/ansible/playbooks/ping_google.retry

PLAY RECAP ********************************************************************************************************************************
CSR1                       : ok=1    changed=0    unreachable=0    failed=1   

root@ansible:/opt/ansible/playbooks# 
```
After:
```
root@ansible:/opt/ansible/playbooks# ansible-playbook ping_google.yaml 

PLAY [CSR1] *******************************************************************************************************************************

TASK [Gathering Facts] ********************************************************************************************************************
ok: [CSR1]

TASK [Test reachability to 8.8.8.8 using default vrf] *************************************************************************************
ok: [CSR1]

TASK [Show Output] ************************************************************************************************************************
ok: [CSR1] => {
    "msg": {
        "changed": false, 
        "commands": [
            "ping 10.1.1.1 repeat 71"
        ], 
        "failed": false, 
        "packet_loss": "0%", 
        "packets_rx": 71, 
        "packets_tx": 71, 
        "rtt": {
            "avg": 2, 
            "max": 3, 
            "min": 1
        }
    }
}

TASK [Save Output] ************************************************************************************************************************
changed: [CSR1]

PLAY RECAP ********************************************************************************************************************************
CSR1                       : ok=4    changed=1    unreachable=0    failed=0   

root@ansible:/opt/ansible/playbooks# 

```
