### PR TITLE
Add setup.cfg to embed README and licenses @ dists

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,4 @@
 [metadata]
-license_file = file: licenses/MIT-license.txt, licenses/PSF-license.txt, licenses/simplified_bsd.txt
 long_description = file: README.md
 long_description_content_type = text/markdown
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,7 @@
+[metadata]
+license_file = file: licenses/MIT-license.txt, licenses/PSF-license.txt, licenses/simplified_bsd.txt
+long_description = file: README.md
+long_description_content_type = text/markdown
+
+[bdist_wheel]
+universal = 1


### PR DESCRIPTION
##### SUMMARY
There's no project description @ [PYPI](https://pypi.org/project/ansible/2.5.0/) since v2.3.2.0. The last one I've found with long description is v2.3.1.0.

This is a suggestion of how to fix it by rendering README.md into the long_description.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request ?
 - Bugfix Pull Request
 - Docs Pull Request ?

##### COMPONENT NAME
python distribution meta / setup.py

##### ANSIBLE VERSION
2.3.2.0‒2.5.0+

##### ADDITIONAL INFORMATION
has description: https://pypi.org/project/ansible/2.3.1.0/
doesn't: https://pypi.org/project/ansible/2.5.0/