### PR TITLE
Fix ansible-test --redact option with delegation.

### DIFF
--- a/test/runner/lib/delegation.py
+++ b/test/runner/lib/delegation.py
@@ -367,6 +367,7 @@ def filter_options(args, argv, options, exclude, require):
 
     options['--requirements'] = 0
     options['--truncate'] = 1
+    options['--redact'] = 0
 
     if isinstance(args, TestConfig):
         options.update({
@@ -418,3 +419,6 @@ def filter_options(args, argv, options, exclude, require):
 
     yield '--truncate'
     yield '%d' % args.truncate
+
+    if args.redact:
+        yield '--redact'


### PR DESCRIPTION
##### SUMMARY

Fix ansible-test --redact option with delegation.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.6.0 (at-delegate-redact 8015c638b7) last updated 2018/02/19 16:42:57 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.11 (default, Jan 22 2016, 08:29:18) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```
