### PR TITLE
Error when trying to use older iosxr modules with netconf

### DIFF
--- a/lib/ansible/plugins/action/iosxr.py
+++ b/lib/ansible/plugins/action/iosxr.py
@@ -42,12 +42,12 @@ class ActionModule(_ActionModule):
         del tmp  # tmp no longer has any effect
 
         socket_path = None
-        cli_only = ('iosxr_netconf', 'iosxr_config', 'iosxr_command', 'iosxr_facts')
+        force_cli = self._task.action in ('iosxr_netconf', 'iosxr_config', 'iosxr_command', 'iosxr_facts')
 
         if self._play_context.connection == 'local':
             provider = load_provider(iosxr_provider_spec, self._task.args)
             pc = copy.deepcopy(self._play_context)
-            if self._task.action in cli_only or (provider['transport'] == 'cli'):
+            if force_cli or provider['transport'] == 'cli':
                 pc.connection = 'network_cli'
                 pc.port = int(provider['port'] or self._play_context.port or 22)
             elif provider['transport'] == 'netconf':
@@ -75,7 +75,7 @@ class ActionModule(_ActionModule):
 
             task_vars['ansible_socket'] = socket_path
         elif self._play_context.connection in ('netconf', 'network_cli'):
-            if self._task.action in cli_only and self._play_context.connection != 'network_cli':
+            if force_cli and self._play_context.connection != 'network_cli':
                 return {'failed': True, 'msg': 'Connection type %s is not valid for module %s' %
                         (self._play_context.connection, self._task.action)}
             provider = self._task.args.get('provider', {})

--- a/lib/ansible/plugins/action/iosxr.py
+++ b/lib/ansible/plugins/action/iosxr.py
@@ -42,12 +42,12 @@ class ActionModule(_ActionModule):
         del tmp  # tmp no longer has any effect
 
         socket_path = None
+        cli_only = ('iosxr_netconf', 'iosxr_config', 'iosxr_command', 'iosxr_facts')
 
         if self._play_context.connection == 'local':
             provider = load_provider(iosxr_provider_spec, self._task.args)
             pc = copy.deepcopy(self._play_context)
-            if self._task.action in ['iosxr_netconf', 'iosxr_config', 'iosxr_command'] or \
-                    (provider['transport'] == 'cli'):
+            if self._task.action in cli_only or (provider['transport'] == 'cli'):
                 pc.connection = 'network_cli'
                 pc.port = int(provider['port'] or self._play_context.port or 22)
             elif provider['transport'] == 'netconf':
@@ -75,6 +75,9 @@ class ActionModule(_ActionModule):
 
             task_vars['ansible_socket'] = socket_path
         elif self._play_context.connection in ('netconf', 'network_cli'):
+            if self._task.action in cli_only and self._play_context.connection != 'network_cli':
+                return {'failed': True, 'msg': 'Connection type %s is not valid for module %s' %
+                        (self._play_context.connection, self._task.action)}
             provider = self._task.args.get('provider', {})
             if any(provider.values()):
                 display.warning('provider is unnecessary when using {0} and will be ignored'.format(self._play_context.connection))

--- a/lib/ansible/plugins/netconf/iosxr.py
+++ b/lib/ansible/plugins/netconf/iosxr.py
@@ -73,7 +73,6 @@ def transform_reply():
     if sys.version < '3':
         return reply
     else:
-        print("utf8")
         return reply.encode('UTF-8')
 
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Fixes #37362 
Fixes #37363 

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
iosxr

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```