### PR TITLE
fixes example address parameters

### DIFF
--- a/lib/ansible/modules/net_tools/nios/nios_host_record.py
+++ b/lib/ansible/modules/net_tools/nios/nios_host_record.py
@@ -96,7 +96,7 @@ EXAMPLES = '''
   nios_host_record:
     name: host.ansible.com
     ipv4:
-      address: 192.168.10.1
+      - address: 192.168.10.1
     state: present
     provider:
       host: "{{ inventory_hostname_short }}"
@@ -108,7 +108,7 @@ EXAMPLES = '''
   nios_host_record:
     name: host.ansible.com
     ipv4:
-      address: 192.168.10.1
+      - address: 192.168.10.1
     comment: this is a test comment
     state: present
     provider:


### PR DESCRIPTION
##### SUMMARY

Modified the examples to show the address values as list items as required by the code. Fix for https://github.com/ansible/ansible/issues/37032

##### ISSUE TYPE

 - Docs Pull Request

##### COMPONENT NAME

nios_host_record.py

##### ANSIBLE VERSION

```
ansible 2.6.0 (fix-host-record-examples 89fb519395) last updated 2018/03/21 18:00:51 (GMT -700)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/brampling/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/brampling/Dropbox/src/ansibledev/ansible/lib/ansible
  executable location = /home/brampling/Dropbox/src/ansibledev/ansible/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION

N/A