### PR TITLE
Bkprt py3 haproxy

### DIFF
--- a/changelogs/fragments/py3-haproxy.yaml
+++ b/changelogs/fragments/py3-haproxy.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+- Fix to send and receive bytes over a socket in the haproxy module which was
+  causing tracebacks on Python3 https://github.com/ansible/ansible/pull/35176

--- a/lib/ansible/modules/net_tools/haproxy.py
+++ b/lib/ansible/modules/net_tools/haproxy.py
@@ -202,6 +202,7 @@ import time
 from string import Template
 
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_bytes, to_text
 
 
 DEFAULT_SOCKET_LOCATION = "/var/run/haproxy.sock"
@@ -251,13 +252,16 @@ class HAProxy(object):
         """
         self.client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         self.client.connect(self.socket)
-        self.client.sendall('%s\n' % cmd)
-        result = ''
-        buf = ''
+        self.client.sendall(to_bytes('%s\n' % cmd))
+
+        result = b''
+        buf = b''
         buf = self.client.recv(RECV_SIZE)
         while buf:
             result += buf
             buf = self.client.recv(RECV_SIZE)
+        result = to_text(result, errors='surrogate_or_strict')
+
         if capture_output:
             self.capture_command_output(cmd, result.strip())
         self.client.close()


### PR DESCRIPTION
##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/35176 to stable-2.5

(Fix for haproxy module on python3)

##### ISSUE TYPE

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
lib/ansible/modules/net_tools/haproxy.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5.x
```