### PR TITLE
hashi_vault: fix missing self.verify

### DIFF
--- a/lib/ansible/plugins/lookup/hashi_vault.py
+++ b/lib/ansible/plugins/lookup/hashi_vault.py
@@ -122,6 +122,8 @@ class HashiVault:
         else:
             self.secret_field = ''
 
+        self.verify = self.boolean_or_cacert(kwargs.get('validate_certs', True), kwargs.get('cacert', ''))
+
         # If a particular backend is asked for (and its method exists) we call it, otherwise drop through to using
         # token auth. This means if a particular auth backend is requested and a token is also given, then we
         # ignore the token and attempt authentication against the specified backend.
@@ -149,8 +151,6 @@ class HashiVault:
 
             if self.token is None:
                 raise AnsibleError("No Vault Token specified")
-
-            self.verify = self.boolean_or_cacert(kwargs.get('validate_certs', True), kwargs.get('cacert', ''))
 
             self.client = hvac.Client(url=self.url, token=self.token, verify=self.verify)
 


### PR DESCRIPTION
##### SUMMARY

For `auth_method != 'token'` the `self.verify` property was undefined but used.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
hashi_vault

##### ANSIBLE VERSION
```
ansible 2.4.3.0
```

##### ADDITIONAL INFORMATION
Use `hashi_vault` with a different auth_method (not token).