### PR TITLE
VMware: handle permission denied while reading facts

### DIFF
--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -307,8 +307,14 @@ def gather_vm_facts(content, vm):
 
     # facts that may or may not exist
     if vm.summary.runtime.host:
-        host = vm.summary.runtime.host
-        facts['hw_esxi_host'] = host.summary.config.name
+        try:
+            host = vm.summary.runtime.host
+            facts['hw_esxi_host'] = host.summary.config.name
+        except vim.fault.NoPermission:
+            # User does not have read permission for the host system,
+            # proceed without this value. This value does not contribute or hamper
+            # provisioning or power management operations.
+            pass
     if vm.summary.runtime.dasVmProtection:
         facts['hw_guest_ha_state'] = vm.summary.runtime.dasVmProtection.dasProtected
 


### PR DESCRIPTION
##### SUMMARY
This fix adds exception handling which is raised when user
does not have correct set of permissions/privileges to read virtual machine
facts.

Fixes: #37056

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/vmware.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6devel
```