### PR TITLE
Move notes higher up in order

### DIFF
--- a/docs/templates/plugin.rst.j2
+++ b/docs/templates/plugin.rst.j2
@@ -188,6 +188,19 @@ Options
     </br>
 
 {% endif %}
+{% if notes -%}
+
+
+Notes
+-----
+
+.. note::
+{%   for note in notes %}
+    - @{ note | convert_symbols_to_format }@
+{%   endfor %}
+
+
+{% endif %}
 {% if examples or plainexamples -%}
 
 
@@ -266,19 +279,6 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
 {% endif %}
 
 
-{% if notes -%}
-
-
-Notes
------
-
-.. note::
-{%   for note in notes %}
-    - @{ note | convert_symbols_to_format }@
-{%   endfor %}
-
-
-{% endif %}
 {% if author is defined -%}
 
 


### PR DESCRIPTION
##### SUMMARY
So people reading the module documentation usually look for parameters
first, and are interested in examples. However the notes are at the very
end even below the Return Values (the least interesting part).

So this change moves the notes higher up, below parameters, but before
examples so people at least see the notes.

##### ISSUE TYPE
 - Feature Pull Request
 - Docs Pull Request

##### COMPONENT NAME
module docs

##### ANSIBLE VERSION
v2.5