### PR TITLE
Having uppercase in the resource_prefix can cause unexpected issues

### DIFF
--- a/test/runner/lib/cloud/__init__.py
+++ b/test/runner/lib/cloud/__init__.py
@@ -350,7 +350,7 @@ class CloudProvider(CloudBase):
                 os.environ['SHIPPABLE_JOB_NUMBER'],
             )
 
-        node = re.sub(r'[^a-zA-Z0-9]+', '-', platform.node().split('.')[0])
+        node = re.sub(r'[^a-zA-Z0-9]+', '-', platform.node().split('.')[0]).lower()
 
         return 'ansible-test-%s-%d' % (node, random.randint(10000000, 99999999))
 


### PR DESCRIPTION
##### SUMMARY
We may as well enforce lower case resource prefixes at source

See https://github.com/ansible/ansible/pull/36941#discussion_r172657369 for reasons - I think it's better to have a consistent format for resource_prefix than to have to append `|lower` to all tests.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
test/runner/lib/cloud

##### ANSIBLE VERSION
```
ansible 2.6.0 (devel efb8b539c1) last updated 2018/03/07 10:01:14 (GMT +1000)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/will/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/will/src/ansible/lib/ansible
  executable location = /home/will/src/ansible/bin/ansible
  python version = 2.7.14 (default, Jan 17 2018, 14:28:32) [GCC 7.2.1 20170915 (Red Hat 7.2.1-2)]

```

