### PR TITLE
issue:37307 Add support for changes in pfc output in onyx 3.6.6000

### DIFF
--- a/lib/ansible/modules/network/onyx/onyx_pfc_interface.py
+++ b/lib/ansible/modules/network/onyx/onyx_pfc_interface.py
@@ -140,12 +140,27 @@ class OnyxPfcInterfaceModule(BaseOnyxModule):
 
     def load_current_config(self):
         # called in base class in run function
+        self._os_version = self._get_os_version()
         self._current_config = dict()
         pfc_config = self._get_pfc_config()
         if not pfc_config:
             return
-        if 'Table 2' in pfc_config:
-            pfc_config = pfc_config['Table 2']
+        stage = 0
+        if self._os_version >= self.ONYX_API_VERSION:
+            if len(pfc_config) >= 3:
+                pfc_config = pfc_config[2]
+                stage = 1
+            else:
+                pfc_config = dict()
+                stage = 2
+        else:
+            stage = 3
+            if 'Table 2' in pfc_config:
+                pfc_config = pfc_config['Table 2']
+                stage = 4
+        with open('/tmp/pfc', 'w') as fp:
+            fp.write(str(pfc_config))
+            fp.write('\n%s\n' % self._os_version)
         for if_name, if_pfc_data in iteritems(pfc_config):
             match = self.PFC_IF_REGEX.match(if_name)
             if not match:

--- a/lib/ansible/modules/network/onyx/onyx_pfc_interface.py
+++ b/lib/ansible/modules/network/onyx/onyx_pfc_interface.py
@@ -145,22 +145,15 @@ class OnyxPfcInterfaceModule(BaseOnyxModule):
         pfc_config = self._get_pfc_config()
         if not pfc_config:
             return
-        stage = 0
         if self._os_version >= self.ONYX_API_VERSION:
             if len(pfc_config) >= 3:
                 pfc_config = pfc_config[2]
-                stage = 1
             else:
                 pfc_config = dict()
-                stage = 2
         else:
-            stage = 3
             if 'Table 2' in pfc_config:
                 pfc_config = pfc_config['Table 2']
-                stage = 4
-        with open('/tmp/pfc', 'w') as fp:
-            fp.write(str(pfc_config))
-            fp.write('\n%s\n' % self._os_version)
+
         for if_name, if_pfc_data in iteritems(pfc_config):
             match = self.PFC_IF_REGEX.match(if_name)
             if not match:

--- a/test/units/modules/network/onyx/test_onyx_pfc_interface.py
+++ b/test/units/modules/network/onyx/test_onyx_pfc_interface.py
@@ -28,7 +28,7 @@ class TestOnyxPfcInterfaceModule(TestOnyxModule):
             'ansible.module_utils.network.onyx.onyx.load_config')
         self.load_config = self.mock_load_config.start()
         self.mock_get_version = patch.object(
-             onyx_pfc_interface.OnyxPfcInterfaceModule, "_get_os_version")
+            onyx_pfc_interface.OnyxPfcInterfaceModule, "_get_os_version")
         self.get_version = self.mock_get_version.start()
 
     def tearDown(self):

--- a/test/units/modules/network/onyx/test_onyx_pfc_interface.py
+++ b/test/units/modules/network/onyx/test_onyx_pfc_interface.py
@@ -27,11 +27,15 @@ class TestOnyxPfcInterfaceModule(TestOnyxModule):
         self.mock_load_config = patch(
             'ansible.module_utils.network.onyx.onyx.load_config')
         self.load_config = self.mock_load_config.start()
+        self.mock_get_version = patch.object(
+             onyx_pfc_interface.OnyxPfcInterfaceModule, "_get_os_version")
+        self.get_version = self.mock_get_version.start()
 
     def tearDown(self):
         super(TestOnyxPfcInterfaceModule, self).tearDown()
         self.mock_get_config.stop()
         self.mock_load_config.stop()
+        self.mock_get_version.stop()
 
     def load_fixtures(self, commands=None, transport='cli'):
         if self._pfc_enabled:
@@ -42,6 +46,7 @@ class TestOnyxPfcInterfaceModule(TestOnyxModule):
 
         self.get_config.return_value = load_fixture(config_file)
         self.load_config.return_value = None
+        self.get_version.return_value = "3.6.5000"
 
     def _test_pfc_if(self, if_name, enabled, changed, commands):
         state = 'enabled' if enabled else 'disabled'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fix PFC result parsing for onyx version 3.6.6000

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Fixes #37307
Add support for the new json structure returned in onyx version 3.6.6000

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
onyx_pfc_interface.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0 (issue/37307 24f69815bd) last updated 2018/03/20 16:15:12 (GMT +000)
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  python version = 2.7.5 (default, Nov  6 2016, 00:28:07) [GCC 4.8.5 20150623 (Red Hat 4.8.5-11)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
