### PR TITLE
Bkprt py3 interfaces file

### DIFF
--- a/changelogs/fragments/py3-interfaces_file.yaml
+++ b/changelogs/fragments/py3-interfaces_file.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - interfaces_file - Fix a crash on python3 when writing a changed interfaces file https://github.com/ansible/ansible/pull/37504

--- a/lib/ansible/modules/system/interfaces_file.py
+++ b/lib/ansible/modules/system/interfaces_file.py
@@ -150,6 +150,7 @@ import re
 import tempfile
 
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_bytes
 
 
 def lineDict(line):
@@ -330,7 +331,7 @@ def write_changes(module, lines, dest):
 
     tmpfd, tmpfile = tempfile.mkstemp()
     f = os.fdopen(tmpfd, 'wb')
-    f.writelines(lines)
+    f.writelines(to_bytes(lines, errors='surrogate_or_strict'))
     f.close()
     module.atomic_move(tmpfile, os.path.realpath(dest))
 


### PR DESCRIPTION
##### SUMMARY
Backport of a crash in the interfaces_file module when used with python3

##### ISSUE TYPE

 - Bugfix Pull Request


##### COMPONENT NAME
lib/ansible/modules/system/interfaces_file.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```
