### PR TITLE
VMware: Fix regression in get_all_host_objs

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_vmkernel.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_vmkernel.py
@@ -189,7 +189,13 @@ class PyVmomiHelper(PyVmomi):
         self.vlan_id = self.params['vlan_id']
 
         self.esxi_host_name = self.params['esxi_hostname']
-        self.esxi_host_obj = self.get_all_host_objs(esxi_host_name=self.esxi_host_name)[0]
+
+        hosts = self.get_all_host_objs(esxi_host_name=self.esxi_host_name)
+        if hosts:
+            self.esxi_host_obj = hosts[0]
+        else:
+            self.module.fail_json("Failed to get details of ESXi server."
+                                  " Please specify esxi_hostname.")
 
         self.port_group_obj = self.get_port_group_by_name(host_system=self.esxi_host_obj, portgroup_name=self.port_group_name)
         if not self.port_group_obj:


### PR DESCRIPTION
##### SUMMARY
If user does not specify esxi_hostname then module
fails to detect ESXi hostsystem from given configuration.
This fixes the regression in get_all_host_objs API by
getting first host managed object from list.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
lib/ansible/modules/cloud/vmware/vmware_vmkernel.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6devel
```