### PR TITLE
Use NormalizedOperationMethod to catch ClientErrors in custom waiter

### DIFF
--- a/lib/ansible/module_utils/aws/waiters.py
+++ b/lib/ansible/module_utils/aws/waiters.py
@@ -24,7 +24,7 @@ ec2_data = {
                     "matcher": "error",
                     "expected": "InvalidRouteTableID.NotFound",
                     "state": "retry"
-                }
+                },
             ]
         }
     }
@@ -40,7 +40,9 @@ waiters_by_name = {
     ('EC2', 'route_table_exists'): lambda ec2: core_waiter.Waiter(
         'route_table_exists',
         model_for('RouteTableExists'),
-        ec2.describe_route_tables)
+        core_waiter.NormalizedOperationMethod(
+            ec2.describe_route_tables
+        ))
 }
 
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Wrap the describe_route_tables call so that ClientError exceptions are caught and error responses can be handled by the error-matchers in custom waiters. 
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
ec2_vpc_route_table

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
