### PR TITLE
examples fix: mode selection

### DIFF
--- a/lib/ansible/modules/cloud/atomic/atomic_container.py
+++ b/lib/ansible/modules/cloud/atomic/atomic_container.py
@@ -77,7 +77,7 @@ EXAMPLES = '''
     image: rhel/etcd
     backend: ostree
     state: latest
-    system: True
+    mode: system
     values:
         - ETCD_NAME=etcd.server
 
@@ -87,7 +87,7 @@ EXAMPLES = '''
     image: rhel/etcd
     backend: ostree
     state: absent
-    system: True
+    mode: system
 '''
 
 RETURN = '''


### PR DESCRIPTION


##### SUMMARY

Documentation:
Mode selection in the examples didn't match (or work) for system: true.
It should be 
`mode: <mode here>`

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
atomic_container

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.2.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, May  3 2017, 07:55:04) [GCC 4.8.5 20150623 (Red Hat 4.8.5-14)]
```


##### ADDITIONAL INFORMATION
<!---
When using this module, Mode selection in the examples didn't match (or work) for `system: true`.
It should be 
`mode: <mode here>`
With this fix, mode selection is shown properly in the examples of the documentation.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
# before:
fatal: [ansible-node-hostname]: FAILED! => {"changed": false, "msg": "Unsupported parameters for (atomic_container) module: system Supported parameters include: backend,image,mode,name,rootfs,state,values"}

# after:
no such error as above.
```
