### PR TITLE
fix bug in modules/system/user.py (FreeBSD)

### DIFF
--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -905,9 +905,8 @@ class FreeBsdUser(User):
                 cmd.append(','.join(new_groups))
 
         if self.expires:
-            days = (time.mktime(self.expires) - time.time()) // 86400
             cmd.append('-e')
-            cmd.append(str(int(days)))
+            cmd.append(str(int(time.mktime(self.expires))))
 
         # modify the user if cmd will do anything
         if cmd_len != len(cmd):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
for freebsd tool "pw" use date not days in "modify_user"
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
user

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
When you modify a user and set a expire date that is in the past, the "-e" argument of the FreeBSD tool "pw" is set to "-1" because it calculates the day diff to now. This means the expire date of the user is set to "now - 1 second" => thats wrong. Here is the man page info:

>       -e date       Set the account's expiration date.  Format of the date is
>                    either a UNIX time in decimal, or a date in `dd-mmm-yy[yy]'
>                    format, where dd is the day, mmm is the month, either in
>                    numeric or alphabetic format ('Jan', 'Feb', etc) and year
>                    is either a two or four digit year.  This option also
>                    accepts a relative date in the form `+n[mhdwoy]' where `n'
>                    is a decimal, octal (leading 0) or hexadecimal (leading 0x)
>                    digit followed by the number of Minutes, Hours, Days,
>                    Weeks, Months or Years from the current date at which the
>                    expiration date is to be set.