### PR TITLE
Update network debug troubleshooting guide (#36288)

### DIFF
--- a/docs/docsite/rst/networking_guide/network_debug_troubleshooting.rst
+++ b/docs/docsite/rst/networking_guide/network_debug_troubleshooting.rst
@@ -138,6 +138,61 @@ Then review the log file and find the relevant error message in the rest of this
 
 .. For details on other ways to authenticate, see LINKTOAUTHHOWTODOCS.
 
+.. _socket_path_issue:
+
+Category "socket_path issue"
+============================
+
+**Platforms:** Any
+
+The ``socket_path does not exist or cannot be found``  and ``unable to connect to socket`` messages are new in Ansible 2.5. These messages indicate that the socket used to communicate with the remote network device is unavailable or does not exist.
+
+
+For example:
+
+.. code-block:: none
+
+   fatal: [spine02]: FAILED! => {
+       "changed": false,
+       "failed": true,
+       "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_TSqk5J/ansible_modlib.zip/ansible/module_utils/connection.py\", line 115, in _exec_jsonrpc\nansible.module_utils.connection.ConnectionError: socket_path does not exist or cannot be found\n",
+       "module_stdout": "",
+       "msg": "MODULE FAILURE",
+       "rc": 1
+   }
+
+or
+
+.. code-block:: none
+
+   fatal: [spine02]: FAILED! => {
+       "changed": false,
+       "failed": true,
+       "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_TSqk5J/ansible_modlib.zip/ansible/module_utils/connection.py\", line 123, in _exec_jsonrpc\nansible.module_utils.connection.ConnectionError: unable to connect to socket\n",
+       "module_stdout": "",
+       "msg": "MODULE FAILURE",
+       "rc": 1
+   }
+
+Suggestions to resolve:
+
+Follow the steps detailed in :ref:`enable network logging <enable_network_logging>`.
+
+If the identified error message from the log file is:
+
+.. code-block:: yaml
+
+   2017-04-04 12:19:05,670 p=18591 u=fred |  command timeout triggered, timeout value is 10 secs
+
+or
+
+.. code-block:: yaml
+
+   2017-04-04 12:19:05,670 p=18591 u=fred |  persistent connection idle timeout triggered, timeout value is 30 secs
+
+Follow the steps detailed in :ref:`timeout issues <timeout_issues>`
+
+
 .. _unable_to_open_shell:
 
 Category "Unable to open shell"
@@ -324,6 +379,7 @@ To clear out a persistent connection before it times out (the default timeout is
 of inactivity), simple delete the socket file.
 
 
+.. _timeout_issues:
 
 Timeout issues
 ==============


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
* Update network debug troubleshooting guide

Fix #35914

Command timeout and connection timeout error messages
are dsiplayed in log file instead on console.
Update the same in troubleshooting guide.

* Update example error

* Fix CI issues

* Fix review comments

* Copy edit

(cherry picked from commit b57cc7cf31abc0f35459009d32d96d7292f1951b)
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
networking_guide/network_debug_troubleshooting.rst

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
