### PR TITLE
Add mindepth, maxdepth parameters to find module

### DIFF
--- a/test/integration/targets/find/tasks/main.yml
+++ b/test/integration/targets/find/tasks/main.yml
@@ -95,3 +95,22 @@
           - 'find_test2.matched == 1'
           - 'find_test2.files[0].pw_name is defined'
           - 'find_test2.files[0].gr_name is defined'
+
+- name: find with max_depth and min_depth
+  find:
+      paths: "{{ output_dir_test }}"
+      recurse: yes
+      mindepth: 3
+      maxdepth: 4
+  register: find_test3
+- debug: var=find_test3
+- name: validate find with max_depth and min_depth
+  assert:
+      that:
+          - 'find_test3 is defined'
+          - 'find_test3.examined is defined'
+          - 'find_test3.files is defined'
+          - 'find_test3.matched is defined'
+          - 'find_test3.msg is defined'
+          - 'find_test3.matched == 4'
+          - 'find_test3.files | length == 4'


### PR DESCRIPTION
##### SUMMARY
Fixes #36369 
This PR adds the "mindepth" and "maxdepth" parameters to the module find in the source code and in ansible-doc module page.
This parameter are based on the homonym features present in GNU find command.

Furthermore a new test for mindepth maxdepth parameters has been added in test/integration/targets/find/tasks/main.yml  file

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
find.py

##### ANSIBLE VERSION
```
$ ./bin/ansible --version
ansible 2.6.0 (pull-issue-36369 6b965ce1e2) last updated 2018/02/19 15:41:02 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/gsciorti/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/gsciorti/PycharmProjects/ansible/lib/ansible
  executable location = ./bin/ansible
  python version = 2.7.14 (default, Dec 11 2017, 14:52:53) [GCC 7.2.1 20170915 (Red Hat 7.2.1-2)]
```


##### ADDITIONAL INFORMATION
Before this pull request mindepth and maxdepth parameters wasn't implemented

```
Prepare the a directory/file structure to test the PR:

[g@g ansible]$ mkdir -p /tmp/test_find/a/b/c/d
[g@g ansible]$ mkdir -p /tmp/test_find/e/f/g/h
[g@g ansible]$ touch /tmp/test_find/a/1.txt /tmp/test_find/a/b/2.jpg /tmp/test_find/a/b/c/d/4.xml /tmp/test_find/e/5.json /tmp/test_find/e/f/6.swp /tmp/test_find/e/f/g/7.img /tmp/test_find/e/f/g/h/8.ogg

Example 1: module find with mindepth parameter

[g@g ansible]$ ./bin/ansible localhost -m module -m find -a "paths=/tmp/test_find recurse=True mindepth=3" | grep path
...
            "path": "/tmp/test_find/e/f/6.swp", 
...
            "path": "/tmp/test_find/e/f/g/7.img", 
...
            "path": "/tmp/test_find/e/f/g/h/8.ogg", 
...
            "path": "/tmp/test_find/a/b/2.jpg", 
...
            "path": "/tmp/test_find/a/b/c/d/4.xml", 
...

Example 2: module find with maxdepth parameter

[gsciorti@gsciorti ansible]$ ./bin/ansible localhost -m module -m find -a "paths=/tmp/test_find recurse=True maxdepth=4" | grep path
...
            "path": "/tmp/test_find/e/5.json", 
...
            "path": "/tmp/test_find/e/f/6.swp", 
...
            "path": "/tmp/test_find/e/f/g/7.img", 
...
            "path": "/tmp/test_find/a/1.txt", 
...
            "path": "/tmp/test_find/a/b/2.jpg", 
...

Example 3: module find with mindepth and maxdepth parameters

[g@g ansible]$ ./bin/ansible localhost -m module -m find -a "paths=/tmp/test_find recurse=True mindepth=2 maxdepth=3" |grep path
...
            "path": "/tmp/test_find/e/5.json", 
...
            "path": "/tmp/test_find/e/f/6.swp", 
...
            "path": "/tmp/test_find/a/1.txt", 
...
            "path": "/tmp/test_find/a/b/2.jpg", 
...

Example 3: module find with mindepth and maxdepth parameters with different values

[g@g ansible]$ ./bin/ansible localhost -m module -m find -a "paths=/tmp/test_find recurse=True mindepth=4 maxdepth=5" |grep path
...
            "path": "/tmp/test_find/e/f/g/7.img", 
...
            "path": "/tmp/test_find/e/f/g/h/8.ogg", 
...
            "path": "/tmp/test_find/a/b/c/d/4.xml", 
...



```
