### PR TITLE
Fix n3k separate to combined image upgrade

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_install_os.py
+++ b/lib/ansible/modules/network/nxos/nxos_install_os.py
@@ -245,6 +245,8 @@ def parse_show_install(data):
             ud['server_error'] = True
         elif data == -32603:
             ud['server_error'] = True
+        elif data == 'No install all data found':
+            ud['server_error'] = True
         return ud
     else:
         ud['list_data'] = data.split('\n')
@@ -383,6 +385,7 @@ def build_install_cmd_set(issu, image, kick, type):
     else:
         commands.append(
             '%s system %s kickstart %s' % (rootcmd, image, kick))
+
     return commands
 
 
@@ -452,7 +455,7 @@ def check_mode_nextgen(module, issu, image, kick=None):
         # The system may be busy from the previous call to check_mode so loop
         # until it's done.
         data = check_install_in_progress(module, commands, opts)
-    if re.search(r'No install all data found', data['raw']):
+    if data['server_error']:
         data['error'] = True
     return data
 

--- a/lib/ansible/modules/network/nxos/nxos_install_os.py
+++ b/lib/ansible/modules/network/nxos/nxos_install_os.py
@@ -245,8 +245,6 @@ def parse_show_install(data):
             ud['server_error'] = True
         elif data == -32603:
             ud['server_error'] = True
-        elif data == 'No install all data found':
-            ud['server_error'] = True
         return ud
     else:
         ud['list_data'] = data.split('\n')


### PR DESCRIPTION
##### SUMMARY
This fixes a problem when attempting to upgrade from a 6.x kickstart/system image to a combined 7.x image.


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
nxos_install_os

##### ANSIBLE VERSION
```
ansible 2.6.0 (rel250/fix_nxos_install_os d6a56457cc) last updated 2018/03/05 10:32:55 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /root/agents-ci/ansible/lib/ansible
  executable location = /root/agents-ci/ansible/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]

```

##### ADDITIONAL INFORMATION
**NOTE** This fix is needed in `2.5`