### PR TITLE
Remove manual SSH connection test

### DIFF
--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -139,13 +139,6 @@ class Connection(ConnectionBase):
     def _connect(self):
         return self
 
-    def transport_test(self, connect_timeout):
-        ''' Test the transport mechanism, if available '''
-        port = int(self.port or 22)
-        display.vvv("attempting transport test to %s:%s" % (self.host, port))
-        sock = socket.create_connection((self.host, port), connect_timeout)
-        sock.close()
-
     @staticmethod
     def _create_control_path(host, port, user):
         '''Make a hash for the controlpath based on con attributes'''


### PR DESCRIPTION
Breaks when using a bastion for SSH connections

##### SUMMARY
Backports existing fix in 2.4:
https://github.com/ansible/ansible/pull/28450

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
SSH connection plugin

##### ANSIBLE VERSION
2.3 stable branch


##### ADDITIONAL INFORMATION
wait_for_connection tries to use a raw socket connection which breaks my use case of SSH connections via a bastion host.
This was fixed in 2.4 but doesn't seem to have been backported.
