### PR TITLE
Change to longer interval jittered backoffs for efs facts (#36266)

### DIFF
--- a/lib/ansible/modules/cloud/amazon/efs_facts.py
+++ b/lib/ansible/modules/cloud/amazon/efs_facts.py
@@ -186,7 +186,7 @@ class EFSConnection(object):
 
         self.region = region
 
-    @AWSRetry.exponential_backoff()
+    @AWSRetry.exponential_backoff(catch_extra_error_codes=['ThrottlingException'])
     def list_file_systems(self, **kwargs):
         """
          Returns generator of file systems including all attributes of FS
@@ -194,7 +194,7 @@ class EFSConnection(object):
         paginator = self.connection.get_paginator('describe_file_systems')
         return paginator.paginate(**kwargs).build_full_result()['FileSystems']
 
-    @AWSRetry.exponential_backoff()
+    @AWSRetry.exponential_backoff(catch_extra_error_codes=['ThrottlingException'])
     def get_tags(self, file_system_id):
         """
          Returns tag list for selected instance of EFS
@@ -202,7 +202,7 @@ class EFSConnection(object):
         paginator = self.connection.get_paginator('describe_tags')
         return boto3_tag_list_to_ansible_dict(paginator.paginate(FileSystemId=file_system_id).build_full_result()['Tags'])
 
-    @AWSRetry.exponential_backoff()
+    @AWSRetry.exponential_backoff(catch_extra_error_codes=['ThrottlingException'])
     def get_mount_targets(self, file_system_id):
         """
          Returns mount targets for selected instance of EFS
@@ -210,7 +210,7 @@ class EFSConnection(object):
         paginator = self.connection.get_paginator('describe_mount_targets')
         return paginator.paginate(FileSystemId=file_system_id).build_full_result()['MountTargets']
 
-    @AWSRetry.exponential_backoff()
+    @AWSRetry.jittered_backoff(catch_extra_error_codes=['ThrottlingException'])
     def get_security_groups(self, mount_target_id):
         """
          Returns security groups for selected instance of EFS


### PR DESCRIPTION
* Change to longer interval jittered backoffs for security group fact gathering

* Add the ECS throttling error code to the list of things to retry on

##### SUMMARY
Merged to devel in https://github.com/ansible/ansible/pull/36266. 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/efs_facts.py

##### ANSIBLE VERSION
```
ansible 2.5.0b2
```