### PR TITLE
fetch: set fail_on_missing: True as default as per docs

### DIFF
--- a/lib/ansible/modules/files/fetch.py
+++ b/lib/ansible/modules/files/fetch.py
@@ -41,9 +41,9 @@ options:
     version_added: "1.1"
     description:
       - When set to 'yes', the task will fail if the remote file cannot be
-        read for any reason.  Prior to Ansible-2.4, setting this would only fail
+        read for any reason.  Prior to Ansible-2.5, setting this would only fail
         if the source file was missing.
-      - The default was changed to "yes" in Ansible-2.4.
+      - The default was changed to "yes" in Ansible-2.5.
     required: false
     choices: [ "yes", "no" ]
     default: "yes"
@@ -73,8 +73,8 @@ notes:
       depending on the file size can consume all available memory on the
       remote or local hosts causing a C(MemoryError). Due to this it is
       advisable to run this module without C(become) whenever possible.
-    - Prior to Ansible-2.4 this module would not fail if reading the remote
-      file was impossible unless fail_on_missing was set.  In Ansible-2.4+,
+    - Prior to Ansible-2.5 this module would not fail if reading the remote
+      file was impossible unless fail_on_missing was set.  In Ansible-2.5+,
       playbook authors are encouraged to use fail_when or ignore_errors to
       get this ability.  They may also explicitly set fail_on_missing to False
       to get the non-failing behaviour.

--- a/lib/ansible/plugins/action/fetch.py
+++ b/lib/ansible/plugins/action/fetch.py
@@ -54,7 +54,7 @@ class ActionModule(ActionBase):
             source = self._task.args.get('src', None)
             dest = self._task.args.get('dest', None)
             flat = boolean(self._task.args.get('flat'), strict=False)
-            fail_on_missing = boolean(self._task.args.get('fail_on_missing'), strict=False)
+            fail_on_missing = boolean(self._task.args.get('fail_on_missing', True), strict=False)
             validate_checksum = boolean(self._task.args.get('validate_checksum',
                                                             self._task.args.get('validate_md5', True)),
                                         strict=False)

--- a/test/integration/targets/fetch/tasks/main.yml
+++ b/test/integration/targets/fetch/tasks/main.yml
@@ -77,6 +77,18 @@
       - "fetch_missing.msg"
       - "fetch_missing is not changed"
 
+- name: attempt to fetch a non-existent file - fail on missing implicit
+  fetch: src={{ output_dir }}/doesnotexist dest={{ output_dir }}/fetched
+  register: fetch_missing_implicit
+  ignore_errors: true
+
+- name: check fetch missing with failure with implicit fail
+  assert:
+    that:
+      - "fetch_missing_implicit is failed"
+      - "fetch_missing_implicit.msg"
+      - "fetch_missing_implicit is not changed"
+
 - name: attempt to fetch a directory - should not fail but return a message
   fetch: src={{ output_dir }} dest={{ output_dir }}/somedir fail_on_missing=False
   register: fetch_dir

--- a/test/integration/targets/win_fetch/tasks/main.yml
+++ b/test/integration/targets/win_fetch/tasks/main.yml
@@ -136,7 +136,7 @@
       - "fetch_small_bs_stat.stat.checksum == fetch_small_bs.checksum"
 
 - name: attempt to fetch a non-existent file - do not fail on missing
-  fetch: src="C:/this_file_should_not_exist.txt" dest={{ host_output_dir }}
+  fetch: src="C:/this_file_should_not_exist.txt" dest={{ host_output_dir }} fail_on_missing=no
   register: fetch_missing_nofail
 
 - name: check fetch missing no fail result
@@ -157,6 +157,18 @@
       - "fetch_missing is failed"
       - "fetch_missing.msg"
       - "fetch_missing is not changed"
+
+- name: attempt to fetch a non-existent file - fail on missing implicit
+  fetch: src="~/this_file_should_not_exist.txt" dest={{ host_output_dir }}
+  register: fetch_missing_implicit
+  ignore_errors: true
+
+- name: check fetch missing with failure on implicit
+  assert:
+    that:
+      - "fetch_missing_implicit is failed"
+      - "fetch_missing_implicit.msg"
+      - "fetch_missing_implicit is not changed"
 
 - name: attempt to fetch a directory
   fetch: src="C:\\Windows" dest={{ host_output_dir }}


### PR DESCRIPTION
##### SUMMARY
The docs indicate that `fail_on_missing` has been set to `yes` by default since 2.4 but this is not the case. Changing it default to True, will require a cherry-pick to 2.5 and changes to the 2.5 porting guide.

For 2.4 it was decided to just update the docs so it keeps the 2.3 behaviour.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
fetch

##### ANSIBLE VERSION
```
2.5
devel
```