### PR TITLE
Fix bug in DigitalOcean module_util

### DIFF
--- a/lib/ansible/module_utils/digital_ocean.py
+++ b/lib/ansible/module_utils/digital_ocean.py
@@ -62,16 +62,15 @@ class DigitalOceanHelper:
     def __init__(self, module):
         self.module = module
         self.baseurl = 'https://api.digitalocean.com/v2'
-        self.oauth_token = None
+        self.timeout = module.params.get('timeout', 30)
+        self.oauth_token = module.params.get('oauth_token')
         self.headers = {'Authorization': 'Bearer {0}'.format(self.oauth_token),
                         'Content-type': 'application/json'}
 
         # Check if api_token is valid or not
         response = self.get('account')
         if response.status_code == 401:
-            module.fail_json(msg='Failed to login using API token, please verify validity of API token.')
-
-        self.timeout = module.params.get('timeout', 30)
+            self.module.fail_json(msg='Failed to login using API token, please verify validity of API token.')
 
     def _url_builder(self, path):
         if path[0] == '/':

--- a/test/sanity/validate-modules/ignore.txt
+++ b/test/sanity/validate-modules/ignore.txt
@@ -670,11 +670,9 @@ lib/ansible/modules/cloud/digital_ocean/digital_ocean.py E326
 lib/ansible/modules/cloud/digital_ocean/digital_ocean_floating_ip.py E322
 lib/ansible/modules/cloud/digital_ocean/digital_ocean_floating_ip.py E324
 lib/ansible/modules/cloud/digital_ocean/digital_ocean_floating_ip.py E325
-lib/ansible/modules/cloud/digital_ocean/digital_ocean_floating_ip_facts.py E325
 lib/ansible/modules/cloud/digital_ocean/digital_ocean_sshkey.py E322
 lib/ansible/modules/cloud/digital_ocean/digital_ocean_sshkey.py E324
 lib/ansible/modules/cloud/digital_ocean/digital_ocean_sshkey.py E325
-lib/ansible/modules/cloud/digital_ocean/digital_ocean_sshkey_facts.py E325
 lib/ansible/modules/cloud/dimensiondata/dimensiondata_network.py E325
 lib/ansible/modules/cloud/dimensiondata/dimensiondata_network.py E326
 lib/ansible/modules/cloud/dimensiondata/dimensiondata_vlan.py E324


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
DigitalOcean module_util has a bug around timeout being called before being set. Moved the timeout up in the module initialization.

oauth_token was being set to None instead of looking at the argument_spec.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
lib/ansible/module_utils/digital_ocean.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0 (bugfix/do_module_util bbe36a8ca7) last updated 2018/02/17 15:53:21 (GMT -400)
  config file = /Users/abond/ansible/ansible.cfg
  configured module search path = [u'/Users/abond/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/abond/Development/github/ansible/lib/ansible
  executable location = /Users/abond/Development/github/ansible/bin/ansible
  python version = 2.7.10 (default, Oct 23 2015, 19:19:21) [GCC 4.2.1 Compatible Apple LLVM 7.0.0 (clang-700.0.59.5)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
fatal: [localhost]: FAILED! => {
    "changed": false,
    "failed": true,
    "invocation": {
        "module_args": {
            "oauth_token": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "timeout": 30,
            "validate_certs": true
        }
    },
    "msg": "Failed to login using API token, please verify validity of API token."
}
```

Works login validation works and the module returns control to the executed digital_ocean module.