### PR TITLE
Added variables to terraform destroy command

### DIFF
--- a/lib/ansible/modules/cloud/misc/terraform.py
+++ b/lib/ansible/modules/cloud/misc/terraform.py
@@ -257,6 +257,8 @@ def main():
     if state == 'absent':
         # deleting cannot use a statefile
         needs_application = True
+        # add variables settings to destroy command
+        command.extend(variables_args)
     elif plan_file and os.path.exists(plan_file):
         command.append(plan_file)
     elif plan_file and not os.path.exists(plan_file):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Variables weren't used for destroy command (like in #36837)

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
terraform

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/ubuntu/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/ubuntu/venv/ansible/local/lib/python2.7/site-packages/ansible
  executable location = /home/ubuntu/venv/ansible/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

- Terraform variable file:
```
variable "cluster_tag" {
  description = "Tag of Cluster"
}

variable "aws_access_key" {}

variable "aws_secret_key" {}

variable "aws_region" {
  description = "Region for AWS"
}
```
- Provide infrastructure:
```
  tasks:
  - name: Provide infrastructure
    terraform:
      variables:
        aws_access_key: <access_key>
        aws_secret_key: <secret_keky>
        aws_region: eu-west-1
        cluster_tag: ansible-test
        state: present
      project_path: ./terraform
      force_init: true
```
- Destroy infrastructure: 
```
  tasks:
  - name: Provide infrastructure
    terraform:
      variables:
        aws_access_key: <access_key>
        aws_secret_key: <secret_keky>
        aws_region: eu-west-1
        cluster_tag: ansible-test
        state: absent
      project_path: ./terraform
      force_init: true
```
<!--- Paste verbatim command output below, e.g. before and after your change -->
Before:
```
TASK [Provide infrastructure] *****************************************************************************************************************************************************************
fatal: [localhost]: FAILED! => {"changed": false, "command": "/usr/local/bin/terraform destroy -no-color -force -lock=true", "msg": "Failure when executing Terraform command. Exited 1.\nstdou
t: var.aws_access_key\n  Enter a value: \nvar.aws_access_key\n  Enter a value: \nvar.aws_access_key\n  Enter a value: \nvar.aws_access_key\n  Enter a value: \n\nstderr: \nError: Error asking
for user input: missing required value for \"aws_access_key\"\n\n\n"}
        to retry, use: --limit @/home/ubuntu/git/cadmium/terraform/kubernetes/main.retry

```
After:
```
TASK [Provide infrastructure] *****************************************************************************************************************************************************************
changed: [localhost]

PLAY RECAP ************************************************************************************************************************************************************************************
localhost                  : ok=2    changed=1    unreachable=0    failed=0

```