### PR TITLE
win_setup: Added connection name to interfaces

### DIFF
--- a/test/integration/targets/win_setup/tasks/main.yml
+++ b/test/integration/targets/win_setup/tasks/main.yml
@@ -45,6 +45,7 @@
       - setup_result.ansible_facts.ansible_interfaces
       - setup_result.ansible_facts.ansible_interfaces[0]
       - setup_result.ansible_facts.ansible_interfaces[0].interface_name
+      - setup_result.ansible_facts.ansible_interfaces[0].connection_name
       - setup_result.ansible_facts.ansible_interfaces[0].interface_index
       - setup_result.ansible_facts.ansible_architecture
       - setup_result.ansible_facts.ansible_os_name
@@ -114,6 +115,7 @@
     - setup_result.ansible_facts.ansible_interfaces
     - setup_result.ansible_facts.ansible_interfaces[0]
     - setup_result.ansible_facts.ansible_interfaces[0].interface_name
+    - setup_result.ansible_facts.ansible_interfaces[0].connection_name
     - setup_result.ansible_facts.ansible_interfaces[0].interface_index
     - setup_result.ansible_facts.keys() | union(['ansible_interfaces','gather_subset','module_setup']) | length == 3
 


### PR DESCRIPTION
##### SUMMARY
Adds the windows friendly name to the interface result. This makes it easier to determine what adapter the entry is for.

Fixes https://github.com/ansible/ansible/issues/37013

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
setup.ps1

##### ANSIBLE VERSION
```
2.6
```

##### ADDITIONAL INFORMATION

