### PR TITLE
Fix ansible_lo being used inside of ansible_facts

### DIFF
--- a/lib/ansible/vars/clean.py
+++ b/lib/ansible/vars/clean.py
@@ -106,7 +106,7 @@ def namespace_facts(facts):
     ''' return all facts inside 'ansible_facts' w/o an ansible_ prefix '''
     deprefixed = {}
     for k in facts:
-        if k in ('ansible_local'):
+        if k in ('ansible_local',):
             # exceptions to 'deprefixing'
             deprefixed[k] = deepcopy(facts[k])
         else:


### PR DESCRIPTION
The logic was keeping ansible_facts['ansible_lo'] instead of fixing it
to be ansible_facts['lo']

##### ISSUE TYPE

 - Bugfix Pull Request


##### COMPONENT NAME
ansible_facts

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel 2.5
```


##### ADDITIONAL INFORMATION
This causes a user facing backwards incompatibilty between 2.5rc2 and the future.