### PR TITLE
Add network fact to obtain FC WWN initiator ports

### DIFF
--- a/changelogs/fragments/fibre_channel_wwn_fact.yaml
+++ b/changelogs/fragments/fibre_channel_wwn_fact.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - gather Fibre Channel WWNs fact (https://github.com/ansible/ansible/pull/37043)

--- a/lib/ansible/module_utils/facts/default_collectors.py
+++ b/lib/ansible/module_utils/facts/default_collectors.py
@@ -68,6 +68,7 @@ from ansible.module_utils.facts.network.base import NetworkCollector
 from ansible.module_utils.facts.network.aix import AIXNetworkCollector
 from ansible.module_utils.facts.network.darwin import DarwinNetworkCollector
 from ansible.module_utils.facts.network.dragonfly import DragonFlyNetworkCollector
+from ansible.module_utils.facts.network.fc_wwn import FcWwnInitiatorFactCollector
 from ansible.module_utils.facts.network.freebsd import FreeBSDNetworkCollector
 from ansible.module_utils.facts.network.hpux import HPUXNetworkCollector
 from ansible.module_utils.facts.network.hurd import HurdNetworkCollector
@@ -143,6 +144,7 @@ _hardware = [
 
 _network = [
     DnsFactCollector,
+    FcWwnInitiatorFactCollector,
     NetworkCollector,
     AIXNetworkCollector,
     DarwinNetworkCollector,

--- a/lib/ansible/module_utils/facts/network/fc_wwn.py
+++ b/lib/ansible/module_utils/facts/network/fc_wwn.py
@@ -1,0 +1,46 @@
+# Fibre Channel WWN initiator related facts collection for ansible.
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import sys
+import glob
+
+from ansible.module_utils.facts.utils import get_file_lines
+from ansible.module_utils.facts.collector import BaseFactCollector
+
+
+class FcWwnInitiatorFactCollector(BaseFactCollector):
+    name = 'fibre_channel_wwn'
+    _fact_ids = set()
+
+    def collect(self, module=None, collected_facts=None):
+        """
+        Example contents /sys/class/fc_host/*/port_name:
+
+        0x21000014ff52a9bb
+
+        """
+
+        fc_facts = {}
+        fc_facts['fibre_channel_wwn'] = []
+        if sys.platform.startswith('linux'):
+            for fcfile in glob.glob('/sys/class/fc_host/*/port_name'):
+                for line in get_file_lines(fcfile):
+                    fc_facts['fibre_channel_wwn'].append(line.rstrip()[2:])
+        return fc_facts


### PR DESCRIPTION
##### SUMMARY
This new fact enables the discovery of host fibre channel WWPNs if HBA cards are present.
External storage modules can use this information to automate external storage array configuration
for hosts.
Fact discovery enabled for Linux only.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
module_utils/facts/network

##### ANSIBLE VERSION
2.5

