### PR TITLE
aws_ssm_parameter_store - Make the module idempotent

### DIFF
--- a/lib/ansible/modules/cloud/amazon/aws_ssm_parameter_store.py
+++ b/lib/ansible/modules/cloud/amazon/aws_ssm_parameter_store.py
@@ -138,7 +138,7 @@ def create_update_parameter(client, module):
         args.update(KeyId=module.params.get('key_id'))
 
     try:
-        existing_parameter = client.get_parameter(Name=args['Name'],WithDecryption=True)
+        existing_parameter = client.get_parameter(Name=args['Name'], WithDecryption=True)
     except:
         pass
 
@@ -162,7 +162,7 @@ def create_update_parameter(client, module):
                 # Description field not available from get_parameter function so get it from describe_parameters
                 describe_existing_parameter = None
                 try:
-                    describe_existing_parameter = client.describe_parameters(Filters=[{"Key":"Name","Values":[args['Name']]}])
+                    describe_existing_parameter = client.describe_parameters(Filters=[{"Key": "Name", "Values": [args['Name']]}])
                 except:
                     module.fail_json_aws(e, msg="getting description value")
 

--- a/lib/ansible/modules/cloud/amazon/aws_ssm_parameter_store.py
+++ b/lib/ansible/modules/cloud/amazon/aws_ssm_parameter_store.py
@@ -55,6 +55,7 @@ options:
       - Option to overwrite an existing value if it already exists.
       - String
     required: false
+    version_added: "2.6"
     choices: ['never', 'changed', 'always']
     default: changed
   region:

--- a/lib/ansible/modules/cloud/amazon/aws_ssm_parameter_store.py
+++ b/lib/ansible/modules/cloud/amazon/aws_ssm_parameter_store.py
@@ -185,7 +185,7 @@ def create_update_parameter(client, module):
                 describe_existing_parameter = None
                 try:
                     describe_existing_parameter = client.describe_parameters(Filters=[{"Key": "Name", "Values": [args['Name']]}])
-                except:
+                except ClientError as e:
                     module.fail_json_aws(e, msg="getting description value")
 
                 if describe_existing_parameter['Parameters'][0]['Description'] != args['Description']:


### PR DESCRIPTION
##### SUMMARY
Changes to make the module idempotent.  Currently, a new version of the parameter will be stored every time the playbook is ran, even if nothing has changed which isn't idempotent and causes unnecessary versions to be created.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
aws_ssm_parameter_store

##### ANSIBLE VERSION
```
ansible 2.5.0b1 (stable-2.5 a7a03bbf4a) last updated 2018/02/15 17:54:35 (GMT +100)
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

Before:
```
⇒  ansible-playbook -vv current_module.yml

PLAYBOOK: current_module.yml ***********************************************************************************************************************************************************************************
1 plays in current_module.yml

PLAY [Current Module] ******************************************************************************************************************************************************************************************

TASK [Gathering Facts] *****************************************************************************************************************************************************************************************
ok: [localhost]
META: ran handlers

TASK [Manage keys in AWS Parameter store] **********************************************************************************************************************************************************************
changed: [localhost] => (item={'name': 'test_name', 'value': 'test_value', 'description': 'test_description', 'string_type': 'String', 'overwrite': 'true'}) => {"changed": true, "item": {"description": "test_description", "name": "test_name", "overwrite": "true", "string_type": "String", "value": "test_value"}, "response": {"ResponseMetadata": {"HTTPHeaders": {"content-length": "13", "content-type": "application/x-amz-json-1.1", "date": "Thu, 15 Feb 2018 18:04:34 GMT", "x-amzn-requestid": "adbd1448-127a-11e8-b547-ff682365b6d1"}, "HTTPStatusCode": 200, "RequestId": "adbd1448-127a-11e8-b547-ff682365b6d1", "RetryAttempts": 0}, "Version": 1}}
META: ran handlers
META: ran handlers

PLAY RECAP *****************************************************************************************************************************************************************************************************
localhost                  : ok=2    changed=1    unreachable=0    failed=0




⇒  ansible-playbook -vv current_module.yml

PLAYBOOK: current_module.yml ***********************************************************************************************************************************************************************************
1 plays in current_module.yml

PLAY [Current Module] ******************************************************************************************************************************************************************************************

TASK [Gathering Facts] *****************************************************************************************************************************************************************************************
ok: [localhost]
META: ran handlers

TASK [Manage keys in AWS Parameter store] **********************************************************************************************************************************************************************
changed: [localhost] => (item={'name': 'test_name', 'value': 'test_value', 'description': 'test_description', 'string_type': 'String', 'overwrite': 'true'}) => {"changed": true, "item": {"description": "test_description", "name": "test_name", "overwrite": "true", "string_type": "String", "value": "test_value"}, "response": {"ResponseMetadata": {"HTTPHeaders": {"content-length": "13", "content-type": "application/x-amz-json-1.1", "date": "Thu, 15 Feb 2018 18:04:39 GMT", "x-amzn-requestid": "b112f5cb-127a-11e8-bdee-8f7444e0535d"}, "HTTPStatusCode": 200, "RequestId": "b112f5cb-127a-11e8-bdee-8f7444e0535d", "RetryAttempts": 0}, "Version": 2}}
META: ran handlers
META: ran handlers

PLAY RECAP *****************************************************************************************************************************************************************************************************
localhost                  : ok=2    changed=1    unreachable=0    failed=0
```


After:
```
⇒  ansible-playbook -vv working_idempotence.yml

PLAYBOOK: working_idempotence.yml ******************************************************************************************************************************************************************************
1 plays in working_idempotence.yml

PLAY [Working SSM Idempotence] *********************************************************************************************************************************************************************************

TASK [Gathering Facts] *****************************************************************************************************************************************************************************************
ok: [localhost]
META: ran handlers

TASK [Manage keys in AWS Parameter store] **********************************************************************************************************************************************************************
changed: [localhost] => (item={'name': 'test_name', 'value': 'test_value', 'description': 'test_description', 'string_type': 'String', 'overwrite': 'true'}) => {"changed": true, "item": {"description": "test_description", "name": "test_name", "overwrite": "true", "string_type": "String", "value": "test_value"}, "response": {"ResponseMetadata": {"HTTPHeaders": {"content-length": "13", "content-type": "application/x-amz-json-1.1", "date": "Thu, 15 Feb 2018 18:00:09 GMT", "x-amzn-requestid": "105e5e50-127a-11e8-8efa-3745e3a9736d"}, "HTTPStatusCode": 200, "RequestId": "105e5e50-127a-11e8-8efa-3745e3a9736d", "RetryAttempts": 0}, "Version": 1}}
META: ran handlers
META: ran handlers

PLAY RECAP *****************************************************************************************************************************************************************************************************
localhost                  : ok=2    changed=1    unreachable=0    failed=0



⇒  ansible-playbook -vv working_idempotence.yml

PLAYBOOK: working_idempotence.yml ******************************************************************************************************************************************************************************
1 plays in working_idempotence.yml

PLAY [Working SSM Idempotence] *********************************************************************************************************************************************************************************

TASK [Gathering Facts] *****************************************************************************************************************************************************************************************
ok: [localhost]
META: ran handlers

TASK [Manage keys in AWS Parameter store] **********************************************************************************************************************************************************************
ok: [localhost] => (item={'name': 'test_name', 'value': 'test_value', 'description': 'test_description', 'string_type': 'String', 'overwrite': 'true'}) => {"changed": false, "item": {"description": "test_description", "name": "test_name", "overwrite": "true", "string_type": "String", "value": "test_value"}, "response": {}}
META: ran handlers
META: ran handlers

PLAY RECAP *****************************************************************************************************************************************************************************************************
localhost                  : ok=2    changed=0    unreachable=0    failed=0
```