### PR TITLE
[WIP] Don't needlessly insert noop blocks, causing task offsets with dynamic includes

### DIFF
--- a/lib/ansible/playbook/included_file.py
+++ b/lib/ansible/playbook/included_file.py
@@ -56,7 +56,7 @@ class IncludedFile:
     @staticmethod
     def process_include_results(results, iterator, loader, variable_manager):
         included_files = []
-        hosts_per_file = {}
+        hosts_per_file = {}  # Used later to squash noop blocks for identical files
         task_vars_cache = {}
 
         for res in results:

--- a/lib/ansible/playbook/included_file.py
+++ b/lib/ansible/playbook/included_file.py
@@ -56,6 +56,7 @@ class IncludedFile:
     @staticmethod
     def process_include_results(results, iterator, loader, variable_manager):
         included_files = []
+        hosts_per_file = {}
         task_vars_cache = {}
 
         for res in results:
@@ -186,4 +187,9 @@ class IncludedFile:
                         else:
                             break
 
-        return included_files
+                    try:
+                        hosts_per_file[inc_file._filename].append(original_host)
+                    except KeyError:
+                        hosts_per_file[inc_file._filename] = [original_host]
+
+        return included_files, hosts_per_file

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -886,7 +886,7 @@ class StrategyBase:
         host_results = self._wait_on_pending_results(iterator)
 
         try:
-            included_files = IncludedFile.process_include_results(
+            included_files, dummy = IncludedFile.process_include_results(
                 host_results,
                 iterator=iterator,
                 loader=self._loader,

--- a/lib/ansible/plugins/strategy/free.py
+++ b/lib/ansible/plugins/strategy/free.py
@@ -178,7 +178,7 @@ class StrategyModule(StrategyBase):
             self.update_active_connections(results)
 
             try:
-                included_files = IncludedFile.process_include_results(
+                included_files, dummy = IncludedFile.process_include_results(
                     host_results,
                     iterator=iterator,
                     loader=self._loader,

--- a/lib/ansible/plugins/strategy/linear.py
+++ b/lib/ansible/plugins/strategy/linear.py
@@ -346,6 +346,7 @@ class StrategyModule(StrategyBase):
                     display.debug("generating all_blocks data")
                     all_blocks = dict((host, []) for host in hosts_left)
                     display.debug("done generating all_blocks data")
+                    # Loop sorted files, so we can ensure they are grouped
                     for included_file in sorted(included_files, key=lambda inc_f: inc_f._filename):
                         display.debug("processing included file: %s" % included_file._filename)
                         # included hosts get the task list while those excluded get an equal-length

--- a/lib/ansible/plugins/strategy/linear.py
+++ b/lib/ansible/plugins/strategy/linear.py
@@ -346,7 +346,7 @@ class StrategyModule(StrategyBase):
                     display.debug("generating all_blocks data")
                     all_blocks = dict((host, []) for host in hosts_left)
                     display.debug("done generating all_blocks data")
-                    for included_file in sorted(included_files, key=lambda inc_f: getattr(inc_f, '_filename', None)):
+                    for included_file in sorted(included_files, key=lambda inc_f: inc_f._filename):
                         display.debug("processing included file: %s" % included_file._filename)
                         # included hosts get the task list while those excluded get an equal-length
                         # list of noop tasks, to make sure that they continue running in lock-step
@@ -376,15 +376,13 @@ class StrategyModule(StrategyBase):
                                 noop_block = self._prepare_and_create_noop_block_from(final_block, task._parent, iterator)
 
                                 for host in hosts_left:
-                                    included_filename = getattr(included_file, '_filename', None)
-
                                     if host in included_file._hosts:
                                         all_blocks[host].append(final_block)
-                                    elif host not in hosts_per_included_file[included_filename]:
+                                    elif host not in hosts_per_included_file[included_file._filename]:
                                         all_blocks[host].append(noop_block)
                                         # Ensure we only insert the extra blocks once
                                         # We could insert them multiple times if hosts were excluded due to when statements
-                                        hosts_per_included_file[included_filename].append(host)
+                                        hosts_per_included_file[included_file._filename].append(host)
                             display.debug("done iterating over new_blocks loaded from include file")
 
                         except AnsibleError as e:

--- a/test/units/playbook/test_included_file.py
+++ b/test/units/playbook/test_included_file.py
@@ -77,12 +77,13 @@ def test_process_include_results(mock_iterator, mock_variable_manager):
 
     fake_loader = DictDataLoader({'include_test.yml': ""})
 
-    res = IncludedFile.process_include_results(results, mock_iterator, fake_loader, mock_variable_manager)
+    res, hosts_per_file = IncludedFile.process_include_results(results, mock_iterator, fake_loader, mock_variable_manager)
     assert isinstance(res, list)
     assert len(res) == 1
     assert res[0]._filename == os.path.join(os.getcwd(), 'include_test.yml')
     assert res[0]._hosts == ['testhost1', 'testhost2']
     assert res[0]._args == {}
+    assert hosts_per_file == {os.path.join(os.getcwd(), 'include_test.yml'): ['testhost1', 'testhost2']}
 
 
 def test_process_include_diff_files(mock_iterator, mock_variable_manager):
@@ -109,7 +110,7 @@ def test_process_include_diff_files(mock_iterator, mock_variable_manager):
     fake_loader = DictDataLoader({'include_test.yml': "",
                                   'other_include_test.yml': ""})
 
-    res = IncludedFile.process_include_results(results, mock_iterator, fake_loader, mock_variable_manager)
+    res, hosts_per_file = IncludedFile.process_include_results(results, mock_iterator, fake_loader, mock_variable_manager)
     assert isinstance(res, list)
     assert res[0]._filename == os.path.join(os.getcwd(), 'include_test.yml')
     assert res[1]._filename == os.path.join(os.getcwd(), 'other_include_test.yml')
@@ -119,6 +120,11 @@ def test_process_include_diff_files(mock_iterator, mock_variable_manager):
 
     assert res[0]._args == {}
     assert res[1]._args == {}
+
+    assert hosts_per_file == {
+        os.path.join(os.getcwd(), 'include_test.yml'): ['testhost1'],
+        os.path.join(os.getcwd(), 'other_include_test.yml'): ['testhost2']
+    }
 
 
 def test_process_include_simulate_free(mock_iterator, mock_variable_manager):
@@ -141,7 +147,7 @@ def test_process_include_simulate_free(mock_iterator, mock_variable_manager):
 
     fake_loader = DictDataLoader({'include_test.yml': ""})
 
-    res = IncludedFile.process_include_results(results, mock_iterator, fake_loader, mock_variable_manager)
+    res, hosts_per_file = IncludedFile.process_include_results(results, mock_iterator, fake_loader, mock_variable_manager)
     assert isinstance(res, list)
     assert len(res) == 2
     assert res[0]._filename == os.path.join(os.getcwd(), 'include_test.yml')


### PR DESCRIPTION
##### SUMMARY
Don't needlessly insert noop blocks, causing task offsets with dynamic includes

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/strategy/linear.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
Ref: https://github.com/ansible/ansible/issues/12933

The `noop_block` exists to address includes across multiple filenames (e.g. `include_tasks: "{{inventory_hostname}}.yml"`).

This tracks all hosts that include a specific filename, sorts `included_files` by filename, and only inserts `noop_block`s only for hosts not sharing the same included filename.

Example:
```
TASK [debug] *********************************************************************************************************************************************************************************************************************************
ok: [localhost0] => {
    "msg": "before"
}
ok: [localhost1] => {
    "msg": "before"
}
ok: [localhost2] => {
    "msg": "before"
}
ok: [localhost3] => {
    "msg": "before"
}
ok: [localhost4] => {
    "msg": "before"
}
ok: [localhost5] => {
    "msg": "before"
}

TASK [include_tasks] *************************************************************************************************************************************************************************************************************************
included: /Users/matt/projects/ansibledev/playbooks/36978/do_otherthing.yml for localhost1
included: /Users/matt/projects/ansibledev/playbooks/36978/do_otherthing.yml for localhost3
included: /Users/matt/projects/ansibledev/playbooks/36978/do_otherthing.yml for localhost5
included: /Users/matt/projects/ansibledev/playbooks/36978/do_something.yml for localhost0
included: /Users/matt/projects/ansibledev/playbooks/36978/do_something.yml for localhost2
included: /Users/matt/projects/ansibledev/playbooks/36978/do_something.yml for localhost4

TASK [fail] **********************************************************************************************************************************************************************************************************************************
fatal: [localhost1]: FAILED! => {"changed": false, "msg": "otherthing"}
fatal: [localhost3]: FAILED! => {"changed": false, "msg": "otherthing"}
fatal: [localhost5]: FAILED! => {"changed": false, "msg": "otherthing"}

TASK [debug] *********************************************************************************************************************************************************************************************************************************
ok: [localhost0] => {
    "msg": "0 something"
}
ok: [localhost2] => {
    "msg": "2 something"
}
ok: [localhost4] => {
    "msg": "4 something"
}

TASK [debug] *********************************************************************************************************************************************************************************************************************************
ok: [localhost0] => {
    "msg": "after"
}
ok: [localhost2] => {
    "msg": "after"
}
ok: [localhost4] => {
    "msg": "after"
}

PLAY RECAP ***********************************************************************************************************************************************************************************************************************************
localhost0                 : ok=5    changed=0    unreachable=0    failed=0
localhost1                 : ok=3    changed=0    unreachable=0    failed=1
localhost2                 : ok=5    changed=0    unreachable=0    failed=0
localhost3                 : ok=3    changed=0    unreachable=0    failed=1
localhost4                 : ok=5    changed=0    unreachable=0    failed=0
localhost5                 : ok=3    changed=0    unreachable=0    failed=1
```