### PR TITLE
sub-interface support for nxos module

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_interface.py
+++ b/lib/ansible/modules/network/nxos/nxos_interface.py
@@ -316,7 +316,7 @@ def normalize_interface(name):
     def _get_number(name):
         digits = ''
         for char in name:
-            if char.isdigit() or char == '/' or char == '.':
+            if char.isdigit() or char in '/.':
                 digits += char
         return digits
 

--- a/lib/ansible/modules/network/nxos/nxos_interface.py
+++ b/lib/ansible/modules/network/nxos/nxos_interface.py
@@ -316,7 +316,7 @@ def normalize_interface(name):
     def _get_number(name):
         digits = ''
         for char in name:
-            if char.isdigit() or char == '/':
+            if char.isdigit() or char == '/' or char == '.':
                 digits += char
         return digits
 

--- a/lib/ansible/modules/network/nxos/nxos_l3_interface.py
+++ b/lib/ansible/modules/network/nxos/nxos_l3_interface.py
@@ -122,7 +122,6 @@ def map_obj_to_commands(updates, module):
                 if command:
                     command.append('exit')
                     command.insert(0, 'interface {0}'.format(name))
-                    command.insert(1, 'no switchport')
             commands.extend(command)
 
         elif state == 'present' and obj_in_have:
@@ -135,10 +134,8 @@ def map_obj_to_commands(updates, module):
                 if command:
                     command.append('exit')
                     command.insert(0, 'interface {0}'.format(name))
-                    command.insert(1, 'no switchport')
                 elif not ipv4 and not ipv6:
                     command.append('interface {0}'.format(name))
-                    command.append('no switchport')
             commands.extend(command)
 
     return commands

--- a/test/integration/targets/nxos_interface/tests/common/sub_int.yaml
+++ b/test/integration/targets/nxos_interface/tests/common/sub_int.yaml
@@ -1,0 +1,77 @@
+---
+- debug: msg="START connection={{ ansible_connection }} nxos_interface sub-interface test"
+- debug: msg="Using provider={{ connection.transport }}"
+  when: ansible_connection == "local"
+
+- set_fact: testint="{{ nxos_int1 }}"
+
+- name: Setup - delete sub-interface
+  nxos_interface: &rm
+    name: "{{ testint }}.20"
+    state: absent
+  ignore_errors: yes
+
+- name: Setup - Ensure the interface is layer3
+  nxos_interface:
+    name: "{{ testint }}"
+    mode: layer3
+
+- name: Create sub-interface
+  nxos_interface: &sub_int
+    name: "{{ testint }}.20"
+    description: "sub-interface Configured by Ansible"
+    admin_state: up
+    mtu: 800
+    provider: "{{ connection }}"
+  register: result
+
+- assert:
+    that:
+      - "result.changed == true"
+
+- name: Create sub-interface (Idempotence)
+  nxos_interface: *sub_int
+  register: result
+
+- assert:
+    that:
+      - "result.changed == false"
+
+- name: Make admin_state down
+  nxos_interface: &state_down
+    name: "{{ testint }}.20"
+    description: "sub-interface Configured by Ansible"
+    admin_state: down
+    mtu: 800
+    provider: "{{ connection }}"
+  register: result
+
+- assert:
+    that:
+      - "result.changed == true"
+
+- name: Create sub-interface (Idempotence)
+  nxos_interface: *state_down
+  register: result
+
+- assert:
+    that:
+      - "result.changed == false"
+
+- name: Remove sub-interface
+  nxos_interface: *rm
+  register: result
+
+- assert:
+    that:
+      - "result.changed == true"
+
+- name: Remove sub-interface (Idempotence)
+  nxos_interface: *rm
+  register: result
+
+- assert:
+    that:
+      - "result.changed == false"
+
+- debug: msg="END connection={{ ansible_connection }} nxos_interface sub-interface test"

--- a/test/integration/targets/nxos_l3_interface/tests/cli/sanity.yaml
+++ b/test/integration/targets/nxos_l3_interface/tests/cli/sanity.yaml
@@ -30,6 +30,14 @@
     provider: "{{ cli }}"
   ignore_errors: yes
 
+- name: Setup - Ensure interfaces are layer3
+  nxos_interface:
+    aggregate:
+      - name: "{{ testint2 }}"
+      - name: "{{ testint3 }}"
+    mode: layer3
+    provider: "{{ cli }}"
+
 - name: Configure ipv4 address to interface
   nxos_l3_interface: &conf
     name: "{{ testint2 }}"

--- a/test/integration/targets/nxos_l3_interface/tests/nxapi/sanity.yaml
+++ b/test/integration/targets/nxos_l3_interface/tests/nxapi/sanity.yaml
@@ -20,6 +20,14 @@
     state: absent
   ignore_errors: yes
 
+- name: Setup - Ensure interfaces are layer3
+  nxos_interface:
+    aggregate:
+      - name: "{{ testint2 }}"
+      - name: "{{ testint3 }}"
+    mode: layer3
+    provider: "{{ nxapi }}"
+
 - name: Configure ipv4 address to interface
   nxos_l3_interface: &conf
     name: "{{ testint2 }}"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
fixes https://github.com/ansible/ansible/issues/29164 
- Support sub-interface like `Ethernet1/6.20`
- Don't send `no switchport` by default in nxos_l3_interface. User should do make routed interface (mode: layer3) on his/her own before using `nxos_l3_interface`.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
modules/network/nxos/{nxos_interface,nxos_l3_interface}.py
test/integration/targets/nxos_l3_interface/tests/{cli,nxapi}/sanity.yaml
test/integration/targets/nxos_interface/tests/common/sub_int.yaml
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```