### PR TITLE
New module: manage 1&1 VPNs (cloud/oneandone/oneandone_vpn)

### DIFF
--- a/lib/ansible/module_utils/oneandone.py
+++ b/lib/ansible/module_utils/oneandone.py
@@ -36,6 +36,8 @@ class OneAndOneResources:
     server = 'server'
     user = 'user'
     vpn = 'vpn'
+    block_storage = 'block_storage'
+    shared_storage = 'shared_storage'
 
 
 def get_resource(oneandone_conn, resource_type, resource_id):
@@ -49,6 +51,8 @@ def get_resource(oneandone_conn, resource_type, resource_id):
         'server': oneandone_conn.get_server,
         'user': oneandone_conn.get_user,
         'vpn': oneandone_conn.get_vpn,
+        'block_storage': oneandone_conn.get_block_storage,
+        'shared_storage': oneandone_conn.get_shared_storage,
     }
 
     return switcher.get(resource_type, None)(resource_id)
@@ -202,6 +206,44 @@ def get_public_ip(oneandone_conn, public_ip, full_object=False):
             if full_object:
                 return _public_ip
             return _public_ip['id']
+
+
+def get_block_storage(oneandone_conn, block_storage, full_object=False):
+    """
+    Validates that the block storage exists by ID or a name.
+    Returns the block storage if one was found.
+    """
+    for _block_storage in oneandone_conn.list_block_storages(per_page=1000):
+        if block_storage in (_block_storage['id'], _block_storage['name']):
+            if full_object:
+                return _block_storage
+            return _block_storage['id']
+
+
+def get_shared_storage(oneandone_conn, shared_storage, full_object=False):
+    """
+    Validates that the shared storage exists by ID or a name.
+    Returns the shared storage if one was found.
+    """
+    for _shared_storage in oneandone_conn.list_shared_storages(per_page=1000):
+        if shared_storage in (_shared_storage['id'], _shared_storage['name']):
+            if full_object:
+                return _shared_storage
+            return _shared_storage['id']
+
+
+def get_shared_storage_server(oneandone_conn, shared_storage, server_id, full_object=False):
+    """
+    Validates that the server is attached to the shared storage.
+    Returns the shared storage server if one was found.
+    """
+    shared_store = get_shared_storage(oneandone_conn, shared_storage, True)
+    _server = get_shared_storage_server(shared_storage_id=shared_store['id'],
+                                        server_id=server_id)
+    if _server:
+        if full_object:
+            return _server
+        return _server['id']
 
 
 def wait_for_resource_creation_completion(oneandone_conn,

--- a/lib/ansible/modules/cloud/oneandone/oneandone_vpn.py
+++ b/lib/ansible/modules/cloud/oneandone/oneandone_vpn.py
@@ -27,7 +27,7 @@ short_description: Configure 1&1 VPN.
 description:
      - Create, remove, update vpn
        This module has a dependency on 1and1 >= 1.0
-version_added: "2.1"
+version_added: "2.5"
 options:
   auth_token:
     description:

--- a/lib/ansible/modules/cloud/oneandone/oneandone_vpn.py
+++ b/lib/ansible/modules/cloud/oneandone/oneandone_vpn.py
@@ -67,7 +67,7 @@ options:
       - wait for the instance to be in the appropriate state before returning
     required: false
     default: "yes"
-    choices: [ "yes", "no" ]
+    type: bool
   wait_timeout:
     description:
       - how long before wait gives up, in seconds

--- a/lib/ansible/modules/cloud/oneandone/oneandone_vpn.py
+++ b/lib/ansible/modules/cloud/oneandone/oneandone_vpn.py
@@ -14,11 +14,12 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
-ANSIBLE_METADATA = {
-    'metadata_version': '1.0',
-    'status': ['preview'],
-    'supported_by': 'community'
-}
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
 
 DOCUMENTATION = '''
 ---
@@ -27,7 +28,7 @@ short_description: Configure 1&1 VPN.
 description:
      - Create, remove, update vpn
        This module has a dependency on 1and1 >= 1.0
-version_added: "2.5"
+version_added: "2.6"
 options:
   auth_token:
     description:
@@ -41,7 +42,7 @@ options:
   name:
     description:
       - VPN name used with present state. Used as identifier (id or name) when used with absent state.
-    maxLength: 128
+        maxLength=128
     required: true
   vpn:
     description:
@@ -49,8 +50,7 @@ options:
     required: true
   description:
     description:
-      - VPN description.
-    maxLength: 256
+      - VPN description. maxLength=256
     required: false
   datacenter_id:
     description:
@@ -107,6 +107,14 @@ EXAMPLES = '''
     name: ansible VPN updated
     state: absent
 
+'''
+
+RETURN = '''
+vpn:
+    description: Information about the vpn that was processed
+    type: dict
+    sample: '{"id": "F77CC589EBC120905B4F4719217BFF6D", "name": "My VPN"}'
+    returned: always
 '''
 
 import os

--- a/lib/ansible/modules/cloud/oneandone/oneandone_vpn.py
+++ b/lib/ansible/modules/cloud/oneandone/oneandone_vpn.py
@@ -30,6 +30,12 @@ description:
        This module has a dependency on 1and1 >= 1.0
 version_added: "2.6"
 options:
+  state:
+    description:
+      - Define a VPN state to create, remove, or update.
+    required: false
+    default: 'present'
+    choices: [ "present", "absent", "update" ]
   auth_token:
     description:
       - Authenticating API token provided by 1&1.
@@ -52,7 +58,7 @@ options:
     description:
       - VPN description. maxLength=256
     required: false
-  datacenter_id:
+  datacenter:
     description:
       - ID (or name) of the datacenter where the vpn will be created.
     required: false

--- a/lib/ansible/modules/cloud/oneandone/oneandone_vpn.py
+++ b/lib/ansible/modules/cloud/oneandone/oneandone_vpn.py
@@ -1,0 +1,257 @@
+#!/usr/bin/python
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.0',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: oneandone_vpn
+short_description: Configure 1&1 VPN.
+description:
+     - Create, remove, update vpn
+       This module has a dependency on 1and1 >= 1.0
+version_added: "2.1"
+options:
+  auth_token:
+    description:
+      - Authenticating API token provided by 1&1.
+    required: true
+  name:
+    description:
+      - VPN name used with present state. Used as identifier (id or name) when used with absent state.
+    maxLength: 128
+    required: true
+  vpn:
+    description:
+      - The identifier (id or name) of the VPN used with update state.
+    required: true
+  description:
+    description:
+      - VPN description.
+    maxLength: 256
+    required: false
+  datacenter_id:
+    description:
+      - ID (or name) of the datacenter where the vpn will be created.
+    required: false
+
+requirements:
+     - "1and1"
+     - "python >= 2.6"
+
+author: "Amel Ajdinovic (@aajdinov), Ethan Devenport (@edevenport)"
+'''
+
+EXAMPLES = '''
+
+# Create a VPN.
+
+- oneandone_vpn:
+    auth_token: oneandone_private_api_key
+    datacenter: US
+    name: ansible VPN
+    description: Create a VPN using ansible
+
+# Update a VPN.
+
+- oneandone_vpn:
+    auth_token: oneandone_private_api_key
+    vpn: ansible VPN
+    name: ansible VPN updated
+    description: Update a VPN using ansible
+    state: update
+
+
+# Delete a VPN
+
+- oneandone_vpn:
+    auth_token: oneandone_private_api_key
+    name: ansible VPN updated
+    state: absent
+
+'''
+
+import os
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.oneandone import (
+    get_datacenter,
+    get_vpn,
+    OneAndOneResources,
+    wait_for_resource_creation_completion
+)
+
+HAS_ONEANDONE_SDK = True
+
+try:
+    import oneandone.client
+except ImportError:
+    HAS_ONEANDONE_SDK = False
+
+
+def update_vpn(module, oneandone_conn):
+    """
+    Modify VPN configuration file.
+
+    module : AnsibleModule object
+    oneandone_conn: authenticated oneandone object
+    """
+    _vpn_id = module.params.get('vpn')
+    _name = module.params.get('name')
+    _description = module.params.get('description')
+
+    vpn = get_vpn(oneandone_conn, _vpn_id, True)
+
+    try:
+        updated_vpn = oneandone_conn.modify_vpn(vpn_id=vpn['id'],
+                                                name=_name,
+                                                description=_description)
+
+        changed = True if updated_vpn else False
+
+        return (changed, updated_vpn)
+    except Exception as e:
+        module.fail_json(msg=str(e))
+
+
+def create_vpn(module, oneandone_conn):
+    """
+    Adds a new VPN.
+
+    module : AnsibleModule object
+    oneandone_conn: authenticated oneandone object
+    """
+    try:
+        name = module.params.get('name')
+        description = module.params.get('description')
+        datacenter = module.params.get('datacenter')
+        wait = module.params.get('wait')
+        wait_timeout = module.params.get('wait_timeout')
+
+        if datacenter is not None:
+            datacenter_id = get_datacenter(oneandone_conn, datacenter)
+            if datacenter_id is None:
+                module.fail_json(
+                    msg='datacenter %s not found.' % datacenter)
+
+        _vpn = oneandone.client.Vpn(name,
+                                    description,
+                                    datacenter_id)
+
+        vpn = oneandone_conn.create_vpn(_vpn)
+
+        if wait:
+            wait_for_resource_creation_completion(
+                oneandone_conn,
+                OneAndOneResources.vpn,
+                vpn['id'],
+                wait_timeout)
+
+        changed = True if vpn else False
+
+        return (changed, vpn)
+    except Exception as e:
+        module.fail_json(msg=str(e))
+
+
+def remove_vpn(module, oneandone_conn):
+    """
+    Removes a VPN.
+
+    module : AnsibleModule object
+    oneandone_conn: authenticated oneandone object
+    """
+    try:
+        _vpn = module.params.get('name')
+
+        vpn_id = get_vpn(oneandone_conn, _vpn)
+        vpn = oneandone_conn.delete_vpn(vpn_id)
+
+        changed = True if vpn else False
+
+        return (changed, {
+            'id': vpn['id'],
+            'name': vpn['name']
+        })
+    except Exception as e:
+        module.fail_json(msg=str(e))
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            auth_token=dict(
+                type='str',
+                default=os.environ.get('ONEANDONE_AUTH_TOKEN'),
+                no_log=True),
+            vpn=dict(type='str'),
+            name=dict(type='str'),
+            description=dict(type='str'),
+            datacenter=dict(type='str'),
+            wait=dict(type='bool', default=True),
+            wait_timeout=dict(type='int', default=600),
+            state=dict(type='str', default='present'),
+        )
+    )
+
+    if not HAS_ONEANDONE_SDK:
+        module.fail_json(msg='1and1 required for this module')
+
+    if not module.params.get('auth_token'):
+        module.fail_json(
+            msg='auth_token parameter is required.')
+
+    auth_token = module.params.get('auth_token')
+
+    oneandone_conn = oneandone.client.OneAndOneService(
+        api_token=auth_token)
+
+    state = module.params.get('state')
+
+    if state == 'absent':
+        if not module.params.get('name'):
+            module.fail_json(
+                msg="'name' parameter is required to delete a VPN.")
+        try:
+            (changed, vpn) = remove_vpn(module, oneandone_conn)
+        except Exception as e:
+            module.fail_json(msg=str(e))
+    elif state == 'update':
+        if not module.params.get('vpn'):
+            module.fail_json(
+                msg="'vpn' parameter is required to update a VPN.")
+        try:
+            (changed, vpn) = update_vpn(module, oneandone_conn)
+        except Exception as e:
+            module.fail_json(msg=str(e))
+
+    elif state == 'present':
+        if not module.params.get('name'):
+            module.fail_json(
+                msg="name parameter is required for a new VPN.")
+        try:
+            (changed, vpn) = create_vpn(module, oneandone_conn)
+        except Exception as e:
+            module.fail_json(msg=str(e))
+
+    module.exit_json(changed=changed, vpn=vpn)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
##### SUMMARY
Adding a new cloud module to support oneandone VPN management.

##### ISSUE TYPE
 - Feature Pull Request
 - New Module Pull Request

##### COMPONENT NAME
 - oneandone_vpn cloud module
 - oneandone module_util

##### ANSIBLE VERSION
```
ansible 2.6.0 (oneandone_users ad143452d7) last updated 2018/02/14 22:52:46 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```

##### ADDITIONAL INFORMATION
Below is the output from one of the test playbooks utilizing the new module:
```
PLAY [localhost] ****************************************************************

TASK [Gathering Facts] *******************************************************
ok: [localhost]

TASK [Update a VPN] **********************************************************
changed: [localhost]

PLAY RECAP ********************************************************************
localhost                  : ok=2    changed=1    unreachable=0    failed=0   

```
