### PR TITLE
winrm connection; attempt to make winrm.py work on python 2 or 3

### DIFF
--- a/lib/ansible/plugins/connection/winrm.py
+++ b/lib/ansible/plugins/connection/winrm.py
@@ -117,7 +117,7 @@ from ansible.errors import AnsibleError, AnsibleConnectionFailure
 from ansible.errors import AnsibleFileNotFound
 from ansible.module_utils.six.moves.urllib.parse import urlunsplit
 from ansible.module_utils._text import to_bytes, to_native, to_text
-from ansible.module_utils.six import binary_type
+from ansible.module_utils.six import binary_type, PY2
 from ansible.plugins.connection import ConnectionBase
 from ansible.plugins.shell.powershell import leaf_exec
 from ansible.utils.hashing import secure_hash
@@ -297,7 +297,10 @@ class Connection(ConnectionBase):
                                  stdout=subprocess.PIPE,
                                  stderr=subprocess.PIPE,
                                  env=krb5env)
-            stdout, stderr = p.communicate(password + b'\n')
+            if six.PY2:
+               stdout, stderr = p.communicate(password + b'\n')
+            else: 
+               stdout, stderr = p.communicate(bytes(password + '\n', 'utf-8'))               
             rc = p.returncode != 0
 
         if rc != 0:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
To allow kerberos connections to work when using python 3 as well as python 2
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
No github issue, but recently discussed on #ansible-windows channel
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
winrm connection plugin
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0 (winrm-py3 45a654a240) last updated 2018/02/16 08:16:38 (GMT +100)
  config file = None
  configured module search path = [u'/home/jon/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/jon/ansible-dev/lib/ansible
  executable location = /home/jon/ansible-dev/bin/ansible
  python version = 2.7.6 (default, Oct 26 2016, 20:30:19) [GCC 4.8.4]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
Not fully tested at the time of creating PR.  I know the bytes() call lets p.communicate function but haven't yet been able to try the six.PY2 test.
```
