### PR TITLE
remove unused tx_rate and rx_rate from vyos_interface

### DIFF
--- a/lib/ansible/modules/network/vyos/vyos_interface.py
+++ b/lib/ansible/modules/network/vyos/vyos_interface.py
@@ -306,11 +306,9 @@ def check_declarative_intent_params(module, want, result):
     have_neighbors = None
     for w in want:
         want_state = w.get('state')
-        want_tx_rate = w.get('tx_rate')
-        want_rx_rate = w.get('rx_rate')
         want_neighbors = w.get('neighbors')
 
-        if want_state not in ('up', 'down') and not want_tx_rate and not want_rx_rate and not want_neighbors:
+        if want_state not in ('up', 'down') and not want_neighbors:
             continue
 
         if result['changed']:


### PR DESCRIPTION
Signed-off-by: Trishna Guha <trishnaguha17@gmail.com>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions --
vyos_interface module doesn't have any parameter named as `tx_rate`, `rx_rate`. So removing the line.
These parameters should have been there as intent params, but are missing in 2.5, we plan to fix this in 2.6
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
modules/network/vyos/vyos_interface
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel, 2.5
```