### PR TITLE
doc: 2.3.3 has been released

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1205,7 +1205,7 @@ While neither is technically a new plugin, these connections may now be used dir
 
 <a id="2.3.3"></a>
 
-## 2.3.3 "Ramble On" - TBD
+## 2.3.3 "Ramble On" - 2017-12-20
 
 ### Bugfixes
 * Fix alternatives module handlling of non existing options

--- a/docs/docsite/rst/reference_appendices/release_and_maintenance.rst
+++ b/docs/docsite/rst/reference_appendices/release_and_maintenance.rst
@@ -42,7 +42,7 @@ Ansible Release   Latest Version               Status
 ===============   ==========================   =================================================
 devel             `2.5`_ (unreleased, trunk)   In development
 2.4               `2.4.3`_ (2018-01-31)        Supported (security **and** general bug fixes)
-2.3               `2.3.2`_ (2017-08-08)        Supported (security **and** critical bug fixes)
+2.3               `2.3.3`_ (2017-12-20)        Supported (security **and** critical bug fixes)
 2.2               `2.2.3`_ (2017-05-09)        Unsupported (end of life)
 2.1               `2.1.6`_ (2017-06-01)        Unsupported (end of life)
 2.0               `2.0.2`_ (2016-04-19)        Unsupported (end of life)
@@ -56,7 +56,7 @@ devel             `2.5`_ (unreleased, trunk)   In development
 
 .. _2.5: https://github.com/ansible/ansible/blob/devel/CHANGELOG.md
 .. _2.4.3: https://github.com/ansible/ansible/blob/stable-2.4/CHANGELOG.md
-.. _2.3.2: https://github.com/ansible/ansible/blob/stable-2.3/CHANGELOG.md
+.. _2.3.3: https://github.com/ansible/ansible/blob/stable-2.3/CHANGELOG.md
 .. _2.2.3: https://github.com/ansible/ansible/blob/stable-2.2/CHANGELOG.md
 .. _2.1.6: https://github.com/ansible/ansible/blob/stable-2.1/CHANGELOG.md
 .. _2.0.2: https://github.com/ansible/ansible/blob/stable-2.0/CHANGELOG.md


### PR DESCRIPTION
##### SUMMARY
2.3.3 has been released: update CHANGELOG and documentation

Sources:
* https://github.com/ansible/ansible/releases/tag/v2.3.3.0-1
* https://pypi.python.org/pypi/ansible/2.3.3.0

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
documentation

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0 (devel 0f893027c4) last updated 2018/02/15 15:58:31 (GMT +200)
```

##### ADDITIONAL INFORMATION
`stable-2.4` and `stable-2.5` need to be updated too, not sure if `stable-2.3` should be updated.
I have created branches for 2.4 and 2.5 with this commit cherry-picked:
* https://github.com/pilou-/ansible/tree/doc_2.3.3_has_been_released_backport_2.4
* https://github.com/pilou-/ansible/tree/doc_2.3.3_has_been_released_backport_2.5

if this one is accepted i will created pull-requests for both of them.