### PR TITLE
Fixes reconcile inventory to correctly remove hosts from ungrouped

### DIFF
--- a/lib/ansible/inventory/data.py
+++ b/lib/ansible/inventory/data.py
@@ -128,7 +128,7 @@ class InventoryData(object):
             if self.groups['ungrouped'] in mygroups:
                 # clear ungrouped of any incorrectly stored by parser
                 if set(mygroups).difference(set([self.groups['all'], self.groups['ungrouped']])):
-                    host.remove_group(self.groups['ungrouped'])
+                    self.groups['ungrouped'].remove_host(host)
 
             elif not host.implicit:
                 # add ungrouped hosts to ungrouped, except implicit

--- a/test/units/plugins/inventory/test_inventory.py
+++ b/test/units/plugins/inventory/test_inventory.py
@@ -198,6 +198,6 @@ class TestInventoryPlugins(unittest.TestCase):
         all_hosts = set(host.name for host in inventory.groups['all'].get_hosts())
         self.assertEqual(set(['host1', 'host2', 'host3', 'host4', 'host5']), all_hosts)
         ungrouped_hosts = set(host.name for host in inventory.groups['ungrouped'].get_hosts())
-        self.assertEqual(set(['host1', 'host2', 'host3']), ungrouped_hosts)
+        self.assertEqual(set(['host1', 'host2']), ungrouped_hosts)
         servers_hosts = set(host.name for host in inventory.groups['servers'].get_hosts())
         self.assertEqual(set(['host3', 'host4', 'host5']), servers_hosts)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #32146 

When data.py calls reconciliate, in order to reconciliate "ungrouped" it removes the group from the host:
```
                if set(mygroups).difference(set([self.groups['all'], self.groups['ungrouped']])):
                    host.remove_group(self.groups['ungrouped'])
```

We can see in host.py that 
```
    def remove_group(self, group):

        if group in self.groups:
            self.groups.remove(group)

            # remove exclusive ancestors, xcept all!
            for oldg in group.get_ancestors():
                if oldg.name != 'all':
                    for childg in self.groups:
                        if oldg in childg.get_ancestors():
                            break
                    else:
                        self.remove_group(oldg)
```
When we remove the group from the host, the group information is not fed-back.

But, when we look at group.py code, we can see that the group will manage the host deletion too:
```
    def remove_host(self, host):

        if host.name in self.host_names:
            self.hosts.remove(host)
            self._hosts.remove(host.name)
            host.remove_group(self)
            self.clear_hosts_cache()
```

We can assume that groups are responsible of their hosts, but hosts are not responsible of their groups, since add_group/host's behavior is the same. With this assumption (that I don't know if it's right or not) we can solve this issue deleting the host from the group insted of the group from the host. That's what this commit does.


<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
reconcile_inventory
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0 (issues_32146 ff8c3ea8c5) last updated 2018/03/19 11:53:52 (GMT -700)
  config file = /home/user/github/issues_32146/ansible.cfg
  configured module search path = [u'/home/user/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/user/github/ansible/lib/ansible
  executable location = /home/user/github/ansible/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

Using the input given in [32146 data](https://gist.github.com/halberom/e7791aa22c7dd1ef3f1ece3c815b4af8)


Before this commit we get:

```
:~/github/issues_32146$ ansible host5 -i hosts -i dynamic.config -m debug -a 'var=groups'
host5 | SUCCESS => {
    "groups": {
        "all": [
            "host1", 
            "host2", 
            "host3", 
            "host4", 
            "host5"
        ], 
        "foo_bar": [
            "host2"
        ], 
        "foo_foo": [
            "host5", 
            "host3"
        ], 
        "foo_none": [
            "host4", 
            "host1"
        ], 
        "ungrouped": [
            "host1", 
            "host2", 
            "host3", 
            "host4", 
            "host5"
        ]
    }
}

```


After this commit we get the following output:

```
~/github/issues_32146$ ansible host5 -i hosts -i dynamic.config -m debug -a 'var=groups'
host5 | SUCCESS => {
    "groups": {
        "all": [
            "host4", 
            "host1", 
            "host5", 
            "host3", 
            "host2"
        ], 
        "foo_bar": [
            "host2"
        ], 
        "foo_foo": [
            "host5", 
            "host3"
        ], 
        "foo_none": [
            "host4", 
            "host1"
        ], 
        "ungrouped": []
    }
}
```
