### PR TITLE
Fix rst link syntax.

### DIFF
--- a/docs/docsite/rst/roadmap/ROADMAP_2_3.rst
+++ b/docs/docsite/rst/roadmap/ROADMAP_2_3.rst
@@ -145,7 +145,7 @@ Amazon
 Lead by ryansb
 
 - Improve ec2.py integration tests **(partial, more to do in 2.4)**
-- ELB version 2 **(pushed - needs_revision [PR](https://github.com/ansible/ansible/pull/19491))**
+- ELB version 2 **(pushed - needs_revision)** `PR <https://github.com/ansible/ansible/pull/19491>`_
 - CloudFormation YAML, cross-stack reference, and roles support **(done)**
 - ECS module refactor **(done)**
 - AWS module unit testing w/ placebo (boto3 only) **(pushed 2.4)**

--- a/docs/docsite/rst/scenario_guides/guide_azure.rst
+++ b/docs/docsite/rst/scenario_guides/guide_azure.rst
@@ -21,7 +21,7 @@ root directory of the Ansible repo.
 
     $ pip install .[azure]
 
-You can also directly run Ansible in [Azure Cloud Shell](https://shell.azure.com), where Ansible is pre-installed.  
+You can also directly run Ansible in `Azure Cloud Shell <https://shell.azure.com>`_, where Ansible is pre-installed.
 
 Authenticating with Azure
 -------------------------


### PR DESCRIPTION
##### SUMMARY

Fix rst link syntax.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

docs

##### ANSIBLE VERSION

```
ansible 2.6.0 (rst-syntax-fix f7310a34ea) last updated 2018/02/26 11:11:00 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```
