### PR TITLE
[2.5] cloudstack: fix common E324 in docs (#37082)

### DIFF
--- a/lib/ansible/utils/module_docs_fragments/cloudstack.py
+++ b/lib/ansible/utils/module_docs_fragments/cloudstack.py
@@ -11,24 +11,35 @@ options:
   api_key:
     description:
       - API key of the CloudStack API.
+      - If not given, the C(CLOUDSTACK_KEY) env variable is considered.
+      - As the last option, the value is taken from the ini config file, also see the notes.
   api_secret:
     description:
       - Secret key of the CloudStack API.
+      - If not set, the C(CLOUDSTACK_SECRET) env variable is considered.
+      - As the last option, the value is taken from the ini config file, also see the notes.
   api_url:
     description:
       - URL of the CloudStack API e.g. https://cloud.example.com/client/api.
+      - If not given, the C(CLOUDSTACK_ENDPOINT) env variable is considered.
+      - As the last option, the value is taken from the ini config file, also see the notes.
   api_http_method:
     description:
-      - HTTP method used.
-    default: get
+      - HTTP method used to query the API endpoint.
+      - If not given, the C(CLOUDSTACK_METHOD) env variable is considered.
+      - As the last option, the value is taken from the ini config file, also see the notes.
+      - Fallback value is C(get) if not specified.
     choices: [ get, post ]
   api_timeout:
     description:
-      - HTTP timeout.
-    default: 10
+      - HTTP timeout in seconds.
+      - If not given, the C(CLOUDSTACK_TIMEOUT) env variable is considered.
+      - As the last option, the value is taken from the ini config file, also see the notes.
+      - Fallback value is 10 seconds if not specified.
   api_region:
     description:
       - Name of the ini section in the C(cloustack.ini) file.
+      - If not given, the C(CLOUDSTACK_REGION) env variable is considered.
     default: cloudstack
 requirements:
   - "python >= 2.6"


### PR DESCRIPTION
Notes about precedence of common args.

(partly cherry picked from commit 2559e832dfdd06086489a4905789ca0d10bcadf2)

##### SUMMARY
Backport doc fix

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
cloudstack

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
