### PR TITLE
dont unique by file for certain plugins

### DIFF
--- a/lib/ansible/plugins/loader.py
+++ b/lib/ansible/plugins/loader.py
@@ -76,6 +76,7 @@ class PluginLoader:
 
         self._extra_dirs = []
         self._searched_paths = set()
+        self._matched = []
 
     def __setstate__(self, data):
         '''
@@ -233,6 +234,7 @@ class PluginLoader:
                 # append the directory and invalidate the path cache
                 self._extra_dirs.append(directory)
                 self._paths = None
+                self._matched = []
                 display.debug('Added %s to loader search path' % (directory))
 
     def find_plugin(self, name, mod_type='', ignore_deprecated=False, check_aliases=False):
@@ -418,18 +420,18 @@ class PluginLoader:
         path_only = kwargs.pop('path_only', False)
         class_only = kwargs.pop('class_only', False)
 
-        all_matches = []
         found_in_cache = True
 
-        for i in self._get_paths():
-            all_matches.extend(glob.glob(os.path.join(i, "*.py")))
+        if not self._matched:
+            for i in self._get_paths():
+                self._matched.extend(glob.glob(os.path.join(i, "*.py")))
 
         if self.unique_file:
             # first found wins, so the list indicates the precedence
-            pathlist = sorted(all_matches, key=os.path.basename)
+            pathlist = sorted(self._matched, key=os.path.basename)
         else:
             # since we load all files 'last loaded' wins in this case so we reverse the list to maintain precedence
-            pathlist = reversed(all_matches)
+            pathlist = reversed(self._matched)
 
         for path in pathlist:
 

--- a/lib/ansible/plugins/loader.py
+++ b/lib/ansible/plugins/loader.py
@@ -424,7 +424,14 @@ class PluginLoader:
         for i in self._get_paths():
             all_matches.extend(glob.glob(os.path.join(i, "*.py")))
 
-        for path in sorted(all_matches, key=os.path.basename):
+        if self.unique_file:
+            # first found wins, so the list indicates the precedence
+            pathlist = sorted(all_matches, key=os.path.basename)
+        else:
+            # since we load all files 'last loaded' wins in this case so we reverse the list to maintain precedence
+            pathlist = reversed(all_matches)
+
+        for path in pathlist:
 
             if self.unique_file:
                 name = os.path.basename(os.path.splitext(path)[0])

--- a/test/integration/targets/plugin_loader/aliases
+++ b/test/integration/targets/plugin_loader/aliases
@@ -1,0 +1,1 @@
+posix/ci/group3

--- a/test/integration/targets/plugin_loader/normal/filters.yml
+++ b/test/integration/targets/plugin_loader/normal/filters.yml
@@ -1,0 +1,13 @@
+- hosts: testhost
+  gather_facts: false
+  tasks:
+    - name: ensure filters work as shipped from core
+      assert:
+         that:
+             - a|flatten == [1,2,3,4,5]
+             - a|ternary('yes', 'no') == 'yes'
+      vars:
+        a:
+         - 1
+         - 2
+         - [3,4,5]

--- a/test/integration/targets/plugin_loader/normal/filters.yml
+++ b/test/integration/targets/plugin_loader/normal/filters.yml
@@ -4,10 +4,10 @@
     - name: ensure filters work as shipped from core
       assert:
          that:
-             - a|flatten == [1,2,3,4,5]
+             - a|flatten == [1, 2, 3, 4, 5]
              - a|ternary('yes', 'no') == 'yes'
       vars:
         a:
          - 1
          - 2
-         - [3,4,5]
+         - [3 , 4, 5]

--- a/test/integration/targets/plugin_loader/override/filter_plugins/core.py
+++ b/test/integration/targets/plugin_loader/override/filter_plugins/core.py
@@ -1,0 +1,16 @@
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+def do_flag(myval):
+    return 'flagged'
+
+class FilterModule(object):
+    ''' Ansible core jinja2 filters '''
+
+    def filters(self):
+        return {
+            # jinja2 overrides
+            'flag': do_flag,
+            'flatten': do_flag,
+        }

--- a/test/integration/targets/plugin_loader/override/filter_plugins/core.py
+++ b/test/integration/targets/plugin_loader/override/filter_plugins/core.py
@@ -2,8 +2,10 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+
 def do_flag(myval):
     return 'flagged'
+
 
 class FilterModule(object):
     ''' Ansible core jinja2 filters '''

--- a/test/integration/targets/plugin_loader/override/filters.yml
+++ b/test/integration/targets/plugin_loader/override/filters.yml
@@ -5,11 +5,11 @@
       assert:
          that:
              - a|flag == 'flagged'
-             - a|flatten != [1,2,3,4,5]
+             - a|flatten != [1 , 2, 3, 4, 5]
              - a|flatten == "flagged"
              - a|ternary('yes', 'no') == 'yes'
       vars:
         a:
          - 1
          - 2
-         - [3,4,5]
+         - [ 3, 4, 5]

--- a/test/integration/targets/plugin_loader/override/filters.yml
+++ b/test/integration/targets/plugin_loader/override/filters.yml
@@ -1,0 +1,15 @@
+- hosts: testhost
+  gather_facts: false
+  tasks:
+    - name: ensure local 'flag' filter works, 'flatten' is overriden and 'ternary' is still from core
+      assert:
+         that:
+             - a|flag == 'flagged'
+             - a|flatten != [1,2,3,4,5]
+             - a|flatten == "flagged"
+             - a|ternary('yes', 'no') == 'yes'
+      vars:
+        a:
+         - 1
+         - 2
+         - [3,4,5]

--- a/test/integration/targets/plugin_loader/runme.sh
+++ b/test/integration/targets/plugin_loader/runme.sh
@@ -4,9 +4,9 @@ set -ux
 
 
 # check normal execution
-for myplay in `ls normal/*.yml`
+for myplay in normal/*.yml
 do
-	ansible-playbook ${myplay} -i ../../inventory -vvv "$@"
+	ansible-playbook "${myplay}" -i ../../inventory -vvv "$@"
 	if test $? != 0 ; then
 		echo "### Failed to run ${myplay} normally"
 		exit 1
@@ -14,9 +14,9 @@ do
 done
 
 # check overrides
-for myplay in `ls override/*.yml`
+for myplay in override/*.yml
 do
-	ansible-playbook ${myplay} -i ../../inventory -vvv "$@"
+	ansible-playbook "${myplay}" -i ../../inventory -vvv "$@"
 	if test $? != 0 ; then
 		echo "### Failed to run ${myplay} override"
 		exit 1

--- a/test/integration/targets/plugin_loader/runme.sh
+++ b/test/integration/targets/plugin_loader/runme.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -ux
+
+
+# check normal execution
+for myplay in `ls normal/*.yml`
+do
+	ansible-playbook ${myplay} -i ../../inventory -vvv "$@"
+	if test $? != 0 ; then
+		echo "### Failed to run ${myplay} normally"
+		exit 1
+	fi
+done
+
+# check overrides
+for myplay in `ls override/*.yml`
+do
+	ansible-playbook ${myplay} -i ../../inventory -vvv "$@"
+	if test $? != 0 ; then
+		echo "### Failed to run ${myplay} override"
+		exit 1
+	fi
+done


### PR DESCRIPTION
##### SUMMARY
test and filter plugins can have multiple by file so we should not unique file loading

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
plugin loader

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.4-2.6
```