### PR TITLE
Fix structured output bug in nxos_user module

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_user.py
+++ b/lib/ansible/modules/network/nxos/nxos_user.py
@@ -221,7 +221,10 @@ def parse_password(data):
 
 
 def parse_roles(data):
-    configured_roles = data.get('TABLE_role')['ROW_role']
+    configured_roles = None
+    if 'TABLE_role' in data:
+        configured_roles = data.get('TABLE_role')['ROW_role']
+
     roles = list()
     if configured_roles:
         for item in to_list(configured_roles):


### PR DESCRIPTION
##### SUMMARY
Not all Nexus users contain roles data under the `TABLE_role` structured output key.  This fix skips role processing if the user does not contain the key.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
nxos_user

##### ANSIBLE VERSION
```
ansible 2.6.0 (rel250/fix_nxos_user 5a98076eb3) last updated 2018/02/14 13:01:12 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/Users/mwiebe/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mwiebe/Projects/nxos_ansible/fix_ansible/lib/ansible
  executable location = /Users/mwiebe/Projects/nxos_ansible/fix_ansible/bin/ansible
  python version = 2.7.13 (default, Apr  4 2017, 08:47:57) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.38)]
```


##### ADDITIONAL INFORMATION
Here is the error that occurs without the fix on certain Nexus versions.

```
 306831: TASK [nxos_user : Create user] ***********************************************************************************************************************************
 306832: task path: /root/agents-ci/ansible/test/integration/targets/nxos_user/tests/cli/sanity.yaml:2
 306833: <n7k.example.com> connection transport is cli
 306834: <n7k.example.com> using connection plugin network_cli (was local)
 306835: <n7k.example.com> starting connection from persistent connection plugin
 306836: <n7k.example.com> local domain socket does not exist, starting it
 306837: <n7k.example.com> control socket path is /root/.ansible/pc/ee80ebbf11
 306838: <n7k.example.com> connection to remote device started successfully
 306839: <n7k.example.com> local domain socket listeners started successfully
 306840: <n7k.example.com> 
 306841: <n7k.example.com> local domain socket path is /root/.ansible/pc/ee80ebbf11
 306842: <n7k.example.com> socket_path: /root/.ansible/pc/ee80ebbf11
 306843: Using module file /root/agents-ci/ansible/lib/ansible/modules/network/nxos/nxos_user.py
 306844: <n7k.example.com> ESTABLISH LOCAL CONNECTION FOR USER: root
 306845: <n7k.example.com> EXEC /bin/sh -c 'echo ~ && sleep 0'
 306846: <n7k.example.com> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /root/.ansible/tmp/ansible-tmp-1517870962.49-94563359191058 `" && echo ansible-tmp-1517870962.49-94563359191058="` echo /root/.ansible/tmp/ansible-tmp-1517870962.49-94563359191058 `" ) && sleep 0'
 306847: <n7k.example.com> PUT /root/.ansible/tmp/ansible-local-93335OEC9m/tmpFQnxqB TO /root/.ansible/tmp/ansible-tmp-1517870962.49-94563359191058/nxos_user.py
 306848: <n7k.example.com> EXEC /bin/sh -c 'chmod u+x /root/.ansible/tmp/ansible-tmp-1517870962.49-94563359191058/ /root/.ansible/tmp/ansible-tmp-1517870962.49-94563359191058/nxos_user.py && sleep 0'
 306849: <n7k.example.com> EXEC /bin/sh -c '/usr/bin/python /root/.ansible/tmp/ansible-tmp-1517870962.49-94563359191058/nxos_user.py && sleep 0'
 306850: The full traceback is:
 306851: Traceback (most recent call last):
 306852:   File "/tmp/ansible_gf2Ycn/ansible_module_nxos_user.py", line 387, in <module>
 306853:     main()
 306854:   File "/tmp/ansible_gf2Ycn/ansible_module_nxos_user.py", line 361, in main
 306855:     have = map_config_to_obj(module)
 306856:   File "/tmp/ansible_gf2Ycn/ansible_module_nxos_user.py", line 243, in map_config_to_obj
 306857:     'roles': parse_roles(item),
 306858:   File "/tmp/ansible_gf2Ycn/ansible_module_nxos_user.py", line 224, in parse_roles
 306859:     configured_roles = data.get('TABLE_role')['ROW_role']
 306860: TypeError: 'NoneType' object has no attribute '__getitem__'
 306861: FAILED! => {
 306862:     "changed": false, 
 306863:     "failed": true, 
 306864:     "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_gf2Ycn/ansible_module_nxos_user.py\", line 387, in <module>\n    main()\n  File \"/tmp/ansible_gf2Ycn/ansible_module_nxos_user.py\", line 361, in main\n    have = map_config_to_obj(module)\n  File \"/tmp/ansible_gf2Ycn/ansible_module_nxos_user.py\", line 243, in map_config_to_obj\n    'roles': parse_roles(item),\n  File \"/tmp/ansible_gf2Ycn/ansible_module_nxos_user.py\", line 224, in parse_roles\n    configured_roles = data.get('TABLE_role')['ROW_role']\nTypeError: 'NoneType' object has no attribute '__getitem__'\n", 
 306865:     "module_stdout": "", 
 306866:     "msg": "MODULE FAILURE", 
 306867:     "rc": 1
 306868: }
```

