### PR TITLE
[contrib] Digital Ocean dynamic inventory enhancements

### DIFF
--- a/contrib/inventory/digital_ocean.ini
+++ b/contrib/inventory/digital_ocean.ini
@@ -24,6 +24,11 @@ cache_path = /tmp
 cache_max_age = 300
 
 # Use the private network IP address instead of the public when available.
+# This can also be a Digital Ocean region slug (or comma-separated list of the
+# same) to use the private IP addresses only for droplets in certain region(s)
+# (for when you have connectivity to only those region(s) private nets), e.g.:
+#
+#    use_private_network = nyc1, nyc3
 #
 use_private_network = False
 

--- a/contrib/inventory/digital_ocean.ini
+++ b/contrib/inventory/digital_ocean.ini
@@ -32,6 +32,11 @@ cache_max_age = 300
 #
 use_private_network = False
 
+# Use the IPv6 address instead of the IPv4 address when available.
+# Note that use_private_network will still take precedence if both options are
+# viable.
+use_ipv6 = False
+
 # Pass variables to every group, e.g.:
 #
 #   group_variables = { 'ansible_user': 'root' }

--- a/contrib/inventory/digital_ocean.ini
+++ b/contrib/inventory/digital_ocean.ini
@@ -37,6 +37,12 @@ use_private_network = False
 # viable.
 use_ipv6 = False
 
+# The primary means of identifying hosts. Supported options are:
+# address - The default; use the connect address as the identifier
+# name - Use the droplet name (with a suffix like -1 in case of duplicates)
+# id - Use the numeric Digital Ocean droplet ID
+identifier = name
+
 # Pass variables to every group, e.g.:
 #
 #   group_variables = { 'ansible_user': 'root' }

--- a/contrib/inventory/digital_ocean.py
+++ b/contrib/inventory/digital_ocean.py
@@ -441,6 +441,16 @@ class DigitalOceanInventory(object):
             self.inventory[group]['hosts'].append(host)
         return
 
+    def select_droplet_address(self, droplet):
+        for net in droplet['networks']['v4']:
+            if net['type'] == 'public':
+                dest = net['ip_address']
+            elif net['type'] == 'private' and self.use_private_network:
+                dest = net['ip_address']
+                break
+
+        return dest
+
     def build_inventory(self):
         """ Build Ansible inventory of droplets """
         self.inventory = {
@@ -453,12 +463,7 @@ class DigitalOceanInventory(object):
 
         # add all droplets by id and name
         for droplet in self.data['droplets']:
-            for net in droplet['networks']['v4']:
-                if net['type'] == 'public':
-                    dest = net['ip_address']
-                elif net['type'] == 'private' and self.use_private_network:
-                    dest = net['ip_address']
-                    break
+            dest = self.select_droplet_address(droplet)
 
             self.inventory['all']['hosts'].append(dest)
 

--- a/contrib/inventory/digital_ocean.py
+++ b/contrib/inventory/digital_ocean.py
@@ -456,8 +456,9 @@ class DigitalOceanInventory(object):
             for net in droplet['networks']['v4']:
                 if net['type'] == 'public':
                     dest = net['ip_address']
-                else:
-                    continue
+                elif net['type'] == 'private' and self.use_private_network:
+                    dest = net['ip_address']
+                    break
 
             self.inventory['all']['hosts'].append(dest)
 

--- a/contrib/inventory/digital_ocean.py
+++ b/contrib/inventory/digital_ocean.py
@@ -336,7 +336,11 @@ class DigitalOceanInventory(object):
 
         # Private IP Address
         if config.has_option('digital_ocean', 'use_private_network'):
-            self.use_private_network = config.getboolean('digital_ocean', 'use_private_network')
+            try:
+                self.use_private_network = config.getboolean('digital_ocean', 'use_private_network')
+            except ValueError:
+                private_regions = config.get('digital_ocean', 'use_private_network')
+                self.use_private_network = [x.strip() for x in private_regions.split(',')]
 
         # Group variables
         if config.has_option('digital_ocean', 'group_variables'):
@@ -446,8 +450,10 @@ class DigitalOceanInventory(object):
             if net['type'] == 'public':
                 dest = net['ip_address']
             elif net['type'] == 'private' and self.use_private_network:
-                dest = net['ip_address']
-                break
+                if (self.use_private_network is True or
+                        droplet['region']['slug'] in self.use_private_network):
+                    dest = net['ip_address']
+                    break
 
         return dest
 


### PR DESCRIPTION
##### SUMMARY
This updates the Digital Ocean dynamic inventory script with the following enhancements:

- Fixes bug where `use_private_network` isn't actually used anywhere and hence has no effect. (Commit 1)
- Enhances `use_private_network` even further where users can optionally specify a comma-separated list of region slugs where they'd like the private network address used. This is useful for performing management over the region's private network where possible, and falling back to public network addresses where not. (Commits 2 and 3)
- Adds `use_ipv6`, which uses the IPv6 public address instead of the IPv4 public address where applicable (i.e. where one exists and private network isn't used/possible). (Commit 4)
- Allows users to switch the identifier used to name hosts, since IP addresses aren't very comfortable in Ansible log output. The default is still IP address for compatibility with already-existing `digital_ocean.ini` files, but the provided ini is set to "name" by default, for beginner-friendliness. (Commit 5)

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
N/A (contrib)

##### ANSIBLE VERSION
```
ansible 2.4.2.0
  config file = None
  configured module search path = [u'/home/cfsworks/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib64/python2.7/site-packages/ansible
  executable location = /usr/lib/python-exec/python2.7/ansible
  python version = 2.7.14 (default, Feb 24 2018, 19:02:58) [GCC 7.3.0]
```


##### ADDITIONAL INFORMATION

Note that the first commit is a bugfix; if the PR is not fully up-to-standard, I'd like to request that, at the very least, the first commit be included.
