### PR TITLE
TrueOS FreeBSD flavor support

### DIFF
--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -427,7 +427,7 @@ class Distribution(object):
                      'AIX': ['AIX'],
                      'HP-UX': ['HPUX'],
                      'Darwin': ['MacOSX'],
-                     'FreeBSD': ['FreeBSD']}
+                     'FreeBSD': ['FreeBSD', 'TrueOS']}
 
     OS_FAMILY = {}
     for family, names in OS_FAMILY_MAP.items():
@@ -502,7 +502,9 @@ class Distribution(object):
     def get_distribution_FreeBSD(self):
         freebsd_facts = {}
         freebsd_facts['distribution_release'] = platform.release()
-        data = re.search(r'(\d+)\.(\d+)-(RELEASE|STABLE).*', freebsd_facts['distribution_release'])
+        data = re.search(r'(\d+)\.(\d+)-(RELEASE|STABLE|CURRENT).*', freebsd_facts['distribution_release'])
+        if 'trueos' in platform.version():
+            freebsd_facts['distribution'] = 'TrueOS'
         if data:
             freebsd_facts['distribution_major_version'] = data.group(1)
             freebsd_facts['distribution_version'] = '%s.%s' % (data.group(1), data.group(2))


### PR DESCRIPTION
##### SUMMARY
[TrueOS](https://www.trueos.org/) (formerly PC-BSD) is a type of FreeBSD, but with some differences: 
- git instead of svn 
- OpenRC instead of sysv init
- LibreSSL instead of OpenSSL

Making TruOS recognisable as a distribution willl greatly help in working with FreeBSD related roles and modules

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
module_utils/facts/system/distribution

##### ANSIBLE VERSION

```
ansible 2.6.0 (devel d36b07bb6b) last updated 2018/03/13 23:38:36 (GMT +300)
  config file = None
  configured module search path = [u'/usr/home/user/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/home/user/github/digitalist/ansible/lib/ansible
  executable location = /usr/home/user/github/digitalist/ansible/bin/ansible
  python version = 2.7.14 (default, Feb 12 2018, 16:49:01) [GCC 4.2.1 Compatible FreeBSD Clang 6.0.0 (branches/release_60 324090)
```


##### ADDITIONAL INFORMATION


<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
