### PR TITLE
adding support for loopback interface (#36141)

### DIFF
--- a/lib/ansible/modules/network/vyos/vyos_l3_interface.py
+++ b/lib/ansible/modules/network/vyos/vyos_l3_interface.py
@@ -117,27 +117,40 @@ def map_obj_to_commands(updates, module):
         obj_in_have = search_obj_in_list(name, have)
         if state == 'absent' and obj_in_have:
             if not ipv4 and not ipv6 and (obj_in_have['ipv4'] or obj_in_have['ipv6']):
-                commands.append('delete interfaces ethernet ' + name + ' address')
+                if name == "lo":
+                    commands.append('delete interfaces loopback lo address')
+                else:
+                    commands.append('delete interfaces ethernet ' + name + ' address')
             else:
                 if ipv4 and obj_in_have['ipv4']:
-                    commands.append('delete interfaces ethernet ' + name + ' address ' + ipv4)
+                    if name == "lo":
+                        commands.append('delete interfaces loopback lo address ' + ipv4)
+                    else:
+                        commands.append('delete interfaces ethernet ' + name + ' address ' + ipv4)
                 if ipv6 and obj_in_have['ipv6']:
-                    commands.append('delete interfaces ethernet ' + name + ' address ' + ipv6)
+                    if name == "lo":
+                        commands.append('delete interfaces loopback lo address ' + ipv6)
+                    else:
+                        commands.append('delete interfaces ethernet ' + name + ' address ' + ipv6)
         elif (state == 'present' and obj_in_have):
             if ipv4 and ipv4 != obj_in_have['ipv4']:
-                commands.append('set interfaces ethernet ' + name + ' address ' +
-                                ipv4)
+                if name == "lo":
+                    commands.append('set interfaces loopback lo address ' + ipv4)
+                else:
+                    commands.append('set interfaces ethernet ' + name + ' address ' + ipv4)
 
             if ipv6 and ipv6 != obj_in_have['ipv6']:
-                commands.append('set interfaces ethernet ' + name + ' address ' +
-                                ipv6)
+                if name == "lo":
+                    commands.append('set interfaces loopback lo address ' + ipv6)
+                else:
+                    commands.append('set interfaces ethernet ' + name + ' address ' + ipv6)
 
     return commands
 
 
 def map_config_to_obj(module):
     obj = []
-    output = run_commands(module, ['show interfaces ethernet'])
+    output = run_commands(module, ['show interfaces'])
     lines = output[0].splitlines()
 
     if len(lines) > 3:


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
* adding support for loopback interface

currently the loopback interface lo is not supported with vyos_l3_interface, this commit fixes that.  Right now there is a limit of loopback interfaces to just lo, if you want more interfaces you need to use a dummy interface https://wiki.vyos.net/wiki/Dummy_interfaces

* fixing spacing as per pep8 test

fixing issues for sanity test

* ugh, missed on spacing issue

* getting rid of continuation lines, the CI system does not like it

(cherry picked from commit a52a7d2065a2f9607fd6893fb93f9a654f51ce66)


<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
vyos_l3_interface

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
