### PR TITLE
portage: Add support for --quiet-build and --quiet-fail

### DIFF
--- a/lib/ansible/modules/packaging/os/portage.py
+++ b/lib/ansible/modules/packaging/os/portage.py
@@ -172,6 +172,25 @@ options:
     default: None
     version_added: 2.3
 
+  quietbuild:
+    description:
+      - Redirect all build output to logs alone, and do not display it
+      - on stdout (--quiet-build)
+    required: false
+    default: False
+    choices: [ "yes", "no" ]
+    version_added: 2.6
+
+  quietfail:
+    description:
+      - Suppresses display of the build log on stdout (--quiet-fail)
+      - Only the die message and the path of the build log will be
+      - displayed on stdout.
+    required: false
+    default: False
+    choices: [ "yes", "no" ]
+    version_added: 2.6
+
 requirements: [ gentoolkit ]
 author:
     - "William L Thomson Jr (@wltjr)"
@@ -320,6 +339,8 @@ def emerge_packages(module, packages):
         'usepkgonly': '--usepkgonly',
         'usepkg': '--usepkg',
         'keepgoing': '--keep-going',
+        'quietbuild': '--quiet-build',
+        'quietfail': '--quiet-fail',
     }
     for flag, arg in emerge_flags.items():
         if p[flag]:
@@ -490,9 +511,16 @@ def main():
             keepgoing=dict(default=False, type='bool'),
             jobs=dict(default=None, type='int'),
             loadavg=dict(default=None, type='float'),
+            quietbuild=dict(default=False, type='bool'),
+            quietfail=dict(default=False, type='bool'),
         ),
         required_one_of=[['package', 'sync', 'depclean']],
-        mutually_exclusive=[['nodeps', 'onlydeps'], ['quiet', 'verbose']],
+        mutually_exclusive=[
+            ['nodeps', 'onlydeps'],
+            ['quiet', 'verbose'],
+            ['quietbuild', 'verbose'],
+            ['quietfail', 'verbose'],
+        ],
         supports_check_mode=True,
     )
 


### PR DESCRIPTION
##### SUMMARY
Added support for options --quiet-build and --quiet-fail

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
portage

##### ANSIBLE VERSION
```
ansible 2.6.0
  config file = None
  configured module search path = ['/home/wlt/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib64/python3.5/site-packages/ansible
  executable location = /usr/lib/python-exec/python3.5/ansible
  python version = 3.5.4 (default, Jan  4 2018, 03:19:06) [GCC 7.2.0]
```

##### ADDITIONAL INFORMATION
May set these by default to Yes/True, along with quiet and set verbose to No/False. I am not sure there is much use for having portage generate output as normal. Seems the default should be quiet across the board, and let the user override as they prefer. It creates a fair amount of noise. I may look to change this in future revisions.
