### PR TITLE
VMware: Gather facts when powerstate is specified

### DIFF
--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -826,8 +826,7 @@ def set_vm_power_state(content, vm, state, force, timeout=0):
                 result['changed'] = True
 
     # need to get new metadata if changed
-    if result['changed']:
-        result['instance'] = gather_vm_facts(content, vm)
+    result['instance'] = gather_vm_facts(content, vm)
 
     return result
 

--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -2134,6 +2134,7 @@ def main():
                 result["changed"] = True
             if not tmp_result["failed"]:
                 result["failed"] = False
+            result['instance'] = tmp_result['instance']
         else:
             # This should not happen
             raise AssertionError()

--- a/test/integration/targets/vmware_guest/tasks/create_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/create_d1_c1_f0.yml
@@ -103,6 +103,12 @@
     that:
         - "clone_d1_c1_f0_recreate.results|map(attribute='changed')|unique|list == [false]"
 
+- name: assert that no changes were made after re-creating VM and task returns facts
+  assert:
+    that:
+        - "'newvm_' + item | basename in clone_d1_c1_f0.results|map(attribute='instance.hw_name')|list"
+  with_items: "{{ vmlist['json'] }}"
+
 - name: modify the new VMs
   vmware_guest:
     validate_certs: False


### PR DESCRIPTION
##### SUMMARY
This fix adds additional facts after VM powerstate management.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/vmware.py
lib/ansible/modules/cloud/vmware/vmware_guest.py
test/integration/targets/vmware_guest/tasks/create_d1_c1_f0.yml

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6devel
```