### PR TITLE
Backport #36685 for stable-2.5

### DIFF
--- a/lib/ansible/modules/storage/zfs/zfs.py
+++ b/lib/ansible/modules/storage/zfs/zfs.py
@@ -166,7 +166,7 @@ class Zfs(object):
                     cmd += ['-b', value]
                 else:
                     cmd += ['-o', '%s="%s"' % (prop, value)]
-        if origin:
+        if origin and action == 'clone':
             cmd.append(origin)
         cmd.append(self.name)
         (rc, out, err) = self.module.run_command(' '.join(cmd))
@@ -239,6 +239,9 @@ def main():
 
     state = module.params.get('state')
     name = module.params.get('name')
+
+    if module.params.get('origin') and '@' in name:
+        module.fail_json(msg='cannot specify origin when operating on a snapshot')
 
     # The following is deprecated.  Remove in Ansible 2.9
     # Get all valid zfs-properties


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Backport #36685 for stable-2.5

Ideally this would make it in before 2.5 final, so there's not a release that silently breaks backwards compatibility.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
lib/ansible/modules/storage/zfs/zfs.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
