### PR TITLE
fix documentation fragment as it doesn't match real implementation

### DIFF
--- a/lib/ansible/utils/module_docs_fragments/azure.py
+++ b/lib/ansible/utils/module_docs_fragments/azure.py
@@ -79,8 +79,6 @@ options:
         description:
         - Selects an API profile to use when communicating with Azure services. Default value of C(latest) is appropriate for public clouds;
           future values will allow use with Azure Stack.
-        choices:
-        - latest
         default: latest
         version_added: 2.5
 requirements:


### PR DESCRIPTION
##### SUMMARY

Removed documentation fragment which is not implemented in azure_rm_common.py and causes E326 sanity error

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME

##### ANSIBLE VERSION
2.5

##### ADDITIONAL INFORMATION

lib/ansible/modules/cloud/azure/azure_rm_storageaccount_keys.py:0:0: E326 Value for "choices" from the argument_spec ([]) for "api_profile" does not match the documentation (['latest'])
