### PR TITLE
Fixing default value of gpgcheck

### DIFF
--- a/lib/ansible/modules/packaging/os/yum_repository.py
+++ b/lib/ansible/modules/packaging/os/yum_repository.py
@@ -124,7 +124,7 @@ options:
   gpgcheck:
     required: false
     choices: ['yes', 'no']
-    default: 'no'
+    default: null
     description:
       - Tells yum whether or not it should perform a GPG signature check on
         packages.

--- a/lib/ansible/modules/packaging/os/yum_repository.py
+++ b/lib/ansible/modules/packaging/os/yum_repository.py
@@ -128,6 +128,8 @@ options:
     description:
       - Tells yum whether or not it should perform a GPG signature check on
         packages.
+      - Doesn't add anything to config, by default, which implies fallback
+        to global default in /etc/yum.conf
   gpgkey:
     required: false
     default: null

--- a/lib/ansible/modules/packaging/os/yum_repository.py
+++ b/lib/ansible/modules/packaging/os/yum_repository.py
@@ -128,8 +128,6 @@ options:
     description:
       - Tells yum whether or not it should perform a GPG signature check on
         packages.
-      - Doesn't add anything to config, by default, which implies fallback
-        to global default in /etc/yum.conf
   gpgkey:
     required: false
     default: null

--- a/test/integration/targets/yum_repository/tasks/yum_repository_centos.yml
+++ b/test/integration/targets/yum_repository/tasks/yum_repository_centos.yml
@@ -189,6 +189,7 @@
     description: EPEL yum repo
     baseurl: https://download.fedoraproject.org/pub/epel/{{ ansible_distribution_major_version }}/{{ ansible_architecture }}/
     state: present
+    gpgcheck: no
 
 - set_fact:
     repofile: "{{ lookup('file', '/etc/yum.repos.d/epel.repo') }}"

--- a/test/integration/targets/yum_repository/tasks/yum_repository_centos.yml
+++ b/test/integration/targets/yum_repository/tasks/yum_repository_centos.yml
@@ -177,3 +177,23 @@
   yum_repository:
     name: listtest
     state: absent
+
+- name: disable epel (clean up)
+  yum_repository:
+    name: epel
+    state: absent
+
+- name: add epel
+  yum_repository:
+    name: epel
+    description: EPEL yum repo
+    baseurl: https://download.fedoraproject.org/pub/epel/{{ ansible_distribution_major_version }}/{{ ansible_architecture }}/
+    state: present
+
+- set_fact:
+    repofile: "{{ lookup('file', '/etc/yum.repos.d/epel.repo') }}"
+
+- name: check for gpgcheck=0
+  assert:
+    that:
+      - "'gpgcheck = 0' in repofile"


### PR DESCRIPTION
##### SUMMARY
This PR is fixing documentation of the `yum_repository` module to match the actual module code behavior. By default the `gpgcheck` value is set to `null` but the documentation was saying that the default value is `True` which is not correct.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
`yum_repository`

##### ANSIBLE VERSION
```
ansible 2.4.3.0
```

##### ADDITIONAL INFORMATION
None