### PR TITLE
added support for --testcase flag in ansible-test (#36134)

### DIFF
--- a/test/runner/lib/config.py
+++ b/test/runner/lib/config.py
@@ -189,6 +189,7 @@ class NetworkIntegrationConfig(IntegrationConfig):
 
         self.platform = args.platform  # type: list [str]
         self.inventory = args.inventory  # type: str
+        self.testcase = args.testcase  # type: str
 
 
 class UnitsConfig(TestConfig):

--- a/test/runner/lib/executor.py
+++ b/test/runner/lib/executor.py
@@ -943,6 +943,10 @@ def command_integration_role(args, target, start_at_task):
         if args.diff:
             cmd += ['--diff']
 
+        if isinstance(args, NetworkIntegrationConfig):
+            if args.testcase:
+                cmd += ['-e', 'testcase=%s' % args.testcase]
+
         if args.verbosity:
             cmd.append('-' + ('v' * args.verbosity))
 

--- a/test/runner/test.py
+++ b/test/runner/test.py
@@ -268,6 +268,10 @@ def parse_args():
                                      metavar='PATH',
                                      help='path to inventory used for tests')
 
+    network_integration.add_argument('--testcase',
+                                     metavar='TESTCASE',
+                                     help='limit a test to a specified testcase').completer = complete_network_testcase
+
     windows_integration = subparsers.add_parser('windows-integration',
                                                 parents=[integration],
                                                 help='windows integration tests')
@@ -659,6 +663,31 @@ def complete_network_platform(prefix, parsed_args, **_):
         images = completion_fd.read().splitlines()
 
     return [i for i in images if i.startswith(prefix) and (not parsed_args.platform or i not in parsed_args.platform)]
+
+
+def complete_network_testcase(prefix, parsed_args, **_):
+    """
+    :type prefix: unicode
+    :type parsed_args: any
+    :rtype: list[str]
+    """
+    testcases = []
+
+    # since testcases are module specific, don't autocomplete if more than one
+    # module is specidied
+    if len(parsed_args.include) != 1:
+        return []
+
+    test_dir = 'test/integration/targets/%s/tests' % parsed_args.include[0]
+    connections = os.listdir(test_dir)
+
+    for conn in connections:
+        if os.path.isdir(os.path.join(test_dir, conn)):
+            for testcase in os.listdir(os.path.join(test_dir, conn)):
+                if testcase.startswith(prefix):
+                    testcases.append(testcase.split('.')[0])
+
+    return testcases
 
 
 def complete_sanity_test(prefix, parsed_args, **_):


### PR DESCRIPTION
##### SUMMARY
* added support for --testcase flag in ansible-test
* added tab completion
* don't autocomplete when multiple modules are selected

(cherry picked from commit 3f5caf659ec8beda364bd801fc2e4e86b1f5c658)

WITHOUT DOCS CHANGES - as there were merge conflicts and they are not needed

Cherry picked into `stable-2.4` to allow network testing to be consistent