### PR TITLE
Bypass load average arg value through equal sign

### DIFF
--- a/lib/ansible/modules/packaging/os/portage.py
+++ b/lib/ansible/modules/packaging/os/portage.py
@@ -156,7 +156,7 @@ options:
   jobs:
     description:
       - Specifies the number of packages to build simultaneously.
-      - Since version 2.6: Value of 0 or False resets any previously added
+      - "Since version 2.6: Value of 0 or False resets any previously added"
       - --jobs setting values
     required: false
     default: None
@@ -166,7 +166,7 @@ options:
     description:
       - Specifies that no new builds should be started if there are
       - other builds running and the load average is at least LOAD
-      - Since version 2.6: Value of 0 or False resets any previously added
+      - "Since version 2.6: Value of 0 or False resets any previously added"
       - --load-average setting values
     required: false
     default: None

--- a/lib/ansible/modules/packaging/os/portage.py
+++ b/lib/ansible/modules/packaging/os/portage.py
@@ -340,7 +340,7 @@ def emerge_packages(module, packages):
         if flag_val is None:
             continue
 
-        if flag_val:
+        if not flag_val:
             args.append(arg)
             continue
 

--- a/lib/ansible/modules/packaging/os/portage.py
+++ b/lib/ansible/modules/packaging/os/portage.py
@@ -156,6 +156,8 @@ options:
   jobs:
     description:
       - Specifies the number of packages to build simultaneously.
+      - Since version 2.6: Value of 0 resets any previously added
+      - --jobs setting values
     required: false
     default: None
     version_added: 2.3
@@ -164,6 +166,8 @@ options:
     description:
       - Specifies that no new builds should be started if there are
       - other builds running and the load average is at least LOAD
+      - Since version 2.6: Value of 0 resets any previously added
+      - --load-average setting values
     required: false
     default: None
     version_added: 2.3
@@ -333,10 +337,10 @@ def emerge_packages(module, packages):
 
     for flag, arg in emerge_flags.items():
         flag_val = p[flag]
-        if flag_val is None or flag_val is False:
+        if flag_val is None:
             continue
 
-        if flag_val is True:
+        if flag_val:
             args.append(arg)
             continue
 

--- a/lib/ansible/modules/packaging/os/portage.py
+++ b/lib/ansible/modules/packaging/os/portage.py
@@ -292,6 +292,7 @@ def sync_repositories(module, webrsync=False):
 
 
 def emerge_packages(module, packages):
+    """Run emerge command against given list of atoms."""
     p = module.params
 
     if not (p['update'] or p['noreplace'] or p['state'] == 'latest'):

--- a/lib/ansible/modules/packaging/os/portage.py
+++ b/lib/ansible/modules/packaging/os/portage.py
@@ -337,11 +337,9 @@ def emerge_packages(module, packages):
 
     for flag, arg in emerge_flags.items():
         flag_val = p[flag]
-        if flag_val is None:
-            continue
-
         if not flag_val:
-            args.append(arg)
+            if flag_val is not None:
+                args.append(arg)
             continue
 
         args.extend((arg, to_native(flag_val)))

--- a/lib/ansible/modules/packaging/os/portage.py
+++ b/lib/ansible/modules/packaging/os/portage.py
@@ -337,11 +337,17 @@ def emerge_packages(module, packages):
 
     for flag, arg in emerge_flags.items():
         flag_val = p[flag]
-        if not flag_val:
-            if flag_val is not None:
-                args.append(arg)
+
+        if flag_val is None:
+            """Fallback to default: don't use this argument at all."""
             continue
 
+        if not flag_val:
+            """If the value is 0 or 0.0: add the flag, but not the value."""
+            args.append(arg)
+            continue
+
+        """Add the --flag=value pair."""
         args.extend((arg, to_native(flag_val)))
 
     cmd, (rc, out, err) = run_emerge(module, packages, *args)

--- a/lib/ansible/modules/packaging/os/portage.py
+++ b/lib/ansible/modules/packaging/os/portage.py
@@ -156,7 +156,7 @@ options:
   jobs:
     description:
       - Specifies the number of packages to build simultaneously.
-      - Since version 2.6: Value of 0 resets any previously added
+      - Since version 2.6: Value of 0 or False resets any previously added
       - --jobs setting values
     required: false
     default: None
@@ -166,7 +166,7 @@ options:
     description:
       - Specifies that no new builds should be started if there are
       - other builds running and the load average is at least LOAD
-      - Since version 2.6: Value of 0 resets any previously added
+      - Since version 2.6: Value of 0 or False resets any previously added
       - --load-average setting values
     required: false
     default: None

--- a/lib/ansible/modules/packaging/os/portage.py
+++ b/lib/ansible/modules/packaging/os/portage.py
@@ -224,7 +224,7 @@ import os
 import re
 
 from ansible.module_utils.basic import AnsibleModule
-from module_utils._text import to_native
+from ansible.module_utils._text import to_native
 
 
 def query_package(module, package, action):

--- a/lib/ansible/modules/packaging/os/portage.py
+++ b/lib/ansible/modules/packaging/os/portage.py
@@ -224,6 +224,7 @@ import os
 import re
 
 from ansible.module_utils.basic import AnsibleModule
+from module_utils._text import to_native
 
 
 def query_package(module, package, action):
@@ -339,7 +340,7 @@ def emerge_packages(module, packages):
             args.append(arg)
             continue
 
-        args.extend((arg, str(flag_val)))
+        args.extend((arg, to_native(flag_val)))
 
     cmd, (rc, out, err) = run_emerge(module, packages, *args)
     if rc != 0:

--- a/lib/ansible/modules/packaging/os/portage.py
+++ b/lib/ansible/modules/packaging/os/portage.py
@@ -327,7 +327,7 @@ def emerge_packages(module, packages):
 
     emerge_flags = {
         'jobs': '--jobs=',
-        'loadavg': '--load-average ',
+        'loadavg': '--load-average=',
     }
 
     for flag, arg in emerge_flags.items():

--- a/lib/ansible/modules/packaging/os/portage.py
+++ b/lib/ansible/modules/packaging/os/portage.py
@@ -326,13 +326,20 @@ def emerge_packages(module, packages):
         module.fail_json(msg='Use only one of usepkg, usepkgonly')
 
     emerge_flags = {
-        'jobs': '--jobs=',
-        'loadavg': '--load-average=',
+        'jobs': '--jobs',
+        'loadavg': '--load-average',
     }
 
     for flag, arg in emerge_flags.items():
-        if p[flag] is not None:
-            args.append(arg + str(p[flag]))
+        flag_val = p[flag]
+        if flag_val is None or flag_val is False:
+            continue
+
+        if flag_val is True:
+            args.append(arg)
+            continue
+
+        args.extend((arg, str(flag_val)))
 
     cmd, (rc, out, err) = run_emerge(module, packages, *args)
     if rc != 0:


### PR DESCRIPTION
##### SUMMARY
TL;DR Using `loadavg` argument of `portage` module causes task to fail.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
portage

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0b2
  config file = None
  configured module search path = ['~/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = ~/.pyenv/versions/3.6.4/lib/python3.6/site-packages/ansible
  executable location = ~/.pyenv/versions/3.6.4/bin/ansible
  python version = 3.6.4 (default, Feb 17 2018, 17:11:17) [GCC 7.3.0]
```


##### ADDITIONAL INFORMATION
```
    "stderr_lines": [
        "!!! '--load-average 4.0' is not a valid package atom.",
        "!!! Please check ebuild(5) for full details."
    ],
```
