### PR TITLE
Fix eos integration test failures (#37020)

### DIFF
--- a/lib/ansible/modules/network/eos/eos_interface.py
+++ b/lib/ansible/modules/network/eos/eos_interface.py
@@ -330,7 +330,7 @@ def check_declarative_intent_params(module, want, result):
         if result['changed']:
             sleep(w['delay'])
 
-        command = 'show interfaces %s' % w['name']
+        command = {'command': 'show interfaces %s' % w['name'], 'output': 'text'}
         output = run_commands(module, [command])
 
         if want_state in ('up', 'down'):
@@ -363,7 +363,8 @@ def check_declarative_intent_params(module, want, result):
             have_host = []
             have_port = []
             if have_neighbors is None:
-                have_neighbors = run_commands(module, ['show lldp neighbors {}'.format(w['name'])])
+                command = {'command': 'show lldp neighbors {}'.format(w['name']), 'output': 'text'}
+                have_neighbors = run_commands(module, [command])
 
             if have_neighbors[0]:
                 lines = have_neighbors[0].strip().split('\n')

--- a/lib/ansible/modules/network/eos/eos_lldp.py
+++ b/lib/ansible/modules/network/eos/eos_lldp.py
@@ -58,10 +58,10 @@ from ansible.module_utils.network.eos.eos import eos_argument_spec
 
 
 def has_lldp(module):
-    output = run_commands(module, ['show lldp'])
+    config = get_config(module, flags=['| section lldp'])
 
     is_lldp_enable = False
-    if len(output) > 0 and "LLDP is not enabled" not in output[0]:
+    if "no lldp run" not in config:
         is_lldp_enable = True
 
     return is_lldp_enable

--- a/test/integration/targets/eos_facts/tests/eapi/all_facts.yaml
+++ b/test/integration/targets/eos_facts/tests/eapi/all_facts.yaml
@@ -1,6 +1,11 @@
 ---
 - debug: msg="START eapi/all_facts.yaml"
 
+- name: Make sure LLDP is running (setup)
+  eos_config:
+    lines: lldp run
+    authorize: yes
+    provider: "{{ eapi }}"
 
 - name: test getting all facts
   eos_facts:
@@ -8,8 +13,6 @@
     gather_subset:
       - all
   register: result
-
-
 
 - assert:
     that:
@@ -27,5 +30,11 @@
       # Check that these facts not only are present, but are valid (positive integers)
       - "result.ansible_facts.ansible_net_memfree_mb > 1"
       - "result.ansible_facts.ansible_net_memtotal_mb > 1"
+
+- name: Make sure LLDP is running (teardown)
+  eos_config:
+    lines: no lldp run
+    authorize: yes
+    provider: "{{ eapi }}"
 
 - debug: msg="END eapi/all_facts.yaml"

--- a/test/integration/targets/eos_interface/tests/eapi/intent.yaml
+++ b/test/integration/targets/eos_interface/tests/eapi/intent.yaml
@@ -6,6 +6,13 @@
     test_interface_1: ethernet1
     test_interface_2: ethernet2
 
+- name: Make sure LLDP is running
+  eos_config:
+    lines: lldp run
+    authorize: yes
+    provider: "{{ eapi }}"
+  become: yes
+
 - name: Check intent arguments
   eos_interface:
     name: "{{ test_interface_1 }}"
@@ -159,3 +166,9 @@
           - "'host dummy_host' in result.failed_conditions"
           - "'port dummy_port' in result.failed_conditions"
   when: "'an-vyos-02' in show_lldp_neighbors_result.stdout[0]"
+
+- name: Make sure LLDP is running (teardown)
+  eos_config:
+    lines: no lldp run
+    authorize: yes
+    provider: "{{ eapi }}"

--- a/test/integration/targets/eos_l3_interface/tests/cli/basic.yaml
+++ b/test/integration/targets/eos_l3_interface/tests/cli/basic.yaml
@@ -18,7 +18,7 @@
 - name: Configure interface ipv4 address
   eos_l3_interface:
     name: "{{ test_interface_1 }}"
-    ipv4: 192.108.0.1/24
+    ipv4: 192.108.1.1/24
     state: present
     authorize: yes
     provider: "{{ cli }}"
@@ -29,12 +29,12 @@
     that:
       - 'result.changed == true'
       - '"interface {{ test_interface_1 }}" in result.commands'
-      - '"ip address 192.108.0.1/24" in result.commands'
+      - '"ip address 192.108.1.1/24" in result.commands'
 
 - name: Configure interface ipv4 address (idempotent)
   eos_l3_interface:
     name: "{{ test_interface_1 }}"
-    ipv4: 192.108.0.1/24
+    ipv4: 192.108.1.1/24
     state: present
     authorize: yes
     provider: "{{ cli }}"
@@ -144,8 +144,8 @@
 - name: Configure ipv4 and ipv6 address using aggregate
   eos_l3_interface:
     aggregate:
-    - { name: "{{ test_interface_1 }}", ipv4: 192.108.0.1/24, ipv6: "fd5d:12c9:2201:2::2/64" }
-    - { name: "{{ test_interface_2 }}", ipv4: 192.109.0.2/16, ipv6: "fd5e:12c9:2201:3::3/32" }
+    - { name: "{{ test_interface_1 }}", ipv4: 192.108.1.1/24, ipv6: "fd5d:12c9:2201:2::2/64" }
+    - { name: "{{ test_interface_2 }}", ipv4: 192.109.1.2/16, ipv6: "fd5e:12c9:2201:3::3/32" }
     authorize: yes
     provider: "{{ cli }}"
   become: yes
@@ -155,17 +155,17 @@
     that:
       - 'result.changed == true'
       - '"interface {{ test_interface_1 }}" in result.commands'
-      - '"ip address 192.108.0.1/24" in result.commands'
+      - '"ip address 192.108.1.1/24" in result.commands'
       - '"ipv6 address fd5d:12c9:2201:2::2/64" in result.commands'
       - '"interface {{ test_interface_2 }}" in result.commands'
-      - '"ip address 192.109.0.2/16" in result.commands'
+      - '"ip address 192.109.1.2/16" in result.commands'
       - '"ipv6 address fd5e:12c9:2201:3::3/32" in result.commands'
 
 - name:  Configure ipv4 and ipv6 address using aggregate (idempotent)
   eos_l3_interface:
     aggregate:
-    - { name: "{{ test_interface_1 }}", ipv4: 192.108.0.1/24, ipv6: "fd5d:12c9:2201:2::2/64" }
-    - { name: "{{ test_interface_2 }}", ipv4: 192.109.0.2/16, ipv6: "fd5e:12c9:2201:3::3/32" }
+    - { name: "{{ test_interface_1 }}", ipv4: 192.108.1.1/24, ipv6: "fd5d:12c9:2201:2::2/64" }
+    - { name: "{{ test_interface_2 }}", ipv4: 192.109.1.2/16, ipv6: "fd5e:12c9:2201:3::3/32" }
     authorize: yes
     provider: "{{ cli }}"
   become: yes

--- a/test/integration/targets/eos_l3_interface/tests/eapi/basic.yaml
+++ b/test/integration/targets/eos_l3_interface/tests/eapi/basic.yaml
@@ -17,7 +17,7 @@
 - name: Configure interface ipv4 address
   eos_l3_interface:
     name: "{{ test_interface_1 }}"
-    ipv4: 192.168.0.1/24
+    ipv4: 192.168.1.1/24
     state: present
     authorize: yes
     provider: "{{ eapi }}"
@@ -27,12 +27,12 @@
     that:
       - 'result.changed == true'
       - '"interface {{ test_interface_1 }}" in result.commands'
-      - '"ip address 192.168.0.1/24" in result.commands'
+      - '"ip address 192.168.1.1/24" in result.commands'
 
 - name: Configure interface ipv4 address (idempotent)
   eos_l3_interface:
     name: "{{ test_interface_1 }}"
-    ipv4: 192.168.0.1/24
+    ipv4: 192.168.1.1/24
     state: present
     authorize: yes
     provider: "{{ eapi }}"


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #36919

Fix other eos modules integration test failure in dci
(cherry picked from commit ba3201cd2fd949f1f6566cfbd4a617de660ec500)
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request
 - Test Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
eos_interface
eos_lldp

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
