### PR TITLE
Better handling of absent AWS SES identity notification information.

### DIFF
--- a/lib/ansible/modules/cloud/amazon/aws_ses_identity.py
+++ b/lib/ansible/modules/cloud/amazon/aws_ses_identity.py
@@ -303,6 +303,7 @@ def get_identity_notifications(connection, module, identity, retries=0, retryDel
                         notification_attributes.keys(),
                     )
                 )
+        time.sleep(retryDelay)
     if identity not in notification_attributes:
         return None
     return notification_attributes[identity]

--- a/lib/ansible/modules/cloud/amazon/aws_ses_identity.py
+++ b/lib/ansible/modules/cloud/amazon/aws_ses_identity.py
@@ -239,6 +239,7 @@ import traceback
 
 try:
     from botocore.exceptions import BotoCoreError, ClientError
+    from botocore.config import Config
 except ImportError:
     pass  # caught by imported HAS_BOTO3
 
@@ -473,7 +474,15 @@ def main():
 
     region, ec2_url, aws_connect_params = get_aws_connection_info(module, boto3=True)
 
-    connection = boto3_conn(module, conn_type='client', resource='ses', region=region, endpoint=ec2_url, **aws_connect_params)
+    # Allow up to 10 attempts to call the SES APIs before giving up (9 retries).
+    # SES APIs seem to have a much lower throttling threshold than most of the rest of the AWS APIs.
+    # Docs say 1 call per second. This shouldn't actually be a big problem for normal usage, but
+    # the ansible build runs multiple instances of the test in parallel.
+    # As a result there are build failures due to throttling that exceeds boto's default retries.
+    # The back-off is exponential, so upping the retry attempts allows multiple parallel runs
+    # to succeed.
+    boto_core_config = Config(retries={'max_attempts': 9})
+    connection = boto3_conn(module, conn_type='client', resource='ses', region=region, endpoint=ec2_url, config=boto_core_config, **aws_connect_params)
 
     state = module.params.get("state")
 


### PR DESCRIPTION
##### SUMMARY
Fixes #36065

aws_ses_identity module now handles the cases where information about
the notification setup for the identity isn't returned by the AWS api.

This seems to happen in an edge case, believed to be eventual
consistency on registering new identities. So this case is treated
as if has been no notification setup for the identity yet.

Also fix 2 flake8 warnings in the module, a missing newline and unused
import.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
aws_ses_identity

##### ANSIBLE VERSION
```
ansible 2.6.0 (bugfix-unstable-ses-identity-integration-test 99ae804adb) last updated 2018/02/18 10:23:56 (GMT +1300)
  config file = None
  configured module search path = [u'/USER_HOME/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /ANSIBLE_CHECKOUT/lib/ansible
  executable location = /ANSIBLE_CHECKOUT/bin/ansible
  python version = 2.7.14 (default, Sep 23 2017, 22:06:14) [GCC 7.2.0]
```


##### ADDITIONAL INFORMATION
I've not actually been able to reprouce the unstable integration test locally, I'm guessing my latency from regious with SES is sufficiently high that I'm not seeing the inconsistent state where the identity is registered but is not being returned from the notifications api.

None the less, there's are some clear logic bugs in the handling of the case where the notifications aren't returned, so I've fixed those which I'm fairly sure will address the unstable integration test.