### PR TITLE
Fix incorrect docs in `ec2_tag` per #35738

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_tag.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_tag.py
@@ -94,8 +94,7 @@ EXAMPLES = '''
     tags:
       Name: dbserver
       Env: production
-  with_items:
-    - ec2_vol.volumes
+  with_items: '{{ ec2_vol.volumes }}'
 
 - name: Get EC2 facts
   action: ec2_facts


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fix misuse of `with_items` in ec2_tag module docs. 

Fixes #35738
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
