### PR TITLE
cloudfront_distribution: fix restrictions

### DIFF
--- a/lib/ansible/modules/cloud/amazon/cloudfront_distribution.py
+++ b/lib/ansible/modules/cloud/amazon/cloudfront_distribution.py
@@ -1689,7 +1689,7 @@ class CloudFrontValidationManager(object):
                                               rest not in geo_restriction_items])
             valid_restrictions = ansible_list_to_cloudfront_list(geo_restriction_items)
             valid_restrictions['restriction_type'] = geo_restriction.get('restriction_type')
-            return valid_restrictions
+            return {'geo_restriction': valid_restrictions}
         except Exception as e:
             self.module.fail_json_aws(e, msg="Error validating restrictions")
 

--- a/test/integration/targets/cloudfront_distribution/tasks/main.yml
+++ b/test/integration/targets/cloudfront_distribution/tasks/main.yml
@@ -53,6 +53,23 @@
       that:
         - update_origin_http_port.changed
 
+  - name: update restrictions
+    cloudfront_distribution:
+      alias: "{{ cloudfront_alias }}"
+      restrictions:
+        geo_restriction:
+          restriction_type: "whitelist"
+          items:
+            - "US"
+      state: present
+      <<: *aws_connection_info
+    register: update_restrictions
+
+  - name: ensure restrictions was updated
+    assert:
+      that:
+        - update_restrictions.changed
+
   - name: set a random comment
     set_fact:
       comment: "{{'ABCDEFabcdef123456'|shuffle|join }}"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Fixes the restriction format that was sent to cloudfront
```python
# What we sent before the fix
'Restrictions': {
    'RestrictionType': 'blacklist'|'whitelist'|'none',
    'Quantity': 123,
    'Items': [
        'string',
    ]
}

# What AWS API Expect
'Restrictions': {
    'GeoRestriction': {
        'RestrictionType': 'blacklist'|'whitelist'|'none',
        'Quantity': 123,
        'Items': [
            'string',
        ]
    }
}
```

Fixes #36959

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
cloudfront_distribution

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6.0
```

