### PR TITLE
[docker-container]: specify location of file when using `env_file`

### DIFF
--- a/lib/ansible/modules/cloud/docker/_docker.py
+++ b/lib/ansible/modules/cloud/docker/_docker.py
@@ -204,6 +204,7 @@ options:
       - Pass in a path to a file with environment variable (FOO=BAR).
         If a key value is present in both explicitly presented (i.e. as 'env')
         and in the environment file, the explicit value will override.
+        The file must be located on the target system.
         Requires docker-py >= 1.4.0.
     version_added: "2.1"
   dns:


### PR DESCRIPTION
I am sure it's a silly mistake but it looks like I am not the only one to have made it: thinking that the env file is on the control server (where one is running the `ansible` commands).
It needs to be on the target server.
By adding a single sentence, you can help poor souls like myself save some time and a the feeling of frustration.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
A simple change to the docs

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
docker-container

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.2.0
  config file = /Users/neo/workspace/SYSDIG/ansible/ansible.cfg
  configured module search path = [u'/Users/neo/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/Cellar/ansible/2.4.2.0_2/libexec/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.10 (default, Jul 15 2017, 17:16:57) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.31)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
