### PR TITLE
Test include role with items in name #36372

### DIFF
--- a/test/integration/targets/include_import/role/test_include_role.yml
+++ b/test/integration/targets/include_import/role/test_include_role.yml
@@ -47,7 +47,6 @@
     - name: Test role include with a loop
       include_role:
         name: "{{ item }}"
-      register: loop_test
       with_items:
         - role1
         - role3

--- a/test/integration/targets/include_import/role/test_include_role.yml
+++ b/test/integration/targets/include_import/role/test_include_role.yml
@@ -53,6 +53,13 @@
         - role3
         - role2
 
+    - name: Assert that roles run with_items
+      assert:
+        that:
+          - _role1_result.msg == 'In role1'
+          - _role2_result.msg == 'In role2'
+          - _role3_result.msg == 'In role3'
+
     - name: Test including a task file from a role
       include_role:
         name: role1

--- a/test/integration/targets/include_import/roles/role2/tasks/main.yml
+++ b/test/integration/targets/include_import/roles/role2/tasks/main.yml
@@ -1,2 +1,3 @@
 - debug:
     msg: In role2
+  register: _role2_result

--- a/test/integration/targets/include_import/roles/role3/tasks/main.yml
+++ b/test/integration/targets/include_import/roles/role3/tasks/main.yml
@@ -1,2 +1,3 @@
 - debug:
     msg: In role3
+  register: _role3_result


### PR DESCRIPTION
##### SUMMARY

Simple test to support "Fix name parameter templating in include_role module #36372"

From: #36372 (Please see this for full details)
Followup to #33386 and #21285.

Fixes problem that include_role looping over with_items and name: "{{ item }}" will use the same name for all items in the loop.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
include_role module
include_import integration testing

##### ANSIBLE VERSION

```
ansible 2.6.0 (test_include_role_with_items_in_name 3826e6e28b) last updated 2018/03/05 22:06:24 (GMT +1100)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/Im0/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/Im0/ansible/hacking/ansible/lib/ansible
  executable location = /home/Im0/ansible/hacking/ansible/bin/ansible
  python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]

```


##### ADDITIONAL INFORMATION
Please see https://github.com/ansible/ansible/pull/36372 for full instructions to reproduce.

This test will FAIL without PR #36372.

```
Im0:~/ansible/hacking/ansible/test/integration/targets/include_import$ ./runme.sh
...
TASK [Test role include with a loop] ******************************************************************************************************************

TASK [role2 : debug] **********************************************************************************************************************************
ok: [testhost] => {
    "msg": "In role2"
}

TASK [role2 : debug] **********************************************************************************************************************************
ok: [testhost] => {
    "msg": "In role2"
}

TASK [role2 : debug] **********************************************************************************************************************************
ok: [testhost] => {
    "msg": "In role2"
}

TASK [Assert that roles run with_items] ***************************************************************************************************************
fatal: [testhost]: FAILED! => {"msg": "The conditional check '_role2_result.msg == 'In role2'' failed. The error was: error while evaluating conditional (_role2_result.msg == 'In role2'): '_role2_result' is undefined"}

```

With PR #36372 and this test:

```
TASK [Test role include with a loop] ******************************************************************************************************************

TASK [role1 : debug] **********************************************************************************************************************************
ok: [testhost] => {
    "msg": "In role1"
}

TASK [role3 : debug] **********************************************************************************************************************************
ok: [testhost] => {
    "msg": "In role3"
}

TASK [role2 : debug] **********************************************************************************************************************************
ok: [testhost] => {
    "msg": "In role2"
}

TASK [Assert that roles run with_items] ***************************************************************************************************************
ok: [testhost] => {
    "changed": false,
    "msg": "All assertions passed"
}

```