### PR TITLE
Notify acozine & gundalow on Network Docs

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -1231,6 +1231,13 @@ files:
   docs/:
     labels: docs_pull_request
     notify: dharmabumstead
+  docs/docsite/rst/network/:
+    labels:
+      - docs_pull_request
+      - networking
+    maintainers:
+      - acozine
+      - gundalow
   packaging/:
   test/:
     # 'test' is a component path, then 'test' label will be automatically added


### PR DESCRIPTION
##### SUMMARY
`BOTMETA.yml` is what informs Ansibullbot on who is responsible for certain directories and allows labels to be added on Issues and PRs

Now we have a docs directory notify and add label `network` on any network docs PRs and notify some people


##### ISSUE TYPE
 - Docs Pull Request

