### PR TITLE
Correct method to get timedelta seconds value

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters.rst
@@ -919,10 +919,10 @@ This will result in::
 
 To get date object from string use the `to_datetime` filter, (new in version in 2.2)::
 
-    # get total amount of seconds between two dates, default date format is %Y-%m-%d %H:%M:%S but you can pass your own one
+    # Get total amount of seconds between two dates. Default date format is %Y-%m-%d %H:%M:%S but you can pass your own format
     {{ (("2016-08-14 20:00:12"|to_datetime) - ("2015-12-25"|to_datetime('%Y-%m-%d'))).total_seconds()  }}
     
-    # get remaining seconds after delta has been calculated. NOTE: This does NOT convert years, days, hours, etc to seconds. For that, use total_seconds()
+    # Get remaining seconds after delta has been calculated. NOTE: This does NOT convert years, days, hours, etc to seconds. For that, use total_seconds()
     {{ (("2016-08-14 20:00:12"|to_datetime) - ("2016-08-14 18:00:00"|to_datetime)).seconds  }}
     # This expression evaluates to "12" and not "132". Delta is 2 hours, 12 seconds
     

--- a/docs/docsite/rst/user_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters.rst
@@ -919,9 +919,15 @@ This will result in::
 
 To get date object from string use the `to_datetime` filter, (new in version in 2.2)::
 
-    # get amount of seconds between two dates, default date format is %Y-%m-%d %H:%M:%S but you can pass your own one
-    {{ (("2016-08-14 20:00:12"|to_datetime) - ("2015-12-25"|to_datetime('%Y-%m-%d'))).seconds  }}
-
+    # get total amount of seconds between two dates, default date format is %Y-%m-%d %H:%M:%S but you can pass your own one
+    {{ (("2016-08-14 20:00:12"|to_datetime) - ("2015-12-25"|to_datetime('%Y-%m-%d'))).total_seconds()  }}
+    
+    # get remaining seconds after delta has been calculated. NOTE: This does NOT convert years, days, hours, etc to seconds. For that, use total_seconds()
+    {{ (("2016-08-14 20:00:12"|to_datetime) - ("2016-08-14 18:00:00"|to_datetime)).seconds  }}
+    # This expression evaluates to "12" and not "132". Delta is 2 hours, 12 seconds
+    
+    # get amount of days between two dates. This returns only number of days and discards remaining hours, minutes, and seconds
+    {{ (("2016-08-14 20:00:12"|to_datetime) - ("2015-12-25"|to_datetime('%Y-%m-%d'))).days  }}
 
 Combination Filters
 ````````````````````


### PR DESCRIPTION
This also adds additional clarification for extracting different time/date values for time deltas

##### SUMMARY
Documentation incorrectly uses `.seconds` to get total number of seconds between two dates. This has been corrected and I've added additional examples for how to extract additional values from the resulting object.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
Filters

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.3.0
  config file = /home/xxx/.ansible.cfg
  configured module search path = [u'/home/xxx/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/xxxxxxxxx/ansible24/lib/python2.7/site-packages/ansible
  executable location = /home/xxxxxxxxx/ansible24/bin/ansible
  python version = 2.7.14 (default, Feb 27 2018, 20:43:24) [GCC 7.3.1 20180130 (Red Hat 7.3.1-2)]
```


##### ADDITIONAL INFORMATION
