### PR TITLE
Fixes #36621, support adfs auth through adal 

### DIFF
--- a/docs/docsite/rst/scenario_guides/guide_azure.rst
+++ b/docs/docsite/rst/scenario_guides/guide_azure.rst
@@ -84,7 +84,16 @@ To pass Active Directory username/password via the environment, define the follo
 
 * AZURE_AD_USER
 * AZURE_PASSWORD
-* AZURE_SUBSCRIPTION_ID
+
+To pass Active Directory username/password in ADFS via the environment, define the following variables:
+
+* AZURE_AD_USER
+* AZURE_PASSWORD
+* AZURE_CLIENT_ID
+* AZURE_TENANT
+* AZURE_ADFS_AUTHORITY_URL
+
+"AZURE_ADFS_AUTHORITY_URL" is optional. It's necessary only when you have own ADFS authority like https://xxx.com/adfs.
 
 Storing in a File
 `````````````````
@@ -118,7 +127,16 @@ Or, pass the following parameters for Active Directory username/password:
 
 * ad_user
 * password
-* subscription_id
+
+Or, pass the following parameters for ADFS username/pasword:
+
+* ad_user
+* password
+* client_id
+* tenant
+* adfs_authority_url
+
+"adfs_authority_url" is optional. It's necessary only when you have own ADFS authority like https://xxx.com/adfs.
 
 
 Other Cloud Environments

--- a/lib/ansible/module_utils/azure_rm_common.py
+++ b/lib/ansible/module_utils/azure_rm_common.py
@@ -319,11 +319,8 @@ class AzureRMModuleBase(object):
         self.subscription_id = self.credentials['subscription_id']
 
         # get authentication authority
-<<<<<<< HEAD
         # for adfs, user could pass in authority or not.
         # for others, use default authority from cloud environment
-=======
->>>>>>> remove default client_id after discussion
         if self.credentials.get('adfs_authority_url') is None:
             self._adfs_authority_url = self._cloud_environment.endpoints.active_directory
         else:

--- a/lib/ansible/module_utils/azure_rm_common.py
+++ b/lib/ansible/module_utils/azure_rm_common.py
@@ -319,8 +319,11 @@ class AzureRMModuleBase(object):
         self.subscription_id = self.credentials['subscription_id']
 
         # get authentication authority
+<<<<<<< HEAD
         # for adfs, user could pass in authority or not.
         # for others, use default authority from cloud environment
+=======
+>>>>>>> remove default client_id after discussion
         if self.credentials.get('adfs_authority_url') is None:
             self._adfs_authority_url = self._cloud_environment.endpoints.active_directory
         else:
@@ -364,7 +367,6 @@ class AzureRMModuleBase(object):
                                                          tenant=tenant,
                                                          cloud_environment=self._cloud_environment,
                                                          verify=self._cert_validation_mode == 'validate')
-
         else:
             self.fail("Failed to authenticate with provided credentials. Some attributes were missing. "
                       "Credentials must include client_id, secret and tenant or ad_user and password, or "

--- a/lib/ansible/module_utils/azure_rm_common.py
+++ b/lib/ansible/module_utils/azure_rm_common.py
@@ -34,7 +34,8 @@ AZURE_COMMON_ARGS = dict(
     password=dict(type='str', no_log=True),
     cloud_environment=dict(type='str'),
     cert_validation_mode=dict(type='str', choices=['validate', 'ignore']),
-    api_profile=dict(type='str', default='latest')
+    api_profile=dict(type='str', default='latest'),
+    adfs_authority_url=dict(type='str', default=None)
     # debug=dict(type='bool', default=False),
 )
 
@@ -48,6 +49,7 @@ AZURE_CREDENTIAL_ENV_MAPPING = dict(
     password='AZURE_PASSWORD',
     cloud_environment='AZURE_CLOUD_ENVIRONMENT',
     cert_validation_mode='AZURE_CERT_VALIDATION_MODE',
+    adfs_authority_url='AZURE_ADFS_AUTHORITY_URL'
 )
 
 # FUTURE: this should come from the SDK or an external location.
@@ -126,6 +128,7 @@ except ImportError as exc:
 
 try:
     from enum import Enum
+    from msrestazure.azure_active_directory import AADTokenCredentials
     from msrestazure.azure_exceptions import CloudError
     from msrestazure.azure_active_directory import MSIAuthentication
     from msrestazure.tools import resource_id, is_valid_resource_id
@@ -146,6 +149,7 @@ try:
     from azure.mgmt.web import WebSiteManagementClient
     from azure.mgmt.containerservice import ContainerServiceClient
     from azure.storage.cloudstorageaccount import CloudStorageAccount
+    from adal.authentication_context import AuthenticationContext
 except ImportError as exc:
     HAS_AZURE_EXC = exc
     HAS_AZURE = False
@@ -262,6 +266,8 @@ class AzureRMModuleBase(object):
         self._dns_client = None
         self._web_client = None
         self._containerservice_client = None
+        self._adfs_authority_url = None
+        self._resource = None
 
         self.check_mode = self.module.check_mode
         self.api_profile = self.module.params.get('api_profile')
@@ -312,6 +318,17 @@ class AzureRMModuleBase(object):
         self.log("setting subscription_id")
         self.subscription_id = self.credentials['subscription_id']
 
+        # get authentication authority
+        # for adfs, user could pass in authority or not.
+        # for others, use default authority from cloud environment
+        if self.credentials.get('adfs_authority_url') is None:
+            self._adfs_authority_url = self._cloud_environment.endpoints.active_directory
+        else:
+            self._adfs_authority_url = self.credentials.get('adfs_authority_url')
+
+        # get resource from cloud environment
+        self._resource = self._cloud_environment.endpoints.active_directory_resource_id
+
         if self.credentials.get('credentials') is not None:
             # AzureCLI credentials
             self.azure_credentials = self.credentials['credentials']
@@ -324,6 +341,19 @@ class AzureRMModuleBase(object):
                                                                      cloud_environment=self._cloud_environment,
                                                                      verify=self._cert_validation_mode == 'validate')
 
+        elif self.credentials.get('ad_user') is not None and \
+                self.credentials.get('password') is not None and \
+                self.credentials.get('client_id') is not None and \
+                self.credentials.get('tenant') is not None:
+
+                self.azure_credentials = self.acquire_token_with_username_password(
+                    self._adfs_authority_url,
+                    self._resource,
+                    self.credentials['ad_user'],
+                    self.credentials['password'],
+                    self.credentials['client_id'],
+                    self.credentials['tenant'])
+
         elif self.credentials.get('ad_user') is not None and self.credentials.get('password') is not None:
             tenant = self.credentials.get('tenant')
             if not tenant:
@@ -334,10 +364,12 @@ class AzureRMModuleBase(object):
                                                          tenant=tenant,
                                                          cloud_environment=self._cloud_environment,
                                                          verify=self._cert_validation_mode == 'validate')
+
         else:
             self.fail("Failed to authenticate with provided credentials. Some attributes were missing. "
-                      "Credentials must include client_id, secret and tenant or ad_user and password or "
-                      "be logged using AzureCLI.")
+                      "Credentials must include client_id, secret and tenant or ad_user and password, or "
+                      "ad_user, password, client_id, tenant and adfs_authority_url(optional) for ADFS authentication, or "
+                      "be logged in using AzureCLI.")
 
         # common parameter validation
         if self.module.params.get('tags'):
@@ -346,6 +378,17 @@ class AzureRMModuleBase(object):
         if not skip_exec:
             res = self.exec_module(**self.module.params)
             self.module.exit_json(**res)
+
+    def acquire_token_with_username_password(self, authority, resource, username, password, client_id, tenant):
+        authority_uri = authority
+
+        if tenant is not None:
+            authority_uri = authority + '/' + tenant
+
+        context = AuthenticationContext(authority_uri)
+        token_response = context.acquire_token_with_username_password(resource, username, password, client_id)
+
+        return AADTokenCredentials(token_response)
 
     def check_client_version(self, client_type):
         # Ensure Azure modules are at least 2.0.0rc5.

--- a/lib/ansible/utils/module_docs_fragments/azure.py
+++ b/lib/ansible/utils/module_docs_fragments/azure.py
@@ -54,6 +54,12 @@ options:
               the C(AZURE_CLOUD_ENVIRONMENT) environment variable.
         default: AzureCloud
         version_added: 2.4
+    adfs_authority_url:
+        description:
+            - Azure AD authority url. Use when authenticating with Username/password, and has your own ADFS authority.
+        required: false
+        default: null
+        version_added: 2.6
     cert_validation_mode:
         description:
             - Controls the certificate validation behavior for Azure endpoints. By default, all modules will validate the server certificate, but


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Fix Issue [#36621](https://github.com/ansible/ansible/issues/36621)

support ADFS auth by using username, password, through adal. User will need to provide below credentials:
- ad_user
- password
- client_id
- authority(optional, only necessary for ADFS authoriazation)
- tenant(optional, only necessary when authenticate to specific tenant)


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
- azure_rm_common.py
- azure_rm.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0b2
  config file = /home/ubuntu/azure/ansible/ansible.cfg
  configured module search path = [u'/home/ubuntu/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
@yuwzho  @zikalino 