### PR TITLE
Typo: Fixed Network Command Modules Error Message

### DIFF
--- a/lib/ansible/modules/network/aireos/aireos_command.py
+++ b/lib/ansible/modules/network/aireos/aireos_command.py
@@ -205,7 +205,7 @@ def main():
 
     if conditionals:
         failed_conditions = [item.raw for item in conditionals]
-        msg = 'One or more conditional statements have not be satisfied'
+        msg = 'One or more conditional statements have not been satisfied'
         module.fail_json(msg=msg, failed_conditions=failed_conditions)
 
     result.update({

--- a/lib/ansible/modules/network/aruba/aruba_command.py
+++ b/lib/ansible/modules/network/aruba/aruba_command.py
@@ -205,7 +205,7 @@ def main():
 
     if conditionals:
         failed_conditions = [item.raw for item in conditionals]
-        msg = 'One or more conditional statements have not be satisfied'
+        msg = 'One or more conditional statements have not been satisfied'
         module.fail_json(msg=msg, failed_conditions=failed_conditions)
 
     result.update({

--- a/lib/ansible/modules/network/cloudengine/ce_command.py
+++ b/lib/ansible/modules/network/cloudengine/ce_command.py
@@ -248,7 +248,7 @@ def main():
 
     if conditionals:
         failed_conditions = [item.raw for item in conditionals]
-        msg = 'One or more conditional statements have not be satisfied'
+        msg = 'One or more conditional statements have not been satisfied'
         module.fail_json(msg=msg, failed_conditions=failed_conditions)
 
     result.update({

--- a/lib/ansible/modules/network/dellos10/dellos10_command.py
+++ b/lib/ansible/modules/network/dellos10/dellos10_command.py
@@ -214,7 +214,7 @@ def main():
 
     if conditionals:
         failed_conditions = [item.raw for item in conditionals]
-        msg = 'One or more conditional statements have not be satisfied'
+        msg = 'One or more conditional statements have not been satisfied'
         module.fail_json(msg=msg, failed_conditions=failed_conditions)
 
     result.update({

--- a/lib/ansible/modules/network/dellos6/dellos6_command.py
+++ b/lib/ansible/modules/network/dellos6/dellos6_command.py
@@ -213,7 +213,7 @@ def main():
 
     if conditionals:
         failed_conditions = [item.raw for item in conditionals]
-        msg = 'One or more conditional statements have not be satisfied'
+        msg = 'One or more conditional statements have not been satisfied'
         module.fail_json(msg=msg, failed_conditions=failed_conditions)
 
     result.update({

--- a/lib/ansible/modules/network/dellos9/dellos9_command.py
+++ b/lib/ansible/modules/network/dellos9/dellos9_command.py
@@ -222,7 +222,7 @@ def main():
 
     if conditionals:
         failed_conditions = [item.raw for item in conditionals]
-        msg = 'One or more conditional statements have not be satisfied'
+        msg = 'One or more conditional statements have not been satisfied'
         module.fail_json(msg=msg, failed_conditions=failed_conditions)
 
     result.update({

--- a/lib/ansible/modules/network/enos/enos_command.py
+++ b/lib/ansible/modules/network/enos/enos_command.py
@@ -208,7 +208,7 @@ def main():
 
     if conditionals:
         failed_conditions = [item.raw for item in conditionals]
-        msg = 'One or more conditional statements have not be satisfied'
+        msg = 'One or more conditional statements have not been satisfied'
         module.fail_json(msg=msg, failed_conditions=failed_conditions)
 
     result.update({

--- a/lib/ansible/modules/network/eos/eos_command.py
+++ b/lib/ansible/modules/network/eos/eos_command.py
@@ -263,7 +263,7 @@ def main():
 
     if conditionals:
         failed_conditions = [item.raw for item in conditionals]
-        msg = 'One or more conditional statements have not be satisfied'
+        msg = 'One or more conditional statements have not been satisfied'
         module.fail_json(msg=msg, failed_conditions=failed_conditions)
 
     result.update({

--- a/lib/ansible/modules/network/ios/ios_command.py
+++ b/lib/ansible/modules/network/ios/ios_command.py
@@ -230,7 +230,7 @@ def main():
 
     if conditionals:
         failed_conditions = [item.raw for item in conditionals]
-        msg = 'One or more conditional statements have not be satisfied'
+        msg = 'One or more conditional statements have not been satisfied'
         module.fail_json(msg=msg, failed_conditions=failed_conditions)
 
     result.update({

--- a/lib/ansible/modules/network/iosxr/iosxr_command.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_command.py
@@ -209,7 +209,7 @@ def main():
 
     if conditionals:
         failed_conditions = [item.raw for item in conditionals]
-        msg = 'One or more conditional statements have not be satisfied'
+        msg = 'One or more conditional statements have not been satisfied'
         module.fail_json(msg=msg, failed_conditions=failed_conditions)
 
     result = {

--- a/lib/ansible/modules/network/ironware/ironware_command.py
+++ b/lib/ansible/modules/network/ironware/ironware_command.py
@@ -161,7 +161,7 @@ def main():
 
     if conditionals:
         failed_conditions = [item.raw for item in conditionals]
-        msg = 'One or more conditional statements have not be satisfied'
+        msg = 'One or more conditional statements have not been satisfied'
         module.fail_json(msg=msg, failed_conditions=failed_conditions)
 
     result.update({

--- a/lib/ansible/modules/network/junos/junos_command.py
+++ b/lib/ansible/modules/network/junos/junos_command.py
@@ -434,7 +434,7 @@ def main():
 
     if conditionals:
         failed_conditions = [item.raw for item in conditionals]
-        msg = 'One or more conditional statements have not be satisfied'
+        msg = 'One or more conditional statements have not been satisfied'
         module.fail_json(msg=msg, failed_conditions=failed_conditions)
 
     result = {

--- a/lib/ansible/modules/network/junos/junos_interface.py
+++ b/lib/ansible/modules/network/junos/junos_interface.py
@@ -371,7 +371,7 @@ def main():
                 if port and port not in have_port:
                     failed_conditions.append('port ' + port)
     if failed_conditions:
-        msg = 'One or more conditional statements have not be satisfied'
+        msg = 'One or more conditional statements have not been satisfied'
         module.fail_json(msg=msg, failed_conditions=failed_conditions)
 
     module.exit_json(**result)

--- a/lib/ansible/modules/network/nxos/nxos_command.py
+++ b/lib/ansible/modules/network/nxos/nxos_command.py
@@ -233,7 +233,7 @@ def main():
 
     if conditionals:
         failed_conditions = [item.raw for item in conditionals]
-        msg = 'One or more conditional statements have not be satisfied'
+        msg = 'One or more conditional statements have not been satisfied'
         module.fail_json(msg=msg, failed_conditions=failed_conditions)
 
     result.update({

--- a/lib/ansible/modules/network/onyx/onyx_command.py
+++ b/lib/ansible/modules/network/onyx/onyx_command.py
@@ -199,7 +199,7 @@ def main():
 
     if conditionals:
         failed_conditions = [item.raw for item in conditionals]
-        msg = 'One or more conditional statements have not be satisfied'
+        msg = 'One or more conditional statements have not been satisfied'
         module.fail_json(msg=msg, failed_conditions=failed_conditions)
 
     result.update({

--- a/lib/ansible/modules/network/sros/sros_command.py
+++ b/lib/ansible/modules/network/sros/sros_command.py
@@ -220,7 +220,7 @@ def main():
 
     if conditionals:
         failed_conditions = [item.raw for item in conditionals]
-        msg = 'One or more conditional statements have not be satisfied'
+        msg = 'One or more conditional statements have not been satisfied'
         module.fail_json(msg=msg, failed_conditions=failed_conditions)
 
     result = {


### PR DESCRIPTION
##### SUMMARY

Fixes language used in conditional status check error message for network device command modules.

##### ISSUE TYPE
 - Bugfix Pull Request


##### COMPONENT NAME

aireos_command
aruba_command
ce_command
dellos10_command
dellos6_command
dellos9_command
enos_command
eos_command
ios_command
iosxr_command
ironware_command
junos_command
junos_interface
nxos_command
onyx_command
sros_command

##### ANSIBLE VERSION

```
ansible 2.6.0 (slxos_modules 2a7acba239) last updated 2018/02/21 02:06:16 (GMT +200)
  config file = /home/lhill/.ansible.cfg
  configured module search path = [u'/home/lhill/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/lhill/ansible/lib/ansible
  executable location = /home/lhill/ansible/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```

##### ADDITIONAL INFORMATION

Small language cleanup to make it 'more correct' English. NB this also makes it the same as the validation message for other modules such as `ios_interface`.

Before
```shell
(venv) lhill@bwc:~/playbooks$ ansible-playbook -i hosts -k ios_command_ntp.yaml
SSH password:

PLAY [cisco01] *************************************************************************************************************************

TASK [Check for non-existent NTP server] *********************************************************************************************
fatal: [cisco01]: FAILED! => {"changed": false, "failed": true, "failed_conditions": ["result[0] contains 172.16.10.3"], "msg": "One or more conditional statements have not be satisfied"}
	to retry, use: --limit @/home/lhill/playbooks/ios_command_ntp.retry

PLAY RECAP ***************************************************************************************************************************
cisco01                      : ok=1    changed=0    unreachable=0    failed=1

(venv) lhill@bwc:~/playbooks$
```

After
```shell
(venv) lhill@bwc:~/playbooks$ ansible-playbook -i hosts -k ios_command_ntp.yaml
SSH password:

PLAY [cisco01] *************************************************************************************************************************

TASK [Check for non-existent NTP server] *********************************************************************************************
fatal: [cisco01]: FAILED! => {"changed": false, "failed": true, "failed_conditions": ["result[0] contains 172.16.10.3"], "msg": "One or more conditional statements have not been satisfied"}
	to retry, use: --limit @/home/lhill/playbooks/ios_command_ntp.retry

PLAY RECAP ***************************************************************************************************************************
cisco01                      : ok=1    changed=0    unreachable=0    failed=1

(venv) lhill@bwc:~/playbooks$
```