### PR TITLE
Fix docker_secret test on RHEL.

### DIFF
--- a/test/integration/targets/docker_secret/tasks/RedHat.yml
+++ b/test/integration/targets/docker_secret/tasks/RedHat.yml
@@ -11,6 +11,10 @@
     - lvm2
     - libseccomp
 
+- name: Install epel repo which is missing on rhel-7 and is needed for pigz (needed for docker-ce 18)
+  yum:
+    name: https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+
 - name: Enable extras repository for RHEL on AWS
   command: yum-config-manager --enable rhui-REGION-rhel-server-extras
 


### PR DESCRIPTION
##### SUMMARY

Fix docker_secret test on RHEL.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

docker_secret integration test

##### ANSIBLE VERSION

```
ansible 2.6.0 (docker-secret-rhel-fix cb00669ae6) last updated 2018/03/22 10:56:38 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```
