### PR TITLE
Add aws_caller_facts module to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ See [Porting Guide](http://docs.ansible.com/ansible/devel/porting_guides/porting
 
 ### New Modules
 
+#### Cloud
+- amazon
+  * aws_caller_facts
+
 
 <a id="2.5"></a>
 


### PR DESCRIPTION
##### SUMMARY

Adding Changelog entry for aws_caller_facts module added in #36683

cc @willthames 

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
aws_caller_facts

##### ANSIBLE VERSION
```
ansible 2.6.0 (aws_caller_facts_module ee8565737c) last updated 2018/02/25 12:41:33 (GMT +1300)
  config file = None
  configured module search path = [u'USER_HOME/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = ANSIBLE_CHECKOUT/lib/ansible
  executable location = ANSIBLE_CHECKOUT/bin/ansible
  python version = 2.7.14 (default, Sep 23 2017, 22:06:14) [GCC 7.2.0]
```

