### PR TITLE
azure_rm_virtualmachine - backport of docs change around images supported

### DIFF
--- a/changelogs/fragments/azure_rm_virtualmachine-docs-images.yaml
+++ b/changelogs/fragments/azure_rm_virtualmachine-docs-images.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- azure_rm_virtualmachine - removed docs note that says on marketplace images can be used, custom images were added in 2.5

--- a/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
@@ -26,8 +26,9 @@ description:
     - Create, update, stop and start a virtual machine. Provide an existing storage account and network interface or
       allow the module to create these for you. If you choose not to provide a network interface, the resource group
       must contain a virtual network with at least one subnet.
-    - Currently requires an image found in the Azure Marketplace. Use azure_rm_virtualmachineimage_facts module
-      to discover the publisher, offer, sku and version of a particular image.
+    - Before Ansible 2.5, this required an image found in the Azure Marketplace which can be discovered with
+      M(azure_rm_virtualmachineimage_facts). In Ansible 2.5 and newer, custom images can be used as well, see the
+      examples for more details.
 
 options:
     resource_group:


### PR DESCRIPTION
##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/37686, just updates the docs on `azure_rm_virtualmachine` to say custom images can be used from Ansible 2.5 and onwards.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
azure_rm_virtualmachine

##### ANSIBLE VERSION
```
2.5
```