### PR TITLE
Fix nxos_linkagg tests

### DIFF
--- a/test/integration/targets/nxos_linkagg/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_linkagg/tests/common/sanity.yaml
@@ -26,6 +26,7 @@
       - no channel-group 20
     provider: "{{ connection }}"
     parents: "{{ item }}"
+  ignore_errors: yes
   loop:
     - "interface {{ testint1 }}"
     - "interface {{ testint2 }}"
@@ -181,6 +182,7 @@
       - no channel-group 20
     provider: "{{ connection }}"
     parents: "{{ item }}"
+  ignore_errors: yes
   loop:
     - "interface {{ testint1 }}"
     - "interface {{ testint2 }}"


### PR DESCRIPTION
##### SUMMARY
On some Nexus platforms, issuing the `no channel-group 20` command under an interface will generate the following error:

```
            "clierror": "Ethernet1/2: not part of port-channel 20\n", 
            "code": "400", 
            "input": "no channel-group 20", 
            "msg": "CLI execution error"
```

This error is effectively ignored for transport `cli` but not for `nxapi`.  This is an issue with nxapi but for the tests that issue this command in the setup and teardown sections of the `nxos_linkagg` we can add a `ignore_errors: yes` in the test playbook.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
nxos_linkagg

##### ANSIBLE VERSION
```
ansible 2.6.0 (rel250/fix_nxos_linkagg d7361605f1) last updated 2018/02/14 09:39:41 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/Users/mwiebe/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mwiebe/Projects/nxos_ansible/fix_ansible/lib/ansible
  executable location = /Users/mwiebe/Projects/nxos_ansible/fix_ansible/bin/ansible
  python version = 2.7.13 (default, Apr  4 2017, 08:47:57) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.38)]
```


##### ADDITIONAL INFORMATION

Test results following the update:
```
TASK [nxos_linkagg : debug] ********************************************************************************************************************************************************************************
task path: /Users/mwiebe/Projects/nxos_ansible/fix_ansible/test/integration/targets/nxos_linkagg/tests/common/sanity.yaml:197
ok: [n7k.example.com] => {
    "failed": false, 
    "msg": "END connection=local nxos_linkagg sanity test"
}
META: ran handlers
META: ran handlers

PLAY RECAP *************************************************************************************************************************************************************************************************
n7k.example.com           : ok=138  changed=33   unreachable=0    failed=0   
```