### PR TITLE
Use pycrypto backend, rather than python-cryptography, on Ubuntu Precise

### DIFF
--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -6,6 +6,9 @@ DEB_PYTHON2_MODULE_PACKAGES=ansible
 include /usr/share/cdbs/1/rules/debhelper.mk
 include /usr/share/cdbs/1/class/python-distutils.mk
 
+ifeq ($(shell lsb_release -cs), precise)
+  export ANSIBLE_CRYPTO_BACKEND = pycrypto
+endif
 ifeq ($(shell lsb_release -cs), trusty)
   export ANSIBLE_CRYPTO_BACKEND = pycrypto
 endif


### PR DESCRIPTION
##### SUMMARY
The ansible 2.4 ubuntu precise (12.04) packages on the official Ubuntu PPA repo do not install because of a missing dependency on python-cryptography. 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ansible deb

##### ANSIBLE VERSION
```
ansible 2.4.3.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.3 (default, Oct 26 2016, 21:01:49) [GCC 4.6.3]
```


##### ADDITIONAL INFORMATION
Before: 
```
root@8adfff42b4eb:/# add-apt-repository ppa:ansible/ansible -y
gpg: keyring `/tmp/tmpEIupqU/secring.gpg' created
gpg: keyring `/tmp/tmpEIupqU/pubring.gpg' created
gpg: requesting key 7BB9C367 from hkp server keyserver.ubuntu.com
gpg: /tmp/tmpEIupqU/trustdb.gpg: trustdb created
gpg: key 7BB9C367: public key "Launchpad PPA for Ansible, Inc." imported
gpg: Total number processed: 1
gpg:               imported: 1  (RSA: 1)
OK

root@8adfff42b4eb:/# apt-get update
Hit http://archive.ubuntu.com precise Release.gpg
…
Get:4 http://ppa.launchpad.net precise/main amd64 Packages [1413 B]
Get:5 http://ppa.launchpad.net precise/main i386 Packages [1410 B]
Fetched 17.8 kB in 1s (8990 B/s)
Reading package lists... Done

root@8adfff42b4eb:/# apt-get install ansible
Reading package lists... Done
Building dependency tree
Reading state information... Done
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:

The following packages have unmet dependencies:
 ansible : Depends: python-cryptography but it is not installable
E: Unable to correct problems, you have held broken packages.
```
After:
Package installs as expected.
```
root@33d00baf0665:/# add-apt-repository ppa:ansible/ansible -y
gpg: keyring `/tmp/tmp3T34NZ/secring.gpg' created
gpg: keyring `/tmp/tmp3T34NZ/pubring.gpg' created
gpg: requesting key 7BB9C367 from hkp server keyserver.ubuntu.com
gpg: /tmp/tmp3T34NZ/trustdb.gpg: trustdb created
gpg: key 7BB9C367: public key "Launchpad PPA for Ansible, Inc." imported
gpg: Total number processed: 1
gpg:               imported: 1  (RSA: 1)
OK

root@33d00baf0665:/# apt-get update
Get:1 http://ppa.launchpad.net precise Release.gpg [819 B]
…
Get:5 http://ppa.launchpad.net precise/main i386 Packages [1410 B]
Fetched 17.8 kB in 1s (9014 B/s)
Reading package lists... Done

root@33d00baf0665:/# dpkg -i /deb-build/precise/ansible_2.4.3.0-100.git201802190000~precise_all.deb
Selecting previously unselected package ansible.
(Reading database ... 9729 files and directories currently installed.)
Unpacking ansible (from .../ansible_2.4.3.0-100.git201802190000~precise_all.deb) ...
dpkg: dependency problems prevent configuration of ansible:
 ansible depends on python-jinja2; however:
  Package python-jinja2 is not installed.
 ansible depends on python-yaml; however:
  Package python-yaml is not installed.
 ansible depends on python-paramiko; however:
  Package python-paramiko is not installed.
 ansible depends on python-httplib2; however:
  Package python-httplib2 is not installed.
 ansible depends on python-six; however:
  Package python-six is not installed.
 ansible depends on python-crypto (>= 2.6); however:
  Package python-crypto is not installed.
 ansible depends on python-setuptools; however:
  Package python-setuptools is not installed.
 ansible depends on sshpass; however:
  Package sshpass is not installed.
 ansible depends on python-pkg-resources; however:
  Package python-pkg-resources is not installed.
dpkg: error processing ansible (--install):
 dependency problems - leaving unconfigured
Errors were encountered while processing:
 ansible

root@33d00baf0665:/# apt-get -f install -y
Reading package lists... Done
Building dependency tree
Reading state information... Done
Correcting dependencies... Done
The following extra packages will be installed:
  libbsd0 libedit2 libgmp10 libx11-6 libx11-data libxau6 libxcb1 libxdmcp6 libxext6 libxmuu1 libyaml-0-2 openssh-client python-crypto python-httplib2 python-jinja2 python-markupsafe python-paramiko python-pkg-resources python-setuptools python-six python-yaml sshpass xauth
Suggested packages:
  ssh-askpass libpam-ssh keychain monkeysphere openssh-blacklist openssh-blacklist-extra python-crypto-dbg python-crypto-doc python-jinja2-doc python-distribute python-distribute-doc
Recommended packages:
  ssh-client
The following NEW packages will be installed:
  libbsd0 libedit2 libgmp10 libx11-6 libx11-data libxau6 libxcb1 libxdmcp6 libxext6 libxmuu1 libyaml-0-2 openssh-client python-crypto python-httplib2 python-jinja2 python-markupsafe python-paramiko python-pkg-resources python-setuptools python-six python-yaml sshpass xauth
0 upgraded, 23 newly installed, 0 to remove and 0 not upgraded.
1 not fully installed or removed.
Need to get 0 B/4687 kB of archives.
After this operation, 19.5 MB of additional disk space will be used.
Selecting previously unselected package python-markupsafe.
(Reading database ... 14463 files and directories currently installed.)
Unpacking python-markupsafe (from .../python-markupsafe_0.15-1_amd64.deb) ...
…
Selecting previously unselected package xauth.
Unpacking xauth (from .../xauth_1%3a1.0.6-1_amd64.deb) ...
Setting up python-markupsafe (0.15-1) ...
…
Setting up xauth (1:1.0.6-1) ...
Processing triggers for libc-bin ...
ldconfig deferred processing now taking place

root@33d00baf0665:/# ansible --version
ansible 2.4.3.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.3 (default, Oct 26 2016, 21:01:49) [GCC 4.6.3]
```

This PR should be back ported to ```stable-2.4``` release