### PR TITLE
adding support for loopback interface

### DIFF
--- a/lib/ansible/modules/network/vyos/vyos_l3_interface.py
+++ b/lib/ansible/modules/network/vyos/vyos_l3_interface.py
@@ -117,36 +117,36 @@ def map_obj_to_commands(updates, module):
         obj_in_have = search_obj_in_list(name, have)
         if state == 'absent' and obj_in_have:
             if not ipv4 and not ipv6 and (obj_in_have['ipv4'] or obj_in_have['ipv6']):
-              if name == "lo":
-                commands.append('delete interfaces loopback lo address')
-              else:
-                commands.append('delete interfaces ethernet ' + name + ' address')
+                if name == "lo":
+                    commands.append('delete interfaces loopback lo address')
+                else:
+                    commands.append('delete interfaces ethernet ' + name + ' address')
             else:
                 if ipv4 and obj_in_have['ipv4']:
-                  if name == "lo":
-                    commands.append('delete interfaces loopback lo address ' + ipv4)
-                  else:
-                    commands.append('delete interfaces ethernet ' + name + ' address ' + ipv4)
+                    if name == "lo":
+                        commands.append('delete interfaces loopback lo address ' + ipv4)
+                    else:
+                        commands.append('delete interfaces ethernet ' + name + ' address ' + ipv4)
                 if ipv6 and obj_in_have['ipv6']:
-                  if name == "lo":
-                    commands.append('delete interfaces loopback lo address ' + ipv6)
-                  else:
-                    commands.append('delete interfaces ethernet ' + name + ' address ' + ipv6)
+                    if name == "lo":
+                        commands.append('delete interfaces loopback lo address ' + ipv6)
+                    else:
+                        commands.append('delete interfaces ethernet ' + name + ' address ' + ipv6)
         elif (state == 'present' and obj_in_have):
             if ipv4 and ipv4 != obj_in_have['ipv4']:
-              if name == "lo":
-                commands.append('set interfaces loopback lo address ' +
+                if name == "lo":
+                    commands.append('set interfaces loopback lo address ' +
                                 ipv4)
               else:
-                commands.append('set interfaces ethernet ' + name + ' address ' +
+                  commands.append('set interfaces ethernet ' + name + ' address ' +
                                 ipv4)
 
             if ipv6 and ipv6 != obj_in_have['ipv6']:
-              if name == "lo":
-                commands.append('set interfaces loopback lo address ' +
+                if name == "lo":
+                    commands.append('set interfaces loopback lo address ' +
                                 ipv6)
-              else:
-                commands.append('set interfaces ethernet ' + name + ' address ' +
+                else:
+                    commands.append('set interfaces ethernet ' + name + ' address ' +
                                 ipv6)
 
     return commands

--- a/lib/ansible/modules/network/vyos/vyos_l3_interface.py
+++ b/lib/ansible/modules/network/vyos/vyos_l3_interface.py
@@ -117,18 +117,35 @@ def map_obj_to_commands(updates, module):
         obj_in_have = search_obj_in_list(name, have)
         if state == 'absent' and obj_in_have:
             if not ipv4 and not ipv6 and (obj_in_have['ipv4'] or obj_in_have['ipv6']):
+              if name == "lo":
+                commands.append('delete interfaces loopback lo address')
+              else:
                 commands.append('delete interfaces ethernet ' + name + ' address')
             else:
                 if ipv4 and obj_in_have['ipv4']:
+                  if name == "lo":
+                    commands.append('delete interfaces loopback lo address ' + ipv4)
+                  else:
                     commands.append('delete interfaces ethernet ' + name + ' address ' + ipv4)
                 if ipv6 and obj_in_have['ipv6']:
+                  if name == "lo":
+                    commands.append('delete interfaces loopback lo address ' + ipv6)
+                  else:
                     commands.append('delete interfaces ethernet ' + name + ' address ' + ipv6)
         elif (state == 'present' and obj_in_have):
             if ipv4 and ipv4 != obj_in_have['ipv4']:
+              if name == "lo":
+                commands.append('set interfaces loopback lo address ' +
+                                ipv4)
+              else:
                 commands.append('set interfaces ethernet ' + name + ' address ' +
                                 ipv4)
 
             if ipv6 and ipv6 != obj_in_have['ipv6']:
+              if name == "lo":
+                commands.append('set interfaces loopback lo address ' +
+                                ipv6)
+              else:
                 commands.append('set interfaces ethernet ' + name + ' address ' +
                                 ipv6)
 
@@ -137,7 +154,7 @@ def map_obj_to_commands(updates, module):
 
 def map_config_to_obj(module):
     obj = []
-    output = run_commands(module, ['show interfaces ethernet'])
+    output = run_commands(module, ['show interfaces'])
     lines = output[0].splitlines()
 
     if len(lines) > 3:

--- a/lib/ansible/modules/network/vyos/vyos_l3_interface.py
+++ b/lib/ansible/modules/network/vyos/vyos_l3_interface.py
@@ -135,19 +135,15 @@ def map_obj_to_commands(updates, module):
         elif (state == 'present' and obj_in_have):
             if ipv4 and ipv4 != obj_in_have['ipv4']:
                 if name == "lo":
-                    commands.append('set interfaces loopback lo address ' +
-                                ipv4)
+                    commands.append('set interfaces loopback lo address ' + ipv4)
                 else:
-                    commands.append('set interfaces ethernet ' + name + ' address ' +
-                                ipv4)
+                    commands.append('set interfaces ethernet ' + name + ' address ' + ipv4)
 
             if ipv6 and ipv6 != obj_in_have['ipv6']:
                 if name == "lo":
-                    commands.append('set interfaces loopback lo address ' +
-                                ipv6)
+                    commands.append('set interfaces loopback lo address ' + ipv6)
                 else:
-                    commands.append('set interfaces ethernet ' + name + ' address ' +
-                                ipv6)
+                    commands.append('set interfaces ethernet ' + name + ' address ' + ipv6)
 
     return commands
 

--- a/lib/ansible/modules/network/vyos/vyos_l3_interface.py
+++ b/lib/ansible/modules/network/vyos/vyos_l3_interface.py
@@ -137,8 +137,8 @@ def map_obj_to_commands(updates, module):
                 if name == "lo":
                     commands.append('set interfaces loopback lo address ' +
                                 ipv4)
-              else:
-                  commands.append('set interfaces ethernet ' + name + ' address ' +
+                else:
+                    commands.append('set interfaces ethernet ' + name + ' address ' +
                                 ipv4)
 
             if ipv6 and ipv6 != obj_in_have['ipv6']:


### PR DESCRIPTION
##### SUMMARY
currently the loopback interface lo is not supported with vyos_l3_interface, this commit fixes that.  Right now there is a limit of loopback interfaces to just lo, if you want more interfaces you need to use a dummy interface https://wiki.vyos.net/wiki/Dummy_interfaces

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
vyos_l3_interface

##### ANSIBLE VERSION
```
[vagrant@ansible test]$ ansible --version
ansible 2.6.0
  config file = /home/vagrant/.ansible.cfg
  configured module search path = [u'/home/vagrant/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Aug  4 2017, 00:39:18) [GCC 4.8.5 20150623 (Red Hat 4.8.5-16)]
```


##### ADDITIONAL INFORMATION
The following playbook will now work with loopback interface
```
---
- hosts: network
  connection: network_cli
  vars:
    interface_data:
      spine01:
          - { name: lo, ipv4: 10.0.0.1/32 }
          - { name: eth2, ipv4: 192.168.11.1/30 }
          - { name: eth3, ipv4: 192.168.12.1/30 }
      spine02:
          - { name: lo, ipv4: 10.0.0.2/32 }
          - { name: eth2, ipv4: 192.168.21.1/30 }
          - { name: eth3, ipv4: 192.168.22.1/30 }
      leaf01:
          - { name: lo, ipv4: 10.0.0.11/32 }
          - { name: eth6, ipv4: 192.168.11.2/30 }
          - { name: eth7, ipv4: 192.168.21.2/30 }
      leaf02:
          - { name: lo, ipv4: 10.0.0.12/32 }
          - { name: eth6, ipv4: 192.168.12.2/30 }
          - { name: eth7, ipv4: 192.168.22.2/30 }
  tasks:
    - name: Set IP addresses on aggregate
      vyos_l3_interface:
        aggregate: "{{interface_data[inventory_hostname]}}"
```
