### PR TITLE
Add aws_caller_facts module and use it in setup-iam.yml

### DIFF
--- a/hacking/aws_config/setup-iam.yml
+++ b/hacking/aws_config/setup-iam.yml
@@ -25,13 +25,12 @@
       when: iam_group is not defined
 
     - name: Get aws account ID
-      command: aws sts get-caller-identity --output text --query 'Account' "{{ '--profile=' ~ profile if profile else '' }}"
-      changed_when: False
-      register: aws_account_command
+      aws_caller_facts:
+      register: aws_caller_facts
 
     - name: Set aws_account_fact
       set_fact:
-        aws_account: "{{ aws_account_command.stdout }}"
+        aws_account: "{{ aws_caller_facts.account }}"
 
 
     - name: Ensure Managed IAM policies exist

--- a/lib/ansible/modules/cloud/amazon/aws_caller_facts.py
+++ b/lib/ansible/modules/cloud/amazon/aws_caller_facts.py
@@ -1,0 +1,115 @@
+#!/usr/bin/python
+# Copyright (c) 2017 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: aws_caller_facts
+short_description: Get facts about the user and account being used to make AWS calls.
+description:
+    - This module returns information about the accont and user / role that the AWS access tokens are from.
+    - The primary use of this is to get the account id for templating into ARNs or similar to avoid needing to specify this information in inventory.
+version_added: "2.6"
+
+author: Ed Costello    (@orthanc)
+
+requirements: [ 'botocore', 'boto3' ]
+extends_documentation_fragment:
+    - aws
+    - ec2
+'''
+
+EXAMPLES = '''
+# Note: These examples do not set authentication details, see the AWS Guide for details.
+
+- name: Get the current caller identity facts
+  aws_caller_facts:
+  register: caller_facts
+'''
+
+RETURN = '''
+account:
+    description: The account id the access credentials are associated with.
+    returned: success
+    type: string
+    sample: "123456789012"
+arn:
+    description: The arn identifying the user the credentials are associated with.
+    returned: success
+    type: string
+    sample: arn:aws:sts::123456789012:federated-user/my-federated-user-name
+user_id:
+    description: |
+        The user id the access credentials are associated with. Note that this may not correspond to
+        anything you can look up in the case of roles or federated identities.
+    returned: success
+    type: string
+    sample: 123456789012:my-federated-user-name
+error:
+    description: The details of the error response from AWS.
+    returned: on client error from AWS
+    type: complex
+    sample: {
+        "code": "InvalidParameterValue",
+        "message": "Feedback notification topic is not set.",
+        "type": "Sender"
+    }
+    contains:
+        code:
+            description: The AWS error code.
+            type: string
+        message:
+            description: The AWS error message.
+            type: string
+        type:
+            description: The AWS error type.
+            type: string
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.ec2 import camel_dict_to_snake_dict, ec2_argument_spec, get_aws_connection_info, boto3_conn
+from ansible.module_utils.ec2 import HAS_BOTO3
+
+import traceback
+
+try:
+    from botocore.exceptions import BotoCoreError, ClientError
+except ImportError:
+    pass  # caught by imported HAS_BOTO3
+
+
+def main():
+    argument_spec = ec2_argument_spec()
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+    )
+
+    if not HAS_BOTO3:
+        module.fail_json(msg='boto3 required for this module')
+
+    region, ec2_url, aws_connect_params = get_aws_connection_info(module, boto3=True)
+
+    client = boto3_conn(module, conn_type='client', resource='sts', region=region, endpoint=ec2_url, **aws_connect_params)
+
+    try:
+        caller_identity = client.get_caller_identity()
+        module.exit_json(
+            changed=False,
+            **camel_dict_to_snake_dict(caller_identity)
+        )
+    except ClientError as e:
+        module.fail_json(msg=str(e), exception=traceback.format_exc(),
+                         **camel_dict_to_snake_dict(e.response))
+    except BotoCoreError as e:
+        module.fail_json(msg=str(e), exception=traceback.format_exc())
+
+
+if __name__ == '__main__':
+    main()

--- a/test/integration/targets/aws_caller_facts/aliases
+++ b/test/integration/targets/aws_caller_facts/aliases
@@ -1,0 +1,2 @@
+cloud/aws
+posix/ci/cloud/group4/aws

--- a/test/integration/targets/aws_caller_facts/tasks/main.yaml
+++ b/test/integration/targets/aws_caller_facts/tasks/main.yaml
@@ -1,18 +1,14 @@
----
-# ======test caller facts are returned==============
 - name: retrieve caller facts
   aws_caller_facts:
-    region: "{{ ec2_region }}"
-    aws_access_key: "{{ ec2_access_key }}"
-    aws_secret_key: "{{ ec2_secret_key }}"
+    region: "{{ aws_region }}"
+    aws_access_key: "{{ aws_access_key }}"
+    aws_secret_key: "{{ aws_secret_key }}"
     security_token: "{{security_token}}"
   register: result
-- name: assert account present
+
+- name: assert correct keys are returned
   assert:
-    that: result.account is not none
-- name: assert arn present
-  assert:
-    that: result.arn is not none
-- name: assert user_id present
-  assert:
-    that: result.user_id is not none
+    that:
+      - result.account is not none
+      - result.arn is not none
+      - result.user_id is not none

--- a/test/integration/targets/aws_caller_facts/tasks/main.yaml
+++ b/test/integration/targets/aws_caller_facts/tasks/main.yaml
@@ -1,0 +1,18 @@
+---
+# ======test caller facts are returned==============
+- name: retrieve caller facts
+  aws_caller_facts:
+    region: "{{ ec2_region }}"
+    aws_access_key: "{{ ec2_access_key }}"
+    aws_secret_key: "{{ ec2_secret_key }}"
+    security_token: "{{security_token}}"
+  register: result
+- name: assert account present
+  assert:
+    that: result.account is not none
+- name: assert arn present
+  assert:
+    that: result.arn is not none
+- name: assert user_id present
+  assert:
+    that: result.user_id is not none


### PR DESCRIPTION
##### SUMMARY
Introduce a new module aws_caller_facts that returns details about the user and account being used to make AWS calls.

This is primarily useful for getting the account ID so that it can be inserted into templates of IAM policies and other things that need full ARNs.

Specifically in this case I'm updating the `hacking/aws_config/setup-iam.yml` playbook to use it so as to remove the dependency on having the AWS command line tools installed.

##### ISSUE TYPE
 - New Module Pull Request

##### COMPONENT NAME
aws_caller_facts

##### ANSIBLE VERSION
```
ansible 2.6.0 (aws_caller_facts_module ee8565737c) last updated 2018/02/25 12:41:33 (GMT +1300)
  config file = None
  configured module search path = [u'USER_HOME/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = ANSIBLE_CHECKOUT/lib/ansible
  executable location = ANSIBLE_CHECKOUT/bin/ansible
  python version = 2.7.14 (default, Sep 23 2017, 22:06:14) [GCC 7.2.0]
```