### PR TITLE
Fixed issue with accessing response in digital_ocean module

### DIFF
--- a/lib/ansible/modules/cloud/digital_ocean/digital_ocean_domain.py
+++ b/lib/ansible/modules/cloud/digital_ocean/digital_ocean_domain.py
@@ -137,7 +137,8 @@ class DoManager(DigitalOceanHelper, object):
     def edit_domain_record(self):
         params = {'name': self.domain_name}
         resp = self.put('domains/%s/records/%s' % (self.domain_name, self.domain_id), data=params)
-        return resp['domain_record']
+        status, json = self.jsonify(resp)
+        return json['domain_record']
 
 
 def core(module):


### PR DESCRIPTION
##### SUMMARY
The digital ocean DNS module has a small bug when DNS entries are already present.
The response object is not accessed properly which causes DNS entry updates to fail

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
digital_ocean_domain

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0
  config file = /Users/aasoni/.ansible.cfg
  configured module search path = ['/Users/aasoni/Developer/ansible/lib/ansible/modules']
  ansible python module location = /usr/local/lib/python3.6/site-packages/ansible-2.6.0-py3.6.egg/ansible
  executable location = /usr/local/bin/ansible
  python version = 3.6.4 (default, Mar  9 2018, 18:35:59) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```