### PR TITLE
[2.5] Fixing domain to authorization matching for ACME v2. (#37558)

### DIFF
--- a/lib/ansible/modules/web_infrastructure/letsencrypt.py
+++ b/lib/ansible/modules/web_infrastructure/letsencrypt.py
@@ -1112,10 +1112,12 @@ class ACMEClient(object):
         if info['status'] not in [201]:
             self.module.fail_json(msg="Error new order: CODE: {0} RESULT: {1}".format(info['status'], result))
 
-        for identifier, auth_uri in zip(result['identifiers'], result['authorizations']):
-            domain = identifier['value']
+        for auth_uri in result['authorizations']:
             auth_data = simple_get(self.module, auth_uri)
             auth_data['uri'] = auth_uri
+            domain = auth_data['identifier']['value']
+            if auth_data.get('wildcard', False):
+                domain = '*.{0}'.format(domain)
             self.authorizations[domain] = auth_data
 
         self.order_uri = info['location']


### PR DESCRIPTION
(cherry picked from commit 190755ff659aa18a4a05951c04c41808358121c9)

##### SUMMARY
backport of the bug fix #37558 

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
letsencrypt

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
