### PR TITLE
re enabled tests that were fixed in  ansible/ansible-modules-core#500…

### DIFF
--- a/test/integration/targets/ios_config/tests/cli/save.yaml
+++ b/test/integration/targets/ios_config/tests/cli/save.yaml
@@ -17,22 +17,16 @@
     save: true
     provider: "{{ cli }}"
   register: result
-# FIXME https://github.com/ansible/ansible-modules-core/issues/5008
-  ignore_errors: true
 
 - assert:
     that:
       - "result.changed == true"
-# FIXME https://github.com/ansible/ansible-modules-core/issues/5008
-  ignore_errors: true
 
 - name: save should always run
   ios_config:
     save: true
     provider: "{{ cli }}"
   register: result
-# FIXME https://github.com/ansible/ansible-modules-core/issues/5008
-  ignore_errors: true
 
 - name: delete config (setup)
   ios_config:


### PR DESCRIPTION
…8 (#36257)

(cherry picked from commit a7c2f6d09207fad9fb3bc381dcb67dd1e8c1da5e)

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - tests

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
ios_config

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
