### PR TITLE
Ensure passwords meet complexity specified in char sets provided for password lookup

### DIFF
--- a/lib/ansible/plugins/lookup/password.py
+++ b/lib/ansible/plugins/lookup/password.py
@@ -218,11 +218,9 @@ def _check_complexity(characters, password):
                 foundCharSpec = True
                 break
 
-        foundAllRequired=foundAllRequired & foundCharSpec
+        foundAllRequired = foundAllRequired & foundCharSpec
 
     return foundAllRequired
-
-
 
 def _random_salt():
     """Return a text string suitable for use as a salt for the hash functions we use to encrypt passwords.
@@ -311,7 +309,7 @@ class LookupModule(LookupBase):
 
                 if plaintext_password is None:
                     raise AnsibleError(
-                        'Unuable to generate password of sufficient complexity in {} tries'.format(COMPLEXITY_RETRIES))
+                        'Unuable to generate password of sufficient complexity in {0} tries'.format(COMPLEXITY_RETRIES))
                 salt = None
                 changed = True
             else:

--- a/lib/ansible/plugins/lookup/password.py
+++ b/lib/ansible/plugins/lookup/password.py
@@ -101,6 +101,7 @@ from ansible.utils.path import makedirs_safe
 
 
 DEFAULT_LENGTH = 20
+COMPLEXITY_RETRIES = 25
 VALID_PARAMS = frozenset(('length', 'encrypt', 'chars'))
 
 
@@ -205,10 +206,10 @@ def _gen_candidate_chars(characters):
 
 def _check_complexity(characters, password):
     foundAllRequired = True
-    #print("checking password: {}".format(password))
+    # print("checking password: {}".format(password))
     for chars_spec in characters:
         foundCharSpec = False
-        #print("checking {}".format(chars_spec))
+        # print("checking {}".format(chars_spec))
         charsset = to_text(getattr(string, to_native(chars_spec), chars_spec),
                            errors='strict')
 
@@ -301,17 +302,16 @@ class LookupModule(LookupBase):
 
             if content is None or b_path == to_bytes('/dev/null'):
 
-                for attempts in range(10):
+                for attempts in range(COMPLEXITY_RETRIES):
                     plaintext_password = random_password(params['length'], chars)
                     if _check_complexity(params['chars'], plaintext_password):
                         break
                     else:
-                        print("trying again!!!")
                         plaintext_password = None
 
                 if plaintext_password is None:
                     raise AnsibleError(
-                        'Unuable to generate password of sufficient complexity in 10 tries')
+                        'Unuable to generate password of sufficient complexity in {} tries'.format(COMPLEXITY_RETRIES))
                 salt = None
                 changed = True
             else:

--- a/lib/ansible/plugins/lookup/password.py
+++ b/lib/ansible/plugins/lookup/password.py
@@ -222,6 +222,7 @@ def _check_complexity(characters, password):
 
     return foundAllRequired
 
+
 def _random_salt():
     """Return a text string suitable for use as a salt for the hash functions we use to encrypt passwords.
     """


### PR DESCRIPTION
##### SUMMARY

The password lookup plugin is useful for generating random passwords for mysql users. However recent mysql versions use the `validate_password` plugin which defaults to requiring at least one char in each of the categories ["numeric, lowercase, uppercase, and special characters"](https://dev.mysql.com/doc/refman/5.7/en/validate-password-options-variables.html#sysvar_validate_password_policy).

The current implementation of the password lookup plugin does not enforce the complexity indicated by the provided chars parameter, and therefore some proportion of calls to mysql_user will fail with a message like;

```
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: 
OperationalError: (1819, 'Your password does not satisfy the current policy requirements')
failed: [57-centos-7] (item=31) => {
    "changed": false,
    "item": "31"
}
MSG:
(1819, 'Your password does not satisfy the current policy requirements')
```
when it's used like this....

```
  - name: Create a new database with name 'testdb'
    mysql_db:
      name: testdb
      state: present
  - mysql_user:
      name: "test_user"
      password: >-
        "{{ lookup('password', '/dev/null chars=ascii_lowercase,ascii_uppercase,digits,#=+_-*^$') }}"
      priv: "testdb.*:ALL"
    register: mysql_user
```

This patch causes the plugin to sample passwords until the required complexity is met, or raises an error if this is not achieved in a specific number of tries.


##### ISSUE TYPE
 - Feature Pull Request


##### COMPONENT NAME
password lookup plugin

##### ANSIBLE VERSION
```
ansible 2.6.0 (fix-password-complexity fb979aa523) last updated 2018/03/12 03:40:36 (GMT +100)
  config file = /home/tomhodder/.ansible.cfg
  configured module search path = [u'/home/tomhodder/.local/lib/python2.7/site-packages/ara/plugins/modules']
  ansible python module location = /home/tomhodder/git/ansible/lib/ansible
  executable location = /home/tomhodder/git/ansible/bin/ansible
  python version = 2.7.14 (default, Feb 27 2018, 20:43:24) [GCC 7.3.1 20180130 (Red Hat 7.3.1-2)]
```


##### ADDITIONAL INFORMATION


```

```
