### PR TITLE
Improve default values and choices in module docs

### DIFF
--- a/docs/templates/plugin.rst.j2
+++ b/docs/templates/plugin.rst.j2
@@ -87,7 +87,7 @@ Parameters
             {% if plugin_type != 'module' %}
                 <th class="head"><div class="cell-border">Configuration</div></th>
             {% endif %}
-            <th class="head"><div class="cell-border">Comments</div></th>
+            <th class="head" width="100%"><div class="cell-border">Comments</div></th>
         </tr>
         {% for key, value in options|dictsort recursive %}
             <tr class="return-value-column">

--- a/docs/templates/plugin.rst.j2
+++ b/docs/templates/plugin.rst.j2
@@ -83,7 +83,7 @@ Parameters
         {# Header of the documentation #}
         <tr>
             <th class="head"><div class="cell-border">Parameter</div></th>
-            <th class="head"><div class="cell-border" style="color: blue">Default</div></th>
+            <th class="head"><div class="cell-border">Choices/<font color="blue">Defaults</font></div></th>
             {% if plugin_type != 'module' %}
                 <th class="head"><div class="cell-border">Configuration</div></th>
             {% endif %}

--- a/docs/templates/plugin.rst.j2
+++ b/docs/templates/plugin.rst.j2
@@ -83,8 +83,7 @@ Options
         {# Header of the documentation #}
         <tr>
             <th class="head"><div class="cell-border">Parameter</div></th>
-            <th class="head"><div class="cell-border">Default</div></th>
-            <th class="head"><div class="cell-border">Choices</div></th>
+            <th class="head"><div class="cell-border" style="color: blue">Default</div></th>
             {% if plugin_type != 'module' %}
                 <th class="head"><div class="cell-border">Configuration</div></th>
             {% endif %}
@@ -106,24 +105,31 @@ Options
                         </div>
                     <div class="outer-elbow-container">
                 </td>
-                {# default value #}
-                <td><div class="cell-border">{% if value.default %}@{ value.default | html_ify }@{% endif %}</div></td>
-                {# choices #}
+                {# default / choices #}
                 <td>
                     <div class="cell-border">
-                        {% if value.type == 'bool' %}
-                            <ul>
-                                <li>yes</li>
-                                <li>no</li>
-                            </ul>
-                        {% else %}
-                            {% if value.choices %}
-                                <ul>
-                                    {% for choice in value.choices %}
-                                        <li>@{ choice }@</li>
-                                    {% endfor %}
-                                </ul>
+                        {% if value.default is defined %}
+                            {% if value.default == true %}
+                                {% set _x = value.update({'default': 'yes'}) %}
+                            {% elif value.default == false %}
+                                {% set _x = value.update({'default': 'no'}) %}
                             {% endif %}
+                        {% endif %}
+                        {% if value.type == 'bool' %}
+                            {% set _x = value.update({'choices': ['no', 'yes']}) %}
+                        {% endif %}
+                        {% if value.choices %}
+                            <ul><b>Choices:</b>
+                                {% for choice in value.choices %}
+                                    {% if value.default is defined and choice == value.default %}
+                                        <li><div style="color: blue"><b>@{ choice }@</b>&nbsp;&larr;</div></li>
+                                    {% else %}
+                                        <li>@{ choice }@</li>
+                                    {% endif %}
+                                {% endfor %}
+                            </ul>
+                        {% elif value.default is defined %}
+                            <div style="color: blue">@{ value.default | html_ify }@</div>
                         {% endif %}
                     </div>
                 </td>
@@ -162,7 +168,7 @@ Options
                             {% endfor %}
                         {% endif %}
                         {% if 'aliases' in value and value.aliases %}
-                            </br><div style="font-size: small;">aliases: @{ value.aliases|join(', ') }@</div>
+                            <div style="font-size: small; color: darkgreen"><br/>aliases: @{ value.aliases|join(', ') }@</div>
                         {% endif %}
                     </div>
                 </td>

--- a/docs/templates/plugin.rst.j2
+++ b/docs/templates/plugin.rst.j2
@@ -74,8 +74,8 @@ The below requirements are needed on the local master node that executes this @{
 
 {% if options -%}
 
-Options
--------
+Parameters
+----------
 
 .. raw:: html
 
@@ -91,19 +91,18 @@ Options
         </tr>
         {% for key, value in options|dictsort recursive %}
             <tr class="return-value-column">
-                {# parameter name with introduced label #}
+                {# parameter name with required and/or introduced label #}
                 <td>
                     <div class="outer-elbow-container">
                         {% for i in range(1, loop.depth) %}
-                            <div class="elbow-placeholder">
-                            </div>
+                            <div class="elbow-placeholder"></div>
                         {% endfor %}
                         <div class="elbow-key">
                             <b>@{ key }@</b>
                             {% if value.get('required', False) %}<br/><div style="font-size: small; color: red">required</div>{% endif %}
                             {% if value.version_added %}<br/><div style="font-size: small; color: darkgreen">(added in @{value.version_added}@)</div>{% endif %}
                         </div>
-                    <div class="outer-elbow-container">
+                    </div>
                 </td>
                 {# default / choices #}
                 <td>
@@ -119,10 +118,13 @@ Options
                             {% set _x = value.update({'choices': ['no', 'yes']}) %}
                         {% endif %}
                         {% if value.choices %}
-                            <ul><b>Choices:</b>
+                            <ul style="list-style-type: circle"><b>Choices:</b>
+                                {% if value.default not in value.choices %}
+                                    <li type="disc"><div style="color: blue"><b>@{ value.default }@</b>&nbsp;&larr;</div></li>
+                                {% endif %}
                                 {% for choice in value.choices %}
                                     {% if value.default is defined and choice == value.default %}
-                                        <li><div style="color: blue"><b>@{ choice }@</b>&nbsp;&larr;</div></li>
+                                        <li type="disc"><div style="color: blue"><b>@{ value.default }@</b>&nbsp;&larr;</div></li>
                                     {% else %}
                                         <li>@{ choice }@</li>
                                     {% endif %}
@@ -182,7 +184,7 @@ Options
             {% endif %}
         {% endfor %}
     </table>
-    </br>
+    <br/>
 
 {% endif %}
 


### PR DESCRIPTION
##### SUMMARY
So currently we show defaults and choices in separate columns.

For each parameter we have
- Mostly empty default and choices cells
- A list of choices and a separate default value
- Only a default value

So there's a lot of space being wasted on empty cells which makes it unfit for smartphones and tablets.
We can do this better.

This is part of a long list of module docs improvements:
#37129 #37023, #36943, #36844, #36841, #36815, #36813, #36812, #36688, #36680, #36678, #36675, #36674, #36672, #36667

**Original v2.4 docs**
![screenshot from 2018-03-01 15-54-59](https://user-images.githubusercontent.com/388198/36851206-fedccc42-1d68-11e8-9de5-3506bb6bffc2.png)

**Current v2.5 docs after first changes**
![screenshot from 2018-03-01 12-47-38](https://user-images.githubusercontent.com/388198/36843304-d15abcee-1d4e-11e8-8849-f44fd9acd1e8.png)

**Screenshot after**
![screenshot from 2018-03-01 12-42-27](https://user-images.githubusercontent.com/388198/36843254-a4109344-1d4e-11e8-846f-9477fc4a3f9a.png)

**Complimentary screenshot showing different choices**
![screenshot from 2018-03-07 18-41-12](https://user-images.githubusercontent.com/388198/37108352-2f13c0c8-2237-11e8-9a98-a434531b5bdb.png)


##### ISSUE TYPE
 - Feature Pull Request
 - Docs Pull Request

##### COMPONENT NAME
module docs

##### ANSIBLE VERSION
v2.5