### PR TITLE
[cloud] ec2_vpc_route_table: ignore routes without DestinationCidrBlock - fixes #37003

### DIFF
--- a/test/integration/targets/ec2_vpc_route_table/tasks/main.yml
+++ b/test/integration/targets/ec2_vpc_route_table/tasks/main.yml
@@ -545,10 +545,55 @@
         - recreate_private_table.changed
         - recreate_private_table.route_table.id != create_public_table.route_table.id
 
+  - name: create a VPC endpoint to test ec2_vpc_route_table ignores it
+    ec2_vpc_endpoint:
+      state: present
+      vpc_id: "{{ vpc.vpc.id }}"
+      service: "com.amazonaws.{{ aws_region }}.s3"
+      route_table_ids:
+        - "{{ recreate_private_table.route_table.route_table_id }}"
+      <<: *aws_connection_info
+    register: vpc_endpoint
+
+  - name: purge routes
+    ec2_vpc_route_table:
+      vpc_id: "{{ vpc.vpc.id }}"
+      tags:
+        Public: "false"
+        Name: "Private route table"
+      routes:
+      - nat_gateway_id: "{{ nat_gateway.nat_gateway_id }}"
+        dest: 0.0.0.0/0
+      subnets: "{{ vpc_subnets|json_query('subnets[?tags.Public == `False`].id') }}"
+      purge_routes: true
+      <<: *aws_connection_info
+    register: result
+
+  - name: Get endpoint facts to verify that it wasn't purged from the route table
+    ec2_vpc_endpoint_facts:
+      query: endpoints
+      vpc_endpoint_ids:
+        - "{{ vpc_endpoint.result.vpc_endpoint_id }}"
+      <<: *aws_connection_info
+    register: endpoint_details
+
+  - name: assert the route table is associated with the VPC endpoint
+    assert:
+      that:
+        - endpoint_details.vpc_endpoints[0].route_table_ids[0] == recreate_private_table.route_table.route_table_id
+
   always:
   #############################################################################
   # TEAR DOWN STARTS HERE
   #############################################################################
+  - name: remove the VPC endpoint
+    ec2_vpc_endpoint:
+      state: absent
+      vpc_endpoint_id: "{{ vpc_endpoint.result.vpc_endpoint_id }}"
+      <<: *aws_connection_info
+    when: vpc_endpoint is defined
+    ignore_errors: yes
+
   - name: destroy route tables
     ec2_vpc_route_table:
       route_table_id: "{{ item.route_table.id }}"


### PR DESCRIPTION
##### SUMMARY
Fixes #37003. Regression introduced when porting the module from boto to boto3.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/ec2_vpc_route_table.py

##### ANSIBLE VERSION
```
2.6.0
```
