### PR TITLE
Grafana datasource module : tls_ca_cert or tls_skip_verify options

### DIFF
--- a/lib/ansible/modules/monitoring/grafana_datasource.py
+++ b/lib/ansible/modules/monitoring/grafana_datasource.py
@@ -16,7 +16,7 @@ DOCUMENTATION = '''
 ---
 module: grafana_datasource
 author:
-  - Thierry Sallé (@tsalle)
+  - Thierry Sallé (@seuf)
 version_added: "2.5"
 short_description: Manage Grafana datasources
 description:

--- a/lib/ansible/modules/monitoring/grafana_datasource.py
+++ b/lib/ansible/modules/monitoring/grafana_datasource.py
@@ -96,6 +96,8 @@ options:
     required: false
     description:
       - Skip the TLS datasource certificate verification.
+    type: bool
+    version_added: 2.6
   is_default:
     description:
       - Make this datasource the default one.

--- a/lib/ansible/modules/monitoring/grafana_datasource.py
+++ b/lib/ansible/modules/monitoring/grafana_datasource.py
@@ -93,10 +93,10 @@ options:
       - The TLS CA certificate for self signed certificates.
       - Only used when C(tls_client_cert) and C(tls_client_key) are set.
   tls_skip_verify:
-    required: false
     description:
       - Skip the TLS datasource certificate verification.
     type: bool
+    default: False
     version_added: 2.6
   is_default:
     description:

--- a/lib/ansible/modules/monitoring/grafana_datasource.py
+++ b/lib/ansible/modules/monitoring/grafana_datasource.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# Copyright: (c) 2017, Thierry Sallé (@tsalle)
+# Copyright: (c) 2017, Thierry Sallé (@seuf)
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function


### PR DESCRIPTION
##### SUMMARY
Allow to set tls_ca_cert or skip verify for grafana datasources

##### ISSUE TYPE
 - Bugfix Pull Request


##### COMPONENT NAME
grafana_datasource module

##### ANSIBLE VERSION
Here is my ansible --version
```
ansible 2.4.2.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.14 (default, Dec 11 2017, 16:08:01) [GCC 7.2.1 20170915 (Red Hat 7.2.1-2)]
```


##### ADDITIONAL INFORMATION
With the release of grafana 5.0.0, the datasource tls certificate are verified by default.
this pull request allow to set the `tls_ca_cert` option to set the certificate authority to validate the datasource certificate or `tls_skip_verify` to skip the datasource certificate.