### PR TITLE
fix nxos_switchport/l2_interface trunk_vlans state absent

### DIFF
--- a/lib/ansible/modules/network/nxos/_nxos_switchport.py
+++ b/lib/ansible/modules/network/nxos/_nxos_switchport.py
@@ -271,7 +271,7 @@ def remove_switchport_config_commands(interface, existing, proposed, module):
     elif mode == 'trunk':
         tv_check = existing.get('trunk_vlans_list') == proposed.get('trunk_vlans_list')
 
-        if not tv_check:
+        if tv_check:
             existing_vlans = existing.get('trunk_vlans_list')
             proposed_vlans = proposed.get('trunk_vlans_list')
             vlans_to_remove = set(proposed_vlans).intersection(existing_vlans)

--- a/lib/ansible/modules/network/nxos/nxos_l2_interface.py
+++ b/lib/ansible/modules/network/nxos/nxos_l2_interface.py
@@ -254,7 +254,7 @@ def remove_switchport_config_commands(name, existing, proposed, module):
     elif mode == 'trunk':
         tv_check = existing.get('trunk_vlans_list') == proposed.get('trunk_vlans_list')
 
-        if not tv_check:
+        if tv_check:
             existing_vlans = existing.get('trunk_vlans_list')
             proposed_vlans = proposed.get('trunk_vlans_list')
             vlans_to_remove = set(proposed_vlans).intersection(existing_vlans)

--- a/test/integration/targets/nxos_l2_interface/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_l2_interface/tests/common/sanity.yaml
@@ -95,7 +95,7 @@
     nxos_l2_interface: &no_tag
       name: "{{ intname }}"
       mode: trunk
-      trunk_vlans: 30-4094
+      trunk_vlans: 2-50
       state: absent
       provider: "{{ connection }}"
     register: result

--- a/test/integration/targets/nxos_switchport/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_switchport/tests/common/sanity.yaml
@@ -92,7 +92,7 @@
     nxos_switchport: &no_tag
       interface: "{{ intname }}"
       mode: trunk
-      trunk_vlans: 30-4094
+      trunk_vlans: 2-50
       state: absent
       provider: "{{ connection }}"
     register: result


### PR DESCRIPTION
Signed-off-by: Trishna Guha <trishnaguha17@gmail.com>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
fixes https://github.com/ansible/ansible/issues/37046
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
- modules/network/nxos/{_nxos_switchport,nxos_l2_interface}.py
- test/integration/targets/{_nxos_switchport,nxos_l2_interface}/tests/common/sanity
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel, 2.5
```