### PR TITLE
Re-enable ios_config tests that were fixed in a previous patch

### DIFF
--- a/test/integration/targets/ios_config/tests/cli/save.yaml
+++ b/test/integration/targets/ios_config/tests/cli/save.yaml
@@ -17,22 +17,16 @@
     save: true
     provider: "{{ cli }}"
   register: result
-# FIXME https://github.com/ansible/ansible-modules-core/issues/5008
-  ignore_errors: true
 
 - assert:
     that:
       - "result.changed == true"
-# FIXME https://github.com/ansible/ansible-modules-core/issues/5008
-  ignore_errors: true
 
 - name: save should always run
   ios_config:
     save: true
     provider: "{{ cli }}"
   register: result
-# FIXME https://github.com/ansible/ansible-modules-core/issues/5008
-  ignore_errors: true
 
 - name: delete config (setup)
   ios_config:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
A couple of tests were disabled and meant to be re enabled once https://github.com/ansible/ansible-modules-core/issues/5008 was fixed. The tests that were disabled pass now, so I am re-enabling them.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - test

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
ios_config

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0 (enable_ios_tests f3ef02e03e) last updated 2018/02/15 14:23:29 (GMT -400)
  config file = None
  configured module search path = ['/Users/david/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/david/code/ansible/lib/ansible
  executable location = /Users/david/code/ansible/bin/ansible
  python version = 3.6.4 (default, Jan  6 2018, 11:51:59) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
