### PR TITLE
aws_ssm_parameter_store module - value parameter should be no_log sin…

### DIFF
--- a/lib/ansible/modules/cloud/amazon/aws_ssm_parameter_store.py
+++ b/lib/ansible/modules/cloud/amazon/aws_ssm_parameter_store.py
@@ -169,7 +169,7 @@ def setup_module_object():
     argument_spec = dict(
         name=dict(required=True),
         description=dict(),
-        value=dict(required=False),
+        value=dict(required=False, no_log=True),
         state=dict(default='present', choices=['present', 'absent']),
         string_type=dict(default='String', choices=['String', 'StringList', 'SecureString']),
         decryption=dict(default=True, type='bool'),


### PR DESCRIPTION
…ce it's often a secret (#36843)

(cherry picked from commit 3f19ef680ab8a8051a0f90ae34fcc0f89db8db0e)

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - New Module Pull Request
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
