### PR TITLE
Pass code-smell paths on stdin.

### DIFF
--- a/test/runner/lib/sanity/__init__.py
+++ b/test/runner/lib/sanity/__init__.py
@@ -224,6 +224,7 @@ class SanityCodeSmellTest(SanityTest):
         env = ansible_environment(args, color=False)
 
         pattern = None
+        data = None
 
         if self.config:
             with open(self.config, 'r') as config_fd:
@@ -251,10 +252,11 @@ class SanityCodeSmellTest(SanityTest):
             if not paths:
                 return SanitySkipped(self.name)
 
-            cmd += paths
+            data = '\n'.join(paths)
 
+            display.info(data, verbosity=4)
         try:
-            stdout, stderr = run_command(args, cmd, env=env, capture=True)
+            stdout, stderr = run_command(args, cmd, data=data, env=env, capture=True)
             status = 0
         except SubprocessError as ex:
             stdout = ex.stdout

--- a/test/sanity/code-smell/boilerplate.py
+++ b/test/sanity/code-smell/boilerplate.py
@@ -34,7 +34,7 @@ def main():
         'test/'
     ]
 
-    for path in sys.argv[1:]:
+    for path in sys.argv[1:] or sys.stdin.read().splitlines():
         if path in skip:
             continue
 

--- a/test/sanity/code-smell/empty-init.py
+++ b/test/sanity/code-smell/empty-init.py
@@ -15,7 +15,7 @@ def main():
         'lib/ansible/module_utils/six/__init__.py',
     ])
 
-    for path in sys.argv[1:]:
+    for path in sys.argv[1:] or sys.stdin.read().splitlines():
         if path in skip:
             continue
 

--- a/test/sanity/code-smell/no-assert.py
+++ b/test/sanity/code-smell/no-assert.py
@@ -10,7 +10,7 @@ ASSERT_RE = re.compile(r'.*(?<![-:a-zA-Z#][ -])\bassert\b(?!:).*')
 def main():
     failed = False
 
-    for path in sys.argv[1:]:
+    for path in sys.argv[1:] or sys.stdin.read().splitlines():
         with open(path, 'r') as f:
             for i, line in enumerate(f.readlines()):
                 matches = ASSERT_RE.findall(line)

--- a/test/sanity/code-smell/no-basestring.py
+++ b/test/sanity/code-smell/no-basestring.py
@@ -11,7 +11,7 @@ def main():
         'lib/ansible/module_utils/six/__init__.py',
     ])
 
-    for path in sys.argv[1:]:
+    for path in sys.argv[1:] or sys.stdin.read().splitlines():
         if path in skip:
             continue
 

--- a/test/sanity/code-smell/no-dict-iteritems.py
+++ b/test/sanity/code-smell/no-dict-iteritems.py
@@ -11,7 +11,7 @@ def main():
         'lib/ansible/module_utils/six/__init__.py',
     ])
 
-    for path in sys.argv[1:]:
+    for path in sys.argv[1:] or sys.stdin.read().splitlines():
         if path in skip:
             continue
 

--- a/test/sanity/code-smell/no-dict-iterkeys.py
+++ b/test/sanity/code-smell/no-dict-iterkeys.py
@@ -11,7 +11,7 @@ def main():
         'lib/ansible/module_utils/six/__init__.py',
     ])
 
-    for path in sys.argv[1:]:
+    for path in sys.argv[1:] or sys.stdin.read().splitlines():
         if path in skip:
             continue
 

--- a/test/sanity/code-smell/no-dict-itervalues.py
+++ b/test/sanity/code-smell/no-dict-itervalues.py
@@ -11,7 +11,7 @@ def main():
         'lib/ansible/module_utils/six/__init__.py',
     ])
 
-    for path in sys.argv[1:]:
+    for path in sys.argv[1:] or sys.stdin.read().splitlines():
         if path in skip:
             continue
 

--- a/test/sanity/code-smell/no-get-exception.py
+++ b/test/sanity/code-smell/no-get-exception.py
@@ -20,7 +20,7 @@ def main():
 
     basic_allow_once = True
 
-    for path in sys.argv[1:]:
+    for path in sys.argv[1:] or sys.stdin.read().splitlines():
         if path in skip:
             continue
 

--- a/test/sanity/code-smell/no-tests-as-filters.py
+++ b/test/sanity/code-smell/no-tests-as-filters.py
@@ -51,7 +51,7 @@ FILTER_RE = re.compile(r'((.+?)\s*(?P<left>[\w \.\'"]+)(\s*)\|(\s*)(?P<filter>\w
 def main():
     failed = False
 
-    for path in sys.argv[1:]:
+    for path in sys.argv[1:] or sys.stdin.read().splitlines():
         with open(path) as f:
             text = f.read()
 

--- a/test/sanity/code-smell/no-underscore-variable.py
+++ b/test/sanity/code-smell/no-underscore-variable.py
@@ -123,7 +123,7 @@ def main():
         'test/units/modules/system/interfaces_file/test_interfaces_file.py',
     ])
 
-    for path in sys.argv[1:]:
+    for path in sys.argv[1:] or sys.stdin.read().splitlines():
         if path in skip:
             continue
 

--- a/test/sanity/code-smell/replace-urlopen.py
+++ b/test/sanity/code-smell/replace-urlopen.py
@@ -12,7 +12,7 @@ def main():
         'lib/ansible/module_utils/urls.py',
     ])
 
-    for path in sys.argv[1:]:
+    for path in sys.argv[1:] or sys.stdin.read().splitlines():
         if path in skip:
             continue
 

--- a/test/sanity/code-smell/required-and-default-attributes.py
+++ b/test/sanity/code-smell/required-and-default-attributes.py
@@ -10,7 +10,7 @@ def main():
         'test/sanity/code-smell/%s' % os.path.basename(__file__),
     ])
 
-    for path in sys.argv[1:]:
+    for path in sys.argv[1:] or sys.stdin.read().splitlines():
         if path in skip:
             continue
 

--- a/test/sanity/code-smell/use-argspec-type-path.py
+++ b/test/sanity/code-smell/use-argspec-type-path.py
@@ -27,7 +27,7 @@ def main():
         'lib/ansible/modules/files/find.py',
     ])
 
-    for path in sys.argv[1:]:
+    for path in sys.argv[1:] or sys.stdin.read().splitlines():
         if path in skip:
             continue
 

--- a/test/sanity/code-smell/use-compat-six.py
+++ b/test/sanity/code-smell/use-compat-six.py
@@ -32,7 +32,7 @@ def main():
         'docs/bin/plugin_formatter.py',
     ])
 
-    for path in sys.argv[1:]:
+    for path in sys.argv[1:] or sys.stdin.read().splitlines():
         if path in skip:
             continue
 


### PR DESCRIPTION
##### SUMMARY

Pass code-smell paths on stdin. This avoids limits on command line arguments.

Command line arguments are still accepted for easier testing.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.6.0 (at-code-smell-stdin 782a99d1cd) last updated 2018/02/26 23:51:07 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```
