### PR TITLE
Additions to AWS Module Guidlines from Pull Request Feedback

### DIFF
--- a/lib/ansible/module_utils/aws/core.py
+++ b/lib/ansible/module_utils/aws/core.py
@@ -38,10 +38,11 @@ The 'AnsibleAWSModule' module provides similar, but more restricted,
 interfaces to the normal Ansible module.  It also includes the
 additional methods for connecting to AWS using the standard module arguments
 
-  try:
-      m.aws_connect(resource='lambda') # - get an AWS connection.
-  except Exception:
-      m.fail_json_aws(Exception, msg="trying to connect") # - take an exception and make a decent failure
+      m.resource('lambda') # - get an AWS connection as a boto3 resource.
+
+or
+
+      m.client('sts') # - get an AWS connection as a boto3 client.
 
 
 """

--- a/lib/ansible/modules/cloud/amazon/GUIDELINES.md
+++ b/lib/ansible/modules/cloud/amazon/GUIDELINES.md
@@ -176,6 +176,28 @@ region, ec2_url, aws_connect_params = get_aws_connection_info(module, boto3=True
 connection = boto3_conn(module, conn_type='client', resource='ec2', region=region, endpoint=ec2_url, **aws_connect_params)
 ```
 
+### Common Documentation Fragments for Connection Parameters
+
+There are two [common documentation fragments](http://docs.ansible.com/ansible/latest/dev_guide/developing_modules_documenting.html#documentation-fragments)
+that should be included into almost all AWS modules:
+
+* `aws` - contains the common boto connection parameters
+* `ec2` - contains the common region parameter required for many AWS modules
+
+These fragments should be used rather than re-documenting these properties to ensure consistency
+and that the more esoteric connection options are documented. e.g.
+
+```python
+DOCUMENTATION = '''
+module: my_module
+...
+requirements: [ 'botocore', 'boto3' ]
+extends_documentation_fragment:
+    - aws
+    - ec2
+'''
+```
+
 ### Exception Handling for boto
 
 You should wrap any boto call in a try block. If an exception is thrown, it is up to you decide how

--- a/lib/ansible/modules/cloud/amazon/GUIDELINES.md
+++ b/lib/ansible/modules/cloud/amazon/GUIDELINES.md
@@ -544,25 +544,13 @@ Particularly the [cloud test configuration section](http://docs.ansible.com/ansi
 
 The integration tests for your module should be added in `test/integration/targets/MODULE_NAME`.
 
-You must have the following in `test/integration/targets/MODULE_NAME/aliases`
+You must also have a aliases file in `test/integration/targets/MODULE_NAME/aliases`. This file serves
+two purposes. First indicates it's in an AWS test causing the test framework to make AWS credentials
+available during the test run. Second putting the test in a test group causing it to be run in the
+continuous integration build.
 
-```
-cloud/aws
-posix/ci/cloud/group2/aws
-```
-
-The first line indicates in an AWS test causing the test framework to make AWS credentials available
-during the test run.
-
-The second line puts the test in a test group causing it to be run in the continuous integration build.
-There are currently 5 groups (group1 - group5). The groups are just to parallelize the build, so try
-to place your new tests in the group that's currently taking the least time to run.
-
-Look at the recent sucessful [CI builds](https://app.shippable.com/github/ansible/ansible/runs?branchName=devel#completedJobs)
-to see if one of the _T=cloud/default/3.6/X_ builds is obviously shorter, if so put your test in group X.
-
-If there's not an obvious candidate just pick any group as this will achieve the goal of distributing
-the tests between the groups.
+Tests for new modules should be added to the same group as existing AWS tests. In general just copy
+an existing aliases file such as the [aws_s3 tests aliases file](https://github.com/ansible/ansible/blob/devel/test/integration/targets/aws_s3/aliases).
 
 ### AWS Credentials for Integration Tests
 

--- a/lib/ansible/modules/cloud/amazon/GUIDELINES.md
+++ b/lib/ansible/modules/cloud/amazon/GUIDELINES.md
@@ -125,10 +125,11 @@ if my_new_feature_Parameter_is_set:
 
 ### Connecting to AWS
 
-To connect to AWS, you should use `get_aws_connection_info` and then `boto3_conn`.
+AnsibleAWSModule provides the `resource` and `client` helper methods for obtaining boto3 connections.
+These handle some of the more esoteric connection options, such as security tokens and boto profiles.
 
-These functions handle some of the more esoteric connection options, such as security tokens and
-boto profiles.
+If using the basic AnsibleModule then you should use `get_aws_connection_info` and then `boto3_conn`
+to connect to AWS as these handle the same range of connection options.
 
 
 #### boto
@@ -157,6 +158,18 @@ exception handling like in boto.  Instead, an `AuthFailure` exception will be th
 caught, you should catch `ClientError` and `BotoCoreError` exceptions with every boto3 connection call.
 See exception handling. module_utils.ec2 checks for missing profiles or a region not set when it needs to be,
 so you don't have to.
+
+```python
+module.client('ec2')
+```
+
+or for the higher level ec2 resource:
+
+```python
+module.resource('ec2')
+```
+
+An example of the older style connection used for modules based on AnsibleModule rather than AnsibleAWSModule:
 
 ```python
 region, ec2_url, aws_connect_params = get_aws_connection_info(module, boto3=True)


### PR DESCRIPTION
##### SUMMARY
A number of documentation updates to the AWS module guidelines and AnsibleAWSModule suport class to capture things that I've only been able to find from copying other modules and pull request feedback or otherwise have tripped me up a couple of times.

Specifically:
* New AnsibleAWSModule connection helpers`client` and `resource`
* Requirement for integration tests for new modules
* Necessary aliases file to get AWS credentials in integration tests
* How to access aws credentials in integration test
* Need to update permissions for integration tests
* Common documentation fragments that should be used

I've also removed the try/except block from the documentation in AnsibleAWSModule connect since according to the guidelines these methods do not throw connection exceptions and the exceptions instead come when using the connection.

Happy to move or restructure if there is a more appropriate place for any of this information.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
aws

##### ANSIBLE VERSION
```
ansible 2.6.0 (docfix_connect_in_ansible_aws_module 41bee9fda3) last updated 2018/02/28 22:19:52 (GMT +1300)
  config file = None
  configured module search path = [u'USER_HOME/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = ANSIBLE_CHECKOUT/lib/ansible
  executable location = ANSIBLE_CHECKOUT/bin/ansible
  python version = 2.7.14 (default, Sep 23 2017, 22:06:14) [GCC 7.2.0]
```


##### ADDITIONAL INFORMATION

Most of these are triggered by feedback on #36683