### PR TITLE
copy action/module docs: don't use ansbile_managed

### DIFF
--- a/lib/ansible/modules/files/copy.py
+++ b/lib/ansible/modules/files/copy.py
@@ -33,7 +33,10 @@ options:
   content:
     description:
       - When used instead of I(src), sets the contents of a file directly to the specified value.
-        For anything advanced or with formatting also look at the template module.
+        For anything advanced or with formatting also look at the M(template) module. For example,
+        You must use the template module to use advanced variables like 'ansible_managed'.
+        Templating of vars happens before the copy module can do anything with them, so such
+        special vars are simply not available here.
     version_added: "1.1"
   dest:
     description:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
The copy module cannot support the special vars that the template module injects into its templates.
This is because the var templating happens before the action is even selected, and therefore the copy
module cannot inject the vars into the content attribute templating. Note in the docs that using the
template module is required.

This note is only relevant to the copy module's content attribute, because it acts a lot like the template
module. This clarifies at least for the copy module.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
copy module

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.2.0
  config file = /home/cognifloyd/.ansible.cfg
  configured module search path = ['/home/cognifloyd/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib64/python3.6/site-packages/ansible
  executable location = /usr/lib/python-exec/python3.6/ansible
  python version = 3.6.3 (default, Dec 24 2017, 05:53:49) [GCC 6.4.0]
```
