### PR TITLE
Add support for vault_credential

### DIFF
--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_template.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_template.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-ANSIBLE_METADATA = {'metadata_version': '1.1',
+ANSIBLE_METADATA = {'metadata_version': '1.2',
                     'status': ['preview'],
                     'supported_by': 'community'}
 
@@ -17,7 +17,7 @@ DOCUMENTATION = '''
 ---
 module: tower_job_template
 author: "Wayne Witzel III (@wwitzel3)"
-version_added: "2.3"
+version_added: "2.6"
 short_description: create, update, or destroy Ansible Tower job_template.
 description:
     - Create, update, or destroy Ansible Tower job templates. See
@@ -65,6 +65,7 @@ options:
         - Vault_credential to use for the job_template.
       required: False
       default: null
+      version_added: 2.6
     network_credential:
       description:
         - The network_credential to use for the job_template.

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_template.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_template.py
@@ -60,6 +60,11 @@ options:
         - Cloud_credential to use for the job_template.
       required: False
       default: null
+    vault_credential:
+      description:
+        - Vault_credential to use for the job_template.
+      required: False
+      default: null
     network_credential:
       description:
         - The network_credential to use for the job_template.
@@ -200,6 +205,7 @@ def update_resources(module, p):
         'machine_credential': 'name',
         'network_credential': 'name',
         'cloud_credential': 'name',
+        'vault_credential': 'name',
     }
     for k, v in identity_map.items():
         try:
@@ -223,6 +229,7 @@ def main():
         playbook=dict(required=True),
         machine_credential=dict(),
         cloud_credential=dict(),
+        vault_credential=dict(),
         network_credential=dict(),
         forks=dict(type='int'),
         limit=dict(),

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_template.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_template.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-ANSIBLE_METADATA = {'metadata_version': '1.2',
+ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],
                     'supported_by': 'community'}
 


### PR DESCRIPTION
##### SUMMARY
ansible-tower-cli now supports the vault_credential type. I updated the tower_job_template_module to allow an additional non required option of vault_credential. This allows you to create jobs with the vault_credential all ready assigned to the job. 

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
web_infrastructure/ansible_tower/tower_job_template_module

##### ANSIBLE VERSION
```
ansible 2.4.3.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/*/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION
ansible-tower-cli, supports vault_credential type for import, added type to tower_job_template_module

https://github.com/ansible/tower-cli/blob/master/docs/source/api_ref/resources/job_template.rst
