### PR TITLE
[WIP] raise error if an invalid hosts order is provided - fixes #36582

### DIFF
--- a/lib/ansible/inventory/manager.py
+++ b/lib/ansible/inventory/manager.py
@@ -25,7 +25,7 @@ import re
 import itertools
 
 from ansible import constants as C
-from ansible.errors import AnsibleError, AnsibleParserError
+from ansible.errors import AnsibleError, AnsibleOptionsError, AnsibleParserError
 from ansible.inventory.data import InventoryData
 from ansible.module_utils.six import string_types
 from ansible.module_utils._text import to_bytes, to_native, to_text
@@ -372,7 +372,8 @@ class InventoryManager(object):
                 from random import shuffle
                 shuffle(hosts)
             elif order not in [None, 'inventory']:
-                raise AnsibleError("Invalid 'order' specified for inventory hosts: %s" % order)
+                raise AnsibleOptionsError("Invalid 'order' specified for inventory hosts: %s. 'order' may be one "
+                                          "of [null|inventory|reverse_inventory|reverse_sorted|shuffle|sorted]." % order)
 
         return hosts
 

--- a/lib/ansible/inventory/manager.py
+++ b/lib/ansible/inventory/manager.py
@@ -25,7 +25,7 @@ import re
 import itertools
 
 from ansible import constants as C
-from ansible.errors import AnsibleError, AnsibleOptionsError, AnsibleParserError
+from ansible.errors import AnsibleError, AnsibleParserError
 from ansible.inventory.data import InventoryData
 from ansible.module_utils.six import string_types
 from ansible.module_utils._text import to_bytes, to_native, to_text
@@ -372,7 +372,7 @@ class InventoryManager(object):
                 from random import shuffle
                 shuffle(hosts)
             elif order not in [None, 'inventory']:
-                AnsibleOptionsError("Invalid 'order' specified for inventory hosts: %s" % order)
+                raise AnsibleError("Invalid 'order' specified for inventory hosts: %s" % order)
 
         return hosts
 


### PR DESCRIPTION
##### SUMMARY
An exception was there but wasn't being raised if an invalid host order was provided. ~Since AnsibleOptionsError doesn't output anything mentioning order, raised an AnsibleError instead.~ Raising AnsibleOptionsError but adding the permitted values to the message since there is no CLI flag. Fixes #36582

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/inventory/manager.py

##### ANSIBLE VERSION
```
2.6.0
```