### PR TITLE
[backport stable-2.5] modules: zypper: Optimize the 'search' subcommand (#37191)

### DIFF
--- a/lib/ansible/modules/packaging/os/zypper.py
+++ b/lib/ansible/modules/packaging/os/zypper.py
@@ -313,6 +313,9 @@ def get_cmd(m, subcommand):
     if (is_install or is_refresh) and m.params['disable_gpg_check']:
         cmd.append('--no-gpg-checks')
 
+    if subcommand == 'search':
+        cmd.append('--disable-repositories')
+
     cmd.append(subcommand)
     if subcommand not in ['patch', 'dist-upgrade'] and not is_refresh:
         cmd.extend(['--type', m.params['type']])


### PR DESCRIPTION
When looking for installed packages we do not need to query
repositories since we only care about the rpmdb. As such, we can
disable all the repositories operations in order to improve the
performance of that step

Before this patch, when using 'state: present' in the zypper module,
the operation was taking about 12 seconds to complete:

time ansible-playbook foo.yml 1>/dev/null

real	0m12.614s
user	0m10.880s
sys	0m0.683s

After this patch:

time ansible-playbook foo.yml 1>/dev/null

real	0m4.193s
user	0m2.560s
sys	0m0.575s

see:
https://bugzilla.opensuse.org/show_bug.cgi?id=1084525
(cherry picked from commit 5234b78b5f5a911f710565f2596ff3edb59b2665)