### PR TITLE
Required changes to support redirects on HTTP 307/308

### DIFF
--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -509,7 +509,7 @@ def RedirectHandlerFactory(follow_redirects=None, validate_certs=True):
 
                 return RequestWithMethod(newurl,
                                          method=method,
-                                         headers=req.headers,
+                                         headers=newheaders,
                                          data=data,
                                          origin_req_host=origin_req_host,
                                          unverifiable=True,

--- a/test/integration/targets/uri/tasks/redirect-all.yml
+++ b/test/integration/targets/uri/tasks/redirect-all.yml
@@ -1,4 +1,3 @@
-# NOTE: The HTTP HEAD turns into an HTTP GET
 - name: Test HTTP 301 using HEAD
   uri:
     url: http://{{ httpbin_host }}/redirect-to?status_code=301&url=http://{{ httpbin_host }}/anything
@@ -9,8 +8,7 @@
 
 - assert:
     that:
-    - http_301_head.json.data == ''
-    - http_301_head.json.method == 'GET'
+    - http_301_head.json is not defined
     - http_301_head.redirected == true
     - http_301_head.status == 200
     - http_301_head.url == 'http://{{ httpbin_host }}/anything'
@@ -27,6 +25,7 @@
     that:
     - http_301_get.json.data == ''
     - http_301_get.json.method == 'GET'
+    - http_301_get.json.url == 'http://{{ httpbin_host }}/anything'
     - http_301_get.redirected == true
     - http_301_get.status == 200
     - http_301_get.url == 'http://{{ httpbin_host }}/anything'
@@ -46,11 +45,11 @@
     that:
     - http_301_post.json.data == ''
     - http_301_post.json.method == 'GET'
+    - http_301_post.json.url == 'http://{{ httpbin_host }}/anything'
     - http_301_post.redirected == true
     - http_301_post.status == 200
     - http_301_post.url == 'http://{{ httpbin_host }}/anything'
 
-# NOTE: The HTTP HEAD turns into an HTTP GET
 - name: Test HTTP 302 using HEAD
   uri:
     url: http://{{ httpbin_host }}/redirect-to?status_code=302&url=http://{{ httpbin_host }}/anything
@@ -61,8 +60,7 @@
 
 - assert:
     that:
-    - http_302_head.json.data == ''
-    - http_302_head.json.method == 'GET'
+    - http_302_head.json is not defined
     - http_302_head.redirected == true
     - http_302_head.status == 200
     - http_302_head.url == 'http://{{ httpbin_host }}/anything'
@@ -79,6 +77,7 @@
     that:
     - http_302_get.json.data == ''
     - http_302_get.json.method == 'GET'
+    - http_302_get.json.url == 'http://{{ httpbin_host }}/anything'
     - http_302_get.redirected == true
     - http_302_get.status == 200
     - http_302_get.url == 'http://{{ httpbin_host }}/anything'
@@ -98,11 +97,11 @@
     that:
     - http_302_post.json.data == ''
     - http_302_post.json.method == 'GET'
+    - http_302_post.json.url == 'http://{{ httpbin_host }}/anything'
     - http_302_post.redirected == true
     - http_302_post.status == 200
     - http_302_post.url == 'http://{{ httpbin_host }}/anything'
 
-# NOTE: The HTTP HEAD turns into an HTTP GET
 - name: Test HTTP 303 using HEAD
   uri:
     url: http://{{ httpbin_host }}/redirect-to?status_code=303&url=http://{{ httpbin_host }}/anything
@@ -113,8 +112,7 @@
 
 - assert:
     that:
-    - http_303_head.json.data == ''
-    - http_303_head.json.method == 'GET'
+    - http_303_head.json is not defined
     - http_303_head.redirected == true
     - http_303_head.status == 200
     - http_303_head.url == 'http://{{ httpbin_host }}/anything'
@@ -131,6 +129,7 @@
     that:
     - http_303_get.json.data == ''
     - http_303_get.json.method == 'GET'
+    - http_303_get.json.url == 'http://{{ httpbin_host }}/anything'
     - http_303_get.redirected == true
     - http_303_get.status == 200
     - http_303_get.url == 'http://{{ httpbin_host }}/anything'
@@ -150,11 +149,11 @@
     that:
     - http_303_post.json.data == ''
     - http_303_post.json.method == 'GET'
+    - http_303_post.json.url == 'http://{{ httpbin_host }}/anything'
     - http_303_post.redirected == true
     - http_303_post.status == 200
     - http_303_post.url == 'http://{{ httpbin_host }}/anything'
 
-# NOTE: The HTTP HEAD turns into an HTTP GET
 - name: Test HTTP 307 using HEAD
   uri:
     url: http://{{ httpbin_host }}/redirect-to?status_code=307&url=http://{{ httpbin_host }}/anything
@@ -165,8 +164,7 @@
 
 - assert:
     that:
-    - http_307_head.json.data == ''
-    - http_307_head.json.method == 'GET'
+    - http_307_head.json is not defined
     - http_307_head.redirected == true
     - http_307_head.status == 200
     - http_307_head.url == 'http://{{ httpbin_host }}/anything'
@@ -183,11 +181,11 @@
     that:
     - http_307_get.json.data == ''
     - http_307_get.json.method == 'GET'
+    - http_307_get.json.url == 'http://{{ httpbin_host }}/anything'
     - http_307_get.redirected == true
     - http_307_get.status == 200
     - http_307_get.url == 'http://{{ httpbin_host }}/anything'
 
-# FIXME: The HTTP POST turns into an HTTP GET. This is fixed in https://github.com/ansible/ansible/pull/36809
 - name: Test HTTP 307 using POST
   uri:
     url: http://{{ httpbin_host }}/redirect-to?status_code=307&url=http://{{ httpbin_host }}/anything
@@ -200,30 +198,27 @@
 
 - assert:
     that:
-    - http_307_post.json.data == ''
-    - http_307_post.json.method == 'GET'
+    - http_307_post.json.json.foo == 'bar'
+    - http_307_post.json.method == 'POST'
+    - http_307_post.json.url == 'http://{{ httpbin_host }}/anything'
     - http_307_post.redirected == true
     - http_307_post.status == 200
     - http_307_post.url == 'http://{{ httpbin_host }}/anything'
 
-# FIXME: This is fixed in https://github.com/ansible/ansible/pull/36809
 - name: Test HTTP 308 using HEAD
   uri:
     url: http://{{ httpbin_host }}/redirect-to?status_code=308&url=http://{{ httpbin_host }}/anything
     follow_redirects: all
     return_content: yes
-    method: GET
-  ignore_errors: yes
+    method: HEAD
   register: http_308_head
 
 - assert:
     that:
-    - http_308_head.json is not defined
-    - http_308_head.location == 'http://{{ httpbin_host }}/anything'
-    - "http_308_head.msg == 'Status code was 308 and not [200]: HTTP Error 308: UNKNOWN'"
-    - http_308_head.redirected == false
-    - http_308_head.status == 308
-    - http_308_head.url == 'http://{{ httpbin_host }}/redirect-to?status_code=308&url=http://{{ httpbin_host }}/anything'
+    - http_308_head.json is undefined
+    - http_308_head.redirected == true
+    - http_308_head.status == 200
+    - http_308_head.url == 'http://{{ httpbin_host }}/anything'
 
 # FIXME: This is fixed in https://github.com/ansible/ansible/pull/36809
 - name: Test HTTP 308 using GET
@@ -232,19 +227,17 @@
     follow_redirects: all
     return_content: yes
     method: GET
-  ignore_errors: yes
   register: http_308_get
 
 - assert:
     that:
-    - http_308_get.json is not defined
-    - http_308_get.location == 'http://{{ httpbin_host }}/anything'
-    - "http_308_get.msg == 'Status code was 308 and not [200]: HTTP Error 308: UNKNOWN'"
-    - http_308_get.redirected == false
-    - http_308_get.status == 308
-    - http_308_get.url == 'http://{{ httpbin_host }}/redirect-to?status_code=308&url=http://{{ httpbin_host }}/anything'
+    - http_308_get.json.data == ''
+    - http_308_get.json.method == 'GET'
+    - http_308_get.json.url == 'http://{{ httpbin_host }}/anything'
+    - http_308_get.redirected == true
+    - http_308_get.status == 200
+    - http_308_get.url == 'http://{{ httpbin_host }}/anything'
 
-# FIXME: This is fixed in https://github.com/ansible/ansible/pull/36809
 - name: Test HTTP 308 using POST
   uri:
     url: http://{{ httpbin_host }}/redirect-to?status_code=308&url=http://{{ httpbin_host }}/anything
@@ -253,14 +246,13 @@
     method: POST
     body: '{ "foo": "bar" }'
     body_format: json
-  ignore_errors: yes
   register: http_308_post
 
 - assert:
     that:
-    - http_308_post.json is not defined
-    - http_308_post.location == 'http://{{ httpbin_host }}/anything'
-    - "http_308_post.msg == 'Status code was 308 and not [200]: HTTP Error 308: UNKNOWN'"
-    - http_308_post.redirected == false
-    - http_308_post.status == 308
-    - http_308_post.url == 'http://{{ httpbin_host }}/redirect-to?status_code=308&url=http://{{ httpbin_host }}/anything'
+    - http_308_post.json.json.foo == 'bar'
+    - http_308_post.json.method == 'POST'
+    - http_308_post.json.url == 'http://{{ httpbin_host }}/anything'
+    - http_308_post.redirected == true
+    - http_308_post.status == 200
+    - http_308_post.url == 'http://{{ httpbin_host }}/anything'

--- a/test/integration/targets/uri/tasks/redirect-all.yml
+++ b/test/integration/targets/uri/tasks/redirect-all.yml
@@ -8,6 +8,7 @@
 
 - assert:
     that:
+    - http_301_head is successful
     - http_301_head.json is not defined
     - http_301_head.redirected == true
     - http_301_head.status == 200
@@ -23,6 +24,7 @@
 
 - assert:
     that:
+    - http_301_get is successful
     - http_301_get.json.data == ''
     - http_301_get.json.method == 'GET'
     - http_301_get.json.url == 'http://{{ httpbin_host }}/anything'
@@ -43,6 +45,7 @@
 
 - assert:
     that:
+    - http_301_post is successful
     - http_301_post.json.data == ''
     - http_301_post.json.method == 'GET'
     - http_301_post.json.url == 'http://{{ httpbin_host }}/anything'
@@ -60,6 +63,7 @@
 
 - assert:
     that:
+    - http_302_head is successful
     - http_302_head.json is not defined
     - http_302_head.redirected == true
     - http_302_head.status == 200
@@ -75,6 +79,7 @@
 
 - assert:
     that:
+    - http_302_get is successful
     - http_302_get.json.data == ''
     - http_302_get.json.method == 'GET'
     - http_302_get.json.url == 'http://{{ httpbin_host }}/anything'
@@ -95,6 +100,7 @@
 
 - assert:
     that:
+    - http_302_post is successful
     - http_302_post.json.data == ''
     - http_302_post.json.method == 'GET'
     - http_302_post.json.url == 'http://{{ httpbin_host }}/anything'
@@ -112,6 +118,7 @@
 
 - assert:
     that:
+    - http_303_head is successful
     - http_303_head.json is not defined
     - http_303_head.redirected == true
     - http_303_head.status == 200
@@ -127,6 +134,7 @@
 
 - assert:
     that:
+    - http_303_get is successful
     - http_303_get.json.data == ''
     - http_303_get.json.method == 'GET'
     - http_303_get.json.url == 'http://{{ httpbin_host }}/anything'
@@ -147,6 +155,7 @@
 
 - assert:
     that:
+    - http_303_post is successful
     - http_303_post.json.data == ''
     - http_303_post.json.method == 'GET'
     - http_303_post.json.url == 'http://{{ httpbin_host }}/anything'
@@ -164,6 +173,7 @@
 
 - assert:
     that:
+    - http_307_head is successful
     - http_307_head.json is not defined
     - http_307_head.redirected == true
     - http_307_head.status == 200
@@ -179,6 +189,7 @@
 
 - assert:
     that:
+    - http_307_get is successful
     - http_307_get.json.data == ''
     - http_307_get.json.method == 'GET'
     - http_307_get.json.url == 'http://{{ httpbin_host }}/anything'
@@ -198,6 +209,7 @@
 
 - assert:
     that:
+    - http_307_post is successful
     - http_307_post.json.json.foo == 'bar'
     - http_307_post.json.method == 'POST'
     - http_307_post.json.url == 'http://{{ httpbin_host }}/anything'
@@ -215,12 +227,12 @@
 
 - assert:
     that:
+    - http_308_head is successful
     - http_308_head.json is undefined
     - http_308_head.redirected == true
     - http_308_head.status == 200
     - http_308_head.url == 'http://{{ httpbin_host }}/anything'
 
-# FIXME: This is fixed in https://github.com/ansible/ansible/pull/36809
 - name: Test HTTP 308 using GET
   uri:
     url: http://{{ httpbin_host }}/redirect-to?status_code=308&url=http://{{ httpbin_host }}/anything
@@ -231,6 +243,7 @@
 
 - assert:
     that:
+    - http_308_get is successful
     - http_308_get.json.data == ''
     - http_308_get.json.method == 'GET'
     - http_308_get.json.url == 'http://{{ httpbin_host }}/anything'
@@ -250,6 +263,7 @@
 
 - assert:
     that:
+    - http_308_post is successful
     - http_308_post.json.json.foo == 'bar'
     - http_308_post.json.method == 'POST'
     - http_308_post.json.url == 'http://{{ httpbin_host }}/anything'

--- a/test/integration/targets/uri/tasks/redirect-none.yml
+++ b/test/integration/targets/uri/tasks/redirect-none.yml
@@ -9,6 +9,7 @@
 
 - assert:
     that:
+    - http_301_head is failure
     - http_301_head.json is not defined
     - http_301_head.location == 'http://{{ httpbin_host }}/anything'
     - "http_301_head.msg == 'Status code was 301 and not [200]: HTTP Error 301: MOVED PERMANENTLY'"
@@ -27,6 +28,7 @@
 
 - assert:
     that:
+    - http_301_get is failure
     - http_301_get.json is not defined
     - http_301_get.location == 'http://{{ httpbin_host }}/anything'
     - "http_301_get.msg == 'Status code was 301 and not [200]: HTTP Error 301: MOVED PERMANENTLY'"
@@ -47,6 +49,7 @@
 
 - assert:
     that:
+    - http_301_post is failure
     - http_301_post.json is not defined
     - http_301_post.location == 'http://{{ httpbin_host }}/anything'
     - "http_301_post.msg == 'Status code was 301 and not [200]: HTTP Error 301: MOVED PERMANENTLY'"
@@ -65,6 +68,7 @@
 
 - assert:
     that:
+    - http_302_head is failure
     - http_302_head.json is not defined
     - http_302_head.location == 'http://{{ httpbin_host }}/anything'
     - "http_302_head.msg == 'Status code was 302 and not [200]: HTTP Error 302: FOUND'"
@@ -83,6 +87,7 @@
 
 - assert:
     that:
+    - http_302_get is failure
     - http_302_get.json is not defined
     - http_302_get.location == 'http://{{ httpbin_host }}/anything'
     - "http_302_get.msg == 'Status code was 302 and not [200]: HTTP Error 302: FOUND'"
@@ -103,6 +108,7 @@
 
 - assert:
     that:
+    - http_302_post is failure
     - http_302_post.json is not defined
     - http_302_post.location == 'http://{{ httpbin_host }}/anything'
     - "http_302_post.msg == 'Status code was 302 and not [200]: HTTP Error 302: FOUND'"
@@ -121,6 +127,7 @@
 
 - assert:
     that:
+    - http_303_head is failure
     - http_303_head.json is not defined
     - http_303_head.location == 'http://{{ httpbin_host }}/anything'
     - "http_303_head.msg == 'Status code was 303 and not [200]: HTTP Error 303: SEE OTHER'"
@@ -139,6 +146,7 @@
 
 - assert:
     that:
+    - http_303_get is failure
     - http_303_get.json is not defined
     - http_303_get.location == 'http://{{ httpbin_host }}/anything'
     - "http_303_get.msg == 'Status code was 303 and not [200]: HTTP Error 303: SEE OTHER'"
@@ -159,6 +167,7 @@
 
 - assert:
     that:
+    - http_303_post is failure
     - http_303_post.json is not defined
     - http_303_post.location == 'http://{{ httpbin_host }}/anything'
     - "http_303_post.msg == 'Status code was 303 and not [200]: HTTP Error 303: SEE OTHER'"
@@ -177,6 +186,7 @@
 
 - assert:
     that:
+    - http_307_head is failure
     - http_307_head.json is not defined
     - http_307_head.location == 'http://{{ httpbin_host }}/anything'
     - "http_307_head.msg == 'Status code was 307 and not [200]: HTTP Error 307: TEMPORARY REDIRECT'"
@@ -195,6 +205,7 @@
 
 - assert:
     that:
+    - http_307_get is failure
     - http_307_get.json is not defined
     - http_307_get.location == 'http://{{ httpbin_host }}/anything'
     - "http_307_get.msg == 'Status code was 307 and not [200]: HTTP Error 307: TEMPORARY REDIRECT'"
@@ -215,6 +226,7 @@
 
 - assert:
     that:
+    - http_307_post is failure
     - http_307_post.json is not defined
     - http_307_post.location == 'http://{{ httpbin_host }}/anything'
     - "http_307_post.msg == 'Status code was 307 and not [200]: HTTP Error 307: TEMPORARY REDIRECT'"
@@ -234,6 +246,7 @@
 
 - assert:
     that:
+    - http_308_head is failure
     - http_308_head.json is not defined
     - http_308_head.location == 'http://{{ httpbin_host }}/anything'
     - "http_308_head.msg == 'Status code was 308 and not [200]: HTTP Error 308: UNKNOWN'"
@@ -253,6 +266,7 @@
 
 - assert:
     that:
+    - http_308_get is failure
     - http_308_get.json is not defined
     - http_308_get.location == 'http://{{ httpbin_host }}/anything'
     - "http_308_get.msg == 'Status code was 308 and not [200]: HTTP Error 308: UNKNOWN'"
@@ -273,6 +287,7 @@
 
 - assert:
     that:
+    - http_308_post is failure
     - http_308_post.json is not defined
     - http_308_post.location == 'http://{{ httpbin_host }}/anything'
     - "http_308_post.msg == 'Status code was 308 and not [200]: HTTP Error 308: UNKNOWN'"

--- a/test/integration/targets/uri/tasks/redirect-safe.yml
+++ b/test/integration/targets/uri/tasks/redirect-safe.yml
@@ -1,4 +1,3 @@
-# NOTE: The HTTP HEAD turns into an HTTP GET
 - name: Test HTTP 301 using HEAD
   uri:
     url: http://{{ httpbin_host }}/redirect-to?status_code=301&url=http://{{ httpbin_host }}/anything
@@ -9,8 +8,8 @@
 
 - assert:
     that:
-    - http_301_head.json.data == ''
-    - http_301_head.json.method == 'GET'
+    - http_301_head is successful
+    - http_301_head.json is not defined
     - http_301_head.redirected == true
     - http_301_head.status == 200
     - http_301_head.url == 'http://{{ httpbin_host }}/anything'
@@ -25,8 +24,10 @@
 
 - assert:
     that:
+    - http_301_get is successful
     - http_301_get.json.data == ''
     - http_301_get.json.method == 'GET'
+    - http_301_get.json.url == 'http://{{ httpbin_host }}/anything'
     - http_301_get.redirected == true
     - http_301_get.status == 200
     - http_301_get.url == 'http://{{ httpbin_host }}/anything'
@@ -44,6 +45,7 @@
 
 - assert:
     that:
+    - http_301_post is failure
     - http_301_post.json is not defined
     - http_301_post.location == 'http://{{ httpbin_host }}/anything'
     - "http_301_post.msg == 'Status code was 301 and not [200]: HTTP Error 301: MOVED PERMANENTLY'"
@@ -51,7 +53,6 @@
     - http_301_post.status == 301
     - http_301_post.url == 'http://{{ httpbin_host }}/redirect-to?status_code=301&url=http://{{ httpbin_host }}/anything'
 
-# NOTE: The HTTP HEAD turns into an HTTP GET
 - name: Test HTTP 302 using HEAD
   uri:
     url: http://{{ httpbin_host }}/redirect-to?status_code=302&url=http://{{ httpbin_host }}/anything
@@ -62,8 +63,8 @@
 
 - assert:
     that:
-    - http_302_head.json.data == ''
-    - http_302_head.json.method == 'GET'
+    - http_302_head is successful
+    - http_302_head.json is not defined
     - http_302_head.redirected == true
     - http_302_head.status == 200
     - http_302_head.url == 'http://{{ httpbin_host }}/anything'
@@ -78,8 +79,10 @@
 
 - assert:
     that:
+    - http_302_get is successful
     - http_302_get.json.data == ''
     - http_302_get.json.method == 'GET'
+    - http_302_get.json.url == 'http://{{ httpbin_host }}/anything'
     - http_302_get.redirected == true
     - http_302_get.status == 200
     - http_302_get.url == 'http://{{ httpbin_host }}/anything'
@@ -97,6 +100,7 @@
 
 - assert:
     that:
+    - http_302_post is failure
     - http_302_post.json is not defined
     - http_302_post.location == 'http://{{ httpbin_host }}/anything'
     - "http_302_post.msg == 'Status code was 302 and not [200]: HTTP Error 302: FOUND'"
@@ -104,7 +108,6 @@
     - http_302_post.status == 302
     - http_302_post.url == 'http://{{ httpbin_host }}/redirect-to?status_code=302&url=http://{{ httpbin_host }}/anything'
 
-# NOTE: The HTTP HEAD turns into an HTTP GET
 - name: Test HTTP 303 using HEAD
   uri:
     url: http://{{ httpbin_host }}/redirect-to?status_code=303&url=http://{{ httpbin_host }}/anything
@@ -115,8 +118,8 @@
 
 - assert:
     that:
-    - http_303_head.json.data == ''
-    - http_303_head.json.method == 'GET'
+    - http_303_head is successful
+    - http_303_head.json is not defined
     - http_303_head.redirected == true
     - http_303_head.status == 200
     - http_303_head.url == 'http://{{ httpbin_host }}/anything'
@@ -131,8 +134,10 @@
 
 - assert:
     that:
+    - http_303_get is successful
     - http_303_get.json.data == ''
     - http_303_get.json.method == 'GET'
+    - http_303_get.json.url == 'http://{{ httpbin_host }}/anything'
     - http_303_get.redirected == true
     - http_303_get.status == 200
     - http_303_get.url == 'http://{{ httpbin_host }}/anything'
@@ -150,6 +155,7 @@
 
 - assert:
     that:
+    - http_303_post is failure
     - http_303_post.json is not defined
     - http_303_post.location == 'http://{{ httpbin_host }}/anything'
     - "http_303_post.msg == 'Status code was 303 and not [200]: HTTP Error 303: SEE OTHER'"
@@ -167,8 +173,8 @@
 
 - assert:
     that:
-    - http_307_head.json.data == ''
-    - http_307_head.json.method == 'GET'
+    - http_307_head is successful
+    - http_307_head.json is not defined
     - http_307_head.redirected == true
     - http_307_head.status == 200
     - http_307_head.url == 'http://{{ httpbin_host }}/anything'
@@ -183,8 +189,10 @@
 
 - assert:
     that:
+    - http_307_get is successful
     - http_307_get.json.data == ''
     - http_307_get.json.method == 'GET'
+    - http_307_get.json.url == 'http://{{ httpbin_host }}/anything'
     - http_307_get.redirected == true
     - http_307_get.status == 200
     - http_307_get.url == 'http://{{ httpbin_host }}/anything'
@@ -202,6 +210,7 @@
 
 - assert:
     that:
+    - http_307_post is failure
     - http_307_post.json is not defined
     - http_307_post.location == 'http://{{ httpbin_host }}/anything'
     - "http_307_post.msg == 'Status code was 307 and not [200]: HTTP Error 307: TEMPORARY REDIRECT'"
@@ -209,43 +218,39 @@
     - http_307_post.status == 307
     - http_307_post.url == 'http://{{ httpbin_host }}/redirect-to?status_code=307&url=http://{{ httpbin_host }}/anything'
 
-# NOTE: In my opinion this should work, see https://github.com/ansible/ansible/pull/36809
 - name: Test HTTP 308 using HEAD
   uri:
     url: http://{{ httpbin_host }}/redirect-to?status_code=308&url=http://{{ httpbin_host }}/anything
     follow_redirects: safe
     return_content: yes
-    method: GET
-  ignore_errors: yes
+    method: HEAD
   register: http_308_head
 
 - assert:
     that:
+    - http_308_head is successful
     - http_308_head.json is not defined
-    - http_308_head.location == 'http://{{ httpbin_host }}/anything'
-    - "http_308_head.msg == 'Status code was 308 and not [200]: HTTP Error 308: UNKNOWN'"
-    - http_308_head.redirected == false
-    - http_308_head.status == 308
-    - http_308_head.url == 'http://{{ httpbin_host }}/redirect-to?status_code=308&url=http://{{ httpbin_host }}/anything'
+    - http_308_head.redirected == true
+    - http_308_head.status == 200
+    - http_308_head.url == 'http://{{ httpbin_host }}/anything'
 
-# NOTE: In my opinion this should work, see https://github.com/ansible/ansible/pull/36809
 - name: Test HTTP 308 using GET
   uri:
     url: http://{{ httpbin_host }}/redirect-to?status_code=308&url=http://{{ httpbin_host }}/anything
     follow_redirects: safe
     return_content: yes
     method: GET
-  ignore_errors: yes
   register: http_308_get
 
 - assert:
     that:
-    - http_308_get.json is not defined
-    - http_308_get.location == 'http://{{ httpbin_host }}/anything'
-    - "http_308_get.msg == 'Status code was 308 and not [200]: HTTP Error 308: UNKNOWN'"
-    - http_308_get.redirected == false
-    - http_308_get.status == 308
-    - http_308_get.url == 'http://{{ httpbin_host }}/redirect-to?status_code=308&url=http://{{ httpbin_host }}/anything'
+    - http_308_get is successful
+    - http_308_get.json.data == ''
+    - http_308_get.json.method == 'GET'
+    - http_308_get.json.url == 'http://{{ httpbin_host }}/anything'
+    - http_308_get.redirected == true
+    - http_308_get.status == 200
+    - http_308_get.url == 'http://{{ httpbin_host }}/anything'
 
 - name: Test HTTP 308 using POST
   uri:
@@ -260,6 +265,7 @@
 
 - assert:
     that:
+    - http_308_post is failure
     - http_308_post.json is not defined
     - http_308_post.location == 'http://{{ httpbin_host }}/anything'
     - "http_308_post.msg == 'Status code was 308 and not [200]: HTTP Error 308: UNKNOWN'"

--- a/test/integration/targets/uri/tasks/redirect-urllib2.yml
+++ b/test/integration/targets/uri/tasks/redirect-urllib2.yml
@@ -9,8 +9,10 @@
 
 - assert:
     that:
+    - http_301_head is successful
     - http_301_head.json.data == ''
     - http_301_head.json.method == 'GET'
+    - http_301_head.json.url == 'http://{{ httpbin_host }}/anything'
     - http_301_head.redirected == true
     - http_301_head.status == 200
     - http_301_head.url == 'http://{{ httpbin_host }}/anything'
@@ -25,8 +27,10 @@
 
 - assert:
     that:
+    - http_301_get is successful
     - http_301_get.json.data == ''
     - http_301_get.json.method == 'GET'
+    - http_301_get.json.url == 'http://{{ httpbin_host }}/anything'
     - http_301_get.redirected == true
     - http_301_get.status == 200
     - http_301_get.url == 'http://{{ httpbin_host }}/anything'
@@ -44,8 +48,10 @@
 
 - assert:
     that:
+    - http_301_post is successful
     - http_301_post.json.data == ''
     - http_301_post.json.method == 'GET'
+    - http_301_post.json.url == 'http://{{ httpbin_host }}/anything'
     - http_301_post.redirected == true
     - http_301_post.status == 200
     - http_301_post.url == 'http://{{ httpbin_host }}/anything'
@@ -61,8 +67,10 @@
 
 - assert:
     that:
+    - http_302_head is successful
     - http_302_head.json.data == ''
     - http_302_head.json.method == 'GET'
+    - http_302_head.json.url == 'http://{{ httpbin_host }}/anything'
     - http_302_head.redirected == true
     - http_302_head.status == 200
     - http_302_head.url == 'http://{{ httpbin_host }}/anything'
@@ -77,8 +85,10 @@
 
 - assert:
     that:
+    - http_302_get is successful
     - http_302_get.json.data == ''
     - http_302_get.json.method == 'GET'
+    - http_302_get.json.url == 'http://{{ httpbin_host }}/anything'
     - http_302_get.redirected == true
     - http_302_get.status == 200
     - http_302_get.url == 'http://{{ httpbin_host }}/anything'
@@ -96,8 +106,10 @@
 
 - assert:
     that:
+    - http_302_post is successful
     - http_302_post.json.data == ''
     - http_302_post.json.method == 'GET'
+    - http_302_post.json.url == 'http://{{ httpbin_host }}/anything'
     - http_302_post.redirected == true
     - http_302_post.status == 200
     - http_302_post.url == 'http://{{ httpbin_host }}/anything'
@@ -113,8 +125,10 @@
 
 - assert:
     that:
+    - http_303_head is successful
     - http_303_head.json.data == ''
     - http_303_head.json.method == 'GET'
+    - http_303_head.json.url == 'http://{{ httpbin_host }}/anything'
     - http_303_head.redirected == true
     - http_303_head.status == 200
     - http_303_head.url == 'http://{{ httpbin_host }}/anything'
@@ -129,8 +143,10 @@
 
 - assert:
     that:
+    - http_303_get is successful
     - http_303_get.json.data == ''
     - http_303_get.json.method == 'GET'
+    - http_303_get.json.url == 'http://{{ httpbin_host }}/anything'
     - http_303_get.redirected == true
     - http_303_get.status == 200
     - http_303_get.url == 'http://{{ httpbin_host }}/anything'
@@ -148,8 +164,10 @@
 
 - assert:
     that:
+    - http_303_post is successful
     - http_303_post.json.data == ''
     - http_303_post.json.method == 'GET'
+    - http_303_post.json.url == 'http://{{ httpbin_host }}/anything'
     - http_303_post.redirected == true
     - http_303_post.status == 200
     - http_303_post.url == 'http://{{ httpbin_host }}/anything'
@@ -165,8 +183,10 @@
 
 - assert:
     that:
+    - http_307_head is successful
     - http_307_head.json.data == ''
     - http_307_head.json.method == 'GET'
+    - http_307_head.json.url == 'http://{{ httpbin_host }}/anything'
     - http_307_head.redirected == true
     - http_307_head.status == 200
     - http_307_head.url == 'http://{{ httpbin_host }}/anything'
@@ -181,8 +201,10 @@
 
 - assert:
     that:
+    - http_307_get is successful
     - http_307_get.json.data == ''
     - http_307_get.json.method == 'GET'
+    - http_307_get.json.url == 'http://{{ httpbin_host }}/anything'
     - http_307_get.redirected == true
     - http_307_get.status == 200
     - http_307_get.url == 'http://{{ httpbin_host }}/anything'
@@ -201,6 +223,7 @@
 
 - assert:
     that:
+    - http_307_post is failure
     - http_307_post.json is not defined
     - http_307_post.location == 'http://{{ httpbin_host }}/anything'
     - "http_307_post.msg == 'Status code was 307 and not [200]: HTTP Error 307: TEMPORARY REDIRECT'"
@@ -220,6 +243,7 @@
 
 - assert:
     that:
+    - http_308_head is failure
     - http_308_head.json is not defined
     - http_308_head.location == 'http://{{ httpbin_host }}/anything'
     - "http_308_head.msg == 'Status code was 308 and not [200]: HTTP Error 308: UNKNOWN'"
@@ -239,6 +263,7 @@
 
 - assert:
     that:
+    - http_308_get is failure
     - http_308_get.json is not defined
     - http_308_get.location == 'http://{{ httpbin_host }}/anything'
     - "http_308_get.msg == 'Status code was 308 and not [200]: HTTP Error 308: UNKNOWN'"
@@ -260,6 +285,7 @@
 
 - assert:
     that:
+    - http_308_post is failure
     - http_308_post.json is not defined
     - http_308_post.location == 'http://{{ httpbin_host }}/anything'
     - "http_308_post.msg == 'Status code was 308 and not [200]: HTTP Error 308: UNKNOWN'"


### PR DESCRIPTION
##### SUMMARY
This PR includes fixes to `follow_redirects=all`:
- Ensure HTTP 307 and 308 will redirect the request to the new location without modification. (including support for POST/PUT and payload)
- Ensure that HTTP 301, 302 and 303 do GET requests only

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
module_utils/urls.py

##### ANSIBLE VERSION
v2.5