### PR TITLE
Fix the initial value of a variable

### DIFF
--- a/lib/ansible/module_utils/facts/network/iscsi.py
+++ b/lib/ansible/module_utils/facts/network/iscsi.py
@@ -52,7 +52,7 @@ class IscsiInitiatorNetworkCollector(NetworkCollector):
         num_cmd_elems  200                           Maximum number of commands to queue to driver True
         """
 
-        iscsi_facts = ""
+        iscsi_facts = {}
         iscsi_facts['iscsi_iqn'] = ""
         if sys.platform.startswith('linux') or sys.platform.startswith('sunos'):
             for line in get_file_content('/etc/iscsi/initiatorname.iscsi', '').splitlines():


### PR DESCRIPTION
This should be a dict, not a string.

Fixes #37455

##### ISSUE TYPE

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
lib/ansible/module_utils/facts/network/iscsi.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
The iscsi fact is not present until ansible-2.6 so this is only needed in the devel branch.
