### PR TITLE
[WIP] Support for multiple role versions in ansible-galaxy

### DIFF
--- a/test/units/cli/test_galaxy.py
+++ b/test/units/cli/test_galaxy.py
@@ -178,10 +178,11 @@ class TestGalaxy(unittest.TestCase):
                 'remove': 'usage: %prog remove role1 role2 ...',
                 'search': ('usage: %prog search [searchterm1 searchterm2] [--galaxy-tags galaxy_tag1,galaxy_tag2] [--platforms platform1,platform2] '
                            '[--author username]'),
+                'select': 'usage: %prog select [options] role_name,version',
                 'setup': 'usage: %prog setup [options] source github_user github_repo secret',
             }
 
-            first_call = 'usage: %prog [delete|import|info|init|install|list|login|remove|search|setup] [--help] [options] ...'
+            first_call = 'usage: %prog [delete|import|info|init|install|list|login|remove|search|select|setup] [--help] [options] ...'
             second_call = formatted_call[action]
             calls = [call(first_call), call(second_call)]
             mocked_usage.assert_has_calls(calls)


### PR DESCRIPTION
##### SUMMARY
This commit adds support for installing multiple versions of a role via the 'ansible-galaxy' command. It adds a 'select' action, which manages the symlink between multiple module versions to pick the "default" one when a role name is used without a version in a playbook.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
ansible-galaxy

##### ANSIBLE VERSION
```
ansible 2.6.0 (galaxy_multiple_versions 07bcac1cf6) last updated 2018/03/24 14:27:45 (GMT -500)
```

##### ADDITIONAL INFORMATION
@bcoca made me do it