### PR TITLE
Fixes #26760 - Added ability to create Openstack users without password

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_user.py
+++ b/lib/ansible/modules/cloud/openstack/os_user.py
@@ -33,7 +33,7 @@ options:
      description:
         - Password for the user
    update_password:
-     default: always
+     required: false
      choices: ['always', 'on_create']
      version_added: "2.3"
      description:
@@ -94,6 +94,15 @@ EXAMPLES = '''
     name: demouser
     password: secret
     update_password: on_create
+    email: demo@example.com
+    domain: default
+    default_project: demo
+
+# Create a user without password
+- os_user:
+    cloud: mycloud
+    state: present
+    name: demouser
     email: demo@example.com
     domain: default
     default_project: demo
@@ -181,7 +190,7 @@ def main():
         domain=dict(required=False, default=None),
         enabled=dict(default=True, type='bool'),
         state=dict(default='present', choices=['absent', 'present']),
-        update_password=dict(default='always', choices=['always', 'on_create']),
+        update_password=dict(default=None, choices=['always', 'on_create']),
     )
 
     module_kwargs = openstack_module_kwargs()


### PR DESCRIPTION
##### SUMMARY
Fixes #26760 - Added ability to create Openstack users without a password

Currently, openstack users can't be created without specifying the password. Openstack command line allows doing this as there is a requirement to create users with external auth like LDAP and SAML. 

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
ansible/lib/ansible/modules/cloud/openstack/os_user.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
(test) [arun@fedora flavor-test(keystone_admin)]$ ansible --version
ansible 2.6.0 (devel ff28429e2a) last updated 2018/03/07 18:05:40 (GMT +550)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/arun/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/arun/Projects/bingoarun/flavor-test/ansible/lib/ansible
  executable location = /home/arun/Projects/bingoarun/flavor-test/test/bin/ansible
  python version = 2.7.14 (default, Feb 27 2018, 20:43:24) [GCC 7.3.1 20180130 (Red Hat 7.3.1-2)]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
- For this change, I just changed the default value to 'None'. In the _needs_update function, if the password parameters are not given, then it is ignored. (No update required for password)
- Also before this change, the update_password and password parameters are marked as optional (required: false). But without those the program won't work. However now that those parameters are made optional, the program will run without any error. Appropriate documentation changes are made. 

<!--- Paste verbatim command output below, e.g. before and after your change -->
**Before change**
```
(test) [arun@fedora flavor-test(keystone_admin)]$ ansible-playbook sg.yml  --connection=local -vvv 
ansible-playbook 2.6.0 (devel ff28429e2a) last updated 2018/03/07 18:05:40 (GMT +550)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/arun/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/arun/Projects/bingoarun/flavor-test/ansible/lib/ansible
  executable location = /home/arun/Projects/bingoarun/flavor-test/test/bin/ansible-playbook
  python version = 2.7.14 (default, Feb 27 2018, 20:43:24) [GCC 7.3.1 20180130 (Red Hat 7.3.1-2)]
Using /etc/ansible/ansible.cfg as config file
Parsed /etc/ansible/hosts inventory source with ini plugin
 [WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'


PLAYBOOK: sg.yml **************************************************************************************************************************************
1 plays in sg.yml

PLAY [localhost] **************************************************************************************************************************************

TASK [Gathering Facts] ********************************************************************************************************************************
task path: /home/arun/Projects/bingoarun/flavor-test/sg.yml:2
Using module file /home/arun/Projects/bingoarun/flavor-test/ansible/lib/ansible/modules/system/setup.py
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: arun
<127.0.0.1> EXEC /bin/sh -c 'echo ~ && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/arun/.ansible/tmp/ansible-tmp-1520931764.63-33779391266975 `" && echo ansible-tmp-1520931764.63-33779391266975="` echo /home/arun/.ansible/tmp/ansible-tmp-1520931764.63-33779391266975 `" ) && sleep 0'
<127.0.0.1> PUT /home/arun/.ansible/tmp/ansible-local-52692Z4yHs/tmpMPjUiR TO /home/arun/.ansible/tmp/ansible-tmp-1520931764.63-33779391266975/setup.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /home/arun/.ansible/tmp/ansible-tmp-1520931764.63-33779391266975/ /home/arun/.ansible/tmp/ansible-tmp-1520931764.63-33779391266975/setup.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/home/arun/Projects/bingoarun/flavor-test/test/bin/python2 /home/arun/.ansible/tmp/ansible-tmp-1520931764.63-33779391266975/setup.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /home/arun/.ansible/tmp/ansible-tmp-1520931764.63-33779391266975/ > /dev/null 2>&1 && sleep 0'
ok: [localhost]
META: ran handlers

TASK [os_user] ****************************************************************************************************************************************
task path: /home/arun/Projects/bingoarun/flavor-test/sg.yml:5
Using module file /home/arun/Projects/bingoarun/flavor-test/library/os_user.py
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: arun
<127.0.0.1> EXEC /bin/sh -c 'echo ~ && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/arun/.ansible/tmp/ansible-tmp-1520931765.63-257824929743526 `" && echo ansible-tmp-1520931765.63-257824929743526="` echo /home/arun/.ansible/tmp/ansible-tmp-1520931765.63-257824929743526 `" ) && sleep 0'
<127.0.0.1> PUT /home/arun/.ansible/tmp/ansible-local-52692Z4yHs/tmpenElea TO /home/arun/.ansible/tmp/ansible-tmp-1520931765.63-257824929743526/os_user.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /home/arun/.ansible/tmp/ansible-tmp-1520931765.63-257824929743526/ /home/arun/.ansible/tmp/ansible-tmp-1520931765.63-257824929743526/os_user.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/home/arun/Projects/bingoarun/flavor-test/test/bin/python2 /home/arun/.ansible/tmp/ansible-tmp-1520931765.63-257824929743526/os_user.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /home/arun/.ansible/tmp/ansible-tmp-1520931765.63-257824929743526/ > /dev/null 2>&1 && sleep 0'
fatal: [localhost]: FAILED! => {
    "changed": false, 
    "invocation": {
        "module_args": {
            "api_timeout": null, 
            "auth": null, 
            "auth_type": null, 
            "availability_zone": null, 
            "cacert": null, 
            "cert": null, 
            "default_project": null, 
            "description": null, 
            "domain": "default", 
            "email": "test@exa.co1m", 
            "enabled": true, 
            "interface": "public", 
            "key": null, 
            "name": "myuser2", 
            "password": null, 
            "region_name": null, 
            "state": "present", 
            "timeout": 180, 
            "update_password": "always", 
            "verify": null, 
            "wait": true
        }
    }, 
    "msg": "update_password is always but a password value is missing"
}
	to retry, use: --limit @/home/arun/Projects/bingoarun/flavor-test/sg.retry

PLAY RECAP ********************************************************************************************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=1   

(test) [arun@fedora flavor-test(keystone_admin)]$
```
**After change**
```
(test) [arun@fedora flavor-test(keystone_admin)]$ ansible-playbook sg.yml  --connection=local -vvv 
ansible-playbook 2.6.0 (devel ff28429e2a) last updated 2018/03/07 18:05:40 (GMT +550)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/arun/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/arun/Projects/bingoarun/flavor-test/ansible/lib/ansible
  executable location = /home/arun/Projects/bingoarun/flavor-test/test/bin/ansible-playbook
  python version = 2.7.14 (default, Feb 27 2018, 20:43:24) [GCC 7.3.1 20180130 (Red Hat 7.3.1-2)]
Using /etc/ansible/ansible.cfg as config file
Parsed /etc/ansible/hosts inventory source with ini plugin
 [WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'


PLAYBOOK: sg.yml **************************************************************************************************************************************
1 plays in sg.yml

PLAY [localhost] **************************************************************************************************************************************

TASK [Gathering Facts] ********************************************************************************************************************************
task path: /home/arun/Projects/bingoarun/flavor-test/sg.yml:2
Using module file /home/arun/Projects/bingoarun/flavor-test/ansible/lib/ansible/modules/system/setup.py
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: arun
<127.0.0.1> EXEC /bin/sh -c 'echo ~ && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/arun/.ansible/tmp/ansible-tmp-1520931873.79-136670041879696 `" && echo ansible-tmp-1520931873.79-136670041879696="` echo /home/arun/.ansible/tmp/ansible-tmp-1520931873.79-136670041879696 `" ) && sleep 0'
<127.0.0.1> PUT /home/arun/.ansible/tmp/ansible-local-5612CBiJEa/tmpp22b4C TO /home/arun/.ansible/tmp/ansible-tmp-1520931873.79-136670041879696/setup.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /home/arun/.ansible/tmp/ansible-tmp-1520931873.79-136670041879696/ /home/arun/.ansible/tmp/ansible-tmp-1520931873.79-136670041879696/setup.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/home/arun/Projects/bingoarun/flavor-test/test/bin/python2 /home/arun/.ansible/tmp/ansible-tmp-1520931873.79-136670041879696/setup.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /home/arun/.ansible/tmp/ansible-tmp-1520931873.79-136670041879696/ > /dev/null 2>&1 && sleep 0'
ok: [localhost]
META: ran handlers

TASK [os_user] ****************************************************************************************************************************************
task path: /home/arun/Projects/bingoarun/flavor-test/sg.yml:5
Using module file /home/arun/Projects/bingoarun/flavor-test/library/os_user.py
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: arun
<127.0.0.1> EXEC /bin/sh -c 'echo ~ && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/arun/.ansible/tmp/ansible-tmp-1520931874.51-33746967401990 `" && echo ansible-tmp-1520931874.51-33746967401990="` echo /home/arun/.ansible/tmp/ansible-tmp-1520931874.51-33746967401990 `" ) && sleep 0'
<127.0.0.1> PUT /home/arun/.ansible/tmp/ansible-local-5612CBiJEa/tmpSA1DFs TO /home/arun/.ansible/tmp/ansible-tmp-1520931874.51-33746967401990/os_user.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /home/arun/.ansible/tmp/ansible-tmp-1520931874.51-33746967401990/ /home/arun/.ansible/tmp/ansible-tmp-1520931874.51-33746967401990/os_user.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/home/arun/Projects/bingoarun/flavor-test/test/bin/python2 /home/arun/.ansible/tmp/ansible-tmp-1520931874.51-33746967401990/os_user.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /home/arun/.ansible/tmp/ansible-tmp-1520931874.51-33746967401990/ > /dev/null 2>&1 && sleep 0'
changed: [localhost] => {
    "changed": true, 
    "invocation": {
        "module_args": {
            "api_timeout": null, 
            "auth": null, 
            "auth_type": null, 
            "availability_zone": null, 
            "cacert": null, 
            "cert": null, 
            "default_project": null, 
            "description": null, 
            "domain": "default", 
            "email": "test@exa.co1m", 
            "enabled": true, 
            "interface": "public", 
            "key": null, 
            "name": "myuser2", 
            "password": null, 
            "region_name": null, 
            "state": "present", 
            "timeout": 180, 
            "update_password": null, 
            "verify": null, 
            "wait": true
        }
    }, 
    "user": {
        "default_project_id": null, 
        "description": null, 
        "domain_id": "default", 
        "email": "test@exa.co1m", 
        "enabled": true, 
        "id": "71c99e9b4c3f4feab7489be994030dd4", 
        "name": "myuser2", 
        "username": null
    }
}
META: ran handlers
META: ran handlers

PLAY RECAP ********************************************************************************************************************************************
localhost                  : ok=2    changed=1    unreachable=0    failed=0 
```