### PR TITLE
Fix issue with vNIC redundancy templates

### DIFF
--- a/lib/ansible/modules/remote_management/ucs/ucs_vnic_template.py
+++ b/lib/ansible/modules/remote_management/ucs/ucs_vnic_template.py
@@ -306,7 +306,7 @@ def main():
                             descr=module.params['description'],
                             switch_id=module.params['fabric'],
                             redundancy_pair_type=module.params['redundancy_type'],
-                            peer_redundancy_templ_name=module.params['peer_redundancy_templ'],
+                            peer_redundancy_templ_name=module.params['peer_redundancy_template'],
                             target=module.params['target'],
                             templ_type=module.params['template_type'],
                             cdn_source=module.params['cdn_source'],

--- a/lib/ansible/modules/remote_management/ucs/ucs_vnic_template.py
+++ b/lib/ansible/modules/remote_management/ucs/ucs_vnic_template.py
@@ -93,6 +93,11 @@ options:
     - "  Designates the VLAN as a native VLAN.  Only one VLAN in the list can be a native VLAN."
     - "  [choices: 'no', 'yes']"
     - "  [Default: 'no']"
+    - "- state"
+    - "  If present, will verify VLAN is present on template."
+    - "  If absent, will verify VLAN is absent on template."
+    - "  choices: [present, absent]"
+    - "  default: present"
   cdn_source:
     description:
     - CDN Source field.
@@ -161,7 +166,7 @@ EXAMPLES = r'''
     vlans_list:
     - name: default
       native: 'yes'
-    - name: finance
+      state: present
 
 - name: Remove vNIC template
   ucs_vnic_template:
@@ -178,6 +183,18 @@ EXAMPLES = r'''
     password: password
     name: vNIC-A-B
     state: absent
+
+- name: Remove VLAN from template
+  ucs_vnic_template:
+    hostname: 172.16.143.150
+    username: admin
+    password: password
+    name: vNIC-A-B
+    fabric: A-B
+    vlans_list:
+    - name: default
+      native: 'yes'
+      state: absent
 '''
 
 RETURN = r'''
@@ -250,6 +267,8 @@ def main():
                 for vlan in module.params['vlans_list']:
                     if not vlan.get('native'):
                         vlan['native'] = 'no'
+                    if not vlan.get('state'):
+                        vlan['state'] = 'present'
             # for target 'adapter', change to internal UCS Manager spelling 'adaptor'
             if module.params['target'] == 'adapter':
                 module.params['target'] = 'adaptor'
@@ -271,19 +290,27 @@ def main():
                     kwargs['nw_ctrl_policy_name'] = module.params['network_control_policy']
                     kwargs['pin_to_group_name'] = module.params['pin_group']
                     kwargs['stats_policy_name'] = module.params['stats_policy']
-                if (mo.check_prop_match(**kwargs)):
+                if mo.check_prop_match(**kwargs):
                     # top-level props match, check next level mo/props
                     if not module.params.get('vlans_list'):
                         props_match = True
                     else:
                         # check vlan props
                         for vlan in module.params['vlans_list']:
-                            child_dn = dn + '/if-' + vlan['name']
+                            child_dn = dn + '/if-' + str(vlan['name'])
                             mo_1 = ucs.login_handle.query_dn(child_dn)
-                            if mo_1:
-                                kwargs = dict(default_net=vlan['native'])
-                                if (mo_1.check_prop_match(**kwargs)):
-                                    props_match = True
+                            if vlan['state'] == 'absent':
+                                if mo_1:
+                                    props_match = False
+                                    break
+                            else:
+                                if mo_1:
+                                    kwargs = dict(default_net=vlan['native'])
+                                    if mo_1.check_prop_match(**kwargs):
+                                        props_match = True
+                                else:
+                                    props_match = False
+                                    break
 
             if not props_match:
                 if not module.check_mode:
@@ -321,11 +348,16 @@ def main():
 
                     if module.params.get('vlans_list'):
                         for vlan in module.params['vlans_list']:
-                            mo_1 = VnicEtherIf(
-                                parent_mo_or_dn=mo,
-                                name=vlan['name'],
-                                default_net=vlan['native'],
-                            )
+                            if vlan['state'] == 'absent':
+                                child_dn = dn + '/if-' + str(vlan['name'])
+                                mo_1 = ucs.login_handle.query_dn(child_dn)
+                                ucs.login_handle.remove_mo(mo_1)
+                            else:
+                                mo_1 = VnicEtherIf(
+                                    parent_mo_or_dn=mo,
+                                    name=str(vlan['name']),
+                                    default_net=vlan['native'],
+                                )
 
                     ucs.login_handle.add_mo(mo, True)
                     ucs.login_handle.commit()

--- a/test/integration/targets/ucs_vnic_template/tasks/main.yml
+++ b/test/integration/targets/ucs_vnic_template/tasks/main.yml
@@ -19,6 +19,18 @@
     name: vNIC-A-B
     state: absent
 
+- name: vNIC primary template absent
+  ucs_vnic_template: &vnic_primary_templates_absent
+    <<: *login_info
+    name: vNIC-A
+    state: absent
+
+- name: vNIC secondary template absent
+  ucs_vnic_template: &vnic_secondary_templates_absent
+    <<: *login_info
+    name: vNIC-B
+    state: absent
+
 
 # Test present (check_mode)
 - name: vNIC template present (check_mode)
@@ -33,11 +45,48 @@
   check_mode: yes
   register: cm_vnic_templates_present
 
+- name: vNIC primary template present (check_mode)
+  ucs_vnic_template: &vnic_primary_templates_present
+    <<: *login_info
+    name: vNIC-A
+    fabric: A
+    redundancy_type: primary
+    peer_redundancy_templ: vNIC-B
+    template_type: updating-template
+    mtu: '9000'
+    mac_pool: MAC-Pool-A
+    network_control_policy: Enable-CDP-LLDP
+    vlans_list:
+    - name: default
+      native: 'yes'
+    - name: finance
+  check_mode: yes
+  register: cm_vnic_primary_templates_present
+
+- name: vNIC secondary template present (check_mode)
+  ucs_vnic_template: &vnic_secondary_templates_present
+    <<: *login_info
+    name: vNIC-B
+    fabric: B
+    redundancy_type: secondary
+    peer_redundancy_templ: vNIC-A
+    mac_pool: MAC-Pool-B
+  check_mode: yes
+  register: cm_vnic_secondary_templates_present
+
 
 # Present (normal mode)
 - name: vNIC template present (normal mode)
   ucs_vnic_template: *vnic_templates_present
   register: nm_vnic_templates_present
+
+- name: vNIC primary template present (normal mode)
+  ucs_vnic_template: *vnic_primary_templates_present
+  register: nm_vnic_primary_templates_present
+
+- name: vNIC secondary template present (normal mode)
+  ucs_vnic_template: *vnic_secondary_templates_present
+  register: nm_vnic_secondary_templates_present
 
 
 # Test present again (idempotent)
@@ -46,11 +95,29 @@
   check_mode: yes
   register: cm_vnic_templates_present_again
 
+- name: vNIC primary template present again (check_mode)
+  ucs_vnic_template: *vnic_primary_templates_present
+  check_mode: yes
+  register: cm_vnic_primary_templates_present_again
+
+- name: vNIC secondary template present again (check_mode)
+  ucs_vnic_template: *vnic_secondary_templates_present
+  check_mode: yes
+  register: cm_vnic_secondary_templates_present_again
+
 
 # Present again (normal mode)
 - name: vNIC template present again (normal mode)
   ucs_vnic_template: *vnic_templates_present
   register: nm_vnic_templates_present_again
+
+- name: vNIC primary template present again (normal mode)
+  ucs_vnic_template: *vnic_primary_templates_present
+  register: nm_vnic_primary_templates_present_again
+
+- name: vNIC secondary template present again (normal mode)
+  ucs_vnic_template: *vnic_secondary_templates_present
+  register: nm_vnic_secondary_templates_present_again
 
 
 # Verfiy present
@@ -59,6 +126,10 @@
     that:
     - cm_vnic_templates_present.changed == nm_vnic_templates_present.changed == true
     - cm_vnic_templates_present_again.changed == nm_vnic_templates_present_again.changed == false
+    - cm_vnic_primary_templates_present.changed == nm_vnic_primary_templates_present.changed == true
+    - cm_vnic_primary_templates_present_again.changed == nm_vnic_primary_templates_present_again.changed == false
+    - cm_vnic_secondary_templates_present.changed == nm_vnic_secondary_templates_present.changed == true
+    - cm_vnic_secondary_templates_present_again.changed == nm_vnic_secondary_templates_present_again.changed == false
 
 
 # Test change (check_mode)
@@ -103,11 +174,29 @@
   check_mode: yes
   register: cm_vnic_templates_absent
 
+- name: vNIC primary template absent (check_mode)
+  ucs_vnic_template: *vnic_primary_templates_absent
+  check_mode: yes
+  register: cm_vnic_primary_templates_absent
+
+- name: vNIC secondary template absent (check_mode)
+  ucs_vnic_template: *vnic_secondary_templates_absent
+  check_mode: yes
+  register: cm_vnic_secondary_templates_absent
+
 
 # Absent (normal mode)
 - name: vNIC template absent (normal mode)
   ucs_vnic_template: *vnic_templates_absent
   register: nm_vnic_templates_absent
+
+- name: vNIC primary template absent (normal mode)
+  ucs_vnic_template: *vnic_primary_templates_absent
+  register: nm_vnic_primary_templates_absent
+
+- name: vNIC secondary template absent (normal mode)
+  ucs_vnic_template: *vnic_secondary_templates_absent
+  register: nm_vnic_secondary_templates_absent
 
 
 # Test absent again (idempotent)
@@ -116,11 +205,29 @@
   check_mode: yes
   register: cm_vnic_templates_absent_again
 
+- name: vNIC primary template absent again (check_mode)
+  ucs_vnic_template: *vnic_primary_templates_absent
+  check_mode: yes
+  register: cm_vnic_primary_templates_absent_again
+
+- name: vNIC secondary template absent again (check_mode)
+  ucs_vnic_template: *vnic_secondary_templates_absent
+  check_mode: yes
+  register: cm_vnic_secondary_templates_absent_again
+
 
 # Absent again (normal mode)
 - name: vNIC template absent again (normal mode)
   ucs_vnic_template: *vnic_templates_absent
   register: nm_vnic_templates_absent_again
+
+- name: vNIC primary template absent again (normal mode)
+  ucs_vnic_template: *vnic_primary_templates_absent
+  register: nm_vnic_primary_templates_absent_again
+
+- name: vNIC secondary template absent again (normal mode)
+  ucs_vnic_template: *vnic_secondary_templates_absent
+  register: nm_vnic_secondary_templates_absent_again
 
 
 # Verfiy absent
@@ -129,3 +236,7 @@
     that:
     - cm_vnic_templates_absent.changed == nm_vnic_templates_absent.changed == true
     - cm_vnic_templates_absent_again.changed == nm_vnic_templates_absent_again.changed == false
+    - cm_vnic_primary_templates_absent.changed == nm_vnic_primary_templates_absent.changed == true
+    - cm_vnic_primary_templates_absent_again.changed == nm_vnic_primary_templates_absent_again.changed == false
+    - cm_vnic_secondary_templates_absent.changed == nm_vnic_secondary_templates_absent.changed == true
+    - cm_vnic_secondary_templates_absent_again.changed == nm_vnic_secondary_templates_absent_again.changed == false

--- a/test/integration/targets/ucs_vnic_template/tasks/main.yml
+++ b/test/integration/targets/ucs_vnic_template/tasks/main.yml
@@ -41,7 +41,7 @@
     vlans_list:
     - name: default
       native: 'yes'
-    - name: finance
+    - name: 10
   check_mode: yes
   register: cm_vnic_templates_present
 
@@ -133,39 +133,43 @@
 
 
 # Test change (check_mode)
-- name: vNIC template description change (check_mode)
+- name: vNIC template change (check_mode)
   ucs_vnic_template: &vnic_templates_change
     <<: *vnic_templates_present
-    descr: Testing Ansible
+    vlans_list:
+    - name: default
+      native: 'yes'
+    - name: 10
+      state: absent
   check_mode: yes
-  register: cm_vnic_templates_descr_change
+  register: cm_vnic_templates_change
 
 
 # Change (normal mode)
-- name: vNIC template description change (normal mode)
+- name: vNIC template change (normal mode)
   ucs_vnic_template: *vnic_templates_change
-  register: nm_vnic_templates_descr_change
+  register: nm_vnic_templates_change
 
 
 # Test change again (idempotent)
-- name: vNIC template description again (check_mode)
+- name: vNIC template change again (check_mode)
   ucs_vnic_template: *vnic_templates_change
   check_mode: yes
-  register: cm_vnic_templates_descr_change_again
+  register: cm_vnic_templates_change_again
 
 
 # Change again (normal mode)
-- name: vNIC template description change again (normal mode)
+- name: vNIC template change again (normal mode)
   ucs_vnic_template: *vnic_templates_change
-  register: nm_vnic_templates_descr_change_again
+  register: nm_vnic_templates_change_again
 
 
 # Verfiy change
 - name: Verify vNIC template change results
   assert:
     that:
-    - cm_vnic_templates_descr_change.changed == nm_vnic_templates_descr_change.changed == true
-    - cm_vnic_templates_descr_change_again.changed == nm_vnic_templates_descr_change_again.changed == false
+    - cm_vnic_templates_change.changed == nm_vnic_templates_change.changed == true
+    - cm_vnic_templates_change_again.changed == nm_vnic_templates_change_again.changed == false
 
 
 # Teardown (clean environment)


### PR DESCRIPTION
Fix issue with vNIC redundancy templates.
Add integration tests for vNIC redudancy templates.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
vNIC redundancy option naming fixed.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
ucs_vnic_template
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0 (vnic_fixes 462b445cf2) last updated 2018/02/22 12:20:00 (GMT -500)
  config file = /Users/dsoper/.ansible.cfg
  configured module search path = [u'/Users/dsoper/Documents/ucsm-ansible-1/library']
  ansible python module location = /Users/dsoper/Documents/ansible/lib/ansible
  executable location = /Users/dsoper/Documents/ansible/bin/ansible
  python version = 2.7.12 (default, Oct 11 2016, 05:20:59) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.38)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
