### PR TITLE
Bring aws_ssm None fixes into stable (from #36456) 

### DIFF
--- a/lib/ansible/plugins/lookup/aws_ssm.py
+++ b/lib/ansible/plugins/lookup/aws_ssm.py
@@ -193,10 +193,16 @@ class LookupModule(LookupBase):
                 response = client.get_parameters(**ssm_dict)
             except ClientError as e:
                 raise AnsibleError("SSM lookup exception: {0}".format(to_native(e)))
-            if len(response['Parameters']) == len(terms):
-                ret = [p['Value'] for p in response['Parameters']]
-            else:
-                raise AnsibleError('Undefined AWS SSM parameter: %s ' % str(response['InvalidParameters']))
+            params = boto3_tag_list_to_ansible_dict(response['Parameters'], tag_name_key_name="Name",
+                                                    tag_value_key_name="Value")
+            for i in terms:
+                if i in params:
+                    ret.append(params[i])
+                elif i in response['InvalidParameters']:
+                    ret.append(None)
+                else:
+                    raise AnsibleError("Ansible internal error: aws_ssm lookup failed to understand boto3 return value".format(str(response)))
+            return ret
 
         display.vvvv("AWS_ssm path lookup returning: %s " % str(ret))
         return ret

--- a/lib/ansible/plugins/lookup/aws_ssm.py
+++ b/lib/ansible/plugins/lookup/aws_ssm.py
@@ -201,7 +201,7 @@ class LookupModule(LookupBase):
                 elif i in response['InvalidParameters']:
                     ret.append(None)
                 else:
-                    raise AnsibleError("Ansible internal error: aws_ssm lookup failed to understand boto3 return value".format(str(response)))
+                    raise AnsibleError("Ansible internal error: aws_ssm lookup failed to understand boto3 return value: {0}".format(str(response)))
             return ret
 
         display.vvvv("AWS_ssm path lookup returning: %s " % str(ret))

--- a/test/integration/targets/aws_ssm_parameters/tasks/main.yml
+++ b/test/integration/targets/aws_ssm_parameters/tasks/main.yml
@@ -76,7 +76,7 @@
     # ============================================================
     - name: Returns empty value in case we don't find a named parameter
       assert:
-       that: 
+       that:
         - "'{{lookup('aws_ssm', '/' ~ ssm_key_prefix ~ '/Goodbye', region=ec2_region, aws_access_key=ec2_access_key, aws_secret_key=ec2_secret_key, aws_security_token=security_token )}}' == ''"
 
     # ============================================================

--- a/test/integration/targets/aws_ssm_parameters/tasks/main.yml
+++ b/test/integration/targets/aws_ssm_parameters/tasks/main.yml
@@ -74,17 +74,10 @@
         - "'{{lookup('aws_ssm', '/' ~ ssm_key_prefix ~ '/path', region=ec2_region, aws_access_key=ec2_access_key, aws_secret_key=ec2_secret_key, aws_security_token=security_token, bypath=True, shortnames=true ) | to_json }}' == '{\"toovar\": \"too value\", \"wonvar\": \"won value\"}'"
 
     # ============================================================
-    - name: Error in case we don't find a named parameter
-      debug:
-       msg: "'{{lookup('aws_ssm', '/' ~ ssm_key_prefix ~ '/Goodbye', region=ec2_region, aws_access_key=ec2_access_key, aws_secret_key=ec2_secret_key, aws_security_token=security_token )}}' == 'World'"
-      register: result
-      ignore_errors: true
-
-    - name: assert failure from failure to find parameter
+    - name: Returns empty value in case we don't find a named parameter
       assert:
-        that:
-           - 'result.failed'
-           - "'Undefined AWS SSM parameter' in result.msg"
+       that: 
+        - "'{{lookup('aws_ssm', '/' ~ ssm_key_prefix ~ '/Goodbye', region=ec2_region, aws_access_key=ec2_access_key, aws_secret_key=ec2_secret_key, aws_security_token=security_token )}}' == ''"
 
     # ============================================================
     - name: Handle multiple paths with one that doesn't exist - default to full names.
@@ -134,3 +127,4 @@
         - "/{{ssm_key_prefix}}/path/wonvar"
         - "/{{ssm_key_prefix}}/path/toovar"
         - "/{{ssm_key_prefix}}/path/tree/treevar"
+        - "/{{ssm_key_prefix}}/deeppath/wondir/samevar"


### PR DESCRIPTION
##### SUMMARY

Backport of #36456 - In the case that a variable is missing we should return None otherwise we can break filters - to stable 2.5 branch.

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

aws_ssm lookup plugin

##### ANSIBLE VERSION

```
ansible 2.5.0b2 (stable-2.5-aws_ssm_return_none_noexist_fix 1e479b34c7) last updated 2018/02/21 08:34:24 (GMT +100)
  config file = None
  configured module search path = [u'/home/mikedlr/dev/ansible/ansible-dev/library']
  ansible python module location = /home/mikedlr/dev/ansible/ansible-dev/lib/ansible
  executable location = /home/mikedlr/dev/ansible/ansible-dev/bin/ansible
  python version = 2.7.5 (default, Aug  4 2017, 00:39:18) [GCC 4.8.5 20150623 (Red Hat 4.8.5-16)]
```

##### ADDITIONAL INFORMATION

see also PR #36456 for further description but I might add some further changes there.  This will be the minimal change for easy digestion into stable.  
