### PR TITLE
Fix py3 issue in wait_for_connection

### DIFF
--- a/lib/ansible/plugins/action/wait_for_connection.py
+++ b/lib/ansible/plugins/action/wait_for_connection.py
@@ -54,11 +54,12 @@ class ActionModule(ActionBase):
                     display.debug("wait_for_connection: %s success" % what_desc)
                 return
             except Exception as e:
+                error = e  # PY3 compatibility to store exception for use outside of this block
                 if what_desc:
                     display.debug("wait_for_connection: %s fail (expected), retrying in %d seconds..." % (what_desc, sleep))
                 time.sleep(sleep)
 
-        raise TimedOutException("timed out waiting for %s: %s" % (what_desc, e))
+        raise TimedOutException("timed out waiting for %s: %s" % (what_desc, error))
 
     def run(self, tmp=None, task_vars=None):
         if task_vars is None:


### PR DESCRIPTION
##### SUMMARY
In py3, if `wait_for_connection` times out, you get an exception:

```
Traceback (most recent call last):
  File "/Users/matt/projects/ansibledev/ansible/lib/ansible/executor/task_executor.py", line 138, in run
    res = self._execute()
  File "/Users/matt/projects/ansibledev/ansible/lib/ansible/executor/task_executor.py", line 554, in _execute
    result = self._handler.run(task_vars=variables)
  File "/Users/matt/projects/ansibledev/ansible/lib/ansible/plugins/action/wait_for_connection.py", line 109, in run
    self.do_until_success_or_timeout(ping_module_test, timeout, connect_timeout, what_desc="ping module test success", sleep=sleep)
  File "/Users/matt/projects/ansibledev/ansible/lib/ansible/plugins/action/wait_for_connection.py", line 61, in do_until_success_or_timeout
    raise TimedOutException("timed out waiting for %s: %s" % (what_desc, e))
UnboundLocalError: local variable 'e' referenced before assignment
```

This is due to:

> When an exception has been assigned using `as target`, it is cleared at the end of the except clause

See: https://docs.python.org/3/reference/compound_stmts.html#the-try-statement

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/action/wait_for_connection.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.4
2.5
2.6
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```