### PR TITLE
Auto install of python-apt without recommends.

### DIFF
--- a/lib/ansible/modules/packaging/os/apt.py
+++ b/lib/ansible/modules/packaging/os/apt.py
@@ -891,7 +891,7 @@ def main():
                                  "If run normally this module can auto-install it." % PYTHON_APT)
         try:
             module.run_command(['apt-get', 'update'], check_rc=True)
-            module.run_command(['apt-get', 'install', PYTHON_APT, '-y', '-q'], check_rc=True)
+            module.run_command(['apt-get', 'install', '--no-install-recommends', PYTHON_APT, '-y', '-q'], check_rc=True)
             global apt, apt_pkg
             import apt
             import apt.debfile


### PR DESCRIPTION
##### SUMMARY
python-apt installation without recommended packages to prevent two versions of python on remote hosts and save disk space.

Output from debian:9

`apt-get install python-apt` - this will install python2.7 and python3
After this operation, *88.4 MB* of additional disk space will be used.

`apt-get install --no-install-recommends python-apt` - only python2.7
After this operation, *35.0 MB* of additional disk space will be used.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
modules/packaging/os/apt.py

##### ANSIBLE VERSION
```
2.4, 2.5, devel
```

##### ADDITIONAL INFORMATION

Fixes #37120 