### PR TITLE
win_uri: backport fix custom header override

### DIFF
--- a/changelogs/fragments/win_uri-fix-header-override.yaml
+++ b/changelogs/fragments/win_uri-fix-header-override.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+- win_uri - do not override existing header when using the ``headers`` key.
+  https://github.com/ansible/ansible/pull/37845

--- a/lib/ansible/modules/windows/win_uri.ps1
+++ b/lib/ansible/modules/windows/win_uri.ps1
@@ -125,7 +125,7 @@ if ($headers) {
             default { $req_headers.Add($header.Name, $header.Value) }
         }
     }
-    $client.Headers = $req_headers
+    $client.Headers.Add($req_headers)
 }
 
 if ($client_cert) {

--- a/test/integration/targets/win_uri/tasks/test.yml
+++ b/test/integration/targets/win_uri/tasks/test.yml
@@ -338,3 +338,24 @@
     - invalid_path.content is defined
     - invalid_path.method == 'GET'
     - invalid_path.connection is defined
+
+- name: post request with custom headers
+  win_uri:
+    url: http://{{httpbin_host}}/post
+    method: POST
+    headers:
+      Test-Header: hello
+      Another-Header: world
+    content_type: application/json
+    body: '{"foo": "bar"}'
+    return_content: yes
+  register: post_request_with_custom_headers
+
+- name: assert post with custom headers
+  assert:
+    that:
+    - not post_request_with_custom_headers.changed
+    - post_request_with_custom_headers.status_code == 200
+    - post_request_with_custom_headers.json.headers['Content-Type'] == "application/json"
+    - post_request_with_custom_headers.json.headers['Test-Header'] == 'hello'
+    - post_request_with_custom_headers.json.headers['Another-Header'] == 'world'


### PR DESCRIPTION
##### SUMMARY
Fix for win_uri that overrode the headers that were already set like `Content-Type` when using the `headers` key.

Backport of https://github.com/ansible/ansible/pull/37845

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
win_uri

##### ANSIBLE VERSION
```
2.5
```