### PR TITLE
Fix nxos_banner module for unstructured output

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_banner.py
+++ b/lib/ansible/modules/network/nxos/nxos_banner.py
@@ -93,6 +93,7 @@ from ansible.module_utils.network.nxos.nxos import load_config, run_commands
 from ansible.module_utils.network.nxos.nxos import nxos_argument_spec, check_args
 import re
 
+
 def execute_show_command(module, command):
     format = 'json'
     cmds = [{


### PR DESCRIPTION
##### SUMMARY
Some NXOS platforms do not support structured output for the `show banner motd` command.  This update detects the problem and re-sends the command using `output = 'text'` instead of `output = 'json'`

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
nxos_banner

##### ANSIBLE VERSION
```
ansible 2.6.0 (rel250/fix_nxos_banner fd461bdac1) last updated 2018/02/19 16:36:48 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/Users/mwiebe/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mwiebe/Projects/nxos_ansible/fix_ansible/lib/ansible
  executable location = /Users/mwiebe/Projects/nxos_ansible/fix_ansible/bin/ansible
  python version = 2.7.13 (default, Apr  4 2017, 08:47:57) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.38)]
```


##### ERROR WITHOUT THE FIX
```
TASK [nxos_banner : setup - remove motd] ******************************************************************************************************************************
task path: /Users/mwiebe/Projects/nxos_ansible/fix_ansible/test/integration/targets/nxos_banner/tests/nxapi/basic-motd.yaml:4
<n3k.example.com> connection transport is nxapi
Using module file /Users/mwiebe/Projects/nxos_ansible/fix_ansible/lib/ansible/modules/network/nxos/nxos_banner.py
<n3k.example.com> ESTABLISH LOCAL CONNECTION FOR USER: mwiebe
<n3k.example.com> EXEC /bin/sh -c 'echo ~ && sleep 0'
<n3k.example.com> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /Users/mwiebe/.ansible/tmp/ansible-tmp-1519075351.4-2432870101377 `" && echo ansible-tmp-1519075351.4-2432870101377="` echo /Users/mwiebe/.ansible/tmp/ansible-tmp-1519075351.4-2432870101377 `" ) && sleep 0'
<n3k.example.com> PUT /Users/mwiebe/.ansible/tmp/ansible-local-48775SCg2RH/tmpiZx5V9 TO /Users/mwiebe/.ansible/tmp/ansible-tmp-1519075351.4-2432870101377/nxos_banner.py
<n3k.example.com> EXEC /bin/sh -c 'chmod u+x /Users/mwiebe/.ansible/tmp/ansible-tmp-1519075351.4-2432870101377/ /Users/mwiebe/.ansible/tmp/ansible-tmp-1519075351.4-2432870101377/nxos_banner.py && sleep 0'
<n3k.example.com> EXEC /bin/sh -c '/Users/mwiebe/Virtualenvs/py2-ansible/bin/python /Users/mwiebe/.ansible/tmp/ansible-tmp-1519075351.4-2432870101377/nxos_banner.py && sleep 0'
<n3k.example.com> EXEC /bin/sh -c 'rm -f -r /Users/mwiebe/.ansible/tmp/ansible-tmp-1519075351.4-2432870101377/ > /dev/null 2>&1 && sleep 0'
The full traceback is:
Traceback (most recent call last):
  File "/var/folders/ww/538d42ys18l5tjyz0l1yk1rc0000gn/T/ansible_mI4SUZ/ansible_module_nxos_banner.py", line 189, in <module>
    main()
  File "/var/folders/ww/538d42ys18l5tjyz0l1yk1rc0000gn/T/ansible_mI4SUZ/ansible_module_nxos_banner.py", line 176, in main
    have = map_config_to_obj(module)
  File "/var/folders/ww/538d42ys18l5tjyz0l1yk1rc0000gn/T/ansible_mI4SUZ/ansible_module_nxos_banner.py", line 114, in map_config_to_obj
    output = run_commands(module, ['show banner %s' % module.params['banner']], False)[0]
IndexError: list index out of range

fatal: [n3k.example.com]: FAILED! => {
    "changed": false, 
    "failed": true, 
    "module_stderr": "Traceback (most recent call last):\n  File \"/var/folders/ww/538d42ys18l5tjyz0l1yk1rc0000gn/T/ansible_mI4SUZ/ansible_module_nxos_banner.py\", line 189, in <module>\n    main()\n  File \"/var/folders/ww/538d42ys18l5tjyz0l1yk1rc0000gn/T/ansible_mI4SUZ/ansible_module_nxos_banner.py\", line 176, in main\n    have = map_config_to_obj(module)\n  File \"/var/folders/ww/538d42ys18l5tjyz0l1yk1rc0000gn/T/ansible_mI4SUZ/ansible_module_nxos_banner.py\", line 114, in map_config_to_obj\n    output = run_commands(module, ['show banner %s' % module.params['banner']], False)[0]\nIndexError: list index out of range\n", 
    "module_stdout": "", 
    "msg": "MODULE FAILURE", 
    "rc": 1
}
	to retry, use: --limit @/Users/mwiebe/Projects/nxos_ansible/fix_ansible/test/integration/nxos.retry
```