### PR TITLE
correctly support no_device on ec2_lc

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_lc.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_lc.py
@@ -172,6 +172,17 @@ EXAMPLES = '''
       iops: 3000
       delete_on_termination: true
 
+# create a launch configuration to omit the /dev/sdf EBS device that is included in the AMI image
+
+- ec2_lc:
+    name: special
+    image_id: ami-XXX
+    key_name: default
+    security_groups: ['group', 'group2' ]
+    instance_type: t1.micro
+    volumes:
+    - device_name: /dev/sdf
+      no_device: true
 '''
 
 RETURN = '''
@@ -396,7 +407,7 @@ def create_block_device_meta(module, volume):
     if 'device_type' in volume:
         volume['volume_type'] = volume.pop('device_type')
 
-    if 'snapshot' not in volume and 'ephemeral' not in volume:
+    if 'snapshot' not in volume and 'ephemeral' not in volume and 'no_device' not in volume:
         if 'volume_size' not in volume:
             module.fail_json(msg='Size must be specified when creating a new volume or modifying the root volume')
     if 'snapshot' in volume:
@@ -414,7 +425,7 @@ def create_block_device_meta(module, volume):
     if 'device_name' in volume:
         return_object['DeviceName'] = volume.get('device_name')
 
-    if 'no_device' is volume:
+    if 'no_device' in volume:
         return_object['NoDevice'] = volume.get('no_device')
 
     if any(key in volume for key in ['snapshot', 'volume_size', 'volume_type', 'delete_on_termination', 'ips', 'encrypted']):


### PR DESCRIPTION
##### SUMMARY
The `no_device` attribute defined for a volume is getting ignored, and is not correctly represented in the generated `BlockDeviceMappings` for the created launch configuration.

This addresses #37042 .

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ec2_lc

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.3.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.6 (default, Jun 22 2015, 17:58:13) [GCC 4.8.2]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```yaml
    - name: Create Launch Configurations
      ec2_lc:
        name: "{{ cluster_name }}-lc-{{ item }}"
        region: "{{ ec2_region }}"
        key_name: "{{ key_name }}"
        security_groups:
          - "{{ ec2_group.group_id }}"
        instance_type: "{{ ec2_instance_type }}"
        image_id: "{{ ec2_image }}"
        instance_profile_name: "{{marklogic_role_profile_arn}}"
        volumes:
          - device_name: /dev/sdf
            no_device: true
```
