### PR TITLE
Fix Porting Guide links for Ansible 2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Ansible Changes By Release
 
 ## 2.5 "Kashmir" - March 2018 (estimated)
 
-[Porting Guide](http://docs.ansible.com/ansible/devel/porting_guides.html)
+[Porting Guide](https://docs.ansible.com/ansible/devel/porting_guides/porting_guide_2.5.html)
 
 ### Major Changes
 * Removed the previously deprecated 'accelerate' mode and all associated keywords and code.
@@ -57,7 +57,7 @@ Ansible Changes By Release
 * panos_security_policy: Use panos_security_rule - the old module uses deprecated API calls
 * vsphere_guest is deprecated in Ansible 2.5 and will be removed in Ansible-2.9. Use vmware_guest module instead.
 
-See [Porting Guide](http://docs.ansible.com/ansible/devel/porting_guides.html) for more information
+See [Porting Guide](https://docs.ansible.com/ansible/devel/porting_guides/porting_guide_2.5.html) for more information
 
 ### Minor Changes
 * added a few new magic vars corresponding to configuration/command line options:


### PR DESCRIPTION
##### SUMMARY
Fix Porting Guide links for Ansible 2.5

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
-

##### ANSIBLE VERSION
-

##### ADDITIONAL INFORMATION
The current links result in 404 Not Found. Also changed protocol to HTTPS.

Could also link to https://docs.ansible.com/ansible/devel/porting_guides/porting_guides.html, but I figured the link to the specific version's guide is more appropriate.