### PR TITLE
Bkprt onyx tmp file

### DIFF
--- a/changelogs/fragments/onyx-tmpfile.yaml
+++ b/changelogs/fragments/onyx-tmpfile.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- Fix onyx_linkagg module writing debugging information to a tempfile on the remote machine: https://github.com/ansible/ansible/pull/37308

--- a/lib/ansible/modules/network/onyx/onyx_linkagg.py
+++ b/lib/ansible/modules/network/onyx/onyx_linkagg.py
@@ -246,9 +246,6 @@ class OnyxLinkAggModule(BaseOnyxModule):
             lag_summary = self._get_port_channels(if_type)
             if lag_summary:
                 self._parse_port_channels_summary(lag_type, lag_summary)
-        with open('/tmp/linagg.txt', 'w') as fp:
-            fp.write('current_config: %s\n' % self._current_config)
-            fp.write('required_config: %s\n' % self._required_config)
 
     def _get_interface_command_suffix(self, if_name):
         if if_name.startswith('Eth'):


### PR DESCRIPTION
##### SUMMARY
remove creating temp file for debug purposes

Fixes #36955 

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME
onyx_linkagg.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
stable-2.5
```


##### ADDITIONAL INFORMATION
There could be sensitive information in this debugging information so we definitely want this in 2.5.0