### PR TITLE
ovirt_vms: Pass correct VM entity to create method

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_vms.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_vms.py
@@ -1898,6 +1898,7 @@ def main():
                 vms_module.changed = import_vm(module, connection)
 
             ret = vms_module.create(
+                entity=vm,
                 result_state=otypes.VmStatus.DOWN if vm is None else None,
                 clone=module.params['clone'],
                 clone_permissions=module.params['clone_permissions'],
@@ -1920,6 +1921,7 @@ def main():
                 )
         elif state == 'suspended':
             vms_module.create(
+                entity=vm,
                 result_state=otypes.VmStatus.DOWN if vm is None else None,
                 clone=module.params['clone'],
                 clone_permissions=module.params['clone_permissions'],


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
When user is using following task:

```yaml
ovirt_vms:
  name: myvm
  state: stopped
  serial_console: true
```

we fail on:

```bash
{'changed': False,
                    u'exception': u'Traceback (most recent call last):\n  File "/tmp/ansible_j18cwF/ansible_module_ovirt_vms.py", line 1909, in main\n    clone_permissions=module.par
{u'vmstop_result': {u'msg': u"'NoneType' object has no attribute 'enabled'", u'failed': True, u'exce.__doc__: "dict() -> new empty dictionary\ndict(mapping) -> new dictionary initialized from a mapping object's\n    (key, value) pairs\ndict(iterable) -> new dictionary initialized as if via:\n    d = {}\n    for k, v in iterable:\n        d[k] = v\ndict(**kwargs) -> new dictionary initialized with the name=value pairs\n    in the keyword argument list.  For example:  dict(one=1, two=2)"
{u'vmstop_result': {u'msg': u"'NoneType' object has no attribute 'enabled'", u'failed': True, u'exce.__hash__: None
```


<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
ovirt_vms

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5.0.rc1
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
