### PR TITLE
Fix uri test on Python 2.6.

### DIFF
--- a/test/integration/targets/uri/files/constraints.txt
+++ b/test/integration/targets/uri/files/constraints.txt
@@ -1,0 +1,1 @@
+cryptography < 2.2 ; python_version < "2.7" # cryptography 2.2+ requires python 2.7+

--- a/test/integration/targets/uri/tasks/main.yml
+++ b/test/integration/targets/uri/tasks/main.yml
@@ -285,6 +285,7 @@
   pip:
     name: "{{ item }}"
     state: latest
+    extra_args: "-c {{ role_path }}/files/constraints.txt"
   with_items:
     - urllib3
     - PyOpenSSL


### PR DESCRIPTION
##### SUMMARY

Fix uri test on Python 2.6 by limiting the cryptography version.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

uri integration test

##### ANSIBLE VERSION

```
ansible 2.6.0 (uri-test-fix d902090196) last updated 2018/03/19 22:52:44 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```
