### PR TITLE
Fixing domain to authorization matching for ACME v2.

### DIFF
--- a/lib/ansible/modules/web_infrastructure/letsencrypt.py
+++ b/lib/ansible/modules/web_infrastructure/letsencrypt.py
@@ -1150,10 +1150,12 @@ class ACMEClient(object):
         if info['status'] not in [201]:
             raise ModuleFailException("Error new order: CODE: {0} RESULT: {1}".format(info['status'], result))
 
-        for identifier, auth_uri in zip(result['identifiers'], result['authorizations']):
-            domain = identifier['value']
+        for auth_uri in result['authorizations']:
             auth_data = simple_get(self.module, auth_uri)
             auth_data['uri'] = auth_uri
+            domain = auth_data['identifier']['value']
+            if auth_data.get('wildcard', False):
+                domain = '*.{0}'.format(domain)
             self.authorizations[domain] = auth_data
 
         self.order_uri = info['location']


### PR DESCRIPTION
##### SUMMARY
Fixes #37557.

##### ISSUE TYPE
Bugfix Pull Request

##### COMPONENT NAME
letsencrypt

##### ANSIBLE VERSION
```
2.5.0rc3
```

##### ADDITIONAL INFORMATION
This fix is for devel, but backporting to stable-2.5 should be trivial.
