### PR TITLE
Small typo in the ipaddr filter

### DIFF
--- a/lib/ansible/plugins/filter/ipaddr.py
+++ b/lib/ansible/plugins/filter/ipaddr.py
@@ -785,7 +785,7 @@ def next_nth_usable(value, offset):
         return False
 
     if type(offset) != int:
-        raise errors.AnsibleFilterError('Must pass in an interger')
+        raise errors.AnsibleFilterError('Must pass in an integer')
     if v.size > 1:
         first_usable, last_usable = _first_last(v)
         nth_ip = int(netaddr.IPAddress(int(v.ip) + offset))
@@ -807,7 +807,7 @@ def previous_nth_usable(value, offset):
         return False
 
     if type(offset) != int:
-        raise errors.AnsibleFilterError('Must pass in an interger')
+        raise errors.AnsibleFilterError('Must pass in an integer')
     if v.size > 1:
         first_usable, last_usable = _first_last(v)
         nth_ip = int(netaddr.IPAddress(int(v.ip) - offset))


### PR DESCRIPTION
interger = integer

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Small typo in the ipaddr filter, interger = integer

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
ipaddr

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.3.0
  config file = None
  configured module search path = [u'/home/user/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, May  3 2017, 07:55:04) [GCC 4.8.5 20150623 (Red Hat 4.8.5-14)]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
Traceback (most recent call last):
...
 File "/usr/lib/python2.7/site-packages/ansible/plugins/filter/ipaddr.py", line 788, in next_nth_usable
    raise errors.AnsibleFilterError('Must pass in an interger')
ansible.errors.AnsibleFilterError: Must pass in an interger

```
