### PR TITLE
Allow using action/local_action on includes and imports

### DIFF
--- a/lib/ansible/parsing/mod_args.py
+++ b/lib/ansible/parsing/mod_args.py
@@ -159,7 +159,7 @@ class ModuleArgsParser:
         if action is not None:
             args = self._normalize_new_style_args(thing, action)
         else:
-            (action, args) = self._normalize_old_style_args(thing)
+            (action, args) = self._normalize_old_style_args(thing, action)
 
             # this can occasionally happen, simplify
             if args and 'args' in args:
@@ -210,7 +210,7 @@ class ModuleArgsParser:
             raise AnsibleParserError("unexpected parameter type in action: %s" % type(thing), obj=self._task_ds)
         return args
 
-    def _normalize_old_style_args(self, thing):
+    def _normalize_old_style_args(self, thing, original_action):
         '''
         deals with fuzziness in old-style (action/local_action) module invocations
         returns tuple of (module_name, dictionary_args)
@@ -245,6 +245,9 @@ class ModuleArgsParser:
         else:
             # need a dict or a string, so giving up
             raise AnsibleParserError("unexpected parameter type in action: %s" % type(thing), obj=self._task_ds)
+
+        if action in ('include', 'include_tasks', 'import_tasks', 'include_role', 'import_role'):
+            raise AnsibleParserError('%s can not be used with %s' % (action, original_action), obj=self._task_ds)
 
         return (action, args)
 

--- a/lib/ansible/parsing/mod_args.py
+++ b/lib/ansible/parsing/mod_args.py
@@ -159,7 +159,7 @@ class ModuleArgsParser:
         if action is not None:
             args = self._normalize_new_style_args(thing, action)
         else:
-            (action, args) = self._normalize_old_style_args(thing, action)
+            (action, args) = self._normalize_old_style_args(thing)
 
             # this can occasionally happen, simplify
             if args and 'args' in args:
@@ -210,7 +210,7 @@ class ModuleArgsParser:
             raise AnsibleParserError("unexpected parameter type in action: %s" % type(thing), obj=self._task_ds)
         return args
 
-    def _normalize_old_style_args(self, thing, original_action):
+    def _normalize_old_style_args(self, thing):
         '''
         deals with fuzziness in old-style (action/local_action) module invocations
         returns tuple of (module_name, dictionary_args)
@@ -245,9 +245,6 @@ class ModuleArgsParser:
         else:
             # need a dict or a string, so giving up
             raise AnsibleParserError("unexpected parameter type in action: %s" % type(thing), obj=self._task_ds)
-
-        if action in ('include', 'include_tasks', 'import_tasks', 'include_role', 'import_role'):
-            raise AnsibleParserError('%s can not be used with %s' % (action, original_action), obj=self._task_ds)
 
         return (action, args)
 

--- a/lib/ansible/playbook/helpers.py
+++ b/lib/ansible/playbook/helpers.py
@@ -129,7 +129,7 @@ def load_list_of_tasks(ds, play, block=None, role=None, task_include=None, use_h
                 if e._obj:
                     raise
                 # But if it wasn't, we can add the yaml object now to get more detail
-                raise AnsibleParserError(to_native(e), obj=ds, orig_exc=e)
+                raise AnsibleParserError(to_native(e), obj=task_ds, orig_exc=e)
 
             if action in ('include', 'import_tasks', 'include_tasks'):
 

--- a/lib/ansible/playbook/helpers.py
+++ b/lib/ansible/playbook/helpers.py
@@ -22,6 +22,7 @@ import os
 
 from ansible import constants as C
 from ansible.errors import AnsibleParserError, AnsibleUndefinedVariable, AnsibleFileNotFound, AnsibleAssertionError
+from ansible.module_utils._text import to_native
 from ansible.module_utils.six import string_types
 from ansible.parsing.mod_args import ModuleArgsParser
 

--- a/lib/ansible/playbook/helpers.py
+++ b/lib/ansible/playbook/helpers.py
@@ -23,6 +23,7 @@ import os
 from ansible import constants as C
 from ansible.errors import AnsibleParserError, AnsibleUndefinedVariable, AnsibleFileNotFound, AnsibleAssertionError
 from ansible.module_utils.six import string_types
+from ansible.parsing.mod_args import ModuleArgsParser
 
 try:
     from __main__ import display
@@ -105,7 +106,18 @@ def load_list_of_tasks(ds, play, block=None, role=None, task_include=None, use_h
         if not isinstance(task_ds, dict):
             AnsibleAssertionError('The ds (%s) should be a dict but was a %s' % (ds, type(ds)))
 
-        if 'block' in task_ds:
+        args_parser = ModuleArgsParser(task_ds)
+        try:
+            (action, args, delegate_to) = args_parser.parse()
+        except AnsibleParserError as e:
+            # if the raises exception was created with obj=ds args, then it includes the detail
+            # so we dont need to add it so we can just re raise.
+            if e._obj:
+                raise
+            # But if it wasn't, we can add the yaml object now to get more detail
+            raise AnsibleParserError(to_native(e), obj=ds, orig_exc=e)
+
+        if action == 'block':
             t = Block.load(
                 task_ds,
                 play=play,
@@ -118,7 +130,7 @@ def load_list_of_tasks(ds, play, block=None, role=None, task_include=None, use_h
             )
             task_list.append(t)
         else:
-            if 'include' in task_ds or 'import_tasks' in task_ds or 'include_tasks' in task_ds:
+            if action in ('include', 'import_tasks', 'include_tasks'):
 
                 if use_handlers:
                     include_class = HandlerTaskInclude
@@ -140,9 +152,9 @@ def load_list_of_tasks(ds, play, block=None, role=None, task_include=None, use_h
                 # check to see if this include is dynamic or static:
                 # 1. the user has set the 'static' option to false or true
                 # 2. one of the appropriate config options was set
-                if 'include_tasks' in task_ds:
+                if action == 'include_tasks':
                     is_static = False
-                elif 'import_tasks' in task_ds:
+                elif action == 'import_tasks':
                     is_static = True
                 elif t.static is not None:
                     display.deprecated("The use of 'static' has been deprecated. "
@@ -155,7 +167,7 @@ def load_list_of_tasks(ds, play, block=None, role=None, task_include=None, use_h
 
                 if is_static:
                     if t.loop is not None:
-                        if 'import_tasks' in task_ds:
+                        if action == 'import_tasks':
                             raise AnsibleParserError("You cannot use loops on 'import_tasks' statements. You should use 'include_tasks' instead.", obj=task_ds)
                         else:
                             raise AnsibleParserError("You cannot use 'static' on an include with a loop", obj=task_ds)
@@ -262,7 +274,7 @@ def load_list_of_tasks(ds, play, block=None, role=None, task_include=None, use_h
                         tags = tags.split(',')
 
                     if len(tags) > 0:
-                        if 'include_tasks' in task_ds or 'import_tasks' in task_ds:
+                        if action in ('include_tasks', 'import_tasks'):
                             raise AnsibleParserError('You cannot specify "tags" inline to the task, it is a task keyword')
                         if len(ti_copy.tags) > 0:
                             raise AnsibleParserError(
@@ -292,7 +304,7 @@ def load_list_of_tasks(ds, play, block=None, role=None, task_include=None, use_h
                     t.is_static = False
                     task_list.append(t)
 
-            elif 'include_role' in task_ds or 'import_role' in task_ds:
+            elif action in ('include_role', 'import_role'):
                 ir = IncludeRole.load(
                     task_ds,
                     block=block,
@@ -305,7 +317,7 @@ def load_list_of_tasks(ds, play, block=None, role=None, task_include=None, use_h
                 #   1. the user has set the 'static' option to false or true
                 #   2. one of the appropriate config options was set
                 is_static = False
-                if 'import_role' in task_ds:
+                if action == 'import_role':
                     is_static = True
 
                 elif ir.static is not None:
@@ -315,7 +327,7 @@ def load_list_of_tasks(ds, play, block=None, role=None, task_include=None, use_h
 
                 if is_static:
                     if ir.loop is not None:
-                        if 'import_role' in task_ds:
+                        if action == 'import_role':
                             raise AnsibleParserError("You cannot use loops on 'import_role' statements. You should use 'include_role' instead.", obj=task_ds)
                         else:
                             raise AnsibleParserError("You cannot use 'static' on an include_role with a loop", obj=task_ds)

--- a/lib/ansible/playbook/helpers.py
+++ b/lib/ansible/playbook/helpers.py
@@ -107,18 +107,7 @@ def load_list_of_tasks(ds, play, block=None, role=None, task_include=None, use_h
         if not isinstance(task_ds, dict):
             AnsibleAssertionError('The ds (%s) should be a dict but was a %s' % (ds, type(ds)))
 
-        args_parser = ModuleArgsParser(task_ds)
-        try:
-            (action, args, delegate_to) = args_parser.parse()
-        except AnsibleParserError as e:
-            # if the raises exception was created with obj=ds args, then it includes the detail
-            # so we dont need to add it so we can just re raise.
-            if e._obj:
-                raise
-            # But if it wasn't, we can add the yaml object now to get more detail
-            raise AnsibleParserError(to_native(e), obj=ds, orig_exc=e)
-
-        if action == 'block':
+        if 'block' in task_ds:
             t = Block.load(
                 task_ds,
                 play=play,
@@ -131,6 +120,17 @@ def load_list_of_tasks(ds, play, block=None, role=None, task_include=None, use_h
             )
             task_list.append(t)
         else:
+            args_parser = ModuleArgsParser(task_ds)
+            try:
+                (action, args, delegate_to) = args_parser.parse()
+            except AnsibleParserError as e:
+                # if the raises exception was created with obj=ds args, then it includes the detail
+                # so we dont need to add it so we can just re raise.
+                if e._obj:
+                    raise
+                # But if it wasn't, we can add the yaml object now to get more detail
+                raise AnsibleParserError(to_native(e), obj=ds, orig_exc=e)
+
             if action in ('include', 'import_tasks', 'include_tasks'):
 
                 if use_handlers:

--- a/test/integration/targets/include_import/tasks/test_include_tasks.yml
+++ b/test/integration/targets/include_import/tasks/test_include_tasks.yml
@@ -39,3 +39,6 @@
           assert:
             that:
               - set_in_tasks4
+
+    - name: include_tasks + action
+      action: include_tasks tasks1.yml


### PR DESCRIPTION
##### SUMMARY
Allow using action/local_action on includes and imports. Fixes #28822

Using action or local_action on includes and imports doesn't work.  This is due to `playbooks/helpers.py` doing things like `if 'include_role' in task_ds:` which fails because the `task_ds` may look like:

```
{'local_action': {'module': 'include_role', 'name': 'foo'}}
```

or

```
{'local_action': 'include_role name=foo'}
```

This PR uses mod_args to determine the action in a more robust way.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/playbooks/helpers.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.4
2.5
2.6
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```