### PR TITLE
Don't split line when no version available for plugin

### DIFF
--- a/lib/ansible/modules/monitoring/grafana_plugin.py
+++ b/lib/ansible/modules/monitoring/grafana_plugin.py
@@ -178,7 +178,11 @@ def grafana_plugin(module, params):
         stdout_lines = stdout.split("\n")
         for line in stdout_lines:
             if line.find(params['name']):
-                plugin_name, plugin_version = line.split(' @ ')
+                if line.find(' @ ') != -1:
+                    line = line.rstrip()
+                    plugin_name, plugin_version = line.split(' @ ')
+                else:
+                    plugin_version = None
                 return {'msg': 'Grafana plugin {} installed : {}'.format(params['name'], cmd),
                         'changed': True,
                         'version': plugin_version}

--- a/lib/ansible/modules/monitoring/grafana_plugin.py
+++ b/lib/ansible/modules/monitoring/grafana_plugin.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# Copyright: (c) 2017, Thierry Sallé (@tsalle)
+# Copyright: (c) 2017, Thierry Sallé (@seuf)
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function


### PR DESCRIPTION
##### SUMMARY
Fix grafana plugin version fetching : Don't split line when no version available in grafana plugin list.
Related Issue : #37886 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
grafana_plugin module

##### ANSIBLE VERSION
```
ansible 2.4.2.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.14 (default, Dec 11 2017, 16:08:01) [GCC 7.2.1 20170915 (Red Hat 7.2.1-2)]
```