### PR TITLE
Avoid 2nd processing of facts for actions

### DIFF
--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -593,7 +593,7 @@ class TaskExecutor:
                     failed_when_result = False
                 return failed_when_result
 
-            if 'ansible_facts' in result:
+            if 'ansible_facts' in result and self._task.action not in ('set_fact', 'include_vars'):
                 vars_copy.update(namespace_facts(result['ansible_facts']))
                 if C.INJECT_FACTS_AS_VARS:
                     vars_copy.update(clean_facts(result['ansible_facts']))
@@ -651,7 +651,7 @@ class TaskExecutor:
         if self._task.register:
             variables[self._task.register] = wrap_var(result)
 
-        if 'ansible_facts' in result:
+        if 'ansible_facts' in result and self._task.action not in ('set_fact', 'include_vars'):
             variables.update(namespace_facts(result['ansible_facts']))
             if C.INJECT_FACTS_AS_VARS:
                 variables.update(clean_facts(result['ansible_facts']))


### PR DESCRIPTION
##### SUMMARY
include_vars and set_fact are already updating hostvars in strategy
no need to 're add again' with lower priority the same data.

fixes #37535, mostly by avoiding reprocessing and 'cleaning'


<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
facts
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5/2.6
```