### PR TITLE
Ensure non ansilbe exceptions keep tracebacks

### DIFF
--- a/lib/ansible/inventory/manager.py
+++ b/lib/ansible/inventory/manager.py
@@ -275,7 +275,7 @@ class InventoryManager(object):
                         failures.append({'src': source, 'plugin': plugin_name, 'exc': e})
                     except Exception as e:
                         display.debug('%s failed to parse %s' % (plugin_name, to_text(source)))
-                        failures.append({'src': source, 'plugin': plugin_name, 'exc': e})
+                        failures.append({'src': source, 'plugin': plugin_name, 'exc': AnsibleError(e)})
                 else:
                     display.debug('%s did not meet %s requirements' % (to_text(source), plugin_name))
             else:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Now you get to see traceback on -vvv even when inventory plugin throws 'non ansible' exceptions

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
inventory manager

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.4/2.5/2.6
```