### PR TITLE
Fix crash in py3: 'TypeError: a bytes-like object is required, not 'str'

### DIFF
--- a/lib/ansible/modules/system/interfaces_file.py
+++ b/lib/ansible/modules/system/interfaces_file.py
@@ -141,6 +141,7 @@ import re
 import tempfile
 
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_bytes
 
 
 def lineDict(line):
@@ -320,8 +321,8 @@ def addOptionAfterLine(option, value, iface, lines, last_line_dict, iface_option
 def write_changes(module, lines, dest):
 
     tmpfd, tmpfile = tempfile.mkstemp()
-    f = os.fdopen(tmpfd, 'w')
-    f.writelines(lines)
+    f = os.fdopen(tmpfd, 'wb')
+    f.writelines(to_bytes(lines, errors='surrogate_or_strict'))
     f.close()
     module.atomic_move(tmpfile, os.path.realpath(dest))
 

--- a/lib/ansible/modules/system/interfaces_file.py
+++ b/lib/ansible/modules/system/interfaces_file.py
@@ -320,7 +320,7 @@ def addOptionAfterLine(option, value, iface, lines, last_line_dict, iface_option
 def write_changes(module, lines, dest):
 
     tmpfd, tmpfile = tempfile.mkstemp()
-    f = os.fdopen(tmpfd, 'wb')
+    f = os.fdopen(tmpfd, 'w')
     f.writelines(lines)
     f.close()
     module.atomic_move(tmpfile, os.path.realpath(dest))


### PR DESCRIPTION
##### SUMMARY
Fixes #37387

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
interfaces_file

##### ANSIBLE VERSION
```
$ ansible --version
ansible 2.4.3.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/alu/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.14 (default, Sep 23 2017, 22:06:14) [GCC 7.2.0]
```