### PR TITLE
[WIP] Start of flexible duration specification

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -500,6 +500,10 @@ def _remove_values_conditions(value, no_log_strings, deferred_removals):
 
     elif isinstance(value, datetime.datetime):
         value = value.isoformat()
+
+    elif isinstance(value, datetime.timedelta):
+        value = value.total_seconds()
+
     else:
         raise TypeError('Value of unknown type: %s, %s' % (type(value), value))
 

--- a/lib/ansible/module_utils/parsing/duration.py
+++ b/lib/ansible/module_utils/parsing/duration.py
@@ -1,0 +1,113 @@
+# Copyright (c) 2018 Matt Martz <matt@sivel.net>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+import datetime
+import itertools
+import re
+
+DURATION_RE = re.compile(
+    '(?P<sign>[-+]?)(?P<value>[0-9]*(?:\.[0-9]*)?)(?P<unit>[a-z]{1,2})'
+)
+
+SECOND = 1
+MILLISECOND = SECOND / 1000
+MICROSECOND = MILLISECOND / 1000
+NANOSECOND = MICROSECOND / 1000
+MINUTE = SECOND * 60
+HOUR = MINUTE * 60
+
+UNIT_MAP = {
+    "ns": NANOSECOND,
+    "us": MICROSECOND,
+    "ms": MILLISECOND,
+    "s":  SECOND,
+    "m":  MINUTE,
+    "h":  HOUR,
+}
+
+
+def duration(s):
+    """Type function for use in an ``argument_spec`` to parse a duration.
+
+    This function accepts a int/float value as seconds, or a duration value
+    as described by ``parse_duration``.
+
+    :param s: duration string
+    :type s: str, float, or int
+    :return: returns timedelta of parsed duration
+    :rtype: datetime.timedelta
+
+    >>> duration(300)
+    datetime.timedelta(0, 300)
+    >>> duration(300.0)
+    datetime.timedelta(0, 300)
+    >>> duration('300.0')
+    datetime.timedelta(0, 300)
+    >>> duration('5m')
+    datetime.timedelta(0, 300)
+
+    """
+
+    try:
+        return datetime.timedelta(seconds=float(s))
+    except ValueError:
+        return parse_duration(s)
+
+
+def parse_duration(s):
+    """parses a duration string. A duration string is a possibly signed
+    sequence of decimal numbers, each with optional fraction and a unit
+    suffix, such as "300ms", "-1.5h" or "2h45m". Valid time units are
+    "ns", "us", "ms", "s", "m", "h".
+
+    Python does not support nanoseconds. The parser will accept and
+    handle it, but any value less than 1 microsecond will be lost
+    when returning a timedelta object.
+
+    :param s: duration string
+    :type s: str
+    :return: returns timedelta of parsed duration
+    :rtype: datetime.timedelta
+
+    >>> parse_duration("1h15m30.918273645s")
+    datetime.timedelta(0, 4530, 918274)
+    >>> parse_duration("10h")
+    datetime.timedelta(0, 36000)
+    >>> parse_duration("1h10m10s")
+    datetime.timedelta(0, 4210)
+    >>> parse_duration("4h30m")
+    datetime.timedelta(0, 16200)
+    >>> parse_duration("1h30m")
+    datetime.timedelta(0, 5400)
+    >>> parse_duration("1000ns")
+    datetime.timedelta(0, 0, 1)
+    >>> parse_duration("1m30s")
+    datetime.timedelta(0, 90)
+    >>> parse_duration("-1m")
+    datetime.timedelta(-1, 86340)
+    >>> parse_duration("9007199254.740993ms")
+    datetime.timedelta(104, 21599, 254741)
+    >>> parse_duration("9007199254740993ns")
+    datetime.timedelta(104, 21599, 254741)
+    >>> parse_duration("7199254.740993ms") == parse_duration("7199254740993ns")
+    True
+
+    """
+    matches = list(DURATION_RE.finditer(s))
+    if not all(itertools.chain.from_iterable([m.groups()[1:] for m in matches])):
+        raise ValueError("%r is not a valid duration" % s)
+
+    run = []
+    for match in matches:
+        if match.group('sign') not in ('', '-', '+'):
+            raise ValueError('%r is not a valid number sign' % match.group('sign'))
+        sign = -1 if match.group('sign') == '-' else 1
+        try:
+            unit = UNIT_MAP[match.group('unit')]
+            run.append(
+                sign * float(match.group('value')) * unit
+            )
+        except KeyError:
+            raise ValueError("%r is not a valid unit" % match.group('unit'))
+
+    return datetime.timedelta(seconds=sum(run))

--- a/lib/ansible/module_utils/parsing/duration.py
+++ b/lib/ansible/module_utils/parsing/duration.py
@@ -20,10 +20,68 @@ UNIT_MAP = {
     "ns": NANOSECOND,
     "us": MICROSECOND,
     "ms": MILLISECOND,
-    "s":  SECOND,
-    "m":  MINUTE,
-    "h":  HOUR,
+    "s": SECOND,
+    "m": MINUTE,
+    "h": HOUR,
 }
+
+
+def timedelta_to_dict(delta):
+    """Accepts a ``datetime.timedelta``, returns a dictionary of units
+
+    :param delta: timedelta
+    :type delta: datetime.timedelta
+    :return: returns a dictionary of units
+    :rtype: dict
+    """
+
+    delta = abs(delta)
+    return {
+        'year': delta.days // 365,
+        'day': delta.days % 365,
+        'hour': delta.seconds // 3600,
+        'minute': (delta.seconds // 60),
+        'second': delta.seconds % 60,
+        'microsecond': delta.microseconds
+    }
+
+
+def human_time_delta(dt, units=['year', 'day', 'hour', 'minute', 'second'],
+                     past_tense='{0} ago', future_tense='in {0}'):
+    """Accept a datetime or timedelta, return a human readable delta string
+
+    :param dt: datetime or timedelta
+    :param units: list of possible units to be used in resultant string
+    :params past_tense: string with ``{0}`` format for output of positive delta
+    :params future_tense: string with ``{0}`` format for output of negtive delta
+    :type delta: datetime.datetime or datetime.timedelta
+    :type units: list
+    :type past_tense: str
+    :type future_tense: str
+    :return: Human readable string representation of a time delta
+    :rtype: str
+    """
+
+    delta = dt
+    if isinstance(dt, datetime.timedelta):
+        delta = dt
+    else:
+        delta = datetime.datetime.now() - dt
+
+    if delta < datetime.timedelta(0):
+        tense = future_tense
+    else:
+        tense = past_tense
+
+    d = timedelta_to_dict(delta)
+    hlist = []
+    for unit in units:
+        if d[unit] == 0:
+            continue  # skip 0's
+        s = '' if d[unit] == 1 else 's'  # handle plurals
+        hlist.append('%s %s%s' % (d[unit], unit, s))
+    human_delta = ', '.join(hlist)
+    return tense.format(human_delta)
 
 
 def duration(s):

--- a/lib/ansible/module_utils/parsing/duration.py
+++ b/lib/ansible/module_utils/parsing/duration.py
@@ -26,6 +26,15 @@ UNIT_MAP = {
 }
 
 
+class timedelta(datetime.timedelta):
+    """Compat class that provides total_seconds for python<2.7"""
+
+    def total_seconds(self):
+        """Total seconds in the duration."""
+        return ((self.days * 86400 + self.seconds) * 10**6 +
+                self.microseconds) / 10**6
+
+
 def timedelta_to_dict(delta):
     """Accepts a ``datetime.timedelta``, returns a dictionary of units
 
@@ -96,18 +105,18 @@ def duration(s):
     :rtype: datetime.timedelta
 
     >>> duration(300)
-    datetime.timedelta(0, 300)
+    timedelta(0, 300)
     >>> duration(300.0)
-    datetime.timedelta(0, 300)
+    timedelta(0, 300)
     >>> duration('300.0')
-    datetime.timedelta(0, 300)
+    timedelta(0, 300)
     >>> duration('5m')
-    datetime.timedelta(0, 300)
+    timedelta(0, 300)
 
     """
 
     try:
-        return datetime.timedelta(seconds=float(s))
+        return timedelta(seconds=float(s))
     except ValueError:
         return parse_duration(s)
 
@@ -128,25 +137,25 @@ def parse_duration(s):
     :rtype: datetime.timedelta
 
     >>> parse_duration("1h15m30.918273645s")
-    datetime.timedelta(0, 4530, 918274)
+    timedelta(0, 4530, 918274)
     >>> parse_duration("10h")
-    datetime.timedelta(0, 36000)
+    timedelta(0, 36000)
     >>> parse_duration("1h10m10s")
-    datetime.timedelta(0, 4210)
+    timedelta(0, 4210)
     >>> parse_duration("4h30m")
-    datetime.timedelta(0, 16200)
+    timedelta(0, 16200)
     >>> parse_duration("1h30m")
-    datetime.timedelta(0, 5400)
+    timedelta(0, 5400)
     >>> parse_duration("1000ns")
-    datetime.timedelta(0, 0, 1)
+    timedelta(0, 0, 1)
     >>> parse_duration("1m30s")
-    datetime.timedelta(0, 90)
+    timedelta(0, 90)
     >>> parse_duration("-1m")
-    datetime.timedelta(-1, 86340)
+    timedelta(-1, 86340)
     >>> parse_duration("9007199254.740993ms")
-    datetime.timedelta(104, 21599, 254741)
+    timedelta(104, 21599, 254741)
     >>> parse_duration("9007199254740993ns")
-    datetime.timedelta(104, 21599, 254741)
+    timedelta(104, 21599, 254741)
     >>> parse_duration("7199254.740993ms") == parse_duration("7199254740993ns")
     True
 
@@ -168,4 +177,4 @@ def parse_duration(s):
         except KeyError:
             raise ValueError("%r is not a valid unit" % match.group('unit'))
 
-    return datetime.timedelta(seconds=sum(run))
+    return timedelta(seconds=sum(run))

--- a/lib/ansible/module_utils/parsing/duration.py
+++ b/lib/ansible/module_utils/parsing/duration.py
@@ -26,13 +26,22 @@ UNIT_MAP = {
 }
 
 
+def _total_seconds(delta):
+    return ((delta.days * 86400 + delta.seconds) * 10**6 +
+            delta.microseconds) / 10**6
+
+
 class timedelta(datetime.timedelta):
     """Compat class that provides total_seconds for python<2.7"""
 
     def total_seconds(self):
         """Total seconds in the duration."""
-        return ((self.days * 86400 + self.seconds) * 10**6 +
-                self.microseconds) / 10**6
+        return _total_seconds(self)
+
+    @classmethod
+    def from_timedelta(cls, delta):
+        """Return an instance of this class, created from a ``datetime.timedelta`` instance"""
+        return cls(seconds=_total_seconds(delta))
 
 
 def timedelta_to_dict(delta):

--- a/lib/ansible/module_utils/parsing/duration.py
+++ b/lib/ansible/module_utils/parsing/duration.py
@@ -6,7 +6,7 @@ import itertools
 import re
 
 DURATION_RE = re.compile(
-    '(?P<sign>[-+]?)(?P<value>[0-9]*(?:\.[0-9]*)?)(?P<unit>[a-z]{1,2})'
+    r'(?P<sign>[-+]?)(?P<value>[0-9]*(?:\.[0-9]*)?)(?P<unit>[a-z]{1,2})'
 )
 
 SECOND = 1
@@ -55,7 +55,7 @@ def timedelta_to_dict(delta):
     }
 
 
-def human_time_delta(dt, units=['year', 'day', 'hour', 'minute', 'second'],
+def human_time_delta(dt, units=('year', 'day', 'hour', 'minute', 'second'),
                      past_tense='{0} ago', future_tense='in {0}'):
     """Accept a datetime or timedelta, return a human readable delta string
 

--- a/lib/ansible/modules/utilities/logic/wait_for.py
+++ b/lib/ansible/modules/utilities/logic/wait_for.py
@@ -484,10 +484,10 @@ def main():
     start = datetime.datetime.utcnow()
 
     if delay:
-        time.sleep(_timedelta_total_seconds(delay))
+        time.sleep(delay.total_seconds())
 
     if not port and not path and state != 'drained':
-        time.sleep(_timedelta_total_seconds(timeout))
+        time.sleep(timeout.total_seconds())
     elif state in ['absent', 'stopped']:
         # first wait for the stop condition
         end = start + timeout
@@ -501,13 +501,13 @@ def main():
                     break
             elif port:
                 try:
-                    s = _create_connection(host, port, _timedelta_total_seconds(connect_timeout))
+                    s = _create_connection(host, port, connect_timeout.total_seconds())
                     s.shutdown(socket.SHUT_RDWR)
                     s.close()
                 except:
                     break
             # Conditions not yet met, wait and try again
-            time.sleep(_timedelta_total_seconds(module.params['sleep']))
+            time.sleep(module.params['sleep'].total_seconds())
         else:
             elapsed = datetime.datetime.utcnow() - start
             if port:
@@ -546,7 +546,7 @@ def main():
             elif port:
                 alt_connect_timeout = math.ceil(_timedelta_total_seconds(end - datetime.datetime.utcnow()))
                 try:
-                    s = _create_connection(host, port, min(_timedelta_total_seconds(connect_timeout), alt_connect_timeout))
+                    s = _create_connection(host, port, min(connect_timeout.total_seconds(), alt_connect_timeout))
                 except:
                     # Failed to connect by connect_timeout. wait and try again
                     pass
@@ -596,7 +596,7 @@ def main():
                         break
 
             # Conditions not yet met, wait and try again
-            time.sleep(_timedelta_total_seconds(module.params['sleep']))
+            time.sleep(module.params['sleep'].total_seconds())
 
         else:   # while-else
             # Timeout expired
@@ -623,7 +623,7 @@ def main():
             except IOError:
                 pass
             # Conditions not yet met, wait and try again
-            time.sleep(_timedelta_total_seconds(module.params['sleep']))
+            time.sleep(module.params['sleep'].total_seconds())
         else:
             elapsed = datetime.datetime.utcnow() - start
             module.fail_json(msg=msg or "Timeout when waiting for %s:%s to drain" % (host, port), elapsed=elapsed.seconds)

--- a/lib/ansible/plugins/action/pause.py
+++ b/lib/ansible/plugins/action/pause.py
@@ -280,7 +280,7 @@ class ActionModule(ActionBase):
             stop = datetime.datetime.now()
             duration = stop - start
             result['stop'] = to_text(stop)
-            result['delta'] = int(timedelta.total_seconds(duration))
+            result['delta'] = int(timedelta.from_timedelta(duration).total_seconds())
 
             result['stdout'] = human_time_delta(duration, past_tense='Paused for {0}')
 

--- a/lib/ansible/plugins/action/pause.py
+++ b/lib/ansible/plugins/action/pause.py
@@ -28,7 +28,7 @@ from os import isatty
 from ansible.errors import AnsibleError
 from ansible.module_utils._text import to_text, to_native
 from ansible.module_utils.parsing.convert_bool import boolean
-from ansible.module_utils.parsing.duration import parse_duration, human_time_delta
+from ansible.module_utils.parsing.duration import parse_duration, human_time_delta, timedelta
 from ansible.module_utils.six import PY3
 from ansible.plugins.action import ActionBase
 
@@ -280,7 +280,7 @@ class ActionModule(ActionBase):
             stop = datetime.datetime.now()
             duration = stop - start
             result['stop'] = to_text(stop)
-            result['delta'] = int(duration.total_seconds())
+            result['delta'] = int(timedelta.total_seconds(duration))
 
             result['stdout'] = human_time_delta(duration, past_tense='Paused for {0}')
 


### PR DESCRIPTION
##### SUMMARY
This PR aims to provide a more flexible duration spec for use in user input, instead of relying on the user providing an integer defining seconds, or in cases where a module accepts `seconds` and `minutes` as exclusive parameters.

Using this, a module could define:

```
from ansible.module_utils.parsing.duration import duration

module = AnsibleModule(
    argument_spec=dict(
        duration=dict(type=duration)
    )
)
```

The user would provide something like the following:

```
duration: 5m5s
duration: 1d
duration: 1m
duration: 60
```

The `duration` type function, returns a `datetime.timedelta` object, and if the module needs seconds it can rely on `params['duration'].total_seconds()`

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/parsing/duration.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION

The `human_time_delta` and `timedelta_to_dict` functions probably don't belong in `parsing`, eventually they should move to `text.format`