### PR TITLE
ACI: Parameter username is not required

### DIFF
--- a/lib/ansible/utils/module_docs_fragments/aci.py
+++ b/lib/ansible/utils/module_docs_fragments/aci.py
@@ -23,7 +23,6 @@ options:
   username:
     description:
     - The username to use for authentication.
-    required: yes
     default: admin
     aliases: [ user ]
   password:


### PR DESCRIPTION
##### SUMMARY
Another parameter incorrectly documented.

##### ISSUE TYPE
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
ACI modules

##### ANSIBLE VERSION
v2.5