### PR TITLE
letsencrypt: add new param force

### DIFF
--- a/lib/ansible/modules/web_infrastructure/letsencrypt.py
+++ b/lib/ansible/modules/web_infrastructure/letsencrypt.py
@@ -102,7 +102,8 @@ options:
       - "Boolean indicating whether you agree to the terms of service document."
       - "ACME servers can require this to be true."
       - This option will only be used when C(acme_version) is not 1.
-    default: false
+    default: no
+    type: bool
     version_added: "2.5"
   challenge:
     description: The challenge to be performed.
@@ -140,8 +141,6 @@ options:
   chain_dest:
     description:
       - If specified, the intermediate certificate will be written to this file.
-    required: false
-    default: null
     aliases: ['chain']
     version_added: 2.5
   remaining_days:
@@ -156,8 +155,8 @@ options:
       - Whether calls to the ACME directory will validate TLS certificates.
       - I(Warning:) Should I(only ever) be set to C(false) for testing purposes,
         for example when testing against a local Pebble server.
-    required: false
-    default: true
+    default: yes
+    type: bool
     version_added: 2.5
   deactivate_authzs:
     description:
@@ -167,8 +166,8 @@ options:
          for a certain amount of time, and can be used to issue certificates
          without having to re-authenticate the domain. This can be a security
          concern. "
-    required: false
-    default: false
+    default: no
+    type: bool
     version_added: 2.6
   force:
     description:
@@ -176,8 +175,8 @@ options:
         existing certificate is still valid.
       - This is especially helpful when having an updated CSR e.g. with
         additional domains for which a new certificate is desired.
-    required: false
-    default: false
+    default: no
+    type: bool
     version_added: 2.6
 '''
 

--- a/lib/ansible/modules/web_infrastructure/letsencrypt.py
+++ b/lib/ansible/modules/web_infrastructure/letsencrypt.py
@@ -170,6 +170,15 @@ options:
     required: false
     default: false
     version_added: 2.6
+  force:
+    description:
+      - Enforces the execution of the challenge and validation, even if an
+        existing certificate is still valid.
+      - This is especially helpful when having an updated CSR e.g. with
+        additional domains for which a new certificate is desired.
+    required: false
+    default: false
+    version_added: 2.6
 '''
 
 EXAMPLES = '''
@@ -1281,6 +1290,7 @@ def main():
             remaining_days=dict(required=False, default=10, type='int'),
             validate_certs=dict(required=False, default=True, type='bool'),
             deactivate_authzs=dict(required=False, default=False, type='bool'),
+            force=dict(required=False, default=False, type='bool'),
         ),
         required_one_of=(
             ['account_key_src', 'account_key_content'],
@@ -1306,7 +1316,8 @@ def main():
             cert_days = get_cert_days(module, module.params['dest'])
         else:
             cert_days = get_cert_days(module, module.params['fullchain_dest'])
-        if cert_days < module.params['remaining_days']:
+
+        if module.params['force'] or cert_days < module.params['remaining_days']:
             # If checkmode is active, base the changed state solely on the status
             # of the certificate file as all other actions (accessing an account, checking
             # the authorization status...) would lead to potential changes of the current

--- a/test/sanity/validate-modules/ignore.txt
+++ b/test/sanity/validate-modules/ignore.txt
@@ -2187,5 +2187,4 @@ lib/ansible/modules/web_infrastructure/jenkins_script.py E325
 lib/ansible/modules/web_infrastructure/jira.py E322
 lib/ansible/modules/web_infrastructure/jira.py E324
 lib/ansible/modules/web_infrastructure/jira.py E325
-lib/ansible/modules/web_infrastructure/letsencrypt.py E325
 lib/ansible/modules/web_infrastructure/taiga_issue.py E324


### PR DESCRIPTION
##### SUMMARY
Recently had the usecase for an updated cert with additional domains (multidomain cert). Created a new CSR but letsencrypt ignored it because the remaining days were still above the threshold.

Implemented a force param, to enforce the execution

~~~yml
- tasks:
  - name: create a new csr
    ...
    register: csr

  - name: run letsencrypt validate
    letsencrypt:
    ...
    force: "{{ csr.changed }}"

...
~~~
 

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
letsencrypt

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
