### PR TITLE
Normalize usage of temp and tmp on tmp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,9 @@ See [Porting Guide](http://docs.ansible.com/ansible/devel/porting_guides.html) f
 * `osx_say` module was renamed into `say`.
 * Task debugger functionality was moved into `StrategyBase`, and extended to allow explicit invocation from use of the `debugger` keyword.
   The `debug` strategy is still functional, and is now just a trigger to enable this functionality
+* The ANSIBLE_REMOTE_TMP environment variable has been added to supplement (and
+  override) ANSIBLE_REMOTE_TEMP.  This matches with the spelling of the config
+  value. ANSIBLE_REMOTE_TEMP will be deprecated in the future.
 
 #### Removed Modules (previously deprecated):
 * accelerate.

--- a/bin/ansible
+++ b/bin/ansible
@@ -157,7 +157,7 @@ if __name__ == '__main__':
         display.display(u"the full traceback was:\n\n%s" % to_text(traceback.format_exc()), log_only=log_only)
         exit_code = 250
     finally:
-        # Remove ansible tempdir
+        # Remove ansible tmpdir
         shutil.rmtree(C.DEFAULT_LOCAL_TMP, True)
 
     sys.exit(exit_code)

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -47,7 +47,7 @@ PASS_VARS = {
     'shell_executable': '_shell',
     'socket': '_socket_path',
     'syslog_facility': '_syslog_facility',
-    'tempdir': 'tempdir',
+    'tmpdir': 'tmpdir',
     'verbosity': '_verbosity',
     'version': 'ansible_version',
 }
@@ -2199,7 +2199,7 @@ class AnsibleModule(object):
         except:
             # we don't have access to the cwd, probably because of sudo.
             # Try and move to a neutral location to prevent errors
-            for cwd in [self.tempdir, os.path.expandvars('$HOME'), tempfile.gettempdir()]:
+            for cwd in [self.tmpdir, os.path.expandvars('$HOME'), tempfile.gettempdir()]:
                 try:
                     if os.access(cwd, os.F_OK | os.R_OK):
                         os.chdir(cwd)
@@ -2511,7 +2511,7 @@ class AnsibleModule(object):
                     # would end in something like:
                     #     file = _os.path.join(dir, pre + name + suf)
                     # TypeError: can't concat bytes to str
-                    error_msg = ('Failed creating temp file for atomic move.  This usually happens when using Python3 less than Python3.5. '
+                    error_msg = ('Failed creating tmp file for atomic move.  This usually happens when using Python3 less than Python3.5. '
                                  'Please use Python2.x or Python3.5 or greater.')
                 finally:
                     if error_msg:
@@ -2531,7 +2531,7 @@ class AnsibleModule(object):
                             try:
                                 shutil.move(b_src, b_tmp_dest_name)
                             except OSError:
-                                # cleanup will happen by 'rm' of tempdir
+                                # cleanup will happen by 'rm' of tmpdir
                                 # copy2 will preserve some metadata
                                 shutil.copy2(b_src, b_tmp_dest_name)
 

--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -988,7 +988,8 @@ def fetch_url(module, url, data=None, headers=None, method=None,
         module.fail_json(msg='urlparse is not installed')
 
     # ensure we use proper tempdir
-    tempfile.tempdir = module.tempdir
+    old_tempdir = tempfile.tempdir
+    tempfile.tempdir = module.tmpdir
 
     # Get validate_certs from the module params
     validate_certs = module.params.get('validate_certs', True)
@@ -1052,5 +1053,7 @@ def fetch_url(module, url, data=None, headers=None, method=None,
     except Exception as e:
         info.update(dict(msg="An unknown error occurred: %s" % to_native(e), status=-1),
                     exception=traceback.format_exc())
+    finally:
+        tempfile.tempdir = old_tempdir
 
     return r, info

--- a/lib/ansible/plugins/action/assemble.py
+++ b/lib/ansible/plugins/action/assemble.py
@@ -147,11 +147,11 @@ class ActionModule(ActionBase):
                 if self._play_context.diff:
                     diff = self._get_diff_data(dest, path, task_vars)
 
-                remote_path = self._connection._shell.join_path(self._connection._shell.tempdir, 'src')
+                remote_path = self._connection._shell.join_path(self._connection._shell.tmpdir, 'src')
                 xfered = self._transfer_file(path, remote_path)
 
                 # fix file permissions when the copy is done as a different user
-                self._fixup_perms2((self._connection._shell.tempdir, remote_path))
+                self._fixup_perms2((self._connection._shell.tmpdir, remote_path))
 
                 new_module_args.update(dict(src=xfered,))
 
@@ -165,6 +165,6 @@ class ActionModule(ActionBase):
         except AnsibleAction as e:
             result.update(e.result)
         finally:
-            self._remove_tmp_path(self._connection._shell.tempdir)
+            self._remove_tmp_path(self._connection._shell.tmpdir)
 
         return result

--- a/lib/ansible/plugins/action/command.py
+++ b/lib/ansible/plugins/action/command.py
@@ -25,6 +25,6 @@ class ActionModule(ActionBase):
 
         if not wrap_async:
             # remove a temporary path we created
-            self._remove_tmp_path(self._connection._shell.tempdir)
+            self._remove_tmp_path(self._connection._shell.tmpdir)
 
         return results

--- a/lib/ansible/plugins/action/copy.py
+++ b/lib/ansible/plugins/action/copy.py
@@ -258,7 +258,7 @@ class ActionModule(ActionBase):
                 return result
 
             # Define a remote directory that we will copy the file to.
-            tmp_src = self._connection._shell.join_path(self._connection._shell.tempdir, 'source')
+            tmp_src = self._connection._shell.join_path(self._connection._shell.tmpdir, 'source')
 
             remote_path = None
 
@@ -273,7 +273,7 @@ class ActionModule(ActionBase):
 
             # fix file permissions when the copy is done as a different user
             if remote_path:
-                self._fixup_perms2((self._connection._shell.tempdir, remote_path))
+                self._fixup_perms2((self._connection._shell.tmpdir, remote_path))
 
             if raw:
                 # Continue to next iteration if raw is defined.
@@ -417,7 +417,7 @@ class ActionModule(ActionBase):
         # Define content_tempfile in case we set it after finding content populated.
         content_tempfile = None
 
-        # If content is defined make a temp file and write the content into it.
+        # If content is defined make a tmp file and write the content into it.
         if content is not None:
             try:
                 # If content comes to us as a dict it should be decoded json.
@@ -549,6 +549,6 @@ class ActionModule(ActionBase):
             result.update(dict(dest=dest, src=source, changed=changed))
 
         # Delete tmp path
-        self._remove_tmp_path(self._connection._shell.tempdir)
+        self._remove_tmp_path(self._connection._shell.tmpdir)
 
         return result

--- a/lib/ansible/plugins/action/fetch.py
+++ b/lib/ansible/plugins/action/fetch.py
@@ -213,6 +213,6 @@ class ActionModule(ActionBase):
                 result.update(dict(changed=False, md5sum=local_md5, file=source, dest=dest, checksum=local_checksum))
 
         finally:
-            self._remove_tmp_path(self._connection._shell.tempdir)
+            self._remove_tmp_path(self._connection._shell.tmpdir)
 
         return result

--- a/lib/ansible/plugins/action/normal.py
+++ b/lib/ansible/plugins/action/normal.py
@@ -52,6 +52,6 @@ class ActionModule(ActionBase):
 
         if not wrap_async:
             # remove a temporary path we created
-            self._remove_tmp_path(self._connection._shell.tempdir)
+            self._remove_tmp_path(self._connection._shell.tmpdir)
 
         return result

--- a/lib/ansible/plugins/action/package.py
+++ b/lib/ansible/plugins/action/package.py
@@ -77,6 +77,6 @@ class ActionModule(ActionBase):
         finally:
             if not self._task.async_val:
                 # remove a temporary path we created
-                self._remove_tmp_path(self._connection._shell.tempdir)
+                self._remove_tmp_path(self._connection._shell.tmpdir)
 
         return result

--- a/lib/ansible/plugins/action/patch.py
+++ b/lib/ansible/plugins/action/patch.py
@@ -53,7 +53,7 @@ class ActionModule(ActionBase):
             except AnsibleError as e:
                 raise AnsibleActionFail(to_native(e))
 
-            tmp_src = self._connection._shell.join_path(self._connection._shell.tempdir, os.path.basename(src))
+            tmp_src = self._connection._shell.join_path(self._connection._shell.tmpdir, os.path.basename(src))
             self._transfer_file(src, tmp_src)
             self._fixup_perms2((tmp_src,))
 
@@ -68,5 +68,5 @@ class ActionModule(ActionBase):
         except AnsibleAction as e:
             result.update(e.result)
         finally:
-            self._remove_tmp_path(self._connection._shell.tempdir)
+            self._remove_tmp_path(self._connection._shell.tmpdir)
         return result

--- a/lib/ansible/plugins/action/script.py
+++ b/lib/ansible/plugins/action/script.py
@@ -89,7 +89,8 @@ class ActionModule(ActionBase):
 
             if not self._play_context.check_mode:
                 # transfer the file to a remote tmp location
-                tmp_src = self._connection._shell.join_path(self._connection._shell.tempdir, os.path.basename(source))
+                tmp_src = self._connection._shell.join_path(self._connection._shell.tmpdir,
+                                                            os.path.basename(source))
 
                 # Convert raw_params to text for the purpose of replacing the script since
                 # parts and tmp_src are both unicode strings and raw_params will be different
@@ -133,6 +134,6 @@ class ActionModule(ActionBase):
         except AnsibleAction as e:
             result.update(e.result)
         finally:
-            self._remove_tmp_path(self._connection._shell.tempdir)
+            self._remove_tmp_path(self._connection._shell.tmpdir)
 
         return result

--- a/lib/ansible/plugins/action/service.py
+++ b/lib/ansible/plugins/action/service.py
@@ -85,6 +85,6 @@ class ActionModule(ActionBase):
             result.update(e.result)
         finally:
             if not self._task.async_val:
-                self._remove_tmp_path(self._connection._shell.tempdir)
+                self._remove_tmp_path(self._connection._shell.tmpdir)
 
         return result

--- a/lib/ansible/plugins/action/template.py
+++ b/lib/ansible/plugins/action/template.py
@@ -162,6 +162,6 @@ class ActionModule(ActionBase):
         except AnsibleAction as e:
             result.update(e.result)
         finally:
-            self._remove_tmp_path(self._connection._shell.tempdir)
+            self._remove_tmp_path(self._connection._shell.tmpdir)
 
         return result

--- a/lib/ansible/plugins/action/unarchive.py
+++ b/lib/ansible/plugins/action/unarchive.py
@@ -84,7 +84,7 @@ class ActionModule(ActionBase):
 
             if not remote_src:
                 # transfer the file to a remote tmp location
-                tmp_src = self._connection._shell.join_path(self._connection._shell.tempdir, 'source')
+                tmp_src = self._connection._shell.join_path(self._connection._shell.tmpdir, 'source')
                 self._transfer_file(source, tmp_src)
 
             # handle diff mode client side
@@ -92,7 +92,7 @@ class ActionModule(ActionBase):
 
             if not remote_src:
                 # fix file permissions when the copy is done as a different user
-                self._fixup_perms2((self._connection._shell.tempdir, tmp_src))
+                self._fixup_perms2((self._connection._shell.tmpdir, tmp_src))
                 # Build temporary module_args.
                 new_module_args = self._task.args.copy()
                 new_module_args.update(
@@ -120,5 +120,5 @@ class ActionModule(ActionBase):
         except AnsibleAction as e:
             result.update(e.result)
         finally:
-            self._remove_tmp_path(self._connection._shell.tempdir)
+            self._remove_tmp_path(self._connection._shell.tmpdir)
         return result

--- a/lib/ansible/plugins/action/win_copy.py
+++ b/lib/ansible/plugins/action/win_copy.py
@@ -374,7 +374,7 @@ class ActionModule(ActionBase):
                 source = content_tempfile
             except Exception as err:
                 result['failed'] = True
-                result['msg'] = "could not write content temp file: %s" % to_native(err)
+                result['msg'] = "could not write content tmp file: %s" % to_native(err)
                 return result
         # all actions should occur on the remote server, run win_copy module
         elif remote_src:
@@ -487,15 +487,15 @@ class ActionModule(ActionBase):
             result.update(query_return)
             return result
 
-        if len(query_return['files']) > 0 or len(query_return['directories']) > 0 and self._connection._shell.tempdir is None:
-            self._connection._shell.tempdir = self._make_tmp_path()
+        if len(query_return['files']) > 0 or len(query_return['directories']) > 0 and self._connection._shell.tmpdir is None:
+            self._connection._shell.tmpdir = self._make_tmp_path()
 
         if len(query_return['files']) == 1 and len(query_return['directories']) == 0:
             # we only need to copy 1 file, don't mess around with zips
             file_src = query_return['files'][0]['src']
             file_dest = query_return['files'][0]['dest']
             copy_result = self._copy_single_file(file_src, dest, file_dest,
-                                                 task_vars, self._connection._shell.tempdir)
+                                                 task_vars, self._connection._shell.tmpdir)
 
             result['changed'] = True
             if copy_result.get('failed') is True:
@@ -507,14 +507,14 @@ class ActionModule(ActionBase):
             # TODO: handle symlinks
             result.update(self._copy_zip_file(dest, source_files['files'],
                                               source_files['directories'],
-                                              task_vars, self._connection._shell.tempdir))
+                                              task_vars, self._connection._shell.tmpdir))
             result['changed'] = True
         else:
             # no operations need to occur
             result['failed'] = False
             result['changed'] = False
 
-        # remove the content temp file and remote tmp file if it was created
+        # remove the content tmp file and remote tmp file if it was created
         self._remove_tempfile_if_content_defined(content, content_tempfile)
-        self._remove_tmp_path(self._connection._shell.tempdir)
+        self._remove_tmp_path(self._connection._shell.tmpdir)
         return result

--- a/lib/ansible/plugins/shell/__init__.py
+++ b/lib/ansible/plugins/shell/__init__.py
@@ -47,19 +47,19 @@ class ShellBase(AnsiblePlugin):
 
         self.tmpdir = None
 
-    def _normalize_system_tmps(self):
+    def _normalize_system_tmpdirs(self):
         # Normalize the tmp directory strings. We don't use expanduser/expandvars because those
         # can vary between remote user and become user.  Therefore the safest practice will be for
         # this to always be specified as full paths)
-        normalized_paths = [d.rstrip('/') for d in self.get_option('system_tmps')]
+        normalized_paths = [d.rstrip('/') for d in self.get_option('system_tmpdirs')]
 
-        # Make sure all system_tmps are absolute otherwise they'd be relative to the login dir
+        # Make sure all system_tmpdirs are absolute otherwise they'd be relative to the login dir
         # which is almost certainly going to fail in a cornercase.
         if not all(os.path.isabs(d) for d in normalized_paths):
-            raise AnsibleError('The configured system_tmps contains a relative path: {0}. All'
-                               ' system_tmps must be absolute'.format(to_native(normalized_paths)))
+            raise AnsibleError('The configured system_tmpdirs contains a relative path: {0}. All'
+                               ' system_tmpdirs must be absolute'.format(to_native(normalized_paths)))
 
-        self.set_option('system_tmps', normalized_paths)
+        self.set_option('system_tmpdirs', normalized_paths)
 
     def set_options(self, task_keys=None, var_options=None, direct=None):
 
@@ -70,9 +70,9 @@ class ShellBase(AnsiblePlugin):
 
         # We can remove the try: except in the future when we make ShellBase a proper subset of
         # *all* shells.  Right now powershell and third party shells which do not use the
-        # shell_common documentation fragment (and so do not have system_tmps) will fail
+        # shell_common documentation fragment (and so do not have system_tmpdirs) will fail
         try:
-            self._normalize_system_tmps()
+            self._normalize_system_tmpdirs()
         except AnsibleError:
             pass
 
@@ -131,7 +131,7 @@ class ShellBase(AnsiblePlugin):
         # other users can read and access the tmp directory.
         # This is because we use system to create tmp dirs for unprivileged users who are
         # sudo'ing to a second unprivileged user.
-        # The 'system_tmps' setting defines dirctories we can use for this purpose
+        # The 'system_tmpdirs' setting defines dirctories we can use for this purpose
         # the default are, /tmp and /var/tmp.
         # So we only allow one of those locations if system=True, using the
         # passed in tmpdir if it is valid or the first one from the setting if not.
@@ -139,10 +139,10 @@ class ShellBase(AnsiblePlugin):
         if system:
             tmpdir = tmpdir.rstrip('/')
 
-            if tmpdir in self.get_option('system_tmps'):
+            if tmpdir in self.get_option('system_tmpdirs'):
                 basetmpdir = tmpdir
             else:
-                basetmpdir = self.get_option('system_tmps')[0]
+                basetmpdir = self.get_option('system_tmpdirs')[0]
         else:
             if tmpdir is None:
                 basetmpdir = self.get_option('remote_tmp')

--- a/lib/ansible/plugins/shell/__init__.py
+++ b/lib/ansible/plugins/shell/__init__.py
@@ -45,21 +45,21 @@ class ShellBase(AnsiblePlugin):
                         'LC_ALL': module_locale,
                         'LC_MESSAGES': module_locale}
 
-        self.tempdir = None
+        self.tmpdir = None
 
-    def _normalize_system_temps(self):
-        # Normalize the temp directory strings. We don't use expanduser/expandvars because those
+    def _normalize_system_tmps(self):
+        # Normalize the tmp directory strings. We don't use expanduser/expandvars because those
         # can vary between remote user and become user.  Therefore the safest practice will be for
         # this to always be specified as full paths)
-        normalized_paths = [d.rstrip('/') for d in self.get_option('system_temps')]
+        normalized_paths = [d.rstrip('/') for d in self.get_option('system_tmps')]
 
-        # Make sure all system_temps are absolute otherwise they'd be relative to the login dir
+        # Make sure all system_tmps are absolute otherwise they'd be relative to the login dir
         # which is almost certainly going to fail in a cornercase.
         if not all(os.path.isabs(d) for d in normalized_paths):
-            raise AnsibleError('The configured system_temps contains a relative path: {0}. All'
-                               ' system_temps must be absolute'.format(to_native(normalized_paths)))
+            raise AnsibleError('The configured system_tmps contains a relative path: {0}. All'
+                               ' system_tmps must be absolute'.format(to_native(normalized_paths)))
 
-        self.set_option('system_temps', normalized_paths)
+        self.set_option('system_tmps', normalized_paths)
 
     def set_options(self, task_keys=None, var_options=None, direct=None):
 
@@ -70,9 +70,9 @@ class ShellBase(AnsiblePlugin):
 
         # We can remove the try: except in the future when we make ShellBase a proper subset of
         # *all* shells.  Right now powershell and third party shells which do not use the
-        # shell_common documentation fragment (and so do not have system_temps) will fail
+        # shell_common documentation fragment (and so do not have system_tmps) will fail
         try:
-            self._normalize_system_temps()
+            self._normalize_system_tmps()
         except AnsibleError:
             pass
 
@@ -128,10 +128,10 @@ class ShellBase(AnsiblePlugin):
             basefile = 'ansible-tmp-%s-%s' % (time.time(), random.randint(0, 2**48))
 
         # When system is specified we have to create this in a directory where
-        # other users can read and access the temp directory.
+        # other users can read and access the tmp directory.
         # This is because we use system to create tmp dirs for unprivileged users who are
         # sudo'ing to a second unprivileged user.
-        # The 'system_temps' setting defines dirctories we can use for this purpose
+        # The 'system_tmps' setting defines dirctories we can use for this purpose
         # the default are, /tmp and /var/tmp.
         # So we only allow one of those locations if system=True, using the
         # passed in tmpdir if it is valid or the first one from the setting if not.
@@ -139,13 +139,13 @@ class ShellBase(AnsiblePlugin):
         if system:
             tmpdir = tmpdir.rstrip('/')
 
-            if tmpdir in self.get_option('system_temps'):
+            if tmpdir in self.get_option('system_tmps'):
                 basetmpdir = tmpdir
             else:
-                basetmpdir = self.get_option('system_temps')[0]
+                basetmpdir = self.get_option('system_tmps')[0]
         else:
             if tmpdir is None:
-                basetmpdir = self.get_option('remote_temp')
+                basetmpdir = self.get_option('remote_tmp')
             else:
                 basetmpdir = tmpdir
 

--- a/lib/ansible/plugins/shell/powershell.py
+++ b/lib/ansible/plugins/shell/powershell.py
@@ -12,7 +12,7 @@ DOCUMENTATION = '''
     description:
       - The only option when using 'winrm' as a connection plugin
     options:
-      remote_temp:
+      remote_tmp:
         description:
         - Temporary directory to use on targets when copying files to the host.
         default: '%TEMP%'
@@ -1883,7 +1883,7 @@ class ShellModule(ShellBase):
         # Windows does not have an equivalent for the system temp files, so
         # the param is ignored
         basefile = self._escape(self._unquote(basefile))
-        basetmpdir = tmpdir if tmpdir else self.get_option('remote_temp')
+        basetmpdir = tmpdir if tmpdir else self.get_option('remote_tmp')
 
         script = '''
         $tmp_path = [System.Environment]::ExpandEnvironmentVariables('%s')

--- a/lib/ansible/utils/module_docs_fragments/shell_common.py
+++ b/lib/ansible/utils/module_docs_fragments/shell_common.py
@@ -11,7 +11,7 @@ options:
     description:
       - Temporary directory to use on targets when executing tasks.
     default: '~/.ansible/tmp'
-    env: [{name: ANSIBLE_REMOTE_TEMP}]
+    env: [{name: ANSIBLE_REMOTE_TMP}, {name: ANSIBLE_REMOTE_TEMP}]
     ini:
       - section: defaults
         key: remote_tmp

--- a/lib/ansible/utils/module_docs_fragments/shell_common.py
+++ b/lib/ansible/utils/module_docs_fragments/shell_common.py
@@ -17,19 +17,19 @@ options:
         key: remote_tmp
     vars:
       - name: ansible_remote_tmp
-  system_tmps:
+  system_tmpdirs:
     description:
        - "List of valid system temporary directories for Ansible to choose when it cannot use
          ``remote_tmp``, normally due to permission issues.  These must be world readable, writable,
          and executable."
     default: [ /var/tmp, /tmp ]
     type: list
-    env: [{name: ANSIBLE_SYSTEM_TMPS}]
+    env: [{name: ANSIBLE_SYSTEM_TMPDIRS}]
     ini:
       - section: defaults
-        key: system_tmps
+        key: system_tmpdirs
     vars:
-      - name: ansible_system_tmps
+      - name: ansible_system_tmpdirs
   async_dir:
     description:
        - Directory in which ansible will keep async job inforamtion

--- a/lib/ansible/utils/module_docs_fragments/shell_common.py
+++ b/lib/ansible/utils/module_docs_fragments/shell_common.py
@@ -11,7 +11,7 @@ options:
     description:
       - Temporary directory to use on targets when executing tasks.
     default: '~/.ansible/tmp'
-    env: [{name: ANSIBLE_REMOTE_TMP}, {name: ANSIBLE_REMOTE_TEMP}]
+    env: [{name: ANSIBLE_REMOTE_TEMP}, {name: ANSIBLE_REMOTE_TMP}]
     ini:
       - section: defaults
         key: remote_tmp

--- a/lib/ansible/utils/module_docs_fragments/shell_common.py
+++ b/lib/ansible/utils/module_docs_fragments/shell_common.py
@@ -7,7 +7,7 @@ class ModuleDocFragment(object):
     # common shelldocumentation fragment
     DOCUMENTATION = """
 options:
-  remote_temp:
+  remote_tmp:
     description:
       - Temporary directory to use on targets when executing tasks.
     default: '~/.ansible/tmp'
@@ -17,10 +17,10 @@ options:
         key: remote_tmp
     vars:
       - name: ansible_remote_tmp
-  system_temps:
+  system_tmps:
     description:
        - "List of valid system temporary directories for Ansible to choose when it cannot use
-         ``remote_temp``, normally due to permission issues.  These must be world readable, writable,
+         ``remote_tmp``, normally due to permission issues.  These must be world readable, writable,
          and executable."
     default: [ /var/tmp, /tmp ]
     type: list

--- a/test/integration/targets/async_fail/action_plugins/normal.py
+++ b/test/integration/targets/async_fail/action_plugins/normal.py
@@ -57,6 +57,6 @@ class ActionModule(ActionBase):
 
         if not wrap_async:
             # remove a temporary path we created
-            self._remove_tmp_path(self._connection._shell.tempdir)
+            self._remove_tmp_path(self._connection._shell.tmpdir)
 
         return result

--- a/test/units/plugins/action/test_action.py
+++ b/test/units/plugins/action/test_action.py
@@ -235,7 +235,7 @@ class TestActionBase(unittest.TestCase):
             ret = None
             if opt == 'admin_users':
                 ret = ['root', 'toor', 'Administrator']
-            elif opt == 'remote_temp':
+            elif opt == 'remote_tmp':
                 ret = '~/.ansible/tmp'
 
             return ret
@@ -419,7 +419,7 @@ class TestActionBase(unittest.TestCase):
         mock_connection.socket_path = None
         mock_connection._shell.get_remote_filename.return_value = 'copy.py'
         mock_connection._shell.join_path.side_effect = os.path.join
-        mock_connection._shell.tempdir = '/var/tmp/mytempdir'
+        mock_connection._shell.tmpdir = '/var/tmp/mytempdir'
 
         # we're using a real play context here
         play_context = PlayContext()


### PR DESCRIPTION
##### SUMMARY
* We were exposing some things as tmp and some things as temp.  This would just confuse people as to which was right.  Standardize on tmp.

* Also fixed urls.py to reset tempfile.tempdir to the system defaults once we exit the get-url function
* Did not rename the ANSIBLE_REMOTE_TEMP environment variable as it was in prior versions of ansible.

##### ISSUE TYPE

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
Vairous.  All temporary file related.

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel 2.5
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
