### PR TITLE
azure_rm_networkinterface: backport no public IP fix

### DIFF
--- a/changelogs/fragments/azure_rm_networkinterface-specify-no-public-ip.yaml
+++ b/changelogs/fragments/azure_rm_networkinterface-specify-no-public-ip.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- azure_rm_networkinterface - fixed examples in module documentation and added fix to allow an IP configuration with no public IP (https://github.com/ansible/ansible/pull/36824)

--- a/lib/ansible/modules/cloud/azure/azure_rm_networkinterface.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_networkinterface.py
@@ -173,68 +173,68 @@ author:
 EXAMPLES = '''
     - name: Create a network interface with minimal parameters
       azure_rm_networkinterface:
-            name: nic001
-            resource_group: Testing
-            virtual_network_name: vnet001
-            subnet_name: subnet001
-            ip_configurations:
-                name: ipconfig1
-                public_ip_address_name: publicip001
-                primary: True
+        name: nic001
+        resource_group: Testing
+        virtual_network_name: vnet001
+        subnet_name: subnet001
+        ip_configurations:
+          - name: ipconfig1
+            public_ip_address_name: publicip001
+            primary: True
 
     - name: Create a network interface with private IP address only (no Public IP)
       azure_rm_networkinterface:
-            name: nic001
-            resource_group: Testing
-            virtual_network_name: vnet001
-            subnet_name: subnet001
-            ip_configurations:
-                name: ipconfig1
-                primary: True
+        name: nic001
+        resource_group: Testing
+        virtual_network_name: vnet001
+        subnet_name: subnet001
+        ip_configurations:
+          - name: ipconfig1
+            primary: True
 
     - name: Create a network interface for use in a Windows host (opens RDP port) with custom RDP port
       azure_rm_networkinterface:
-            name: nic002
-            resource_group: Testing
-            virtual_network_name: vnet001
-            subnet_name: subnet001
-            os_type: Windows
-            rdp_port: 3399
-            ip_configurations:
-                name: ipconfig1
-                public_ip_address_name: publicip001
-                primary: True
+        name: nic002
+        resource_group: Testing
+        virtual_network_name: vnet001
+        subnet_name: subnet001
+        os_type: Windows
+        rdp_port: 3399
+        ip_configurations:
+          - name: ipconfig1
+            public_ip_address_name: publicip001
+            primary: True
 
     - name: Create a network interface using existing security group and public IP
       azure_rm_networkinterface:
-            name: nic003
-            resource_group: Testing
-            virtual_network_name: vnet001
-            subnet_name: subnet001
-            security_group_name: secgroup001
-            ip_configurations:
-                name: ipconfig1
-                public_ip_address_name: publicip001
-                primary: True
+        name: nic003
+        resource_group: Testing
+        virtual_network_name: vnet001
+        subnet_name: subnet001
+        security_group_name: secgroup001
+        ip_configurations:
+          - name: ipconfig1
+            public_ip_address_name: publicip001
+            primary: True
 
     - name: Create a network with mutilple ip configurations
       azure_rm_networkinterface:
-            name: nic004
-            resource_group: Testing
-            subnet_name: subnet001
-            virtual_network_name: vnet001
-            security_group_name: secgroup001
-            ip_configurations:
-                - name: ipconfig1
-                  public_ip_address_name: publicip001
-                  primary: True
-                - name: ipconfig2
+        name: nic004
+        resource_group: Testing
+        subnet_name: subnet001
+        virtual_network_name: vnet001
+        security_group_name: secgroup001
+        ip_configurations:
+          - name: ipconfig1
+            public_ip_address_name: publicip001
+            primary: True
+          - name: ipconfig2
 
     - name: Delete network interface
       azure_rm_networkinterface:
-            resource_group: Testing
-            name: nic003
-            state: absent
+        resource_group: Testing
+        name: nic003
+        state: absent
 '''
 
 RETURN = '''
@@ -536,6 +536,10 @@ class AzureRMNetworkInterface(AzureRMModuleBase):
 
     def get_or_create_public_ip_address(self, ip_config):
         name = ip_config.get('public_ip_address_name')
+
+        if not (self.public_ip and name):
+            return None
+
         pip = self.get_public_ip_address(name)
         if not pip:
             params = self.network_models.PublicIPAddress(

--- a/test/integration/targets/azure_rm_networkinterface/tasks/main.yml
+++ b/test/integration/targets/azure_rm_networkinterface/tasks/main.yml
@@ -134,6 +134,22 @@
       - not output.state.ip_configuration
       - output.state.ip_configurations | length == 2
 
+- name: IP configuration without public IP
+  azure_rm_networkinterface:
+      resource_group: "{{ resource_group }}"
+      name: testnic001noip
+      security_group: testnic001
+      virtual_network: "{{ vn.state.id }}"
+      subnet: testnic001
+      ip_configurations:
+        - name: ipconfig1
+          primary: True
+  register: output
+
+- assert:
+    that:
+      - output.state.ip_configurations[0].public_ip_address == None
+
 - name: Delete the NIC (check mode)
   azure_rm_networkinterface:
       resource_group: "{{ resource_group }}"


### PR DESCRIPTION
##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/36824 to stable-2.5

Fixes documentation and ip configuration where no public ip is defined.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
azure_rm_networkinterface

##### ANSIBLE VERSION
```
2.5
```
