### PR TITLE
fix credentials for Tower `/api/v2/`

### DIFF
--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_credential.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_credential.py
@@ -165,6 +165,11 @@ except ImportError:
     pass
 
 
+def _add_input_(module, param, results):
+    if module.params.get(param):
+        results[param] = module.params.get(param)
+
+
 def main():
 
     argument_spec = tower_argument_spec()
@@ -213,22 +218,57 @@ def main():
         tower_check_mode(module)
         credential = tower_cli.get_resource('credential')
         try:
-            params = module.params.copy()
+            params = {}
             params['create_on_missing'] = True
+            params['name'] = name
 
             if organization:
                 org_res = tower_cli.get_resource('organization')
                 org = org_res.get(name=organization)
                 params['organization'] = org['id']
 
-            if params['ssh_key_data']:
-                filename = params['ssh_key_data']
+            credential_type_res = tower_cli.get_resource('credential_type')
+            credential_type = credential_type_res.get(kind=module.params.get('kind'))
+            params['credential_type'] = credential_type['id']
+
+            if module.params.get('description'):
+                params['description'] = module.params.get('description')
+
+            if module.params.get('user'):
+                user_res = tower_cli.get_resource('user')
+                user = user_res.get(name=module.params.get('user'))
+                params['user'] = user['id']
+
+            if module.params.get('team'):
+                team_res = tower_cli.get_resource('team')
+                team = team_res.get(name=module.params.get('team'))
+                params['team'] = team['id']
+
+            params['inputs'] = {}
+            if module.params.get('ssh_key_data'):
+                filename = module.params.get('ssh_key_data')
                 if not os.path.exists(filename):
                     module.fail_json(msg='file not found: %s' % filename)
                 if os.path.isdir(filename):
                     module.fail_json(msg='attempted to read contents of directory: %s' % filename)
                 with open(filename, 'rb') as f:
-                    params['ssh_key_data'] = f.read()
+                    params['inputs']['ssh_key_data'] = f.read()
+
+            _add_input_(module, 'authorize', params['inputs'])
+            _add_input_(module, 'authorize_password', params['inputs'])
+            _add_input_(module, 'client', params['inputs'])
+            _add_input_(module, 'secret', params['inputs'])
+            _add_input_(module, 'tenant', params['inputs'])
+            _add_input_(module, 'subscription', params['inputs'])
+            _add_input_(module, 'domain', params['inputs'])
+            _add_input_(module, 'become_method', params['inputs'])
+            _add_input_(module, 'become_username', params['inputs'])
+            _add_input_(module, 'become_password', params['inputs'])
+            _add_input_(module, 'vault_password', params['inputs'])
+            _add_input_(module, 'project', params['inputs'])
+            _add_input_(module, 'host', params['inputs'])
+            _add_input_(module, 'username', params['inputs'])
+            _add_input_(module, 'password', params['inputs'])
 
             if state == 'present':
                 result = credential.modify(**params)

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_credential.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_credential.py
@@ -165,9 +165,41 @@ except ImportError:
     pass
 
 
-def _add_input_(module, param, results):
-    if module.params.get(param):
-        results[param] = module.params.get(param)
+KIND_CHOICES = {
+    'ssh': 'Machine',
+    'vault': 'Ansible Vault',
+    'net': 'Network',
+    'scm': 'Source Control',
+    'aws': 'Amazon Web Services',
+    'vmware': 'VMware vCenter',
+    'satellite6': 'Red Hat Satellite 6',
+    'cloudforms': 'Red Hat CloudForms',
+    'gce': 'Google Compute Engine',
+    'azure_rm': 'Microsoft Azure Resource Manager',
+    'openstack': 'OpenStack',
+    'rhv': 'Red Hat Virtualization',
+    'insights': 'Insights',
+    'tower': 'Ansible Tower',
+}
+
+
+def credential_type_for_v1_kind(params, module):
+    credential_type_res = tower_cli.get_resource('credential_type')
+    kind = params.pop('kind')
+    arguments = {'managed_by_tower': True}
+    if kind == 'ssh':
+        if params.get('vault_password'):
+            arguments['kind'] = 'vault'
+        else:
+            arguments['kind'] = 'ssh'
+    elif kind in ('net', 'scm', 'insights', 'vault'):
+        arguments['kind'] = kind
+    elif kind in KIND_CHOICES:
+        arguments.update(dict(
+            kind='cloud',
+            name=KIND_CHOICES[kind]
+        ))
+    return credential_type_res.get(**arguments)
 
 
 def main():
@@ -178,8 +210,7 @@ def main():
         user=dict(),
         team=dict(),
         kind=dict(required=True,
-                  choices=["ssh", "net", "scm", "aws", "rax", "vmware", "satellite6",
-                           "cloudforms", "gce", "azure", "azure_rm", "openstack"]),
+                  choices=KIND_CHOICES.keys()),
         host=dict(),
         username=dict(),
         password=dict(no_log=True),
@@ -227,8 +258,7 @@ def main():
                 org = org_res.get(name=organization)
                 params['organization'] = org['id']
 
-            credential_type_res = tower_cli.get_resource('credential_type')
-            credential_type = credential_type_res.get(kind=module.params.get('kind'))
+            credential_type = credential_type_for_v1_kind(module.params, module)
             params['credential_type'] = credential_type['id']
 
             if module.params.get('description'):
@@ -254,21 +284,13 @@ def main():
                 with open(filename, 'rb') as f:
                     params['inputs']['ssh_key_data'] = f.read()
 
-            _add_input_(module, 'authorize', params['inputs'])
-            _add_input_(module, 'authorize_password', params['inputs'])
-            _add_input_(module, 'client', params['inputs'])
-            _add_input_(module, 'secret', params['inputs'])
-            _add_input_(module, 'tenant', params['inputs'])
-            _add_input_(module, 'subscription', params['inputs'])
-            _add_input_(module, 'domain', params['inputs'])
-            _add_input_(module, 'become_method', params['inputs'])
-            _add_input_(module, 'become_username', params['inputs'])
-            _add_input_(module, 'become_password', params['inputs'])
-            _add_input_(module, 'vault_password', params['inputs'])
-            _add_input_(module, 'project', params['inputs'])
-            _add_input_(module, 'host', params['inputs'])
-            _add_input_(module, 'username', params['inputs'])
-            _add_input_(module, 'password', params['inputs'])
+            for key in ('authorize', 'authorize_password', 'client', 'secret',
+                        'tenant', 'subscription', 'domain', 'become_method',
+                        'become_username', 'become_password', 'vault_password',
+                        'project', 'host', 'username', 'password',
+                        'ssh_key_unlock'):
+                if module.params.get(key):
+                    params['inputs'][key] = module.params.get(key)
 
             if state == 'present':
                 result = credential.modify(**params)

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_credential.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_credential.py
@@ -266,7 +266,7 @@ def main():
 
             if module.params.get('user'):
                 user_res = tower_cli.get_resource('user')
-                user = user_res.get(name=module.params.get('user'))
+                user = user_res.get(username=module.params.get('user'))
                 params['user'] = user['id']
 
             if module.params.get('team'):

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_credential.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_credential.py
@@ -54,7 +54,7 @@ options:
       description:
         - Type of credential being added.
       required: True
-      choices: ["ssh", "net", "scm", "aws", "rax", "vmware", "satellite6", "cloudforms", "gce", "azure", "azure_rm", "openstack"]
+      choices: ["ssh", "vault", "net", "scm", "aws", "vmware", "satellite6", "cloudforms", "gce", "azure_rm", "openstack", "rhv", "insights", "tower"]
     host:
       description:
         - Host for this credential.


### PR DESCRIPTION
**SUMMARY**

This change builds on top of the work done in https://github.com/ansible/ansible/pull/34882 to properly set the `kind` parameter.  An additional PR is coming soon which actually allows for specifying a custom credential type and the `inputs` key.

Fixes #31655

**ISSUE TYPE**

- Bugfix Pull Request

**COMPONENT NAME**

ansible_tower