### PR TITLE
Add http(s)_proxy support in yum module

### DIFF
--- a/lib/ansible/modules/packaging/os/yum.py
+++ b/lib/ansible/modules/packaging/os/yum.py
@@ -649,14 +649,13 @@ def set_env_proxy(conf_file, installroot):
                 schem = 'https'
             else:
                 schem = 'http'
-        if yumb.conf.proxy_username:
-            namepass = namepass + yumb.conf.proxy_username
-            if yumb.conf.proxy_password:
-                namepass = namepass + ":" + yumb.conf.proxy_password
-            namepass = namepass + '@'
-
-        os.environ["{0}_proxy".format(schem)] = re.sub(r"({0}://)".format(schem),
-                                                       r"\1" + namepass, yumb.conf.proxy)
+            if yumb.conf.proxy_username:
+                namepass = namepass + yumb.conf.proxy_username
+                if yumb.conf.proxy_password:
+                    namepass = namepass + ":" + yumb.conf.proxy_password
+                namepass = namepass + '@'
+            os.environ["{0}_proxy".format(schem)] = re.sub(r"({0}://)".format(schem),
+                                                           r"\1" + namepass, yumb.conf.proxy)
     except AttributeError as ae:
         raise ae
 

--- a/lib/ansible/modules/packaging/os/yum.py
+++ b/lib/ansible/modules/packaging/os/yum.py
@@ -642,6 +642,7 @@ def local_envra(path):
 def set_env_proxy(conf_file, installroot):
     yumb = yum_base(conf_file, installroot)
     namepass = ""
+    schem = "http"
     try:
         if yumb.conf.proxy:
             if 'https:' in yumb.conf.proxy:
@@ -654,8 +655,8 @@ def set_env_proxy(conf_file, installroot):
                 namepass = namepass + ":" + yumb.conf.proxy_password
             namepass = namepass + '@'
 
-        os.environ["{}_proxy".format(schem)] = re.sub(r"({}://)".format(schem),
-                                                      r"\1" + namepass, yumb.conf.proxy)
+        os.environ["{0}_proxy".format(schem)] = re.sub(r"({0}://)".format(schem),
+                                                       r"\1" + namepass, yumb.conf.proxy)
     except AttributeError as ae:
         raise ae
 

--- a/lib/ansible/modules/packaging/os/yum.py
+++ b/lib/ansible/modules/packaging/os/yum.py
@@ -642,31 +642,29 @@ def local_envra(path):
 def set_env_proxy(function):
     def fetching(spec, module, conf_file, installroot):
         # setting system proxy environment and saving old, if exists
-        yumb = yum_base(conf_file, installroot)
+        my = yum_base(conf_file, installroot)
         namepass = ""
-        schem = "http"
+        scheme = "http"
         old_proxy_env = [os.getenv("http_proxy"), os.getenv("https_proxy")]
         try:
-            if yumb.conf.proxy:
-                if 'https' in yumb.conf.proxy:
-                    schem = 'https'
-                else:
-                    schem = 'http'
-                if yumb.conf.proxy_username:
-                    namepass = namepass + yumb.conf.proxy_username
-                    if yumb.conf.proxy_password:
-                        namepass = namepass + ":" + yumb.conf.proxy_password
+            if my.conf.proxy:
+                if my.conf.proxy.startswith('https'):
+                    scheme = 'https'
+                if my.conf.proxy_username:
+                    namepass = namepass + my.conf.proxy_username
+                    if my.conf.proxy_password:
+                        namepass = namepass + ":" + my.conf.proxy_password
                 namepass = namepass + '@'
-                os.environ["{0}_proxy".format(schem)] = re.sub(
-                    r"({0}://)".format(schem), r"\1" + namepass, yumb.conf.proxy
+                os.environ["{0}_proxy".format(scheme)] = re.sub(
+                    r"({0}://)".format(scheme), r"\1" + namepass, my.conf.proxy
                 )
         except yum.Errors.YumBaseError as e:
             module.fail_json(msg="Error setting/accessing proxy: %s" % to_native(e))
         # getting package with new proxy environment
         package = fetch_rpm_from_url(spec, module)
         # revert back to previously system configuration
-        if os.getenv("{0}_proxy".format(schem)):
-            del os.environ["{0}_proxy".format(schem)]
+        if os.getenv("{0}_proxy".format(scheme)):
+            del os.environ["{0}_proxy".format(scheme)]
         if old_proxy_env[0]:
             os.environ["http_proxy"] = old_proxy_env[0]
         if old_proxy_env[1]:


### PR DESCRIPTION
##### SUMMARY
Fixes #18979

Added set_env_proxy function, that set system http(s)_proxy
environment for fetching RPM if proxy settings set in yum.conf file


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
packaging/os/yum.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0
```


##### ADDITIONAL INFORMATION
```

```
