### PR TITLE
enabling storage blob as it seems that test is stable

### DIFF
--- a/test/integration/targets/azure_rm_storageblob/aliases
+++ b/test/integration/targets/azure_rm_storageblob/aliases
@@ -1,2 +1,3 @@
 cloud/azure
+posix/ci/cloud/group2/azure
 destructive


### PR DESCRIPTION
##### SUMMARY
I noticed that azure_rm_storageblob test is currently disabled.
It works perfectly in our CI so I will try to enable it and see if it still causes any problems 

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
  - Bugfix Pull Request
 
##### COMPONENT NAME
azure_rm_storageblob

##### ANSIBLE VERSION
2.5

##### ADDITIONAL INFORMATION

