### PR TITLE
Fix typo in inventory docs

### DIFF
--- a/docs/docsite/rst/user_guide/intro_inventory.rst
+++ b/docs/docsite/rst/user_guide/intro_inventory.rst
@@ -304,7 +304,7 @@ is an excellent way to track changes to your inventory and host variables.
 How Variables Are Merged
 ++++++++++++++++++++++++
 
-By default variables are merged/flattened to the specific host before a play is run. This keeps Ansible focused on the Host and Task, so groups don't really surive outside of inventory and host matching. By default, Ansible overwrites variables including the ones defined for a group and/or host (see the `hash_merge` setting to change this) . The order/precedence is (from lowest to highest):
+By default variables are merged/flattened to the specific host before a play is run. This keeps Ansible focused on the Host and Task, so groups don't really survive outside of inventory and host matching. By default, Ansible overwrites variables including the ones defined for a group and/or host (see the `hash_merge` setting to change this) . The order/precedence is (from lowest to highest):
 
 - all group (because it is the 'parent' of all other groups)
 - parent group


### PR DESCRIPTION
##### SUMMARY

`surive` -> `survive`


##### ISSUE TYPE

 - Docs Pull Request

##### COMPONENT NAME

user_guide

##### ANSIBLE VERSION

```
ansible-playbook 2.5.0a1
```


##### ADDITIONAL INFORMATION

Introduced in commit 48da0597c0888a13bcc9adf431ac05643a9ba9bb, PR #28777 (document ansible_group_priority)

