### PR TITLE
backport: Fix boolean input and string-type validation

### DIFF
--- a/docs/templates/plugin.rst.j2
+++ b/docs/templates/plugin.rst.j2
@@ -95,7 +95,7 @@ Parameters
                 <td>
                     <div class="outer-elbow-container">
                         {% for i in range(1, loop.depth) %}
-                            <div class="elbow-placeholder">&nbsp;</div>
+                            <div class="elbow-placeholder"/>
                         {% endfor %}
                         <div class="elbow-key">
                             <b>@{ key }@</b>
@@ -107,7 +107,7 @@ Parameters
                 {# default / choices #}
                 <td>
                     <div class="cell-border">
-                        {# Recalculate choices and boolean values #}
+                        {# Turn boolean values in 'yes' and 'no' values #}
                         {% if value.default is defined %}
                             {% if value.default == true %}
                                 {% set _x = value.update({'default': 'yes'}) %}
@@ -122,10 +122,16 @@ Parameters
                         {% if value.choices %}
                             <ul><b>Choices:</b>
                                 {% for choice in value.choices %}
-                                    {% if (value.default is string and choice == value.default) or (value.default is iterable and choice in value.default) %}
-                                        <li type="disc"><div style="color: blue"><b>@{ choice | escape }@</b>&nbsp;&larr;</div></li>
+                                    {# Turn boolean values in 'yes' and 'no' values #}
+                                    {% if choice == true %}
+                                        {% set choice = 'yes' %}
+                                    {% elif choice == false %}
+                                        {% set choice = 'no' %}
+                                    {% endif %}
+                                    {% if (value.default is string and value.default == choice) or (value.default is iterable and value.default is not string and choice in value.default) %}
+                                        <li><div style="color: blue"><b>@{ choice | escape }@</b>&nbsp;&larr;</div></li>
                                     {% else %}
-                                        <li type="circle">@{ choice | escape }@</li>
+                                        <li>@{ choice | escape }@</li>
                                     {% endif %}
                                 {% endfor %}
                             </ul>
@@ -240,7 +246,7 @@ Facts returned by this module are added/updated in the ``hostvars`` host facts a
                 <td>
                     <div class="outer-elbow-container">
                         {% for i in range(1, loop.depth) %}
-                            <div class="elbow-placeholder">&nbsp;</div>
+                            <div class="elbow-placeholder"/>
                         {% endfor %}
                         <div class="elbow-key">
                             <b>@{ key }@</b>
@@ -304,8 +310,7 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
                 <td>
                     <div class="outer-elbow-container">
                         {% for i in range(1, loop.depth) %}
-                            <div class="elbow-placeholder">&nbsp;</div>
-                            </div>
+                            <div class="elbow-placeholder"/>
                         {% endfor %}
                         <div class="elbow-key">
                             <b>@{ key }@</b>
@@ -324,9 +329,9 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
                             {% endfor %}
                         {% endif %}
                         <br/>
-                        {% if value.sample is defined  and value.sample %}
+                        {% if value.sample is defined and value.sample %}
                             <div style="font-size: smaller"><b>Sample:</b></div>
-                            {# TODO: The sample should be escaped, using | escape or | htmlify, but both mess things up beyond repair with dicts #}
+                            {# TODO: The sample should be escaped, using |escape or |htmlify, but both mess things up beyond repair with dicts #}
                             <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">@{ value.sample | replace('\n', '\n    ') | html_ify }@</div>
                         {% endif %}
                     </div>


### PR DESCRIPTION
(cherry picked from commit e691e07646d3a4122d1735f4fe0f47f1fae4e8d1)

##### SUMMARY
Fixes the issue when trying to generate the docs for stable-2.5.

Backport of https://github.com/ansible/ansible/pull/37488

##### ISSUE TYPE
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
module docs

##### ANSIBLE VERSION
```
2.5
```

##### ADDITIONAL INFORMATION
Fixes the issue when trying to build the docs on 2.5

```
rendering: bundler
Traceback (most recent call last):
  File "../bin/plugin_formatter.py", line 650, in <module>
    main()
  File "../bin/plugin_formatter.py", line 637, in main
    process_plugins(plugin_info, templates, outputname, output_dir, options.ansible_version, plugin_type)
  File "../bin/plugin_formatter.py", line 461, in process_plugins
    text = templates['plugin'].render(doc)
  File "/home/mdavis/.virtualenvs/ansible-dev/lib/python2.7/site-packages/jinja2/environment.py", line 989, in render
    return self.environment.handle_exception(exc_info, True)
  File "/home/mdavis/.virtualenvs/ansible-dev/lib/python2.7/site-packages/jinja2/environment.py", line 754, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "../templates/plugin.rst.j2", line 92, in top-level template code
    {% for key, value in options|dictsort recursive %}
  File "../templates/plugin.rst.j2", line 125, in template
    {% if (value.default is string and choice == value.default) or (value.default is iterable and choice in value.default) %}
TypeError: coercing to Unicode: need string or buffer, bool found
Makefile:86: recipe for target 'modules' failed
make: *** [modules] Error 1
```