### PR TITLE
Revert "remove query/q (#36315)"

### DIFF
--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -604,6 +604,11 @@ class Templar:
     def _fail_lookup(self, name, *args, **kwargs):
         raise AnsibleError("The lookup `%s` was found, however lookups were disabled from templating" % name)
 
+    def _query_lookup(self, name, *args, **kwargs):
+        ''' wrapper for lookup, force wantlist true'''
+        kwargs['wantlist'] = True
+        return self._lookup(name, *args, **kwargs)
+
     def _lookup(self, name, *args, **kwargs):
         instance = self._lookup_loader.get(name.lower(), loader=self._loader, templar=self)
 
@@ -694,9 +699,10 @@ class Templar:
                     return data
 
             if disable_lookups:
-                t.globals['lookup'] = self._fail_lookup
+                t.globals['query'] = t.globals['q'] = t.globals['lookup'] = self._fail_lookup
             else:
                 t.globals['lookup'] = self._lookup
+                t.globals['query'] = t.globals['q'] = self._query_lookup
 
             t.globals['finalize'] = self._finalize
 

--- a/test/integration/targets/lookups/tasks/main.yml
+++ b/test/integration/targets/lookups/tasks/main.yml
@@ -299,7 +299,7 @@
 
 - name: Test that we can give a list of values to var and receive a list of values back
   set_fact:
-    var_host_info: '{{ lookup("vars", "ansible_host", "ansible_user", wantlist=True) }}'
+    var_host_info: '{{ query("vars", "ansible_host", "ansible_user") }}'
 
 - assert:
     that:

--- a/test/integration/targets/loops/tasks/main.yml
+++ b/test/integration/targets/loops/tasks/main.yml
@@ -103,6 +103,54 @@
       - 'results6["results"][0]["ping"] == "Hello World"'
       - 'results6["results"][1]["ping"] == "Olá Mundo"'
 
+- name: Test that loop works with a list via the query lookup
+  ping:
+    data: '{{ item }}'
+  loop: '{{ query("list", "Hello World", "Olá Mundo") }}'
+  register: results7
+
+- name: Assert that we ran the module twice with the correct strings
+  assert:
+    that:
+      - 'results7["results"][0]["ping"] == "Hello World"'
+      - 'results7["results"][1]["ping"] == "Olá Mundo"'
+
+- name: Test that loop works with a list in a variable via the query lookup
+  ping:
+    data: '{{ item }}'
+  loop: '{{ q("list", *phrases) }}'
+  register: results8
+
+- name: Assert that we ran the module twice with the correct strings
+  assert:
+    that:
+      - 'results8["results"][0]["ping"] == "Hello World"'
+      - 'results8["results"][1]["ping"] == "Olá Mundo"'
+
+- name: Test that loop works with a list and keyword args
+  ping:
+    data: '{{ item }}'
+  loop: '{{ q("file", "data1.txt", "data2.txt", lstrip=True) }}'
+  register: results9
+
+- name: Assert that we ran the module twice with the correct strings
+  assert:
+    that:
+      - 'results9["results"][0]["ping"] == "Hello World"'
+      - 'results9["results"][1]["ping"] == "Olá Mundo"'
+
+- name: Test that loop works with a list in variable and keyword args
+  ping:
+    data: '{{ item }}'
+  loop: '{{ q("file", lstrip=True, *filenames) }}'
+  register: results10
+
+- name: Assert that we ran the module twice with the correct strings
+  assert:
+    that:
+      - 'results10["results"][0]["ping"] == "Hello World"'
+      - 'results10["results"][1]["ping"] == "Olá Mundo"'
+
 #
 # loop_control/index_var
 #


### PR DESCRIPTION
This reverts commit b47d2e07e15a8a15307f146e0c12e70e5e4ca0cd.

query is a feature for 2.5.  We're not reverting it now.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel 2.5
```


##### ADDITIONAL INFORMATION
This feature was removed from 2.5 when it seems most of the team wanted it to stay.