### PR TITLE
sphinx_rtd_theme/layout.html 2.5

### DIFF
--- a/docs/docsite/_themes/sphinx_rtd_theme/layout.html
+++ b/docs/docsite/_themes/sphinx_rtd_theme/layout.html
@@ -154,7 +154,7 @@
                 <div class="DocSiteProduct-logoText">
                     Ansible  
                     <div class="DocSiteProduct-CurrentVersion" align="right">
-                      devel
+                      2.5
                   </div>
                 </div>
             </div>


### PR DESCRIPTION
##### SUMMARY
Used to use 
`docs/docsite/_themes/srtd/layout.html` looks like that got changed to be `docs/docsite/_themes/sphinx_rtd_theme/layout.html`