### PR TITLE
tower_role: Add support for ansible-tower-cli 3.2.1

### DIFF
--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_role.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_role.py
@@ -147,11 +147,12 @@ def main():
         module.fail_json(msg='ansible-tower-cli required for this module')
 
     role_type = module.params.pop('role')
-    state = module.params.get('state')
+    state = module.params.pop('state')
 
     json_output = {'role': role_type, 'state': state}
 
     tower_auth = tower_auth_config(module)
+    module.params.pop('tower_verify_ssl', None)
     with settings.runtime_values(**tower_auth):
         tower_check_mode(module)
         role = tower_cli.get_resource('role')


### PR DESCRIPTION
##### SUMMARY

Fixes #36991

From ansible-tower-cli python library version 3.2.1 the ansible module tower_role fails with the error described in #36991
As observed in [https://github.com/ansible/ansible/issues/36991#issuecomment-370368040](https://github.com/ansible/ansible/issues/36991#issuecomment-370368040) from ansible-tower-cli = 3.2.1 the API /api/v2/teams/2/object_roles/ is called with the parameters

1. - state=present
2. - tower_verify_ssl=True

This parameters aren't used by the method by the method [grant](https://github.com/ansible/ansible/blob/44f5b2bd25b4ab0acfac7926f2ed069dac0c0e0e/lib/ansible/modules/web_infrastructure/ansible_tower/tower_role.py#L164) or [revoke](https://github.com/ansible/ansible/blob/44f5b2bd25b4ab0acfac7926f2ed069dac0c0e0e/lib/ansible/modules/web_infrastructure/ansible_tower/tower_role.py#L167)

The first parameter is used internally from ansible tower_role module
The second parameter is used only in the authentication part of the module https://github.com/ansible/ansible/blob/44f5b2bd25b4ab0acfac7926f2ed069dac0c0e0e/lib/ansible/modules/web_infrastructure/ansible_tower/tower_role.py#L154

So they can be stripped away before the use of params variable in grant/revoke methods.

In this way the module tower_role is compatible with all the ansible-tower-cli version supported in ansible module doc (  ansible-tower-cli >= 3.0.2 )

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
tower_role

##### ANSIBLE VERSION
```
$ ./bin/ansible --version
ansible 2.6.0 (pull-issue-36991 4e3851ffb7) last updated 2018/03/05 13:44:12 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/gsciorti/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/gsciorti/PycharmProjects/ansible/lib/ansible
  executable location = ./bin/ansible
  python version = 2.7.14 (default, Dec 11 2017, 14:52:53) [GCC 7.2.1 20170915 (Red Hat 7.2.1-2)]
```


##### ADDITIONAL INFORMATION
Prepare the environment executing the following playbook:
```
$ cat ../ansible_test/ansible_tower_role.yml 
- hosts: localhost
  tasks:
    - name: Create tower organization
      tower_organization:
        name: "startrek"
        description: "Star trek organization"
        state: present

    - name: Create tower team
      tower_team:
        name: ussr
        description: Team ussr of star trek
        organization: "startrek"
        state: present

    - name: Add tower user
      tower_user:
        username: kirk
        password: "K!rkK!rk@"
        email: "kirk@startrek.com"
        first_name: Kirk
        last_name: Kirk
        state: present
```

Before this PR(current devel branch):
```
$ for ansible_tower_cli_version in 3.0.2 3.0.3 3.1.0 3.1.1 3.1.2 3.1.3 3.1.4 3.1.5 3.1.6 3.1.7 3.1.8 3.2.0 3.2.1 ; do echo "$ansible_tower_cli_version" ; pip install ansible-tower-cli==${ansible_tower_cli_version} > /dev/null 2>&1 ; ./bin/ansible localhost -m tower_role -a "user=kirk target_team=ussr role=member state=absent" -o ; ./bin/ansible localhost -m tower_role -a "user=kirk target_team=ussr role=member state=present" -o ; done

3.0.2
localhost | SUCCESS => {"changed": true, "role": "member", "state": "absent"}
localhost | SUCCESS => {"changed": true, "id": 136, "role": "member", "state": "present"}
3.0.3
localhost | SUCCESS => {"changed": true, "role": "member", "state": "absent"}
localhost | SUCCESS => {"changed": true, "id": 136, "role": "member", "state": "present"}
3.1.0
localhost | SUCCESS => {"changed": true, "role": "member", "state": "absent"}
localhost | SUCCESS => {"changed": true, "id": 136, "role": "member", "state": "present"}
3.1.1
localhost | SUCCESS => {"changed": true, "role": "member", "state": "absent"}
localhost | SUCCESS => {"changed": true, "id": 136, "role": "member", "state": "present"}
3.1.2
localhost | SUCCESS => {"changed": true, "role": "member", "state": "absent"}
localhost | SUCCESS => {"changed": true, "id": 136, "role": "member", "state": "present"}
3.1.3
localhost | SUCCESS => {"changed": true, "role": "member", "state": "absent"}
localhost | SUCCESS => {"changed": true, "id": 136, "role": "member", "state": "present"}
3.1.4
localhost | SUCCESS => {"changed": true, "role": "member", "state": "absent"}
localhost | SUCCESS => {"changed": true, "id": 136, "role": "member", "state": "present"}
3.1.5
localhost | FAILED! => {"changed": false, "msg": "ansible-tower-cli required for this module"}
localhost | FAILED! => {"changed": false, "msg": "ansible-tower-cli required for this module"}
3.1.6
localhost | FAILED! => {"changed": false, "msg": "ansible-tower-cli required for this module"}
localhost | FAILED! => {"changed": false, "msg": "ansible-tower-cli required for this module"}
3.1.7
localhost | SUCCESS => {"changed": true, "role": "member", "state": "absent"}
localhost | SUCCESS => {"changed": true, "id": 136, "role": "member", "state": "present"}
3.1.8
localhost | SUCCESS => {"changed": true, "role": "member", "state": "absent"}
localhost | SUCCESS => {"changed": true, "id": 136, "role": "member", "state": "present"}
3.2.0
localhost | SUCCESS => {"changed": true, "role": "member", "state": "absent"}
localhost | SUCCESS => {"changed": true, "id": 136, "role": "member", "state": "present"}
3.2.1
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: Response: {"detail":"Role has no field named 'tower_verify_ssl'"}
localhost | FAILED! => {"changed": false, "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_1hDefy/ansible_module_tower_role.py\", line 177, in <module>\n    main()\n  File \"/tmp/ansible_1hDefy/ansible_module_tower_role.py\", line 167, in main\n    result = role.revoke(**params)\n  File \"/home/gsciorti/PyCharmVirtualEnv/ansibleenv/lib/python2.7/site-packages/tower_cli/resources/role.py\", line 388, in revoke\n    disassociate=True, **kwargs)\n  File \"/home/gsciorti/PyCharmVirtualEnv/ansibleenv/lib/python2.7/site-packages/tower_cli/resources/role.py\", line 236, in role_write\n    fail_on_multiple_results=True, **data)\n  File \"/home/gsciorti/PyCharmVirtualEnv/ansibleenv/lib/python2.7/site-packages/tower_cli/models/base.py\", line 286, in read\n    r = client.get(url, params=kwargs)\n  File \"/home/gsciorti/PyCharmVirtualEnv/ansibleenv/lib/python2.7/site-packages/requests/sessions.py\", line 521, in get\n    return self.request('GET', url, **kwargs)\n  File \"/home/gsciorti/PyCharmVirtualEnv/ansibleenv/lib/python2.7/site-packages/tower_cli/api.py\", line 236, in request\n    kwargs.get('data', None), r.content.decode('utf8'))\ntower_cli.exceptions.BadRequest: The Tower server claims it was sent a bad request.\n\nGET https://192.168.121.123/api/v2/teams/2/object_roles/\nParams: {'tower_verify_ssl': True, 'state': 'absent', 'role_field': 'member_role'}\nData: None\n\nResponse: {\"detail\":\"Role has no field named 'tower_verify_ssl'\"}\n", "module_stdout": "", "msg": "MODULE FAILURE", "rc": 1}
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: Response: {"detail":"Role has no field named 'tower_verify_ssl'"}
localhost | FAILED! => {"changed": false, "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_H3H1hE/ansible_module_tower_role.py\", line 177, in <module>\n    main()\n  File \"/tmp/ansible_H3H1hE/ansible_module_tower_role.py\", line 164, in main\n    result = role.grant(**params)\n  File \"/home/gsciorti/PyCharmVirtualEnv/ansibleenv/lib/python2.7/site-packages/tower_cli/resources/role.py\", line 359, in grant\n    return self.role_write(fail_on_found=fail_on_found, **kwargs)\n  File \"/home/gsciorti/PyCharmVirtualEnv/ansibleenv/lib/python2.7/site-packages/tower_cli/resources/role.py\", line 236, in role_write\n    fail_on_multiple_results=True, **data)\n  File \"/home/gsciorti/PyCharmVirtualEnv/ansibleenv/lib/python2.7/site-packages/tower_cli/models/base.py\", line 286, in read\n    r = client.get(url, params=kwargs)\n  File \"/home/gsciorti/PyCharmVirtualEnv/ansibleenv/lib/python2.7/site-packages/requests/sessions.py\", line 521, in get\n    return self.request('GET', url, **kwargs)\n  File \"/home/gsciorti/PyCharmVirtualEnv/ansibleenv/lib/python2.7/site-packages/tower_cli/api.py\", line 236, in request\n    kwargs.get('data', None), r.content.decode('utf8'))\ntower_cli.exceptions.BadRequest: The Tower server claims it was sent a bad request.\n\nGET https://192.168.121.123/api/v2/teams/2/object_roles/\nParams: {'tower_verify_ssl': True, 'state': 'present', 'role_field': 'member_role'}\nData: None\n\nResponse: {\"detail\":\"Role has no field named 'tower_verify_ssl'\"}\n", "module_stdout": "", "msg": "MODULE FAILURE", "rc": 1}
```

After this PR(current devel branch):
```
$ for ansible_tower_cli_version in 3.0.2 3.0.3 3.1.0 3.1.1 3.1.2 3.1.3 3.1.4 3.1.5 3.1.6 3.1.7 3.1.8 3.2.0 3.2.1 ; do echo "$ansible_tower_cli_version" ; pip install ansible-tower-cli==${ansible_tower_cli_version} > /dev/null 2>&1 ; ./bin/ansible localhost -m tower_role -a "user=kirk target_team=ussr role=member state=absent" -o ; ./bin/ansible localhost -m tower_role -a "user=kirk target_team=ussr role=member state=present" -o ; done

3.0.2
localhost | SUCCESS => {"changed": false, "role": "member", "state": "absent"}
localhost | SUCCESS => {"changed": true, "id": 136, "role": "member", "state": "present"}
3.0.3
localhost | SUCCESS => {"changed": true, "role": "member", "state": "absent"}
localhost | SUCCESS => {"changed": true, "id": 136, "role": "member", "state": "present"}
3.1.0
localhost | SUCCESS => {"changed": true, "role": "member", "state": "absent"}
localhost | SUCCESS => {"changed": true, "id": 136, "role": "member", "state": "present"}
3.1.1
localhost | SUCCESS => {"changed": true, "role": "member", "state": "absent"}
localhost | SUCCESS => {"changed": true, "id": 136, "role": "member", "state": "present"}
3.1.2
localhost | SUCCESS => {"changed": true, "role": "member", "state": "absent"}
localhost | SUCCESS => {"changed": true, "id": 136, "role": "member", "state": "present"}
3.1.3
localhost | SUCCESS => {"changed": true, "role": "member", "state": "absent"}
localhost | SUCCESS => {"changed": true, "id": 136, "role": "member", "state": "present"}
3.1.4
localhost | SUCCESS => {"changed": true, "role": "member", "state": "absent"}
localhost | SUCCESS => {"changed": true, "id": 136, "role": "member", "state": "present"}
3.1.5
localhost | FAILED! => {"changed": false, "msg": "ansible-tower-cli required for this module"}
localhost | FAILED! => {"changed": false, "msg": "ansible-tower-cli required for this module"}
3.1.6
localhost | FAILED! => {"changed": false, "msg": "ansible-tower-cli required for this module"}
localhost | FAILED! => {"changed": false, "msg": "ansible-tower-cli required for this module"}
3.1.7
localhost | SUCCESS => {"changed": true, "role": "member", "state": "absent"}
localhost | SUCCESS => {"changed": true, "id": 136, "role": "member", "state": "present"}
3.1.8
localhost | SUCCESS => {"changed": true, "role": "member", "state": "absent"}
localhost | SUCCESS => {"changed": true, "id": 136, "role": "member", "state": "present"}
3.2.0
localhost | SUCCESS => {"changed": true, "role": "member", "state": "absent"}
localhost | SUCCESS => {"changed": true, "id": 136, "role": "member", "state": "present"}
3.2.1
localhost | SUCCESS => {"changed": true, "role": "member", "state": "absent"}
localhost | SUCCESS => {"changed": true, "id": 136, "role": "member", "state": "present"}

```

Note: the module fails with ansible-tower-cli 3.1.5 and 3.1.6 version but this is a different issue. The same problem occurs using the devel branch without this PR
