### PR TITLE
In edgeos_facts, do not try to add an entry if none exist

### DIFF
--- a/lib/ansible/modules/network/edgeos/edgeos_config.py
+++ b/lib/ansible/modules/network/edgeos/edgeos_config.py
@@ -27,6 +27,9 @@ description:
     in the device configuration.
 notes:
   - Tested against EdgeOS 1.9.7
+  - Setting C(ANSIBLE_PERSISTENT_COMMAND_TIMEOUT) to 30 is recommended since
+    the save command can take longer than the default of 10 seconds on
+    some EdgeOS hardware.
 options:
   lines:
     description:

--- a/lib/ansible/modules/network/edgeos/edgeos_facts.py
+++ b/lib/ansible/modules/network/edgeos/edgeos_facts.py
@@ -170,7 +170,7 @@ class Config(FactsBase):
                              by=str(match.group(3)).strip(),
                              via=str(match.group(4)).strip(),
                              comment=None)
-            else:
+            elif entry:
                 entry['comment'] = line.strip()
 
         self.facts['commits'] = entries


### PR DESCRIPTION
##### SUMMARY
When commit revisions are disabled, there will be no revision items returned. 

Fixes #37123 

##### ISSUE TYPE
 - Bugfix Pull Request


##### COMPONENT NAME
`edgeos_config.py`

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6
```
