### PR TITLE
Compare byte strings to byte strings

### DIFF
--- a/lib/ansible/cli/pull.py
+++ b/lib/ansible/cli/pull.py
@@ -30,7 +30,7 @@ import time
 
 from ansible.cli import CLI
 from ansible.errors import AnsibleOptionsError
-from ansible.module_utils._text import to_native
+from ansible.module_utils._text import to_native, to_text
 from ansible.plugins.loader import module_loader
 from ansible.utils.cmd_functions import run_cmd
 
@@ -238,14 +238,14 @@ class PullCLI(CLI):
         # RUN the Checkout command
         display.debug("running ansible with VCS module to checkout repo")
         display.vvvv('EXEC: %s' % cmd)
-        rc, out, err = run_cmd(cmd, live=True)
+        rc, b_out, b_err = run_cmd(cmd, live=True)
 
         if rc != 0:
             if self.options.force:
                 display.warning("Unable to update repository. Continuing with (forced) run of playbook.")
             else:
                 return rc
-        elif self.options.ifchanged and '"changed": true' not in out:
+        elif self.options.ifchanged and b'"changed": true' not in b_out:
             display.display("Repository has not changed, quitting.")
             return 0
 
@@ -287,14 +287,14 @@ class PullCLI(CLI):
         # RUN THE PLAYBOOK COMMAND
         display.debug("running ansible-playbook to do actual work")
         display.debug('EXEC: %s' % cmd)
-        rc, out, err = run_cmd(cmd, live=True)
+        rc, b_out, b_err = run_cmd(cmd, live=True)
 
         if self.options.purge:
             os.chdir('/')
             try:
                 shutil.rmtree(self.options.dest)
             except Exception as e:
-                display.error("Failed to remove %s: %s" % (self.options.dest, str(e)))
+                display.error(u"Failed to remove %s: %s" % (self.options.dest, to_text(e)))
 
         return rc
 


### PR DESCRIPTION
* Fix a traceback in ansible-pull on python3 comparing output from
  subprocess with a text string.
* Rename variables that hold byte strings so we are clear that those are
  not text strings.
* Use to_text() to transform variable that's being displayed as it's
  less fragile than str().

Fixes #36962

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/cli/pull.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel 2.5 2.4
```