### PR TITLE
timezone module: fixed timezone identification logic in *BSD

### DIFF
--- a/lib/ansible/modules/system/timezone.py
+++ b/lib/ansible/modules/system/timezone.py
@@ -69,6 +69,7 @@ EXAMPLES = '''
 '''
 
 import errno
+import filecmp
 import os
 import platform
 import random
@@ -581,15 +582,59 @@ class BSDTimezone(Timezone):
     def __init__(self, module):
         super(BSDTimezone, self).__init__(module)
 
+    def __get_timezone(self):
+        zoneinfo_dir = '/usr/share/zoneinfo/'
+        localtime_file = '/etc/localtime'
+
+        # Strategy 1:
+        #   If /etc/localtime does not exist, assum the timezone is UTC.
+        if not os.path.exists(localtime_file):
+            self.module.warn('Could not read /etc/localtime. Assuming UTC.')
+            return 'UTC'
+
+        # Strategy 2:
+        #   Return planned timezone as current timezone if their content matches.
+        #   This is bad design to see `self.value` here,
+        #   but it's intended to avoid useless diff.
+        planned = self.value['name']['planned']
+        try:
+            already_planned_state = filecmp.cmp(os.path.join(zoneinfo_dir, planned), localtime_file)
+        except OSError:
+            # Even if reading planned zoneinfo file gives an OSError, don't abort here,
+            # because a bit more detailed check will be done in `set`.
+            already_planned_state = False
+        if already_planned_state:
+            return planned
+
+        # Strategy 3:
+        #   Follow symlink of /etc/localtime
+        zoneinfo_file = localtime_file
+        while not zoneinfo_file.startswith(zoneinfo_dir):
+            try:
+                zoneinfo_file = os.readlink(localtime_file)
+            except OSError:
+                # OSError means "end of symlink chain" or broken link.
+                break
+        else:
+            return zoneinfo_file.replace(zoneinfo_dir, '')
+
+        # Strategy 4:
+        #   Check all files in /usr/share/zoneinfo and return first match.
+        for dname, _, fnames in os.walk(zoneinfo_dir):
+            for fname in fnames:
+                zoneinfo_file = os.path.join(dname, fname)
+                if filecmp.cmp(zoneinfo_file, localtime_file):
+                    return zoneinfo_file.replace(zoneinfo_dir, '')
+
+        # Strategy 5:
+        #   As a fall-back, return 'UTC' as default assumption.
+        self.module.warn('Could not identify timezone name from /etc/localtime. Assuming UTC.')
+        return 'UTC'
+
     def get(self, key, phase):
         """Lookup the current timezone by resolving `/etc/localtime`."""
         if key == 'name':
-            try:
-                tz = os.readlink('/etc/localtime')
-                return tz.replace('/usr/share/zoneinfo/', '')
-            except:
-                self.module.warn('Could not read /etc/localtime. Assuming UTC')
-                return 'UTC'
+            return self.__get_timezone()
         else:
             self.module.fail_json(msg='%s is not a supported option on target platform' % key)
 


### PR DESCRIPTION
##### SUMMARY

#32048 reports the timezone module fails in *BSD environment, if `/etc/localtime` is copied from `/usr/share/timezone` rather than symlinked.

This is because our previous logic use symlink info to decide timezone name.

I modified this logic to utilize more "content-based" comparison.

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

- timezone module

##### ANSIBLE VERSION

```
ansible 2.6.0 (timezone#32048 9f4ebbc25d) last updated 2018/02/26 17:36:07 (GMT +900)
  config file = None
  configured module search path = [u'/Users/xxxxx/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/xxxxx/Documents/dev/oss/ansible/lib/ansible
  executable location = ./bin/ansible
  python version = 2.7.12 |Anaconda custom (x86_64)| (default, Jul  2 2016, 17:43:17) [GCC 4.2.1 (Based on Apple Inc. build 5658) (LLVM build 2336.11.00)]
```
