### PR TITLE
Support list of censored attributes

### DIFF
--- a/lib/ansible/plugins/callback/yaml.py
+++ b/lib/ansible/plugins/callback/yaml.py
@@ -73,10 +73,8 @@ def my_represent_scalar(self, tag, value, style=None):
 
 #returns a flattened formatting of a complex dict which we can "walk"
 def clean_result(input, scensored):
-    #print(type(input))
     if type(input) is dict:
         for item in input.keys():
-            #print(item)
             if item in scensored:
                 input[item] = '###########'
             else:
@@ -85,10 +83,8 @@ def clean_result(input, scensored):
         for item in input:
             item = clean_result(item, scensored)
     else:
-        #print('str: ' + input)
         if input in scensored:
             pass
-    #print('\n')
     return input
 
 class CallbackModule(Default):

--- a/lib/ansible/plugins/callback/yaml.py
+++ b/lib/ansible/plugins/callback/yaml.py
@@ -71,19 +71,19 @@ def my_represent_scalar(self, tag, value, style=None):
         self.represented_objects[self.alias_key] = node
     return node
 
-#returns a flattened formatting of a complex dict which we can "walk"
-def clean_result(input, scensored):
+#iterate output object and replace censored values
+def clean_result(input, censored):
     if type(input) is dict:
         for item in input.keys():
-            if item in scensored:
+            if item in censored:
                 input[item] = '###########'
             else:
-                input[item]  = clean_result(input[item], scensored)
+                input[item]  = clean_result(input[item], censored)
     elif type(input) is list:
         for item in input:
-            item = clean_result(item, scensored)
+            item = clean_result(item, censored)
     else:
-        if input in scensored:
+        if input in censored:
             pass
     return input
 

--- a/lib/ansible/plugins/callback/yaml.py
+++ b/lib/ansible/plugins/callback/yaml.py
@@ -71,14 +71,15 @@ def my_represent_scalar(self, tag, value, style=None):
         self.represented_objects[self.alias_key] = node
     return node
 
-#iterate output object and replace censored values
+
 def clean_result(input, censored):
+    """iterate output object and replace censored values"""
     if type(input) is dict:
         for item in input.keys():
             if item in censored:
                 input[item] = '###########'
             else:
-                input[item]  = clean_result(input[item], censored)
+                input[item] = clean_result(input[item], censored)
     elif type(input) is list:
         for item in input:
             item = clean_result(item, censored)
@@ -86,6 +87,7 @@ def clean_result(input, censored):
         if input in censored:
             pass
     return input
+
 
 class CallbackModule(Default):
 
@@ -136,7 +138,6 @@ class CallbackModule(Default):
         # if we already have stdout, we don't need stdout_lines
         if 'stdout' in abridged_result and 'stdout_lines' in abridged_result:
             abridged_result['stdout_lines'] = '<omitted>'
-
 
         if abridged_result:
             if censored:

--- a/lib/ansible/plugins/callback/yaml.py
+++ b/lib/ansible/plugins/callback/yaml.py
@@ -78,7 +78,7 @@ def clean_result(input, scensored):
         for item in input.keys():
             #print(item)
             if item in scensored:
-                input[item] = 'scensored'
+                input[item] = '###########'
             else:
                 input[item]  = clean_result(input[item], scensored)
     elif type(input) is list:


### PR DESCRIPTION
##### SUMMARY
This change allows a comma-separated list of censored vars to be configured either in ansible.cfg or envvars. The rationale for this is that the "no_log" flag hides too much information, so in many situations it's desireable to only hide a few known variables from the output, and to have that controllable outside of module code (so that the setting will have a "global" effect)

This addition will traverse the "dict tree" of the output object prior to dumping, and rip out the value for any "censored" attribute - it should therefor work for obj attributes as well as string attributes.

If the `censored_use_regex` is set to `1`, regex matching will be used so that an item called `my_little_token` will be matched by `token`. This allows users to configure a very short list of censored words such as `export ANSIBLE_YAML_CALLBACK_CENSORED="token, password, secret"`
##### ISSUE TYPE
 - Feature Pull Request


##### COMPONENT NAME
callback_yaml

##### ANSIBLE VERSION
```
2.5.0
```


##### ADDITIONAL INFORMATION

```
cat > test.yml <<EOF
- name: Stuff
  hosts: localhost
  tasks:
  - name: set a fact
    set_fact:
      myvar:
        - firstname: Peter
          lastname: File
          secret: passw
          objstuff:
            wakka: makka
            secret: passw
  - name: write another thing
    debug:
      msg: "{{ myvar }}"
EOF

export ANSIBLE_YAML_CALLBACK_CENSORED="secret,"
ansible-playbook test.yml
export ANSIBLE_YAML_CALLBACK_CENSORED="secret, wakka"
ansible-playbook test.yml
#use regex matching:
export ANSIBLE_YAML_CALLBACK_CENSORED_USE_REGEX=1
export ANSIBLE_YAML_CALLBACK_CENSORED="secr, wak"
ansible-playbook test.yml
```
