### PR TITLE
ldap_attr module: Encode value when setting unicodePwd attribute

### DIFF
--- a/lib/ansible/modules/net_tools/ldap/ldap_attr.py
+++ b/lib/ansible/modules/net_tools/ldap/ldap_attr.py
@@ -252,13 +252,15 @@ class LdapAttr(object):
         current = results[0][1].get(self.name, [])
         modlist = []
 
-        if frozenset(self.values) != frozenset(current):
-            if len(current) == 0:
-                modlist = [(ldap.MOD_ADD, self.name, self.values)]
-            elif len(self.values) == 0:
-                modlist = [(ldap.MOD_DELETE, self.name, None)]
-            else:
-                modlist = [(ldap.MOD_REPLACE, self.name, self.values)]
+        if self.name == 'unicodePwd':
+            pwd = unicode('\"' + self.values[0] + '\"', 'iso-8859-1')
+            modlist = [(ldap.MOD_REPLACE, self.name, [pwd.encode('utf-16-le')])]
+        elif len(current) == 0:
+            modlist = [(ldap.MOD_ADD, self.name, self.values)]
+        elif len(self.values) == 0:
+            modlist = [(ldap.MOD_DELETE, self.name, None)]
+        else:
+            modlist = [(ldap.MOD_REPLACE, self.name, self.values)]
 
         return modlist
 


### PR DESCRIPTION
##### SUMMARY
The unicodePwd attribute for a principal in Active Directory must be encoded and surrounded with quotes in order for the Active Directory server to accept the value. 

See https://msdn.microsoft.com/en-us/library/cc223248.aspx

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ldap_attr

##### ANSIBLE VERSION
```
ansible 2.6.0 (devel 5a0f4f0646) last updated 2018/02/22 11:12:16 (GMT -700)
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
```
    - name: Set the unicodePwd for principal testuser1
      ldap_attr:
        dn: 'CN=testuser1,CN=Users,DC=domain,DC=com'
        name: unicodePwd
        values: s3curePassword
        state: exact
        server_uri: 'ldaps://ad1.server.com'
        bind_dn: 'CN=lookup,CN=Users,DC=domain,DC=com'
        bind_pw: '******'
```
Running the above playbook results in an error from the Active Directory server.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: UNWILLING_TO_PERFORM: {'info': '0000001F: SvcErr: DSID-031A12D2, problem 5003 (WILL_NOT_PERFORM), data 0\n', 'desc': 'Server is unwilling to perform'}
fatal: [mgr1.sfire.phemi.com]: FAILED! => {"changed": false, "details": "{'info': '0000001F: SvcErr: DSID-031A12D2, problem 5003 (WILL_NOT_PERFORM), data 0\\n', 'desc': 'Server is unwilling to perform'}", "msg": "Attribute action failed."}
```
