### PR TITLE
Re-enable WAF tests in CI now that they are able to run in parallel

### DIFF
--- a/test/integration/targets/aws_waf_web_acl/aliases
+++ b/test/integration/targets/aws_waf_web_acl/aliases
@@ -1,4 +1,5 @@
 cloud/aws
+posix/ci/cloud/group4/aws
 aws_waf_facts
 aws_waf_web_acl
 aws_waf_web_match


### PR DESCRIPTION
##### SUMMARY
Running WAF tests in parallel was fixed in https://github.com/ansible/ansible/pull/36405. These can run in CI again.

##### ISSUE TYPE
 - Test Pull Request

##### COMPONENT NAME
test/integration/targets/aws_waf_web_acl/aliases

##### ANSIBLE VERSION
```
2.6.0
```