### PR TITLE
Fix ansible-test handling of network plugins.

### DIFF
--- a/test/runner/lib/classification.py
+++ b/test/runner/lib/classification.py
@@ -335,7 +335,9 @@ class PathMapper(object):
                 'units': units_path,
             }
 
-        if path.startswith('lib/ansible/plugins/terminal/'):
+        if (path.startswith('lib/ansible/plugins/terminal/') or
+                path.startswith('lib/ansible/plugins/cliconf/') or
+                path.startswith('lib/ansible/plugins/netconf/')):
             if ext == '.py':
                 if name in self.prefixes and self.prefixes[name] == 'network':
                     network_target = 'network/%s/' % name


### PR DESCRIPTION
##### SUMMARY

Fix ansible-test handling of network plugins.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.6.0 (at-network-plugins 401776aba6) last updated 2018/03/22 14:00:28 (GMT -700)
  config file = None
  configured module search path = ['/Users/mclay/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 3.6.4 (default, Mar 22 2018, 13:54:22) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
