### PR TITLE
yum is Python 2 only. If Python 3 use dnf (#37140)

### DIFF
--- a/lib/ansible/modules/packaging/os/yum.py
+++ b/lib/ansible/modules/packaging/os/yum.py
@@ -23,6 +23,7 @@ version_added: historical
 short_description: Manages packages with the I(yum) package manager
 description:
      - Installs, upgrade, downgrades, removes, and lists packages and groups with the I(yum) package manager.
+     - This module only works on Python 2. If you require Python 3 support see the M(dnf) module.
 options:
   name:
     description:
@@ -1295,9 +1296,9 @@ def main():
 
     error_msgs = []
     if not HAS_RPM_PYTHON:
-        error_msgs.append('python2 bindings for rpm are needed for this module')
+        error_msgs.append('The Python 2 bindings for rpm are needed for this module. If you require Python 3 support use the `dnf` Ansible module instead.')
     if not HAS_YUM_PYTHON:
-        error_msgs.append('python2 yum module is needed for this  module')
+        error_msgs.append('The Python 2 yum module is needed for this module. If you require Python 3 support use the `dnf` Ansible module instead.')
 
     if error_msgs:
         module.fail_json(msg='. '.join(error_msgs))


### PR DESCRIPTION
##### SUMMARY
* PY3 = dnf

Red Hat are unlikely to provide a Python 2 version of the yum bindings
as they are moving to `dnf`.

If Ansible can't find the yum Python library give the user a hint about
dnf and Python 3

(cherry picked from commit 6c8d40f653063a70bdb127026860b2905eadf4d2)

