### PR TITLE
handlers should not run with force_handlers and any_errors_fatal

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_error_handling.rst
+++ b/docs/docsite/rst/user_guide/playbooks_error_handling.rst
@@ -56,7 +56,8 @@ You can change this behavior with the ``--force-handlers`` command-line option,
 or by including ``force_handlers: True`` in a play, or ``force_handlers = True``
 in ansible.cfg. When handlers are forced, they will run when notified even
 if a task fails on that host. (Note that certain errors could still prevent
-the handler from running, such as a host becoming unreachable.)
+the handler from running, such as a host becoming unreachable or
+``any_errors_fatal = True``.)
 
 .. _controlling_what_defines_failure:
 

--- a/test/integration/targets/handlers/runme.sh
+++ b/test/integration/targets/handlers/runme.sh
@@ -24,6 +24,11 @@ ansible-playbook test_listening_handlers.yml -i inventory.handlers -v "$@"
 [ "$(ansible-playbook test_force_handlers.yml -i inventory.handlers -v "$@" --tags normal --force-handlers -e fail_all=yes \
 | egrep -o CALLED_HANDLER_. | sort | uniq | xargs)" = "CALLED_HANDLER_A CALLED_HANDLER_B" ]
 
+# Test handler doesn't run on any_errors_fatal: yes and force_handlers: yes
+# https://github.com/ansible/ansible/issues/36772
+[ "$(ansible-playbook test_force_handlers_error_fatal.yml -i inventory.handlers -v "$@" \
+| egrep -o CALLED_HANDLER_. | sort | uniq | xargs)" = "" ]
+
 # Forcing from ansible.cfg
 [ "$(ANSIBLE_FORCE_HANDLERS=true ansible-playbook test_force_handlers.yml -i inventory.handlers -v "$@" --tags normal \
 | egrep -o CALLED_HANDLER_. | sort | uniq | xargs)" = "CALLED_HANDLER_A CALLED_HANDLER_B" ]

--- a/test/integration/targets/handlers/test_force_handlers_error_fatal.yml
+++ b/test/integration/targets/handlers/test_force_handlers_error_fatal.yml
@@ -1,0 +1,19 @@
+---
+
+- name: test force handlers with any_errors_fatal True should not run
+  hosts: testgroup
+  gather_facts: False
+  connection: local
+  force_handlers: yes
+  any_errors_fatal: yes
+  handlers:
+  - name: handler one
+    debug:
+      msg: Running handler one
+  tasks:
+  - name: run task to notify handler
+    shell: exit 0
+    notify: handler one
+
+  - name: run failure task that will stop the whole playbook, inc. handlers
+    shell: exit 1


### PR DESCRIPTION
##### SUMMARY
When using `force_handlers` and `any_errors_fatal`, the latter currently trumps handler running. This PR just adds a test for this behaviour and adds a minor mention in the docs around this.

Somewhat related to https://github.com/ansible/ansible/issues/36772

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
handlers

##### ANSIBLE VERSION
```
devel
```