### PR TITLE
[FIX] define a default path where none is given in callback plugin junit

### DIFF
--- a/lib/ansible/plugins/callback/junit.py
+++ b/lib/ansible/plugins/callback/junit.py
@@ -147,6 +147,8 @@ class CallbackModule(CallbackBase):
         play = self._play_name
         name = task.get_name().strip()
         path = task.get_path()
+        if not path: # implicit setup module doesn't have a task path
+            path = "UnknownPath." + name
 
         if not task.no_log:
             args = ', '.join(('%s=%s' % a for a in task.args.items()))


### PR DESCRIPTION
##### SUMMARY

At least implicit setup tasks (i.e. where gather_facts isn't denied) have no path,
which leads to ugly warnings in the output of the plugin. This fix sets the default
path to `UnknownPath.<name>`, where name is the name of the task.

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

junit callback plugin

##### ANSIBLE VERSION

```
ansible 2.4.2.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/elavarde/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.14 (default, Feb 17 2018, 10:42:17) [GCC 7.3.1 20180130 (Red Hat 7.3.1-2)]
```


##### ADDITIONAL INFORMATION

I hesitated to put a dummy line number at the end of the default path, something like:

```
        if not path: # implicit setup module doesn't have a task path
            path = "UnknownPath.%s:0" % name
```

but I thought it better to have no line than a line which doesn't represent anything.