### PR TITLE
[2.5] cs_sshkeypair: fix ssh key rename (#36726)

### DIFF
--- a/lib/ansible/modules/cloud/cloudstack/cs_sshkeypair.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_sshkeypair.py
@@ -169,7 +169,7 @@ class AnsibleCloudStackSshKey(AnsibleCloudStack):
                     # We need to make another lookup if there is a key with identical name.
                     self.ssh_key = None
                     ssh_key = self.get_ssh_key()
-                    if ssh_key['fingerprint'] != fingerprint:
+                    if ssh_key and ssh_key['fingerprint'] != fingerprint:
                         args['name'] = name
                         self.query_api('deleteSSHKeyPair', **args)
 

--- a/test/integration/targets/cs_sshkeypair/tasks/main.yml
+++ b/test/integration/targets/cs_sshkeypair/tasks/main.yml
@@ -1,9 +1,17 @@
 ---
 - name: setup cleanup
-  cs_sshkeypair: name=first-sshkey state=absent
-
-- name: setup cleanup
-  cs_sshkeypair: name=second-sshkey state=absent
+  cs_sshkeypair:
+    name: "{{ item }}"
+    state: absent
+  register: sshkey
+  with_items:
+    - first-sshkey
+    - first-sshkey-renamed
+    - second-sshkey
+- name: verify setup cleanup
+  assert:
+    that:
+    - sshkey is success
 
 - name: test fail on missing name
   action: cs_sshkeypair
@@ -17,7 +25,7 @@
 
 - name: test ssh key creation in check mode
   cs_sshkeypair:
-    name: "first-sshkey"
+    name: first-sshkey
   register: sshkey
   check_mode: true
 - name: verify results of ssh key creation in check mode
@@ -28,7 +36,7 @@
 
 - name: test ssh key creation
   cs_sshkeypair:
-    name: "first-sshkey"
+    name: first-sshkey
   register: sshkey
 - name: verify results of ssh key creation
   assert:
@@ -41,7 +49,7 @@
 
 - name: test ssh key creation idempotence
   cs_sshkeypair:
-    name: "first-sshkey"
+    name: first-sshkey
   register: sshkey2
 - name: verify results of ssh key creation idempotence
   assert:
@@ -54,7 +62,7 @@
 
 - name: test replace ssh public key in check mode
   cs_sshkeypair:
-    name: "first-sshkey"
+    name: first-sshkey
     public_key: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDsTI7KJZ8tz/CwQIrSol41c6s3vzkGYCMI8o7P9Et48UG9eRoGaMaGYaTvBTj/VQrD7cfurI6Bn0HTT3FLK3OHOweyelm9rIiQ2hjkSl+2lIKWHu992GO58E5Gcy9yYW4sHGgGLNZkPBKrrj0w7lhmiHjPtVnf+2+7Ix1WOO2/HXPcAHhsX/AlyItDewIL4mr/BT83vq0202sPCiM2cFQJl+5WGwS1wYYK8d167cspsmdyX7OyAFCUB0vueuqjE8MFqJvyIJR9y8Lj9Ny71pSV5/QWrXUgELxMYOKSby3gHkxcIXgYBMFLl4DipRTO74OWQlRRaOlqXlOOQbikcY4T rene.moser@swisstxt.ch"
   register: sshkey2
   check_mode: true
@@ -69,13 +77,12 @@
 
 - name: test replace ssh public key
   cs_sshkeypair:
-    name: "first-sshkey"
+    name: first-sshkey
     public_key: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDsTI7KJZ8tz/CwQIrSol41c6s3vzkGYCMI8o7P9Et48UG9eRoGaMaGYaTvBTj/VQrD7cfurI6Bn0HTT3FLK3OHOweyelm9rIiQ2hjkSl+2lIKWHu992GO58E5Gcy9yYW4sHGgGLNZkPBKrrj0w7lhmiHjPtVnf+2+7Ix1WOO2/HXPcAHhsX/AlyItDewIL4mr/BT83vq0202sPCiM2cFQJl+5WGwS1wYYK8d167cspsmdyX7OyAFCUB0vueuqjE8MFqJvyIJR9y8Lj9Ny71pSV5/QWrXUgELxMYOKSby3gHkxcIXgYBMFLl4DipRTO74OWQlRRaOlqXlOOQbikcY4T rene.moser@swisstxt.ch"
   register: sshkey3
 - name: verify results of replace ssh public key
   assert:
     that:
-    - sshkey3 is successful
     - sshkey3 is changed
     - sshkey3.fingerprint is defined and sshkey3.fingerprint != sshkey2.fingerprint
     - sshkey3.private_key is not defined
@@ -83,31 +90,69 @@
 
 - name: test replace ssh public key idempotence
   cs_sshkeypair:
-    name: "first-sshkey"
+    name: first-sshkey
     public_key: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDsTI7KJZ8tz/CwQIrSol41c6s3vzkGYCMI8o7P9Et48UG9eRoGaMaGYaTvBTj/VQrD7cfurI6Bn0HTT3FLK3OHOweyelm9rIiQ2hjkSl+2lIKWHu992GO58E5Gcy9yYW4sHGgGLNZkPBKrrj0w7lhmiHjPtVnf+2+7Ix1WOO2/HXPcAHhsX/AlyItDewIL4mr/BT83vq0202sPCiM2cFQJl+5WGwS1wYYK8d167cspsmdyX7OyAFCUB0vueuqjE8MFqJvyIJR9y8Lj9Ny71pSV5/QWrXUgELxMYOKSby3gHkxcIXgYBMFLl4DipRTO74OWQlRRaOlqXlOOQbikcY4T rene.moser@swisstxt.ch"
   register: sshkey4
 - name: verify results of ssh public key idempotence
   assert:
     that:
-    - sshkey4 is successful
     - sshkey4 is not changed
     - sshkey4.fingerprint is defined and sshkey4.fingerprint == sshkey3.fingerprint
     - sshkey4.private_key is not defined
     - sshkey4.name == "first-sshkey"
 
-- name: setup ssh key with name "second-sshke"
+- name: test rename ssh key in check mode
   cs_sshkeypair:
-    name: "second-sshkey"
+    name: first-sshkey-renamed
+    public_key: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDsTI7KJZ8tz/CwQIrSol41c6s3vzkGYCMI8o7P9Et48UG9eRoGaMaGYaTvBTj/VQrD7cfurI6Bn0HTT3FLK3OHOweyelm9rIiQ2hjkSl+2lIKWHu992GO58E5Gcy9yYW4sHGgGLNZkPBKrrj0w7lhmiHjPtVnf+2+7Ix1WOO2/HXPcAHhsX/AlyItDewIL4mr/BT83vq0202sPCiM2cFQJl+5WGwS1wYYK8d167cspsmdyX7OyAFCUB0vueuqjE8MFqJvyIJR9y8Lj9Ny71pSV5/QWrXUgELxMYOKSby3gHkxcIXgYBMFLl4DipRTO74OWQlRRaOlqXlOOQbikcY4T rene.moser@swisstxt.ch"
+  register: sshkey4
+  check_mode: true
+- name: verify test rename ssh key in check mode
+  assert:
+    that:
+    - sshkey4 is changed
+    - sshkey4.fingerprint is defined and sshkey4.fingerprint == sshkey3.fingerprint
+    - sshkey4.private_key is not defined
+    - sshkey4.name == "first-sshkey"
+
+- name: test rename ssh key
+  cs_sshkeypair:
+    name: first-sshkey-renamed
+    public_key: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDsTI7KJZ8tz/CwQIrSol41c6s3vzkGYCMI8o7P9Et48UG9eRoGaMaGYaTvBTj/VQrD7cfurI6Bn0HTT3FLK3OHOweyelm9rIiQ2hjkSl+2lIKWHu992GO58E5Gcy9yYW4sHGgGLNZkPBKrrj0w7lhmiHjPtVnf+2+7Ix1WOO2/HXPcAHhsX/AlyItDewIL4mr/BT83vq0202sPCiM2cFQJl+5WGwS1wYYK8d167cspsmdyX7OyAFCUB0vueuqjE8MFqJvyIJR9y8Lj9Ny71pSV5/QWrXUgELxMYOKSby3gHkxcIXgYBMFLl4DipRTO74OWQlRRaOlqXlOOQbikcY4T rene.moser@swisstxt.ch"
+  register: sshkey4
+- name: verify test rename ssh key
+  assert:
+    that:
+    - sshkey4 is changed
+    - sshkey4.fingerprint is defined and sshkey4.fingerprint == sshkey3.fingerprint
+    - sshkey4.private_key is not defined
+    - sshkey4.name == "first-sshkey-renamed"
+
+- name: test rename ssh key idempotence
+  cs_sshkeypair:
+    name: first-sshkey-renamed
+    public_key: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDsTI7KJZ8tz/CwQIrSol41c6s3vzkGYCMI8o7P9Et48UG9eRoGaMaGYaTvBTj/VQrD7cfurI6Bn0HTT3FLK3OHOweyelm9rIiQ2hjkSl+2lIKWHu992GO58E5Gcy9yYW4sHGgGLNZkPBKrrj0w7lhmiHjPtVnf+2+7Ix1WOO2/HXPcAHhsX/AlyItDewIL4mr/BT83vq0202sPCiM2cFQJl+5WGwS1wYYK8d167cspsmdyX7OyAFCUB0vueuqjE8MFqJvyIJR9y8Lj9Ny71pSV5/QWrXUgELxMYOKSby3gHkxcIXgYBMFLl4DipRTO74OWQlRRaOlqXlOOQbikcY4T rene.moser@swisstxt.ch"
+  register: sshkey4
+- name: verify test rename ssh key idempotence
+  assert:
+    that:
+    - sshkey4 is not changed
+    - sshkey4.fingerprint is defined and sshkey4.fingerprint == sshkey3.fingerprint
+    - sshkey4.private_key is not defined
+    - sshkey4.name == "first-sshkey-renamed"
+
+- name: setup ssh key with name "second-sshkey"
+  cs_sshkeypair:
+    name: second-sshkey
 
 - name: test different but exisitng name but same ssh public key as first-sshkey
   cs_sshkeypair:
-    name: "second-sshkey"
+    name: second-sshkey
     public_key: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDsTI7KJZ8tz/CwQIrSol41c6s3vzkGYCMI8o7P9Et48UG9eRoGaMaGYaTvBTj/VQrD7cfurI6Bn0HTT3FLK3OHOweyelm9rIiQ2hjkSl+2lIKWHu992GO58E5Gcy9yYW4sHGgGLNZkPBKrrj0w7lhmiHjPtVnf+2+7Ix1WOO2/HXPcAHhsX/AlyItDewIL4mr/BT83vq0202sPCiM2cFQJl+5WGwS1wYYK8d167cspsmdyX7OyAFCUB0vueuqjE8MFqJvyIJR9y8Lj9Ny71pSV5/QWrXUgELxMYOKSby3gHkxcIXgYBMFLl4DipRTO74OWQlRRaOlqXlOOQbikcY4T rene.moser@swisstxt.ch"
   register: sshkey
 - name: verify test different but exisitng name but same ssh public key as first-sshkey
   assert:
     that:
-    - sshkey is successful
     - sshkey is changed
     - sshkey.fingerprint is defined and sshkey.fingerprint == sshkey4.fingerprint
     - sshkey.private_key is not defined
@@ -120,31 +165,32 @@
 - name: verify result of key absent in check mode
   assert:
     that:
-    - sshkey5 is successful
     - sshkey5 is changed
     - sshkey5.fingerprint is defined and sshkey5.fingerprint == sshkey3.fingerprint
     - sshkey5.private_key is not defined
     - sshkey5.name == "second-sshkey"
 
 - name: test ssh key absent
-  cs_sshkeypair: name=second-sshkey state=absent
+  cs_sshkeypair:
+    name: second-sshkey
+    state: absent
   register: sshkey5
 - name: verify result of key absent
   assert:
     that:
-    - sshkey5 is successful
     - sshkey5 is changed
     - sshkey5.fingerprint is defined and sshkey5.fingerprint == sshkey3.fingerprint
     - sshkey5.private_key is not defined
     - sshkey5.name == "second-sshkey"
 
 - name: test ssh key absent idempotence
-  cs_sshkeypair: name=second-sshkey state=absent
+  cs_sshkeypair:
+    name: second-sshkey
+    state: absent
   register: sshkey6
 - name: verify result of ssh key absent idempotence
   assert:
     that:
-    - sshkey6 is successful
     - sshkey6 is not changed
     - sshkey6.fingerprint is not defined
     - sshkey6.private_key is not defined


### PR DESCRIPTION
* tests: cs_sshkeypair: add reproducer for failed key rename
* cs_sshkeypair: fix rename ssh key

(cherry picked from commit cdb2969703285524e2a53bc562ce81f666b4a90c)

##### SUMMARY
backport fix ssh key rename

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
cs_sshkeypair

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
