### PR TITLE
fix cliconf get_config method to match base signature

### DIFF
--- a/lib/ansible/plugins/cliconf/aireos.py
+++ b/lib/ansible/plugins/cliconf/aireos.py
@@ -55,7 +55,7 @@ class Cliconf(CliconfBase):
         return device_info
 
     @enable_mode
-    def get_config(self, source='running'):
+    def get_config(self, source='running', format='text'):
         if source not in ('running', 'startup'):
             return self.invalid_params("fetching configuration from %s is not supported" % source)
         if source == 'running':

--- a/lib/ansible/plugins/cliconf/aruba.py
+++ b/lib/ansible/plugins/cliconf/aruba.py
@@ -56,7 +56,7 @@ class Cliconf(CliconfBase):
         return device_info
 
     @enable_mode
-    def get_config(self, source='running'):
+    def get_config(self, source='running', format='text'):
         if source not in ('running', 'startup'):
             return self.invalid_params("fetching configuration from %s is not supported" % source)
         if source == 'running':

--- a/lib/ansible/plugins/cliconf/asa.py
+++ b/lib/ansible/plugins/cliconf/asa.py
@@ -53,7 +53,7 @@ class Cliconf(CliconfBase):
         return device_info
 
     @enable_mode
-    def get_config(self, source='running'):
+    def get_config(self, source='running', format='text'):
         if source not in ('running', 'startup'):
             return self.invalid_params("fetching configuration from %s is not supported" % source)
         if source == 'running':

--- a/lib/ansible/plugins/cliconf/dellos10.py
+++ b/lib/ansible/plugins/cliconf/dellos10.py
@@ -57,7 +57,7 @@ class Cliconf(CliconfBase):
         return device_info
 
     @enable_mode
-    def get_config(self, source='running'):
+    def get_config(self, source='running', format='text'):
         if source not in ('running', 'startup'):
             return self.invalid_params("fetching configuration from %s is not supported" % source)
         if source == 'running':

--- a/lib/ansible/plugins/cliconf/dellos6.py
+++ b/lib/ansible/plugins/cliconf/dellos6.py
@@ -57,7 +57,7 @@ class Cliconf(CliconfBase):
         return device_info
 
     @enable_mode
-    def get_config(self, source='running'):
+    def get_config(self, source='running', format='text'):
         if source not in ('running', 'startup'):
             return self.invalid_params("fetching configuration from %s is not supported" % source)
 #        if source == 'running':

--- a/lib/ansible/plugins/cliconf/dellos9.py
+++ b/lib/ansible/plugins/cliconf/dellos9.py
@@ -57,7 +57,7 @@ class Cliconf(CliconfBase):
         return device_info
 
     @enable_mode
-    def get_config(self, source='running'):
+    def get_config(self, source='running', format='text'):
         if source not in ('running', 'startup'):
             return self.invalid_params("fetching configuration from %s is not supported" % source)
 #        if source == 'running':

--- a/lib/ansible/plugins/cliconf/edgeos.py
+++ b/lib/ansible/plugins/cliconf/edgeos.py
@@ -38,7 +38,7 @@ class Cliconf(CliconfBase):
 
         return device_info
 
-    def get_config(self):
+    def get_config(self, source='running', format='text'):
         return self.send_command(b'show configuration commands')
 
     def edit_config(self, command):

--- a/lib/ansible/plugins/cliconf/enos.py
+++ b/lib/ansible/plugins/cliconf/enos.py
@@ -58,7 +58,7 @@ class Cliconf(CliconfBase):
         return device_info
 
     @enable_mode
-    def get_config(self, source='running'):
+    def get_config(self, source='running', format='text'):
         if source not in ('running', 'startup'):
             msg = "fetching configuration from %s is not supported"
             return self.invalid_params(msg % source)

--- a/lib/ansible/plugins/cliconf/ios.py
+++ b/lib/ansible/plugins/cliconf/ios.py
@@ -53,7 +53,7 @@ class Cliconf(CliconfBase):
         return device_info
 
     @enable_mode
-    def get_config(self, source='running', flags=None):
+    def get_config(self, source='running', format='text', flags=None):
         if source not in ('running', 'startup'):
             return self.invalid_params("fetching configuration from %s is not supported" % source)
         if source == 'running':

--- a/lib/ansible/plugins/cliconf/iosxr.py
+++ b/lib/ansible/plugins/cliconf/iosxr.py
@@ -56,7 +56,7 @@ class Cliconf(CliconfBase):
 
         return device_info
 
-    def get_config(self, source='running', filter=None):
+    def get_config(self, source='running', format='text', filter=None):
         lookup = {'running': 'running-config'}
         if source not in lookup:
             return self.invalid_params("fetching configuration from %s is not supported" % source)

--- a/lib/ansible/plugins/cliconf/ironware.py
+++ b/lib/ansible/plugins/cliconf/ironware.py
@@ -49,7 +49,7 @@ class Cliconf(CliconfBase):
         return device_info
 
     @enable_mode
-    def get_config(self, source='running', flags=None):
+    def get_config(self, source='running', format='text', flags=None):
         if source not in ('running', 'startup'):
             return self.invalid_params("fetching configuration from %s is not supported" % source)
 

--- a/lib/ansible/plugins/cliconf/nxos.py
+++ b/lib/ansible/plugins/cliconf/nxos.py
@@ -50,11 +50,12 @@ class Cliconf(CliconfBase):
 
         return device_info
 
-    def get_config(self, source='running', flags=None):
+    def get_config(self, source='running', format='text', flags=None):
         lookup = {'running': 'running-config', 'startup': 'startup-config'}
 
         cmd = 'show {} '.format(lookup[source])
-        cmd += ' '.join(flags)
+        if flags:
+            cmd += ' '.join(flags)
         cmd = cmd.strip()
 
         return self.send_command(cmd)

--- a/lib/ansible/plugins/cliconf/onyx.py
+++ b/lib/ansible/plugins/cliconf/onyx.py
@@ -48,7 +48,7 @@ class Cliconf(CliconfBase):
         return device_info
 
     @enable_mode
-    def get_config(self, source='running'):
+    def get_config(self, source='running', format='text'):
         if source not in ('running',):
             return self.invalid_params("fetching configuration from %s is not supported" % source)
         cmd = b'show running-config'

--- a/lib/ansible/plugins/cliconf/vyos.py
+++ b/lib/ansible/plugins/cliconf/vyos.py
@@ -51,7 +51,7 @@ class Cliconf(CliconfBase):
 
         return device_info
 
-    def get_config(self):
+    def get_config(self, source='running', format='text'):
         return self.send_command(b'show configuration commands')
 
     def edit_config(self, command):


### PR DESCRIPTION
This commit fixes up the get_config method to match the minimum method
signature as defined by the base class.  Without this patch, the
get_config method calls will fail in some cirumstances.

