### PR TITLE
win_wait_for: use loopback IP instead of hostname if 127.0.0.1 is used

### DIFF
--- a/lib/ansible/modules/windows/win_wait_for.ps1
+++ b/lib/ansible/modules/windows/win_wait_for.ps1
@@ -54,22 +54,9 @@ if ($port -ne $null) {
 }
 
 Function Test-Port($hostname, $port) {
-    if ($hostname -eq "127.0.0.1") {
-        # use the loopback IP if it has been specified
-        $resolve_hostname = $hostname
-    } else {
-        # try and resolve the IP/Host, if it fails then just use the host passed in
-        try {
-            $resolve_hostname = ([System.Net.Dns]::GetHostEntry($hostname)).HostName
-        } catch {
-            # oh well just use the IP addres
-            $resolve_hostname = $hostname
-        }
-    }
-
     $timeout = $connect_timeout * 1000
     $socket = New-Object -TypeName System.Net.Sockets.TcpClient
-    $connect = $socket.BeginConnect($resolve_hostname, $port, $null, $null)
+    $connect = $socket.BeginConnect($hostname, $port, $null, $null)
     $wait = $connect.AsyncWaitHandle.WaitOne($timeout, $false)
 
     if ($wait) {

--- a/lib/ansible/modules/windows/win_wait_for.ps1
+++ b/lib/ansible/modules/windows/win_wait_for.ps1
@@ -54,12 +54,17 @@ if ($port -ne $null) {
 }
 
 Function Test-Port($hostname, $port) {
-    # try and resolve the IP/Host, if it fails then just use the host passed in
-    try {
-        $resolve_hostname = ([System.Net.Dns]::GetHostEntry($hostname)).HostName
-    } catch {
-        # oh well just use the IP addres
+    if ($hostname -eq "127.0.0.1") {
+        # use the loopback IP if it has been specified
         $resolve_hostname = $hostname
+    } else {
+        # try and resolve the IP/Host, if it fails then just use the host passed in
+        try {
+            $resolve_hostname = ([System.Net.Dns]::GetHostEntry($hostname)).HostName
+        } catch {
+            # oh well just use the IP addres
+            $resolve_hostname = $hostname
+        }
     }
 
     $timeout = $connect_timeout * 1000


### PR DESCRIPTION
##### SUMMARY
Use the actual IP when checking if a port is active and the IP is `127.0.0.1` as it will check for locally listening ports. Still not 100% sure on the correct behaviour for this.

Fixes https://github.com/ansible/ansible/issues/35460

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
win_wait_for

##### ANSIBLE VERSION
```
2.5
```