### PR TITLE
Bkprt conn err msg no template

### DIFF
--- a/changelogs/fragments/no-template-conn-err.yaml
+++ b/changelogs/fragments/no-template-conn-err.yaml
@@ -1,0 +1,4 @@
+bugfixes:
+  - Connection error messages may contain characters that jinja2 would
+    interpret as a template.  Wrap the error string so this doesn't happen
+    (https://github.com/ansible/ansible/pull/37329)

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -170,7 +170,7 @@ class TaskExecutor:
             display.debug("done dumping result, returning")
             return res
         except AnsibleError as e:
-            return dict(failed=True, msg=to_text(e, nonstring='simplerepr'))
+            return dict(failed=True, msg=wrap_var(to_text(e, nonstring='simplerepr')))
         except Exception as e:
             return dict(failed=True, msg='Unexpected failure during module execution.', exception=to_text(traceback.format_exc()), stdout='')
         finally:

--- a/test/integration/targets/connection/aliases
+++ b/test/integration/targets/connection/aliases
@@ -1,0 +1,1 @@
+posix/ci/group2

--- a/test/integration/targets/connection/inventory
+++ b/test/integration/targets/connection/inventory
@@ -1,0 +1,2 @@
+[local]
+testhost

--- a/test/integration/targets/connection/play.yml
+++ b/test/integration/targets/connection/play.yml
@@ -1,0 +1,19 @@
+- hosts: testhost
+  gather_facts: false
+  tasks:
+    - name: "use a connection plugin raising an exception, exception message contains Jinja template."
+      connection: dummy
+      command: /bin/true  # command won't be executed
+      register: result
+      ignore_errors: True
+
+    - name: "check that Jinja template embedded in exception message isn't rendered"
+      debug:
+        msg: 'ok'
+      when: result is failed
+      register: debug_task
+
+    - assert:
+        that:
+          - result is failed
+          - debug_task is success

--- a/test/integration/targets/connection/plugin/dummy.py
+++ b/test/integration/targets/connection/plugin/dummy.py
@@ -1,0 +1,46 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+DOCUMENTATION = """
+    author:
+        - John Doe
+    connection: dummy
+    short_description: defective connection plugin
+    description:
+        - defective connection plugin
+    version_added: "2.0"
+    options: {}
+"""
+import ansible.constants as C
+from ansible.errors import AnsibleError
+from ansible.plugins.connection import ConnectionBase
+
+
+class Connection(ConnectionBase):
+
+    transport = 'dummy'
+    has_pipelining = True
+    become_methods = frozenset(C.BECOME_METHODS)
+
+    def __init__(self, play_context, new_stdin, *args, **kwargs):
+        super(Connection, self).__init__(play_context, new_stdin, *args, **kwargs)
+
+        raise AnsibleError('an error with {{ some Jinja }}')
+
+    def transport(self):
+        pass
+
+    def _connect(self):
+        pass
+
+    def exec_command(self, cmd, in_data=None, sudoable=True):
+        pass
+
+    def put_file(self, in_path, out_path):
+        pass
+
+    def fetch_file(self, in_path, out_path):
+        pass
+
+    def close(self):
+        pass

--- a/test/integration/targets/connection/runme.sh
+++ b/test/integration/targets/connection/runme.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -o nounset -o errexit -o xtrace
+
+ANSIBLE_CONNECTION_PLUGINS="$(pwd)/plugin" ansible-playbook -i inventory "$(pwd)/play.yml" -v "$@"


### PR DESCRIPTION
##### SUMMARY
Connection errors can contain characters that jinja will ocnsider templates.  Wrap them so that that does not happen.

##### ISSUE TYPE
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```


##### ADDITIONAL INFORMATION
Not a blocker for 2.5.0.  This can go into 2.5.1 instead.