### PR TITLE
fix yamllint issue

### DIFF
--- a/changelogs/fragments/v2.5.0rc1_catchup.yaml
+++ b/changelogs/fragments/v2.5.0rc1_catchup.yaml
@@ -23,4 +23,3 @@ bugfixes:
 - aws_waf_* - fixed traceback on WAFStaleDataException (https://github.com/ansible/ansible/pull/36405)
 - ec2_group - fixed check_mode when using tags (https://github.com/ansible/ansible/pull/36503)
 - loop item labels will now update if templated (https://github.com/ansible/ansible/pull/36430)
-


### PR DESCRIPTION
##### SUMMARY
Fix
```
changelogs/fragments/v2.5.0rc1_catchup.yaml:26:1: empty-lines too many blank lines (1 > 0)
```
##### ISSUE TYPE
 - Bugfix Pull Request
