### PR TITLE
Enforce required parameters for the various aws_s3 modes

### DIFF
--- a/lib/ansible/modules/cloud/amazon/aws_s3.py
+++ b/lib/ansible/modules/cloud/amazon/aws_s3.py
@@ -636,7 +636,10 @@ def main():
     module = AnsibleModule(
         argument_spec=argument_spec,
         supports_check_mode=True,
-        required_if=[('mode', 'put', ('src',))],
+        required_if=[['mode', 'put', ['src', 'object']],
+                     ['mode', 'get', ['dest', 'object']],
+                     ['mode', 'getstr', ['object']],
+                     ['mode', 'geturl', ['object']]],
     )
 
     if module._name == 's3':


### PR DESCRIPTION
##### SUMMARY

Most modes require `object` parameter, and this is easy to
get wrong (e.g. through confusion with the `dest` parameter). As
it's as easy to enforce, let's do that.


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
aws_s3

##### ANSIBLE VERSION
```
ansible 2.6.0 (devel e15a903bdf) last updated 2018/02/27 12:23:02 (GMT +1000)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/will/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/will/src/ansible/lib/ansible
  executable location = /home/will/src/ansible/bin/ansible
  python version = 2.7.14 (default, Jan 17 2018, 14:28:32) [GCC 7.2.1 20170915 (Red Hat 7.2.1-2)]
```

##### ADDITIONAL INFORMATION
No tests - as long as existing tests pass, I'm confident with this change (we don't need to check that Ansible does a good job of enforcing missing parameters here, I'd hope that's well tested elsewhere!)