### PR TITLE
[backport] stable-2.5 backport of 'Fix ansible_lo being used inside of ansible_facts'

### DIFF
--- a/lib/ansible/vars/clean.py
+++ b/lib/ansible/vars/clean.py
@@ -106,7 +106,7 @@ def namespace_facts(facts):
     ''' return all facts inside 'ansible_facts' w/o an ansible_ prefix '''
     deprefixed = {}
     for k in facts:
-        if k in ('ansible_local'):
+        if k in ('ansible_local',):
             # exceptions to 'deprefixing'
             deprefixed[k] = deepcopy(facts[k])
         else:


### PR DESCRIPTION

##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/37317

The logic was keeping ansible_facts['ansible_lo'] instead of fixing it
to be ansible_facts['lo']

(cherry picked from commit 31878ee0eadd4e9d692d48121ec5e34f4dc45dd5)

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
lib/ansible/vars/clean.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0rc2 (stable-2.5-ansible-lo-backport-37317 cb47a10d1b) last updated 2018/03/13 12:52:27 (GMT -400)
  config file = None
  configured module search path = [u'/home/adrian/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/adrian/src/ansible/lib/ansible
  executable location = /home/adrian/src/ansible/bin/ansible
  python version = 2.7.14 (default, Feb 27 2018, 20:43:24) [GCC 7.3.1 20180130 (Red Hat 7.3.1-2)]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
