### PR TITLE
Add --truncate option to ansible-test.

### DIFF
--- a/test/runner/test.py
+++ b/test/runner/test.py
@@ -79,6 +79,7 @@ def main():
         args = parse_args()
         config = args.config(args)
         display.verbosity = config.verbosity
+        display.truncate = config.truncate
         display.color = config.color
         display.info_stderr = (isinstance(config, SanityConfig) and config.lint) or (isinstance(config, IntegrationConfig) and config.list_targets)
         check_startup()
@@ -148,6 +149,13 @@ def parse_args():
     common.add_argument('--debug',
                         action='store_true',
                         help='run ansible commands in debug mode')
+
+    common.add_argument('--truncate',
+                        dest='truncate',
+                        metavar='COLUMNS',
+                        type=int,
+                        default=display.columns,
+                        help='truncate some long output (0=disabled) (default: auto)')
 
     test = argparse.ArgumentParser(add_help=False, parents=[common])
 


### PR DESCRIPTION
##### SUMMARY

Add --truncate option to ansible-test.

Currently only long commands shown with -e or -v are truncated.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.6.0 (at-truncate 2b6557919e) last updated 2018/02/16 01:10:20 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```
