### PR TITLE
[cloud] ec2_ami_copy: undeprecate wait_timeout

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_ami_copy.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_ami_copy.py
@@ -58,8 +58,10 @@ options:
     default: 'no'
   wait_timeout:
     description:
-      - How long before wait gives up, in seconds. (As of 2.3 this option is deprecated. See boto3 Waiters)
-    default: 1200
+      - How long before wait gives up, in seconds. Prior to 2.3 the default was 1200.
+      - From 2.3-2.5 this option was deprecated in favor of boto3 waiter defaults.
+        This was reenabled in 2.6 to allow timeouts greater than 10 minutes.
+    default: 600
   tags:
     description:
       - A hash/dictionary of tags to add to the new copied AMI; '{"key":"value"}' and '{"key":"value","key":"value"}'
@@ -84,6 +86,7 @@ EXAMPLES = '''
     region: eu-west-1
     source_image_id: ami-xxxxxxx
     wait: yes
+    wait_timeout: 1200  # Default timeout is 600
   register: image_id
 
 # Named AMI copy
@@ -159,7 +162,12 @@ def copy_image(module, ec2):
     try:
         image_id = ec2.copy_image(**params)['ImageId']
         if module.params.get('wait'):
-            ec2.get_waiter('image_available').wait(ImageIds=[image_id])
+            delay = 15
+            max_attempts = module.params.get('wait_timeout') // delay
+            ec2.get_waiter('image_available').wait(
+                ImageIds=[image_id],
+                WaiterConfig={'Delay': delay, 'MaxAttempts': max_attempts}
+            )
         if module.params.get('tags'):
             ec2.create_tags(
                 Resources=[image_id],
@@ -187,7 +195,7 @@ def main():
         encrypted=dict(type='bool', default=False, required=False),
         kms_key_id=dict(type='str', required=False),
         wait=dict(type='bool', default=False),
-        wait_timeout=dict(default=1200),
+        wait_timeout=dict(type='int', default=600),
         tags=dict(type='dict')))
 
     module = AnsibleModule(argument_spec=argument_spec)


### PR DESCRIPTION
##### SUMMARY
Allow a longer timeout than 10 minutes. Fixes #37111.

Prior to 2.3, the default wait_timeout was 1200 seconds. Since 2.3 the wait timeout has been non-modifiable and only 600 seconds.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/ec2_ami_copy.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6.0
```