### PR TITLE
Test tower-cli verify_ssl config parameter

### DIFF
--- a/test/integration/targets/tower_user/tasks/main.yml
+++ b/test/integration/targets/tower_user/tasks/main.yml
@@ -74,3 +74,20 @@
 - assert:
     that:
       - "result is changed"
+
+- name: Test tower SSL parameter
+  tower_user:
+    first_name: Joe
+    last_name: User
+    username: joe
+    password: "{{ 65535 | random | to_uuid }}"
+    email: joe@example.org
+    state: present
+    tower_verify_ssl: true
+    tower_host: http://foo.invalid
+  ignore_errors: true
+  register: result
+
+- assert:
+    that:
+      - "'not verify ssl with non-https protocol' in result.exception"


### PR DESCRIPTION
##### SUMMARY
Add tests for tower-cli verify_ssl config

##### ISSUE TYPE
 - Tests Pull Request

##### COMPONENT NAME
tower_user module

tower_verify_ssl parameter

##### ANSIBLE VERSION
2.6 / 2.7


##### ADDITIONAL INFORMATION

Ultimately I would also like to cross-verify against the built-in credential type, and correspondingly, the environment variables allowed to specify this. See https://github.com/ansible/tower-cli/issues/497 and https://github.com/ansible/awx/blob/devel/awx/plugins/inventory/tower.py and https://github.com/ansible/awx/blob/681918be9a14b4e4e7b8e3695ca4a50c5a1b3613/awx/main/models/credential/__init__.py#L1163