### PR TITLE
fix mysql config read host (.my.cnf) #6761

### DIFF
--- a/lib/ansible/module_utils/mysql.py
+++ b/lib/ansible/module_utils/mysql.py
@@ -53,8 +53,9 @@ def mysql_connect(module, login_user=None, login_password=None, config_file='', 
     if module.params['login_unix_socket']:
         config['unix_socket'] = module.params['login_unix_socket']
     else:
-        config['host'] = module.params['login_host']
         config['port'] = module.params['login_port']
+    if module.params['login_host'] is not None:
+        config['host'] = module.params['login_host']
 
     if os.path.exists(config_file):
         config['read_default_file'] = config_file

--- a/lib/ansible/modules/database/mysql/mysql_db.py
+++ b/lib/ansible/modules/database/mysql/mysql_db.py
@@ -250,7 +250,7 @@ def main():
         argument_spec=dict(
             login_user=dict(type='str'),
             login_password=dict(type='str', no_log=True),
-            login_host=dict(type='str', default='localhost'),
+            login_host=dict(type='str', default=None),
             login_port=dict(type='int', default=3306),
             login_unix_socket=dict(type='str'),
             name=dict(type='str', required=True, aliases=['db']),

--- a/lib/ansible/modules/database/mysql/mysql_replication.py
+++ b/lib/ansible/modules/database/mysql/mysql_replication.py
@@ -197,7 +197,7 @@ def main():
         argument_spec=dict(
             login_user=dict(type='str'),
             login_password=dict(type='str', no_log=True),
-            login_host=dict(type='str', default='localhost'),
+            login_host=dict(type='str', default=None),
             login_port=dict(type='int', default=3306),
             login_unix_socket=dict(type='str'),
             mode=dict(type='str', default='getslave', choices=[

--- a/lib/ansible/modules/database/mysql/mysql_user.py
+++ b/lib/ansible/modules/database/mysql/mysql_user.py
@@ -589,7 +589,7 @@ def main():
         argument_spec=dict(
             login_user=dict(type='str'),
             login_password=dict(type='str', no_log=True),
-            login_host=dict(type='str', default='localhost'),
+            login_host=dict(type='str', default=None),
             login_port=dict(type='int', default=3306),
             login_unix_socket=dict(type='str'),
             user=dict(type='str', required=True, aliases=['name']),

--- a/lib/ansible/modules/database/mysql/mysql_variables.py
+++ b/lib/ansible/modules/database/mysql/mysql_variables.py
@@ -114,7 +114,7 @@ def main():
         argument_spec=dict(
             login_user=dict(type='str'),
             login_password=dict(type='str', no_log=True),
-            login_host=dict(type='str', default='localhost'),
+            login_host=dict(type='str', default=None),
             login_port=dict(type='int', default=3306),
             login_unix_socket=dict(type='str'),
             variable=dict(type='str'),

--- a/lib/ansible/plugins/doc_fragments/mysql.py
+++ b/lib/ansible/plugins/doc_fragments/mysql.py
@@ -19,9 +19,8 @@ options:
     type: str
   login_host:
     description:
-      - Host running the database.
+      - Host running the database. Default values taken by mysqlclient (localhost or from e.g. ~/my.cnf)
     type: str
-    default: localhost
   login_port:
     description:
       - Port of the MySQL server. Requires I(login_host) be defined as other than localhost if login_port is used.

--- a/lib/ansible/plugins/doc_fragments/mysql.py
+++ b/lib/ansible/plugins/doc_fragments/mysql.py
@@ -19,7 +19,7 @@ options:
     type: str
   login_host:
     description:
-      - Host running the database. Default values taken by mysqlclient (localhost or from e.g. ~/my.cnf)
+      - Host running the database. Default inherited from client library
     type: str
   login_port:
     description:


### PR DESCRIPTION
let mysqllib choose default values)

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
every mysql_* module

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.3.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/genofire/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/sbin/ansible
  python version = 2.7.14 (default, Jan  5 2018, 10:41:29) [GCC 7.2.1 20171224]
```


##### ADDITIONAL INFORMATION
see issue
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
