### PR TITLE
Fix ansible-test python and pip executable search.

### DIFF
--- a/test/runner/lib/cloud/tower.py
+++ b/test/runner/lib/cloud/tower.py
@@ -15,7 +15,6 @@ from lib.util import (
     display,
     ApplicationError,
     is_shippable,
-    find_pip,
     run_command,
     generate_password,
     SubprocessError,
@@ -151,8 +150,7 @@ class TowerCloudEnvironment(CloudEnvironment):
 
         display.info('Installing Tower CLI version: %s' % tower_cli_version)
 
-        pip = find_pip(version=self.args.python_version)
-        cmd = [pip, 'install', '--disable-pip-version-check', 'ansible-tower-cli==%s' % tower_cli_version]
+        cmd = self.args.pip_command + ['install', '--disable-pip-version-check', 'ansible-tower-cli==%s' % tower_cli_version]
 
         run_command(self.args, cmd)
 

--- a/test/runner/lib/config.py
+++ b/test/runner/lib/config.py
@@ -9,6 +9,8 @@ from lib.util import (
     CommonConfig,
     is_shippable,
     docker_qualify_image,
+    find_python,
+    generate_pip_command,
 )
 
 from lib.metadata import (
@@ -66,6 +68,20 @@ class EnvironmentConfig(CommonConfig):
 
         if self.delegate:
             self.requirements = True
+
+    @property
+    def python_executable(self):
+        """
+        :rtype: str
+        """
+        return find_python(self.python_version)
+
+    @property
+    def pip_command(self):
+        """
+        :rtype: list[str]
+        """
+        return generate_pip_command(self.python_executable)
 
 
 class TestConfig(EnvironmentConfig):

--- a/test/runner/lib/sanity/__init__.py
+++ b/test/runner/lib/sanity/__init__.py
@@ -221,7 +221,11 @@ class SanityCodeSmellTest(SanityTest):
         :type targets: SanityTargets
         :rtype: SanityResult
         """
-        cmd = [self.path]
+        if self.path.endswith('.py'):
+            cmd = [args.python_executable, self.path]
+        else:
+            cmd = [self.path]
+
         env = ansible_environment(args, color=False)
 
         pattern = None

--- a/test/runner/lib/sanity/compile.py
+++ b/test/runner/lib/sanity/compile.py
@@ -16,6 +16,7 @@ from lib.util import (
     SubprocessError,
     run_command,
     display,
+    find_python,
 )
 
 from lib.config import (
@@ -50,7 +51,7 @@ class CompileTest(SanityMultipleVersion):
         if not paths:
             return SanitySkipped(self.name, python_version=python_version)
 
-        cmd = ['python%s' % python_version, 'test/sanity/compile/compile.py']
+        cmd = [find_python(python_version), 'test/sanity/compile/compile.py']
 
         data = '\n'.join(paths)
 

--- a/test/runner/lib/sanity/import.py
+++ b/test/runner/lib/sanity/import.py
@@ -18,6 +18,7 @@ from lib.util import (
     intercept_command,
     remove_tree,
     display,
+    find_python,
 )
 
 from lib.ansible_util import (
@@ -66,7 +67,7 @@ class ImportTest(SanityMultipleVersion):
 
         remove_tree(virtual_environment_path)
 
-        cmd = ['virtualenv', virtual_environment_path, '--python', 'python%s' % python_version, '--no-setuptools', '--no-wheel']
+        cmd = ['virtualenv', virtual_environment_path, '--python', find_python(python_version), '--no-setuptools', '--no-wheel']
 
         if not args.coverage:
             cmd.append('--no-pip')
@@ -84,8 +85,8 @@ class ImportTest(SanityMultipleVersion):
 
         # make sure coverage is available in the virtual environment if needed
         if args.coverage:
-            run_command(args, generate_pip_install('pip', 'sanity.import', packages=['setuptools']), env=env)
-            run_command(args, generate_pip_install('pip', 'sanity.import', packages=['coverage']), env=env)
+            run_command(args, generate_pip_install(['pip'], 'sanity.import', packages=['setuptools']), env=env)
+            run_command(args, generate_pip_install(['pip'], 'sanity.import', packages=['coverage']), env=env)
             run_command(args, ['pip', 'uninstall', '--disable-pip-version-check', '-y', 'setuptools'], env=env)
             run_command(args, ['pip', 'uninstall', '--disable-pip-version-check', '-y', 'pip'], env=env)
 

--- a/test/runner/lib/sanity/pep8.py
+++ b/test/runner/lib/sanity/pep8.py
@@ -15,7 +15,6 @@ from lib.util import (
     SubprocessError,
     display,
     run_command,
-    find_executable,
 )
 
 from lib.config import (
@@ -56,8 +55,8 @@ class Pep8Test(SanitySingleVersion):
         paths = sorted(i.path for i in targets.include if (os.path.splitext(i.path)[1] == '.py' or i.path.startswith('bin/')) and i.path not in skip_paths_set)
 
         cmd = [
-            'python%s' % args.python_version,
-            find_executable('pycodestyle'),
+            args.python_executable,
+            '-m', 'pycodestyle',
             '--max-line-length', '160',
             '--config', '/dev/null',
             '--ignore', ','.join(sorted(current_ignore)),

--- a/test/runner/lib/sanity/pylint.py
+++ b/test/runner/lib/sanity/pylint.py
@@ -252,8 +252,8 @@ class PylintTest(SanitySingleVersion):
         load_plugins = set(self.plugin_names) - disable_plugins
 
         cmd = [
-            'python%s' % args.python_version,
-            find_executable('pylint'),
+            args.python_executable,
+            '-m', 'pylint',
             '--jobs', '0',
             '--reports', 'n',
             '--max-line-length', '160',

--- a/test/runner/lib/sanity/rstcheck.py
+++ b/test/runner/lib/sanity/rstcheck.py
@@ -15,11 +15,16 @@ from lib.util import (
     SubprocessError,
     run_command,
     parse_to_dict,
+    display,
     find_executable,
 )
 
 from lib.config import (
     SanityConfig,
+)
+
+UNSUPPORTED_PYTHON_VERSIONS = (
+    '2.6',
 )
 
 
@@ -31,6 +36,10 @@ class RstcheckTest(SanitySingleVersion):
         :type targets: SanityTargets
         :rtype: SanityResult
         """
+        if args.python_version in UNSUPPORTED_PYTHON_VERSIONS:
+            display.warning('Skipping rstcheck on unsupported Python version %s.' % args.python_version)
+            return SanitySkipped(self.name)
+
         with open('test/sanity/rstcheck/ignore-substitutions.txt', 'r') as ignore_fd:
             ignore_substitutions = sorted(set(ignore_fd.read().splitlines()))
 
@@ -40,8 +49,8 @@ class RstcheckTest(SanitySingleVersion):
             return SanitySkipped(self.name)
 
         cmd = [
-            'python%s' % args.python_version,
-            find_executable('rstcheck'),
+            args.python_executable,
+            '-m', 'rstcheck',
             '--report', 'warning',
             '--ignore-substitutions', ','.join(ignore_substitutions),
         ] + paths

--- a/test/runner/lib/sanity/validate_modules.py
+++ b/test/runner/lib/sanity/validate_modules.py
@@ -57,7 +57,7 @@ class ValidateModulesTest(SanitySingleVersion):
             return SanitySkipped(self.name)
 
         cmd = [
-            'python%s' % args.python_version,
+            args.python_executable,
             'test/sanity/validate-modules/validate-modules',
             '--format', 'json',
             '--arg-spec',

--- a/test/runner/lib/sanity/yamllint.py
+++ b/test/runner/lib/sanity/yamllint.py
@@ -65,7 +65,7 @@ class YamllintTest(SanitySingleVersion):
         :rtype: list[SanityMessage]
         """
         cmd = [
-            'python%s' % args.python_version,
+            args.python_executable,
             'test/sanity/yamllint/yamllinter.py',
         ]
 

--- a/test/runner/requirements/sanity.txt
+++ b/test/runner/requirements/sanity.txt
@@ -5,7 +5,7 @@ paramiko
 pycodestyle
 pylint ; python_version >= '2.7' # pylint 1.5.3+ is required for non-buggy JSON output, but 1.4+ requires python 2.7+
 pytest
-rstcheck
+rstcheck ; python_version >= '2.7' # rstcheck requires python 2.7+
 sphinx
 virtualenv
 voluptuous

--- a/test/runner/test.py
+++ b/test/runner/test.py
@@ -12,8 +12,8 @@ from lib.util import (
     ApplicationError,
     display,
     raw_command,
-    find_pip,
     get_docker_completion,
+    generate_pip_command,
 )
 
 from lib.delegation import (
@@ -112,7 +112,7 @@ def parse_args():
     except ImportError:
         if '--requirements' not in sys.argv:
             raise
-        raw_command(generate_pip_install(find_pip(), 'ansible-test'))
+        raw_command(generate_pip_install(generate_pip_command(sys.executable), 'ansible-test'))
         import argparse
 
     try:


### PR DESCRIPTION
##### SUMMARY

Fix ansible-test python and pip executable search.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.6.0 (at-python-version 0000af5a36) last updated 2018/03/14 22:39:03 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.11 (default, Jan 22 2016, 08:29:18) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```
