### PR TITLE
properly detect the absence of credential_type in older tower-cli

### DIFF
--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_credential.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_credential.py
@@ -260,7 +260,7 @@ def main():
 
             try:
                 tower_cli.get_resource('credential_type')
-            except (AttributeError):
+            except (ImportError, AttributeError):
                 # /api/v1/ backwards compat
                 # older versions of tower-cli don't *have* a credential_type
                 # resource


### PR DESCRIPTION
##### SUMMARY
Older versions of `tower-cli` don't have a `credential_type` resources; this change properly detects that scenario.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ansible_tower

##### ANSIBLE VERSION
```
ansible --version
ansible 2.6.0 (devel d9b1f80e09) last updated 2018/03/01 10:01:27 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/ryan/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/ryan/venvs/tmp-b2bf955ff953b039/ansible/lib/ansible
  executable location = /home/ryan/venvs/tmp-b2bf955ff953b039/bin/ansible
  python version = 2.7.14 (default, Jan  5 2018, 10:41:29) [GCC 7.2.1 20171224]
```