### PR TITLE
fail module when config is invalid and jsonrpc doesn't return error (#36482)

### DIFF
--- a/lib/ansible/plugins/terminal/nxos.py
+++ b/lib/ansible/plugins/terminal/nxos.py
@@ -43,7 +43,8 @@ class TerminalModule(TerminalBase):
         re.compile(br"'[^']' +returned error code: ?\d+"),
         re.compile(br"syntax error"),
         re.compile(br"unknown command"),
-        re.compile(br"user not present")
+        re.compile(br"user not present"),
+        re.compile(br"invalid (.+?)at '\^' marker", re.I)
     ]
 
     def on_open_shell(self):


### PR DESCRIPTION
Signed-off-by: Trishna Guha <trishnaguha17@gmail.com>
(cherry picked from commit d5858bbcbe14c4afe2e8e24dac51ee2e32533c49)