### PR TITLE
Support ansible-test --truncate with delegation.

### DIFF
--- a/test/runner/lib/delegation.py
+++ b/test/runner/lib/delegation.py
@@ -366,6 +366,7 @@ def filter_options(args, argv, options, exclude, require):
     options = options.copy()
 
     options['--requirements'] = 0
+    options['--truncate'] = 1
 
     if isinstance(args, TestConfig):
         options.update({
@@ -414,3 +415,6 @@ def filter_options(args, argv, options, exclude, require):
         if args.metadata_path:
             yield '--metadata'
             yield args.metadata_path
+
+    yield '--truncate'
+    yield '%d' % args.truncate


### PR DESCRIPTION
##### SUMMARY

Support ansible-test --truncate with delegation.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.6.0 (at-truncate-delegation d72ce15918) last updated 2018/02/19 10:04:43 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```
