### PR TITLE
letsencrypt: don't mask values specified in data

### DIFF
--- a/lib/ansible/modules/web_infrastructure/letsencrypt.py
+++ b/lib/ansible/modules/web_infrastructure/letsencrypt.py
@@ -128,6 +128,11 @@ options:
       - "The data to validate ongoing challenges."
       - "The value that must be used here will be provided by a previous use
          of this module."
+      - "I(Note): the C(data) option was marked as C(no_log) up to
+         Ansible 2.5. From Ansible 2.6 on, it is no longer marked this way
+         as it causes error messages to be come unusable, and C(data) does
+         not contain any information which can be used without having
+         access to the account key or which are not public anyway."
   dest:
     description:
       - "The destination file for the certificate."

--- a/lib/ansible/modules/web_infrastructure/letsencrypt.py
+++ b/lib/ansible/modules/web_infrastructure/letsencrypt.py
@@ -1293,7 +1293,7 @@ def main():
             terms_agreed=dict(required=False, default=False, type='bool'),
             challenge=dict(required=False, default='http-01', choices=['http-01', 'dns-01', 'tls-sni-02'], type='str'),
             csr=dict(required=True, aliases=['src'], type='path'),
-            data=dict(required=False, no_log=True, default=None, type='dict'),
+            data=dict(required=False, default=None, type='dict'),
             dest=dict(aliases=['cert'], type='path'),
             fullchain_dest=dict(aliases=['fullchain'], type='path'),
             chain_dest=dict(required=False, default=None, aliases=['chain'], type='path'),


### PR DESCRIPTION
##### SUMMARY
The `data` option is marked as `no_log`, despite it not containing really sensitive data. This in general is not a problem, but it can lead to very unreadable error messages, as error messages can contain things which also appear in `data`, and which are subsequently censored out. An example error I got from ansible:

```
Authorization for ******** returned in********:  CHALLENGE: ********-01 DETAILS: Incorrect TXT record "********" (and 1 more) found at ********.********;
```

All relevant information I would need to debug this problem is completely censored away. That's why I'm labeling this as a bugfix PR.

##### ISSUE TYPE
Bugfix Pull Request

##### COMPONENT NAME
letsencrypt

##### ANSIBLE VERSION
2.5, 2.6

##### ADDITIONAL INFORMATION
The information in `data` is not really sensitive. So there's no good reason (from my point of view) to censor it away. It mainly contains information on the challenges, and things like the account and order URI, and how long the current certificate is still valid. The account key is not contained in there, neither its path nor its contents.
