### PR TITLE
Fix path handling in validate-modules sanity test.

### DIFF
--- a/test/runner/lib/sanity/validate_modules.py
+++ b/test/runner/lib/sanity/validate_modules.py
@@ -17,7 +17,6 @@ from lib.util import (
     SubprocessError,
     display,
     run_command,
-    deepest_path,
 )
 
 from lib.ansible_util import (
@@ -45,10 +44,14 @@ class ValidateModulesTest(SanitySingleVersion):
         :type targets: SanityTargets
         :rtype: SanityResult
         """
+        with open(VALIDATE_SKIP_PATH, 'r') as skip_fd:
+            skip_paths = skip_fd.read().splitlines()
+
+        skip_paths_set = set(skip_paths)
+
         env = ansible_environment(args, color=False)
 
-        paths = [deepest_path(i.path, 'lib/ansible/modules/') for i in targets.include_external]
-        paths = sorted(set(p for p in paths if p))
+        paths = sorted([i.path for i in targets.include if i.module and i.path not in skip_paths_set])
 
         if not paths:
             return SanitySkipped(self.name)
@@ -59,9 +62,6 @@ class ValidateModulesTest(SanitySingleVersion):
             '--format', 'json',
             '--arg-spec',
         ] + paths
-
-        with open(VALIDATE_SKIP_PATH, 'r') as skip_fd:
-            skip_paths = skip_fd.read().splitlines()
 
         invalid_ignores = []
 
@@ -80,11 +80,6 @@ class ValidateModulesTest(SanitySingleVersion):
                 path, code = ignore_entry.split(' ', 1)
 
                 ignore[path][code] = line
-
-        skip_paths += [e.path for e in targets.exclude_external]
-
-        if skip_paths:
-            cmd += ['--exclude', '^(%s)' % '|'.join(skip_paths)]
 
         if args.base_branch:
             cmd.extend([

--- a/test/sanity/validate-modules/ignore.txt
+++ b/test/sanity/validate-modules/ignore.txt
@@ -51,13 +51,11 @@ lib/ansible/modules/cloud/azure/azure_rm_storageaccount.py E322
 lib/ansible/modules/cloud/azure/azure_rm_storageblob.py E323
 lib/ansible/modules/cloud/azure/azure_rm_subnet.py E322
 lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py E322
-lib/ansible/modules/cloud/azure/azure_rm_virtualmachine_extension.py E322
 lib/ansible/modules/cloud/azure/azure_rm_virtualmachine_scaleset.py E322
 lib/ansible/modules/cloud/azure/azure_rm_virtualmachine_scaleset_facts.py E322
 lib/ansible/modules/cloud/azure/azure_rm_virtualmachineimage_facts.py E322
 lib/ansible/modules/cloud/azure/azure_rm_virtualmachineimage_facts.py E323
 lib/ansible/modules/cloud/azure/azure_rm_virtualnetwork.py E322
-lib/ansible/modules/cloud/azure/azure_rm_virtualnetwork_facts.py E322
 lib/ansible/modules/cloud/centurylink/clc_alert_policy.py E317
 lib/ansible/modules/cloud/centurylink/clc_firewall_policy.py E317
 lib/ansible/modules/cloud/cloudstack/cs_ip_address.py E322
@@ -80,8 +78,6 @@ lib/ansible/modules/cloud/digital_ocean/digital_ocean_floating_ip_facts.py E322
 lib/ansible/modules/cloud/digital_ocean/digital_ocean_sshkey.py E322
 lib/ansible/modules/cloud/digital_ocean/digital_ocean_sshkey_facts.py E322
 lib/ansible/modules/cloud/digital_ocean/digital_ocean_tag.py E322
-lib/ansible/modules/cloud/dimensiondata/dimensiondata_network.py E321
-lib/ansible/modules/cloud/docker/_docker.py E322
 lib/ansible/modules/cloud/docker/docker_container.py E322
 lib/ansible/modules/cloud/docker/docker_image.py E322
 lib/ansible/modules/cloud/docker/docker_image_facts.py E322
@@ -321,7 +317,6 @@ lib/ansible/modules/network/cnos/cnos_facts.py E323
 lib/ansible/modules/network/cnos/cnos_rollback.py E322
 lib/ansible/modules/network/cnos/cnos_rollback.py E323
 lib/ansible/modules/network/cnos/cnos_showrun.py E323
-lib/ansible/modules/network/dellos10/dellos10_command.py E322
 lib/ansible/modules/network/enos/enos_command.py E323
 lib/ansible/modules/network/enos/enos_config.py E323
 lib/ansible/modules/network/enos/enos_facts.py E323
@@ -347,10 +342,10 @@ lib/ansible/modules/network/onyx/onyx_config.py E323
 lib/ansible/modules/network/onyx/onyx_interface.py E323
 lib/ansible/modules/network/ordnance/ordnance_config.py E322
 lib/ansible/modules/network/ordnance/ordnance_facts.py E322
+lib/ansible/modules/network/panos/_panos_security_policy.py E322
 lib/ansible/modules/network/panos/panos_nat_rule.py E322
 lib/ansible/modules/network/panos/panos_sag.py E322
 lib/ansible/modules/network/panos/panos_sag.py E323
-lib/ansible/modules/network/panos/_panos_security_policy.py E322
 lib/ansible/modules/network/panos/panos_security_rule.py E322
 lib/ansible/modules/network/radware/vdirect_commit.py E321
 lib/ansible/modules/network/radware/vdirect_file.py E321


### PR DESCRIPTION
##### SUMMARY

Fix path handling in validate-modules sanity test.

(cherry picked from commit a9b58b84d8188e009ea6d4d25149927058d3bc2f)


##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.5.0b2 (at-vm-fix-2.5 0fe3b0c585) last updated 2018/02/20 13:39:45 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```
