### PR TITLE
Add stub porting_guide_2.6.rst

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Ansible Changes By Release
 
 ### Deprecations (to be removed in 2.10)
 
-See [Porting Guide](http://docs.ansible.com/ansible/devel/porting_guides/porting_guides.htmlthat's ) for more information
+See [Porting Guide](http://docs.ansible.com/ansible/devel/porting_guides/porting_guides.html) for more information
 
 ### Minor Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,13 @@ Ansible Changes By Release
 
 ## 2.6 "Heartbreaker" - ACTIVE DEVELOPMENT
 
+[Porting Guide](http://docs.ansible.com/ansible/devel/porting_guides/porting_guides.html)
+
 ### Major Changes
 
 ### Deprecations (to be removed in 2.10)
+
+See [Porting Guide](http://docs.ansible.com/ansible/devel/porting_guides/porting_guides.htmlthat's ) for more information
 
 ### Minor Changes
 

--- a/docs/docsite/rst/porting_guides/porting_guide_2.6.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.6.rst
@@ -1,0 +1,65 @@
+.. _porting_2.6_guide:
+
+*************************
+Ansible 2.6 Porting Guide
+*************************
+
+This section discusses the behavioral changes between Ansible 2.5 and Ansible 2.6.
+
+It is intended to assist in updating your playbooks, plugins and other parts of your Ansible infrastructure so they will work with this version of Ansible.
+
+We suggest you read this page along with `Ansible Changelog <https://github.com/ansible/ansible/blob/devel/CHANGELOG.md#2.6>`_ to understand what updates you may need to make.
+
+This document is part of a collection on porting. The complete list of porting guides can be found at :ref:`porting guides <porting_guides>`.
+
+.. contents:: Topics
+
+Playbook
+========
+
+No notable changes.
+
+Deprecated
+==========
+
+No notable changes.
+
+Modules
+=======
+
+Major changes in popular modules are detailed here
+
+
+
+Modules removed
+---------------
+
+The following modules no longer exist:
+
+
+Deprecation notices
+-------------------
+
+The following modules will be removed in Ansible 2.10. Please update update your playbooks accordingly.
+
+
+Noteworthy module changes
+-------------------------
+
+No notable changes.
+
+Plugins
+=======
+
+No notable changes.
+
+Porting custom scripts
+======================
+
+No notable changes.
+
+Networking
+==========
+
+No notable changes.
+

--- a/docs/docsite/rst/porting_guides/porting_guides.rst
+++ b/docs/docsite/rst/porting_guides/porting_guides.rst
@@ -13,3 +13,4 @@ This section lists porting guides that can help you playbooks, plugins and other
    porting_guide_2.3
    porting_guide_2.4
    porting_guide_2.5
+   porting_guide_2.6


### PR DESCRIPTION
##### SUMMARY
We've branched, so time for stub `porting_guide`

Define the structure so people can add details during Ansible 2.6 development