### PR TITLE
fail module when config is invalid and jsonrpc doesn't return error

### DIFF
--- a/lib/ansible/plugins/terminal/nxos.py
+++ b/lib/ansible/plugins/terminal/nxos.py
@@ -43,7 +43,8 @@ class TerminalModule(TerminalBase):
         re.compile(br"'[^']' +returned error code: ?\d+"),
         re.compile(br"syntax error"),
         re.compile(br"unknown command"),
-        re.compile(br"user not present")
+        re.compile(br"user not present"),
+        re.compile(br"invalid (.+?)at '\^' marker", re.I)
     ]
 
     def on_open_shell(self):


### PR DESCRIPTION
Signed-off-by: Trishna Guha <trishnaguha17@gmail.com>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes https://github.com/ansible/ansible/issues/36434
The existing code doesn't return error when `update_source` has `invalid interface` for `nxos_bgp_neighbor module`, Update terminal plugin to catch the error.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
plugins/terminal/nxos.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel, 2.5
```

With this fix the module failed with the following traceback which is expected:
```
The full traceback is:
  File "/tmp/ansible_Hd51B8/ansible_modlib.zip/ansible/module_utils/network/nxos/nxos.py", line 195, in load_config
    responses = connection.edit_config(config)
  File "/tmp/ansible_Hd51B8/ansible_modlib.zip/ansible/module_utils/connection.py", line 146, in __rpc__
    raise ConnectionError(to_text(msg, errors='surrogate_then_replace'), code=code)

fatal: [nxos9k-01]: FAILED! => {
    "changed": false, 
    "invocation": {
        "module_args": {
            "asn": "65001", 
            "capability_negotiation": null, 
            "connected_check": null, 
            "description": null, 
            "dynamic_capability": null, 
            "ebgp_multihop": null, 
            "host": null, 
            "local_as": null, 
            "log_neighbor_changes": null, 
            "low_memory_exempt": null, 
            "maximum_peers": null, 
            "neighbor": "1.1.1.21", 
            "password": null, 
            "port": null, 
            "provider": null, 
            "pwd": null, 
            "pwd_type": null, 
            "remote_as": "65001", 
            "remove_private_as": null, 
            "shutdown": null, 
            "ssh_keyfile": null, 
            "state": "present", 
            "suppress_4_byte_as": null, 
            "timeout": null, 
            "timers_holdtime": null, 
            "timers_keepalive": null, 
            "transport": null, 
            "transport_passive_only": null, 
            "update_source": "1.1.1.1", 
            "use_ssl": null, 
            "username": null, 
            "validate_certs": null, 
            "vrf": "default"
        }
    }, 
    "msg": "update-source 1.1.1.1\r\r\n                                                    ^\r\nInvalid interface format at '^' marker.\r\n\ran-nxos9k-01(config-router-neighbor)# "
}
```