### PR TITLE
Drop duplicate imports from apt_repository module

### DIFF
--- a/lib/ansible/modules/packaging/os/apt_repository.py
+++ b/lib/ansible/modules/packaging/os/apt_repository.py
@@ -109,10 +109,7 @@ import re
 import sys
 import tempfile
 import json
-# import module snippets
-from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.urls import fetch_url
-from ansible.module_utils._text import to_native
+
 try:
     import apt
     import apt_pkg

--- a/lib/ansible/modules/packaging/os/apt_repository.py
+++ b/lib/ansible/modules/packaging/os/apt_repository.py
@@ -108,7 +108,6 @@ import os
 import re
 import sys
 import tempfile
-import json
 
 try:
     import apt


### PR DESCRIPTION
##### SUMMARY
This fixes duplicate imports appearing in the `apt_repository` module

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
apt_repository

##### ANSIBLE VERSION
devel branch

##### ADDITIONAL INFORMATION
N/A