### PR TITLE
VMware: Handle exception gracefully

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -783,7 +783,12 @@ class PyVmomiHelper(PyVmomi):
                 self.module.fail_json(msg="hardware.num_cpus attribute is mandatory for VM creation")
 
             if 'memory_mb' in self.params['hardware']:
-                self.configspec.memoryMB = int(self.params['hardware']['memory_mb'])
+                try:
+                    self.configspec.memoryMB = int(self.params['hardware']['memory_mb'])
+                except ValueError:
+                    self.module.fail_json(msg="Failed to parse hardware.memory_mb value."
+                                              " Please refer the documentation and provide"
+                                              " correct value.")
                 if vm_obj is None or self.configspec.memoryMB != vm_obj.config.hardware.memoryMB:
                     self.change_detected = True
             # memory_mb is mandatory for VM creation


### PR DESCRIPTION
##### SUMMARY
This fix adds logic to handle exception raised from conversion of
user parameter 'memory_mb'.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
lib/ansible/modules/cloud/vmware/vmware_guest.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6devel
```