### PR TITLE
Proxmox - cpuunits/startup/cores options

### DIFF
--- a/lib/ansible/modules/cloud/misc/proxmox.py
+++ b/lib/ansible/modules/cloud/misc/proxmox.py
@@ -100,6 +100,10 @@ options:
       - specifies whether a VM will be started during system bootup
     type: bool
     default: 'no'
+  startup:
+    description:
+      - startup and shutdown behavior
+    version_added: "2.5"
   storage:
     description:
       - target storage
@@ -239,6 +243,18 @@ EXAMPLES = '''
     hostname: example.org
     ostemplate: local:vztmpl/ubuntu-14.04-x86_64.tar.gz'
     cores: 2
+
+# Create new container with minimal options defining startup order
+- proxmox:
+    vmid: 100
+    node: uk-mc02
+    api_user: root@pam
+    api_password: 1q2w3e
+    api_host: node1
+    password: 123456
+    hostname: example.org
+    ostemplate: 'local:vztmpl/ubuntu-14.04-x86_64.tar.gz'
+    startup: 'order=1'
 
 # Start container
 - proxmox:
@@ -430,6 +446,7 @@ def main():
             mounts=dict(type='dict'),
             ip_address=dict(),
             onboot=dict(type='bool', default='no'),
+            startup=dict(),
             storage=dict(default='local'),
             cpuunits=dict(type='int', default=1024),
             nameserver=dict(),
@@ -514,6 +531,7 @@ def main():
                             mounts=module.params['mounts'],
                             ip_address=module.params['ip_address'],
                             onboot=int(module.params['onboot']),
+                            startup=module.params['startup'],
                             cpuunits=module.params['cpuunits'],
                             nameserver=module.params['nameserver'],
                             searchdomain=module.params['searchdomain'],

--- a/lib/ansible/modules/cloud/misc/proxmox.py
+++ b/lib/ansible/modules/cloud/misc/proxmox.py
@@ -102,7 +102,7 @@ options:
   startup:
     description:
       - startup and shutdown behavior
-    version_added: "2.5"
+    version_added: "2.6"
   storage:
     description:
       - target storage

--- a/lib/ansible/modules/cloud/misc/proxmox.py
+++ b/lib/ansible/modules/cloud/misc/proxmox.py
@@ -107,7 +107,7 @@ options:
   cpuunits:
     description:
       - CPU weight for a VM
-    default: 1000
+    default: 1024
   nameserver:
     description:
       - sets DNS server IP address for a container
@@ -431,7 +431,7 @@ def main():
             ip_address=dict(),
             onboot=dict(type='bool', default='no'),
             storage=dict(default='local'),
-            cpuunits=dict(type='int', default=1000),
+            cpuunits=dict(type='int', default=1024),
             nameserver=dict(),
             searchdomain=dict(),
             timeout=dict(type='int', default=30),

--- a/lib/ansible/modules/cloud/misc/proxmox.py
+++ b/lib/ansible/modules/cloud/misc/proxmox.py
@@ -71,7 +71,6 @@ options:
   cores:
     description:
       - Specify number of cores per socket.
-    default: 1
     version_added: 2.4
   cpus:
     description:
@@ -438,7 +437,7 @@ def main():
             hostname=dict(),
             ostemplate=dict(),
             disk=dict(type='str', default='3'),
-            cores=dict(type='int', default=1),
+            cores=dict(type='int'),
             cpus=dict(type='int', default=1),
             memory=dict(type='int', default=512),
             swap=dict(type='int', default=0),


### PR DESCRIPTION
##### SUMMARY
- Fix `cpuunits` default from 1000 to 1024
- Introduce `startup` option support
- Unset default `cores` value

##### ISSUE TYPE
 - Feature Pull Request
 - Bugfix Pull Request

##### COMPONENT NAME
modules/could/misc/proxmox.py

##### ANSIBLE VERSION
```
ansible 2.4.3.0
  config file = None
  configured module search path = [u'/Users/florian.rey/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/Cellar/ansible/2.4.3.0_4/libexec/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.14 (default, Mar  9 2018, 23:57:12) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```

##### ADDITIONAL INFORMATION
- According to the official documentation api (https://pve.proxmox.com/pve-docs/pct.1.html#pct_options) `cpuunits` default is 1024, and not 1000
- `cores` value could be omitted, resulting in "unlimited" cores
