### PR TITLE
Add netconf unsupported note to iosxr_(command|config|facts)

### DIFF
--- a/lib/ansible/modules/network/iosxr/iosxr_command.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_command.py
@@ -27,6 +27,7 @@ description:
     Please use M(iosxr_config) to configure iosxr devices.
 extends_documentation_fragment: iosxr
 notes:
+  - This module does not support netconf connection
   - Tested against IOS XR 6.1.2
 options:
   commands:

--- a/lib/ansible/modules/network/iosxr/iosxr_config.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_config.py
@@ -26,6 +26,7 @@ description:
 extends_documentation_fragment: iosxr
 notes:
   - Tested against IOS XRv 6.1.2
+  - This module does not support netconf connection
   - Avoid service disrupting changes (viz. Management IP) from config replace.
   - Do not use C(end) in the replace config file.
 options:

--- a/lib/ansible/modules/network/iosxr/iosxr_facts.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_facts.py
@@ -25,6 +25,9 @@ description:
     module will always collect a base set of facts from the device
     and can enable or disable collection of additional facts.
 extends_documentation_fragment: iosxr
+notes:
+  - Tested against IOS XRv 6.1.2
+  - This module does not support netconf connection
 options:
   gather_subset:
     description:


### PR DESCRIPTION

(cherry picked from commit ed3dcae0b879db884b30cba8f5a2feb516e13857)

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Add netconf unsupported note to iosxr_(command|config|facts)
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
iosxr_command
iosxr_config
iosxr_facts

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0 (add_note_iosxr_modules_not_supporting_netconf ed3dcae0b8) last updated 2018/03/14 10:10:36 (GMT +200)
```
