### PR TITLE
Reduces the unit test time of select bigip modules

### DIFF
--- a/test/units/modules/network/f5/test_bigip_asm_policy.py
+++ b/test/units/modules/network/f5/test_bigip_asm_policy.py
@@ -89,6 +89,11 @@ class TestManager(unittest.TestCase):
     def setUp(self):
         self.spec = ArgumentSpec()
         self.policy = os.path.join(fixture_path, 'fake_policy.xml')
+        self.patcher1 = patch('time.sleep')
+        self.patcher1.start()
+
+    def tearDown(self):
+        self.patcher1.stop()
 
     def test_activate_import_from_file(self, *args):
         set_module_args(dict(

--- a/test/units/modules/network/f5/test_bigip_command.py
+++ b/test/units/modules/network/f5/test_bigip_command.py
@@ -71,6 +71,11 @@ class TestManager(unittest.TestCase):
 
     def setUp(self):
         self.spec = ArgumentSpec()
+        self.patcher1 = patch('time.sleep')
+        self.patcher1.start()
+
+    def tearDown(self):
+        self.patcher1.stop()
 
     def test_run_single_command(self, *args):
         set_module_args(dict(

--- a/test/units/modules/network/f5/test_bigip_configsync_action.py
+++ b/test/units/modules/network/f5/test_bigip_configsync_action.py
@@ -91,6 +91,11 @@ class TestManager(unittest.TestCase):
 
     def setUp(self):
         self.spec = ArgumentSpec()
+        self.patcher1 = patch('time.sleep')
+        self.patcher1.start()
+
+    def tearDown(self):
+        self.patcher1.stop()
 
     def test_update_agent_status_traps(self, *args):
         set_module_args(dict(

--- a/test/units/modules/network/f5/test_bigip_device_httpd.py
+++ b/test/units/modules/network/f5/test_bigip_device_httpd.py
@@ -83,6 +83,11 @@ class TestModuleManager(unittest.TestCase):
 
     def setUp(self):
         self.spec = ArgumentSpec()
+        self.patcher1 = patch('time.sleep')
+        self.patcher1.start()
+
+    def tearDown(self):
+        self.patcher1.stop()
 
     def test_update(self, *args):
         set_module_args(

--- a/test/units/modules/network/f5/test_bigip_iapplx_package.py
+++ b/test/units/modules/network/f5/test_bigip_iapplx_package.py
@@ -73,6 +73,11 @@ class TestManager(unittest.TestCase):
 
     def setUp(self):
         self.spec = ArgumentSpec()
+        self.patcher1 = patch('time.sleep')
+        self.patcher1.start()
+
+    def tearDown(self):
+        self.patcher1.stop()
 
     def test_create_iapp_template(self, *args):
         # Configure the arguments that would be sent to the Ansible module

--- a/test/units/modules/network/f5/test_bigip_provision.py
+++ b/test/units/modules/network/f5/test_bigip_provision.py
@@ -75,6 +75,11 @@ class TestManager(unittest.TestCase):
 
     def setUp(self):
         self.spec = ArgumentSpec()
+        self.patcher1 = patch('time.sleep')
+        self.patcher1.start()
+
+    def tearDown(self):
+        self.patcher1.stop()
 
     def test_provision_one_module_default_level(self, *args):
         # Configure the arguments that would be sent to the Ansible module

--- a/test/units/modules/network/f5/test_bigip_ucs.py
+++ b/test/units/modules/network/f5/test_bigip_ucs.py
@@ -112,6 +112,11 @@ class TestV1Manager(unittest.TestCase):
 
     def setUp(self):
         self.spec = ArgumentSpec()
+        self.patcher1 = patch('time.sleep')
+        self.patcher1.start()
+
+    def tearDown(self):
+        self.patcher1.stop()
 
     def test_ucs_default_present(self, *args):
         set_module_args(dict(

--- a/test/units/modules/network/f5/test_bigip_vcmp_guest.py
+++ b/test/units/modules/network/f5/test_bigip_vcmp_guest.py
@@ -149,6 +149,11 @@ class TestParameters(unittest.TestCase):
 class TestManager(unittest.TestCase):
     def setUp(self):
         self.spec = ArgumentSpec()
+        self.patcher1 = patch('time.sleep')
+        self.patcher1.start()
+
+    def tearDown(self):
+        self.patcher1.stop()
 
     def test_create_vlan(self, *args):
         set_module_args(dict(

--- a/test/units/modules/network/f5/test_bigip_wait.py
+++ b/test/units/modules/network/f5/test_bigip_wait.py
@@ -93,6 +93,11 @@ class TestParameters(unittest.TestCase):
 class TestManager(unittest.TestCase):
     def setUp(self):
         self.spec = ArgumentSpec()
+        self.patcher1 = patch('time.sleep')
+        self.patcher1.start()
+
+    def tearDown(self):
+        self.patcher1.stop()
 
     def test_wait_already_available(self, *args):
         set_module_args(dict(
@@ -115,4 +120,4 @@ class TestManager(unittest.TestCase):
         results = mm.exec_module()
 
         assert results['changed'] is False
-        assert results['elapsed'] == 1
+        assert results['elapsed'] == 0

--- a/test/units/modules/network/f5/test_bigiq_regkey_license.py
+++ b/test/units/modules/network/f5/test_bigiq_regkey_license.py
@@ -88,6 +88,11 @@ class TestManager(unittest.TestCase):
 
     def setUp(self):
         self.spec = ArgumentSpec()
+        self.patcher1 = patch('time.sleep')
+        self.patcher1.start()
+
+    def tearDown(self):
+        self.patcher1.stop()
 
     def test_create(self, *args):
         set_module_args(dict(


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
The modules in this patch include waits that need to happen to ensure
something is correctly configured on a BIG-IP. These waits were
raised as an issue in a recent ansible-testing meeting.

This patch eliminates the waits by mocking time.sleep

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
f5 modules

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0
  config file = None
  configured module search path = ['/root/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python3.6/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 3.6.4 (default, Dec 21 2017, 01:35:12) [GCC 4.9.2]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
