### PR TITLE
Backport #37646 for 2.5

### DIFF
--- a/changelogs/fragments/py3-wait-for-connection.yaml
+++ b/changelogs/fragments/py3-wait-for-connection.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- wait_for_connection - Fix python3 compatibility bug (https://github.com/ansible/ansible/pull/37646)

--- a/lib/ansible/plugins/action/wait_for_connection.py
+++ b/lib/ansible/plugins/action/wait_for_connection.py
@@ -54,11 +54,12 @@ class ActionModule(ActionBase):
                     display.debug("wait_for_connection: %s success" % what_desc)
                 return
             except Exception as e:
+                error = e  # PY3 compatibility to store exception for use outside of this block
                 if what_desc:
                     display.debug("wait_for_connection: %s fail (expected), retrying in %d seconds..." % (what_desc, sleep))
                 time.sleep(sleep)
 
-        raise TimedOutException("timed out waiting for %s: %s" % (what_desc, e))
+        raise TimedOutException("timed out waiting for %s: %s" % (what_desc, error))
 
     def run(self, tmp=None, task_vars=None):
         if task_vars is None:


### PR DESCRIPTION
##### SUMMARY
Backport #37646 for 2.5

Probably a 2.5.1 candidate

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/action/wait_for_connection.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```