### PR TITLE
VMware SPBM Module

### DIFF
--- a/lib/ansible/module_utils/spbm_client.py
+++ b/lib/ansible/module_utils/spbm_client.py
@@ -1,0 +1,202 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# pylint: disable=import-error, E0611, W0611, W0613, W0612, W0212, R0201
+# (c) 2017, Prasanna Nanda < pnanda@cloudsimple.com >
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+"""SPBM Client"""
+
+import time
+import re
+from pyVmomi import vim, pbm
+from pyVim.connect import SoapStubAdapter
+
+class SPBMClient(object):
+    """SPBM Client"""
+    def __init__(self, vc_si, hostname, version="version2"):
+        """
+        Creates a Service Instance for VMware Profile Based Management
+        :param vc_si: vCenter Service Instance
+        :param version: PBM Version
+        """
+        option_manager = vc_si.RetrieveContent().setting
+        hostname_option = option_manager.QueryOptions("config.vpxd.hostnameUrl")
+        client_stub = vc_si._GetStub()
+        session_cookie = client_stub.cookie.split('"')[1]
+        ssl_context = client_stub.schemeArgs.get('context')
+        additional_headers = {'vcSessionCookie': session_cookie}
+        stub = SoapStubAdapter(host=hostname, path="/pbm/sdk", version="pbm.version.version2",
+                               sslContext=ssl_context, requestContext=additional_headers)
+        self.vc_si = vc_si
+        self.pbm_si = pbm.ServiceInstance("ServiceInstance", stub)
+        self.pbm_content = self.pbm_si.PbmRetrieveServiceContent()
+
+    def get_pbmsi(self):
+        """
+        Returns PBM Service Instance
+        :return: PBM Service Instance
+        """
+        return self.pbm_si
+
+    def get_pbmcontent(self):
+        """
+        Returns PBM Content
+        :return: PBM RetrieveContent()
+        """
+        return self.pbm_content
+
+    def get_profilemgr(self):
+        """
+        Gets MoRef to Profile Manager
+        :return: Profile Manager
+        """
+        return self.pbm_content.profileManager
+
+    def get_compliancemgr(self):
+        """
+        Gets MoRef to Profile Compliance Manager
+        """
+        return self.pbm_content.complianceManager
+
+    def get_profiles(self):
+        """
+        Gets list of Storage Profiles on vCenter
+        :return: list of Storage Profiles on vCenter
+        """
+        profile_mgr = self.get_profilemgr()
+        profile_ids = profile_mgr.PbmQueryProfile(resourceType=pbm.profile.ResourceType(\
+        resourceType="STORAGE"), profileCategory="REQUIREMENT")
+
+        profiles = []
+        if profile_ids:
+            return profile_mgr.PbmRetrieveContent(profileIds=profile_ids)
+        return None
+
+    def return_cap_meta_data(self, metadatas, keyname):
+        """
+        Return Storage Profile capability metadata
+        """
+        for metadata in metadatas:
+            for cap_meta in metadata.capabilityMetadata:
+                if keyname == cap_meta.id.id:
+                    return cap_meta
+        return None
+
+    def build_capability(self, capability_name, value):
+        """Build capability metadata"""
+        metadatas = self.get_profilemgr().FetchCapabilityMetadata()
+        capability_meta = self.return_cap_meta_data(metadatas=metadatas, keyname=capability_name)
+        if capability_meta is None:
+            raise Exception('capability_meta is None')
+        prop = pbm.PbmCapabilityPropertyInstance()
+        prop.id = capability_name
+        prop.value = value
+        rule = pbm.PbmCapabilityConstraintInstance()
+        rule.propertyInstance.append(prop)
+
+        capability = pbm.PbmCapabilityInstance()
+        capability.id = capability_meta.id
+        capability.constraint.append(rule)
+        return capability
+
+    def delete_storage_profile(self, profile_name=None, force=False):
+        """
+        Deletes a Storage Profile
+        """
+        profiles = self.get_profiles()
+        for profile in profiles:
+            if profile.name == profile_name:
+                return self.get_profilemgr().PbmDelete(profileId=[profile.profileId])
+
+    def check_compliance_vm(self, virtual_machine):
+        """
+        Checks if a VM is compliant with attached profile
+        """
+        pbm_object_ref = pbm.ServerObjectRef(key=str(virtual_machine._moId), \
+        objectType="virtualMachine", serverUuid=self.vc_si.content.about.instanceUuid)
+        compliance_status = {}
+        compliance_status['vm_name'] = virtual_machine.name
+        results = self.get_compliancemgr().PbmCheckRollupCompliance(entity=[pbm_object_ref])
+        compliance_result = []
+        for result in results:
+            compliance_status['overallComplianceStatus'] = result.overallComplianceStatus
+            if result.result:
+                subresults = result.result
+                for complianceresult in subresults:
+                    individual_compliance = {}
+                    individual_compliance['checkTime'] = complianceresult.checkTime
+                    individual_compliance['complianceStatus'] = complianceresult.complianceStatus
+                    individual_compliance['key'] = complianceresult.entity.key
+                    individual_compliance['objectType'] = complianceresult.entity.objectType
+                    compliance_result.append(individual_compliance)
+        compliance_status['result'] = compliance_result
+        return compliance_status
+
+    def get_ds_default_profile(self, datastore):
+        """
+        Get Default Profile for a datastore
+        """
+        placementhub = pbm.placement.PlacementHub(hubId=datastore._moId, hubType='Datastore')
+        default_profile = self.get_profilemgr().PbmQueryDefaultRequirementProfile(hub=placementhub)
+        if default_profile:
+            return default_profile
+        return None
+
+    def create_storage_profile(self, profile_name=None, \
+    description="Sample Storage Profile", rules=None):
+        """
+        Creates a Storage Profile
+        """
+        res_types = self.get_profilemgr().FetchResourceType()
+        # Only supported resource type is storage
+        res_type = res_types[0]
+        create_spec = pbm.profile.CapabilityBasedProfileCreateSpec()
+        create_spec.name = profile_name
+        create_spec.description = description
+        create_spec.resourceType = res_type
+        constraints = pbm.PbmCapabilitySubProfileConstraints()
+        rule_number = 1
+        for rule in rules:
+            rule_set = pbm.PbmCapabilitySubProfile()
+            capabilities = []
+            for key in rule.keys():
+                capabilities.append(self.build_capability(key, rule[key]))
+            rule_set.capability.extend(capabilities)
+            rule_set.name = 'Rule-Set ' + str(rule_number)
+            rule_number += 1
+            constraints.subProfiles.append(rule_set)
+        create_spec.constraints = constraints
+        return self.get_profilemgr().PbmCreate(createSpec=create_spec)
+
+
+    def update_storage_profile(self, profile_id=None, rules=None):
+        """
+        Updates a Storage Profile
+        """
+        update_spec = pbm.profile.CapabilityBasedProfileUpdateSpec()
+        constraints = pbm.PbmCapabilitySubProfileConstraints()
+        rule_number = 1
+        for rule in rules:
+            rule_set = pbm.PbmCapabilitySubProfile()
+            capabilities = []
+            for key in rule.keys():
+                capabilities.append(self.build_capability(key, rule[key]))
+            rule_set.capability.extend(capabilities)
+            rule_set.name = 'Rule-Set ' + str(rule_number)
+            rule_number += 1
+            constraints.subProfiles.append(rule_set)
+        update_spec.constraints = constraints
+        return self.get_profilemgr().PbmUpdate(updateSpec=update_spec, profileId=profile_id)

--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# pylint: skip-file
 
 # (c) 2015, Joseph Callen <jcallen () csc.com>
 #
@@ -442,7 +443,7 @@ def vmware_argument_spec():
     )
 
 
-def connect_to_api(module, disconnect_atexit=True):
+def connect_to_api(module, disconnect_atexit=True, return_service_instance=False):
     hostname = module.params['hostname']
     username = module.params['username']
     password = module.params['password']
@@ -483,6 +484,8 @@ def connect_to_api(module, disconnect_atexit=True):
     # Also removal significantly speeds up the return of the module
     if disconnect_atexit:
         atexit.register(connect.Disconnect, service_instance)
+    if return_service_instance:
+        return service_instance, service_instance.RetrieveContent()
     return service_instance.RetrieveContent()
 
 

--- a/lib/ansible/modules/cloud/vmware/vmware_spbm.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_spbm.py
@@ -1,0 +1,164 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# pylint: disable=invalid-name, too-many-instance-attributes, broad-except
+# Prasanna Nanda <pnanda@cloudsimple.com>
+
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+"""Manages Storage Profiles"""
+
+from ansible.module_utils.vmware import vmware_argument_spec, connect_to_api, find_datastore_by_name
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_native
+from ansible.module_utils.spbm_client import SPBMClient
+
+try:
+    from pyVmomi import vmodl
+    HAS_PYVMOMI = True
+except ImportError:
+    HAS_PYVMOMI = False
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.0',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = '''
+---
+module: vmware_spbm
+short_description: VMware Storage Profile Utilities
+description:
+    - Create, Destroy VM Storage Profiles
+version_added: 2.6
+author:
+    - Prasanna Nanda <pnanda@cloudsimple.com>
+notes:
+    - Tested on vSphere 6.5
+requirements:
+    - "python >= 2.7"
+    - PyVmomi
+options:
+    profile_name:
+        description:
+            - Name of the storage profile to Create
+        required: True
+    state:
+        description:
+            - Valid values are present or absent
+        required: True
+    description:
+        description:
+            - Some Text Describing the Storage profile
+        required: False
+extends_documentation_fragment: vmware.documentation
+'''
+
+EXAMPLES = r'''
+  - name: Create a Storage Profile
+    vmware_spbm:
+      hostname: A vCenter host
+      username: vCenter username
+      password: vCenter password
+      profile_name: Name of the storage profile to create
+      description: Text Describing Storage Profile
+      state: present|absent
+'''
+
+class vmware_spbm(object):
+    """VMware Storage Profile Methods"""
+    def __init__(self, module):
+        self.module = module
+        self.name = module.params['profile_name']
+        self.description = module.params['description']
+        self.desiredstate = module.params['state']
+        self.rules = module.params['rules']
+        self.currentstate = 'absent'
+        self.content = None
+        try:
+            service_instance, content = connect_to_api(module, return_service_instance=True)
+            self.content = content
+            self.spbmclient = SPBMClient(vc_si=service_instance, hostname=module.params['hostname'])
+        except vmodl.RuntimeFault as runtime_fault:
+            module.fail_json(msg=runtime_fault.msg)
+        except vmodl.MethodFault as method_fault:
+            module.fail_json(msg=method_fault.msg)
+        except Exception as e:
+            module.fail_json(msg=to_native(e))
+
+    def force_provision(self):
+        """Allow Force Provision on vsanDatastore"""
+        datastore = find_datastore_by_name(self.content, "vsanDatastore")
+        vsan_profile_id = self.spbmclient.get_ds_default_profile(datastore)
+        rules = [{'forceProvisioning': True}]
+        self.spbmclient.update_storage_profile(profile_id=vsan_profile_id, rules=rules)
+
+    def process_state(self):
+        """Process Current State of Profiles"""
+        profiles = self.spbmclient.get_profiles()
+        if not profiles:
+            self.module.fail_json(changed=False, msg="Could not retrieve \
+            Storage Profile Information from vCenter")
+        else:
+            for profile in profiles:
+                if self.module.params['profile_name'] == profile.name:
+                    self.currentstate = 'present'
+        # Current State of System and Desired State are same
+        if self.currentstate == self.desiredstate:
+            self.module.exit_json(changed=False)
+
+        # Profile is absent and you need to create one
+        if self.currentstate == 'absent' and self.desiredstate == 'present':
+            profileId = self.spbmclient.create_storage_profile(profile_name=self.name, \
+            description=self.description, rules=self.rules)
+            if profileId:
+                self.module.exit_json(changed=True, msg="Created Storage Profile {} \
+                and ID {}".format(self.name, profileId.uniqueId))
+            else:
+                self.module.fail_json(changed=False, msg="Failed to create \
+                Storage Profile {}".format(self.name))
+
+        # Profile is Present and you need to delete one
+        if self.currentstate == 'present' and self.desiredstate == 'absent':
+            results = self.spbmclient.delete_storage_profile(profile_name=self.name)
+            if not results:
+                self.module.exit_json(changed=True, \
+                msg="Deleted Storage Profile {}".format(self.name))
+            else:
+                profile_op_outcome = results[0]
+                if profile_op_outcome.fault is not None:
+                    self.module.fail_json(changed=False, msg=str(profile_op_outcome.fault))
+
+
+def main():
+    """Manages VM Storage Profiles"""
+    argument_spec = vmware_argument_spec()
+    argument_spec.update(dict(profile_name=dict(required=True, type='str'), \
+    description=dict(required=False, type='str', default='Sample Storage Profile'), \
+    force_provision=dict(required=False, type='bool', default=False), \
+    rules=dict(required=False, type='list', default=[{'stripeWidth': 1}, \
+    {'hostFailuresToTolerate': 1}, {'replicaPreference':'RAID-5/6 (Erasure Coding) - Capacity'}]), \
+    state=dict(default='present', choices=['present', 'absent'], type='str')))
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=False)
+    if not HAS_PYVMOMI:
+        module.fail_json(msg="pyvmomi is required for this module")
+    spbm = vmware_spbm(module)
+    if module.params['force_provision']:
+        spbm.force_provision()
+        module.exit_json(changed=True, msg="Allow Force Provision")
+    else:
+        spbm.process_state()
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
##### VMware SPBM Module to Create/Delete storage Profile
VMware SPBM Module to Create/Delete storage Profile.

The SPBM Module needs access to service instance. So I have refactored ```connect_to_api``` to return a ```service_instance``` and ```content``` both if ```return_service_instance``` is set. By default it is false so all existing functionalities work.

##### ISSUE TYPE
 - New Module Pull Request

##### COMPONENT NAME
vmware_spbm

##### ANSIBLE VERSION
```
ansible 2.6.0
  config file = None
  configured module search path = [u'/home/pnanda/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible-2.6.0-py2.7.egg/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.12 (default, Nov 20 2017, 18:23:56) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION
<!--- Paste verbatim command output below, e.g. before and after your change -->
```
  - name: Create a Storage Profile
    vmware_spbm:
      hostname: A vCenter host
      username: vCenter username
      password: vCenter password
      name: Name of the storage profile to create
      description: Text Describing Storage Profile
      state: present|absent
```
