### PR TITLE
Fix loader for filters

### DIFF
--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -300,7 +300,8 @@ class Templar:
         if self._filters is not None:
             return self._filters.copy()
 
-        plugins = [x for x in self._filter_loader.all()]
+        plugins = [x for x in self._filter_loader.all(dedupe=False)]
+        plugins.reverse()
 
         self._filters = dict()
         for fp in plugins:
@@ -320,7 +321,8 @@ class Templar:
         if self._tests is not None:
             return self._tests.copy()
 
-        plugins = [x for x in self._test_loader.all()]
+        plugins = [x for x in self._test_loader.all(dedupe=False)]
+        plugins.reverse()
 
         self._tests = dict()
         for fp in plugins:

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -300,16 +300,14 @@ class Templar:
         if self._filters is not None:
             return self._filters.copy()
 
-        plugins = [x for x in self._filter_loader.all(dedupe=False)]
-        plugins.reverse()
-
         self._filters = dict()
-        for fp in plugins:
-            self._filters.update(fp.filters())
 
         # TODO: Remove registering tests as filters in 2.9
         for name, func in self._get_tests().items():
             self._filters[name] = tests_as_filters_warning(name, func)
+
+        for fp in self._filter_loader.all():
+            self._filters.update(fp.filters())
 
         return self._filters.copy()
 
@@ -321,11 +319,8 @@ class Templar:
         if self._tests is not None:
             return self._tests.copy()
 
-        plugins = [x for x in self._test_loader.all(dedupe=False)]
-        plugins.reverse()
-
         self._tests = dict()
-        for fp in plugins:
+        for fp in self._test_loader.all():
             self._tests.update(fp.tests())
 
         return self._tests.copy()

--- a/lib/ansible/template/safe_eval.py
+++ b/lib/ansible/template/safe_eval.py
@@ -91,11 +91,11 @@ def safe_eval(expr, locals=None, include_exceptions=False):
         )
 
     filter_list = []
-    for filter in reversed([f for f in filter_loader.all(dedupe=False)]):
-        filter_list.extend(filter.filters().keys())
+    for filter_ in filter_loader.all():
+        filter_list.extend(filter_.filters().keys())
 
     test_list = []
-    for test in reversed([t for t in test_loader.all(dedupe=False)]):
+    for test in test_loader.all():
         test_list.extend(test.tests().keys())
 
     CALL_WHITELIST = C.DEFAULT_CALLABLE_WHITELIST + filter_list + test_list

--- a/lib/ansible/template/safe_eval.py
+++ b/lib/ansible/template/safe_eval.py
@@ -91,11 +91,11 @@ def safe_eval(expr, locals=None, include_exceptions=False):
         )
 
     filter_list = []
-    for filter in filter_loader.all():
+    for filter in reversed([f for f in filter_loader.all(dedupe=False)]):
         filter_list.extend(filter.filters().keys())
 
     test_list = []
-    for test in test_loader.all():
+    for test in reversed([t for t in test_loader.all(dedupe=False)]):
         test_list.extend(test.tests().keys())
 
     CALL_WHITELIST = C.DEFAULT_CALLABLE_WHITELIST + filter_list + test_list

--- a/test/integration/targets/plugin_loader/aliases
+++ b/test/integration/targets/plugin_loader/aliases
@@ -1,0 +1,1 @@
+posix/ci/group3

--- a/test/integration/targets/plugin_loader/normal/filters.yml
+++ b/test/integration/targets/plugin_loader/normal/filters.yml
@@ -1,0 +1,13 @@
+- hosts: testhost
+  gather_facts: false
+  tasks:
+    - name: ensure filters work as shipped from core
+      assert:
+         that:
+             - a|flatten == [1,2,3,4,5]
+             - a|ternary('yes', 'no') == 'yes'
+      vars:
+        a:
+         - 1
+         - 2
+         - [3,4,5]

--- a/test/integration/targets/plugin_loader/normal/filters.yml
+++ b/test/integration/targets/plugin_loader/normal/filters.yml
@@ -4,10 +4,10 @@
     - name: ensure filters work as shipped from core
       assert:
          that:
-             - a|flatten == [1,2,3,4,5]
+             - a|flatten == [1, 2, 3, 4, 5]
              - a|ternary('yes', 'no') == 'yes'
       vars:
         a:
          - 1
          - 2
-         - [3,4,5]
+         - [3, 4, 5]

--- a/test/integration/targets/plugin_loader/override/filter_plugins/core.py
+++ b/test/integration/targets/plugin_loader/override/filter_plugins/core.py
@@ -1,0 +1,16 @@
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+def do_flag(myval):
+    return 'flagged'
+
+class FilterModule(object):
+    ''' Ansible core jinja2 filters '''
+
+    def filters(self):
+        return {
+            # jinja2 overrides
+            'flag': do_flag,
+            'flatten': do_flag,
+        }

--- a/test/integration/targets/plugin_loader/override/filter_plugins/core.py
+++ b/test/integration/targets/plugin_loader/override/filter_plugins/core.py
@@ -2,8 +2,10 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+
 def do_flag(myval):
     return 'flagged'
+
 
 class FilterModule(object):
     ''' Ansible core jinja2 filters '''

--- a/test/integration/targets/plugin_loader/override/filters.yml
+++ b/test/integration/targets/plugin_loader/override/filters.yml
@@ -5,11 +5,11 @@
       assert:
          that:
              - a|flag == 'flagged'
-             - a|flatten != [1,2,3,4,5]
+             - a|flatten != [1, 2, 3, 4, 5]
              - a|flatten == "flagged"
              - a|ternary('yes', 'no') == 'yes'
       vars:
         a:
          - 1
          - 2
-         - [3,4,5]
+         - [3, 4, 5]

--- a/test/integration/targets/plugin_loader/override/filters.yml
+++ b/test/integration/targets/plugin_loader/override/filters.yml
@@ -1,0 +1,15 @@
+- hosts: testhost
+  gather_facts: false
+  tasks:
+    - name: ensure local 'flag' filter works, 'flatten' is overriden and 'ternary' is still from core
+      assert:
+         that:
+             - a|flag == 'flagged'
+             - a|flatten != [1,2,3,4,5]
+             - a|flatten == "flagged"
+             - a|ternary('yes', 'no') == 'yes'
+      vars:
+        a:
+         - 1
+         - 2
+         - [3,4,5]

--- a/test/integration/targets/plugin_loader/runme.sh
+++ b/test/integration/targets/plugin_loader/runme.sh
@@ -4,9 +4,9 @@ set -ux
 
 
 # check normal execution
-for myplay in `ls normal/*.yml`
+for myplay in normal/*.yml
 do
-	ansible-playbook ${myplay} -i ../../inventory -vvv "$@"
+	ansible-playbook "${myplay}" -i ../../inventory -vvv "$@"
 	if test $? != 0 ; then
 		echo "### Failed to run ${myplay} normally"
 		exit 1
@@ -14,9 +14,9 @@ do
 done
 
 # check overrides
-for myplay in `ls override/*.yml`
+for myplay in override/*.yml
 do
-	ansible-playbook ${myplay} -i ../../inventory -vvv "$@"
+	ansible-playbook "${myplay}" -i ../../inventory -vvv "$@"
 	if test $? != 0 ; then
 		echo "### Failed to run ${myplay} override"
 		exit 1

--- a/test/integration/targets/plugin_loader/runme.sh
+++ b/test/integration/targets/plugin_loader/runme.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -ux
+
+
+# check normal execution
+for myplay in `ls normal/*.yml`
+do
+	ansible-playbook ${myplay} -i ../../inventory -vvv "$@"
+	if test $? != 0 ; then
+		echo "### Failed to run ${myplay} normally"
+		exit 1
+	fi
+done
+
+# check overrides
+for myplay in `ls override/*.yml`
+do
+	ansible-playbook ${myplay} -i ../../inventory -vvv "$@"
+	if test $? != 0 ; then
+		echo "### Failed to run ${myplay} override"
+		exit 1
+	fi
+done


### PR DESCRIPTION
##### SUMMARY
This is an alternative for https://github.com/ansible/ansible/pull/37730

Instead of adding more to the API, I bisected back to the commit where this was introduced: f921369445900dcc756821e40c9257d5359087af and tried to modify that to get it to work.  With that commit, just removing the call to os.path.basename was needed.  In devel, there was more needed.  I've fiddled around to get that working but I haven't yet confirmed that this doesn't break something else.  Pushing it to a PR so that we get integration tests to run with this.

Also includes the test cases from https://github.com/ansible/ansible/pull/37730

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/loader.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel 2.5 2.4
```
The problematic commit was introduced for ansible-2.4.0