### PR TITLE
Add ansible-config and ansible-inventory to setup.py scripts

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -218,6 +218,8 @@ setup(
         'bin/ansible-console',
         'bin/ansible-connection',
         'bin/ansible-vault',
+        'bin/ansible-config',
+        'bin/ansible-inventory',
     ],
     data_files=[],
     extras_require=extra_requirements,


### PR DESCRIPTION
##### SUMMARY
This seems to not affect everything, but is specifically noticeable with `pip install -e`

This should be a backport candidate.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
setup.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.4
2.5
2.6
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
