### PR TITLE
quote path name before executing setfacl / getfacl

### DIFF
--- a/lib/ansible/modules/files/acl.py
+++ b/lib/ansible/modules/files/acl.py
@@ -130,7 +130,6 @@ acl:
 import os
 
 from ansible.module_utils.basic import AnsibleModule, get_platform
-from ansible.module_utils.six.moves import shlex_quote
 from ansible.module_utils._text import to_native
 
 
@@ -202,7 +201,7 @@ def build_command(module, mode, path, follow, default, recursive, entry=''):
     if default:
         cmd.insert(1, '-d')
 
-    cmd.append(shlex_quote(path))
+    cmd.append(path)
     return cmd
 
 
@@ -225,7 +224,7 @@ def acl_changed(module, cmd):
 def run_acl(module, cmd, check_rc=True):
 
     try:
-        (rc, out, err) = module.run_command(' '.join(cmd), check_rc=check_rc)
+        (rc, out, err) = module.run_command(cmd, check_rc=check_rc)
     except Exception as e:
         module.fail_json(msg=to_native(e))
 

--- a/lib/ansible/modules/files/acl.py
+++ b/lib/ansible/modules/files/acl.py
@@ -130,6 +130,7 @@ acl:
 import os
 
 from ansible.module_utils.basic import AnsibleModule, get_platform
+from ansible.module_utils.six.moves import shlex_quote
 from ansible.module_utils._text import to_native
 
 
@@ -201,7 +202,7 @@ def build_command(module, mode, path, follow, default, recursive, entry=''):
     if default:
         cmd.insert(1, '-d')
 
-    cmd.append(path)
+    cmd.append(shlex_quote(path))
     return cmd
 
 

--- a/test/integration/targets/acl/tasks/acl.yml
+++ b/test/integration/targets/acl/tasks/acl.yml
@@ -43,7 +43,7 @@
   register: output
 
 - name: get getfacl output
-  shell: "getfacl {{ test_file }}"
+  shell: "getfacl {{ test_file | quote }}"
   register: getfacl_output
 
 - name: verify output
@@ -60,7 +60,7 @@
   register: output
 
 - name: get getfacl output
-  shell: "getfacl {{ test_file }}"
+  shell: "getfacl {{ test_file | quote }}"
   register: getfacl_output
 
 - name: verify output
@@ -88,7 +88,7 @@
   register: output
 
 - name: get getfacl output
-  shell: "getfacl {{ test_file }}"
+  shell: "getfacl {{ test_file | quote }}"
   register: getfacl_output
 
 - name: verify output
@@ -110,7 +110,7 @@
   register: output
 
 - name: get getfacl output
-  shell: "getfacl {{ test_dir }}"
+  shell: "getfacl {{ test_dir | quote }}"
   register: getfacl_output
 
 - name: verify output
@@ -122,7 +122,7 @@
       - "'default:user:{{ test_user }}:rw-' in getfacl_output.stdout_lines"
 ##############################################################################
 - name: Cleanup
-  shell: "setfacl -b {{ test_dir }}"
+  shell: "setfacl -b {{ test_dir | quote }}"
 ##############################################################################
 - name: Same as previous but using entry shorthand
   acl:
@@ -133,7 +133,7 @@
   register: output
 
 - name: get getfacl output
-  shell: "getfacl {{ test_dir }}"
+  shell: "getfacl {{ test_dir | quote }}"
   register: getfacl_output
 
 - name: verify output
@@ -153,7 +153,7 @@
   register: output
 
 - name: get getfacl output
-  shell: "getfacl {{ test_dir }}"
+  shell: "getfacl {{ test_dir | quote }}"
   register: getfacl_output
 
 - name: verify output
@@ -165,7 +165,7 @@
       - "'default:user:{{ test_user }}:rw-' in getfacl_output.stdout_lines"
 ##############################################################################
 - name: Cleanup
-  shell: "setfacl -b {{ test_dir }}"
+  shell: "setfacl -b {{ test_dir | quote }}"
 ##############################################################################
 - name: Set default acls
   acl:
@@ -186,7 +186,7 @@
   register: output
 
 - name: get getfacl output
-  shell: "getfacl {{ test_dir }}"
+  shell: "getfacl {{ test_dir | quote }}"
   register: getfacl_output
 
 - name: verify output

--- a/test/integration/targets/acl/tasks/main.yml
+++ b/test/integration/targets/acl/tasks/main.yml
@@ -32,5 +32,5 @@
   vars:
     test_user: ansible_user
     test_group: ansible_group
-    test_file: /tmp/ansible_file
-    test_dir: "/tmp/ansible_dir/with some space"
+    test_file: '{{ output_dir }}/ansible file'
+    test_dir: "{{ output_dir }}/ansible_dir/with some space"

--- a/test/integration/targets/acl/tasks/main.yml
+++ b/test/integration/targets/acl/tasks/main.yml
@@ -33,4 +33,4 @@
     test_user: ansible_user
     test_group: ansible_group
     test_file: /tmp/ansible_file
-    test_dir: /tmp/ansible_dir
+    test_dir: "/tmp/ansible_dir/with some space"


### PR DESCRIPTION
##### SUMMARY
This PR quotes the path name before executing setfacl / getfacl.
It also adjust the test to use a path name with spaces

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
file ACL module

lib/ansible/modules/files/acl.py

##### ANSIBLE VERSION
2.6

##### ADDITIONAL INFORMATION
acl.py performs os.path.exists() before executing setfacl / getfacl. However, if path contains spaces, and is escaped in the playbook, os.path.exists() will fail due to the added quotes. If the path is not quoted setfacl / getfacl will fail.