### PR TITLE
Add wait_for_task to snapshot_vm

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest_snapshot.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_snapshot.py
@@ -270,6 +270,7 @@ class PyVmomiHelper(PyVmomi):
             self.module.fail_json(msg="Failed to take snapshot due to VMware Licence: %s" % to_native(exc.msg))
         except Exception as exc:
             self.module.fail_json(msg="Failed to create snapshot of VM %s due to %s" % (self.module.params['name'], to_native(exc)))
+        self.wait_for_task(task)
         return task
 
     def rename_snapshot(self, vm):


### PR DESCRIPTION
##### SUMMARY
Add wait_for_task to snapshot_vm so that it will hold for snapshot completion before moving on to the next task

Fixes #37760 

##### ISSUE TYPE
 - Bugfix Pull Request


##### COMPONENT NAME
vmware_guest_snapshot

##### ANSIBLE VERSION
2.4.3
