### PR TITLE
virt_net: add way to get facts for only one specified network

### DIFF
--- a/lib/ansible/modules/cloud/misc/virt_net.py
+++ b/lib/ansible/modules/cloud/misc/virt_net.py
@@ -441,9 +441,13 @@ class VirtNetwork(object):
     def info(self):
         return self.facts(facts_mode='info')
 
-    def facts(self, facts_mode='facts'):
+    def facts(self, name=None, facts_mode='facts'):
         results = dict()
-        for entry in self.list_nets():
+        if name:
+            entries = [ name ]
+        else:
+            entries = self.list_nets()
+        for entry in entries:
             results[entry] = dict()
             results[entry]["autostart"] = self.conn.get_autostart(entry)
             results[entry]["persistent"] = self.conn.get_persistent(entry)
@@ -556,7 +560,10 @@ def core(module):
             return VIRT_SUCCESS, res
 
         elif hasattr(v, command):
-            res = getattr(v, command)()
+            if command = 'facts' and name:
+                res = getattr(v, command)(name)
+            else:
+                res = getattr(v, command)()
             if not isinstance(res, dict):
                 res = {command: res}
             return VIRT_SUCCESS, res


### PR DESCRIPTION
##### SUMMARY
This permits to get facts for only one specified network. Getting facts with a big setup is a very time consuming task.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
cloud/misc/virt_net

##### ANSIBLE VERSION
```
ansible 2.4.3.0
  config file = /home/troissix/.ansible.cfg
  configured module search path = [u'/home/troissix/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.14+ (default, Feb  6 2018, 19:12:18) [GCC 7.3.0]
```


##### ADDITIONAL INFORMATION
