### PR TITLE
fix nxos_l2_interface tests for fretta

### DIFF
--- a/test/integration/targets/nxos_l2_interface/tests/common/agg.yaml
+++ b/test/integration/targets/nxos_l2_interface/tests/common/agg.yaml
@@ -27,6 +27,10 @@
     state: absent
     provider: "{{ connection }}"
 
+- name: Sleep for 2 seconds on Fretta Platform
+  wait_for: timeout=2
+  when: platform is match("N9K-F")
+
 - block:
   - name: Configure interface for access_vlan aggregate
     nxos_l2_interface: &conf_agg
@@ -39,6 +43,10 @@
   - assert:
       that:
         - "result.changed == true"
+
+  - name: Sleep for 2 seconds on Fretta Platform
+    wait_for: timeout=2
+    when: platform is match("N9K-F")
 
   - name: Configure interface for access_vlan aggregate(Idempotence)
     nxos_l2_interface: *conf_agg
@@ -60,6 +68,10 @@
   - assert:
       that:
         - "result.changed == true"
+
+  - name: Sleep for 2 seconds on Fretta Platform
+    wait_for: timeout=2
+    when: platform is match("N9K-F")
 
   - name: Remove interface aggregate(Idempotence)
     nxos_l2_interface: *rm_agg

--- a/test/integration/targets/nxos_l2_interface/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_l2_interface/tests/common/sanity.yaml
@@ -45,6 +45,10 @@
       that:
         - "result.changed == true"
 
+  - name: Sleep for 2 seconds on Fretta Platform
+    wait_for: timeout=2
+    when: platform is match("N9K-F")
+
   - name: "access vlan Idempotence"
     nxos_l2_interface: *acc_vl
     register: result


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Some timing issues were seen on the fretta platform using nxapi. The playbook goes through very quickly and the device (backend) can't seem to keep up resulting in idempotency issues.

Added a few `sleeps` for the fretta platform only. 

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
- nxos_l2_interface

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0 (fretta_fixes e1f016a92c) last updated 2018/03/06 13:51:53 (GMT -400)
  config file = None
  configured module search path = [u'/Users/rahushen/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/rahushen/cisco/ansible/lib/ansible
  executable location = /Users/rahushen/cisco/ansible/bin/ansible
  python version = 2.7.12 (v2.7.12:d33e0cf91556, Jun 26 2016, 12:10:39) [GCC 4.2.1 (Apple Inc. build 5666) (dot 3)]
```