### PR TITLE
Ability to link to other pages from plugin docs

### DIFF
--- a/docs/bin/plugin_formatter.py
+++ b/docs/bin/plugin_formatter.py
@@ -75,6 +75,7 @@ _ITALIC = re.compile(r"I\(([^)]+)\)")
 _BOLD = re.compile(r"B\(([^)]+)\)")
 _MODULE = re.compile(r"M\(([^)]+)\)")
 _URL = re.compile(r"U\(([^)]+)\)")
+_LINK = re.compile(r"L\(([^)]+),([^)]+)\)")
 _CONST = re.compile(r"C\(([^)]+)\)")
 
 DEPRECATED = b" (D)"
@@ -90,6 +91,7 @@ def rst_ify(text):
         t = _ITALIC.sub(r"*\1*", text)
         t = _BOLD.sub(r"**\1**", t)
         t = _MODULE.sub(r":ref:`\1 <\1>`", t)
+        t = _LINK.sub(r"`\1 <\2>`_", t)
         t = _URL.sub(r"\1", t)
         t = _CONST.sub(r"`\1`", t)
     except Exception as e:
@@ -109,6 +111,7 @@ def html_ify(text):
     t = _BOLD.sub(r"<b>\1</b>", t)
     t = _MODULE.sub(r"<span class='module'>\1</span>", t)
     t = _URL.sub(r"<a href='\1'>\1</a>", t)
+    t = _LINK.sub(r"<a href='\2'>\1</a>", t)
     t = _CONST.sub(r"<code>\1</code>", t)
 
     return t

--- a/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
@@ -407,6 +407,8 @@ Example usage::
     See also M(win_copy) or M(win_template).
     ...
     See U(https://www.ansible.com/tower) for an overview.
+    ...
+    See L(IOS Platform Options guide, ../network/user_guide/platform_ios.html)
 
 
 .. note::


### PR DESCRIPTION
##### SUMMARY
Support relative links

We can't use `ref:` in the table describing DOCUMENATION.OPTIONS as this is inside `.. raw:: html`

Example
```
See the L(IOS Platform Options guide, ../network/user_guide/platform_ios.html) for more information
```

Tested in options table (html_ify) & notes (convert_symbols_to_format)

##### ISSUE TYPE
 - Docs Pull Request

