### PR TITLE
New module: rds_tag

### DIFF
--- a/lib/ansible/modules/cloud/amazon/rds_tag.py
+++ b/lib/ansible/modules/cloud/amazon/rds_tag.py
@@ -110,9 +110,7 @@ response_metadata:
 
 from ansible.module_utils.aws.core import AnsibleAWSModule
 from ansible.module_utils.ec2 import (
-    HAS_BOTO3, ec2_argument_spec, boto3_conn, get_aws_connection_info)
-from ansible.module_utils.ec2 import (
-    camel_dict_to_snake_dict, snake_dict_to_camel_dict)
+    ec2_argument_spec, camel_dict_to_snake_dict)
 
 try:
     import botocore

--- a/lib/ansible/modules/cloud/amazon/rds_tag.py
+++ b/lib/ansible/modules/cloud/amazon/rds_tag.py
@@ -1,0 +1,157 @@
+#!/usr/bin/python
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.ec2 import (HAS_BOTO3, boto3_conn, ec2_argument_spec, get_aws_connection_info)
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.0'}
+
+DOCUMENTATION = '''
+---
+module: rds_tag
+short_description: create and remove tag(s) to rds instance.
+description:
+    - Creates, removes and lists tags from any rds instance. The instance is referenced by its instance name.
+      It is designed to be used with complex args (tags), see the examples.  This module has a dependency on python-boto3.
+options:
+  instance_name:
+    description:
+      - The RDS instance name.
+  state:
+    description:
+      - Whether the tags should be present or absent on the resource. Use list to interrogate the tags of an instance.
+    default: present
+    choices: ['present', 'absent', 'list']
+  tags:
+    description:
+      - a hash/dictionary of tags to add to the resource; '{"key":"value"}' and '{"key":"value","key":"value"}'
+    required: true
+'''
+
+EXAMPLES = '''
+- name: Ensure tags are present on a resource
+  rds_tag:
+    region: eu-west-1
+    instance_name: name-database
+    state: present
+    tags:
+      Name: environment
+      env: sandbox
+'''
+
+try:
+    import boto3
+    HAS_BOTO = True
+except ImportError:
+    HAS_BOTO = False
+
+
+def list_rds_arn(client, instance_name):
+    if instance_name is None:
+        response_instances = client.describe_db_instances()
+    else:
+        response_instances = client.describe_db_instances(
+            DBInstanceIdentifier=instance_name)
+
+    list_arn = [{'arn': instance['DBInstanceArn'],
+                 'identifier': instance['DBInstanceIdentifier']}
+                for instance in response_instances['DBInstances']]
+
+    return list_arn
+
+
+def list_rds_tags(client, list_arn):
+    list_tags = []
+    for map_arn in list_arn:
+        response_tags = client.list_tags_for_resource(
+            ResourceName=map_arn['arn'])
+        tags = {}
+        for datum in response_tags['TagList']:
+            tags[datum['Key']] = datum['Value']
+
+        list_tags.append({'identifier': map_arn['identifier'],
+                          'tags': tags,
+                          'arn': map_arn['arn']})
+    return list_tags
+
+
+def main():
+    argument_spec = ec2_argument_spec()
+    argument_spec.update(
+        dict(
+            instance_name=dict(type='str'),
+            tags=dict(type='dict'),
+            state=dict(type='str',
+                       choices=['present', 'absent', 'list'],
+                       required=True)
+        )
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True)
+
+    if not HAS_BOTO:
+        module.fail_json(msg='boto required for this module')
+
+    region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module,
+                                                                  boto3=True)
+    client = boto3_conn(module, conn_type='client', resource='rds',
+                        region=region, **aws_connect_kwargs)
+
+    instance_name = module.params.get('instance_name')
+    tags = module.params.get('tags')
+    state = module.params.get('state')
+
+    list_arn = list_rds_arn(client, instance_name)
+    list_tags = list_rds_tags(client, list_arn)
+
+    if state == 'list':
+        module.exit_json(tags=list_tags, changed=False)
+
+    if not instance_name:
+        module.fail_json(
+            msg="instance_name argument is required when state is %s." % state)
+
+    if not tags:
+        module.fail_json(
+            msg="tags argument is required when state is %s." % state)
+
+    if state == 'present':
+        configured_tags = list_tags[0]
+
+        if set(tags.items()) <= set(configured_tags['tags'].items()):
+            module.exit_json(message='tags already exists.', changed=False)
+
+        if module.check_mode:
+            module.exit_json(message='check mode.', changed=True)
+
+        add_tags = [{'Key': datum[0], 'Value': datum[1]}
+                    for datum in tags.items()]
+        response = client.add_tags_to_resource(
+            ResourceName=configured_tags['arn'],
+            Tags=add_tags)
+        module.exit_json(msg="tags %s created for resource %s." %
+                         (add_tags, instance_name), changed=True)
+
+    if state == 'absent':
+        configured_tags = list_tags[0]
+
+        if not set(tags.keys()) <= set(configured_tags['tags'].keys()):
+            module.exit_json(message='nothing to tags.', changed=False)
+
+        if module.check_mode:
+            module.exit_json(message='check mode.', changed=True)
+
+        response = client.remove_tags_from_resource(
+            ResourceName=configured_tags['arn'],
+            TagKeys=tags.keys())
+
+        module.exit_json(msg="tags %s remove for resource %s." %
+                         (tags.keys(), instance_name), changed=True)
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/cloud/amazon/rds_tag.py
+++ b/lib/ansible/modules/cloud/amazon/rds_tag.py
@@ -223,8 +223,7 @@ def main():
             tags=dict(type='dict'),
             state=dict(default='present',
                        type='str',
-                       choices=['present', 'absent', 'list']
-            )
+                       choices=['present', 'absent', 'list'])
         )
     )
 

--- a/lib/ansible/modules/cloud/amazon/rds_tag.py
+++ b/lib/ansible/modules/cloud/amazon/rds_tag.py
@@ -142,6 +142,10 @@ def add_rds_tags(module, client, configured_tags, tags):
             botocore.exceptions.BotoCoreError) as e:
         module.fail_json_aws(e, msg="Couldn't add tag to %s"
                              % configured_tags['arn'])
+
+    response['message'] = 'Add %s tag to %s instance' % (
+        add_tags, configured_tags['arn'])
+
     return response
 
 
@@ -161,6 +165,10 @@ def remove_rds_tags(module, client, configured_tags, tags):
         module.fail_json_aws(e,
                              msg="Couldn't remove tag to %s instance"
                              % configured_tags['arn'])
+
+    response['message'] = 'Remove %s tag to %s instance' % (
+        tags.keys(), configured_tags['arn'])
+
     return response
 
 
@@ -237,7 +245,7 @@ def main():
     list_tags = list_rds_tags(client, list_arn)
 
     if state == 'list':
-        module.exit_json(tags=list_tags, changed=False)
+        module.exit_json(response_tags=list_tags, changed=False)
 
     if not instance_name:
         module.fail_json(

--- a/lib/ansible/modules/cloud/amazon/rds_tag.py
+++ b/lib/ansible/modules/cloud/amazon/rds_tag.py
@@ -215,10 +215,9 @@ def main():
         module.exit_json(changed=True,
                          **camel_dict_to_snake_dict(response))
 
-    if state == 'absent':
-        response = remove_rds_tags(module, client, configured_tags, tags)
-        module.exit_json(changed=True,
-                         **camel_dict_to_snake_dict(response))
+    response = remove_rds_tags(module, client, tags_configured, tags_operate)
+    module.exit_json(changed=True,
+                     **camel_dict_to_snake_dict(response))
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/cloud/amazon/rds_tag.py
+++ b/lib/ansible/modules/cloud/amazon/rds_tag.py
@@ -172,7 +172,7 @@ def remove_rds_tags(module, client, configured_tags, tags):
     return response
 
 
-def list_rds_arn(client, instance_name):
+def list_rds_arn(module, client, instance_name):
     if instance_name is None:
         try:
             response_instances = client.describe_db_instances()
@@ -195,7 +195,7 @@ def list_rds_arn(client, instance_name):
     return list_arn
 
 
-def list_rds_tags(client, list_arn):
+def list_rds_tags(module, client, list_arn, instance_name):
     list_tags = []
     for map_arn in list_arn:
         try:
@@ -241,8 +241,8 @@ def main():
     tags = module.params.get('tags')
     state = module.params.get('state')
 
-    list_arn = list_rds_arn(client, instance_name)
-    list_tags = list_rds_tags(client, list_arn)
+    list_arn = list_rds_arn(module, client, instance_name)
+    list_tags = list_rds_tags(module, client, list_arn, instance_name)
 
     if state == 'list':
         module.exit_json(response_tags=list_tags, changed=False)

--- a/lib/ansible/modules/cloud/amazon/rds_tag.py
+++ b/lib/ansible/modules/cloud/amazon/rds_tag.py
@@ -7,7 +7,9 @@ from ansible.module_utils.ec2 import (HAS_BOTO3, boto3_conn, ec2_argument_spec, 
 
 __metaclass__ = type
 
-ANSIBLE_METADATA = {'metadata_version': '1.0'}
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
 
 DOCUMENTATION = '''
 ---

--- a/lib/ansible/modules/cloud/amazon/rds_tag.py
+++ b/lib/ansible/modules/cloud/amazon/rds_tag.py
@@ -17,7 +17,7 @@ description: >
   The instance is referenced by its instance name.
   It is designed to be used with complex args (tags), see the examples.
   This module has a dependency on python-boto3.
-version_added: "2.5"
+version_added: "2.6"
 options:
   instance_name:
     description:

--- a/lib/ansible/modules/cloud/amazon/rds_tag.py
+++ b/lib/ansible/modules/cloud/amazon/rds_tag.py
@@ -75,24 +75,6 @@ message:
   returned: always
   type: string
   sample: Add tag to arn:aws:rds:eu-west-1:xxxxxxxxxxxx:db:db_name instance
-invocation:
-  description: Parameters used during invocation.
-  returned: always
-  type: dict
-  sample:
-    module_args:
-      aws_access_key: null
-      aws_secret_key: null
-      ec2_url: null
-      instance_name: xxx-instance
-      profile: your profile
-      region: eu-west-1
-      security_token: null
-      state: present
-      tags:
-        your_setting_key_a: your_setting_value_a
-        your_setting_key_b: your_setting_value_b
-      validate_certs: true
 response_metadata:
   description: Value returned by boto3.
   returned: When not in dry run mode.

--- a/lib/ansible/modules/cloud/amazon/rds_tag.py
+++ b/lib/ansible/modules/cloud/amazon/rds_tag.py
@@ -128,8 +128,9 @@ def add_rds_tags(module, client, tags_configured, tags_operate):
     return response
 
 
-def remove_rds_tags(module, client, configured_tags, tags):
-    if not set(tags.keys()) <= set(configured_tags['tags'].keys()):
+def remove_rds_tags(module, client, tags_configured, tags_operate):
+    tags_inter = set(tags_operate.keys()) & set(tags_configured['tags'].keys())
+    if 0 == len(tags_inter):
         module.exit_json(message='nothing to tags.', changed=False)
 
     if module.check_mode:
@@ -137,8 +138,8 @@ def remove_rds_tags(module, client, configured_tags, tags):
 
     try:
         response = client.remove_tags_from_resource(
-            ResourceName=configured_tags['arn'],
-            TagKeys=list(tags.keys()))
+            ResourceName=tags_configured['arn'],
+            TagKeys=list(tags_inter))
     except (botocore.exceptions.ClientError,
             botocore.exceptions.BotoCoreError) as e:
         module.fail_json_aws(e,
@@ -146,7 +147,7 @@ def remove_rds_tags(module, client, configured_tags, tags):
                              % tags_configured['arn'])
 
     response['message'] = 'Remove %s tag to %s instance' % (
-        tags.keys(), configured_tags['arn'])
+        list(tags_inter), tags_configured['arn'])
 
     return response
 

--- a/lib/ansible/modules/cloud/amazon/rds_tag.py
+++ b/lib/ansible/modules/cloud/amazon/rds_tag.py
@@ -27,7 +27,7 @@ options:
       Whether the tags should be present or absent on the resource.
       Use list to interrogate the tags of an instance.
     default: present
-    choices: ['present', 'absent', 'list']
+    choices: ['present', 'absent']
   tags:
     description: >-
       a hash/dictionary of tags to add to the resource;
@@ -43,11 +43,6 @@ author: "Akane Morikawa (@cahlchang)"
 EXAMPLES = '''
 # Note: None of these examples set aws_access_key, aws_secret_key, or region.
 # It is assumed that their matching environment variables are set.
-- name: Ensure tags are present on a instance
-  rds_tag:
-    region: eu-west-1
-    instance_name: name-database
-    state: list
 
 - name: add tags to instance
   rds_tag:
@@ -244,8 +239,6 @@ def main():
     list_arn = list_rds_arn(module, client, instance_name)
     list_tags = list_rds_tags(module, client, list_arn, instance_name)
 
-    if state == 'list':
-        module.exit_json(response_tags=list_tags, changed=False)
 
     if not instance_name:
         module.fail_json(

--- a/lib/ansible/modules/cloud/amazon/rds_tag.py
+++ b/lib/ansible/modules/cloud/amazon/rds_tag.py
@@ -221,9 +221,10 @@ def main():
         dict(
             instance_name=dict(type='str'),
             tags=dict(type='dict'),
-            state=dict(type='str',
-                       choices=['present', 'absent', 'list'],
-                       required=True)
+            state=dict(default='present',
+                       type='str',
+                       choices=['present', 'absent', 'list']
+            )
         )
     )
 

--- a/lib/ansible/modules/cloud/amazon/rds_tag.py
+++ b/lib/ansible/modules/cloud/amazon/rds_tag.py
@@ -206,11 +206,7 @@ def main():
         argument_spec=argument_spec,
         supports_check_mode=True)
 
-    region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module,
-                                                                  boto3=True)
-
-    client = boto3_conn(module, conn_type='client', resource='rds',
-                        region=region, **aws_connect_kwargs)
+    client = module.client('rds')
 
     instance_name = module.params.get('instance_name')
     tags = module.params.get('tags')

--- a/lib/ansible/modules/cloud/amazon/rds_tag.py
+++ b/lib/ansible/modules/cloud/amazon/rds_tag.py
@@ -101,8 +101,11 @@ except ImportError:
     pass  # handled by AnsibleAWSModule
 
 
-    if set(tags.items()) <= set(configured_tags['tags'].items()):
 def add_rds_tags(module, client, tags_configured, tags_operate):
+    lst_compare = compare_aws_tags(tags_configured['tags'],
+                                   tags_operate,
+                                   False)
+    if 0 == len(lst_compare[0]):
         module.exit_json(message='tags already exists.', changed=False)
 
     if module.check_mode:

--- a/lib/ansible/modules/cloud/amazon/rds_tag.py
+++ b/lib/ansible/modules/cloud/amazon/rds_tag.py
@@ -120,10 +120,9 @@ from ansible.module_utils.ec2 import (
     camel_dict_to_snake_dict, snake_dict_to_camel_dict)
 
 try:
-    import boto3
-    HAS_BOTO = True
+    import botocore
 except ImportError:
-    HAS_BOTO = False
+    pass  # handled by AnsibleAWSModule
 
 
 def list_rds_arn(client, instance_name):
@@ -167,15 +166,13 @@ def main():
         )
     )
 
-    module = AnsibleModule(
+    module = AnsibleAWSModule(
         argument_spec=argument_spec,
         supports_check_mode=True)
 
-    if not HAS_BOTO:
-        module.fail_json(msg='boto required for this module')
-
     region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module,
                                                                   boto3=True)
+
     client = boto3_conn(module, conn_type='client', resource='rds',
                         region=region, **aws_connect_kwargs)
 

--- a/lib/ansible/modules/cloud/amazon/rds_tag.py
+++ b/lib/ansible/modules/cloud/amazon/rds_tag.py
@@ -198,7 +198,7 @@ def main():
             tags=dict(type='dict'),
             state=dict(default='present',
                        type='str',
-                       choices=['present', 'absent', 'list'])
+                       choices=['present', 'absent'])
         )
     )
 

--- a/lib/ansible/modules/cloud/amazon/rds_tag.py
+++ b/lib/ansible/modules/cloud/amazon/rds_tag.py
@@ -2,9 +2,6 @@
 # GNU General Public License v3.0+
 # (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.ec2 import (HAS_BOTO3, boto3_conn, ec2_argument_spec, get_aws_connection_info)
-
 __metaclass__ = type
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
@@ -115,6 +112,12 @@ response_metadata:
     request_id: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
     retry_attempts: 0
 '''
+
+from ansible.module_utils.aws.core import AnsibleAWSModule
+from ansible.module_utils.ec2 import (
+    HAS_BOTO3, ec2_argument_spec, boto3_conn, get_aws_connection_info)
+from ansible.module_utils.ec2 import (
+    camel_dict_to_snake_dict, snake_dict_to_camel_dict)
 
 try:
     import boto3

--- a/lib/ansible/modules/cloud/amazon/rds_tag.py
+++ b/lib/ansible/modules/cloud/amazon/rds_tag.py
@@ -15,26 +15,44 @@ DOCUMENTATION = '''
 ---
 module: rds_tag
 short_description: create and remove tag(s) to rds instance.
-description:
-    - Creates, removes and lists tags from any rds instance. The instance is referenced by its instance name.
-      It is designed to be used with complex args (tags), see the examples.  This module has a dependency on python-boto3.
+description: >
+  Creates, removes and lists tags from any rds instance.
+  The instance is referenced by its instance name.
+  It is designed to be used with complex args (tags), see the examples.
+  This module has a dependency on python-boto3.
+version_added: "2.5"
 options:
   instance_name:
     description:
       - The RDS instance name.
   state:
-    description:
-      - Whether the tags should be present or absent on the resource. Use list to interrogate the tags of an instance.
+    description: >
+      Whether the tags should be present or absent on the resource.
+      Use list to interrogate the tags of an instance.
     default: present
     choices: ['present', 'absent', 'list']
   tags:
-    description:
-      - a hash/dictionary of tags to add to the resource; '{"key":"value"}' and '{"key":"value","key":"value"}'
+    description: >-
+      a hash/dictionary of tags to add to the resource;
+      '{"key":"value"}' and '{"key":"value","key":"value"}'
     required: true
+extends_documentation_fragment:
+    - aws
+    - ec2
+
+author: "Akane Morikawa (@cahlchang)"
 '''
 
 EXAMPLES = '''
-- name: Ensure tags are present on a resource
+# Note: None of these examples set aws_access_key, aws_secret_key, or region.
+# It is assumed that their matching environment variables are set.
+- name: Ensure tags are present on a instance
+  rds_tag:
+    region: eu-west-1
+    instance_name: name-database
+    state: list
+
+- name: add tags to instance
   rds_tag:
     region: eu-west-1
     instance_name: name-database
@@ -42,6 +60,60 @@ EXAMPLES = '''
     tags:
       Name: environment
       env: sandbox
+
+- name: remove tags to instance
+  rds_tag:
+    region: eu-west-1
+    instance_name: name-database
+    state: absent
+    tags:
+      Name: environment
+      env: sandbox
+'''
+
+RETURN = '''
+---
+changed:
+  description: Whether there was any change.
+  returned: always
+  type: bool
+  sample: true
+message:
+  description: Summary of module execution results.
+  returned: always
+  type: string
+  sample: Add tag to arn:aws:rds:eu-west-1:xxxxxxxxxxxx:db:db_name instance
+invocation:
+  description: Parameters used during invocation.
+  returned: always
+  type: dict
+  sample:
+    module_args:
+      aws_access_key: null
+      aws_secret_key: null
+      ec2_url: null
+      instance_name: xxx-instance
+      profile: your profile
+      region: eu-west-1
+      security_token: null
+      state: present
+      tags:
+        your_setting_key_a: your_setting_value_a
+        your_setting_key_b: your_setting_value_b
+      validate_certs: true
+response_metadata:
+  description: Value returned by boto3.
+  returned: When not in dry run mode.
+  type: dict
+  sample:
+    http_headers:
+      content-length: xxx
+      content-type: text/xml
+      date: Mon, 02 Apr 2018 03:53:23 GMT
+      x-amzn-requestid: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+    http_status_code: 200
+    request_id: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+    retry_attempts: 0
 '''
 
 try:

--- a/lib/ansible/modules/cloud/amazon/rds_tag.py
+++ b/lib/ansible/modules/cloud/amazon/rds_tag.py
@@ -17,7 +17,7 @@ description: >
   The instance is referenced by its instance name.
   It is designed to be used with complex args (tags), see the examples.
   This module has a dependency on python-boto3.
-version_added: "2.6"
+version_added: "2.7"
 options:
   instance_name:
     description:

--- a/lib/ansible/modules/cloud/amazon/rds_tag.py
+++ b/lib/ansible/modules/cloud/amazon/rds_tag.py
@@ -37,7 +37,7 @@ extends_documentation_fragment:
     - aws
     - ec2
 
-author: "Akane Morikawa (@cahlchang)"
+author: "Nao Morikawa (@cahlchang)"
 '''
 
 EXAMPLES = '''


### PR DESCRIPTION
I think, RDS module requires only the tagging operation.
It is desirable that the module is loosely coupled.
Like ec2-tag Module.
https://github.com/ansible/ansible/blob/devel/lib/ansible/modules/cloud/amazon/ec2_tag.py

It is different for RDS and EC2 in the tag rules
I made a new module with the same Playbook interface.

##### SUMMARY

Added module to manipulate tags with RDS of AWS.

##### ISSUE TYPE
 - New Module Pull Request

##### COMPONENT NAME
 - rds_tag

##### ANSIBLE VERSION
```
$ ansible --version
ansible 2.4.3.0
  config file = /home/user/git/ansible_repo/ansible.cfg
  configured module search path = ['/home/user/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/pyenv/versions/3.6.3/lib/python3.6/site-packages/ansible
  executable location = /usr/local/pyenv/versions/3.6.3/bin/ansible
  python version = 3.6.3 (default, Dec 13 2017, 03:46:07) [GCC 4.8.2]
```

##### ADDITIONAL INFORMATION
This ticket has also been discussed.
#20395

```
$ ansible-playbook my_rds_tag.yml
```

```yml:my_rds_tag.yml
- hosts: localhost
  become: no
  gather_facts: no
  vars:
    profile: "profile my-profile"
    region: us-east-1a
  tasks:
- name: add tags
  role: rds_tag
    instance_name: "my-rds-db"
    region: "{{ region }}"
    profile: "{{ profile }}"
    state: present
    tags:
      tagkey: "tagvalue"

- name: list tags
  role: rds_tag
    instance_name: "my-rds-db"
    region: "{{ region }}"
    profile: "{{ profile }}"
    state: list
  register: register-tag

- debug:
    msg: "{{ register-tag}}"

- name: remove tags
  role: rds_tag
    instance_name: "my-rds-db"
    region: "{{ region }}"
    profile: "{{ profile }}"
    state: absent
    tags:
      tagkey: "tagvalue"
```
