### PR TITLE
WIP ec2_vpc_endpoint: allow endpoints to be modified

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_endpoint.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_endpoint.py
@@ -291,7 +291,7 @@ def modify_endpoint(client, module, endpoint, new_policy, current_policy, new_en
     modification_params = {'VpcEndpointId': module.params['vpc_endpoint_id']}
     if new_policy is not None and compare_policies(current_policy, new_policy):
         changed = True
-        modification_params['PolicyDocument'] = new_policy
+        modification_params['PolicyDocument'] = json.dumps(new_policy)
     if new_endpoint_rt_ids:
         changed = True
         modification_params['AddRouteTableIds'] = list(new_endpoint_rt_ids)
@@ -323,10 +323,7 @@ def get_policy(client, module):
         except Exception as e:
             module.fail_json(msg=str(e), exception=traceback.format_exc())
 
-    if policy is None:
-        return policy
-
-    return json.dumps(policy)
+    return policy
 
 
 def create_vpc_endpoint(client, module):

--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_route_table.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_route_table.py
@@ -355,7 +355,7 @@ def ensure_tags(connection=None, module=None, resource_id=None, tags=None, purge
             module.fail_json_aws(e, msg="Couldn't delete tags")
     if to_add:
         try:
-            connection.create_tags(Resources=[resource_id], Tags=ansible_dict_to_boto3_tag_list(to_add))
+            AWSRetry.exponential_backoff()(connection.create_tags)(Resources=[resource_id], Tags=ansible_dict_to_boto3_tag_list(to_add))
         except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
             module.fail_json_aws(e, msg="Couldn't create tags")
 

--- a/test/integration/targets/ec2_vpc_endpoint/aliases
+++ b/test/integration/targets/ec2_vpc_endpoint/aliases
@@ -1,0 +1,2 @@
+cloud/aws
+posix/ci/cloud/group4/aws

--- a/test/integration/targets/ec2_vpc_endpoint/meta/main.yml
+++ b/test/integration/targets/ec2_vpc_endpoint/meta/main.yml
@@ -1,0 +1,3 @@
+dependencies:
+  - prepare_tests
+  - setup_ec2

--- a/test/integration/targets/ec2_vpc_endpoint/tasks/main.yml
+++ b/test/integration/targets/ec2_vpc_endpoint/tasks/main.yml
@@ -1,0 +1,180 @@
+---
+- block:
+
+    # ============================================================
+    - debug: msg="Setting up ec2_vpc_endpoint dependencies"
+
+    # ============================================================
+    - name: set up aws connection info
+      set_fact:
+        aws_connection_info: &aws_connection_info
+          aws_access_key: "{{ aws_access_key }}"
+          aws_secret_key: "{{ aws_secret_key }}"
+          security_token: "{{ security_token }}"
+          region: "{{ aws_region }}"
+      no_log: yes
+
+    # ============================================================
+    - name: create a VPC
+      ec2_vpc_net:
+        name: "{{ resource_prefix }}-vpc"
+        state: present
+        cidr_block: "120.0.0.0/24"
+        <<: *aws_connection_info
+        tags:
+          Name: "{{ resource_prefix }}-vpc"
+          Description: "Created by ansible-test"
+      register: vpc
+
+    - name: create route tables
+      ec2_vpc_route_table:
+        vpc_id: "{{ vpc.vpc.id }}"
+        tags:
+          ansible-test: "{{ resource_prefix }}-{{ item }}"
+        routes: []
+        <<: *aws_connection_info
+      register: route_tables
+      loop:
+        - route-table-1
+        - route-table-2
+
+    # ============================================================
+    - debug: msg="Running ec2_vpc_endpoint tests"
+
+    - name: test failure with no parameters
+      ec2_vpc_endpoint:
+      register: result
+      ignore_errors: true
+
+    - name: assert failure with no parameters
+      assert:
+        that:
+           - 'result.failed'
+           - 'result.msg == "state is present but all of the following are missing: vpc_id, service"'
+
+    # ============================================================
+    - name: test failure with no parameters and state=absent
+      ec2_vpc_endpoint:
+        state: absent
+      register: result
+      ignore_errors: true
+
+    - name: assert failure with no parameters
+      assert:
+        that:
+          - 'result.failed'
+          - 'result.msg == "state is absent but all of the following are missing: vpc_endpoint_id"'
+
+    # ============================================================
+    # FIXME: currently not VPC endpoint removal is not idempotent and fails
+    #- name: remove an endpoint that does not exist
+    #  ec2_vpc_endpoint:
+    #    state: absent
+    #    vpc_endpoint_id: vpce-12345678
+    #    <<: *aws_connection_info
+    #  register: result
+
+    # ============================================================
+    - name: create a VPC endpoint and add it to the route table
+      ec2_vpc_endpoint:
+        state: present
+        vpc_id: "{{ vpc.vpc.id }}"
+        service: "com.amazonaws.{{ aws_region }}.s3"
+        route_table_ids:
+          - "{{ route_tables['results'][0]['route_table']['route_table_id'] }}"
+          - "{{ route_tables['results'][1]['route_table']['route_table_id'] }}"
+        <<: *aws_connection_info
+      register: result_1
+
+    - name: assert the VPC endpoint was correctly created
+      assert:
+        that:
+          - result_1.changed
+          - result_1.result.vpc_endpoint_id.startswith('vpce-')
+
+    # ============================================================
+    - name: test idempotence
+      ec2_vpc_endpoint:
+        state: present
+        vpc_id: "{{ vpc.vpc.id }}"
+        service: "com.amazonaws.{{ aws_region }}.s3"
+        route_table_ids:
+          - "{{ route_tables['results'][0]['route_table']['route_table_id'] }}"
+          - "{{ route_tables['results'][1]['route_table']['route_table_id'] }}"
+        <<: *aws_connection_info
+      register: result_1_again
+
+    - name: assert nothing changed
+      assert:
+        that:
+          - not result_1_again.changed
+          - result_1_again.result.vpc_endpoint_id == result_1.result.vpc_endpoint_id
+
+    # ============================================================
+    - name: assert that using the same vpc and service still results in a new vpc endpoint
+      ec2_vpc_endpoint:
+        state: present
+        vpc_id: "{{ vpc.vpc.id }}"
+        service: "com.amazonaws.{{ aws_region }}.s3"
+        route_table_ids: []
+        <<: *aws_connection_info
+      register: result_2
+
+    - name: assert a new VPC endpoint was created
+      assert:
+        that:
+          - result_2.changed
+          - result_2.result.vpc_endpoint_id != result_1.result.vpc_endpoint_id
+
+    # ============================================================
+    - name: Delete the first VPC endpoint
+      ec2_vpc_endpoint:
+        state: absent
+        vpc_endpoint_id: "{{ result_1.result.vpc_endpoint_id }}"
+        <<: *aws_connection_info
+      register: result
+
+    # FIXME: Removing a VPC endpoint does not display changed=true
+    #- name: assert VPC endpoint was removed
+    #  assert:
+    #    that:
+    #      - result.changed
+
+    # ============================================================
+    - name: Delete the second VPC endpoint
+      ec2_vpc_endpoint:
+        state: absent
+        vpc_endpoint_id: "{{ result_2.result.vpc_endpoint_id }}"
+        <<: *aws_connection_info
+      register: result
+
+    - name: assert that the results are empty now
+      assert:
+        that:
+          - not result.result
+
+    # ============================================================
+
+  always:
+
+    # ============================================================
+    - debug: msg="Cleaning up after ec2_vpc_endpoint tests"
+
+    - name: remove route tables
+      ec2_vpc_route_table:
+        vpc_id: "{{ vpc.vpc.id }}"
+        route_table_id: "{{ item['route_table']['route_table_id'] }}"
+        #route_table_id: "{{ item }}"
+        lookup: id
+        state: absent
+        <<: *aws_connection_info
+      ignore_errors: yes
+      loop: "{{ route_tables['results'] }}"
+
+    - name: Remove VPC
+      ec2_vpc_net:
+        name: "{{ resource_prefix }}-vpc"
+        state: absent
+        cidr_block: "120.0.0.0/24"
+        <<: *aws_connection_info
+      ignore_errors: yes

--- a/test/integration/targets/ec2_vpc_endpoint/tasks/main.yml
+++ b/test/integration/targets/ec2_vpc_endpoint/tasks/main.yml
@@ -50,7 +50,7 @@
       assert:
         that:
            - 'result.failed'
-           - 'result.msg == "state is present but all of the following are missing: vpc_id, service"'
+           - 'result.msg == "state is present but all of the following are missing: [vpc_id, service] or [vpc_endpoint_id]"'
 
     # ============================================================
     - name: test failure with no parameters and state=absent
@@ -66,13 +66,18 @@
           - 'result.msg == "state is absent but all of the following are missing: vpc_endpoint_id"'
 
     # ============================================================
-    # FIXME: currently not VPC endpoint removal is not idempotent and fails
-    #- name: remove an endpoint that does not exist
-    #  ec2_vpc_endpoint:
-    #    state: absent
-    #    vpc_endpoint_id: vpce-12345678
-    #    <<: *aws_connection_info
-    #  register: result
+    - name: remove an endpoint that does not exist
+      ec2_vpc_endpoint:
+        state: absent
+        vpc_endpoint_id: vpce-12345678
+        <<: *aws_connection_info
+      register: result
+
+    - name: assert nothing was changed
+      assert:
+        that:
+          - not result.changed
+          - not result.result
 
     # ============================================================
     - name: create a VPC endpoint and add it to the route table
@@ -134,11 +139,11 @@
         <<: *aws_connection_info
       register: result
 
-    # FIXME: Removing a VPC endpoint does not display changed=true
-    #- name: assert VPC endpoint was removed
-    #  assert:
-    #    that:
-    #      - result.changed
+    - name: assert VPC endpoint was removed
+      assert:
+        that:
+          - result.changed
+          - not result.result
 
     # ============================================================
     - name: Delete the second VPC endpoint

--- a/test/integration/targets/ec2_vpc_endpoint/tasks/main.yml
+++ b/test/integration/targets/ec2_vpc_endpoint/tasks/main.yml
@@ -242,7 +242,7 @@
         purge_route_tables: False
         route_table_ids: []
         policy:
-          Version: 2008-10-17
+          Version: "2008-10-17"
           Statement:
             - Effect: "Deny"
               Principal: "*"

--- a/test/integration/targets/ec2_vpc_endpoint/tasks/main.yml
+++ b/test/integration/targets/ec2_vpc_endpoint/tasks/main.yml
@@ -96,6 +96,7 @@
         that:
           - result_1.changed
           - result_1.result.vpc_endpoint_id.startswith('vpce-')
+          - "'Allow' in result_1.result.policy_document"
 
     # ============================================================
     - name: test idempotence
@@ -150,6 +151,7 @@
       ec2_vpc_endpoint:
         state: absent
         vpc_endpoint_id: "{{ result_2.result.vpc_endpoint_id }}"
+        wait: yes
         <<: *aws_connection_info
       register: result
 
@@ -159,6 +161,107 @@
           - not result.result
 
     # ============================================================
+    - name: create a VPC endpoint to test modifying it
+      ec2_vpc_endpoint:
+        state: present
+        vpc_id: "{{ vpc.vpc.id }}"
+        service: "com.amazonaws.{{ aws_region }}.s3"
+        wait: yes
+        route_table_ids:
+          - "{{ route_tables['results'][0]['route_table']['route_table_id'] }}"
+          - "{{ route_tables['results'][1]['route_table']['route_table_id'] }}"
+        <<: *aws_connection_info
+      register: result
+
+    - name: set the vpc endpoint id as a fact for future tasks
+      set_fact:
+        vpc_endpoint: "{{ result.result.vpc_endpoint_id }}"
+
+    - name: assert that it has two route tables
+      assert:
+        that:
+          - result.changed
+          - result.result.route_table_ids|length == 2
+
+    # ============================================================
+    - name: test a helpful error is given if trying to modify without id
+      ec2_vpc_endpoint:
+        state: present
+        vpc_id: "{{ vpc.vpc.id }}"
+        service: "com.amazonaws.{{ aws_region }}.s3"
+        route_table_ids:
+          - "{{ route_tables['results'][0]['route_table']['route_table_id'] }}"
+        <<: *aws_connection_info
+      register: result
+      ignore_errors: yes
+
+    - name: assert a vpc endpoint id should be provided for modification
+      assert:
+        that:
+          - result.failed
+          - result.msg.startswith('To update an endpoint, provide the vpc_endpoint_id to the task')
+
+    # ============================================================
+    - name: test purging a route table
+      ec2_vpc_endpoint:
+        state: present
+        vpc_endpoint_id: "{{ vpc_endpoint }}"
+        route_table_ids:
+          - "{{ route_tables['results'][0]['route_table']['route_table_id'] }}"
+        purge_route_tables: True
+        <<: *aws_connection_info
+      register: result
+
+    - name: assert there is only one route table
+      assert:
+        that:
+          - result.changed
+          - result.result.route_table_ids|length == 1
+          - result.result.route_table_ids[0] == "{{ route_tables['results'][0]['route_table']['route_table_id'] }}"
+
+    # ============================================================
+    - name: test no modifications are made with purge_route_tables=false
+      ec2_vpc_endpoint:
+        state: present
+        vpc_endpoint_id: "{{ vpc_endpoint }}"
+        route_table_ids: []
+        <<: *aws_connection_info
+      register: result
+
+    - name: assert there is still one route table
+      assert:
+        that:
+          - not result.changed
+          - result.result.route_table_ids|length == 1
+
+    # ============================================================
+    - name: test modifying the policy of the vpc endpoint
+      ec2_vpc_endpoint:
+        state: present
+        vpc_endpoint_id: "{{ vpc_endpoint }}"
+        purge_route_tables: False
+        route_table_ids: []
+        policy:
+          Version: 2008-10-17
+          Statement:
+            - Effect: "Deny"
+              Principal: "*"
+              Action: "*"
+              Resource: "*"
+        <<: *aws_connection_info
+      register: result
+
+    - name: assert the policy now denies all rather than allows all
+      assert:
+        that:
+          - "'Deny' in result.result.policy_document"
+
+    # ============================================================
+    - name: remove the endpoint
+      ec2_vpc_endpoint:
+        state: absent
+        vpc_endpoint_id: "{{ vpc_endpoint }}"
+        <<: *aws_connection_info
 
   always:
 


### PR DESCRIPTION
##### SUMMARY
Adding integration tests.

Allows endpoints to be modified if the vpc_endpoint_id option is provided when state == present. Allows policies and routes to be updated while maintaining backwards compatibility.

Backwards compat:
* Add integration tests for Ansible <= 2.5 behavior

New feature:
* Add a purge_route_tables option
* Allow route_table_ids and policy to be updated after VPC endpoint creation by specifying vpc_endpoint_id with state=present (previously only allowed for state=absent)
* add an example for updating endpoints
* Add integration tests for modifying endpoints

Exception handling:
* Remove exception handling around the boto3 connection
* Handle BotoCoreErrors instead of ‘Exception’
* Use AnsibleAWSModule for simple exception handling

Fixes:
* Fix wait: yes for state=absent and update the documentation
* Fix idempotence for deleting an endpoint
* Report changed=true when successfully deleting an endpoint


##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/ec2_vpc_endpoint.py

##### ANSIBLE VERSION
```
2.6.0
```
