### PR TITLE
Added ability to read config from env. instead of .init for use in Asible Tower (and AWX)

### DIFF
--- a/contrib/inventory/cobbler.py
+++ b/contrib/inventory/cobbler.py
@@ -90,8 +90,10 @@ class CobblerInventory(object):
 
         self.inventory = dict()  # A list of groups and the hosts in that group
         self.cache = dict()  # Details about hosts in the inventory
+        self.ignore_settings = False # used to only look at env vars for settings.
 
-        # Read settings and parse CLI arguments
+        # Read env vars, read settings, and parse CLI arguments
+        self.parse_env_vars()
         self.read_settings()
         self.parse_cli_args()
 
@@ -138,6 +140,9 @@ class CobblerInventory(object):
 
     def read_settings(self):
         """ Reads the settings from the cobbler.ini file """
+        
+        if(self.ignore_settings):
+            return
 
         config = ConfigParser.SafeConfigParser()
         config.read(os.path.dirname(os.path.realpath(__file__)) + '/cobbler.ini')
@@ -155,6 +160,32 @@ class CobblerInventory(object):
         self.cache_path_cache = cache_path + "/ansible-cobbler.cache"
         self.cache_path_inventory = cache_path + "/ansible-cobbler.index"
         self.cache_max_age = config.getint('cobbler', 'cache_max_age')
+
+    def parse_env_vars(self):
+        """ Reads the settings from the environment """
+
+        # Env. Vars:
+        #   COBBLER_host
+        #   COBBLER_username
+        #   COBBLER_password
+        #   COBBLER_cache_path
+        #   COBBLER_cache_max_age
+        #   COBBLER_ignore_settings
+
+        self.cobbler_host = os.getenv('COBBLER_host', None)
+        self.cobbler_username = os.getenv('COBBLER_username', None)
+        self.cobbler_password = os.getenv('COBBLER_password', None)
+
+        # Cache related
+        cache_path = os.getenv('COBBLER_cache_path', None)
+        self.cache_path_cache = cache_path + "/ansible-cobbler.cache"
+        self.cache_path_inventory = cache_path + "/ansible-cobbler.index"
+        self.cache_max_age = int(os.getenv('COBBLER_cache_max_age', "30"))
+        
+        # ignore_settings is used to ignore the settings file, for use in Ansible
+        # Tower (or AWX inventory scripts and not throw python exceptions.)
+        if(os.getenv('COBBLER_ignore_settings', False) == "True") :
+            self.ignore_settings = True;
 
     def parse_cli_args(self):
         """ Command line argument processing """

--- a/contrib/inventory/cobbler.py
+++ b/contrib/inventory/cobbler.py
@@ -178,8 +178,10 @@ class CobblerInventory(object):
 
         # Cache related
         cache_path = os.getenv('COBBLER_cache_path', None)
-        self.cache_path_cache = cache_path + "/ansible-cobbler.cache"
-        self.cache_path_inventory = cache_path + "/ansible-cobbler.index"
+        if(cache_path != None) :
+            self.cache_path_cache = cache_path + "/ansible-cobbler.cache"
+            self.cache_path_inventory = cache_path + "/ansible-cobbler.index"
+
         self.cache_max_age = int(os.getenv('COBBLER_cache_max_age', "30"))
         
         # ignore_settings is used to ignore the settings file, for use in Ansible

--- a/contrib/inventory/cobbler.py
+++ b/contrib/inventory/cobbler.py
@@ -90,7 +90,7 @@ class CobblerInventory(object):
 
         self.inventory = dict()  # A list of groups and the hosts in that group
         self.cache = dict()  # Details about hosts in the inventory
-        self.ignore_settings = False # used to only look at env vars for settings.
+        self.ignore_settings = False  # used to only look at env vars for settings.
 
         # Read env vars, read settings, and parse CLI arguments
         self.parse_env_vars()
@@ -140,7 +140,7 @@ class CobblerInventory(object):
 
     def read_settings(self):
         """ Reads the settings from the cobbler.ini file """
-        
+
         if(self.ignore_settings):
             return
 
@@ -178,16 +178,16 @@ class CobblerInventory(object):
 
         # Cache related
         cache_path = os.getenv('COBBLER_cache_path', None)
-        if(cache_path != None) :
+        if(cache_path is not None):
             self.cache_path_cache = cache_path + "/ansible-cobbler.cache"
             self.cache_path_inventory = cache_path + "/ansible-cobbler.index"
 
         self.cache_max_age = int(os.getenv('COBBLER_cache_max_age', "30"))
-        
+
         # ignore_settings is used to ignore the settings file, for use in Ansible
         # Tower (or AWX inventory scripts and not throw python exceptions.)
-        if(os.getenv('COBBLER_ignore_settings', False) == "True") :
-            self.ignore_settings = True;
+        if(os.getenv('COBBLER_ignore_settings', False) == "True"):
+            self.ignore_settings = True
 
     def parse_cli_args(self):
         """ Command line argument processing """


### PR DESCRIPTION
##### SUMMARY
Changing the cobbler.py inventory script to accept its settings via the Environment.  This allows easier use of the script in AWX and possibly Ansible Tower.

##### COMPONENT NAME
contrib/inventory/cobbler.py

##### ANSIBLE VERSION
ansible 2.4.2.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/jasonw/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Aug  4 2017, 00:39:18) [GCC 4.8.5 20150623 (Red Hat 4.8.5-16)]


##### ADDITIONAL INFORMATION

