### PR TITLE
fix erroneous example in inventory (#36625)

### DIFF
--- a/docs/docsite/rst/user_guide/intro_patterns.rst
+++ b/docs/docsite/rst/user_guide/intro_patterns.rst
@@ -81,9 +81,10 @@ You can refer to hosts within the group by adding a subscript to the group name:
 
     webservers[0]       # == cobweb
     webservers[-1]      # == weber
-    webservers[0:1]     # == webservers[0],webservers[1]
-                        # == cobweb,webbing
+    webservers[0:1]     # == webservers[0]
+                        # == cobweb
     webservers[1:]      # == webbing,weber
+    webservers[:3]      # == cobweb,webbing,weber
 
 Most people don't specify patterns as regular expressions, but you can.  Just start the pattern with a '~'::
 


### PR DESCRIPTION
##### SUMMARY

After initializing a list in both Python2/Python3 with below elements,
I've tested the indexing and realised that the examples provided in the
documentation are erroneous.

As a result, update the examples with correct values in order to avoid
any future confusion.

Resolves:
Related:
Signed-off-by: Daniel Andrei Minca <mandrei17@gmail.com>
(cherry picked from commit 62f237f21edbe65ee53773d6a44c5b7ce91f650c)


