### PR TITLE
[aws doc fragment] document type for validate_certs

### DIFF
--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -159,7 +159,7 @@ def aws_common_argument_spec():
         ec2_url=dict(),
         aws_secret_key=dict(aliases=['ec2_secret_key', 'secret_key'], no_log=True),
         aws_access_key=dict(aliases=['ec2_access_key', 'access_key']),
-        validate_certs=dict(default=True, type='bool'),
+        validate_certs=dict(default=True, type='bool', choices=['yes', 'no']),
         security_token=dict(aliases=['access_token'], no_log=True),
         profile=dict(),
     )


### PR DESCRIPTION
Add boolean choices to argument_spec

##### SUMMARY
Fix doc fragment and boolean choices.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/utils/module_docs_fragments/aws.py

##### ANSIBLE VERSION
```
2.6.0
```

