### PR TITLE
Disable failing github_issue integration test.

### DIFF
--- a/test/integration/targets/github_issue/aliases
+++ b/test/integration/targets/github_issue/aliases
@@ -1,2 +1,1 @@
 destructive
-posix/ci/group1


### PR DESCRIPTION
##### SUMMARY

Disable failing github_issue integration test.

Failure: https://app.shippable.com/github/ansible/ansible/runs/57735/34/tests

The failure appears to be due to the release of github3.py version 1.0.0.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

github_issue integration test

##### ANSIBLE VERSION

```
ansible 2.6.0 (github_issue 6d33b715b0) last updated 2018/03/13 15:39:33 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.11 (default, Jan 22 2016, 08:29:18) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```
