### PR TITLE
Digital Ocean SSH keys error while decoding Base64.

### DIFF
--- a/lib/ansible/modules/cloud/digital_ocean/digital_ocean_sshkey.py
+++ b/lib/ansible/modules/cloud/digital_ocean/digital_ocean_sshkey.py
@@ -239,7 +239,7 @@ def core(module):
 
 def ssh_key_fingerprint(ssh_pub_key):
     key = ssh_pub_key.split(None, 2)[1]
-    fingerprint = hashlib.md5(base64.decodestring(key)).hexdigest()
+    fingerprint = hashlib.md5(base64.b64decode(key)).hexdigest()
     return ':'.join(a + b for a, b in zip(fingerprint[::2], fingerprint[1::2]))
 
 


### PR DESCRIPTION
##### SUMMARY

Python 3 base64 decodestring expects a bytes-like object, not a string.
```
TypeError: expected bytes-like object, not str
```

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

digital_ocean_sshkey.py

##### ANSIBLE VERSION

```
ansible 2.4.3.0
```

previous versions are also affected.

##### ADDITIONAL INFORMATION

Full stack trace when running with python 3

```
Traceback (most recent call last):
  File "/var/folders/3w/knmcr7_d49183rwvzq_mfmlm0000gn/T/ansible_64vql_7d/ansible_module_digital_ocean_sshkey.py", line 272, in <module>
    main()
  File "/var/folders/3w/knmcr7_d49183rwvzq_mfmlm0000gn/T/ansible_64vql_7d/ansible_module_digital_ocean_sshkey.py", line 268, in main
    core(module)
  File "/var/folders/3w/knmcr7_d49183rwvzq_mfmlm0000gn/T/ansible_64vql_7d/ansible_module_digital_ocean_sshkey.py", line 171, in core
    fingerprint = fingerprint or ssh_key_fingerprint(ssh_pub_key)
  File "/var/folders/3w/knmcr7_d49183rwvzq_mfmlm0000gn/T/ansible_64vql_7d/ansible_module_digital_ocean_sshkey.py", line 239, in ssh_key_fingerprint
    base64.decodestring(key)
  File "/usr/local/Cellar/python/3.6.4_3/Frameworks/Python.framework/Versions/3.6/lib/python3.6/base64.py", line 561, in decodestring
    return decodebytes(s)
  File "/usr/local/Cellar/python/3.6.4_3/Frameworks/Python.framework/Versions/3.6/lib/python3.6/base64.py", line 552, in decodebytes
    _input_type_check(s)
  File "/usr/local/Cellar/python/3.6.4_3/Frameworks/Python.framework/Versions/3.6/lib/python3.6/base64.py", line 520, in _input_type_check
    raise TypeError(msg) from err
TypeError: expected bytes-like object, not str

```
