### PR TITLE
Add documentation for import FCP storage domain

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_storage_domains.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_storage_domains.py
@@ -114,8 +114,6 @@ options:
     fcp:
         description:
             - "Dictionary with values for fibre channel storage type:"
-            - "C(address) - Address of the fibre channel storage server."
-            - "C(port) - Port of the fibre channel storage server."
             - "C(lun_id) - LUN id."
             - "C(override_luns) - If I(True) FCP storage domain luns will be overridden before adding."
             - "Note that these parameters are not idempotent."
@@ -246,6 +244,14 @@ EXAMPLES = '''
     nfs:
       address: 10.34.63.199
       path: /path/export
+
+# Import FCP storage domain:
+- ovirt_storage_domains:
+    state: imported
+    name: data_fcp
+    host: myhost
+    data_center: mydatacenter
+    fcp: {}
 
 # Update OVF_STORE:
 - ovirt_storage_domains:


### PR DESCRIPTION
FCP storage domain task, does not need to contain port or address
since the storage domain is already on the Host.
Added an example for FCP import.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - New Module Pull Request
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
