### PR TITLE
aci_rest: Parameter method is not required

### DIFF
--- a/lib/ansible/modules/network/aci/aci_rest.py
+++ b/lib/ansible/modules/network/aci/aci_rest.py
@@ -42,7 +42,6 @@ options:
     - Using C(delete) is typically used for deleting objects.
     - Using C(get) is typically used for querying objects.
     - Using C(post) is typically used for modifying objects.
-    required: yes
     default: get
     choices: [ delete, get, post ]
     aliases: [ action ]


### PR DESCRIPTION
##### SUMMARY
This fixes an issue with the documentation

##### ISSUE TYPE
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
aci_rest

##### ANSIBLE VERSION
v2.5