### PR TITLE
Bump docker-py minimum version to 1.8.0

### DIFF
--- a/lib/ansible/module_utils/docker_common.py
+++ b/lib/ansible/module_utils/docker_common.py
@@ -59,7 +59,7 @@ except ImportError as exc:
 DEFAULT_DOCKER_HOST = 'unix://var/run/docker.sock'
 DEFAULT_TLS = False
 DEFAULT_TLS_VERIFY = False
-MIN_DOCKER_VERSION = "1.7.0"
+MIN_DOCKER_VERSION = "1.8.0"
 
 DOCKER_COMMON_ARGS = dict(
     docker_host=dict(type='str', aliases=['docker_url']),

--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -404,7 +404,7 @@ author:
 
 requirements:
     - "python >= 2.6"
-    - "docker-py >= 1.7.0"
+    - "docker-py >= 1.8.0"
     - "Docker API >= 1.20"
 '''
 

--- a/lib/ansible/modules/cloud/docker/docker_image.py
+++ b/lib/ansible/modules/cloud/docker/docker_image.py
@@ -168,7 +168,7 @@ extends_documentation_fragment:
 
 requirements:
   - "python >= 2.6"
-  - "docker-py >= 1.7.0"
+  - "docker-py >= 1.8.0"
   - "Docker API >= 1.20"
 
 author:

--- a/lib/ansible/modules/cloud/docker/docker_image_facts.py
+++ b/lib/ansible/modules/cloud/docker/docker_image_facts.py
@@ -35,7 +35,7 @@ extends_documentation_fragment:
 
 requirements:
   - "python >= 2.6"
-  - "docker-py >= 1.7.0"
+  - "docker-py >= 1.8.0"
   - "Docker API >= 1.20"
 
 author:

--- a/lib/ansible/modules/cloud/docker/docker_login.py
+++ b/lib/ansible/modules/cloud/docker/docker_login.py
@@ -76,7 +76,7 @@ extends_documentation_fragment:
     - docker
 requirements:
     - "python >= 2.6"
-    - "docker-py >= 1.7.0"
+    - "docker-py >= 1.8.0"
     - "Docker API >= 1.20"
     - 'Only to be able to logout (state=absent): the docker command line utility'
 author:

--- a/lib/ansible/modules/cloud/docker/docker_network.py
+++ b/lib/ansible/modules/cloud/docker/docker_network.py
@@ -95,7 +95,7 @@ author:
 
 requirements:
     - "python >= 2.6"
-    - "docker-py >= 1.7.0"
+    - "docker-py >= 1.8.0"
     - "The docker server >= 1.9.0"
 '''
 


### PR DESCRIPTION
##### SUMMARY
docker_container and docker_image uses docker API called
`pull` with option decode which was introduced in docker-py 1.8.0
This fix bumps the requirement of minimum version to 1.8.0
Docker-py PR for decode - https://github.com/docker/docker-py/pull/968

Fixes: #29512 #20776

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
lib/ansible/module_utils/docker_common.py
lib/ansible/modules/cloud/docker/docker_container.py
lib/ansible/modules/cloud/docker/docker_image.py
lib/ansible/modules/cloud/docker/docker_image_facts.py
lib/ansible/modules/cloud/docker/docker_login.py
lib/ansible/modules/cloud/docker/docker_network.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6devel
```