### PR TITLE
Allow removed_in: "2.10"

### DIFF
--- a/test/sanity/validate-modules/schema.py
+++ b/test/sanity/validate-modules/schema.py
@@ -90,7 +90,7 @@ def deprecation_schema():
         # Deprecation cycle changed at 2.4 (though not retroactively)
         # 2.3 -> removed_in: "2.5" + n for docs stub
         # 2.4 -> removed_in: "2.8" + n for docs stub
-        Required('removed_in'): Any("2.2", "2.3", "2.4", "2.5", "2.8", "2.9"),
+        Required('removed_in'): Any("2.2", "2.3", "2.4", "2.5", "2.8", "2.9", "2.10"),
         Required('why'): Any(*string_types),
         Required('alternative'): Any(*string_types),
         'removed': Any(True),


### PR DESCRIPTION
##### SUMMARY
Update the list of allowed removed_in for modules

We have a hard coded list of versions that a module could be removed in
2.6+4=2.10, so add that to the list.

I've not added this to the release managers doc as a step

##### ISSUE TYPE
 - Bugfix Pull Request
