### PR TITLE
Aws ec2 inventory fix

### DIFF
--- a/lib/ansible/plugins/inventory/aws_ec2.py
+++ b/lib/ansible/plugins/inventory/aws_ec2.py
@@ -56,39 +56,44 @@ DOCUMENTATION = '''
 '''
 
 EXAMPLES = '''
-simple_config_file:
+plugin: aws_ec2
+boto_profile: aws_profile
+regions: # populate inventory with instances in these regions
+  - us-east-1
+  - us-east-2
+filters:
+  # all instances with their `Environment` tag set to `dev`
+  tag:Environment: dev
+  # all dev and QA hosts
+  tag:Environment:
+    - dev
+    - qa
+  instance.group-id: sg-xxxxxxxx
+# ignores 403 errors rather than failing
+strict_permissions: False
+hostnames:
+  - tag:Name=Tag1,Name=Tag2  # return specific hosts only
+  - tag:CustomDNSName
+  - dns-name
 
-    plugin: aws_ec2
-    boto_profile: aws_profile
-    regions: # populate inventory with instances in these regions
-      - us-east-1
-      - us-east-2
-    filters:
-      # all instances with their `Environment` tag set to `dev`
-      tag:Environment: dev
-      # all dev and QA hosts
-      tag:Environment:
-        - dev
-        - qa
-      instance.group-id: sg-xxxxxxxx
-    # ignores 403 errors rather than failing
-    strict_permissions: False
-    hostnames:
-      - tag:Name=Tag1,Name=Tag2
-      - tag:CustomDNSName
-      - dns-name
-
-    # constructed features may be used to create custom groups
-    strict: False
-    keyed_groups:
-      - prefix: arch
-        key: 'architecture'
-        value: 'x86_64'
-      - prefix: tag
-        key: tags
-        value:
-          "Name": "Test"
-
+# keyed_groups may be used to create custom groups
+strict: False
+keyed_groups:
+  # add e.g. x86_64 hosts to an arch_x86_64 group
+  - prefix: arch
+    key: 'architecture'
+  # add hosts to tag_Name_Value groups for each Name/Value tag pair
+  - prefix: tag
+    key: tags
+  # add hosts to e.g. instance_type_z3_tiny
+  - prefix: instance_type
+    key: instance_type
+  # create security_groups_sg_abcd1234 group for each SG
+  - key: 'security_groups|json_query("[].group_id")'
+    prefix: 'security_groups'
+  # create a group for each value of the Application tag
+  - key: tag.Application
+    separator: ''
 '''
 
 from ansible.errors import AnsibleError, AnsibleParserError


### PR DESCRIPTION
##### SUMMARY
Improve AWS EC2 inventory plugin

* Better grouping by tags
* Allow hostname tag to be set without providing a value
* Fix EXAMPLE documentation formatting

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
aws_ec2 inventory plugin 

##### ANSIBLE VERSION
```
ansible 2.6.0 (devel 0214a85382) last updated 2018/03/21 15:11:32 (GMT +1000)
  config file = /home/will/tmp/ansible/aws_ec2_inventory/ansible.cfg
  configured module search path = [u'/home/will/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/will/src/ansible/lib/ansible
  executable location = /home/will/src/ansible/bin/ansible
  python version = 2.7.14 (default, Feb 27 2018, 20:43:24) [GCC 7.3.1 20180130 (Red Hat 7.3.1-2)]
```

##### ADDITIONAL INFORMATION
