### PR TITLE
Change path to "Edit on GitHub" link

### DIFF
--- a/docs/docsite/_themes/srtd/breadcrumbs.html
+++ b/docs/docsite/_themes/srtd/breadcrumbs.html
@@ -3,7 +3,7 @@
   <li><a href="">{{ title }}</a></li>
   {% if not pagename.endswith('_module') and (not 'list_of' in pagename) and (not 'category' in pagename) %}
     <li class="wy-breadcrumbs-aside">
-      <a href="https://github.com/ansible/ansible/blob/devel/docs/docsite/rst/{{ pagename }}.rst" class="icon icon-github"> Edit on GitHub</a>
+      <a href="https://github.com/ansible/ansible/blob/devel/docs/docsite/rst/user_guide/{{ pagename }}.rst" class="icon icon-github"> Edit on GitHub</a>
     </li>
   {% endif %}
 </ul>


### PR DESCRIPTION
It seems that the source path of the Ansible documentation has changed. This should be updated.