### PR TITLE
updated example with correct parameters

### DIFF
--- a/lib/ansible/modules/monitoring/grafana_datasource.py
+++ b/lib/ansible/modules/monitoring/grafana_datasource.py
@@ -158,10 +158,9 @@ EXAMPLES = '''
   grafana_datasource:
     name: my_elastic
     grafana_url: http://grafana.company.com
-    type: elasticsearch
+    ds_type: elasticsearch
     url: https://elasticsearch.company.com:9200
     database: my-index_*
-    basic_auth: yes
     basic_auth_user: grafana
     basic_auth_password: xxxxxxxx
     json_data: '{"esVersion":5, "timeField": "@timestamp"}'


### PR DESCRIPTION
Updated EXAMPLES documentation which had following 2 incorrect parameters: 
'type' has been changed to 'ds_type'
'basic_auth' parameter has been removed.

+label: docsite_pr

##### SUMMARY
Updated the EXAMPLES given in the documentation of grafana_datasource with correct available parameters.


##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
grafana_datasource

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
