### PR TITLE
Make modprobe module check for builtins as well

### DIFF
--- a/changelogs/fragments/37150-make_modprobe_module_check_for_builtins_as_well.yaml
+++ b/changelogs/fragments/37150-make_modprobe_module_check_for_builtins_as_well.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- "modprobe - The modprobe module now detects builtin kernel modules. If a kernel module is builtin the modprobe module will now: succeed (without incorrectly reporting changed) if ``state`` is ``present``; and fail if ``state`` is ``absent`` (with an error message like ``modprobe: ERROR: Module nfs is builtin.``). (https://github.com/ansible/ansible/pull/37150)"

--- a/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
@@ -131,6 +131,13 @@ Noteworthy module changes
 * The ``na_ontap_cluster_peer`` module has replaced ``source_intercluster_lif`` and ``dest_intercluster_lif`` string options with
   ``source_intercluster_lifs`` and ``dest_intercluster_lifs`` list options
 
+* The ``modprobe`` module now detects kernel builtins. Previously, attempting to remove (with ``state: absent``)
+  a builtin kernel module succeeded without any error message because ``modprobe`` did not detect the module as
+  ``present``. Now, ``modprobe`` will fail if a kernel module is builtin and ``state: absent`` (with an error message
+  from the modprobe binary like ``modprobe: ERROR: Module nfs is builtin.``), and it will succeed without reporting
+  changed if ``state: present``. Any playbooks that are using ``changed_when: no`` to mask this quirk can safely
+  remove that workaround. To get the previous behavior when applying ``state: absent`` to a builtin kernel module,
+  use ``failed_when: false`` or ``ignore_errors: true`` in your playbook.
 
 Plugins
 =======

--- a/lib/ansible/modules/system/modprobe.py
+++ b/lib/ansible/modules/system/modprobe.py
@@ -83,14 +83,22 @@ def main():
 
     # Check if module is present
     try:
-        modules = open('/proc/modules')
         present = False
-        module_name = name.replace('-', '_') + ' '
-        for line in modules:
-            if line.startswith(module_name):
-                present = True
-                break
-        modules.close()
+        with open('/proc/modules') as modules:
+            module_name = name.replace('-', '_') + ' '
+            for line in modules:
+                if line.startswith(module_name):
+                    present = True
+                    break
+        if not present:
+            command = [module.get_bin_path('uname', True), '-r']
+            rc, uname_kernel_release, err = module.run_command(command)
+            module_file = '/' + name + '.ko'
+            with open('/lib/modules/' + uname_kernel_release + '/modules.builtin') as builtins:
+                for line in builtins:
+                    if line.endswith(module_file):
+                        present = True
+                        break
     except IOError as e:
         module.fail_json(msg=to_native(e), exception=traceback.format_exc(), **result)
 


### PR DESCRIPTION
Without this modprobe always reports changed when modprobe-ing a builtin module.

##### SUMMARY
This makes the modprobe module check `/usr/lib/$kernel_release/modules.builtin` to avoid reporting changed when state is `present` and the module is builtin.

When the module is builtin, it is already loaded and running modprobe can't change anything (neither adding or removing the kernel module). So, if it's builtin, this should never report changed.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
modprobe module

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```
