### PR TITLE
adds name server group support to nios_zone

### DIFF
--- a/lib/ansible/modules/net_tools/nios/nios_zone.py
+++ b/lib/ansible/modules/net_tools/nios/nios_zone.py
@@ -47,7 +47,6 @@ options:
       name:
         description:
           - The name of the grid primary server
-        required: true
   grid_secondaries:
     description:
       - Configures the grid secondary servers for this zone.
@@ -55,7 +54,10 @@ options:
       name:
         description:
           - The name of the grid secondary server
-        required: true
+  ns_group:
+    description:
+      - Configures the name server group for this zone. Name server group is
+        mutually exclusive with grid primary and grid secondaries.
   extattrs:
     description:
       - Allows for the configuration of Extensible Attributes on the
@@ -79,9 +81,25 @@ options:
 '''
 
 EXAMPLES = '''
-- name: configure a zone on the system
+- name: configure a zone on the system using grid primary and secondaries
   nios_zone:
     name: ansible.com
+    grid_primary:
+      - name: gridprimary.grid.com
+    grid_secondaries:
+      - name: gridsecondary1.grid.com
+      - name: gridsecondary2.grid.com
+    state: present
+    provider:
+      host: "{{ inventory_hostname_short }}"
+      username: admin
+      password: admin
+  connection: local
+
+- name: configure a zone on the system using a name server group
+  nios_zone:
+    name: ansible.com
+    ns_group: examplensg
     state: present
     provider:
       host: "{{ inventory_hostname_short }}"
@@ -132,6 +150,7 @@ def main():
 
         grid_primary=dict(type='list', elements='dict', options=grid_spec),
         grid_secondaries=dict(type='list', elements='dict', options=grid_spec),
+        ns_group=dict(),
 
         extattrs=dict(type='dict'),
         comment=dict()
@@ -146,7 +165,11 @@ def main():
     argument_spec.update(WapiModule.provider_spec)
 
     module = AnsibleModule(argument_spec=argument_spec,
-                           supports_check_mode=True)
+                           supports_check_mode=True,
+			   mutually_exclusive=[
+			   	['ns_group', 'grid_primary'],
+				['ns_group', 'grid_secondaries']
+		  	   ])
 
     wapi = WapiModule(module)
     result = wapi.run('zone_auth', ib_spec)


### PR DESCRIPTION
##### SUMMARY

Adds support for Infoblox name server groups to the nios_zone module. Currently only grid primary and grid secondary are supported. Many users have name server groups that consolidate the nameservers.

##### ISSUE TYPE

 - Feature Pull Request

##### COMPONENT NAME

nios_zone.py

##### ANSIBLE VERSION

ansible 2.6.0 (ns-group-branch 8a995d02ec) last updated 2018/03/16 15:00:35 (GMT -700)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/brampling/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/brampling/Dropbox/src/ansibledev/ansible/lib/ansible
  executable location = /home/brampling/Dropbox/src/ansibledev/ansible/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]

##### ADDITIONAL INFORMATION
N/A