### PR TITLE
fix vmware_guest with multiple controllers

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -432,9 +432,9 @@ class PyVmomiDeviceHelper(object):
     def __init__(self, module):
         self.module = module
         self.next_disk_unit_number = 0
+        self.next_controller_number = -1
 
-    @staticmethod
-    def create_scsi_controller(scsi_type):
+    def create_scsi_controller(self, scsi_type):
         scsi_ctl = vim.vm.device.VirtualDeviceSpec()
         scsi_ctl.operation = vim.vm.device.VirtualDeviceSpec.Operation.add
         if scsi_type == 'lsilogic':
@@ -455,6 +455,8 @@ class PyVmomiDeviceHelper(object):
         scsi_ctl.device.hotAddRemove = True
         scsi_ctl.device.sharedBus = 'noSharing'
         scsi_ctl.device.scsiCtlrUnitNumber = 7
+        scsi_ctl.device.key = self.next_controller_number
+        self.next_controller_number -= 1
 
         return scsi_ctl
 
@@ -465,13 +467,14 @@ class PyVmomiDeviceHelper(object):
             isinstance(device, vim.vm.device.VirtualBusLogicController) or \
             isinstance(device, vim.vm.device.VirtualLsiLogicSASController)
 
-    @staticmethod
-    def create_ide_controller():
+    def create_ide_controller(self):
         ide_ctl = vim.vm.device.VirtualDeviceSpec()
         ide_ctl.operation = vim.vm.device.VirtualDeviceSpec.Operation.add
         ide_ctl.device = vim.vm.device.VirtualIDEController()
         ide_ctl.device.deviceInfo = vim.Description()
         ide_ctl.device.busNumber = 0
+        ide_ctl.device.key = self.next_controller_number
+        self.next_controller_number -= 1
 
         return ide_ctl
 


### PR DESCRIPTION
with the vmware_guest module, if you added multiple controllers (e.g. disk & cdrom) you would get the following error:

    Number of virtual devices exceeds the maximum for a given controller

This was happening because each controller was getting `key = 0`. According to [the documentation][0], `key` is used to uniquely identify the controller so that when adding devices, you can reference the controller to add the device to.

[0]: https://www.vmware.com/support/developer/converter-sdk/conv55_apireference/vim.vm.device.VirtualDevice.html#key

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
vmware_guest

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0
  config file = None
  configured module search path = [u'/Users/phemmer/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/phemmer/ansible-2.5/lib/python2.7/site-packages/ansible
  executable location = /Users/phemmer/ansible-2.5/bin/ansible
  python version = 2.7.10 (default, Feb  7 2017, 00:08:15) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.34)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before:
```
TASK [vmware-template : launch vm] ********************************************************************************************************************************
task path: /Users/phemmer/git/c14n/core/ansible/roles/vmware-template/tasks/main.yaml:24
Using module file /Users/phemmer/ansible-2.5/lib/python2.7/site-packages/ansible/modules/cloud/vmware/vmware_guest.py
<localhost> ESTABLISH LOCAL CONNECTION FOR USER: phemmer
<localhost> EXEC /bin/sh -c 'echo ~ && sleep 0'
<localhost> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /Users/phemmer/.ansible/tmp/ansible-tmp-1521879383.52-269281465277502 `" && echo ansible-tmp-1521879383.52-269281465277502="` echo /Users/phemmer/.ansible/tmp/ansible-tmp-1521879383.52-269281465277502 `" ) && sleep 0'
<localhost> PUT /Users/phemmer/.ansible/tmp/ansible-local-140699Dz0L6/tmpqAvjHO TO /Users/phemmer/.ansible/tmp/ansible-tmp-1521879383.52-269281465277502/vmware_guest.py
<localhost> EXEC /bin/sh -c 'chmod u+x /Users/phemmer/.ansible/tmp/ansible-tmp-1521879383.52-269281465277502/ /Users/phemmer/.ansible/tmp/ansible-tmp-1521879383.52-269281465277502/vmware_guest.py && sleep 0'
<localhost> EXEC /bin/sh -c '/usr/bin/python /Users/phemmer/.ansible/tmp/ansible-tmp-1521879383.52-269281465277502/vmware_guest.py && sleep 0'
<localhost> EXEC /bin/sh -c 'rm -f -r /Users/phemmer/.ansible/tmp/ansible-tmp-1521879383.52-269281465277502/ > /dev/null 2>&1 && sleep 0'
fatal: [localhost]: FAILED! => {
    "changed": false, 
    "invocation": {
        "module_args": {
            "annotation": null, 
            "cdrom": {
                "iso_path": "[FLL2-ENT-UNITY-02] CentOS-Atomic-Host-7.1802-Installer.iso", 
                "type": "iso"
            }, 
            "cluster": null, 
            "customization": {}, 
            "customvalues": [
                {
                    "key": "disk.EnableUUID", 
                    "value": "TRUE"
                }
            ], 
            "datacenter": "FLL2-DC-ENT", 
            "disk": [
                {
                    "autoselect_datastore": true, 
                    "datastore": "FLL2-ENT-UNITY-", 
                    "size_kb": 500000, 
                    "type": "thin"
                }, 
                {
                    "autoselect_datastore": true, 
                    "datastore": "FLL2-ENT-UNITY-", 
                    "size_gb": 16, 
                    "type": "thin"
                }
            ], 
            "esxi_hostname": null, 
            "folder": "/Templates", 
            "force": false, 
            "guest_id": "centos64Guest", 
            "hardware": {
                "memory_mb": 8192, 
                "num_cpus": 3
            }, 
            "hostname": "fll2avca01.chewy.local", 
            "is_template": false, 
            "linked_clone": false, 
            "name": "CentOS-Atomic-Host-7.1802", 
            "name_match": "first", 
            "networks": [
                {
                    "name": "ECOM-DEV_VLAN33"
                }
            ], 
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
            "port": 443, 
            "resource_pool": null, 
            "snapshot_src": null, 
            "state": "present", 
            "template": null, 
            "username": "aa-phemmer@chewy", 
            "uuid": null, 
            "validate_certs": false, 
            "wait_for_ip_address": false
        }
    }, 
    "msg": "Failed to create a virtual machine : Number of virtual devices exceeds the maximum for a given controller."
}
```
After:
```
TASK [vmware-template : launch vm] ********************************************************************************************************************************
task path: /Users/phemmer/git/c14n/core/ansible/roles/vmware-template/tasks/main.yaml:24
Using module file /Users/phemmer/ansible-2.5/lib/python2.7/site-packages/ansible/modules/cloud/vmware/vmware_guest.py
<localhost> ESTABLISH LOCAL CONNECTION FOR USER: phemmer
<localhost> EXEC /bin/sh -c 'echo ~ && sleep 0'
<localhost> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /Users/phemmer/.ansible/tmp/ansible-tmp-1521879472.69-32066751338161 `" && echo ansible-tmp-1521879472.69-32066751338161="` echo /Users/phemmer/.ansible/tmp/ansible-tmp-1521879472.69-32066751338161 `" ) && sleep 0'
<localhost> PUT /Users/phemmer/.ansible/tmp/ansible-local-145849HOoIb/tmp4wrvp1 TO /Users/phemmer/.ansible/tmp/ansible-tmp-1521879472.69-32066751338161/vmware_guest.py
<localhost> EXEC /bin/sh -c 'chmod u+x /Users/phemmer/.ansible/tmp/ansible-tmp-1521879472.69-32066751338161/ /Users/phemmer/.ansible/tmp/ansible-tmp-1521879472.69-32066751338161/vmware_guest.py && sleep 0'
<localhost> EXEC /bin/sh -c '/usr/bin/python /Users/phemmer/.ansible/tmp/ansible-tmp-1521879472.69-32066751338161/vmware_guest.py && sleep 0'
<localhost> EXEC /bin/sh -c 'rm -f -r /Users/phemmer/.ansible/tmp/ansible-tmp-1521879472.69-32066751338161/ > /dev/null 2>&1 && sleep 0'
changed: [localhost] => {
    "changed": true, 
    "instance": {
        "annotation": "", 
        "current_snapshot": null, 
        "customvalues": {}, 
        "guest_consolidation_needed": false, 
        "guest_question": null, 
        "guest_tools_status": "guestToolsNotRunning", 
        "guest_tools_version": null, 
        "hw_cores_per_socket": 1, 
        "hw_datastores": [
            "FLL2-ENT-UNITY-02", 
            "FLL2-ENT-UNITY-10"
        ], 
        "hw_esxi_host": "fll2aesx27.chewy.local", 
        "hw_eth0": {
            "addresstype": "assigned", 
            "ipaddresses": null, 
            "label": "Network adapter 1", 
            "macaddress": "00:50:56:82:68:41", 
            "macaddress_dash": "00-50-56-82-68-41", 
            "summary": "DVSwitch: 60 d1 02 50 f2 a9 7a c7-0a 1c fc d0 b0 9d 52 12"
        }, 
        "hw_files": [
            "[FLL2-ENT-UNITY-10] CentOS-Atomic-Host-7.1802/CentOS-Atomic-Host-7.1802.vmx", 
            "[FLL2-ENT-UNITY-10] CentOS-Atomic-Host-7.1802/CentOS-Atomic-Host-7.1802.vmsd", 
            "[FLL2-ENT-UNITY-10] CentOS-Atomic-Host-7.1802/CentOS-Atomic-Host-7.1802.vmdk", 
            "[FLL2-ENT-UNITY-10] CentOS-Atomic-Host-7.1802/CentOS-Atomic-Host-7.1802_1.vmdk"
        ], 
        "hw_folder": "/FLL2-DC-ENT/vm/Templates", 
        "hw_guest_full_name": null, 
        "hw_guest_ha_state": null, 
        "hw_guest_id": null, 
        "hw_interfaces": [
            "eth0"
        ], 
        "hw_is_template": false, 
        "hw_memtotal_mb": 8192, 
        "hw_name": "CentOS-Atomic-Host-7.1802", 
        "hw_power_status": "poweredOff", 
        "hw_processor_count": 3, 
        "hw_product_uuid": "4202a424-5442-cc6a-6b54-4735f0f4e78b", 
        "ipv4": null, 
        "ipv6": null, 
        "module_hw": true, 
        "snapshots": []
    }, 
    "invocation": {
        "module_args": {
            "annotation": null, 
            "cdrom": {
                "iso_path": "[FLL2-ENT-UNITY-02] CentOS-Atomic-Host-7.1802-Installer.iso", 
                "type": "iso"
            }, 
            "cluster": null, 
            "customization": {}, 
            "customvalues": [
                {
                    "key": "disk.EnableUUID", 
                    "value": "TRUE"
                }
            ], 
            "datacenter": "FLL2-DC-ENT", 
            "disk": [
                {
                    "autoselect_datastore": true, 
                    "datastore": "FLL2-ENT-UNITY-", 
                    "size_kb": 500000, 
                    "type": "thin"
                }, 
                {
                    "autoselect_datastore": true, 
                    "datastore": "FLL2-ENT-UNITY-", 
                    "size_gb": 16, 
                    "type": "thin"
                }
            ], 
            "esxi_hostname": null, 
            "folder": "/Templates", 
            "force": false, 
            "guest_id": "centos64Guest", 
            "hardware": {
                "memory_mb": 8192, 
                "num_cpus": 3
            }, 
            "hostname": "fll2avca01.chewy.local", 
            "is_template": false, 
            "linked_clone": false, 
            "name": "CentOS-Atomic-Host-7.1802", 
            "name_match": "first", 
            "networks": [
                {
                    "name": "ECOM-DEV_VLAN33"
                }
            ], 
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
            "port": 443, 
            "resource_pool": null, 
            "snapshot_src": null, 
            "state": "present", 
            "template": null, 
            "username": "aa-phemmer@chewy", 
            "uuid": null, 
            "validate_certs": false, 
            "wait_for_ip_address": false
        }
    }
}
```