### PR TITLE
virt_net: add way to get facts for only one specified network

### DIFF
--- a/lib/ansible/modules/cloud/misc/virt_net.py
+++ b/lib/ansible/modules/cloud/misc/virt_net.py
@@ -450,9 +450,13 @@ class VirtNetwork(object):
     def info(self):
         return self.facts(facts_mode='info')
 
-    def facts(self, facts_mode='facts'):
+    def facts(self, name=None, facts_mode='facts'):
         results = dict()
-        for entry in self.list_nets():
+        if name:
+            entries = [name]
+        else:
+            entries = self.list_nets()
+        for entry in entries:
             results[entry] = dict()
             results[entry]["autostart"] = self.conn.get_autostart(entry)
             results[entry]["persistent"] = self.conn.get_persistent(entry)
@@ -565,7 +569,10 @@ def core(module):
             return VIRT_SUCCESS, res
 
         elif hasattr(v, command):
-            res = getattr(v, command)()
+            if command == 'facts' and name:
+                res = v.facts(name)
+            else:
+                res = getattr(v, command)()
             if not isinstance(res, dict):
                 res = {command: res}
             return VIRT_SUCCESS, res

--- a/test/integration/targets/virt_net/tasks/main.yml
+++ b/test/integration/targets/virt_net/tasks/main.yml
@@ -42,6 +42,13 @@
         name: foobar
       register: second_virt_net_start
 
+    - name: Get facts for default network
+      virt_net:
+        uri: qemu:///system
+        command: facts
+        name: foobar
+      register: virt_net_facts
+
     - name: Destroy the foobar network
       virt_net:
         command: destroy


### PR DESCRIPTION
##### SUMMARY
This permits to get facts for only one specified network. Getting facts with a big setup is a very time consuming task.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
virt_net

##### ANSIBLE VERSION
```
ansible 2.4.3.0
  config file = /home/troissix/.ansible.cfg
  configured module search path = [u'/home/troissix/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.14+ (default, Feb  6 2018, 19:12:18) [GCC 7.3.0]
```

##### ADDITIONAL INFORMATION

