### PR TITLE
Fix ansible-console always asking for vault passwords

### DIFF
--- a/lib/ansible/cli/console.py
+++ b/lib/ansible/cli/console.py
@@ -417,15 +417,6 @@ class ConsoleCLI(CLI, cmd.Cmd):
 
         self.loader, self.inventory, self.variable_manager = self._play_prereqs(self.options)
 
-        default_vault_ids = C.DEFAULT_VAULT_IDENTITY_LIST
-        vault_ids = self.options.vault_ids
-        vault_ids = default_vault_ids + vault_ids
-        vault_secrets = self.setup_vault_secrets(self.loader,
-                                                 vault_ids=vault_ids,
-                                                 vault_password_files=self.options.vault_password_files,
-                                                 ask_vault_pass=self.options.ask_vault_pass)
-        self.loader.set_vault_secrets(vault_secrets)
-
         hosts = CLI.get_host_list(self.inventory, self.options.subset, self.pattern)
 
         self.groups = self.inventory.list_groups()


### PR DESCRIPTION
##### SUMMARY

Fix ansible-console always asking for vault passwords

ansible-console was calling setup_vault_secrets
twice. Once directly and once via _play_prereqs()

The direct invocation was not setting auto_prompt=False.

However, the direct invocation isn't need at all so
this removes it so only _play_reqs() is used.
That fixes the unrequested vault password
prompting.

Fixes #33027


<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
lib/ansible/cli/console.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0 (console_vault_auto_prompt_33027 c417dc547f) last updated 2018/02/15 11:07:35 (GMT -400)
  config file = None
  configured module search path = [u'/home/adrian/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/adrian/src/ansible/lib/ansible
  executable location = /home/adrian/src/ansible/bin/ansible
  python version = 2.7.14 (default, Jan 17 2018, 14:28:32) [GCC 7.2.1 20170915 (Red Hat 7.2.1-2)]


```


##### ADDITIONAL INFORMATION
Likely candidate for backporting to stable-2.4/stable-2.5

<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
