### PR TITLE
Load plugin config defs on first load only (fixes #37553)

### DIFF
--- a/lib/ansible/plugins/loader.py
+++ b/lib/ansible/plugins/loader.py
@@ -348,9 +348,6 @@ class PluginLoader:
 
     def _update_object(self, obj, name, path):
 
-        # load plugin config data
-        self._load_config_defs(name, path)
-
         # set extra info on the module, in case we want it later
         setattr(obj, '_original_path', path)
         setattr(obj, '_load_name', name)
@@ -393,6 +390,10 @@ class PluginLoader:
                     # fully implement the defined interface.
                     return None
                 raise
+
+        # load plugin config data
+        if not found_in_cache:
+            self._load_config_defs(name, path)
 
         self._update_object(obj, name, path)
         return obj
@@ -466,6 +467,10 @@ class PluginLoader:
                     obj = obj(*args, **kwargs)
                 except TypeError as e:
                     display.warning("Skipping plugin (%s) as it seems to be incomplete: %s" % (path, to_text(e)))
+
+            # load plugin config data
+            if not found_in_cache:
+                self._load_config_defs(name, path)
 
             self._update_object(obj, name, path)
             yield obj


### PR DESCRIPTION
##### SUMMARY
A plugin's docstring is extracted/parsed and config defs loaded each time that a plugin is loaded. This is amplified in the case of shell plugins, which are enumerated for each task.

This commit changes the behavior to only load config defs from a plugin if it was not found in the cache. 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
plugin loader

##### ANSIBLE VERSION
```
ansible 2.6.0 (plugin_config_defs_speedup f62fc2d008) last updated 2018/03/18 14:55:51 (GMT -500)
```

##### ADDITIONAL INFORMATION
For a somewhat contrived test case, this fix has a very apparent effect.

Playbook:

```yaml
- hosts: localhost
  gather_facts: no
  tasks:
    - debug: msg="foo"
      with_sequence: count=5000
```

Test command:

```
$ (source ~/dev/ansible/hacking/env-setup &>/dev/null; ansible --version | head -n 1; time ansible-playbook foo.yml &>/dev/null)
```

Results:

`v2.4.3.0-1`

```
ansible 2.4.3.0 (detached HEAD 8a7f9beab7) last updated 2018/03/18 15:03:15 (GMT -500)

real    0m17.164s
user    0m19.488s
sys     0m1.848s
```

`devel`

```
ansible 2.6.0 (devel e541bed186) last updated 2018/03/16 14:33:21 (GMT -500)

real    1m0.518s
user    1m3.740s
sys     0m2.748s
```

`devel` + this PR

```
ansible 2.6.0 (plugin_config_defs_speedup f62fc2d008) last updated 2018/03/18 14:55:51 (GMT -500)

real    0m9.835s
user    0m11.856s
sys     0m2.036s
```

Not only does it fix the problem in `devel`, it even improves over the `2.4.3` baseline.