### PR TITLE
Add details to see decrypted vault value

### DIFF
--- a/docs/docsite/rst/network/getting_started/first_inventory.rst
+++ b/docs/docsite/rst/network/getting_started/first_inventory.rst
@@ -179,9 +179,9 @@ With the ``-k`` flag, you provide the SSH password(s) at the prompt. Alternative
 Protecting Sensitive Variables with ``ansible-vault`` 
 ================================================================================
 
-The ``ansible-vault`` command provides encryption for files and/or individual variables like passwords. This tutorial uses SSH passwords for an example. You can use the commands below to encrypt other sensitive information, such as database passwords, privilege-escalation passwords and more.
+The ``ansible-vault`` command provides encryption for files and/or individual variables like passwords. This tutorial will show you how to encrypt a single SSH password. You can use the commands below to encrypt other sensitive information, such as database passwords, privilege-escalation passwords and more.
 
-First you must create a password for ansible-vault itself. Then you can encrypt dozens of different passwords across your Ansible project. You can access all those secrets with a single password (the ansible-vault password) when you run your playbooks. Here's a simple example.
+First you must create a password for ansible-vault itself. It is used as the encryption key, and with this you can encrypt dozens of different passwords across your Ansible project. You can access all those secrets (encrypted values) with a single password (the ansible-vault password) when you run your playbooks. Here's a simple example.
 
 Create a file and write your password for ansible-vault to it:
 
@@ -189,13 +189,13 @@ Create a file and write your password for ansible-vault to it:
 
    echo "my-ansible-vault-pw" > ~/my-ansible-vault-pw-file
 
-Encrypt the ssh password for your VyOS network devices, pulling your ansible-vault password from the file you just created:
+Create the encrypted ssh password for your VyOS network devices, pulling your ansible-vault password from the file you just created:
 
 .. code-block:: bash
 
    ansible-vault encrypt_string --vault-id my_user@~/my-ansible-vault-pw-file 'VyOS_SSH_password' --name 'ansible_ssh_pass'
 
-If you prefer to type your vault password rather than store it in a file, you can request a prompt:
+If you prefer to type your ansible-vault password rather than store it in a file, you can request a prompt:
 
 .. code-block:: bash
 
@@ -242,6 +242,19 @@ Or with a prompt instead of the vault password file:
 .. code-block:: bash
 
    ansible-playbook -i inventory --vault-id my_user@prompt first_playbook.yml
+
+To see the original value, you can use the debug module. Please note if your yaml file defines the `ansible_connection` variable (as we used in our example), it will take effect when you execute the command below. To prevent this please make a copy of the file without the ansible_connection variable for this. 
+
+.. code-block:: bash
+
+   cat vyos.yml | grep -v ansible_connection >> vyos_no_connection.yml
+
+   ansible localhost -m debug -a var="ansible_ssh_pass" -e "@vyos_no_connection.yml" --ask-vault-pass
+   Vault password:
+
+   localhost | SUCCESS => {
+       "ansible_ssh_pass": "VyOS_SSH_password"
+   }
 
 
 .. warning::

--- a/docs/docsite/rst/network/getting_started/first_inventory.rst
+++ b/docs/docsite/rst/network/getting_started/first_inventory.rst
@@ -243,7 +243,7 @@ Or with a prompt instead of the vault password file:
 
    ansible-playbook -i inventory --vault-id my_user@prompt first_playbook.yml
 
-To see the original value, you can use the debug module. Please note if your yaml file defines the `ansible_connection` variable (as we used in our example), it will take effect when you execute the command below. To prevent this please make a copy of the file without the ansible_connection variable for this. 
+To see the original value, you can use the debug module. Please note if your YAML file defines the `ansible_connection` variable (as we used in our example), it will take effect when you execute the command below. To prevent this, please make a copy of the file without the ansible_connection variable. 
 
 .. code-block:: console
 

--- a/docs/docsite/rst/network/getting_started/first_inventory.rst
+++ b/docs/docsite/rst/network/getting_started/first_inventory.rst
@@ -245,7 +245,7 @@ Or with a prompt instead of the vault password file:
 
 To see the original value, you can use the debug module. Please note if your yaml file defines the `ansible_connection` variable (as we used in our example), it will take effect when you execute the command below. To prevent this please make a copy of the file without the ansible_connection variable for this. 
 
-.. code-block:: bash
+.. code-block:: console
 
    cat vyos.yml | grep -v ansible_connection >> vyos_no_connection.yml
 


### PR DESCRIPTION
<!--- Your description here -->
1. Added workaround to display single encrypted value in ansible-vault. Thanks to @dirtyonekanobi from NTC.
2. Added some wording for clarity.

+label: docsite_pr

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Improving beginners guide for Network Engineers by adding an example how to display the original value of an encrypted single variable in a var file.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
Docs

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ubuntu@ubuntu-xenial:~$ ansible --version
ansible 2.5.0rc2 (stable-2.5 2ee6a85463) last updated 2018/03/09 18:40:28 (GMT +000)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/ubuntu/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/ubuntu/ansible/lib/ansible
  executable location = /home/ubuntu/ansible/bin/ansible
  python version = 2.7.12 (default, Nov 20 2017, 18:23:56) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
n/a
```
