### PR TITLE
change get_virtual_servers() to get_all_servers(). Fixes #36370

### DIFF
--- a/contrib/inventory/softlayer.py
+++ b/contrib/inventory/softlayer.py
@@ -85,7 +85,7 @@ class SoftLayerInventory(object):
             self.get_all_servers()
             print(self.json_format_dict(self.inventory, True))
         elif self.args.host:
-            self.get_virtual_servers()
+            self.get_all_servers()
             print(self.json_format_dict(self.inventory["_meta"]["hostvars"][self.args.host], True))
 
     def to_safe(self, word):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This changes the method called from `get_virtual_servers()` to `get_all_servers()` when the `--host` arg is given to softlayer.py. 

Currently, when we use the `--host` arg, python crashes and complains of the client attribute not existing. This fixes that by implementing the correct method so that the `self.client` object can be instantiated properly. 

This makes the `--host` arg usable, where before it was not. Fixes #36370 .
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
softlayer.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.3.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.14 (default, Sep 23 2017, 22:06:14) [GCC 7.2.0]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

Before the change this was the output when using `--host`:
```bash
scott@black-lotus:~/Git/ansible$ contrib/inventory/softlayer.py --host '119.81.162.236'
Traceback (most recent call last):
  File "./softlayer.py", line 201, in <module>
    SoftLayerInventory()
  File "./softlayer.py", line 88, in __init__
    self.get_virtual_servers()
  File "./softlayer.py", line 180, in get_virtual_servers
    vs = SoftLayer.VSManager(self.client)
AttributeError: 'SoftLayerInventory' object has no attribute 'client'
```

After the change, `--host` works correctly as originally intended:

```
scott@black-lotus:~/Git/ansible$ contrib/inventory/softlayer.py --host '119.81.162.236'
{
  "datacenter": {
    "euCompliantFlag": false, 
    "id": 352994, 
    "longName": "Hong Kong 2", 
    "name": "hkg02", 
    "statusId": 2
  }, 
  "domain": "softlayer.com", 
  "fullyQualifiedDomainName": "cst-test.softlayer.com", 
  "globalIdentifier": "4156ca40-1d6a-4212-ad7f-586e778de5e8", 
  "hostname": "cst-test", 
  "id": 46309867, 
  "maxCpu": 1, 
  "maxMemory": 2048, 
  "powerState": {
    "keyName": "RUNNING", 
    "name": "Running"
  }, 
  "primaryBackendIpAddress": "10.110.181.197", 
  "primaryIpAddress": "119.81.162.236", 
  "status": {
    "keyName": "ACTIVE", 
    "name": "Active"
  }, 
  "tagReferences": [], 
  "userData": ""
}
```