### PR TITLE
docs: Workaround for non-string values

### DIFF
--- a/docs/bin/plugin_formatter.py
+++ b/docs/bin/plugin_formatter.py
@@ -48,7 +48,7 @@ from jinja2 import Environment, FileSystemLoader
 from six import iteritems, string_types
 
 from ansible.errors import AnsibleError
-from ansible.module_utils._text import to_bytes
+from ansible.module_utils._text import to_bytes, to_text
 from ansible.plugins.loader import fragment_loader
 from ansible.utils import plugin_docs
 from ansible.utils.display import Display
@@ -100,6 +100,9 @@ def rst_ify(text):
 
 def html_ify(text):
     ''' convert symbols like I(this is in italics) to valid HTML '''
+
+    if not isinstance(text, string_types):
+        text = to_text(text)
 
     t = html_escape(text)
     t = _ITALIC.sub(r"<em>\1</em>", t)

--- a/docs/templates/plugin.rst.j2
+++ b/docs/templates/plugin.rst.j2
@@ -116,7 +116,7 @@ Options
                 {# required #}
                 <td><div class="cell-border">{% if value.get('required', False) %}required{% endif %}</div></td>
                 {# default value #}
-                <td><div class="cell-border">{% if value.default is string %}@{ value.default | html_ify }@{% else %}@{ value.default }@{% endif %}</div></td>
+                <td><div class="cell-border">{% if value.default %}@{ value.default | html_ify }@{% endif %}</div></td>
                 {# choices #}
                 <td>
                     <div class="cell-border">

--- a/docs/templates/plugin.rst.j2
+++ b/docs/templates/plugin.rst.j2
@@ -116,7 +116,7 @@ Options
                 {# required #}
                 <td><div class="cell-border">{% if value.get('required', False) %}required{% endif %}</div></td>
                 {# default value #}
-                <td><div class="cell-border">{% if value.default %}@{ value.default | html_ify }@{% endif %}</div></td>
+                <td><div class="cell-border">{% if value.default is string %}@{ value.default | html_ify }@{% else %}@{ value.default }@{% endif %}</div></td>
                 {# choices #}
                 <td>
                     <div class="cell-border">


### PR DESCRIPTION
##### SUMMARY
So first implementation was to only call **html_ify** when the value was a string. New implementation makes **html_ify** convert value to a string.

##### ISSUE TYPE
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
webdocs

##### ANSIBLE VERSION
v2.5