### PR TITLE
Fix problems with virtualbox inventory and composed vars and groups

### DIFF
--- a/lib/ansible/plugins/inventory/virtualbox.py
+++ b/lib/ansible/plugins/inventory/virtualbox.py
@@ -82,15 +82,20 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                 for varname in query:
                     hostvars[host][varname] = self._query_vbox_data(host, query[varname])
 
+            strict = self._options.get('strict', False)
+
             # create composite vars
-            self._set_composite_vars(self.get_option('compose'), hostvars, host)
+            self._set_composite_vars(self.get_option('compose'), hostvars[host], host, strict=strict)
 
             # actually update inventory
             for key in hostvars[host]:
                 self.inventory.set_variable(host, key, hostvars[host][key])
 
             # constructed groups based on conditionals
-            self._add_host_to_composed_groups(self.get_option('groups'), hostvars, host)
+            self._add_host_to_composed_groups(self.get_option('groups'), hostvars[host], host, strict=strict)
+
+            # constructed keyed_groups
+            self._add_host_to_keyed_groups(self.get_option('keyed_groups'), hostvars[host], host, strict=strict)
 
     def _populate_from_cache(self, source_data):
         hostvars = source_data.pop('_meta', {}).get('hostvars', {})


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Virtualbox inventory plugin implements "constructed". Since "constructed" documentation ([constructed](http://docs.ansible.com/ansible/devel/plugins/inventory/constructed.html)) , it should handle variables "strict" and  "keyed_groups" in its configuration, and it currently doesn't do it.

This commit adds the code to handle "strict" and "keyed_groups".

Plus, now it is not able able to construct the variables nor the groups properly, since the plugin cannot find the hostvars, and when executed with "strict: True" the plugin always fails. This bug happens because we are passing "hostvars" as a parameter to "_set_composite_vars" and "_add_host_to_composed_groups". This commit will use "hostvars[host]" instead, so that the hostvars can be found while constructing the variables and groups.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
virtualbox inventory plugin

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0 (devel 3cc362d958) last updated 2018/03/15 14:38:15 (GMT -700)
  config file = None
  configured module search path = [u'/home/user/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/user/ansible/lib/ansible
  executable location = /home/user/ansible/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

To reproduce de bugs:

Enable virtualbox plugin in ansible.cfg

```
[inventory]
enable_plugins = virtualbox
```

Execute this command:

```
ansible-doc -t inventory virtualbox
```

You will see that the output is telling you that it supports "strict" and "keyed_groups" variables, when it actually doesn't.


To reproduce the failures regarding the "composed" vars:

Use this inventory file (the one used in the example), named, for instance "inventory_vbox.vbox.yml"
```
    plugin: virtualbox
    settings_password_file: /etc/virtulbox/secrets
    query:
      logged_in_users: /VirtualBox/GuestInfo/OS/LoggedInUsersList
    compose:
      ansible_connection: ('indows' in vbox_Guest_OS)|ternary('winrm', 'ssh')
      this_variable_always_fails: ('indows' in vbox_Guest_OS)|ternary('winrm', 'ssh')
```

Execute the command
```
 ansible -i inventory_vbox.vbox.yml -m debug -a "var=hostvars[inventory_hostname]" all
```

You will see that the variable "this_variable_always_fails" will never be set. Actually no compose variable will be set, it will always fail silently. It happens because the plugin cannot actually find the hostvars to make the constructions, and it always executes the compose with "strict: False", no matter the configuration file.

Changing:
```
self._set_composite_vars(self.get_option('compose'), hostvars, host)
```
for
```
self._set_composite_vars(self.get_option('compose'), hostvars[host], host)
```
in lib/ansible/plugins/inventory/virtualbox.py fixes the problem.

This commit makes this change, plus includes the extra parameter "strict".

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
