### PR TITLE
vyos_config IndexError in sanitize_config (#36375)

### DIFF
--- a/lib/ansible/modules/network/vyos/vyos_config.py
+++ b/lib/ansible/modules/network/vyos/vyos_config.py
@@ -205,11 +205,15 @@ def diff_config(commands, config):
 
 def sanitize_config(config, result):
     result['filtered'] = list()
+    index_to_filter = list()
     for regex in CONFIG_FILTERS:
         for index, line in enumerate(list(config)):
             if regex.search(line):
                 result['filtered'].append(line)
-                del config[index]
+                index_to_filter.append(index)
+    # Delete all filtered configs
+    for filter_index in sorted(index_to_filter, reverse=True):
+        del config[filter_index]
 
 
 def run(module, result):

--- a/test/integration/targets/vyos_config/tests/cli/check_config.yaml
+++ b/test/integration/targets/vyos_config/tests/cli/check_config.yaml
@@ -47,4 +47,17 @@
     that:
       - "result.changed == false"
 
+- name: check multiple line config filter is working
+  vyos_config:
+      lines:
+          - set system login user esa level admin
+          - set system login user esa authentication encrypted-password '!abc!'
+          - set system login user vyos level admin
+          - set system login user vyos authentication encrypted-password 'abc'
+  register: result
+
+- assert:
+    that:
+      - "{{ result.filtered|length }} == 2"
+
 - debug: msg="END cli/config_check.yaml on connection={{ ansible_connection }}"


### PR DESCRIPTION
* Bug in del(list) logic. Say you have a list of 4 elements a[0-3]
and you have to remove index 1 and 3, if you remove index 1 first
then list is cut short a[0-2] and does not have index 3

Fix: Remove indexes in reverse sorted order e.g. 3 and 1 in above
example so that order of indexes remain preserved even after deleting

fix is to remove indexes in reverse sorted order

* Add test cases for failed case

(cherry picked from commit 0bbea9a57973ddfadbe1e5f456fa57c23404ff9c)

