### PR TITLE
Add test to cover network module command timeout scenario

### DIFF
--- a/test/integration/targets/ios_command/tests/cli/timeout.yaml
+++ b/test/integration/targets/ios_command/tests/cli/timeout.yaml
@@ -16,4 +16,17 @@
       - "result.failed == true"
       - "result.msg is defined"
 
+
+- name: test command timeout scenario
+  ios_command:
+    commands:
+      - command: 'clear counters GigabitEthernet0/2'
+    provider: "{{ cli }}"
+  register: result
+  ignore_errors: yes
+
+- assert:
+    that:
+      - "result.failed == true"
+
 - debug: msg="END cli/timeout.yaml on connection={{ ansible_connection }}"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Add tests to cover network command timeout scenario
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Test Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
ios_command/tests/cli/timeout.yaml

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
