### PR TITLE
os_image_facts: add ability to list all Openstack images (fixes #32741)

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_image_facts.py
+++ b/lib/ansible/modules/cloud/openstack/os_image_facts.py
@@ -28,7 +28,7 @@ options:
    image:
      description:
         - Name or ID of the image
-     required: true
+     required: false
    availability_zone:
      description:
        - Ignored. Present for backwards compatibility
@@ -47,6 +47,14 @@ EXAMPLES = '''
     image: image1
 
 - name: Show openstack facts
+  debug:
+    var: openstack_image
+
+# Show all available Openstack images
+- name: Retrieve all available Openstack images
+  os_image_facts:
+
+- name: Show images
   debug:
     var: openstack_image
 '''
@@ -134,16 +142,21 @@ from ansible.module_utils.openstack import openstack_full_argument_spec, opensta
 def main():
 
     argument_spec = openstack_full_argument_spec(
-        image=dict(required=True),
+        image=dict(required=False),
     )
     module_kwargs = openstack_module_kwargs()
     module = AnsibleModule(argument_spec, **module_kwargs)
 
     shade, cloud = openstack_cloud_from_module(module)
     try:
-        image = cloud.get_image(module.params['image'])
-        module.exit_json(changed=False, ansible_facts=dict(
-            openstack_image=image))
+        if module.params['image']:
+            image = cloud.get_image(module.params['image'])
+            module.exit_json(changed=False, ansible_facts=dict(
+                openstack_image=image))
+        else:
+            images = cloud.list_images()
+            module.exit_json(changed=False, ansible_facts=dict(
+                openstack_image=images))
 
     except shade.OpenStackCloudException as e:
         module.fail_json(msg=str(e))


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This PR adds the missing ability to list all available Openstack images.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
os_image_facts
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.2.0
  config file = /root/26635-ATTM-EDI/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
