### PR TITLE
Module for UCSM Manager Timezone Management

### DIFF
--- a/lib/ansible/modules/remote_management/ucs/ucs_timezone.py
+++ b/lib/ansible/modules/remote_management/ucs/ucs_timezone.py
@@ -94,7 +94,7 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.remote_management.ucs import UCSModule, ucs_argument_spec
 
 
-def main():
+def run_module():
     argument_spec = ucs_argument_spec
     argument_spec.update(
         timezone=dict(type='str'),
@@ -161,6 +161,10 @@ def main():
     if err:
         module.fail_json(**ucs.result)
     module.exit_json(**ucs.result)
+
+
+def main():
+    run_module()
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/remote_management/ucs/ucs_timezone.py
+++ b/lib/ansible/modules/remote_management/ucs/ucs_timezone.py
@@ -13,57 +13,51 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = r'''
 ---
 module: ucs_timezone
-
 short_description: Configures timezone on Cisco UCS Manager
-
-version_added: "2.7"
-
 description:
-    - Configures timezone on Cisco UCS Manager.
-    - Examples can be used with the UCS Platform Emulator U(https://communities.cisco.com/ucspe).
-
+- Configures timezone on Cisco UCS Manager.
+- Examples can be used with the L(UCS Platform Emulator,https://communities.cisco.com/ucspe).
+extends_documentation_fragment: ucs
 options:
-    state:
-        description:
-            - If C(present), will set or update timezone.
-            - If C(absent), will unset timezone.
-        choices: [present, absent]
-        default: present
-
-    admin_state:
-        description: admin state indicates if the timezone confguration is enabled and being utilized by UCS Manager
-            or disabled and being ignored by UCS Manager
-        choices: ['disabled', 'enabled']
-        default: "enabled"
-
-    timezone:
-        description:
-            - The timezone name. Time zone names are from the tz database U(https://en.wikipedia.org/wiki/List_of_tz_database_time_zones)
-            - The timezone name is case sensitive.
-            - This name can be between 0 and 510 alphanumeric characters.
-            - You cannot use spaces or any special characters other than
-            - "\"-\" (hyphen), \"_\" (underscore), \"/\" (backslash)."
-
+  state:
     description:
-        description:
-            - A user-defined description of the timezone object.
-            - Enter up to 256 characters.
-            - "You can use any characters or spaces except the following:"
-            - "` (accent mark), \ (backslash), ^ (carat), \" (double quote), = (equal sign), > (greater than), < (less than), or ' (single quote)."
-        aliases: [ descr ]
-        default: ""
+    - If C(absent), will unset timezone.
+    - If C(present), will set or update timezone.
+    choices: [absent, present]
+    default: present
 
-extends_documentation_fragment:
-    - ucs
+  admin_state:
+    description:
+    - The admin_state setting
+    - The enabled admin_state indicates the timezone confguration is utilized by UCS Manager.
+    - The disabled admin_state indicates the timezone confguration is ignored by UCS Manager.
+    choices: [disabled, enabled]
+    default: enabled
+
+  description:
+    description:
+    - A user-defined description of the timezone.
+    - Enter up to 256 characters.
+    - "You can use any characters or spaces except the following:"
+    - "` (accent mark), \ (backslash), ^ (carat), \" (double quote), = (equal sign), > (greater than), < (less than), or ' (single quote)."
+    aliases: [ descr ]
+    default: ""
+
+  timezone:
+    description:
+    - The timezone name.
+    - Time zone names are from the L(tz database,https://en.wikipedia.org/wiki/List_of_tz_database_time_zones)
+    - The timezone name is case sensitive.
+    - The timezone name can be between 0 and 510 alphanumeric characters.
+    - You cannot use spaces or any special characters other than
+    - "\"-\" (hyphen), \"_\" (underscore), \"/\" (backslash)."
 
 requirements:
-
-    - ucsmsdk
-
+- ucsmsdk
 author:
-
-    - John McDonough (@movinalot)
-    - CiscoUcs (@CiscoUcs)
+- John McDonough (@movinalot)
+- CiscoUcs (@CiscoUcs)
+version_added: '2.7'
 '''
 
 EXAMPLES = r'''

--- a/lib/ansible/modules/remote_management/ucs/ucs_timezone.py
+++ b/lib/ansible/modules/remote_management/ucs/ucs_timezone.py
@@ -16,7 +16,7 @@ module: ucs_timezone
 
 short_description: Configures timezone on Cisco UCS Manager
 
-version_added: "2.6"
+version_added: "2.7"
 
 description:
     - Configures timezone on Cisco UCS Manager.

--- a/lib/ansible/modules/remote_management/ucs/ucs_timezone.py
+++ b/lib/ansible/modules/remote_management/ucs/ucs_timezone.py
@@ -1,0 +1,169 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = r'''
+---
+module: ucs_timezone
+
+short_description: Configures timezone on Cisco UCS Manager
+
+version_added: "2.6"
+
+description:
+    - Configures time zone on Cisco UCS Manager.
+    - Examples can be used with the UCS Platform Emulator U(https://communities.cisco.com/ucspe).
+
+options:
+    state:
+        description:
+            - If C(present), will verify timezone is set (persent) and will set (create) if needed.
+            - If C(absent), will verify timezone is unset (absent) and will unset (delete) if needed.
+        choices: [present, absent]
+        default: absent
+        aliases: [admin_state]
+
+    timezone:
+        description:
+            - The timezone name. Time zone names are from the tz database U(https://en.wikipedia.org/wiki/List_of_tz_database_time_zones)
+            - The timezone name is case sensitive.
+            - This name can be between 0 and 510 alphanumeric characters.
+            - You cannot use spaces or any special characters other than
+            - "\"-\" (hyphen), \"_\" (underscore), \"/\" (backslash)."
+        default: unset
+        required: no
+
+    description:
+        description:
+            - A user-defined description of the timezone object.
+            - Enter up to 256 characters.
+            - "You can use any characters or spaces except the following:"
+            - "` (accent mark), \ (backslash), ^ (carat), \" (double quote), = (equal sign), > (greater than), < (less than), or ' (single quote)."
+        required: no
+        aliases: [ descr ]
+
+extends_documentation_fragment:
+    - ucs
+
+requirements:
+
+    - ucsmsdk
+    - pytz
+
+author:
+
+    - John McDonough (@movinalot)
+    - CiscoUcs (@CiscoUcs)
+'''
+
+EXAMPLES = r'''
+- name: Configure Time Zone
+  ucs_timezone:
+    hostname: 172.16.143.150
+    username: admin
+    password: password
+    state: present
+    timezone: America/Los_Angeles
+    descr: 'Time Zone for Los Angeles'
+
+- name: Unconfigure Time Zone
+  ucs_timezone:
+    hostname: 172.16.143.150
+    username: admin
+    password: password
+    state: absent
+'''
+
+RETURN = r'''
+#
+'''
+
+import pytz
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.remote_management.ucs import UCSModule, ucs_argument_spec
+
+
+def main():
+    argument_spec = ucs_argument_spec
+    argument_spec.update(
+        timezone=dict(type='str', default=''),
+        descr=dict(type='str'),
+        state=dict(type='str', default='absent', choices=['present', 'absent']),
+    )
+
+    module = AnsibleModule(
+        argument_spec,
+        supports_check_mode=True,
+        required_if=[
+            ['state', 'present', ['timezone']],
+        ],
+    )
+    ucs = UCSModule(module)
+
+    err = False
+
+    # UCSModule creation above verifies ucsmsdk is present and exits on failure, so additional imports are done below.
+
+    changed = False
+    try:
+        mo_exists = False
+        props_match = False
+
+        if (module.params['timezone'] in pytz.all_timezones or
+                len(module.params['timezone']) <= 0):
+
+            dn = 'sys/svc-ext/datetime-svc'
+
+            mo = ucs.login_handle.query_dn(dn)
+            if mo:
+                mo_exists = True
+
+            if module.params['state'] == 'absent':
+                # mo must exist but all properties do not have to match
+                if mo_exists:
+                    if not module.check_mode:
+                        mo.timezone = ""
+                        mo.descr = ""
+                        ucs.login_handle.add_mo(mo, modify_present=True)
+                        ucs.login_handle.commit()
+                    changed = True
+            else:
+                if mo_exists:
+                    # check top-level mo props
+                    kwargs = dict(timezone=module.params['timezone'])
+                    kwargs['descr'] = module.params['descr']
+                    if mo.check_prop_match(**kwargs):
+                        props_match = True
+
+                if not props_match:
+                    if not module.check_mode:
+                        # update mo timezone mo always exists
+                        mo.timezone = module.params['timezone']
+                        mo.descr = module.params['descr']
+                        ucs.login_handle.add_mo(mo, modify_present=True)
+                        ucs.login_handle.commit()
+                    changed = True
+        else:
+            err = True
+            module.fail_json(msg='time zone: ' + module.params['timezone'] + ' is not a valid time zone string')
+
+    except Exception as e:
+        err = True
+        ucs.result['msg'] = "setup error: %s " % str(e)
+
+    ucs.result['changed'] = changed
+    if err:
+        module.fail_json(**ucs.result)
+    module.exit_json(**ucs.result)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/remote_management/ucs/ucs_timezone.py
+++ b/lib/ansible/modules/remote_management/ucs/ucs_timezone.py
@@ -101,7 +101,7 @@ def main():
     argument_spec.update(
         timezone=dict(type='str'),
         descr=dict(type='str'),
-        admin_state=dict(type='str', default='absent', choices=['disabled', 'enabled']),
+        admin_state=dict(type='str', default='enabled', choices=['disabled', 'enabled']),
         state=dict(type='str', default='absent', choices=['present', 'absent']),
     )
 

--- a/lib/ansible/modules/remote_management/ucs/ucs_timezone.py
+++ b/lib/ansible/modules/remote_management/ucs/ucs_timezone.py
@@ -29,7 +29,6 @@ options:
             - If C(absent), will unset timezone.
         choices: [present, absent]
         default: present
-        required: true
 
     admin_state:
         description: admin state indicates if the timezone confguration is enabled and being utilized by UCS Manager
@@ -52,6 +51,7 @@ options:
             - "You can use any characters or spaces except the following:"
             - "` (accent mark), \ (backslash), ^ (carat), \" (double quote), = (equal sign), > (greater than), < (less than), or ' (single quote)."
         aliases: [ descr ]
+        default: ""
 
 extends_documentation_fragment:
     - ucs
@@ -100,7 +100,7 @@ def main():
         timezone=dict(type='str'),
         description=dict(type='str', aliases=['descr'], default=''),
         admin_state=dict(type='str', default='enabled', choices=['disabled', 'enabled']),
-        state=dict(type='str', default='absent', choices=['present', 'absent']),
+        state=dict(type='str', default='present', choices=['present', 'absent']),
     )
 
     module = AnsibleModule(

--- a/test/integration/targets/ucs_timezone/aliases
+++ b/test/integration/targets/ucs_timezone/aliases
@@ -4,3 +4,4 @@
 # ucs_hostname: 172.22.251.170
 # ucs_username: admin
 # ucs_password: password
+unsupported

--- a/test/integration/targets/ucs_timezone/aliases
+++ b/test/integration/targets/ucs_timezone/aliases
@@ -1,0 +1,6 @@
+# Not enabled, but can be used with the UCS Platform Emulator or UCS hardware.
+# Example integration_config.yml:
+# ---
+# ucs_hostname: 172.22.251.170
+# ucs_username: admin
+# ucs_password: password

--- a/test/integration/targets/ucs_timezone/tasks/main.yml
+++ b/test/integration/targets/ucs_timezone/tasks/main.yml
@@ -1,5 +1,5 @@
 # Test code for the UCS modules
-# Copyright 2017, David Soper (@dsoper2)
+# Copyright 2018, John McDonough (@movinalot)
 
 - name: Test that we have a UCS host, UCS username, and UCS password
   fail:
@@ -58,8 +58,8 @@
 
 # Test change (check_mode)
 - name: Timezone description change (check_mode)
-  ucs_timezone: &vtimezone_change
-    <<: *vtimezone_present
+  ucs_timezone: &timezone_change
+    <<: *timezone_present
     descr: Testing Ansible
   check_mode: yes
   register: cm_timezone_descr_change
@@ -123,4 +123,4 @@
   assert:
     that:
     - cm_timezone_absent.changed == nm_timezone_absent.changed == true
-- cm_timezone_absent_again.changed == nm_timezone_absent_again.changed == false
+    - cm_timezone_absent_again.changed == nm_timezone_absent_again.changed == false

--- a/test/integration/targets/ucs_timezone/tasks/main.yml
+++ b/test/integration/targets/ucs_timezone/tasks/main.yml
@@ -1,0 +1,126 @@
+# Test code for the UCS modules
+# Copyright 2017, David Soper (@dsoper2)
+
+- name: Test that we have a UCS host, UCS username, and UCS password
+  fail:
+    msg: 'Please define the following variables: ucs_hostname, ucs_username and ucs_password.'
+  when: ucs_hostname is not defined or ucs_username is not defined or ucs_password is not defined
+  vars:
+    login_info: &login_info
+      hostname: "{{ ucs_hostname }}"
+      username: "{{ ucs_username }}"
+      password: "{{ ucs_password }}"
+
+
+# Setup (clean environment)
+- name: Timezone absent
+  ucs_timezone: &timezone_absent
+    <<: *login_info
+    state: absent
+
+
+# Test present (check_mode)
+- name: Timezone present (check_mode)
+  ucs_timezone: &timezone_present
+    <<: *login_info
+    timezone: America/Los_Angeles
+    description: Timezone for America/Los_Angeles
+  check_mode: yes
+  register: cm_timezone_present
+
+
+# Present (normal mode)
+- name: Timezone present (normal mode)
+  ucs_timezone: *timezone_present
+  register: nm_timezone_present
+
+
+# Test present again (idempotent)
+- name: Timezone present again (check_mode)
+  ucs_timezone: *timezone_present
+  check_mode: yes
+  register: cm_timezone_present_again
+
+
+# Present again (normal mode)
+- name: Timezone present again (normal mode)
+  ucs_timezone: *timezone_present
+  register: nm_timezone_present_again
+
+
+# Verfiy present
+- name: Verify Timezone present results
+  assert:
+    that:
+    - cm_timezone_present.changed == nm_timezone_present.changed == true
+    - cm_timezone_present_again.changed == nm_timezone_present_again.changed == false
+
+
+# Test change (check_mode)
+- name: Timezone description change (check_mode)
+  ucs_timezone: &vtimezone_change
+    <<: *vtimezone_present
+    descr: Testing Ansible
+  check_mode: yes
+  register: cm_timezone_descr_change
+
+
+# Change (normal mode)
+- name: Timezone description change (normal mode)
+  ucs_timezone: *timezone_change
+  register: nm_timezone_descr_change
+
+
+# Test change again (idempotent)
+- name: Timezone description again (check_mode)
+  ucs_timezone: *timezone_change
+  check_mode: yes
+  register: cm_timezone_descr_change_again
+
+
+# Change again (normal mode)
+- name: Timezone description change again (normal mode)
+  ucs_timezone: *timezone_change
+  register: nm_timezone_descr_change_again
+
+
+# Verfiy change
+- name: Verify Timezone change results
+  assert:
+    that:
+    - cm_timezone_descr_change.changed == nm_timezone_descr_change.changed == true
+    - cm_timezone_descr_change_again.changed == nm_timezone_descr_change_again.changed == false
+
+
+# Teardown (clean environment)
+- name: Timezone absent (check_mode)
+  ucs_timezone: *timezone_absent
+  check_mode: yes
+  register: cm_timezone_absent
+
+
+# Absent (normal mode)
+- name: Timezone absent (normal mode)
+  ucs_timezone: *timezone_absent
+  register: nm_timezone_absent
+
+
+# Test absent again (idempotent)
+- name: Timezone absent again (check_mode)
+  ucs_timezone: *timezone_absent
+  check_mode: yes
+  register: cm_timezone_absent_again
+
+
+# Absent again (normal mode)
+- name: Timezone absent again (normal mode)
+  ucs_timezone: *timezone_absent
+  register: nm_timezone_absent_again
+
+
+# Verfiy absent
+- name: Verify Timezone absent results
+  assert:
+    that:
+    - cm_timezone_absent.changed == nm_timezone_absent.changed == true
+- cm_timezone_absent_again.changed == nm_timezone_absent_again.changed == false


### PR DESCRIPTION
##### SUMMARY
Cisco UCS Manager Time zone management. UCS Manager allows for specifying a time zone, the time zone is in the tz database format. UCS Manager also allows for a time zone to not be specified.

##### ISSUE TYPE
 - New Module Pull Request

##### COMPONENT NAME
ucs_timezone

##### ANSIBLE VERSION
```
ansible 2.6.0 (ucs_timezone 0b8608443a) last updated 2018/03/03 18:31:03 (GMT -700)
  config file = /Users/jomcdono/.ansible.cfg
  configured module search path = ['/Users/jomcdono/Documents/src/ucs/ansible/lib/ansible/modules/remote_management/ucs']
  ansible python module location = /Users/jomcdono/Documents/src/ucs/ansible/lib/ansible
  executable location = /Users/jomcdono/Documents/src/ucs/ansible/bin/ansible
  python version = 3.6.4 (default, Jan 11 2018, 12:13:21) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
