### PR TITLE
apt: allow for integration tests using fake repo

### DIFF
--- a/test/integration/targets/apt/meta/main.yml
+++ b/test/integration/targets/apt/meta/main.yml
@@ -1,2 +1,3 @@
 dependencies:
   - prepare_tests
+  - setup_deb_repo

--- a/test/integration/targets/apt/tasks/main.yml
+++ b/test/integration/targets/apt/tasks/main.yml
@@ -18,8 +18,16 @@
  - include: 'apt.yml'
    when: ansible_distribution in ('Ubuntu', 'Debian')
 
- - include: 'repo.yml'
-   when: ansible_distribution in ('Ubuntu', 'Debian')
+ - block:
+   - include: 'repo.yml'
+     when: ansible_distribution in ('Ubuntu', 'Debian')
+   always:
+     - apt_repository:
+         repo: "deb file:{{ repodir }} ./"
+         state: absent
+     - file:
+         name: "{{ repodir }}"
+         state: absent
 
  - include: 'apt-multiarch.yml'
    when: ansible_distribution in ('Ubuntu', 'Debian') and ansible_userspace_architecture != apt_foreign_arch

--- a/test/integration/targets/apt/tasks/main.yml
+++ b/test/integration/targets/apt/tasks/main.yml
@@ -19,8 +19,7 @@
    when: ansible_distribution in ('Ubuntu', 'Debian')
 
  - block:
-   - include: 'repo.yml'
-     when: ansible_distribution in ('Ubuntu', 'Debian')
+     - include: 'repo.yml'
    always:
      - apt_repository:
          repo: "deb file:{{ repodir }} ./"
@@ -28,6 +27,7 @@
      - file:
          name: "{{ repodir }}"
          state: absent
+   when: ansible_distribution in ('Ubuntu', 'Debian')
 
  - include: 'apt-multiarch.yml'
    when: ansible_distribution in ('Ubuntu', 'Debian') and ansible_userspace_architecture != apt_foreign_arch

--- a/test/integration/targets/apt/tasks/main.yml
+++ b/test/integration/targets/apt/tasks/main.yml
@@ -18,6 +18,9 @@
  - include: 'apt.yml'
    when: ansible_distribution in ('Ubuntu', 'Debian')
 
+ - include: 'repo.yml'
+   when: ansible_distribution in ('Ubuntu', 'Debian')
+
  - include: 'apt-multiarch.yml'
    when: ansible_distribution in ('Ubuntu', 'Debian') and ansible_userspace_architecture != apt_foreign_arch
 

--- a/test/integration/targets/apt/tasks/repo.yml
+++ b/test/integration/targets/apt/tasks/repo.yml
@@ -1,58 +1,42 @@
-- name: Install foo package version 1.0.0
-  apt:
-    name: foo=1.0.0
-    allow_unauthenticated: yes
-  register: apt_result
+- block:
+  - name: Install foo package version 1.0.0
+    apt:
+      name: foo=1.0.0
+      allow_unauthenticated: yes
+    register: apt_result
 
-- name: Check install with dpkg
-  shell: dpkg-query -l foo
-  register: dpkg_result
+  - name: Check install with dpkg
+    shell: dpkg-query -l foo
+    register: dpkg_result
 
-- name: Check if install was successful
-  assert:
-    that:
-      - "apt_result is success"
-      - "dpkg_result is success"
-      - "'1.0.0' in dpkg_result.stdout"
+  - name: Check if install was successful
+    assert:
+      that:
+        - "apt_result is success"
+        - "dpkg_result is success"
+        - "'1.0.0' in dpkg_result.stdout"
 
-- name: Update to foo version 1.0.1
-  apt:
-    name: foo
-    state: latest
-    allow_unauthenticated: yes
-  register: apt_result
+  - name: Update to foo version 1.0.1
+    apt:
+      name: foo
+      state: latest
+      allow_unauthenticated: yes
+    register: apt_result
 
-- name: Check install with dpkg
-  shell: dpkg-query -l foo
-  register: dpkg_result
+  - name: Check install with dpkg
+    shell: dpkg-query -l foo
+    register: dpkg_result
 
-- name: Check if install was successful
-  assert:
-    that:
-      - "apt_result is success"
-      - "dpkg_result is success"
-      - "'1.0.1' in dpkg_result.stdout"
+  - name: Check if install was successful
+    assert:
+      that:
+        - "apt_result is success"
+        - "dpkg_result is success"
+        - "'1.0.1' in dpkg_result.stdout"
 
-- name: Clean up
-  apt:
-    name: foo
-    state: absent
-    allow_unauthenticated: yes
-
-# https://github.com/ansible/ansible/issues/19102
-- name: Install foo package version 1.0.1 using wildcards
-  apt:
-    name: foo=1.*.1*
-    allow_unauthenticated: yes
-  register: apt_result
-
-- name: Check install with dpkg
-  shell: dpkg-query -l foo
-  register: dpkg_result
-
-- name: Check if install was successful
-  assert:
-    that:
-      - "apt_result is success"
-      - "dpkg_result is success"
-      - "'1.0.1' in dpkg_result.stdout"
+  always:
+    - name: Clean up
+      apt:
+        name: foo
+        state: absent
+        allow_unauthenticated: yes

--- a/test/integration/targets/apt/tasks/repo.yml
+++ b/test/integration/targets/apt/tasks/repo.yml
@@ -38,3 +38,21 @@
     name: foo
     state: absent
     allow_unauthenticated: yes
+
+# https://github.com/ansible/ansible/issues/19102
+- name: Install foo package version 1.0.1 using wildcards
+  apt:
+    name: foo=1.*.1*
+    allow_unauthenticated: yes
+  register: apt_result
+
+- name: Check install with dpkg
+  shell: dpkg-query -l foo
+  register: dpkg_result
+
+- name: Check if install was successful
+  assert:
+    that:
+      - "apt_result is success"
+      - "dpkg_result is success"
+      - "'1.0.1' in dpkg_result.stdout"

--- a/test/integration/targets/apt/tasks/repo.yml
+++ b/test/integration/targets/apt/tasks/repo.yml
@@ -1,0 +1,40 @@
+- name: Install foo package version 1.0.0
+  apt:
+    name: foo=1.0.0
+    allow_unauthenticated: yes
+  register: apt_result
+
+- name: Check install with dpkg
+  shell: dpkg-query -l foo
+  register: dpkg_result
+
+- name: Check if install was successful
+  assert:
+    that:
+      - "apt_result is success"
+      - "dpkg_result is success"
+      - "'1.0.0' in dpkg_result.stdout"
+
+- name: Update to foo version 1.0.1
+  apt:
+    name: foo
+    state: latest
+    allow_unauthenticated: yes
+  register: apt_result
+
+- name: Check install with dpkg
+  shell: dpkg-query -l foo
+  register: dpkg_result
+
+- name: Check if install was successful
+  assert:
+    that:
+      - "apt_result is success"
+      - "dpkg_result is success"
+      - "'1.0.1' in dpkg_result.stdout"
+
+- name: Clean up
+  apt:
+    name: foo
+    state: absent
+    allow_unauthenticated: yes

--- a/test/integration/targets/setup_deb_repo/files/package_specs/foo-1.0.0
+++ b/test/integration/targets/setup_deb_repo/files/package_specs/foo-1.0.0
@@ -1,0 +1,10 @@
+Section: misc
+Priority: optional
+Standards-Version: 2.3.3
+
+Package: foo
+Version: 1.0.0
+Section: system
+Maintainer: John Doe <john@doe.com>
+Architecture: all
+Description: Dummy package

--- a/test/integration/targets/setup_deb_repo/files/package_specs/foo-1.0.1
+++ b/test/integration/targets/setup_deb_repo/files/package_specs/foo-1.0.1
@@ -1,0 +1,10 @@
+Section: misc
+Priority: optional
+Standards-Version: 2.3.3
+
+Package: foo
+Version: 1.0.1
+Section: system
+Maintainer: John Doe <john@doe.com>
+Architecture: all
+Description: Dummy package

--- a/test/integration/targets/setup_deb_repo/tasks/main.yml
+++ b/test/integration/targets/setup_deb_repo/tasks/main.yml
@@ -1,0 +1,36 @@
+- block:
+  - name: Install needed packages
+    apt:
+      name: "{{ item }}"
+    with_items:
+      - dpkg-dev
+      - equivs
+      - libfile-fcntllock-perl  # to silence warning by equivs-build
+
+  - set_fact:
+      repodir: /tmp/repo/
+
+  - name: Create repo dir
+    file:
+      path: "{{ repodir }}"
+      state: directory
+      mode: 0755
+
+  - name: Create deb files
+    shell: "equivs-build {{ item }}"
+    args:
+      chdir: "{{ repodir }}"
+    with_fileglob:
+      - "files/package_specs/*"
+
+  - name: Create repo
+    shell: dpkg-scanpackages --multiversion . /dev/null | gzip -9c > Packages.gz
+    args:
+      chdir: "{{ repodir }}"
+
+  - name: Install the repo
+    apt_repository:
+      repo: "deb file:{{ repodir }} ./"
+      validate_certs: no
+
+  when: ansible_distribution in ['Ubuntu', 'Debian']


### PR DESCRIPTION
##### SUMMARY
Just like we have with yum https://github.com/ansible/ansible/tree/devel/test/integration/targets/setup_rpm_repo

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Test Pull Request

##### COMPONENT NAME
apt
tests

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION