### PR TITLE
Fix junos_command py3 related issues

### DIFF
--- a/lib/ansible/module_utils/network/common/netconf.py
+++ b/lib/ansible/module_utils/network/common/netconf.py
@@ -27,7 +27,7 @@
 #
 import sys
 
-from ansible.module_utils._text import to_text, to_native
+from ansible.module_utils._text import to_text, to_bytes
 from ansible.module_utils.connection import Connection, ConnectionError
 
 try:
@@ -67,9 +67,9 @@ class NetconfConnection(Connection):
         response = self._exec_jsonrpc(name, *args, **kwargs)
         if 'error' in response:
             rpc_error = response['error'].get('data')
-            return self.parse_rpc_error(to_native(rpc_error, errors='surrogate_then_replace'))
+            return self.parse_rpc_error(to_bytes(rpc_error, errors='surrogate_then_replace'))
 
-        return fromstring(to_native(response['result'], errors='surrogate_then_replace'))
+        return fromstring(to_bytes(response['result'], errors='surrogate_then_replace'))
 
     def parse_rpc_error(self, rpc_error):
         if self.check_rc:

--- a/lib/ansible/modules/network/junos/junos_command.py
+++ b/lib/ansible/modules/network/junos/junos_command.py
@@ -171,6 +171,7 @@ import re
 import shlex
 
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_text
 from ansible.module_utils.network.common.netconf import exec_rpc
 from ansible.module_utils.network.junos.junos import junos_argument_spec, get_configuration, get_connection, get_capabilities
 from ansible.module_utils.network.common.parsing import Conditional, FailedConditionalError
@@ -240,7 +241,7 @@ def rpc(module, items):
         if fetch_config:
             reply = get_configuration(module, format=xattrs['format'])
         else:
-            reply = exec_rpc(module, tostring(element), ignore_warning=False)
+            reply = exec_rpc(module, to_text(tostring(element), errors='surrogate_then_replace'), ignore_warning=False)
 
         if xattrs['format'] == 'text':
             if fetch_config:

--- a/lib/ansible/plugins/netconf/__init__.py
+++ b/lib/ansible/plugins/netconf/__init__.py
@@ -102,7 +102,7 @@ class NetconfBase(with_metaclass(ABCMeta, object)):
         """RPC to be execute on remote device
            :name: Name of rpc in string format"""
         try:
-            obj = to_ele(to_bytes(name, errors='surrogate_or_strict'))
+            obj = to_ele(name)
             resp = self.m.rpc(obj)
             return resp.data_xml if hasattr(resp, 'data_xml') else resp.xml
         except RPCError as exc:

--- a/lib/ansible/plugins/netconf/junos.py
+++ b/lib/ansible/plugins/netconf/junos.py
@@ -50,7 +50,7 @@ class Netconf(NetconfBase):
         device_info['network_os'] = 'junos'
         ele = new_ele('get-software-information')
         data = self.execute_rpc(to_xml(ele))
-        reply = to_ele(to_bytes(data, errors='surrogate_or_strict'))
+        reply = to_ele(data)
         sw_info = reply.find('.//software-information')
 
         device_info['network_os_version'] = self.get_text(sw_info, 'junos-version')


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #36204

*  tostring() input string should be in byte string format
*  to_ele() input is required in unicode format
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
junos_command

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
