### PR TITLE
Fix subprompts 'None' stringification in call to send_command

### DIFF
--- a/lib/ansible/plugins/cliconf/ios.py
+++ b/lib/ansible/plugins/cliconf/ios.py
@@ -81,8 +81,7 @@ class Cliconf(CliconfBase):
                 answer = None
                 newline = True
 
-            self.send_command(to_bytes(command), to_bytes(prompt), to_bytes(answer),
-                              False, newline)
+            self.send_command(command, prompt, answer, False, newline)
 
     def get(self, command, prompt=None, answer=None, sendonly=False):
         return self.send_command(command, prompt=prompt, answer=answer, sendonly=sendonly)


### PR DESCRIPTION
send_command already performs the to_bytes safely on prompts (checking for None).  Without this check the literal 'None' became a subprompt trigger!

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

The call to `send_command` in ios `edit_config` was interning `prompts=None` to the literal string `'None'`  causing any output from the device to be scanned for a subprompt None and sending 'None' back as the answer was also `'None'`.

Since send_command already does a safer `to_bytes()` on these parameters, I removed the unneccessary calls in `cliconf/ios.py`
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
cliconf/ios.py
network_cli

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Example play that triggered this bug:

```
---

- hosts: onerouter
  gather_facts: no
  connection: network_cli

  tasks:
  - name: Set Interfaces Descriptions

    ios_config:
      parents: "interface GigabitEthernet1"
      lines:
        - description "Interface tag triggers a prompt response [None]"
```
