### PR TITLE
nxos_install_os Remove kickstart_image_required check

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_install_os.py
+++ b/lib/ansible/modules/network/nxos/nxos_install_os.py
@@ -60,6 +60,7 @@ options:
     kickstart_image_file:
         description:
             - Name of the kickstart image file on flash.
+              (Not required on all Nexus platforms)
         required: false
         default: null
     issu:
@@ -179,17 +180,6 @@ def get_platform(module):
         type = 'unknown'
 
     return type
-
-
-def kickstart_image_required(module):
-    '''Determine if platform requires a kickstart image'''
-    data = execute_show_command(module, 'show version')[0]
-    kickstart_required = False
-    for x in data.split('\n'):
-        if re.search(r'kickstart image file is:', x):
-            kickstart_required = True
-
-    return kickstart_required
 
 
 def parse_show_install(data):
@@ -563,10 +553,6 @@ def main():
 
     if kif == 'null' or kif == '':
         kif = None
-
-    if kickstart_image_required(module) and kif is None:
-        msg = 'This platform requires a kickstart_image_file'
-        module.fail_json(msg=msg)
 
     install_result = do_install_all(module, issu, sif, kick=kif)
     if install_result['error']:


### PR DESCRIPTION
##### SUMMARY
This update removes a check to indicate if a kickstart image is required or not.  It's possible to upgrade from a system that requires both a kickstart and system image to the singe image that combines the system/kickstart.  This check needs to be removed to allow these kinds of upgrades.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
nxos_os_install

##### ANSIBLE VERSION
```
ansible 2.6.0 (rel250/fix_nxos_os_install 6f5af5c195) last updated 2018/02/16 13:17:54 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/Users/mwiebe/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mwiebe/Projects/nxos_ansible/fix_ansible/lib/ansible
  executable location = /Users/mwiebe/Projects/nxos_ansible/fix_ansible/bin/ansible
  python version = 2.7.13 (default, Apr  4 2017, 08:47:57) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.38)]
```

##### ADDITIONAL INFORMATION
This update needs to be included in `2.5`.