### PR TITLE
[2.5] cs_instance: fix error when state destroyed but querying user_data

### DIFF
--- a/lib/ansible/modules/cloud/cloudstack/cs_instance.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_instance.py
@@ -460,7 +460,7 @@ class AnsibleCloudStackInstance(AnsibleCloudStack):
             return instance['userdata']
 
         user_data = ""
-        if self.get_user_data() is not None:
+        if self.get_user_data() is not None and instance.get('id'):
             res = self.query_api('getVirtualMachineUserData', virtualmachineid=instance['id'])
             user_data = res['virtualmachineuserdata'].get('userdata', "")
         return user_data


### PR DESCRIPTION
(cherry picked from commit 190d3fbbed19c04f207f9b0cc94efe90cfc7ec21)

##### SUMMARY
backport fix of #37143

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
cs_instance 
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
