### PR TITLE
ec2_group:documentation explicit a behaviour for sg rules

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_group.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_group.py
@@ -167,6 +167,13 @@ EXAMPLES = '''
       - proto: all
         # the containing group name may be specified here
         group_name: example
+      - proto: all
+        # in the 'proto' attribute, if you specify -1, all, or a protocol number other than tcp, udp, icmp, or 58 (ICMPv6),
+        # traffic on all ports is allowed, regardless of any ports you specify
+        from_port: 10050 # this value is ignored
+        to_port: 10050 # this value is ignored
+        cidr_ip: 10.0.0.0/8
+
     rules_egress:
       - proto: tcp
         from_port: 80


### PR DESCRIPTION
##### SUMMARY
Fixes ##35811

Explicit a behaviour described in [AWS documentation](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_AuthorizeSecurityGroupIngress.html).
 When setting `IpProtocol` (or `proto` in ansible) to `all`, traffic on all ports is allowed, regardless of any ports you specify
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
ec2_group

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6.0
```
