### PR TITLE
Included documentation related with parameters wait and wait_timeout. By default enabled wait.

### DIFF
--- a/lib/ansible/modules/cloud/amazon/elb_target_group.py
+++ b/lib/ansible/modules/cloud/amazon/elb_target_group.py
@@ -130,6 +130,19 @@ options:
     description:
       - The identifier of the virtual private cloud (VPC). Required when I(state) is C(present).
     required: false
+  wait:
+    description:
+      - Indicates if the module has to wait to the target group to be created.
+    required: false
+    default: yes
+    choices: [ 'yes', 'no' ]
+    version_added: 2.6
+  wait_timeout:
+    description:
+      - If wait is enable, the time to wait to the target group to be created.
+    required: false
+    default: 60
+    version_added: 2.6
 extends_documentation_fragment:
     - aws
     - ec2
@@ -685,8 +698,8 @@ def main():
             targets=dict(type='list'),
             unhealthy_threshold_count=dict(type='int'),
             vpc_id=dict(type='str'),
-            wait_timeout=dict(type='int'),
-            wait=dict(type='bool')
+            wait_timeout=dict(default=60, type='int'),
+            wait=dict(default=True, type='bool')
         )
     )
 


### PR DESCRIPTION
Included documentation related with parameters wait and wait_timeout. By default enabled wait.

##### SUMMARY
Added descriptions for parameters _wait_ and _wait_timeout_ in module elb_target_group. Also I changed the default behaviour to explicitly enable it by default, because at least in my deployments this is a point of failure when I am creating the target group (not updating).

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
elb_target_group

##### ANSIBLE VERSION
```
ansible 2.6.0 (feature/elb_target_group_doc_wait f12eaf3342) last updated 2018/02/26 09:39:06 (GMT +200)
  config file = None
  configured module search path = [u'/Users/jcortejoso/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/jcortejoso/Projects/Public/ansible/lib/ansible
  executable location = /Users/jcortejoso/Projects/Public/ansible/bin/ansible
  python version = 2.7.14 (default, Jan 22 2018, 10:11:22) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```