### PR TITLE
fix aws_s3 module to use custum s3_url.

### DIFF
--- a/changelogs/fragments/aws_s3_fix_custom_endpoints.yaml
+++ b/changelogs/fragments/aws_s3_fix_custom_endpoints.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- allow custom endpoints to be used in the aws_s3 module (https://github.com/ansible/ansible/pull/36832)

--- a/lib/ansible/modules/cloud/amazon/aws_s3.py
+++ b/lib/ansible/modules/cloud/amazon/aws_s3.py
@@ -625,17 +625,6 @@ def is_fakes3(s3_url):
         return False
 
 
-def is_walrus(s3_url):
-    """ Return True if it's Walrus endpoint, not S3
-
-    We assume anything other than *.amazonaws.com is Walrus"""
-    if s3_url is not None:
-        o = urlparse(s3_url)
-        return not o.netloc.endswith('amazonaws.com')
-    else:
-        return False
-
-
 def get_s3_connection(module, aws_connect_kwargs, location, rgw, s3_url, sig_4=False):
     if s3_url and rgw:  # TODO - test this
         rgw = urlparse(s3_url)
@@ -654,9 +643,6 @@ def get_s3_connection(module, aws_connect_kwargs, location, rgw, s3_url, sig_4=F
         params = dict(module=module, conn_type='client', resource='s3', region=location,
                       endpoint="%s://%s:%s" % (protocol, fakes3.hostname, to_text(port)),
                       use_ssl=fakes3.scheme == 'fakes3s', **aws_connect_kwargs)
-    elif is_walrus(s3_url):
-        walrus = urlparse(s3_url).hostname
-        params = dict(module=module, conn_type='client', resource='s3', region=location, endpoint=walrus, **aws_connect_kwargs)
     else:
         params = dict(module=module, conn_type='client', resource='s3', region=location, endpoint=s3_url, **aws_connect_kwargs)
         if module.params['mode'] == 'put' and module.params['encryption_mode'] == 'aws:kms':


### PR DESCRIPTION
##### SUMMARY
It is not possible to use aws_s3 modules with a customized s3_url.

With a custom s3_url url it is never possible to reach the else in get_s3_connection.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
aws_s3

##### ANSIBLE VERSION
```
2.4.3.0
```

##### ADDITIONAL INFORMATION

The walrus code extracts the hostname from the s3_url and boto3 throws `Invalid Endpoint`
```
  - aws_s3:
      bucket: hermestest123
      aws_access_key: XXXXX
      aws_secret_key: XXXXXXXXXXXX
      s3_url: https://obs.otc.t-systems.com
      mode: create
```

The boto3 documentation says that you need to define a full URL with a schema.
```
http://boto3.readthedocs.io/en/latest/reference/core/session.html

endpoint_url (string) -- The complete URL to use for the constructed client. Normally, botocore 
will automatically construct the appropriate URL to use when communicating with a service. You 
can specify a complete URL (including the "http/https" scheme) to override this behavior. 
If this value is provided, then use_ssl is ignored.
```

```
The full traceback is:
  File "/tmp/ansible_YwcUE7/ansible_modlib.zip/ansible/module_utils/ec2.py", line 99, in boto3_conn
    return _boto3_conn(conn_type=conn_type, resource=resource, region=region, endpoint=endpoint, **params)
  File "/tmp/ansible_YwcUE7/ansible_modlib.zip/ansible/module_utils/ec2.py", line 118, in _boto3_conn
    client = boto3.session.Session(profile_name=profile).client(resource, region_name=region, endpoint_url=endpoint, **params)
  File "/home/groschuppchr/venv/lib/python2.7/site-packages/boto3/session.py", line 263, in client
    aws_session_token=aws_session_token, config=config)
  File "/home/groschuppchr/venv/lib/python2.7/site-packages/botocore/session.py", line 861, in create_client
    client_config=config, api_version=api_version)
  File "/home/groschuppchr/venv/lib/python2.7/site-packages/botocore/client.py", line 76, in create_client
    verify, credentials, scoped_config, client_config, endpoint_bridge)
  File "/home/groschuppchr/venv/lib/python2.7/site-packages/botocore/client.py", line 285, in _get_client_args
    verify, credentials, scoped_config, client_config, endpoint_bridge)
  File "/home/groschuppchr/venv/lib/python2.7/site-packages/botocore/args.py", line 79, in get_client_args
    timeout=(new_config.connect_timeout, new_config.read_timeout))
  File "/home/groschuppchr/venv/lib/python2.7/site-packages/botocore/endpoint.py", line 289, in create_endpoint
    raise ValueError("Invalid endpoint: %s" % endpoint_url)

fatal: [localhost]: FAILED! => {
    "changed": false,
    "invocation": {
        "module_args": {
            "aws_access_key": "S3RHEYTMWRHJ6QW0C7ZA",
            "aws_secret_key": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "bucket": "hermestest123",
            "dest": null,
            "ec2_url": null,
            "encrypt": true,
            "expiry": 600,
            "headers": null,
            "ignore_nonexistent_bucket": false,
            "marker": "",
            "max_keys": 1000,
            "metadata": null,
            "mode": "create",
            "object": null,
            "overwrite": "always",
            "permission": [
                "private"
            ],
            "prefix": "",
            "profile": null,
            "region": null,
            "retries": 0,
            "rgw": false,
            "s3_url": "https://obs.otc.t-systems.com",
            "security_token": null,
            "src": null,
            "validate_certs": false,
            "version": null
        }
    },
    "msg": "There is an issue in the code of the module. You must specify either both, resource or client to the conn_type parameter in the boto3_conn function call"
}

```

With an s3_url without schema, the endpoint is always empty and boto connects to the aws endpoints.
```
  - aws_s3:
      bucket: hermestest123
      aws_access_key: XXXXX
      aws_secret_key: XXXXXXXXXXXX
      s3_url: obs.otc.t-systems.com
      mode: create
```

```
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ClientError: An error occurred (403) when calling the HeadBucket operation: Forbidden
fatal: [localhost]: FAILED! => {"changed": false, "error": {"code": "403", "message": "Forbidden"}, "msg": "Failed while looking up bucket (during bucket_check) hermestest123.", "response_metadata": {"host_id": "B65bpv5BmRUQ1xgEzvXc3+v1syjrl08tNAWCYGl8H489uADMJz05OQMbQwUcAvzVikVvjJgTtTU=", "http_headers": {"content-type": "application/xml", "date": "Wed, 28 Feb 2018 08:27:19 GMT", "server": "AmazonS3", "transfer-encoding": "chunked", "x-amz-id-2": "B65bpv5BmRUQ1xgEzvXc3+v1syjrl08tNAWCYGl8H489uADMJz05OQMbQwUcAvzVikVvjJgTtTU=", "x-amz-request-id": "C4A401E2DFDA9DB4"}, "http_status_code": 403, "request_id": "C4A401E2DFDA9DB4", "retry_attempts": 0}}
```