### PR TITLE
Support recursive suboptions schema

### DIFF
--- a/test/runner/requirements/constraints.txt
+++ b/test/runner/requirements/constraints.txt
@@ -15,3 +15,4 @@ pytest < 3.3.0 ; python_version < '2.7' # pytest 3.3.0 drops support for python 
 ntlm-auth >= 1.0.6 # message encryption support
 requests-ntlm >= 1.1.0 # message encryption support
 requests-credssp >= 0.1.0 # message encryption support
+voluptuous >= 0.11.0 # Schema recursion via Self

--- a/test/sanity/validate-modules/schema.py
+++ b/test/sanity/validate-modules/schema.py
@@ -173,6 +173,5 @@ def metadata_1_1_schema(deprecated):
 # 1) Don't allow empty options for choices, aliases, etc
 # 2) If type: bool ensure choices isn't set - perhaps use Exclusive
 # 3) both version_added should be quoted floats
-# 4) Use Recursive Schema via `Self`, see `suboption_schema` above
 
 #  Tool that takes JSON and generates RETURN skeleton (needs to support complex structures)

--- a/test/sanity/validate-modules/schema.py
+++ b/test/sanity/validate-modules/schema.py
@@ -16,7 +16,7 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from voluptuous import PREVENT_EXTRA, Any, Required, Schema
+from voluptuous import PREVENT_EXTRA, Any, Required, Schema, Self
 from ansible.module_utils.six import string_types
 list_string_types = list(string_types)
 
@@ -29,7 +29,9 @@ suboption_schema = Schema(
         'version_added': Any(float, *string_types),
         'default': Any(None, float, int, bool, list, dict, *string_types),
         # Note: Types are strings, not literal bools, such as True or False
-        'type': Any(None, "bool")
+        'type': Any(None, "bool"),
+        # Recursive suboptions
+        'suboptions': Any(None, *list({str_type: Self} for str_type in string_types)),
     },
     extra=PREVENT_EXTRA
 )
@@ -171,6 +173,6 @@ def metadata_1_1_schema(deprecated):
 # 1) Don't allow empty options for choices, aliases, etc
 # 2) If type: bool ensure choices isn't set - perhaps use Exclusive
 # 3) both version_added should be quoted floats
-# 4) Use Recursive Schema: https://github.com/alecthomas/voluptuous/issues/128 though don't allow two layers
+# 4) Use Recursive Schema via `Self`, see `suboption_schema` above
 
 #  Tool that takes JSON and generates RETURN skeleton (needs to support complex structures)


### PR DESCRIPTION
##### SUMMARY

`argument_spec` allows "recursive" options, the documentation should allow recursive `suboptions`.

This requires voluptuous>=0.11.0

See https://github.com/ansible/ansible/pull/37196

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
test/sanity/validate-modules/schema.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```

##### ADDITIONAL INFORMATION
Before:

```
ansible/lib/ansible/modules/network/fortios/fortios_webfilter.py:0:0: E305 DOCUMENTATION.options.webfilter_url.suboptions.entries.suboptions: extra keys not allowed @ data['options']['webfilter_url']['suboptions']['entries']['suboptions']. Got {'id': {'description': ['Id of URL.'], 'required': True, 'type': 'integer'}, 'url': {'description': ['URL to be filtered.'], 'required': True}, 'type': {'description': ['Filter type (simple, regex, or wildcard).'], 'required': True, 'choices': ['simple', 'regex', 'wildcard']}, 'action': {'description': ['Action to take for URL filter matches.'], 'required': True, 'choices': ['exempt', 'block', 'allow', 'monitor']}, 'status': {'description': ['Enable/disable this URL filter.'], 'required': Tru...
ansible/lib/ansible/modules/network/fortios/fortios_webfilter.py:0:0: E305 DOCUMENTATION.options.webfilter_content.suboptions.entries.suboptions: extra keys not allowed @ data['options']['webfilter_content']['suboptions']['entries']['suboptions']. Got {'name': {'description': ['Banned word.'], 'required': True}, 'pattern-type': {'description': [{'Banned word pattern type': 'wildcard pattern or Perl regular expression.'}], 'required': True, 'choices': ['wildcard', 'regexp']}, 'status': {'description': ['Enable/disable banned word.'], 'required': True, 'choices': ['enable', 'disable']}, 'lang': {'description': ['Language of banned word.'], 'required': True, 'choices': ['western', 'simch', 'trach', 'japanese', 'korean', 'french', 'thai', 'spa...
```

After:

```
ansible/lib/ansible/modules/network/fortios/fortios_webfilter.py:0:0: E305 DOCUMENTATION.options.webfilter_url.suboptions.entries.suboptions.id.type: not a valid value for dictionary value @ data['options']['webfilter_url']['suboptions']['entries']['suboptions']['id']['type']. Got 'integer'
ansible/lib/ansible/modules/network/fortios/fortios_webfilter.py:0:0: E305 DOCUMENTATION.options.webfilter_content.suboptions.entries.suboptions.pattern-type.description.0: expected str @ data['options']['webfilter_content']['suboptions']['entries']['suboptions']['pattern-type']['description'][0]. Got {'Banned word pattern type': 'wildcard pattern or Perl regular expression.'}
```