### PR TITLE
Making sure that the key value is converted to a string to avoid concatenation errors

### DIFF
--- a/contrib/inventory/vmware_inventory.py
+++ b/contrib/inventory/vmware_inventory.py
@@ -491,7 +491,7 @@ class VMWareInventory(object):
                         keylist = map(lambda x: x.strip(), tv['value'].split(','))
                         for kl in keylist:
                             try:
-                                newkey = self.config.get('vmware', 'custom_field_group_prefix') + field_name + '_' + kl
+                                newkey = self.config.get('vmware', 'custom_field_group_prefix') + str(field_name) + '_' + kl
                                 newkey = newkey.strip()
                             except Exception as e:
                                 self.debugl(e)


### PR DESCRIPTION
##### SUMMARY
VMWare for certain custom attributes returns some key's as a number. This causes the vmware_inventory.py script to fail when concatenating the values to produce a group name for the VMWare inventory.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
vmware_inventory tool

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.3.0
  config file = None
  configured module search path = [u'/Users/jroach/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Library/Python/2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.10 (default, Jul 15 2017, 17:16:57) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.31)]
```


##### ADDITIONAL INFORMATION
Steps for reproduction:
1- Create a custom attribute using the VMWare's interface
2- Choose to group by custom attribute in your `vmware_inventory.ini` file
3- Try to execute vmware_inventory.py file
4- Custom attribute groups won't show
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
Example host meta data: {'dynamictype': None, 'dynamicproperty': [], 'value': 'jenkins', 'key': 102}
Run result after change:
{'vmware102_jenkins': {'hosts': ['someawesomehost']}}
```
