### PR TITLE
Fix None stringification call to send_command

### DIFF
--- a/lib/ansible/plugins/cliconf/ios.py
+++ b/lib/ansible/plugins/cliconf/ios.py
@@ -81,8 +81,7 @@ class Cliconf(CliconfBase):
                 answer = None
                 newline = True
 
-            self.send_command(to_bytes(command), to_bytes(prompt), to_bytes(answer),
-                              False, newline)
+            self.send_command(command, prompt, answer, False, newline)
 
     def get(self, command, prompt=None, answer=None, sendonly=False):
         return self.send_command(command, prompt=prompt, answer=answer, sendonly=sendonly)


### PR DESCRIPTION

##### SUMMARY
send_command already performs the to_bytes safely on prompts (checking
for None).  Without this check the literal 'None' became a subprompt trigger!

(cherry picked from commit f2818caa61669bb6e41c98c7a686dfd6b6ead0b9)

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
ios

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```