### PR TITLE
win_wait_for: fix local port check on port not accessible externally

### DIFF
--- a/changelogs/fragments/win_wait_for-local-port-fix.yaml
+++ b/changelogs/fragments/win_wait_for-local-port-fix.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_wait_for - fixed issue when trying to check a localport when the port is not available externally

--- a/lib/ansible/modules/windows/win_wait_for.ps1
+++ b/lib/ansible/modules/windows/win_wait_for.ps1
@@ -54,17 +54,9 @@ if ($port -ne $null) {
 }
 
 Function Test-Port($hostname, $port) {
-    # try and resolve the IP/Host, if it fails then just use the host passed in
-    try {
-        $resolve_hostname = ([System.Net.Dns]::GetHostEntry($hostname)).HostName
-    } catch {
-        # oh well just use the IP addres
-        $resolve_hostname = $hostname
-    }
-
     $timeout = $connect_timeout * 1000
     $socket = New-Object -TypeName System.Net.Sockets.TcpClient
-    $connect = $socket.BeginConnect($resolve_hostname, $port, $null, $null)
+    $connect = $socket.BeginConnect($hostname, $port, $null, $null)
     $wait = $connect.AsyncWaitHandle.WaitOne($timeout, $false)
 
     if ($wait) {


### PR DESCRIPTION
##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/36762. When a port that isn't accessible remotely but accessible locally, this change makes it possible to do so.

Fixes https://github.com/ansible/ansible/issues/35460

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
win_wait_for

##### ANSIBLE VERSION
```
2.5
```