### PR TITLE
Fix the aws_kms_facts module name in module docs

### DIFF
--- a/lib/ansible/modules/cloud/amazon/aws_kms_facts.py
+++ b/lib/ansible/modules/cloud/amazon/aws_kms_facts.py
@@ -45,15 +45,15 @@ EXAMPLES = '''
 # Note: These examples do not set authentication details, see the AWS Guide for details.
 
 # Gather facts about all KMS keys
-- kms_facts
+- aws_kms_facts
 
 # Gather facts about all keys with a Name tag
-- kms_facts:
+- aws_kms_facts:
     filters:
       tag-key: Name
 
 # Gather facts about all keys with a specific name
-- kms_facts:
+- aws_kms_facts:
     filters:
       "tag:Name": Example
 '''


### PR DESCRIPTION
##### SUMMARY

Forgot to update the examples when the module name changed to
have the `aws_` prefix

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
aws_kms_facts

##### ANSIBLE VERSION
```
ansible 2.6.0 (devel 2c44061a04) last updated 2018/03/26 09:26:15 (GMT +1000)
  config file = None
  configured module search path = [u'/home/will/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/will/src/ansible/lib/ansible
  executable location = /home/will/src/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 14 2018, 13:36:31) [GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]

```
