### PR TITLE
tower cred: support credential kind/type for /api/v1/ and /api/v2/

### DIFF
--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_credential.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_credential.py
@@ -258,8 +258,16 @@ def main():
                 org = org_res.get(name=organization)
                 params['organization'] = org['id']
 
-            credential_type = credential_type_for_v1_kind(module.params, module)
-            params['credential_type'] = credential_type['id']
+            try:
+                tower_cli.get_resource('credential_type')
+            except (AttributeError):
+                # /api/v1/ backwards compat
+                # older versions of tower-cli don't *have* a credential_type
+                # resource
+                params['kind'] = module.params['kind']
+            else:
+                credential_type = credential_type_for_v1_kind(module.params, module)
+                params['credential_type'] = credential_type['id']
 
             if module.params.get('description'):
                 params['description'] = module.params.get('description')


### PR DESCRIPTION
##### SUMMARY
older versions of Tower (3.1) don't have a concept of CredentialTypes
(this was introduced in Tower 3.2).  This change detects older versions
of pre-3.2 tower-cli that *only* support the deprecated `kind`
attribute.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ansible_tower

##### ANSIBLE VERSION
```
ansible 2.6.0 (tower-credential-support 31fa624595) last updated 2018/02/23 16:47:49 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/ryan/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/ryan/dev/ansible/lib/ansible
  executable location = /home/ryan/venvs/cli/bin/ansible
  python version = 2.7.14 (default, Jan  5 2018, 10:41:29) [GCC 7.2.1 20171224]
```

related: https://github.com/ansible/ansible/pull/36587