### PR TITLE
Have added functionality to add/remove interfaces to/from namespace

### DIFF
--- a/lib/ansible/modules/net_tools/ip_netns.py
+++ b/lib/ansible/modules/net_tools/ip_netns.py
@@ -25,7 +25,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = """
 ---
 module: ip_netns
-version_added: 2.5
+version_added: 2.6
 author: "Arie Bregman (@bregman-arie)"
 short_description: Manage network namespaces
 requirements: [ ip ]
@@ -37,10 +37,16 @@ options:
         description:
             - Name of the namespace
     interfaces:
-        required: True
+        required: False
         default: None
         description:
             - List of interface names that need to be part of the namespace
+    operation:
+        required: False
+        choices: ['add', 'remove']
+        default: add
+        description:
+            - Whether interfaces should be add/deleted to/from namespace
     state:
         required: True
         choices: [ present, absent ]

--- a/lib/ansible/modules/net_tools/ip_netns.py
+++ b/lib/ansible/modules/net_tools/ip_netns.py
@@ -37,11 +37,13 @@ options:
         description:
             - Name of the namespace
     interfaces:
+        version_added: 2.6
         required: False
-        default: None
+        default: []
         description:
             - List of interface names that need to be part of the namespace
     operation:
+        version_added: 2.6
         required: False
         choices: ['add', 'remove']
         default: add
@@ -212,7 +214,7 @@ def main():
     module = AnsibleModule(
         argument_spec=dict(
             name=dict(required=True, type='str'),
-            interfaces=dict(required=False, default=None, type='list'),
+            interfaces=dict(required=False, default=[], type='list'),
             operation=dict(required=False, default='add', choices=['add', 'remove']),
             state=dict(required=True, choices=['present', 'absent'], type='str'),
         ),


### PR DESCRIPTION
Signed-off-by: vswamy <vswamy@avinetworks.com>

##### SUMMARY
Have made the below changes (enhancement):
[1] Current code has a documentation bug which says module name as `namespace` instead of `ip_netns`
[2] Added changes to support interface addition and removal to/from namespace

##### ISSUE TYPE

 - Feature Pull Request
 - Docs Pull Request

##### COMPONENT NAME

net_tools/ip_netns.py

##### ANSIBLE VERSION
```
ansible 2.4.3.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/aviuser/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.6 (default, Oct 26 2016, 20:30:19) [GCC 4.8.4]
```


##### ADDITIONAL INFORMATION

This neither a new feature or bug fix rather an enhancement to the existing funcationlity

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
