### PR TITLE
doc: modules involving file transfert bypass pipelining

### DIFF
--- a/docs/docsite/rst/user_guide/become.rst
+++ b/docs/docsite/rst/user_guide/become.rst
@@ -148,8 +148,8 @@ Ways to resolve this include:
 * Use :ref:`pipelining`.  When pipelining is enabled, Ansible doesn't save the
   module to a temporary file on the client.  Instead it pipes the module to
   the remote python interpreter's stdin. Pipelining does not work for
-  python modules involving file transfert (for example: :ref:`copy <copy>`,
-  :ref:`fetch <fetch>`, :ref:`template <template>`), nor for non-python modules.
+  python modules involving file transfer (for example: :ref:`copy <copy>`,
+  :ref:`fetch <fetch>`, :ref:`template <template>`), or for non-python modules.
 
 * (Available in Ansible 2.1) Install POSIX.1e filesystem acl support on the
   managed host.  If the temporary directory on the remote host is mounted with

--- a/docs/docsite/rst/user_guide/become.rst
+++ b/docs/docsite/rst/user_guide/become.rst
@@ -147,8 +147,9 @@ Ways to resolve this include:
 
 * Use :ref:`pipelining`.  When pipelining is enabled, Ansible doesn't save the
   module to a temporary file on the client.  Instead it pipes the module to
-  the remote python interpreter's stdin.  Pipelining does not work for
-  non-python modules.
+  the remote python interpreter's stdin. Pipelining does not work for
+  python modules involving file transfert (for example: :ref:`copy <copy>`,
+  :ref:`fetch <fetch>`, :ref:`template <template>`), nor for non-python modules.
 
 * (Available in Ansible 2.1) Install POSIX.1e filesystem acl support on the
   managed host.  If the temporary directory on the remote host is mounted with


### PR DESCRIPTION
##### SUMMARY

Mention in the documentation that modules involving file transfert bypass pipelining.

Note that I wasn't able to build the doc locally.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
user_guide

##### ANSIBLE VERSION
```
ansible 2.6.0 (devel f0dc0b28d4) last updated 2018/03/06 20:03:56 (GMT +200)
```