### PR TITLE
Add option to hide sensitive ansible-test output.

### DIFF
--- a/test/runner/lib/core_ci.py
+++ b/test/runner/lib/core_ci.py
@@ -166,6 +166,8 @@ class AnsibleCoreCI(object):
             self.instance_id = str(uuid.uuid4())
             self.endpoint = None
 
+            display.sensitive.add(self.instance_id)
+
     def _get_parallels_endpoints(self):
         """
         :rtype: tuple[str]
@@ -298,6 +300,9 @@ class AnsibleCoreCI(object):
                 username=con['username'],
                 password=con.get('password'),
             )
+
+            if self.connection.password:
+                display.sensitive.add(self.connection.password)
 
         status = 'running' if self.connection.running else 'starting'
 
@@ -452,6 +457,8 @@ class AnsibleCoreCI(object):
         self.instance_id = config['instance_id']
         self.endpoint = config['endpoint']
         self.started = True
+
+        display.sensitive.add(self.instance_id)
 
         return True
 

--- a/test/runner/lib/util.py
+++ b/test/runner/lib/util.py
@@ -491,6 +491,8 @@ class Display(object):
         self.rows = 0
         self.columns = 0
         self.truncate = 0
+        self.redact = False
+        self.sensitive = set()
 
         if os.isatty(0):
             self.rows, self.columns = unpack('HHHH', fcntl.ioctl(0, TIOCGWINSZ, pack('HHHH', 0, 0, 0, 0)))[:2]
@@ -554,6 +556,10 @@ class Display(object):
         :type fd: file
         :type truncate: bool
         """
+        if self.redact and self.sensitive:
+            for item in self.sensitive:
+                message = message.replace(item, '*' * len(item))
+
         if truncate:
             if len(message) > self.truncate > 5:
                 message = message[:self.truncate - 5] + ' ...'
@@ -633,6 +639,10 @@ class CommonConfig(object):
         self.verbosity = args.verbosity  # type: int
         self.debug = args.debug  # type: bool
         self.truncate = args.truncate  # type: int
+        self.redact = args.redact  # type: bool
+
+        if is_shippable():
+            self.redact = True
 
 
 def docker_qualify_image(name):

--- a/test/runner/test.py
+++ b/test/runner/test.py
@@ -80,6 +80,7 @@ def main():
         config = args.config(args)
         display.verbosity = config.verbosity
         display.truncate = config.truncate
+        display.redact = config.redact
         display.color = config.color
         display.info_stderr = (isinstance(config, SanityConfig) and config.lint) or (isinstance(config, IntegrationConfig) and config.list_targets)
         check_startup()
@@ -156,6 +157,11 @@ def parse_args():
                         type=int,
                         default=display.columns,
                         help='truncate some long output (0=disabled) (default: auto)')
+
+    common.add_argument('--redact',
+                        dest='redact',
+                        action='store_true',
+                        help='redact sensitive values in output')
 
     test = argparse.ArgumentParser(add_help=False, parents=[common])
 


### PR DESCRIPTION
##### SUMMARY

Add option to hide sensitive ansible-test output.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.6.0 (at-redact 0b3965ad4f) last updated 2018/02/19 14:22:36 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.11 (default, Jan 22 2016, 08:29:18) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```
