### PR TITLE
Fixes #36483 Assume firewall is offline on DBUS_ERROR during init

### DIFF
--- a/lib/ansible/modules/system/firewalld.py
+++ b/lib/ansible/modules/system/firewalld.py
@@ -164,6 +164,7 @@ try:
     from firewall.client import Rich_Rule
     from firewall.client import FirewallClient
     from firewall.client import FirewallClientZoneSettings
+    from firewall.errors import FirewallError
     fw = None
     fw_offline = False
     import_failure = False
@@ -171,7 +172,7 @@ try:
     try:
         fw = FirewallClient()
         fw.getDefaultZone()
-    except AttributeError:
+    except (AttributeError, FirewallError):
         # Firewalld is not currently running, permanent-only operations
         fw_offline = True
 


### PR DESCRIPTION
During init, the FirewallClient tries to connect to the DBUS socket.  If it
fails to connect it should be safe to assume firewalld is offline.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #36483
During init, the FirewallClient tries to connect to the DBUS socket.  If it
fails to connect it should be safe to assume firewalld is offline.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
firewalld
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.2.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, May  3 2017, 07:55:04) [GCC 4.8.5 20150623 (Red Hat 4.8.5-14)]```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```