### PR TITLE
Consistent lazy unvaulting for ansible-inventory

### DIFF
--- a/lib/ansible/cli/inventory.py
+++ b/lib/ansible/cli/inventory.py
@@ -25,7 +25,11 @@ from ansible.cli import CLI
 from ansible.errors import AnsibleError, AnsibleOptionsError
 from ansible.inventory.host import Host
 from ansible.plugins.loader import vars_loader
+
 from ansible.parsing.dataloader import DataLoader
+from ansible.parsing.yaml.objects import AnsibleVaultEncryptedUnicode
+from ansible.parsing.vault import AnsibleVaultError
+
 from ansible.utils.vars import combine_vars
 
 try:
@@ -189,10 +193,39 @@ class InventoryCLI(CLI):
         if self.options.yaml:
             import yaml
             from ansible.parsing.yaml.dumper import AnsibleDumper
+
+            def walk_dicts(data):
+                if isinstance(data, dict):
+                    yield data
+                    for key, value in data.items():
+                        for d in walk_dicts(value):
+                            yield d
+
+            # Convert Vault objects into strings
+            for d in walk_dicts(stuff):
+                for key, value in d.items():
+                    if isinstance(value, AnsibleVaultEncryptedUnicode):
+                        try:
+                            decrypted_value = str(value)
+                        except AnsibleVaultError as exc:
+                            pass
+                        else:
+                            d[key] = decrypted_value
+
             results = yaml.dump(stuff, Dumper=AnsibleDumper, default_flow_style=False)
         else:
-            from ansible.module_utils.basic import jsonify
-            results = jsonify(stuff, sort_keys=True, indent=4)
+            from ansible.module_utils.basic import jsonify, _json_encode_fallback
+
+            def vault_converter(s):
+                if isinstance(s, AnsibleVaultEncryptedUnicode):
+                    try:
+                        ret = str(s)
+                    except AnsibleVaultError as exc:
+                        ret = '!vault: {}'.format(s._ciphertext)
+                    return ret
+                return _json_encode_fallback(s)
+
+            results = jsonify(stuff, sort_keys=True, indent=4, default=vault_converter)
 
         return results
 

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -780,15 +780,16 @@ def _json_encode_fallback(obj):
 
 def jsonify(data, **kwargs):
     for encoding in ("utf-8", "latin-1"):
+        kwargs.setdefault('default', _json_encode_fallback)
         try:
-            return json.dumps(data, encoding=encoding, default=_json_encode_fallback, **kwargs)
+            return json.dumps(data, encoding=encoding, **kwargs)
         # Old systems using old simplejson module does not support encoding keyword.
         except TypeError:
             try:
                 new_data = json_dict_bytes_to_unicode(data, encoding=encoding)
             except UnicodeDecodeError:
                 continue
-            return json.dumps(new_data, default=_json_encode_fallback, **kwargs)
+            return json.dumps(new_data, **kwargs)
         except UnicodeDecodeError:
             continue
     raise UnicodeError('Invalid unicode encoding encountered')


### PR DESCRIPTION
##### SUMMARY
Given an inventory source with vaulted content, this polishes behavior in 2 cases,
1) vault secrets given
2) vault secrets not given

Prior behavior was that --yaml option returned 'unvaulted' content in both cases, even with valid secrets, and default JSON format would not work in either case.

New behavior with this change is that 'unvaulted' content is returned in both cases when secrets are not given (2) and in scenario (1) it correctly decrypts in both formats.

Here, I summarize with a table.

|      | secrets provided | secrets not provided |
|------|------------------|----------------------|
| json | 💥->✅            | 💥->ㅃ*               |
| yaml | ㅃ->✅            | ㅃ->ㅃ               |

table key:
 - ✅ returns all decrypted plaintext variables
 - 💥error
 - ㅃ returns 'undecrypted' vault content
 - `*` qualifier, this isn't a raw object due to rules of the JSON standard

Replaces #36862 with new suggested method

Fixes #31141

##### ISSUE TYPE
 - Feature Pull Request
 - Bugfix Pull Request

##### COMPONENT NAME
ansible-inventory CLI

##### ANSIBLE VERSION
```
ansible --version
ansible 2.6.0 (just_dont_decrypt a2efe74001) last updated 2018/03/05 13:28:04 (GMT -400)
  config file = None
  configured module search path = [u'/Users/alancoding/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/alancoding/Documents/repos/ansible/lib/ansible
  executable location = /Users/alancoding/Documents/repos/ansible/bin/ansible
  python version = 2.7.11 (default, Oct 17 2016, 14:59:40) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```


##### ADDITIONAL INFORMATION
Note that JSON output can not be loaded again (via `json.loads`) without additional post-processing. This returns it as a normal string, and I suspect that is best.

As far as AWX is concerned, this fixes it for me.

For JSON loading, This requires reserving the "!vault " starting string in the variables namespace. While this could be a problem for some people, I feel like it shouldn't be.