### PR TITLE
Add compatibility for docker-py version 3

### DIFF
--- a/lib/ansible/module_utils/docker_common.py
+++ b/lib/ansible/module_utils/docker_common.py
@@ -29,6 +29,7 @@ from ansible.module_utils.parsing.convert_bool import BOOLEANS_TRUE, BOOLEANS_FA
 
 HAS_DOCKER_PY = True
 HAS_DOCKER_PY_2 = False
+HAS_DOCKER_PY_3 = False
 HAS_DOCKER_ERROR = None
 
 try:
@@ -38,7 +39,12 @@ try:
     from docker.tls import TLSConfig
     from docker.constants import DEFAULT_TIMEOUT_SECONDS, DEFAULT_DOCKER_API_VERSION
     from docker import auth
-    if LooseVersion(docker_version) >= LooseVersion('2.0.0'):
+
+    if LooseVersion(docker_version) >= LooseVersion('3.0.0'):
+        HAS_DOCKER_PY_3 = True
+        from docker import APIClient as Client
+        from docker.types import Ulimit, LogConfig
+    elif LooseVersion(docker_version) >= LooseVersion('2.0.0'):
         HAS_DOCKER_PY_2 = True
         from docker import APIClient as Client
         from docker.types import Ulimit, LogConfig

--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -688,12 +688,12 @@ import re
 import shlex
 
 from ansible.module_utils.basic import human_to_bytes
-from ansible.module_utils.docker_common import HAS_DOCKER_PY_2, AnsibleDockerClient, DockerBaseClass
+from ansible.module_utils.docker_common import HAS_DOCKER_PY_2, HAS_DOCKER_PY_3, AnsibleDockerClient, DockerBaseClass
 from ansible.module_utils.six import string_types
 
 try:
     from docker import utils
-    if HAS_DOCKER_PY_2:
+    if HAS_DOCKER_PY_2 or HAS_DOCKER_PY_3:
         from docker.types import Ulimit, LogConfig
     else:
         from docker.utils.types import Ulimit, LogConfig
@@ -894,13 +894,15 @@ class TaskParameters(DockerBaseClass):
             environment='env',
             name='name',
             entrypoint='entrypoint',
-            cpu_shares='cpu_shares',
             mac_address='mac_address',
             labels='labels',
             stop_signal='stop_signal',
-            volume_driver='volume_driver',
             working_dir='working_dir',
         )
+
+        if not HAS_DOCKER_PY_3:
+            create_params['cpu_shares'] = 'cpu_shares'
+            create_params['volume_driver'] = 'volume_driver'
 
         result = dict(
             host_config=self._host_config(),
@@ -990,9 +992,14 @@ class TaskParameters(DockerBaseClass):
             tmpfs='tmpfs'
         )
 
-        if HAS_DOCKER_PY_2:
+        if HAS_DOCKER_PY_2 or HAS_DOCKER_PY_3:
             # auto_remove is only supported in docker>=2
             host_config_params['auto_remove'] = 'auto_remove'
+
+        if HAS_DOCKER_PY_3:
+            # cpu_shares and volume_driver moved to create_host_config in > 3
+            host_config_params['cpu_shares'] = 'cpu_shares'
+            host_config_params['volume_driver'] = 'volume_driver'
 
         params = dict()
         for key, value in host_config_params.items():
@@ -1973,7 +1980,10 @@ class ContainerManager(DockerBaseClass):
                 self.fail("Error starting container %s: %s" % (container_id, str(exc)))
 
             if not self.parameters.detach:
-                status = self.client.wait(container_id)
+                if HAS_DOCKER_PY_3:
+                    status = self.client.wait(container_id)['StatusCode']
+                else:
+                    status = self.client.wait(container_id)
                 config = self.client.inspect_container(container_id)
                 logging_driver = config['HostConfig']['LogConfig']['Type']
 
@@ -2141,8 +2151,8 @@ def main():
         supports_check_mode=True
     )
 
-    if not HAS_DOCKER_PY_2 and client.module.params.get('auto_remove'):
-        client.module.fail_json(msg="'auto_remove' is not compatible with docker-py, and requires the docker python module")
+    if (not (HAS_DOCKER_PY_2 or HAS_DOCKER_PY_3)) and client.module.params.get('auto_remove'):
+        client.module.fail_json(msg="'auto_remove' is not compatible with the 'docker-py' Python package. It requires the newer 'docker' Python package.")
 
     cm = ContainerManager(client)
     client.module.exit_json(**cm.results)

--- a/lib/ansible/modules/cloud/docker/docker_network.py
+++ b/lib/ansible/modules/cloud/docker/docker_network.py
@@ -151,11 +151,11 @@ facts:
     sample: {}
 '''
 
-from ansible.module_utils.docker_common import AnsibleDockerClient, DockerBaseClass, HAS_DOCKER_PY_2
+from ansible.module_utils.docker_common import AnsibleDockerClient, DockerBaseClass, HAS_DOCKER_PY_2, HAS_DOCKER_PY_3
 
 try:
     from docker import utils
-    if HAS_DOCKER_PY_2:
+    if HAS_DOCKER_PY_2 or HAS_DOCKER_PY_3:
         from docker.types import IPAMPool, IPAMConfig
 except:
     # missing docker-py handled in ansible.module_utils.docker
@@ -269,12 +269,12 @@ class DockerNetworkManager(object):
         if not self.existing_network:
             ipam_pools = []
             if self.parameters.ipam_options:
-                if HAS_DOCKER_PY_2:
+                if HAS_DOCKER_PY_2 or HAS_DOCKER_PY_3:
                     ipam_pools.append(IPAMPool(**self.parameters.ipam_options))
                 else:
                     ipam_pools.append(utils.create_ipam_pool(**self.parameters.ipam_options))
 
-            if HAS_DOCKER_PY_2:
+            if HAS_DOCKER_PY_2 or HAS_DOCKER_PY_3:
                 ipam_config = IPAMConfig(driver=self.parameters.ipam_driver,
                                          pool_configs=ipam_pools)
             else:


### PR DESCRIPTION
##### SUMMARY
Adds decision trees in the container, image, and network docker modules to account for Docker SDK for Python changes made in version 3. Effectively adds Ansible support for the docker_ modules for Python 3.6 since Docker SDK 3 adds that support.

The SDK changes being fixed for comptatibility are specifically outlined at https://docker-py.readthedocs.io/en/stable/change-log.html#breaking-changes . I cannot guarantee I've fixed every incompatibility, but I'm fairly sure I've found at least "most" of them - and certainly this addresses more than current devel, which is "none of them". I tested creating images, pulling an image, pushing an image to a tar file, and running a container with and without detaching it, using (docker-py, docker < 3, and docker >= 3).

Fixes #35612 .

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/docker_common.py
lib/ansible/modules/cloud/docker/docker_container.py
lib/ansible/modules/cloud/docker/docker_image.py
lib/ansible/modules/cloud/docker/docker_network.py

##### ANSIBLE VERSION
devel
(This may want to be backported to at least 2.5, which was separated from devel at about the same time that docker SDK 3 came out.)


##### ADDITIONAL INFORMATION
Credit to @sivel for early clues as to where to apply module fixes. I took those, modified, and applied more of them.
