### PR TITLE
issue:37306 Fix issue with vlan support for onyx version 3.6.6000

### DIFF
--- a/lib/ansible/module_utils/network/onyx/onyx.py
+++ b/lib/ansible/module_utils/network/onyx/onyx.py
@@ -140,18 +140,24 @@ def get_interfaces_config(module, interface_type, flags=None, json_fmt=True):
     return show_cmd(module, cmd, json_fmt)
 
 
+def show_version(module):
+    return show_cmd(module, "show version")
+
+
 def get_bgp_summary(module):
     cmd = "show running-config protocol bgp"
     return show_cmd(module, cmd, json_fmt=False, fail_on_error=False)
 
 
 class BaseOnyxModule(object):
+    ONYX_API_VERSION = "3.6.6000"
 
     def __init__(self):
         self._module = None
         self._commands = list()
         self._current_config = None
         self._required_config = None
+        self._os_version = None
 
     def init_module(self):
         pass
@@ -161,6 +167,11 @@ class BaseOnyxModule(object):
 
     def get_required_config(self):
         pass
+
+    def _get_os_version(self):
+        version_data = show_version(self._module)
+        self._os_version = self.get_config_attr(
+            version_data, "Product release")
 
     # pylint: disable=unused-argument
     def check_declarative_intent_params(self, result):

--- a/lib/ansible/module_utils/network/onyx/onyx.py
+++ b/lib/ansible/module_utils/network/onyx/onyx.py
@@ -170,7 +170,7 @@ class BaseOnyxModule(object):
 
     def _get_os_version(self):
         version_data = show_version(self._module)
-        self._os_version = self.get_config_attr(
+        return self.get_config_attr(
             version_data, "Product release")
 
     # pylint: disable=unused-argument

--- a/lib/ansible/modules/network/onyx/onyx_vlan.py
+++ b/lib/ansible/modules/network/onyx/onyx_vlan.py
@@ -150,7 +150,7 @@ class OnyxVlanModule(BaseOnyxModule):
 
     def load_current_config(self):
         # called in base class in run function
-        self._get_os_version()
+        self._os_version = self._get_os_version()
         self._current_config = dict()
         vlan_config = self._get_vlan_config()
         if not vlan_config:

--- a/lib/ansible/modules/network/onyx/onyx_vlan.py
+++ b/lib/ansible/modules/network/onyx/onyx_vlan.py
@@ -138,6 +138,8 @@ class OnyxVlanModule(BaseOnyxModule):
             self._required_config.append(params)
 
     def _create_vlan_data(self, vlan_id, vlan_data):
+        if self._os_version >= self.ONYX_API_VERSION:
+            vlan_data = vlan_data[0]
         return {
             'vlan_id': vlan_id,
             'name': self.get_config_attr(vlan_data, 'Name')
@@ -148,6 +150,7 @@ class OnyxVlanModule(BaseOnyxModule):
 
     def load_current_config(self):
         # called in base class in run function
+        self._get_os_version()
         self._current_config = dict()
         vlan_config = self._get_vlan_config()
         if not vlan_config:

--- a/test/units/modules/network/onyx/test_onyx_vlan.py
+++ b/test/units/modules/network/onyx/test_onyx_vlan.py
@@ -20,8 +20,6 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-import json
-
 from ansible.compat.tests.mock import patch
 from ansible.modules.network.onyx import onyx_vlan
 from units.modules.utils import set_module_args
@@ -56,7 +54,7 @@ class TestOnyxVlanModule(TestOnyxModule):
         config_file = 'onyx_vlan_show.cfg'
         self.get_config.return_value = load_fixture(config_file)
         self.load_config.return_value = None
-        self.mock_get_version.return_value = "3.6.5000"
+        self.get_version.return_value = "3.6.5000"
 
     def test_vlan_no_change(self):
         set_module_args(dict(vlan_id=20))

--- a/test/units/modules/network/onyx/test_onyx_vlan.py
+++ b/test/units/modules/network/onyx/test_onyx_vlan.py
@@ -42,15 +42,21 @@ class TestOnyxVlanModule(TestOnyxModule):
             'ansible.module_utils.network.onyx.onyx.load_config')
         self.load_config = self.mock_load_config.start()
 
+        self.mock_get_version = patch.object(
+            onyx_vlan.OnyxVlanModule, "_get_os_version")
+        self.get_version = self.mock_get_version.start()
+
     def tearDown(self):
         super(TestOnyxVlanModule, self).tearDown()
         self.mock_get_config.stop()
         self.mock_load_config.stop()
+        self.mock_get_version.stop()
 
     def load_fixtures(self, commands=None, transport='cli'):
         config_file = 'onyx_vlan_show.cfg'
         self.get_config.return_value = load_fixture(config_file)
         self.load_config.return_value = None
+        self.mock_get_version.return_value = "3.6.5000"
 
     def test_vlan_no_change(self):
         set_module_args(dict(vlan_id=20))


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fix vlan result parsing for onyx version 3.6.6000

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Fixes #37306 
Add support for the new json structure returned in onyx version 3.6.6000

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
onyx_vlan.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (issue/37306 c73dd67dc4) last updated 2018/03/12 17:37:13 (GMT +000)
  config file = None
  python version = 2.7.5 (default, Nov  6 2016, 00:28:07) [GCC 4.8.5 20150623 (Red Hat 4.8.5-11)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
