### PR TITLE
Eos :do not push config to device if check_mode is enabled

### DIFF
--- a/lib/ansible/module_utils/network/eos/eos.py
+++ b/lib/ansible/module_utils/network/eos/eos.py
@@ -231,7 +231,12 @@ class Cli:
             pass
 
         if not all((bool(use_session), self.supports_sessions)):
-            return self.configure(self, commands)
+            if commit:
+                return self.configure(self, commands)
+            else:
+                self._module.warn("EOS can not check config without config session")
+                result = {'changed': True}
+                return result
 
         conn = self._get_connection()
         session = 'ansible_%s' % int(time.time())
@@ -408,7 +413,12 @@ class Eapi:
         there will be no returned diff or session values
         """
         if not self.supports_sessions:
-            return self.configure(self, config)
+            if commit:
+                return self.configure(self, config)
+            else:
+                self._module.warn("EOS can not check config without config session")
+                result = {'changed': True}
+                return result
 
         session = 'ansible_%s' % int(time.time())
         result = {'session': session}

--- a/lib/ansible/module_utils/network/eos/eos.py
+++ b/lib/ansible/module_utils/network/eos/eos.py
@@ -412,7 +412,13 @@ class Eapi:
         fallback to using configure() to load the commands.  If that happens,
         there will be no returned diff or session values
         """
-        if not self.supports_sessions:
+        use_session = os.getenv('ANSIBLE_EOS_USE_SESSIONS', True)
+        try:
+            use_session = int(use_session)
+        except ValueError:
+            pass
+
+        if not all((bool(use_session), self.supports_sessions)):
             if commit:
                 return self.configure(self, config)
             else:

--- a/test/integration/targets/eos_config/tests/cli/check_mode.yaml
+++ b/test/integration/targets/eos_config/tests/cli/check_mode.yaml
@@ -37,4 +37,33 @@
    that:
      - "config.session not in result.stdout[0].sessions"
 
+- name: invalid configuration in check mode + no config session
+  eos_config:
+     lines:
+         - ip address 119.31.1.1 255.255.255.256
+     parents: interface Loopback911
+  check_mode: 1
+  environment:
+    ANSIBLE_EOS_USE_SESSIONS: 0
+  register: result
+  ignore_errors: yes
+
+- assert:
+   that:
+   - "result.changed == true"
+
+- name: valid configuration in check mode + no config session
+  eos_config:
+     lines:
+         - ip address 119.31.1.1 255.255.255.255
+     parents: interface Loopback911
+  check_mode: yes
+  register: result
+  environment:
+    ANSIBLE_EOS_USE_SESSIONS: 0
+
+- assert:
+   that:
+   - "result.changed == true"
+
 - debug: msg="END cli/check_mode.yaml on connection={{ ansible_connection }}"


### PR DESCRIPTION
Fixes #36980
eos_config module was configuring the device if check_mode was enabled and ANSIBLE_EOS_USE_SESSIONS was set to 0. If config session is disabled then we can not check the configuration as EOS applies config to device as soon as newline is entered on a config and there is no option to abort config unlike the case when a config session is used.
Fix warns user of this EOS limitation that config check can not be done without use of config_session and does not play configuration to device.