### PR TITLE
zfs: fix broken parameter handling

### DIFF
--- a/lib/ansible/modules/storage/zfs/zfs.py
+++ b/lib/ansible/modules/storage/zfs/zfs.py
@@ -166,7 +166,7 @@ class Zfs(object):
                     cmd += ['-b', value]
                 else:
                     cmd += ['-o', '%s="%s"' % (prop, value)]
-        if origin:
+        if origin and action == 'clone':
             cmd.append(origin)
         cmd.append(self.name)
         (rc, out, err) = self.module.run_command(' '.join(cmd))
@@ -239,6 +239,9 @@ def main():
 
     state = module.params.get('state')
     name = module.params.get('name')
+
+    if module.params.get('origin') and '@' in name:
+        module.fail_json(msg='cannot specify origin when operating on a snapshot')
 
     # The following is deprecated.  Remove in Ansible 2.9
     # Get all valid zfs-properties


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
cc7a5228b02344658dac69c38ccb7d6580d2b4c6 included a typo (`extras_zfs_properties` instead of `extra_zfs_properties`) that broke the intended backwards compatibility for the zfs module. It was also incomplete, since the `origin` parameter wasn't marked as an actual parameter and was only processed by the deprecated code.

Once that was fixed I could address the issue originally raised on IRC, which is that when passed some invalid combinations of parameters  the module would execute an invalid command line instead of returning an error early.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
lib/ansible/modules/storage/zfs/zfs.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Original state:
```
changed: [localhost] => {
    "changed": true, 
    "invocation": {
        "module_args": {
            "createparent": null, 
            "extra_zfs_properties": {}, 
            "extras_zfs_properties": {
                "origin": "sherman/backup2"
            }, 
            "origin": "sherman/backup2"
        }
    }, 
    "name": "sherman/backup@test", 
    "state": "present"
}
```

After 8d20c0623fb7ecc727b55140fb397830e35a9c5e:
```
fatal: [localhost]: FAILED! => {
    "changed": false, 
    "invocation": {
        "module_args": {
            "createparent": null, 
            "extra_zfs_properties": {}, 
            "name": "sherman/backup@test", 
            "origin": "sherman/backup2", 
            "state": "present"
        }
    }, 
    "msg": "usage:\n\tsnapshot|snap [-r] [-o property=value] ... <filesystem|volume>@<snap> ...\n\nFor the property list, run: zfs set|get\n\nFor the delegated permission list, run: zfs allow|unallow\n"
}
```

Final state:
```
fatal: [localhost]: FAILED! => {
    "changed": false, 
    "invocation": {
        "module_args": {
            "createparent": null, 
            "extra_zfs_properties": {}, 
            "name": "sherman/backup@test", 
            "origin": "sherman/backup2", 
            "state": "present"
        }
    }, 
    "msg": "cannot specify origin when operating on a snapshot"
}
```