### PR TITLE
Fix indentation of requirements

### DIFF
--- a/docs/templates/plugin.rst.j2
+++ b/docs/templates/plugin.rst.j2
@@ -65,16 +65,15 @@ Aliases: @{ ','.join(aliases) }@
 {% endif %}
 
 {% if requirements %}
-{%   set req = 'Requirements' %}
+{%   set req_title = 'Requirements' %}
 {%   if plugin_type == 'module' %}
-{%     set req = req + ' (on host that executes module)' %}
+{%     set req_title = req_title + ' (on host that executes module)' %}
 {%   endif %}
-{%   set req_len = req|length %}
-@{ req }@
-@{ '-' * req_len }@
+@{ req_title }@
+@{ '-' * req_title|length }@
 
 {%   for req in requirements %}
-  * @{ req | convert_symbols_to_format }@
+* @{ req | convert_symbols_to_format }@
 {%   endfor %}
 
 {% endif %}


### PR DESCRIPTION
##### SUMMARY
Just discovered that the requirements were indented, whereas all other
lists were not. This makes them stand out for no good reason.

https://docs.ansible.com/ansible/devel/modules/aci_rest_module.html#aci-rest

##### ISSUE TYPE
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
module docs

##### ANSIBLE VERSION
v2.5