### PR TITLE
properly pass /api/v1/ credential fields for older Towers

### DIFF
--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_credential.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_credential.py
@@ -282,7 +282,6 @@ def main():
                 team = team_res.get(name=module.params.get('team'))
                 params['team'] = team['id']
 
-            params['inputs'] = {}
             if module.params.get('ssh_key_data'):
                 filename = module.params.get('ssh_key_data')
                 if not os.path.exists(filename):
@@ -290,15 +289,17 @@ def main():
                 if os.path.isdir(filename):
                     module.fail_json(msg='attempted to read contents of directory: %s' % filename)
                 with open(filename, 'rb') as f:
-                    params['inputs']['ssh_key_data'] = f.read()
+                    module.params['ssh_key_data'] = f.read()
 
             for key in ('authorize', 'authorize_password', 'client', 'secret',
                         'tenant', 'subscription', 'domain', 'become_method',
                         'become_username', 'become_password', 'vault_password',
                         'project', 'host', 'username', 'password',
-                        'ssh_key_unlock'):
-                if module.params.get(key):
-                    params['inputs'][key] = module.params.get(key)
+                        'ssh_key_data', 'ssh_key_unlock'):
+                if 'kind' in params:
+                    params[key] = module.params.get(key)
+                elif module.params.get(key):
+                    params.setdefault('inputs', {})[key] = module.params.get(key)
 
             if state == 'present':
                 result = credential.modify(**params)


### PR DESCRIPTION
##### SUMMARY
This fixes a bug that causes credential values to be sent incorrect to older Towers over `/api/v1/`.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ansible_tower

##### ANSIBLE VERSION
```
ansible --version
ansible 2.6.0 (devel d9b1f80e09) last updated 2018/03/01 10:01:27 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/ryan/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/ryan/venvs/tmp-b2bf955ff953b039/ansible/lib/ansible
  executable location = /home/ryan/venvs/tmp-b2bf955ff953b039/bin/ansible
  python version = 2.7.14 (default, Jan  5 2018, 10:41:29) [GCC 7.2.1 20171224]
```