### PR TITLE
cloudstack: fix do not rely on APIs list queries for names

### DIFF
--- a/lib/ansible/modules/cloud/cloudstack/cs_configuration.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_configuration.py
@@ -219,7 +219,9 @@ class AnsibleCloudStackConfiguration(AnsibleCloudStack):
         configurations = self.query_api('listConfigurations', **args)
         if not configurations:
             self.module.fail_json(msg="Configuration %s not found." % args['name'])
-        configuration = configurations['configuration'][0]
+        for config in configurations['configuration']:
+            if args['name'] == config['name']:
+                configuration = config
         return configuration
 
     def get_value(self):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Make an explicit comparison between args['name'] and the result of listConfigurations API.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Fixes #37824

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
lib/ansible/modules/cloud/cloudstack/cs_configuration.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.4, 2.5
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
