### PR TITLE
Update httptester for httpbin==0.6.2

### DIFF
--- a/test/utils/docker/httptester/Dockerfile
+++ b/test/utils/docker/httptester/Dockerfile
@@ -1,7 +1,13 @@
-FROM nginx:alpine
+# We are pinning at 1.13.8 due to the 1.13.9 image having a vastly different /etc/ssl/openssl.cnf that do not work with our below commands
+FROM nginx:1.13.8-alpine
 
+# The following packages are required to get httpbin/brotlipy/cffi installed
+#     openssl-dev python2-dev libffi-dev gcc libstdc++ make musl-dev
+# Symlinking /usr/lib/libstdc++.so.6 to /usr/lib/libstdc++.so is specifically required for brotlipy
 RUN set -x && \
-    apk add -U openssl py-pip && \
+    apk add --no-cache openssl ca-certificates py-pip openssl-dev python2-dev libffi-dev gcc libstdc++ make musl-dev && \
+    update-ca-certificates && \
+    ln -s /usr/lib/libstdc++.so.6 /usr/lib/libstdc++.so && \
     mkdir -p /root/ca/certs /root/ca/private /root/ca/newcerts && \
     echo 1000 > /root/ca/serial && \
     touch /root/ca/index.txt && \
@@ -23,7 +29,8 @@ RUN set -x && \
     cp /root/ca/cacert.pem /usr/share/nginx/html/cacert.pem && \
     cp /root/ca/client.ansible.http.tests-cert.pem /usr/share/nginx/html/client.pem && \
     cp /root/ca/private/client.ansible.http.tests-key.pem /usr/share/nginx/html/client.key && \
-    pip install gunicorn httpbin==0.5.0
+    pip install gunicorn httpbin==0.6.2 && \
+    apk del openssl-dev python2-dev libffi-dev gcc libstdc++ make musl-dev
 
 ADD services.sh /services.sh
 ADD nginx.sites.conf /etc/nginx/conf.d/default.conf

--- a/test/utils/docker/httptester/httptester.yml
+++ b/test/utils/docker/httptester/httptester.yml
@@ -6,15 +6,31 @@
       apk:
         - openssl
         - py-pip
+        - ca-certificates
+        - openssl-dev
+        - python2-dev
+        - libffi-dev
+        - gcc
+        - libstdc\+\+
+        - make
+        - musl-dev
       apt:
         - openssl
         - python-pip
+        - python-dev
+        - libffi-dev
       yum:
         - openssl
         - python-pip
+        - python-devel
+        - gcc
+        - libffi-devel
       dnf:
         - openssl
         - python-pip
+        - python-devel
+        - gcc
+        - libffi-devel
   tasks:
     - name: Check for nginx
       stat:
@@ -29,9 +45,15 @@
 
     - name: Install OS Packages
       package:
-        name: "{{ item }}"
+        name: "{{ os_packages[ansible_pkg_mgr] }}"
         update_cache: "{{ (ansible_pkg_mgr == 'dnf')|ternary(omit, 'yes') }}"
-      with_items: "{{ os_packages[ansible_pkg_mgr] }}"
+
+    - name: Symlink libstdc++
+      file:
+        state: link
+        src: /usr/lib/libstdc++.so.6
+        dest: /usr/lib/libstdc++.so
+      when: ansible_pkg_mgr == 'apk'
 
     - name: Create cert directories
       file:
@@ -134,7 +156,7 @@
       with_items:
         - name: gunicorn
         - name: httpbin
-          version: '0.5.0'
+          version: '0.6.2'
 
     - name: Copy services.sh script
       copy:

--- a/test/utils/docker/httptester/nginx.sites.conf
+++ b/test/utils/docker/httptester/nginx.sites.conf
@@ -28,6 +28,10 @@ server {
 
     location / {
         proxy_pass http://127.0.0.1:8000;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Host $http_host;
+        proxy_redirect off;
     }
 }
 

--- a/test/utils/docker/httptester/packer.json
+++ b/test/utils/docker/httptester/packer.json
@@ -1,8 +1,11 @@
 {
+    "variables": {
+        "docker_image": "nginx:1.13.8-alpine"
+    },
     "builders": [
         {
             "type": "docker",
-            "image": "nginx:alpine",
+            "image": "{{user `docker_image`}}",
             "commit": true,
             "run_command": [
                 "-d",
@@ -22,7 +25,7 @@
                 "[ -f /usr/bin/dnf ] && /usr/bin/dnf -y install ansible python2-dnf || true",
                 "[ ! -f /usr/bin/dnf -a -f /usr/bin/yum ] && /usr/bin/yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-`grep -o [0-9] /etc/redhat-release | head -1`.noarch.rpm || true",
                 "[ ! -f /usr/bin/dnf -a -f /usr/bin/yum ] && /usr/bin/yum -y install ansible || true",
-                "[ -f /usr/bin/apt-get ] && /usr/bin/apt-get update && /usr/bin/apt-get -y install ansible || true"
+                "[ -f /usr/bin/apt-get ] && /usr/bin/apt-get update && /usr/bin/apt-get -y install software-properties-common && /usr/bin/add-apt-repository ppa:ansible/ansible && /usr/bin/apt-get update && /usr/bin/apt-get -y install ansible || true"
             ]
         },
         {


### PR DESCRIPTION
##### SUMMARY

The overall update here is to support `httpbin==0.6.2`

Within, a few things are happening:

1. Pin `nginx:alpine` to `1.13.8` due to some underlying changes to openssl.cnf that I didn't feel were important to troubleshoot or resolve
1. Update the nginx conf to pass on some additional proxy info to avoid the URL in httpbin results from using `127.0.0.1` instead of `ansible.http.tests`
1. Address necessary changes to the packer file to work on ubuntu
1. Make the docker image used with the packer file user configurable with `nginx:1.13.8-alpinne` as a default
1. Resolve all the dependency issues required to get `httpbin==0.6.2` to install

Additionally, due to the extra deps, the docker image originally ballooned from `72MB` to over `200MB`.  I've added a clean up task to remove the build deps after the pip install. But it's still grown a little to `93.2MB`

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
test/utils/docker/httptester

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
Testing against #36809:

```
$ docker build --no-cache -t local/httptester test/utils/docker/httptester
$ ansible-test integration --docker default -v --python 2.7 --docker-util local/httptester --docker-no-pull uri
[SNIP]
PLAY RECAP *********************************************************************
testhost                   : ok=81   changed=10   unreachable=0    failed=0
$ ansible-test integration --docker default -v --python 2.7 --docker-util local/httptester --docker-no-pull get_url
[SNIP]
PLAY RECAP *********************************************************************
testhost                   : ok=44   changed=17   unreachable=0    failed=0
```

