### PR TITLE
added junos_smoke tests

### DIFF
--- a/test/integration/targets/junos_smoke/defaults/main.yaml
+++ b/test/integration/targets/junos_smoke/defaults/main.yaml
@@ -1,0 +1,3 @@
+---
+testcase: "*"
+test_items: []

--- a/test/integration/targets/junos_smoke/meta/main.yml
+++ b/test/integration/targets/junos_smoke/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_junos_tests

--- a/test/integration/targets/junos_smoke/tasks/main.yaml
+++ b/test/integration/targets/junos_smoke/tasks/main.yaml
@@ -1,0 +1,2 @@
+---
+- { include: netconf.yaml, tags: ['netconf'] }

--- a/test/integration/targets/junos_smoke/tasks/netconf.yaml
+++ b/test/integration/targets/junos_smoke/tasks/netconf.yaml
@@ -1,0 +1,21 @@
+- name: collect netconf test cases
+  find:
+    paths: "{{ role_path }}/tests/netconf"
+    patterns: "{{ testcase }}.yaml"
+  connection: local
+  register: test_cases
+
+- name: set test_items
+  set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
+
+- name: run test case (connection=netconf)
+  include: "{{ test_case_to_run }} ansible_connection=netconf"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test case (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run

--- a/test/integration/targets/junos_smoke/tests/netconf/common_utils.yaml
+++ b/test/integration/targets/junos_smoke/tests/netconf/common_utils.yaml
@@ -1,0 +1,56 @@
+---
+  # junos interface -> remove_default_spec() conditional()
+  - debug: msg="START junos_interface netconf/common_utils.yaml on connection={{ ansible_connection }}"
+
+  - name: get facts
+    junos_facts:
+      provider: "{{ netconf }}"
+    register: result
+
+
+  - name: Define interface name for vSRX
+    set_fact:
+      intf_name: pp0
+    when: result['ansible_facts']['ansible_net_model']  is search("vSRX*")
+
+  - name: Define interface name for vsrx
+    set_fact:
+      intf_name: pp0
+    when: result['ansible_facts']['ansible_net_model']  is search("vsrx")
+
+  - name: Define interface name for vQFX
+    set_fact:
+      intf_name: gr-0/0/0
+    when: result['ansible_facts']['ansible_net_model']  is search("vqfx*")
+
+  - name: Check intent arguments
+    junos_interface:
+      name: "{{ intf_name }}"
+      state: up
+      tx_rate: ge(0)
+      rx_rate: le(0)
+      provider: "{{ netconf }}"
+    register: result
+
+  - assert:
+      that:
+        - "result.failed == false"
+
+  - name: Check intent arguments (failed condition)
+    junos_interface:
+      name: "{{ intf_name }}"
+      state: down
+      tx_rate: gt(0)
+      rx_rate: lt(0)
+      provider: "{{ netconf }}"
+    ignore_errors: yes
+    register: result
+
+  - assert:
+      that:
+        - "result.failed == true"
+        - "'state eq(down)' in result.failed_conditions"
+        - "'tx_rate gt(0)' in result.failed_conditions"
+        - "'rx_rate lt(0)' in result.failed_conditions"
+
+  - debug: msg="END junos_interface netconf/common_utils.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/junos_smoke/tests/netconf/module_utils_junos.yaml
+++ b/test/integration/targets/junos_smoke/tests/netconf/module_utils_junos.yaml
@@ -43,18 +43,18 @@
       - "'<message>this is my login banner</message>' in config.xml"
 
 # hit discard_changes()
-# - name: check mode
-#   junos_banner:
-#     banner: login
-#     text: this is not the banner you're looking for
-#     state: present
-#     provider: "{{ netconf }}"
-#   register: result
-#   check_mode: yes
-#
-# - assert:
-#     that:
-#       - result.changed == false
+- name: check mode
+  junos_banner:
+    banner: login
+    text: this is not the banner you're looking for
+    state: present
+    provider: "{{ netconf }}"
+  register: result
+  check_mode: yes
+
+- assert:
+    that:
+      - result.changed == false
 
 
 # hit field_top in map_obj_to_ele

--- a/test/integration/targets/junos_smoke/tests/netconf/module_utils_junos.yaml
+++ b/test/integration/targets/junos_smoke/tests/netconf/module_utils_junos.yaml
@@ -54,7 +54,8 @@
 
 - assert:
     that:
-      - result.changed == false
+      - "result.changed == true"
+      - "result.failed == false"
 
 
 # hit field_top in map_obj_to_ele

--- a/test/integration/targets/junos_smoke/tests/netconf/module_utils_junos.yaml
+++ b/test/integration/targets/junos_smoke/tests/netconf/module_utils_junos.yaml
@@ -1,0 +1,98 @@
+---
+- debug: msg="START netconf/module_utils_junos.yaml on connection={{ ansible_connection }}"
+
+# hit get_capabilities()
+
+- name: get output for single command
+  junos_command:
+    commands: ['show version']
+    format: json
+    provider: "{{ netconf }}"
+  register: result
+
+- assert:
+    that:
+      - "result.changed == false"
+      - "result.stdout is defined"
+      - "result.stdout_lines is defined"
+
+# hit commit_configuration()
+- name: setup - remove login banner
+  junos_banner:
+    banner: login
+    state: absent
+    provider: "{{ netconf }}"
+
+- name: Create login banner
+  junos_banner:
+    banner: login
+    text: this is my login banner
+    state: present
+    provider: "{{ netconf }}"
+  register: result
+
+- name: Get running configuration
+  junos_rpc:
+    rpc: get-configuration
+    provider: "{{ netconf }}"
+  register: config
+
+- assert:
+    that:
+      - "result.changed == true"
+      - "'<message>this is my login banner</message>' in config.xml"
+
+# hit discard_changes()
+# - name: check mode
+#   junos_banner:
+#     banner: login
+#     text: this is not the banner you're looking for
+#     state: present
+#     provider: "{{ netconf }}"
+#   register: result
+#   check_mode: yes
+#
+# - assert:
+#     that:
+#       - result.changed == false
+
+
+# hit field_top in map_obj_to_ele
+- name: setup - remove interface address
+  net_l3_interface:
+    name: ge-0/0/1
+    ipv4: 1.1.1.1
+    ipv6: fd5d:12c9:2201:1::1
+    state: absent
+    provider: "{{ netconf }}"
+
+- name: Configure interface address using platform agnostic module
+  net_l3_interface:
+    name: ge-0/0/1
+    ipv4: 1.1.1.1
+    ipv6: fd5d:12c9:2201:1::1
+    state: present
+    provider: "{{ netconf }}"
+  register: result
+
+- name: Get running configuration
+  junos_rpc:
+    rpc: get-configuration
+    provider: "{{ netconf }}"
+  register: config
+
+- assert:
+    that:
+      - "result.changed == true"
+      - "'<name>1.1.1.1/32</name>' in config.xml"
+      - "'<name>fd5d:12c9:2201:1::1/128</name>' in config.xml"
+      - result.diff.prepared is search("\+ *address 1.1.1.1/32")
+      - result.diff.prepared is search("\+ *address fd5d:12c9:2201:1::1/128")
+
+- name: teardown - remove interface address
+  net_l3_interface:
+    name: ge-0/0/1
+    ipv4: 1.1.1.1
+    ipv6: fd5d:12c9:2201:1::1
+    state: absent
+    provider: "{{ netconf }}"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Adds junos_smoke tests
Covers:

module_utils:
- network.common.utils
- network.common.config
- network.junos

plugins:
- plugins.action.junos
- plugins. cliconf.junos
- plugins.terminal.junos
- plugins.netconf.junos

Coverage results:
https://newswangerd.github.io/junos/
*Note, coverage results are for an older commit in stable-2.5 because of #37530

cliconf.junos.py is mostly untested because the only modules which support cliconf are junos_command and junos_netconf.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Test pull request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->


##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0 (junos_smoke 263b5b99de) last updated 2018/03/08 15:26:48 (GMT -400)
  config file = None
  configured module search path = [u'/Users/david/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/david/code/ansible/lib/ansible
  executable location = /Users/david/code/ansible/bin/ansible
  python version = 2.7.10 (default, Jul 15 2017, 17:16:57) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.31)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
