### PR TITLE
Update Cisco NSO module required versions.

### DIFF
--- a/lib/ansible/module_utils/network/nso/nso.py
+++ b/lib/ansible/module_utils/network/nso/nso.py
@@ -555,10 +555,7 @@ def connect(params):
     return client
 
 
-def verify_version(client, required_versions=None):
-    if required_versions is None:
-        required_versions = [(4, 5), (4, 4, 3)]
-
+def verify_version(client, required_versions):
     version_str = client.get_system_setting('version')
     if not verify_version_str(version_str, required_versions):
         supported_versions = ', '.join(

--- a/lib/ansible/modules/network/nso/nso_action.py
+++ b/lib/ansible/modules/network/nso/nso_action.py
@@ -37,7 +37,7 @@ description:
   - This module provices support for executing Cisco NSO actions and then
     verifying that the output is as expected.
 requirements:
-  - Cisco NSO version 4.4.3 or higher.
+  - Cisco NSO version 3.4 or higher.
 author: "Claes Nästén (@cnasten)"
 options:
   path:
@@ -87,6 +87,10 @@ from ansible.module_utils.basic import AnsibleModule
 
 
 class NsoAction(object):
+    REQUIRED_VERSIONS = [
+        (3, 4)
+    ]
+
     def __init__(self, check_mode, client,
                  path, input,
                  output_required, output_invalid, validate_strict):
@@ -167,7 +171,7 @@ def main():
         p['output_invalid'],
         p['validate_strict'])
     try:
-        verify_version(client)
+        verify_version(client, NsoAction.REQUIRED_VERSIONS)
 
         output = nso_action.main()
         client.logout()

--- a/lib/ansible/modules/network/nso/nso_config.py
+++ b/lib/ansible/modules/network/nso/nso_config.py
@@ -37,7 +37,8 @@ description:
   - This module provides support for managing configuration in Cisco NSO and
     can also ensure services are in sync.
 requirements:
-  - Cisco NSO version 4.4.3 or higher.
+  - Cisco NSO version 3.4.12 or higher, 4.2.7 or higher,
+    4.3.8 or higher, 4.4.3 or higher, 4.5 or higher.
 author: "Claes Nästén (@cnasten)"
 options:
   data:
@@ -144,6 +145,14 @@ from ansible.module_utils.basic import AnsibleModule
 
 
 class NsoConfig(object):
+    REQUIRED_VERSIONS = [
+        (4, 5),
+        (4, 4, 3),
+        (4, 3, 8),
+        (4, 2, 7),
+        (3, 4, 12)
+    ]
+
     def __init__(self, check_mode, client, data):
         self._check_mode = check_mode
         self._client = client
@@ -257,7 +266,7 @@ def main():
     client = connect(p)
     nso_config = NsoConfig(module.check_mode, client, p['data'])
     try:
-        verify_version(client)
+        verify_version(client, NsoConfig.REQUIRED_VERSIONS)
 
         changes, diffs = nso_config.main()
         client.logout()

--- a/lib/ansible/modules/network/nso/nso_verify.py
+++ b/lib/ansible/modules/network/nso/nso_verify.py
@@ -37,7 +37,8 @@ description:
   - This module provides support for verifying Cisco NSO configuration is in
     compliance with specified values.
 requirements:
-  - Cisco NSO version 4.4.3 or higher.
+  - Cisco NSO version 3.4.12 or higher, 4.2.7 or higher,
+    4.3.8 or higher, 4.4.3 or higher, 4.5 or higher.
 author: "Claes Nästén (@cnasten)"
 options:
   data:
@@ -99,6 +100,14 @@ from ansible.module_utils.basic import AnsibleModule
 
 
 class NsoVerify(object):
+    REQUIRED_VERSIONS = [
+        (4, 5),
+        (4, 4, 3),
+        (4, 3, 8),
+        (4, 2, 7),
+        (3, 4, 12)
+    ]
+
     def __init__(self, client, data):
         self._client = client
         self._data = data
@@ -165,7 +174,7 @@ def main():
     client = connect(p)
     nso_verify = NsoVerify(client, p['data'])
     try:
-        verify_version(client)
+        verify_version(client, NsoVerify.REQUIRED_VERSIONS)
 
         violations = nso_verify.main()
         client.logout()

--- a/test/units/modules/network/nso/test_nso_config.py
+++ b/test/units/modules/network/nso/test_nso_config.py
@@ -32,11 +32,11 @@ class TestNsoConfig(nso_module.TestNsoModule):
 
     @patch('ansible.module_utils.network.nso.nso.open_url')
     def test_nso_config_invalid_version_short(self, open_url_mock):
-        self._test_invalid_version(open_url_mock, '4.4')
+        self._test_invalid_version(open_url_mock, '3.3')
 
     @patch('ansible.module_utils.network.nso.nso.open_url')
     def test_nso_config_invalid_version_long(self, open_url_mock):
-        self._test_invalid_version(open_url_mock, '4.4.2')
+        self._test_invalid_version(open_url_mock, '3.3.2')
 
     def _test_invalid_version(self, open_url_mock, version):
         calls = [


### PR DESCRIPTION
NSO modules will now work with older versions of NSO, update version
requirements.

##### SUMMARY
Older NSO versions have been updated with the required functionality for the Ansible NSO modules, update the list of required versions to match.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
nso_config

##### ANSIBLE VERSION
```
ansible 2.6.0 (nso_config_required_versions 9e8c1b48fc) last updated 2018/02/26 14:44:41 (GMT +200)
  config file = None
  configured module search path = [u'/home/cnasten/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/cnasten/dev/ansible/lib/ansible
  executable location = /home/cnasten/dev/ansible/bin/ansible
  python version = 2.7.14+ (default, Feb  6 2018, 19:12:18) [GCC 7.3.0]
```


##### ADDITIONAL INFORMATION
NA