### PR TITLE
If inventory file isn't able to be parsed by aws_ec2, raise an AnsibleParserError

### DIFF
--- a/lib/ansible/plugins/inventory/aws_ec2.py
+++ b/lib/ansible/plugins/inventory/aws_ec2.py
@@ -451,7 +451,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             :return the contents of the config file
         '''
         if super(InventoryModule, self).verify_file(path):
-            if path.endswith('.aws_ec2.yml' or '.aws_ec2.yaml'):
+            if path.endswith('.aws_ec2.yml') or path.endswith('.aws_ec2.yaml'):
                 return self._read_config_data(path)
         raise AnsibleParserError("Not a ec2 inventory plugin configuration file")
 

--- a/lib/ansible/plugins/inventory/aws_ec2.py
+++ b/lib/ansible/plugins/inventory/aws_ec2.py
@@ -453,6 +453,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         if super(InventoryModule, self).verify_file(path):
             if path.endswith('.aws_ec2.yml' or '.aws_ec2.yaml'):
                 return self._read_config_data(path)
+            return {}
         else:
             raise AnsibleParserError("Not a ec2 inventory plugin configuration file")
 

--- a/lib/ansible/plugins/inventory/aws_ec2.py
+++ b/lib/ansible/plugins/inventory/aws_ec2.py
@@ -453,9 +453,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         if super(InventoryModule, self).verify_file(path):
             if path.endswith('.aws_ec2.yml' or '.aws_ec2.yaml'):
                 return self._read_config_data(path)
-            raise AnsibleParserError("Not a ec2 inventory plugin configuration file")
-        else:
-            raise AnsibleParserError("Not a ec2 inventory plugin configuration file")
+        raise AnsibleParserError("Not a ec2 inventory plugin configuration file")
 
     def _get_query_options(self, config_data):
         '''

--- a/lib/ansible/plugins/inventory/aws_ec2.py
+++ b/lib/ansible/plugins/inventory/aws_ec2.py
@@ -453,7 +453,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         if super(InventoryModule, self).verify_file(path):
             if path.endswith('.aws_ec2.yml' or '.aws_ec2.yaml'):
                 return self._read_config_data(path)
-            return {}
+            raise AnsibleParserError("Not a ec2 inventory plugin configuration file")
         else:
             raise AnsibleParserError("Not a ec2 inventory plugin configuration file")
 


### PR DESCRIPTION
… instead of None

##### SUMMARY

To reproduce bug:
Enable ec2_aws in ansible.cfg.
Do not create an inventory config file, which will result in /etc/ansible/hosts being parsed (which just contains localhost)
Run ansible-inventory --list
```
 [WARNING]:  * Failed to parse /etc/ansible/hosts with aws_ec2 plugin: 'NoneType' object has no attribute 'get'
```
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/inventory/aws_ec2.py

##### ANSIBLE VERSION
```
2.6.0
```