### PR TITLE
Fix documentation of validate_certificates option in aws doc_fragment.

### DIFF
--- a/lib/ansible/utils/module_docs_fragments/aws.py
+++ b/lib/ansible/utils/module_docs_fragments/aws.py
@@ -53,7 +53,7 @@ options:
       - When set to "no", SSL certificates will not be validated for boto versions >= 2.6.0.
     required: false
     default: "yes"
-    choices: ["yes", "no"]
+    type: bool
     aliases: []
     version_added: "1.5"
   profile:


### PR DESCRIPTION
##### SUMMARY

Fix documentation of validate_certificates option in aws doc_fragment.

Unignore sanity test failures for AWS modules caused by this common
fragment.

(cherry picked from commit 2a0c7c43315140789bde934a8002bfbddf049516)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

aws docs fragment

##### ANSIBLE VERSION

```
ansible 2.5.0rc1 (cp-doc-fix-2.5 cbc3677781) last updated 2018/02/23 21:11:59 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```
