### PR TITLE
Correct msg to detect idempotent yum groupinstall

### DIFF
--- a/lib/ansible/modules/packaging/os/yum.py
+++ b/lib/ansible/modules/packaging/os/yum.py
@@ -770,7 +770,7 @@ def exec_install(module, items, action, pkgs, res, yum_basecmd):
     res['msg'] += err
     res['changed'] = True
 
-    if ('Nothing to do' in out and rc == 0) or ('does not have any packages to install' in err):
+    if ('Nothing to do' in out and rc == 0) or ('does not have any packages' in err):
         res['changed'] = False
 
     if rc != 0:


### PR DESCRIPTION
Signed-off-by: Adam Miller <admiller@redhat.com>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
The message text used to check stderr for a warning about
groupinstall in order to determine if a change occurred is specific
to the version of yum that is in RHEL7 and newer. This change simply
removes a couple words off the end in order to only use text found
in the warning message in older versions of yum.

Fixes #35982
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
yum

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0 (yum-groupinstall a2e4cc3851) last updated 2018/03/23 16:47:20 (GMT -500)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/admiller/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/admiller/src/dev/ansible/lib/ansible
  executable location = /home/admiller/src/dev/ansible/bin/ansible
  python version = 2.7.14 (default, Feb 27 2018, 20:43:24) [GCC 7.3.1 20180130 (Red Hat 7.3.1-2)]

```

