### PR TITLE
Fix error option name and invalid option.

### DIFF
--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -285,7 +285,7 @@
 # on the CLI.  If this is True then multiple arguments are merged together.  If
 # it is False, then the last specified argument is used and the others are ignored.
 # This option will be removed in 2.8.
-#merge_multiple_cli_flags = True
+#merge_multiple_cli_tags = True
 
 # Controls showing custom stats at the end, off by default
 #show_custom_stats = True

--- a/lib/ansible/utils/display.py
+++ b/lib/ansible/utils/display.py
@@ -224,7 +224,7 @@ class Display:
             self.display(new_msg.strip(), color=C.COLOR_DEPRECATE, stderr=True)
             self._deprecations[new_msg] = 1
 
-    def warning(self, msg, formatted=False):
+    def system_warning(self, msg, formatted=False):
 
         if not formatted:
             new_msg = "\n[WARNING]: %s" % msg
@@ -237,9 +237,9 @@ class Display:
             self.display(new_msg, color=C.COLOR_WARN, stderr=True)
             self._warns[new_msg] = 1
 
-    def system_warning(self, msg):
+    def warning(self, msg):
         if C.SYSTEM_WARNINGS:
-            self.warning(msg)
+            self.system_warning(msg)
 
     def banner(self, msg, color=None, cows=True):
         '''

--- a/lib/ansible/utils/display.py
+++ b/lib/ansible/utils/display.py
@@ -237,9 +237,9 @@ class Display:
             self.display(new_msg, color=C.COLOR_WARN, stderr=True)
             self._warns[new_msg] = 1
 
-    def warning(self, msg):
+    def warning(self, msg, formatted=False):
         if C.SYSTEM_WARNINGS:
-            self.system_warning(msg)
+            self.system_warning(msg, formatted=False)
 
     def banner(self, msg, color=None, cows=True):
         '''


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
There's no option named "merge_multiple_cli_flags", so modify it  to "merge_multiple_cli_tags".

The config option "system_warnings" is unavailable as the function system_warning() in "/lib/ansible/utils/display.py" has never been used anywhere.  So reverse the relationship of  
"warning()" and "system_warning()" to make option "system_warnings" available.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
examples/ansible.cfg
/lib/ansible/utils/display.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6.0 0.0.devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
