### PR TITLE
Fix ec2_metadata_facts documentation

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_metadata_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_metadata_facts.py
@@ -26,8 +26,6 @@ description:
       The module must be called from within the EC2 instance itself.
 notes:
     - Parameters to filter on ec2_metadata_facts may be added later.
-extends_documentation_fragment:
-    - url
 '''
 
 EXAMPLES = '''
@@ -423,7 +421,7 @@ import socket
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_text
-from ansible.module_utils.urls import fetch_url, url_argument_spec
+from ansible.module_utils.urls import fetch_url
 
 
 socket.setdefaulttimeout(5)
@@ -528,10 +526,8 @@ class Ec2Metadata(object):
 
 
 def main():
-    argument_spec = url_argument_spec()
-
     module = AnsibleModule(
-        argument_spec=argument_spec,
+        argument_spec={},
         supports_check_mode=True,
     )
 


### PR DESCRIPTION
##### SUMMARY
ec2_metadata_facts does not extend `url`.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
Module documentation for ec2_metadata_facts

##### ANSIBLE VERSION
Technically this is incorrect in 2.5 and devel as of right now.