### PR TITLE
[WIP]Pattern to catch string post to ERROR nxos terminal plugin

### DIFF
--- a/lib/ansible/plugins/terminal/nxos.py
+++ b/lib/ansible/plugins/terminal/nxos.py
@@ -34,6 +34,7 @@ class TerminalModule(TerminalBase):
 
     terminal_stderr_re = [
         re.compile(br"% ?Error"),
+        re.compile(br"^error:(.*)", re.I),
         re.compile(br"^% \w+", re.M),
         re.compile(br"% ?Bad secret"),
         re.compile(br"invalid input", re.I),


### PR DESCRIPTION
Signed-off-by: Trishna Guha <trishnaguha17@gmail.com>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
fixes https://github.com/ansible/ansible/issues/36499
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
plugins/terminal/nxos.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```

With the PR the actual error is caught instead of silently ignoring.
e.g
<!--- Paste verbatim command output below, e.g. before and after your change -->
```
The full traceback is:
  File "/tmp/ansible_ebpU1k/ansible_modlib.zip/ansible/module_utils/network/nxos/nxos.py", line 195, in load_config
    responses = connection.edit_config(config)
  File "/tmp/ansible_ebpU1k/ansible_modlib.zip/ansible/module_utils/connection.py", line 146, in __rpc__
    raise ConnectionError(to_text(msg, errors='surrogate_then_replace'), code=code)

fatal: [nxos9k-01]: FAILED! => {
    "changed": false, 
    "invocation": {
        "module_args": {
            "after": null, 
            "backup": false, 
            "before": null, 
            "defaults": false, 
            "diff_against": null, 
            "diff_ignore_lines": null, 
            "force": false, 
            "host": null, 
            "intended_config": null, 
            "lines": null, 
            "match": "line", 
            "parents": null, 
            "password": null, 
            "port": null, 
            "provider": null, 
            "replace": "line", 
            "replace_src": null, 
            "running_config": null, 
            "save": false, 
            "save_when": "never", 
            "src": "interface Vlan1301\n  description BLUE\n  no shutdown\n  vrf member BLUE\n  no ip redirects\n  ip address 10.144.0.2/24\n  ip router ospf 100 area 0.0.0.130\n  hsrp version 2\n  ip dhcp relay address 10.167.128.127 \n  ip dhcp relay address 10.167.128.128\n  hsrp 1301\n    authentication md5 key-chain hsrp-md5-key\n    preempt delay minimum 120 reload 300\n    priority 255\n    ip 10.144.0.1\n", 
            "ssh_keyfile": null, 
            "timeout": null, 
            "transport": null, 
            "use_ssl": null, 
            "username": null, 
            "validate_certs": null
        }
    }, 
    "msg": "authentication md5 key-chain hsrp-md5-key\r\r\nERROR: Group 1301 is not created\r\n\r\n\ran-nxos9k-01(config-if-hsrp)# "
}
```
