### PR TITLE
fix 'doas' become_method support, previously committed patch not submitted to devel branch

### DIFF
--- a/lib/ansible/playbook/play_context.py
+++ b/lib/ansible/playbook/play_context.py
@@ -544,7 +544,7 @@ class PlayContext(Base):
                     flags += ' -u %s ' % self.become_user
 
                 # FIXME: make shell independent
-                becomecmd = '%s %s echo %s && %s %s env ANSIBLE=true %s' % (exe, flags, success_key, exe, flags, cmd)
+                becomecmd = '%s %s %s -c %s' % (exe, flags, executable, success_cmd)
 
             elif self.become_method == 'dzdo':
 

--- a/test/units/playbook/test_play_context.py
+++ b/test/units/playbook/test_play_context.py
@@ -153,8 +153,7 @@ def test_play_context_make_become_cmd(parser):
 
     play_context.become_method = 'doas'
     cmd = play_context.make_become_cmd(cmd=default_cmd, executable="/bin/bash")
-    assert (cmd == """%s %s echo %s && %s %s env ANSIBLE=true %s""" % (doas_exe, doas_flags, play_context.
-                                                                       success_key, doas_exe, doas_flags, default_cmd))
+    assert (cmd == """%s %s %s -c 'echo %s; %s'""" % (doas_exe, doas_flags, default_exe, play_context.success_key, default_cmd))
 
     play_context.become_method = 'ksu'
     cmd = play_context.make_become_cmd(cmd=default_cmd, executable="/bin/bash")


### PR DESCRIPTION
##### SUMMARY
Re-submit previously submitted https://github.com/ansible/ansible/pull/13451 which was only submitted into 2.0 branch and NOT devel for further use in all later ansible versions.

Fixes #18721

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request
 
##### COMPONENT NAME
Sorry, I'm not sure what to put here.

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible-playbook 2.6.0 (devel e50a1a42ca) last updated 2018/03/16 07:49:33 (GMT -400)
  config file = /tank/git/ansible-configs/ansible.cfg
  configured module search path = [u'/home/jforman/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /tank/git/forked-repos/ansible/lib/ansible
  executable location = /tank/git/forked-repos/ansible/bin/ansible-playbook
  python version = 2.7.13 (default, Nov 24 2017, 17:33:09) [GCC 6.3.0 20170516]
```


##### ADDITIONAL INFORMATION
I tested this from a Debian 9.4 machine to an OpenBSD 6.2 machine which uses doas for privilege escalation (instead of sudo).

Previously an ansible-playbook run would hang after the doas prompt, but now the playbook is successfully executed.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
/tank/git/forked-repos/ansible/bin/ansible-playbook -e ansible_python_interpreter=/usr/local/bin/python --become-method=doas --ask-become-pass -i hosts -l 'formangate1*' site.yml --tags common

```
