### PR TITLE
state: present added in docs

### DIFF
--- a/lib/ansible/modules/cloud/atomic/atomic_container.py
+++ b/lib/ansible/modules/cloud/atomic/atomic_container.py
@@ -48,7 +48,7 @@ options:
         description:
           - State of the container
         required: True
-        choices: ["latest", "absent", "rollback"]
+        choices: ["latest", "present", "absent", "rollback"]
         default: "latest"
     mode:
         description:

--- a/test/sanity/validate-modules/ignore.txt
+++ b/test/sanity/validate-modules/ignore.txt
@@ -139,7 +139,6 @@ lib/ansible/modules/cloud/amazon/s3_website.py E324
 lib/ansible/modules/cloud/amazon/sns_topic.py E325
 lib/ansible/modules/cloud/amazon/sts_assume_role.py E317
 lib/ansible/modules/cloud/atomic/atomic_container.py E317
-lib/ansible/modules/cloud/atomic/atomic_container.py E326
 lib/ansible/modules/cloud/azure/_azure.py E324
 lib/ansible/modules/cloud/azure/_azure.py E326
 lib/ansible/modules/cloud/centurylink/clc_alert_policy.py E317


### PR DESCRIPTION
'Present' was not in the docs, though it is in the code.
2.4 documentation shows 2 entries of "latest" instead of "present" so perhaps this could backport to 2.4 as well as being in devel.

##### SUMMARY
'Present' was not in the docs, though it is in the code.
2.4 documentation shows 2 entries of "latest" instead of "present" so perhaps this could backport to 2.4 as well as being in devel.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
atomic_container

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.2.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, May  3 2017, 07:55:04) [GCC 4.8.5 20150623 (Red Hat 4.8.5-14)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
n/a .. purely documentation to serve code.
