### PR TITLE
Restore skipped/failed in JSON callback, add custom facts

### DIFF
--- a/lib/ansible/plugins/callback/json.py
+++ b/lib/ansible/plugins/callback/json.py
@@ -33,7 +33,6 @@ import json
 
 from functools import partial
 
-from ansible import constants as C
 from ansible.inventory.host import Host
 
 from ansible.plugins.callback import CallbackBase

--- a/lib/ansible/plugins/callback/json.py
+++ b/lib/ansible/plugins/callback/json.py
@@ -17,6 +17,7 @@ DOCUMENTATION = '''
       - Set as stdout in config
     options:
       show_custom_stats:
+        version_added: "2.6"
         name: Show custom stats
         description: 'This adds the custom stats set via the set_stats plugin to the play recap'
         default: False

--- a/lib/ansible/plugins/callback/json.py
+++ b/lib/ansible/plugins/callback/json.py
@@ -91,7 +91,7 @@ class CallbackModule(CallbackBase):
             summary[h] = s
 
         custom_stats = {}
-        if self._plugin_options.get('show_custom_stats', C.SHOW_CUSTOM_STATS) and stats.custom:  # fallback on constants for inherited plugins missing docs
+        if self.get_option('show_custom_stats') and stats.custom:
             custom_stats.update(dict((self._convert_host_to_name(k), v) for k, v in stats.custom.items()))
             custom_stats.pop('_run', None)
 


### PR DESCRIPTION
##### SUMMARY

This PR addresses 2 issues:

1. Restore skipped/failed keys. Fixes #37050
2. Display custom stats. Fixes #37184

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/callback/json.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```