### PR TITLE
win_certificate_store: fix typo stopping key_storage from working

### DIFF
--- a/lib/ansible/modules/windows/win_certificate_store.ps1
+++ b/lib/ansible/modules/windows/win_certificate_store.ps1
@@ -21,7 +21,7 @@ $store_name = Get-AnsibleParam -obj $params -name "store_name" -type "str" -defa
 $store_location = Get-AnsibleParam -obj $params -name "store_location" -type "str" -default "LocalMachine" -validateset $store_location_values
 $password = Get-AnsibleParam -obj $params -name "password" -type "str"
 $key_exportable = Get-AnsibleParam -obj $params -name "key_exportable" -type "bool" -default $true
-$key_storage = Get-AnsibleParam -obj $param -name "key_storage" -type "str" -default "default" -validateset "default", "machine", "user"
+$key_storage = Get-AnsibleParam -obj $params -name "key_storage" -type "str" -default "default" -validateset "default", "machine", "user"
 $file_type = Get-AnsibleParam -obj $params -name "file_type" -type "str" -default "der" -validateset "der", "pem", "pkcs12"
 
 $result = @{


### PR DESCRIPTION
##### SUMMARY
Minor typo stopped user's from being able to supply the `key_storage` value.

Fixes https://github.com/ansible/ansible/issues/37789

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
win_certificate_store

##### ANSIBLE VERSION
```
devel
```