### PR TITLE
Remove protocol restriction for SRV records in cloudflare_dns module. Fixes #36708

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Ansible Changes By Release
 See [Porting Guide](http://docs.ansible.com/ansible/devel/porting_guides/porting_guides.html) for more information
 
 ### Minor Changes
+* Removed restriction from protocol in cloudflare_dns module to allow other protocols than tcp and udp to be specified.
 
 #### Removed modules (previously deprecated)
 

--- a/lib/ansible/modules/net_tools/cloudflare_dns.py
+++ b/lib/ansible/modules/net_tools/cloudflare_dns.py
@@ -42,9 +42,8 @@ options:
     required: false
     default: "1"
   proto:
-    description: Service protocol. Required for C(type=SRV)
+    description: Service protocol. Required for C(type=SRV). Common values are tcp and udp. (Before Ansible 2.6 only tcp and udp were available).
     required: false
-    choices: [ 'tcp', 'udp' ]
     default: null
   proxied:
     description: Proxy through cloudflare network or just use DNS
@@ -602,7 +601,7 @@ def main():
             account_email=dict(required=True, type='str'),
             port=dict(required=False, default=None, type='int'),
             priority=dict(required=False, default=1, type='int'),
-            proto=dict(required=False, default=None, choices=['tcp', 'udp'], type='str'),
+            proto=dict(required=False, default=None, type='str'),
             proxied=dict(required=False, default=False, type='bool'),
             record=dict(required=False, default='@', aliases=['name'], type='str'),
             service=dict(required=False, default=None, type='str'),


### PR DESCRIPTION
##### SUMMARY
Remove protocol restriction for SRV records in cloudflare_dns module. Fixes #36708

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
cloudflare_dns

##### ANSIBLE VERSION
```
ansible 2.4.3.0
  python version = 2.7.14 (default, Feb 17 2018, 10:42:17) [GCC 7.3.1 20180130 (Red Hat 7.3.1-2)]

```
