### PR TITLE
add timeout parameter and increase default timeout for nso modules

### DIFF
--- a/lib/ansible/module_utils/network/nso/nso.py
+++ b/lib/ansible/module_utils/network/nso/nso.py
@@ -36,7 +36,8 @@ except NameError:
 nso_argument_spec = dict(
     url=dict(required=True),
     username=dict(fallback=(env_fallback, ['ANSIBLE_NET_USERNAME']), required=True),
-    password=dict(fallback=(env_fallback, ['ANSIBLE_NET_PASSWORD']), required=True, no_log=True)
+    password=dict(fallback=(env_fallback, ['ANSIBLE_NET_PASSWORD']), required=True, no_log=True),
+    timeout=dict(default=300, type=int)
 )
 
 
@@ -66,8 +67,9 @@ class NsoException(Exception):
 
 
 class JsonRpc(object):
-    def __init__(self, url):
+    def __init__(self, url, timeout):
         self._url = url
+        self._timeout = timeout
 
         self._id = 0
         self._trans = {}
@@ -219,7 +221,8 @@ class JsonRpc(object):
 
         data = json.dumps(payload)
         resp = open_url(
-            self._url, method='POST', data=data, headers=self._headers)
+            self._url, timeout=self._timeout,
+            method='POST', data=data, headers=self._headers)
         if resp.code != 200:
             raise NsoException(
                 'NSO returned HTTP code {0}, expected 200'.format(resp.status), {})
@@ -620,7 +623,7 @@ class ValueBuilder(object):
 
 
 def connect(params):
-    client = JsonRpc(params['url'])
+    client = JsonRpc(params['url'], params['timeout'])
     client.login(params['username'], params['password'])
     return client
 

--- a/lib/ansible/utils/module_docs_fragments/nso.py
+++ b/lib/ansible/utils/module_docs_fragments/nso.py
@@ -32,4 +32,8 @@ options:
   password:
     description: NSO password
     required: true
+  timeout:
+    description: JSON-RPC request timeout in seconds
+    default: 300
+    version_added: "2.6"
 '''

--- a/test/units/module_utils/network/nso/test_nso.py
+++ b/test/units/module_utils/network/nso/test_nso.py
@@ -331,7 +331,7 @@ class MockResponse(object):
         return self.body
 
 
-def mock_call(calls, url, data=None, headers=None, method=None):
+def mock_call(calls, url, timeout, data=None, headers=None, method=None):
     result = calls[0]
     del calls[0]
 
@@ -366,7 +366,7 @@ class TestJsonRpc(unittest.TestCase):
             MockResponse('exists', {'path': '/not-exists'}, 200, '{"result": {"exists": false}}')
         ]
         open_url_mock.side_effect = lambda *args, **kwargs: mock_call(calls, *args, **kwargs)
-        client = nso.JsonRpc('http://localhost:8080/jsonrpc')
+        client = nso.JsonRpc('http://localhost:8080/jsonrpc', 10)
         self.assertEquals(True, client.exists('/exists'))
         self.assertEquals(False, client.exists('/not-exists'))
 
@@ -379,7 +379,7 @@ class TestJsonRpc(unittest.TestCase):
             MockResponse('exists', {'path': '/list{missing-parent}/list{child}'}, 200, '{"error":{"type":"data.not_found"}}')
         ]
         open_url_mock.side_effect = lambda *args, **kwargs: mock_call(calls, *args, **kwargs)
-        client = nso.JsonRpc('http://localhost:8080/jsonrpc')
+        client = nso.JsonRpc('http://localhost:8080/jsonrpc', 10)
         self.assertEquals(False, client.exists('/list{missing-parent}/list{child}'))
 
         self.assertEqual(0, len(calls))
@@ -400,7 +400,7 @@ class TestValueBuilder(unittest.TestCase):
             SCHEMA_DATA['/an:id-name-leaf'])
         schema = schema_data['data']
 
-        vb = nso.ValueBuilder(nso.JsonRpc('http://localhost:8080/jsonrpc'))
+        vb = nso.ValueBuilder(nso.JsonRpc('http://localhost:8080/jsonrpc', 10))
         vb.build(parent, None, 'ansible-nso:id-two', schema)
         self.assertEquals(1, len(vb.values))
         value = vb.values[0]
@@ -425,7 +425,7 @@ class TestValueBuilder(unittest.TestCase):
             SCHEMA_DATA['/an:id-name-values/id-name-value'])
         schema = schema_data['data']
 
-        vb = nso.ValueBuilder(nso.JsonRpc('http://localhost:8080/jsonrpc'))
+        vb = nso.ValueBuilder(nso.JsonRpc('http://localhost:8080/jsonrpc', 10))
         vb.build(parent, 'id-name-value', [{'name': 'ansible-nso:id-one', 'value': '1'}], schema)
         self.assertEquals(1, len(vb.values))
         value = vb.values[0]
@@ -450,7 +450,7 @@ class TestValueBuilder(unittest.TestCase):
             SCHEMA_DATA['/test:test'])
         schema = schema_data['data']
 
-        vb = nso.ValueBuilder(nso.JsonRpc('http://localhost:8080/jsonrpc'))
+        vb = nso.ValueBuilder(nso.JsonRpc('http://localhost:8080/jsonrpc', 10))
         vb.build(parent, None, [{'name': 'direct', 'direct-child': 'direct-value'},
                                 {'name': 'nested', 'nested-child': 'nested-value'}], schema)
         self.assertEquals(2, len(vb.values))
@@ -480,7 +480,7 @@ class TestValueBuilder(unittest.TestCase):
             SCHEMA_DATA['/test:test'])
         schema = schema_data['data']
 
-        vb = nso.ValueBuilder(nso.JsonRpc('http://localhost:8080/jsonrpc'))
+        vb = nso.ValueBuilder(nso.JsonRpc('http://localhost:8080/jsonrpc', 10))
         vb.build(parent, None, {'device-list': ['one', 'two']}, schema)
         self.assertEquals(1, len(vb.values))
         value = vb.values[0]
@@ -503,7 +503,7 @@ class TestValueBuilder(unittest.TestCase):
             SCHEMA_DATA['/test:test'])
         schema = schema_data['data']
 
-        vb = nso.ValueBuilder(nso.JsonRpc('http://localhost:8080/jsonrpc'))
+        vb = nso.ValueBuilder(nso.JsonRpc('http://localhost:8080/jsonrpc', 10))
         vb.build(parent, None, {'device-list': ['one', 'two']}, schema)
         self.assertEquals(3, len(vb.values))
         value = vb.values[0]
@@ -537,7 +537,7 @@ class TestValueBuilder(unittest.TestCase):
             'c': '3',
         }
 
-        vb = nso.ValueBuilder(nso.JsonRpc('http://localhost:8080/jsonrpc'))
+        vb = nso.ValueBuilder(nso.JsonRpc('http://localhost:8080/jsonrpc', 10))
         vb.build(parent, None, values, schema)
         self.assertEquals(3, len(vb.values))
         value = vb.values[0]
@@ -570,7 +570,7 @@ class TestValueBuilder(unittest.TestCase):
             'b': '2'
         }
 
-        vb = nso.ValueBuilder(nso.JsonRpc('http://localhost:8080/jsonrpc'))
+        vb = nso.ValueBuilder(nso.JsonRpc('http://localhost:8080/jsonrpc', 10))
         vb.build(parent, None, values, schema)
         self.assertEquals(2, len(vb.values))
         value = vb.values[0]

--- a/test/units/modules/network/nso/nso_module.py
+++ b/test/units/modules/network/nso/nso_module.py
@@ -60,7 +60,7 @@ class MockResponse(object):
         return self.body
 
 
-def mock_call(calls, url, data=None, headers=None, method=None):
+def mock_call(calls, url, timeout, data=None, headers=None, method=None):
     result = calls[0]
     del calls[0]
 


### PR DESCRIPTION
##### SUMMARY
NSO operations can take much longer than 10 seconds as they operate on
real network equipment, set default timeout to 5 minutes and allow for
user override.

Without this option it's not possible to use the NSO modules to use time consuming actions.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
nso_config

##### ANSIBLE VERSION
```
ansible 2.6.0 (nso_action_result_format a8a1bcaf29) last updated 2018/03/14 09:44:35 (GMT +200)
  config file = None
  configured module search path = [u'/home/cnasten/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/cnasten/dev/ansible/lib/ansible
  executable location = /home/cnasten/dev/ansible/bin/ansible
  python version = 2.7.14+ (default, Feb  6 2018, 19:12:18) [GCC 7.3.0]

```


##### ADDITIONAL INFORMATION
NA