### PR TITLE
ACI: Avoid using 'previous' with query operations

### DIFF
--- a/lib/ansible/module_utils/network/aci/aci.py
+++ b/lib/ansible/module_utils/network/aci/aci.py
@@ -930,8 +930,9 @@ class ACIModule(object):
 
     def exit_json(self, **kwargs):
 
-        if self.params['output_level'] in ('debug', 'info'):
-            self.result['previous'] = self.existing
+        if self.params['state'] in ('absent', 'present'):
+            if self.params['output_level'] in ('debug', 'info'):
+                self.result['previous'] = self.existing
 
         # Return the gory details when we need it
         if self.params['output_level'] == 'debug':
@@ -945,13 +946,13 @@ class ACIModule(object):
         self.original = self.existing
         if self.params['state'] in ('absent', 'present'):
             self.get_existing()
-        self.result['current'] = self.existing
 
-        # if self.module._diff and self.original != self.existing:
-        #     self.result['diff'] = dict(
-        #         before=json.dumps(self.original, sort_keys=True, indent=4),
-        #         after=json.dumps(self.existing, sort_keys=True, indent=4),
-        #     )
+            # if self.module._diff and self.original != self.existing:
+            #     self.result['diff'] = dict(
+            #         before=json.dumps(self.original, sort_keys=True, indent=4),
+            #         after=json.dumps(self.existing, sort_keys=True, indent=4),
+            #     )
+        self.result['current'] = self.existing
 
         if self.params['output_level'] in ('debug', 'info'):
             self.result['sent'] = self.config
@@ -966,8 +967,9 @@ class ACIModule(object):
         if self.error['code'] is not None and self.error['text'] is not None:
             self.result['error'] = self.error
 
-        if self.params['output_level'] in ('debug', 'info'):
-            self.result['previous'] = self.existing
+        if self.params['state'] in ('absent', 'present'):
+            if self.params['output_level'] in ('debug', 'info'):
+                self.result['previous'] = self.existing
 
         # Return the gory details when we need it
         if self.params['output_level'] == 'debug':

--- a/test/integration/targets/aci_access_port_to_interface_policy_leaf_profile/tasks/main.yml
+++ b/test/integration/targets/aci_access_port_to_interface_policy_leaf_profile/tasks/main.yml
@@ -73,7 +73,7 @@
   assert:
     that:
       - binding_query.changed == false
-      - binding_query.previous | length >= 1
+      - binding_query.current | length >= 1
       - '"api/mo/uni/infra/accportprof-leafintprftest/hports-anstest_accessportselector-typ-range.json" in binding_query.url'
 
 - name: Remove binding of interface access port selector and Interface Policy Leaf Profile - check mode

--- a/test/integration/targets/aci_ap/tasks/main.yml
+++ b/test/integration/targets/aci_ap/tasks/main.yml
@@ -101,21 +101,21 @@
   assert:
     that:
       - query_ap.changed == false
-      - query_ap.previous | length == 1
-      - 'query_ap.previous.0.fvAp.attributes.name == "anstest"'
+      - query_ap.current | length == 1
+      - 'query_ap.current.0.fvAp.attributes.name == "anstest"'
       - '"tn-anstest/ap-anstest.json" in query_ap.url'
       - query_ap_tenant.changed == false
-      - query_ap_tenant.previous | length == 1
-      - query_ap_tenant.previous.0.fvTenant.children | length == 2
+      - query_ap_tenant.current | length == 1
+      - query_ap_tenant.current.0.fvTenant.children | length == 2
       - '"rsp-subtree-class=fvAp" in query_ap_tenant.filter_string'
       - '"tn-anstest.json" in query_ap_tenant.url'
       - query_ap_ap.changed == false
-      - query_ap_ap.previous != []
-      - query_ap_ap.previous.0.fvAp is defined
+      - query_ap_ap.current != []
+      - query_ap_ap.current.0.fvAp is defined
       - '"query-target-filter=eq(fvAp.name, \"anstest\")" in query_ap_ap.filter_string'
       - '"class/fvAp.json" in query_ap_ap.url'
       - query_all.changed == false
-      - query_all.previous | length > 1
+      - query_all.current | length > 1
       - '"class/fvAp.json" in query_all.url'
 
 - name: delete ap - check_mode works

--- a/test/integration/targets/aci_bd/tasks/main.yml
+++ b/test/integration/targets/aci_bd/tasks/main.yml
@@ -119,23 +119,23 @@
   assert:
     that:
       - query_all.changed == false
-      - query_all.previous | length > 1
-      - query_all.previous.0.fvBD is defined
+      - query_all.current | length > 1
+      - query_all.current.0.fvBD is defined
       - '"rsp-subtree-class=fvRsCtx,fvRsIgmpsn,fvRsBDToNdP,fvRsBdToEpRet" in query_all.filter_string'
       - '"class/fvBD.json" in query_all.url'
       - query_tenant.changed == false
-      - query_tenant.previous | length == 1
-      - query_tenant.previous.0.fvTenant.children | length == 2
+      - query_tenant.current | length == 1
+      - query_tenant.current.0.fvTenant.children | length == 2
       - '"rsp-subtree-class=fvRsCtx,fvRsIgmpsn,fvRsBDToNdP,fvRsBdToEpRet,fvBD" in query_tenant.filter_string'
       - '"tn-anstest.json" in query_tenant.url'
       - query_bd_bd.changed == false
-      - query_bd_bd.previous != []
+      - query_bd_bd.current != []
       - '"query-target-filter=eq(fvBD.name, \"anstest\")" in query_bd_bd.filter_string'
       - '"rsp-subtree=full&rsp-subtree-class=fvRsCtx,fvRsIgmpsn,fvRsBDToNdP,fvRsBdToEpRet" in query_bd_bd.filter_string'
       - '"class/fvBD.json" in query_bd_bd.url'
       - query_bd.changed == false
-      - query_bd.previous | length == 1
-      - 'query_bd.previous.0.fvBD.attributes.name == "anstest"'
+      - query_bd.current | length == 1
+      - 'query_bd.current.0.fvBD.attributes.name == "anstest"'
       - '"rsp-subtree-class=fvRsCtx,fvRsIgmpsn,fvRsBDToNdP,fvRsBdToEpRet" in query_bd.filter_string'
       - '"tn-anstest/BD-anstest.json" in query_bd.url'
 

--- a/test/integration/targets/aci_bd_subnet/tasks/main.yml
+++ b/test/integration/targets/aci_bd_subnet/tasks/main.yml
@@ -170,7 +170,7 @@
   assert:
     that:
       - get_all.changed == false
-      - get_all.previous | length > 1
+      - get_all.current | length > 1
       - get_all_tenant.changed == false
       - '"tn-anstest.json" in get_all_tenant.url'
       - get_all_bd.changed == false
@@ -178,7 +178,7 @@
       - '"class/fvBD.json" in get_all_bd.url'
       - get_all_tenant_bd.changed == false
       - '"tn-anstest/BD-anstest.json" in get_all_tenant_bd.url'
-      - get_all_tenant_bd.previous.0.fvBD.children | length > 1
+      - get_all_tenant_bd.current.0.fvBD.children | length > 1
       - get_subnet_tenant.changed == false
       - '"rsp-subtree-filter=eq(fvSubnet.ip, \"10.100.100.1/24\")" in get_subnet_tenant.filter_string'
       - '"tn-anstest.json" in get_subnet_tenant.url'
@@ -186,7 +186,7 @@
       - '"query-target-filter=eq(fvBD.name, \"anstest\")" and "rsp-subtree-filter=eq(fvSubnet.ip, \"10.100.100.1/24\")" in get_subnet_bd.filter_string'
       - '"class/fvBD.json" in get_subnet_bd.url'
       - get_subnet.changed == false
-      - get_subnet.previous | length == 1
+      - get_subnet.current | length == 1
       - '"tn-anstest/BD-anstest/subnet-[10.100.100.1/24].json" in get_subnet.url'
       - get_subnets_gateway.changed == false
       - '"query-target-filter=eq(fvSubnet.ip, \"10.100.100.1/24\")" in get_subnets_gateway.filter_string'

--- a/test/integration/targets/aci_config_rollback/tasks/main.yml
+++ b/test/integration/targets/aci_config_rollback/tasks/main.yml
@@ -49,15 +49,15 @@
     <<: *create_snapshot
     state: preview
     compare_export_policy: anstest
-    compare_snapshot: "{{ snapshots.previous.0.configSnapshotCont.children[-1].configSnapshot.attributes.name }}"
-    snapshot: "{{ snapshots.previous.0.configSnapshotCont.children[-2].configSnapshot.attributes.name }}"
+    compare_snapshot: "{{ snapshots.current.0.configSnapshotCont.children[-1].configSnapshot.attributes.name }}"
+    snapshot: "{{ snapshots.current.0.configSnapshotCont.children[-2].configSnapshot.attributes.name }}"
   register: rollback_preview
 
 - name: rollback to snapshot
   aci_config_rollback: &aci_rollback
     <<: *create_snapshot
     state: rollback
-    snapshot: "{{ snapshots.previous.0.configSnapshotCont.children[-1].configSnapshot.attributes.name }}"
+    snapshot: "{{ snapshots.current.0.configSnapshotCont.children[-1].configSnapshot.attributes.name }}"
   ignore_errors: yes
   register: rollback_missing_param
 
@@ -69,7 +69,7 @@
     import_mode: atomic
   register: rollback_rollback
 
-- name: pause execution to let rollback take affect
+- name: pause execution to let rollback take effect
   pause:
     seconds: 15
 

--- a/test/integration/targets/aci_config_snapshot/tasks/main.yml
+++ b/test/integration/targets/aci_config_snapshot/tasks/main.yml
@@ -67,7 +67,7 @@
 
 - name: generate snapshot name
   set_fact:
-    test_snapshot: "{{ query_export.previous.0.configSnapshotCont.children.0.configSnapshot.attributes.rn.strip('snapshot-') }}"
+    test_snapshot: "{{ query_export.current.0.configSnapshotCont.children.0.configSnapshot.attributes.rn.strip('snapshot-') }}"
 
 - name: query with export_policy and snapshot
   aci_config_snapshot: &query_both
@@ -94,12 +94,12 @@
       - query_export.failed == false
       - query_export.changed == false
       - '"snapshots-[uni/fabric/configexp-anstest].json" in query_export.url'
-      - query_export.previous.0.configSnapshotCont.attributes.name == "anstest"
-      - query_export.previous.0.configSnapshotCont.children | length > 1
+      - query_export.current.0.configSnapshotCont.attributes.name == "anstest"
+      - query_export.current.0.configSnapshotCont.children | length > 1
       - query_export_snapshot.failed == false
       - query_export_snapshot.changed == false
       - '"snapshots-[uni/fabric/configexp-anstest]/snapshot-{{ test_snapshot }}.json" in query_export_snapshot.url'
-      - query_export_snapshot.previous | length == 1
+      - query_export_snapshot.current | length == 1
       - query_snapshot.failed == false
       - query_snapshot.changed == false
       - '"class/configSnapshot.json" in query_snapshot.url'
@@ -107,7 +107,7 @@
       - query_all.failed == false
       - query_all.changed == false
       - '"class/configSnapshot.json" in query_all.url'
-      - query_all.previous | length > 1
+      - query_all.current | length > 1
 
 - name: delete works
   aci_config_snapshot: &delete

--- a/test/integration/targets/aci_contract/tasks/main.yml
+++ b/test/integration/targets/aci_contract/tasks/main.yml
@@ -100,19 +100,19 @@
   assert:
     that:
       - query_contract.changed == false
-      - query_contract.previous | length == 1
+      - query_contract.current | length == 1
       - '"tn-anstest/brc-anstest.json" in query_contract.url'
       - query_tenant.changed == false
-      - query_tenant.previous | length == 1
-      - query_tenant.previous.0.fvTenant.children | length > 1
+      - query_tenant.current | length == 1
+      - query_tenant.current.0.fvTenant.children | length > 1
       - '"rsp-subtree-class=vzBrCP" in query_tenant.filter_string'
       - '"tn-anstest.json" in query_tenant.url'
       - query_name.changed == false
-      - query_name.previous != []
+      - query_name.current != []
       - '"query-target-filter=eq(vzBrCP.name, \"anstest\")" in query_name.filter_string'
       - '"class/vzBrCP.json" in query_name.url'
       - query_all.changed == false
-      - query_all.previous | length > 1
+      - query_all.current | length > 1
       - '"class/vzBrCP.json" in query_all.url'
 
 - name: delete contract - check mode works

--- a/test/integration/targets/aci_contract_subject/tasks/main.yml
+++ b/test/integration/targets/aci_contract_subject/tasks/main.yml
@@ -142,48 +142,48 @@
   assert:
     that:
       - query_tenant_contract_subject.changed == false
-      - query_tenant_contract_subject.previous | length == 1
-      - 'query_tenant_contract_subject.previous.0.vzSubj.attributes.name == "anstest"'
+      - query_tenant_contract_subject.current | length == 1
+      - 'query_tenant_contract_subject.current.0.vzSubj.attributes.name == "anstest"'
       - '"tn-anstest/brc-anstest/subj-anstest.json" in query_tenant_contract_subject.url'
       - query_tenant_contract.changed == false
-      - query_tenant_contract.previous | length == 1
-      - 'query_tenant_contract.previous.0.vzBrCP.attributes.name == "anstest"'
-      - query_tenant_contract.previous.0.vzBrCP.children | length == 2
+      - query_tenant_contract.current | length == 1
+      - 'query_tenant_contract.current.0.vzBrCP.attributes.name == "anstest"'
+      - query_tenant_contract.current.0.vzBrCP.children | length == 2
       - '"rsp-subtree-class=vzSubj" in query_tenant_contract.filter_string'
       - '"tn-anstest/brc-anstest.json" in query_tenant_contract.url'
       - query_tenant_subject.changed == false
-      - query_tenant_subject.previous | length == 1
-      - 'query_tenant_subject.previous.0.fvTenant.attributes.name == "anstest"'
-      - query_tenant_subject.previous.0.fvTenant.children.0.vzBrCP.children | length == 1
-      - 'query_tenant_subject.previous.0.fvTenant.children.0.vzBrCP.children.0.vzSubj.attributes.name == "anstest"'
+      - query_tenant_subject.current | length == 1
+      - 'query_tenant_subject.current.0.fvTenant.attributes.name == "anstest"'
+      - query_tenant_subject.current.0.fvTenant.children.0.vzBrCP.children | length == 1
+      - 'query_tenant_subject.current.0.fvTenant.children.0.vzBrCP.children.0.vzSubj.attributes.name == "anstest"'
       - '"rsp-subtree-filter=eq(vzSubj.name, \"anstest\")" in query_tenant_subject.filter_string'
       - '"rsp-subtree-class=vzSubj" in query_tenant_subject.filter_string'
       - '"tn-anstest.json" in query_tenant_subject.url'
       - query_contract_subject.changed == false
-      - 'query_contract_subject.previous.0.vzBrCP.attributes.name == "anstest"'
-      - query_contract_subject.previous.0.vzBrCP.children | length == 1
-      - 'query_contract_subject.previous.0.vzBrCP.children.0.vzSubj.attributes.name == "anstest"'
+      - 'query_contract_subject.current.0.vzBrCP.attributes.name == "anstest"'
+      - query_contract_subject.current.0.vzBrCP.children | length == 1
+      - 'query_contract_subject.current.0.vzBrCP.children.0.vzSubj.attributes.name == "anstest"'
       - '"query-target-filter=eq(vzBrCP.name, \"anstest\")" in query_contract_subject.filter_string'
       - '"rsp-subtree-filter=eq(vzSubj.name, \"anstest\")" in query_contract_subject.filter_string'
       - '"rsp-subtree-class=vzSubj" in query_contract_subject.filter_string'
       - '"class/vzBrCP.json" in query_contract_subject.url'
       - query_tenant.changed == false
-      - query_tenant.previous | length == 1
-      - 'query_tenant.previous.0.fvTenant.attributes.name == "anstest"'
+      - query_tenant.current | length == 1
+      - 'query_tenant.current.0.fvTenant.attributes.name == "anstest"'
       - '"rsp-subtree-class=vzBrCP,vzSubj" in query_tenant.filter_string'
       - '"tn-anstest.json" in query_tenant.url'
       - query_contract.changed == false
-      - 'query_contract.previous.0.vzBrCP.attributes.name == "anstest"'
+      - 'query_contract.current.0.vzBrCP.attributes.name == "anstest"'
       - '"query-target-filter=eq(vzBrCP.name, \"anstest\")" in query_contract.filter_string'
       - '"rsp-subtree-class=vzSubj" in query_contract.filter_string'
       - '"class/vzBrCP.json" in query_contract.url'
       - query_subject.changed == false
-      - 'query_subject.previous.0.vzSubj.attributes.name == "anstest"'
+      - 'query_subject.current.0.vzSubj.attributes.name == "anstest"'
       - '"query-target-filter=eq(vzSubj.name, \"anstest\")" in query_subject.filter_string'
       - '"class/vzSubj.json" in query_subject.url'
       - query_all.changed == false
-      - query_all.previous > 1
-      - query_all.previous.0.vzSubj is defined
+      - query_all.current > 1
+      - query_all.current.0.vzSubj is defined
       - '"class/vzSubj.json" in query_all.url'
 
 - name: delete subject - check mode works

--- a/test/integration/targets/aci_contract_subject_to_filter/tasks/main.yml
+++ b/test/integration/targets/aci_contract_subject_to_filter/tasks/main.yml
@@ -115,10 +115,10 @@
   assert:
     that:
       - query_all.changed == false
-      - query_all.previous | length > 1
-      - query_all.previous.0.vzRsSubjFiltAtt is defined
+      - query_all.current | length > 1
+      - query_all.current.0.vzRsSubjFiltAtt is defined
       - query_binding.changed == false
-      - query_binding.previous != []
+      - query_binding.current != []
 
 - name: delete subject filter binding - check mode works
   aci_contract_subject_to_filter: &aci_subject_filter_absent

--- a/test/integration/targets/aci_encap_pool/tasks/vlan.yml
+++ b/test/integration/targets/aci_encap_pool/tasks/vlan.yml
@@ -158,7 +158,7 @@
     that:
       - get_all_pools.changed == false
       - get_all_pools.method == "GET"
-      - get_all_pools.previous | length > 1
+      - get_all_pools.current | length > 1
 
 - name: get created static vlan pool - get mo works
   aci_encap_pool:
@@ -171,9 +171,9 @@
     that:
       - get_static_pool.changed == false
       - get_static_pool.method == "GET"
-      - get_static_pool.previous | length == 1
-      - get_static_pool.previous.0.fvnsVlanInstP.attributes.allocMode == "static"
-      - get_static_pool.previous.0.fvnsVlanInstP.attributes.name == "anstest"
+      - get_static_pool.current | length == 1
+      - get_static_pool.current.0.fvnsVlanInstP.attributes.allocMode == "static"
+      - get_static_pool.current.0.fvnsVlanInstP.attributes.name == "anstest"
 
 - name: get created dynamic vlan pool - get mo works
   aci_encap_pool:
@@ -186,9 +186,9 @@
     that:
       - get_dynamic_pool.changed == false
       - get_dynamic_pool.method == "GET"
-      - get_dynamic_pool.previous | length == 1
-      - get_dynamic_pool.previous.0.fvnsVlanInstP.attributes.allocMode == "dynamic"
-      - get_dynamic_pool.previous.0.fvnsVlanInstP.attributes.name == "anstest"
+      - get_dynamic_pool.current | length == 1
+      - get_dynamic_pool.current.0.fvnsVlanInstP.attributes.allocMode == "dynamic"
+      - get_dynamic_pool.current.0.fvnsVlanInstP.attributes.name == "anstest"
 
 - name: get created dynamic vlan pool - get mo works
   aci_encap_pool:

--- a/test/integration/targets/aci_encap_pool/tasks/vxlan.yml
+++ b/test/integration/targets/aci_encap_pool/tasks/vxlan.yml
@@ -97,7 +97,7 @@
   assert:
     that:
       - query_vxlan.changed == false
-      - query_vxlan.previous | length == 1
+      - query_vxlan.current | length == 1
       - '"infra/vxlanns-anstest.json" in query_vxlan.url'
 
 - name: get created static vlan pool - get class works
@@ -110,7 +110,7 @@
   assert:
     that:
       - query_vxlan_all.changed == false
-      - query_vxlan_all.previous | length > 1
+      - query_vxlan_all.current | length > 1
       - '"class/fvnsVxlanInstP.json" in query_vxlan_all.url'
 
 - name: delete vxlan pool - check mode works

--- a/test/integration/targets/aci_encap_pool_range/tasks/vlan.yml
+++ b/test/integration/targets/aci_encap_pool_range/tasks/vlan.yml
@@ -213,8 +213,8 @@
     that:
       - range_query.changed == false
       - range_query.url.endswith("infra/vlanns-[anstest]-static/from-[vlan-20]-to-[vlan-40].json")
-      - range_query.previous | length == 1
-      - 'range_query.previous.0.fvnsEncapBlk.attributes.name == "anstest"'
+      - range_query.current | length == 1
+      - 'range_query.current.0.fvnsEncapBlk.attributes.name == "anstest"'
 
 - name: query vlan pool range - from, to, and name are filtered
   aci_encap_pool_range: &aci_range_query_filter
@@ -228,9 +228,9 @@
       - range_query_from_to_name.changed == false
       - 'range_query_from_to_name.url.endswith("class/fvnsEncapBlk.json")'
       - '"query-target-filter=and(eq(fvnsEncapBlk.from, \"vlan-20\"),eq(fvnsEncapBlk.to, \"vlan-40\"),eq(fvnsEncapBlk.name, \"anstest\"))" in range_query_from_to_name.filter_string'
-      - 'range_query_from_to_name.previous.0.fvnsEncapBlk.attributes.name == "anstest"'
-      - 'range_query_from_to_name.previous.0.fvnsEncapBlk.attributes.from == "vlan-20"'
-      - 'range_query_from_to_name.previous.0.fvnsEncapBlk.attributes.to == "vlan-40"'
+      - 'range_query_from_to_name.current.0.fvnsEncapBlk.attributes.name == "anstest"'
+      - 'range_query_from_to_name.current.0.fvnsEncapBlk.attributes.from == "vlan-20"'
+      - 'range_query_from_to_name.current.0.fvnsEncapBlk.attributes.to == "vlan-40"'
 
 - name: query vlan pool range - from and name are filtered
   aci_encap_pool_range:
@@ -244,8 +244,8 @@
       - range_query_from_name.changed == false
       - 'range_query_from_name.url.endswith("class/fvnsEncapBlk.json")'
       - '"query-target-filter=and(eq(fvnsEncapBlk.from, \"vlan-20\"),eq(fvnsEncapBlk.name, \"anstest\"))" in range_query_from_name.filter_string'
-      - 'range_query_from_name.previous.0.fvnsEncapBlk.attributes.name == "anstest"'
-      - 'range_query_from_name.previous.0.fvnsEncapBlk.attributes.from == "vlan-20"'
+      - 'range_query_from_name.current.0.fvnsEncapBlk.attributes.name == "anstest"'
+      - 'range_query_from_name.current.0.fvnsEncapBlk.attributes.from == "vlan-20"'
 
 - name: query vlan pool range - to and name are filtered
   aci_encap_pool_range:
@@ -259,8 +259,8 @@
       - range_query_to_name.changed == false
       - 'range_query_to_name.url.endswith("class/fvnsEncapBlk.json")'
       - '"query-target-filter=and(eq(fvnsEncapBlk.to, \"vlan-40\"),eq(fvnsEncapBlk.name, \"anstest\"))" in range_query_to_name.filter_string'
-      - 'range_query_to_name.previous.0.fvnsEncapBlk.attributes.name == "anstest"'
-      - 'range_query_to_name.previous.0.fvnsEncapBlk.attributes.to == "vlan-40"'
+      - 'range_query_to_name.current.0.fvnsEncapBlk.attributes.name == "anstest"'
+      - 'range_query_to_name.current.0.fvnsEncapBlk.attributes.to == "vlan-40"'
 
 - name: query vlan pool range - name is filtered
   aci_encap_pool_range:
@@ -275,7 +275,7 @@
       - range_query_name.changed == false
       - 'range_query_name.url.endswith("class/fvnsEncapBlk.json")'
       - '"query-target-filter=eq(fvnsEncapBlk.name, \"anstest\")" in range_query_name.filter_string'
-      - 'range_query_name.previous.0.fvnsEncapBlk.attributes.name == "anstest"'
+      - 'range_query_name.current.0.fvnsEncapBlk.attributes.name == "anstest"'
 
 - name: query vlan pool range - from and to are filtered
   aci_encap_pool_range:
@@ -289,8 +289,8 @@
       - range_query_from_to.changed == false
       - 'range_query_from_to.url.endswith("class/fvnsEncapBlk.json")'
       - '"query-target-filter=and(eq(fvnsEncapBlk.from, \"vlan-20\"),eq(fvnsEncapBlk.to, \"vlan-40\"))" in range_query_from_to.filter_string'
-      - 'range_query_from_to.previous.0.fvnsEncapBlk.attributes.from == "vlan-20"'
-      - 'range_query_from_to.previous.0.fvnsEncapBlk.attributes.to == "vlan-40"'
+      - 'range_query_from_to.current.0.fvnsEncapBlk.attributes.from == "vlan-20"'
+      - 'range_query_from_to.current.0.fvnsEncapBlk.attributes.to == "vlan-40"'
 
 - name: query all ranges in a vlan pool
   aci_encap_pool_range:
@@ -302,9 +302,9 @@
 - name: query assertions
   assert:
     that:
-      - range_query_pool.previous | length == 1
-      - 'range_query_pool.previous.0.fvnsVlanInstP.attributes.name == "anstest"'
-      - range_query_pool.previous.0.fvnsVlanInstP.children | length > 1
+      - range_query_pool.current | length == 1
+      - 'range_query_pool.current.0.fvnsVlanInstP.attributes.name == "anstest"'
+      - range_query_pool.current.0.fvnsVlanInstP.children | length > 1
       - 'range_query_pool.url.endswith("infra/vlanns-[anstest]-static.json")'
 
 - name: query all ranges
@@ -318,8 +318,8 @@
   assert:
     that:
       - range_query_all.changed == false
-      - range_query_all.previous | length > 1
-      - range_query_all.previous.0.fvnsEncapBlk is defined
+      - range_query_all.current | length > 1
+      - range_query_all.current.0.fvnsEncapBlk is defined
       - 'range_query_all.url.endswith("class/fvnsEncapBlk.json")'
 
 - name: delete vlan pool range - deletion works

--- a/test/integration/targets/aci_epg/tasks/main.yml
+++ b/test/integration/targets/aci_epg/tasks/main.yml
@@ -103,11 +103,11 @@
   assert:
     that:
       - epg_query.changed == false
-      - epg_query.previous | length == 1
-      - 'epg_query.previous.0.fvAEPg.attributes.name == "anstest"'
+      - epg_query.current | length == 1
+      - 'epg_query.current.0.fvAEPg.attributes.name == "anstest"'
       - '"tn-anstest/ap-anstest/epg-anstest.json" in epg_query.url'
       - epg_query_all.changed == false
-      - epg_query_all.previous | length > 1
+      - epg_query_all.current | length > 1
       - '"rsp-subtree-class=fvRsBd" in epg_query_all.filter_string'
       - '"class/fvAEPg.json" in epg_query_all.url'
 

--- a/test/integration/targets/aci_epg_to_contract/tasks/main.yml
+++ b/test/integration/targets/aci_epg_to_contract/tasks/main.yml
@@ -142,10 +142,10 @@
   assert:
     that:
       - query_provide_contract.changed == false
-      - query_provide_contract.previous != []
+      - query_provide_contract.current != []
       - '"class/fvRsProv.json" in query_provide_contract.url'
       - query_consume_contract.changed == false
-      - query_consume_contract.previous != []
+      - query_consume_contract.current != []
       - '"class/fvRsCons.json" in query_consume_contract.url'
       - query_all.changed == false
       - '"class/fvRsProv.json" in query_all.url'

--- a/test/integration/targets/aci_epg_to_domain/tasks/main.yml
+++ b/test/integration/targets/aci_epg_to_domain/tasks/main.yml
@@ -139,7 +139,7 @@
   assert:
     that:
       - binding_query.changed == false
-      - binding_query.previous | length > 1
+      - binding_query.current | length > 1
       - '"class/fvRsDomAtt.json" in binding_query.url'
 
 - name: delete domain epg binding - check mode

--- a/test/integration/targets/aci_filter_entry/tasks/main.yml
+++ b/test/integration/targets/aci_filter_entry/tasks/main.yml
@@ -188,44 +188,44 @@
   assert:
     that:
       - query_tenant_filter_entry.changed == false
-      - query_tenant_filter_entry.previous | length == 1
-      - 'query_tenant_filter_entry.previous.0.vzEntry.attributes.name == "anstest"'
+      - query_tenant_filter_entry.current | length == 1
+      - 'query_tenant_filter_entry.current.0.vzEntry.attributes.name == "anstest"'
       - '"tn-anstest/flt-anstest/e-anstest.json" in query_tenant_filter_entry.url'
       - query_filter_entry.changed == false
-      - 'query_filter_entry.previous.0.vzFilter.attributes.name == "anstest"'
-      - query_filter_entry.previous.0.vzFilter.children | length == 1
+      - 'query_filter_entry.current.0.vzFilter.attributes.name == "anstest"'
+      - query_filter_entry.current.0.vzFilter.children | length == 1
       - '"query-target-filter=eq(vzFilter.name, \"anstest\")" in query_filter_entry.filter_string'
       - '"rsp-subtree-filter=eq(vzEntry.name, \"anstest\")" in query_filter_entry.filter_string'
       - '"class/vzFilter.json" in query_filter_entry.url'
       - query_tenant_entry.changed == false
-      - query_tenant_entry.previous | length == 1
-      - 'query_tenant_entry.previous.0.fvTenant.attributes.name == "anstest"'
+      - query_tenant_entry.current | length == 1
+      - 'query_tenant_entry.current.0.fvTenant.attributes.name == "anstest"'
       - '"rsp-subtree-filter=eq(vzEntry.name, \"anstest\")" in query_tenant_entry.filter_string'
       - '"rsp-subtree-class=vzEntry" in query_tenant_entry.filter_string'
       - '"tn-anstest.json" in query_tenant_entry.url'
       - query_tenant_filter.changed == false
-      - query_tenant_filter.previous | length == 1
-      - 'query_tenant_filter.previous.0.vzFilter.attributes.name == "anstest"'
-      - query_tenant_filter.previous.0.vzFilter.children | length == 4
+      - query_tenant_filter.current | length == 1
+      - 'query_tenant_filter.current.0.vzFilter.attributes.name == "anstest"'
+      - query_tenant_filter.current.0.vzFilter.children | length == 4
       - '"rsp-subtree-class=vzEntry" in query_tenant_filter.filter_string'
       - '"tn-anstest/flt-anstest.json" in query_tenant_filter.url'
       - query_entry.changed == false
-      - 'query_entry.previous.0.vzEntry.attributes.name == "anstest"'
+      - 'query_entry.current.0.vzEntry.attributes.name == "anstest"'
       - '"query-target-filter=eq(vzEntry.name, \"anstest\")" in query_entry.filter_string'
       - '"class/vzEntry.json" in query_entry.url'
       - query_filter.changed == false
-      - 'query_filter.previous.0.vzFilter.attributes.name == "anstest"'
+      - 'query_filter.current.0.vzFilter.attributes.name == "anstest"'
       - '"query-target-filter=eq(vzFilter.name, \"anstest\")" in query_filter.filter_string'
       - '"rsp-subtree-class=vzEntry" in query_filter.filter_string'
       - '"class/vzFilter.json" in query_filter.url'
       - query_tenant.changed == false
-      - query_tenant.previous | length == 1
-      - 'query_tenant.previous.0.fvTenant.attributes.name == "anstest"'
+      - query_tenant.current | length == 1
+      - 'query_tenant.current.0.fvTenant.attributes.name == "anstest"'
       - '"rsp-subtree-class=vzFilter,vzEntry" in query_tenant.filter_string'
       - '"tn-anstest.json" in query_tenant.url'
       - query_all.changed == false
-      - query_all.previous | length > 1
-      - query_all.previous.0.vzEntry is defined
+      - query_all.current | length > 1
+      - query_all.current.0.vzEntry is defined
       - '"class/vzEntry.json" in query_all.url'
 
 - name: delete entry - check mode works

--- a/test/integration/targets/aci_interface_policy_leaf_policy_group/tasks/main.yml
+++ b/test/integration/targets/aci_interface_policy_leaf_policy_group/tasks/main.yml
@@ -114,7 +114,7 @@
   assert:
     that:
       - binding_query.changed == false
-      - binding_query.previous | length >= 1
+      - binding_query.current | length >= 1
       - '"/api/mo/uni/infra/funcprof/accbundle-policygroupname.json" in binding_query.url'
 
 - name: Remove interface policy leaf policy group (PC) - check mode
@@ -233,7 +233,7 @@
   assert:
     that:
       - binding_query.changed == false
-      - binding_query.previous | length >= 1
+      - binding_query.current | length >= 1
       - '"/api/mo/uni/infra/funcprof/accbundle-policygroupname.json" in binding_query.url'
 
 - name: Remove interface policy leaf policy group (VPC) - check mode
@@ -360,7 +360,7 @@
   assert:
     that:
       - binding_query.changed == false
-      - binding_query.previous | length >= 1
+      - binding_query.current | length >= 1
       - '"/api/mo/uni/infra/funcprof/accportgrp-policygroupname.json" in binding_query.url'
 
 - name: Remove interface policy leaf policy group (Leaf Access Port) - check mode

--- a/test/integration/targets/aci_interface_selector_to_switch_policy_leaf_profile/tasks/main.yml
+++ b/test/integration/targets/aci_interface_selector_to_switch_policy_leaf_profile/tasks/main.yml
@@ -95,7 +95,7 @@
   assert:
     that:
       - binding_query.changed == false
-      - binding_query.previous | length >= 1
+      - binding_query.current | length >= 1
       - '"api/mo/uni/infra/nprof-swleafprftest/rsaccPortP-[uni/infra/accportprof-leafintprftest].json" in binding_query.url'
 
 - name: Remove binding of interface access port selector and Interface Policy Leaf Profile - check mode

--- a/test/integration/targets/aci_switch_leaf_selector/tasks/main.yml
+++ b/test/integration/targets/aci_switch_leaf_selector/tasks/main.yml
@@ -84,7 +84,7 @@
   assert:
     that:
       - binding_query.changed == false
-      - binding_query.previous | length >= 1
+      - binding_query.current | length >= 1
       - '"api/mo/uni/infra/nprof-sw_name_test/leaves-leaf_selector_name-typ-range.json" in binding_query.url'
 
 - name: Remove binding of interface access port selector and Interface Policy Leaf Profile - check mode

--- a/test/integration/targets/aci_vlan_pool_encap_block/tasks/main.yml
+++ b/test/integration/targets/aci_vlan_pool_encap_block/tasks/main.yml
@@ -209,8 +209,8 @@
     that:
       - encap_block_query.changed == false
       - encap_block_query.url.endswith("infra/vlanns-[anstest]-static/from-[vlan-20]-to-[vlan-40].json")
-      - encap_block_query.previous | length == 1
-      - encap_block_query.previous.0.fvnsEncapBlk.attributes.name == "anstest"
+      - encap_block_query.current | length == 1
+      - encap_block_query.current.0.fvnsEncapBlk.attributes.name == "anstest"
 
 - name: Query vlan pool range - from, to, and name are filtered
   aci_vlan_pool_encap_block: &aci_encap_block_query_filter
@@ -224,9 +224,9 @@
       - encap_block_query_from_to_name.changed == false
       - encap_block_query_from_to_name.url.endswith("class/fvnsEncapBlk.json")
       - '"query-target-filter=and(eq(fvnsEncapBlk.from, \"vlan-20\"),eq(fvnsEncapBlk.to, \"vlan-40\"),eq(fvnsEncapBlk.name, \"anstest\"))" in encap_block_query_from_to_name.filter_string'
-      - encap_block_query_from_to_name.previous.0.fvnsEncapBlk.attributes.name == "anstest"
-      - encap_block_query_from_to_name.previous.0.fvnsEncapBlk.attributes.from == "vlan-20"
-      - encap_block_query_from_to_name.previous.0.fvnsEncapBlk.attributes.to == "vlan-40"
+      - encap_block_query_from_to_name.current.0.fvnsEncapBlk.attributes.name == "anstest"
+      - encap_block_query_from_to_name.current.0.fvnsEncapBlk.attributes.from == "vlan-20"
+      - encap_block_query_from_to_name.current.0.fvnsEncapBlk.attributes.to == "vlan-40"
 
 - name: Query vlan pool range - from and name are filtered
   aci_vlan_pool_encap_block:
@@ -240,8 +240,8 @@
       - encap_block_query_from_name.changed == false
       - encap_block_query_from_name.url.endswith("class/fvnsEncapBlk.json")
       - '"query-target-filter=and(eq(fvnsEncapBlk.from, \"vlan-20\"),eq(fvnsEncapBlk.name, \"anstest\"))" in encap_block_query_from_name.filter_string'
-      - encap_block_query_from_name.previous.0.fvnsEncapBlk.attributes.name == "anstest"
-      - encap_block_query_from_name.previous.0.fvnsEncapBlk.attributes.from == "vlan-20"
+      - encap_block_query_from_name.current.0.fvnsEncapBlk.attributes.name == "anstest"
+      - encap_block_query_from_name.current.0.fvnsEncapBlk.attributes.from == "vlan-20"
 
 - name: Query vlan pool range - to and name are filtered
   aci_vlan_pool_encap_block:
@@ -255,8 +255,8 @@
       - encap_block_query_to_name.changed == false
       - encap_block_query_to_name.url.endswith("class/fvnsEncapBlk.json")
       - '"query-target-filter=and(eq(fvnsEncapBlk.to, \"vlan-40\"),eq(fvnsEncapBlk.name, \"anstest\"))" in encap_block_query_to_name.filter_string'
-      - encap_block_query_to_name.previous.0.fvnsEncapBlk.attributes.name == "anstest"
-      - encap_block_query_to_name.previous.0.fvnsEncapBlk.attributes.to == "vlan-40"
+      - encap_block_query_to_name.current.0.fvnsEncapBlk.attributes.name == "anstest"
+      - encap_block_query_to_name.current.0.fvnsEncapBlk.attributes.to == "vlan-40"
 
 - name: Query vlan pool range - name is filtered
   aci_vlan_pool_encap_block:
@@ -271,7 +271,7 @@
       - encap_block_query_name.changed == false
       - encap_block_query_name.url.endswith("class/fvnsEncapBlk.json")
       - '"query-target-filter=eq(fvnsEncapBlk.name, \"anstest\")" in encap_block_query_name.filter_string'
-      - encap_block_query_name.previous.0.fvnsEncapBlk.attributes.name == "anstest"
+      - encap_block_query_name.current.0.fvnsEncapBlk.attributes.name == "anstest"
 
 - name: Query vlan pool range - from and to are filtered
   aci_vlan_pool_encap_block:
@@ -285,8 +285,8 @@
       - encap_block_query_from_to.changed == false
       - encap_block_query_from_to.url.endswith("class/fvnsEncapBlk.json")
       - '"query-target-filter=and(eq(fvnsEncapBlk.from, \"vlan-20\"),eq(fvnsEncapBlk.to, \"vlan-40\"))" in encap_block_query_from_to.filter_string'
-      - encap_block_query_from_to.previous.0.fvnsEncapBlk.attributes.from == "vlan-20"
-      - encap_block_query_from_to.previous.0.fvnsEncapBlk.attributes.to == "vlan-40"
+      - encap_block_query_from_to.current.0.fvnsEncapBlk.attributes.from == "vlan-20"
+      - encap_block_query_from_to.current.0.fvnsEncapBlk.attributes.to == "vlan-40"
 
 - name: Query all ranges in a vlan pool
   aci_vlan_pool_encap_block:
@@ -298,9 +298,9 @@
 - name: Query assertions
   assert:
     that:
-      - encap_block_query_pool.previous | length == 1
-      - encap_block_query_pool.previous.0.fvnsVlanInstP.attributes.name == "anstest"
-      - encap_block_query_pool.previous.0.fvnsVlanInstP.children | length > 1
+      - encap_block_query_pool.current | length == 1
+      - encap_block_query_pool.current.0.fvnsVlanInstP.attributes.name == "anstest"
+      - encap_block_query_pool.current.0.fvnsVlanInstP.children | length > 1
       - encap_block_query_pool.url.endswith("infra/vlanns-[anstest]-static.json")
 
 - name: Query all ranges
@@ -314,8 +314,8 @@
   assert:
     that:
       - encap_block_query_all.changed == false
-      - encap_block_query_all.previous | length > 1
-      - encap_block_query_all.previous.0.fvnsEncapBlk is defined
+      - encap_block_query_all.current | length > 1
+      - encap_block_query_all.current.0.fvnsEncapBlk is defined
       - encap_block_query_all.url.endswith("class/fvnsEncapBlk.json")
 
 - name: Delete vlan pool range - deletion works

--- a/test/integration/targets/aci_vrf/tasks/main.yml
+++ b/test/integration/targets/aci_vrf/tasks/main.yml
@@ -107,22 +107,22 @@
   assert:
     that:
       - query_all.changed == false
-      - query_all.previous | length > 1
-      - query_all.previous.0.fvCtx is defined
+      - query_all.current | length > 1
+      - query_all.current.0.fvCtx is defined
       - '"class/fvCtx.json" in query_all.url'
       - query_tenant.changed == false
-      - query_tenant.previous | length == 1
-      - query_tenant.previous.0.fvTenant.children | length == 2
-      - 'query_tenant.previous.0.fvTenant.attributes.name == "anstest"'
+      - query_tenant.current | length == 1
+      - query_tenant.current.0.fvTenant.children | length == 2
+      - 'query_tenant.current.0.fvTenant.attributes.name == "anstest"'
       - '"rsp-subtree-class=fvCtx" in query_tenant.filter_string'
       - '"tn-anstest.json" in query_tenant.url'
       - query_vrf_vrf.changed == false
-      - query_vrf_vrf.previous != []
-      - 'query_vrf_vrf.previous.0.fvCtx.attributes.name == "anstest"'
+      - query_vrf_vrf.current != []
+      - 'query_vrf_vrf.current.0.fvCtx.attributes.name == "anstest"'
       - '"query-target-filter=eq(fvCtx.name, \"anstest\")" in query_vrf_vrf.filter_string'
       - '"class/fvCtx.json" in query_vrf_vrf.url'
       - query_vrf.changed == false
-      - query_vrf.previous | length == 1
+      - query_vrf.current | length == 1
       - '"tn-anstest/ctx-anstest.json" in query_vrf.url'
 
 - name: delete vrf - check mode works


### PR DESCRIPTION
##### SUMMARY
When ACI modules are being used for querying MOs, we should not return
the previous state, as there is no previous state, there's only the
current state.

This impacts a lot of tests that were used to testing the current state
as 'previous'.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
aci modules

##### ANSIBLE VERSION
v2.5