### PR TITLE
Reduces the unit test time of select bigip modules (#36256)

### DIFF
--- a/test/units/modules/network/f5/test_bigip_asm_policy.py
+++ b/test/units/modules/network/f5/test_bigip_asm_policy.py
@@ -89,6 +89,11 @@ class TestManager(unittest.TestCase):
     def setUp(self):
         self.spec = ArgumentSpec()
         self.policy = os.path.join(fixture_path, 'fake_policy.xml')
+        self.patcher1 = patch('time.sleep')
+        self.patcher1.start()
+
+    def tearDown(self):
+        self.patcher1.stop()
 
     def test_activate_import_from_file(self, *args):
         set_module_args(dict(

--- a/test/units/modules/network/f5/test_bigip_command.py
+++ b/test/units/modules/network/f5/test_bigip_command.py
@@ -71,6 +71,11 @@ class TestManager(unittest.TestCase):
 
     def setUp(self):
         self.spec = ArgumentSpec()
+        self.patcher1 = patch('time.sleep')
+        self.patcher1.start()
+
+    def tearDown(self):
+        self.patcher1.stop()
 
     def test_run_single_command(self, *args):
         set_module_args(dict(

--- a/test/units/modules/network/f5/test_bigip_configsync_action.py
+++ b/test/units/modules/network/f5/test_bigip_configsync_action.py
@@ -91,6 +91,11 @@ class TestManager(unittest.TestCase):
 
     def setUp(self):
         self.spec = ArgumentSpec()
+        self.patcher1 = patch('time.sleep')
+        self.patcher1.start()
+
+    def tearDown(self):
+        self.patcher1.stop()
 
     def test_update_agent_status_traps(self, *args):
         set_module_args(dict(

--- a/test/units/modules/network/f5/test_bigip_device_httpd.py
+++ b/test/units/modules/network/f5/test_bigip_device_httpd.py
@@ -83,6 +83,11 @@ class TestModuleManager(unittest.TestCase):
 
     def setUp(self):
         self.spec = ArgumentSpec()
+        self.patcher1 = patch('time.sleep')
+        self.patcher1.start()
+
+    def tearDown(self):
+        self.patcher1.stop()
 
     def test_update(self, *args):
         set_module_args(

--- a/test/units/modules/network/f5/test_bigip_iapplx_package.py
+++ b/test/units/modules/network/f5/test_bigip_iapplx_package.py
@@ -73,6 +73,11 @@ class TestManager(unittest.TestCase):
 
     def setUp(self):
         self.spec = ArgumentSpec()
+        self.patcher1 = patch('time.sleep')
+        self.patcher1.start()
+
+    def tearDown(self):
+        self.patcher1.stop()
 
     def test_create_iapp_template(self, *args):
         # Configure the arguments that would be sent to the Ansible module

--- a/test/units/modules/network/f5/test_bigip_provision.py
+++ b/test/units/modules/network/f5/test_bigip_provision.py
@@ -75,6 +75,11 @@ class TestManager(unittest.TestCase):
 
     def setUp(self):
         self.spec = ArgumentSpec()
+        self.patcher1 = patch('time.sleep')
+        self.patcher1.start()
+
+    def tearDown(self):
+        self.patcher1.stop()
 
     def test_provision_one_module_default_level(self, *args):
         # Configure the arguments that would be sent to the Ansible module

--- a/test/units/modules/network/f5/test_bigip_ucs.py
+++ b/test/units/modules/network/f5/test_bigip_ucs.py
@@ -112,6 +112,11 @@ class TestV1Manager(unittest.TestCase):
 
     def setUp(self):
         self.spec = ArgumentSpec()
+        self.patcher1 = patch('time.sleep')
+        self.patcher1.start()
+
+    def tearDown(self):
+        self.patcher1.stop()
 
     def test_ucs_default_present(self, *args):
         set_module_args(dict(

--- a/test/units/modules/network/f5/test_bigip_vcmp_guest.py
+++ b/test/units/modules/network/f5/test_bigip_vcmp_guest.py
@@ -149,6 +149,11 @@ class TestParameters(unittest.TestCase):
 class TestManager(unittest.TestCase):
     def setUp(self):
         self.spec = ArgumentSpec()
+        self.patcher1 = patch('time.sleep')
+        self.patcher1.start()
+
+    def tearDown(self):
+        self.patcher1.stop()
 
     def test_create_vlan(self, *args):
         set_module_args(dict(

--- a/test/units/modules/network/f5/test_bigip_wait.py
+++ b/test/units/modules/network/f5/test_bigip_wait.py
@@ -93,6 +93,11 @@ class TestParameters(unittest.TestCase):
 class TestManager(unittest.TestCase):
     def setUp(self):
         self.spec = ArgumentSpec()
+        self.patcher1 = patch('time.sleep')
+        self.patcher1.start()
+
+    def tearDown(self):
+        self.patcher1.stop()
 
     def test_wait_already_available(self, *args):
         set_module_args(dict(
@@ -115,4 +120,4 @@ class TestManager(unittest.TestCase):
         results = mm.exec_module()
 
         assert results['changed'] is False
-        assert results['elapsed'] == 1
+        assert results['elapsed'] == 0

--- a/test/units/modules/network/f5/test_bigiq_regkey_license.py
+++ b/test/units/modules/network/f5/test_bigiq_regkey_license.py
@@ -88,6 +88,11 @@ class TestManager(unittest.TestCase):
 
     def setUp(self):
         self.spec = ArgumentSpec()
+        self.patcher1 = patch('time.sleep')
+        self.patcher1.start()
+
+    def tearDown(self):
+        self.patcher1.stop()
 
     def test_create(self, *args):
         set_module_args(dict(


### PR DESCRIPTION
##### SUMMARY
The modules in this patch include waits that need to happen to ensure
something is correctly configured on a BIG-IP. These waits were
raised as an issue in a recent ansible-testing meeting.

This patch eliminates the waits by mocking time.sleep
(cherry picked from commit 77fa41795eaaba7bf5d3405ebf411406025fd9d8)

