### PR TITLE
Fixes #35284 - Added ability for os_nova_flavor to update existing fl…

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_nova_flavor.py
+++ b/lib/ansible/modules/cloud/openstack/os_nova_flavor.py
@@ -226,6 +226,20 @@ def main():
             module.exit_json(changed=_system_state_change(module, flavor))
 
         if state == 'present':
+            old_extra_specs = {}
+            require_update = False
+
+            if flavor:
+                old_extra_specs = flavor['extra_specs']
+                for param_key in ['ram', 'vcpus', 'disk', 'ephemeral', 'swap', 'rxtx_factor', 'is_public']:
+                    if module.params[param_key] != flavor[param_key]:
+                        require_update = True
+                        break
+
+            if flavor and require_update:
+                cloud.delete_flavor(name)
+                flavor = None
+
             if not flavor:
                 flavor = cloud.create_flavor(
                     name=name,
@@ -242,11 +256,10 @@ def main():
             else:
                 changed = False
 
-            old_extra_specs = flavor['extra_specs']
             new_extra_specs = dict([(k, str(v)) for k, v in extra_specs.items()])
-            unset_keys = set(flavor['extra_specs'].keys()) - set(extra_specs.keys())
+            unset_keys = set(old_extra_specs.keys()) - set(extra_specs.keys())
 
-            if unset_keys:
+            if unset_keys and not require_update:
                 cloud.unset_flavor_specs(flavor['id'], unset_keys)
 
             if old_extra_specs != new_extra_specs:


### PR DESCRIPTION
##### SUMMARY
Added ability for os_nova_flavor to update existing flavors. 

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
os_nova_flavor

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.3.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/arun/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.14 (default, Feb 17 2018, 10:42:17) [GCC 7.3.1 20180130 (Red Hat 7.3.1-2)]

```


##### ADDITIONAL INFORMATION
* As discussed in this [email thread ](https://groups.google.com/forum/#!topic/ansible-project/3lcvd61SvoM), if the flavor requires update, the old flavor is deleted and new one is created. 
* Since the extra_specs needs to be handled differently (not as part of other flavor parameters, as it requires unset), I had to move `old_extra_specs = flavor['extra_specs']` up before deleting the old flavor. 
* Checked the following conditions - 
  * New flavor creation
  * New flavor creation with extra specs
  * Flavor update (No extra specs in new and old) => Only flavor changed
  * Flavor update (No extra specs in new, Few extra specs in old) => Flavor updated and All extra specs gets deleted
  * Flavor update (Few extra specs in new, No extra specs in old) => Flavor updated and All extra specs gets added
  * Flavor update (M+N extra specs in new, N extra specs in old) => Flavor updated and M extra specs got added => M+N extra specs remains
  * Flavor update (N extra specs in new, M+N exra specs in old) => Flavor updated and M extra specs got removed => N extra specs remains
  * Extra specs update (M+N required, M existing) => N extra specs is added => M+N extra specs remains
  * Extra specs update (M required, M+N existing) => N extra specs is unset => M extra specs remains
  * Extra specs update (No extra specs required (in playbook) , M existing) => All extra specs deleted
  * Extra specs update (M extra specs required , None existing ) => M extra specs added


Basically, the extra_specs in the playbook is applied. If no extra_specs in playbook then the existing extra_specs will be deleted. 
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
##### Before change
```
(test) [arun@fedora flavor-test(keystone_admin)]$ nova flavor-list
+--------------------------------------+-----------------+-----------+------+-----------+------+-------+-------------+-----------+
| ID                                   | Name            | Memory_MB | Disk | Ephemeral | Swap | VCPUs | RXTX_Factor | Is_Public |
+--------------------------------------+-----------------+-----------+------+-----------+------+-------+-------------+-----------+
| 1                                    | m1.tiny         | 512       | 1    | 0         |      | 1     | 1.0         | True      |
| 2                                    | m1.small        | 2048      | 20   | 0         |      | 1     | 1.0         | True      |
| 3                                    | m1.medium       | 4096      | 40   | 0         |      | 2     | 1.0         | True      |
| 4                                    | m1.large        | 8192      | 80   | 0         |      | 4     | 1.0         | True      |
| 5                                    | m1.xlarge       | 16384     | 160  | 0         |      | 8     | 1.0         | True      |
| bebd100a-2daa-4e08-a9a1-a50a7d3abaa1 | existing_flavor | 510       | 21   | 0         |      | 55    | 1.0         | True      |
+--------------------------------------+-----------------+-----------+------+-----------+------+-------+-------------+-----------+

(test) [arun@fedora flavor-test(keystone_admin)]$ cat test.yml 
---
- hosts: localhost
  connection: local
  tasks:
    - name: Update flavor
      os_nova_flavor:
       cloud: packstack
       name: existing_flavor
       vcpus: 2
       ram: 512
       disk: 20
       ephemeral: 0
       is_public: true
       state: present
       extra_specs:
           quota:disk_read_iops_sec=5000
           quota:write_bytes_sec=10240000


(test) [arun@fedora flavor-test(keystone_admin)]$ ansible-playbook test.yml  --connection=local -vv
ansible-playbook 2.6.0 (devel ff28429e2a) last updated 2018/03/07 18:05:40 (GMT +550)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/arun/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/arun/Projects/bingoarun/flavor-test/ansible/lib/ansible
  executable location = /home/arun/Projects/bingoarun/flavor-test/ansible/bin/ansible-playbook
  python version = 2.7.14 (default, Feb 17 2018, 10:42:17) [GCC 7.3.1 20180130 (Red Hat 7.3.1-2)]
Using /etc/ansible/ansible.cfg as config file
 [WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'


PLAYBOOK: test.yml *******************************************************************************************************************************************************************************************
1 plays in test.yml

PLAY [localhost] *********************************************************************************************************************************************************************************************

TASK [Gathering Facts] ***************************************************************************************************************************************************************************************
task path: /home/arun/Projects/bingoarun/flavor-test/test.yml:2
ok: [localhost]
META: ran handlers

TASK [Update flavor] *****************************************************************************************************************************************************************************************
task path: /home/arun/Projects/bingoarun/flavor-test/test.yml:5
ok: [localhost] => {"changed": false, "flavor": {"OS-FLV-DISABLED:disabled": false, "OS-FLV-EXT-DATA:ephemeral": 0, "disk": 21, "ephemeral": 0, "extra_specs": {"quota:disk_read_iops_sec": "5000", "quota:write_bytes_sec": "10240000"}, "id": "bebd100a-2daa-4e08-a9a1-a50a7d3abaa1", "is_disabled": false, "is_public": true, "location": {"cloud": "packstack", "project": {"domain_id": null, "domain_name": "default", "id": "6ed3c427f9274406afd7a1c62e118497", "name": "admin"}, "region_name": "RegionOne", "zone": null}, "name": "existing_flavor", "os-flavor-access:is_public": true, "properties": {"OS-FLV-DISABLED:disabled": false, "OS-FLV-EXT-DATA:ephemeral": 0, "os-flavor-access:is_public": true}, "ram": 510, "rxtx_factor": 1.0, "swap": 0, "vcpus": 55}, "id": "bebd100a-2daa-4e08-a9a1-a50a7d3abaa1"}
META: ran handlers
META: ran handlers

PLAY RECAP ***************************************************************************************************************************************************************************************************
localhost                  : ok=2    changed=0    unreachable=0    failed=0   

(test) [arun@fedora flavor-test(keystone_admin)]$ 
```
Flavor changes are not getting applied

##### After change
```
(test) [arun@fedora flavor-test(keystone_admin)]$ ansible-playbook test.yml  --connection=local -vv
ansible-playbook 2.6.0 (devel ff28429e2a) last updated 2018/03/07 18:05:40 (GMT +550)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/arun/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/arun/Projects/bingoarun/flavor-test/ansible/lib/ansible
  executable location = /home/arun/Projects/bingoarun/flavor-test/ansible/bin/ansible-playbook
  python version = 2.7.14 (default, Feb 17 2018, 10:42:17) [GCC 7.3.1 20180130 (Red Hat 7.3.1-2)]
Using /etc/ansible/ansible.cfg as config file
 [WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'


PLAYBOOK: test.yml *******************************************************************************************************************************************************************************************
1 plays in test.yml

PLAY [localhost] *********************************************************************************************************************************************************************************************

TASK [Gathering Facts] ***************************************************************************************************************************************************************************************
task path: /home/arun/Projects/bingoarun/flavor-test/test.yml:2
ok: [localhost]
META: ran handlers

TASK [Update flavor] *****************************************************************************************************************************************************************************************
task path: /home/arun/Projects/bingoarun/flavor-test/test.yml:5
changed: [localhost] => {"changed": true, "flavor": {"OS-FLV-DISABLED:disabled": false, "OS-FLV-EXT-DATA:ephemeral": 0, "disk": 20, "ephemeral": 0, "extra_specs": {}, "id": "1755bc60-cdad-4d70-abb2-5059f359f5b2", "is_disabled": false, "is_public": true, "location": {"cloud": "packstack", "project": {"domain_id": null, "domain_name": "default", "id": "6ed3c427f9274406afd7a1c62e118497", "name": "admin"}, "region_name": "RegionOne", "zone": null}, "name": "existing_flavor", "os-flavor-access:is_public": true, "properties": {"OS-FLV-DISABLED:disabled": false, "OS-FLV-EXT-DATA:ephemeral": 0, "os-flavor-access:is_public": true}, "ram": 512, "rxtx_factor": 1.0, "swap": 0, "vcpus": 2}, "id": "1755bc60-cdad-4d70-abb2-5059f359f5b2"}
META: ran handlers
META: ran handlers

PLAY RECAP ***************************************************************************************************************************************************************************************************
localhost                  : ok=2    changed=1    unreachable=0    failed=0   

(test) [arun@fedora flavor-test(keystone_admin)]$ nova flavor-show existing_flavor
+----------------------------+--------------------------------------+
| Property                   | Value                                |
+----------------------------+--------------------------------------+
| OS-FLV-DISABLED:disabled   | False                                |
| OS-FLV-EXT-DATA:ephemeral  | 0                                    |
| disk                       | 20                                   |
| extra_specs                | {}                                   |
| id                         | 1755bc60-cdad-4d70-abb2-5059f359f5b2 |
| name                       | existing_flavor                      |
| os-flavor-access:is_public | True                                 |
| ram                        | 512                                  |
| rxtx_factor                | 1.0                                  |
| swap                       |                                      |
| vcpus                      | 2                                    |
+----------------------------+--------------------------------------+
(test) [arun@fedora flavor-test(keystone_admin)]$ 
```
Flavor changes are applied