### PR TITLE
Add support for collections.Mapping to combine() filter (fixes #37727)

### DIFF
--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -34,7 +34,7 @@ import time
 import uuid
 import yaml
 
-from collections import MutableMapping, MutableSequence
+from collections import MutableMapping, MutableSequence, Mapping
 import datetime
 from functools import partial
 from random import Random, SystemRandom, shuffle
@@ -326,7 +326,7 @@ def combine(*terms, **kwargs):
 
     dicts = []
     for t in terms:
-        if isinstance(t, MutableMapping):
+        if isinstance(t, (MutableMapping, Mapping)):
             dicts.append(t)
         elif isinstance(t, list):
             dicts.append(combine(*t, **kwargs))


### PR DESCRIPTION
##### SUMMARY
This allows the `|combine()` filter to be used with `hostvars[host]`.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
`combine` filter

##### ANSIBLE VERSION
```
ansible 2.6.0 (combine_filter_mapping b824e010d2) last updated 2018/03/21 11:53:39 (GMT -500)
```

##### ADDITIONAL INFORMATION
N/A