### PR TITLE
Adds example on how to "delegate" wait_for_connection

### DIFF
--- a/lib/ansible/modules/utilities/logic/wait_for_connection.py
+++ b/lib/ansible/modules/utilities/logic/wait_for_connection.py
@@ -36,8 +36,8 @@ options:
     default: 0
   sleep:
     default: 1
-      - Number of seconds to sleep between checks.
     description:
+      - Number of seconds to sleep between checks.
   timeout:
     description:
       - Maximum number of seconds to wait for.

--- a/lib/ansible/modules/utilities/logic/wait_for_connection.py
+++ b/lib/ansible/modules/utilities/logic/wait_for_connection.py
@@ -23,8 +23,7 @@ description:
 - Tests the transport connection every C(sleep) seconds.
 - This module makes use of internal ansible transport (and configuration) and the ping/win_ping module to guarantee correct end-to-end functioning.
 - This module is also supported for Windows targets.
-- This module does not support delegation (see the last example on how to
-  overcome this).
+- This module does not support delegation (see the last example on how to overcome this).
 version_added: "2.3"
 options:
   connect_timeout:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
`wait_for_connection` is an action plugin and does not support `delegate_to`. I added a note and an example on how to overcome this limitation, without mentioning 'action plugins' or other technical terms that are irrelevant to end users.

See #36519 

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
wait_for_connection

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0 (waitforconnectiondoc c534f60828) last updated 2018/02/21 16:55:00 (GMT +200)
  config file = None
  configured module search path = ['/home/nikos/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/nikos/Projects/ansible/lib/ansible
  executable location = /home/nikos/Projects/ansible/bin/ansible
  python version = 3.6.4 (default, Jan  5 2018, 02:35:40) [GCC 7.2.1 20171224]
```
