### PR TITLE
Add check and diff mode support to assemble module

### DIFF
--- a/lib/ansible/modules/files/assemble.py
+++ b/lib/ansible/modules/files/assemble.py
@@ -76,6 +76,8 @@ author:
 extends_documentation_fragment:
     - files
     - decrypt
+notes:
+  - As of Ansible 2.6, this module supports check mode.
 '''
 
 EXAMPLES = '''
@@ -174,6 +176,7 @@ def main():
             validate=dict(required=False, type='str'),
         ),
         add_file_common_args=True,
+        supports_check_mode=True
     )
 
     changed = False
@@ -219,6 +222,18 @@ def main():
         dest_hash = module.sha1(dest)
 
     if path_hash != dest_hash:
+
+        if module._diff:
+            f = open(path, 'rb')
+            after_content = f.read()
+            f.close()
+            if os.path.exists(dest):
+                f = open(dest, 'rb')
+                before_content = f.read()
+                f.close()
+            else:
+                before_content = ""
+
         if validate:
             (rc, out, err) = module.run_command(validate % path)
             result['validation'] = dict(rc=rc, stdout=out, stderr=err)
@@ -228,17 +243,31 @@ def main():
         if backup and dest_hash is not None:
             result['backup_file'] = module.backup_local(dest)
 
-        module.atomic_move(path, dest, unsafe_writes=module.params['unsafe_writes'])
+        if not module.check_mode:
+            module.atomic_move(path, dest, unsafe_writes=module.params['unsafe_writes'])
         changed = True
 
     cleanup(path, result)
 
     # handle file permissions
-    file_args = module.load_file_common_arguments(module.params)
-    result['changed'] = module.set_fs_attributes_if_different(file_args, changed)
+    attr_diff = {}
+    if os.path.exists(dest):
+        file_args = module.load_file_common_arguments(module.params)
+        result['changed'] = module.set_fs_attributes_if_different(file_args, changed, diff=attr_diff)
+    else:
+        result['changed'] = True
 
     # Mission complete
     result['msg'] = "OK"
+
+    if module._diff:
+        content_diff = {'before': before_content,
+                        'after': after_content,
+                        'before_header': '%s (content)' % dest,
+                        'after_header': '%s (content)' % dest}
+
+        result['diff'] = [content_diff, attr_diff]
+
     module.exit_json(**result)
 
 if __name__ == '__main__':

--- a/lib/ansible/plugins/action/assemble.py
+++ b/lib/ansible/plugins/action/assemble.py
@@ -81,7 +81,7 @@ class ActionModule(ActionBase):
 
     def run(self, tmp=None, task_vars=None):
 
-        self._supports_check_mode = False
+        self._supports_check_mode = True
 
         result = super(ActionModule, self).run(tmp, task_vars)
         del tmp  # tmp no longer has any effect


### PR DESCRIPTION


##### SUMMARY
Fixes #11568



##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - New Module Pull Request
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
assemble.py

##### ANSIBLE VERSION
```
$ ./bin/ansible --version
ansible 2.6.0 (pull-issue-11568 7830d382f5) last updated 2018/02/20 21:18:42 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/gsciorti/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/gsciorti/PycharmProjects/ansible/lib/ansible
  executable location = ./bin/ansible
  python version = 2.7.14 (default, Dec 11 2017, 14:52:53) [GCC 7.2.1 20170915 (Red Hat 7.2.1-2)]
```


##### ADDITIONAL INFORMATION
With this pull request the module assemble allows to use check and diff mode.
In order to implement this features the module blockinfile has been used as reference.

**Enviroment used for the example described below:**
```
$ mkdir /tmp/tmpdir ; echo "file 1 content" > /tmp/tmpdir/file1 ; echo "file 2 content" > /tmp/tmpdir/file2
```

**Example 1) dest file not created and check mode enabled**
```


$ ./bin/ansible localhost -m assemble -a "src=/tmp/tmpdir dest=/tmp/tmpdest" --check
localhost | SUCCESS => {
    "changed": true, 
    "checksum": "32e13b4b4128d780d3266c7736a9379611b23dfb", 
    "dest": "/tmp/tmpdest", 
    "md5sum": "f7c888b2e1badc67084f5fab560e09a0", 
    "msg": "OK", 
    "src": "/tmp/tmpdir", 
    "state": "absent"
}

```
**Example 2) dest file not created and check mode and diff mode enabled**
```
$ ./bin/ansible localhost -m assemble -a "src=/tmp/tmpdir dest=/tmp/tmpdest" --check --diff
--- before: /tmp/tmpdest (content)
+++ after: /tmp/tmpdest (content)
@@ -0,0 +1,2 @@
+file 1 content
+file 2 content

localhost | SUCCESS => {
    "changed": true, 
    "checksum": "0954fe7206ceb606cb24958cb19dba273ad47009", 
    "dest": "/tmp/tmpdest", 
    "md5sum": "13649c06e975eab9291054d61896e88a", 
    "msg": "OK", 
    "src": "/tmp/tmpdir", 
    "state": "absent"
}

```
**Example 3) dest file created disabling check mode**
```

$ ./bin/ansible localhost -m assemble -a "src=/tmp/tmpdir dest=/tmp/tmpdest" 
localhost | SUCCESS => {
    "changed": true, 
    "checksum": "0954fe7206ceb606cb24958cb19dba273ad47009", 
    "dest": "/tmp/tmpdest", 
    "gid": 1000, 
    "group": "gsciorti", 
    "md5sum": "13649c06e975eab9291054d61896e88a", 
    "mode": "0664", 
    "msg": "OK", 
    "owner": "gsciorti", 
    "secontext": "unconfined_u:object_r:user_tmp_t:s0", 
    "size": 30, 
    "src": "/tmp/tmpdir", 
    "state": "file", 
    "uid": 1000
}

```
**Example 4) Add line in file 1 to /tmp/tmpdest file and execute assemble module changing permission with check mode and diff mode enabled**
```

$ echo "NEW LINE" >> /tmp/tmpdir/file1

$ ./bin/ansible localhost -m assemble -a "src=/tmp/tmpdir dest=/tmp/tmpdest mode=0600" --check --diff
--- before: /tmp/tmpdest (content)
+++ after: /tmp/tmpdest (content)
@@ -1,2 +1,3 @@
 file 1 content
+NEW LINE
 file 2 content

--- before
+++ after
@@ -1,3 +1,3 @@
 {
-    "mode": "0664"
+    "mode": "0600"
 }

localhost | SUCCESS => {
    "changed": true, 
    "checksum": "60729077d9665afc0c9667381bbbc8137a397bbe", 
    "dest": "/tmp/tmpdest", 
    "gid": 1000, 
    "group": "gsciorti", 
    "md5sum": "652992afa3411707845a406646a29139", 
    "mode": "0664", 
    "msg": "OK", 
    "owner": "gsciorti", 
    "secontext": "unconfined_u:object_r:user_tmp_t:s0", 
    "size": 30, 
    "src": "/tmp/tmpdir", 
    "state": "file", 
    "uid": 1000
}

```