### PR TITLE
Fixing module docs so they dont show up as a list on ansible docs.

### DIFF
--- a/lib/ansible/modules/network/panos/panos_nat_rule.py
+++ b/lib/ansible/modules/network/panos/panos_nat_rule.py
@@ -11,9 +11,9 @@ DOCUMENTATION = '''
 ---
 module: panos_nat_rule
 short_description: create a policy NAT rule
-description: >
+description:
     - Create a policy nat rule. Keep in mind that we can either end up configuring source NAT, destination NAT, or
-    both. Instead of splitting it into two we will make a fair attempt to determine which one the user wants.
+      both. Instead of splitting it into two we will make a fair attempt to determine which one the user wants.
 author: "Luigi Mori (@jtschichold), Ivan Bojer (@ivanbojer), Robert Hagen (@rnh556)"
 version_added: "2.4"
 requirements:


### PR DESCRIPTION
#37203

* Fixing module docs so they dont show up as a list on ansible docs.

* Fixing spacing in description.

(cherry picked from commit df0f9d1d913e5c10c6694b4385592de025d7bbb4)

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
two panos modules

##### ANSIBLE VERSION
2.5.0