### PR TITLE
nxos_facts fix and integration tests

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_facts.py
+++ b/lib/ansible/modules/network/nxos/nxos_facts.py
@@ -409,7 +409,11 @@ class Interfaces(FactsBase):
                     name = item['ROW_intf']['intf-name']
                     intf = self.facts['interfaces'][name]
                     intf['ipv6'] = self.transform_dict(item, self.INTERFACE_IPV6_MAP)
-                    self.facts['all_ipv6_addresses'].append(item['ROW_intf']['addr'])
+                    try:
+                        addr = item['ROW_intf']['addr']
+                    except KeyError:
+                        addr = item['ROW_intf']['TABLE_addr']['ROW_addr']['addr']
+                    self.facts['all_ipv6_addresses'].append(addr)
             else:
                 return ""
         except TypeError:

--- a/test/integration/targets/nxos_acl/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_acl/tests/common/sanity.yaml
@@ -4,7 +4,7 @@
   when: ansible_connection == "local"
 
 - set_fact: time_range="ans-range"
-  when: not ( platform is match("N5K"))
+  when: not (platform is match("N5K")) and not (platform is match("N35"))
 
 - name: "Setup: Cleanup possibly existing acl."
   nxos_acl: &remove

--- a/test/integration/targets/nxos_command/tests/cli/sanity.yaml
+++ b/test/integration/targets/nxos_command/tests/cli/sanity.yaml
@@ -21,7 +21,6 @@
   - assert: &fail
       that:
         - "result.failed == true"
-        - "'Invalid command' in result.msg"
 
   - name: "Enable feature BGP"
     nxos_feature:

--- a/test/integration/targets/nxos_command/tests/nxapi/sanity.yaml
+++ b/test/integration/targets/nxos_command/tests/nxapi/sanity.yaml
@@ -21,7 +21,6 @@
   - assert: &fail
       that:
         - "result.failed == true"
-        - "'Input CLI command error' in result.msg"
 
   - name: "Enable feature BGP"
     nxos_feature:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #36795
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
nxos_facts

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (devel 788010d0f0) last updated 2018/01/08 11:49:21 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /root/agents-ci/ansible/lib/ansible
  executable location = /root/agents-ci/ansible/bin/ansible
  python version = 2.7.6 (default, Oct 26 2016, 20:30:19) [GCC 4.8.4]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
1. This PR fixes #36795 Since the new output is generating a KeyError, we check for it and parse accordingly.
2. Integration tests for nxos_command and nxos_acl are modified slightly to take care of platform differences. For nxos_command, the error string is different in different versions. For nxos_acl, the parameter time_range is not supported on N35 platform.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
```
