### PR TITLE
VMware: Make a common API for hostsystem params

### DIFF
--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -1100,3 +1100,33 @@ class PyVmomi(object):
         for pg in host_system.config.network.portgroup:
             pgs_list.append(pg)
         return pgs_list
+
+    def get_all_host_objs(self, cluster_name=None, esxi_host_name=None):
+        """
+        Function to get all host system managed object
+
+        Args:
+            cluster_name: Name of Cluster
+            esxi_host_name: Name of ESXi server
+
+        Returns: A list of all host system managed objects, else empty list
+
+        """
+        host_obj_list = []
+        if not self.is_vcenter():
+            host_obj_list.append(get_all_objs(self.content, [vim.HostSystem])[0])
+        else:
+            if cluster_name:
+                cluster_obj = self.find_cluster_by_name(cluster_name=cluster_name)
+                if cluster_obj:
+                    host_obj_list = [host for host in cluster_obj.host]
+                else:
+                    self.module.fail_json(changed=False, msg="Cluster '%s' not found" % cluster_name)
+            elif esxi_host_name:
+                esxi_host_obj = self.find_hostsystem_by_name(host_name=esxi_host_name)
+                if esxi_host_obj:
+                    host_obj_list = [esxi_host_obj]
+                else:
+                    self.module.fail_json(changed=False, msg="ESXi '%s' not found" % esxi_host_name)
+
+        return host_obj_list

--- a/lib/ansible/modules/cloud/vmware/vmware_host_acceptance.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_acceptance.py
@@ -111,19 +111,7 @@ class VMwareAccpetanceManager(PyVmomi):
         super(VMwareAccpetanceManager, self).__init__(module)
         cluster_name = self.params.get('cluster_name', None)
         esxi_host_name = self.params.get('esxi_hostname', None)
-        self.hosts = []
-        if cluster_name:
-            cluster_obj = self.find_cluster_by_name(cluster_name=cluster_name)
-            if cluster_obj:
-                self.hosts = [host for host in cluster_obj.host]
-            else:
-                module.fail_json(changed=False, msg="Cluster '%s' not found" % cluster_name)
-        elif esxi_host_name:
-            esxi_host_obj = self.find_hostsystem_by_name(host_name=esxi_host_name)
-            if esxi_host_obj:
-                self.hosts = [esxi_host_obj]
-            else:
-                module.fail_json(changed=False, msg="ESXi '%s' not found" % esxi_host_name)
+        self.hosts = self.get_all_host_objs(cluster_name=cluster_name, esxi_host_name=esxi_host_name)
         self.desired_state = self.params.get('state')
         self.hosts_facts = {}
         self.acceptance_level = self.params.get('acceptance_level')

--- a/lib/ansible/modules/cloud/vmware/vmware_host_config_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_config_facts.py
@@ -67,19 +67,7 @@ class VmwareConfigFactsManager(PyVmomi):
         super(VmwareConfigFactsManager, self).__init__(module)
         cluster_name = self.params.get('cluster_name', None)
         esxi_host_name = self.params.get('esxi_hostname', None)
-        self.hosts = []
-        if cluster_name:
-            cluster_obj = self.find_cluster_by_name(cluster_name=cluster_name)
-            if cluster_obj:
-                self.hosts = [host for host in cluster_obj.host]
-            else:
-                module.fail_json(changed=False, msg="Cluster '%s' not found" % cluster_name)
-        elif esxi_host_name:
-            esxi_host_obj = self.find_hostsystem_by_name(host_name=esxi_host_name)
-            if esxi_host_obj:
-                self.hosts = [esxi_host_obj]
-            else:
-                module.fail_json(changed=False, msg="ESXi '%s' not found" % esxi_host_name)
+        self.hosts = self.get_all_host_objs(cluster_name=cluster_name, esxi_host_name=esxi_host_name)
 
     def gather_host_facts(self):
         hosts_facts = {}

--- a/lib/ansible/modules/cloud/vmware/vmware_host_config_manager.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_config_manager.py
@@ -95,19 +95,7 @@ class VmwareConfigManager(PyVmomi):
         cluster_name = self.params.get('cluster_name', None)
         esxi_host_name = self.params.get('esxi_hostname', None)
         self.options = self.params.get('options', dict())
-        self.hosts = []
-        if cluster_name:
-            cluster_obj = self.find_cluster_by_name(cluster_name=cluster_name)
-            if cluster_obj:
-                self.hosts = [host for host in cluster_obj.host]
-            else:
-                module.fail_json(changed=False, msg="Cluster '%s' not found" % cluster_name)
-        elif esxi_host_name:
-            esxi_host_obj = self.find_hostsystem_by_name(host_name=esxi_host_name)
-            if esxi_host_obj:
-                self.hosts = [esxi_host_obj]
-            else:
-                module.fail_json(changed=False, msg="ESXi '%s' not found" % esxi_host_name)
+        self.hosts = self.get_all_host_objs(cluster_name=cluster_name, esxi_host_name=esxi_host_name)
 
     def set_host_configuration_facts(self):
         changed = False

--- a/lib/ansible/modules/cloud/vmware/vmware_host_dns_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_dns_facts.py
@@ -86,19 +86,7 @@ class VmwareDnsFactsManager(PyVmomi):
         super(VmwareDnsFactsManager, self).__init__(module)
         cluster_name = self.params.get('cluster_name', None)
         esxi_host_name = self.params.get('esxi_hostname', None)
-        self.hosts = []
-        if cluster_name:
-            cluster_obj = self.find_cluster_by_name(cluster_name=cluster_name)
-            if cluster_obj:
-                self.hosts = [host for host in cluster_obj.host]
-            else:
-                module.fail_json(changed=False, msg="Cluster '%s' not found" % cluster_name)
-        elif esxi_host_name:
-            esxi_host_obj = self.find_hostsystem_by_name(host_name=esxi_host_name)
-            if esxi_host_obj:
-                self.hosts = [esxi_host_obj]
-            else:
-                module.fail_json(changed=False, msg="ESXi '%s' not found" % esxi_host_name)
+        self.hosts = self.get_all_host_objs(cluster_name=cluster_name, esxi_host_name=esxi_host_name)
 
     def gather_dns_facts(self):
         hosts_facts = {}

--- a/lib/ansible/modules/cloud/vmware/vmware_host_firewall_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_firewall_facts.py
@@ -93,19 +93,7 @@ class FirewallFactsManager(PyVmomi):
         super(FirewallFactsManager, self).__init__(module)
         cluster_name = self.params.get('cluster_name', None)
         esxi_host_name = self.params.get('esxi_hostname', None)
-        self.hosts = []
-        if cluster_name:
-            cluster_obj = self.find_cluster_by_name(cluster_name=cluster_name)
-            if cluster_obj:
-                self.hosts = [host for host in cluster_obj.host]
-            else:
-                module.fail_json(changed=False, msg="Cluster '%s' not found" % cluster_name)
-        elif esxi_host_name:
-            esxi_host_obj = self.find_hostsystem_by_name(host_name=esxi_host_name)
-            if esxi_host_obj:
-                self.hosts = [esxi_host_obj]
-            else:
-                module.fail_json(changed=False, msg="ESXi '%s' not found" % esxi_host_name)
+        self.hosts = self.get_all_host_objs(cluster_name=cluster_name, esxi_host_name=esxi_host_name)
 
     @staticmethod
     def normalize_rule_set(rule_obj):

--- a/lib/ansible/modules/cloud/vmware/vmware_host_firewall_manager.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_firewall_manager.py
@@ -121,19 +121,7 @@ class VmwareFirewallManager(PyVmomi):
         cluster_name = self.params.get('cluster_name', None)
         esxi_host_name = self.params.get('esxi_hostname', None)
         self.options = self.params.get('options', dict())
-        self.hosts = []
-        if cluster_name:
-            cluster_obj = self.find_cluster_by_name(cluster_name=cluster_name)
-            if cluster_obj:
-                self.hosts = [host for host in cluster_obj.host]
-            else:
-                module.fail_json(changed=False, msg="Cluster '%s' not found" % cluster_name)
-        elif esxi_host_name:
-            esxi_host_obj = self.find_hostsystem_by_name(host_name=esxi_host_name)
-            if esxi_host_obj:
-                self.hosts = [esxi_host_obj]
-            else:
-                module.fail_json(changed=False, msg="ESXi '%s' not found" % esxi_host_name)
+        self.hosts = self.get_all_host_objs(cluster_name=cluster_name, esxi_host_name=esxi_host_name)
         self.firewall_facts = dict()
         self.rule_options = self.module.params.get("rules")
         self.gather_rule_set()

--- a/lib/ansible/modules/cloud/vmware/vmware_host_lockdown.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_lockdown.py
@@ -125,20 +125,7 @@ class VmwareLockdownManager(PyVmomi):
                                       "as vCenter server." % self.module.params['hostname'])
         cluster_name = self.params.get('cluster_name', None)
         esxi_host_name = self.params.get('esxi_hostname', None)
-        self.hosts = []
-        if cluster_name:
-            cluster_obj = self.find_cluster_by_name(cluster_name=cluster_name)
-            if cluster_obj:
-                self.hosts = [host for host in cluster_obj.host]
-            else:
-                module.fail_json(changed=False, msg="Cluster '%s' not found" % cluster_name)
-        elif esxi_host_name:
-            for host in esxi_host_name:
-                esxi_host_obj = self.find_hostsystem_by_name(host_name=host)
-                if esxi_host_obj:
-                    self.hosts.append(esxi_host_obj)
-                else:
-                    module.fail_json(changed=False, msg="ESXi '%s' not found" % host)
+        self.hosts = self.get_all_host_objs(cluster_name=cluster_name, esxi_host_name=esxi_host_name)
 
     def ensure(self):
         """

--- a/lib/ansible/modules/cloud/vmware/vmware_host_ntp.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_ntp.py
@@ -106,19 +106,7 @@ class VmwareNtpConfigManager(PyVmomi):
         cluster_name = self.params.get('cluster_name', None)
         esxi_host_name = self.params.get('esxi_hostname', None)
         self.ntp_servers = self.params.get('ntp_servers', list())
-        self.hosts = []
-        if cluster_name:
-            cluster_obj = self.find_cluster_by_name(cluster_name=cluster_name)
-            if cluster_obj:
-                self.hosts = [host for host in cluster_obj.host]
-            else:
-                module.fail_json(changed=False, msg="Cluster '%s' not found" % cluster_name)
-        elif esxi_host_name:
-            esxi_host_obj = self.find_hostsystem_by_name(host_name=esxi_host_name)
-            if esxi_host_obj:
-                self.hosts = [esxi_host_obj]
-            else:
-                module.fail_json(changed=False, msg="ESXi '%s' not found" % esxi_host_name)
+        self.hosts = self.get_all_host_objs(cluster_name=cluster_name, esxi_host_name=esxi_host_name)
         self.results = {}
         self.desired_state = module.params['state']
 

--- a/lib/ansible/modules/cloud/vmware/vmware_host_package_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_package_facts.py
@@ -77,19 +77,7 @@ class VmwarePackageManager(PyVmomi):
         super(VmwarePackageManager, self).__init__(module)
         cluster_name = self.params.get('cluster_name', None)
         esxi_host_name = self.params.get('esxi_hostname', None)
-        self.hosts = []
-        if cluster_name:
-            cluster_obj = self.find_cluster_by_name(cluster_name=cluster_name)
-            if cluster_obj:
-                self.hosts = [host for host in cluster_obj.host]
-            else:
-                module.fail_json(changed=False, msg="Cluster '%s' not found" % cluster_name)
-        elif esxi_host_name:
-            esxi_host_obj = self.find_hostsystem_by_name(host_name=esxi_host_name)
-            if esxi_host_obj:
-                self.hosts = [esxi_host_obj]
-            else:
-                module.fail_json(changed=False, msg="ESXi '%s' not found" % esxi_host_name)
+        self.hosts = self.get_all_host_objs(cluster_name=cluster_name, esxi_host_name=esxi_host_name)
 
     def gather_package_facts(self):
         hosts_facts = {}

--- a/lib/ansible/modules/cloud/vmware/vmware_host_service_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_service_facts.py
@@ -71,19 +71,7 @@ class VmwareServiceManager(PyVmomi):
         super(VmwareServiceManager, self).__init__(module)
         cluster_name = self.params.get('cluster_name', None)
         esxi_host_name = self.params.get('esxi_hostname', None)
-        self.hosts = []
-        if cluster_name:
-            cluster_obj = self.find_cluster_by_name(cluster_name=cluster_name)
-            if cluster_obj:
-                self.hosts = [host for host in cluster_obj.host]
-            else:
-                module.fail_json(changed=False, msg="Cluster '%s' not found" % cluster_name)
-        elif esxi_host_name:
-            esxi_host_obj = self.find_hostsystem_by_name(host_name=esxi_host_name)
-            if esxi_host_obj:
-                self.hosts = [esxi_host_obj]
-            else:
-                module.fail_json(changed=False, msg="ESXi '%s' not found" % esxi_host_name)
+        self.hosts = self.get_all_host_objs(cluster_name=cluster_name, esxi_host_name=esxi_host_name)
 
     def gather_host_facts(self):
         hosts_facts = {}

--- a/lib/ansible/modules/cloud/vmware/vmware_host_service_manager.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_service_manager.py
@@ -118,19 +118,7 @@ class VmwareServiceManager(PyVmomi):
         cluster_name = self.params.get('cluster_name', None)
         esxi_host_name = self.params.get('esxi_hostname', None)
         self.options = self.params.get('options', dict())
-        self.hosts = []
-        if cluster_name:
-            cluster_obj = self.find_cluster_by_name(cluster_name=cluster_name)
-            if cluster_obj:
-                self.hosts = [host for host in cluster_obj.host]
-            else:
-                module.fail_json(changed=False, msg="Cluster '%s' not found" % cluster_name)
-        elif esxi_host_name:
-            esxi_host_obj = self.find_hostsystem_by_name(host_name=esxi_host_name)
-            if esxi_host_obj:
-                self.hosts = [esxi_host_obj]
-            else:
-                module.fail_json(changed=False, msg="ESXi '%s' not found" % esxi_host_name)
+        self.hosts = self.get_all_host_objs(cluster_name=cluster_name, esxi_host_name=esxi_host_name)
         self.desired_state = self.params.get('state')
         self.desired_policy = self.params.get('service_policy', None)
         self.service_name = self.params.get('service_name')

--- a/lib/ansible/modules/cloud/vmware/vmware_host_vmnic_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_vmnic_facts.py
@@ -79,19 +79,7 @@ class HostVmnicMgr(PyVmomi):
         super(HostVmnicMgr, self).__init__(module)
         cluster_name = self.params.get('cluster_name', None)
         esxi_host_name = self.params.get('esxi_hostname', None)
-        self.hosts = []
-        if cluster_name:
-            cluster_obj = self.find_cluster_by_name(cluster_name=cluster_name)
-            if cluster_obj:
-                self.hosts = [host for host in cluster_obj.host]
-            else:
-                module.fail_json(changed=False, msg="Cluster '%s' not found" % cluster_name)
-        elif esxi_host_name:
-            esxi_host_obj = self.find_hostsystem_by_name(host_name=esxi_host_name)
-            if esxi_host_obj:
-                self.hosts = [esxi_host_obj]
-            else:
-                module.fail_json(changed=False, msg="ESXi '%s' not found" % esxi_host_name)
+        self.hosts = self.get_all_host_objs(cluster_name=cluster_name, esxi_host_name=esxi_host_name)
 
     def gather_host_vmnic_facts(self):
         hosts_vmnic_facts = {}

--- a/lib/ansible/modules/cloud/vmware/vmware_portgroup.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_portgroup.py
@@ -171,17 +171,7 @@ class PyVmomiHelper(PyVmomi):
         self.mac_changes = self.params['network_policy'].get('mac_changes')
         self.network_policy = self.create_network_policy()
         self.state = self.params['state']
-
-        self.host_obj_list = []
-        if cluster and self.find_cluster_by_name(cluster_name=cluster):
-            self.host_obj_list = self.get_all_hosts_by_cluster(cluster_name=cluster)
-        elif hosts:
-            for host in hosts:
-                host_system = self.find_hostsystem_by_name(host_name=host)
-                if host_system:
-                    self.host_obj_list.append(host_system)
-                else:
-                    self.module.fail_json(msg="Failed to find ESXi %s" % host)
+        self.host_obj_list = self.get_all_host_objs(cluster_name=cluster, esxi_host_name=hosts)
 
     def process_state(self):
         """

--- a/lib/ansible/modules/cloud/vmware/vmware_vmkernel.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_vmkernel.py
@@ -184,9 +184,7 @@ class PyVmomiHelper(PyVmomi):
         self.vlan_id = self.params['vlan_id']
 
         self.esxi_host_name = self.params['esxi_hostname']
-        self.esxi_host_obj = self.find_hostsystem_by_name(host_name=self.esxi_host_name)
-        if not self.esxi_host_obj:
-            module.fail_json(changed=False, msg="ESXi '%s' not found" % self.esxi_host_name)
+        self.esxi_host_obj = self.get_all_host_objs(esxi_host_name=self.esxi_host_name)[0]
 
         self.port_group_obj = self.get_port_group_by_name(host_system=self.esxi_host_obj, portgroup_name=self.port_group_name)
         if not self.port_group_obj:

--- a/lib/ansible/modules/cloud/vmware/vmware_vmkernel_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_vmkernel_facts.py
@@ -102,19 +102,7 @@ class VmkernelFactsManager(PyVmomi):
         super(VmkernelFactsManager, self).__init__(module)
         cluster_name = self.params.get('cluster_name', None)
         esxi_host_name = self.params.get('esxi_hostname', None)
-        self.hosts = []
-        if cluster_name:
-            cluster_obj = self.find_cluster_by_name(cluster_name=cluster_name)
-            if cluster_obj:
-                self.hosts = [host for host in cluster_obj.host]
-            else:
-                module.fail_json(changed=False, msg="Cluster '%s' not found" % cluster_name)
-        elif esxi_host_name:
-            esxi_host_obj = self.find_hostsystem_by_name(host_name=esxi_host_name)
-            if esxi_host_obj:
-                self.hosts = [esxi_host_obj]
-            else:
-                module.fail_json(changed=False, msg="ESXi '%s' not found" % esxi_host_name)
+        self.hosts = self.get_all_host_objs(cluster_name=cluster_name, esxi_host_name=esxi_host_name)
         self.service_type_vmks = dict()
         self.get_all_vmks_by_service_type()
 


### PR DESCRIPTION
##### SUMMARY
This fix adds a common API for getting host system managed object
from either cluster name or host system.

Fixes: #36010

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Feature Pull Request
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
lib/ansible/module_utils/vmware.py
lib/ansible/modules/cloud/vmware/vmware_host_acceptance.py
lib/ansible/modules/cloud/vmware/vmware_host_config_facts.py
lib/ansible/modules/cloud/vmware/vmware_host_config_manager.py
lib/ansible/modules/cloud/vmware/vmware_host_dns_facts.py
lib/ansible/modules/cloud/vmware/vmware_host_firewall_facts.py
lib/ansible/modules/cloud/vmware/vmware_host_firewall_manager.py
lib/ansible/modules/cloud/vmware/vmware_host_lockdown.py
lib/ansible/modules/cloud/vmware/vmware_host_ntp.py
lib/ansible/modules/cloud/vmware/vmware_host_package_facts.py
lib/ansible/modules/cloud/vmware/vmware_host_service_facts.py
lib/ansible/modules/cloud/vmware/vmware_host_service_manager.py
lib/ansible/modules/cloud/vmware/vmware_host_vmnic_facts.py
lib/ansible/modules/cloud/vmware/vmware_portgroup.py
lib/ansible/modules/cloud/vmware/vmware_vmkernel.py
lib/ansible/modules/cloud/vmware/vmware_vmkernel_facts.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6devel
```