### PR TITLE
Make the foreman callback more defensive

### DIFF
--- a/lib/ansible/plugins/callback/foreman.py
+++ b/lib/ansible/plugins/callback/foreman.py
@@ -98,11 +98,11 @@ class CallbackModule(CallbackBase):
         self.FOREMAN_SSL_CERT = (self._plugin_options['ssl_cert'], self._plugin_options['ssl_key'])
         self.FOREMAN_SSL_VERIFY = self._plugin_options['verify_certs']
 
+        self.ssl_verify = self._ssl_verify()
+
         if HAS_REQUESTS:
             requests_major = int(requests.__version__.split('.')[0])
-            if requests_major >= 2:
-                self.ssl_verify = self._ssl_verify()
-            else:
+            if requests_major < 2:
                 self._disable_plugin('The `requests` python module is too old.')
         else:
             self._disable_plugin('The `requests` python module is not installed.')
@@ -116,7 +116,10 @@ class CallbackModule(CallbackBase):
 
     def _disable_plugin(self, msg):
         self.disabled = True
-        self._display.warning(msg + ' Disabling the Foreman callback plugin.')
+        if msg:
+            self._display.warning(msg + ' Disabling the Foreman callback plugin.')
+        else:
+            self._display.warning('Disabling the Foreman callback plugin.')
 
     def _ssl_verify(self):
         if self.FOREMAN_SSL_VERIFY.lower() in ["1", "true", "on"]:

--- a/lib/ansible/plugins/callback/foreman.py
+++ b/lib/ansible/plugins/callback/foreman.py
@@ -160,8 +160,10 @@ class CallbackModule(CallbackBase):
             source, msg = entry
             if 'failed' in msg:
                 level = 'err'
+            elif 'changed' in msg and msg['changed']:
+                level = 'notice'
             else:
-                level = 'notice' if 'changed' in msg and msg['changed'] else 'info'
+                level = 'info'
             logs.append({
                 "log": {
                     'sources': {

--- a/lib/ansible/plugins/callback/foreman.py
+++ b/lib/ansible/plugins/callback/foreman.py
@@ -96,7 +96,7 @@ class CallbackModule(CallbackBase):
 
         self.FOREMAN_URL = self._plugin_options['url']
         self.FOREMAN_SSL_CERT = (self._plugin_options['ssl_cert'], self._plugin_options['ssl_key'])
-        self.FOREMAN_SSL_VERIFY = self._plugin_options['verify_certs']
+        self.FOREMAN_SSL_VERIFY = str(self._plugin_options['verify_certs'])
 
         self.ssl_verify = self._ssl_verify()
 

--- a/lib/ansible/plugins/callback/foreman.py
+++ b/lib/ansible/plugins/callback/foreman.py
@@ -94,9 +94,9 @@ class CallbackModule(CallbackBase):
 
         super(CallbackModule, self).set_options(task_keys=task_keys, var_options=var_options, direct=direct)
 
-        self.FOREMAN_URL = self._plugin_options['url']
-        self.FOREMAN_SSL_CERT = (self._plugin_options['ssl_cert'], self._plugin_options['ssl_key'])
-        self.FOREMAN_SSL_VERIFY = str(self._plugin_options['verify_certs'])
+        self.FOREMAN_URL = self.get_option('url')
+        self.FOREMAN_SSL_CERT = (self.get_option['ssl_cert'], self.get_option['ssl_key'])
+        self.FOREMAN_SSL_VERIFY = str(self.get_option['verify_certs'])
 
         self.ssl_verify = self._ssl_verify()
 


### PR DESCRIPTION
This ensures the ssl_verify attribute is always set. It also handles None in _disable_plugin.

This is an attempt to address https://community.theforeman.org/t/i-got-an-error-when-ansible-plugin-for-calling-back-is-run-callbackmodule-object-has-no-attribute-ssl-verify/8401