### PR TITLE
Fixes 36950. Added support for missing options capabilities and root_device in properties of os_ironic.py ansible module

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_ironic.py
+++ b/lib/ansible/modules/cloud/openstack/os_ironic.py
@@ -93,6 +93,14 @@ options:
           description:
             - size of first storage device in this machine (typically /dev/sda), in GB
           default: 1
+        capabilities:
+          description:
+            - special capabilities for the node, such as boot_option, node_role etc
+          default: ""
+        root_device:
+          description:
+            - Root disk selections. eg: /dev/sda
+          default: ""
     skip_update_of_driver_password:
       description:
         - Allows the code that would assert changes to nodes to skip the
@@ -120,6 +128,9 @@ EXAMPLES = '''
       cpu_arch: "x86_64"
       ram: 8192
       disk_size: 64
+      capabilities: "boot_option:local"
+      root_device:
+        name: "/dev/sda"
     nics:
       - mac: "aa:bb:cc:aa:bb:cc"
       - mac: "dd:ee:ff:dd:ee:ff"
@@ -149,6 +160,8 @@ def _parse_properties(module):
         cpus=p.get('cpus') if p.get('cpus') else 1,
         memory_mb=p.get('ram') if p.get('ram') else 1,
         local_gb=p.get('disk_size') if p.get('disk_size') else 1,
+        capabilities=p.get('capabilities') if p.get('capabilities') else '',
+        root_device=p.get('root_device') if p.get('root_device') else '',
     )
     return props
 

--- a/lib/ansible/modules/cloud/openstack/os_ironic.py
+++ b/lib/ansible/modules/cloud/openstack/os_ironic.py
@@ -96,13 +96,13 @@ options:
         capabilities:
           description:
             - special capabilities for the node, such as boot_option, node_role etc
-              (see U(https://docs.openstack.org/ironic/pike/install/advanced.html)
+              (see U(https://docs.openstack.org/ironic/latest/install/advanced.html)
               for more information)
           default: ""
         root_device:
           description:
             - Root disk device hints for deployment.
-              (see U(https://docs.openstack.org/ironic/pike/install/include/root-device-hints.html)
+              (see U(https://docs.openstack.org/ironic/latest/install/include/root-device-hints.html)
               for allowed hints)
           default: ""
     skip_update_of_driver_password:
@@ -134,7 +134,7 @@ EXAMPLES = '''
       disk_size: 64
       capabilities: "boot_option:local"
       root_device:
-        name: "/dev/md0"
+        wwn: "0x4000cca77fc4dba1"
     nics:
       - mac: "aa:bb:cc:aa:bb:cc"
       - mac: "dd:ee:ff:dd:ee:ff"

--- a/lib/ansible/modules/cloud/openstack/os_ironic.py
+++ b/lib/ansible/modules/cloud/openstack/os_ironic.py
@@ -96,10 +96,14 @@ options:
         capabilities:
           description:
             - special capabilities for the node, such as boot_option, node_role etc
+              (see U(https://docs.openstack.org/ironic/pike/install/advanced.html)
+              for more information)
           default: ""
         root_device:
           description:
-            - Root disk selections. eg: /dev/sda
+            - Root disk device hints for deployment.
+              (see U(https://docs.openstack.org/ironic/pike/install/include/root-device-hints.html)
+              for allowed hints)
           default: ""
     skip_update_of_driver_password:
       description:
@@ -130,7 +134,7 @@ EXAMPLES = '''
       disk_size: 64
       capabilities: "boot_option:local"
       root_device:
-        name: "/dev/sda"
+        name: "/dev/md0"
     nics:
       - mac: "aa:bb:cc:aa:bb:cc"
       - mac: "dd:ee:ff:dd:ee:ff"

--- a/lib/ansible/modules/cloud/openstack/os_ironic.py
+++ b/lib/ansible/modules/cloud/openstack/os_ironic.py
@@ -99,12 +99,14 @@ options:
               (see U(https://docs.openstack.org/ironic/latest/install/advanced.html)
               for more information)
           default: ""
+          version_added: "2.8"
         root_device:
           description:
             - Root disk device hints for deployment.
               (see U(https://docs.openstack.org/ironic/latest/install/include/root-device-hints.html)
               for allowed hints)
           default: ""
+          version_added: "2.8"
     skip_update_of_driver_password:
       description:
         - Allows the code that would assert changes to nodes to skip the


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
 Added support for missing options capabilities and root_device in properties of os_ironic.py ansible module

Fixes: #36950
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
os_ironic.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
