### PR TITLE
aws_ec2 inventory plugin: support group by tag value

### DIFF
--- a/contrib/inventory/ec2.ini
+++ b/contrib/inventory/ec2.ini
@@ -140,6 +140,7 @@ group_by_key_pair = True
 group_by_vpc_id = True
 group_by_security_group = True
 group_by_tag_keys = True
+group_by_tag_values = True
 group_by_tag_none = True
 group_by_route53_names = True
 group_by_rds_engine = True

--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -212,6 +212,7 @@ DEFAULTS = {
     'group_by_route53_names': 'True',
     'group_by_security_group': 'True',
     'group_by_tag_keys': 'True',
+    'group_by_tag_values': 'True',
     'group_by_tag_none': 'True',
     'group_by_vpc_id': 'True',
     'hostname_variable': None,
@@ -1049,6 +1050,13 @@ class Ec2Inventory(object):
                         self.push_group(self.inventory, 'tags', self.to_safe("tag_" + k))
                         if v:
                             self.push_group(self.inventory, self.to_safe("tag_" + k), key)
+        # Inventory: Group by tag valyes
+        if self.group_by_tag_values:
+            for k, v in instance.tags.items():
+                if v and self.to_safe(v) != hostname:
+                    self.push(self.inventory, self.to_safe(v), hostname)
+                    if self.nested_groups:
+                        self.push_group(self.inventory, 'tags', self.to_safe(v))
 
         # Inventory: Group by Route53 domain names if enabled
         if self.route53_enabled and self.group_by_route53_names:


### PR DESCRIPTION
##### SUMMARY

This version add a new functionallity to group hosts by value from tags (without 'tag_'). Is the same behaviour of openstack inventory (group by metadata vaue.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
 - Feature Pull Request

##### COMPONENT NAME

- aws_ec2 inventory


##### ANSIBLE VERSION

```
ansible 2.4.2.0
  config file = None
  configured module search path = [u'/home/vasartori/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]

```
##### STEPS TO REPRODUCE

Create a instance on aws, and use tags.

##### Additional Informations

Describe of AWS Instance....

``` aws ec2 describe-instances
Snipped....
[...]
                   "Tags": [
                        {
                            "Value": "etcd", 
                            "Key": "purpose"
                        }, 
                        {
                            "Value": "kubernetes-sarta-etcd-1", 
                            "Key": "name"
                        }, 
                    ], 
[...]
```
##### ACTUAL RESULTS

Snippet output of inventory plugin

```
[...]
  "tag_groups_etcd": [
    "kubernetes_sarta_etcd_1"
  ], 
[...]
```

#### EXPECTED RESULTS

Snippet output of modified inventory plugin

```
[...]
  "etcd": [
    "kubernetes_sarta_etcd_1"
  ], 
[...]
```

At this moment, is possible reach instances using the group "etcd" (value on tag purpose on instance)