### PR TITLE
Allow subnets with names formatted like `subnet-1234`

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_nacl.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_nacl.py
@@ -538,7 +538,7 @@ def subnets_to_associate(nacl, client, module):
             all_found.extend(subnets.get('Subnets', []))
         except botocore.exceptions.ClientError as e:
             module.fail_json(msg=str(e), exception=traceback.format_exc())
-    return [s['SubnetId'] for s in all_found if s.get('SubnetId')]
+    return list(set(s['SubnetId'] for s in all_found if s.get('SubnetId')))
 
 
 def main():

--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_nacl.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_nacl.py
@@ -141,6 +141,7 @@ try:
 except ImportError:
     HAS_BOTO3 = False
 
+import traceback
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ec2 import boto3_conn, ec2_argument_spec, get_aws_connection_info
 
@@ -522,19 +523,22 @@ def subnets_to_associate(nacl, client, module):
     params = list(module.params.get('subnets'))
     if not params:
         return []
-    if params[0].startswith("subnet-"):
+    all_found = []
+    if any(x.startswith("subnet-") for x in params):
         try:
             subnets = client.describe_subnets(Filters=[
                 {'Name': 'subnet-id', 'Values': params}])
+            all_found.extend(subnets.get('Subnets', []))
         except botocore.exceptions.ClientError as e:
-            module.fail_json(msg=str(e))
-    else:
+            module.fail_json(msg=str(e), exception=traceback.format_exc())
+    if len(params) != len(all_found):
         try:
             subnets = client.describe_subnets(Filters=[
                 {'Name': 'tag:Name', 'Values': params}])
+            all_found.extend(subnets.get('Subnets', []))
         except botocore.exceptions.ClientError as e:
-            module.fail_json(msg=str(e))
-    return [s['SubnetId'] for s in subnets['Subnets'] if s['SubnetId']]
+            module.fail_json(msg=str(e), exception=traceback.format_exc())
+    return [s['SubnetId'] for s in all_found if s.get('SubnetId')]
 
 
 def main():


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
When any/all subnets listed in NACL preferences start with `subnet-*`, this module will skip searching for subnets by name and assume they are IDs. This is not always correct, as in #32133 and in this PR I add checking to see if any subnet-id-like strings don't match real subnet IDs. If they do not, then also search by name. 

Fixes #32133 

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
ec2_vpc_nacl

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
