### PR TITLE
Network F5: Adjust for Python 3 scoping rules

### DIFF
--- a/lib/ansible/modules/network/f5/bigip_device_httpd.py
+++ b/lib/ansible/modules/network/f5/bigip_device_httpd.py
@@ -454,15 +454,13 @@ class ModuleManager(object):
             resource.modify(**params)
             return True
         except ConnectionError as ex:
-            pass
-
-        # BIG-IP will kill your management connection when you change the HTTP
-        # redirect setting. So this catches that and handles it gracefully.
-        if 'Connection aborted' in str(ex) and 'redirectHttpToHttps' in params:
-            # Wait for BIG-IP web server to settle after changing this
-            time.sleep(2)
-            return True
-        raise F5ModuleError(str(ex))
+            # BIG-IP will kill your management connection when you change the HTTP
+            # redirect setting. So this catches that and handles it gracefully.
+            if 'Connection aborted' in str(ex) and 'redirectHttpToHttps' in params:
+                # Wait for BIG-IP web server to settle after changing this
+                time.sleep(2)
+                return True
+            raise F5ModuleError(str(ex))
 
     def read_current_from_device(self):
         resource = self.client.api.tm.sys.httpd.load()


### PR DESCRIPTION
This PR makes and adjustment for Python 3 scoping rules which differ from Python 2.  In Python 3, the variable __ex__ goes out of scope at the exit of the __try-except__ block.  This means that when __ex__ is referred to on the lines that follow, it would be an _undefined name_ causing a __NameError__ to be raised instead of the expected __ConnectionError__.

flake8 testing of https://github.com/ansible/ansible on Python 3.6.3

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./lib/ansible/modules/network/f5/bigip_device_httpd.py:461:40: F821 undefined name 'ex'
        if 'Connection aborted' in str(ex) and 'redirectHttpToHttps' in params:
                                       ^
./lib/ansible/modules/network/f5/bigip_device_httpd.py:465:33: F821 undefined name 'ex'
        raise F5ModuleError(str(ex))
                                ^
```
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request  (Python 3 related)

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
Network F5

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
All
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
