### PR TITLE
Fixing module docs so they dont show up as a list on ansible docs.

### DIFF
--- a/lib/ansible/modules/network/panos/panos_nat_rule.py
+++ b/lib/ansible/modules/network/panos/panos_nat_rule.py
@@ -11,7 +11,7 @@ DOCUMENTATION = '''
 ---
 module: panos_nat_rule
 short_description: create a policy NAT rule
-description: >
+description:
     - Create a policy nat rule. Keep in mind that we can either end up configuring source NAT, destination NAT, or
     both. Instead of splitting it into two we will make a fair attempt to determine which one the user wants.
 author: "Luigi Mori (@jtschichold), Ivan Bojer (@ivanbojer), Robert Hagen (@rnh556)"

--- a/lib/ansible/modules/network/panos/panos_nat_rule.py
+++ b/lib/ansible/modules/network/panos/panos_nat_rule.py
@@ -13,7 +13,7 @@ module: panos_nat_rule
 short_description: create a policy NAT rule
 description:
     - Create a policy nat rule. Keep in mind that we can either end up configuring source NAT, destination NAT, or
-    both. Instead of splitting it into two we will make a fair attempt to determine which one the user wants.
+      both. Instead of splitting it into two we will make a fair attempt to determine which one the user wants.
 author: "Luigi Mori (@jtschichold), Ivan Bojer (@ivanbojer), Robert Hagen (@rnh556)"
 version_added: "2.4"
 requirements:

--- a/lib/ansible/modules/network/panos/panos_object.py
+++ b/lib/ansible/modules/network/panos/panos_object.py
@@ -28,7 +28,7 @@ DOCUMENTATION = '''
 ---
 module: panos_object
 short_description: create/read/update/delete object in PAN-OS or Panorama
-description: >
+description:
     - Policy objects form the match criteria for policy rules and many other functions in PAN-OS. These may include
     address object, address groups, service objects, service groups, and tag.
 author: "Bob Hagen (@rnh556)"

--- a/lib/ansible/modules/network/panos/panos_object.py
+++ b/lib/ansible/modules/network/panos/panos_object.py
@@ -30,7 +30,7 @@ module: panos_object
 short_description: create/read/update/delete object in PAN-OS or Panorama
 description:
     - Policy objects form the match criteria for policy rules and many other functions in PAN-OS. These may include
-    address object, address groups, service objects, service groups, and tag.
+      address object, address groups, service objects, service groups, and tag.
 author: "Bob Hagen (@rnh556)"
 version_added: "2.4"
 requirements:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
The docs for these 2 modules showed every character as a list on http://docs.ansible.com/
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
panos_nat_rule, panos_object
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.4 (panos_docs 878030c073) last updated 2018/03/08 08:54:32 (GMT -700)
  config file = None
  configured module search path = [u'/Users/james/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/james/Documents/git/ansible/lib/ansible
  executable location = /Users/james/Documents/git/ansible/bin/ansible
  python version = 2.7.14 (default, Feb  6 2018, 20:04:00) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```


