### PR TITLE
Adding module win_dns_a

### DIFF
--- a/lib/ansible/modules/windows/win_dns_a.ps1
+++ b/lib/ansible/modules/windows/win_dns_a.ps1
@@ -1,0 +1,151 @@
+#!powershell
+#
+# Copyright: (c) 2017, AMTEGA - Xunta de Galicia
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+#Requires -Module Ansible.ModuleUtils.Legacy
+
+
+# ------------------------------------------------------------------------------
+$ErrorActionPreference = "Stop"
+
+# Preparing result
+$result = New-Object PSObject
+Set-Attr $result "changed" $false
+
+# Parameter ingestion
+$params = Parse-Args $args -supports_check_mode $true
+
+$check_mode = Get-AnsibleParam -obj $params -name "_ansible_check_mode" -default $false | ConvertTo-Bool
+$diff_support = Get-AnsibleParam -obj $params -name "_ansible_diff" -default $false | ConvertTo-Bool
+
+# ------------------------------------------------------------------------------
+Function Get-DesiredState($params) {
+  $computer_name = Get-AnsibleParam -obj $params -name "computer_name" -failifempty $true -resultobj $result
+  $zone_name = Get-AnsibleParam -obj $params -name "zone_name" -failifempty $true -resultobj $result
+  $name = Get-AnsibleParam -obj $params -name "name" -failifempty $true -resultobj $result
+  $state = (Get-AnsibleParam -obj $params -name "state" -ValidateSet "Present","Absent" -default "Present").ToLower()
+  If ($state -eq "present") {
+    $ipv4_address = Get-AnsibleParam -obj $params -name "ipv4_address" -failifempty $true -resultobj $result
+  } Else {
+    $ipv4_address = $null
+  }
+  $desired_state = New-Object psobject @{
+    computer_name = $computer_name
+    ipv4_address = $ipv4_address
+    name = $name
+    state = $state
+    zone_name = $zone_name
+  }
+
+  Return $desired_state
+}
+
+# ------------------------------------------------------------------------------
+Function Get-InitialState($desired_state) {
+  # Test DnsServerResourceRecord exists
+  $record = Try { Get-DnsServerResourceRecord `
+                    -ComputerName $desired_state.computer_name `
+                    -ZoneName $desired_state.zone_name `
+                    -RRType A `
+                    -Name $desired_state.name
+                } Catch { $null }
+  If ($record) {
+    $initial_state = New-Object psobject @{
+      computer_name = $desired_state.computer_name # Same DNS server
+      zone_name = $desired_state.zone_name
+      name = $record.HostName
+      ipv4_address = $record.RecordData.IPv4Address.IPAddressToString
+      state = "present"
+    }
+  } Else {
+    $initial_state = New-Object psobject @{
+      computer_name = $desired_state.computer_name # Same DNS server
+      zone_name = $desired_state.zone_name
+      name = ""
+      ipv4_address = ""
+      state = "absent"
+    }
+  }
+  Return $initial_state
+}
+
+# ------------------------------------------------------------------------------
+Function Set-ConstructedState($desired_state) {
+  Remove-ConstructedState($desired_state)
+  Add-ConstructedState($desired_state)
+
+  Set-Attr $result "changed" $true
+}
+
+# ------------------------------------------------------------------------------
+Function Add-ConstructedState($desired_state) {
+  Add-DnsServerResourceRecordA `
+    -ComputerName $desired_state.computer_name `
+    -ZoneName $desired_state.zone_name `
+    -Name $desired_state.name `
+    -IPv4Address $desired_state.ipv4_address `
+    -Confirm:$False `
+    -WhatIf:$check_mode
+
+  Set-Attr $result "changed" $true
+}
+
+# ------------------------------------------------------------------------------
+Function Remove-ConstructedState($desired_state) {
+  Remove-DnsServerResourceRecord `
+    -ComputerName $desired_state.computer_name `
+    -ZoneName $desired_state.zone_name `
+    -Name $desired_state.name `
+    -RRType A `
+    -Confirm:$False `
+    -Force:$True `
+    -WhatIf:$check_mode
+
+  Set-Attr $result "changed" $true
+}
+
+# ------------------------------------------------------------------------------
+Function are_hashtables_equal($x, $y) {
+  foreach ($key in $x.Keys) {
+      if (($y.Keys -notcontains $key) -or ($x[$key] -ne $y[$key])) {
+          return $false
+      }
+  }
+  foreach ($key in $y.Keys) {
+      if (($x.Keys -notcontains $key) -or ($x[$key] -ne $y[$key])) {
+          return $false
+      }
+  }
+  Return $true
+}
+
+# ------------------------------------------------------------------------------
+$desired_state = Get-DesiredState($params)
+$initial_state = Get-InitialState($desired_state)
+
+If ($desired_state.state -eq "Present") {
+    If ($initial_state.state -eq "Present") {
+      $in_desired_state =  are_hashtables_equal $initial_state $desired_state
+
+      If (-not $in_desired_state) {
+        Set-ConstructedState($desired_state)
+      }
+    } Else { # $desired_state.state = "Present" & $initial_state.state = "Absent"
+      Add-ConstructedState($desired_state)
+    }
+  } Else { # $desired_state.state = "Absent"
+    If ($initial_state.state -eq "Present") {
+      Remove-ConstructedState($desired_state)
+    }
+  }
+
+If ($diff_support) {
+  $diff = @{
+    before = $initial_state
+    after = $desired_state
+  }
+  Set-Attr $result "diff" $diff
+}
+
+Exit-Json $result

--- a/lib/ansible/modules/windows/win_dns_a.py
+++ b/lib/ansible/modules/windows/win_dns_a.py
@@ -1,0 +1,69 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2017, AMTEGA - Xunta de Galicia
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = r'''
+---
+module: win_dns_a
+short_description: Manage DNS A records of Active Directory Computers
+description:
+  - Create, read, update and delete DNS A records in Active Directory using a
+    windows brigde computer.
+options:
+  computer_name:
+    description:
+      - Specifies a DNS server. You can specify an IP address or any value that
+        resolves to an IP address, such as a fully qualified domain name
+        (FQDN), host name, or NETBIOS name.
+    required: true
+  zone_name:
+    description: Specifies the name of a DNS server zone.
+    required: true
+  name:
+    description: Host name.
+    required: true
+  ipv4_address:
+    description: Host IP. Required when I(state=present).
+  state:
+    description:
+      - Specified whether the A record should be C(present) or C(absent) in
+        Active Directory DNS.
+    choices:
+      - present
+      - absent
+    default: present
+notes:
+  - Enabled --check --diff options
+version_added: 2.6
+author: Daniel Sánchez Fábregas (@Daniel-Sanchez-Fabregas)
+'''
+
+EXAMPLES = r'''
+  - name: Add linux computer DNS A record in Active Directory using a windows machine
+    win_dns_a:
+      computer_name: dns_controller.example.com
+      zone_name: example.com
+      name: linux_server.example.com
+      ipv4_address: 192.168.0.1
+      state: present
+    delegate_to: windows_brigde.example.com
+
+  - name: Remove linux computer DNS A record in Active Directory using a windows machine
+    win_dns_a:
+      computer_name: dns_controller.example.com
+      zone_name: example.com
+      name: linux_server.example.com
+      state: absent
+    delegate_to: windows_brigde.example.com
+'''
+
+RETURN = '''
+'''


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This module adds a DNS A record to Active Directory.
The main use case is to add non-windows computers to Active Directory
DNS through a bridge windows computer.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New Module Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
win_dns_a

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.3.0
  config file = ~/.ansible.cfg
  configured module search path = ['~/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = ~/.local/share/virtualenvs/ansible/lib/python3.6/site-packages/ansible
  executable location = ~/.local/share/virtualenvs/ansible/bin/ansible
  python version = 3.6.4 (default, Feb  8 2018, 14:42:51) [GCC 7.3.1 20180130 (Red Hat 7.3.1-2)]
```


##### ADDITIONAL INFORMATION
Example of use:
```
  - name: Add linux computer DNS A record in Active Directory using a windows machine
    win_dns_a:
      computer_name: dns_controller.example.com
      zone_name: example.com
      name: linux_server.example.com
      ipv4_address: 192.168.0.1
      state: present
    delegate_to: windows_brigde.example.com

  - name: Remove linux computer DNS A record in Active Directory using a windows machine
    win_dns_a:
      computer_name: dns_controller.example.com
      zone_name: example.com
      name: linux_server.example.com
      state: absent
    delegate_to: windows_brigde.example.com
```