### PR TITLE
tower_job_template: add support for vault_credential 

### DIFF
--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_template.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_template.py
@@ -52,6 +52,10 @@ options:
     cloud_credential:
       description:
         - Cloud_credential to use for the job template.
+    vault_credential:
+      description:
+        - Vault_credential to use for the job_template.
+      version_added: 2.6
     network_credential:
       description:
         - The network_credential to use for the job template.
@@ -175,6 +179,7 @@ def update_resources(module, p):
         'machine_credential': 'name',
         'network_credential': 'name',
         'cloud_credential': 'name',
+        'vault_credential': 'name',
     }
     for k, v in identity_map.items():
         try:
@@ -198,6 +203,7 @@ def main():
         playbook=dict(required=True),
         machine_credential=dict(),
         cloud_credential=dict(),
+        vault_credential=dict(),
         network_credential=dict(),
         forks=dict(type='int'),
         limit=dict(),

--- a/test/integration/targets/tower_job_template/tasks/main.yml
+++ b/test/integration/targets/tower_job_template/tasks/main.yml
@@ -4,6 +4,12 @@
     organization: Default
     kind: scm
 
+- name: Create an SCM Credential
+  tower_credential:
+    name: Vault Credential for JT
+    organization: Default
+    kind: vault
+
 - name: Create a Demo Project
   tower_project:
     name: Job Template Test Project
@@ -45,6 +51,21 @@
     inventory: Demo Inventory
     playbook: hello_world.yml
     machine_credential: Demo Credential
+    job_type: run
+    state: present
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+
+- name: Create a Job Template with Vault Credential
+  tower_job_template:
+    name: hello-world
+    project: Job Template Test Project
+    inventory: Demo Inventory
+    playbook: hello_world.yml
+    vault_credential: Vault Credential for JT
     job_type: run
     state: present
   register: result

--- a/test/integration/targets/tower_job_template/tasks/main.yml
+++ b/test/integration/targets/tower_job_template/tasks/main.yml
@@ -4,11 +4,12 @@
     organization: Default
     kind: scm
 
-- name: Create an SCM Credential
+- name: Create an Vault Credential
   tower_credential:
     name: Vault Credential for JT
     organization: Default
     kind: vault
+    vault_password: test_password123456
 
 - name: Create a Demo Project
   tower_project:


### PR DESCRIPTION
##### SUMMARY
ansible-tower-cli now supports the vault_credential type. I updated the tower_job_template_module to allow an additional non required option of vault_credential. This allows you to create jobs with the vault_credential all ready assigned to the job. 

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
web_infrastructure/ansible_tower/tower_job_template_module

##### ANSIBLE VERSION
```
ansible 2.4.3.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/*/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION
ansible-tower-cli, supports vault_credential type for import, added type to tower_job_template_module

https://github.com/ansible/tower-cli/blob/master/docs/source/api_ref/resources/job_template.rst
