### PR TITLE
Validate SSL in panos_import

### DIFF
--- a/lib/ansible/modules/network/panos/panos_import.py
+++ b/lib/ansible/modules/network/panos/panos_import.py
@@ -59,7 +59,7 @@ options:
         description:
             - URL of the file that will be imported to device.
         default: None
-    validate_ssl:
+    validate_cert:
         description:
             - If C(no), SSL certificates will not be validated. This should only set to no used on personally controlled sites using self-signed certificates.
         default: yes
@@ -124,7 +124,7 @@ def import_file(xapi, module, ip_address, file_, category):
 
     r = requests.post(
         'https://' + ip_address + '/api/',
-        verify=module.params['validate_ssl'],
+        verify=module.params['validate_cert'],
         params=params,
         headers={'Content-Type': mef.content_type},
         data=mef
@@ -162,7 +162,7 @@ def main():
         category=dict(default='software'),
         file=dict(),
         url=dict(),
-        validate_ssl=dict(type='bool', default=True),
+        validate_cert=dict(type='bool', default=True),
     )
     module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=False, required_one_of=[['file', 'url']])
     if not HAS_LIB:

--- a/lib/ansible/modules/network/panos/panos_import.py
+++ b/lib/ansible/modules/network/panos/panos_import.py
@@ -27,7 +27,7 @@ description:
     - Import file on PAN-OS device
 notes:
     - API reference documentation can be read from the C(/api/) directory of your appliance
-    - SSL validation is enabled by default as of Ansible 2.6. This may break existing playbooks but should be disabled with caution.
+    - Certificate validation is enabled by default as of Ansible 2.6. This may break existing playbooks but should be disabled with caution.
 author: "Luigi Mori (@jtschichold), Ivan Bojer (@ivanbojer)"
 version_added: "2.3"
 requirements:

--- a/lib/ansible/modules/network/panos/panos_import.py
+++ b/lib/ansible/modules/network/panos/panos_import.py
@@ -58,9 +58,9 @@ options:
     url:
         description:
             - URL of the file that will be imported to device.
-    validate_cert:
+    validate_certs:
         description:
-            - If C(no), SSL certificates will not be validated. This should only set to no used on personally controlled sites using self-signed certificates.
+            - If C(no), SSL certificates will not be validated. Disabling certificate validation is not recommended.
         default: yes
         type: bool
         version_added: "2.6"
@@ -123,7 +123,7 @@ def import_file(xapi, module, ip_address, file_, category):
 
     r = requests.post(
         'https://' + ip_address + '/api/',
-        verify=module.params['validate_cert'],
+        verify=module.params['validate_certs'],
         params=params,
         headers={'Content-Type': mef.content_type},
         data=mef
@@ -161,7 +161,7 @@ def main():
         category=dict(default='software'),
         file=dict(),
         url=dict(),
-        validate_cert=dict(type='bool', default=True),
+        validate_certs=dict(type='bool', default=True),
     )
     module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=False, required_one_of=[['file', 'url']])
     if not HAS_LIB:

--- a/lib/ansible/modules/network/panos/panos_import.py
+++ b/lib/ansible/modules/network/panos/panos_import.py
@@ -58,7 +58,6 @@ options:
     url:
         description:
             - URL of the file that will be imported to device.
-        default: None
     validate_cert:
         description:
             - If C(no), SSL certificates will not be validated. This should only set to no used on personally controlled sites using self-signed certificates.

--- a/lib/ansible/modules/network/panos/panos_import.py
+++ b/lib/ansible/modules/network/panos/panos_import.py
@@ -27,6 +27,7 @@ description:
     - Import file on PAN-OS device
 notes:
     - API reference documentation can be read from the C(/api/) directory of your appliance
+    - SSL validation is enabled by default as of Ansible 2.6. This may break existing playbooks but should be disabled with caution.
 author: "Luigi Mori (@jtschichold), Ivan Bojer (@ivanbojer)"
 version_added: "2.3"
 requirements:
@@ -63,10 +64,8 @@ options:
         default: None
     validate_ssl:
         description:
-            - Whether or not certificates should be validated
-        type: bool
-        default: True
-        version_added: "2.6"
+            - If C(no), SSL certificates will not be validated. This should only set to no used on personally controlled sites using self-signed certificates.
+        default: yes
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/network/panos/panos_import.py
+++ b/lib/ansible/modules/network/panos/panos_import.py
@@ -49,11 +49,9 @@ options:
     category:
         description:
             - Category of file uploaded. The default is software.
-<<<<<<< HEAD
-=======
-            - See API > Import section of the API reference for category options.            
+
+            - See API > Import section of the API reference for category options.
         required: false
->>>>>>> Fix bug 36936
         default: software
     file:
         description:
@@ -61,15 +59,14 @@ options:
     url:
         description:
             - URL of the file that will be imported to device.
-<<<<<<< HEAD
-=======
         required: false
         default: None
     validate_ssl:
         description:
             - Whether or not certificates should be validated
+        type: bool
         default: True
->>>>>>> Fix bug 36936
+        version_added: "2.6"
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/network/panos/panos_import.py
+++ b/lib/ansible/modules/network/panos/panos_import.py
@@ -50,9 +50,7 @@ options:
     category:
         description:
             - Category of file uploaded. The default is software.
-
             - See API > Import section of the API reference for category options.
-        required: false
         default: software
     file:
         description:
@@ -60,7 +58,6 @@ options:
     url:
         description:
             - URL of the file that will be imported to device.
-        required: false
         default: None
     validate_ssl:
         description:

--- a/lib/ansible/modules/network/panos/panos_import.py
+++ b/lib/ansible/modules/network/panos/panos_import.py
@@ -165,7 +165,7 @@ def main():
         category=dict(default='software'),
         file=dict(),
         url=dict(),
-        validate_ssl=dict(type='bool', default=False),
+        validate_ssl=dict(type='bool', default=True),
     )
     module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=False, required_one_of=[['file', 'url']])
     if not HAS_LIB:

--- a/lib/ansible/modules/network/panos/panos_import.py
+++ b/lib/ansible/modules/network/panos/panos_import.py
@@ -25,6 +25,8 @@ module: panos_import
 short_description: import file on PAN-OS devices
 description:
     - Import file on PAN-OS device
+notes:
+    - API reference documentation can be read from the C(/api/) directory of your appliance
 author: "Luigi Mori (@jtschichold), Ivan Bojer (@ivanbojer)"
 version_added: "2.3"
 requirements:
@@ -47,6 +49,11 @@ options:
     category:
         description:
             - Category of file uploaded. The default is software.
+<<<<<<< HEAD
+=======
+            - See API > Import section of the API reference for category options.            
+        required: false
+>>>>>>> Fix bug 36936
         default: software
     file:
         description:
@@ -54,6 +61,15 @@ options:
     url:
         description:
             - URL of the file that will be imported to device.
+<<<<<<< HEAD
+=======
+        required: false
+        default: None
+    validate_ssl:
+        description:
+            - Whether or not certificates should be validated
+        default: True
+>>>>>>> Fix bug 36936
 '''
 
 EXAMPLES = '''
@@ -113,7 +129,7 @@ def import_file(xapi, module, ip_address, file_, category):
 
     r = requests.post(
         'https://' + ip_address + '/api/',
-        verify=False,
+        verify=module.params['validate_ssl'],
         params=params,
         headers={'Content-Type': mef.content_type},
         data=mef
@@ -150,7 +166,8 @@ def main():
         username=dict(default='admin'),
         category=dict(default='software'),
         file=dict(),
-        url=dict()
+        url=dict(),
+        validate_ssl=dict(type='bool', default=True),
     )
     module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=False, required_one_of=[['file', 'url']])
     if not HAS_LIB:

--- a/lib/ansible/modules/network/panos/panos_import.py
+++ b/lib/ansible/modules/network/panos/panos_import.py
@@ -66,6 +66,7 @@ options:
         description:
             - If C(no), SSL certificates will not be validated. This should only set to no used on personally controlled sites using self-signed certificates.
         default: yes
+        type: bool
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/network/panos/panos_import.py
+++ b/lib/ansible/modules/network/panos/panos_import.py
@@ -165,7 +165,7 @@ def main():
         category=dict(default='software'),
         file=dict(),
         url=dict(),
-        validate_ssl=dict(type='bool', default=True),
+        validate_ssl=dict(type='bool', default=False),
     )
     module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=False, required_one_of=[['file', 'url']])
     if not HAS_LIB:

--- a/lib/ansible/modules/network/panos/panos_import.py
+++ b/lib/ansible/modules/network/panos/panos_import.py
@@ -67,6 +67,7 @@ options:
             - If C(no), SSL certificates will not be validated. This should only set to no used on personally controlled sites using self-signed certificates.
         default: yes
         type: bool
+        version_added: "2.6"
 '''
 
 EXAMPLES = '''


### PR DESCRIPTION
##### SUMMARY
Bug #36936 states `panos_import` should validate SSL connections to avoid man in the middle attacks.

Fixes #36936 
##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
panos_import

##### ANSIBLE VERSION
```
ansible 2.6.0 (panos/bug-36936 67c27ef877) last updated 2018/03/03 19:53:31 (GMT -500)
  config file = None
  configured module search path = ['/Users/kbreit/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/kbreit/Documents/Programming/ansible/lib/ansible
  executable location = /Users/kbreit/Documents/Programming/ansible/bin/ansible
  python version = 3.5.4 (default, Feb 25 2018, 14:56:02) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```


##### ADDITIONAL INFORMATION
This should likely be back ported to previous versions since the code seems to be the same.

No difference in output