### PR TITLE
Fixes ec2.py assume_role.

### DIFF
--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -152,13 +152,13 @@ import os
 import argparse
 import re
 from time import time
+from copy import deepcopy
 import boto
 from boto import ec2
 from boto import rds
 from boto import elasticache
 from boto import route53
 from boto import sts
-from copy import deepcopy
 import six
 
 from ansible.module_utils import ec2 as ec2_utils

--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -158,6 +158,7 @@ from boto import rds
 from boto import elasticache
 from boto import route53
 from boto import sts
+from copy import deepcopy
 import six
 
 from ansible.module_utils import ec2 as ec2_utils
@@ -565,7 +566,7 @@ class Ec2Inventory(object):
         return connect_args
 
     def connect_to_aws(self, module, region):
-        connect_args = self.credentials
+        connect_args = deepcopy(self.credentials)
 
         # only pass the profile name if it's set (as it is not supported by older boto versions)
         if self.boto_profile:


### PR DESCRIPTION
##### SUMMARY
Previously when connect_to_aws was called it updated the credentials in place.  "connect_to_aws" is called multiple times: on the second run it tries to assume the same role it is already using, and potentially failing depending on your iam policies.   @patdowney found this one.

Fixes #40336

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
AWS ec2 dynamic inventory

##### ANSIBLE VERSION
```
ansible 2.4.3.0
python version = 2.7.5
```
##### ADDITIONAL INFORMATION
Set ```iam_role``` in ec2.ini to be the role you want to assume. 

Make sure the role you assume has a trust relationship that allows you to assume it, but does not allow anyone to assume it. 

```
python ec2.py 
# ERROR: "Error connecting to AWS backend.
# User: arn:aws:sts::12345:assumed-role/your-role/your-profile is not authorized to perform: sts:AssumeRole on resource arn:aws:sts::12345:assumed-role/your-role/your-profile" while: getting EC2 instances
```