### PR TITLE
allows ib_spec attrs to be filtered in update

### DIFF
--- a/lib/ansible/module_utils/net_tools/nios/api.py
+++ b/lib/ansible/module_utils/net_tools/nios/api.py
@@ -240,6 +240,7 @@ class WapiModule(WapiBase):
                 elif 'view' in proposed_object:
                     self.check_if_dns_view_exists(proposed_object['view'])
                 if not self.module.check_mode:
+                    proposed_object = self.on_update(proposed_object, ib_spec)
                     res = self.update_object(ref, proposed_object)
                 result['changed'] = True
 
@@ -321,3 +322,23 @@ class WapiModule(WapiBase):
                     return False
 
         return True
+
+    def on_update(self, proposed_object, ib_spec):
+        ''' Event called before the update is sent to the API endpoing
+
+        This method will allow the final proposed object to be changed
+        and/or keys filtered before it is sent to the API endpoint to
+        be processed.
+
+        :args proposed_object: A dict item that will be encoded and sent
+            the the API endpoint with the updated data structure
+
+        :returns: updated object to be sent to API endpoint
+        '''
+        keys = set()
+        for key, value in iteritems(proposed_object):
+            update = ib_spec[key].get('update', True)
+            if not update:
+                keys.add(key)
+
+        return dict([(k, v) for k, v in iteritems(proposed_object) if k not in keys])

--- a/lib/ansible/modules/net_tools/nios/nios_zone.py
+++ b/lib/ansible/modules/net_tools/nios/nios_zone.py
@@ -134,7 +134,7 @@ def main():
     )
 
     ib_spec = dict(
-        fqdn=dict(required=True, aliases=['name'], ib_req=True),
+        fqdn=dict(required=True, aliases=['name'], ib_req=True, update=False),
         view=dict(default='default', aliases=['dns_view'], ib_req=True),
 
         grid_primary=dict(type='list', elements='dict', options=grid_spec),

--- a/test/units/module_utils/net_tools/nios/test_api.py
+++ b/test/units/module_utils/net_tools/nios/test_api.py
@@ -97,6 +97,32 @@ class TestNiosApi(unittest.TestCase):
         self.assertTrue(res['changed'])
         wapi.update_object.called_once_with(test_object)
 
+    def test_wapi_change_false(self):
+        self.module.params = {'provider': None, 'state': 'present', 'name': 'default',
+                              'comment': 'updated comment', 'extattrs': None, 'fqdn': 'foo'}
+
+        test_object = [
+            {
+                "comment": "test comment",
+                "_ref": "networkview/ZG5zLm5ldHdvcmtfdmlldyQw:default/true",
+                "name": "default",
+                "extattrs": {}
+            }
+        ]
+
+        test_spec = {
+            "name": {"ib_req": True},
+            "fqdn": {"ib_req": True, 'update': False},
+            "comment": {},
+            "extattrs": {}
+            }
+
+        wapi = self._get_wapi(test_object)
+        res = wapi.run('testobject', test_spec)
+
+        self.assertTrue(res['changed'])
+        wapi.update_object.called_once_with(test_object)
+
     def test_wapi_extattrs_change(self):
         self.module.params = {'provider': None, 'state': 'present', 'name': 'default',
                               'comment': 'test comment', 'extattrs': {'Site': 'update'}}

--- a/test/units/module_utils/net_tools/nios/test_api.py
+++ b/test/units/module_utils/net_tools/nios/test_api.py
@@ -115,7 +115,7 @@ class TestNiosApi(unittest.TestCase):
             "fqdn": {"ib_req": True, 'update': False},
             "comment": {},
             "extattrs": {}
-            }
+        }
 
         wapi = self._get_wapi(test_object)
         res = wapi.run('testobject', test_spec)


### PR DESCRIPTION
This change will allow the ib_spec entries to be be filtered on a change
object by setting the update keyword to false.  The default value for
update is true.  When the update keyword is set to false, the keyed
entry will be removed from the update object before it is sent to the
api endpoint.

fixes #36563

