### PR TITLE
Added extra choice floppy for bootdev option in ipmi_boot module (#36174)

### DIFF
--- a/lib/ansible/modules/remote_management/ipmi/ipmi_boot.py
+++ b/lib/ansible/modules/remote_management/ipmi/ipmi_boot.py
@@ -45,6 +45,7 @@ options:
     required: true
     choices:
       - network -- Request network boot
+      - floppy -- Boot from floppy
       - hd -- Boot from hard drive
       - safe -- Boot from hard drive, requesting 'safe mode'
       - optical -- boot from CD/DVD/BD drive
@@ -129,7 +130,7 @@ def main():
             user=dict(required=True, no_log=True),
             password=dict(required=True, no_log=True),
             state=dict(default='present', choices=['present', 'absent']),
-            bootdev=dict(required=True, choices=['network', 'hd', 'safe', 'optical', 'setup', 'default']),
+            bootdev=dict(required=True, choices=['network', 'hd', 'floppy', 'safe', 'optical', 'setup', 'default']),
             persistent=dict(default=False, type='bool'),
             uefiboot=dict(default=False, type='bool')
         ),


### PR DESCRIPTION
##### SUMMARY
…174)

(cherry picked from commit 52627f3fa02541f61a8f5ed52734b3caa0660a8c)


<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
