### PR TITLE
Allow specifying --diff for ansible-pull

### DIFF
--- a/lib/ansible/cli/pull.py
+++ b/lib/ansible/cli/pull.py
@@ -29,6 +29,7 @@ import sys
 import time
 
 from ansible.cli import CLI
+from ansible import constants as C
 from ansible.errors import AnsibleOptionsError
 from ansible.module_utils._text import to_native, to_text
 from ansible.plugins.loader import module_loader
@@ -91,6 +92,7 @@ class PullCLI(CLI):
             vault_opts=True,
             runtask_opts=True,
             subset_opts=True,
+            check_opts=False,  # prevents conflict of --checkout/-C and --check/-C
             inventory_opts=True,
             module_opts=True,
             runas_prompt_opts=True,
@@ -123,8 +125,12 @@ class PullCLI(CLI):
                                help='modified files in the working repository will be discarded')
         self.parser.add_option('--track-subs', dest='tracksubs', default=False, action='store_true',
                                help='submodules will track the latest changes. This is equivalent to specifying the --remote flag to git submodule update')
+        # add a subset of the check_opts flag group manually, as the full set's
+        # shortcodes conflict with above --checkout/-C
         self.parser.add_option("--check", default=False, dest='check', action='store_true',
                                help="don't make any changes; instead, try to predict some of the changes that may occur")
+        self.parser.add_option("--diff", default=C.DIFF_ALWAYS, dest='diff', action='store_true',
+                               help="when changing (small) files and templates, show the differences in those files; works great with --check")
 
         super(PullCLI, self).parse()
 
@@ -276,6 +282,8 @@ class PullCLI(CLI):
             cmd += ' -l "%s"' % limit_opts
         if self.options.check:
             cmd += ' -C'
+        if self.options.diff:
+            cmd += ' -D'
 
         os.chdir(self.options.dest)
 


### PR DESCRIPTION
##### SUMMARY
The ansible-pull command does not support the `--diff` (and `--syntax-check`) flags. This is due to the fact that the `PullCLI` parsing does not include the general `check_opts` CLI flag group which contains the two flags in question, as well as the `--check` flag. The `check_opts` group was propably left out due to a conflict between the ansible-pull specific `--checkout`/`-C` flag and the `--check`/`-C` flag which is part of the default CLI. Instead, the `--check` flag was added manually to the ansible-pull CLI parser, without its shorthand `-C`.

This PR does the same for the `--diff` and `--syntax-check` flags, and also adds comments describing the rationale behind adding these three manually (and without their shorthand versions).

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
ansible-pull

##### ANSIBLE VERSION
```
ansible 2.6.0
  config file = None
  configured module search path = [u'/home/danieln/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/danieln/.virtualenvs/ansible-dev/lib/python2.7/site-packages/ansible-2.6.0-py2.7.egg/ansible
  executable location = /home/danieln/.virtualenvs/ansible-dev/bin/ansible
  python version = 2.7.14 (default, Jan  5 2018, 10:41:29) [GCC 7.2.1 20171224]
```

##### ADDITIONAL INFORMATION
The change works as expected. Running `ansible-pull --diff -U git@github.com:debugloop/test-playbook.git test.yml` on my machine yields the following results. The playbook can be viewed in said repo, but it is just a `copy` to a tmpfile with static content.

Before:

```
Usage: ansible-pull -U <repository> [options] [<playbook.yml>]

ansible-pull: error: no such option: --diff
```

After:

```
Starting Ansible Pull at 2018-03-20 15:52:06
/home/danieln/.virtualenvs/ansible-dev/bin/ansible-pull --diff -U git@gitlab.com:danieln/test-playbook.git test.yml
 [WARNING]: Could not match supplied host pattern, ignoring: icemark
localhost | SUCCESS => {
    "after": "09151533adff4ec72cac060c03c00bce1bfe8a90", 
    "before": "09151533adff4ec72cac060c03c00bce1bfe8a90", 
    "changed": false, 
    "remote_url_changed": false
}
 [WARNING]: Unable to parse /etc/ansible/hosts as an inventory source
 [WARNING]: No inventory was parsed, only implicit localhost is available
 [WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match
'all'
 [WARNING]: Could not match supplied host pattern, ignoring: icemark

PLAY [test] ************************************************************************************************************

TASK [Gathering Facts] *************************************************************************************************
ok: [localhost]

TASK [test writing a file] *********************************************************************************************
--- before: /tmp/test.txt
+++ after: /home/danieln/.ansible/tmp/ansible-local-155702xmYGP/tmpmP6VBq
@@ -1,3 +1,5 @@
 blabla
+bloblo
 blibli
+bleble
 blublu

changed: [localhost]

PLAY RECAP *************************************************************************************************************
localhost                  : ok=2    changed=1    unreachable=0    failed=0
```