### PR TITLE
fix parameters passed as string that should be integer

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_deployment.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_deployment.py
@@ -490,6 +490,12 @@ class AzureRMDeploymentManager(AzureRMModuleBase):
                 uri=self.template_link
             )
 
+        # this is to fix issue #35536 -- it's impossible to pass int parameters
+        if self.parameters and self.template:
+            for k in self.parameters:
+                if self.template['parameters'][k]['type'] == "int":
+                    self.parameters[k]['value'] = int(self.parameters[k]['value'])
+
         params = self.rm_models.ResourceGroup(location=self.location, tags=self.tags)
 
         try:


### PR DESCRIPTION
##### SUMMARY
Fixes bug #35536 
Converts parameters passed as string to int based on template definition.
Note: template has to be specified via **template** parameter, for example using **lookup** instead of **template_url**

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
azure_rm_deployment

##### ANSIBLE VERSION
2.4

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
