### PR TITLE
Add function for initializing modules and providers

### DIFF
--- a/lib/ansible/modules/cloud/misc/terraform.py
+++ b/lib/ansible/modules/cloud/misc/terraform.py
@@ -79,8 +79,9 @@ options:
       - To avoid duplicating infra, if a state file can't be found this will
         force a `terraform init`. Generally, this should be turned off unless
         you intend to provision an entirely new Terraform deployment.
-    required: false
     default: false
+    required: false
+    type: bool
 notes:
    - To just run a `terraform plan`, use check mode.
 requirements: [ "terraform" ]

--- a/lib/ansible/modules/cloud/misc/terraform.py
+++ b/lib/ansible/modules/cloud/misc/terraform.py
@@ -155,6 +155,13 @@ def _state_args(state_file):
     return []
 
 
+def init_plugins(bin_path, project_path):
+    command = [bin_path, 'init']
+    rc, out, err = module.run_command(command, cwd=project_path)
+    if rc != 0:
+        module.fail_json(msg="Failed to initialize Terraform modules:\r\n{0}".format(err))
+
+
 def build_plan(bin_path, project_path, variables_args, state_file, plan_path=None):
     if plan_path is None:
         f, plan_path = tempfile.mkstemp(suffix='.tfplan')
@@ -191,6 +198,7 @@ def main():
             targets=dict(type='list', default=[]),
             lock=dict(type='bool', default=True),
             lock_timeout=dict(type='int',),
+            force_init=dict(type='bool', default=False)
         ),
         required_if=[('state', 'planned', ['plan_file'])],
         supports_check_mode=True,
@@ -208,6 +216,8 @@ def main():
         command = [bin_path]
     else:
         command = [module.get_bin_path('terraform')]
+
+    init_plugins(command[0], project_path)
 
     variables_args = []
     for k, v in variables.items():

--- a/lib/ansible/modules/cloud/misc/terraform.py
+++ b/lib/ansible/modules/cloud/misc/terraform.py
@@ -212,13 +212,15 @@ def main():
     variables_file = module.params.get('variables_file')
     plan_file = module.params.get('plan_file')
     state_file = module.params.get('state_file')
+    force_init = module.params.get('force_init')
 
     if bin_path is not None:
         command = [bin_path]
     else:
         command = [module.get_bin_path('terraform')]
 
-    init_plugins(command[0], project_path)
+    if force_init:
+        init_plugins(command[0], project_path)
 
     variables_args = []
     for k, v in variables.items():

--- a/test/sanity/validate-modules/ignore.txt
+++ b/test/sanity/validate-modules/ignore.txt
@@ -573,7 +573,6 @@ lib/ansible/modules/cloud/misc/rhevm.py E324
 lib/ansible/modules/cloud/misc/rhevm.py E325
 lib/ansible/modules/cloud/misc/serverless.py E324
 lib/ansible/modules/cloud/misc/serverless.py E325
-lib/ansible/modules/cloud/misc/terraform.py E323
 lib/ansible/modules/cloud/misc/terraform.py E324
 lib/ansible/modules/cloud/misc/terraform.py E325
 lib/ansible/modules/cloud/misc/virt.py E322


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #36994
Added function for force initializing modules and providers

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
terraform

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0
  config file = /home/ubuntu/kubernetes/ansible.cfg
  configured module search path = [u'/home/ubuntu/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/ubuntu/ansible/local/lib/python2.7/site-packages/ansible
  executable location = /home/ubuntu/ansible/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
