### PR TITLE
Fix nxos_l2_interface and test typo

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_l2_interface.py
+++ b/lib/ansible/modules/network/nxos/nxos_l2_interface.py
@@ -252,18 +252,15 @@ def remove_switchport_config_commands(name, existing, proposed, module):
             commands.append(command)
 
     elif mode == 'trunk':
-        tv_check = existing.get('trunk_vlans_list') == proposed.get('trunk_vlans_list')
+        existing_vlans = existing.get('trunk_vlans_list')
+        proposed_vlans = proposed.get('trunk_vlans_list')
+        vlans_to_remove = set(proposed_vlans).intersection(existing_vlans)
 
-        if tv_check:
-            existing_vlans = existing.get('trunk_vlans_list')
-            proposed_vlans = proposed.get('trunk_vlans_list')
-            vlans_to_remove = set(proposed_vlans).intersection(existing_vlans)
-
-            if vlans_to_remove:
-                proposed_allowed_vlans = proposed.get('trunk_allowed_vlans')
-                remove_trunk_allowed_vlans = proposed.get('trunk_vlans', proposed_allowed_vlans)
-                command = 'switchport trunk allowed vlan remove {0}'.format(remove_trunk_allowed_vlans)
-                commands.append(command)
+        if vlans_to_remove:
+            proposed_allowed_vlans = proposed.get('trunk_allowed_vlans')
+            remove_trunk_allowed_vlans = proposed.get('trunk_vlans', proposed_allowed_vlans)
+            command = 'switchport trunk allowed vlan remove {0}'.format(remove_trunk_allowed_vlans)
+            commands.append(command)
 
         native_check = existing.get('native_vlan') == proposed.get('native_vlan')
         if native_check and proposed.get('native_vlan'):

--- a/test/integration/targets/nxos_l2_interface/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_l2_interface/tests/common/sanity.yaml
@@ -20,6 +20,7 @@
   nxos_interface:
     interface: "{{ intname }}"
     mode: layer2
+    provider: "{{ connection }}"
 
 - name: "Setup vlans"
   nxos_vlan:
@@ -91,7 +92,7 @@
 
   - assert: *false
 
-  - name: Ensure these VLANs are not being tagged on the trunk
+  - name: Remove full trunk vlan range 2-50
     nxos_l2_interface: &no_tag
       name: "{{ intname }}"
       mode: trunk
@@ -102,8 +103,37 @@
 
   - assert: *true
 
-  - name: "no tag vlan Idempotence"
+  - name: Check Idempotence Remove full trunk vlan range 2-50
     nxos_l2_interface: *no_tag
+    register: result
+
+  - assert: *false
+
+  - name: Reconfigure interface trunk port and ensure 2-50 are being tagged
+    nxos_l2_interface: *tag
+    register: result
+
+  - assert: *true
+
+  - name: Check Idempotence Reconfigure interface trunk port and ensure 2-50 are being tagged
+    nxos_l2_interface: *tag
+    register: result
+
+  - assert: *false
+
+  - name: Remove partial trunk vlan range 30-4094 are removed
+    nxos_l2_interface: &partial
+      name: "{{ intname }}"
+      mode: trunk
+      trunk_vlans: 30-4094
+      state: absent
+      provider: "{{ connection }}"
+    register: result
+
+  - assert: *true
+
+  - name: Check Idempotence Remove partial trunk vlan range 30-4094 are removed
+    nxos_l2_interface: *partial
     register: result
 
   - assert: *false

--- a/test/integration/targets/nxos_switchport/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_switchport/tests/common/sanity.yaml
@@ -117,7 +117,7 @@
 
   - assert: *false
 
-  - name: Remove partial trunk vlan range 30-4096 are removed
+  - name: Remove partial trunk vlan range 30-4094 are removed
     nxos_switchport: &partial
       interface: "{{ intname }}"
       mode: trunk
@@ -128,7 +128,7 @@
 
   - assert: *true
 
-  - name: Check Idempotence Remove partial trunk vlan range 30-4096 are removed
+  - name: Check Idempotence Remove partial trunk vlan range 30-4094 are removed
     nxos_switchport: *partial
     register: result
 


### PR DESCRIPTION
Signed-off-by: Trishna Guha <trishnaguha17@gmail.com>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes nxos_l2_interface so that full and partial trunk vlan ranges can be removed.
Related https://github.com/ansible/ansible/pull/37328

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
modules/network/nxos/nxos_l2_interface.py
test/integration/targets/nxos_l2_interface/
test/integration/targets/nxos_switchport/
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel, 2.5
```