### PR TITLE
Fix the script and patch plugins tempfile ownership

### DIFF
--- a/lib/ansible/plugins/action/patch.py
+++ b/lib/ansible/plugins/action/patch.py
@@ -55,7 +55,7 @@ class ActionModule(ActionBase):
 
             tmp_src = self._connection._shell.join_path(self._connection._shell.tmpdir, os.path.basename(src))
             self._transfer_file(src, tmp_src)
-            self._fixup_perms2((tmp_src,))
+            self._fixup_perms2((self._connection._shell.tmpdir, tmp_src))
 
             new_module_args = self._task.args.copy()
             new_module_args.update(

--- a/lib/ansible/plugins/action/script.py
+++ b/lib/ansible/plugins/action/script.py
@@ -104,7 +104,7 @@ class ActionModule(ActionBase):
                 self._transfer_file(source, tmp_src)
 
                 # set file permissions, more permissive when the copy is done as a different user
-                self._fixup_perms2((tmp_src,), execute=True)
+                self._fixup_perms2((self._connection._shell.tmpdir, tmp_src), execute=True)
 
                 # add preparation steps to one ssh roundtrip executing the script
                 env_dict = dict()


### PR DESCRIPTION
Unified tmp accidentally removed the containing tmpdir from the list of
files to fix the permissions on when we're becoming a different
unprivileged user.  This resulted in a visible bug for script but not
for patch.  This is because patch also uploads the module to the same
temporary directory and the uploaded module also ends up calling
fixup_perms2() which includes the temporary directory.  So by the time
patch needs to access the temporary patch file, the directory is
appropriately set.

script's breakage was visible because script does not upload a module
(it's akin to raw in this way).  Therefore, we only call fixup_perms2()
once in script and so leaving out the tmpdir in script means that the
containing directory never has its permissions set appropriately.

Fixing both because it does not cause an extra round trip for patch so
any speedup would be minimal and it's better to fix the perms as close
as possible to where we know we need it.  Otherwise, changes to
seemingly unrelated code later could end up breaking it.

Fixes #36398

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
script and patch modules

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel 2.5
```