### PR TITLE
Adds k8s_raw tests

### DIFF
--- a/test/integration/targets/k8s_raw/aliases
+++ b/test/integration/targets/k8s_raw/aliases
@@ -1,0 +1,2 @@
+cloud/openshift
+posix/ci/cloud/group4/openshift

--- a/test/integration/targets/k8s_raw/tasks/main.yml
+++ b/test/integration/targets/k8s_raw/tasks/main.yml
@@ -2,13 +2,10 @@
   pip:
     name: openshift
 
-- name: Create a project
-  openshift_raw:
+- name: Create a namespace
+  k8s_raw:
     name: testing
-    kind: project
-    description: My testing project
-    display_name: Testing Project
-    api_version: v1
+    kind: namespace 
   register: output
 
 - name: show output
@@ -16,7 +13,7 @@
     var: output
 
 - name: Create a service
-  openshift_raw:
+  k8s_raw:
     state: present
     resource_definition: &svc
       apiVersion: v1
@@ -43,7 +40,7 @@
     var: output
 
 - name: Create the service again
-  openshift_raw:
+  k8s_raw:
     state: present
     resource_definition: *svc 
   register: output
@@ -53,7 +50,7 @@
     that: not output.changed
 
 - name: Create PVC
-  openshift_raw:
+  k8s_raw:
     state: present
     inline: &pvc
       apiVersion: v1
@@ -73,7 +70,7 @@
     var: output
 
 - name: Create the PVC again
-  openshift_raw:
+  k8s_raw:
     state: present
     inline: *pvc
 
@@ -81,12 +78,12 @@
   assert:
     that: not output.changed
 
-- name: Create deployment config
-  openshift_raw:
+- name: Create deployment
+  k8s_raw:
     state: present
     inline: &dc
-      apiVersion: v1
-      kind: DeploymentConfig
+      apiVersion: Apps/V1Beta1
+      kind: Deployment
       metadata:
         name: elastic
         labels:
@@ -113,19 +110,19 @@
                 claimName: elastic-volume
         replicas: 1
         strategy:
-          type: Rolling
+          type: RollingUpdate
   register: output
 
 - name: Show output
   debug:
     var: output
 
-- name: Create deployment config again
-  openshift_raw:
+- name: Create deployment again
+  k8s_raw:
     state: present
     inline: *dc 
   register: output
 
-- name: DC creation should be idempotent
+- name: Deployment creation should be idempotent
   assert:
     that: not output.changed

--- a/test/runner/lib/cloud/openshift.py
+++ b/test/runner/lib/cloud/openshift.py
@@ -44,7 +44,7 @@ class OpenShiftCloudProvider(CloudProvider):
         super(OpenShiftCloudProvider, self).__init__(args, config_extension='.kubeconfig')
 
         # The image must be pinned to a specific version to guarantee CI passes with the version used.
-        self.image = 'openshift/origin:v3.9.0'
+        self.image = 'openshift/origin:v3.7.1'
         self.container_name = ''
 
     def filter(self, targets, exclude):


### PR DESCRIPTION
##### SUMMARY
- Adds additional tasks to `openshift_raw` role
- Adds new role for `k8s_raw`
- Sets openshift image to 3.7.1, to fall within Kubernetes Python client supported range. See [the compatibility matrix](https://github.com/kubernetes-client/python/blob/master/README.md#compatibility).

**NOTE** 
[openshift-restclient-python PR #153](https://github.com/openshift/openshift-restclient-python/pull/153) needs to land before this will work.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
test/integration/targets/k8s_raw

##### ANSIBLE VERSION
```
ansible 2.6.0 (feature/k8s_testing cbf64a291a) last updated 2018/02/15 02:41:57 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/Users/chouseknecht/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/chouseknecht/projects/ansible/lib/ansible
  executable location = /Users/chouseknecht/projects/ansible/bin/ansible
  python version = 2.7.14 (default, Nov 14 2017, 23:24:24) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.38)]
```
