### PR TITLE
ovrit_cluster: fix for CPU arch entity #37425

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_cluster.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_cluster.py
@@ -487,7 +487,7 @@ class ClustersModule(BaseModule):
             cpu=otypes.Cpu(
                 architecture=otypes.Architecture(
                     self.param('cpu_arch')
-                ),
+                ) if self.param('cpu_arch') else None,
                 type=self.param('cpu_type'),
             ) if (
                 self.param('cpu_arch') or self.param('cpu_type')

--- a/lib/ansible/modules/cloud/ovirt/ovirt_cluster.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_cluster.py
@@ -485,7 +485,9 @@ class ClustersModule(BaseModule):
                 name=self.param('network'),
             ) if self.param('network') else None,
             cpu=otypes.Cpu(
-                architecture=self.param('cpu_arch'),
+                architecture=otypes.Architecture(
+                     self.param('cpu_arch')
+                ),
                 type=self.param('cpu_type'),
             ) if (
                 self.param('cpu_arch') or self.param('cpu_type')

--- a/lib/ansible/modules/cloud/ovirt/ovirt_cluster.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_cluster.py
@@ -486,7 +486,7 @@ class ClustersModule(BaseModule):
             ) if self.param('network') else None,
             cpu=otypes.Cpu(
                 architecture=otypes.Architecture(
-                     self.param('cpu_arch')
+                    self.param('cpu_arch')
                 ),
                 type=self.param('cpu_type'),
             ) if (


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
CPU arch entity is passing the value as it is from the request, this would validate it. 

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT NAME
ovirt_cluster

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
Ansible 2.4.0.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
This fix would take care of below error message, when the request comes with CPU arch defined.
```
- name: set cluster policies
  ovirt_cluster:
    auth: "{{ ovirt_auth }}"
    name: "{{ rhv_cluster_name }}"
    data_center: "{{ rhv_datacenter_name }}"
    cpu_arch: x86_64
    cpu_type: Intel Broadwell-noTSX Family
```
The error,
```
"msg": "The type 'str' isn't valid for attribute 'architecture', it must be 'Architecture'"
```
