### PR TITLE
unarchive: properly require required executables

### DIFF
--- a/lib/ansible/modules/files/unarchive.py
+++ b/lib/ansible/modules/files/unarchive.py
@@ -180,8 +180,8 @@ class ZipArchive(object):
         self.module = module
         self.excludes = module.params['exclude']
         self.includes = []
-        self.cmd_path = self.module.get_bin_path('unzip')
-        self.zipinfocmd_path = self.module.get_bin_path('zipinfo')
+        self.cmd_path = self.module.get_bin_path('unzip', required=True)
+        self.zipinfocmd_path = self.module.get_bin_path('zipinfo', required=True)
         self._files_in_archive = []
         self._infodict = dict()
 


### PR DESCRIPTION
##### SUMMARY

This changes the error returned on missing executable from `[Errno 2] No such file or directory` to a more clear `Failed to find required executable zipinfo in paths:`. (Ispired to existing #32250)

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
unarchive

##### ANSIBLE VERSION
```
ansible 2.4.3.0
  config file = /home/lapo/.ansible.cfg
  configured module search path = [u'/home/lapo/.ansible/plugins/modules', u'/usr/local/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.14 (default, Nov  7 2017, 01:18:58) [GCC 4.2.1 Compatible FreeBSD Clang 3.8.0 (tags/RELEASE_380/final 262564)]
```

##### ADDITIONAL INFORMATION
FreeBSD does not have either `zipinfo` nor `unzip` by default so the solution to my problem was actually to install it with `pkngng: name=unzip` but this bug made it difficult to understand.
