### PR TITLE
docsite: Add 'Edit on GitHub' for module docs

### DIFF
--- a/docs/bin/plugin_formatter.py
+++ b/docs/bin/plugin_formatter.py
@@ -240,6 +240,7 @@ def get_plugin_info(module_dir, limit_to=None, verbose=False):
 
         # save all the information
         module_info[module] = {'path': module_path,
+                               'source': os.path.relpath(module_path, module_dir),
                                'deprecated': deprecated,
                                'aliases': set(),
                                'metadata': metadata,
@@ -413,6 +414,7 @@ def process_plugins(module_map, templates, outputname, output_dir, ansible_versi
 
         doc['option_keys'] = option_names
         doc['filename'] = fname
+        doc['source'] = module_map[module]['source']
         doc['docuri'] = doc['module'].replace('_', '-')
         doc['now_date'] = datetime.date.today().strftime('%Y-%m-%d')
         doc['ansible_version'] = ansible_version

--- a/docs/docsite/_themes/sphinx_rtd_theme/breadcrumbs.html
+++ b/docs/docsite/_themes/sphinx_rtd_theme/breadcrumbs.html
@@ -1,9 +1,13 @@
 <ul class="wy-breadcrumbs">
   <li><a href="{{ pathto(master_doc) }}">Docs</a> &raquo;</li>
   <li><a href="">{{ title }}</a></li>
-  {% if not pagename.endswith('_module') and (not 'list_of' in pagename) and (not 'category' in pagename) %}
+  {% if pagename.endswith('_module') %}
     <li class="wy-breadcrumbs-aside">
-      <a href="https://github.com/ansible/ansible/blob/devel/docs/docsite/rst/{{ pagename }}.rst" class="icon icon-github"> Edit on GitHub</a>
+      <a href="https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/{{ meta.get('source', '') }}" class="icon icon-github"> Edit on GitHub</a>
+    </li>
+  {% elif (not 'list_of' in pagename) and (not 'category' in pagename) %}
+    <li class="wy-breadcrumbs-aside">
+      <a href="https://github.com/ansible/ansible/edit/devel/docs/docsite/rst/{{ pagename }}.rst" class="icon icon-github"> Edit on GitHub</a>
     </li>
   {% endif %}
 </ul>

--- a/docs/docsite/_themes/srtd/breadcrumbs.html
+++ b/docs/docsite/_themes/srtd/breadcrumbs.html
@@ -3,7 +3,7 @@
   <li><a href="">{{ title }}</a></li>
   {% if not pagename.endswith('_module') and (not 'list_of' in pagename) and (not 'category' in pagename) %}
     <li class="wy-breadcrumbs-aside">
-      <a href="https://github.com/ansible/ansible/blob/devel/docs/docsite/rst/{{ pagename }}.rst" class="icon icon-github"> Edit on GitHub</a>
+      <a href="https://github.com/ansible/ansible/edit/devel/docs/docsite/rst/{{ pagename }}.rst" class="icon icon-github"> Edit on GitHub</a>
     </li>
   {% endif %}
 </ul>

--- a/docs/docsite/_themes/srtd/footer.html
+++ b/docs/docsite/_themes/srtd/footer.html
@@ -22,7 +22,7 @@
 </script>
 
   <p>
-  Copyright © 2017 Red Hat, Inc.
+  Copyright © 2018 Red Hat, Inc.
   <br>
 
   {%- if last_updated %}
@@ -30,6 +30,6 @@
   {%- endif %}
   </p>
 <p>
-Ansible docs are generated from <a href="https://github.com/ansible/ansible">GitHub sources</a> using <a href="http://sphinx-doc.org/">Sphinx</a> using a theme provided by <a href="http://readthedocs.org">Read the Docs</a>. {% if pagename.endswith("_module") %}Module documentation is not edited directly, but is generated from the source code for the modules.  To submit an update to module docs, edit the 'DOCUMENTATION' metadata in the <a href="https://github.com/ansible/ansible/tree/devel/lib/ansible/modules">modules directory</a> of the <a href="https://github.com/ansible/ansible/">core source code repository</a>. {% endif %}
+Ansible docs are generated from <a href="https://github.com/ansible/ansible">GitHub sources</a> using <a href="http://sphinx-doc.org/">Sphinx</a> using a theme provided by <a href="http://readthedocs.org">Read the Docs</a>.
 </p>
 </footer>

--- a/docs/templates/plugin.rst.j2
+++ b/docs/templates/plugin.rst.j2
@@ -1,3 +1,5 @@
+:source: @{ source }@
+
 .. _@{ module }@:
 
 {% if short_description %}


### PR DESCRIPTION
##### SUMMARY
This is something I always wanted, a 'Edit on GitHub' button for module
documentation.

I also removed the additional statement in the footer with instructions
on how to edit the module documentation.

PS The links go directly into the GitHub file editor now !

This fixes #36241

##### ISSUE TYPE
 - Feature Pull Request
 - Docs Pull Request

##### COMPONENT NAME
module docs

##### ANSIBLE VERSION
v2.5