### PR TITLE
Documentation/default fix for keycloak modules

### DIFF
--- a/lib/ansible/module_utils/keycloak.py
+++ b/lib/ansible/module_utils/keycloak.py
@@ -53,7 +53,7 @@ def keycloak_argument_spec():
     """
     return dict(
         auth_keycloak_url=dict(type='str', aliases=['url'], required=True),
-        auth_client_id=dict(type='str'),
+        auth_client_id=dict(type='str', default='admin-cli'),
         auth_realm=dict(type='str', required=True),
         auth_client_secret=dict(type='str', default=None),
         auth_username=dict(type='str', aliases=['username'], required=True),

--- a/lib/ansible/module_utils/keycloak.py
+++ b/lib/ansible/module_utils/keycloak.py
@@ -53,7 +53,7 @@ def keycloak_argument_spec():
     """
     return dict(
         auth_keycloak_url=dict(type='str', aliases=['url'], required=True),
-        auth_client_id=dict(type='str', default='admin-cli'),
+        auth_client_id=dict(type='str'),
         auth_realm=dict(type='str', required=True),
         auth_client_secret=dict(type='str', default=None),
         auth_username=dict(type='str', aliases=['username'], required=True),

--- a/lib/ansible/utils/module_docs_fragments/keycloak.py
+++ b/lib/ansible/utils/module_docs_fragments/keycloak.py
@@ -31,6 +31,7 @@ options:
     auth_client_id:
         description:
             - OpenID Connect I(client_id) to authenticate to the API with.
+        default: admin-cli
         required: true
 
     auth_realm:

--- a/lib/ansible/utils/module_docs_fragments/keycloak.py
+++ b/lib/ansible/utils/module_docs_fragments/keycloak.py
@@ -60,4 +60,5 @@ options:
         description:
             - Verify TLS certificates (do not disable this in production).
         default: True
+        type: bool
 '''


### PR DESCRIPTION
##### SUMMARY
This PR fixes two issues uncovered by recent new CI tests -- namely that validate_certs was not specified as bool in documentation and that auth_client_id had an undocumented default. 

This is required for #35558, #35844, and #35637 to pass CI again :)

##### ISSUE TYPE
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
keycloak

##### ANSIBLE VERSION
ansible 2.6.0
