### PR TITLE
Updating License Information

### DIFF
--- a/lib/ansible/plugins/cliconf/enos.py
+++ b/lib/ansible/plugins/cliconf/enos.py
@@ -1,20 +1,13 @@
+# Copyright (C) 2017 Lenovo. All rights reserved.
 #
-# (c) 2017 Red Hat Inc.
+# GNU General Public License v3.0+
 #
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
+# This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 #
 # Contains CLIConf Plugin methods for ENOS Modules
 # Lenovo Networking

--- a/lib/ansible/plugins/cliconf/enos.py
+++ b/lib/ansible/plugins/cliconf/enos.py
@@ -29,7 +29,6 @@ class Cliconf(CliconfBase):
 
     def get_device_info(self):
         device_info = {}
-
         device_info['network_os'] = 'enos'
         reply = self.get(b'show version')
         data = to_text(reply, errors='surrogate_or_strict').strip()


### PR DESCRIPTION
SUMMARY

Updating License after review from Lenovo legal team.

ISSUE TYPE

Documentation Pull Request

COMPONENT NAME

lib/ansible/plugins/cliconf/enos.py

ANSIBLE VERSION

ansible 2.5.0
config file = /etc/ansible/ansible.cfg
configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible-2.5.0-py2.7.egg/ansible
executable location = /usr/local/bin/ansible
python version = 2.7.6 (default, Oct 26 2016, 20:30:19) [GCC 4.8.4]

ADDITIONAL INFORMATION

This is an effort to create config modules for enos based switches from Lenovo.