### PR TITLE
Fix name parameter templating in include_role module

### DIFF
--- a/lib/ansible/playbook/included_file.py
+++ b/lib/ansible/playbook/included_file.py
@@ -146,13 +146,14 @@ class IncludedFile:
                         if role_name is not None:
                             role_name = templar.template(role_name)
 
-                        original_task._role_name = role_name
-                        for from_arg in original_task.FROM_ARGS:
+                        new_task = original_task.copy()
+                        new_task._role_name = role_name
+                        for from_arg in new_task.FROM_ARGS:
                             if from_arg in include_variables:
                                 from_key = from_arg.replace('_from', '')
-                                original_task._from_files[from_key] = templar.template(include_variables[from_arg])
+                                new_task._from_files[from_key] = templar.template(include_variables[from_arg])
 
-                        inc_file = IncludedFile("role", include_variables, original_task, is_role=True)
+                        inc_file = IncludedFile("role", include_variables, new_task, is_role=True)
 
                     try:
                         pos = included_files.index(inc_file)


### PR DESCRIPTION
##### SUMMARY
Followup to #33386 and #21285.

Fixes problem that `include_role` looping over `with_items` and `name: "{{ item }}"` will use the same `name` for all items in the loop.

In the current code, an `IncludedFile()` object built using the `original_task` will have its `inc_file._task` bound to the `original_task`. The iterative reassignment of `original_task._role_name` during `with_items` loops leaves all returned `included_files` with the same `inc_file._task._role_name`. All have the final name from the `with_items` list.

This PR builds `IncludedFile()` objects from an `original_task.copy()` to avoid the problematic binding.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
include_role module

##### ANSIBLE VERSION
```
ansible 2.6.0 (devel a5654bd63c) last updated 2018/02/18 20:37:44 (GMT -600)
  config file = None
  configured module search path = [u'/Users/philip/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/philip/projects/ansible/ansible/lib/ansible
  executable location = /Users/philip/projects/ansible/ansible/bin/ansible
  python version = 2.7.13 (default, Mar 13 2017, 12:42:50) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]
```

##### ADDITIONAL INFORMATION

To reproduce, create a test playbook with a looping `include_role`:
```yaml
# include-role-test.yml
- gather_facts: false
  hosts: localhost
  tasks:
    - include_role:
        name: "{{ role }}"
      with_items:
        - role1
        - role2
      loop_control:
        loop_var: role
```

Create `role1` and `role2`:
```yaml
# roles/role1/tasks/main.yml
- debug:
    msg: this is role 1
```

```yaml
# roles/role2/tasks/main.yml
- debug:
    msg: this is role 2
```

**Output from current devel branch**

The `include_role` task runs `role2` both times, despite `with_items: ['role1', 'role2']`.

```
$ ansible-playbook -i hosts include-role-test.yml

PLAY [localhost] ***************************************************************************

TASK [include_role] ************************************************************************

TASK [role2 : debug] ***********************************************************************
ok: [localhost] => {
    "failed": false,
    "msg": "this is role 2"
}

TASK [role2 : debug] ***********************************************************************
ok: [localhost] => {
    "failed": false,
    "msg": "this is role 2"
}

PLAY RECAP *******************************************************************************
localhost                  : ok=2    changed=0    unreachable=0    failed=0
```

**Output after applying this PR**

```
$ ansible-playbook -i hosts include-role-test.yml

PLAY [localhost] ***************************************************************************

TASK [include_role] ************************************************************************

TASK [role1 : debug] ***********************************************************************
ok: [localhost] => {
    "failed": false,
    "msg": "this is role 1"
}

TASK [role2 : debug] ***********************************************************************
ok: [localhost] => {
    "failed": false,
    "msg": "this is role 2"
}

PLAY RECAP *******************************************************************************
localhost                  : ok=2    changed=0    unreachable=0    failed=0
```
