### PR TITLE
[WIP] Tip to see the content of a single encrypted var

### DIFF
--- a/docs/docsite/rst/user_guide/vault.rst
+++ b/docs/docsite/rst/user_guide/vault.rst
@@ -193,6 +193,19 @@ Result::
 
 See also :ref:`single_encrypted_variable`
 
+After you added the encrypted value to a var file, you can see the original value by using the debug module. Please note if your YAML file defines the `ansible_connection` variable (as we used in our example), it will take effect when you execute the command below. To prevent this, please make a copy of the file without the ansible_connection variable. 
+
+.. code-block:: console
+
+   cat vars.yml | grep -v ansible_connection >> vars_no_connection.yml
+
+   ansible localhost -m debug -a var="new_user_password" -e "@vars_no_connection.yml" --ask-vault-pass
+   Vault password:
+
+   localhost | SUCCESS => {
+       "new_user_password": "hunter2"
+   }
+
 
 .. _vault_ids:
 

--- a/docs/docsite/rst/user_guide/vault.rst
+++ b/docs/docsite/rst/user_guide/vault.rst
@@ -193,7 +193,7 @@ Result::
 
 See also :ref:`single_encrypted_variable`
 
-After you added the encrypted value to a var file, you can see the original value by using the debug module. Please note if your YAML file defines the `ansible_connection` variable (as we used in our example), it will take effect when you execute the command below. To prevent this, please make a copy of the file without the ansible_connection variable. 
+After you added the encrypted value to a var file, you can see the original value by using the debug module. Please note if your YAML file defines the `ansible_connection` variable, it will take effect when you execute the command below. To prevent this, please make a copy of the file without the ansible_connection variable. 
 
 .. code-block:: console
 

--- a/docs/docsite/rst/user_guide/vault.rst
+++ b/docs/docsite/rst/user_guide/vault.rst
@@ -193,13 +193,11 @@ Result::
 
 See also :ref:`single_encrypted_variable`
 
-After you added the encrypted value to a var file, you can see the original value by using the debug module. Please note if your YAML file defines the `ansible_connection` variable, it will take effect when you execute the command below. To prevent this, please make a copy of the file without the ansible_connection variable. 
+After you added the encrypted value to a var file (vars.yml), you can see the original value using the debug module.
 
 .. code-block:: console
 
-   cat vars.yml | grep -v ansible_connection >> vars_no_connection.yml
-
-   ansible localhost -m debug -a var="new_user_password" -e "@vars_no_connection.yml" --ask-vault-pass
+   ansible localhost -m debug -a var="new_user_password" -e "@vars.yml" --ask-vault-pass
    Vault password:
 
    localhost | SUCCESS => {


### PR DESCRIPTION
<!--- Your description here -->
This tip was added by PR #37341 to the network getting started guide and it was suggested that it should be added to the main vault docs as well.

+label: docsite_pr

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
Vault documentation

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
$ ansible --version
ansible 2.5.0 (stable-2.5 4b406de19a) last updated 2018/03/25 13:51:08 (GMT +000)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/ubuntu/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/ubuntu/ansible/lib/ansible
  executable location = /home/ubuntu/ansible/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
```
