### PR TITLE
Provide the ability to blacklist custom fields from having groups cre…

### DIFF
--- a/contrib/inventory/vmware_inventory.ini
+++ b/contrib/inventory/vmware_inventory.ini
@@ -96,9 +96,9 @@ password=vmware
 # You can blacklist custom fields so that they are not included in the
 # groupby_custom_field option. This is useful when you have custom fields that
 # have values that are unique to individual hosts. Timestamps for example.
-# The custom_field_blacklist option should be a comma separated list of custom
-# field keys to be blacklisted. These keys should be integers.
-# custom_field_blacklist=<key1>,<key2>,<key3>
+# The groupby_custom_field_excludes option should be a comma separated list of custom
+# field keys to be blacklisted.
+#groupby_custom_field_excludes=<custom_field_1>,<custom_field_2>,<custom_field_3>
 
 # The script attempts to recurse into virtualmachine objects and serialize
 # all available data. The serialization is comprehensive but slow. If the

--- a/contrib/inventory/vmware_inventory.ini
+++ b/contrib/inventory/vmware_inventory.ini
@@ -93,6 +93,13 @@ password=vmware
 # vmware_tag_ prefix is the default and consistent with ec2_tag_
 #custom_field_group_prefix = vmware_tag_
 
+# You can blacklist custom fields so that they are not included in the
+# groupby_custom_field option. This is useful when you have custom fields that
+# have values that are unique to individual hosts. Timestamps for example.
+# The custom_field_blacklist option should be a comma separated list of custom
+# field keys to be blacklisted. These keys should be integers.
+# custom_field_blacklist=<key1>,<key2>,<key3>
+
 # The script attempts to recurse into virtualmachine objects and serialize
 # all available data. The serialization is comprehensive but slow. If the
 # vcenter environment is large and the desired properties are known, create

--- a/contrib/inventory/vmware_inventory.py
+++ b/contrib/inventory/vmware_inventory.py
@@ -99,6 +99,7 @@ class VMWareInventory(object):
     host_filters = []
     skip_keys = []
     groupby_patterns = []
+    custom_field_blacklist = []
 
     safe_types = [bool, str, float, None] + list(integer_types)
     iter_types = [dict, list]
@@ -230,6 +231,7 @@ class VMWareInventory(object):
             'groupby_patterns': '{{ guest.guestid }},{{ "templates" if config.template else "guests"}}',
             'lower_var_keys': True,
             'custom_field_group_prefix': 'vmware_tag_',
+            'custom_field_blacklist': '',
             'groupby_custom_field': False}
         }
 
@@ -304,6 +306,10 @@ class VMWareInventory(object):
                     groupby_pattern += "}}"
                 self.groupby_patterns.append(groupby_pattern)
         self.debugl('groupby patterns are %s' % self.groupby_patterns)
+        if config.get('vmware', 'custom_field_blacklist') == '':
+            self.custom_field_blacklist = []
+        else:
+            self.custom_field_blacklist = list(map(int, config.get('vmware', 'custom_field_blacklist').split(',')))
         # Special feature to disable the brute force serialization of the
         # virtulmachine objects. The key name for these properties does not
         # matter because the values are just items for a larger list.
@@ -494,6 +500,8 @@ class VMWareInventory(object):
             for k, v in inventory['_meta']['hostvars'].items():
                 if 'customvalue' in v:
                     for tv in v['customvalue']:
+                        if tv['key'] in self.custom_field_blacklist:
+                            continue
                         newkey = None
                         field_name = self.custom_fields[tv['key']] if tv['key'] in self.custom_fields else tv['key']
                         values = []


### PR DESCRIPTION
…ated for them.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Our vmware environment includes custom fields that are automatically updated by our backup system. The value of the field is a timestamp of the last successful backup. As you can imagine, this creates an large amount of groups when using the vmware_inventory.py script to groupby custom fields. This patch allows you to blacklist fields from having groups created.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
vmware dynamic inventory script

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0 (devel e84f807446) last updated 2018/02/28 12:13:30 (GMT -400)
  config file = /home/tod.detre/.ansible.cfg
  configured module search path = [u'/home/tod.detre/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/tod.detre/code/github/tod-uma/ansible/lib/ansible
  executable location = /home/tod.detre/code/github/tod-uma/ansible/bin/ansible
  python version = 2.7.5 (default, Aug  4 2017, 00:39:18) [GCC 4.8.5 20150623 (Red Hat 4.8.5-16)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
