### PR TITLE
powershell: backport of environment key and value fix 2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,9 @@ Ansible Changes By Release
 * Fix for unarchive when users use the --strip-components extra_opt to tar
   causing ansible to set permissions on the wrong directory.
   https://github.com/ansible/ansible/pull/37048
+* Fix powershell plugin to handle special chars in environment keys as well as
+  int and bool values
+  (https://github.com/ansible/ansible/pull/37215)
 
 
 <a id="2.4.3"></a>

--- a/lib/ansible/plugins/shell/powershell.py
+++ b/lib/ansible/plugins/shell/powershell.py
@@ -112,7 +112,10 @@ Function Run($payload) {
     $ps.AddStatement().AddScript("Function Write-Host(`$msg){ Write-Output `$msg }") | Out-Null
 
     ForEach ($env_kv in $payload.environment.GetEnumerator()) {
-        $escaped_env_set = "`$env:{0} = '{1}'" -f $env_kv.Key,$env_kv.Value.Replace("'","''")
+        # need to escape ' in both the key and value
+        $env_key = $env_kv.Key.ToString().Replace("'", "''")
+        $env_value = $env_kv.Value.ToString().Replace("'", "''")
+        $escaped_env_set = "[System.Environment]::SetEnvironmentVariable('{0}', '{1}')" -f $env_key, $env_value
         $ps.AddStatement().AddScript($escaped_env_set) | Out-Null
     }
 

--- a/test/integration/targets/win_exec_wrapper/aliases
+++ b/test/integration/targets/win_exec_wrapper/aliases
@@ -1,0 +1,1 @@
+windows/ci/group2

--- a/test/integration/targets/win_exec_wrapper/tasks/main.yml
+++ b/test/integration/targets/win_exec_wrapper/tasks/main.yml
@@ -1,0 +1,26 @@
+---
+- name: test out environment block for task
+  win_shell: set | more
+  args:
+    executable: cmd.exe
+  environment:
+    String: string value
+    Int: 1234
+    Bool: True
+    double_quote: 'double " quote'
+    single_quote: "single ' quote"
+    hyphen-var: abc@123
+    '_-(){}[]<>*+-/\?"''!@#$%^&|;:i,.`~0': '_-(){}[]<>*+-/\?"''!@#$%^&|;:i,.`~0'
+  register: environment_block
+
+- name: assert environment block for task
+  assert:
+    that:
+    - '"String=string value" in environment_block.stdout_lines'
+    - '"Int=1234" in environment_block.stdout_lines'
+    - '"Bool=True" in environment_block.stdout_lines'
+    - '"double_quote=double \" quote" in environment_block.stdout_lines'
+    - '"single_quote=single '' quote" in environment_block.stdout_lines'
+    - '"hyphen-var=abc@123" in environment_block.stdout_lines'
+    # yaml escaping rules - (\\ == \), (\" == "), ('' == ')
+    - '"_-(){}[]<>*+-/\\?\"''!@#$%^&|;:i,.`~0=_-(){}[]<>*+-/\\?\"''!@#$%^&|;:i,.`~0" in environment_block.stdout_lines'


### PR DESCRIPTION
##### SUMMARY
Fixes the issue when setting an environment value that is an int or boolean for powershell.

Backport of https://github.com/ansible/ansible/pull/37215

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
powershell

##### ANSIBLE VERSION
```
2.4
```
