### PR TITLE
Don't assume that self._task.action is copy, explicitly set module_name

### DIFF
--- a/lib/ansible/plugins/action/copy.py
+++ b/lib/ansible/plugins/action/copy.py
@@ -435,7 +435,7 @@ class ActionModule(ActionBase):
         # if we have first_available_file in our vars
         # look up the files and use the first one we find as src
         elif remote_src:
-            result.update(self._execute_module(task_vars=task_vars))
+            result.update(self._execute_module(module_name='copy', task_vars=task_vars))
             return result
         else:
             # find_needle returns a path that may not have a trailing slash on


### PR DESCRIPTION
##### SUMMARY
Don't assume that self._task.action is copy, explicitly set module_name. Addresses #37238

If someone passes something like `remote_src=True` to template (which is invalid for that module), when `template` invokes `copy` and `copy` tries to execute the actual `copy` module, it will actually execute `template` instead.

This will prevent the error of `module (template) is missing interpreter line`

Eventually, we'll get argument_spec like functionality in action plugins.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/action/copy.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
2.6
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```