### PR TITLE
Adding emr_add_steps module

### DIFF
--- a/lib/ansible/modules/cloud/amazon/emr_add_steps.py
+++ b/lib/ansible/modules/cloud/amazon/emr_add_steps.py
@@ -1,0 +1,137 @@
+#!/usr/bin/python
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'certified'}
+
+
+DOCUMENTATION = '''
+---
+module: emr_add_steps
+short_description: Add a step or a series of steps to an existing EMR Cluster
+description:
+    - Module adds a step or a series of steps to an existing Amazon EMR cluster
+version_added: "2.5"
+requirements: [ 'botocore', 'boto3' ]
+author:
+    - "Aaron Smith (@slapula)"
+options:
+    cluster_id:
+        description:
+            - Cluster ID of the EMR cluster.
+        required: true
+        default: None
+    steps:
+        description:
+            - Steps to run against the EMR cluster.
+        required: true
+        default: None
+extends_documentation_fragment:
+  - aws
+  - ec2
+'''
+
+EXAMPLES = '''
+- name: Add steps to be run on specified EMR Cluster
+  emr_add_steps:
+    cluster_id: j-4FCCDFFHRASSX
+    steps:
+      - name: arbitrary_step
+        action_on_failure: 'CANCEL_AND_WAIT'
+        hadoop_jar_step:
+          jar: 'command-runner.jar'
+          args: ['-e', 'example-arg']
+          properties:
+            - key:
+              value:
+'''
+
+RETURN = '''
+step_ids:
+    description: The identifiers of the list of steps added to the job flow.
+    returned: success
+    type: list
+'''
+
+
+from collections import defaultdict
+
+try:
+    import botocore
+except ImportError:
+    pass  # caught by AnsibleAWSModule
+
+import json
+
+from ansible.module_utils.aws.core import AnsibleAWSModule
+from ansible.module_utils.ec2 import boto3_conn, get_aws_connection_info, ec2_argument_spec, AWSRetry
+from ansible.module_utils.ec2 import camel_dict_to_snake_dict, boto3_tag_list_to_ansible_dict
+
+
+class EMRConnection(object):
+
+    def __init__(self, module, region, **aws_connect_params):
+        try:
+            self.connection = boto3_conn(module, conn_type='client',
+                                         resource='emr', region=region,
+                                         **aws_connect_params)
+            self.module = module
+        except Exception as e:
+            module.fail_json(msg="Failed to connect to AWS: %s" % str(e))
+
+        self.region = region
+
+
+    def add_emr_steps(self):
+        cluster_id = self.module.params.get('cluster_id')
+        steps_raw = self.module.params.get('steps')
+        steps_json = json.loads(steps_raw)
+
+        try:
+            results = self.connection.add_job_flow_steps(
+                JobFlowId=cluster_id,
+                Steps=steps_json
+            )
+        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+            self.module.fail_json_aws(e, msg="Couldn't add step to EMR Cluster")
+        return camel_dict_to_snake_dict(results)
+
+
+def main():
+    argument_spec = ec2_argument_spec()
+    argument_spec.update(dict(
+        cluster_id=dict(type='string', required=True),
+        steps=dict(type='list', required=True)
+    ))
+
+    module = AnsibleAWSModule(argument_spec=argument_spec,
+                              supports_check_mode=True)
+
+    region, dummy, aws_connect_params = get_aws_connection_info(module, boto3=True)
+    connection = EMRConnection(module, region, **aws_connect_params)
+
+    emr_step_details = connection.add_emr_steps()
+
+    module.exit_json(changed=True, ansible_facts={'emr': emr_step_details})
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/cloud/amazon/emr_add_steps.py
+++ b/lib/ansible/modules/cloud/amazon/emr_add_steps.py
@@ -54,14 +54,11 @@ EXAMPLES = '''
   emr_add_steps:
     cluster_id: j-4FCCDFFHRASSX
     steps:
-      - name: arbitrary_step
-        action_on_failure: 'CANCEL_AND_WAIT'
-        hadoop_jar_step:
-          jar: 'command-runner.jar'
-          args: ['-e', 'example-arg']
-          properties:
-            - key:
-              value:
+      - Name: arbitrary_step
+        ActionOnFailure: 'CANCEL_AND_WAIT'
+        HadoopJarStep:
+          Jar: 'command-runner.jar'
+          Args: ['-e', 'example-arg']
 '''
 
 RETURN = '''
@@ -78,8 +75,6 @@ try:
     import botocore
 except ImportError:
     pass  # caught by AnsibleAWSModule
-
-import json
 
 from ansible.module_utils.aws.core import AnsibleAWSModule
 from ansible.module_utils.ec2 import boto3_conn, get_aws_connection_info, ec2_argument_spec, AWSRetry
@@ -101,13 +96,12 @@ class EMRConnection(object):
 
     def add_emr_steps(self):
         cluster_id = self.module.params.get('cluster_id')
-        steps_raw = self.module.params.get('steps')
-        steps_json = json.loads(steps_raw)
+        steps = self.module.params.get('steps')
 
         try:
             results = self.connection.add_job_flow_steps(
                 JobFlowId=cluster_id,
-                Steps=steps_json
+                Steps=steps
             )
         except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
             self.module.fail_json_aws(e, msg="Couldn't add step to EMR Cluster")

--- a/lib/ansible/modules/cloud/amazon/emr_add_steps.py
+++ b/lib/ansible/modules/cloud/amazon/emr_add_steps.py
@@ -29,7 +29,7 @@ module: emr_add_steps
 short_description: Add a step or a series of steps to an existing EMR Cluster
 description:
     - Module adds a step or a series of steps to an existing Amazon EMR cluster
-version_added: "2.5"
+version_added: "2.6"
 requirements: [ 'botocore', 'boto3' ]
 author:
     - "Aaron Smith (@slapula)"
@@ -98,7 +98,6 @@ class EMRConnection(object):
             module.fail_json(msg="Failed to connect to AWS: %s" % str(e))
 
         self.region = region
-
 
     def add_emr_steps(self):
         cluster_id = self.module.params.get('cluster_id')

--- a/lib/ansible/modules/cloud/amazon/emr_add_steps.py
+++ b/lib/ansible/modules/cloud/amazon/emr_add_steps.py
@@ -66,14 +66,14 @@ from ansible.module_utils.ec2 import boto3_conn, get_aws_connection_info, AWSRet
 from ansible.module_utils.ec2 import camel_dict_to_snake_dict, boto3_tag_list_to_ansible_dict
 
 
-def add_emr_steps(cluster_id, steps):
+def add_emr_steps(conn, module, cluster_id, steps):
     try:
-        results = self.connection.add_job_flow_steps(
+        results = conn.add_job_flow_steps(
             JobFlowId=cluster_id,
             Steps=steps
         )
     except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
-        self.module.fail_json_aws(e, msg="Couldn't add step(s) to EMR Cluster")
+        module.fail_json_aws(e, msg="Couldn't add step(s) to EMR Cluster")
     return camel_dict_to_snake_dict(results)
 
 
@@ -92,7 +92,7 @@ def main():
     cluster_id = module.params.get('cluster_id')
     steps = module.params.get('steps')
 
-    emr_step_details = connection.add_emr_steps(cluster_id, steps)
+    emr_step_details = add_emr_steps(connection, module, cluster_id, steps)
 
     module.exit_json(changed=True, ansible_facts={'emr': emr_step_details})
 

--- a/test/units/modules/cloud/amazon/test_emr_add_steps.py
+++ b/test/units/modules/cloud/amazon/test_emr_add_steps.py
@@ -16,6 +16,7 @@ def test_warn_if_cluster_id_not_specified():
     with pytest.raises(SystemExit):
         print(emr_add_steps.main())
 
+
 def test_warn_if_steps_not_specified():
     set_module_args({
         "cluster_id": "j-AZ1R45HYKET3"

--- a/test/units/modules/cloud/amazon/test_emr_add_steps.py
+++ b/test/units/modules/cloud/amazon/test_emr_add_steps.py
@@ -1,0 +1,24 @@
+import boto3
+import pytest
+
+from units.modules.utils import set_module_args
+from ansible.module_utils.ec2 import HAS_BOTO3
+from ansible.modules.cloud.amazon import emr_add_steps
+
+if not HAS_BOTO3:
+    pytestmark = pytest.mark.skip("emr_add_steps.py requires the `boto3` and `botocore` modules")
+
+
+def test_warn_if_cluster_id_not_specified():
+    set_module_args({
+        "steps": [{"name": "arbitrary_step"}]
+    })
+    with pytest.raises(SystemExit):
+        print(emr_add_steps.main())
+
+def test_warn_if_steps_not_specified():
+    set_module_args({
+        "cluster_id": "j-AZ1R45HYKET3"
+    })
+    with pytest.raises(SystemExit):
+        print(emr_add_steps.main())


### PR DESCRIPTION
##### SUMMARY
I've been tasked to use Ansible to interact more and more with EMR.  Ansible is missing a number of possible modules for this service including the ability to execute steps on a cluster.  This is a simple module that will take steps (in form of a list of dicts) and add them to a specified EMR cluster.  The resulting output will be the step_ids of the submitted steps.

##### ISSUE TYPE
 - New Module Pull Request

##### COMPONENT NAME
`emr_add_steps`

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (emr_cluster_facts 8ff4caad2f) last updated 2018/02/08 22:41:42 (GMT -500)
  config file = None
  configured module search path = ['/Users/slapula/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/slapula/Github/ansible/lib/ansible
  executable location = /Users/slapula/Github/ansible/bin/ansible
  python version = 3.6.2 (default, Aug  9 2017, 09:09:38) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```
