### PR TITLE
ovirt: Fix documentation for interface parameter

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_disk.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_disk.py
@@ -82,6 +82,7 @@ options:
     interface:
         description:
             - "Driver of the storage interface."
+            - "It's required parameter when creating the new disk."
         choices: ['virtio', 'ide', 'virtio_scsi']
         default: 'virtio'
     format:

--- a/lib/ansible/modules/cloud/ovirt/ovirt_nics.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_nics.py
@@ -45,9 +45,9 @@ options:
             - Virtual network interface profile to be attached to VM network interface.
     interface:
         description:
-            - Type of the network interface.
+            - "Type of the network interface."
+            - "It's required parameter when creating the new NIC."
         choices: [ e1000, pci_passthrough, rtl8139, rtl8139_virtio, spapr_vlan, virtio ]
-        default: virtio
     mac_address:
         description:
             - Custom MAC address of the network interface, by default it's obtained from MAC pool.


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fix documentation of `interface` parameter in `ovirt_disk` and `ovirt_nics` modules.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
ovirt_disk
ovirt_nics

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.4.2
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
