### PR TITLE
[cloud] Retry WAF actions on WAFStaleDataException (#36405)

### DIFF
--- a/lib/ansible/module_utils/aws/waf.py
+++ b/lib/ansible/module_utils/aws/waf.py
@@ -180,3 +180,9 @@ def get_change_token(client, module):
         return token['ChangeToken']
     except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
         module.fail_json_aws(e, msg="Couldn't obtain change token")
+
+
+@AWSRetry.backoff(tries=10, delay=2, backoff=2.0, catch_extra_error_codes=['WAFStaleDataException'])
+def run_func_with_change_token_backoff(client, module, params, func):
+    params['ChangeToken'] = get_change_token(client, module)
+    return func(**params)

--- a/lib/ansible/modules/cloud/amazon/aws_waf_rule.py
+++ b/lib/ansible/modules/cloud/amazon/aws_waf_rule.py
@@ -126,7 +126,7 @@ except ImportError:
 from ansible.module_utils.aws.core import AnsibleAWSModule
 from ansible.module_utils.ec2 import boto3_conn, get_aws_connection_info, ec2_argument_spec
 from ansible.module_utils.ec2 import camel_dict_to_snake_dict
-from ansible.module_utils.aws.waf import get_change_token, list_rules_with_backoff, MATCH_LOOKUP
+from ansible.module_utils.aws.waf import run_func_with_change_token_backoff, list_rules_with_backoff, MATCH_LOOKUP
 from ansible.module_utils.aws.waf import get_web_acl_with_backoff, list_web_acls_with_backoff
 
 
@@ -201,10 +201,13 @@ def find_and_update_rule(client, module, rule_id):
                               if not all_conditions[condition_type][condition['data_id']]['name'] in desired_conditions[condition_type]])
 
     changed = bool(insertions or deletions)
+    update = {
+        'RuleId': rule_id,
+        'Updates': insertions + deletions
+    }
     if changed:
         try:
-            client.update_rule(RuleId=rule_id, ChangeToken=get_change_token(client, module),
-                               Updates=insertions + deletions)
+            run_func_with_change_token_backoff(client, module, update, client.update_rule)
         except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
             module.fail_json_aws(e, msg='Could not update rule conditions')
 
@@ -229,8 +232,7 @@ def remove_rule_conditions(client, module, rule_id):
     conditions = get_rule(client, module, rule_id)['Predicates']
     updates = [format_for_deletion(camel_dict_to_snake_dict(condition)) for condition in conditions]
     try:
-        client.update_rule(RuleId=rule_id,
-                           ChangeToken=get_change_token(client, module), Updates=updates)
+        run_func_with_change_token_backoff(client, module, {'RuleId': rule_id, 'Updates': updates}, client.update_rule)
     except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
         module.fail_json_aws(e, msg='Could not remove rule conditions')
 
@@ -247,9 +249,8 @@ def ensure_rule_present(client, module):
         if not metric_name:
             metric_name = re.sub(r'[^a-zA-Z0-9]', '', module.params['name'])
         params['MetricName'] = metric_name
-        params['ChangeToken'] = get_change_token(client, module)
         try:
-            new_rule = client.create_rule(**params)['Rule']
+            new_rule = run_func_with_change_token_backoff(client, module, params, client.create_rule)['Rule']
         except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
             module.fail_json_aws(e, msg='Could not create rule')
         return find_and_update_rule(client, module, new_rule['RuleId'])
@@ -281,7 +282,7 @@ def ensure_rule_absent(client, module):
     if rule_id:
         remove_rule_conditions(client, module, rule_id)
         try:
-            return True, client.delete_rule(RuleId=rule_id, ChangeToken=get_change_token(client, module))
+            return True, run_func_with_change_token_backoff(client, module, {'RuleId': rule_id}, client.delete_rule)
         except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
             module.fail_json_aws(e, msg='Could not delete rule')
     return False, {}

--- a/lib/ansible/modules/cloud/amazon/aws_waf_web_acl.py
+++ b/lib/ansible/modules/cloud/amazon/aws_waf_web_acl.py
@@ -136,7 +136,7 @@ import re
 
 from ansible.module_utils.aws.core import AnsibleAWSModule
 from ansible.module_utils.ec2 import boto3_conn, get_aws_connection_info, ec2_argument_spec, camel_dict_to_snake_dict
-from ansible.module_utils.aws.waf import list_rules_with_backoff, list_web_acls_with_backoff, get_change_token
+from ansible.module_utils.aws.waf import list_rules_with_backoff, list_web_acls_with_backoff, run_func_with_change_token_backoff
 
 
 def get_web_acl_by_name(client, module, name):
@@ -186,16 +186,26 @@ def find_and_update_web_acl(client, module, web_acl_id):
     insertions = [format_for_update(rule, 'INSERT') for rule in missing]
     deletions = [format_for_update(rule, 'DELETE') for rule in extras]
     changed = bool(insertions + deletions)
-    if changed:
+
+    # Purge rules before adding new ones in case a deletion shares the same
+    # priority as an insertion.
+    params = {
+        'WebACLId': acl['WebACLId'],
+        'DefaultAction': acl['DefaultAction']
+    }
+    if deletions:
         try:
-            client.update_web_acl(
-                WebACLId=acl['WebACLId'],
-                ChangeToken=get_change_token(client, module),
-                Updates=insertions + deletions,
-                DefaultAction=acl['DefaultAction']
-            )
+            params['Updates'] = deletions
+            run_func_with_change_token_backoff(client, module, params, client.update_web_acl)
         except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
             module.fail_json_aws(e, msg='Could not update Web ACL')
+    if insertions:
+        try:
+            params['Updates'] = insertions
+            run_func_with_change_token_backoff(client, module, params, client.update_web_acl)
+        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+            module.fail_json_aws(e, msg='Could not update Web ACL')
+    if changed:
         acl = get_web_acl(client, module, web_acl_id)
     return changed, acl
 
@@ -217,8 +227,8 @@ def remove_rules_from_web_acl(client, module, web_acl_id):
     acl = get_web_acl(client, module, web_acl_id)
     deletions = [format_for_update(rule, 'DELETE') for rule in acl['Rules']]
     try:
-        client.update_web_acl(WebACLId=acl['WebACLId'], ChangeToken=get_change_token(client, module),
-                              Updates=deletions, DefaultAction=acl['DefaultAction'])
+        params = {'WebACLId': acl['WebACLId'], 'DefaultAction': acl['DefaultAction'], 'Updates': deletions}
+        run_func_with_change_token_backoff(client, module, params, client.update_web_acl)
     except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
         module.fail_json_aws(e, msg='Could not remove rule')
 
@@ -236,9 +246,8 @@ def ensure_web_acl_present(client, module):
             metric_name = re.sub(r'[^A-Za-z0-9]', '', module.params['name'])
         default_action = module.params['default_action'].upper()
         try:
-            new_web_acl = client.create_web_acl(Name=name, MetricName=metric_name,
-                                                DefaultAction={'Type': default_action},
-                                                ChangeToken=get_change_token(client, module))
+            params = {'Name': name, 'MetricName': metric_name, 'DefaultAction': {'Type': default_action}}
+            new_web_acl = run_func_with_change_token_backoff(client, module, params, client.create_web_acl)
         except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
             module.fail_json_aws(e, msg='Could not create Web ACL')
         (changed, result) = find_and_update_web_acl(client, module, new_web_acl['WebACL']['WebACLId'])
@@ -252,7 +261,7 @@ def ensure_web_acl_absent(client, module):
         if web_acl['Rules']:
             remove_rules_from_web_acl(client, module, web_acl_id)
         try:
-            client.delete_web_acl(WebACLId=web_acl_id, ChangeToken=get_change_token(client, module))
+            run_func_with_change_token_backoff(client, module, {'WebACLId': web_acl_id}, client.delete_web_acl)
             return True, {}
         except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
             module.fail_json_aws(e, msg='Could not delete Web ACL')

--- a/test/integration/targets/aws_waf_web_acl/tasks/main.yml
+++ b/test/integration/targets/aws_waf_web_acl/tasks/main.yml
@@ -481,10 +481,19 @@
   - debug:
       msg: "****** TEARDOWN STARTS HERE ******"
 
+  - name: delete the web acl
+    aws_waf_web_acl:
+      name: "{{ resource_prefix }}_web_acl"
+      state: absent
+      purge_rules: yes
+      <<: *aws_connection_info
+    ignore_errors: yes
+
   - name: remove second WAF rule
     aws_waf_rule:
       name: "{{ resource_prefix }}_rule_2"
       state: absent
+      purge_conditions: yes
       <<: *aws_connection_info
     ignore_errors: yes
 
@@ -492,6 +501,7 @@
     aws_waf_rule:
       name: "{{ resource_prefix }}_rule"
       state: absent
+      purge_conditions: yes
       <<: *aws_connection_info
     ignore_errors: yes
 


### PR DESCRIPTION
Add a util to run functions with AWSRetry to retry on WAFStaleDataExceptions and update ChangeToken for each attempt

##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/36405. Change tokens are not scoped, so when WAF tasks are run in parallel it caused WAFStaleDataException exceptions. These modules are new in 2.5. Backporting so we don't ship semi-broken modules.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
WAF modules and tests.

##### ANSIBLE VERSION
```
ansible 2.5.0b2
```