### PR TITLE
timezone module: allow suse linux as target

### DIFF
--- a/lib/ansible/modules/system/timezone.py
+++ b/lib/ansible/modules/system/timezone.py
@@ -356,9 +356,8 @@ class NosystemdTimezone(Timezone):
             # The key for timezone might be `ZONE` or `TIMEZONE`
             # (the former is used in RHEL/CentOS and the latter is used in SUSE linux).
             # So check the content of /etc/sysconfig/clock and decide which key to use.
-            file = open(self.conf_files['name'], mode='r')
-            sysconfig_clock = file.read()
-            file.close()
+            with open(self.conf_files['name'], mode='r') as f:
+                sysconfig_clock = f.read()
             if re.search(r'^TIMEZONE\s*=', sysconfig_clock, re.MULTILINE):
                 # For SUSE
                 self.regexps['name'] = re.compile(r'^TIMEZONE\s*=\s*"?([^"\s]+)"?', re.MULTILINE)

--- a/lib/ansible/modules/system/timezone.py
+++ b/lib/ansible/modules/system/timezone.py
@@ -344,7 +344,7 @@ class NosystemdTimezone(Timezone):
             self.regexps['name'] = re.compile(r'^([^\s]+)', re.MULTILINE)
             self.tzline_format = '%s\n'
         else:
-            # RHEL/CentOS
+            # RHEL/CentOS/SUSE
             if self.module.get_bin_path('tzdata-update') is not None:
                 self.update_timezone = [self.module.get_bin_path('tzdata-update', required=True)]
                 self.allow_no_file['name'] = True
@@ -353,8 +353,20 @@ class NosystemdTimezone(Timezone):
             #   self.allow_no_file['name'] = False <- this is default behavior
             self.conf_files['name'] = '/etc/sysconfig/clock'
             self.conf_files['hwclock'] = '/etc/sysconfig/clock'
-            self.regexps['name'] = re.compile(r'^ZONE\s*=\s*"?([^"\s]+)"?', re.MULTILINE)
-            self.tzline_format = 'ZONE="%s"\n'
+            # The key for timezone might be `ZONE` or `TIMEZONE`
+            # (the former is used in RHEL/CentOS and the latter is used in SUSE linux).
+            # So check the content of /etc/sysconfig/clock and decide which key to use.
+            file = open(self.conf_files['name'], mode='r')
+            sysconfig_clock = file.read()
+            file.close()
+            if re.search(r'^TIMEZONE\s*=', sysconfig_clock, re.MULTILINE):
+                # For SUSE
+                self.regexps['name'] = re.compile(r'^TIMEZONE\s*=\s*"?([^"\s]+)"?', re.MULTILINE)
+                self.tzline_format = 'TIMEZONE="%s"\n'
+            else:
+                # For RHEL/CentOS
+                self.regexps['name'] = re.compile(r'^ZONE\s*=\s*"?([^"\s]+)"?', re.MULTILINE)
+                self.tzline_format = 'ZONE="%s"\n'
 
     def _allow_ioerror(self, err, key):
         # In some cases, even if the target file does not exist,


### PR DESCRIPTION
##### SUMMARY

SUSE Linux uses `/etc/sysconfig/clock` for timezone config like CentOS do, but it's format is differnt: the key is `TIMEZONE` rather than `ZONE`.

To make this module work for SUSE, I added a `if` statement to decide appropriate key.

Note: this is reported in and will fixes #36237

Oh, and actually pointed out in my very original pull request too...!
https://github.com/ansible/ansible-modules-extras/pull/2414#issuecomment-227114655

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

- timezone module

##### ANSIBLE VERSION

```
ansible 2.6.0 (timezone#32048 9f4ebbc25d) last updated 2018/02/26 17:36:07 (GMT +900)
  config file = None
  configured module search path = [u'/Users/xxxxx/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/xxxxx/Documents/dev/oss/ansible/lib/ansible
  executable location = ./bin/ansible
  python version = 2.7.12 |Anaconda custom (x86_64)| (default, Jul  2 2016, 17:43:17) [GCC 4.2.1 (Based on Apple Inc. build 5658) (LLVM build 2336.11.00)]
```