### PR TITLE
Upgrade httpbin from v0.5.0 to v0.6.2

### DIFF
--- a/test/utils/docker/httptester/Dockerfile
+++ b/test/utils/docker/httptester/Dockerfile
@@ -23,7 +23,7 @@ RUN set -x && \
     cp /root/ca/cacert.pem /usr/share/nginx/html/cacert.pem && \
     cp /root/ca/client.ansible.http.tests-cert.pem /usr/share/nginx/html/client.pem && \
     cp /root/ca/private/client.ansible.http.tests-key.pem /usr/share/nginx/html/client.key && \
-    pip install gunicorn httpbin==0.5.0
+    pip install gunicorn httpbin==0.6.2
 
 ADD services.sh /services.sh
 ADD nginx.sites.conf /etc/nginx/conf.d/default.conf

--- a/test/utils/docker/httptester/httptester.yml
+++ b/test/utils/docker/httptester/httptester.yml
@@ -134,7 +134,7 @@
       with_items:
         - name: gunicorn
         - name: httpbin
-          version: '0.5.0'
+          version: '0.6.2'
 
     - name: Copy services.sh script
       copy:


### PR DESCRIPTION
##### SUMMARY
This is required to test against /anything, which is important to test
whether redirected links do a GET or POST request (without making
assumptions and avoiding HTTP 405 METHOD NOT ALLOWED issues)

This functionality was added in httpbin v0.6.0

For more information, see #37068 

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
test docker images

##### ANSIBLE VERSION
v2.5