### PR TITLE
Update ios_ping.py to allow for count > 70. (#36142)

### DIFF
--- a/lib/ansible/modules/network/ios/ios_ping.py
+++ b/lib/ansible/modules/network/ios/ios_ping.py
@@ -143,7 +143,12 @@ def main():
     ping_results = run_commands(module, commands=results["commands"])
     ping_results_list = ping_results[0].split("\n")
 
-    success, rx, tx, rtt = parse_ping(ping_results_list[3])
+    stats = ""
+    for line in ping_results_list:
+        if line.startswith('Success'):
+            stats = line
+
+    success, rx, tx, rtt = parse_ping(stats)
     loss = abs(100 - int(success))
     results["packet_loss"] = str(loss) + "%"
     results["packets_rx"] = int(rx)


### PR DESCRIPTION

##### SUMMARY
* Update ios_ping.py to allow for count > 70.

Find 'Success...' output rather than relying on list index.  Index -1 won't pass unit test.

(cherry picked from commit fed20b825f2edd0f6c5c147a32a494194dfa8164)

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
ios_ping

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```
