### PR TITLE
add instanceUuid (also called PersistentId) in vmware utils

### DIFF
--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -291,6 +291,7 @@ def gather_vm_facts(content, vm):
         'hw_is_template': vm.config.template,
         'hw_folder': None,
         'hw_version': vm.config.version,
+        'instance_uuid': vm.config.instanceUuid,
         'guest_tools_status': _get_vm_prop(vm, ('guest', 'toolsRunningStatus')),
         'guest_tools_version': _get_vm_prop(vm, ('guest', 'toolsVersion')),
         'guest_question': vm.summary.runtime.question,


### PR DESCRIPTION
##### SUMMARY
This PR adds instanceUuid (also called PersistentId in PowerCli) in the output of gather_vm_facts.
instanceUuid is usefull for Zabbix modules (zabbix_*) when managing monitored hosts in Zabbix.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
vmware_utils

##### ANSIBLE VERSION
devel branch

##### ADDITIONAL INFORMATION
The default VMware Discovery rules in Zabbix are using instanceUuid (PersistentId) as host name of monitored hosts . When working with the zabbix_* modules a host name is required parameter. Before it was not possible to determine the instanceUuid within Ansible. Making the field available makes workflows like this possible:

```
tasks:
	- name: Guest Facts about single VM
	  vmware_guest_facts:
		hostname: vcenter
		username: username
		password: password
		datacenter: DC1
		validate_certs: no
		name: monitored_vm
		folder: vm/folder123
	  delegate_to: localhost
	  register: r_facts
	- name: Remove from Zabbix
	  host_name: "{{r_facts.instance.instance_uuid}}"
	  state: absent
	  login_password: zabix_password
	  login_user: zabbix_user
	  server_url: zabbix_server
	  delegate_to: localhost
```
