### PR TITLE
Added parameters to na_cdot_volume

### DIFF
--- a/lib/ansible/modules/storage/netapp/na_cdot_volume.py
+++ b/lib/ansible/modules/storage/netapp/na_cdot_volume.py
@@ -82,7 +82,7 @@ options:
     required: false
     default: default
     version_added: '2.6'
-    
+
   snapshot_policy:
     description:
     - Snapshot policy to set for the specified volume.
@@ -259,7 +259,7 @@ class NetAppCDOTVolume(object):
         create_parameters = {'volume': self.name,
                              'containing-aggr-name': self.aggregate_name,
                              'size': str(self.size),
-        }
+                             }
         if self.junction_path:
             create_parameters['junction-path'] = str(self.junction_path)
         if self.export_policy != 'default':

--- a/lib/ansible/modules/storage/netapp/na_cdot_volume.py
+++ b/lib/ansible/modules/storage/netapp/na_cdot_volume.py
@@ -69,23 +69,26 @@ options:
     - Name of the vserver to use.
     required: true
     default: None
-    
+
   junction_path:
     description:
     - Junction path where to mount the volume
     required: false
+    version_added: '2.6'
 
   export_policy:
     description:
     - Export policy to set for the specified junction path.
     required: false
     default: default
+    version_added: '2.6'
     
   snapshot_policy:
     description:
     - Snapshot policy to set for the specified volume.
     required: false
-    default: default    
+    default: default
+    version_added: '2.6'
 
 '''
 
@@ -188,7 +191,7 @@ class NetAppCDOTVolume(object):
         self.junction_path = p['junction_path']
         self.export_policy = p['export_policy']
         self.snapshot_policy = p['snapshot_policy']
-    	
+
         if p['size'] is not None:
             self.size = p['size'] * self._size_unit_map[self.size_unit]
         else:
@@ -256,15 +259,14 @@ class NetAppCDOTVolume(object):
         create_parameters = {'volume': self.name,
                              'containing-aggr-name': self.aggregate_name,
                              'size': str(self.size),
-                            }
+        }
         if self.junction_path:
             create_parameters['junction-path'] = str(self.junction_path)
-        if self.export_policy != 'default':    
+        if self.export_policy != 'default':
             create_parameters['export-policy'] = str(self.export_policy)
-        if self.snapshot_policy != 'default':    
+        if self.snapshot_policy != 'default':
             create_parameters['snapshot-policy'] = str(self.snapshot_policy)
-            
-                                
+
         volume_create = netapp_utils.zapi.NaElement.create_node_with_children(
             'volume-create', **create_parameters)
 

--- a/lib/ansible/modules/storage/netapp/na_cdot_volume.py
+++ b/lib/ansible/modules/storage/netapp/na_cdot_volume.py
@@ -69,6 +69,23 @@ options:
     - Name of the vserver to use.
     required: true
     default: None
+    
+  junction_path:
+    description:
+    - Junction path where to mount the volume
+    required: false
+
+  export_policy:
+    description:
+    - Export policy to set for the specified junction path.
+    required: false
+    default: default
+    
+  snapshot_policy:
+    description:
+    - Snapshot policy to set for the specified volume.
+    required: false
+    default: default    
 
 '''
 
@@ -86,6 +103,9 @@ EXAMPLES = """
         hostname: "{{ netapp_hostname }}"
         username: "{{ netapp_username }}"
         password: "{{ netapp_password }}"
+        junction_path: /ansibleVolume
+        export_policy: all_nfs_networks
+        snapshot_policy: daily
 
     - name: Make FlexVol offline
       na_cdot_volume:
@@ -143,6 +163,9 @@ class NetAppCDOTVolume(object):
                                     'pb', 'eb', 'zb', 'yb'], type='str'),
             aggregate_name=dict(type='str'),
             vserver=dict(required=True, type='str', default=None),
+            junction_path=dict(required=False, type='str', default=None),
+            export_policy=dict(required=False, type='str', default='default'),
+            snapshot_policy=dict(required=False, type='str', default='default'),
         ))
 
         self.module = AnsibleModule(
@@ -162,7 +185,10 @@ class NetAppCDOTVolume(object):
         self.is_online = p['is_online']
         self.size_unit = p['size_unit']
         self.vserver = p['vserver']
-
+        self.junction_path = p['junction_path']
+        self.export_policy = p['export_policy']
+        self.snapshot_policy = p['snapshot_policy']
+    	
         if p['size'] is not None:
             self.size = p['size'] * self._size_unit_map[self.size_unit]
         else:
@@ -227,10 +253,20 @@ class NetAppCDOTVolume(object):
         return return_value
 
     def create_volume(self):
+        create_parameters = {'volume': self.name,
+                             'containing-aggr-name': self.aggregate_name,
+                             'size': str(self.size),
+                            }
+        if self.junction_path:
+            create_parameters['junction-path'] = str(self.junction_path)
+        if self.export_policy != 'default':    
+            create_parameters['export-policy'] = str(self.export_policy)
+        if self.snapshot_policy != 'default':    
+            create_parameters['snapshot-policy'] = str(self.snapshot_policy)
+            
+                                
         volume_create = netapp_utils.zapi.NaElement.create_node_with_children(
-            'volume-create', **{'volume': self.name,
-                                'containing-aggr-name': self.aggregate_name,
-                                'size': str(self.size)})
+            'volume-create', **create_parameters)
 
         try:
             self.server.invoke_successfully(volume_create,


### PR DESCRIPTION

##### SUMMARY
Before this change there were no parameter for creating a volume
and at the same time also exporting it as NFS volume. 

The added parameters are:
- **junction-path** for specifying where to mount the volume in the namespace
- **export-policy** for specifying which export policy to apply to the given namespace
- **snapshot-policy** if required, applying a snapshot policy for scheduling data protection tasks


##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
na_cdot_volume
##### ANSIBLE VERSION
```
ansible 2.4.3.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/remixtj/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]

```


##### ADDITIONAL INFORMATION

