### PR TITLE
Added ignore unreachable option to the serial variable Feature #37309

### DIFF
--- a/docs/docsite/rst/reference_appendices/glossary.rst
+++ b/docs/docsite/rst/reference_appendices/glossary.rst
@@ -398,7 +398,8 @@ when a term comes up on the mailing list.
         default is to address the batch size all at once, so this is something
         that you must opt-in to.  OS configuration (such as making sure config
         files are correct) does not typically have to use the rolling update
-        model, but can do so if desired.
+        model, but can do so if desired. This option permit also to ignore
+        unreachable nodes in the group of machines.
 
     Serial
         .. seealso::

--- a/docs/docsite/rst/reference_appendices/test_strategies.rst
+++ b/docs/docsite/rst/reference_appendices/test_strategies.rst
@@ -216,6 +216,23 @@ the pool.
 In the event of a problem, fix the few servers that fail using Ansible's automatically generated 
 retry file to repeat the deploy on just those servers.
 
+You can also ignore unreachable node to go ahead with your job, suppose for example you have 6 nodes and you
+want to dived it in groups of 2, an example of serialization option should be::
+
+    ---
+
+    - hosts: webservers
+      serial: [[2, 1], 2, 2]
+
+
+In this case, the first group represented by the list [2, 1] has a value of 1 (True) regarding the question
+"Do you want to ignroe unreachable?". For others groups the implicit answer to the question is 0 (False).
+At this point if one or both machines in the first group of 2 are unreachable, ansible go ahead with the
+second group and does not stop the job. If in the second group one machine is unreachable, ansible does not
+stop (this is the default behavoir also in old versions of ansible). If in the second group both machines
+are unreachable, ansible stop the job.
+
+
 Achieving Continuous Deployment
 ```````````````````````````````
 

--- a/docs/docsite/rst/user_guide/guide_rolling_upgrade.rst
+++ b/docs/docsite/rst/user_guide/guide_rolling_upgrade.rst
@@ -237,6 +237,23 @@ Here is the next part of the update play::
    - The ``serial`` keyword forces the play to be executed in 'batches'. Each batch counts as a full play with a subselection of hosts.
      This has some consequences on play behavior. For example, if all hosts in a batch fails, the play fails, which in turn fails the entire run. You should consider this when combining with ``max_fail_percentage``.
 
+To prevent that unreachable are counted as failed and stop the play, you can ignore unreachable nodes. You need to use a list of list. Suppose for example that you have 6 nodes and you
+want to divide it in groups of 2, an example of serialization option should be::
+
+    ---
+
+    - hosts: webservers
+      serial: [[2, 1], 2, 2]
+
+
+In this case, the first group represented by the list [2, 1] has a value of 1 (True) regarding the question
+"Do you want to ignroe unreachable?". For others groups the implicit answer to the question is 0 (False).
+At this point if one or both machines in the first group of 2 are unreachable, ansible go ahead with the
+second group and does not stop the play. If in the second group one machine is unreachable, ansible does not
+stop (this is the default behavoir also in old versions of ansible). If in the second group both machines
+are unreachable, ansible stop the play. Valid value are only 0 and 1, False and True, other values will be
+ignored and 0 will be used.
+
 The ``pre_tasks`` keyword just lets you list tasks to run before the roles are called. This will make more sense in a minute. If you look at the names of these tasks, you can see that we are disabling Nagios alerts and then removing the webserver that we are currently updating from the HAProxy load balancing pool.
 
 The ``delegate_to`` and ``loop`` arguments, used together, cause Ansible to loop over each monitoring server and load balancer, and perform that operation (delegate that operation) on the monitoring or load balancing server, "on behalf" of the webserver. In programming terms, the outer loop is the list of web servers, and the inner loop is the list of monitoring servers.

--- a/docs/docsite/rst/user_guide/playbooks_delegation.rst
+++ b/docs/docsite/rst/user_guide/playbooks_delegation.rst
@@ -111,6 +111,32 @@ You can also mix and match the values::
 .. note::
      No matter how small the percentage, the number of hosts per pass will always be 1 or greater.
 
+You can also ignore unreachable node to go ahead with your job, suppose for example you have 6 nodes and you
+want to divide it in groups of 2, an example of serialization option should be::
+
+    ---
+
+    - hosts: webservers
+      serial: [[2, 1], 2, 2]
+
+
+In this case, the first group represented by the list [2, 1] has a value of 1 (True) regarding the question
+"Do you want to ignroe unreachable?". For others groups the implicit answer to the question is 0 (False).
+At this point if one or both machines in the first group of 2 are unreachable, ansible go ahead with the
+second group and does not stop the play. If in the second group one machine is unreachable, ansible does not
+stop (this is the default behavoir also in old versions of ansible). If in the second group both machines
+are unreachable, ansible stop the play.
+
+.. note::
+   Valid value are only 0 and 1, False and True, other values will be ignored and 0 will be used. Example::
+
+   ---
+
+    - hosts: webservers
+      serial: [[2, 1], [2,0], 2, [4, False], [3, True], [2, "False"]]
+
+
+Last value will result as [2, 0] because "False" in this case is a string and not a boolean.
 
 .. _maximum_failure_percentage:
 
@@ -132,6 +158,7 @@ In the above example, if more than 3 of the 10 servers in the group were to fail
 
      The percentage set must be exceeded, not equaled. For example, if serial were set to 4 and you wanted the task to abort 
      when 2 of the systems failed, the percentage should be set at 49 rather than 50.
+     Unreachables machine are always not considered as failed if you use max_fail_percentage.
 
 .. _delegation:
 

--- a/lib/ansible/executor/playbook_executor.py
+++ b/lib/ansible/executor/playbook_executor.py
@@ -158,7 +158,7 @@ class PlaybookExecutor:
 
                         break_play = False
                         # we are actually running plays
-                        batches, ignores = self._get_serialized_batches(new_play)
+                        batches, ignores = self._get_serialized_batches(play)
                         if len(batches) == 0:
                             self._tqm.send_callback('v2_playbook_on_play_start', play)
                             self._tqm.send_callback('v2_playbook_on_no_hosts_matched')

--- a/test/units/executor/test_playbook_executor.py
+++ b/test/units/executor/test_playbook_executor.py
@@ -17,6 +17,7 @@
 
 # Make coding more python3-ish
 from __future__ import (absolute_import, division, print_function)
+
 __metaclass__ = type
 
 from units.compat import unittest
@@ -76,6 +77,41 @@ class TestPlaybookExecutor(unittest.TestCase):
               tasks:
               - debug: var=inventory_hostname
             ''',
+            'serial_no_unreachable.yml': '''
+            - hosts: all
+              gather_facts: no
+              serial: [[2, 1]]
+              tasks:
+              - debug: var=inventory_hostname
+            ''',
+            'serial_pct_no_unreachable.yml': '''
+            - hosts: all
+              gather_facts: no
+              serial: [[20%, 1]]
+              tasks:
+              - debug: var=inventory_hostname
+            ''',
+            'serial_list_no_unreachable.yml': '''
+            - hosts: all
+              gather_facts: no
+              serial: [[1, 1], 2, [3, 0]]
+              tasks:
+              - debug: var=inventory_hostname
+            ''',
+            'serial_list_no_unreachable_mixed.yml': '''
+            - hosts: all
+              gather_facts: no
+              serial: [1, ["20%", 1], [-1, 1]]
+              tasks:
+              - debug: var=inventory_hostname
+            ''',
+            'serial_list_no_unreachable_inv.yml': '''
+            - hosts: all
+              gather_facts: no
+              serial: [[1, 1], [2, "not_valid"], [2, 1], [2, 10], [2, 0], 1]
+              tasks:
+              - debug: var=inventory_hostname
+            ''',
         })
 
         mock_inventory = MagicMock()
@@ -84,7 +120,9 @@ class TestPlaybookExecutor(unittest.TestCase):
         templar = Templar(loader=fake_loader)
 
         pbe = PlaybookExecutor(
-            playbooks=['no_serial.yml', 'serial_int.yml', 'serial_pct.yml', 'serial_list.yml', 'serial_list_mixed.yml'],
+            playbooks=['no_serial.yml', 'serial_int.yml', 'serial_pct.yml', 'serial_list.yml', 'serial_list_mixed.yml',
+                       'serial_no_unreachable.yml', 'serial_pct_no_unreachable.yml', 'serial_list_no_unreachable.yml',
+                       'serial_list_no_unreachable_mixed.yml', 'serial_list_no_unreachable_inv.yml'],
             inventory=mock_inventory,
             variable_manager=mock_var_manager,
             loader=fake_loader,
@@ -94,55 +132,119 @@ class TestPlaybookExecutor(unittest.TestCase):
         playbook = Playbook.load(pbe._playbooks[0], variable_manager=mock_var_manager, loader=fake_loader)
         play = playbook.get_plays()[0]
         play.post_validate(templar)
-        mock_inventory.get_hosts.return_value = ['host0', 'host1', 'host2', 'host3', 'host4', 'host5', 'host6', 'host7', 'host8', 'host9']
-        self.assertEqual(pbe._get_serialized_batches(play), [['host0', 'host1', 'host2', 'host3', 'host4', 'host5', 'host6', 'host7', 'host8', 'host9']])
+        mock_inventory.get_hosts.return_value = ['host0', 'host1', 'host2', 'host3', 'host4', 'host5', 'host6', 'host7',
+                                                 'host8', 'host9']
+        self.assertEqual(pbe._get_serialized_batches(play), ([['host0', 'host1', 'host2', 'host3', 'host4', 'host5', 'host6', 'host7', 'host8', 'host9']],
+                                                             [0]))
 
         playbook = Playbook.load(pbe._playbooks[1], variable_manager=mock_var_manager, loader=fake_loader)
         play = playbook.get_plays()[0]
         play.post_validate(templar)
-        mock_inventory.get_hosts.return_value = ['host0', 'host1', 'host2', 'host3', 'host4', 'host5', 'host6', 'host7', 'host8', 'host9']
+        mock_inventory.get_hosts.return_value = ['host0', 'host1', 'host2', 'host3', 'host4', 'host5', 'host6', 'host7',
+                                                 'host8', 'host9']
         self.assertEqual(
             pbe._get_serialized_batches(play),
-            [['host0', 'host1'], ['host2', 'host3'], ['host4', 'host5'], ['host6', 'host7'], ['host8', 'host9']]
+            ([['host0', 'host1'], ['host2', 'host3'], ['host4', 'host5'], ['host6', 'host7'], ['host8', 'host9']],
+             [0, 0, 0, 0, 0])
         )
 
         playbook = Playbook.load(pbe._playbooks[2], variable_manager=mock_var_manager, loader=fake_loader)
         play = playbook.get_plays()[0]
         play.post_validate(templar)
-        mock_inventory.get_hosts.return_value = ['host0', 'host1', 'host2', 'host3', 'host4', 'host5', 'host6', 'host7', 'host8', 'host9']
+        mock_inventory.get_hosts.return_value = ['host0', 'host1', 'host2', 'host3', 'host4', 'host5', 'host6', 'host7',
+                                                 'host8', 'host9']
         self.assertEqual(
             pbe._get_serialized_batches(play),
-            [['host0', 'host1'], ['host2', 'host3'], ['host4', 'host5'], ['host6', 'host7'], ['host8', 'host9']]
+            ([['host0', 'host1'], ['host2', 'host3'], ['host4', 'host5'], ['host6', 'host7'], ['host8', 'host9']],
+             [0, 0, 0, 0, 0])
         )
 
         playbook = Playbook.load(pbe._playbooks[3], variable_manager=mock_var_manager, loader=fake_loader)
         play = playbook.get_plays()[0]
         play.post_validate(templar)
-        mock_inventory.get_hosts.return_value = ['host0', 'host1', 'host2', 'host3', 'host4', 'host5', 'host6', 'host7', 'host8', 'host9']
+        mock_inventory.get_hosts.return_value = ['host0', 'host1', 'host2', 'host3', 'host4', 'host5', 'host6', 'host7',
+                                                 'host8', 'host9']
         self.assertEqual(
             pbe._get_serialized_batches(play),
-            [['host0'], ['host1', 'host2'], ['host3', 'host4', 'host5'], ['host6', 'host7', 'host8'], ['host9']]
+            ([['host0'], ['host1', 'host2'], ['host3', 'host4', 'host5'], ['host6', 'host7', 'host8'], ['host9']],
+             [0, 0, 0, 0, 0])
         )
 
         playbook = Playbook.load(pbe._playbooks[4], variable_manager=mock_var_manager, loader=fake_loader)
         play = playbook.get_plays()[0]
         play.post_validate(templar)
-        mock_inventory.get_hosts.return_value = ['host0', 'host1', 'host2', 'host3', 'host4', 'host5', 'host6', 'host7', 'host8', 'host9']
-        self.assertEqual(pbe._get_serialized_batches(play), [['host0'], ['host1', 'host2'], ['host3', 'host4', 'host5', 'host6', 'host7', 'host8', 'host9']])
+        mock_inventory.get_hosts.return_value = ['host0', 'host1', 'host2', 'host3', 'host4', 'host5', 'host6', 'host7',
+                                                 'host8', 'host9']
+        self.assertEqual(pbe._get_serialized_batches(play),
+                         ([['host0'], ['host1', 'host2'], ['host3', 'host4', 'host5', 'host6', 'host7',
+                                                           'host8', 'host9']], [0, 0, 0]))
 
         # Test when serial percent is under 1.0
         playbook = Playbook.load(pbe._playbooks[2], variable_manager=mock_var_manager, loader=fake_loader)
         play = playbook.get_plays()[0]
         play.post_validate(templar)
         mock_inventory.get_hosts.return_value = ['host0', 'host1', 'host2']
-        self.assertEqual(pbe._get_serialized_batches(play), [['host0'], ['host1'], ['host2']])
+        self.assertEqual(pbe._get_serialized_batches(play), ([['host0'], ['host1'], ['host2']], [0, 0, 0]))
 
         # Test when there is a remainder for serial as a percent
         playbook = Playbook.load(pbe._playbooks[2], variable_manager=mock_var_manager, loader=fake_loader)
         play = playbook.get_plays()[0]
         play.post_validate(templar)
-        mock_inventory.get_hosts.return_value = ['host0', 'host1', 'host2', 'host3', 'host4', 'host5', 'host6', 'host7', 'host8', 'host9', 'host10']
+        mock_inventory.get_hosts.return_value = ['host0', 'host1', 'host2', 'host3', 'host4', 'host5', 'host6', 'host7',
+                                                 'host8', 'host9', 'host10']
         self.assertEqual(
             pbe._get_serialized_batches(play),
-            [['host0', 'host1'], ['host2', 'host3'], ['host4', 'host5'], ['host6', 'host7'], ['host8', 'host9'], ['host10']]
+            ([['host0', 'host1'], ['host2', 'host3'], ['host4', 'host5'], ['host6', 'host7'], ['host8', 'host9'],
+              ['host10']], [0, 0, 0, 0, 0, 0])
+        )
+        playbook = Playbook.load(pbe._playbooks[5], variable_manager=mock_var_manager, loader=fake_loader)
+        play = playbook.get_plays()[0]
+        play.post_validate(templar)
+        mock_inventory.get_hosts.return_value = ['host0', 'host1', 'host2', 'host3', 'host4', 'host5', 'host6', 'host7',
+                                                 'host8', 'host9']
+        self.assertEqual(
+            pbe._get_serialized_batches(play),
+            ([['host0', 'host1'], ['host2', 'host3'], ['host4', 'host5'], ['host6', 'host7'], ['host8', 'host9']],
+             [1, 1, 1, 1, 1])
+        )
+
+        playbook = Playbook.load(pbe._playbooks[6], variable_manager=mock_var_manager, loader=fake_loader)
+        play = playbook.get_plays()[0]
+        play.post_validate(templar)
+        mock_inventory.get_hosts.return_value = ['host0', 'host1', 'host2', 'host3', 'host4', 'host5', 'host6', 'host7',
+                                                 'host8', 'host9']
+        self.assertEqual(
+            pbe._get_serialized_batches(play),
+            ([['host0', 'host1'], ['host2', 'host3'], ['host4', 'host5'], ['host6', 'host7'], ['host8', 'host9']],
+             [1, 1, 1, 1, 1])
+        )
+
+        playbook = Playbook.load(pbe._playbooks[7], variable_manager=mock_var_manager, loader=fake_loader)
+        play = playbook.get_plays()[0]
+        play.post_validate(templar)
+        mock_inventory.get_hosts.return_value = ['host0', 'host1', 'host2', 'host3', 'host4', 'host5', 'host6', 'host7',
+                                                 'host8', 'host9']
+        self.assertEqual(
+            pbe._get_serialized_batches(play),
+            ([['host0'], ['host1', 'host2'], ['host3', 'host4', 'host5'], ['host6', 'host7', 'host8'], ['host9']],
+             [1, 0, 0, 0, 0])
+        )
+
+        playbook = Playbook.load(pbe._playbooks[8], variable_manager=mock_var_manager, loader=fake_loader)
+        play = playbook.get_plays()[0]
+        play.post_validate(templar)
+        mock_inventory.get_hosts.return_value = ['host0', 'host1', 'host2', 'host3', 'host4', 'host5', 'host6', 'host7',
+                                                 'host8', 'host9']
+        self.assertEqual(
+            pbe._get_serialized_batches(play), ([['host0'], ['host1', 'host2'], ['host3', 'host4', 'host5', 'host6', 'host7', 'host8', 'host9']],
+                                                [0, 1, 0])
+        )
+
+        playbook = Playbook.load(pbe._playbooks[9], variable_manager=mock_var_manager, loader=fake_loader)
+        play = playbook.get_plays()[0]
+        play.post_validate(templar)
+        mock_inventory.get_hosts.return_value = ['host0', 'host1', 'host2', 'host3', 'host4', 'host5', 'host6', 'host7', 'host8', 'host9']
+        self.assertEqual(
+            pbe._get_serialized_batches(play), ([['host0'], ['host1', 'host2'], ['host3', 'host4'], ['host5', 'host6'], ['host7', 'host8'],
+                                                ['host9']], [1, 0, 1, 0, 0, 0])
         )


### PR DESCRIPTION
##### SUMMARY
This change permit to pass an ignore unreachable option to serial variable.
Modified also documentation and tests.
It is also backward compatible. You can pass serial option for example as:
[ [2,1], 2]
So, you divide hosts in groups of 2 and with 1 (True) you specific to not count unreachable.
In this case for example first group does not stop the play in case of 2 unreachable.
It is backward compatible because you can also continue to use old syntax and the play works
as expected by old syntax
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request  #37309

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
Used ansible 2.4.3.0 for develop it, but basically works with all versions
it is also backward compatible
```


##### ADDITIONAL INFORMATION
_get_serialized_batches now return 2 lists
serialized_batches, ignore_unreachable
ignore_unreachable contains a list of 0,1 (or False, True) that permit to skip the count of unreachable hosts.
Run function now does not stops in case of unreachable in a group.
We could use also only one list, including the ignore value in the serialized_batches, but I preferred to
keep it clean to have more readable and elegant code.
I also updated the related test cases and documentation
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
