### PR TITLE
[docs] mount module state clarification

### DIFF
--- a/lib/ansible/modules/system/mount.py
+++ b/lib/ansible/modules/system/mount.py
@@ -57,15 +57,14 @@ options:
     default: 0
   state:
     description:
-      - If C(mounted), the device will be actively mounted and appropriately
-        configured in I(fstab). If the mount point is not present, the mount
-        point will be created.
+      - If C(mounted), the device will be mounted and line is added to
+        I(/etc/fstab). If the filesystem mount is not present in I(/etc/fstab),
+        it will be added.
       - If C(unmounted), the device will be unmounted without changing I(fstab).
       - C(present) only specifies that the device is to be configured in
-        I(fstab) and does not trigger or require a mount.
+        I(/etc/fstab) and does not trigger or require a mount.
       - C(absent) specifies that the device mount's entry will be removed from
-        I(fstab) and will also unmount the device and remove the mount
-        point.
+        I(/etc/fstab) and will also unmount the device.
     required: true
     choices: [ absent, mounted, present, unmounted ]
   fstab:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
* it was not clear whether or not it removed the mountpoint when set to
  `state: absent`; well guess what, it doesn't delete the mountpoint (i.e.
  the directory where filesystem is mounted)
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
- `mount`
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
