### PR TITLE
Correct module name in vcenter_license.py

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vcenter_license.py
+++ b/lib/ansible/modules/cloud/vmware/vcenter_license.py
@@ -57,7 +57,7 @@ EXAMPLES = r'''
   delegate_to: localhost
 
 - name: Remove an (unused) vCenter license
-  vmware_license:
+  vcenter_license:
     hostname: '{{ vcenter_hostname }}'
     username: '{{ vcenter_username }}'
     password: '{{ vcenter_password }}'


### PR DESCRIPTION

##### SUMMARY
Documentation incorrectly lists module name as vmware_license.
Module name should be vcenter_license not vmware_license.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
cloud module, vcenter_license

##### ANSIBLE VERSION
```
$ ansible --version 
ansible 2.6.0
```

##### ADDITIONAL INFORMATION
None.
