### PR TITLE
Add eos_command doc with more examples (#36245)

### DIFF
--- a/lib/ansible/modules/network/eos/eos_command.py
+++ b/lib/ansible/modules/network/eos/eos_command.py
@@ -50,7 +50,9 @@ options:
         and what conditionals to apply.  This argument will cause
         the task to wait for a particular conditional to be true
         before moving forward.   If the conditional is not true
-        by the configured retries, the task fails.  See examples.
+        by the configured retries, the task fails.
+        Note - With I(wait_for) the value in C(result['stdout']) can be accessed
+        using C(result), that is to access C(result['stdout'][0]) use C(result[0]) See examples.
     required: false
     default: null
     aliases: ['waitfor']
@@ -115,6 +117,26 @@ EXAMPLES = """
     commands:
       - command: show version
         output: json
+
+- name: using cli transport, check whether the switch is in maintenance mode
+  eos_command:
+    commands: show maintenance
+    wait_for: result[0] contains 'Under Maintenance'
+
+- name: using cli transport, check whether the switch is in maintenance mode using json output
+  eos_command:
+    commands: show maintenance | json
+    wait_for: result[0].units.System.state eq 'underMaintenance'
+
+- name: "using eapi transport check whether the switch is in maintenance,
+         with 8 retries and 2 second interval between retries"
+  eos_command:
+    commands: show maintenance
+    wait_for: result[0]['units']['System']['state'] eq 'underMaintenance'
+    interval: 2
+    retries: 8
+    provider:
+      transport: eapi
 """
 
 RETURN = """


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
* Add eos_command doc with more examples

*  More examples using cli and eapi transport
*  Example on how to handle json output
*  Example on handling result output in wait_for

* Fix typo

(cherry picked from commit cb52509775e3a257f47ccaa95a736e37cbc3acd7)

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
eos_command
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
