### PR TITLE
filesystem: fix documentation

### DIFF
--- a/lib/ansible/modules/system/filesystem.py
+++ b/lib/ansible/modules/system/filesystem.py
@@ -30,10 +30,12 @@ options:
     - since 2.5, I(dev) can be an image file.
     - vfat support was added in 2.5
     required: yes
+    aliases: [type]
   dev:
     description:
     - Target path to device or image file.
     required: yes
+    aliases: [device]
   force:
     description:
     - If C(yes), allows to create new filesystem on devices that already has filesystem.
@@ -276,11 +278,13 @@ def main():
         'lvm': 'LVM2_member',
     }
 
+    fstypes = set(FILESYSTEMS.keys()) - set(friendly_names.values()) | set(friendly_names.keys())
+
     # There is no "single command" to manipulate filesystems, so we map them all out and their options
     module = AnsibleModule(
         argument_spec=dict(
             fstype=dict(required=True, aliases=['type'],
-                        choices=list(FILESYSTEMS.keys()) + list(friendly_names.keys())),
+                        choices=list(fstypes)),
             dev=dict(required=True, aliases=['device']),
             opts=dict(),
             force=dict(type='bool', default=False),

--- a/test/sanity/validate-modules/ignore.txt
+++ b/test/sanity/validate-modules/ignore.txt
@@ -2796,8 +2796,6 @@ lib/ansible/modules/system/beadm.py E325
 lib/ansible/modules/system/beadm.py E326
 lib/ansible/modules/system/capabilities.py E322
 lib/ansible/modules/system/debconf.py E326
-lib/ansible/modules/system/filesystem.py E322
-lib/ansible/modules/system/filesystem.py E326
 lib/ansible/modules/system/firewalld.py E322
 lib/ansible/modules/system/firewalld.py E324
 lib/ansible/modules/system/firewalld.py E325


### PR DESCRIPTION
##### SUMMARY
Fix `filesystem` documentation

Fixed errors:
```
ERROR: lib/ansible/modules/system/filesystem.py:0:0: E322 "device" is listed in the argument_spec, but not documented in the module
ERROR: lib/ansible/modules/system/filesystem.py:0:0: E322 "type" is listed in the argument_spec, but not documented in the module
ERROR: lib/ansible/modules/system/filesystem.py:0:0: E326 Value for "choices" from the argument_spec (['ext2', 'ext3', 'ext4', 'ext4dev', 'reiserfs', 'xfs', 'btrfs', 'vfat', 'LVM2_member', 'lvm']) for "fstype" does not match the documentation (['btrfs', 'ext2', 'ext3', 'ext4', 'ext4dev', 'lvm', 'reiserfs', 'xfs', 'vfat'])
```

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
filesystem

##### ANSIBLE VERSION
```
ansible 2.6.0 (devel 03a6d72633) last updated 2018/02/21 19:39:28 (GMT +200)
```