### PR TITLE
Extend interfaces_file to handle sources-directory

### DIFF
--- a/lib/ansible/modules/system/interfaces_file.py
+++ b/lib/ansible/modules/system/interfaces_file.py
@@ -193,6 +193,9 @@ def read_interfaces_lines(module, line_strings):
         elif words[0] == "source-dir":
             lines.append(lineDict(line))
             currently_processing = "NONE"
+        elif words[0] == "source-directory":
+            lines.append(lineDict(line))
+            currently_processing = "NONE"
         elif words[0] == "iface":
             currif = {
                 "pre-up": [],


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #37808 

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->

interfaces_file

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.3.0
  config file = /home/schallee/devel/ansible/ansible.cfg
  configured module search path = [u'/home/schallee/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.13 (default, Nov 24 2017, 17:33:09) [GCC 6.3.0 20170516]


```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
