### PR TITLE
ec2_vpc_nacl integration tests

### DIFF
--- a/test/integration/targets/ec2_vpc_nacl/aliases
+++ b/test/integration/targets/ec2_vpc_nacl/aliases
@@ -1,0 +1,2 @@
+cloud/aws
+posix/ci/cloud/group4/aws

--- a/test/integration/targets/ec2_vpc_nacl/aliases
+++ b/test/integration/targets/ec2_vpc_nacl/aliases
@@ -1,2 +1,2 @@
 cloud/aws
-posix/ci/cloud/group4/aws
+shippable/aws/group2

--- a/test/integration/targets/ec2_vpc_nacl/aliases
+++ b/test/integration/targets/ec2_vpc_nacl/aliases
@@ -1,2 +1,1 @@
 cloud/aws
-posix/ci/cloud/group4/aws

--- a/test/integration/targets/ec2_vpc_nacl/aliases
+++ b/test/integration/targets/ec2_vpc_nacl/aliases
@@ -1,1 +1,2 @@
 cloud/aws
+posix/ci/cloud/group4/aws

--- a/test/integration/targets/ec2_vpc_nacl/meta/main.yml
+++ b/test/integration/targets/ec2_vpc_nacl/meta/main.yml
@@ -1,0 +1,3 @@
+dependencies:
+  - prepare_tests
+  - setup_ec2

--- a/test/integration/targets/ec2_vpc_nacl/tasks/ingress_and_egress.yml
+++ b/test/integration/targets/ec2_vpc_nacl/tasks/ingress_and_egress.yml
@@ -9,11 +9,11 @@
 
 # ============================================================
 
-- name: create ingress and egress rules using subnet names
+- name: create ingress and egress rules using subnet IDs
   ec2_vpc_nacl:
     vpc_id: "{{ vpc_id }}"
     name: "{{ resource_prefix }}-acl"
-    subnets: "{{ subnet_names }}"
+    subnets: "{{ subnet_ids }}"
     tags:
       Created_by: "Ansible test {{ resource_prefix }}"
     ingress:
@@ -43,34 +43,31 @@
   assert:
     that:
       - nacl_facts.nacls | length == 1
-      - nacl_facts.nacls[0].subnets | length == 4
       - nacl_facts.nacls[0].ingress | length == 3
       - nacl_facts.nacls[0].egress | length == 1
-      - "'{{ nacl_facts.nacls[0].tags.Name }}' == '{{ resource_prefix }}-acl'"
 
 # ============================================================
 
-- name: test idempotence
+- name: remove an ingress rule
   ec2_vpc_nacl:
     vpc_id: "{{ vpc_id }}"
     name: "{{ resource_prefix }}-acl"
-    subnets: "{{ subnet_names }}"
+    subnets: "{{ subnet_ids }}"
     tags:
       Created_by: "Ansible test {{ resource_prefix }}"
     ingress:
       - [100, 'tcp', 'allow', '0.0.0.0/0', null, null, 22, 22]
       - [200, 'tcp', 'allow', '0.0.0.0/0', null, null, 80, 80]
-      - [300, 'icmp', 'allow', '0.0.0.0/0', 0, 8]
     egress:
       - [100, 'all', 'allow', '0.0.0.0/0', null, null, null, null]
     state: 'present'
     <<: *aws_connection_info
   register: nacl
 
-- name: assert the network acl already existed
+- name: assert the network acl changed
   assert:
     that:
-      - not nacl.changed
+      - nacl.changed
       - nacl.nacl_id.startswith('acl-')
 
 - name: get network ACL facts
@@ -78,57 +75,90 @@
     nacl_ids:
       - "{{ nacl.nacl_id }}"
     <<: *aws_connection_info
-  register: nacl_facts_idem
+  register: nacl_facts
 
-- name: assert the facts are the same as before
+- name: assert the nacl has the correct attributes
   assert:
     that:
-      - nacl_facts_idem == nacl_facts
+      - nacl_facts.nacls | length == 1
+      - nacl_facts.nacls[0].ingress | length == 2
+      - nacl_facts.nacls[0].egress | length == 1
 
 # ============================================================
 
-- name: remove a subnet from the network ACL
+- name: remove the egress rule
   ec2_vpc_nacl:
     vpc_id: "{{ vpc_id }}"
     name: "{{ resource_prefix }}-acl"
-    subnets:
-      - "{{ subnet_names[0] }}"
-      - "{{ subnet_names[1] }}"
-      - "{{ subnet_names[2] }}"
+    subnets: "{{ subnet_ids }}"
     tags:
       Created_by: "Ansible test {{ resource_prefix }}"
     ingress:
       - [100, 'tcp', 'allow', '0.0.0.0/0', null, null, 22, 22]
       - [200, 'tcp', 'allow', '0.0.0.0/0', null, null, 80, 80]
-      - [300, 'icmp', 'allow', '0.0.0.0/0', 0, 8]
-    egress:
-      - [100, 'all', 'allow', '0.0.0.0/0', null, null, null, null]
+    egress: []
     state: 'present'
     <<: *aws_connection_info
   register: nacl
 
-- name: assert the network ACL changed
+- name: assert the network acl changed
   assert:
     that:
       - nacl.changed
       - nacl.nacl_id.startswith('acl-')
 
-# FIXME: Currently removing a subnet using the subnet names does not work
-#- name: get network ACL facts
-#  ec2_vpc_nacl_facts:
-#    nacl_ids:
-#      - "{{ nacl.nacl_id }}"
-#    <<: *aws_connection_info
-#  register: nacl_facts
+- name: get network ACL facts
+  ec2_vpc_nacl_facts:
+    nacl_ids:
+      - "{{ nacl.nacl_id }}"
+    <<: *aws_connection_info
+  register: nacl_facts
 
-#- name: assert the nacl has the correct attributes
-#  assert:
-#    that:
-#      - nacl_facts.nacls | length == 1
-#      - nacl_facts.nacls[0].subnets | length == 3
-#      - nacl_facts.nacls[0].ingress | length == 3
-#      - nacl_facts.nacls[0].egress | length == 1
-#      - "'{{ nacl_facts.nacls[0].tags.Name }}' == '{{ resource_prefix }}-acl'"
+- name: assert the nacl has the correct attributes
+  assert:
+    that:
+      - nacl_facts.nacls | length == 1
+      - nacl_facts.nacls[0].ingress | length == 2
+      - nacl_facts.nacls[0].egress | length == 0
+
+# ============================================================
+
+- name: add egress rules
+  ec2_vpc_nacl:
+    vpc_id: "{{ vpc_id }}"
+    name: "{{ resource_prefix }}-acl"
+    subnets: "{{ subnet_ids }}"
+    tags:
+      Created_by: "Ansible test {{ resource_prefix }}"
+    ingress:
+      - [100, 'tcp', 'allow', '0.0.0.0/0', null, null, 22, 22]
+      - [200, 'tcp', 'allow', '0.0.0.0/0', null, null, 80, 80]
+    egress:
+      - [100, 'tcp', 'allow', '10.0.0.0/24', null, null, 22, 22]
+      - [200, 'udp', 'allow', '10.0.0.0/24', null, null, 22, 22]
+    state: 'present'
+    <<: *aws_connection_info
+  register: nacl
+
+- name: assert the network acl changed
+  assert:
+    that:
+      - nacl.changed
+      - nacl.nacl_id.startswith('acl-')
+
+- name: get network ACL facts
+  ec2_vpc_nacl_facts:
+    nacl_ids:
+      - "{{ nacl.nacl_id }}"
+    <<: *aws_connection_info
+  register: nacl_facts
+
+- name: assert the nacl has the correct attributes
+  assert:
+    that:
+      - nacl_facts.nacls | length == 1
+      - nacl_facts.nacls[0].ingress | length == 2
+      - nacl_facts.nacls[0].egress | length == 2
 
 # ============================================================
 

--- a/test/integration/targets/ec2_vpc_nacl/tasks/ipv6.yml
+++ b/test/integration/targets/ec2_vpc_nacl/tasks/ipv6.yml
@@ -1,0 +1,217 @@
+- block:
+
+    - name: set up aws connection info
+      set_fact:
+        aws_connection_info: &aws_connection_info
+          aws_access_key: "{{ aws_access_key }}"
+          aws_secret_key: "{{ aws_secret_key }}"
+          security_token: "{{ security_token }}"
+          region: "{{ aws_region }}"
+      no_log: yes
+
+    - name: create a VPC
+      ec2_vpc_net:
+        cidr_block: 10.230.231.0/24
+        name: "{{ resource_prefix }}-ipv6"
+        state: present
+        <<: *aws_connection_info
+      register: vpc_result
+
+    # FIXME - Replace by creating IPv6 enabled VPC once ec2_vpc_net module supports it.
+    - name: install aws cli - FIXME temporary this should go for a lighterweight solution
+      command: pip install awscli
+
+    - name: Assign an Amazon provided IPv6 CIDR block to the VPC
+      command: aws ec2 associate-vpc-cidr-block --amazon-provided-ipv6-cidr-block --vpc-id '{{ vpc_result.vpc.id }}'
+      environment:
+          AWS_ACCESS_KEY_ID: '{{aws_access_key}}'
+          AWS_SECRET_ACCESS_KEY: '{{aws_secret_key}}'
+          AWS_SESSION_TOKEN: '{{security_token}}'
+          AWS_DEFAULT_REGION: '{{aws_region}}'
+
+    - name: wait for the IPv6 CIDR to be assigned
+      command: sleep 5
+
+    - name: Get the assigned IPv6 CIDR
+      command: aws ec2 describe-vpcs --vpc-ids '{{ vpc_result.vpc.id }}'
+      environment:
+          AWS_ACCESS_KEY_ID: '{{aws_access_key}}'
+          AWS_SECRET_ACCESS_KEY: '{{aws_secret_key}}'
+          AWS_SESSION_TOKEN: '{{security_token}}'
+          AWS_DEFAULT_REGION: '{{aws_region}}'
+      register: vpc_ipv6
+
+    - set_fact:
+        vpc_ipv6_cidr: "{{ vpc_ipv6.stdout | from_json | json_query('Vpcs[0].Ipv6CidrBlockAssociationSet[0].Ipv6CidrBlock') }}"
+
+    # ============================================================
+    - name: create subnet with IPv6 (expected changed=true)
+      ec2_vpc_subnet:
+        cidr: 10.230.231.0/26
+        vpc_id: "{{ vpc_result.vpc.id }}"
+        ipv6_cidr: "{{ vpc_ipv6_cidr | regex_replace('::/56', '::/64') }}"
+        state: present
+        tags:
+          Name: "{{ resource_prefix }}-ipv6-subnet-1"
+        <<: *aws_connection_info
+      register: vpc_subnet_ipv6
+
+    - name: assert creation with IPv6 happened (expected changed=true)
+      assert:
+        that:
+           - "vpc_subnet_ipv6.subnet.ipv6_cidr_block == '{{ vpc_ipv6_cidr | regex_replace('::/56', '::/64') }}'"
+
+    # ============================================================
+
+    - name: create ingress and egress rules using subnet names
+      ec2_vpc_nacl:
+        vpc_id: "{{ vpc_result.vpc.id }}"
+        name: "{{ resource_prefix }}-acl"
+        subnets:
+          - "{{ resource_prefix }}-ipv6-subnet-1"
+        tags:
+          Created_by: "Ansible test {{ resource_prefix }}"
+        ingress:
+          - [100, 'tcp', 'allow', '0.0.0.0/0', null, null, 22, 22]
+          - [200, 'tcp', 'allow', '0.0.0.0/0', null, null, 80, 80]
+          - [300, 'icmp', 'allow', '0.0.0.0/0', 0, 8]
+        egress:
+          - [100, 'all', 'allow', '0.0.0.0/0', null, null, null, null]
+        state: 'present'
+        <<: *aws_connection_info
+      register: nacl
+
+    - assert:
+        that:
+          - nacl.nacl_id
+
+    - name: remove and add an entry
+      ec2_vpc_nacl:
+        vpc_id: "{{ vpc_result.vpc.id }}"
+        name: "{{ resource_prefix }}-acl"
+        subnets:
+          - "{{ resource_prefix }}-ipv6-subnet-1"
+        tags:
+          Created_by: "Ansible test {{ resource_prefix }}"
+        ingress:
+          - [100, 'tcp', 'allow', '0.0.0.0/0', null, null, 22, 22]
+          - [300, 'icmp', 'allow', '0.0.0.0/0', 0, 8]
+        egress:
+          - [100, 'all', 'allow', '0.0.0.0/0', null, null, null, null]
+        state: 'present'
+        <<: *aws_connection_info
+      register: nacl
+      ignore_errors: yes
+
+    # FIXME: Currently VPCs with an IPv6 CIDR are not supported - uncomment correct assertion when fixed
+    - assert:
+        that:
+          - "'Value (32768) for parameter ruleNumber is invalid' in nacl.msg"
+    #- assert:
+    #    that:
+    #      - nacl.changed
+
+    - name: add ipv6 entries
+      ec2_vpc_nacl:
+        vpc_id: "{{ vpc_result.vpc.id }}"
+        name: "{{ resource_prefix }}-acl"
+        subnets:
+          - "{{ resource_prefix }}-ipv6-subnet-1"
+        tags:
+          Created_by: "Ansible test {{ resource_prefix }}"
+        ingress:
+          - [100, 'tcp', 'allow', '0.0.0.0/0', null, null, 22, 22]
+          - [200, 'tcp', 'allow', '0.0.0.0/0', null, null, 80, 80]
+          - [205, 'tcp', 'allow', '::/0', null, null, 80, 80]
+          - [300, 'icmp', 'allow', '0.0.0.0/0', 0, 8]
+          - [305, 'ipv6-icmp', 'allow', '::/0', 0, 8]
+        egress:
+          - [100, 'all', 'allow', '0.0.0.0/0', null, null, null, null]
+          - [105, 'all', 'allow', '::/0', null, null, null, null]
+        state: 'present'
+        <<: *aws_connection_info
+      register: nacl
+      ignore_errors: yes
+
+    # FIXME: Currently IPv6 rules are not supported - uncomment assertion when fixed
+    #- assert:
+    #    that:
+    #      - nacl.changed
+
+    - name: purge ingress entries
+      ec2_vpc_nacl:
+        vpc_id: "{{ vpc_result.vpc.id }}"
+        name: "{{ resource_prefix }}-acl"
+        subnets:
+          - "{{ resource_prefix }}-ipv6-subnet-1"
+        tags:
+          Created_by: "Ansible test {{ resource_prefix }}"
+        ingress: []
+        egress:
+          - [100, 'all', 'allow', '0.0.0.0/0', null, null, null, null]
+          - [105, 'all', 'allow', '::/0', null, null, null, null]
+        state: 'present'
+        <<: *aws_connection_info
+      register: nacl
+      ignore_errors: yes
+
+    # FIXME: Currently IPv6 rules are not supported - uncomment assertion when fixed
+    #- assert:
+    #    that:
+    #      - nacl.changed
+
+    # ============================================================
+    - name: remove subnet ipv6 cidr (expected changed=true)
+      ec2_vpc_subnet:
+        cidr: 10.230.231.0/26
+        vpc_id: "{{ vpc_result.vpc.id }}"
+        <<: *aws_connection_info
+        state: absent
+      register: vpc_remove_ipv6_cidr
+
+    - name: assert subnet ipv6 cidr removed (expected changed=true)
+      assert:
+        that:
+           - 'vpc_remove_ipv6_cidr.changed'
+
+  always:
+
+    ################################################
+    # TEARDOWN STARTS HERE
+    ################################################
+
+    - name: remove network ACL
+      ec2_vpc_nacl:
+        vpc_id: "{{ vpc_result.vpc.id }}"
+        name: "{{ resource_prefix }}-acl"
+        state: absent
+        <<: *aws_connection_info
+      register: removed_acl
+      until: removed_acl is success
+      retries: 5
+      delay: 5
+      ignore_errors: yes
+
+    - name: tidy up subnet
+      ec2_vpc_subnet:
+        cidr: 10.230.231.0/26
+        vpc_id: "{{ vpc_result.vpc.id }}"
+        state: absent
+        <<: *aws_connection_info
+      register: removed_subnet
+      until: removed_subnet is success
+      retries: 5
+      delay: 5
+      ignore_errors: yes
+
+    - name: tidy up VPC
+      ec2_vpc_net:
+        name: "{{ resource_prefix }}-ipv6"
+        state: absent
+        cidr_block: 10.230.231.0/24
+        <<: *aws_connection_info
+      register: removed_vpc
+      until: removed_vpc is success
+      retries: 5
+      delay: 5
+      ignore_errors: yes

--- a/test/integration/targets/ec2_vpc_nacl/tasks/main.yml
+++ b/test/integration/targets/ec2_vpc_nacl/tasks/main.yml
@@ -1,0 +1,132 @@
+---
+- block:
+
+    # ============================================================
+
+    - name: test without any parameters
+      ec2_vpc_nacl:
+      register: result
+      ignore_errors: yes
+
+    - name: assert required parameters
+      assert:
+        that:
+          - result.failed
+          - "result.msg == 'one of the following is required: name, nacl_id'"
+
+    # ============================================================
+
+    - name: set connection information for subsequent tasks
+      set_fact:
+        aws_connection_info: &aws_connection_info
+          aws_access_key: "{{ aws_access_key }}"
+          aws_secret_key: "{{ aws_secret_key }}"
+          security_token: "{{ security_token }}"
+          region: "{{ aws_region }}"
+      no_log: yes
+
+    # ============================================================
+
+    - name: create a VPC
+      ec2_vpc_net:
+        cidr_block: 10.230.230.0/24
+        name: "{{ resource_prefix }}"
+        state: present
+        <<: *aws_connection_info
+      register: vpc
+
+    - name: create subnets
+      ec2_vpc_subnet:
+        cidr: "{{ item.cidr }}"
+        az: "{{ aws_region}}{{ item.az }}"
+        vpc_id: "{{ vpc.vpc.id }}"
+        state: present
+        tags:
+          Name: "{{ item.name }}"
+        <<: *aws_connection_info
+      with_items:
+        - cidr: 10.230.230.0/26
+          az: "a"
+          name: "{{ resource_prefix }}-subnet-1"
+        - cidr: 10.230.230.64/26
+          az: "b"
+          name: "{{ resource_prefix }}-subnet-2"
+        - cidr: 10.230.230.128/26
+          az: "a"
+          name: "{{ resource_prefix }}-subnet-3"
+        - cidr: 10.230.230.192/26
+          az: "b"
+          name: "{{ resource_prefix }}-subnet-4"
+      register: subnets
+
+    # ============================================================
+
+    - include_tasks: tasks/subnet_ids.yml
+      vars:
+        vpc_id: "{{ vpc.vpc.id }}"
+        subnet_ids: "{{ subnets | json_query('results[*].subnet.id') }}"
+
+    - include_tasks: tasks/subnet_names.yml
+      vars:
+        vpc_id: "{{ vpc.vpc.id }}"
+        subnet_names: "{{ subnets | json_query('results[*].subnet.tags.Name') }}"
+
+    - include_tasks: tasks/tags.yml
+      vars:
+        vpc_id: "{{ vpc.vpc.id }}"
+        subnet_ids: "{{ subnets | json_query('results[*].subnet.id') }}"
+
+    - include_tasks: tasks/ingress_and_egress.yml
+      vars:
+        vpc_id: "{{ vpc.vpc.id }}"
+        subnet_ids: "{{ subnets | json_query('results[*].subnet.id') }}"
+
+    # ============================================================
+
+  always:
+
+    - name: remove network ACL
+      ec2_vpc_nacl:
+        vpc_id: "{{ vpc.vpc.id }}"
+        name: "{{ resource_prefix }}-acl"
+        state: absent
+        <<: *aws_connection_info
+      register: removed_acl
+      until: removed_acl is success
+      retries: 5
+      delay: 2
+      ignore_errors: yes
+
+    - name: remove subnets
+      ec2_vpc_subnet:
+        cidr: "{{ item.cidr }}"
+        az: "{{ aws_region}}{{ item.az }}"
+        vpc_id: "{{ vpc.vpc.id }}"
+        state: absent
+        tags:
+          Public: "{{ item.public | string }}"
+          Name: "{{ item.public | ternary('public', 'private') }}-{{ item.az }}"
+        <<: *aws_connection_info
+      with_items:
+        - cidr: 10.230.230.0/26
+          az: "a"
+          public: "True"
+        - cidr: 10.230.230.64/26
+          az: "b"
+          public: "True"
+        - cidr: 10.230.230.128/26
+          az: "a"
+          public: "False"
+        - cidr: 10.230.230.192/26
+          az: "b"
+          public: "False"
+      ignore_errors: yes
+
+    - name: remove the VPC
+      ec2_vpc_net:
+        cidr_block: 10.230.230.0/24
+        name: "{{ resource_prefix }}"
+        state: absent
+        <<: *aws_connection_info
+
+    # ============================================================

--- a/test/integration/targets/ec2_vpc_nacl/tasks/main.yml
+++ b/test/integration/targets/ec2_vpc_nacl/tasks/main.yml
@@ -81,6 +81,8 @@
         vpc_id: "{{ vpc.vpc.id }}"
         subnet_ids: "{{ subnets | json_query('results[*].subnet.id') }}"
 
+    - include_tasks: tasks/ipv6.yml
+
     # ============================================================
 
   always:
@@ -94,7 +96,7 @@
       register: removed_acl
       until: removed_acl is success
       retries: 5
-      delay: 2
+      delay: 5
       ignore_errors: yes
 
     - name: remove subnets
@@ -121,6 +123,10 @@
           az: "b"
           public: "False"
       ignore_errors: yes
+      register: removed_subnets
+      until: removed_subnets is success
+      retries: 5
+      delay: 5
 
     - name: remove the VPC
       ec2_vpc_net:
@@ -128,5 +134,10 @@
         name: "{{ resource_prefix }}"
         state: absent
         <<: *aws_connection_info
+      ignore_errors: yes
+      register: removed_vpc
+      until: removed_vpc is success
+      retries: 5
+      delay: 5
 
     # ============================================================

--- a/test/integration/targets/ec2_vpc_nacl/tasks/subnet_ids.yml
+++ b/test/integration/targets/ec2_vpc_nacl/tasks/subnet_ids.yml
@@ -1,0 +1,156 @@
+- name: set connection information for subsequent tasks
+  set_fact:
+    aws_connection_info: &aws_connection_info
+      aws_access_key: "{{ aws_access_key }}"
+      aws_secret_key: "{{ aws_secret_key }}"
+      security_token: "{{ security_token }}"
+      region: "{{ aws_region }}"
+  no_log: yes
+
+# ============================================================
+
+- name: create ingress and egress rules using subnet IDs
+  ec2_vpc_nacl:
+    vpc_id: "{{ vpc_id }}"
+    name: "{{ resource_prefix }}-acl"
+    subnets: "{{ subnet_ids }}"
+    tags:
+      Created_by: "Ansible test {{ resource_prefix }}"
+    ingress: [
+        [100, 'tcp', 'allow', '0.0.0.0/0', null, null, 22, 22],
+        [200, 'tcp', 'allow', '0.0.0.0/0', null, null, 80, 80],
+        [300, 'icmp', 'allow', '0.0.0.0/0', 0, 8],
+    ]
+    egress: [
+        [100, 'all', 'allow', '0.0.0.0/0', null, null, null, null]
+    ]
+    state: 'present'
+    <<: *aws_connection_info
+  register: nacl
+
+- name: assert the network acl was created
+  assert:
+    that:
+      - nacl.changed
+      - nacl.nacl_id.startswith('acl-')
+
+- name: get network ACL facts
+  ec2_vpc_nacl_facts:
+    nacl_ids:
+      - "{{ nacl.nacl_id }}"
+    <<: *aws_connection_info
+  register: nacl_facts
+
+- name: assert the nacl has the correct attributes
+  assert:
+    that:
+      - nacl_facts.nacls | length == 1
+      - nacl_facts.nacls[0].subnets | length == 4
+      - nacl_facts.nacls[0].subnets | sort == subnet_ids | sort
+      - nacl_facts.nacls[0].ingress | length == 3
+      - nacl_facts.nacls[0].egress | length == 1
+      - "'{{ nacl_facts.nacls[0].tags.Name }}' == '{{ resource_prefix }}-acl'"
+
+# ============================================================
+
+- name: test idempotence
+  ec2_vpc_nacl:
+    vpc_id: "{{ vpc_id }}"
+    name: "{{ resource_prefix }}-acl"
+    subnets: "{{ subnet_ids }}"
+    tags:
+      Created_by: "Ansible test {{ resource_prefix }}"
+    ingress: [
+        [100, 'tcp', 'allow', '0.0.0.0/0', null, null, 22, 22],
+        [200, 'tcp', 'allow', '0.0.0.0/0', null, null, 80, 80],
+        [300, 'icmp', 'allow', '0.0.0.0/0', 0, 8],
+    ]
+    egress: [
+        [100, 'all', 'allow', '0.0.0.0/0', null, null, null, null]
+    ]
+    state: 'present'
+    <<: *aws_connection_info
+  register: nacl
+
+- name: assert the network acl already existed
+  assert:
+    that:
+      - not nacl.changed
+      - nacl.nacl_id.startswith('acl-')
+
+- name: get network ACL facts
+  ec2_vpc_nacl_facts:
+    nacl_ids:
+      - "{{ nacl.nacl_id }}"
+    <<: *aws_connection_info
+  register: nacl_facts_idem
+
+- name: assert the facts are the same as before
+  assert:
+    that:
+      - nacl_facts_idem == nacl_facts
+
+# ============================================================
+
+- name: remove a subnet from the network ACL
+  ec2_vpc_nacl:
+    vpc_id: "{{ vpc_id }}"
+    name: "{{ resource_prefix }}-acl"
+    subnets:
+      - "{{ subnet_ids[0] }}"
+      - "{{ subnet_ids[1] }}"
+      - "{{ subnet_ids[2] }}"
+    tags:
+      Created_by: "Ansible test {{ resource_prefix }}"
+    ingress: [
+        [100, 'tcp', 'allow', '0.0.0.0/0', null, null, 22, 22],
+        [200, 'tcp', 'allow', '0.0.0.0/0', null, null, 80, 80],
+        [300, 'icmp', 'allow', '0.0.0.0/0', 0, 8],
+    ]
+    egress: [
+        [100, 'all', 'allow', '0.0.0.0/0', null, null, null, null]
+    ]
+    state: 'present'
+    <<: *aws_connection_info
+  register: nacl
+
+- name: assert the network ACL changed
+  assert:
+    that:
+      - nacl.changed
+      - nacl.nacl_id.startswith('acl-')
+
+- set_fact:
+  nacl_id: "{{ nacl.nacl_id }}"
+
+- name: get network ACL facts
+  ec2_vpc_nacl_facts:
+    nacl_id:
+      - "{{ nacl.nacl_id }}"
+    <<: *aws_connection_info
+  register: nacl_facts
+
+- name: assert the nacl has the correct attributes
+  assert:
+    that:
+      - nacl_facts.nacls | length == 1
+      - nacl_facts.nacls[0].subnets | length == 3
+      - subnet_ids[3] not in nacl_facts.nacls[0].subnets
+      - nacl_facts.nacls[0].ingress | length == 3
+      - nacl_facts.nacls[0].egress | length == 1
+      - "'{{ nacl_facts.nacls[0].tags.Name }}' == '{{ resource_prefix }}-acl'"
+
+# ============================================================
+
+- name: remove the network ACL
+  ec2_vpc_nacl:
+    vpc_id: "{{ vpc_id }}"
+    name: "{{ resource_prefix }}-acl"
+    state: absent
+    <<: *aws_connection_info
+  register: nacl
+
+- name: assert nacl was removed
+  assert:
+    that:
+      - nacl.changed

--- a/test/integration/targets/ec2_vpc_nacl/tasks/subnet_ids.yml
+++ b/test/integration/targets/ec2_vpc_nacl/tasks/subnet_ids.yml
@@ -16,14 +16,12 @@
     subnets: "{{ subnet_ids }}"
     tags:
       Created_by: "Ansible test {{ resource_prefix }}"
-    ingress: [
-        [100, 'tcp', 'allow', '0.0.0.0/0', null, null, 22, 22],
-        [200, 'tcp', 'allow', '0.0.0.0/0', null, null, 80, 80],
-        [300, 'icmp', 'allow', '0.0.0.0/0', 0, 8],
-    ]
-    egress: [
-        [100, 'all', 'allow', '0.0.0.0/0', null, null, null, null]
-    ]
+    ingress:
+      - [100, 'tcp', 'allow', '0.0.0.0/0', null, null, 22, 22]
+      - [200, 'tcp', 'allow', '0.0.0.0/0', null, null, 80, 80]
+      - [300, 'icmp', 'allow', '0.0.0.0/0', 0, 8]
+    egress:
+      - [100, 'all', 'allow', '0.0.0.0/0', null, null, null, null]
     state: 'present'
     <<: *aws_connection_info
   register: nacl
@@ -60,14 +58,12 @@
     subnets: "{{ subnet_ids }}"
     tags:
       Created_by: "Ansible test {{ resource_prefix }}"
-    ingress: [
-        [100, 'tcp', 'allow', '0.0.0.0/0', null, null, 22, 22],
-        [200, 'tcp', 'allow', '0.0.0.0/0', null, null, 80, 80],
-        [300, 'icmp', 'allow', '0.0.0.0/0', 0, 8],
-    ]
-    egress: [
-        [100, 'all', 'allow', '0.0.0.0/0', null, null, null, null]
-    ]
+    ingress:
+      - [100, 'tcp', 'allow', '0.0.0.0/0', null, null, 22, 22]
+      - [200, 'tcp', 'allow', '0.0.0.0/0', null, null, 80, 80]
+      - [300, 'icmp', 'allow', '0.0.0.0/0', 0, 8]
+    egress:
+      - [100, 'all', 'allow', '0.0.0.0/0', null, null, null, null]
     state: 'present'
     <<: *aws_connection_info
   register: nacl
@@ -102,14 +98,12 @@
       - "{{ subnet_ids[2] }}"
     tags:
       Created_by: "Ansible test {{ resource_prefix }}"
-    ingress: [
-        [100, 'tcp', 'allow', '0.0.0.0/0', null, null, 22, 22],
-        [200, 'tcp', 'allow', '0.0.0.0/0', null, null, 80, 80],
-        [300, 'icmp', 'allow', '0.0.0.0/0', 0, 8],
-    ]
-    egress: [
-        [100, 'all', 'allow', '0.0.0.0/0', null, null, null, null]
-    ]
+    ingress:
+      - [100, 'tcp', 'allow', '0.0.0.0/0', null, null, 22, 22]
+      - [200, 'tcp', 'allow', '0.0.0.0/0', null, null, 80, 80]
+      - [300, 'icmp', 'allow', '0.0.0.0/0', 0, 8]
+    egress:
+      - [100, 'all', 'allow', '0.0.0.0/0', null, null, null, null]
     state: 'present'
     <<: *aws_connection_info
   register: nacl
@@ -121,7 +115,7 @@
       - nacl.nacl_id.startswith('acl-')
 
 - set_fact:
-  nacl_id: "{{ nacl.nacl_id }}"
+    nacl_id: "{{ nacl.nacl_id }}"
 
 - name: get network ACL facts
   ec2_vpc_nacl_facts:
@@ -149,6 +143,10 @@
     state: absent
     <<: *aws_connection_info
   register: nacl
+  until: nacl is success
+  ignore_errors: yes
+  retries: 5
+  delay: 5
 
 - name: assert nacl was removed
   assert:

--- a/test/integration/targets/ec2_vpc_nacl/tasks/subnet_names.yml
+++ b/test/integration/targets/ec2_vpc_nacl/tasks/subnet_names.yml
@@ -1,0 +1,152 @@
+- name: set connection information for subsequent tasks
+  set_fact:
+    aws_connection_info: &aws_connection_info
+      aws_access_key: "{{ aws_access_key }}"
+      aws_secret_key: "{{ aws_secret_key }}"
+      security_token: "{{ security_token }}"
+      region: "{{ aws_region }}"
+  no_log: yes
+
+# ============================================================
+
+- name: create ingress and egress rules using subnet names
+  ec2_vpc_nacl:
+    vpc_id: "{{ vpc_id }}"
+    name: "{{ resource_prefix }}-acl"
+    subnets: "{{ subnet_names }}"
+    tags:
+      Created_by: "Ansible test {{ resource_prefix }}"
+    ingress: [
+        [100, 'tcp', 'allow', '0.0.0.0/0', null, null, 22, 22],
+        [200, 'tcp', 'allow', '0.0.0.0/0', null, null, 80, 80],
+        [300, 'icmp', 'allow', '0.0.0.0/0', 0, 8],
+    ]
+    egress: [
+        [100, 'all', 'allow', '0.0.0.0/0', null, null, null, null]
+    ]
+    state: 'present'
+    <<: *aws_connection_info
+  register: nacl
+
+- name: assert the network acl was created
+  assert:
+    that:
+      - nacl.changed
+      - nacl.nacl_id.startswith('acl-')
+
+- name: get network ACL facts
+  ec2_vpc_nacl_facts:
+    nacl_ids:
+      - "{{ nacl.nacl_id }}"
+    <<: *aws_connection_info
+  register: nacl_facts
+
+- name: assert the nacl has the correct attributes
+  assert:
+    that:
+      - nacl_facts.nacls | length == 1
+      - nacl_facts.nacls[0].subnets | length == 4
+      - nacl_facts.nacls[0].ingress | length == 3
+      - nacl_facts.nacls[0].egress | length == 1
+      - "'{{ nacl_facts.nacls[0].tags.Name }}' == '{{ resource_prefix }}-acl'"
+
+# ============================================================
+
+- name: test idempotence
+  ec2_vpc_nacl:
+    vpc_id: "{{ vpc_id }}"
+    name: "{{ resource_prefix }}-acl"
+    subnets: "{{ subnet_names }}"
+    tags:
+      Created_by: "Ansible test {{ resource_prefix }}"
+    ingress: [
+        [100, 'tcp', 'allow', '0.0.0.0/0', null, null, 22, 22],
+        [200, 'tcp', 'allow', '0.0.0.0/0', null, null, 80, 80],
+        [300, 'icmp', 'allow', '0.0.0.0/0', 0, 8],
+    ]
+    egress: [
+        [100, 'all', 'allow', '0.0.0.0/0', null, null, null, null]
+    ]
+    state: 'present'
+    <<: *aws_connection_info
+  register: nacl
+
+- name: assert the network acl already existed
+  assert:
+    that:
+      - not nacl.changed
+      - nacl.nacl_id.startswith('acl-')
+
+- name: get network ACL facts
+  ec2_vpc_nacl_facts:
+    nacl_ids:
+      - "{{ nacl.nacl_id }}"
+    <<: *aws_connection_info
+  register: nacl_facts_idem
+
+- name: assert the facts are the same as before
+  assert:
+    that:
+      - nacl_facts_idem == nacl_facts
+
+# ============================================================
+
+- name: remove a subnet from the network ACL
+  ec2_vpc_nacl:
+    vpc_id: "{{ vpc_id }}"
+    name: "{{ resource_prefix }}-acl"
+    subnets:
+      - "{{ subnet_names[0] }}"
+      - "{{ subnet_names[1] }}"
+      - "{{ subnet_names[2] }}"
+    tags:
+      Created_by: "Ansible test {{ resource_prefix }}"
+    ingress: [
+        [100, 'tcp', 'allow', '0.0.0.0/0', null, null, 22, 22],
+        [200, 'tcp', 'allow', '0.0.0.0/0', null, null, 80, 80],
+        [300, 'icmp', 'allow', '0.0.0.0/0', 0, 8],
+    ]
+    egress: [
+        [100, 'all', 'allow', '0.0.0.0/0', null, null, null, null]
+    ]
+    state: 'present'
+    <<: *aws_connection_info
+  register: nacl
+
+- name: assert the network ACL changed
+  assert:
+    that:
+      - nacl.changed
+      - nacl.nacl_id.startswith('acl-')
+
+# FIXME: Currently removing a subnet using the subnet names does not work
+#- name: get network ACL facts
+#  ec2_vpc_nacl_facts:
+#    nacl_ids:
+#      - "{{ nacl.nacl_id }}"
+#    <<: *aws_connection_info
+#  register: nacl_facts
+
+#- name: assert the nacl has the correct attributes
+#  assert:
+#    that:
+#      - nacl_facts.nacls | length == 1
+#      - nacl_facts.nacls[0].subnets | length == 3
+#      - nacl_facts.nacls[0].ingress | length == 3
+#      - nacl_facts.nacls[0].egress | length == 1
+#      - "'{{ nacl_facts.nacls[0].tags.Name }}' == '{{ resource_prefix }}-acl'"
+
+# ============================================================
+
+- name: remove the network ACL
+  ec2_vpc_nacl:
+    vpc_id: "{{ vpc_id }}"
+    name: "{{ resource_prefix }}-acl"
+    state: absent
+    <<: *aws_connection_info
+  register: nacl
+
+- name: assert nacl was removed
+  assert:
+    that:
+      - nacl.changed

--- a/test/integration/targets/ec2_vpc_nacl/tasks/tags.yml
+++ b/test/integration/targets/ec2_vpc_nacl/tasks/tags.yml
@@ -1,0 +1,115 @@
+- name: set connection information for subsequent tasks
+  set_fact:
+    aws_connection_info: &aws_connection_info
+      aws_access_key: "{{ aws_access_key }}"
+      aws_secret_key: "{{ aws_secret_key }}"
+      security_token: "{{ security_token }}"
+      region: "{{ aws_region }}"
+  no_log: yes
+
+# ============================================================
+
+- name: create a network ACL using subnet IDs
+  ec2_vpc_nacl:
+    vpc_id: "{{ vpc_id }}"
+    name: "{{ resource_prefix }}-acl"
+    subnets: "{{ subnet_ids }}"
+    state: 'present'
+    <<: *aws_connection_info
+  register: nacl
+
+- name: assert the network acl was created
+  assert:
+    that:
+      - nacl.changed
+      - nacl.nacl_id.startswith('acl-')
+
+- name: get network ACL facts
+  ec2_vpc_nacl_facts:
+    nacl_ids:
+      - "{{ nacl.nacl_id }}"
+    <<: *aws_connection_info
+  register: nacl_facts
+
+- name: assert the nacl has the correct attributes
+  assert:
+    that:
+      - nacl_facts.nacls[0].tags | length == 1
+      - "'{{ nacl_facts.nacls[0].tags.Name }}' == '{{ resource_prefix }}-acl'"
+
+# ============================================================
+
+- name: add a tag
+  ec2_vpc_nacl:
+    vpc_id: "{{ vpc_id }}"
+    name: "{{ resource_prefix }}-acl"
+    subnets: "{{ subnet_ids }}"
+    tags:
+      Created_by: "Ansible test {{ resource_prefix }}"
+    state: 'present'
+    <<: *aws_connection_info
+  register: nacl
+
+- name: assert the network acl changed
+  assert:
+    that:
+      - nacl.changed
+
+- name: get network ACL facts
+  ec2_vpc_nacl_facts:
+    nacl_ids:
+      - "{{ nacl.nacl_id }}"
+    <<: *aws_connection_info
+  register: nacl_facts
+
+- name: assert the facts are the same as before
+  assert:
+    that:
+      - nacl_facts.nacls[0].tags | length == 2
+      - "'{{ nacl_facts.nacls[0].tags.Name }}' == '{{ resource_prefix }}-acl'"
+      - "'{{ nacl_facts.nacls[0].tags.Created_by }}' == 'Ansible test {{ resource_prefix }}'"
+
+# ============================================================
+
+- name: remove a tag
+  ec2_vpc_nacl:
+    vpc_id: "{{ vpc_id }}"
+    name: "{{ resource_prefix }}-acl"
+    subnets: "{{ subnet_ids }}"
+    state: 'present'
+    <<: *aws_connection_info
+  register: nacl
+
+- name: assert the network acl was created
+  assert:
+    that:
+      - nacl.changed
+      - nacl.nacl_id.startswith('acl-')
+
+- name: get network ACL facts
+  ec2_vpc_nacl_facts:
+    nacl_ids:
+      - "{{ nacl.nacl_id }}"
+    <<: *aws_connection_info
+  register: nacl_facts
+
+- name: assert the nacl has the correct attributes
+  assert:
+    that:
+      - nacl_facts.nacls[0].tags | length == 1
+      - "'{{ nacl_facts.nacls[0].tags.Name }}' == '{{ resource_prefix }}-acl'"
+
+# ============================================================
+
+- name: remove the network ACL
+  ec2_vpc_nacl:
+    vpc_id: "{{ vpc_id }}"
+    name: "{{ resource_prefix }}-acl"
+    state: absent
+    <<: *aws_connection_info
+  register: nacl
+
+- name: assert nacl was removed
+  assert:
+    that:
+      - nacl.changed

--- a/test/integration/targets/ec2_vpc_nacl/tasks/tags.yml
+++ b/test/integration/targets/ec2_vpc_nacl/tasks/tags.yml
@@ -108,6 +108,10 @@
     state: absent
     <<: *aws_connection_info
   register: nacl
+  until: nacl is success
+  ignore_errors: yes
+  retries: 5
+  delay: 5
 
 - name: assert nacl was removed
   assert:


### PR DESCRIPTION
##### SUMMARY
Since these tests create subnets, https://github.com/ansible/ansible/pull/37534 needs to be merged first.

Edit: Added retries to the tests (and added back the CI alias) to help stabilize things as I don't have time to work on the module.

~These tests are also currently unstable, failing occasionally with tracebacks like:~
```
The full traceback is:
  File "/tmp/ansible_8XNHnT/ansible_module_ec2_vpc_nacl.py", line 516, in restore_default_acl_association
    client.replace_network_acl_association(**params)
  File "/Users/shertel/Workspace/ansible/venv/python2.7/lib/python2.7/site-packages/botocore/client.py", line 312, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/Users/shertel/Workspace/ansible/venv/python2.7/lib/python2.7/site-packages/botocore/client.py", line 605, in _make_api_call
    raise error_class(parsed_response, operation_name)

fatal: [localhost]: FAILED! => {
    "changed": false,
    "invocation": {
        "module_args": {
            "aws_access_key": "",
            "aws_secret_key": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "ec2_url": null,
            "egress": [],
            "ingress": [],
            "nacl_id": null,
            "name": "ansible-test-shertel-osx-97364438-acl",
            "profile": null,
            "region": "us-east-1",
            "security_token": "",
            "state": "absent",
            "subnets": [],
            "tags": null,
            "validate_certs": true,
            "vpc_id": "vpc-be5dd5c5"
        }
    },
    "msg": "An error occurred (InvalidAssociationID.NotFound) when calling the ReplaceNetworkAclAssociation operation: The association ID 'aclassoc-00fa8d4b' does not exist"
}
```

Once I've addressed those two things I'll add the CI alias to this pull request again.

##### ISSUE TYPE
 - Test Pull Request

##### COMPONENT NAME
test/integration/targets/ec2_vpc_nacl

##### ANSIBLE VERSION
```
2.6.0
```