### PR TITLE
Add aci_login module

### DIFF
--- a/lib/ansible/module_utils/network/aci/aci.py
+++ b/lib/ansible/module_utils/network/aci/aci.py
@@ -67,6 +67,7 @@ def aci_argument_spec():
         host=dict(type='str', required=True, aliases=['hostname']),
         port=dict(type='int', required=False),
         username=dict(type='str', default='admin', aliases=['user']),
+        token=dict(type='str'),
         password=dict(type='str', no_log=True),
         private_key=dict(type='path', aliases=['cert_key']),  # Beware, this is not the same as client_key !
         certificate_name=dict(type='str', aliases=['cert_name']),  # Beware, this is not the same as client_cert !
@@ -155,7 +156,9 @@ class ACIModule(object):
             self.module.warn('Enable debug output because ANSIBLE_DEBUG was set.')
             self.params['output_level'] = 'debug'
 
-        if self.params['private_key']:
+        if self.params['token']:
+            self.headers['Cookie'] = self.params['token']
+        elif self.params['private_key']:
             # Perform signature-based authentication, no need to log on separately
             if not HAS_OPENSSL:
                 self.module.fail_json(msg='Cannot use signature-based authentication because pyopenssl is not available')

--- a/lib/ansible/modules/network/aci/aci_login.py
+++ b/lib/ansible/modules/network/aci/aci_login.py
@@ -1,0 +1,69 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = r'''
+---
+module: aci_login
+short_description: Login to ACI to get a token
+description:
+- Logs into ACI and returns a token which can be used when working with the other ACI modules.
+author:
+- Patrick Ogenstad (@ogenstad)
+version_added: '2.6'
+options:
+extends_documentation_fragment: aci
+'''
+
+EXAMPLES = r'''
+- name: Login
+  aci_login:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+  register: token
+
+- name: Remove a tenant
+  aci_tenant:
+    host: apic
+    token: '{{ token.aci_token }}'
+    tenant: production
+    state: absent
+'''
+
+RETURN = r'''
+aci_token:
+  description: The authentication token from a successful login.
+  returned: success
+  type: string
+  sample: APIC-cookie=6y+wLG1kIkICqvp84LNQ; path=/; HttpOnly; HttpOnly; Secure
+'''
+
+from ansible.module_utils.network.aci.aci import ACIModule, aci_argument_spec
+from ansible.module_utils.basic import AnsibleModule
+
+
+def main():
+    argument_spec = aci_argument_spec()
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True
+    )
+
+    aci = ACIModule(module)
+    aci_token = aci.headers['Cookie']
+
+    module.exit_json(aci_token=aci_token)
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/ansible/modules/network/aci/aci_login.py
+++ b/lib/ansible/modules/network/aci/aci_login.py
@@ -19,7 +19,6 @@ description:
 author:
 - Patrick Ogenstad (@ogenstad)
 version_added: '2.6'
-options:
 extends_documentation_fragment: aci
 '''
 

--- a/lib/ansible/utils/module_docs_fragments/aci.py
+++ b/lib/ansible/utils/module_docs_fragments/aci.py
@@ -36,13 +36,17 @@ options:
   username:
     description:
     - The username to use for authentication.
-    required: yes
+    required: no
     default: admin
     aliases: [ user ]
   password:
     description:
     - The password to use for authentication.
-    required: yes
+    required: no
+  token:
+    description:
+    - Authentication token returned by aci_login module, can be used to authenticate instead of username and password.
+    required: no
   private_key:
     description:
     - PEM formatted file that contains your private key to be used for signature-based authentication.


### PR DESCRIPTION
The aci_login module logs into ACI and collects an authentication token
which can be used from other modules to avoid logging into the ACI
system multiple times, this provides quite a speedup when running
multiple tasks.

##### SUMMARY
With the current ACI modules Ansible authenticates and retrieves a token for each module. This isn't necessary and when running many tasks it slows things down.

##### ISSUE TYPE
 - Feature Pull Request
 - New Module Pull Request
 - Docs Pull Request

##### COMPONENT NAME
* aci_login
##### ANSIBLE VERSION
```
ansible 2.6.0 (aci_login c34005d4f6) last updated 2018/02/14 15:48:13 (GMT +200)
  config file = None
  configured module search path = [u'/Users/patrick/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/patrick/src/forks/ansible/lib/ansible
  executable location = /Users/patrick/src/forks/ansible/bin/ansible
  python version = 2.7.14 (default, Sep 25 2017, 09:53:22) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.37)]
```

##### ADDITIONAL INFORMATION
To test this I've used a playbook which creates 50 VRFs and 200 Bridge domains on the ACI. When running the playbook everything has been pre created so both of them will just run without any changes.

Prior to this PR:
```yaml
---
- name: Create tenant
  aci_tenant:
    tenant: '{{ tenant }}'
    hostname: '{{ hostname }}'
    username: '{{ username }}'
    password: '{{ password }}'
    validate_certs: '{{ validate_certs }}'

- name: Create VRFs
  aci_vrf:
    tenant: '{{ tenant }}'
    hostname: '{{ hostname }}'
    username: '{{ username }}'
    password: '{{ password }}'
    validate_certs: '{{ validate_certs }}'
    vrf_name: '{{ item.name }}'
  with_items: '{{ vrf }}'

- name: Create BDs
  aci_bd:
    tenant: '{{ tenant }}'
    hostname: '{{ hostname }}'
    username: '{{ username }}'
    password: '{{ password }}'
    validate_certs: '{{ validate_certs }}'
    vrf: '{{ item.vrf }}'
    bd: '{{ item.name }}'
    enable_routing: yes
  with_items: '{{ bd }}'
```

With this PR:
```yaml
---
- name: Login
  aci_login:
    hostname: '{{ hostname }}'
    username: '{{ username }}'
    password: '{{ password }}'
    validate_certs: '{{ validate_certs }}'
  register: token

- name: Show
  debug:
    var: token.aci_token

- name: Create tenant
  aci_tenant:
    tenant: '{{ tenant }}'
    hostname: '{{ hostname }}'
    validate_certs: '{{ validate_certs }}'
    token: '{{ token.aci_token }}'

- name: Create VRFs
  aci_vrf:
    tenant: '{{ tenant }}'
    hostname: '{{ hostname }}'
    token: '{{ token.aci_token }}'
    validate_certs: '{{ validate_certs }}'
    vrf_name: '{{ item.name }}'
  with_items: '{{ vrf }}'

- name: Create BDs
  aci_bd:
    tenant: '{{ tenant }}'
    hostname: '{{ hostname }}'
    token: '{{ token.aci_token }}'
    validate_certs: '{{ validate_certs }}'
    vrf: '{{ item.vrf }}'
    bd: '{{ item.name }}'
    enable_routing: yes
  with_items: '{{ bd }}'
```

The first playbook takes about 4,5 minutes, the second one completes in about 3,5 minutes. Also this test was done using a local user account in ACI. Most of our customers have the user database connected to an ISE server or Active Directory and in those scenarios this will probably speed things up even more.

Open for suggestions if anything should be changed in this PR. Was thinking of returning the token as an Ansible fact called aci_token instead of the above way.