### PR TITLE
VMware: Hardware version support

### DIFF
--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -290,6 +290,7 @@ def gather_vm_facts(content, vm):
         'hw_guest_ha_state': None,
         'hw_is_template': vm.config.template,
         'hw_folder': None,
+        'hw_version': vm.config.version,
         'guest_tools_status': _get_vm_prop(vm, ('guest', 'toolsRunningStatus')),
         'guest_tools_version': _get_vm_prop(vm, ('guest', 'toolsVersion')),
         'guest_question': vm.summary.runtime.question,


### PR DESCRIPTION
##### SUMMARY
This fix adds support for specifying hardware version for
virtual machine.

Fixes: #35831

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
lib/ansible/module_utils/vmware.py
lib/ansible/modules/cloud/vmware/vmware_guest.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6devel
```