### PR TITLE
Fix documentation table display width

### DIFF
--- a/docs/docsite/_themes/srtd/static/css/theme.css
+++ b/docs/docsite/_themes/srtd/static/css/theme.css
@@ -4916,6 +4916,8 @@ table {
 .documentation-table {
     border-right: 1px solid #000;
     border-bottom: 1px solid #000;
+    width: 100%;
+    display: table;
 }
 
 .caption {


### PR DESCRIPTION
##### SUMMARY
Fix the table style of the module documentation parameter and return tables
##### ISSUE TYPE - Docs Pull Request

##### COMPONENT NAME
module documentation
##### ANSIBLE VERSION
```
2.5
```


##### ADDITIONAL INFORMATION
For some documentation return or parameter tables, the options will look like this:
![image](https://user-images.githubusercontent.com/3900374/36671043-91bde1de-1afa-11e8-9591-f2a176681347.png)
This is caused by a display:block in the theme css. This change will update this for the documentation tables and set it back to display:table, so it looks right:
![image](https://user-images.githubusercontent.com/3900374/36671085-bd4c29e6-1afa-11e8-8f6b-635a9d08959f.png)

```

```
