### PR TITLE
powershell: backport environment string handler fixes 2.5

### DIFF
--- a/changelogs/fragments/win_environment-stringify-2.5
+++ b/changelogs/fragments/win_environment-stringify-2.5
@@ -1,2 +1,2 @@
-bufixes:
+bugfixes:
 - powershell - fixed issue with passing in a bool and int to the Windows environment block, also allow special chars in the env key name (https://github.com/ansible/ansible/pull/37215)

--- a/changelogs/fragments/win_environment-stringify-2.5
+++ b/changelogs/fragments/win_environment-stringify-2.5
@@ -1,0 +1,2 @@
+bufixes:
+- powershell - fixed issue with passing in a bool and int to the Windows environment block, also allow special chars in the env key name (https://github.com/ansible/ansible/pull/37215)

--- a/lib/ansible/plugins/shell/powershell.py
+++ b/lib/ansible/plugins/shell/powershell.py
@@ -162,7 +162,10 @@ Function Run($payload) {
     $ps.AddStatement().AddScript("Function Write-Host(`$msg){ Write-Output `$msg }") | Out-Null
 
     ForEach ($env_kv in $payload.environment.GetEnumerator()) {
-        $escaped_env_set = "`$env:{0} = '{1}'" -f $env_kv.Key,$env_kv.Value.Replace("'","''")
+        # need to escape ' in both the key and value
+        $env_key = $env_kv.Key.ToString().Replace("'", "''")
+        $env_value = $env_kv.Value.ToString().Replace("'", "''")
+        $escaped_env_set = "[System.Environment]::SetEnvironmentVariable('{0}', '{1}')" -f $env_key, $env_value
         $ps.AddStatement().AddScript($escaped_env_set) | Out-Null
     }
 

--- a/test/integration/targets/win_exec_wrapper/tasks/main.yml
+++ b/test/integration/targets/win_exec_wrapper/tasks/main.yml
@@ -31,6 +31,32 @@
     - invalid_ps_version is failed
     - '"This module cannot run as it requires a minimum PowerShell version of 20.0.0.0, actual was " in invalid_ps_version.msg'
 
+- name: test out environment block for task
+  win_shell: set | more
+  args:
+    executable: cmd.exe
+  environment:
+    String: string value
+    Int: 1234
+    Bool: True
+    double_quote: 'double " quote'
+    single_quote: "single ' quote"
+    hyphen-var: abc@123
+    '_-(){}[]<>*+-/\?"''!@#$%^&|;:i,.`~0': '_-(){}[]<>*+-/\?"''!@#$%^&|;:i,.`~0'
+  register: environment_block
+
+- name: assert environment block for task
+  assert:
+    that:
+    - '"String=string value" in environment_block.stdout_lines'
+    - '"Int=1234" in environment_block.stdout_lines'
+    - '"Bool=True" in environment_block.stdout_lines'
+    - '"double_quote=double \" quote" in environment_block.stdout_lines'
+    - '"single_quote=single '' quote" in environment_block.stdout_lines'
+    - '"hyphen-var=abc@123" in environment_block.stdout_lines'
+    # yaml escaping rules - (\\ == \), (\" == "), ('' == ')
+    - '"_-(){}[]<>*+-/\\?\"''!@#$%^&|;:i,.`~0=_-(){}[]<>*+-/\\?\"''!@#$%^&|;:i,.`~0" in environment_block.stdout_lines'
+
 - name: test out become requires without become_user set
   test_all_options:
   register: become_system


### PR DESCRIPTION
##### SUMMARY
Allows ints and booleans to be set as an environment key as well as special chars to be set on the environment key

Backport of https://github.com/ansible/ansible/pull/37215

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->

##### ANSIBLE VERSION
```
2.5
```