### PR TITLE
add yaml support for body type to uri module

### DIFF
--- a/lib/ansible/modules/net_tools/basics/uri.py
+++ b/lib/ansible/modules/net_tools/basics/uri.py
@@ -54,7 +54,8 @@ options:
       - The serialization format of the body. When set to C(json) or C(form-urlencoded), encodes the
         body argument, if needed, and automatically sets the Content-Type header accordingly.
         As of C(2.3) it is possible to override the `Content-Type` header, when
-        set to C(json) or C(form-urlencoded) via the I(headers) option.
+        set to C(json) or C(form-urlencoded) via the I(headers) option.  Serialization of body to yaml
+        was added as of C(2.10).
     type: str
     choices: [ form-urlencoded, json, raw, yaml ]
     default: raw


### PR DESCRIPTION
##### SUMMARY
When posting messages to an API, YAML body format can be useful to have.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
uri

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.2.0
  config file = None
  configured module search path = [u'/Users/mpae/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/Cellar/ansible/2.4.2.0_2/libexec/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.10 (default, Feb  7 2017, 00:08:15) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.34)]
```


##### ADDITIONAL INFORMATION
Trying to post to an API that only supports YAML body format requires that we use a template, write the template to a file, then read the template back to post it.  Given how similar YAML and JSON are as far as ease of conversion from python dictionaries, it seems reasonable to support both YAML and JSON as target body_types