### PR TITLE
use str instead of bytes

### DIFF
--- a/lib/ansible/inventory/manager.py
+++ b/lib/ansible/inventory/manager.py
@@ -39,11 +39,11 @@ except ImportError:
     from ansible.utils.display import Display
     display = Display()
 
-IGNORED_ALWAYS = [b"^\.", b"^host_vars$", b"^group_vars$", b"^vars_plugins$"]
-IGNORED_PATTERNS = [to_bytes(x) for x in C.INVENTORY_IGNORE_PATTERNS]
-IGNORED_EXTS = [b'%s$' % to_bytes(re.escape(x)) for x in C.INVENTORY_IGNORE_EXTS]
+IGNORED_ALWAYS = ["^\.", "^host_vars$", "^group_vars$", "^vars_plugins$"]
+IGNORED_PATTERNS = C.INVENTORY_IGNORE_PATTERNS
+IGNORED_EXTS = ['%s$' % re.escape(x) for x in C.INVENTORY_IGNORE_EXTS]
 
-IGNORED = re.compile(b'|'.join(IGNORED_ALWAYS + IGNORED_PATTERNS + IGNORED_EXTS))
+IGNORED = re.compile('|'.join(IGNORED_ALWAYS + IGNORED_PATTERNS + IGNORED_EXTS))
 
 
 def order_patterns(patterns):


### PR DESCRIPTION
##### SUMMARY
`PEP 461` add `% formating` since python 3.5.
But for python 3.4, `% formating` doesn't support bytes. so just use str for regex.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME

`lib/ansible`

##### ANSIBLE VERSION
branch `stable-2.4` and `python 3.4`

##### ADDITIONAL INFORMATION
error output
```
$ ansible --version
ERROR! Unexpected Exception, this is probably a bug: unsupported operand type(s) for %: 'bytes' and 'bytes'
the full traceback was:

Traceback (most recent call last):
  File "/home/www/release/new-deploy/venv/bin/ansible", line 85, in <module>
    mycli = getattr(__import__("ansible.cli.%s" % sub, fromlist=[myclass]), myclass)
  File "/home/www/release/new-deploy/venv/lib/python3.4/site-packages/ansible/cli/__init__.py", line 38, in <module>
    from ansible.inventory.manager import InventoryManager
  File "/home/www/release/new-deploy/venv/lib/python3.4/site-packages/ansible/inventory/manager.py", line 44, in <module>
    IGNORED_EXTS = [b'%s$' % to_bytes(re.escape(x)) for x in C.INVENTORY_IGNORE_EXTS]
  File "/home/www/release/new-deploy/venv/lib/python3.4/site-packages/ansible/inventory/manager.py", line 44, in <listcomp>
    IGNORED_EXTS = [b'%s$' % to_bytes(re.escape(x)) for x in C.INVENTORY_IGNORE_EXTS]
TypeError: unsupported operand type(s) for %: 'bytes' and 'bytes'
```
