### PR TITLE
Fix interfaces_file to accept allow-*

### DIFF
--- a/lib/ansible/modules/system/interfaces_file.py
+++ b/lib/ansible/modules/system/interfaces_file.py
@@ -216,7 +216,7 @@ def read_interfaces_lines(module, line_strings):
         elif words[0] == "auto":
             lines.append(lineDict(line))
             currently_processing = "NONE"
-        elif words[0] == "allow-":
+        elif words[0].startswith("allow-"):
             lines.append(lineDict(line))
             currently_processing = "NONE"
         elif words[0] == "no-auto-down":


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Fixes #37846 

Allow lines where the first word is allow-* as per the documentation.

https://manpages.debian.org/stretch/ifupdown/interfaces.5.en.html

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->

interfaces_file

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0 (devel c3ab6cb9b1) last updated 2018/03/23 10:34:51 (GMT -600)
  config file = /home/schallee/devel/ansible/src/ansible.cfg
  configured module search path = [u'/home/schallee/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/schallee/devel/ansible/src/lib/ansible
  executable location = /home/schallee/devel/ansible/src/bin/ansible
  python version = 2.7.13 (default, Nov 24 2017, 17:33:09) [GCC 6.3.0 20170516]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

Before:

```
TASK [get /etc/network/interfaces] ****************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************
fatal: [host]: FAILED! => {
    "changed": false
}

MSG:

misplaced option allow-hotplug eth0
 in line 3

```
After:
```
TASK [get /etc/network/interfaces] ****************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************
ok: [host]

```