### PR TITLE
DigitalOcean: typecast map function for Python3

### DIFF
--- a/lib/ansible/modules/cloud/digital_ocean/digital_ocean.py
+++ b/lib/ansible/modules/cloud/digital_ocean/digital_ocean.py
@@ -307,7 +307,7 @@ class Droplet(JsonfyMixIn):
     @classmethod
     def list_all(cls):
         json = cls.manager.all_active_droplets()
-        return map(cls, json)
+        return [cls(j) for j in json]
 
 
 class SSH(JsonfyMixIn):
@@ -338,7 +338,7 @@ class SSH(JsonfyMixIn):
     @classmethod
     def list_all(cls):
         json = cls.manager.all_ssh_keys()
-        return map(cls, json)
+        return [cls(j) for j in json]
 
     @classmethod
     def add(cls, name, key_pub):


### PR DESCRIPTION
##### SUMMARY
In Python2, `map` returns list whereas Python3, `map` function
 returns iterator. This fix typecast map function for Python3.

Fixes: #37114

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>
(cherry picked from commit 8f3f7f104f6358a8145fbca3002ec46c5278f6a8)

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/digital_ocean/digital_ocean.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
Stable-2.5
```