### PR TITLE
Set hostname to 'switch' on nxos_system

### DIFF
--- a/test/integration/targets/nxos_system/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_system/tests/common/sanity.yaml
@@ -6,7 +6,7 @@
 - block:
   - name: configure hostname and domain-name
     nxos_system: &hostname
-      hostname: "{{ inventory_hostname_short }}"
+      hostname: switch
       domain_name: test.example.com
       provider: "{{ connection }}"
 

--- a/test/integration/targets/nxos_system/tests/common/set_hostname.yaml
+++ b/test/integration/targets/nxos_system/tests/common/set_hostname.yaml
@@ -6,7 +6,7 @@
 - block:
   - name: setup
     nxos_config:
-      lines: "hostname {{ inventory_hostname_short }}"
+      lines: hostname switch
       match: none
       provider: "{{ connection }}"
 
@@ -33,7 +33,7 @@
   always:
   - name: teardown
     nxos_config:
-      lines: "hostname {{ inventory_hostname_short }}"
+      lines: hostname switch
       match: none
       provider: "{{ connection }}"
 


### PR DESCRIPTION
Signed-off-by: Trishna Guha <trishnaguha17@gmail.com>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
We need to revert the hostname back to `switch`.
Using inventory_hostname/inventory_hostname_short breaks the test, since in our CI
it's a long UUID string, which exceeds the 32 chars maximum for setting
a hostname on NXOS.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request
 
##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
test/integration/targets/nxos_system/tests/common
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```