### PR TITLE
Fix unarchive with strip-components in extra_opts

### DIFF
--- a/lib/ansible/modules/files/unarchive.py
+++ b/lib/ansible/modules/files/unarchive.py
@@ -868,7 +868,13 @@ def main():
     if res_args.get('diff', True) and not module.check_mode:
         # do we need to change perms?
         for filename in handler.files_in_archive:
+            # GNU tar won't create absolute filenames. We don't support it either (It causes
+            # problems here.  Could cause issues in other parts of the code as well)
+            if filename.startswith('/'):
+                filename = filename[1:]
+
             file_args['path'] = os.path.join(dest, filename)
+
             try:
                 res_args['changed'] = module.set_fs_attributes_if_different(file_args, res_args['changed'], expand=False)
             except (IOError, OSError) as e:


### PR DESCRIPTION
When unarchive is given extra_opts to strip all leading directories, it
could end up trying to change the permissions on the root directory.
Tar archives shouldn't contain absolute paths anyways so make sure that
all paths are relative as we handle them.

Fixes #21397

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
unarchive.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel 2.5 2.4
```


##### ADDITIONAL INFORMATION
Need input as to whether we do need to handle absolute paths in tar archives.  GNU Tar, at least, does not allow creating those (it removes the leading slash to make them all relative when it creates them.) There's probably other places in the module which will break if we need to handle absolute paths.