### PR TITLE
[DOC] Add ./ansible.cfg to docs where missing

### DIFF
--- a/docs/docsite/rst/user_guide/intro_getting_started.rst
+++ b/docs/docsite/rst/user_guide/intro_getting_started.rst
@@ -128,7 +128,7 @@ Ansible has host key checking enabled by default.
 
 If a host is reinstalled and has a different key in 'known_hosts', this will result in an error message until corrected.  If a host is not initially in 'known_hosts' this will result in prompting for confirmation of the key, which results in an interactive experience if using Ansible, from say, cron.  You might not want this.
 
-If you understand the implications and wish to disable this behavior, you can do so by editing ``/etc/ansible/ansible.cfg`` or ``~/.ansible.cfg``::
+If you understand the implications and wish to disable this behavior, you can do so by editing ``/etc/ansible/ansible.cfg``, ``~/.ansible.cfg`` or ``./ansible.cfg``::
 
     [defaults]
     host_key_checking = False

--- a/docs/templates/cli_rst.j2
+++ b/docs/templates/cli_rst.j2
@@ -117,6 +117,8 @@ Files
 
 :file:`~/.ansible.cfg` -- User config file, overrides the default config if present
 
+:file:`./ansible.cfg` -- User config file, overrides the default config and ~/.ansible.cfg if present
+
 Author
 ======
 

--- a/docs/templates/man.j2
+++ b/docs/templates/man.j2
@@ -99,6 +99,8 @@ FILES
 
 ~/.ansible.cfg -- User config file, overrides the default config if present
 
+./ansible.cfg -- User config file, overrides the default config and ~/.ansible.cfg if present
+
 
 AUTHOR
 ------


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
./ansible.cfg is missing in manpage of ansible, I added it and all other occurrences of the config files I found. 
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
core

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.3.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/klaas/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.14 (default, Feb 17 2018, 10:42:17) [GCC 7.3.1 20180130 (Red Hat 7.3.1-2)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
