### PR TITLE
cs_vpc_offering: listVPCOffering API returns any matching names

### DIFF
--- a/lib/ansible/modules/cloud/cloudstack/cs_vpc_offering.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_vpc_offering.py
@@ -149,9 +149,9 @@ class AnsibleCloudStackVPCOffering(AnsibleCloudStack):
         vo = self.query_api('listVPCOfferings', **args)
 
         if vo:
-            for index, rule in enumerate(vo['vpcoffering']):
-                if args['name'] == rule['name']:
-                    self.vpc_offering = rule
+            for index, vpc_offer in enumerate(vo['vpcoffering']):
+                if args['name'] == vpc_offer['name']:
+                    self.vpc_offering = vpc_offer
 
         return self.vpc_offering
 

--- a/lib/ansible/modules/cloud/cloudstack/cs_vpc_offering.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_vpc_offering.py
@@ -149,7 +149,9 @@ class AnsibleCloudStackVPCOffering(AnsibleCloudStack):
         vo = self.query_api('listVPCOfferings', **args)
 
         if vo:
-            self.vpc_offering = vo['vpcoffering'][0]
+            for _, rule in enumerate(vo['vpcoffering']):
+                if args['name'] == rule['name']:
+                    self.vpc_offering = rule
 
         return self.vpc_offering
 

--- a/lib/ansible/modules/cloud/cloudstack/cs_vpc_offering.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_vpc_offering.py
@@ -149,7 +149,7 @@ class AnsibleCloudStackVPCOffering(AnsibleCloudStack):
         vo = self.query_api('listVPCOfferings', **args)
 
         if vo:
-            for _, rule in enumerate(vo['vpcoffering']):
+            for index, rule in enumerate(vo['vpcoffering']):
                 if args['name'] == rule['name']:
                     self.vpc_offering = rule
 

--- a/lib/ansible/modules/cloud/cloudstack/cs_vpc_offering.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_vpc_offering.py
@@ -149,7 +149,7 @@ class AnsibleCloudStackVPCOffering(AnsibleCloudStack):
         vo = self.query_api('listVPCOfferings', **args)
 
         if vo:
-            for index, vpc_offer in enumerate(vo['vpcoffering']):
+            for vpc_offer in vo['vpcoffering']:
                 if args['name'] == vpc_offer['name']:
                     self.vpc_offering = vpc_offer
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Make an explicit comparison between args['name'] and the result of listVPCOfferings API.

In some cases, get_vpc_offering() returns a bad VPC Offering since the Cloudstack listVPCOffering API returns a list of all VPC offerings that are matching "%name%" argument.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
lib/ansible/modules/cloud/cloudstack/cs_vpc_offering.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
 $ ansible --version
ansible 2.6.0 (listVPCOffering_multiple_match 9f5ac8367e) last updated 2018/03/22 15:13:46 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/dpassante/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /mnt/filer/Github/ansible/lib/ansible
  executable location = /mnt/filer/Github/ansible/bin/ansible
  python version = 2.7.6 (default, Nov 23 2017, 15:49:48) [GCC 4.8.4]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
As get_vpc_offering() returns the first offering that match the name '%test%', running this playbook twice is failing:
```shell
---
- name: listVPCOffering_multiple_match
  hosts: localhost
  tasks:
  - name: test
    cs_vpc_offering:
      name: "test"
      display_text: "test"
      supported_services: [ Dns, Dhcp ]

  - name: test1
    cs_vpc_offering:
      name: "test1"
      display_text: "test1"
      supported_services: [ Dns, Dhcp ]
```
