### PR TITLE
Fix bucket names for aws_s3 integration tests - fixes #37481

### DIFF
--- a/test/integration/targets/aws_s3/tasks/main.yml
+++ b/test/integration/targets/aws_s3/tasks/main.yml
@@ -2,7 +2,7 @@
 # tasks file for test_s3
 # ============================================================
 - name: generate random name for the bucket name
-  command: bash -c 'echo ansible_test_$RANDOM'
+  command: bash -c 'echo ansible-test-$RANDOM'
   register: bucket
 # ============================================================
 # ============================================================


### PR DESCRIPTION
As of March 1st, 2018, bucket names may not contain underscores for the us-east-1 region

##### SUMMARY
Fixes #37481
See https://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html:

`On March 1, 2018, we are updating our naming conventions for S3 buckets in the US East (N. Virginia) Region to match the naming conventions we use in all other worldwide AWS Regions. After this date, Amazon S3 will no longer support creating bucket names that contain uppercase letters or underscores. This change ensures that each bucket can be addressed using virtual host style addressing, such as https://myawsbucket.s3.amazonaws.com. We highly recommend that you review your existing bucket-creation processes to ensure your adherence to our DNS-compliant naming conventions.`

Already fixed in 2.5 and devel by using resource_prefix in the bucket name.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
test/integration/targets/aws_s3

##### ANSIBLE VERSION
```
2.6.0
```
