### PR TITLE
[ec2_vpc_peer] only create tags if tags are provided - fixes #36108

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_peer.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_peer.py
@@ -238,12 +238,10 @@ def tags_changed(pcx_id, client, module):
         tags = [item for sublist in tag_values for item in sublist]
         if sorted(pcx_tags) == sorted(tags):
             changed = False
-            return changed
-        else:
+        elif tags:
             delete_tags(pcx_id, client, module)
             create_tags(pcx_id, client, module)
             changed = True
-            return changed
     return changed
 
 


### PR DESCRIPTION
##### SUMMARY
Fixes #36108. 
Tags should not be a requirement to create a VPC connection or to accept/reject one.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/ec2_vpc_peer.py

##### ANSIBLE VERSION
```
2.6.0
```