### PR TITLE
cs_user: fix return user_api_secret for ACS v4.10 and later

### DIFF
--- a/lib/ansible/modules/cloud/cloudstack/cs_user.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_user.py
@@ -400,6 +400,13 @@ class AnsibleCloudStackUser(AnsibleCloudStack):
                     if value == user['accounttype']:
                         self.result['account_type'] = key
                         break
+
+            # secretkey has been removed since CloudStack 4.10 from listUsers API
+            if self.module.params.get('keys_registered') and 'apikey' in user and 'secretkey' not in user:
+                user_keys = self.query_api('getUserKeys', id=user['id'])
+                if user_keys:
+                    self.result['user_api_secret'] = user_keys['userkeys'].get('secretkey')
+
         return self.result
 
 


### PR DESCRIPTION
##### SUMMARY
compatibility fix with ACS 4.10 and later

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
cs_user

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
