### PR TITLE
WIP: Allow certain, simple Jinja values to be unquoted.

### DIFF
--- a/lib/ansible/parsing/utils/yaml.py
+++ b/lib/ansible/parsing/utils/yaml.py
@@ -48,20 +48,18 @@ def _construct_scalar(loader, node):
         map_as_key_key = node.value[0][0]
         map_as_key_val = node.value[0][1]
 
-        # And have key that is a mapping and a null value:
+        # And have key that is a mapping, and a value that is null:
         if map_as_key_key.tag == 'tag:yaml.org,2002:map' and \
             map_as_key_val.tag == 'tag:yaml.org,2002:null':
 
-            # Get the string intended jinja string value:
-            scalar_node = map_as_key_key.value[0][0]
+            # Get the intended jinja string value:
+            jinja_string = map_as_key_key.value[0][0]
 
-            # Put the braces back onto it:
-            if scalar_node.style in ['"', "'"]:
-                # With quotes if original was quoted:
-                return "{{'%s'}}" % scalar_node.value
-
-            # Else unquoted:
-            return "{{%s}}" % scalar_node.value
+            # If jinja string was not quoted:
+            if jinja_string.tag == 'tag:yaml.org,2002:str' and \
+                jinja_string.style == '':
+                # Add jinja double braces back in:
+                return "{{%s}}" % jinja_string.value
 
     # Else process mapping as usual:
     return loader.construct_mapping(node)

--- a/lib/ansible/parsing/utils/yaml.py
+++ b/lib/ansible/parsing/utils/yaml.py
@@ -41,10 +41,31 @@ def _handle_error(yaml_exc, file_name, show_content):
     raise AnsibleParserError(YAML_SYNTAX_ERROR % to_native(err_msg), obj=err_obj, show_content=show_content, orig_exc=yaml_exc)
 
 
+# Mapping may be jinja scalar: {{ foo... }}
+def _construct_scalar(loader, node):
+    # It would have 1 pair:
+    if len(node.value) == 1:
+        map_as_key_key = node.value[0][0]
+        map_as_key_val = node.value[0][1]
+
+        # And have key that is a mapping and a null value:
+        if map_as_key_key.tag == 'tag:yaml.org,2002:map' and \
+            map_as_key_val.tag == 'tag:yaml.org,2002:null':
+
+            # Get the string intended jinja string value:
+            jinja_value = map_as_key_key.value[0][0].value
+
+            # Put the braces back onto it:
+            return "{{%s}}" % jinja_value
+
+    # Else process mapping as usual:
+    return loader.construct_mapping(node)
+
 def _safe_load(stream, file_name=None, vault_secrets=None):
     ''' Implements yaml.safe_load(), except using our custom loader class. '''
 
     loader = AnsibleLoader(stream, file_name, vault_secrets)
+    loader.add_constructor('tag:yaml.org,2002:map', _construct_scalar)
     try:
         return loader.get_single_data()
     finally:

--- a/lib/ansible/parsing/utils/yaml.py
+++ b/lib/ansible/parsing/utils/yaml.py
@@ -53,10 +53,15 @@ def _construct_scalar(loader, node):
             map_as_key_val.tag == 'tag:yaml.org,2002:null':
 
             # Get the string intended jinja string value:
-            jinja_value = map_as_key_key.value[0][0].value
+            scalar_node = map_as_key_key.value[0][0]
 
             # Put the braces back onto it:
-            return "{{%s}}" % jinja_value
+            if scalar_node.style in ['"', "'"]:
+                # With quotes if original was quoted:
+                return "{{'%s'}}" % scalar_node.value
+
+            # Else unquoted:
+            return "{{%s}}" % scalar_node.value
 
     # Else process mapping as usual:
     return loader.construct_mapping(node)


### PR DESCRIPTION
This allows the following to be unquoted:
```
foo: {{ bar }}
```

The above is valid YAML but semantically means something like this:
```
{ "foo": { { "bar": null}: null} }
```

This patch looks for events of that form coming from the parser, and
reconstructs the key `bar` into a string node of value "{{ bar }}".

##### SUMMARY
You can test this with the simple files here: https://gist.github.com/anonymous/48b8744dcafd8f6e6bdac3803e77aa4b

This is just a proof of concept. It only works for simple values that happen to be valid YAML:
```
- {{ foo }} # works
- {{ foo | bar }} # works
- {{ foo[42] }} # not valid yaml
- {{ 'foo' }} # would be same as {{ foo }} 
```

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
YAML Loader

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
