### PR TITLE
Ensure the table spans the complete page width

### DIFF
--- a/docs/templates/plugin.rst.j2
+++ b/docs/templates/plugin.rst.j2
@@ -224,7 +224,7 @@ Facts returned by this module are added/updated in the ``hostvars`` host facts a
         <tr>
             <th class="head"><div class="cell-border">Fact</div></th>
             <th class="head"><div class="cell-border">Returned</div></th>
-            <th class="head"><div class="cell-border">Description</div></th>
+            <th class="head" width="100%"><div class="cell-border">Description</div></th>
         </tr>
         {% for key, value in returnfacts|dictsort recursive %}
             <tr class="return-value-column">
@@ -289,7 +289,7 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
         <tr>
             <th class="head"><div class="cell-border">Key</div></th>
             <th class="head"><div class="cell-border">Returned</div></th>
-            <th class="head"><div class="cell-border">Description</div></th>
+            <th class="head" width="100%"><div class="cell-border">Description</div></th>
         </tr>
         {% for key, value in returndocs|dictsort recursive %}
             <tr class="return-value-column">


### PR DESCRIPTION
##### SUMMARY
This fixes the problem with the div/cell-border solution for complex tables causing missing lines.
The fix for the parameter table is in PR #36901 

This has some drawbacks, including pushing the other columns to the narrowest possible width.
I don't see a better option at this point.

**Before (v2.4 and older?)**
![screenshot from 2018-03-07 18-26-36](https://user-images.githubusercontent.com/388198/37107638-2038292e-2235-11e8-8ff1-ed086b4e9115.png)

**Before (v2.5)**
![screenshot from 2018-03-07 18-21-59](https://user-images.githubusercontent.com/388198/37107422-92513aec-2234-11e8-9256-e05770e92564.png)

**After**
![screenshot from 2018-03-07 18-23-37](https://user-images.githubusercontent.com/388198/37107467-ad4d024a-2234-11e8-8ead-3d9c243f923f.png)


##### ISSUE TYPE
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
Module docs

##### ANSIBLE VERSION
v2.5 (and older)