### PR TITLE
ansible_tower modules doc: fix typos, use formatting functions

### DIFF
--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_credential.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_credential.py
@@ -80,12 +80,12 @@ options:
         - Unlock password for ssh_key. Use ASK for prompting.
     authorize:
       description:
-        - Should use authroize for net type.
+        - Should use authorize for net type.
       required: False
       default: False
     authorize_password:
       description:
-        - Password for net credentials that require authroize.
+        - Password for net credentials that require authorize.
       required: False
       default: null
     client:

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_group.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_group.py
@@ -38,7 +38,7 @@ options:
       required: True
     variables:
       description:
-        - Variables to use for the group, use '@' for a file.
+        - Variables to use for the group, use C(@) for a file.
       required: False
       default: null
     credential:
@@ -74,7 +74,7 @@ options:
       default: null
     source_script:
       description:
-        - Inventory script to be used when group type is "custom".
+        - Inventory script to be used when group type is C(custom).
       required: False
       default: null
     overwrite:

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_group.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_group.py
@@ -79,7 +79,7 @@ options:
       default: null
     overwrite:
       description:
-        - Delete child roups and hosts not found in source.
+        - Delete child groups and hosts not found in source.
       required: False
       default: False
     overwrite_vars:

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_host.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_host.py
@@ -43,7 +43,7 @@ options:
       default: True
     variables:
       description:
-        - Variables to use for the host. Use '@' for a file.
+        - Variables to use for the host. Use C(@) for a file.
     state:
       description:
         - Desired state of the resource.

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_inventory.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_inventory.py
@@ -38,7 +38,7 @@ options:
       required: True
     variables:
       description:
-        - Inventory variables. Use '@' to get from file.
+        - Inventory variables. Use C(@) to get from file.
       required: False
       default: null
     state:

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_cancel.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_cancel.py
@@ -29,7 +29,7 @@ options:
       required: True
     fail_if_not_running:
       description:
-        - Fail loudly if the job_id does not reference a running job.
+        - Fail loudly if the I(job_id) does not reference a running job.
       default: False
 extends_documentation_fragment: tower
 '''

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_launch.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_launch.py
@@ -46,11 +46,11 @@ options:
       default: null
     extra_vars:
       description:
-        - Extra_vars to use for the job_template. Prepend '@' if a file.
+        - Extra_vars to use for the job_template. Prepend C(@) if a file.
       default: null
     limit:
       description:
-        - Limit to use for the job_template.
+        - Limit to use for the I(job_template).
       default: null
     tags:
       description:

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_launch.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_launch.py
@@ -25,7 +25,7 @@ description:
 options:
     job_template:
       description:
-        - Name of the job_template to use.
+        - Name of the job template to use.
       required: True
     job_explanation:
       description:

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_list.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_list.py
@@ -38,7 +38,7 @@ options:
       default: False
     query:
       description:
-        - Query used to further filter the list of jobs. {"foo":"bar"} will be passed at ?foo=bar
+        - Query used to further filter the list of jobs. C({"foo":"bar"}) will be passed at C(?foo=bar)
       default: null
 extends_documentation_fragment: tower
 '''

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_template.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_template.py
@@ -18,7 +18,7 @@ DOCUMENTATION = '''
 module: tower_job_template
 author: "Wayne Witzel III (@wwitzel3)"
 version_added: "2.3"
-short_description: create, update, or destroy Ansible Tower job_template.
+short_description: create, update, or destroy Ansible Tower job template.
 description:
     - Create, update, or destroy Ansible Tower job templates. See
       U(https://www.ansible.com/tower) for an overview.
@@ -29,40 +29,40 @@ options:
       required: True
     description:
       description:
-        - Description to use for the job_template.
+        - Description to use for the job template.
       required: False
       default: null
     job_type:
       description:
-        - The job_type to use for the job_template.
+        - The job_type to use for the job template.
       required: True
       choices: ["run", "check", "scan"]
     inventory:
       description:
-        - Inventory to use for the job_template.
+        - Inventory to use for the job template.
       required: False
       default: null
     project:
       description:
-        - Project to use for the job_template.
+        - Project to use for the job template.
       required: True
     playbook:
       description:
-        - Playbook to use for the job_template.
+        - Playbook to use for the job template.
       required: True
     machine_credential:
       description:
-        - Machine_credential to use for the job_template.
+        - Machine_credential to use for the job template.
       required: False
       default: null
     cloud_credential:
       description:
-        - Cloud_credential to use for the job_template.
+        - Cloud_credential to use for the job template.
       required: False
       default: null
     network_credential:
       description:
-        - The network_credential to use for the job_template.
+        - The network_credential to use for the job template.
       required: False
       default: null
     forks:
@@ -83,12 +83,12 @@ options:
       default: null
     job_tags:
       description:
-        - The job_tags to use for the job_template.
+        - The job_tags to use for the job template.
       required: False
       default: null
     skip_tags:
       description:
-        - The skip_tags to use for the job_template.
+        - The skip_tags to use for the job template.
       required: False
       default: null
     host_config_key:

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_template.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_template.py
@@ -98,7 +98,7 @@ options:
       default: null
     extra_vars_path:
       description:
-        - Path to the C(extra_vars) yaml file.
+        - Path to the C(extra_vars) YAML file.
       required: False
       default: null
     ask_extra_vars:

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_template.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_template.py
@@ -128,7 +128,7 @@ options:
       default: False
     become_enabled:
       description:
-        - Should become_enabled.
+        - Activate privilege escalation.
       required: False
       default: False
     state:

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_template.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_template.py
@@ -98,12 +98,12 @@ options:
       default: null
     extra_vars_path:
       description:
-        - Path to the extra_vars yaml file.
+        - Path to the C(extra_vars) yaml file.
       required: False
       default: null
     ask_extra_vars:
       description:
-        - Prompt user for extra_vars on launch.
+        - Prompt user for C(extra_vars) on launch.
       required: False
       default: False
     ask_tags:

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_project.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_project.py
@@ -35,13 +35,13 @@ options:
       default: null
     scm_type:
       description:
-        - Type of scm resource.
+        - Type of SCM resource.
       required: False
       default: "manual"
       choices: ["manual", "git", "hg", "svn"]
     scm_url:
       description:
-        - URL of scm resource.
+        - URL of SCM resource.
       required: False
       default: null
     local_path:
@@ -51,12 +51,12 @@ options:
       default: null
     scm_branch:
       description:
-        - The branch to use for the scm resource.
+        - The branch to use for the SCM resource.
       required: False
       default: null
     scm_credential:
       description:
-        - Name of the credential to use with this scm resource.
+        - Name of the credential to use with this SCM resource.
       required: False
       default: null
     scm_clean:

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_role.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_role.py
@@ -50,7 +50,7 @@ options:
       default: null
     job_template:
       description:
-        - The job_template the role acts on.
+        - The job template the role acts on.
       required: False
       default: null
     credential:

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_role.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_role.py
@@ -60,7 +60,7 @@ options:
       default: null
     organization:
       description:
-        - Organiation the role acts on.
+        - Organization the role acts on.
       required: False
       default: null
     project:


### PR DESCRIPTION
##### SUMMARY
Improve `ansible_tower` modules documentation:
* fix typo
* use formatting functions
* acronyms: use uppercase
* s/job_template/job template/
* `become_enabled`: improve description

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
ansible_tower modules

##### ANSIBLE VERSION
```
ansible 2.6.0 (devel dd0140dfed) last updated 2018/03/14 17:59:25 (GMT +200)
```