### PR TITLE
Fix lineinfile example

### DIFF
--- a/lib/ansible/modules/files/lineinfile.py
+++ b/lib/ansible/modules/files/lineinfile.py
@@ -150,11 +150,11 @@ EXAMPLES = r"""
     insertbefore: '^www.*80/tcp'
     line: '# port for http by default'
 
-# Add a line to a file if it does not exist, without passing regexp
+# Add a line to a file if the file does not exist, without passing regexp
 - lineinfile:
     path: /tmp/testfile
     line: '192.168.1.99 foo.lab.net foo'
-    create: true
+    create: yes
 
 # Fully quoted because of the ': ' on the line. See the Gotchas in the YAML docs.
 - lineinfile:

--- a/lib/ansible/modules/files/lineinfile.py
+++ b/lib/ansible/modules/files/lineinfile.py
@@ -154,6 +154,7 @@ EXAMPLES = r"""
 - lineinfile:
     path: /tmp/testfile
     line: '192.168.1.99 foo.lab.net foo'
+    create: true
 
 # Fully quoted because of the ': ' on the line. See the Gotchas in the YAML docs.
 - lineinfile:


### PR DESCRIPTION
##### SUMMARY
The examples comment said 'Add a line to a file if it does not exist, without passing regexp' which suggests, that the file is being created. But the default for 'create' is false. Thus the example lacked this option.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
lineinfile

##### ANSIBLE VERSION
2.4.3.0

##### ADDITIONAL INFORMATION
