### PR TITLE
Fix path handling in validate-modules sanity test.

### DIFF
--- a/test/runner/lib/sanity/validate_modules.py
+++ b/test/runner/lib/sanity/validate_modules.py
@@ -17,7 +17,6 @@ from lib.util import (
     SubprocessError,
     display,
     run_command,
-    deepest_path,
 )
 
 from lib.ansible_util import (
@@ -45,10 +44,14 @@ class ValidateModulesTest(SanitySingleVersion):
         :type targets: SanityTargets
         :rtype: SanityResult
         """
+        with open(VALIDATE_SKIP_PATH, 'r') as skip_fd:
+            skip_paths = skip_fd.read().splitlines()
+
+        skip_paths_set = set(skip_paths)
+
         env = ansible_environment(args, color=False)
 
-        paths = [deepest_path(i.path, 'lib/ansible/modules/') for i in targets.include_external]
-        paths = sorted(set(p for p in paths if p))
+        paths = sorted([i.path for i in targets.include if i.module and i.path not in skip_paths_set])
 
         if not paths:
             return SanitySkipped(self.name)
@@ -59,9 +62,6 @@ class ValidateModulesTest(SanitySingleVersion):
             '--format', 'json',
             '--arg-spec',
         ] + paths
-
-        with open(VALIDATE_SKIP_PATH, 'r') as skip_fd:
-            skip_paths = skip_fd.read().splitlines()
 
         invalid_ignores = []
 
@@ -80,11 +80,6 @@ class ValidateModulesTest(SanitySingleVersion):
                 path, code = ignore_entry.split(' ', 1)
 
                 ignore[path][code] = line
-
-        skip_paths += [e.path for e in targets.exclude_external]
-
-        if skip_paths:
-            cmd += ['--exclude', '^(%s)' % '|'.join(skip_paths)]
 
         if args.base_branch:
             cmd.extend([

--- a/test/sanity/validate-modules/ignore.txt
+++ b/test/sanity/validate-modules/ignore.txt
@@ -2414,7 +2414,6 @@ lib/ansible/modules/network/nxos/nxos_bgp_neighbor_af.py E325
 lib/ansible/modules/network/nxos/nxos_bgp_neighbor_af.py E326
 lib/ansible/modules/network/nxos/nxos_command.py E325
 lib/ansible/modules/network/nxos/nxos_command.py E326
-lib/ansible/modules/network/nxos/nxos_config.py E324
 lib/ansible/modules/network/nxos/nxos_config.py E325
 lib/ansible/modules/network/nxos/nxos_config.py E326
 lib/ansible/modules/network/nxos/nxos_evpn_global.py E325


### PR DESCRIPTION
##### SUMMARY

Fix path handling in validate-modules sanity test.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

validate-modules sanity test

##### ANSIBLE VERSION

```
ansible 2.6.0 (at-validate-modules-fix 7e6a802863) last updated 2018/02/20 09:58:48 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.11 (default, Jan 22 2016, 08:29:18) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```
