### PR TITLE
Clarify the "refresh_inventory" meta task when using a dynamic invent…

### DIFF
--- a/lib/ansible/modules/utilities/helper/meta.py
+++ b/lib/ansible/modules/utilities/helper/meta.py
@@ -31,7 +31,9 @@ options:
           points to implicitly trigger handler runs (after pre/post tasks, the final role execution, and the main tasks section of your plays).
         - >
           C(refresh_inventory) (added in 2.0) forces the reload of the inventory, which in the case of dynamic inventory scripts means they will be
-          re-executed. This is mainly useful when additional hosts are created and users wish to use them instead of using the `add_host` module."
+          re-executed. If the dynamic inventory script is using a cache, Ansible cannot know this and has no way of refreshing it (you can disable the cache
+          or, if available for your specific inventory datasource (for es.: aws), you can use the an inventory plugin instead of an inventory script).
+          This is mainly useful when additional hosts are created and users wish to use them instead of using the `add_host` module."
         - "C(noop) (added in 2.0) This literally does 'nothing'. It is mainly used internally and not recommended for general use."
         - "C(clear_facts) (added in 2.1) causes the gathered facts for the hosts specified in the play's list of hosts to be cleared, including the fact cache."
         - "C(clear_host_errors) (added in 2.1) clears the failed state (if any) from hosts specified in the play's list of hosts."


### PR DESCRIPTION
…ory script

##### SUMMARY
Clarify the "refresh_inventory" meta task when using a dynamic inventory script since it was only somehow documented in this old mailing list message:
https://groups.google.com/forum/#!topic/ansible-project/ImhePKKDBZM

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
utilities/helper/meta.py

##### ANSIBLE VERSION
```
ansible 2.4.3.0
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.14 (default, Feb 27 2018, 20:43:24) [GCC 7.3.1 20180130 (Red Hat 7.3.1-2)]
```

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
Maybe we should also embed a link to the inventory plugins page:
http://docs.ansible.com/ansible/devel/plugins/inventory.html
