### PR TITLE
[docs] fix erroneous example in inventory

### DIFF
--- a/docs/docsite/rst/user_guide/intro_patterns.rst
+++ b/docs/docsite/rst/user_guide/intro_patterns.rst
@@ -81,9 +81,10 @@ You can refer to hosts within the group by adding a subscript to the group name:
 
     webservers[0]       # == cobweb
     webservers[-1]      # == weber
-    webservers[0:1]     # == webservers[0],webservers[1]
-                        # == cobweb,webbing
+    webservers[0:1]     # == webservers[0]
+                        # == cobweb
     webservers[1:]      # == webbing,weber
+    webservers[:3]      # == cobweb,webbing,weber
 
 Most people don't specify patterns as regular expressions, but you can.  Just start the pattern with a '~'::
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
After initializing a list in both Python2/Python3 with below elements,
I've tested the indexing and realised that the examples provided in the
documentation are **erroneous**.

Also, I've **added** another example in addition to loop through maximum 3 nodes.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
As a result, update the examples with correct values in order to avoid
any future confusion.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.2.0                                                                                                    
  config file = None                                                                                               
  configured module search path = [u'/home/dminca/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible                                        
  executable location = /usr/bin/ansible                                                                           
  python version = 2.7.14 (default, Feb 17 2018, 10:42:17) [GCC 7.3.1 20180130 (Red Hat 7.3.1-2)]                  
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
Tests issued in the Python interpreter prove that the examples in documentation were erroneous:

<!--- Paste verbatim command output below, e.g. before and after your change -->
```python
In [1]: webservers = ['cobweb', 'webbing', 'weber']
                                                               
In [5]: webservers[0:1]
Out[5]: ['cobweb']     

In [9]: webservers[1:2]
Out[9]: ['webbing']    

In [7]: webservers[2:3]
Out[7]: ['weber']      
```
