### PR TITLE
correct message to have consistent pluralisation

### DIFF
--- a/lib/ansible/modules/system/locale_gen.py
+++ b/lib/ansible/modules/system/locale_gen.py
@@ -209,7 +209,7 @@ def main():
         ubuntuMode = False
 
     if not is_available(name, ubuntuMode):
-        module.fail_json(msg="The locales you've entered is not available "
+        module.fail_json(msg="The locale you've entered is not available "
                              "on your system.")
 
     if is_present(name):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
A minor consistency issue I noticed.

##### ISSUE TYPE
Bugfix Pull Request

##### COMPONENT NAME
system

##### ANSIBLE VERSION
```
2.6.0
```


##### ADDITIONAL INFORMATION
This should not affect the Googleability of this error :)

```
fatal: [localhost]: FAILED! => {"changed": false, "msg": "The
                locales you've entered is not available on your system."}
```
```
fatal: [localhost]: FAILED! => {"changed": false, "msg": "The
                locale you've entered is not available on your system."}
```