### PR TITLE
Production ACME v2 endpoint is available.

### DIFF
--- a/lib/ansible/modules/web_infrastructure/letsencrypt.py
+++ b/lib/ansible/modules/web_infrastructure/letsencrypt.py
@@ -36,8 +36,7 @@ description:
       U(https://tools.ietf.org/html/draft-ietf-acme-acme-09#section-8)"
    - "Although the defaults are chosen so that the module can be used with
       the Let's Encrypt CA, the module can be used with any service using the ACME
-      v1 or v2 protocol. I(Warning): ACME v2 support is currently experimental, as
-      the Let's Encrypt production ACME v2 endpoint is still under development."
+      v1 or v2 protocol."
    - "At least one of C(dest) and C(fullchain_dest) must be specified."
 requirements:
   - "python >= 2.6"
@@ -77,6 +76,9 @@ options:
          U(https://letsencrypt.org/docs/staging-environment/)"
       - "The production Let's Encrypt ACME v1 directory URL, which produces properly
          trusted certificates, is U(https://acme-v01.api.letsencrypt.org/directory)."
+      - "The production Let's Encrypt ACME v2 directory URL, which produces properly
+         trusted certificates, including wildcard certificates, is
+         U(https://acme-v02.api.letsencrypt.org/directory)."
     default: https://acme-staging.api.letsencrypt.org/directory
   acme_version:
     description:


### PR DESCRIPTION
##### SUMMARY
There's now a ACME v2 endpoint with Let's Encrypt. This updates the documentation of the Let's Encrypt module accordingly.

Official announcement: https://community.letsencrypt.org/t/acme-v2-and-wildcard-certificate-support-is-live/55579

##### ISSUE TYPE
Docs Pull Request

##### COMPONENT NAME
letsencrypt

##### ANSIBLE VERSION
2.5.0, 2.6.0

##### ADDITIONAL INFORMATION
The current `letsencrypt` module doesn't work with the endpoint, due to the problem described here:  https://github.com/ansible/ansible/pull/37165#issuecomment-372779851, so this shouldn't be backported to 2.5.0 until that is resolved.
