### PR TITLE
Add sumologic callback plugin

### DIFF
--- a/lib/ansible/modules/windows/win_uri.ps1
+++ b/lib/ansible/modules/windows/win_uri.ps1
@@ -125,7 +125,7 @@ if ($headers) {
             default { $req_headers.Add($header.Name, $header.Value) }
         }
     }
-    $client.Headers = $req_headers
+    $client.Headers.Add($req_headers)
 }
 
 if ($client_cert) {

--- a/lib/ansible/plugins/callback/sumologic.py
+++ b/lib/ansible/plugins/callback/sumologic.py
@@ -20,13 +20,15 @@ __metaclass__ = type
 DOCUMENTATION = '''
 callback: sumologic
 type: aggregate
-short_description: Sends playbook task result events to Sumologic
+short_description: Sends task result events to Sumologic
+author: "Ryan Currah (@ryancurrah)"
 description:
-  - This callback plugin will send playbook task results as JSON formatted events to a Sumologic HTTP collector source
-version_added: "2.3"
+  - This callback plugin will send task results as JSON formatted events to a Sumologic HTTP collector source
+version_added: "2.6"
 requirements:
   - Whitelisting this callback plugin in ansible.cfg configuration
-  - Create a HTTP collector source in Sumologic and specify a custom timestamp format of 'yyyy-MM-dd HH:mm:ss ZZZZ' and a custom timestamp locator of '"timestamp":\s"(.*)"'
+  - Create a HTTP collector source in Sumologic and specify a custom timestamp format of 'yyyy-MM-dd HH:mm:ss ZZZZ' and a custom timestamp locator
+    of '"timestamp": "(.*)"'
 options:
   url:
     description: URL to the Sumologic HTTP collector source
@@ -44,10 +46,13 @@ examples: >
     callback_whitelist = sumologic
 
   Set the environment variable
-    export SUMOLOGIC_URL=https://endpoint1.collection.us2.sumologic.com/receiver/v1/http/R8moVSv1d8EW9LAUFZJ6dbxCFxwLH6kfCdcBfddl-ddr2J8oeJdbqv5sR4NH0tDaN5naz2ZmIfxCbLuL-BN5twcTpMk__pYy_cDmp==
+    export SUMOLOGIC_URL=https://endpoint1.collection.us2.sumologic.com/receiver/v1/http/R8moSv1d8EW9LAUFZJ6dbxCFxwLH6kfCdcBfddlfxCbLuL-BN5twcTpMk__pYy_cDmp==
+
+  Set the ansible.cfg variable
+    [callback_sumologic]
+    url = https://endpoint1.collection.us2.sumologic.com/receiver/v1/http/R8moSv1d8EW9LAUFZJ6dbxCFxwLH6kfCdcBfddlfxCbLuL-BN5twcTpMk__pYy_cDmp==
 '''
 
-import os
 import json
 import uuid
 import socket
@@ -76,7 +81,7 @@ class SumologicHTTPCollectorSource(object):
 
         if result._task_fields['args'].get('_ansible_version'):
             self.ansible_version = \
-              result._task_fields['args'].get('_ansible_version')
+                result._task_fields['args'].get('_ansible_version')
 
         if result._task._role:
             ansible_role = str(result._task._role)
@@ -191,4 +196,3 @@ class CallbackModule(CallbackBase):
             result,
             self._runtime(result)
         )
-

--- a/lib/ansible/plugins/callback/sumologic.py
+++ b/lib/ansible/plugins/callback/sumologic.py
@@ -1,0 +1,194 @@
+# -*- coding: utf-8 -*-
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+DOCUMENTATION = '''
+callback: sumologic
+type: aggregate
+short_description: Sends playbook task result events to Sumologic
+description:
+  - This callback plugin will send playbook task results as JSON formatted events to a Sumologic HTTP collector source
+version_added: "2.3"
+requirements:
+  - Whitelisting this callback plugin in ansible.cfg configuration
+  - Create a HTTP collector source in Sumologic and specify a custom timestamp format of 'yyyy-MM-dd HH:mm:ss ZZZZ' and a custom timestamp locator of '"timestamp":\s"(.*)"'
+options:
+  url:
+    description: URL to the Sumologic HTTP collector source
+    env:
+      - name: SUMOLOGIC_URL
+    ini:
+      - section: callback_sumologic
+        key: url
+'''
+
+EXAMPLES = '''
+examples: >
+  To enable, add this to your ansible.cfg file in the defaults block
+    [defaults]
+    callback_whitelist = sumologic
+
+  Set the environment variable
+    export SUMOLOGIC_URL=https://endpoint1.collection.us2.sumologic.com/receiver/v1/http/R8moVSv1d8EW9LAUFZJ6dbxCFxwLH6kfCdcBfddl-ddr2J8oeJdbqv5sR4NH0tDaN5naz2ZmIfxCbLuL-BN5twcTpMk__pYy_cDmp==
+'''
+
+import os
+import json
+import uuid
+import socket
+import getpass
+
+from datetime import datetime
+from os.path import basename
+
+from ansible.plugins.callback import CallbackBase
+from ansible.module_utils.urls import open_url
+
+
+class SumologicHTTPCollectorSource(object):
+    def __init__(self):
+        self.ansible_check_mode = False
+        self.ansible_playbook = ""
+        self.ansible_version = ""
+        self.session = str(uuid.uuid4())
+        self.host = socket.gethostname()
+        self.ip_address = socket.gethostbyname(socket.gethostname())
+        self.user = getpass.getuser()
+
+    def send_event(self, url, state, result, runtime):
+        if result._task_fields['args'].get('_ansible_check_mode') is True:
+            self.ansible_check_mode = True
+
+        if result._task_fields['args'].get('_ansible_version'):
+            self.ansible_version = \
+              result._task_fields['args'].get('_ansible_version')
+
+        if result._task._role:
+            ansible_role = str(result._task._role)
+        else:
+            ansible_role = None
+
+        data = {}
+        data['uuid'] = result._task._uuid
+        data['session'] = self.session
+        data['status'] = state
+        data['timestamp'] = datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S '
+                                                       '+0000')
+        data['host'] = self.host
+        data['ip_address'] = self.ip_address
+        data['user'] = self.user
+        data['runtime'] = runtime
+        data['ansible_version'] = self.ansible_version
+        data['ansible_check_mode'] = self.ansible_check_mode
+        data['ansible_host'] = result._host.name
+        data['ansible_playbook'] = self.ansible_playbook
+        data['ansible_role'] = ansible_role
+        data['ansible_task'] = result._task_fields
+        data['ansible_result'] = result._result
+
+        open_url(
+            url,
+            data=json.dumps(data, sort_keys=True),
+            headers={
+                'Content-type': 'application/json',
+                'X-Sumo-Host': data['ansible_host']
+            },
+            method='POST'
+        )
+
+
+class CallbackModule(CallbackBase):
+    CALLBACK_VERSION = 2.0
+    CALLBACK_TYPE = 'aggregate'
+    CALLBACK_NAME = 'sumologic'
+    CALLBACK_NEEDS_WHITELIST = True
+
+    def __init__(self, display=None):
+        super(CallbackModule, self).__init__(display=display)
+        self.start_datetimes = {}  # Collect task start times
+        self.url = None
+        self.sumologic = SumologicHTTPCollectorSource()
+
+    def _runtime(self, result):
+        return (
+            datetime.utcnow() -
+            self.start_datetimes[result._task._uuid]
+        ).total_seconds()
+
+    def set_options(self, task_keys=None, var_options=None, direct=None):
+        super(CallbackModule, self).set_options(task_keys=task_keys, var_options=var_options, direct=direct)
+
+        self.url = self.get_option('url')
+
+        if self.url is None:
+            self.disabled = True
+            self._display.warning('Sumologic HTTP collector source URL was '
+                                  'not provided. The Sumologic HTTP collector '
+                                  'source URL can be provided using the '
+                                  '`SUMOLOGIC_URL` environment variable or '
+                                  'in the ansible ini settings.')
+
+    def v2_playbook_on_start(self, playbook):
+        self.sumologic.ansible_playbook = basename(playbook._file_name)
+
+    def v2_playbook_on_task_start(self, task, is_conditional):
+        self.start_datetimes[task._uuid] = datetime.utcnow()
+
+    def v2_playbook_on_handler_task_start(self, task):
+        self.start_datetimes[task._uuid] = datetime.utcnow()
+
+    def v2_runner_on_ok(self, result, **kwargs):
+        self.sumologic.send_event(
+            self.url,
+            'OK',
+            result,
+            self._runtime(result)
+        )
+
+    def v2_runner_on_skipped(self, result, **kwargs):
+        self.sumologic.send_event(
+            self.url,
+            'SKIPPED',
+            result,
+            self._runtime(result)
+        )
+
+    def v2_runner_on_failed(self, result, **kwargs):
+        self.sumologic.send_event(
+            self.url,
+            'FAILED',
+            result,
+            self._runtime(result)
+        )
+
+    def runner_on_async_failed(self, result, **kwargs):
+        self.sumologic.send_event(
+            self.url,
+            'FAILED',
+            result,
+            self._runtime(result)
+        )
+
+    def v2_runner_on_unreachable(self, result, **kwargs):
+        self.sumologic.send_event(
+            self.url,
+            'UNREACHABLE',
+            result,
+            self._runtime(result)
+        )
+

--- a/test/integration/targets/win_uri/tasks/test.yml
+++ b/test/integration/targets/win_uri/tasks/test.yml
@@ -338,3 +338,24 @@
     - invalid_path.content is defined
     - invalid_path.method == 'GET'
     - invalid_path.connection is defined
+
+- name: post request with custom headers
+  win_uri:
+    url: http://{{httpbin_host}}/post
+    method: POST
+    headers:
+      Test-Header: hello
+      Another-Header: world
+    content_type: application/json
+    body: '{"foo": "bar"}'
+    return_content: yes
+  register: post_request_with_custom_headers
+
+- name: assert post with custom headers
+  assert:
+    that:
+    - not post_request_with_custom_headers.changed
+    - post_request_with_custom_headers.status_code == 200
+    - post_request_with_custom_headers.json.headers['Content-Type'] == "application/json"
+    - post_request_with_custom_headers.json.headers['Test-Header'] == 'hello'
+    - post_request_with_custom_headers.json.headers['Another-Header'] == 'world'


### PR DESCRIPTION
##### SUMMARY
Sumologic callback plugin to send task result events to Sumologic log aggregation tool. This will allow Ansible users to monitor the results of their tasks, monitor task runtimes and create dashboards using the event result data.

Results exported from Sumologic...

[search-results-2018-03-25T09_27_32.843-0700.csv.zip](https://github.com/ansible/ansible/files/1845533/search-results-2018-03-25T09_27_32.843-0700.csv.zip)

Results screenshot in Sumologic...

<img width="1305" alt="screen shot 2018-03-25 at 12 42 27 pm" src="https://user-images.githubusercontent.com/6209771/37877491-20416018-302a-11e8-87ed-0ea4b7bda20a.png">

<img width="1306" alt="screen shot 2018-03-25 at 12 37 31 pm" src="https://user-images.githubusercontent.com/6209771/37877440-691929e8-3029-11e8-9bad-0e5e3e32669c.png">

<img width="1305" alt="screen shot 2018-03-25 at 12 38 56 pm" src="https://user-images.githubusercontent.com/6209771/37877451-86f50bf8-3029-11e8-821b-2ebba804957b.png">

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
`plugins/callback/sumologic.py`

##### ANSIBLE VERSION

##### ADDITIONAL INFORMATION
