### PR TITLE
winrm: (backport) Fix kerberos auth encoding for Python 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,8 @@ Ansible Changes By Release
   https://github.com/ansible/ansible/pull/36124
 * Fix dependency in the deb package on Ubuntu-12.04:
   https://github.com/ansible/ansible/pull/36407
+* Fix WinRM Python 3 encoding when getting Kerberos ticket
+  (https://github.com/ansible/ansible/issues/36255)
 
 
 <a id="2.4.3"></a

--- a/lib/ansible/plugins/connection/winrm.py
+++ b/lib/ansible/plugins/connection/winrm.py
@@ -196,8 +196,9 @@ class Connection(ConnectionBase):
         display.vvvvv("calling kinit for principal %s" % principal)
         p = subprocess.Popen(kinit_cmdline, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=krbenv)
 
-        # TODO: unicode/py3
-        stdout, stderr = p.communicate(password + b'\n')
+        b_password = to_bytes(password, encoding='utf-8',
+                              errors='surrogate_or_strict')
+        stdout, stderr = p.communicate(b_password + b'\n')
 
         if p.returncode != 0:
             raise AnsibleConnectionFailure("Kerberos auth failure: %s" % stderr.strip())


### PR DESCRIPTION
##### SUMMARY
On Python 3, subprocess stdin should be a byte string and currently password is stored as a unicode string. This fix converts the string to bytes and uses that in the communicate process.

Was fixed in devel with https://github.com/ansible/ansible/commit/92e52ef5154fc78758cbc3bbb3edac95d81f46e0#diff-4027b6fb84a6b8cdcd2ae5a0d348998d but because it added new features this is a manual backport for this fix.

Fixes https://github.com/ansible/ansible/issues/36255

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
winrm

##### ANSIBLE VERSION
```
2.4
```