### PR TITLE
 Connection error messages are unsafe: wrap them

### DIFF
--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -170,7 +170,7 @@ class TaskExecutor:
             display.debug("done dumping result, returning")
             return res
         except AnsibleError as e:
-            return dict(failed=True, msg=to_text(e, nonstring='simplerepr'))
+            return dict(failed=True, msg=wrap_var(to_text(e, nonstring='simplerepr')))
         except Exception as e:
             return dict(failed=True, msg='Unexpected failure during module execution.', exception=to_text(traceback.format_exc()), stdout='')
         finally:

--- a/test/integration/targets/connection/aliases
+++ b/test/integration/targets/connection/aliases
@@ -1,0 +1,1 @@
+posix/ci/group2

--- a/test/integration/targets/connection/inventory
+++ b/test/integration/targets/connection/inventory
@@ -1,0 +1,2 @@
+[local]
+testhost

--- a/test/integration/targets/connection/play.yml
+++ b/test/integration/targets/connection/play.yml
@@ -1,0 +1,19 @@
+- hosts: testhost
+  gather_facts: false
+  tasks:
+    - name: "use a connection plugin raising an exception, exception message contains Jinja template."
+      connection: dummy
+      command: /bin/true  # command won't be executed
+      register: result
+      ignore_errors: True
+
+    - name: "check that Jinja template embedded in exception message isn't rendered"
+      debug:
+        msg: 'ok'
+      when: result is failed
+      register: debug_task
+
+    - assert:
+        that:
+          - result is failed
+          - debug_task is success

--- a/test/integration/targets/connection/plugin/dummy.py
+++ b/test/integration/targets/connection/plugin/dummy.py
@@ -1,0 +1,46 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+DOCUMENTATION = """
+    author:
+        - John Doe
+    connection: dummy
+    short_description: defective connection plugin
+    description:
+        - defective connection plugin
+    version_added: "2.0"
+    options: {}
+"""
+import ansible.constants as C
+from ansible.errors import AnsibleError
+from ansible.plugins.connection import ConnectionBase
+
+
+class Connection(ConnectionBase):
+
+    transport = 'dummy'
+    has_pipelining = True
+    become_methods = frozenset(C.BECOME_METHODS)
+
+    def __init__(self, play_context, new_stdin, *args, **kwargs):
+        super(Connection, self).__init__(play_context, new_stdin, *args, **kwargs)
+
+        raise AnsibleError('an error with {{ some Jinja }}')
+
+    def transport(self):
+        pass
+
+    def _connect(self):
+        pass
+
+    def exec_command(self, cmd, in_data=None, sudoable=True):
+        pass
+
+    def put_file(self, in_path, out_path):
+        pass
+
+    def fetch_file(self, in_path, out_path):
+        pass
+
+    def close(self):
+        pass

--- a/test/integration/targets/connection/runme.sh
+++ b/test/integration/targets/connection/runme.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -o nounset -o errexit -o xtrace
+
+ANSIBLE_CONNECTION_PLUGINS="$(pwd)/plugin" ansible-playbook -i inventory "$(pwd)/play.yml" -v "$@"


### PR DESCRIPTION
##### SUMMARY
Connection error messages are unsafe: wrap them.

For example, in case of error, `docker` connection plugin returns exception message containing Go template (`{{.Server.Version}}`). These messages weren't tagged as unsafe and were consequently rendered, then a template exception occurred.

```
The conditional check 'result is failed' failed. The error was:
{
  'msg': u'Docker version check ([\'/usr/bin/docker\', \'version\', \'--format\', "\'{{.Server.Version}}\'"]) failed: Got permission denied while trying to connect to the Docker daemon socket at unix:///var/run/docker.sock: Get http://%2Fvar%2Frun%2Fdocker.sock/v1.35/version: dial unix /var/run/docker.sock: connect: permission denied\n',
  'failed': True
}:
template error while templating string: unexpected '.'.
String: Docker version check (['/usr/bin/docker', 'version', '--format', "'{{.Server.Version}}'"]) failed: Got permission denied while trying to connect to the Docker daemon socket at unix:///var/run/docker.sock: Get http://%2Fvar%2Frun%2Fdocker.sock/v1.35/version: dial unix /var/run/docker.sock: connect: permission denied
```
Integration test provided :tada:

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
connection plugin

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0 (devel c1008d693c) last updated 2018/03/12 18:09:57 (GMT +200)
```

##### ADDITIONAL INFORMATION
2.4 and 2.5 are affected too: bugfix should be backported.