### PR TITLE
yum_repository: fix gpgcheck default

### DIFF
--- a/lib/ansible/modules/packaging/os/yum_repository.py
+++ b/lib/ansible/modules/packaging/os/yum_repository.py
@@ -626,7 +626,7 @@ def main():
         failovermethod=dict(choices=['roundrobin', 'priority']),
         file=dict(),
         gpgcakey=dict(),
-        gpgcheck=dict(type='bool'),
+        gpgcheck=dict(default=False, type='bool'),
         gpgkey=dict(type='list'),
         http_caching=dict(choices=['all', 'packages', 'none']),
         include=dict(),

--- a/test/integration/targets/yum_repository/tasks/yum_repository_centos.yml
+++ b/test/integration/targets/yum_repository/tasks/yum_repository_centos.yml
@@ -177,3 +177,23 @@
   yum_repository:
     name: listtest
     state: absent
+
+- name: disable epel (clean up)
+  yum_repository:
+    name: epel
+    state: absent
+
+- name: add epel
+  yum_repository:
+    name: epel
+    description: EPEL yum repo
+    baseurl: https://download.fedoraproject.org/pub/epel/{{ ansible_distribution_major_version }}/{{ ansible_architecture }}/
+    state: present
+
+- set_fact:
+    repofile: "{{ lookup('file', '/etc/yum.repos.d/epel.repo') }}"
+
+- name: check for gpgcheck=0
+  assert:
+    that:
+      - "'gpgcheck = 0' in repofile"


### PR DESCRIPTION
##### SUMMARY
By default yum sets gpgcheck to 1, so we need to explicitly set the
module's default, which is 0.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
yum_repository

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```

##### ADDITIONAL INFORMATION