### PR TITLE
append request headers instead of replacing

### DIFF
--- a/lib/ansible/modules/windows/win_uri.ps1
+++ b/lib/ansible/modules/windows/win_uri.ps1
@@ -125,7 +125,7 @@ if ($headers) {
             default { $req_headers.Add($header.Name, $header.Value) }
         }
     }
-    $client.Headers = $req_headers
+    $client.Headers.Add($req_headers)
 }
 
 if ($client_cert) {

--- a/test/integration/targets/win_uri/tasks/test.yml
+++ b/test/integration/targets/win_uri/tasks/test.yml
@@ -338,3 +338,24 @@
     - invalid_path.content is defined
     - invalid_path.method == 'GET'
     - invalid_path.connection is defined
+
+- name: post request with custom headers
+  win_uri:
+    url: http://{{httpbin_host}}/post
+    method: POST
+    headers:
+      Test-Header: hello
+      Another-Header: world
+    content_type: application/json
+    body: '{"foo": "bar"}'
+    return_content: yes
+  register: post_request_with_custom_headers
+
+- name: assert post with custom headers
+  assert:
+    that:
+    - not post_request_with_custom_headers.changed
+    - post_request_with_custom_headers.status_code == 200
+    - post_request_with_custom_headers.json.headers['Content-Type'] == "application/json"
+    - post_request_with_custom_headers.json.headers['Test-Header'] == 'hello'
+    - post_request_with_custom_headers.json.headers['Another-Header'] == 'world'


### PR DESCRIPTION
##### SUMMARY
Request headers are being replaced if any custom headers are supplied. This causes servers to respond with a 415 status code due to the Content-Type header not being sent.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
win_uri

##### ANSIBLE VERSION
```
ansible 2.6.0 (devel c29d616f9c) last updated 2018/03/23 15:03:52 (GMT +000)
  config file = None
  configured module search path = [u'/home/vagrant/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/vagrant/ansible/lib/ansible
  executable location = /home/vagrant/ansible/bin/ansible
  python version = 2.7.6 (default, Nov 23 2017, 15:49:48) [GCC 4.8.4]
```

##### ADDITIONAL INFORMATION
Test task:
```
    - name: Add Members
      win_uri:
        method: POST
        content_type: 'application/json'
        url: https://anstest.sysqa.com:8888/post-test/members
        validate_certs: no
        headers:
          Cookie: "X_AUTH_TOKEN={{token.content}}"
        body: "{{ member_body | to_json }}" 
        return_content: yes
      with_sequence: count={{ number_of_members }}
      register: member_response
```

Before:
```
failed: [anstest.sysqa.com] (item=1) => {
    "accept": "application/octet-stream, text/plain;charset=ISO-8859-1, application/xml, text/xml, application/x-www-form-urlencoded, application/*+xml, multipart/form-data, application/json;charset=UTF-8, application/*+json;charset=UTF-8, */*",
    "cache_control": "no-cache, no-store, max-age=0, must-revalidate",
    "changed": false,
    "character_set": null,
    "connection": "close",
    "content": "",
    "content_encoding": "",
    "content_length": "0",
    "content_type": "",
    "cookies": [],
    "date": "Fri, 23 Mar 2018 15:17:32 GMT",
    "expires": "0",
    "headers": [
        "X-Content-Type-Options",
        "X-XSS-Protection",
        "Pragma",
        "Strict-Transport-Security",
        "X-Frame-Options",
        "Accept",
        "Connection",
        "Content-Length",
        "Cache-Control",
        "Date",
        "Expires"
    ],
    "is_from_cache": false,
    "is_mutually_authenticated": false,
    "item": "1",
    "last_modified": "2018-03-23T10:17:32.2103489-05:00",
    "method": "POST",
    "msg": "Status code of request 'UnsupportedMediaType' is not in list of valid status codes 200.",
    "pragma": "no-cache",
    "protocol_version": {
        "Build": -1,
        "Major": 1,
        "MajorRevision": -1,
        "Minor": 1,
        "MinorRevision": -1,
        "Revision": -1
    },
    "response_uri": "https://anstest.sysqa.com:8888/post-test/members",
    "server": "",
    "status_code": 415,
    "status_description": "",
    "strict_transport_security": "max-age=31536000 ; includeSubDomains",
    "supports_headers": true,
    "url": "https://anstest.sysqa.com:8888/post-test/members",
    "x_content_type_options": "nosniff",
    "x_frame_options": "DENY",
    "xxss_protection": "1; mode=block"
}
```
After:
```
ok: [anstest.sysqa.com] => (item=1) => {
    "cache_control": "no-cache, no-store, max-age=0, must-revalidate",
    "changed": false,
    "character_set": "ISO-8859-1",
    "content": "12acaf7c-476e-45fc-89f6-024b7724b02f",
    "content_encoding": "",
    "content_length": "36",
    "content_type": "text/plain;charset=ISO-8859-1",
    "cookies": [],
    "date": "Fri, 23 Mar 2018 15:18:40 GMT",
    "expires": "0",
    "headers": [
        "X-Content-Type-Options",
        "X-XSS-Protection",
        "Pragma",
        "Strict-Transport-Security",
        "X-Frame-Options",
        "Content-Length",
        "Cache-Control",
        "Content-Type",
        "Date",
        "Expires"
    ],
    "is_from_cache": false,
    "is_mutually_authenticated": false,
    "item": "1",
    "last_modified": "2018-03-23T10:18:40.4782029-05:00",
    "method": "POST",
    "pragma": "no-cache",
    "protocol_version": {
        "Build": -1,
        "Major": 1,
        "MajorRevision": -1,
        "Minor": 1,
        "MinorRevision": -1,
        "Revision": -1
    },
    "response_uri": "https://anstest.sysqa.com:8888/post-test/members",
    "server": "",
    "status_code": 200,
    "status_description": "",
    "strict_transport_security": "max-age=31536000 ; includeSubDomains",
    "supports_headers": true,
    "url": "https://anstest.sysqa.com:8888/post-test/members",
    "x_content_type_options": "nosniff",
    "x_frame_options": "DENY",
    "xxss_protection": "1; mode=block"
}
```
