### PR TITLE
Fixes for the N3500 platform that uses the A8 image

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_feature.py
+++ b/lib/ansible/modules/network/nxos/nxos_feature.py
@@ -236,6 +236,9 @@ def main():
         cmds = get_commands(proposed, existing, state, module)
 
         if cmds:
+            # On N35 A8 images, some features return a yes/no prompt
+            # on enablement or disablement. Bypass using terminal dont-ask
+            cmds.insert(0, 'terminal dont-ask')
             if not module.check_mode:
                 load_config(module, cmds)
             results['changed'] = True

--- a/lib/ansible/modules/network/nxos/nxos_lldp.py
+++ b/lib/ansible/modules/network/nxos/nxos_lldp.py
@@ -99,6 +99,9 @@ def main():
     result['commands'] = commands
 
     if commands:
+        # On N35 A8 images, some features return a yes/no prompt
+        # on enablement or disablement. Bypass using terminal dont-ask
+        commands.insert(0, 'terminal dont-ask')
         if not module.check_mode:
             load_config(module, commands)
 

--- a/test/integration/targets/nxos_l3_interface/tests/cli/sanity.yaml
+++ b/test/integration/targets/nxos_l3_interface/tests/cli/sanity.yaml
@@ -7,6 +7,10 @@
 - set_fact: testint2="{{ nxos_int2 }}"
 - set_fact: testint3="{{ nxos_int3 }}"
 
+- set_fact: ipv6_address=""
+- set_fact: ipv6_address="33:db::2/8"
+  when: ipv6_supported
+
 - name: Setup - remove address from interface prior to testing(Part1)
   nxos_config:
     lines:
@@ -69,7 +73,7 @@
   nxos_l3_interface: &conf_agg
     aggregate:
       - { name: "{{ testint2 }}", ipv4: 192.168.22.1/24 }
-      - { name: "{{ testint3 }}", ipv4: 192.168.20.1/24, ipv6: "33:db::2/8" }
+      - { name: "{{ testint3 }}", ipv4: 192.168.20.1/24, ipv6: "{{ ipv6_address }}" }
     provider: "{{ cli }}"
   register: result
 
@@ -89,7 +93,7 @@
   nxos_l3_interface: &rm_agg
     aggregate:
       - { name: "{{ testint2 }}", ipv4: 192.168.22.1/24 }
-      - { name: "{{ testint3 }}", ipv4: 192.168.20.1/24, ipv6: "33:db::2/8" }
+      - { name: "{{ testint3 }}", ipv4: 192.168.20.1/24, ipv6: "{{ ipv6_address }}" }
     provider: "{{ cli }}"
     state: absent
   register: result

--- a/test/integration/targets/nxos_l3_interface/tests/nxapi/sanity.yaml
+++ b/test/integration/targets/nxos_l3_interface/tests/nxapi/sanity.yaml
@@ -7,11 +7,15 @@
 - set_fact: testint2="{{ nxos_int2 }}"
 - set_fact: testint3="{{ nxos_int3 }}"
 
+- set_fact: ipv6_address=""
+- set_fact: ipv6_address="33:db::2/8"
+  when: ipv6_supported
+
 - name: Setup - Remove address from interfaces aggregate
   nxos_l3_interface:
     aggregate:
       - { name: "{{ testint2 }}", ipv4: 192.168.22.1/24 }
-      - { name: "{{ testint3 }}", ipv4: 192.168.20.1/24, ipv6: "33:db::2/8" }
+      - { name: "{{ testint3 }}", ipv4: 192.168.20.1/24, ipv6: "{{ ipv6_address }}" }
     provider: "{{ nxapi }}"
     state: absent
   ignore_errors: yes
@@ -59,7 +63,7 @@
   nxos_l3_interface: &conf_agg
     aggregate:
       - { name: "{{ testint2 }}", ipv4: 192.168.22.1/24 }
-      - { name: "{{ testint3 }}", ipv4: 192.168.20.1/24, ipv6: "33:db::2/8" }
+      - { name: "{{ testint3 }}", ipv4: 192.168.20.1/24, ipv6: "{{ ipv6_address }}" }
     provider: "{{ nxapi }}"
   register: result
 
@@ -79,7 +83,7 @@
   nxos_l3_interface: &rm_agg
     aggregate:
       - { name: "{{ testint2 }}", ipv4: 192.168.22.1/24 }
-      - { name: "{{ testint3 }}", ipv4: 192.168.20.1/24, ipv6: "33:db::2/8" }
+      - { name: "{{ testint3 }}", ipv4: 192.168.20.1/24, ipv6: "{{ ipv6_address }}" }
     provider: "{{ nxapi }}"
     state: absent
   register: result

--- a/test/integration/targets/nxos_linkagg/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_linkagg/tests/common/sanity.yaml
@@ -31,6 +31,14 @@
     - "interface {{ testint1 }}"
     - "interface {{ testint2 }}"
 
+- name: Put interface in L2 mode
+  nxos_interface:
+    aggregate:
+    - { name: "{{testint1}}" }
+    - { name: "{{testint2}}" }
+    mode: layer2
+  when: platform is match("N35")
+
 - name: create linkagg
   nxos_linkagg: &create
     group: 20

--- a/test/integration/targets/nxos_lldp/tests/cli/sanity.yaml
+++ b/test/integration/targets/nxos_lldp/tests/cli/sanity.yaml
@@ -4,8 +4,9 @@
   when: ansible_connection == "local"
 
 - name: Make sure LLDP is not running before tests
-  nxos_config:
-    lines: no feature lldp
+  nxos_feature:
+    feature: lldp
+    state: disabled
     provider: "{{ connection }}"
 
 - name: Enable LLDP service

--- a/test/integration/targets/nxos_lldp/tests/nxapi/sanity.yaml
+++ b/test/integration/targets/nxos_lldp/tests/nxapi/sanity.yaml
@@ -4,8 +4,9 @@
   when: ansible_connection == "local"
 
 - name: Make sure LLDP is not running before tests
-  nxos_config:
-    lines: no feature lldp
+  nxos_feature:
+    feature: lldp
+    state: disabled
     provider: "{{ connection }}"
 
 - name: Enable LLDP service

--- a/test/integration/targets/prepare_nxos_tests/tasks/main.yml
+++ b/test/integration/targets/prepare_nxos_tests/tasks/main.yml
@@ -105,3 +105,7 @@
 - debug: msg="IMAGE VERSION {{ image_version }}"
 - debug: msg="IMAGE TAG {{ imagetag }}"
 - debug: msg="IMAGE MR {{ imagemr }}"
+
+- set_fact: ipv6_supported="true"
+- set_fact: ipv6_supported="false"
+  when: platform is match("N35")

--- a/test/units/modules/network/nxos/test_nxos_feature.py
+++ b/test/units/modules/network/nxos/test_nxos_feature.py
@@ -69,9 +69,9 @@ class TestNxosFeatureModule(TestNxosModule):
     def test_nxos_feature_enable(self):
         set_module_args(dict(feature='nve', state='enabled'))
         result = self.execute_module(changed=True)
-        self.assertEqual(result['commands'], ['feature nv overlay'])
+        self.assertEqual(result['commands'], ['terminal dont-ask', 'feature nv overlay'])
 
     def test_nxos_feature_disable(self):
         set_module_args(dict(feature='ospf', state='disabled'))
         result = self.execute_module(changed=True)
-        self.assertEqual(result['commands'], ['no feature ospf'])
+        self.assertEqual(result['commands'], ['terminal dont-ask', 'no feature ospf'])


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Some of the newer module added in Ansible 2.5 were failing on the N35 platform. This PR addresses those failures.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
- nxos_lldp
- nxos_linkagg
- nxos_l3_interface

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0b1 (stable-2.5 a7a03bbf4a) last updated 2018/02/15 12:05:44 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /root/agents-ci/ansible/lib/ansible
  executable location = /root/agents-ci/ansible/bin/ansible
  python version = 2.7.6 (default, Oct 26 2016, 20:30:19) [GCC 4.8.4]
```