### PR TITLE
aws_ssm_parameter_store module - value parameter should be no_log

### DIFF
--- a/lib/ansible/modules/cloud/amazon/aws_ssm_parameter_store.py
+++ b/lib/ansible/modules/cloud/amazon/aws_ssm_parameter_store.py
@@ -169,7 +169,7 @@ def setup_module_object():
     argument_spec = dict(
         name=dict(required=True),
         description=dict(),
-        value=dict(required=False),
+        value=dict(required=False, no_log=True),
         state=dict(default='present', choices=['present', 'absent']),
         string_type=dict(default='String', choices=['String', 'StringList', 'SecureString']),
         decryption=dict(default=True, type='bool'),


### PR DESCRIPTION
##### SUMMARY

change the value parameter to be no_log

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

aws_ssm_parameter_store module

##### ANSIBLE VERSION

```
ansible 2.6.0 (aws_ssm_parameter_store_nolog ddc398eda0) last updated 2018/02/28 12:42:01 (GMT +100)
  config file = None
  configured module search path = [u'/home/mikedlr/dev/ansible/ansible-dev/library']
  ansible python module location = /home/mikedlr/dev/ansible/ansible-dev/lib/ansible
  executable location = /home/mikedlr/dev/ansible/ansible-dev/bin/ansible
  python version = 2.7.5 (default, Aug  4 2017, 00:39:18) [GCC 4.8.5 20150623 (Red Hat 4.8.5-16)]
```


##### ADDITIONAL INFORMATION

It would be nice to allow logging if the value is from a String and not a SecureString parameter. 

