### PR TITLE
Ensure network_cli, nxapi nxos tests run only once - remove unnecessary files

### DIFF
--- a/test/integration/targets/nxos_hsrp/tests/cli/sanity.yaml
+++ b/test/integration/targets/nxos_hsrp/tests/cli/sanity.yaml
@@ -1,4 +1,0 @@
----
-- set_fact: connection="{{ cli }}"
-
-- import_tasks: targets/nxos_hsrp/tests/common/sanity.yaml

--- a/test/integration/targets/nxos_hsrp/tests/nxapi/sanity.yaml
+++ b/test/integration/targets/nxos_hsrp/tests/nxapi/sanity.yaml
@@ -1,4 +1,0 @@
----
-- set_fact: connection="{{ nxapi }}"
-
-- import_tasks: targets/nxos_hsrp/tests/common/sanity.yaml

--- a/test/integration/targets/nxos_ntp/tests/cli/sanity.yaml
+++ b/test/integration/targets/nxos_ntp/tests/cli/sanity.yaml
@@ -1,4 +1,0 @@
----
-- set_fact: connection="{{ cli }}"
-
-- import_tasks: targets/nxos_ntp/tests/common/sanity.yaml

--- a/test/integration/targets/nxos_ntp/tests/nxapi/sanity.yaml
+++ b/test/integration/targets/nxos_ntp/tests/nxapi/sanity.yaml
@@ -1,4 +1,0 @@
----
-- set_fact: connection="{{ nxapi }}"
-
-- import_tasks: targets/nxos_ntp/tests/common/sanity.yaml

--- a/test/integration/targets/nxos_ospf_vrf/tests/cli/sanity.yaml
+++ b/test/integration/targets/nxos_ospf_vrf/tests/cli/sanity.yaml
@@ -1,4 +1,0 @@
----
-- set_fact: connection="{{ cli }}"
-
-- import_tasks: targets/nxos_ospf_vrf/tests/common/sanity.yaml

--- a/test/integration/targets/nxos_ospf_vrf/tests/nxapi/sanity.yaml
+++ b/test/integration/targets/nxos_ospf_vrf/tests/nxapi/sanity.yaml
@@ -1,4 +1,0 @@
----
-- set_fact: connection="{{ nxapi }}"
-
-- import_tasks: targets/nxos_ospf_vrf/tests/common/sanity.yaml

--- a/test/integration/targets/nxos_overlay_global/tests/cli/sanity.yaml
+++ b/test/integration/targets/nxos_overlay_global/tests/cli/sanity.yaml
@@ -1,4 +1,0 @@
----
-- set_fact: connection="{{ cli }}"
-
-- import_tasks: "{{ role_path }}/tests/common/sanity.yaml"

--- a/test/integration/targets/nxos_overlay_global/tests/nxapi/sanity.yaml
+++ b/test/integration/targets/nxos_overlay_global/tests/nxapi/sanity.yaml
@@ -1,4 +1,0 @@
----
-- set_fact: connection="{{ nxapi }}"
-
-- import_tasks: "{{ role_path }}/tests/common/sanity.yaml"

--- a/test/integration/targets/nxos_pim_interface/tests/cli/sanity.yaml
+++ b/test/integration/targets/nxos_pim_interface/tests/cli/sanity.yaml
@@ -1,4 +1,0 @@
----
-- set_fact: connection="{{ cli }}"
-
-- import_tasks: "{{ role_path }}/tests/common/sanity.yaml"

--- a/test/integration/targets/nxos_pim_interface/tests/nxapi/sanity.yaml
+++ b/test/integration/targets/nxos_pim_interface/tests/nxapi/sanity.yaml
@@ -1,4 +1,0 @@
----
-- set_fact: connection="{{ nxapi }}"
-
-- import_tasks: "{{ role_path }}/tests/common/sanity.yaml"

--- a/test/integration/targets/nxos_snapshot/tests/cli/sanity.yaml
+++ b/test/integration/targets/nxos_snapshot/tests/cli/sanity.yaml
@@ -1,4 +1,0 @@
----
-- set_fact: connection="{{ cli }}"
-
-- import_tasks: targets/nxos_snapshot/tests/common/sanity.yaml

--- a/test/integration/targets/nxos_snapshot/tests/nxapi/sanity.yaml
+++ b/test/integration/targets/nxos_snapshot/tests/nxapi/sanity.yaml
@@ -1,4 +1,0 @@
----
-- set_fact: connection="{{ nxapi }}"
-
-- import_tasks: targets/nxos_snapshot/tests/common/sanity.yaml

--- a/test/integration/targets/nxos_snmp_community/tests/cli/sanity.yaml
+++ b/test/integration/targets/nxos_snmp_community/tests/cli/sanity.yaml
@@ -1,4 +1,0 @@
----
-- set_fact: connection="{{ cli }}"
-
-- import_tasks: "{{ role_path }}/tests/common/sanity.yaml"

--- a/test/integration/targets/nxos_snmp_community/tests/nxapi/sanity.yaml
+++ b/test/integration/targets/nxos_snmp_community/tests/nxapi/sanity.yaml
@@ -1,4 +1,0 @@
----
-- set_fact: connection="{{ nxapi }}"
-
-- import_tasks: "{{ role_path }}/tests/common/sanity.yaml"

--- a/test/integration/targets/nxos_snmp_location/tests/cli/sanity.yaml
+++ b/test/integration/targets/nxos_snmp_location/tests/cli/sanity.yaml
@@ -1,4 +1,0 @@
----
-- set_fact: connection="{{ cli }}"
-
-- import_tasks: "{{ role_path }}/tests/common/sanity.yaml"

--- a/test/integration/targets/nxos_snmp_location/tests/nxapi/sanity.yaml
+++ b/test/integration/targets/nxos_snmp_location/tests/nxapi/sanity.yaml
@@ -1,4 +1,0 @@
----
-- set_fact: connection="{{ nxapi }}"
-
-- import_tasks: "{{ role_path }}/tests/common/sanity.yaml"

--- a/test/integration/targets/nxos_snmp_user/tests/cli/sanity.yaml
+++ b/test/integration/targets/nxos_snmp_user/tests/cli/sanity.yaml
@@ -1,4 +1,0 @@
----
-- set_fact: connection="{{ cli }}"
-
-- import_tasks: targets/nxos_snmp_user/tests/common/sanity.yaml

--- a/test/integration/targets/nxos_snmp_user/tests/nxapi/sanity.yaml
+++ b/test/integration/targets/nxos_snmp_user/tests/nxapi/sanity.yaml
@@ -1,4 +1,0 @@
----
-- set_fact: connection="{{ nxapi }}"
-
-- import_tasks: targets/nxos_snmp_user/tests/common/sanity.yaml

--- a/test/integration/targets/nxos_static_route/tests/cli/sanity.yaml
+++ b/test/integration/targets/nxos_static_route/tests/cli/sanity.yaml
@@ -1,4 +1,0 @@
----
-- set_fact: connection="{{ cli }}"
-
-- import_tasks: targets/nxos_static_route/tests/common/sanity.yaml

--- a/test/integration/targets/nxos_static_route/tests/nxapi/sanity.yaml
+++ b/test/integration/targets/nxos_static_route/tests/nxapi/sanity.yaml
@@ -1,4 +1,0 @@
----
-- set_fact: connection="{{ nxapi }}"
-
-- import_tasks: targets/nxos_static_route/tests/common/sanity.yaml

--- a/test/integration/targets/nxos_udld/tests/cli/sanity.yaml
+++ b/test/integration/targets/nxos_udld/tests/cli/sanity.yaml
@@ -1,4 +1,0 @@
----
-- set_fact: connection="{{ cli }}"
-
-- import_tasks: targets/nxos_udld/tests/common/sanity.yaml

--- a/test/integration/targets/nxos_udld/tests/nxapi/sanity.yaml
+++ b/test/integration/targets/nxos_udld/tests/nxapi/sanity.yaml
@@ -1,4 +1,0 @@
----
-- set_fact: connection="{{ nxapi }}"
-
-- import_tasks: targets/nxos_udld/tests/common/sanity.yaml

--- a/test/integration/targets/nxos_udld_interface/tests/cli/sanity.yaml
+++ b/test/integration/targets/nxos_udld_interface/tests/cli/sanity.yaml
@@ -1,4 +1,0 @@
----
-- set_fact: connection="{{ cli }}"
-
-- import_tasks: targets/nxos_udld_interface/tests/common/sanity.yaml

--- a/test/integration/targets/nxos_udld_interface/tests/nxapi/sanity.yaml
+++ b/test/integration/targets/nxos_udld_interface/tests/nxapi/sanity.yaml
@@ -1,4 +1,0 @@
----
-- set_fact: connection="{{ nxapi }}"
-
-- import_tasks: targets/nxos_udld_interface/tests/common/sanity.yaml

--- a/test/integration/targets/nxos_vpc/tests/cli/sanity.yaml
+++ b/test/integration/targets/nxos_vpc/tests/cli/sanity.yaml
@@ -1,4 +1,0 @@
----
-- set_fact: connection="{{ cli }}"
-
-- import_tasks: targets/nxos_vpc/tests/common/sanity.yaml

--- a/test/integration/targets/nxos_vpc/tests/nxapi/sanity.yaml
+++ b/test/integration/targets/nxos_vpc/tests/nxapi/sanity.yaml
@@ -1,4 +1,0 @@
----
-- set_fact: connection="{{ nxapi }}"
-
-- import_tasks: targets/nxos_vpc/tests/common/sanity.yaml

--- a/test/integration/targets/nxos_vpc_interface/tests/cli/sanity.yaml
+++ b/test/integration/targets/nxos_vpc_interface/tests/cli/sanity.yaml
@@ -1,4 +1,0 @@
----
-- set_fact: connection="{{ cli }}"
-
-- import_tasks: targets/nxos_vpc_interface/tests/common/sanity.yaml

--- a/test/integration/targets/nxos_vpc_interface/tests/nxapi/sanity.yaml
+++ b/test/integration/targets/nxos_vpc_interface/tests/nxapi/sanity.yaml
@@ -1,4 +1,0 @@
----
-- set_fact: connection="{{ nxapi }}"
-
-- import_tasks: targets/nxos_vpc_interface/tests/common/sanity.yaml

--- a/test/integration/targets/nxos_vrf_af/tests/cli/sanity.yaml
+++ b/test/integration/targets/nxos_vrf_af/tests/cli/sanity.yaml
@@ -1,4 +1,0 @@
----
-- set_fact: connection="{{ cli }}"
-
-- import_tasks: targets/nxos_vrf_af/tests/common/sanity.yaml

--- a/test/integration/targets/nxos_vrf_af/tests/nxapi/sanity.yaml
+++ b/test/integration/targets/nxos_vrf_af/tests/nxapi/sanity.yaml
@@ -1,4 +1,0 @@
----
-- set_fact: connection="{{ nxapi }}"
-
-- import_tasks: targets/nxos_vrf_af/tests/common/sanity.yaml

--- a/test/integration/targets/nxos_vxlan_vtep_vni/tests/cli/sanity.yaml
+++ b/test/integration/targets/nxos_vxlan_vtep_vni/tests/cli/sanity.yaml
@@ -1,4 +1,0 @@
----
-- set_fact: connection="{{ cli }}"
-
-- import_tasks: targets/nxos_vxlan_vtep_vni/tests/common/sanity.yaml

--- a/test/integration/targets/nxos_vxlan_vtep_vni/tests/nxapi/sanity.yaml
+++ b/test/integration/targets/nxos_vxlan_vtep_vni/tests/nxapi/sanity.yaml
@@ -1,4 +1,0 @@
----
-- set_fact: connection="{{ nxapi }}"
-
-- import_tasks: targets/nxos_vxlan_vtep_vni/tests/common/sanity.yaml


### PR DESCRIPTION
Signed-off-by: Trishna Guha <trishnaguha17@gmail.com>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Ensure network_cli, nxapi nxos tests run only once - remove unnecessary files - cli,nxapi tests are in common dir.
FIX: some of the network_cli, nxapi nxos tests run twice.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
test/integration/targets/nxos_*/tests/{cli,nxapi}/
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel , 2.5
```