### PR TITLE
Automatically stuff reference in commit message

### DIFF
--- a/docs/docsite/_themes/sphinx_rtd_theme/breadcrumbs.html
+++ b/docs/docsite/_themes/sphinx_rtd_theme/breadcrumbs.html
@@ -7,7 +7,7 @@
     </li>
   {% elif (not 'list_of' in pagename) and (not 'category' in pagename) %}
     <li class="wy-breadcrumbs-aside">
-      <a href="https://github.com/ansible/ansible/edit/devel/docs/docsite/rst/{{ pagename }}.rst" class="icon icon-github"> Edit on GitHub</a>
+      <a href="https://github.com/ansible/ansible/edit/devel/docs/docsite/rst/{{ pagename }}.rst?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A+label:%20docsite_pr" class="icon icon-github"> Edit on GitHub</a>
     </li>
   {% endif %}
 </ul>

--- a/docs/docsite/_themes/sphinx_rtd_theme/breadcrumbs.html
+++ b/docs/docsite/_themes/sphinx_rtd_theme/breadcrumbs.html
@@ -3,7 +3,7 @@
   <li><a href="">{{ title }}</a></li>
   {% if pagename.endswith('_module') %}
     <li class="wy-breadcrumbs-aside">
-      <a href="https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/{{ meta.get('source', '') }}" class="icon icon-github"> Edit on GitHub</a>
+      <a href="https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/{{ meta.get('source', '') }}?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A+label:%20docsite_pr" class="icon icon-github"> Edit on GitHub</a>
     </li>
   {% elif (not 'list_of' in pagename) and (not 'category' in pagename) %}
     <li class="wy-breadcrumbs-aside">

--- a/docs/templates/plugin.rst.j2
+++ b/docs/templates/plugin.rst.j2
@@ -318,4 +318,4 @@ please refer to this `Knowledge Base article <https://access.redhat.com/articles
 {%   endif %}
 {% endif %}
 
-If you notice any issues in this documentation you can ``edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/@{ source }@>`` to improve it.
+If you notice any issues in this documentation you can ``edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/@{ source }@?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A+label:%20docsite_pr>`` to improve it.


### PR DESCRIPTION
##### SUMMARY
So we probably want to track which edits were performed through the
Github interface, and this change automatically adds a label to the
commit message.

```yaml
<!--- Your description here -->

+label: docsite_pr
```

Eventually this allows to (on regular basis) list the changes from
documentation readers and process them in a separate process.

The "Edit on GitHub" link on the **aci_rest** module docs will actually bring you to [this page](https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/network/aci/aci_rest.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A+label:%20docsite_pr).

This is part of a long list of module docs improvements:
https://github.com/ansible/ansible/pull/36815, https://github.com/ansible/ansible/pull/36813, https://github.com/ansible/ansible/pull/36812, https://github.com/ansible/ansible/pull/36688, https://github.com/ansible/ansible/pull/36667, https://github.com/ansible/ansible/pull/36841

This builds on top of #36841 

##### ISSUE TYPE
 - Feature Pull Request
 - Docs Pull Request

##### COMPONENT NAME
module docs

##### ANSIBLE VERSION
v2.5