### PR TITLE
cloudfront_distribution: fix the order of headers to avoid updates again and again

### DIFF
--- a/lib/ansible/modules/cloud/amazon/cloudfront_distribution.py
+++ b/lib/ansible/modules/cloud/amazon/cloudfront_distribution.py
@@ -1405,10 +1405,10 @@ class CloudFrontValidationManager(object):
                 all_origins[origin['domain_name']] = origin
                 new_domains.append(origin['domain_name'])
             if purge_origins:
-                for domain in all_origins:
+                for domain in list(all_origins.keys()):
                     if domain not in new_domains:
                         del(all_origins[domain])
-            return ansible_list_to_cloudfront_list(all_origins.values())
+            return ansible_list_to_cloudfront_list(list(all_origins.values()))
         except Exception as e:
             self.module.fail_json_aws(e, msg="Error validating distribution origins")
 
@@ -1488,7 +1488,7 @@ class CloudFrontValidationManager(object):
             if purge_cache_behaviors:
                 for target_origin_id in set(all_cache_behaviors.keys()) - set([cb['path_pattern'] for cb in cache_behaviors]):
                     del(all_cache_behaviors[target_origin_id])
-            return ansible_list_to_cloudfront_list(all_cache_behaviors.values())
+            return ansible_list_to_cloudfront_list(list(all_cache_behaviors.values()))
         except Exception as e:
             self.module.fail_json_aws(e, msg="Error validating distribution cache behaviors")
 

--- a/lib/ansible/modules/cloud/amazon/cloudfront_distribution.py
+++ b/lib/ansible/modules/cloud/amazon/cloudfront_distribution.py
@@ -1540,6 +1540,8 @@ class CloudFrontValidationManager(object):
                 forwarded_values = dict()
             existing_config = config.get('forwarded_values', {})
             headers = forwarded_values.get('headers', existing_config.get('headers', {}).get('items'))
+            if headers:
+                headers.sort()
             forwarded_values['headers'] = ansible_list_to_cloudfront_list(headers)
             if 'cookies' not in forwarded_values:
                 forward = existing_config.get('cookies', {}).get('forward', self.__default_cache_behavior_forwarded_values_forward_cookies)

--- a/test/integration/targets/cloudfront_distribution/defaults/main.yml
+++ b/test/integration/targets/cloudfront_distribution/defaults/main.yml
@@ -1,12 +1,16 @@
-cloudfront_hostname: "{{ resource_prefix | lower }}01"
+cloudfront_hostname: "{{ resource_prefix }}01"
 # Use a domain that has a wildcard DNS
-cloudfront_alias: "{{ cloudfront_hostname | lower }}.github.io"
+cloudfront_alias: "{{ cloudfront_hostname }}.github.io"
 
 cloudfront_test_cache_behaviors:
   - path_pattern: /test/path
     forwarded_values:
       headers:
         - Host
+        - X-HTTP-Forwarded-For
+        - CloudFront-Forwarded-Proto
+        - Origin
+        - Referer
     allowed_methods:
       items:
         - GET


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

* Wrap `OrderedDict.values()` in a `list()` call to avoid errors _"expected type list, got odict_values"_ from `ansible_list_to_cloudfront_list`
* Update the way we loop over `all_origins` keys to fix the error _"RuntimeError: OrderedDict mutated during iteration"_

I think both issues were related to some kind of python2/3 compatibilty (I was running the integration tests in the `ansible/ansible:default` docker image)

* Add sorting of `headers` list to be consistent between two idempotent updates (Fixes #37239). I added more headers to the integration tests (I was able to reproduce the bug by adding them before the changes)

* Also removed `lower` filter for resource prefix. It's done by default since #37095

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
cloudfront_distribution

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6.0
```
