### PR TITLE
Fix eos_facts eapi integration test failures

### DIFF
--- a/test/integration/targets/eos_facts/tests/eapi/default_facts.yaml
+++ b/test/integration/targets/eos_facts/tests/eapi/default_facts.yaml
@@ -1,6 +1,11 @@
 ---
 - debug: msg="START eapi/default_facts.yaml"
 
+- name: Make sure LLDP is running (setup)
+  eos_config:
+    lines: lldp run
+    authorize: yes
+    provider: "{{ eapi }}"
 
 - name: test getting default facts
   eos_facts:
@@ -27,5 +32,11 @@
 
       # ... and not present
       - "result.ansible_facts.ansible_net_config is not defined" # config
+
+- name: Make sure LLDP is running (setup)
+  eos_config:
+    lines: lldp run
+    authorize: yes
+    provider: "{{ eapi }}"
 
 - debug: msg="END eapi/default.yaml"

--- a/test/integration/targets/eos_facts/tests/eapi/not_hardware.yaml
+++ b/test/integration/targets/eos_facts/tests/eapi/not_hardware.yaml
@@ -1,6 +1,11 @@
 ---
 - debug: msg="START eapi/not_hardware_facts.yaml"
 
+- name: Make sure LLDP is running (setup)
+  eos_config:
+    lines: lldp run
+    authorize: yes
+    provider: "{{ eapi }}"
 
 - name: test not hardware
   eos_facts:
@@ -26,5 +31,11 @@
       - "result.ansible_facts.ansible_net_interfaces.Management1.ipv4.masklen > 1" # interfaces
       # ... and not present
       - "result.ansible_facts.ansible_net_filesystems is not defined"
+
+- name: Make sure LLDP is running (teardown)
+  eos_config:
+    lines: no lldp run
+    authorize: yes
+    provider: "{{ eapi }}"
 
 - debug: msg="END eapi/not_hardware_facts.yaml"


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
(cherry picked from commit af777c0f895fb37db0e28fbcea9ddaaa66e451e1)
Merged to devel https://github.com/ansible/ansible/pull/37301
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Test Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
eos_facts/tests/eapi/default_facts.yaml

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
