### PR TITLE
win_reboot: fixed up warning message for dep args

### DIFF
--- a/lib/ansible/plugins/action/win_reboot.py
+++ b/lib/ansible/plugins/action/win_reboot.py
@@ -85,7 +85,7 @@ class ActionModule(ActionBase):
         }
         for arg, version in deprecated_args.items():
             if self._task.args.get(arg) is not None:
-                display.warning("Since Ansible %s, %s is no longer used with win_reboot" % (arg, version))
+                display.warning("Since Ansible %s, %s is no longer used with win_reboot" % (version, arg))
 
         if self._task.args.get('connect_timeout') is not None:
             connect_timeout = int(self._task.args.get('connect_timeout', self.DEFAULT_CONNECT_TIMEOUT))


### PR DESCRIPTION
##### SUMMARY
Fixes the win_reboot action plugin to correct display the arg and version in the right order when a deprecated argument is used.

Fixes https://github.com/ansible/ansible/issues/37891

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
win_reboot

##### ANSIBLE VERSION
```
devel
2.5
```