### PR TITLE
Fix docs build

### DIFF
--- a/docs/templates/plugin.rst.j2
+++ b/docs/templates/plugin.rst.j2
@@ -1,6 +1,9 @@
 :source: @{ source }@
 
 .. _@{ module }@:
+{% for alias in aliases %}
+.. _@{ alias }@:
+{% endfor %}
 
 {% if short_description %}
 {%   set title = module + ' - ' + short_description|convert_symbols_to_format %}


### PR DESCRIPTION
##### SUMMARY
Fix docs build and add a ref target for modules

##### ISSUE TYPE
 - Feature Pull Request
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
Docs

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```
Might want to backport the alias change to stable-2.5 and stable-2.4.  I'll submit separate PRs with just that commit if so.

##### ADDITIONAL INFORMATION
The bugfix portion of this may not be final.  I suspect that value.default is being converted to a string somewhere and that is the actual root of this problem.