### PR TITLE
issue:36955 remove creating temp file for debug

### DIFF
--- a/lib/ansible/modules/network/onyx/onyx_linkagg.py
+++ b/lib/ansible/modules/network/onyx/onyx_linkagg.py
@@ -246,9 +246,6 @@ class OnyxLinkAggModule(BaseOnyxModule):
             lag_summary = self._get_port_channels(if_type)
             if lag_summary:
                 self._parse_port_channels_summary(lag_type, lag_summary)
-        with open('/tmp/linagg.txt', 'w') as fp:
-            fp.write('current_config: %s\n' % self._current_config)
-            fp.write('required_config: %s\n' % self._required_config)
 
     def _get_interface_command_suffix(self, if_name):
         if if_name.startswith('Eth'):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

Backport of https://github.com/ansible/ansible/pull/37308 

Remove temporary code that was accessing temp directory

Fixes #36955
There was a temporary code used for debugging, that code was accessing /tmp directly.
This code was removed since there is no need for it

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
lib/ansible/modules/network/onyx/onyx_linkagg.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0rc2 (stable-2.5-rm-onyx-link-agg-tmp-37308 c89b767847) last updated 2018/03/13 12:45:20 (GMT -400)
  config file = None
  configured module search path = [u'/home/adrian/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/adrian/src/ansible/lib/ansible
  executable location = /home/adrian/src/ansible/bin/ansible
  python version = 2.7.14 (default, Feb 27 2018, 20:43:24) [GCC 7.3.1 20180130 (Red Hat 7.3.1-2)]

```

