### PR TITLE
Change the phrase used to describe module dependencies

### DIFF
--- a/docs/templates/plugin.rst.j2
+++ b/docs/templates/plugin.rst.j2
@@ -66,7 +66,7 @@ Aliases: @{ ','.join(aliases) }@
 {% if requirements %}
 {% set req = 'Requirements' %}
 {% if plugin_type == 'module' %}
-{% set req = req + ' (on managed node)' %}
+{% set req = req + ' (on each managed node)' %}
 {% endif %}
 {% set req_len = req|length %}
 @{ req }@

--- a/docs/templates/plugin.rst.j2
+++ b/docs/templates/plugin.rst.j2
@@ -66,7 +66,7 @@ Aliases: @{ ','.join(aliases) }@
 {% if requirements %}
 {% set req = 'Requirements' %}
 {% if plugin_type == 'module' %}
-{% set req = req + ' (on each managed node)' %}
+{% set req = req + ' (on each target host)' %}
 {% endif %}
 {% set req_len = req|length %}
 @{ req }@

--- a/docs/templates/plugin.rst.j2
+++ b/docs/templates/plugin.rst.j2
@@ -66,7 +66,7 @@ Aliases: @{ ','.join(aliases) }@
 {% if requirements %}
 {% set req = 'Requirements' %}
 {% if plugin_type == 'module' %}
-{% set req = req + ' (on host that executes module)' %}
+{% set req = req + ' (on managed node)' %}
 {% endif %}
 {% set req_len = req|length %}
 @{ req }@


### PR DESCRIPTION
##### SUMMARY
Changes the ambiguous and confusing 'on host that executes module' phrase to the consistently documented term 'managed node', as already used in documentation.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
docs/templates/plugin.rst.j2

##### ANSIBLE VERSION
```
ansible-playbook 2.5.0b2 (detached HEAD 62139bb828) last updated 2018/02/16 13:54:57 (GMT +000)
  config file = /home/vagrant/ansible-config/ansible.cfg
  configured module search path = [u'/home/vagrant/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/vagrant/ansible/src/ansible-v2.5.0b2/lib/ansible
  executable location = /home/vagrant/ansible/bin/ansible-playbook
  python version = 2.7.13 (default, Nov 24 2017, 17:33:09) [GCC 6.3.0 20170516]
```


##### ADDITIONAL INFORMATION
The term 'managed node' appears in core Ansible documentation, as a descriptor of 'a system which you are manipulating using Ansible'. It's understandable, and contains the payload phrase 'managed' which makes clear to an end user that this is the system you are connecting to. (The opposite is called the 'controller machine).

In documentation, because of the template I'm proposing changing, the phrase 'On host that executes module' is used to describe managed node dependencies. The phrase is ambiguous, and especially to newer Ansible users, is difficult to distinguish. It CAN sound like 'the controller machine' if you consider that the controller machine "is the origin from which modules are told to execute". In essence, this means the phrase is a bad one to use.

This change makes crystal clear which machines do and don't need the requirements specified, and uses the same term used elsewhere in Ansible documentation to refer to managed nodes.