### PR TITLE
Add a note for multiple changes in one file

### DIFF
--- a/lib/ansible/modules/files/blockinfile.py
+++ b/lib/ansible/modules/files/blockinfile.py
@@ -95,6 +95,7 @@ notes:
   - When using 'with_*' loops be aware that if you do not set a unique mark the block will be overwritten on each iteration.
   - As of Ansible 2.3, the I(dest) option has been changed to I(path) as default, but I(dest) still works as well.
   - Option I(follow) has been removed in version 2.5, because this module modifies the contents of the file so I(follow=no) doesn't make sense.
+  - When more then one block should be handled in **one** file you **must** change the I(marker) per task
 """
 
 EXAMPLES = r"""


### PR DESCRIPTION
##### SUMMARY

As mentioned in this answer https://stackoverflow.com/a/41549694/6778826 we was able to solve a bad behaviour of `blockinfile` module.
We must change two parts in one file which we have done in two tasks. Every run have rewriten the first block with the second block in the wrong position. **After** we have set the `marker` in the second task to another value was the `blockinfile` module able to insert both parts in the right position in the same file.


##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
blockinfile module

##### ANSIBLE VERSION

I have no access now for the full output

```
2.4
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
