### PR TITLE
Move _start_connection() to module_utils/connection and fix Popen() call

### DIFF
--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -857,16 +857,9 @@ class TaskExecutor:
         '''
         master, slave = pty.openpty()
 
-        def find_file_in_path(filename):
-            path = os.environ['PATH']
-            for dirname in path.split(os.pathsep):
-                fullpath = os.path.join(dirname, filename)
-                if os.path.isfile(fullpath):
-                    return fullpath
-            raise AnsibleError("Unable to find '%s' in PATH" % filename)
-
         python = sys.executable
-        ansible_connection = find_file_in_path('ansible-connection')
+        # Assume ansible-connection is in the same dir as sys.argv[0]
+        ansible_connection = os.path.join(os.path.dirname(sys.argv[0]), 'ansible-connection')
         p = subprocess.Popen([python, ansible_connection, to_text(os.getppid())], stdin=slave, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         stdin = os.fdopen(master, 'wb', 0)
         os.close(slave)

--- a/lib/ansible/plugins/connection/persistent.py
+++ b/lib/ansible/plugins/connection/persistent.py
@@ -77,16 +77,9 @@ class Connection(ConnectionBase):
         '''
         master, slave = pty.openpty()
 
-        def find_file_in_path(filename):
-            path = os.environ['PATH']
-            for dirname in path.split(os.pathsep):
-                fullpath = os.path.join(dirname, filename)
-                if os.path.isfile(fullpath):
-                    return fullpath
-            raise AnsibleError("Unable to find '%s' in PATH" % filename)
-
         python = sys.executable
-        ansible_connection = find_file_in_path('ansible-connection')
+        # Assume ansible-connection is in the same dir as sys.argv[0]
+        ansible_connection = os.path.join(os.path.dirname(sys.argv[0]), 'ansible-connection')
         p = subprocess.Popen([python, ansible_connection, to_text(os.getppid())], stdin=slave, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         stdin = os.fdopen(master, 'wb', 0)
         os.close(slave)

--- a/lib/ansible/plugins/connection/persistent.py
+++ b/lib/ansible/plugins/connection/persistent.py
@@ -17,6 +17,7 @@ import os
 import pty
 import json
 import subprocess
+import sys
 
 from ansible import constants as C
 from ansible.plugins.connection import ConnectionBase
@@ -75,7 +76,18 @@ class Connection(ConnectionBase):
         Starts the persistent connection
         '''
         master, slave = pty.openpty()
-        p = subprocess.Popen(["ansible-connection", to_text(os.getppid())], stdin=slave, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+        def find_file_in_path(filename):
+            path = os.environ['PATH']
+            for dirname in path.split(os.pathsep):
+                fullpath = os.path.join(dirname, filename)
+                if os.path.isfile(fullpath):
+                    return fullpath
+            raise AnsibleError("Unable to find '%s' in PATH" % filename)
+
+        python = sys.executable
+        ansible_connection = find_file_in_path('ansible-connection')
+        p = subprocess.Popen([python, ansible_connection, to_text(os.getppid())], stdin=slave, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         stdin = os.fdopen(master, 'wb', 0)
         os.close(slave)
 
@@ -96,7 +108,10 @@ class Connection(ConnectionBase):
         if p.returncode == 0:
             result = json.loads(to_text(stdout, errors='surrogate_then_replace'))
         else:
-            result = json.loads(to_text(stderr, errors='surrogate_then_replace'))
+            try:
+                result = json.loads(to_text(stderr, errors='surrogate_then_replace'))
+            except json.decoder.JSONDecodeError:
+                result = {'error': to_text(stderr, errors='surrogate_then_replace')}
 
         if 'messages' in result:
             for msg in result.get('messages'):
@@ -104,8 +119,9 @@ class Connection(ConnectionBase):
 
         if 'error' in result:
             if self._play_context.verbosity > 2:
-                msg = "The full traceback is:\n" + result['exception']
-                display.display(msg, color=C.COLOR_ERROR)
+                if result.get('exception'):
+                    msg = "The full traceback is:\n" + result['exception']
+                    display.display(msg, color=C.COLOR_ERROR)
             raise AnsibleError(result['error'])
 
         return result['socket_path']


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Fixes #35902

Also unifies `_start_connection()` implementation from task_executor and connection/persistent. There might be a better place for it than module_utils/connection, but that seemed like the best place to me.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
ansible-connection

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```

