### PR TITLE
Tolerate win line endings on windows module_util load

### DIFF
--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -826,8 +826,7 @@ def _find_module_utils(module_name, b_module_data, module_path, module_args, tas
                 become_required = True
 
         for m in set(module_names):
-            m = to_text(m)
-            m = m.rstrip('\r\n')  # tolerate windows line endings
+            m = to_text(m).rstrip()  # tolerate windows line endings
             mu_path = ps_module_utils_loader.find_plugin(m, ".psm1")
             if not mu_path:
                 raise AnsibleError('Could not find imported module support code for \'%s\'.' % m)

--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -827,6 +827,7 @@ def _find_module_utils(module_name, b_module_data, module_path, module_args, tas
 
         for m in set(module_names):
             m = to_text(m)
+            m = m.rstrip('\r\n') # tolerate windows line endings
             mu_path = ps_module_utils_loader.find_plugin(m, ".psm1")
             if not mu_path:
                 raise AnsibleError('Could not find imported module support code for \'%s\'.' % m)

--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -827,7 +827,7 @@ def _find_module_utils(module_name, b_module_data, module_path, module_args, tas
 
         for m in set(module_names):
             m = to_text(m)
-            m = m.rstrip('\r\n') # tolerate windows line endings
+            m = m.rstrip('\r\n')  # tolerate windows line endings
             mu_path = ps_module_utils_loader.find_plugin(m, ".psm1")
             if not mu_path:
                 raise AnsibleError('Could not find imported module support code for \'%s\'.' % m)

--- a/test/integration/targets/win_module_utils/library/legacy_only_new_way_win_line_ending.ps1
+++ b/test/integration/targets/win_module_utils/library/legacy_only_new_way_win_line_ending.ps1
@@ -1,0 +1,6 @@
+#!powershell
+
+#Requires -Module Ansible.ModuleUtils.Legacy
+
+Exit-Json @{ data="success" }
+

--- a/test/integration/targets/win_module_utils/library/legacy_only_old_way_win_line_ending.ps1
+++ b/test/integration/targets/win_module_utils/library/legacy_only_old_way_win_line_ending.ps1
@@ -1,0 +1,4 @@
+#!powershell
+# POWERSHELL_COMMON
+
+Exit-Json @{ data="success" }

--- a/test/integration/targets/win_module_utils/tasks/main.yml
+++ b/test/integration/targets/win_module_utils/tasks/main.yml
@@ -14,6 +14,22 @@
     that:
     - new_way.data == 'success'
 
+- name: call old WANTS_JSON module with windows line endings
+  legacy_only_old_way_win_line_ending:
+  register: old_way_win
+
+- assert:
+    that:
+    - old_way_win.data == 'success'
+
+- name: call module with only legacy requires and windows line endings
+  legacy_only_new_way_win_line_ending:
+  register: new_way_win
+
+- assert:
+    that:
+    - new_way_win.data == 'success'
+
 - name: call module with local module_utils
   uses_local_utils:
   register: local_utils

--- a/test/sanity/code-smell/line-endings.py
+++ b/test/sanity/code-smell/line-endings.py
@@ -8,6 +8,8 @@ def main():
         'test/integration/targets/template/files/foo.dos.txt',
         'test/integration/targets/win_regmerge/templates/win_line_ending.j2',
         'test/integration/targets/win_template/files/foo.dos.txt',
+        'test/integration/targets/win_module_utils/library/legacy_only_new_way_win_line_ending.ps1',
+        'test/integration/targets/win_module_utils/library/legacy_only_old_way_win_line_ending.ps1',
     ])
 
     for path in sys.argv[1:] or sys.stdin.read().splitlines():

--- a/test/sanity/code-smell/shebang.py
+++ b/test/sanity/code-smell/shebang.py
@@ -23,6 +23,10 @@ def main():
         '.ps1': b'#!powershell',
     }
 
+    alternative_shebangs = {
+        '.ps1': b'#!powershell\r',
+    }
+
     skip = set([
         'hacking/cherrypick.py',
     ])
@@ -57,11 +61,16 @@ def main():
             if is_module:
                 ext = os.path.splitext(path)[1]
                 expected_shebang = module_shebangs.get(ext)
+                alternative_shebang = alternative_shebangs.get(ext)
                 expected_ext = ' or '.join(['"%s"' % k for k in module_shebangs])
 
                 if expected_shebang:
                     if shebang == expected_shebang:
                         continue
+                    if alternative_shebang:
+                        if shebang == alternative_shebang:
+                           continue
+                        print('%s:%d:%d: expected module shebang "%s" or "%s" but found: %s' % (path, 1, 1, expected_shebang, alternative_shebang, shebang))
 
                     print('%s:%d:%d: expected module shebang "%s" but found: %s' % (path, 1, 1, expected_shebang, shebang))
                 else:

--- a/test/sanity/code-smell/shebang.py
+++ b/test/sanity/code-smell/shebang.py
@@ -23,12 +23,10 @@ def main():
         '.ps1': b'#!powershell',
     }
 
-    alternative_shebangs = {
-        '.ps1': b'#!powershell\r',
-    }
-
     skip = set([
         'hacking/cherrypick.py',
+        'test/integration/targets/win_module_utils/library/legacy_only_new_way_win_line_ending.ps1',
+        'test/integration/targets/win_module_utils/library/legacy_only_old_way_win_line_ending.ps1',
     ])
 
     for path in sys.argv[1:] or sys.stdin.read().splitlines():
@@ -61,16 +59,11 @@ def main():
             if is_module:
                 ext = os.path.splitext(path)[1]
                 expected_shebang = module_shebangs.get(ext)
-                alternative_shebang = alternative_shebangs.get(ext)
                 expected_ext = ' or '.join(['"%s"' % k for k in module_shebangs])
 
                 if expected_shebang:
                     if shebang == expected_shebang:
                         continue
-                    if alternative_shebang:
-                        if shebang == alternative_shebang:
-                            continue
-                        print('%s:%d:%d: expected module shebang "%s" or "%s" but found: %s' % (path, 1, 1, expected_shebang, alternative_shebang, shebang))
 
                     print('%s:%d:%d: expected module shebang "%s" but found: %s' % (path, 1, 1, expected_shebang, shebang))
                 else:

--- a/test/sanity/code-smell/shebang.py
+++ b/test/sanity/code-smell/shebang.py
@@ -69,7 +69,7 @@ def main():
                         continue
                     if alternative_shebang:
                         if shebang == alternative_shebang:
-                           continue
+                            continue
                         print('%s:%d:%d: expected module shebang "%s" or "%s" but found: %s' % (path, 1, 1, expected_shebang, alternative_shebang, shebang))
 
                     print('%s:%d:%d: expected module shebang "%s" but found: %s' % (path, 1, 1, expected_shebang, shebang))


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
I hit this when converting my playbooks to run under ansible 2.5 syntax.

It allows custom modules to load without hitting the following error message:

"Could not find imported module support code for 'Ansible.ModuleUtils.Legacy\r'
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
No existing bug report
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
windows module_utils
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0 (tolerate_win_line_endings_on_module_load ed1d4c9120) last updated 2018/03/12 08:14:22 (GMT +100)
  config file = None
  configured module search path = [u'/home/jon/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/jon/ansible-dev/lib/ansible
  executable location = /home/jon/ansible-dev/bin/ansible
  python version = 2.7.6 (default, Oct 26 2016, 20:30:19) [GCC 4.8.4]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
test using:

ansible-test windows-integration win_module_utils
<!--- Paste verbatim command output below, e.g. before and after your change -->
```
before, 
"Could not find imported module support code for 'Ansible.ModuleUtils.Legacy\r'
after
new win_module_util tests complete.
```
