### PR TITLE
Collect enc data in foreman inventory

### DIFF
--- a/contrib/inventory/foreman.ini
+++ b/contrib/inventory/foreman.ini
@@ -152,6 +152,9 @@ want_hostcollections = False
 # Disabled by default as the change would else not be backward compatible.
 rich_params = False
 
+# Whether to fetch enc(External node classifier) data from Foreman and store them on the host
+want_enc = False
+
 [cache]
 path = .
 max_age = 60


### PR DESCRIPTION
Fixes #36300

##### SUMMARY
With this PR a new option want_enc is introduced in foreman.ini . It's default value is False so this features is disabled for default in order to avoid to increase the execution time of this inventory when enc (External node classifier ) details on hosts aren't needed.

When the option want_enc is enabled, the foreman.py inventory collect also the enc(External node classifier) host info calling the api /api/v2/hosts/:id:/enc including them in the key "enc" of host vars.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
foreman.py

##### ANSIBLE VERSION
```
$ ./bin/ansible --version
ansible 2.3.2.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.14 (default, Dec 11 2017, 14:52:53) [GCC 7.2.1 20170915 (Red Hat 7.2.1-2)]

```


##### ADDITIONAL INFORMATION

**Output before this PR:**
https://gist.github.com/giovannisciortino/a7d7cb3a176c5a5472c5c6d4b4f17211

**Output after this PR:**
https://gist.github.com/giovannisciortino/7a9b5cc95468864efa2c5770f2cf0d24
