### PR TITLE
Added executable parameter to the script module

### DIFF
--- a/lib/ansible/modules/commands/script.py
+++ b/lib/ansible/modules/commands/script.py
@@ -44,8 +44,6 @@ options:
     description:
       - Name or path of an interpreter to invoke the script with
     version_added: "2.6"
-    required: false
-    default: null
 notes:
   - It is usually preferable to write Ansible modules than pushing scripts. Convert your script to an Ansible module for bonus points!
   - The ssh connection plugin will force pseudo-tty allocation via -tt when scripts are executed. pseudo-ttys do not have a stderr channel and all

--- a/lib/ansible/modules/commands/script.py
+++ b/lib/ansible/modules/commands/script.py
@@ -40,9 +40,9 @@ options:
     description:
       - cd into this directory on the remote node before running the script
     version_added: "2.4"
-  interpreter:
+  executable:
     description:
-      - Name or path of an interpreter to invoke the script with
+      - Name or path of a executable to invoke the script with
     version_added: "2.6"
 notes:
   - It is usually preferable to write Ansible modules than pushing scripts. Convert your script to an Ansible module for bonus points!
@@ -71,13 +71,13 @@ EXAMPLES = '''
   args:
     removes: /the/removed/file.txt
 
-# Run a script using an interpreter in a non-system path
+# Run a script using a executable in a non-system path
 - script: /some/local/script
   args:
-    interpreter: /some/remote/interpreter
+    executable: /some/remote/executable
 
-# Run a script using an interpreter in a system path
+# Run a script using a executable in a system path
 - script: /some/local/script.py
   args:
-    interpreter: python3
+    executable: python3
 '''

--- a/lib/ansible/modules/commands/script.py
+++ b/lib/ansible/modules/commands/script.py
@@ -40,6 +40,12 @@ options:
     description:
       - cd into this directory on the remote node before running the script
     version_added: "2.4"
+  interpreter:
+    description:
+      - Name or path of an interpreter to invoke the script with
+    version_added: "2.6"
+    required: false
+    default: null
 notes:
   - It is usually preferable to write Ansible modules than pushing scripts. Convert your script to an Ansible module for bonus points!
   - The ssh connection plugin will force pseudo-tty allocation via -tt when scripts are executed. pseudo-ttys do not have a stderr channel and all
@@ -66,4 +72,14 @@ EXAMPLES = '''
 - script: /some/local/remove_file.sh --some-arguments 1234
   args:
     removes: /the/removed/file.txt
+
+# Run a script using an interpreter in a non-system path
+- script: /some/local/script
+  args:
+    interpreter: /some/remote/interpreter
+
+# Run a script using an interpreter in a system path
+- script: /some/local/script.py
+  args:
+    interpreter: python3
 '''

--- a/lib/ansible/plugins/action/script.py
+++ b/lib/ansible/plugins/action/script.py
@@ -79,8 +79,8 @@ class ActionModule(ActionBase):
             parts = [to_text(s, errors='surrogate_or_strict') for s in shlex.split(raw_params.strip())]
             source = parts[0]
 
-            # Support interpreter paths and files with spaces in the name.
-            interpreter = to_native(self._task.args.get('interpreter', ''), errors='surrogate_or_strict')
+            # Support executable paths and files with spaces in the name.
+            executable = to_native(self._task.args.get('executable', ''), errors='surrogate_or_strict')
 
             try:
                 source = self._loader.get_real_file(self._find_needle('files', source), decrypt=self._task.args.get('decrypt', True))
@@ -113,8 +113,8 @@ class ActionModule(ActionBase):
                 env_dict = dict()
                 env_string = self._compute_environment_string(env_dict)
 
-                if interpreter:
-                    script_cmd = ' '.join([env_string, interpreter, target_command])
+                if executable:
+                    script_cmd = ' '.join([env_string, executable, target_command])
                 else:
                     script_cmd = ' '.join([env_string, target_command])
 

--- a/lib/ansible/plugins/action/script.py
+++ b/lib/ansible/plugins/action/script.py
@@ -79,6 +79,9 @@ class ActionModule(ActionBase):
             parts = [to_text(s, errors='surrogate_or_strict') for s in shlex.split(raw_params.strip())]
             source = parts[0]
 
+            # Support interpreter paths and files with spaces in the name.
+            interpreter = to_native(self._task.args.get('interpreter', ''), errors='surrogate_or_strict')
+
             try:
                 source = self._loader.get_real_file(self._find_needle('files', source), decrypt=self._task.args.get('decrypt', True))
             except AnsibleError as e:
@@ -109,7 +112,11 @@ class ActionModule(ActionBase):
                 # add preparation steps to one ssh roundtrip executing the script
                 env_dict = dict()
                 env_string = self._compute_environment_string(env_dict)
-                script_cmd = ' '.join([env_string, target_command])
+
+                if interpreter:
+                    script_cmd = ' '.join([env_string, interpreter, target_command])
+                else:
+                    script_cmd = ' '.join([env_string, target_command])
 
             if self._play_context.check_mode:
                 raise _AnsibleActionDone()

--- a/test/integration/targets/script/files/no_shebang.py
+++ b/test/integration/targets/script/files/no_shebang.py
@@ -1,0 +1,3 @@
+import sys
+
+sys.stdout.write("Script with shebang omitted")

--- a/test/integration/targets/script/tasks/main.yml
+++ b/test/integration/targets/script/tasks/main.yml
@@ -221,3 +221,21 @@
     that:
       - _check_mode_test3 is skipped
       - '_check_mode_test3.msg == "{{ output_dir_test | expanduser }}/afile2.txt does not exist, matching removes option"'
+
+# interpreter
+
+- name: Run script with shebang omitted
+  script: no_shebang.py
+  args:
+    interpreter: python
+  register: _shebang_omitted_test
+  tags:
+    - noshebang
+
+- name: Assert that script with shebang omitted succeeded
+  assert:
+    that:
+      - _shebang_omitted_test is success
+      - _shebang_omitted_test.stdout == 'Script with shebang omitted'
+  tags:
+    - noshebang

--- a/test/integration/targets/script/tasks/main.yml
+++ b/test/integration/targets/script/tasks/main.yml
@@ -222,12 +222,12 @@
       - _check_mode_test3 is skipped
       - '_check_mode_test3.msg == "{{ output_dir_test | expanduser }}/afile2.txt does not exist, matching removes option"'
 
-# interpreter
+# executable
 
 - name: Run script with shebang omitted
   script: no_shebang.py
   args:
-    interpreter: python
+    executable: python
   register: _shebang_omitted_test
   tags:
     - noshebang


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Added an interpreter parameter to the script module.  This allows the script to be executed remotely using a specific interpreter under a system path or full path provided by the user.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
script  module

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Nov 20 2015, 02:00:19) [GCC 4.8.5 20150623 (Red Hat 4.8.5-4)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
I used the same "space in filename/path logic" as the free_form parameter.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```
BEFORE:

ansible-doc script
> SCRIPT    (/usr/lib/python2.7/site-packages/ansible/modules/commands/script.py)

        The `script' module takes the script name followed by a list of space-delimited arguments.  The local script at path will be
        transferred to the remote node and then executed.  The given script will be processed through the shell environment on the remote
        node.  This module does not require python on the remote system, much like the [raw] module.  This module is also supported for
        Windows targets.

  * note: This module has a corresponding action plugin.

OPTIONS (= is mandatory):

- chdir
        cd into this directory on the remote node before running the script
        [Default: None]
        version_added: 2.4

- creates
        a filename, when it already exists, this step will *not* be run.
        [Default: None]
        version_added: 1.5

- decrypt
        This option controls the autodecryption of source files using vault.
        [Default: Yes]
        type: bool
        version_added: 2.4

= free_form
        Path to the local script file followed by optional arguments. There is no parameter actually named 'free form'; see the examples!
        [Default: None]

- removes
        a filename, when it does not exist, this step will *not* be run.
        [Default: None]
        version_added: 1.5

NOTES:
      * It is usually preferable to write Ansible modules than pushing scripts. Convert your script to an Ansible module for bonus
        points!
      * The ssh connection plugin will force pseudo-tty allocation via -tt when scripts are executed. pseudo-ttys do not have a stderr
        channel and all stderr is sent to stdout. If you depend on separated stdout and stderr result keys, please switch to a
        copy+command set of tasks instead of using script.
      * This module is also supported for Windows targets.
      * If the path to the local script contains spaces, it needs to be quoted.

AUTHOR: Ansible Core Team, Michael DeHaan
        METADATA:
          status:
          - stableinterface
          supported_by: core
 
EXAMPLES:
# Example from Ansible Playbooks
- script: /some/local/script.sh --some-arguments 1234

# Run a script that creates a file, but only if the file is not yet created
- script: /some/local/create_file.sh --some-arguments 1234
  args:
    creates: /the/created/file.txt

# Run a script that removes a file, but only if the file is not yet removed
- script: /some/local/remove_file.sh --some-arguments 1234
  args:
    removes: /the/removed/file.txt

AFTER:

ansible-doc script
> SCRIPT    (/usr/lib/python2.7/site-packages/ansible/modules/commands/script.py)

        The `script' module takes the script name followed by a list of space-delimited arguments.  The local script at path will be
        transferred to the remote node and then executed.  The given script will be processed through the shell environment on the remote
        node.  This module does not require python on the remote system, much like the [raw] module.  This module is also supported for
        Windows targets.

  * note: This module has a corresponding action plugin.

OPTIONS (= is mandatory):

- chdir
        cd into this directory on the remote node before running the script
        [Default: None]
        version_added: 2.4

- creates
        a filename, when it already exists, this step will *not* be run.
        [Default: None]
        version_added: 1.5

- decrypt
        This option controls the autodecryption of source files using vault.
        [Default: Yes]
        type: bool
        version_added: 2.4

= free_form
        Path to the local script file followed by optional arguments. There is no parameter actually named 'free form'; see the examples!
        [Default: None]

- interpreter
        Name or path of an interpreter to invoke the script with
        [Default: None]
        version_added: 2.6

- removes
        a filename, when it does not exist, this step will *not* be run.
        [Default: None]
        version_added: 1.5

NOTES:
      * It is usually preferable to write Ansible modules than pushing scripts. Convert your script to an Ansible module for bonus
        points!
      * The ssh connection plugin will force pseudo-tty allocation via -tt when scripts are executed. pseudo-ttys do not have a stderr
        channel and all stderr is sent to stdout. If you depend on separated stdout and stderr result keys, please switch to a
        copy+command set of tasks instead of using script.
      * This module is also supported for Windows targets.
      * If the path to the local script contains spaces, it needs to be quoted.

AUTHOR: Ansible Core Team, Michael DeHaan
        METADATA:
          status:
          - stableinterface
          supported_by: core
 
EXAMPLES:
# Example from Ansible Playbooks
- script: /some/local/script.sh --some-arguments 1234

# Run a script that creates a file, but only if the file is not yet created
- script: /some/local/create_file.sh --some-arguments 1234
  args:
    creates: /the/created/file.txt

# Run a script that removes a file, but only if the file is not yet removed
- script: /some/local/remove_file.sh --some-arguments 1234
  args:
    removes: /the/removed/file.txt

# Run a script using an interpreter in a non-system path
- script: /some/local/script
  args:
    interpreter: /some/remote/interpreter

# Run a script using an interpreter in a system path
- script: /some/local/script.py
  args:
    interpreter: python3
```
