### PR TITLE
consul_kv: support retrieval of values from KV

### DIFF
--- a/lib/ansible/modules/clustering/consul_kv.py
+++ b/lib/ansible/modules/clustering/consul_kv.py
@@ -101,6 +101,13 @@ options:
 
 
 EXAMPLES = '''
+# If the key does not exist, the value associated to the "data" property in `retrieved_key` will be `None`
+# If the key value is empty string, `retrieved_key["data"]["Value"]` will be `None`
+- name: retrieve a value from the key/value store
+  consul_kv:
+    key: somekey
+  register: retrieved_key
+
 - name: Add or update the value associated with a key in the key/value store
   consul_kv:
     key: somekey

--- a/lib/ansible/modules/clustering/consul_kv.py
+++ b/lib/ansible/modules/clustering/consul_kv.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 #
 # (c) 2015, Steve Gargan <steve.gargan@gmail.com>
-# (c) 2017, 2018 Genome Research Ltd.
+# (c) 2018 Genome Research Ltd.
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function

--- a/lib/ansible/modules/clustering/consul_kv.py
+++ b/lib/ansible/modules/clustering/consul_kv.py
@@ -35,8 +35,8 @@ options:
     state:
         description:
           - The action to take with the supplied key and value. If the state is 'present' and `value` is set, the key
-            contents will be set to the value supplied and `changed` will be set to `true` only if the value was 
-            different to the current contents. If the state is 'present' and `value` is not set, the existing value 
+            contents will be set to the value supplied and `changed` will be set to `true` only if the value was
+            different to the current contents. If the state is 'present' and `value` is not set, the existing value
             associated to the key will be returned. The state 'absent' will remove the key/value pair,
             again 'changed' will be set to true only if the key actually existed
             prior to the removal. An attempt can be made to obtain or free the
@@ -213,7 +213,6 @@ def get_value(module):
     index, existing_value = consul_api.kv.get(key)
 
     module.exit_json(changed=False, index=index, data=existing_value)
-
 
 
 def add_value(module):

--- a/lib/ansible/modules/clustering/consul_kv.py
+++ b/lib/ansible/modules/clustering/consul_kv.py
@@ -213,7 +213,8 @@ def lock(module, state):
 def get_value(module):
     consul_api = get_consul_api(module)
     key = module.params.get('key')
-    index, existing_value = consul_api.kv.get(key)
+
+    index, existing_value = consul_api.kv.get(key, recurse=module.params.get('recurse'))
 
     module.exit_json(changed=False, index=index, data=existing_value)
 

--- a/lib/ansible/modules/clustering/consul_kv.py
+++ b/lib/ansible/modules/clustering/consul_kv.py
@@ -17,7 +17,7 @@ DOCUMENTATION = """
 module: consul_kv
 short_description: Manipulate entries in the key/value store of a consul cluster
 description:
-  - Allows the addition, modification and deletion of key/value entries in a
+  - Allows the retrieval, addition, modification and deletion of key/value entries in a
     consul cluster via the agent. The entire contents of the record, including
     the indices, flags and session are returned as 'value'.
   - If the key represents a prefix then Note that when a value is removed, the existing
@@ -34,10 +34,10 @@ author:
 options:
     state:
         description:
-          - The action to take with the supplied key and value. If the state is
-            'present', the key contents will be set to the value supplied,
-            'changed' will be set to true only if the value was different to the
-            current contents. The state 'absent' will remove the key/value pair,
+          - The action to take with the supplied key and value. If the state is 'present' and `value` is set, the key
+            contents will be set to the value supplied and `changed` will be set to `true` only if the value was 
+            different to the current contents. If the state is 'present' and `value` is not set, the existing value 
+            associated to the key will be returned. The state 'absent' will remove the key/value pair,
             again 'changed' will be set to true only if the key actually existed
             prior to the removal. An attempt can be made to obtain or free the
             lock associated with a key/value pair with the states 'acquire' or


### PR DESCRIPTION
##### SUMMARY
Fixes #37224.

This PR makes it possible to retrieve a key value.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
consul_kv

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0
  config file = None
  configured module search path = [u'/Users/cn13/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/cn13/work/tmp/venv/lib/python2.7/site-packages/ansible
  executable location = /Users/cn13/work/tmp/venv/bin/ansible
  python version = 2.7.14 (default, Feb  1 2018, 11:59:25) [GCC 4.2.1 Compatible Apple LLVM 7.3.0 (clang-703.0.31)]
```


##### ADDITIONAL INFORMATION
It looks like previously, it was only possible to get a KV value without potentially changing it if the module was ran in checked mode!
