### PR TITLE
template: Add option to `lstrip_blocks' and fix setting`trim_blocks` inline

### DIFF
--- a/lib/ansible/modules/files/template.py
+++ b/lib/ansible/modules/files/template.py
@@ -74,6 +74,12 @@ options:
     type: bool
     default: 'no'
     version_added: '2.4'
+  lstrip_blocks:
+    description:
+      - If this is set to True leading spaces and tabs are stripped from the start of a line to a block.
+    type: bool
+    default: 'no'
+    version_added: '2.6'
   force:
     description:
       - the default is C(yes), which will replace the remote file when contents

--- a/lib/ansible/modules/files/template.py
+++ b/lib/ansible/modules/files/template.py
@@ -77,6 +77,7 @@ options:
   lstrip_blocks:
     description:
       - If this is set to True leading spaces and tabs are stripped from the start of a line to a block.
+        Setting this option to True requires Jinja2 version >=2.7.
     type: bool
     default: 'no'
     version_added: '2.6'

--- a/lib/ansible/plugins/action/template.py
+++ b/lib/ansible/plugins/action/template.py
@@ -53,7 +53,7 @@ class ActionModule(ActionBase):
         variable_end_string = self._task.args.get('variable_end_string', None)
         block_start_string = self._task.args.get('block_start_string', None)
         block_end_string = self._task.args.get('block_end_string', None)
-        trim_blocks = self._task.args.get('trim_blocks', None)
+        trim_blocks = boolean(self._task.args.get('trim_blocks', True), strict=False)
 
         wrong_sequences = ["\\n", "\\r", "\\r\\n"]
         allowed_sequences = ["\n", "\r", "\r\n"]
@@ -108,8 +108,7 @@ class ActionModule(ActionBase):
                     self._templar.environment.variable_start_string = variable_start_string
                 if variable_end_string is not None:
                     self._templar.environment.variable_end_string = variable_end_string
-                if trim_blocks is not None:
-                    self._templar.environment.trim_blocks = bool(trim_blocks)
+                self._templar.environment.trim_blocks = trim_blocks
 
                 # add ansible 'template' vars
                 temp_vars = task_vars.copy()

--- a/lib/ansible/plugins/action/template.py
+++ b/lib/ansible/plugins/action/template.py
@@ -54,6 +54,7 @@ class ActionModule(ActionBase):
         block_start_string = self._task.args.get('block_start_string', None)
         block_end_string = self._task.args.get('block_end_string', None)
         trim_blocks = boolean(self._task.args.get('trim_blocks', True), strict=False)
+        lstrip_blocks = boolean(self._task.args.get('lstrip_blocks', False), strict=False)
 
         wrong_sequences = ["\\n", "\\r", "\\r\\n"]
         allowed_sequences = ["\n", "\r", "\r\n"]
@@ -109,6 +110,7 @@ class ActionModule(ActionBase):
                 if variable_end_string is not None:
                     self._templar.environment.variable_end_string = variable_end_string
                 self._templar.environment.trim_blocks = trim_blocks
+                self._templar.environment.lstrip_blocks = lstrip_blocks
 
                 # add ansible 'template' vars
                 temp_vars = task_vars.copy()
@@ -132,6 +134,7 @@ class ActionModule(ActionBase):
             new_task.args.pop('variable_start_string', None)
             new_task.args.pop('variable_end_string', None)
             new_task.args.pop('trim_blocks', None)
+            new_task.args.pop('lstrip_blocks', None)
 
             local_tempdir = tempfile.mkdtemp(dir=C.DEFAULT_LOCAL_TMP)
 

--- a/lib/ansible/plugins/action/template.py
+++ b/lib/ansible/plugins/action/template.py
@@ -56,6 +56,18 @@ class ActionModule(ActionBase):
         trim_blocks = boolean(self._task.args.get('trim_blocks', True), strict=False)
         lstrip_blocks = boolean(self._task.args.get('lstrip_blocks', False), strict=False)
 
+        # Option `lstrip_blocks' was added in Jinja2 version 2.7.
+        if lstrip_blocks:
+            try:
+                import jinja2.defaults
+            except ImportError:
+                raise AnsibleError('Unable to import Jinja2 defaults for determing Jinja2 features.')
+
+            try:
+                jinja2.defaults.LSTRIP_BLOCKS
+            except AttributeError:
+                raise AnsibleError("Option `lstrip_blocks' is only available in Jinja2 versions >=2.7")
+
         wrong_sequences = ["\\n", "\\r", "\\r\\n"]
         allowed_sequences = ["\n", "\r", "\r\n"]
 

--- a/test/integration/targets/template/files/lstrip_blocks_false.expected
+++ b/test/integration/targets/template/files/lstrip_blocks_false.expected
@@ -1,0 +1,4 @@
+    hello world
+        hello world
+        hello world
+    

--- a/test/integration/targets/template/files/lstrip_blocks_true.expected
+++ b/test/integration/targets/template/files/lstrip_blocks_true.expected
@@ -1,0 +1,3 @@
+hello world
+hello world
+hello world

--- a/test/integration/targets/template/files/trim_blocks_false.expected
+++ b/test/integration/targets/template/files/trim_blocks_false.expected
@@ -1,0 +1,4 @@
+
+Hello world
+
+Goodbye

--- a/test/integration/targets/template/files/trim_blocks_true.expected
+++ b/test/integration/targets/template/files/trim_blocks_true.expected
@@ -1,0 +1,2 @@
+Hello world
+Goodbye

--- a/test/integration/targets/template/tasks/main.yml
+++ b/test/integration/targets/template/tasks/main.yml
@@ -120,6 +120,57 @@
         - 'import_as_with_context_diff_result.stdout == ""'
         - "import_as_with_context_diff_result.rc == 0"
 
+# VERIFY lstrip_blocks
+
+- name: Check support for lstrip_blocks in Jinja2
+  shell: "{{ ansible_python.executable }} -c 'import jinja2; jinja2.defaults.LSTRIP_BLOCKS'"
+  register: lstrip_block_support
+  ignore_errors: True
+
+- name: Render a template with "lstrip_blocks" set to False
+  template:
+    src: lstrip_blocks.j2
+    dest: "{{output_dir}}/lstrip_blocks_false.templated"
+    lstrip_blocks: False
+  register: lstrip_blocks_false_result
+
+- name: Get checksum of known good lstrip_blocks_false.expected
+  stat:
+    path: "{{role_path}}/files/lstrip_blocks_false.expected"
+  register: lstrip_blocks_false_good
+
+- name: Verify templated lstrip_blocks_false matches known good using checksum
+  assert:
+    that:
+        - "lstrip_blocks_false_result.checksum == lstrip_blocks_false_good.stat.checksum"
+
+- name: Render a template with "lstrip_blocks" set to True
+  template:
+    src: lstrip_blocks.j2
+    dest: "{{output_dir}}/lstrip_blocks_true.templated"
+    lstrip_blocks: True
+  register: lstrip_blocks_true_result
+  ignore_errors: True
+
+- name: Verify exception is thrown if Jinja2 does not support lstrip_blocks but lstrip_blocks is used
+  assert:
+    that:
+      - "lstrip_blocks_true_result.failed"
+      - 'lstrip_blocks_true_result.msg is search(">=2.7")'
+  when: "lstrip_block_support is failed"
+
+- name: Get checksum of known good lstrip_blocks_true.expected
+  stat:
+    path: "{{role_path}}/files/lstrip_blocks_true.expected"
+  register: lstrip_blocks_true_good
+  when: "lstrip_block_support is successful"
+
+- name: Verify templated lstrip_blocks_true matches known good using checksum
+  assert:
+    that:
+        - "lstrip_blocks_true_result.checksum == lstrip_blocks_true_good.stat.checksum"
+  when: "lstrip_block_support is successful"
+
 # VERIFY CONTENTS
 
 - name: check what python version ansible is running on

--- a/test/integration/targets/template/tasks/main.yml
+++ b/test/integration/targets/template/tasks/main.yml
@@ -120,6 +120,42 @@
         - 'import_as_with_context_diff_result.stdout == ""'
         - "import_as_with_context_diff_result.rc == 0"
 
+# VERIFY trim_blocks
+
+- name: Render a template with "trim_blocks" set to False
+  template:
+    src: trim_blocks.j2
+    dest: "{{output_dir}}/trim_blocks_false.templated"
+    trim_blocks: False
+  register: trim_blocks_false_result
+
+- name: Get checksum of known good trim_blocks_false.expected
+  stat:
+    path: "{{role_path}}/files/trim_blocks_false.expected"
+  register: trim_blocks_false_good
+
+- name: Verify templated trim_blocks_false matches known good using checksum
+  assert:
+    that:
+        - "trim_blocks_false_result.checksum == trim_blocks_false_good.stat.checksum"
+
+- name: Render a template with "trim_blocks" set to True
+  template:
+    src: trim_blocks.j2
+    dest: "{{output_dir}}/trim_blocks_true.templated"
+    trim_blocks: True
+  register: trim_blocks_true_result
+
+- name: Get checksum of known good trim_blocks_true.expected
+  stat:
+    path: "{{role_path}}/files/trim_blocks_true.expected"
+  register: trim_blocks_true_good
+
+- name: Verify templated trim_blocks_true matches known good using checksum
+  assert:
+    that:
+        - "trim_blocks_true_result.checksum == trim_blocks_true_good.stat.checksum"
+
 # VERIFY lstrip_blocks
 
 - name: Check support for lstrip_blocks in Jinja2

--- a/test/integration/targets/template/templates/lstrip_blocks.j2
+++ b/test/integration/targets/template/templates/lstrip_blocks.j2
@@ -1,0 +1,8 @@
+{% set hello_world="hello world" %}
+{% for i in [1, 2, 3] %}
+    {% if loop.first %}
+{{hello_world}}
+    {% else %}
+{{hello_world}}
+    {% endif %}
+{% endfor %}

--- a/test/integration/targets/template/templates/trim_blocks.j2
+++ b/test/integration/targets/template/templates/trim_blocks.j2
@@ -1,0 +1,4 @@
+{% if True %}
+Hello world
+{% endif %}
+Goodbye


### PR DESCRIPTION
[lstrip_blocks_test.zip](https://github.com/ansible/ansible/files/1816249/lstrip_blocks_test.zip)

[trim_blocks_test.zip](https://github.com/ansible/ansible/files/1817420/trim_blocks_test.zip)

##### SUMMARY
Add option to set `lstrip_blocks` when using the template module to render Jinja templates. The Jinja documentation suggests that `trim_blocks` and `lstrip_blocks` is a great combination and the template module already provides an option for `trim_blocks'.

Note that although `trim_blocks` in Ansible is enabled by default since version 2.4, in order to avoid breaking things keep `lstrip_blocks` disabled by default. Maybe in a future version it could be enabled by default.

Also fix the `trim_blocks` argument to make it possible to set it to `False` inline.

This seems to address issue #10725 in a more appropriate way than the
suggested.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
template

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0
  config file = None
  configured module search path = [u'/home/alex/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/alex/git/ansible-ve/lib/python2.7/site-packages/ansible-2.6.0-py2.7.egg/ansible
  executable location = /home/alex/git/ansible-ve/bin/ansible
  python version = 2.7.14 (default, Jan  5 2018, 10:41:29) [GCC 7.2.1 20171224]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

Attached is a simple test. The zip file contains the playbook `lstrip_blocks_test.yml` and the template `test.j2`. The playbook contains two tasks. The first task should render the template without setting the `lstrip_blocks` option, creating the file `test_default` in the working directory.
The second task should render the template with the `lstrip_blocks` options set to `True`, creating the `test_with_lstrip_blocks` file in the working directory.

To run the playbook simply run `ansible-playbook lstrip_blocks_test.yml`.

To test the `trim_blocks` inline option, we provide another test. The zip file contains a playbook `trim_blocks_test.yml` and the template `trim_blocks.j2`. The playbook has a single task, to render the `trim_blocks.j2` template with `trim_blocks` set to `False`, creating the file `trim_blocks.templated` in the working directory. Before this PR the result is the following:
```
Hello World
Goodbye
```

After the PR the result is the following (which is the correct and expected):
```

Hello World

Goodbye
```

To run the playbook simply run `ansible-playbook trim_blocks_test.yml`.