### PR TITLE
csvfile: CSVRecorder: provide a __next__ method.

### DIFF
--- a/lib/ansible/plugins/lookup/csvfile.py
+++ b/lib/ansible/plugins/lookup/csvfile.py
@@ -66,8 +66,10 @@ class CSVRecoder:
     def __iter__(self):
         return self
 
-    def next(self):
+    def __next__(self):
         return self.reader.next().encode("utf-8")
+
+    next = __next__
 
 
 class CSVReader:


### PR DESCRIPTION
Python 3 uses __next__. We keep a 'next' function in order not to break Python
2 compatibility.

This fixes #36808

##### SUMMARY
This is a Python 3 fix.

Fixes #36808


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lookup csvfile

##### ANSIBLE VERSION
Current devel branch.

##### ADDITIONAL INFORMATION
None.