### PR TITLE
Bump OpenShift client req to 0.4.3. Fixes openshift_scale.

### DIFF
--- a/lib/ansible/modules/clustering/k8s/k8s_raw.py
+++ b/lib/ansible/modules/clustering/k8s/k8s_raw.py
@@ -39,7 +39,7 @@ extends_documentation_fragment:
 
 requirements:
   - "python >= 2.7"
-  - "openshift == 0.4.1"
+  - "openshift == 0.4.3"
   - "PyYAML >= 3.11"
 '''
 

--- a/lib/ansible/modules/clustering/k8s/k8s_scale.py
+++ b/lib/ansible/modules/clustering/k8s/k8s_scale.py
@@ -35,7 +35,7 @@ extends_documentation_fragment:
 
 requirements:
     - "python >= 2.7"
-    - "openshift == 0.4.1"
+    - "openshift == 0.4.3"
     - "PyYAML >= 3.11"
 '''
 

--- a/lib/ansible/modules/clustering/openshift/openshift_raw.py
+++ b/lib/ansible/modules/clustering/openshift/openshift_raw.py
@@ -49,7 +49,7 @@ options:
 
 requirements:
     - "python >= 2.7"
-    - "openshift == 0.4.1"
+    - "openshift == 0.4.3"
     - "PyYAML >= 3.11"
 '''
 

--- a/lib/ansible/modules/clustering/openshift/openshift_scale.py
+++ b/lib/ansible/modules/clustering/openshift/openshift_scale.py
@@ -35,7 +35,7 @@ extends_documentation_fragment:
 
 requirements:
     - "python >= 2.7"
-    - "openshift == 0.4.1"
+    - "openshift == 0.4.3"
     - "PyYAML >= 3.11"
 '''
 
@@ -116,11 +116,11 @@ result:
        type: complex
 '''
 
-from ansible.module_utils.k8s.scale import KubernetesAnsibleScaleModule
+from ansible.module_utils.k8s.scale import OpenShiftAnsibleScaleModule
 
 
 def main():
-    KubernetesAnsibleScaleModule().execute_module()
+    OpenShiftAnsibleScaleModule().execute_module()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
##### SUMMARY
- Fixes #36554
- Pins OpenShift client to v0.4.3

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/clustering/openshift/openshift_scale.py

 
##### ANSIBLE VERSION
```
ansible 2.6.0 (devel e70a083d7e) last updated 2018/02/22 16:15:44 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/Users/chouseknecht/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/chouseknecht/projects/ansible/lib/ansible
  executable location = /Users/chouseknecht/projects/ansible/bin/ansible
  python version = 2.7.14 (default, Nov 14 2017, 23:24:24) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.38)]
```
