### PR TITLE
eos_config module exit session gracefully

### DIFF
--- a/test/integration/targets/eos_config/templates/basic/cmds.j2
+++ b/test/integration/targets/eos_config/templates/basic/cmds.j2
@@ -1,0 +1,4 @@
+ip access-list test
+   10 permit ip host 192.168.0.2 host 192.168.0.1
+   20 permit ip host 192.168.0.1 host 192.168.0.2
+!

--- a/test/integration/targets/eos_config/tests/cli/check_mode.yaml
+++ b/test/integration/targets/eos_config/tests/cli/check_mode.yaml
@@ -1,0 +1,40 @@
+---
+- debug: msg="START cli/check_mode.yaml on connection={{ ansible_connection }}"
+
+- name: invalid configuration in check mode
+  eos_config:
+     lines:
+         - ip address 119.31.1.1 255.255.255.256
+     parents: interface Loopback911
+  check_mode: 1
+  environment:
+    ANSIBLE_EOS_USE_SESSIONS: 1
+  register: result
+  ignore_errors: yes
+
+- assert:
+   that:
+   - "result.msg is defined"
+   - "result.failed == true"
+   - "'Error on executing commands' in result.msg"
+
+- name: valid configuration in check mode
+  eos_config:
+    before:
+      - "no ip access-list test"
+    src: basic/cmds.j2
+  check_mode: yes
+  register: config
+
+- name: check if session is removed
+  eos_command:
+    commands:
+      - show configuration sessions | json
+    provider: "{{ cli }}"
+  register: result
+
+- assert:
+   that:
+     - "config.session not in result.stdout[0].sessions"
+
+- debug: msg="END cli/check_mode.yaml on connection={{ ansible_connection }}"


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #36979

If `abort` is not issued in the top level session prompt
the existing session goes to pending state.
The fix is to come out of config mode by issuing `end` command
and enter into same config session to execute `abort`.
This ensures `abort` is issued at the top level session prompt.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
eos/eos.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
