### PR TITLE
Fix SteamOS ansible_distribution fact (Fixes #33628)

### DIFF
--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -311,6 +311,9 @@ class DistributionFiles:
         elif 'Ubuntu' in data:
             debian_facts['distribution'] = 'Ubuntu'
             # nothing else to do, Ubuntu gets correct info from python functions
+        elif 'SteamOS' in data:
+            debian_facts['distribution'] = 'SteamOS'
+            # nothing else to do, SteamOS gets correct info from python functions
         else:
             return False, debian_facts
 
@@ -410,7 +413,7 @@ class Distribution(object):
                                 'Ascendos', 'CloudLinux', 'PSBM', 'OracleLinux', 'OVS',
                                 'OEL', 'Amazon', 'Virtuozzo', 'XenServer'],
                      'Debian': ['Debian', 'Ubuntu', 'Raspbian', 'Neon', 'KDE neon',
-                                'Linux Mint'],
+                                'Linux Mint', 'SteamOS'],
                      'Suse': ['SuSE', 'SLES', 'SLED', 'openSUSE', 'openSUSE Tumbleweed',
                               'SLES_SAP', 'SUSE_LINUX', 'openSUSE Leap'],
                      'Archlinux': ['Archlinux', 'Antergos', 'Manjaro'],

--- a/test/units/module_utils/test_distribution_version.py
+++ b/test/units/module_utils/test_distribution_version.py
@@ -378,6 +378,34 @@ BUG_REPORT_URL="http://bugs.debian.org/"
         }
     },
     {
+        'name': "SteamOS 2.0",
+        'input': {
+            '/etc/os-release': """PRETTY_NAME="SteamOS GNU/Linux 2.0 (brewmaster)"
+NAME="SteamOS GNU/Linux"
+VERSION_ID="2"
+VERSION="2 (brewmaster)"
+ID=steamos
+ID_LIKE=debian
+HOME_URL="http://www.steampowered.com/"
+SUPPORT_URL="http://support.steampowered.com/"
+BUG_REPORT_URL="http://support.steampowered.com/"
+""",
+            '/etc/lsb-release': """DISTRIB_ID=SteamOS
+DISTRIB_RELEASE=2.0
+DISTRIB_CODENAME=brewmaster
+DISTRIB_DESCRIPTION="SteamOS 2.0"
+"""
+        },
+        'platform.dist': ('Steamos', '2.0', 'brewmaster'),
+        'result': {
+            'distribution': u'SteamOS',
+            'distribution_major_version': u'2',
+            'distribution_release': u'brewmaster',
+            "os_family": "Debian",
+            'distribution_version': u'2.0'
+        }
+    },
+    {
         "platform.dist": [
             "Ubuntu",
             "16.04",


### PR DESCRIPTION
##### SUMMARY
This fixes a regression in the detection of SteamOS as a Debian family distribution, as described in #33628. Also adds a test for SteamOS 2.0 with input values corresponding to an actual SteamOS installation.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
setup

##### ANSIBLE VERSION
```
ansible 2.6.0 (fix_issue33628 245afef272) last updated 2018/03/18 18:10:32 (GMT +200)
  config file = None
  configured module search path = [u'/home/[redacted]/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/[redacted]/Code/ansible/lib/ansible
  executable location = /home/[redacted]/Code/ansible/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```
