### PR TITLE
[cloud] add custom waiter for target groups when created - fixes #36628

### DIFF
--- a/lib/ansible/module_utils/aws/waiters.py
+++ b/lib/ansible/module_utils/aws/waiters.py
@@ -224,6 +224,36 @@ rds_data = {
 }
 
 
+elbv2_data = {
+    "version": 2,
+    "waiters": {
+        "TargetGroupExists": {
+            "delay": 5,
+            "maxAttempts": 40,
+            "operation": "DescribeTargetGroups",
+            "acceptors": [
+                {
+                    "matcher": "path",
+                    "expected": True,
+                    "argument": "length(TargetGroups[]) > `0`",
+                    "state": "success"
+                },
+                {
+                    "matcher": "error",
+                    "expected": "TargetGroupNotFound",
+                    "state": "retry"
+                }
+            ]
+        }
+    }
+}
+
+
+def elbv2_model(name):
+    elbv2_models = core_waiter.WaiterModel(waiter_config=elbv2_data)
+    return elbv2_models.get_waiter(name)
+
+
 def ec2_model(name):
     ec2_models = core_waiter.WaiterModel(waiter_config=ec2_data)
     return ec2_models.get_waiter(name)
@@ -316,6 +346,12 @@ waiters_by_name = {
         rds_model('DBInstanceStopped'),
         core_waiter.NormalizedOperationMethod(
             rds.describe_db_instances
+        )),
+    ('ElasticLoadBalancingv2', 'target_group_exists'): lambda elbv2: core_waiter.Waiter(
+        'target_group_exists',
+        elbv2_model('TargetGroupExists'),
+        core_waiter.NormalizedOperationMethod(
+            elbv2.describe_target_groups
         )),
 }
 

--- a/lib/ansible/modules/cloud/amazon/elb_target_group.py
+++ b/lib/ansible/modules/cloud/amazon/elb_target_group.py
@@ -322,7 +322,7 @@ except ImportError:
     pass  # handled by AnsibleAWSModule
 
 from ansible.module_utils.aws.core import AnsibleAWSModule
-from ansible.module_utils.ec2 import (camel_dict_to_snake_dict, boto3_tag_list_to_ansible_dict, ec2_argument_spec,
+from ansible.module_utils.ec2 import (camel_dict_to_snake_dict, boto3_tag_list_to_ansible_dict,
                                       compare_aws_tags, ansible_dict_to_boto3_tag_list)
 from ansible.module_utils.aws.waiters import get_waiter
 from distutils.version import LooseVersion
@@ -698,7 +698,7 @@ def delete_target_group(connection, module):
 
 
 def main():
-    argument_spec = ec2_argument_spec()
+    argument_spec = {}
     argument_spec.update(
         dict(
             deregistration_delay_timeout=dict(type='int'),

--- a/lib/ansible/modules/cloud/amazon/elb_target_group.py
+++ b/lib/ansible/modules/cloud/amazon/elb_target_group.py
@@ -599,6 +599,8 @@ def create_or_update_target_group(connection, module):
             ).wait(
                 Names=[params['Name']],
             )
+        except botocore.exceptions.WaiterError as e:
+            module.fail_json_aws(e, "Failed to wait for target group to be created")
         except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
             module.fail_json_aws(e, msg="Couldn't create target group")
 


### PR DESCRIPTION
##### SUMMARY
Fixes #36628. Wait for a target group to be accessible after creation before subsequent operations.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/elb_target_group.py
lib/ansible/module_utils/aws/waiters.py

##### ANSIBLE VERSION
```
2.6.0
```