### PR TITLE
Terminate Tower instances after CI ends.

### DIFF
--- a/test/runner/lib/manage_ci.py
+++ b/test/runner/lib/manage_ci.py
@@ -135,8 +135,6 @@ class ManagePosixCI(object):
             self.become = ['sudo', '-in', 'PATH=/usr/local/bin:$PATH']
         elif self.core_ci.platform == 'rhel':
             self.become = ['sudo', '-in', 'bash', '-c']
-        elif self.core_ci.platform == 'tower':
-            self.become = ['sudo', '-in', 'bash', '-c']
 
     def setup(self):
         """Start instance and wait for it to become ready and respond to an ansible ping."""

--- a/test/utils/shippable/cloud.sh
+++ b/test/utils/shippable/cloud.sh
@@ -9,6 +9,9 @@ image="${args[1]}"
 python="${args[2]}"
 target="posix/ci/cloud/group${args[3]}/"
 
+stage="${S:-prod}"
+
 # shellcheck disable=SC2086
 ansible-test integration --color -v --retry-on-error "${target}" ${COVERAGE:+"$COVERAGE"} ${CHANGED:+"$CHANGED"} \
+    --remote-terminate always --remote-stage "${stage}" \
     --docker "${image}" --python "${python}" --changed-all-target "${target}smoketest/"


### PR DESCRIPTION
##### SUMMARY

Terminate Tower instances after CI ends. Also remove obsolete code for managing Tower instances.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.6.0 (at-cleanup f1fb0e450e) last updated 2018/03/09 14:50:45 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```
