### PR TITLE
Change to longer interval jittered backoffs for efs facts

### DIFF
--- a/lib/ansible/modules/cloud/amazon/efs_facts.py
+++ b/lib/ansible/modules/cloud/amazon/efs_facts.py
@@ -210,7 +210,7 @@ class EFSConnection(object):
         paginator = self.connection.get_paginator('describe_mount_targets')
         return paginator.paginate(FileSystemId=file_system_id).build_full_result()['MountTargets']
 
-    @AWSRetry.exponential_backoff()
+    @AWSRetry.jittered_backoff()
     def get_security_groups(self, mount_target_id):
         """
          Returns security groups for selected instance of EFS

--- a/lib/ansible/modules/cloud/amazon/efs_facts.py
+++ b/lib/ansible/modules/cloud/amazon/efs_facts.py
@@ -186,7 +186,7 @@ class EFSConnection(object):
 
         self.region = region
 
-    @AWSRetry.exponential_backoff()
+    @AWSRetry.exponential_backoff(catch_extra_error_codes=['ThrottlingException'])
     def list_file_systems(self, **kwargs):
         """
          Returns generator of file systems including all attributes of FS
@@ -194,7 +194,7 @@ class EFSConnection(object):
         paginator = self.connection.get_paginator('describe_file_systems')
         return paginator.paginate(**kwargs).build_full_result()['FileSystems']
 
-    @AWSRetry.exponential_backoff()
+    @AWSRetry.exponential_backoff(catch_extra_error_codes=['ThrottlingException'])
     def get_tags(self, file_system_id):
         """
          Returns tag list for selected instance of EFS
@@ -202,7 +202,7 @@ class EFSConnection(object):
         paginator = self.connection.get_paginator('describe_tags')
         return boto3_tag_list_to_ansible_dict(paginator.paginate(FileSystemId=file_system_id).build_full_result()['Tags'])
 
-    @AWSRetry.exponential_backoff()
+    @AWSRetry.exponential_backoff(catch_extra_error_codes=['ThrottlingException'])
     def get_mount_targets(self, file_system_id):
         """
          Returns mount targets for selected instance of EFS
@@ -210,7 +210,7 @@ class EFSConnection(object):
         paginator = self.connection.get_paginator('describe_mount_targets')
         return paginator.paginate(FileSystemId=file_system_id).build_full_result()['MountTargets']
 
-    @AWSRetry.jittered_backoff()
+    @AWSRetry.jittered_backoff(catch_extra_error_codes=['ThrottlingException'])
     def get_security_groups(self, mount_target_id):
         """
          Returns security groups for selected instance of EFS


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
When using efs facts with large numbers of EFS targets, throttles can go beyond the normal limits for the security group descriptions. Switch to jittered backoff to handle those throttles a bit better. 

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

Addresses #36040

##### ISSUE TYPE

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
efs_facts

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
