### PR TITLE
Add callback binjson.py

### DIFF
--- a/lib/ansible/plugins/callback/binjson.py
+++ b/lib/ansible/plugins/callback/binjson.py
@@ -33,8 +33,8 @@ class CallbackModule(CallbackBase):
         ''' output the result of a command run '''
 
         buf = {
-            "host" : host,
-            "status" : caption
+            "host": host,
+            "status": caption
         }
 
         if result._task.action in C.MODULE_NO_JSON and 'module_stderr' not in result._result:

--- a/lib/ansible/plugins/callback/binjson.py
+++ b/lib/ansible/plugins/callback/binjson.py
@@ -1,0 +1,70 @@
+# (c) 2012-2014, rongzeng54 <rongzeng54@gmail.com>
+# (c) 2017 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+DOCUMENTATION = '''
+    callback: binjson
+    type: stdout
+    short_description: Ansible screen output as JSON
+    version_added: "2.6"
+    description:
+        - This callback converts ansible command (ad-hoc) into JSON output to stdout
+    requirements:
+      - Set as stdout in config
+      - Set bin_ansible_callbacks = True
+'''
+
+import json
+
+from ansible.plugins.callback import CallbackBase
+from ansible import constants as C
+
+
+class CallbackModule(CallbackBase):
+    CALLBACK_VERSION = 2.0
+    CALLBACK_TYPE = 'stdout'
+    CALLBACK_NAME = 'binjson'
+
+    def _command_generic_msg(self, host, result, caption):
+        ''' output the result of a command run '''
+
+        buf = {
+            "host" : host,
+            "status" : caption
+        }
+
+        if result._task.action in C.MODULE_NO_JSON and 'module_stderr' not in result._result:
+            buf['rc'] = result._result.get('rc', -1)
+            buf['stdout'] = result._result.get('stdout', '')
+            buf['stderr'] = result._result.get('stderr', '')
+            buf['msg'] = result._result.get('msg', '')
+        else:
+            buf['result'] = result._result
+
+        return self._dump_results(buf, indent=4)
+
+    def v2_runner_on_failed(self, result, ignore_errors=False):
+        self._handle_exception(result._result)
+        self._handle_warnings(result._result)
+
+        self._display.display(self._command_generic_msg(result._host.get_name(), result, "FAILED"), color=C.COLOR_ERROR)
+
+    def v2_runner_on_ok(self, result):
+        self._clean_results(result._result, result._task.action)
+        self._handle_warnings(result._result)
+
+        color = C.COLOR_OK
+        if 'changed' in result._result and result._result['changed']:
+            color = C.COLOR_CHANGED
+
+        self._display.display(self._command_generic_msg(result._host.get_name(), result, "SUCCESS"), color=color)
+
+    def v2_runner_on_skipped(self, result):
+        self._display.display(self._command_generic_msg(result._host.get_name(), result, "SKIPPED"), color=C.COLOR_SKIP)
+
+    def v2_runner_on_unreachable(self, result):
+        self._display.display(self._command_generic_msg(result._host.get_name(), result, "UNREACHABLE"), color=C.COLOR_UNREACHABLE)


### PR DESCRIPTION
##### SUMMARY
This callback converts ansible command (ad-hoc) into JSON output to stdout

##### ISSUE TYPE
 - New Module Pull Request

##### COMPONENT NAME
binjson.py

##### ANSIBLE VERSION
```
ansible 2.4.2.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/etc/ansible/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.13 (default, Jul 12 2017, 17:32:34) [GCC 4.4.7 20120313 (Red Hat 4.4.7-18)]
```


##### ADDITIONAL INFORMATION
JSON data is easy to handle

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
#before#
$ ansible -m shell -a "hostname" localhost
localhost | SUCCESS | rc=0 >>
testserver

#after#
$ ansible -m shell -a "hostname" localhost
{
    "host": "localhost",
    "msg": "",
    "rc": 0,
    "status": "SUCCESS",
    "stderr": "",
    "stdout": "testserver"
}
```
