### PR TITLE
Auth method for the k8s lookup plugin now matches other modules

### DIFF
--- a/lib/ansible/module_utils/k8s/lookup.py
+++ b/lib/ansible/module_utils/k8s/lookup.py
@@ -88,8 +88,12 @@ class KubernetesLookup(object):
         self.kind = to_snake(self.kind)
         self.helper = self.get_helper(self.api_version, self.kind)
 
+        auth_args = ('host', 'api_key', 'kubeconfig', 'context', 'username', 'password',
+                     'cert_file', 'key_file', 'ssl_ca_cert', 'verify_ssl')
+
         for arg in AUTH_ARG_SPEC:
-            self.connection[arg] = kwargs.get(arg)
+            if arg in auth_args and kwargs.get(arg) is not None:
+                self.connection[arg] = kwargs.get(arg)
 
         try:
             self.helper.set_client_config(**self.connection)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
The kubernetes lookup was not authenticating in the same way as the other kubernetes plugins. This caused it to sometimes fail to connect for certain auth configurations. This change brings the authentication logic in line with the other modules.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
kubernetes lookup module 