### PR TITLE
Add "delay vault decryption" option to ansible-inventory

### DIFF
--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1317,6 +1317,14 @@ INVENTORY_EXPORT:
   ini:
   - {key: export, section: inventory}
   type: bool
+INVENTORY_DELAY_DECRYPTION:
+  name: Set ansible-inventory to delay decryption
+  default: False
+  description: Controls if ansible-inventory will delay decrypting embded values.
+  env: [{name: INVENTORY_DELAY_DECRYPTION}]
+  ini:
+  - {key: delay_decryption, section: inventory}
+  type: bool
 INVENTORY_IGNORE_EXTS:
   name: Inventory ignore extensions
   default: "{{(BLACKLIST_EXTS + ( '~', '.orig', '.ini', '.cfg', '.retry'))}}"

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -780,15 +780,16 @@ def _json_encode_fallback(obj):
 
 def jsonify(data, **kwargs):
     for encoding in ("utf-8", "latin-1"):
+        kwargs.setdefault('default', _json_encode_fallback)
         try:
-            return json.dumps(data, encoding=encoding, default=_json_encode_fallback, **kwargs)
+            return json.dumps(data, encoding=encoding, **kwargs)
         # Old systems using old simplejson module does not support encoding keyword.
         except TypeError:
             try:
                 new_data = json_dict_bytes_to_unicode(data, encoding=encoding)
             except UnicodeDecodeError:
                 continue
-            return json.dumps(new_data, default=_json_encode_fallback, **kwargs)
+            return json.dumps(new_data, **kwargs)
         except UnicodeDecodeError:
             continue
     raise UnicodeError('Invalid unicode encoding encountered')


### PR DESCRIPTION
##### SUMMARY

If used, this flag (or setting) will put off decrypting embedded
vault secrets. "embeded" means that the value of a host or group
variable is encrypted. Full-file encrypted contents are not
compatible with this.

Also, modify the json dumper used by ansible-inventory to print
JSON format even when vault secrets are present. This offers
basic support of the alternative behavior obtained by not applying
the flag.

This is both a feature and a bug fix, because it is allowing 2 use cases, where neither use case really truly worked before.

Fixes #31141

I included a FIXME, because it's not totally functional. I need to find some method inside of the code base that will force-decrypt the content (in arbitrary data) without also JSON-ifying it, and I could use some help there.

To put this limitation in other terms, it's _impossible_ to decrypt secrets if you use the `--yaml` option. The purpose of the flag is:

> the --yaml option is meant to be compatible with the 'yaml' inventory plugin

I can confirm that `ansible-playbook` does decrypt embedded values in yaml inventory, but `ansible-inventory` does not.

##### ISSUE TYPE
 - Feature Pull Request
 - Bugfix Pull Request

##### COMPONENT NAME
ansible-inventory

##### ANSIBLE VERSION
```
ansible --version
ansible 2.6.0
  config file = None
  configured module search path = [u'/Users/alancoding/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/alancoding/.virtualenvs/ansible/lib/python2.7/site-packages/ansible-2.6.0-py2.7.egg/ansible
  executable location = /Users/alancoding/.virtualenvs/ansible/bin/ansible
  python version = 2.7.11 (default, Oct 17 2016, 14:59:40) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```


##### ADDITIONAL INFORMATION
This feature request is for the purpose of enabling the future AWX feature https://github.com/ansible/awx/issues/223

My original intent was to reconfigure AWX to both consume vault-laden YAML (the term I'm using for 
data that contains encrypted values inside host or group variables), and pass vault-laden YAML to `ansible-playbook` in our inventory construction. The 2nd part of this still has a lot of confusion around it and the future path remains unclear. At first, I thought people were telling me that the script inventory plugin read the output as JSON, but experimentation contracts this. Anyway, other parallel developments for the AWX task engine looks like it might rule out the option anyway. Given the pushback, I hope to seriously look into the vars plugin option.

Even if I assume that I'll pass the content via some other contract for AWX running `ansible-playbook`, I still need this content here. Because of that, I'm trying to address it early so that by the time the 2nd problem is solved, supported versions of Ansible core will have the 1st problem solved.

It looks like I have sufficient examples inside of my examples repo from the bug report. The gist of this is the following.

https://github.com/AlanCoding/Ansible-inventory-file-examples/

###### Using the flag

```
ansible-inventory -i vault/yaml_subvar/ansible_example.yml --list --delay
_meta:
  hostvars:
    green.example.com:
      anyvariable: value
      firstvariable: !vault |
        $ANSIBLE_VAULT;1.1;AES256
        32633234373965356537366531333238363166393039306462633137353462396335653531633637
        6335366138623264303862306535303366646630643262650a386433376130383562343037613764
        62653330643635623033323764383461613331336339336435633864303032646233393336643366
        6163383166626565660a623836303939326564346338343338346366373561623862633065613266
        6132
all:
  children:
  - ungrouped
ungrouped:
  hosts:
  - green.example.com
```

###### Not the flag

```
ansible-inventory -i vault/yaml_subvar/ansible_example.yml --list --ask-vault-pass
Vault password: 
{
    "_meta": {
        "hostvars": {
            "green.example.com": {
                "anyvariable": "value", 
                "firstvariable": "191.168.100.32"
            }
        }
    }, 
    "all": {
        "children": [
            "ungrouped"
        ]
    }, 
    "ungrouped": {
        "hosts": [
            "green.example.com"
        ]
    }
}
```
