### PR TITLE
Update default ansible-test docker container.

### DIFF
--- a/test/runner/docker/requirements.sh
+++ b/test/runner/docker/requirements.sh
@@ -48,7 +48,7 @@ for python_version in "${python_versions[@]}"; do
 
     echo "==> Checking for requirements conflicts for ${python_version} ..."
 
-    after=$("pip${python_version}" list)
+    after=$("pip${python_version}" list --format=legacy)
 
     for requirement in "${version_requirements[@]}"; do
         before="${after}"
@@ -57,7 +57,7 @@ for python_version in "${python_versions[@]}"; do
         "pip${python_version}" install --disable-pip-version-check -c constraints.txt -r "${requirement}"
         set +x
 
-        after=$("pip${python_version}" list)
+        after=$("pip${python_version}" list --format=legacy)
 
         if [ "${before}" != "${after}" ]; then
             echo "==> Conflicts detected in requirements for python ${python_version}: ${requirement}"

--- a/test/runner/requirements/constraints.txt
+++ b/test/runner/requirements/constraints.txt
@@ -1,4 +1,5 @@
 coverage >= 4.2, != 4.3.2 # features in 4.2+ required, avoid known bug in 4.3.2 on python 2.6
+cryptography < 2.2 ; python_version < '2.7' # cryptography 2.2 drops support for python 2.6
 pywinrm >= 0.3.0 # message encryption support
 astroid == 1.5.3 ; python_version >= '3.5' # newer versions of astroid require newer versions of pylint to avoid bugs
 pylint == 1.7.4 ; python_version >= '3.5' # versions before 1.7.1 hang or fail to install on python 3.x


### PR DESCRIPTION
##### SUMMARY

Update default ansible-test docker container:

- Limit cryptography version for Python 2.6 tests.
- Specify pip list format to eliminate warning.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test default docker container

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0 (test-constraints 66f1d0e009) last updated 2018/03/20 07:34:29 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```
