### PR TITLE
added parameter for allowing prerelease packages in win_chocolatey fo…

### DIFF
--- a/lib/ansible/modules/windows/win_chocolatey.ps1
+++ b/lib/ansible/modules/windows/win_chocolatey.ps1
@@ -30,13 +30,14 @@ $packageparams = Get-AnsibleParam -obj $params -name "params" -type "str"
 $allowemptychecksums = Get-AnsibleParam -obj $params -name "allow_empty_checksums" -type "bool" -default $false
 $ignorechecksums = Get-AnsibleParam -obj $params -name "ignore_checksums" -type "bool" -default $false
 $ignoredependencies = Get-AnsibleParam -obj $params -name "ignore_dependencies" -type "bool" -default $false
+$allowprerelease = Get-AnsibleParam -obj $params -name "allow_prerelease" -type "bool" -default $false
 $skipscripts = Get-AnsibleParam -obj $params -name "skip_scripts" -type "bool" -default $false
 $proxy_url = Get-AnsibleParam -obj $params -name "proxy_url" -type "str"
 $proxy_username = Get-AnsibleParam -obj $params -name "proxy_username" -type "str"
 $proxy_password = Get-AnsibleParam -obj $params -name "proxy_password" -type "str" -failifempty ($proxy_username -ne $null)
 
 $result = @{
-    changed = $false
+    changed = $false 
 }
 
 if ($upgrade)
@@ -194,6 +195,7 @@ Function Choco-Upgrade
         [bool] $ignorechecksums,
         [bool] $ignoredependencies,
         [bool] $allowdowngrade,
+        [bool] $allowprerelease,
         [string] $proxy_url,
         [string] $proxy_username,
         [string] $proxy_password
@@ -261,6 +263,11 @@ Function Choco-Upgrade
         $options += "--allow-downgrade"
     }
 
+    if ($allowprerelease)
+    {
+        $options += "--prerelease"
+    }
+
     if ($proxy_url)
     {
         $options += "--proxy=`"'$proxy_url'`""
@@ -326,6 +333,7 @@ Function Choco-Install
         [bool] $ignorechecksums,
         [bool] $ignoredependencies,
         [bool] $allowdowngrade,
+        [bool] $allowprerelease,
         [string] $proxy_url,
         [string] $proxy_username,
         [string] $proxy_password
@@ -340,7 +348,8 @@ Function Choco-Install
                 -packageparams $packageparams -allowemptychecksums $allowemptychecksums `
                 -ignorechecksums $ignorechecksums -ignoredependencies $ignoredependencies `
                 -allowdowngrade $allowdowngrade -proxy_url $proxy_url `
-                -proxy_username $proxy_username -proxy_password $proxy_password
+                -proxy_username $proxy_username -proxy_password $proxy_password `
+                -allowprerelease $allowprerelease
             return
         }
         elseif (-not $force)
@@ -384,6 +393,11 @@ Function Choco-Install
     if ($allowemptychecksums)
     {
         $options += "--allow-empty-checksums"
+    }
+
+    if ($allowprerelease)
+    {
+        $options += "--prerelease"
     }
 
     if ($ignorechecksums)
@@ -529,7 +543,8 @@ if ($state -in ("downgrade", "latest", "present", "reinstalled")) {
         -packageparams $packageparams -allowemptychecksums $allowemptychecksums `
         -ignorechecksums $ignorechecksums -ignoredependencies $ignoredependencies `
         -allowdowngrade ($state -eq "downgrade") -proxy_url $proxy_url `
-        -proxy_username $proxy_username -proxy_password $proxy_password
+        -proxy_username $proxy_username -proxy_password $proxy_password `
+        -allowprerelease $allowprerelease
 }
 
 Exit-Json -obj $result

--- a/lib/ansible/modules/windows/win_chocolatey.py
+++ b/lib/ansible/modules/windows/win_chocolatey.py
@@ -111,6 +111,13 @@ options:
       - See notes in C(proxy_username) when dealing with double quotes in a
         password.
     version_added: '2.4'
+  allow_prerelease:
+    description:
+      - Allow install of prerelease packages.
+      - If state C(state) is C(latest) the highest prerelease package will be installed.
+    type: bool
+    default: 'no'
+    version_added: '2.6'
 notes:
 - Provide the C(version) parameter value as a string (e.g. C('6.1')), otherwise it
   is considered to be a floating-point number and depending on the locale could


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Support `--prerelease` flag for installing prerelease Chocolatey packages. 
Fixes #33243
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
win_chocolatey
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible --version
ansible 2.6.0 (devel 02999b77a4) last updated 2018/03/08 14:34:37 (GMT +000)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/ubuntu/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /vagrant/ansible/lib/ansible
  executable location = /vagrant/ansible/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before this change, installation of package fails if only prerelease package is available in the feed.
Now picks the prerelease package. If stable package is installed, `state=latest` and `prerelease=yes`:
```
 "stdout_lines": [
        "Chocolatey v0.10.8",
        "Upgrading the following packages:",
        "dips-dbupgrade",
        "By upgrading you accept licenses for the packages.",
        "",
        "You have dips-dbupgrade v2.4.0 installed. Version 16.0.1-build0001 is available based on your source(s).",
        "[NuGet] Attempting to resolve dependency 'dips-dwdba (≥ 10.0.1)'.",
        "[NuGet] Uninstalling 'dips-dbupgrade 2.4.0'.",
        "[NuGet] Successfully uninstalled 'dips-dbupgrade 2.4.0'.",
        "[NuGet] Installing 'dips-dbupgrade 16.0.1-build0001'.",
        "[NuGet] Successfully installed 'dips-dbupgrade 16.0.1-build0001'.",
        "",
```
