### PR TITLE
Improve module docs return values

### DIFF
--- a/docs/docsite/_themes/sphinx_rtd_theme/footer.html
+++ b/docs/docsite/_themes/sphinx_rtd_theme/footer.html
@@ -22,9 +22,7 @@
 </script>
 
   <p>
+  {%- if last_updated %}{% trans last_updated=last_updated|e %}Last updated on {{ last_updated }}.{% endtrans %}<br/>{% endif %}
   Copyright © 2018 Red Hat, Inc. <br/>
-  {%- if last_updated %}
-    {% trans last_updated=last_updated|e %}Last updated on {{ last_updated }}.{% endtrans %}
-  {%- endif %}
   </p>
 </footer>

--- a/docs/templates/plugin.rst.j2
+++ b/docs/templates/plugin.rst.j2
@@ -13,10 +13,7 @@
 
 {% if version_added is defined and version_added != '' -%}
 .. versionadded:: @{ version_added | default('') }@
-
-
 {% endif %}
-
 
 .. contents::
    :local:
@@ -33,7 +30,6 @@
 
 DEPRECATED
 ----------
-
 {# use unknown here? skip the fields? #}
 :Removed in Ansible: version: @{ deprecated['removed_in'] | default('') | string | convert_symbols_to_format }@
 :Why: @{ deprecated['why'] | default('') | convert_symbols_to_format }@
@@ -44,36 +40,34 @@ DEPRECATED
 
 Synopsis
 --------
-
 {% if description -%}
 
 {%   if description is string -%}
-* @{ description | convert_symbols_to_format }@
-{%   else -%}
+- @{ description | convert_symbols_to_format }@
+{%   else %}
 {%     for desc in description %}
-* @{ desc | convert_symbols_to_format }@
+- @{ desc | convert_symbols_to_format }@
 {%     endfor %}
-{%   endif -%}
+{%   endif %}
 
 {% endif %}
 
 {% if aliases is defined -%}
-
 Aliases: @{ ','.join(aliases) }@
-
-
 {% endif %}
 
-{% if requirements %}
-{%   set req_title = 'Requirements' %}
-{%   if plugin_type == 'module' -%}
-{%     set req_title = req_title + ' (on host that executes module)' %}
-{%   endif -%}
-@{ req_title }@
-@{ '-' * req_title|length }@
+{% if requirements -%}
+
+Requirements
+~~~~~~~~~~~~
+{%   if plugin_type == 'module' %}
+The below requirements are needed on the host that executes this @{ plugin_type }@.
+{%   else %}
+The below requirements are needed on the local master node that executes this @{ plugin_type }@.
+{%   endif %}
 
 {%   for req in requirements %}
-* @{ req | convert_symbols_to_format }@
+- @{ req | convert_symbols_to_format }@
 {%   endfor %}
 
 {% endif %}
@@ -193,7 +187,7 @@ Notes
 
 .. note::
 {%   for note in notes %}
-- @{ note | convert_symbols_to_format }@
+    - @{ note | convert_symbols_to_format }@
 {%   endfor %}
 
 {% endif %}
@@ -222,7 +216,7 @@ Examples
 
 Returned Facts
 --------------
-Facts returned by modules can be referenced by name as any other host fact.
+Facts returned by this module are added/updated in the ``hostvars`` host facts and can be referenced by name just like any other host fact. They do not need to be registered in order to use them.
 
 .. raw:: html
 
@@ -287,14 +281,13 @@ Facts returned by modules can be referenced by name as any other host fact.
 
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this @{ plugin_type }@:
 
 .. raw:: html
 
     <table border=0 cellpadding=0 class="documentation-table">
         <tr>
-            <th class="head"><div class="cell-border">Name</div></th>
+            <th class="head"><div class="cell-border">Key</div></th>
             <th class="head"><div class="cell-border">Returned</div></th>
             <th class="head"><div class="cell-border">Description</div></th>
         </tr>
@@ -349,46 +342,48 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
 
 {% endif %}
 
+Status
+------
+{% if not deprecated %}
+
+{%   set support = { 'core': 'The Ansible Core Team', 'network': 'The Ansible Network Team', 'certified': 'an Ansible Partner', 'community': 'The Ansible Community', 'curated': 'A Third Party'} %}
+{%   set module_states = { 'preview': 'it is not guaranteed to have a backwards compatible interface', 'stableinterface': 'the maintainers for this module guarantee that no backward incompatible interface changes will be made'} %}
+
+{%   if metadata %}
+{%     if metadata.status %}
+
+{%       for cur_state in metadata.status %}
+This module is flagged as **@{cur_state}@** which means that @{module_states[cur_state]}@.
+{%       endfor %}
+
+{%     endif %}
+
+{%     if metadata.supported_by in ('core', 'network') %}
+
+Support
+~~~~~~~
+For more information about Red Hat's support of this @{ plugin_type }@,
+please refer to this `Knowledge Base article <https://access.redhat.com/articles/rhel-top-support-policies/>`_
+
+{%     endif %}
+{%   endif %}
+
+{% else %}
+
+This module is flagged as **deprecated** and will be removed in version { deprecated['removed_in'] | default('') | string | convert_symbols_to_format }@. For more information see :ref:`DEPRECATED`.
+
+{% endif %}
+
 {% if author is defined -%}
 
 Author
 ~~~~~~
 
 {%   for author_name in author %}
-* @{ author_name }@
+- @{ author_name }@
 {%   endfor %}
 
 {% endif %}
 
-{% if not deprecated -%}
-
-{%   set support = { 'core': 'The Ansible Core Team', 'network': 'The Ansible Network Team', 'certified': 'an Ansible Partner', 'community': 'The Ansible Community', 'curated': 'A Third Party'} %}
-{%   set module_states = { 'preview': 'it is not guaranteed to have a backwards compatible interface', 'stableinterface': 'the maintainers for this module guarantee that no backward incompatible interface changes will be made'} %}
-
-{%   if metadata -%}
-{%     if metadata.status -%}
-
-Status
-~~~~~~
-
-{%       for cur_state in metadata.status %}
-This module is flagged as **@{cur_state}@** which means that @{module_states[cur_state]}@.
-{%       endfor %}
-
-{%     endif -%}
-
-{%     if metadata.supported_by in ('core', 'network') -%}
-
-Maintenance Info
-~~~~~~~~~~~~~~~~
-
-For more information about Red Hat's support of this @{ plugin_type }@,
-please refer to this `Knowledge Base article <https://access.redhat.com/articles/rhel-top-support-policies/>`_
-
-{%     endif -%}
-{%   endif -%}
-
-{% endif %}
-
 .. hint::
-If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/@{ source }@?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A+label:%20docsite_pr>`_ to improve it.
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/@{ source }@?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A+label:%20docsite_pr>`_ to improve it.

--- a/docs/templates/plugin.rst.j2
+++ b/docs/templates/plugin.rst.j2
@@ -45,15 +45,15 @@ DEPRECATED
 Synopsis
 --------
 
-{% if description %}
+{% if description -%}
 
 {%   if description is string -%}
 * @{ description | convert_symbols_to_format }@
-{%   else %}
-{%     for desc in description -%}
+{%   else -%}
+{%     for desc in description %}
 * @{ desc | convert_symbols_to_format }@
 {%     endfor %}
-{%   endif %}
+{%   endif -%}
 
 {% endif %}
 
@@ -66,9 +66,9 @@ Aliases: @{ ','.join(aliases) }@
 
 {% if requirements %}
 {%   set req_title = 'Requirements' %}
-{%   if plugin_type == 'module' %}
+{%   if plugin_type == 'module' -%}
 {%     set req_title = req_title + ' (on host that executes module)' %}
-{%   endif %}
+{%   endif -%}
 @{ req_title }@
 @{ '-' * req_title|length }@
 
@@ -79,7 +79,6 @@ Aliases: @{ ','.join(aliases) }@
 {% endif %}
 
 {% if options -%}
-
 
 Options
 -------
@@ -186,21 +185,20 @@ Options
     </br>
 
 {% endif %}
-{% if notes -%}
 
+{% if notes -%}
 
 Notes
 -----
 
 .. note::
 {%   for note in notes %}
-    - @{ note | convert_symbols_to_format }@
+- @{ note | convert_symbols_to_format }@
 {%   endfor %}
 
-
 {% endif %}
-{% if examples or plainexamples -%}
 
+{% if examples or plainexamples -%}
 
 Examples
 --------
@@ -212,17 +210,80 @@ Examples
 @{ example['code'] | escape | indent(4, True) }@
 {%   endfor %}
 {%   if plainexamples %}@{ plainexamples | indent(4, True) }@{% endif %}
+
 {% endif %}
 
+{% if not returnfacts and returndocs and returndocs.ansible_facts is defined %}
+{%   set returnfacts = returndocs.ansible_facts.contains %}
+{%   set _x = returndocs.pop('ansible_facts', None) %}
+{% endif %}
 
 {% if returnfacts -%}
+
 Returned Facts
 --------------
+Facts returned by modules can be referenced by name as any other host fact.
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th class="head"><div class="cell-border">Fact</div></th>
+            <th class="head"><div class="cell-border">Returned</div></th>
+            <th class="head"><div class="cell-border">Description</div></th>
+        </tr>
+        {% for key, value in returnfacts|dictsort recursive %}
+            <tr class="return-value-column">
+                <td>
+                    <div class="outer-elbow-container">
+                        {% for i in range(1, loop.depth) %}
+                            <div class="elbow-placeholder">
+                            </div>
+                        {% endfor %}
+                        <div class="elbow-key">
+                            <b>@{ key }@</b>
+                            <br/><div style="font-size: small; color: red">@{ value.type }@</div>
+                        </div>
+                    </div>
+                </td>
+                <td><div class="cell-border">@{ value.returned }@</div></td>
+                <td>
+                    <div class="cell-border">
+                        {% if value.description is string %}
+                            <div>@{ value.description | html_ify }@</div>
+                        {% else %}
+                            {% for desc in value.description %}
+                                <div>@{ desc | html_ify }@</div>
+                            {% endfor %}
+                        {% endif %}
+                        <br/>
+                        {% if value.sample %}
+                            <div style="font-size: smaller"><b>Sample:</b></div>
+{#                            <div style="font-size: smaller; color: blue; word-wrap: break-word; overflow-wrap: break-word; word-break: break-all;">@{ value.sample | html_ify }@</div> #}
+                            <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">@{ value.sample | html_ify }@</div>
+                        {% endif %}
+                    </div>
+                </td>
+            </tr>
+            {# ---------------------------------------------------------
+             # sadly we cannot blindly iterate through the child dicts,
+             # since in some documentations,
+             # lists are used instead of dicts. This handles both types
+             # ---------------------------------------------------------#}
+            {% if value.contains %}
+                {% if value.contains.items %}
+                    @{ loop(value.contains.items()) }@
+                {% elif value.contains[0].items %}
+                    @{ loop(value.contains[0].items()) }@
+                {% endif %}
+            {% endif %}
+        {% endfor %}
+    </table>
+    <br/><br/>
 
 {% endif %}
 
 {% if returndocs -%}
-
 
 Return Values
 -------------
@@ -284,12 +345,11 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
             {% endif %}
         {% endfor %}
     </table>
-    </br></br>
+    <br/><br/>
+
 {% endif %}
 
-
 {% if author is defined -%}
-
 
 Author
 ~~~~~~
@@ -298,14 +358,15 @@ Author
 * @{ author_name }@
 {%   endfor %}
 
-
 {% endif %}
-{% if not deprecated %}
+
+{% if not deprecated -%}
+
 {%   set support = { 'core': 'The Ansible Core Team', 'network': 'The Ansible Network Team', 'certified': 'an Ansible Partner', 'community': 'The Ansible Community', 'curated': 'A Third Party'} %}
 {%   set module_states = { 'preview': 'it is not guaranteed to have a backwards compatible interface', 'stableinterface': 'the maintainers for this module guarantee that no backward incompatible interface changes will be made'} %}
-{%   if metadata %}
-{%     if metadata.status %}
 
+{%   if metadata -%}
+{%     if metadata.status -%}
 
 Status
 ~~~~~~
@@ -314,10 +375,9 @@ Status
 This module is flagged as **@{cur_state}@** which means that @{module_states[cur_state]}@.
 {%       endfor %}
 
+{%     endif -%}
 
-{%     endif %}
-{%     if metadata.supported_by in ('core', 'network') %}
-
+{%     if metadata.supported_by in ('core', 'network') -%}
 
 Maintenance Info
 ~~~~~~~~~~~~~~~~
@@ -325,8 +385,10 @@ Maintenance Info
 For more information about Red Hat's support of this @{ plugin_type }@,
 please refer to this `Knowledge Base article <https://access.redhat.com/articles/rhel-top-support-policies/>`_
 
-{%     endif %}
-{%   endif %}
+{%     endif -%}
+{%   endif -%}
+
 {% endif %}
 
+.. hint::
 If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/@{ source }@?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A+label:%20docsite_pr>`_ to improve it.

--- a/docs/templates/plugin.rst.j2
+++ b/docs/templates/plugin.rst.j2
@@ -215,6 +215,12 @@ Examples
 {% endif %}
 
 
+{% if returnfacts -%}
+Returned Facts
+--------------
+
+{% endif %}
+
 {% if returndocs -%}
 
 
@@ -228,10 +234,8 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
     <table border=0 cellpadding=0 class="documentation-table">
         <tr>
             <th class="head"><div class="cell-border">Name</div></th>
-            <th class="head"><div class="cell-border">Description</div></th>
             <th class="head"><div class="cell-border">Returned</div></th>
-            <th class="head"><div class="cell-border">Type</div></th>
-            <th class="head"><div class="cell-border">Sample</div></th>
+            <th class="head"><div class="cell-border">Description</div></th>
         </tr>
         {% for key, value in returndocs|dictsort recursive %}
             <tr class="return-value-column">
@@ -243,21 +247,28 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
                         {% endfor %}
                         <div class="elbow-key">
                             <b>@{ key }@</b>
+                            <br/><div style="font-size: small; color: red">@{ value.type }@</div>
                         </div>
                     </div>
                 </td>
-                <td>
-                    {% if value.description is string %}
-                        <div class="cell-border">@{ value.description | replace('\n', '\n    ') | html_ify }@</div>
-                    {% else %}
-                    {% for desc in value.description %}
-                        <div class="cell-border">@{ desc | replace('\n', '\n    ') | html_ify }@</div>
-                    {% endfor %}
-                    {% endif %}
-                </td>
                 <td><div class="cell-border">@{ value.returned }@</div></td>
-                <td><div class="cell-border">@{ value.type }@</div></td>
-                <td><div class="cell-border">@{ value.sample | replace('\n', '\n    ') | html_ify }@</div></td>
+                <td>
+                    <div class="cell-border">
+                        {% if value.description is string %}
+                            <div>@{ value.description | html_ify }@</div>
+                        {% else %}
+                            {% for desc in value.description %}
+                                <div>@{ desc | html_ify }@</div>
+                            {% endfor %}
+                        {% endif %}
+                        <br/>
+                        {% if value.sample %}
+                            <div style="font-size: smaller"><b>Sample:</b></div>
+{#                            <div style="font-size: smaller; color: blue; word-wrap: break-word; overflow-wrap: break-word; word-break: break-all;">@{ value.sample | html_ify }@</div> #}
+                            <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">@{ value.sample | html_ify }@</div>
+                        {% endif %}
+                    </div>
+                </td>
             </tr>
             {# ---------------------------------------------------------
              # sadly we cannot blindly iterate through the child dicts,


### PR DESCRIPTION
##### SUMMARY
Currently the 5 columns shown doesn't make optimal use of the screen estate, especially for facts modules with a lot of "complex"data this is a problem.

This relates to #36901 

**Before (facts module)**
![screenshot from 2018-03-02 13-47-01](https://user-images.githubusercontent.com/388198/36899963-b08655d6-1e21-11e8-9d56-97c547d1db11.png)

**After (facts module)**
![screenshot from 2018-03-06 00-32-26](https://user-images.githubusercontent.com/388198/37006211-a5effb5a-20d7-11e8-9446-b7363a2cc472.png)

**Before (normal module)**
![screenshot from 2018-03-02 13-50-13](https://user-images.githubusercontent.com/388198/36899999-d4a5302c-1e21-11e8-8d97-3939146a6c0e.png)

**After (normal module)**
![screenshot from 2018-03-02 13-49-30](https://user-images.githubusercontent.com/388198/36900002-d8437cfc-1e21-11e8-8edc-e6bd9b290266.png)

Both examples look much better (actually usable) on smartphones and tablets. For normal screens the improvement is less compelling, but nevertheless more pleasing IMO

One more thing we improved for Return Values. The returned facts are now in a separate section and has a short description explaining how these values can be accessed without the need to register it explicilty

This fixes #36867

##### ISSUE TYPE
 - Feature Pull Request
 - Docs Pull Request

##### COMPONENT NAME
module docs

##### ANSIBLE VERSION
v2.5