### PR TITLE
Don't fail on configure in command (#37011)

### DIFF
--- a/lib/ansible/modules/network/ios/ios_command.py
+++ b/lib/ansible/modules/network/ios/ios_command.py
@@ -166,17 +166,18 @@ def parse_commands(module, warnings):
     commands = command(module.params['commands'])
     for item in list(commands):
         configure_type = re.match(r'conf(?:\w*)(?:\s+(\w+))?', item['command'])
-        if module.check_mode and not item['command'].startswith('show'):
-            warnings.append(
-                'only show commands are supported when using check mode, not '
-                'executing `%s`' % item['command']
-            )
-            commands.remove(item)
-        elif configure_type and configure_type.group(1) not in ('confirm', 'replace', 'revert', 'network'):
-            module.fail_json(
-                msg='ios_command does not support running config mode '
-                    'commands.  Please use ios_config instead'
-            )
+        if module.check_mode:
+            if configure_type and configure_type.group(1) not in ('confirm', 'replace', 'revert', 'network'):
+                module.fail_json(
+                    msg='ios_command does not support running config mode '
+                        'commands.  Please use ios_config instead'
+                )
+            if not item['command'].startswith('show'):
+                warnings.append(
+                    'only show commands are supported when using check mode, not '
+                    'executing `%s`' % item['command']
+                )
+                commands.remove(item)
     return commands
 
 

--- a/test/units/modules/network/ios/test_ios_command.py
+++ b/test/units/modules/network/ios/test_ios_command.py
@@ -109,7 +109,10 @@ class TestIosCommandModule(TestIosModule):
 
     def test_ios_command_configure_error(self):
         commands = ['configure terminal']
-        set_module_args(dict(commands=commands))
+        set_module_args({
+            'commands': commands,
+            '_ansible_check_mode': True,
+        })
         result = self.execute_module(failed=True)
         self.assertEqual(
             result['msg'],


### PR DESCRIPTION
* Don't fail on configure in command

* Change test to check mode

(cherry picked from commit efb8b539c1957f93b42b55bde7ff3cfa6ad2009d)

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
ios_command

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```