### PR TITLE
win_certificate_store: backport fix of typo key_storage

### DIFF
--- a/changelogs/fragments/win_certificate_store-params-typo.yaml
+++ b/changelogs/fragments/win_certificate_store-params-typo.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_certificate_store - fixed a typo that stopped it from getting the key_storage values

--- a/lib/ansible/modules/windows/win_certificate_store.ps1
+++ b/lib/ansible/modules/windows/win_certificate_store.ps1
@@ -21,7 +21,7 @@ $store_name = Get-AnsibleParam -obj $params -name "store_name" -type "str" -defa
 $store_location = Get-AnsibleParam -obj $params -name "store_location" -type "str" -default "LocalMachine" -validateset $store_location_values
 $password = Get-AnsibleParam -obj $params -name "password" -type "str"
 $key_exportable = Get-AnsibleParam -obj $params -name "key_exportable" -type "bool" -default $true
-$key_storage = Get-AnsibleParam -obj $param -name "key_storage" -type "str" -default "default" -validateset "default", "machine", "user"
+$key_storage = Get-AnsibleParam -obj $params -name "key_storage" -type "str" -default "default" -validateset "default", "machine", "user"
 $file_type = Get-AnsibleParam -obj $params -name "file_type" -type "str" -default "der" -validateset "der", "pem", "pkcs12"
 
 $result = @{


### PR DESCRIPTION
##### SUMMARY
Fixes a typo in the module that stopped being from setting `key_storage`.

Backport of https://github.com/ansible/ansible/pull/37810

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
win_certificate_store

##### ANSIBLE VERSION
```
2.5
```