### PR TITLE
Add Meaningful Cloudfront Identity Name during creation of cloudfront distribution

### DIFF
--- a/lib/ansible/modules/cloud/amazon/cloudfront_distribution.py
+++ b/lib/ansible/modules/cloud/amazon/cloudfront_distribution.py
@@ -1418,7 +1418,7 @@ class CloudFrontValidationManager(object):
         if not origin['s3_origin_access_identity_enabled']:
             return None
         try:
-            comment = "Origin Access Identity created by Ansible at %s" % self.__default_datetime_string
+            comment = "access-identity-by-ansible-%s-%s" % (origin.get('domain_name'), self.__default_datetime_string)
             cfoai_config = dict(CloudFrontOriginAccessIdentityConfig=dict(CallerReference=self.__default_datetime_string,
                                                                           Comment=comment))
             oai = client.create_cloud_front_origin_access_identity(**cfoai_config)['CloudFrontOriginAccessIdentity']['Id']


### PR DESCRIPTION
##### SUMMARY

During creation of the distribution the default identity seems to be not much meaning than the timestamp. When the number of distribution grows, the identify will become hard to maintained. Putting in origin domain name and timestamp makes more information when selecting or viewing from cloudfront web console in AWS.

```
Original:
"Origin Access Identity created by Ansible at <Date/Timestamp>"

Updated:
"access-identity-by-<Origin Name>-<Date/Timestamp>"
```