### PR TITLE
create sources.list.d directory if needed

### DIFF
--- a/lib/ansible/modules/packaging/os/apt_repository.py
+++ b/lib/ansible/modules/packaging/os/apt_repository.py
@@ -282,6 +282,11 @@ class SourcesList(object):
         for filename, sources in list(self.files.items()):
             if sources:
                 d, fn = os.path.split(filename)
+                try:
+                    os.makedirs(d)
+                except OSError as err:
+                    if not os.path.isdir(d):
+                        self.module.fail_json("Failed to create directory %s: %s" % (d, to_native(err)))
                 fd, tmp_path = tempfile.mkstemp(prefix=".%s-" % fn, dir=d)
 
                 f = os.fdopen(fd, 'w')


### PR DESCRIPTION
##### SUMMARY
if Dir::Etc::sourceparts (/etc/apt/sources.list.d) directory is absent, then apt_repository will fail.

This patch adds the creation of the directory if need.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
apt_repository

##### ANSIBLE VERSION
```
ansible 2.4.1.0
  config file = None
  configured module search path = [u'/Users/cyril/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.14 (default, Feb  6 2018, 20:04:00) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```


##### ADDITIONAL INFORMATION
To reproduce, remove /etc/apt/sources.list.d directory, use apt_repository to add a repository.
