### PR TITLE
Backport part of #33221 to fix azure functionapp ansible modules

### DIFF
--- a/lib/ansible/module_utils/azure_rm_common.py
+++ b/lib/ansible/module_utils/azure_rm_common.py
@@ -758,7 +758,8 @@ class AzureRMModuleBase(object):
     def web_client(self):
         self.log('Getting web client')
         if not self._web_client:
-            self._web_client = self.get_mgmt_svc_client(WebSiteManagementClient, base_url=self.base_url)
+            self._web_client = self.get_mgmt_svc_client(WebSiteManagementClient,
+                                                        base_url=self._cloud_environment.endpoints.resource_manager)
         return self._web_client
 
     @property


### PR DESCRIPTION
##### SUMMARY
Backports the small part of #33221 to fix https://github.com/ansible/ansible/pull/33120 into the 2.4 branch (currently this is only fixed in the 2.5 beta)

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
```
- name: Get FunctionApp info
  azure_rm_functionapp_facts:
      name: "{{ function_name }}"
      resource_group: "{{ resource_group }}"
```

##### ANSIBLE VERSION
```
ansible 2.4.3.0
  config file = /Users/george/Sites/ansible-build/ansible.cfg
  configured module search path = ['/Users/george/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/ansible
  executable location = /Library/Frameworks/Python.framework/Versions/3.5/bin/ansible
  python version = 3.5.1 (v3.5.1:37a07cee5969, Dec  5 2015, 21:12:44) [GCC 4.2.1 (Apple Inc. build 5666) (dot 3)]
```


##### ADDITIONAL INFORMATION

Before:
```
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: AttributeError: 'AzureRMFunctionAppFacts' object has no attribute 'base_url'
fatal: [localhost]: FAILED! => {
    "changed": false,
    "module_stderr": "Traceback (most recent call last):\n  File \"/var/folders/lg/dmcg4t_s0fnd08mc_pcw7_h00000gp/T/ansible_tp8t4guv/ansible_module_azure_rm_functionapp_facts.py\", line 207, in <module>\n    main()\n  File \"/var/folders/lg/dmcg4t_s0fnd08mc_pcw7_h00000gp/T/ansible_tp8t4guv/ansible_module_azure_rm_functionapp_facts.py\", line 203, in main\n    AzureRMFunctionAppFacts()\n  File \"/var/folders/lg/dmcg4t_s0fnd08mc_pcw7_h00000gp/T/ansible_tp8t4guv/ansible_module_azure_rm_functionapp_facts.py\", line 137, in __init__\n    facts_module=True\n  File \"/var/folders/lg/dmcg4t_s0fnd08mc_pcw7_h00000gp/T/ansible_tp8t4guv/ansible_modlib.zip/ansible/module_utils/azure_rm_common.py\", line 286, in __init__\n  File \"/var/folders/lg/dmcg4t_s0fnd08mc_pcw7_h00000gp/T/ansible_tp8t4guv/ansible_module_azure_rm_functionapp_facts.py\", line 149, in exec_module\n    self.results['ansible_facts']['azure_functionapps'] = self.get_functionapp()\n  File \"/var/folders/lg/dmcg4t_s0fnd08mc_pcw7_h00000gp/T/ansible_tp8t4guv/ansible_module_azure_rm_functionapp_facts.py\", line 163, in get_functionapp\n    function_app = self.web_client.web_apps.get(\n  File \"/var/folders/lg/dmcg4t_s0fnd08mc_pcw7_h00000gp/T/ansible_tp8t4guv/ansible_modlib.zip/ansible/module_utils/azure_rm_common.py\", line 761, in web_client\nAttributeError: 'AzureRMFunctionAppFacts' object has no attribute 'base_url'\n",
    "module_stdout": "",
    "rc": 0
}

MSG:

MODULE FAILURE
```

After:

```
TASK [testing : Get FunctionApp information] *************************************************************************************************************
Friday 16 February 2018  18:53:38 +0000 (0:00:00.088)       0:00:00.088 ******* 
ok: [localhost]
```
