### PR TITLE
rabbitmq_user: Add update_password parameter

### DIFF
--- a/lib/ansible/modules/messaging/rabbitmq_user.py
+++ b/lib/ansible/modules/messaging/rabbitmq_user.py
@@ -90,7 +90,7 @@ options:
     required: false
     default: on_create
     choices: [ on_create, always ]
-    version_added: "2.5"
+    version_added: "2.6"
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/messaging/rabbitmq_user.py
+++ b/lib/ansible/modules/messaging/rabbitmq_user.py
@@ -31,7 +31,7 @@ options:
     description:
       - Password of user to add.
       - To change the password of an existing user, you must also specify
-        C(force=yes).
+        C(force=yes) or C(update_password=always).
   tags:
     description:
       - User tags specified as comma delimited

--- a/lib/ansible/modules/messaging/rabbitmq_user.py
+++ b/lib/ansible/modules/messaging/rabbitmq_user.py
@@ -187,6 +187,9 @@ class RabbitMqUser(object):
                                        write_priv=write_priv, read_priv=read_priv))
         return perms_list
 
+    def check_password(self):
+        return self._exec(['authenticate_user', self.username, self.password], True)
+
     def add(self):
         if self.password is not None:
             self._exec(['add_user', self.username, self.password])
@@ -290,8 +293,9 @@ def main():
                 rabbitmq_user.get()
                 result['changed'] = True
             elif update_password == 'always':
-                rabbitmq_user.change_password()
-                result['changed'] = True
+                if not rabbitmq_user.check_password():
+                    rabbitmq_user.change_password()
+                    result['changed'] = True
 
             if rabbitmq_user.has_tags_modifications():
                 rabbitmq_user.set_tags()

--- a/lib/ansible/modules/messaging/rabbitmq_user.py
+++ b/lib/ansible/modules/messaging/rabbitmq_user.py
@@ -31,7 +31,7 @@ options:
     description:
       - Password of user to add.
       - To change the password of an existing user, you must also specify
-        C(force=yes) or C(update_password=always).
+        C(update_password=always).
   tags:
     description:
       - User tags specified as comma delimited


### PR DESCRIPTION
##### SUMMARY

At present the only way to update the password for an existing rabbitmq user is to delete and recreate the user with `force=yes`. These operations are not atomic, which is far from ideal in production environments.

This feature adds a parameter to allow password updates without requiring `force=yes`.

Inspiration for this feature is taken from the `user` module. While `always` has long been the default in that module, it has not here. This new feature defaults to `on_create` to avoid changing existing behaviour.

Fixes #29260

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
rabbitmq_user

##### ANSIBLE VERSION
```
ansible 2.4.2.0
```