### PR TITLE
Fix nxos_switchport

### DIFF
--- a/lib/ansible/modules/network/nxos/_nxos_switchport.py
+++ b/lib/ansible/modules/network/nxos/_nxos_switchport.py
@@ -269,18 +269,23 @@ def remove_switchport_config_commands(interface, existing, proposed, module):
             commands.append(command)
 
     elif mode == 'trunk':
-        tv_check = existing.get('trunk_vlans_list') == proposed.get('trunk_vlans_list')
 
-        if tv_check:
-            existing_vlans = existing.get('trunk_vlans_list')
-            proposed_vlans = proposed.get('trunk_vlans_list')
-            vlans_to_remove = set(proposed_vlans).intersection(existing_vlans)
+        # Supported Remove Scenarios for trunk_vlans_list
+        # 1) Existing: 1,2,3 Proposed: 1,2,3 - Remove all
+        # 2) Existing: 1,2,3 Proposed: 1,2   - Remove 1,2 Leave 3
+        # 3) Existing: 1,2,3 Proposed: 2,3   - Remove 2,3 Leave 1
+        # 4) Existing: 1,2,3 Proposed: 4,5,6 - None removed.
+        # 5) Existing: None  Proposed: 1,2,3 - None removed.
 
-            if vlans_to_remove:
-                proposed_allowed_vlans = proposed.get('trunk_allowed_vlans')
-                remove_trunk_allowed_vlans = proposed.get('trunk_vlans', proposed_allowed_vlans)
-                command = 'switchport trunk allowed vlan remove {0}'.format(remove_trunk_allowed_vlans)
-                commands.append(command)
+        existing_vlans = existing.get('trunk_vlans_list')
+        proposed_vlans = proposed.get('trunk_vlans_list')
+        vlans_to_remove = set(proposed_vlans).intersection(existing_vlans)
+
+        if vlans_to_remove:
+            proposed_allowed_vlans = proposed.get('trunk_allowed_vlans')
+            remove_trunk_allowed_vlans = proposed.get('trunk_vlans', proposed_allowed_vlans)
+            command = 'switchport trunk allowed vlan remove {0}'.format(remove_trunk_allowed_vlans)
+            commands.append(command)
 
         native_check = existing.get('native_vlan') == proposed.get('native_vlan')
         if native_check and proposed.get('native_vlan'):

--- a/test/integration/targets/nxos_switchport/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_switchport/tests/common/sanity.yaml
@@ -88,7 +88,7 @@
 
   - assert: *false
 
-  - name: Ensure these VLANs are not being tagged on the trunk
+  - name: Remove full trunk vlan range 2-50.
     nxos_switchport: &no_tag
       interface: "{{ intname }}"
       mode: trunk
@@ -99,8 +99,37 @@
 
   - assert: *true
 
-  - name: "no tag vlan Idempotence"
+  - name: Check Idempotence Remove full trunk vlan range 2-50.
     nxos_switchport: *no_tag
+    register: result
+
+  - assert: *false
+
+  - name: Reconfigure interface trunk port and ensure 2-50 are being tagged
+    nxos_switchport: *tag
+    register: result
+
+  - assert: *true
+
+  - name: Check Idempotence Reconfigure interface trunk port and ensure 2-50 are being tagged
+    nxos_switchport: *tag
+    register: result
+
+  - assert: *false
+
+  - name: Remove partial trunk vlan range 30-4096 are removed
+    nxos_switchport: &partial
+      interface: "{{ intname }}"
+      mode: trunk
+      trunk_vlans: 30-4094
+      state: absent
+      provider: "{{ connection }}"
+    register: result
+
+  - assert: *true
+
+  - name: Check Idempotence Remove partial trunk vlan range 30-4096 are removed
+    nxos_switchport: *partial
     register: result
 
   - assert: *false


### PR DESCRIPTION
##### SUMMARY
Fixes nxos_switchport so that full and partial trunk vlan ranges can be removed.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
nxos_switchport

##### ANSIBLE VERSION
```
ansible 2.6.0 (rel250/fix_nxos_switchport 3c03ac0afa) last updated 2018/03/12 22:11:50 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/usr/share/ansible']
  ansible python module location = /root/agents-ci/ansible/lib/ansible
  executable location = /root/agents-ci/ansible/bin/ansible
  python version = 2.7.6 (default, Oct 26 2016, 20:30:19) [GCC 4.8.4]
```


##### ADDITIONAL INFORMATION
Tested against various NXOS platforms/versions and they all pass.
