### PR TITLE
Enable eapi integration test for eos modules (#36934)

### DIFF
--- a/test/integration/targets/eos_interface/tasks/main.yaml
+++ b/test/integration/targets/eos_interface/tasks/main.yaml
@@ -1,2 +1,3 @@
 ---
 - { include: cli.yaml, tags: ['cli'] }
+- { include: eapi.yaml, tags: ['eapi'] }

--- a/test/integration/targets/eos_l2_interface/tasks/main.yaml
+++ b/test/integration/targets/eos_l2_interface/tasks/main.yaml
@@ -1,2 +1,3 @@
 ---
 - { include: cli.yaml, tags: ['cli'] }
+- { include: eapi.yaml, tags: ['eapi'] }

--- a/test/integration/targets/eos_l3_interface/tasks/main.yaml
+++ b/test/integration/targets/eos_l3_interface/tasks/main.yaml
@@ -1,2 +1,3 @@
 ---
 - { include: cli.yaml, tags: ['cli'] }
+- { include: eapi.yaml, tags: ['eapi'] }

--- a/test/integration/targets/eos_lldp/tasks/main.yaml
+++ b/test/integration/targets/eos_lldp/tasks/main.yaml
@@ -1,2 +1,3 @@
 ---
 - { include: cli.yaml, tags: ['cli'] }
+- { include: eapi.yaml, tags: ['eapi'] }

--- a/test/integration/targets/eos_logging/tasks/main.yaml
+++ b/test/integration/targets/eos_logging/tasks/main.yaml
@@ -1,2 +1,3 @@
 ---
 - { include: cli.yaml, tags: ['cli'] }
+- { include: eapi.yaml, tags: ['eapi'] }

--- a/test/integration/targets/eos_user/tasks/main.yaml
+++ b/test/integration/targets/eos_user/tasks/main.yaml
@@ -1,2 +1,3 @@
 ---
 - { include: cli.yaml, tags: ['cli'] }
+- { include: eapi.yaml, tags: ['eapi'] }


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
(cherry picked from commit 83c3561ee517ac5b2b90534f369902cae90b2da6)
Merged to devel https://github.com/ansible/ansible/pull/36934
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Test Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
targets/eos_interface/tasks/main.yaml
targets/eos_l2_interface/tasks/main.yaml
targets/eos_l3_interface/tasks/main.yaml
targets/eos_lldp/tasks/main.yaml
targets/eos_logging/tasks/main.yaml
targets/eos_user/tasks/main.yaml
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
