### PR TITLE
VMware: Re-enable VM poweroff testcases

### DIFF
--- a/test/integration/targets/vmware_guest/tasks/main.yml
+++ b/test/integration/targets/vmware_guest/tasks/main.yml
@@ -13,9 +13,8 @@
     vcsim: "{{ lookup('env', 'vcenter_host') }}"
 - debug: var=vcsim
 
-# Commenting following two is failing right now - 15 Dec 2017
-#- include: poweroff_d1_c1_f0.yml
-#- include: poweroff_d1_c1_f1.yml
+- include: poweroff_d1_c1_f0.yml
+- include: poweroff_d1_c1_f1.yml
 - include: check_mode.yml
 - include: clone_d1_c1_f0.yml
 - include: create_d1_c1_f0.yml

--- a/test/integration/targets/vmware_guest/tasks/poweroff_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/poweroff_d1_c1_f0.yml
@@ -48,4 +48,4 @@
 - name: make sure no changes were made
   assert:
     that:
-        - "poweroff_d1_c1_f0.results|map(attribute='changed')|unique|list == [True]"
+        - "poweroff_d1_c1_f0.results|map(attribute='changed')|unique|list == [False]"

--- a/test/integration/targets/vmware_guest/tasks/poweroff_d1_c1_f1.yml
+++ b/test/integration/targets/vmware_guest/tasks/poweroff_d1_c1_f1.yml
@@ -59,4 +59,4 @@
 - name: make sure no changes were made
   assert:
     that:
-        - "poweroff_d1_c1_f1.results|map(attribute='changed')|unique|list == [True]"
+        - "poweroff_d1_c1_f1.results|map(attribute='changed')|unique|list == [False]"


### PR DESCRIPTION

##### SUMMARY
The testcases were failing due to vcsim version. Re-enabling them.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
test/integration/targets/vmware_guest/tasks/main.yml test/integration/targets/vmware_guest/tasks/poweroff_d1_c1_f0.yml test/integration/targets/vmware_guest/tasks/poweroff_d1_c1_f1.yml

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6devel
```