### PR TITLE
Add ansible_scp_executable and ansible_sftp_executable host variables.

### DIFF
--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -129,6 +129,30 @@ ANSIBLE_SSH_EXECUTABLE:
   - {key: ssh_executable, section: ssh_connection}
   yaml: {key: ssh_connection.ssh_executable}
   version_added: "2.2"
+ANSIBLE_SCP_EXECUTABLE:
+  # TODO: move to ssh plugin
+  default: scp
+  description:
+    - This defines the location of the ssh binary. It defaults to `scp` which will use the first scp binary available in $PATH.
+    - This option is usually not required, it might be useful when access to system scp is restricted,
+      or when using ssh wrappers to connect to remote hosts.
+  env: [{name: ANSIBLE_SCP_EXECUTABLE}]
+  ini:
+  - {key: ssh_executable, section: ssh_connection}
+  yaml: {key: ssh_connection.ssh_executable}
+  version_added: "2.6"
+ANSIBLE_SFTP_EXECUTABLE:
+  # TODO: move to ssh plugin
+  default: sftp
+  description:
+    - This defines the location of the ssh binary. It defaults to `sftp` which will use the first sftp binary available in $PATH.
+    - This option is usually not required, it might be useful when access to system sftp is restricted,
+      or when using ssh wrappers to connect to remote hosts.
+  env: [{name: ANSIBLE_SFTP_EXECUTABLE}]
+  ini:
+  - {key: ssh_executable, section: ssh_connection}
+  yaml: {key: ssh_connection.ssh_executable}
+  version_added: "2.6"
 ANSIBLE_SSH_RETRIES:
   # TODO: move to ssh plugin
   default: 0

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -130,6 +130,8 @@ MAGIC_VARIABLE_MAPPING = dict(
 
     # ssh TODO: remove
     ssh_executable=('ansible_ssh_executable', ),
+    scp_executable=('ansible_scp_executable', ),
+    sftp_executable=('ansible_sftp_executable', ),
     ssh_common_args=('ansible_ssh_common_args', ),
     sftp_extra_args=('ansible_sftp_extra_args', ),
     scp_extra_args=('ansible_scp_extra_args', ),

--- a/lib/ansible/playbook/play_context.py
+++ b/lib/ansible/playbook/play_context.py
@@ -113,6 +113,8 @@ RESET_VARS = (
     'ansible_ssh_private_key_file',
     'ansible_ssh_pipelining',
     'ansible_ssh_executable',
+    'ansible_scp_executable',
+    'ansible_sftp_executable',
 )
 
 OPTION_FLAGS = ('connection', 'remote_user', 'private_key_file', 'verbosity', 'force_handlers', 'step', 'start_at_task', 'diff',
@@ -149,6 +151,8 @@ class PlayContext(Base):
 
     # ssh # FIXME: remove these
     _ssh_executable = FieldAttribute(isa='string', default=C.ANSIBLE_SSH_EXECUTABLE)
+    _scp_executable = FieldAttribute(isa='string', default=C.ANSIBLE_SCP_EXECUTABLE)
+    _sftp_executable = FieldAttribute(isa='string', default=C.ANSIBLE_SFTP_EXECUTABLE)
     _ssh_args = FieldAttribute(isa='string', default=C.ANSIBLE_SSH_ARGS)
     _ssh_common_args = FieldAttribute(isa='string')
     _sftp_extra_args = FieldAttribute(isa='string')

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -68,6 +68,30 @@ DOCUMENTATION = '''
           yaml: {key: ssh_connection.ssh_executable}
           #const: ANSIBLE_SSH_EXECUTABLE
           version_added: "2.2"
+      scp_executable:
+          default: scp
+          description:
+            - This defines the location of the scp binary. It defaults to `scp` which will use the first scp binary available in $PATH.
+            - This option is usually not required, it might be useful when access to system ssh is restricted,
+              or when using ssh wrappers to connect to remote hosts.
+          env: [{name: ANSIBLE_SCP_EXECUTABLE}]
+          ini:
+          - {key: scp_executable, section: ssh_connection}
+          yaml: {key: ssh_connection.scp_executable}
+          #const: ANSIBLE_SCP_EXECUTABLE
+          version_added: "2.6"
+      sftp_executable:
+          default: sftp
+          description:
+            - This defines the location of the sftp binary. It defaults to `sftp` which will use the first sftp binary available in $PATH.
+            - This option is usually not required, it might be useful when access to system ssh is restricted,
+              or when using ssh wrappers to connect to remote hosts.
+          env: [{name: ANSIBLE_SFTP_EXECUTABLE}]
+          ini:
+          - {key: sftp_executable, section: ssh_connection}
+          yaml: {key: ssh_connection.sftp_executable}
+          #const: ANSIBLE_SFTP_EXECUTABLE
+          version_added: "2.6"
       scp_extra_args:
           description: Extra exclusive to the 'scp' CLI
           vars:
@@ -914,15 +938,15 @@ class Connection(ConnectionBase):
         for method in methods:
             returncode = stdout = stderr = None
             if method == 'sftp':
-                cmd = self._build_command('sftp', to_bytes(host))
+                cmd = self._build_command(self._play_context.sftp_executable, to_bytes(host))
                 in_data = u"{0} {1} {2}\n".format(sftp_action, shlex_quote(in_path), shlex_quote(out_path))
                 in_data = to_bytes(in_data, nonstring='passthru')
                 (returncode, stdout, stderr) = self._bare_run(cmd, in_data, checkrc=False)
             elif method == 'scp':
                 if sftp_action == 'get':
-                    cmd = self._build_command('scp', u'{0}:{1}'.format(host, shlex_quote(in_path)), out_path)
+                    cmd = self._build_command(self._play_context.scp_executable, u'{0}:{1}'.format(host, shlex_quote(in_path)), out_path)
                 else:
-                    cmd = self._build_command('scp', in_path, u'{0}:{1}'.format(host, shlex_quote(out_path)))
+                    cmd = self._build_command(self._play_context.scp_executable, in_path, u'{0}:{1}'.format(host, shlex_quote(out_path)))
                 in_data = None
                 (returncode, stdout, stderr) = self._bare_run(cmd, in_data, checkrc=False)
             elif method == 'piped':


### PR DESCRIPTION
Also includes the environment variables and config commands - this makes the
SSH executable override framework consistent (if a user is overriding SSH,
they probably want to override these as well).

##### SUMMARY
Adds `ansible_scp_executable` and `ansible_sftp_executable` host parameters, as well as environment variables and config file options, the same as is provided for `ansible_ssh_executable`.

This is to provide complete support for situations where users are wrapping the `ssh` binary and may also be wrapping the `scp` and `sftp` binaries.

#Fixes 36616

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
playbook_executor

##### ANSIBLE VERSION
```
ansible 2.6.0 (devel 60eee696ae) last updated 2018/02/23 17:18:20 (GMT +1100)
  config file = None
  configured module search path = [u'/home/will/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/will/src/ansible-work/ansible/lib/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.14 (default, Sep 23 2017, 22:06:14) [GCC 7.2.0]
```


##### ADDITIONAL INFORMATION
Related to https://github.com/ansible/ansible/issues/36616

The motivation is the use of ansible with a tool which negotiates SSH connectivity to hosts via a specialized lookup system. This can be made to work with ansible by wrapping the SSH executable, but SCP and SFTP transfer methods fail unnecessarily in this situation. Unfortunately, before this change ansible provides no method to wrap the `scp` and `sftp` binaries to negotiate connectivity for these commands (without overriding system binaries). 

This PR adds that functionality using similar options (i.e. least surprise) to those provided for overriding the ssh executable.