### PR TITLE
Correct module name in vcenter_license.py

### DIFF
--- a/changelogs/fragments/vcenter_license.yaml
+++ b/changelogs/fragments/vcenter_license.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- Updated example in vcenter_license module.

--- a/lib/ansible/modules/cloud/vmware/vcenter_license.py
+++ b/lib/ansible/modules/cloud/vmware/vcenter_license.py
@@ -70,7 +70,7 @@ EXAMPLES = r'''
   delegate_to: localhost
 
 - name: Remove an (unused) vCenter license
-  vmware_license:
+  vcenter_license:
     hostname: '{{ vcenter_hostname }}'
     username: '{{ vcenter_username }}'
     password: '{{ vcenter_password }}'


### PR DESCRIPTION
##### SUMMARY
Module name should be vcenter_license not vmware_license.

(cherry picked from commit 0214a8538235c42a3a77131b1d43643e571fca40)

##### ISSUE TYPE
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/vmware/vcenter_license.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
Stable-2.5
```