### PR TITLE
npm: add unsafe_perm parameter

### DIFF
--- a/lib/ansible/modules/packaging/language/npm.py
+++ b/lib/ansible/modules/packaging/language/npm.py
@@ -53,6 +53,12 @@ options:
     choices: [ "yes", "no" ]
     default: no
     version_added: "1.8"
+  unsafe_perm:
+    description:
+      - Use the C(--unsafe-perm) flag when installing.
+    type: bool
+    default: no
+    version_added: "2.8"
   production:
     description:
       - Install dependencies in production mode, excluding devDependencies
@@ -143,6 +149,7 @@ class Npm(object):
         self.registry = kwargs['registry']
         self.production = kwargs['production']
         self.ignore_scripts = kwargs['ignore_scripts']
+        self.unsafe_perm = kwargs['unsafe_perm']
         self.state = kwargs['state']
 
         if kwargs['executable']:
@@ -165,6 +172,8 @@ class Npm(object):
                 cmd.append('--production')
             if self.ignore_scripts:
                 cmd.append('--ignore-scripts')
+            if self.unsafe_perm:
+                cmd.append('--unsafe-perm')
             if self.name:
                 cmd.append(self.name_version)
             if self.registry:
@@ -238,6 +247,7 @@ def main():
         registry=dict(default=None),
         state=dict(default='present', choices=['present', 'absent', 'latest']),
         ignore_scripts=dict(default=False, type='bool'),
+        unsafe_perm=dict(default=False, type='bool'),
     )
     arg_spec['global'] = dict(default='no', type='bool')
     module = AnsibleModule(
@@ -254,6 +264,7 @@ def main():
     registry = module.params['registry']
     state = module.params['state']
     ignore_scripts = module.params['ignore_scripts']
+    unsafe_perm = module.params['unsafe_perm']
 
     if not path and not glbl:
         module.fail_json(msg='path must be specified when not using global')
@@ -261,7 +272,8 @@ def main():
         module.fail_json(msg='uninstalling a package is only available for named packages')
 
     npm = Npm(module, name=name, path=path, version=version, glbl=glbl, production=production,
-              executable=executable, registry=registry, ignore_scripts=ignore_scripts, state=state)
+              executable=executable, registry=registry, ignore_scripts=ignore_scripts,
+              unsafe_perm=unsafe_perm, state=state)
 
     changed = False
     if state == 'present':


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Allow to use to use the `--unsafe-perm` flag when installing a npm module.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
npm

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.3.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/loic/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.3 (default, Jun 21 2016, 18:38:19) [GCC 4.7.2]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
