### PR TITLE
add vmware_guest support for multiple cdroms

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -952,8 +952,7 @@ class PyVmomiHelper(PyVmomi):
                     self.module.fail_json(msg="cdrom.iso_path is mandatory in case cdrom.type is iso")
 
                 if vm_obj and vm_obj.config.template:
-                    # Changing CD-ROM settings on a template is not supported
-                    continue
+                    self.module.fail_json(msg="changing CD-ROM settings on a template is not supported")
 
                 cdrom_spec = None
                 iso_path = cdrom_params["iso_path"] if "iso_path" in cdrom_params else None

--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -555,11 +555,11 @@ class PyVmomiDeviceHelper(object):
         return ide_ctl
 
     @staticmethod
-    def create_cdrom(ide_ctl, cdrom_type, iso_path=None):
+    def create_cdrom(ide_ctl_device, cdrom_type, iso_path=None):
         cdrom_spec = vim.vm.device.VirtualDeviceSpec()
         cdrom_spec.operation = vim.vm.device.VirtualDeviceSpec.Operation.add
         cdrom_spec.device = vim.vm.device.VirtualCdrom()
-        cdrom_spec.device.controllerKey = ide_ctl.device.key
+        cdrom_spec.device.controllerKey = ide_ctl_device.key
         cdrom_spec.device.key = -1
         cdrom_spec.device.connectable = vim.vm.device.VirtualDevice.ConnectInfo()
         cdrom_spec.device.connectable.allowGuestControl = True
@@ -935,16 +935,17 @@ class PyVmomiHelper(PyVmomi):
             iso_path = self.params["cdrom"]["iso_path"] if "iso_path" in self.params["cdrom"] else None
             if cdrom_device is None:
                 # Creating new CD-ROM
-                ide_device = self.get_vm_ide_device(vm=vm_obj)
-                if ide_device is None:
+                ide_ctl_device = self.get_vm_ide_controller(vm=vm_obj)
+                if ide_ctl_device is None:
                     # Creating new IDE device
-                    ide_device = self.device_helper.create_ide_controller()
+                    ide_ctl_spec = self.device_helper.create_ide_controller()
                     self.change_detected = True
-                    self.configspec.deviceChange.append(ide_device)
-                elif len(ide_device.device) > 3:
+                    self.configspec.deviceChange.append(ide_ctl_spec)
+                    ide_ctl_device = ide_ctl_spec.device
+                elif len(ide_ctl_device.device) > 3:
                     self.module.fail_json(msg="hardware.cdrom specified for a VM or template which already has 4 IDE devices of which none are a cdrom")
 
-                cdrom_spec = self.device_helper.create_cdrom(ide_ctl=ide_device, cdrom_type=self.params["cdrom"]["type"], iso_path=iso_path)
+                cdrom_spec = self.device_helper.create_cdrom(ide_ctl_device=ide_ctl_device, cdrom_type=self.params["cdrom"]["type"], iso_path=iso_path)
                 if vm_obj and vm_obj.runtime.powerState == vim.VirtualMachinePowerState.poweredOn:
                     cdrom_spec.device.connectable.connected = (self.params["cdrom"]["type"] != "none")
 
@@ -1036,7 +1037,7 @@ class PyVmomiHelper(PyVmomi):
 
         return None
 
-    def get_vm_ide_device(self, vm=None):
+    def get_vm_ide_controller(self, vm=None):
         if vm is None:
             return None
 

--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -508,9 +508,9 @@ class PyVmomiDeviceHelper(object):
     def __init__(self, module):
         self.module = module
         self.next_disk_unit_number = 0
+        self.next_controller_number = -1
 
-    @staticmethod
-    def create_scsi_controller(scsi_type):
+    def create_scsi_controller(self, scsi_type):
         scsi_ctl = vim.vm.device.VirtualDeviceSpec()
         scsi_ctl.operation = vim.vm.device.VirtualDeviceSpec.Operation.add
         if scsi_type == 'lsilogic':
@@ -531,6 +531,8 @@ class PyVmomiDeviceHelper(object):
         scsi_ctl.device.hotAddRemove = True
         scsi_ctl.device.sharedBus = 'noSharing'
         scsi_ctl.device.scsiCtlrUnitNumber = 7
+        scsi_ctl.device.key = self.next_controller_number
+        self.next_controller_number -= 1
 
         return scsi_ctl
 
@@ -541,13 +543,14 @@ class PyVmomiDeviceHelper(object):
             isinstance(device, vim.vm.device.VirtualBusLogicController) or \
             isinstance(device, vim.vm.device.VirtualLsiLogicSASController)
 
-    @staticmethod
-    def create_ide_controller():
+    def create_ide_controller(self):
         ide_ctl = vim.vm.device.VirtualDeviceSpec()
         ide_ctl.operation = vim.vm.device.VirtualDeviceSpec.Operation.add
         ide_ctl.device = vim.vm.device.VirtualIDEController()
         ide_ctl.device.deviceInfo = vim.Description()
         ide_ctl.device.busNumber = 0
+        ide_ctl.device.key = self.next_controller_number
+        self.next_controller_number -= 1
 
         return ide_ctl
 

--- a/test/integration/targets/vmware_guest/tasks/cdrom_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/cdrom_d1_c1_f0.yml
@@ -47,7 +47,9 @@
       type: thin
       datastore: LocalDS_0
     cdrom:
-      type: iso
+    - type: iso
+      iso_path: "[LocalDS_0] base.iso"
+    - type: iso
       iso_path: "[LocalDS_0] base.iso"
   register: cdrom_vm
 
@@ -69,7 +71,7 @@
     name: CDROM-Test
     datacenter: "{{ (clusterlist['json'][0]|basename).split('_')[0] }}"
     cdrom:
-      type: iso
+    - type: iso
       iso_path: "[LocalDS_0] base_new.iso"
     state: present
   register: cdrom_vm
@@ -92,7 +94,7 @@
     name: CDROM-Test
     datacenter: "{{ (clusterlist['json'][0]|basename).split('_')[0] }}"
     cdrom:
-      type: client
+    - type: client
     state: present
   register: cdrom_vm
 
@@ -114,7 +116,7 @@
     name: CDROM-Test
     datacenter: "{{ (clusterlist['json'][0]|basename).split('_')[0] }}"
     cdrom:
-      type: none
+    - type: none
     state: present
   register: cdrom_vm
 


### PR DESCRIPTION
##### SUMMARY
This adds support for multiple cdrom devices with the vmware_guest module.

My use case is to be able to automatically kickstart CentOS VMs. I stumbled across someone else using the exact same method I am [documented here](https://medium.com/@jackprice/pushing-kickstarts-with-ansible-122b2cd9c1e) where your first CDROM drive is the installer ISO, and your second CDROM drive is an ISO with a special label that the installer pulls the `ks.cfg` from.

Given that someone wrote an article on exactly what I'm doing, as well as #35665 also trying to do the same thing, It seems this is a common use case.

The PR also adds support for removing CD-ROMs.

Assuming the VM has 2 CD-ROMs, the following will...
* ... do nothing to the CD-ROMs:
```
vmware_guest:
  cdrom:
```
* ... remove all CD-ROMs:
```
vmware_guest:
  cdrom: []
```
* ... ignore the first CD-ROM and re-configure the second one:
```
vmware_guest:
  cdrom:
  - {}
  - type: iso
    iso_path: 'foo'
```
* ... ignore the first CD-ROM and delete the second one:
```
vmware_guest:
  cdrom:
  - {}
```

&nbsp;

This PR also adds 2 bug fixes:
* One to fix an issue when adding multiple controllers. This was originally #37868 but I merged into this PR since this PR depends on it. More details on [the commit](https://github.com/ansible/ansible/pull/37869/commits/d21a53a4c2d830c970060563b9862e36ec667d1a).
* Another issue adding a CD-ROM to an existing ide controller. More details on [the commit](https://github.com/ansible/ansible/pull/37869/commits/0525392f43a426f55fe3d7f699436d85ccdfc532).

&nbsp;

[This view](https://github.com/ansible/ansible/pull/37869/files?w=1) will make the PR easier to review.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
vmware_guest

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0
  config file = None
  configured module search path = [u'/Users/phemmer/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/phemmer/ansible-2.5/lib/python2.7/site-packages/ansible
  executable location = /Users/phemmer/ansible-2.5/bin/ansible
  python version = 2.7.10 (default, Feb  7 2017, 00:08:15) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.34)]
```