### PR TITLE
File Module docs, adding mode permission example with sticky bit 

### DIFF
--- a/lib/ansible/modules/files/file.py
+++ b/lib/ansible/modules/files/file.py
@@ -85,6 +85,11 @@ EXAMPLES = '''
     group: foo
     mode: 0644
 - file:
+    path: /work
+    owner: root
+    group: root
+    mode: 01777
+- file:
     src: /file/to/link/to
     dest: /path/to/symlink
     owner: foo

--- a/lib/ansible/utils/module_docs_fragments/files.py
+++ b/lib/ansible/utils/module_docs_fragments/files.py
@@ -25,7 +25,7 @@ options:
     required: false
     default: null
     description:
-      - Mode the file or directory should be. For those used to I(/usr/bin/chmod) remember that modes are actually octal numbers (like 0644 or 01777).
+      - Mode the file or directory should be. For those used to I(/usr/bin/chmod) remember that modes are actually octal numbers (like C(0644) or C(01777)).
         Leaving off the leading zero will likely have unexpected results.
         As of version 1.8, the mode may be specified as a symbolic mode (for example, C(u+rwx) or C(u=rw,g=r,o=r)).
   owner:

--- a/lib/ansible/utils/module_docs_fragments/files.py
+++ b/lib/ansible/utils/module_docs_fragments/files.py
@@ -25,7 +25,7 @@ options:
     required: false
     default: null
     description:
-      - Mode the file or directory should be. For those used to I(/usr/bin/chmod) remember that modes are actually octal numbers (like 0644).
+      - Mode the file or directory should be. For those used to I(/usr/bin/chmod) remember that modes are actually octal numbers (like 0644 or 01777).
         Leaving off the leading zero will likely have unexpected results.
         As of version 1.8, the mode may be specified as a symbolic mode (for example, C(u+rwx) or C(u=rw,g=r,o=r)).
   owner:


### PR DESCRIPTION
##### SUMMARY
Adding example with octal representation for sticky bit permission mode

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
modules/files/ 

##### ANSIBLE VERSION


##### ADDITIONAL INFORMATION
https://github.com/ansible/ansible/issues/9196
https://github.com/ansible/ansible/issues/23521
