### PR TITLE
Asorted docs fixed

### DIFF
--- a/docs/docsite/_themes/sphinx_rtd_theme/footer.html
+++ b/docs/docsite/_themes/sphinx_rtd_theme/footer.html
@@ -22,7 +22,7 @@
 </script>
 
   <p>
-  Copyright © 2017 Red Hat, Inc.
+  Copyright © 2018 Red Hat, Inc.
   <br>
 
   {%- if last_updated %}
@@ -30,6 +30,6 @@
   {%- endif %}
   </p>
 <p>
-Ansible docs are generated from <a href="https://github.com/ansible/ansible">GitHub sources</a> using <a href="http://sphinx-doc.org/">Sphinx</a> using a theme provided by <a href="http://readthedocs.org">Read the Docs</a>. {% if pagename.endswith("_module") %}Module documentation is not edited directly, but is generated from the source code for the modules.  To submit an update to module docs, edit the 'DOCUMENTATION' metadata in the <a href="https://github.com/ansible/ansible/tree/devel/lib/ansible/modules">modules directory</a> of the <a href="https://github.com/ansible/ansible/">core source code repository</a>. {% endif %}
+Ansible docs are generated from <a href="https://github.com/ansible/ansible">GitHub sources</a> using <a href="http://sphinx-doc.org/">Sphinx</a> using a theme provided by <a href="http://readthedocs.org">Read the Docs</a>.
 </p>
 </footer>

--- a/docs/templates/list_of_CATEGORY_plugins.rst.j2
+++ b/docs/templates/list_of_CATEGORY_plugins.rst.j2
@@ -25,7 +25,7 @@
 .. toctree:: :maxdepth: 1
 
 {% for module in info['_modules'] | sort %}
-  :ref:`@{ module }@`{% if module_info[module]['deprecated'] %} **(D)**{% endif%} @{ module_info[module]['doc']['short_description'] }@
+  :ref:`@{ module }@`{% if module_info[module]['deprecated'] %} **(D)**{% endif%} -- @{ module_info[module]['doc']['short_description'] }@
 {% endfor %}
 
 {% endfor %}

--- a/docs/templates/plugin.rst.j2
+++ b/docs/templates/plugin.rst.j2
@@ -211,7 +211,7 @@ Examples
 Return Values
 -------------
 
-Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this {{plugin_type}}:
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this @{ plugin_type }@:
 
 .. raw:: html
 
@@ -287,7 +287,7 @@ Author
 ~~~~~~
 
 {% for author_name in author %}
-    * @{ author_name }@
+* @{ author_name }@
 {% endfor %}
 
 


### PR DESCRIPTION
##### SUMMARY
This PR includes:
- A fix to untemplated {{ plugin_type }} in docs
- Remove the additional info on how to edit module docs (see #36667)
- Add missing delimiter

##### ISSUE TYPE
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
docsite

##### ANSIBLE VERSION
v2.5