### PR TITLE
ansible-galaxy now reinstalls roles dependencies when using 'force'

### DIFF
--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -422,7 +422,9 @@ class GalaxyCLI(CLI):
                                 display.warning('- dependency %s from role %s differs from already installed version (%s), skipping' %
                                                 (str(dep_role), role.name, dep_role.install_info['version']))
                             else:
-                                display.display('- dependency %s is already installed, skipping.' % dep_role.name)
+                                if dep_role not in roles_left:
+                                    display.display('- adding dependency: %s' % str(dep_role))
+                                    roles_left.append(dep_role)
 
             if not installed:
                 display.warning("- %s was NOT installed successfully." % role.name)


### PR DESCRIPTION
##### SUMMARY
Fixes #36769 - make ansible-galaxy reinstall roles dependencies when flag -f (--force) uses.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
galaxy

##### ANSIBLE VERSION
```
ansible --version
ansible 2.4.3.0
  config file = None
  configured module search path = [u'/home/dmitriy/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/dmitriy/ansible-2.4.3/local/lib/python2.7/site-packages/ansible
  executable location = /home/dmitriy/ansible-2.4.3/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION
The problem is, when one of your roles have dependencies and you run
```
ansible-galaxy install -r requirements.yml --force
```
them won't be reinstall. Check issue https://github.com/ansible/ansible/issues/36769 if you are interested in reproduce.

before:
```
ansible-galaxy -v install -r requirements.yml --force          
- changing role ansiblerole from master to master
- extracting ansiblerole to /home/dmtr/.ansible/roles/ansiblerole
- ansiblerole (master) was installed successfully
- dependency git-ansible-network-interfaces is already installed, skipping.
- dependency galaxy-ansible-network-interfaces is already installed, skipping.
```

after:
```
ansible-galaxy install -r requirements.yml --force 
- changing role ansiblerole from master to master
- extracting ansiblerole to /home/dmtr/.ansible/roles/ansiblerole
- ansiblerole (master) was installed successfully
- adding dependency: git-ansible-network-interfaces (master)
- adding dependency: galaxy-ansible-network-interfaces (master)
- changing role git-ansible-network-interfaces from master to master
- extracting git-ansible-network-interfaces to /home/dmtr/.ansible/roles/git-ansible-network-interfaces
- git-ansible-network-interfaces (master) was installed successfully
- changing role galaxy-ansible-network-interfaces from master to master
- downloading role 'network-interfaces', owned by dresden-weekly
- downloading role from https://github.com/dresden-weekly/ansible-network-interfaces/archive/master.tar.gz
- extracting galaxy-ansible-network-interfaces to /home/dmtr/.ansible/roles/galaxy-ansible-network-interfaces
- galaxy-ansible-network-interfaces (master) was installed successfully
```
