### PR TITLE
Adding TowerCLI send modules

### DIFF
--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_send.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_send.py
@@ -1,0 +1,167 @@
+#!/usr/bin/python
+# coding: utf-8 -*-
+
+# (c) 2017, John Westcott IV <john.westcott.iv@redhat.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = '''
+---
+module: tower_send
+author: "John Westcott IV (@john-westcott-iv)"
+version_added: "2.8"
+short_description: Send assets to Ansible Tower.
+description:
+    - Send assets to Ansible Tower. See
+      U(https://www.ansible.com/tower) for an overview.
+options:
+    assets:
+      description:
+        - The assets to import.
+        - This can be the output of tower_receive or loaded from a file
+      required: False
+    files:
+      description:
+        - List of files to import.
+      required: False
+      default: []
+    prevent:
+      description:
+        - A list of asset types to prevent import for
+      required: false
+      default: []
+    password_management:
+      description:
+        - The password management option to use.
+        - The prompt option is not supported.
+      required: false
+      default: 'default'
+      choices: ["default", "random"]
+
+notes:
+  - One of assets or files needs to be passed in
+
+requirements:
+  - "ansible-tower-cli >= 3.3.0"
+  - six.moves.StringIO
+  - sys
+
+extends_documentation_fragment: tower
+'''
+
+EXAMPLES = '''
+- name: Import all tower assets
+  tower_send:
+    assets: "{{ export_output.assets }}"
+    tower_config_file: "~/tower_cli.cfg"
+'''
+
+RETURN = '''
+output:
+    description: The import messages
+    returned: success, fail
+    type: list
+    sample: [ 'Message 1', 'Messag 2' ]
+'''
+
+import os
+import sys
+
+from ansible.module_utils.six.moves import StringIO
+from ansible.module_utils.ansible_tower import TowerModule, tower_auth_config, HAS_TOWER_CLI
+
+from tempfile import mkstemp
+
+try:
+    from tower_cli.cli.transfer.send import Sender
+    from tower_cli.utils.exceptions import TowerCLIError
+
+    from tower_cli.conf import settings
+    TOWER_CLI_HAS_EXPORT = True
+except ImportError:
+    TOWER_CLI_HAS_EXPORT = False
+
+
+def main():
+    argument_spec = dict(
+        assets=dict(required=False),
+        files=dict(required=False, default=[], type='list'),
+        prevent=dict(required=False, default=[], type='list'),
+        password_management=dict(required=False, default='default', choices=['default', 'random']),
+    )
+
+    module = TowerModule(argument_spec=argument_spec, supports_check_mode=False)
+
+    if not HAS_TOWER_CLI:
+        module.fail_json(msg='ansible-tower-cli required for this module')
+
+    if not TOWER_CLI_HAS_EXPORT:
+        module.fail_json(msg='ansible-tower-cli version does not support export')
+
+    assets = module.params.get('assets')
+    prevent = module.params.get('prevent')
+    password_management = module.params.get('password_management')
+    files = module.params.get('files')
+
+    result = dict(
+        changed=False,
+        msg='',
+        output='',
+    )
+
+    if not assets and not files:
+        result['msg'] = "Assets or files must be specified"
+        module.fail_json(**result)
+
+    path = None
+    if assets:
+        # We got assets so we need to dump this out to a temp file and append that to files
+        handle, path = mkstemp(prefix='', suffix='', dir='')
+        with open(path, 'w') as f:
+            f.write(assets)
+        files.append(path)
+
+    tower_auth = tower_auth_config(module)
+    failed = False
+    with settings.runtime_values(**tower_auth):
+        try:
+            sender = Sender(no_color=False)
+            old_stdout = sys.stdout
+            sys.stdout = captured_stdout = StringIO()
+            try:
+                sender.send(files, prevent, password_management)
+            except TypeError as e:
+                # Newer versions of TowerCLI require 4 parameters
+                sender.send(files, prevent, [], password_management)
+
+            if sender.error_messages > 0:
+                failed = True
+                result['msg'] = "Transfer Failed with %d errors" % sender.error_messages
+            if sender.changed_messages > 0:
+                result['changed'] = True
+        except TowerCLIError as e:
+            result['msg'] = e
+            failed = True
+        finally:
+            if path is not None:
+                os.remove(path)
+            result['output'] = captured_stdout.getvalue().split("\n")
+            sys.stdout = old_stdout
+
+    # Return stdout so that module returns will work
+    if failed:
+        module.fail_json(**result)
+    else:
+        module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/test/integration/targets/tower_send/aliases
+++ b/test/integration/targets/tower_send/aliases
@@ -1,0 +1,2 @@
+cloud/tower
+shippable/tower/group1

--- a/test/integration/targets/tower_send/tasks/main.yml
+++ b/test/integration/targets/tower_send/tasks/main.yml
@@ -1,0 +1,75 @@
+- name: Test no parameters
+  tower_send:
+  register: result
+  ignore_errors: yes
+
+- assert:
+    that:
+      - "result is failed"
+
+- name: Create user json
+  set_fact:
+    user:
+      - username: "jowestco"
+        first_name: "John"
+        last_name: "Westcott"
+        asset_type: "user"
+        email: "john.westcott.iv@redhat.com"
+
+- name: Test a new import of asset
+  tower_send:
+    assets: "{{ user | to_json() }}"
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+
+- name: Test an existing import of asset
+  tower_send:
+    assets: "{{ user | to_json() }}"
+  register: result
+
+- assert:
+    that:
+      - "result is successful"
+      - "result is not changed"
+
+- name: Change an existing asset
+  tower_send:
+    assets: "{{ user | combine({'last_name': 'Westcott IV'}) | to_json() }}"
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+
+- name: Create organization json
+  set_fact:
+    organization:
+      - asset_type: organization
+        name: "Red Hat"
+
+- name: Create temp file
+  tempfile:
+    state: file
+  register: my_temp_file
+
+- name: Drop down a file to import
+  copy:
+    dest: "{{ my_temp_file.path }}"
+    content: "{{ organization | to_nice_json() }}"
+
+- name: Create org via files
+  tower_send:
+    files: "{{ my_temp_file.path }}"
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+
+- name: Remove Temp File
+  file:
+    path: "{{ my_temp_file.path }}"
+    state: absent


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Added in Tower modules to leverage new feature in TowerCLI

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New Module Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
tower_send
tower_receive

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/Users/jowestco/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/jowestco/Library/Python/2.7/lib/python/site-packages/ansible-2.6.0-py2.7.egg/ansible
  executable location = /Users/jowestco/Library/Python/2.7/bin/ansible
  python version = 2.7.10 (default, Jul 15 2017, 17:16:57) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.31)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
