### PR TITLE
[2.5] cs_vpc_offering: listVPCOffering API returns any matching names (#37783)

### DIFF
--- a/lib/ansible/modules/cloud/cloudstack/cs_vpc_offering.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_vpc_offering.py
@@ -149,7 +149,9 @@ class AnsibleCloudStackVPCOffering(AnsibleCloudStack):
         vo = self.query_api('listVPCOfferings', **args)
 
         if vo:
-            self.vpc_offering = vo['vpcoffering'][0]
+            for vpc_offer in vo['vpcoffering']:
+                if args['name'] == vpc_offer['name']:
+                    self.vpc_offering = vpc_offer
 
         return self.vpc_offering
 


### PR DESCRIPTION
(cherry picked from commit 270e799cb6073658de13a3b31b075ee4fadfa3e1)

fix an issue caused by a weak filter in the list API, which returns an unexpected result. By manually comparing the result with python to ensure we got the expected object.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
cs_vpc_offering

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
