### PR TITLE
[cloud] If inventory file isn't able to be parsed by aws_ec2, raise a…

### DIFF
--- a/lib/ansible/plugins/inventory/aws_ec2.py
+++ b/lib/ansible/plugins/inventory/aws_ec2.py
@@ -451,10 +451,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             :return the contents of the config file
         '''
         if super(InventoryModule, self).verify_file(path):
-            if path.endswith('.aws_ec2.yml' or '.aws_ec2.yaml'):
+            if path.endswith('.aws_ec2.yml') or path.endswith('.aws_ec2.yaml'):
                 return self._read_config_data(path)
-        else:
-            raise AnsibleParserError("Not a ec2 inventory plugin configuration file")
+        raise AnsibleParserError("Not a ec2 inventory plugin configuration file")
 
     def _get_query_options(self, config_data):
         '''


### PR DESCRIPTION
…n AnsibleParserError (#36387)

Fix path matching logic

##### SUMMARY
New in 2.5. Merged to devel in https://github.com/ansible/ansible/pull/36387. 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/inventory/aws_ec2.py

##### ANSIBLE VERSION
```
ansible 2.5.0b2
```
