### PR TITLE
[WIP] add a __eq__ to TaskInclude 

### DIFF
--- a/lib/ansible/playbook/task_include.py
+++ b/lib/ansible/playbook/task_include.py
@@ -59,6 +59,11 @@ class TaskInclude(Task):
         new_me.statically_loaded = self.statically_loaded
         return new_me
 
+    def __eq__(self, other):
+        if not isinstance(other, TaskInclude):
+            return False
+        return self._uuid == other._uuid
+
     def get_vars(self):
         '''
         We override the parent Task() classes get_vars here because

--- a/test/units/playbook/test_task_include.py
+++ b/test/units/playbook/test_task_include.py
@@ -20,19 +20,17 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from ansible.compat.tests import unittest
-from ansible.compat.tests.mock import MagicMock
 
-from ansible.compat.six import string_types
-from ansible.errors import AnsibleParserError
-from ansible.playbook.attribute import FieldAttribute
 from ansible.playbook.task import Task
+
 from ansible.playbook.task_include import TaskInclude
-from ansible.template import Templar
-from ansible.executor import task_result
 
-from units.mock.loader import DictDataLoader
+import deepdiff
+import pprint
+pp = pprint.pprint
 
-class TestTastInclude(unittest.TestCase):
+
+class TestTaskInclude(unittest.TestCase):
 
     def test(self):
         parent_task_ds = {'debug': 'msg=foo'}
@@ -64,6 +62,8 @@ class TestTastInclude(unittest.TestCase):
         loaded_task = task_include.load(task_ds)
 
         task_include_copy = loaded_task.copy()
+        ddiff = deepdiff.DeepDiff(task_include, task_include_copy)
+        pp(ddiff)
         self.assertEqual(task_include_copy, task_include)
 
     def test_copy_parent(self):
@@ -90,6 +90,8 @@ class TestTastInclude(unittest.TestCase):
 
         task_include_copy = loaded_child_task.copy(exclude_parent=True, exclude_tasks=True)
         print(task_include_copy)
+        ddiff = deepdiff.DeepDiff(task_include, task_include_copy)
+        pp(ddiff)
         self.assertEqual(task_include_copy, loaded_child_task)
 
     def test_get_vars(self):

--- a/test/units/playbook/test_task_include.py
+++ b/test/units/playbook/test_task_include.py
@@ -65,8 +65,37 @@ class TestTaskInclude(unittest.TestCase):
 
         task_include_copy = loaded_task.copy()
         ddiff = deepdiff.DeepDiff(loaded_task, task_include_copy, verbose_level=2)
+        print('loaded task vs task_include_copy')
         pp(ddiff)
-        self.assertEqual(loaded_task, task_include)
+        print('loaded_task')
+        pp(loaded_task.serialize())
+        print('task_include_copy')
+        pp(task_include_copy.serialize())
+        print('lt( %s, uuid=%s) == ti(%s, uuid=%s) : %s' % (loaded_task, loaded_task._uuid,
+                                                            task_include_copy, task_include_copy._uuid,
+                                                            (loaded_task == task_include_copy)))
+        print('t.s == tic.s: %s' % (loaded_task.serialize() == task_include_copy.serialize()))
+        self.assertEqual(loaded_task, task_include_copy)
+
+    def test_copy_static(self):
+        task_ds = {'include': 'include_test.yml'}
+        task_include = TaskInclude()
+        fake_loader = DictDataLoader({})
+        task_include.static = True
+        loaded_task = task_include.load(task_ds, loader=fake_loader)
+
+        task_include_copy = loaded_task.copy()
+        ddiff = deepdiff.DeepDiff(loaded_task, task_include_copy, verbose_level=2)
+        print('s loaded task vs task_include_copy')
+        pp(ddiff)
+        print('s loaded_task')
+        pp(loaded_task.serialize())
+        print('s task_include_copy')
+        pp(task_include_copy.serialize())
+        print('lt( %s, uuid=%s) == ti(%s, uuid=%s) : %s' % (loaded_task, loaded_task._uuid,
+                                                            task_include, task_include._uuid,
+                                                            (loaded_task == task_include)))
+        self.assertEqual(loaded_task, task_include_copy)
 
     def test_copy_exclude_parent(self):
         task_ds = {'include': 'include_test.yml'}
@@ -76,7 +105,7 @@ class TestTaskInclude(unittest.TestCase):
         task_include_copy = loaded_task.copy(exclude_parent=True)
         ddiff = deepdiff.DeepDiff(loaded_task, task_include_copy, verbose_level=2)
         pp(ddiff)
-        self.assertEqual(loaded_task, task_include)
+        self.assertEqual(loaded_task, task_include_copy)
 
     def test_copy_exclude_parent_exclude_tasks(self):
         task_ds = {'include': 'include_test.yml'}
@@ -108,17 +137,17 @@ class TestTaskInclude(unittest.TestCase):
         pp(ddiff)
         self.assertEqual(loaded_child_task, task_include_copy)
 
-        task_include_copy = loaded_child_task.copy(exclude_parent=True)
-        ddiff = deepdiff.DeepDiff(loaded_child_task, task_include_copy, verbose_level=2)
-        pp(ddiff)
-        self.assertEqual(loaded_child_task, task_include_copy)
+#        task_include_copy = loaded_child_task.copy(exclude_parent=True)
+#        ddiff = deepdiff.DeepDiff(loaded_child_task, task_include_copy, verbose_level=2)
+#        pp(ddiff)
+#        self.assertEqual(loaded_child_task, task_include_copy)
 
-        task_include_copy = loaded_child_task.copy(exclude_parent=True, exclude_tasks=True)
-        ddiff = deepdiff.DeepDiff(loaded_child_task, task_include_copy, verbose_level=2)
-        pp(ddiff)
-        self.assertEqual(loaded_child_task, task_include_copy)
+#        task_include_copy = loaded_child_task.copy(exclude_parent=True, exclude_tasks=True)
+#        ddiff = deepdiff.DeepDiff(loaded_child_task, task_include_copy, verbose_level=2)
+#        pp(ddiff)
+#        self.assertEqual(loaded_child_task, task_include_copy)
 
-        self.assertEqual(loaded_task, loaded_child_task)
+#        self.assertEqual(loaded_task, loaded_child_task)
 
 
 class TestTaskIncludeGetVars(unittest.TestCase):

--- a/test/units/playbook/test_task_include.py
+++ b/test/units/playbook/test_task_include.py
@@ -1,0 +1,112 @@
+# (c) 2016, Adrian Likins <alikins@redhat.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.compat.tests import unittest
+from ansible.compat.tests.mock import MagicMock
+
+from ansible.compat.six import string_types
+from ansible.errors import AnsibleParserError
+from ansible.playbook.attribute import FieldAttribute
+from ansible.playbook.task import Task
+from ansible.playbook.task_include import TaskInclude
+from ansible.template import Templar
+from ansible.executor import task_result
+
+from units.mock.loader import DictDataLoader
+
+class TestTastInclude(unittest.TestCase):
+
+    def test(self):
+        parent_task_ds = {'debug': 'msg=foo'}
+        parent_task = Task()
+        parent_task.load(parent_task_ds)
+
+        task_ds = {'include': 'include_test.yml'}
+        task_include = TaskInclude()
+        loaded_task = task_include.load(task_ds, task_include=parent_task)
+        print(loaded_task)
+
+    def test_child(self):
+        parent_task_ds = {'debug': 'msg=foo'}
+        parent_task = Task()
+        parent_task.load(parent_task_ds)
+
+        task_ds = {'include': 'include_test.yml'}
+        task_include = TaskInclude()
+        loaded_task = task_include.load(task_ds, task_include=parent_task)
+
+        child_task_ds = {'include': 'other_include_test.yml'}
+        child_task_include = TaskInclude()
+        loaded_child_task = child_task_include.load(child_task_ds, task_include=loaded_task)
+        print(loaded_child_task)
+
+    def test_copy(self):
+        task_ds = {'include': 'include_test.yml'}
+        task_include = TaskInclude()
+        loaded_task = task_include.load(task_ds)
+
+        task_include_copy = loaded_task.copy()
+        self.assertEqual(task_include_copy, task_include)
+
+    def test_copy_parent(self):
+        task_ds = {'include': 'include_test.yml',
+                   'blip': 'foo',
+                   'vars': {'tags': ['tag1', 'tag2'],
+                            'when': 'true'}
+                   }
+        task_include = TaskInclude()
+        loaded_task = task_include.load(task_ds)
+
+        child_task_ds = {'include': 'other_include_test.yml',
+                         'tags': []}
+        child_task_include = TaskInclude()
+        loaded_child_task = child_task_include.load(child_task_ds, task_include=loaded_task)
+
+        task_include_copy = loaded_child_task.copy()
+        print(task_include_copy)
+        #self.assertEqual(task_include_copy, loaded_child_task)
+
+        task_include_copy = loaded_child_task.copy(exclude_parent=True)
+        print(task_include_copy)
+        #self.assertEqual(task_include_copy, loaded_child_task)
+
+        task_include_copy = loaded_child_task.copy(exclude_parent=True, exclude_tasks=True)
+        print(task_include_copy)
+        self.assertEqual(task_include_copy, loaded_child_task)
+
+    def test_get_vars(self):
+        task_ds = {'include': 'include_test.yml',
+                   'blip': 'foo',
+                   'vars': {'tags': ['tag1', 'tag2'],
+                            'when': 'true'}
+                   }
+        task_include = TaskInclude()
+        loaded_task = task_include.load(task_ds)
+
+        child_task_ds = {'include': 'other_include_test.yml',
+                         'tags': []}
+        child_task_include = TaskInclude()
+        loaded_child_task = child_task_include.load(child_task_ds, task_include=loaded_task)
+
+        task_vars = loaded_child_task.get_vars()
+        self.assertIn('blip', task_vars)
+        self.assertNotIn('tags', task_vars)
+        self.assertNotIn('when', task_vars)

--- a/test/units/playbook/test_task_include.py
+++ b/test/units/playbook/test_task_include.py
@@ -26,10 +26,6 @@ from ansible.playbook.task import Task
 
 from ansible.playbook.task_include import TaskInclude
 
-import deepdiff
-import pprint
-pp = pprint.pprint
-
 
 class TestTaskInclude(unittest.TestCase):
 
@@ -41,7 +37,7 @@ class TestTaskInclude(unittest.TestCase):
         task_ds = {'include': 'include_test.yml'}
         task_include = TaskInclude()
         loaded_task = task_include.load(task_ds, task_include=parent_task)
-        print(loaded_task)
+        self.assertIsInstance(loaded_task, TaskInclude)
 
     def test_child(self):
         parent_task_ds = {'debug': 'msg=foo'}
@@ -51,11 +47,12 @@ class TestTaskInclude(unittest.TestCase):
         task_ds = {'include': 'include_test.yml'}
         task_include = TaskInclude()
         loaded_task = task_include.load(task_ds, task_include=parent_task)
+        self.assertIsInstance(loaded_task, TaskInclude)
 
         child_task_ds = {'include': 'other_include_test.yml'}
         child_task_include = TaskInclude()
         loaded_child_task = child_task_include.load(child_task_ds, task_include=loaded_task)
-        print(loaded_child_task)
+        self.assertIsInstance(loaded_child_task, TaskInclude)
 
     def test_copy(self):
         task_ds = {'include': 'include_test.yml'}
@@ -64,17 +61,6 @@ class TestTaskInclude(unittest.TestCase):
         loaded_task = task_include.load(task_ds, loader=fake_loader)
 
         task_include_copy = loaded_task.copy()
-        ddiff = deepdiff.DeepDiff(loaded_task, task_include_copy, verbose_level=2)
-        print('loaded task vs task_include_copy')
-        pp(ddiff)
-        print('loaded_task')
-        pp(loaded_task.serialize())
-        print('task_include_copy')
-        pp(task_include_copy.serialize())
-        print('lt( %s, uuid=%s) == ti(%s, uuid=%s) : %s' % (loaded_task, loaded_task._uuid,
-                                                            task_include_copy, task_include_copy._uuid,
-                                                            (loaded_task == task_include_copy)))
-        print('t.s == tic.s: %s' % (loaded_task.serialize() == task_include_copy.serialize()))
         self.assertEqual(loaded_task, task_include_copy)
 
     def test_copy_static(self):
@@ -85,16 +71,6 @@ class TestTaskInclude(unittest.TestCase):
         loaded_task = task_include.load(task_ds, loader=fake_loader)
 
         task_include_copy = loaded_task.copy()
-        ddiff = deepdiff.DeepDiff(loaded_task, task_include_copy, verbose_level=2)
-        print('s loaded task vs task_include_copy')
-        pp(ddiff)
-        print('s loaded_task')
-        pp(loaded_task.serialize())
-        print('s task_include_copy')
-        pp(task_include_copy.serialize())
-        print('lt( %s, uuid=%s) == ti(%s, uuid=%s) : %s' % (loaded_task, loaded_task._uuid,
-                                                            task_include, task_include._uuid,
-                                                            (loaded_task == task_include)))
         self.assertEqual(loaded_task, task_include_copy)
 
     def test_copy_exclude_parent(self):
@@ -103,8 +79,6 @@ class TestTaskInclude(unittest.TestCase):
         loaded_task = task_include.load(task_ds)
 
         task_include_copy = loaded_task.copy(exclude_parent=True)
-        ddiff = deepdiff.DeepDiff(loaded_task, task_include_copy, verbose_level=2)
-        pp(ddiff)
         self.assertEqual(loaded_task, task_include_copy)
 
     def test_copy_exclude_parent_exclude_tasks(self):
@@ -114,8 +88,6 @@ class TestTaskInclude(unittest.TestCase):
         loaded_task = task_include.load(task_ds, loader=fake_loader)
 
         task_include_copy = loaded_task.copy(exclude_parent=True, exclude_tasks=True)
-        ddiff = deepdiff.DeepDiff(loaded_task, task_include_copy, verbose_level=2)
-        pp(ddiff)
         self.assertEqual(loaded_task, task_include_copy)
 
     def test_copy_parent(self):
@@ -133,21 +105,7 @@ class TestTaskInclude(unittest.TestCase):
         loaded_child_task = child_task_include.load(child_task_ds, task_include=loaded_task)
 
         task_include_copy = loaded_child_task.copy()
-        ddiff = deepdiff.DeepDiff(loaded_child_task, task_include_copy, verbose_level=2)
-        pp(ddiff)
         self.assertEqual(loaded_child_task, task_include_copy)
-
-#        task_include_copy = loaded_child_task.copy(exclude_parent=True)
-#        ddiff = deepdiff.DeepDiff(loaded_child_task, task_include_copy, verbose_level=2)
-#        pp(ddiff)
-#        self.assertEqual(loaded_child_task, task_include_copy)
-
-#        task_include_copy = loaded_child_task.copy(exclude_parent=True, exclude_tasks=True)
-#        ddiff = deepdiff.DeepDiff(loaded_child_task, task_include_copy, verbose_level=2)
-#        pp(ddiff)
-#        self.assertEqual(loaded_child_task, task_include_copy)
-
-#        self.assertEqual(loaded_task, loaded_child_task)
 
 
 class TestTaskIncludeGetVars(unittest.TestCase):

--- a/test/units/playbook/test_task_include.py
+++ b/test/units/playbook/test_task_include.py
@@ -64,7 +64,7 @@ class TestTaskInclude(unittest.TestCase):
         loaded_task = task_include.load(task_ds, loader=fake_loader)
 
         task_include_copy = loaded_task.copy()
-        ddiff = deepdiff.DeepDiff(loaded_task, task_include_copy)
+        ddiff = deepdiff.DeepDiff(loaded_task, task_include_copy, verbose_level=2)
         pp(ddiff)
         self.assertEqual(loaded_task, task_include)
 
@@ -74,7 +74,7 @@ class TestTaskInclude(unittest.TestCase):
         loaded_task = task_include.load(task_ds)
 
         task_include_copy = loaded_task.copy(exclude_parent=True)
-        ddiff = deepdiff.DeepDiff(loaded_task, task_include_copy)
+        ddiff = deepdiff.DeepDiff(loaded_task, task_include_copy, verbose_level=2)
         pp(ddiff)
         self.assertEqual(loaded_task, task_include)
 
@@ -85,7 +85,7 @@ class TestTaskInclude(unittest.TestCase):
         loaded_task = task_include.load(task_ds, loader=fake_loader)
 
         task_include_copy = loaded_task.copy(exclude_parent=True, exclude_tasks=True)
-        ddiff = deepdiff.DeepDiff(loaded_task, task_include_copy)
+        ddiff = deepdiff.DeepDiff(loaded_task, task_include_copy, verbose_level=2)
         pp(ddiff)
         self.assertEqual(loaded_task, task_include_copy)
 
@@ -104,17 +104,17 @@ class TestTaskInclude(unittest.TestCase):
         loaded_child_task = child_task_include.load(child_task_ds, task_include=loaded_task)
 
         task_include_copy = loaded_child_task.copy()
-        ddiff = deepdiff.DeepDiff(loaded_child_task, task_include_copy)
+        ddiff = deepdiff.DeepDiff(loaded_child_task, task_include_copy, verbose_level=2)
         pp(ddiff)
         self.assertEqual(loaded_child_task, task_include_copy)
 
         task_include_copy = loaded_child_task.copy(exclude_parent=True)
-        ddiff = deepdiff.DeepDiff(loaded_child_task, task_include_copy)
+        ddiff = deepdiff.DeepDiff(loaded_child_task, task_include_copy, verbose_level=2)
         pp(ddiff)
         self.assertEqual(loaded_child_task, task_include_copy)
 
         task_include_copy = loaded_child_task.copy(exclude_parent=True, exclude_tasks=True)
-        ddiff = deepdiff.DeepDiff(loaded_child_task, task_include_copy)
+        ddiff = deepdiff.DeepDiff(loaded_child_task, task_include_copy, verbose_level=2)
         pp(ddiff)
         self.assertEqual(loaded_child_task, task_include_copy)
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

add a __eq__ to TaskInclude
   
Otherwise a TaskInclude and a TaskInclude.copy() compare
as unequal even when their uuid matches.

[WIP] because I don't remember creating the change or why nor what state it is in.

Somewhat similar to https://github.com/ansible/ansible/pull/37083
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
lib/ansible/playbook/task_include.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0 (task_include_eq 48e74cd647) last updated 2018/03/12 10:45:02 (GMT -400)
  config file = None
  configured module search path = [u'/home/adrian/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/adrian/src/ansible/lib/ansible
  executable location = /home/adrian/src/ansible/bin/ansible
  python version = 2.7.14 (default, Feb 27 2018, 20:43:24) [GCC 7.3.1 20180130 (Red Hat 7.3.1-2)]


```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
