### PR TITLE
nso_action use json result format if available in NSO

### DIFF
--- a/lib/ansible/module_utils/network/nso/nso.py
+++ b/lib/ansible/module_utils/network/nso/nso.py
@@ -73,6 +73,7 @@ class JsonRpc(object):
         self._trans = {}
         self._headers = {'Content-Type': 'application/json'}
         self._conn = None
+        self._system_settings = {}
 
     def login(self, user, passwd):
         payload = {
@@ -87,9 +88,11 @@ class JsonRpc(object):
         self._call(payload)
 
     def get_system_setting(self, setting):
-        payload = {'method': 'get_system_setting', 'params': {'operation': setting}}
-        resp, resp_json = self._call(payload)
-        return resp_json['result']
+        if setting not in self._system_settings:
+            payload = {'method': 'get_system_setting', 'params': {'operation': setting}}
+            resp, resp_json = self._call(payload)
+            self._system_settings[setting] = resp_json['result']
+        return self._system_settings[setting]
 
     def new_trans(self, **kwargs):
         payload = {'method': 'new_trans', 'params': kwargs}
@@ -193,10 +196,15 @@ class JsonRpc(object):
         if params is None:
             params = {}
 
+        if is_version(self, [(4, 5), (4, 4, 3)]):
+            result_format = 'json'
+        else:
+            result_format = 'normal'
+
         payload = {
             'method': 'run_action',
             'params': {
-                'format': 'normal',
+                'format': result_format,
                 'path': path,
                 'params': params
             }
@@ -207,7 +215,16 @@ class JsonRpc(object):
             payload['params']['th'] = th
             resp, resp_json = self._call(payload)
 
-        return resp_json['result']
+        if result_format == 'normal':
+            # this only works for one-level results, list entries,
+            # containers etc will have / in their name.
+            result = {}
+            for info in resp_json['result']:
+                result[info['name']] = info['value']
+        else:
+            result = resp_json['result']
+
+        return result
 
     def _call(self, payload):
         self._id += 1


### PR DESCRIPTION
Use JSON result format when it is available and make the result format
returned look like it when JSON result format is not available in NSO.

##### SUMMARY
To allow for easy matching of action results, use the JSON result format whenever it is available.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
nso_action

##### ANSIBLE VERSION
```
ansible 2.6.0 (nso_action_result_format b9b84c5389) last updated 2018/03/14 10:16:13 (GMT +200)
  config file = None
  configured module search path = [u'/home/cnasten/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/cnasten/dev/ansible/lib/ansible
  executable location = /home/cnasten/dev/ansible/bin/ansible
  python version = 2.7.14+ (default, Feb  6 2018, 19:12:18) [GCC 7.3.0]

```

##### ADDITIONAL INFORMATION
NA
