### PR TITLE
New module : tower_credential_type

### DIFF
--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_credential_type.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_credential_type.py
@@ -135,21 +135,22 @@ def main():
     with settings.runtime_values(**tower_auth):
         tower_check_mode(module)
         credential_type_res = tower_cli.get_resource('credential_type')
+
+        params = {}
+        params['name'] = name
+        params['kind'] = kind
+        params['managed_by_tower'] = False
+
+        if module.params.get('description'):
+            params['description'] = module.params.get('description')
+
+        if module.params.get('inputs'):
+            params['inputs'] = module.params.get('inputs')
+
+        if module.params.get('injectors'):
+            params['injectors'] = module.params.get('injectors')
+
         try:
-            params = {}
-            params['name'] = name
-            params['kind'] = kind
-            params['managed_by_tower'] = False
-
-            if module.params.get('description'):
-                params['description'] = module.params.get('description')
-
-            if module.params.get('inputs'):
-                params['inputs'] = module.params.get('inputs')
-
-            if module.params.get('injectors'):
-                params['injectors'] = module.params.get('injectors')
-
             if state == 'present':
                 params['create_on_missing'] = True
                 result = credential_type_res.modify(**params)

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_credential_type.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_credential_type.py
@@ -1,0 +1,172 @@
+#!/usr/bin/python
+# coding: utf-8 -*-
+#
+# (c) 2018, Adrien Fleury <fleu42@gmail.com>
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'metadata_version': '1.1'}
+
+
+DOCUMENTATION = '''
+---
+module: tower_credential_type
+author: "Adrien Fleury (@fleu42)"
+version_added: "2.7"
+short_description: Create, update, or destroy custom Ansible Tower credential type.
+description:
+    - Create, update, or destroy Ansible Tower credential type. See
+      U(https://www.ansible.com/tower) for an overview.
+options:
+    name:
+      description:
+        - The name of the credential type.
+      required: True
+    description:
+      description:
+        - The description of the credential type to give more detail about it.
+      required: False
+    kind:
+      description:
+        - >-
+          The type of credential type being added. Note that only cloud and
+          net can be used for creating credential types. Refer to the Ansible
+          for more information.
+      choices: [ 'ssh', 'vault', 'net', 'scm', 'cloud', 'insights' ]
+      required: False
+    inputs:
+      description:
+        - >-
+          Enter inputs using either JSON or YAML syntax. Refer to the Ansible
+          Tower documentation for example syntax.
+      required: False
+    injectors:
+      description:
+        - >-
+          Enter injectors using either JSON or YAML syntax. Refer to the
+          Ansible Tower documentation for example syntax.
+      required: False
+    state:
+      description:
+        - Desired state of the resource.
+      required: False
+      default: "present"
+      choices: ["present", "absent"]
+    tower_verify_ssl:
+      description:
+        - Tower option to avoid certificates check.
+      required: False
+      type: bool
+extends_documentation_fragment: tower
+'''
+
+
+EXAMPLES = '''
+- tower_credential_type:
+    name: Nexus
+    description: Credentials type for Nexus
+    kind: cloud
+    inputs: "{{ lookup('file', 'tower_credential_inputs_nexus.json') }}"
+    injectors: {'extra_vars': {'nexus_credential': 'test' }}
+    state: present
+    tower_verify_ssl: false
+
+- tower_credential_type:
+    name: Nexus
+    state: absent
+'''
+
+
+RETURN = ''' # '''
+
+
+from ansible.module_utils.ansible_tower import (
+    TowerModule,
+    tower_auth_config,
+    tower_check_mode
+)
+
+try:
+    import tower_cli
+    import tower_cli.exceptions as exc
+    from tower_cli.conf import settings
+except ImportError:
+    pass
+
+
+KIND_CHOICES = {
+    'ssh': 'Machine',
+    'vault': 'Ansible Vault',
+    'net': 'Network',
+    'scm': 'Source Control',
+    'cloud': 'Lots of others',
+    'insights': 'Insights'
+}
+
+
+def main():
+    argument_spec = dict(
+        name=dict(required=True),
+        description=dict(required=False),
+        kind=dict(required=False, choices=KIND_CHOICES.keys()),
+        inputs=dict(type='dict', required=False),
+        injectors=dict(type='dict', required=False),
+        state=dict(choices=['present', 'absent'], default='present'),
+    )
+
+    module = TowerModule(
+        argument_spec=argument_spec,
+        supports_check_mode=False
+    )
+
+    name = module.params.get('name')
+    kind = module.params.get('kind')
+    state = module.params.get('state')
+
+    json_output = {'credential_type': name, 'state': state}
+
+    tower_auth = tower_auth_config(module)
+    with settings.runtime_values(**tower_auth):
+        tower_check_mode(module)
+        credential_type_res = tower_cli.get_resource('credential_type')
+        try:
+            params = {}
+            params['name'] = name
+            params['kind'] = kind
+            params['managed_by_tower'] = False
+
+            if module.params.get('description'):
+                params['description'] = module.params.get('description')
+
+            if module.params.get('inputs'):
+                params['inputs'] = module.params.get('inputs')
+
+            if module.params.get('injectors'):
+                params['injectors'] = module.params.get('injectors')
+
+            if state == 'present':
+                params['create_on_missing'] = True
+                result = credential_type_res.modify(**params)
+                json_output['id'] = result['id']
+            elif state == 'absent':
+                params['fail_on_missing'] = False
+                result = credential_type_res.delete(**params)
+
+        except (exc.ConnectionError, exc.BadRequest) as excinfo:
+            module.fail_json(
+                msg='Failed to update credential type: {0}'.format(excinfo),
+                changed=False
+            )
+
+    json_output['changed'] = result['changed']
+    module.exit_json(**json_output)
+
+
+if __name__ == '__main__':
+    main()

--- a/test/integration/targets/tower_credential_type/aliases
+++ b/test/integration/targets/tower_credential_type/aliases
@@ -1,0 +1,2 @@
+cloud/tower
+shippable/tower/group1

--- a/test/integration/targets/tower_credential_type/tasks/main.yml
+++ b/test/integration/targets/tower_credential_type/tasks/main.yml
@@ -1,0 +1,23 @@
+---
+- name: Add Tower credential type
+  tower_credential_type:
+    description: Credential type for Test
+    name: test-credential-type
+    kind: cloud
+    inputs: '{"fields": [{"type": "string", "id": "username", "label": "Username"}, {"secret": True, "type": "string", "id": "password", "label": "Password"}], "required": ["username", "password"]}'
+    injectors: '{"extra_vars": {"test": "foo"}}'
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+
+- name: Remove a Tower credential type
+  tower_credential_type:
+    name: test-credential-type
+    state: absent
+  register: result
+
+- assert:
+    that:
+      - "result is changed"


### PR DESCRIPTION
##### SUMMARY

Ansible is missing some modules to manage Tower/AWX installation through tower-cli. Here is a way to manage the Tower credential types.

It allows for credential type creation and/or deletion via ansible-tower-cli.

##### ISSUE TYPE

 - New Module Pull Request

##### COMPONENT NAME

 - tower_credential_type

##### ANSIBLE VERSION

```
$ ansible --version
ansible 2.6.0 (feature/add-module-tower_credential_type 8f0bc661a2) last updated 2018/03/09 11:51:51 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/fleu42/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/fleu42/tmp/ansible/lib/ansible
  executable location = /home/fleu42/tmp/ansible/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```

##### ADDITIONAL INFORMATION

That should work with version of Ansible > 2.4 using Tower CLI 3.2.1. But I've only tested it with Ansible 2.6.

Before, it was not possible to manage credential types in Tower, with that module, it is.

Here is the output of a play to add an openstack inventory source to an existing inventory:

```
- name: Add tower credential type                                              
  tower_credential_type:                                                       
    name: Nexus_test                                                  
    description: Credentials type for Nexus                                    
    kind: cloud                                                             
    inputs: "{{ lookup('file', 'tower_credential_inputs_nexus.json') }}"    
    injectors: { 'extra_vars': {'nexus_credential': 'test' }}               
    state: present                                                          
    tower_verify_ssl: false                                                 
  tags:                                                                     
    - credential_type                                                       
 
- name: Delete tower credential type                                                                 
  tower_credential_type:                                                    
    name: Nexus_test                                               
    state: absent                                                           
  tags:                                                                     
        - credential_type  
```

```
$ ansible-playbook -i "localhost," -c local ~/ansible/playbooks/tower_configuration.yml --tags credential_type

PLAY [localhost] ***************************************************************************************************************************************************************************************************

TASK [Add tower credential type] ***********************************************************************************************************************************************************************************
changed: [localhost]

TASK [Delete tower credential type] ***************************************************************************************************************************************************************************************
changed: [localhost]

PLAY RECAP *********************************************************************************************************************************************************************************************************
localhost                  : ok=2    changed=2    unreachable=0    failed=0   
```