### PR TITLE
Upgrade to openshift client 0.4.0 (#35127)

### DIFF
--- a/lib/ansible/modules/clustering/k8s/k8s_raw.py
+++ b/lib/ansible/modules/clustering/k8s/k8s_raw.py
@@ -39,7 +39,7 @@ extends_documentation_fragment:
 
 requirements:
   - "python >= 2.7"
-  - "openshift >= 0.3"
+  - "openshift == 0.4.1"
   - "PyYAML >= 3.11"
 '''
 

--- a/lib/ansible/modules/clustering/k8s/k8s_scale.py
+++ b/lib/ansible/modules/clustering/k8s/k8s_scale.py
@@ -35,7 +35,7 @@ extends_documentation_fragment:
 
 requirements:
     - "python >= 2.7"
-    - "openshift >= 0.3"
+    - "openshift == 0.4.1"
     - "PyYAML >= 3.11"
 '''
 

--- a/lib/ansible/modules/clustering/openshift/openshift_raw.py
+++ b/lib/ansible/modules/clustering/openshift/openshift_raw.py
@@ -49,7 +49,7 @@ options:
 
 requirements:
     - "python >= 2.7"
-    - "openshift >= 0.3"
+    - "openshift == 0.4.1"
     - "PyYAML >= 3.11"
 '''
 

--- a/lib/ansible/modules/clustering/openshift/openshift_scale.py
+++ b/lib/ansible/modules/clustering/openshift/openshift_scale.py
@@ -35,7 +35,7 @@ extends_documentation_fragment:
 
 requirements:
     - "python >= 2.7"
-    - "openshift >= 0.3"
+    - "openshift == 0.4.1"
     - "PyYAML >= 3.11"
 '''
 

--- a/lib/ansible/plugins/inventory/k8s.py
+++ b/lib/ansible/plugins/inventory/k8s.py
@@ -73,6 +73,11 @@ DOCUMENTATION = '''
               description:
               - List of namespaces. If not specified, will fetch all containers for all namespaces user is authorized
                 to access.
+
+    requirements:
+    - "python >= 2.7"
+    - "openshift == 0.4.1"
+    - "PyYAML >= 3.11"
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/plugins/inventory/openshift.py
+++ b/lib/ansible/plugins/inventory/openshift.py
@@ -74,6 +74,11 @@ DOCUMENTATION = '''
               description:
               - List of namespaces. If not specified, will fetch all containers for all namespaces user is authorized
                 to access.
+
+    requirements:
+    - "python >= 2.7"
+    - "openshift == 0.4.1"
+    - "PyYAML >= 3.11"
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/plugins/lookup/k8s.py
+++ b/lib/ansible/plugins/lookup/k8s.py
@@ -115,7 +115,7 @@ DOCUMENTATION = """
 
     requirements:
       - "python >= 2.7"
-      - "openshift >= 0.3"
+      - "openshift == 0.4.1"
       - "PyYAML >= 3.11"
 
     notes:

--- a/lib/ansible/plugins/lookup/openshift.py
+++ b/lib/ansible/plugins/lookup/openshift.py
@@ -115,7 +115,7 @@ DOCUMENTATION = """
 
     requirements:
       - "python >= 2.7"
-      - "openshift >= 0.3"
+      - "openshift == 0.4.1"
       - "PyYAML >= 3.11"
 
     notes:


### PR DESCRIPTION
##### SUMMARY
- Upgrading to v0.4.1 of OpenShift client, which was release a few days ago
- Pinning the client version to v0.4.1
- Cherry picked the change from `devel`

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/k8s/helper.py

##### ANSIBLE VERSION
```
ansible 2.5.0 (feature/k8s-upgrade ed906fc520) last updated 2018/01/20 08:48:13 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/Users/chouseknecht/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/chouseknecht/projects/ansible/lib/ansible
  executable location = /Users/chouseknecht/projects/ansible/bin/ansible
  python version = 2.7.14 (default, Nov 14 2017, 23:24:24) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.38)]
```
