### PR TITLE
Urpmi improve

### DIFF
--- a/lib/ansible/modules/packaging/os/urpmi.py
+++ b/lib/ansible/modules/packaging/os/urpmi.py
@@ -92,6 +92,7 @@ from ansible.module_utils.basic import AnsibleModule
 def query_package(module, name, root):
     # rpm -q returns 0 if the package is installed,
     # 1 if it is not installed
+    RPM_PATH = module.get_bin_path("rpm", True)
     cmd = "%s -q %s %s" % (RPM_PATH, name, root_option(root))
     rc, stdout, stderr = module.run_command(cmd, check_rc=False)
     if rc == 0:
@@ -103,6 +104,7 @@ def query_package(module, name, root):
 def query_package_provides(module, name, root):
     # rpm -q returns 0 if the package is installed,
     # 1 if it is not installed
+    RPM_PATH = module.get_bin_path("rpm", True)
     cmd = "%s -q --whatprovides %s %s" % (RPM_PATH, name, root_option(root))
     rc, stdout, stderr = module.run_command(cmd, check_rc=False)
     return rc == 0
@@ -110,6 +112,7 @@ def query_package_provides(module, name, root):
 
 def update_package_db(module):
 
+    URPMIUPDATE_PATH = module.get_bin_path("urpmi.update", True)
     cmd = "%s -a -q" % (URPMIUPDATE_PATH,)
     rc, stdout, stderr = module.run_command(cmd, check_rc=False)
     if rc != 0:
@@ -125,6 +128,7 @@ def remove_packages(module, packages, root):
         if not query_package(module, package, root):
             continue
 
+        URPME_PATH = module.get_bin_path("urpme", True)
         cmd = "%s --auto %s %s" % (URPME_PATH, root_option(root), package)
         rc, stdout, stderr = module.run_command(cmd, check_rc=False)
 
@@ -158,6 +162,7 @@ def install_packages(module, pkgspec, root, force=True, no_recommends=True):
         else:
             force_yes = ''
 
+        URPMI_PATH = module.get_bin_path("urpmi", True)
         cmd = ("%s --auto %s --quiet %s %s %s" % (URPMI_PATH, force_yes, no_recommends_yes, root_option(root), packages))
 
         rc, out, err = module.run_command(cmd)
@@ -194,15 +199,6 @@ def main():
             root=dict(type='str', aliases=['installroot']),
         ),
     )
-
-    global URPMI_PATH
-    URPMI_PATH = module.get_bin_path("urpmi", True)
-    global RPM_PATH
-    RPM_PATH = module.get_bin_path("rpm", True)
-    global URPME_PATH
-    URPME_PATH = module.get_bin_path("urpme", True)
-    global URPMIUPDATE_PATH
-    URPMIUPDATE_PATH = module.get_bin_path("urpmi.update", True)
 
     p = module.params
 

--- a/lib/ansible/modules/packaging/os/urpmi.py
+++ b/lib/ansible/modules/packaging/os/urpmi.py
@@ -88,14 +88,11 @@ import sys
 
 from ansible.module_utils.basic import AnsibleModule
 
-URPMI_PATH = '/usr/sbin/urpmi'
-URPME_PATH = '/usr/sbin/urpme'
-
 
 def query_package(module, name, root):
     # rpm -q returns 0 if the package is installed,
     # 1 if it is not installed
-    cmd = "rpm -q %s %s" % (name, root_option(root))
+    cmd = "%s -q %s %s" % (RPM_PATH, name, root_option(root))
     rc, stdout, stderr = module.run_command(cmd, check_rc=False)
     if rc == 0:
         return True
@@ -106,13 +103,14 @@ def query_package(module, name, root):
 def query_package_provides(module, name, root):
     # rpm -q returns 0 if the package is installed,
     # 1 if it is not installed
-    cmd = "rpm -q --whatprovides %s %s" % (name, root_option(root))
+    cmd = "%s -q --whatprovides %s %s" % (RPM_PATH, name, root_option(root))
     rc, stdout, stderr = module.run_command(cmd, check_rc=False)
     return rc == 0
 
 
 def update_package_db(module):
-    cmd = "/usr/sbin/urpmi.update -a -q"
+
+    cmd = "%s -a -q" % (URPMIUPDATE_PATH,)
     rc, stdout, stderr = module.run_command(cmd, check_rc=False)
     if rc != 0:
         module.fail_json(msg="could not update package db")
@@ -197,8 +195,14 @@ def main():
         ),
     )
 
-    if not os.path.exists(URPMI_PATH):
-        module.fail_json(msg="cannot find urpmi, looking for %s" % (URPMI_PATH))
+    global URPMI_PATH
+    URPMI_PATH = module.get_bin_path("urpmi", True)
+    global RPM_PATH
+    RPM_PATH =  module.get_bin_path("rpm", True)
+    global URPME_PATH
+    URPME_PATH = module.get_bin_path("urpme", True)
+    global URPMIUPDATE_PATH
+    URPMIUPDATE_PATH = module.get_bin_path("urpmi.update", True)
 
     p = module.params
 

--- a/lib/ansible/modules/packaging/os/urpmi.py
+++ b/lib/ansible/modules/packaging/os/urpmi.py
@@ -198,7 +198,7 @@ def main():
     global URPMI_PATH
     URPMI_PATH = module.get_bin_path("urpmi", True)
     global RPM_PATH
-    RPM_PATH =  module.get_bin_path("rpm", True)
+    RPM_PATH = module.get_bin_path("rpm", True)
     global URPME_PATH
     URPME_PATH = module.get_bin_path("urpme", True)
     global URPMIUPDATE_PATH

--- a/lib/ansible/modules/packaging/os/urpmi.py
+++ b/lib/ansible/modules/packaging/os/urpmi.py
@@ -26,7 +26,8 @@ options:
     description:
       - A list of package names to install, upgrade or remove.
     required: yes
-    aliases: ['package, pkg']
+    version_added: "2.6"
+    aliases: [ package, pkg ]
   state:
     description:
       - Indicates the desired package state.
@@ -200,7 +201,7 @@ def main():
             update_cache=dict(type='bool', default=False, aliases=['update-cache']),
             force=dict(type='bool', default=True),
             no_recommends=dict(type='bool', default=True, aliases=['no-recommends']),
-            package=dict(type='list', required=True, aliases=['name', 'pkg']),
+            name=dict(type='list', required=True, aliases=['package', 'pkg']),
             root=dict(type='str', aliases=['installroot']),
         ),
     )

--- a/lib/ansible/modules/packaging/os/urpmi.py
+++ b/lib/ansible/modules/packaging/os/urpmi.py
@@ -8,7 +8,6 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
-from ansible.module_utils.basic import AnsibleModule
 __metaclass__ = type
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
@@ -82,6 +81,13 @@ EXAMPLES = '''
     state: present
     update_cache: yes
 '''
+
+
+import os
+import shlex
+import sys
+
+from ansible.module_utils.basic import AnsibleModule
 
 
 def query_package(module, name, root):

--- a/lib/ansible/modules/packaging/os/urpmi.py
+++ b/lib/ansible/modules/packaging/os/urpmi.py
@@ -112,7 +112,7 @@ def query_package_provides(module, name, root):
 
 
 def update_package_db(module):
-    cmd = "urpmi.update -a -q"
+    cmd = "/usr/sbin/urpmi.update -a -q"
     rc, stdout, stderr = module.run_command(cmd, check_rc=False)
     if rc != 0:
         module.fail_json(msg="could not update package db")

--- a/lib/ansible/modules/packaging/os/urpmi.py
+++ b/lib/ansible/modules/packaging/os/urpmi.py
@@ -22,10 +22,12 @@ description:
   - Manages packages with I(urpmi) (such as for Mageia or Mandriva)
 version_added: "1.3.4"
 options:
-  pkg:
+  package:
     description:
       - Name of package to install, upgrade or remove.
     required: yes
+    type: list
+    aliases: ['pkg']
   state:
     description:
       - Indicates the desired package state.

--- a/lib/ansible/modules/packaging/os/urpmi.py
+++ b/lib/ansible/modules/packaging/os/urpmi.py
@@ -113,8 +113,8 @@ def query_package_provides(module, name, root):
 
 def update_package_db(module):
 
-    URPMIUPDATE_PATH = module.get_bin_path("urpmi.update", True)
-    cmd = "%s -a -q" % (URPMIUPDATE_PATH,)
+    urpmiupdate_path = module.get_bin_path("urpmi.update", True)
+    cmd = "%s -a -q" % (urpmiupdate_path,)
     rc, stdout, stderr = module.run_command(cmd, check_rc=False)
     if rc != 0:
         module.fail_json(msg="could not update package db")

--- a/lib/ansible/modules/packaging/os/urpmi.py
+++ b/lib/ansible/modules/packaging/os/urpmi.py
@@ -22,12 +22,11 @@ description:
   - Manages packages with I(urpmi) (such as for Mageia or Mandriva)
 version_added: "1.3.4"
 options:
-  package:
+  name:
     description:
-      - Name of package to install, upgrade or remove.
+      - A list of package names to install, upgrade or remove.
     required: yes
-    type: list
-    aliases: ['pkg']
+    aliases: ['package, pkg']
   state:
     description:
       - Indicates the desired package state.


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
- make urpmi module compatible with other packaging modules when using a packages list
- fix the check made to see if a package is installed
- improve error check path
Patches from Arnaud Patard (Hupstream), thanks Arnaud.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Fixes #37432
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
urpmi
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0 (urpmi-improve e8ed0160b5) last updated 2018/03/19 13:48:37 (GMT +200)

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
From Arnaud 
1/ Current code works well if there's only one package given
as argument but it works badly when using with_items due to
the following code:

        packages = p['package'].split(',')

This is even more annoying when the task is using the package
module, as the special way of handling package list of the
urpmi module won't be compatible with other packaging modules
(say apt).

The easiest way to fix this is to make the argument a list.

2/ The code is trying to check if a package (or a provide) is
installed on the system, except that it's using --provides
and not --whatprovides:

--whatprovides                 query/verify the package(s) which provide
                               a dependency

--provides                     list capabilities that this package
                               provides

3/ In order to check if a package has been installed or not,
the code is iterating over pkgspec, using the variable packages
to store the current item, except that it's calling
query_package_provides() with:
        query_package_provides(module, package)

(note the missing "s").

The code has been modified to check each package individually
and fail as soon as a package is not there. Helps for finding
which package is missing.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
