### PR TITLE
Improve module docs wrt. required params

### DIFF
--- a/docs/templates/plugin.rst.j2
+++ b/docs/templates/plugin.rst.j2
@@ -91,7 +91,6 @@ Options
         {# Header of the documentation #}
         <tr>
             <th class="head"><div class="cell-border">Parameter</div></th>
-            <th class="head"><div class="cell-border">Required?</div></th>
             <th class="head"><div class="cell-border">Default</div></th>
             <th class="head"><div class="cell-border">Choices</div></th>
             {% if plugin_type != 'module' %}
@@ -109,12 +108,12 @@ Options
                             </div>
                         {% endfor %}
                         <div class="elbow-key">
-                            <b>@{ key }@</b><br/><div style="font-size: small;">{% if value.version_added %} (added in @{value.version_added}@){% endif %}</div>
+                            <b>@{ key }@</b>
+                            {% if value.get('required', False) %}<br/><div style="font-size: small; color: red">required</div>{% endif %}
+                            {% if value.version_added %}<br/><div style="font-size: small; color: darkgreen">(added in @{value.version_added}@)</div>{% endif %}
                         </div>
                     <div class="outer-elbow-container">
                 </td>
-                {# required #}
-                <td><div class="cell-border">{% if value.get('required', False) %}required{% endif %}</div></td>
                 {# default value #}
                 <td><div class="cell-border">{% if value.default %}@{ value.default | html_ify }@{% endif %}</div></td>
                 {# choices #}


### PR DESCRIPTION
##### SUMMARY
So I am still not satisfied with how required parameters are being
displayed (before it was yes/no, then it became required/optional, and
only required).

Now it will display in small red 'required' under the parameter name.
This is more convenient, and provides more room for the description.
Especially on smaller screens.

##### ISSUE TYPE
 - Feature Pull Request
 - Docs Pull Request

##### COMPONENT NAME
webdocs

##### ANSIBLE VERSION
v2.5