### PR TITLE
Include Digital Ocean Token Alias

### DIFF
--- a/lib/ansible/module_utils/digital_ocean.py
+++ b/lib/ansible/module_utils/digital_ocean.py
@@ -106,6 +106,7 @@ class DigitalOceanHelper:
                 # Support environment variable for DigitalOcean OAuth Token
                 fallback=(env_fallback, ['DO_API_TOKEN', 'DO_API_KEY', 'DO_OAUTH_TOKEN', 'OAUTH_TOKEN']),
                 required=False,
+                aliases=['api_token'],
             ),
             timeout=dict(type='int', default=30),
         )

--- a/lib/ansible/utils/module_docs_fragments/digital_ocean.py
+++ b/lib/ansible/utils/module_docs_fragments/digital_ocean.py
@@ -13,6 +13,7 @@ options:
      - "There are several other environment variables which can be used to provide this value."
      - "i.e., - 'DO_API_TOKEN', 'DO_API_KEY', 'DO_OAUTH_TOKEN' and 'OAUTH_TOKEN'"
     required: false
+    aliases: ['api_token']
   timeout:
     description:
     - The timeout in seconds used for polling DigitalOcean's API.


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
module_utils/digital_ocean.py doesn't allow for the `api_token` alias. This alias needs to be in place to not break existing users who still use the api_token parameter in `digital_ocean_tags` and `digital_ocean` modules.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
lib/ansible/module_utils/digital_ocean.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel@2.6.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Unsupported parameters for (digital_ocean_tag) module: api_token Supported parameters include: name, oauth_token, resource_id, resource_type, state, timeout, validate_certs"}

```