### PR TITLE
add 'localhost_warning' configuration option

### DIFF
--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -819,7 +819,8 @@ class CLI(with_metaclass(ABCMeta, object)):
         no_hosts = False
         if len(inventory.list_hosts()) == 0:
             # Empty inventory
-            display.warning("provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'")
+            if C.LOCALHOST_WARNING:
+                display.warning("provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'")
             no_hosts = True
 
         inventory.subset(subset)

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -321,6 +321,18 @@ COMMAND_WARNINGS:
   - {key: command_warnings, section: defaults}
   type: boolean
   version_added: "1.8"
+LOCALHOST_WARNING:
+  name: Warning when using implicit inventory with only localhost
+  default: True
+  description:
+    - By default Ansible will issue a warning when there are no hosts in the
+      inventory.
+    - These warnings can be silenced by adjusting this setting to False. 
+  env: [{name: ANSIBLE_LOCALHOST_WARNING}]
+  ini:
+  - {key: localhost_warning, section: defaults}
+  type: boolean
+  version_added: "2.6"
 DEFAULT_ACTION_PLUGIN_PATH:
   name: Action plugins path
   default: ~/.ansible/plugins/action:/usr/share/ansible/plugins/action


### PR DESCRIPTION
Add the 'localhost_warning' configuration option. When set to 'false',
this will prevent Ansible from issuing a warning when the inventory is
empty and it is using an implicit inventory with only 'localhost'.

Closes #17086