### PR TITLE
changes default WAPI version to 2.1

### DIFF
--- a/lib/ansible/module_utils/net_tools/nios/api.py
+++ b/lib/ansible/module_utils/net_tools/nios/api.py
@@ -50,7 +50,7 @@ nios_provider_spec = {
     'http_pool_connections': dict(type='int', default=10),
     'http_pool_maxsize': dict(type='int', default=10),
     'max_retries': dict(type='int', default=3),
-    'wapi_version': dict(default='1.4'),
+    'wapi_version': dict(default='2.1'),
     'max_results': dict(type='int', default=1000)
 }
 


### PR DESCRIPTION
##### SUMMARY

Changes the default WAPI version from 1.4 to 2.1. WAPI version 2.1 is from NIOS 7.1 which is the oldest NIOS version currently in extended support. There is no reason to use 1.4 and we will note that NIOS 7.1 is the minimum required version after this change.

##### ISSUE TYPE

 - Feature Pull Request

##### COMPONENT NAME

module_utils/net_tools/nios/api.py

##### ANSIBLE VERSION

```
ansible 2.6.0 (wapi-version cf548489fd) last updated 2018/03/18 11:17:22 (GMT -700)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/brampling/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/brampling/Dropbox/src/ansibledev/ansible/lib/ansible
  executable location = /home/brampling/Dropbox/src/ansibledev/ansible/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```

##### ADDITIONAL INFORMATION

N/A