### PR TITLE
Add support for enhanced code-smell tests.

### DIFF
--- a/test/sanity/code-smell/no-assert.json
+++ b/test/sanity/code-smell/no-assert.json
@@ -1,0 +1,10 @@
+{
+    "extensions": [
+        ".py"
+    ],
+    "prefixes": [
+        "bin/",
+        "lib/ansible/"
+    ],
+    "output": "path-line-column-message"
+}

--- a/test/sanity/code-smell/no-assert.py
+++ b/test/sanity/code-smell/no-assert.py
@@ -1,40 +1,29 @@
 #!/usr/bin/env python
 from __future__ import print_function
 
-import os
 import re
 import sys
 
-from collections import defaultdict
-
-PATH = 'lib/ansible'
 ASSERT_RE = re.compile(r'.*(?<![-:a-zA-Z#][ -])\bassert\b(?!:).*')
 
-all_matches = defaultdict(list)
 
-for dirpath, dirnames, filenames in os.walk(PATH):
-    for filename in filenames:
-        path = os.path.join(dirpath, filename)
-        if not os.path.isfile(path) or not path.endswith('.py'):
-            continue
+def main():
+    failed = False
 
+    for path in sys.argv[1:]:
         with open(path, 'r') as f:
             for i, line in enumerate(f.readlines()):
                 matches = ASSERT_RE.findall(line)
 
                 if matches:
-                    all_matches[path].append((i + 1, line.index('assert') + 1, matches))
+                    failed = True
+                    lineno = i + 1
+                    colno = line.index('assert') + 1
+                    print('%s:%d:%d: raise AssertionError instead of: %s' % (path, lineno, colno, matches[0][colno - 1:]))
+
+    if failed:
+        sys.exit(1)
 
 
-if all_matches:
-    print('Use of assert in production code is not recommended.')
-    print('Python will remove all assert statements if run with optimizations')
-    print('Alternatives:')
-    print('    if not isinstance(value, dict):')
-    print('        raise AssertionError("Expected a dict for value")')
-
-    for path, matches in all_matches.items():
-        for line_matches in matches:
-            for match in line_matches[2]:
-                print('%s:%d:%d: %s' % ((path,) + line_matches[:2] + (match,)))
-    sys.exit(1)
+if __name__ == '__main__':
+    main()

--- a/test/sanity/code-smell/no-tests-as-filters.json
+++ b/test/sanity/code-smell/no-tests-as-filters.json
@@ -1,0 +1,7 @@
+{
+    "extensions": [
+        ".yml",
+        ".yaml"
+    ],
+    "output": "path-line-column-message"
+}

--- a/test/sanity/code-smell/no-tests-as-filters.py
+++ b/test/sanity/code-smell/no-tests-as-filters.py
@@ -19,11 +19,8 @@
 
 from __future__ import print_function
 
-import os
 import re
 import sys
-
-from collections import defaultdict
 
 from ansible.plugins.test import core, files, mathstuff
 
@@ -48,41 +45,42 @@ TEST_MAP = {
 }
 
 
-FILTER_RE = re.compile(r'((.+?)\s*([\w \.\'"]+)(\s*)\|(\s*)(\w+))')
+FILTER_RE = re.compile(r'((.+?)\s*(?P<left>[\w \.\'"]+)(\s*)\|(\s*)(?P<filter>\w+))')
 
 
 def main():
-    all_matches = defaultdict(list)
+    failed = False
 
-    for root, dirs, filenames in os.walk('.'):
-        for name in filenames:
-            if os.path.splitext(name)[1] not in ('.yml', '.yaml'):
+    for path in sys.argv[1:]:
+        with open(path) as f:
+            text = f.read()
+
+        lines = text.splitlines(True)
+        previous = 0
+        offset = 0
+        lineno = 0
+
+        for match in FILTER_RE.finditer(text):
+            filter_name = match.group('filter')
+            test_name = TEST_MAP.get(filter_name, filter_name)
+
+            if test_name not in TESTS:
                 continue
-            path = os.path.join(root, name)
 
-            with open(path) as f:
-                text = f.read()
+            failed = True
+            left = match.group('left').strip()
+            start = match.start('left')
 
-            for match in FILTER_RE.findall(text):
-                filter_name = match[5]
+            while start >= offset:
+                previous = offset
+                offset += len(lines[lineno])
+                lineno += 1
 
-                try:
-                    test_name = TEST_MAP[filter_name]
-                except KeyError:
-                    test_name = filter_name
+            colno = start - previous + 1
 
-                if test_name not in TESTS:
-                    continue
+            print('%s:%d:%d: use `%s is %s` instead of `%s | %s`' % (path, lineno, colno, left, test_name, left, filter_name))
 
-                all_matches[path].append(match[0])
-
-    if all_matches:
-        print('Use of Ansible provided Jinja2 tests as filters is deprecated.')
-        print('Please update to use `is` syntax such as `result is failed`.')
-
-        for path, matches in all_matches.items():
-            for match in matches:
-                print('%s: %s' % (path, match,))
+    if failed:
         sys.exit(1)
 
 


### PR DESCRIPTION
##### SUMMARY

Add support for enhanced code-smell tests:

- Path selection handled by ansible-test.
- Optional path filtering based on extension.
- Optional path filtering based on prefixes.
- Optional lint friendly output.

Two code-smell tests have been updated to use these new features:

- no-assert
- no-tests-as-filters

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.6.0 (at-code-smell 65f24d5b90) last updated 2018/02/16 12:42:51 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.11 (default, Jan 22 2016, 08:29:18) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```
