### PR TITLE
modules: zypper: Optimize the 'search' subcommand

### DIFF
--- a/lib/ansible/modules/packaging/os/zypper.py
+++ b/lib/ansible/modules/packaging/os/zypper.py
@@ -313,6 +313,9 @@ def get_cmd(m, subcommand):
     if (is_install or is_refresh) and m.params['disable_gpg_check']:
         cmd.append('--no-gpg-checks')
 
+    if subcommand == 'search':
+        cmd.append('--disable-repositories')
+
     cmd.append(subcommand)
     if subcommand not in ['patch', 'dist-upgrade'] and not is_refresh:
         cmd.extend(['--type', m.params['type']])


### PR DESCRIPTION
When looking for installed packages we do not need to query
repositories since we only care about the rpmdb. As such, we can
disable all the repositories operations in order to improve the
performance of that step

Before this patch, when using 'state: present' in the zypper module,
the operation was taking about 12 seconds to complete:

time ansible-playbook foo.yml 1>/dev/null

real	0m12.614s
user	0m10.880s
sys	0m0.683s

After this patch:

time ansible-playbook foo.yml 1>/dev/null

real	0m4.193s
user	0m2.560s
sys	0m0.575s

see:
https://bugzilla.opensuse.org/show_bug.cgi?id=1084525

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - New Module Pull Request
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
