### PR TITLE
label: docs

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -1074,9 +1074,7 @@ files:
     labels: docs
     notify: dharmabumstead
   docs/docsite/rst/network/:
-    labels:
-      - networking
-      - docs
+    labels: networking
     maintainers:
       - acozine
       - gundalow

--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -1071,10 +1071,12 @@ files:
     keywords:
     - validate-modules
   docs/:
-    labels: docs_pull_request
+    labels: docs
     notify: dharmabumstead
   docs/docsite/rst/network/:
-    labels: networking
+    labels:
+      - networking
+      - docs
     maintainers:
       - acozine
       - gundalow


### PR DESCRIPTION
##### SUMMARY
Don't use different labels for docs, that's what `is:pr` and `is:issue` is for.

Discussed and approved by @dharmabumstead 

Makes it easier to do `label:docs label:networking` to find all issues and PRs

##### ISSUE TYPE
 - Docs Pull Request

