### PR TITLE
Update network debug troubleshooting guide

### DIFF
--- a/docs/docsite/rst/networking_guide/network_debug_troubleshooting.rst
+++ b/docs/docsite/rst/networking_guide/network_debug_troubleshooting.rst
@@ -153,27 +153,27 @@ For example:
 
 .. code-block:: none
 
-fatal: [spine02]: FAILED! => {
-    "changed": false,
-    "failed": true,
-    "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_TSqk5J/ansible_modlib.zip/ansible/module_utils/connection.py\", line 115, in _exec_jsonrpc\nansible.module_utils.connection.ConnectionError: socket_path does not exist or cannot be found\n",
-    "module_stdout": "",
-    "msg": "MODULE FAILURE",
-    "rc": 1
-}
+   fatal: [spine02]: FAILED! => {
+       "changed": false,
+       "failed": true,
+       "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_TSqk5J/ansible_modlib.zip/ansible/module_utils/connection.py\", line 115, in _exec_jsonrpc\nansible.module_utils.connection.ConnectionError: socket_path does not exist or cannot be found\n",
+       "module_stdout": "",
+       "msg": "MODULE FAILURE",
+       "rc": 1
+   }
 
 or
 
 .. code-block:: none
 
-fatal: [spine02]: FAILED! => {
-    "changed": false,
-    "failed": true,
-    "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_TSqk5J/ansible_modlib.zip/ansible/module_utils/connection.py\", line 123, in _exec_jsonrpc\nansible.module_utils.connection.ConnectionError: unable to connect to socket\n",
-    "module_stdout": "",
-    "msg": "MODULE FAILURE",
-    "rc": 1
-}
+   fatal: [spine02]: FAILED! => {
+       "changed": false,
+       "failed": true,
+       "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_TSqk5J/ansible_modlib.zip/ansible/module_utils/connection.py\", line 123, in _exec_jsonrpc\nansible.module_utils.connection.ConnectionError: unable to connect to socket\n",
+       "module_stdout": "",
+       "msg": "MODULE FAILURE",
+       "rc": 1
+   }
 
 Suggestions to resolve:
 

--- a/docs/docsite/rst/networking_guide/network_debug_troubleshooting.rst
+++ b/docs/docsite/rst/networking_guide/network_debug_troubleshooting.rst
@@ -141,7 +141,7 @@ Then review the log file and find the relevant error message in the rest of this
 .. _socket_path_issue:
 
 Category "socket_path issue"
-========================================================
+============================
 
 **Platforms:** Any
 
@@ -191,7 +191,7 @@ or
 
    2017-04-04 12:19:05,670 p=18591 u=fred |  persistent connection idle timeout triggered, timeout value is 30 secs
 
-Follow the steps detailed in :ref:`timeout issues <timeout_issues>`.
+Follow the steps detailed in :ref:`timeout issues <timeout_issues>`
 
 
 .. _unable_to_open_shell:

--- a/docs/docsite/rst/networking_guide/network_debug_troubleshooting.rst
+++ b/docs/docsite/rst/networking_guide/network_debug_troubleshooting.rst
@@ -145,8 +145,7 @@ Category "socket_path issue"
 
 **Platforms:** Any
 
-The ``socket_path does not exist or cannot be found``  and ``unable to connect to socket`` messages are new in Ansible 2.5. These message means that
-socket used the talk to the remote network device does not exist or unable to connect to.
+The ``socket_path does not exist or cannot be found``  and ``unable to connect to socket`` messages are new in Ansible 2.5. These messages indicate that the socket used to communicate with the remote network device is unavailable or does not exist.
 
 
 For example:
@@ -177,7 +176,7 @@ or
 
 Suggestions to resolve:
 
-Follow the steps detailed in :ref:`enable network logging <enable_network_logging>`
+Follow the steps detailed in :ref:`enable network logging <enable_network_logging>`.
 
 If the identified error message from the log file is:
 

--- a/docs/docsite/rst/networking_guide/network_debug_troubleshooting.rst
+++ b/docs/docsite/rst/networking_guide/network_debug_troubleshooting.rst
@@ -192,6 +192,7 @@ or
 .. code-block:: yaml
 
    2017-04-04 12:19:05,670 p=18591 u=fred |  persistent connection idle timeout triggered, timeout value is 30 secs
+
 Follow the steps detailed in timeout_issues_.
 
 

--- a/docs/docsite/rst/networking_guide/network_debug_troubleshooting.rst
+++ b/docs/docsite/rst/networking_guide/network_debug_troubleshooting.rst
@@ -145,7 +145,7 @@ Category "socket_path issue"
 
 **Platforms:** Any
 
-The ``socket_path does not exist or cannot be found``  and ``unable to connect to socket`` message is new in Ansible 2.5. This message means that
+The ``socket_path does not exist or cannot be found``  and ``unable to connect to socket`` messages are new in Ansible 2.5. These message means that
 socket used the talk to the remote network device does not exist or unable to connect to.
 
 
@@ -177,11 +177,9 @@ or
 
 Suggestions to resolve:
 
-Follow the steps detailed in enable_network_logging_.
+Follow the steps detailed in :ref:`enable network logging <enable_network_logging>`
 
-If the identified the error message from the log file is
-
-For example:
+If the identified error message from the log file is:
 
 .. code-block:: yaml
 
@@ -193,7 +191,7 @@ or
 
    2017-04-04 12:19:05,670 p=18591 u=fred |  persistent connection idle timeout triggered, timeout value is 30 secs
 
-Follow the steps detailed in timeout_issues_.
+Follow the steps detailed in :ref:`timeout issues <timeout_issues>`.
 
 
 .. _unable_to_open_shell:

--- a/docs/docsite/rst/networking_guide/network_debug_troubleshooting.rst
+++ b/docs/docsite/rst/networking_guide/network_debug_troubleshooting.rst
@@ -187,7 +187,11 @@ For example:
 
    2017-04-04 12:19:05,670 p=18591 u=fred |  command timeout triggered, timeout value is 10 secs
 
+or
 
+.. code-block:: yaml
+
+   2017-04-04 12:19:05,670 p=18591 u=fred |  persistent connection idle timeout triggered, timeout value is 30 secs
 Follow the steps detailed in timeout_issues_.
 
 

--- a/docs/docsite/rst/networking_guide/network_debug_troubleshooting.rst
+++ b/docs/docsite/rst/networking_guide/network_debug_troubleshooting.rst
@@ -383,6 +383,7 @@ of inactivity), simple delete the socket file.
 
 
 .. _timeout_issues:
+
 Timeout issues
 ==============
 

--- a/docs/docsite/rst/networking_guide/network_debug_troubleshooting.rst
+++ b/docs/docsite/rst/networking_guide/network_debug_troubleshooting.rst
@@ -138,6 +138,59 @@ Then review the log file and find the relevant error message in the rest of this
 
 .. For details on other ways to authenticate, see LINKTOAUTHHOWTODOCS.
 
+.. _socket_path_issue:
+
+Category "socket_path issue"
+========================================================
+
+**Platforms:** Any
+
+The ``socket_path does not exist or cannot be found``  and ``unable to connect to socket`` message is new in Ansible 2.5. This message means that
+socket used the talk to the remote network device does not exist or unable to connect to.
+
+
+For example:
+
+.. code-block:: none
+
+fatal: [spine02]: FAILED! => {
+    "changed": false,
+    "failed": true,
+    "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_TSqk5J/ansible_modlib.zip/ansible/module_utils/connection.py\", line 115, in _exec_jsonrpc\nansible.module_utils.connection.ConnectionError: socket_path does not exist or cannot be found\n",
+    "module_stdout": "",
+    "msg": "MODULE FAILURE",
+    "rc": 1
+}
+
+or
+
+.. code-block:: none
+
+fatal: [spine02]: FAILED! => {
+    "changed": false,
+    "failed": true,
+    "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_TSqk5J/ansible_modlib.zip/ansible/module_utils/connection.py\", line 123, in _exec_jsonrpc\nansible.module_utils.connection.ConnectionError: unable to connect to socket\n",
+    "module_stdout": "",
+    "msg": "MODULE FAILURE",
+    "rc": 1
+}
+
+Suggestions to resolve:
+
+Follow the steps detailed in enable_network_logging_.
+
+If the identified the error message from the log file is
+
+For example:
+
+.. code-block:: yaml
+
+   2017-04-04 12:19:05,670 p=18591 u=fred |  command timeout triggered, timeout value is 10 secs
+
+
+Follow the steps detailed in timeout_issues_.
+
+
 .. _unable_to_open_shell:
 
 Category "Unable to open shell"
@@ -324,7 +377,7 @@ To clear out a persistent connection before it times out (the default timeout is
 of inactivity), simple delete the socket file.
 
 
-
+.. _timeout_issues:
 Timeout issues
 ==============
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fix #35914

Command timeout and connection timeout error messages
are displayed in the log file instead of on the console.
Update the same in the troubleshooting guide.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
rst/networking_guide/network_debug_troubleshooting.rst

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
