### PR TITLE
Ensure docs are valid before checking deprecation

### DIFF
--- a/test/sanity/validate-modules/main.py
+++ b/test/sanity/validate-modules/main.py
@@ -1235,7 +1235,7 @@ class ModuleValidator(Validator):
             doc_info, docs = self._validate_docs()
 
             # See if current version => deprecated.removed_in, ie, should be docs only
-            if 'deprecated' in docs and docs['deprecated'] is not None:
+            if docs and 'deprecated' in docs and docs['deprecated'] is not None:
                 removed_in = docs.get('deprecated')['removed_in']
                 strict_ansible_version = StrictVersion('.'.join(ansible_version.split('.')[:2]))
                 end_of_deprecation_should_be_docs_only = strict_ansible_version >= removed_in


### PR DESCRIPTION
##### SUMMARY
If `DOCUMENTATION` isn't valid yaml don't backtrace by trying to look inside null.


Testing with a file that has invalid YAML in it's `DOCUMENTATION` block
**Before**
```
ansible-test sanity --test validate-modules  lib/ansible/modules/windows/win_domain_computer.py
Sanity check using validate-modules
WARNING: Cannot perform module comparison against the base branch. Base branch not detected when running locally.
ERROR: Command "python2.7 test/sanity/validate-modules/validate-modules --format json --arg-spec lib/ansible/modules/windows/win_domain_computer.py --exclude '^(lib/ansible/modules/utilities/logic/async_status.py)'" returned exit status 1.
>>> Standard Error
Traceback (most recent call last):
  File "test/sanity/validate-modules/validate-modules", line 1456, in <module>
    main()
  File "test/sanity/validate-modules/validate-modules", line 1355, in main
    mv.validate()
  File "test/sanity/validate-modules/validate-modules", line 1240, in validate
    if 'deprecated' in docs and docs['deprecated'] is not None:
TypeError: argument of type 'NoneType' is not iterable
```



**After**
```
ansible-test sanity --test validate-modules  lib/ansible/modules/windows/win_domain_computer.py
Sanity check using validate-modules
WARNING: Cannot perform module comparison against the base branch. Base branch not detected when running locally.
ERROR: Found 1 validate-modules issue(s) which need to be resolved:
ERROR: lib/ansible/modules/windows/win_domain_computer.py:50:13: E302 DOCUMENTATION is not valid YAML
```

##### ISSUE TYPE

 - Bugfix Pull Request
