### PR TITLE
crypto: Fix incorrect type for privatekey_passphrase

### DIFF
--- a/lib/ansible/modules/crypto/openssl_certificate.py
+++ b/lib/ansible/modules/crypto/openssl_certificate.py
@@ -797,7 +797,7 @@ def main():
 
             # General properties of a certificate
             privatekey_path=dict(type='path'),
-            privatekey_passphrase=dict(type='path', no_log=True),
+            privatekey_passphrase=dict(type='str', no_log=True),
             signature_algorithms=dict(type='list'),
             subject=dict(type='dict'),
             subject_strict=dict(type='bool', default=False),

--- a/lib/ansible/modules/crypto/openssl_publickey.py
+++ b/lib/ansible/modules/crypto/openssl_publickey.py
@@ -259,7 +259,7 @@ def main():
             path=dict(required=True, type='path'),
             privatekey_path=dict(type='path'),
             format=dict(type='str', choices=['PEM', 'OpenSSH'], default='PEM'),
-            privatekey_passphrase=dict(type='path', no_log=True),
+            privatekey_passphrase=dict(type='str', no_log=True),
         ),
         supports_check_mode=True,
         add_file_common_args=True,


### PR DESCRIPTION
##### SUMMARY

Fix incorrect type for privatekey_passphrase path -> str

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

 - openssl_certificate
 - openssl_publickey

##### ANSIBLE VERSION

 - devel

##### ADDITIONAL INFORMATION

 - N/A