### PR TITLE
Fix broken link to cloud utils from AWS guidelines.

### DIFF
--- a/lib/ansible/modules/cloud/amazon/GUIDELINES.md
+++ b/lib/ansible/modules/cloud/amazon/GUIDELINES.md
@@ -299,7 +299,7 @@ catch throttling exceptions to work correctly), you'd need to provide a backoff 
 and then put exception handling around the backoff function.
 
 You can use `exponential_backoff` or `jittered_backoff` strategies - see
-the [cloud module_utils](https://github.com/ansible/ansible/blob/devel/lib/ansible/module_utils/cloud.py)
+the [cloud module_utils](/lib/ansible/module_utils/cloud.py)
 and [AWS Architecture blog](https://www.awsarchitectureblog.com/2015/03/backoff.html)
 for more details.
 
@@ -508,7 +508,7 @@ available during the test run. Second putting the test in a test group causing i
 continuous integration build.
 
 Tests for new modules should be added to the same group as existing AWS tests. In general just copy
-an existing aliases file such as the [aws_s3 tests aliases file](https://github.com/ansible/ansible/blob/devel/test/integration/targets/aws_s3/aliases).
+an existing aliases file such as the [aws_s3 tests aliases file](/test/integration/targets/aws_s3/aliases).
 
 ### AWS Credentials for Integration Tests
 

--- a/lib/ansible/modules/cloud/amazon/GUIDELINES.md
+++ b/lib/ansible/modules/cloud/amazon/GUIDELINES.md
@@ -299,7 +299,7 @@ catch throttling exceptions to work correctly), you'd need to provide a backoff 
 and then put exception handling around the backoff function.
 
 You can use `exponential_backoff` or `jittered_backoff` strategies - see
-the [cloud module_utils](/tree/devel/lib/ansible/module_utils/cloud.py)
+the [cloud module_utils](https://github.com/ansible/ansible/blob/devel/lib/ansible/module_utils/cloud.py)
 and [AWS Architecture blog](https://www.awsarchitectureblog.com/2015/03/backoff.html)
 for more details.
 


### PR DESCRIPTION
##### SUMMARY
The link to module-util/cloud.py from the guidlines seems to be broken, fix the URL.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
aws

##### ANSIBLE VERSION
```
ansible 2.6.0 (docfix-broken-link-to-cloud-utils 24feaf3b44) last updated 2018/03/08 18:31:42 (GMT +1300)
  config file = None
  configured module search path = [u'USER_HOME/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = ANSIBLE_CHECKOUT/lib/ansible
  executable location = ANSIBLE_CHECKOUT/bin/ansible
  python version = 2.7.14 (default, Sep 23 2017, 22:06:14) [GCC 7.2.0]
```

