### PR TITLE
Add rabbitmq_vhost_limits module

### DIFF
--- a/lib/ansible/modules/messaging/rabbitmq_vhost_limits.py
+++ b/lib/ansible/modules/messaging/rabbitmq_vhost_limits.py
@@ -72,30 +72,6 @@ EXAMPLES = '''
     state: absent
 '''
 
-RETURN = '''
-max_connections:
-    description:
-        - Current max number of concurrent connections; negative value if there are no limits.
-    returned: always
-    type: int
-    sample: 64
-max_queues:
-    description: Current max number of queues; negative value if there are no limits.
-    returned: always
-    type: int
-    sample: 256
-node:
-    description: Erlag node name to be configured in this task; C(null) if not specified.
-    returned: always
-    type: string
-    sample: rabbit
-vhost:
-    description: RabbitMQ virtual host to be configured in this task.
-    returned: always
-    type: string
-    sample: /
-'''
-
 
 import json
 from ansible.module_utils.basic import AnsibleModule
@@ -121,8 +97,8 @@ class RabbitMqVhostLimits(object):
     def list(self):
         exec_result = self._exec(['list_vhost_limits'])
         vhost_limits = exec_result['out'][0]
-        max_connections = -1
-        max_queues = -1
+        max_connections = None
+        max_queues = None
         if vhost_limits:
             vhost_limits = json.loads(vhost_limits)
             if 'max-connections' in vhost_limits:
@@ -177,8 +153,8 @@ def main():
         )
     else: # state == 'absent'
         wanted_status = dict(
-            max_connections=-1,
-            max_queues=-1
+            max_connections=None,
+            max_queues=None
         )
 
     if current_status != wanted_status:
@@ -187,16 +163,6 @@ def main():
             rabbitmq_vhost_limits.set()
         else: # state == 'absent'
             rabbitmq_vhost_limits.clear()
-
-    if module.check_mode:
-        module_result['max_connections'] = wanted_status['max_connections']
-        module_result['max_queues'] = wanted_status['max_queues']
-    else: # not module.check_mode
-        current_status = rabbitmq_vhost_limits.list()
-        module_result['max_connections'] = current_status['max_connections']
-        module_result['max_queues'] = current_status['max_queues']
-    module_result['node'] = node
-    module_result['vhost'] = vhost
 
     module.exit_json(**module_result)
 

--- a/lib/ansible/modules/messaging/rabbitmq_vhost_limits.py
+++ b/lib/ansible/modules/messaging/rabbitmq_vhost_limits.py
@@ -151,7 +151,7 @@ def main():
             max_connections=max_connections,
             max_queues=max_queues
         )
-    else: # state == 'absent'
+    else:  # state == 'absent'
         wanted_status = dict(
             max_connections=None,
             max_queues=None
@@ -161,7 +161,7 @@ def main():
         module_result['changed'] = True
         if state == 'present':
             rabbitmq_vhost_limits.set()
-        else: # state == 'absent'
+        else:  # state == 'absent'
             rabbitmq_vhost_limits.clear()
 
     module.exit_json(**module_result)

--- a/lib/ansible/modules/messaging/rabbitmq_vhost_limits.py
+++ b/lib/ansible/modules/messaging/rabbitmq_vhost_limits.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# (c) 2018, Hiroyuki Matsuo <hiroyuki3569825@gmail.com>
+# Copyright: (c) 2018, Hiroyuki Matsuo <h.matsuo.engineer@gmail.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
@@ -16,7 +16,7 @@ DOCUMENTATION = '''
 ---
 module: rabbitmq_vhost_limits
 author: '"Hiroyuki Matsuo (@h-matsuo)"'
-version_added: "2.6"
+version_added: "2.8"
 
 short_description: Manage the state of virtual host limits in RabbitMQ
 description:

--- a/lib/ansible/modules/messaging/rabbitmq_vhost_limits.py
+++ b/lib/ansible/modules/messaging/rabbitmq_vhost_limits.py
@@ -118,8 +118,8 @@ class RabbitMqVhostLimits(object):
     def list(self):
         exec_result = self._exec(['list_vhost_limits', '-p', self._vhost])
         vhost_limits = exec_result['out'][0]
-        max_connections = None
-        max_queues = None
+        max_connections = -1
+        max_queues = -1
         if vhost_limits:
             vhost_limits = json.loads(vhost_limits)
             if 'max-connections' in vhost_limits:
@@ -170,8 +170,8 @@ def main():
         )
     else:  # state == 'absent'
         wanted_status = dict(
-            max_connections=None,
-            max_queues=None
+            max_connections=-1,
+            max_queues=-1
         )
 
     if current_status != wanted_status:
@@ -184,9 +184,13 @@ def main():
                 rabbitmq_vhost_limits.clear()
             module_result['changed'] = True
 
-    current_status = rabbitmq_vhost_limits.list()
-    module_result['max_connections'] = current_status['max_connections']
-    module_result['max_queues'] = current_status['max_queues']
+    if module.check_mode:
+        module_result['max_connections'] = wanted_status['max_connections']
+        module_result['max_queues'] = wanted_status['max_queues']
+    else:
+        current_status = rabbitmq_vhost_limits.list()
+        module_result['max_connections'] = current_status['max_connections']
+        module_result['max_queues'] = current_status['max_queues']
     module_result['node'] = node
     module_result['vhost'] = vhost
 

--- a/lib/ansible/modules/messaging/rabbitmq_vhost_limits.py
+++ b/lib/ansible/modules/messaging/rabbitmq_vhost_limits.py
@@ -51,16 +51,16 @@ options:
 EXAMPLES = '''
 # Limits both of the max number of connections and the max number of queues on / vhost.
 - rabbitmq_vhost_limits:
+    vhost: /
     max_connections: 64
     max_queues: 256
-    vhost: /
     state: present
 
 # Limits the max number of connections on / vhost.
 # This task implicitly clears the max number of queues limit using default value: -1.
 - rabbitmq_vhost_limits:
-    max_connections: 64
     vhost: /
+    max_connections: 64
     state: present
 
 # Clears the limits on / vhost.
@@ -72,12 +72,12 @@ EXAMPLES = '''
 RETURN = '''
 max_connections:
     description:
-        - Current max number of concurrent connections; C(null) if there are no limits.
+        - Current max number of concurrent connections; negative value if there are no limits.
     returned: always
     type: int
     sample: 64
 max_queues:
-    description: Current max number of queues; C(null) if there are no limits.
+    description: Current max number of queues; negative value if there are no limits.
     returned: always
     type: int
     sample: 256

--- a/lib/ansible/modules/messaging/rabbitmq_vhost_limits.py
+++ b/lib/ansible/modules/messaging/rabbitmq_vhost_limits.py
@@ -72,6 +72,8 @@ EXAMPLES = '''
     state: absent
 '''
 
+RETURN = ''' # '''
+
 
 import json
 from ansible.module_utils.basic import AnsibleModule

--- a/lib/ansible/modules/messaging/rabbitmq_vhost_limits.py
+++ b/lib/ansible/modules/messaging/rabbitmq_vhost_limits.py
@@ -20,50 +20,53 @@ version_added: "2.8"
 
 short_description: Manage the state of virtual host limits in RabbitMQ
 description:
-  - This module can enforce or clear limits on a virtual host.
-  - Recognized limits are I(max_connections) and I(max-queues).
+    - This module sets/clears certain limits on a virtual host.
+    - The configurable limits are I(max_connections) and I(max-queues).
 
 options:
     max_connections:
         description:
-            - Max number of concurrent connections.
+            - Max number of concurrent client connections.
             - Negative value means "no limit".
+            - Ignored when the I(state) is C(absent).
         default: -1
     max_queues:
         description:
             - Max number of queues.
             - Negative value means "no limit".
+            - Ignored when the I(state) is C(absent).
         default: -1
     node:
         description:
-            - Erlang node name of the rabbit to be configured.
+            - Name of the RabbitMQ Erlang node to manage.
     state:
         description:
-            - Specify if limits are to be set or cleared.
+            - Specify whether the limits are to be set or cleared.
+            - If set to C(absent), the limits of both I(max_connections) and I(max-queues) will be cleared.
         default: present
         choices: [present, absent]
     vhost:
         description:
-            - RabbitMQ virtual host to apply these limits.
+            - Name of the virtual host to manage.
         default: /
 '''
 
 EXAMPLES = '''
-# Limits both of the max number of connections and the max number of queues on / vhost.
+# Limit both of the max number of connections and queues on the vhost '/'.
 - rabbitmq_vhost_limits:
     vhost: /
     max_connections: 64
     max_queues: 256
     state: present
 
-# Limits the max number of connections on / vhost.
+# Limit the max number of connections on the vhost '/'.
 # This task implicitly clears the max number of queues limit using default value: -1.
 - rabbitmq_vhost_limits:
     vhost: /
     max_connections: 64
     state: present
 
-# Clears the limits on / vhost.
+# Clear the limits on the vhost '/'.
 - rabbitmq_vhost_limits:
     vhost: /
     state: absent

--- a/lib/ansible/modules/messaging/rabbitmq_vhost_limits.py
+++ b/lib/ansible/modules/messaging/rabbitmq_vhost_limits.py
@@ -1,0 +1,113 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2018, First Last <email address>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = '''
+---
+module:
+short_description:
+description:
+  -
+version_added:
+author: '"First Last (@GitHubID)"'
+options:
+'''
+
+
+EXAMPLES = '''
+'''
+
+
+import json
+from ansible.module_utils.basic import AnsibleModule
+
+
+class RabbitMqVhostLimits(object):
+    def __init__(self, module):
+        self._module = module
+        self._max_connections = module.params['max_connections']
+        self._max_queues = module.params['max_queues']
+        self._node = module.params['node']
+        self._state = module.params['state']
+        self._vhost = module.params['vhost']
+        self._rabbitmqctl = module.get_bin_path('rabbitmqctl', True)
+
+    def _exec(self, args, run_in_check_mode=False):
+        if (not self._module.check_mode) or run_in_check_mode:
+            cmd = [self._rabbitmqctl, '-q']
+            if self._node is not None:
+                cmd.extend(['-n', self._node])
+            rc, out, err = self._module.run_command(cmd + args, check_rc=True)
+            # return out.splitlines()
+            # rc, out, err = self._module.run_command(cmd + args)
+            return dict(rc=rc, out=out.splitlines(), err=err.splitlines())
+        return list()
+
+    def list(self):
+        exec_result = self._exec(['list_vhost_limits', '-p', self._vhost])
+        return exec_result['out'][0]
+
+    def set(self):
+        json_str = '{{"max-connections": {0}, "max-queues": {1}}}'.format(self._max_connections, self._max_queues)
+        self._exec(['set_vhost_limits', '-p', self._vhost, json_str])
+
+    def clear(self):
+        self._exec(['clear_vhost_limits', '-p', self._vhost])
+
+
+def main():
+    arg_spec = dict(
+        max_connections=dict(default=-1, type='int'),
+        max_queues=dict(default=-1, type='int'),
+        node=dict(default=None, type='str'),
+        state=dict(default='present', choices=['present', 'absent'], type='str'),
+        vhost=dict(default='/', type='str')
+    )
+
+    module = AnsibleModule(
+        argument_spec=arg_spec,
+        supports_check_mode=True
+    )
+
+    max_connections = module.params['max_connections']
+    max_queues = module.params['max_queues']
+    state = module.params['state']
+
+    module_result = dict(changed=False)
+    rabbitmq_vhost_limits = RabbitMqVhostLimits(module)
+
+    wanted_status = {
+        'max-connections': max_connections,
+        'max-queues': max_queues
+    }
+    current_status = rabbitmq_vhost_limits.list()
+
+    if current_status: # when some value has already set
+        if state == 'present':
+            if wanted_status != json.loads(current_status):
+                rabbitmq_vhost_limits.set()
+                module_result['changed'] = True
+        else: # state == 'absent'
+            rabbitmq_vhost_limits.clear()
+            module_result['changed'] = True
+    else: # when any value has not set yet
+        if state == 'present':
+            rabbitmq_vhost_limits.set()
+            module_result['changed'] = True
+
+    module.exit_json(**module_result)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/messaging/rabbitmq_vhost_limits.py
+++ b/lib/ansible/modules/messaging/rabbitmq_vhost_limits.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# (c) 2018, First Last <email address>
+# (c) 2018, Hiroyuki Matsuo <hiroyuki3569825@gmail.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function

--- a/lib/ansible/modules/messaging/rabbitmq_vhost_limits.py
+++ b/lib/ansible/modules/messaging/rabbitmq_vhost_limits.py
@@ -125,7 +125,7 @@ class RabbitMqVhostLimits(object):
             if 'max-connections' in vhost_limits:
                 max_connections = vhost_limits['max-connections']
             if 'max-queues' in vhost_limits:
-                max_queues = vhost_limits['max-queues'] 
+                max_queues = vhost_limits['max-queues']
         return dict(
             max_connections=max_connections,
             max_queues=max_queues
@@ -168,7 +168,7 @@ def main():
             max_connections=max_connections,
             max_queues=max_queues
         )
-    else: # state == 'absent'
+    else:  # state == 'absent'
         wanted_status = dict(
             max_connections=None,
             max_queues=None
@@ -179,7 +179,7 @@ def main():
             if not module.check_mode:
                 rabbitmq_vhost_limits.set()
             module_result['changed'] = True
-        else: # state == 'absent'
+        else:  # state == 'absent'
             if not module.check_mode:
                 rabbitmq_vhost_limits.clear()
             module_result['changed'] = True

--- a/lib/ansible/modules/messaging/rabbitmq_vhost_limits.py
+++ b/lib/ansible/modules/messaging/rabbitmq_vhost_limits.py
@@ -17,12 +17,12 @@ DOCUMENTATION = '''
 ---
 module: rabbitmq_vhost_limits
 author: '"Hiroyuki Matsuo (@h-matsuo)"'
-version_added: "2.4"
+version_added: "2.5"
 
 short_description: Manage the state of virtual host limits in RabbitMQ
 description:
   - This module can enforce or clear limits on a virtual host.
-  - Recognised limits are `max_connections` and `max-queues`.
+  - Recognized limits are I(max_connections) and I(max-queues).
 
 options:
     max_connections:

--- a/test/integration/targets/rabbitmq_vhost_limits/aliases
+++ b/test/integration/targets/rabbitmq_vhost_limits/aliases
@@ -1,0 +1,5 @@
+destructive
+shippable/posix/group1
+skip/osx
+skip/freebsd
+skip/rhel

--- a/test/integration/targets/rabbitmq_vhost_limits/meta/main.yml
+++ b/test/integration/targets/rabbitmq_vhost_limits/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - setup_rabbitmq

--- a/test/integration/targets/rabbitmq_vhost_limits/tasks/main.yml
+++ b/test/integration/targets/rabbitmq_vhost_limits/tasks/main.yml
@@ -1,0 +1,5 @@
+# Rabbitmq lookup
+- include: ubuntu.yml
+  when: 
+    - ansible_distribution == 'Ubuntu'
+    - ansible_distribution_release != 'trusty'

--- a/test/integration/targets/rabbitmq_vhost_limits/tasks/ubuntu.yml
+++ b/test/integration/targets/rabbitmq_vhost_limits/tasks/ubuntu.yml
@@ -1,0 +1,138 @@
+- name: Test failure without pika installed
+  set_fact:
+    rabbit_missing_pika: "{{ lookup('rabbitmq', url='amqp://guest:guest@192.168.250.1:5672/%2F', queue='hello', count=3) }}"
+  ignore_errors: yes
+  register: rabbitmq_missing_pika_error
+
+- assert:
+    that:
+      - "'pika python package is required' in rabbitmq_missing_pika_error.msg"
+
+- name: Install pika and requests
+  pip:
+    name: pika,requests
+    state: latest
+
+- name: Test that giving an incorrect amqp protocol in URL will error
+  set_fact:
+    rabbitmq_test_protocol: "{{ lookup('rabbitmq', url='zzzamqp://guest:guest@192.168.250.1:5672/%2F', queue='hello', count=3) }}"
+  ignore_errors: yes
+  register: rabbitmq_protocol_error
+
+- assert:
+    that:
+      - "rabbitmq_protocol_error is failed"
+      - "'URL malformed' in rabbitmq_protocol_error.msg"
+
+- name: Test that giving an incorrect IP address in URL will error
+  set_fact:
+    rabbitmq_test_protocol: "{{ lookup('rabbitmq', url='amqp://guest:guest@xxxxx192.112312368.250.1:5672/%2F', queue='hello', count=3) }}"
+  ignore_errors: yes
+  register: rabbitmq_ip_error
+ 
+- assert:
+    that:
+      - "rabbitmq_ip_error is failed"
+      - "'Connection issue' in rabbitmq_ip_error.msg"
+ 
+- name: Test missing parameters will error
+  set_fact:
+    rabbitmq_test_protocol: "{{ lookup('rabbitmq') }}"
+  ignore_errors: yes
+  register: rabbitmq_params_error
+ 
+- assert:
+    that:
+      - "rabbitmq_params_error is failed"
+      - "'URL is required for rabbitmq lookup.' in rabbitmq_params_error.msg"
+ 
+- name: Test missing queue will error
+  set_fact:
+    rabbitmq_queue_protocol: "{{ lookup('rabbitmq', url='amqp://guest:guest@192.168.250.1:5672/%2F') }}"
+  ignore_errors: yes
+  register: rabbitmq_queue_error
+ 
+- assert:
+    that:
+      - "rabbitmq_queue_error is failed"
+      - "'Queue is required for rabbitmq lookup' in rabbitmq_queue_error.msg"
+
+- name: Enables the rabbitmq_management plugin
+  rabbitmq_plugin:
+    names: rabbitmq_management
+    state: enabled
+
+- name: Setup test queue
+  rabbitmq_queue:
+      name: hello
+
+- name: Post test message to the exchange (string)
+  uri:
+    url: http://localhost:15672/api/exchanges/%2f/amq.default/publish
+    method: POST
+    body: '{"properties":{},"routing_key":"hello","payload":"ansible-test","payload_encoding":"string"}'
+    user: guest
+    password: guest
+    force_basic_auth: yes
+    return_content: yes
+    register: post_data
+    headers:
+      Content-Type: "application/json"
+
+
+- name: Post test message to the exchange (json)
+  uri:
+    url: http://localhost:15672/api/exchanges/%2f/amq.default/publish
+    method: POST
+    body: '{"properties":{"content_type": "application/json"},"routing_key":"hello","payload":"{\"key\": \"value\" }","payload_encoding":"string"}'
+    user: guest
+    password: guest
+    force_basic_auth: yes
+    return_content: yes
+    register: post_data_json
+    headers:
+      Content-Type: "application/json"
+
+- name: Test retrieve messages
+  set_fact:
+    rabbitmq_msg: "{{ lookup('rabbitmq', url='amqp://guest:guest@localhost:5672/%2f/hello', queue='hello') }}"
+  ignore_errors: yes
+  register: rabbitmq_msg_error
+
+- name: Ensure two messages received
+  assert:
+    that:
+      - "rabbitmq_msg_error is not failed"
+      - rabbitmq_msg | length == 2
+
+- name: Ensure first message is a string
+  assert:
+    that:
+      - rabbitmq_msg[0].msg == "ansible-test"
+
+- name: Ensure second message is json
+  assert:
+    that:
+      - rabbitmq_msg[1].json.key == "value"
+
+- name: Test missing vhost
+  set_fact:
+    rabbitmq_msg: "{{ lookup('rabbitmq', url='amqp://guest:guest@localhost:5672/missing/', queue='hello') }}"
+  ignore_errors: yes
+  register: rabbitmq_vhost_error
+
+- assert:
+    that:
+      - "rabbitmq_vhost_error is failed"
+      - "'NOT_ALLOWED' in rabbitmq_vhost_error.msg"
+
+# Tidy up
+- name: Uninstall pika and requests
+  pip:
+    name: pika,requests
+    state: absent
+
+- name: Disable the rabbitmq_management plugin
+  rabbitmq_plugin:
+    names: rabbitmq_management
+    state: disabled

--- a/test/integration/targets/rabbitmq_vhost_limits/tasks/ubuntu.yml
+++ b/test/integration/targets/rabbitmq_vhost_limits/tasks/ubuntu.yml
@@ -1,138 +1,146 @@
-- name: Test failure without pika installed
-  set_fact:
-    rabbit_missing_pika: "{{ lookup('rabbitmq', url='amqp://guest:guest@192.168.250.1:5672/%2F', queue='hello', count=3) }}"
-  ignore_errors: yes
-  register: rabbitmq_missing_pika_error
+---
 
-- assert:
-    that:
-      - "'pika python package is required' in rabbitmq_missing_pika_error.msg"
+- name: Test setting virtual host limits in check mode
+  block:
+    - name: Set virtual host limits in check mode
+      rabbitmq_vhost_limits:
+        vhost: /
+        max_connections: 64
+        max_queues: 256
+        state: present
+      check_mode: true
+      register: module_result
 
-- name: Install pika and requests
-  pip:
-    name: pika,requests
-    state: latest
+    - name: Check that the module succeeds with a change
+      assert:
+        that:
+          - module_result is changed
+          - module_result is success
 
-- name: Test that giving an incorrect amqp protocol in URL will error
-  set_fact:
-    rabbitmq_test_protocol: "{{ lookup('rabbitmq', url='zzzamqp://guest:guest@192.168.250.1:5672/%2F', queue='hello', count=3) }}"
-  ignore_errors: yes
-  register: rabbitmq_protocol_error
+    - name: Get a list of configured virtual host limits
+      shell: "rabbitmqctl list_vhost_limits"
+      register: shell_result
 
-- assert:
-    that:
-      - "rabbitmq_protocol_error is failed"
-      - "'URL malformed' in rabbitmq_protocol_error.msg"
+    - name: Check that the check mode does not make any changes
+      assert:
+        that:
+          - shell_result is success
+          - "'\"max-connections\":64' not in shell_result.stdout"
+          - "'\"max-queues\":256' not in shell_result.stdout"
 
-- name: Test that giving an incorrect IP address in URL will error
-  set_fact:
-    rabbitmq_test_protocol: "{{ lookup('rabbitmq', url='amqp://guest:guest@xxxxx192.112312368.250.1:5672/%2F', queue='hello', count=3) }}"
-  ignore_errors: yes
-  register: rabbitmq_ip_error
- 
-- assert:
-    that:
-      - "rabbitmq_ip_error is failed"
-      - "'Connection issue' in rabbitmq_ip_error.msg"
- 
-- name: Test missing parameters will error
-  set_fact:
-    rabbitmq_test_protocol: "{{ lookup('rabbitmq') }}"
-  ignore_errors: yes
-  register: rabbitmq_params_error
- 
-- assert:
-    that:
-      - "rabbitmq_params_error is failed"
-      - "'URL is required for rabbitmq lookup.' in rabbitmq_params_error.msg"
- 
-- name: Test missing queue will error
-  set_fact:
-    rabbitmq_queue_protocol: "{{ lookup('rabbitmq', url='amqp://guest:guest@192.168.250.1:5672/%2F') }}"
-  ignore_errors: yes
-  register: rabbitmq_queue_error
- 
-- assert:
-    that:
-      - "rabbitmq_queue_error is failed"
-      - "'Queue is required for rabbitmq lookup' in rabbitmq_queue_error.msg"
+- name: Test setting virtual host limits
+  block:
+    - name: Set virtual host limits
+      rabbitmq_vhost_limits:
+        vhost: /
+        max_connections: 64
+        max_queues: 256
+        state: present
+      register: module_result
 
-- name: Enables the rabbitmq_management plugin
-  rabbitmq_plugin:
-    names: rabbitmq_management
-    state: enabled
+    - name: Check that the module's result is correct
+      assert:
+        that:
+          - module_result is changed
+          - module_result is success
+          - "module_result.vhost == '/'"
+          - "module_result.max_connections == 64"
+          - "module_result.max_queues == 256"
 
-- name: Setup test queue
-  rabbitmq_queue:
-      name: hello
+    - name: Get a list of configured virtual host limits
+      shell: "rabbitmqctl list_vhost_limits"
+      register: shell_result
 
-- name: Post test message to the exchange (string)
-  uri:
-    url: http://localhost:15672/api/exchanges/%2f/amq.default/publish
-    method: POST
-    body: '{"properties":{},"routing_key":"hello","payload":"ansible-test","payload_encoding":"string"}'
-    user: guest
-    password: guest
-    force_basic_auth: yes
-    return_content: yes
-    register: post_data
-    headers:
-      Content-Type: "application/json"
+    - name: Check that the virtual host limits are actually set
+      assert:
+        that:
+          - shell_result is success
+          - "'\"max-connections\":64' in shell_result.stdout"
+          - "'\"max-queues\":256' in shell_result.stdout"
 
+- name: Test setting virtual host limits (idempotence)
+  block:
+    - name: Set virtual host limits (idempotence)
+      rabbitmq_vhost_limits:
+        vhost: /
+        max_connections: 64
+        max_queues: 256
+        state: present
+      register: module_result
 
-- name: Post test message to the exchange (json)
-  uri:
-    url: http://localhost:15672/api/exchanges/%2f/amq.default/publish
-    method: POST
-    body: '{"properties":{"content_type": "application/json"},"routing_key":"hello","payload":"{\"key\": \"value\" }","payload_encoding":"string"}'
-    user: guest
-    password: guest
-    force_basic_auth: yes
-    return_content: yes
-    register: post_data_json
-    headers:
-      Content-Type: "application/json"
+    - name: Check the idempotence
+      assert:
+        that:
+          - module_result is not changed
+          - module_result is success
 
-- name: Test retrieve messages
-  set_fact:
-    rabbitmq_msg: "{{ lookup('rabbitmq', url='amqp://guest:guest@localhost:5672/%2f/hello', queue='hello') }}"
-  ignore_errors: yes
-  register: rabbitmq_msg_error
+- name: Test changing virtual host limits
+  block:
+    - name: Change virtual host limits
+      rabbitmq_vhost_limits:
+        vhost: /
+        max_connections: 32
+        state: present
+      register: module_result
 
-- name: Ensure two messages received
-  assert:
-    that:
-      - "rabbitmq_msg_error is not failed"
-      - rabbitmq_msg | length == 2
+    - name: Check that the module's result is correct
+      assert:
+        that:
+          - module_result is changed
+          - module_result is success
+          - "module_result.vhost == '/'"
+          - "module_result.max_connections == 32"
+          - "module_result.max_queues == -1"
 
-- name: Ensure first message is a string
-  assert:
-    that:
-      - rabbitmq_msg[0].msg == "ansible-test"
+    - name: Get a list of configured virtual host limits
+      shell: "rabbitmqctl list_vhost_limits"
+      register: shell_result
 
-- name: Ensure second message is json
-  assert:
-    that:
-      - rabbitmq_msg[1].json.key == "value"
+    - name: Check that the virtual host limits are actually set
+      assert:
+        that:
+          - shell_result is success
+          - "'\"max-connections\":32' in shell_result.stdout"
+          - "'\"max-queues\":-1' in shell_result.stdout"
 
-- name: Test missing vhost
-  set_fact:
-    rabbitmq_msg: "{{ lookup('rabbitmq', url='amqp://guest:guest@localhost:5672/missing/', queue='hello') }}"
-  ignore_errors: yes
-  register: rabbitmq_vhost_error
+- name: Test clearing virtual host limits
+  block:
+    - name: Clear virtual host limits
+      rabbitmq_vhost_limits:
+        vhost: /
+        state: absent
+      register: module_result
 
-- assert:
-    that:
-      - "rabbitmq_vhost_error is failed"
-      - "'NOT_ALLOWED' in rabbitmq_vhost_error.msg"
+    - name: Check that the module's result is correct
+      assert:
+        that:
+          - module_result is changed
+          - module_result is success
+          - "module_result.vhost == '/'"
+          - "module_result.max_connections is none"
+          - "module_result.max_queues is none"
 
-# Tidy up
-- name: Uninstall pika and requests
-  pip:
-    name: pika,requests
-    state: absent
+    - name: Get a list of configured virtual host limits
+      shell: "rabbitmqctl list_vhost_limits"
+      register: shell_result
 
-- name: Disable the rabbitmq_management plugin
-  rabbitmq_plugin:
-    names: rabbitmq_management
-    state: disabled
+    - name: Check that the virtual host limits are actually cleared
+      assert:
+        that:
+          - shell_result is success
+          - "'\"max-connections\":' not in shell_result.stdout"
+          - "'\"max-queues\":' not in shell_result.stdout"
+
+- name: Test clearing virtual host limits (idempotence)
+  block:
+    - name: Clear virtual host limits (idempotence)
+      rabbitmq_vhost_limits:
+        vhost: /
+        state: absent
+      register: module_result
+
+    - name: Check the idempotence
+      assert:
+        that:
+          - module_result is not changed
+          - module_result is success

--- a/test/integration/targets/rabbitmq_vhost_limits/tasks/ubuntu.yml
+++ b/test/integration/targets/rabbitmq_vhost_limits/tasks/ubuntu.yml
@@ -117,8 +117,8 @@
           - module_result is changed
           - module_result is success
           - "module_result.vhost == '/'"
-          - "module_result.max_connections is none"
-          - "module_result.max_queues is none"
+          - "module_result.max_connections == -1"
+          - "module_result.max_queues == -1"
 
     - name: Get a list of configured virtual host limits
       shell: "rabbitmqctl list_vhost_limits"

--- a/test/integration/targets/rabbitmq_vhost_limits/tasks/ubuntu.yml
+++ b/test/integration/targets/rabbitmq_vhost_limits/tasks/ubuntu.yml
@@ -16,9 +16,6 @@
         that:
           - module_result is changed
           - module_result is success
-          - "module_result.vhost == '/'"
-          - "module_result.max_connections == 64"
-          - "module_result.max_queues == 256"
 
     - name: Get a list of configured virtual host limits
       shell: "rabbitmqctl list_vhost_limits"
@@ -46,9 +43,6 @@
         that:
           - module_result is changed
           - module_result is success
-          - "module_result.vhost == '/'"
-          - "module_result.max_connections == 64"
-          - "module_result.max_queues == 256"
 
     - name: Get a list of configured virtual host limits
       shell: "rabbitmqctl list_vhost_limits"
@@ -91,9 +85,6 @@
         that:
           - module_result is changed
           - module_result is success
-          - "module_result.vhost == '/'"
-          - "module_result.max_connections == 32"
-          - "module_result.max_queues == -1"
 
     - name: Get a list of configured virtual host limits
       shell: "rabbitmqctl list_vhost_limits"
@@ -120,9 +111,6 @@
         that:
           - module_result is changed
           - module_result is success
-          - "module_result.vhost == '/'"
-          - "module_result.max_connections == -1"
-          - "module_result.max_queues == -1"
 
     - name: Get a list of configured virtual host limits
       shell: "rabbitmqctl list_vhost_limits"
@@ -148,9 +136,6 @@
         that:
           - module_result is changed
           - module_result is success
-          - "module_result.vhost == '/'"
-          - "module_result.max_connections == -1"
-          - "module_result.max_queues == -1"
 
     - name: Get a list of configured virtual host limits
       shell: "rabbitmqctl list_vhost_limits"

--- a/test/integration/targets/rabbitmq_vhost_limits/tasks/ubuntu.yml
+++ b/test/integration/targets/rabbitmq_vhost_limits/tasks/ubuntu.yml
@@ -11,11 +11,14 @@
       check_mode: true
       register: module_result
 
-    - name: Check that the module succeeds with a change
+    - name: Check that the module's result is correct
       assert:
         that:
           - module_result is changed
           - module_result is success
+          - "module_result.vhost == '/'"
+          - "module_result.max_connections == 64"
+          - "module_result.max_queues == 256"
 
     - name: Get a list of configured virtual host limits
       shell: "rabbitmqctl list_vhost_limits"
@@ -97,6 +100,35 @@
       register: shell_result
 
     - name: Check that the virtual host limits are actually set
+      assert:
+        that:
+          - shell_result is success
+          - "'\"max-connections\":32' in shell_result.stdout"
+          - "'\"max-queues\":-1' in shell_result.stdout"
+
+- name: Test clearing virtual host limits in check mode
+  block:
+    - name: Clear virtual host limits in check mode
+      rabbitmq_vhost_limits:
+        vhost: /
+        state: absent
+      check_mode: true
+      register: module_result
+
+    - name: Check that the module's result is correct
+      assert:
+        that:
+          - module_result is changed
+          - module_result is success
+          - "module_result.vhost == '/'"
+          - "module_result.max_connections == -1"
+          - "module_result.max_queues == -1"
+
+    - name: Get a list of configured virtual host limits
+      shell: "rabbitmqctl list_vhost_limits"
+      register: shell_result
+
+    - name: Check that the check mode does not make any changes
       assert:
         that:
           - shell_result is success


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Add a new module: `rabbitmq_vhost_limits`.
This module can manage RabbitMQ's [Virtual Host Limits](https://www.rabbitmq.com/rabbitmqctl.8.html#Virtual_Host_Limits) using `rabbitmqctl` command.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
 - New Module Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
`rabbitmq_vhost_limits`

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0 (rabbitmq_vhost_limits_module e500a7e820) last updated 2018/03/23 17:34:32 (GMT +900)
  config file = None
  configured module search path = ['/Users/uu128051/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/uu128051/Repository/ansible/lib/ansible
  executable location = /Users/uu128051/Repository/ansible/bin/ansible
  python version = 3.6.4 |Anaconda, Inc.| (default, Jan 16 2018, 12:04:33) [GCC 4.2.1 Compatible Clang 4.0.1 (tags/RELEASE_401/final)]
```
