### PR TITLE
[WIP] Properly handle upgrade vs install for yum latest

### DIFF
--- a/test/integration/targets/yum/tasks/main.yml
+++ b/test/integration/targets/yum/tasks/main.yml
@@ -76,3 +76,21 @@
   when:
     - (ansible_distribution in ['RedHat', 'CentOS', 'ScientificLinux'] and ansible_distribution_major_version|int > 6) or ansible_distribution in ['Fedora']
     - ansible_python.version.major == 2
+
+# Ensure that "latest" performs upgrade action instead of install, this test
+# should succeed if we get an upgrade scenario but will fail on install attempt
+# because the glob of 'python*' on a RHEL/CentOS 7 system with EPEL enabled will
+# cause a yum transaction failure because it will attempt to install *all*
+# possible packages that start with "python" by name and the python34 vs python2
+# packages in EPEL vs base (respectively) will create a depsolve conflict.
+# However, if we do the upgrade action then we will simply get an upgrade of all
+# currently installed packages on the system that match the glob.
+- block:
+    - yum:
+        name: 'epel-release'
+        state: installed
+    - yum:
+        name: 'python*'
+        state: latest
+  when:
+      - (ansible_distribution in ['RedHat', 'CentOS', 'ScientificLinux'] and ansible_distribution_major_version|int == 7)


### PR DESCRIPTION
Signed-off-by: Adam Miller <admiller@redhat.com>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #34867

Previously if you run the yum module with state=latest for a package
set, it defaults to `install` instead of `upgrade` for the yum
command which is necessary when upgrading rpms from a local file or
remote URL but is not the correct course of action otherwise.

This patch also includes an improvement to how package globs are
handled for upgrades by not checking if they are installed because
the install check happens via the rpm binary and not the yum binary,
the former has no concept of querying for globs at this time.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
yum

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0 (yum d981867991) last updated 2018/03/23 15:19:53 (GMT -500)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /root/src/dev/ansible/lib/ansible
  executable location = /root/src/dev/ansible/bin/ansible
  python version = 2.7.5 (default, Aug  4 2017, 00:39:18) [GCC 4.8.5 20150623 (Red Hat 4.8.5-16)]

```
