### PR TITLE
Add integration tests for include_role using variable for tasks_file

### DIFF
--- a/test/integration/targets/include_import/role/test_import_role.yml
+++ b/test/integration/targets/include_import/role/test_import_role.yml
@@ -8,7 +8,6 @@
     test_var: templating test in playbook
     role_vars:
       where_am_i_defined: in the playbook
-    tasks_file_name: canary3
     entire_task:
       include_role:
         name: role1
@@ -112,16 +111,6 @@
         tasks_from: vartest.yml
       vars:
         where_am_i_defined: "{{ test_var }}"
-
-    - name: Use a variable in tasks_from field
-      import_role:
-        name: role1
-        tasks_from: "{{ tasks_file_name }}.yml"
-
-    - name: Assert that tasks file was included
-      assert:
-        that:
-          - role1_canary3 == 'r1c3'
 
     # FIXME This fails with the following error:
     # The module {u'import_role': {u'name': u'role1'}} was not found in configured module paths.

--- a/test/integration/targets/include_import/role/test_import_role.yml
+++ b/test/integration/targets/include_import/role/test_import_role.yml
@@ -8,6 +8,7 @@
     test_var: templating test in playbook
     role_vars:
       where_am_i_defined: in the playbook
+    tasks_file_name: canary3
     entire_task:
       include_role:
         name: role1
@@ -111,6 +112,16 @@
         tasks_from: vartest.yml
       vars:
         where_am_i_defined: "{{ test_var }}"
+
+    - name: Use a variable in tasks_from field
+      import_role:
+        name: role1
+        tasks_from: "{{ tasks_file_name }}.yml"
+
+    - name: Assert that tasks file was included
+      assert:
+        that:
+          - role1_canary3 == 'r1c3'
 
     # FIXME This fails with the following error:
     # The module {u'import_role': {u'name': u'role1'}} was not found in configured module paths.

--- a/test/integration/targets/include_import/role/test_include_role.yml
+++ b/test/integration/targets/include_import/role/test_include_role.yml
@@ -111,6 +111,18 @@
       vars:
         where_am_i_defined: "{{ test_var }}"
 
+    - name: Use a variable in tasks_from field
+      include_role:
+        name: role1
+        tasks_from: "{{ tasks_file_name }}.yml"
+      vars:
+        tasks_file_name: canary3
+
+    - name: Assert that tasks file was included
+      assert:
+        that:
+          - role1_canary3 == 'r1c3'
+
     ## FIXME This fails with the following error:
     ## The module {u'include_role': {u'name': u'role1'}} was not found in configured module paths.
     # - name: Include an entire task

--- a/test/integration/targets/include_import/roles/role1/tasks/canary3.yml
+++ b/test/integration/targets/include_import/roles/role1/tasks/canary3.yml
@@ -1,0 +1,2 @@
+- set_fact:
+    role1_canary3: r1c3


### PR DESCRIPTION
##### SUMMARY

Add tests for #32503

The original issue reported a failure for `import_role` and `include_role`. Since host vars are not available for use with `import_role`, these tests only cover `include_role`.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
`include_role`

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6
```
