### PR TITLE
Fixes #36635 - Changed labels type from list to dict on docker_volume module

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_volume.py
+++ b/lib/ansible/modules/cloud/docker/docker_volume.py
@@ -239,7 +239,7 @@ def main():
         state=dict(type='str', default='present', choices=['present', 'absent']),
         driver=dict(type='str', default='local'),
         driver_options=dict(type='dict', default={}),
-        labels=dict(type='list'),
+        labels=dict(type='dict'),
         force=dict(type='bool', default=False),
         debug=dict(type='bool', default=False)
     )


### PR DESCRIPTION
##### SUMMARY
'docker_volume' expects 'labels' to be a list which is a mistake - it should be a dict as expected by docker-py (similarly to docker_container module). Creating a volume with labels fails currently
This fixes #36635

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
docker_volume

##### ANSIBLE VERSION
```
ansible 2.4.2.0
  config file = /mnt/home/ci/apps64/ansible/mssql/LIT-203040-harris/ansible.cfg
  configured module search path = [u'/home/ci/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.9 (default, Jun 29 2016, 13:08:31) [GCC 4.9.2]
```


