### PR TITLE
Start of tests for modify_module

### DIFF
--- a/test/units/executor/module_common/test_modify_module.py
+++ b/test/units/executor/module_common/test_modify_module.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2018 Matt Martz <matt@sivel.net>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# -*- coding: utf-8 -*-
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import pytest
+
+from ansible.executor.module_common import modify_module
+from ansible.module_utils.six import PY2
+
+from test_module_common import templar
+
+
+FAKE_OLD_MODULE = b'''#!/usr/bin/python
+import sys
+print('{"result": "%s"}' % sys.executable)
+'''
+
+
+@pytest.fixture
+def fake_old_module_open(mocker):
+    m = mocker.mock_open(read_data=FAKE_OLD_MODULE)
+    if PY2:
+        mocker.patch('__builtin__.open', m)
+    else:
+        mocker.patch('builtins.open', m)
+
+
+def test_shebang(fake_old_module_open):
+    (data, style, shebang) = modify_module('fake_module', 'fake_path', {})
+    assert shebang == '#!/usr/bin/python'
+
+
+def test_shebang_task_vars(fake_old_module_open, templar):
+    task_vars = {
+        'ansible_python_interpreter': '/usr/bin/python3'
+    }
+
+    (data, style, shebang) = modify_module('fake_module', 'fake_path', {}, task_vars=task_vars, templar=templar)
+    assert shebang == '#!/usr/bin/python3'


### PR DESCRIPTION
##### SUMMARY
Start of tests for modify_module, specifically to ensure proper shebang replacement on old style modules

See #36536 

NOTE: These tests do not work on 2.4 due to `modify_module` not accepting a `templar` kwarg

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
test/units/executor/module_common/test_modify_module.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.4
2.5
2.6
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```