### PR TITLE
Set win_rm protocol to the protocol name, not the ProtocolTypes object

### DIFF
--- a/contrib/inventory/azure_rm.py
+++ b/contrib/inventory/azure_rm.py
@@ -630,7 +630,7 @@ class AzureInventory(object):
                     if machine.os_profile.windows_configuration.win_rm.listeners is not None:
                         host_vars['windows_rm']['listeners'] = []
                         for listener in machine.os_profile.windows_configuration.win_rm.listeners:
-                            host_vars['windows_rm']['listeners'].append(dict(protocol=listener.protocol,
+                            host_vars['windows_rm']['listeners'].append(dict(protocol=listener.protocol.name,
                                                                              certificate_url=listener.certificate_url))
 
             for interface in machine.network_profile.network_interfaces:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
The `azure_rm.py` inventory script fails to serialize Windows VMs with the `win_rm` property set, because the `protocol` key is set to the full `ProtocolTypes` object, not to the protocol name property, either `http` or `https`
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
`azure_rm.py`

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.3.0
  config file = None
  configured module search path = ['/Users/tgregory/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /opt/local/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/ansible
  executable location = bin/ansible
  python version = 3.6.4 (default, Dec 23 2017, 20:35:10) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.38)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
To reproduce: run the `azure_rm.py` script against any Windows host with a WinRM listener set to reproduce. Some of the below has been redacted to protect the innocent.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```
Before:
============
Traceback (most recent call last):
  File "./ansible_src_azure_rm.py", line 860, in <module>
    main()
  File "./ansible_src_azure_rm.py", line 856, in main
    AzureInventory()
  File "./ansible_src_azure_rm.py", line 502, in __init__
    print(self._json_format_dict(pretty=self._args.pretty))
  File "./ansible_src_azure_rm.py", line 745, in _json_format_dict
    return json.dumps(self._inventory, sort_keys=True, indent=2)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/json/__init__.py", line 251, in dumps
    sort_keys=sort_keys, **kw).encode(obj)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/json/encoder.py", line 209, in encode
    chunks = list(chunks)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/json/encoder.py", line 434, in _iterencode
    for chunk in _iterencode_dict(o, _current_indent_level):
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/json/encoder.py", line 408, in _iterencode_dict
    for chunk in chunks:
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/json/encoder.py", line 408, in _iterencode_dict
    for chunk in chunks:
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/json/encoder.py", line 408, in _iterencode_dict
    for chunk in chunks:
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/json/encoder.py", line 408, in _iterencode_dict
    for chunk in chunks:
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/json/encoder.py", line 408, in _iterencode_dict
    for chunk in chunks:
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/json/encoder.py", line 332, in _iterencode_list
    for chunk in chunks:
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/json/encoder.py", line 408, in _iterencode_dict
    for chunk in chunks:
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/json/encoder.py", line 442, in _iterencode
    o = _default(o)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/json/encoder.py", line 184, in default
    raise TypeError(repr(o) + " is not JSON serializable")
TypeError: <ProtocolTypes.http: 'Http'> is not JSON serializable

After:
============
{
  "Build_Date": [
    "azumsapsc003d"
  ] 
  "Creator": [
    "azumsapsc003d"
  ]
  "_meta": {
    "hostvars": {
      "azumsapsc003d": {
        "ansible_connection": "winrm", 
        "ansible_host": null, 
        "computer_name": "azumsapsc003d", 
        "fqdn": null, 
        "id": "",
        "image": {
          "offer": "WindowsServer", 
          "publisher": "MicrosoftWindowsServer", 
          "sku": "2012-R2-Datacenter", 
          "version": "latest"
        }, 
        "location": "northcentralus", 
        "mac_address": "", 
        "name": "azumsapsc003d", 
        "network_interface": "azumsapsc003d_nic0", 
        "network_interface_id": "", 
        "os_disk": {
          "name": "azumsapsc003d_osDisk", 
          "operating_system_type": "Windows"
        }, 
        "plan": null, 
        "powerstate": "running", 
        "private_ip": "", 
        "private_ip_alloc_method": "Dynamic", 
        "provisioning_state": "Succeeded", 
        "public_ip": null, 
        "public_ip_alloc_method": null, 
        "public_ip_id": null, 
        "public_ip_name": null, 
        "resource_group": "", 
        "tags": { }, 
        "type": "Microsoft.Compute/virtualMachines", 
        "virtual_machine_size": "standard_ds11_v2", 
        "windows_auto_updates_enabled": true, 
        "windows_rm": {
          "listeners": [
            {
              "certificate_url": null, 
              "protocol": "http"
            }
          ]
        }, 
        "windows_timezone": null
      }
    }
  }, 
  "azure": [
    "azumsapsc003d"
  ], 
  "northcentralus": [
    "azumsapsc003d"
  ], 
  "rg_scada_pi": [
    "azumsapsc003d"
  ]
}

```
