### PR TITLE
Fail with more meaningful message when the volume can not be found

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_server_volume.py
+++ b/lib/ansible/modules/cloud/openstack/os_server_volume.py
@@ -103,6 +103,10 @@ def main():
     try:
         server = cloud.get_server(module.params['server'])
         volume = cloud.get_volume(module.params['volume'])
+
+        if not volume:
+            module.fail_json(msg='volume %s is not found' % module.params['volume'])
+
         dev = cloud.get_volume_attach_device(volume, server.id)
 
         if module.check_mode:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

Fix then the volume is not found. otherwise, a None type have no attribute error will be raised.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
os_server_volume

##### ANSIBLE VERSION

```
ansible 2.4.3.0
  config file = /home/jeffrey/.ansible.cfg
  configured module search path = [u'/home/jeffrey/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/sbin/ansible
  python version = 2.7.14 (default, Jan  5 2018, 10:41:29) [GCC 7.2.1 20171224]

```
