### PR TITLE
module_common: handle None value for templar

### DIFF
--- a/hacking/test-module
+++ b/hacking/test-module
@@ -150,8 +150,8 @@ def boilerplate_module(modfile, args, interpreters, check, destfile):
         modname,
         modfile,
         complex_args,
-        task_vars=task_vars,
-        templar=Templar(loader=loader)
+        Templar(loader=loader),
+        task_vars=task_vars
     )
 
     if module_style == 'new' and 'ANSIBALLZ_WRAPPER = True' in to_native(module_data):

--- a/hacking/test-module
+++ b/hacking/test-module
@@ -42,6 +42,7 @@ from ansible.parsing.splitter import parse_kv
 import ansible.executor.module_common as module_common
 import ansible.constants as C
 from ansible.module_utils._text import to_native, to_text
+from ansible.template import Templar
 
 try:
     import json
@@ -149,7 +150,8 @@ def boilerplate_module(modfile, args, interpreters, check, destfile):
         modname,
         modfile,
         complex_args,
-        task_vars=task_vars
+        task_vars=task_vars,
+        templar=Templar(loader=loader)
     )
 
     if module_style == 'new' and 'ANSIBALLZ_WRAPPER = True' in to_native(module_data):

--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -874,7 +874,7 @@ def _find_module_utils(module_name, b_module_data, module_path, module_args, tas
     return (b_module_data, module_style, shebang)
 
 
-def modify_module(module_name, module_path, module_args, task_vars=None, templar=None, module_compression='ZIP_STORED', async_timeout=0, become=False,
+def modify_module(module_name, module_path, module_args, templar, task_vars=None, module_compression='ZIP_STORED', async_timeout=0, become=False,
                   become_method=None, become_user=None, become_password=None, become_flags=None, environment=None):
     """
     Used to insert chunks of code into modules before transfer rather than

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -153,8 +153,8 @@ class ActionBase(with_metaclass(ABCMeta, object)):
         final_environment = dict()
         self._compute_environment_string(final_environment)
 
-        (module_data, module_style, module_shebang) = modify_module(module_name, module_path, module_args,
-                                                                    task_vars=task_vars, templar=self._templar,
+        (module_data, module_style, module_shebang) = modify_module(module_name, module_path, module_args, self._templar,
+                                                                    task_vars=task_vars,
                                                                     module_compression=self._play_context.module_compression,
                                                                     async_timeout=self._task.async_val,
                                                                     become=self._play_context.become,

--- a/test/units/executor/module_common/test_modify_module.py
+++ b/test/units/executor/module_common/test_modify_module.py
@@ -28,8 +28,8 @@ def fake_old_module_open(mocker):
         mocker.patch('builtins.open', m)
 
 
-def test_shebang(fake_old_module_open):
-    (data, style, shebang) = modify_module('fake_module', 'fake_path', {})
+def test_shebang(fake_old_module_open, templar):
+    (data, style, shebang) = modify_module('fake_module', 'fake_path', {}, templar)
     assert shebang == '#!/usr/bin/python'
 
 
@@ -38,5 +38,5 @@ def test_shebang_task_vars(fake_old_module_open, templar):
         'ansible_python_interpreter': '/usr/bin/python3'
     }
 
-    (data, style, shebang) = modify_module('fake_module', 'fake_path', {}, task_vars=task_vars, templar=templar)
+    (data, style, shebang) = modify_module('fake_module', 'fake_path', {}, templar, task_vars=task_vars)
     assert shebang == '#!/usr/bin/python3'


### PR DESCRIPTION
##### SUMMARY

Fix the following error introduced by b455901:

    $ ./hacking/test-module -m ./lib/ansible/modules/system/ping.py -I ansible_python_interpreter=/usr/bin/python
    Traceback (most recent call last):
      File "./hacking/test-module", line 268, in <module>
        main()
      File "./hacking/test-module", line 249, in main
        (modfile, modname, module_style) = boilerplate_module(options.module_path, options.module_args, interpreters, options.check, options.filename)
      File "./hacking/test-module", line 152, in boilerplate_module
        task_vars=task_vars
      File "ansible/lib/ansible/executor/module_common.py", line 910, in modify_module
        environment=environment)
      File "ansible/lib/ansible/executor/module_common.py", line 736, in _find_module_utils
        shebang, interpreter = _get_shebang(u'/usr/bin/python', task_vars, templar)
      File "ansible/lib/ansible/executor/module_common.py", line 452, in _get_shebang
        interpreter = templar.template(task_vars[interpreter_config].strip())
    AttributeError: 'NoneType' object has no attribute 'template'

Unit test provided.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 lib/ansible/executor/module_common.py

##### ANSIBLE VERSION
```
ansible 2.6.0 (devel 076ea07bb5) last updated 2018/02/23 19:40:33 (GMT +200)
```

##### ADDITIONAL INFORMATION

Remote pair programming fix, thanks to @mscherer for being the observer.