### PR TITLE
Reduce recursion within group methods

### DIFF
--- a/lib/ansible/inventory/host.py
+++ b/lib/ansible/inventory/host.py
@@ -101,17 +101,22 @@ class Host:
     def get_name(self):
         return self.name
 
-    def populate_ancestors(self):
+    def populate_ancestors(self, additions=None):
         # populate ancestors
-        for group in self.groups:
-            self.add_group(group)
+        if additions is None:
+            for group in self.groups:
+                self.add_group(group)
+        else:
+            for group in additions:
+                if group not in self.groups:
+                    self.groups.append(group)
 
     def add_group(self, group):
 
         # populate ancestors first
         for oldg in group.get_ancestors():
             if oldg not in self.groups:
-                self.add_group(oldg)
+                self.groups.append(oldg)
 
         # actually add group
         if group not in self.groups:

--- a/test/units/plugins/inventory/test_group.py
+++ b/test/units/plugins/inventory/test_group.py
@@ -1,0 +1,125 @@
+# Copyright 2018 Alan Rominger <arominge@redhat.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+from ansible.compat.tests import unittest
+
+from ansible.inventory.group import Group
+from ansible.inventory.host import Host
+from ansible.errors import AnsibleError
+
+
+class TestGroup(unittest.TestCase):
+
+    def test_depth_update(self):
+        A = Group('A')
+        B = Group('B')
+        Z = Group('Z')
+        A.add_child_group(B)
+        A.add_child_group(Z)
+        self.assertEqual(A.depth, 0)
+        self.assertEqual(Z.depth, 1)
+        self.assertEqual(B.depth, 1)
+
+    def test_depth_update_dual_branches(self):
+        alpha = Group('alpha')
+        A = Group('A')
+        alpha.add_child_group(A)
+        B = Group('B')
+        A.add_child_group(B)
+        Z = Group('Z')
+        alpha.add_child_group(Z)
+        beta = Group('beta')
+        B.add_child_group(beta)
+        Z.add_child_group(beta)
+
+        self.assertEqual(alpha.depth, 0)  # apex
+        self.assertEqual(beta.depth, 3)  # alpha -> A -> B -> beta
+
+        omega = Group('omega')
+        omega.add_child_group(alpha)
+
+        # verify that both paths are traversed to get the max depth value
+        self.assertEqual(B.depth, 3)  # omega -> alpha -> A -> B
+        self.assertEqual(beta.depth, 4)  # B -> beta
+
+    def test_depth_recursion(self):
+        A = Group('A')
+        B = Group('B')
+        A.add_child_group(B)
+        # hypothetical of adding B as child group to A
+        A.parent_groups.append(B)
+        B.child_groups.append(A)
+        # can't update depths of groups, because of loop
+        with self.assertRaises(AnsibleError):
+            B._check_children_depth()
+
+    def test_loop_detection(self):
+        A = Group('A')
+        B = Group('B')
+        C = Group('C')
+        A.add_child_group(B)
+        B.add_child_group(C)
+        with self.assertRaises(AnsibleError):
+            C.add_child_group(A)
+
+    def test_populates_descendant_hosts(self):
+        A = Group('A')
+        B = Group('B')
+        C = Group('C')
+        h = Host('h')
+        C.add_host(h)
+        A.add_child_group(B)  # B is child of A
+        B.add_child_group(C)  # C is descendant of A
+        A.add_child_group(B)
+        self.assertEqual(set(h.groups), set([C, B, A]))
+        h2 = Host('h2')
+        C.add_host(h2)
+        self.assertEqual(set(h2.groups), set([C, B, A]))
+
+    def test_ancestor_example(self):
+        # see docstring for Group._walk_relationship
+        groups = {}
+        for name in ['A', 'B', 'C', 'D', 'E', 'F']:
+            groups[name] = Group(name)
+        # first row
+        groups['A'].add_child_group(groups['D'])
+        groups['B'].add_child_group(groups['D'])
+        groups['B'].add_child_group(groups['E'])
+        groups['C'].add_child_group(groups['D'])
+        # second row
+        groups['D'].add_child_group(groups['E'])
+        groups['D'].add_child_group(groups['F'])
+        groups['E'].add_child_group(groups['F'])
+
+        self.assertEqual(
+            set(groups['F'].get_ancestors()),
+            set([
+                groups['A'], groups['B'], groups['C'], groups['D'], groups['E']
+            ])
+        )
+
+    def test_ancestors_recursive_loop_safe(self):
+        '''
+        The get_ancestors method may be referenced before circular parenting
+        checks, so the method is expected to be stable even with loops
+        '''
+        A = Group('A')
+        B = Group('B')
+        A.parent_groups.append(B)
+        B.parent_groups.append(A)
+        # finishes in finite time
+        self.assertEqual(A.get_ancestors(), set([A, B]))


### PR DESCRIPTION
##### SUMMARY

fully Fixes #36431

maybe Fixes #31797

replaces #37039, #36437

This increases the maximum number of hosts / groups that Ansible can handle before the time to parse the inventory becomes so long as to make it unusable.

My metric is the number of hosts or groups that will get the runtime within the 10 second range. I have certain reference cases that I'm running from this repo:

https://github.com/AlanCoding/Ansible-inventory-file-examples/

| improved                                  | old                 | new                   |
|-------------------------------------------|---------------------|-----------------------|
| groups only, dense                        | 24 groups (276 connections)  | 180 groups (16k connections)   |
| hosts + groups, dense, 1 direct h->g membership per host   | 250 hosts                | 10k hosts                  |
| host + groups, dense, max h->g membership | 900 hosts (38k connections) | 2000 hosts (125k connections) |
| **same**                                      |                     |                       |
| groups only, linear (ordering not tested) | 1k-ish hosts             |                       |
| host + groups, linear                     | 1k-ish hosts             |                       |

If you want to run those, run this from the examples repo root

```
# new version can pull off
# 16k connections
time NUMBER_GROUPS=180 ansible-playbook -i scripts/connections/dag_max.py debugging/hello_world.yml
time NUMBER_HOSTS=10000 ansible-playbook -i ./scripts/connections/hosts/dag_max.py debugging/hello_world.yml
# 125k connections
time NUMBER_HOSTS=2000 ALL_GROUPS=true ansible-playbook -i ./scripts/connections/hosts/dag_max.py debugging/hello_world.yml

# still not improved
time NUMBER_HOSTS=1000 ansible-playbook -i ./scripts/connections/hosts/dag_linear.py debugging/hello_world.yml
time NUMBER_GROUPS=900 ansible-playbook -i scripts/connections/dag_linear.py debugging/hello_world.yml
```

(the reason I created a new PR) My prior attempt was assuming that group-group optimization would translate to host-group optimization. After testing it, I found that was not the case because `populate_ancestors` triggered similarly deep recursion, unexpectedly scaling with indirect host-group membership.

This turned into a larger rewrite, and went kind of set-crazy.

Added tests because of the scale of all that.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
inventory

##### ANSIBLE VERSION
```
2.5 / 2.6
```


##### ADDITIONAL INFORMATION
In `devel` all of the tests pass except for `test_ancestors_recursive_loop_safe`. I know this isn't strictly required if the cycles are detected before it's called, but I think it's nice to have coverage of this for while loops that could be altered to misbehave.
