### PR TITLE
dictionary changed size during iteration error

### DIFF
--- a/lib/ansible/modules/cloud/cloudscale/cloudscale_server.py
+++ b/lib/ansible/modules/cloud/cloudscale/cloudscale_server.py
@@ -297,7 +297,7 @@ class AnsibleCloudscaleServer(AnsibleCloudscaleBase):
                                    ' '.join(missing_parameters))
 
         # Sanitize data dictionary
-        for k, v in data.items():
+        for k, v in data.deepcopy().items():
 
             # Remove items not relevant to the create server call
             if k in ('api_token', 'api_timeout', 'uuid', 'state'):


### PR DESCRIPTION
##### SUMMARY
Iterating an object and changing it at the same time is unsecure and no longer permitted in Python >= 3.6

Provisioning an instance fail with the Python error: "RuntimeError: dictionary changed size during iteration"

deepcopy() is backward compatible to Python 2.7.

##### ISSUE TYPE
Bugfix Pull Request

##### COMPONENT NAME
Module cloudscale_server

##### ANSIBLE VERSION
Ansible Version 2.4.3
