### PR TITLE
Waits for the lifecycle hooks to complete

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_asg.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_asg.py
@@ -1390,7 +1390,7 @@ def wait_for_term_inst(connection, term_instances):
             lifecycle = instance_facts[i]['lifecycle_state']
             health = instance_facts[i]['health_status']
             module.debug("Instance %s has state of %s,%s" % (i, lifecycle, health))
-            if lifecycle == 'Terminating' or health == 'Unhealthy':
+            if lifecycle.startswith('Terminating') or health == 'Unhealthy':
                 count += 1
         time.sleep(10)
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
During a rolling deployment, it waits for the lifecycle hooks to complete.

Fixes #37281


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ec2_asg

##### ANSIBLE VERSION
```
ansible 2.4.3.0
```

##### ADDITIONAL INFORMATION

The module was checking for the instance state to match exactly `Terminating`, therefore ignoring the states assumed during the lifecycle hooks: `Terminating:Wait` and `Terminating:Proceed`.
The most immediate solution is to change from an exact match to a `startwith()` comparison.
