### PR TITLE
Fixes anchors scrolling off the top of the screen during navigation.

### DIFF
--- a/docs/docsite/_themes/sphinx_rtd_theme/static/css/theme.css
+++ b/docs/docsite/_themes/sphinx_rtd_theme/static/css/theme.css
@@ -1686,11 +1686,11 @@ code.code-large,.rst-content tt.code-large{font-size:90%}
 .wy-nav-top a{color:#fff;font-weight:bold}
 .wy-nav-top img{margin-right:12px;height:45px;width:45px;background-color:#2980B9;padding:5px;border-radius:100%}
 .wy-nav-top i{font-size:30px;float:left;cursor:pointer;padding-top:inherit}
-@media screen and (max-width: 768px){.wy-nav-content-wrap{margin-top: 30px;margin-left: 300px;width: 100%;float:left;background:#fcfcfc;min-height:100%}
+@media screen and (max-width: 768px){.wy-nav-content-wrap{margin-top: 30px;margin-left: 300px;width: 100%;float:left;background:#fcfcfc;min-height:100%;position:fixed;}
 }
 @media screen and (min-width: 768px){.wy-nav-content-wrap{margin-top: 30px;margin-left: 300px;width: calc(100% - 300px);float:left;background:#fcfcfc;min-height:100%}
 }
-.wy-nav-content{padding:1.618em 3.236em;height:100%;margin:auto;overflow-x: hidden;overflow-y: scroll}
+.wy-nav-content{padding:1.618em 3.236em;height:100%;margin:auto;overflow-x: hidden;overflow-y: scroll;position: fixed;}
 .wy-body-mask{position:fixed;width:100%;height:100%;background:rgba(0,0,0,0.2);display:none;z-index:499}
 .wy-body-mask.on{display:block}
 footer{color:gray}


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This CSS update fixes the problem with the main content pane scrolling just past target anchors during navigation.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - New Module Pull Request
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
