### PR TITLE
Move from asciidoc to rst2man to generate man pages

### DIFF
--- a/docs/bin/generate_man.py
+++ b/docs/bin/generate_man.py
@@ -241,12 +241,12 @@ if __name__ == '__main__':
         if cli_name == 'adhoc':
             cli_class_name = 'AdHocCLI'
             # myclass = 'AdHocCLI'
-            output[cli_name] = 'ansible.1.asciidoc.in'
+            output[cli_name] = 'ansible.1.rst.in'
             cli_bin_name = 'ansible'
         else:
             # myclass = "%sCLI" % libname.capitalize()
             cli_class_name = "%sCLI" % cli_name.capitalize()
-            output[cli_name] = 'ansible-%s.1.asciidoc.in' % cli_name
+            output[cli_name] = 'ansible-%s.1.rst.in' % cli_name
             cli_bin_name = 'ansible-%s' % cli_name
 
         # FIXME:
@@ -255,7 +255,7 @@ if __name__ == '__main__':
 
     cli_list = allvars.keys()
 
-    doc_name_formats = {'man': '%s.1.asciidoc.in',
+    doc_name_formats = {'man': '%s.1.rst.in',
                         'rst': '%s.rst'}
 
     for cli_name in cli_list:

--- a/docs/templates/man.j2
+++ b/docs/templates/man.j2
@@ -1,16 +1,15 @@
 {% set name = ('ansible' if cli == 'adhoc' else 'ansible-%s' % cli) -%}
-{{name}}(1)
-{{ '=' *  ((name|length|int) + 3) }}
-:doctype:      manpage
-:encoding:     utf-8
-:lang:         en
-:man source:   Ansible
-:man version:  %VERSION%
-:man manual:   System administration commands
+{{name}}
+{{ '=' * ( name|length|int ) }}
 
-NAME
-----
-ansible{% if cli != 'adhoc' %}-{{cli}}{% endif %} - {{short_desc|default('')}}
+{{ '-' * ( short_desc|default('')|string|length|int ) }}
+{{short_desc|default('')}}
+{{ '-' * ( short_desc|default('')|string|length|int ) }}
+
+:Version:        Ansible %VERSION%
+:Manual section: 1
+:Manual group:   System administration commands
+
 
 
 SYNOPSIS
@@ -26,9 +25,9 @@ DESCRIPTION
 COMMON OPTIONS
 --------------
 {% for option in options|sort(attribute='options') %}
-{% for switch in option['options'] %}*{{switch}}*{% if option['arg'] %} '{{option['arg']}}'{% endif %}{% if not loop.last %}, {% endif %}{% endfor %}::
+{% for switch in option['options'] %}**{{switch}}**{% if option['arg'] %} '{{option['arg']}}'{% endif %}{% if not loop.last %}, {% endif %}{% endfor %}
 
-{{ option['desc'] }}
+  {{ option['desc'] }}
 {% endfor %}
 {% endif %}
 
@@ -48,11 +47,12 @@ ARGUMENTS
 ACTIONS
 -------
 {% for action in actions %}
-    *{{ action }}*::: {{ (actions[action]['desc']|default(' '))|wordwrap}}
+**{{ action }}**
+  {{ (actions[action]['desc']|default(' '))}}
 
 {% if actions[action]['options'] %}
 {% for option in actions[action]['options']|sort(attribute='options') %}
-{% for switch in option['options'] if switch in actions[action]['option_names'] %}*{{switch}}*{% if option['arg'] %} '{{option['arg']}}'{% endif %}{% if not loop.last %}, {% endif %}{% endfor %}::
+{% for switch in option['options'] if switch in actions[action]['option_names'] %}**{{switch}}**{% if option['arg'] %} '{{option['arg']}}'{% endif %}{% if not loop.last %}, {% endif %}{% endfor %}
 
         {{ (option['desc']) }}
 {% endfor %}
@@ -116,7 +116,7 @@ Ansible is released under the terms of the GPLv3 License.
 SEE ALSO
 --------
 
-{% for other in cli_list|sort %}{% if other != cli %}*ansible{% if other != 'adhoc' %}-{{other}}{% endif %}*(1){% if not loop.last %}, {% endif %}{% endif %}{% endfor %}
+{% for other in cli_list|sort %}{% if other != cli %}**ansible{% if other != 'adhoc' %}-{{other}}{% endif %}** (1){% if not loop.last %}, {% endif %}{% endif %}{% endfor %}
 
 Extensive documentation is available in the documentation site:
 <http://docs.ansible.com>.

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -17,7 +17,7 @@ arch=('any')
 url='https://www.ansible.com'
 license=('GPL3')
 depends=('python2' 'python2-paramiko' 'python2-jinja' 'python2-yaml')
-makedepends=('git' 'asciidoc' 'fakeroot')
+makedepends=('git' 'docutils' 'fakeroot')
 optdepends=('python2-pyasn1: needed for accelerated mode'
             'python2-crypto: needed for accelerated mode'
             'python2-keyczar: needed for accelerated mode')

--- a/packaging/debian/Dockerfile
+++ b/packaging/debian/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:xenial
 
 RUN apt-get update && apt-get install -y \
-    asciidoc \
+    python-docutils \
     cdbs \
     debootstrap \
     devscripts \

--- a/packaging/debian/README.md
+++ b/packaging/debian/README.md
@@ -6,7 +6,7 @@ To create an Ansible DEB package:
 __Note__: You must run this target as root or set `PBUILDER_BIN='sudo pbuilder'`
 
 ```
-apt-get install asciidoc cdbs debootstrap devscripts make pbuilder python-setuptools
+apt-get install python-docutils cdbs debootstrap devscripts make pbuilder python-setuptools
 git clone https://github.com/ansible/ansible.git
 cd ansible
 DEB_DIST='xenial trusty precise' make deb

--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -3,7 +3,7 @@ Section: admin
 Priority: optional
 Standards-Version: 3.9.3
 Maintainer: Ansible, Inc. <info@ansible.com>
-Build-Depends: cdbs, debhelper (>= 5.0.0), asciidoc, python, dh-python | python-support, python-setuptools, lsb-release
+Build-Depends: cdbs, debhelper (>= 5.0.0), python-docutils, python, dh-python | python-support, python-setuptools, lsb-release
 Homepage: http://ansible.github.com/
 
 Package: ansible


### PR DESCRIPTION
##### SUMMARY
Asciidoc is EOL and only supports python2.
Upstream clearly encourages people to move to an equivalent such as asciidoctor, see: https://github.com/asciidoc/asciidoc/releases/tag/8.6.10
As the maintainer of asciidoc in Debian I'm working with the different projects to help the transition, hence the current PR.

##### ISSUE TYPE
 - Prevent a bug that will happen when asciidoc will be removed from the distributions

##### COMPONENT NAME
Makefile => `make docs command` and corresponding docker installations

##### ANSIBLE VERSION
```
2.6.0 0.0.devel
```


##### ADDITIONAL INFORMATION
Note that in the `Makefile`, the `ASCII2HTMLMAN` seems to be unused (and the command itself was sending an error when trying it directly in the shell. I modified it to have a working command but I doubt it's useful.
Let me know if I should remove it.

Thanks for your help!
Joseph