### PR TITLE
Fix junos modules check_mode issue (#37311)

### DIFF
--- a/lib/ansible/module_utils/network/junos/junos.py
+++ b/lib/ansible/module_utils/network/junos/junos.py
@@ -180,9 +180,9 @@ def locked_config(module):
         unlock_configuration(module)
 
 
-def discard_changes(module, exit=False):
+def discard_changes(module):
     conn = get_connection(module)
-    return conn.discard_changes(exit=exit)
+    return conn.discard_changes()
 
 
 def get_diff(module, rollback='0'):

--- a/lib/ansible/plugins/cliconf/junos.py
+++ b/lib/ansible/plugins/cliconf/junos.py
@@ -84,10 +84,8 @@ class Cliconf(CliconfBase):
         command += b' and-quit'
         return self.send_command(command)
 
-    def discard_changes(self, rollback_id=None):
-        command = b'rollback'
-        if rollback_id is not None:
-            command += b' %s' % int(rollback_id)
+    def discard_changes(self):
+        command = b'rollback 0'
         for cmd in chain(to_list(command), b'exit'):
             self.send_command(cmd)
 

--- a/test/integration/targets/junos_banner/tests/netconf/basic.yaml
+++ b/test/integration/targets/junos_banner/tests/netconf/basic.yaml
@@ -78,6 +78,20 @@
       - "result.changed == true"
       - "'<message>this is my login banner</message>' in config.xml"
 
+- name: check mode
+  junos_banner:
+    banner: login
+    text: this is not the login banner you're looking for
+    state: present
+    provider: "{{ netconf }}"
+  register: result
+  check_mode: yes
+
+- assert:
+    that:
+      - "result.changed == true"
+      - "result.failed == false"
+
 - name: delete login banner
   junos_banner:
     banner: login


### PR DESCRIPTION
Fixes #37208

If check_mode is enabled instead of committing th config need to
discard all the changes to candidate db
In case of cli to discard changes issue `rollback 0` command
and for netconf execute `discard-changes` rpc call
(cherry picked from commit 8eaa9cc9380cadf1e81afc01f44637d796e109e8)

merged to devel https://github.com/ansible/ansible/pull/37311
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request
 

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
module_utils/network/junos/junos.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
