### PR TITLE
Fixes #37330: support subnet can refer nsg in another resource group

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_subnet.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_subnet.py
@@ -284,6 +284,7 @@ class AzureRMSubnet(AzureRMModuleBase):
 
     def parse_nsg(self):
         nsg = self.security_group
+        resource_group = self.resource_group
         if isinstance(self.security_group, dict):
             nsg = self.security_group.get('name')
             resource_group = self.security_group.get('resource_group', self.resource_group)

--- a/lib/ansible/modules/cloud/azure/azure_rm_subnet.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_subnet.py
@@ -156,7 +156,7 @@ class AzureRMSubnet(AzureRMModuleBase):
             state=dict(type='str', default='present', choices=['present', 'absent']),
             virtual_network_name=dict(type='str', required=True, aliases=['virtual_network']),
             address_prefix_cidr=dict(type='str', aliases=['address_prefix']),
-            security_group=dict(aliases=['security_group_name'])
+            security_group=dict(type='raw', aliases=['security_group_name'])
         )
 
         required_if = [

--- a/lib/ansible/modules/cloud/azure/azure_rm_subnet.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_subnet.py
@@ -79,6 +79,16 @@ EXAMPLES = '''
         resource_group: Testing
         address_prefix_cidr: "10.1.0.0/24"
 
+    - name: Create a subnet refer nsg from other resource group
+      azure_rm_subnet:
+        name: foobar
+        virtual_network_name: My_Virtual_Network
+        resource_group: Testing
+        address_prefix_cidr: "10.1.0.0/16"
+        security_group:
+          name: secgroupfoo
+          resource_group: Testing1
+
     - name: Delete a subnet
       azure_rm_subnet:
         name: foobar

--- a/test/integration/targets/azure_rm_subnet/tasks/main.yml
+++ b/test/integration/targets/azure_rm_subnet/tasks/main.yml
@@ -87,8 +87,9 @@
     virtual_network_name: My_Virtual_Network
     resource_group: "{{ resource_group }}"
     address_prefix_cidr: "10.1.0.0/16"
-    security_group: secgroupfoo
-    nsg_resource_group: "{{ resource_group_secondary }}"
+    security_group:
+      name: secgroupfoo
+      resource_group: "{{ resource_group_secondary }}"
     tags:
        testing: testing
        delete: on-fini

--- a/test/integration/targets/azure_rm_subnet/tasks/main.yml
+++ b/test/integration/targets/azure_rm_subnet/tasks/main.yml
@@ -75,6 +75,45 @@
 - assert:
     that: not output.changed
 
+- name: Create network security group in another resource group
+  azure_rm_securitygroup:
+    name: secgroupfoo
+    resource_group: "{{ resource_group_secondary }}"
+  register: nsg
+
+- name: Update the subnet
+  azure_rm_subnet:
+    name: foobar
+    virtual_network_name: My_Virtual_Network
+    resource_group: "{{ resource_group }}"
+    address_prefix_cidr: "10.1.0.0/16"
+    security_group: secgroupfoo
+    nsg_resource_group: "{{ resource_group_secondary }}"
+    tags:
+       testing: testing
+       delete: on-fini
+  register: output
+
+- assert:
+    that: 
+    - output.changed
+    - output.state.network_security_group.id == nsg.state.id
+
+- name: Update the subnet (idempotent)
+  azure_rm_subnet:
+    name: foobar
+    virtual_network_name: My_Virtual_Network
+    resource_group: "{{ resource_group }}"
+    address_prefix_cidr: "10.1.0.0/16"
+    security_group: "{{ nsg.state.id }}"
+    tags:
+       testing: testing
+       delete: on-fini
+  register: output
+
+- assert:
+    that: not output.changed
+
 - name: Remove subnet
   azure_rm_subnet:
     state: absent


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #37330
When creating subnet, it can refer a network security group from another resource group

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->

azure_rm_subnet


##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
