### PR TITLE
Changing Lenovo Inc to Lenovo and update License file to be consistent.

### DIFF
--- a/lib/ansible/module_utils/network/enos/enos.py
+++ b/lib/ansible/module_utils/network/enos/enos.py
@@ -4,7 +4,7 @@
 # Ansible still belong to the author of the module, and may assign their own
 # license to the complete work.
 #
-# Copyright (C) 2017 Lenovo, Inc.
+# Copyright (C) 2017 Lenovo.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/lib/ansible/modules/network/enos/enos_command.py
+++ b/lib/ansible/modules/network/enos/enos_command.py
@@ -1,8 +1,13 @@
 #!/usr/bin/python
+# -*- coding: utf-8 -*-
 #
-# Copyright (C) 2017 Lenovo, Inc.
+# Copyright (C) 2017 Lenovo.
 # GNU General Public License v3.0+
 # (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+#
+# Module to execute ENOS Commands on Lenovo Switches.
+# Lenovo Networking
+#
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 

--- a/lib/ansible/modules/network/enos/enos_config.py
+++ b/lib/ansible/modules/network/enos/enos_config.py
@@ -1,8 +1,13 @@
 #!/usr/bin/python
+# -*- coding: utf-8 -*-
 #
-# Copyright (C) 2017 Lenovo, Inc.
+# Copyright (C) 2017 Lenovo.
 # GNU General Public License v3.0+
 # (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+#
+# Module to configure Lenovo Switches.
+# Lenovo Networking
+#
 
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type

--- a/lib/ansible/modules/network/enos/enos_facts.py
+++ b/lib/ansible/modules/network/enos/enos_facts.py
@@ -1,28 +1,17 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function
-__metaclass__ = type
 #
-# Copyright (C) 2017 Lenovo, Inc.
+# Copyright (C) 2017 Lenovo.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 #
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
 # Module to Collect facts from Lenovo Switches running Lenovo ENOS commands
 # Lenovo Networking
 #
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],

--- a/lib/ansible/plugins/action/enos_config.py
+++ b/lib/ansible/plugins/action/enos_config.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2017 Lenovo, Inc.
+# Copyright (C) 2017 Lenovo.
 # All rights reserved.
 #
 # This file is part of Ansible

--- a/lib/ansible/plugins/terminal/enos.py
+++ b/lib/ansible/plugins/terminal/enos.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2017 Lenovo, Inc.
+# Copyright (C) 2017 Lenovo.
 # All rights reserved.
 #
 # This file is part of Ansible


### PR DESCRIPTION
SUMMARY
Changing name Lenovo Inc to Lenovo.
Consistency on License file

ISSUE TYPE
Docs Pull Request

COMPONENT NAME
lib/ansible/module_utils/network/enos/enos.py
lib/ansible/modules/network/enos/enos_command.py
lib/ansible/modules/network/enos/enos_config.py
lib/ansible/modules/network/enos/enos_facts.py
lib/ansible/plugins/action/enos_config.py
lib/ansible/plugins/terminal/enos.py

ANSIBLE VERSION
ansible 2.5.0
config file = /etc/ansible/ansible.cfg
configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible-2.5.0-py2.7.egg/ansible
executable location = /usr/local/bin/ansible
python version = 2.7.6 (default, Oct 26 2016, 20:30:19) [GCC 4.8.4]

ADDITIONAL INFORMATION
This is an effort to support Lenovo ENOS Switches in Ansible