### PR TITLE
Fix yamllinter handling of tuple assignment.

### DIFF
--- a/test/sanity/yamllint/yamllinter.py
+++ b/test/sanity/yamllint/yamllinter.py
@@ -120,6 +120,9 @@ class YamlChecker(object):
         def check_assignment(statement, doc_types=None):
             """Check the given statement for a documentation assignment."""
             for target in statement.targets:
+                if isinstance(target, ast.Tuple):
+                    continue
+
                 if doc_types and target.id not in doc_types:
                     continue
 


### PR DESCRIPTION
##### SUMMARY

Fix yamllinter handling of tuple assignment.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.6.0 (yamllint-fix 7856e686c1) last updated 2018/03/22 20:52:58 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
