### PR TITLE
Fixed `'HashiVault' object has no attribute 'verify'"}`

### DIFF
--- a/lib/ansible/plugins/lookup/hashi_vault.py
+++ b/lib/ansible/plugins/lookup/hashi_vault.py
@@ -122,6 +122,8 @@ class HashiVault:
         else:
             self.secret_field = ''
 
+        self.verify = self.boolean_or_cacert(kwargs.get('validate_certs', True), kwargs.get('cacert', ''))
+
         # If a particular backend is asked for (and its method exists) we call it, otherwise drop through to using
         # token auth. This means if a particular auth backend is requested and a token is also given, then we
         # ignore the token and attempt authentication against the specified backend.
@@ -149,8 +151,6 @@ class HashiVault:
 
             if self.token is None:
                 raise AnsibleError("No Vault Token specified")
-
-            self.verify = self.boolean_or_cacert(kwargs.get('validate_certs', True), kwargs.get('cacert', ''))
 
             self.client = hvac.Client(url=self.url, token=self.token, verify=self.verify)
 


### PR DESCRIPTION
##### SUMMARY

Moved `verify` attribute initialization. It fixed exception `'HashiVault' object has no attribute 'verify'"}` at 134 line: `self.client = hvac.Client(url=self.url, verify=self.verify)`

##### ISSUE TYPE
Bugfix Pull Request

##### COMPONENT NAME
plugin

##### ANSIBLE VERSION
```
ansible 2.5.0b2
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.14 (default, Dec 14 2017, 15:51:29) [GCC 6.4.0]
```


##### ADDITIONAL INFORMATION
```
---
- hosts: localhost
  tasks:
  - debug: msg="{{ lookup('hashi_vault', 'secret=secret/my--secret:value auth_method=approle') }}"
```

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
ansible-playbook site.yml
 [WARNING]: Unable to parse /etc/ansible/hosts as an inventory source

 [WARNING]: No inventory was parsed, only implicit localhost is available

 [WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'


PLAY [localhost] *****************************************************************************************************************************************************************************************

TASK [Gathering Facts] ***********************************************************************************************************************************************************************************
ok: [localhost]

TASK [debug] *********************************************************************************************************************************************************************************************
fatal: [localhost]: FAILED! => {"failed": true, "msg": "An unhandled exception occurred while running the lookup plugin 'hashi_vault'. Error was a <class 'ansible.errors.AnsibleError'>, original message: Authentication method 'approle' not supported"}
	to retry, use: --limit @/site.retry

PLAY RECAP ***********************************************************************************************************************************************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=1
```
