### PR TITLE
Fixed Arista typo in docstring (#36139)

### DIFF
--- a/lib/ansible/modules/network/eos/eos_l2_interface.py
+++ b/lib/ansible/modules/network/eos/eos_l2_interface.py
@@ -20,7 +20,7 @@ author: "Ricardo Carrillo Cruz (@rcarrillocruz)"
 short_description: Manage L2 interfaces on Arista EOS network devices.
 description:
   - This module provides declarative management of L2 interfaces
-    on Arist EOS network devices.
+    on Arista EOS network devices.
 notes:
   - Tested against EOS 4.15
 options:

--- a/lib/ansible/modules/network/eos/eos_l3_interface.py
+++ b/lib/ansible/modules/network/eos/eos_l3_interface.py
@@ -20,7 +20,7 @@ author: "Ganesh Nalawade (@ganeshrn)"
 short_description: Manage L3 interfaces on Arista EOS network devices.
 description:
   - This module provides declarative management of L3 interfaces
-    on Arist EOS network devices.
+    on Arista EOS network devices.
 notes:
   - Tested against EOS 4.15
 options:

--- a/lib/ansible/modules/network/eos/eos_linkagg.py
+++ b/lib/ansible/modules/network/eos/eos_linkagg.py
@@ -17,7 +17,7 @@ DOCUMENTATION = """
 module: eos_linkagg
 version_added: "2.5"
 author: "Trishna Guha (@trishnaguha)"
-short_description: Manage link aggregation groups on Arist EOS network devices
+short_description: Manage link aggregation groups on Arista EOS network devices
 description:
   - This module provides declarative management of link aggregation groups
     on Arista EOS network devices.

--- a/lib/ansible/modules/network/eos/eos_static_route.py
+++ b/lib/ansible/modules/network/eos/eos_static_route.py
@@ -17,7 +17,7 @@ DOCUMENTATION = """
 module: eos_static_route
 version_added: "2.5"
 author: "Trishna Guha (@trishnaguha)"
-short_description: Manage static IP routes on Arist EOS network devices
+short_description: Manage static IP routes on Arista EOS network devices
 description:
   - This module provides declarative management of static
     IP routes on Arista EOS network devices.


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
(cherry picked from commit 08eaf37ca847438b79c293cb891d13dcfa87c12f)
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
eos_l2_interface
eos_l3_interface
eos_linkagg
eos_static_route

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
