### PR TITLE
Fix apt tests

### DIFF
--- a/test/integration/targets/apt/aliases
+++ b/test/integration/targets/apt/aliases
@@ -1,3 +1,4 @@
+posix/ci/group1
 destructive
 skip/freebsd
 skip/osx

--- a/test/integration/targets/apt/files/fix-udev.sh
+++ b/test/integration/targets/apt/files/fix-udev.sh
@@ -1,5 +1,7 @@
+#!/bin/bash
+
 cat > /usr/sbin/policy-rc.d <<EOF
-#!/bin/sh
+#!/bin/bash
 exit 101
 EOF
 chmod +x /usr/sbin/policy-rc.d

--- a/test/integration/targets/apt/files/fix-udev.sh
+++ b/test/integration/targets/apt/files/fix-udev.sh
@@ -1,0 +1,7 @@
+cat > /usr/sbin/policy-rc.d <<EOF
+#!/bin/sh
+exit 101
+EOF
+chmod +x /usr/sbin/policy-rc.d
+dpkg-divert --local --rename --add /sbin/initctl
+ln -s /bin/true /sbin/initctl

--- a/test/integration/targets/apt/files/fix-udev.sh
+++ b/test/integration/targets/apt/files/fix-udev.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-cat > /usr/sbin/policy-rc.d <<EOF
-#!/bin/bash
-exit 101
-EOF
-chmod +x /usr/sbin/policy-rc.d
-dpkg-divert --local --rename --add /sbin/initctl
-ln -s /bin/true /sbin/initctl

--- a/test/integration/targets/apt/tasks/apt.yml
+++ b/test/integration/targets/apt/tasks/apt.yml
@@ -168,7 +168,7 @@
 - name: verify sane error message
   assert:
     that:
-      - "'E:Failed to fetch' in apt_result['msg']"
+      - "'Failed to fetch' in apt_result['msg']"
       - "'403' in apt_result['msg']"
 
 - name: Clean up

--- a/test/integration/targets/apt/tasks/apt.yml
+++ b/test/integration/targets/apt/tasks/apt.yml
@@ -1,6 +1,3 @@
-- name: show python version
-  debug: var=ansible_python_version
-
 - name: use python-apt
   set_fact:
     python_apt: python-apt
@@ -62,9 +59,6 @@
   failed_when: False
   register: dpkg_result
 
-- debug: var=apt_result
-- debug: var=dpkg_result
-
 - name: verify installation of hello
   assert:
     that:
@@ -103,9 +97,6 @@
   shell: dpkg-query -l hello
   failed_when: False
   register: dpkg_result
-
-- debug: var=apt_result
-- debug: var=dpkg_result
 
 - name: verify installation of hello
   assert:

--- a/test/integration/targets/apt/tasks/main.yml
+++ b/test/integration/targets/apt/tasks/main.yml
@@ -16,33 +16,6 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
 - block:
-  - name: Remove mysql which causes the upgrade tests to fail
-    block:
-      - service:
-          name: mysql
-          state: stopped
-
-      - apt:
-          name: mysql*
-          state: absent
-          purge: yes
-          autoremove: yes
-          update_cache: yes
-
-      - file:
-          name: "{{ item }}"
-          state: absent
-        with_items:
-         - /etc/mysql
-         - /var/log/mysql
-         - /var/lib/mysql
-    when: ansible_distribution_version is version('16.04', '==')
-
-  # https://github.com/Microsoft/WSL/issues/143#issuecomment-209072634
-  - name: Fix udev so its upgrade works
-    script: fix-udev.sh
-    when: ansible_distribution_version is version('14.04', '==')
-
   - include: 'apt.yml'
 
   - block:
@@ -99,15 +72,6 @@
       state: absent
     when:
       - aptitude_status.stdout.find('ii') == -1
-
-  - name: Install mysql-server back since we uninstalled it to make upgrades work
-    apt:
-      name: mysql-server
-      state: present
-    environment:
-      noninteractive_env:
-        debian_frontend: noninteractive
-    when: ansible_distribution_version is version ('16.04', '==')
 
   when:
     - ansible_distribution in ('Ubuntu', 'Debian')

--- a/test/integration/targets/apt/tasks/main.yml
+++ b/test/integration/targets/apt/tasks/main.yml
@@ -30,7 +30,9 @@
    when: ansible_distribution in ('Ubuntu', 'Debian')
 
  - include: 'apt-multiarch.yml'
-   when: ansible_distribution in ('Ubuntu', 'Debian') and ansible_userspace_architecture != apt_foreign_arch
+   when:
+     - ansible_distribution in ('Ubuntu', 'Debian')
+     - ansible_userspace_architecture != apt_foreign_arch
 
  - include: 'apt-builddep.yml'
    when: ansible_distribution in ('Ubuntu', 'Debian')
@@ -48,6 +50,7 @@
      pkg: aptitude
      state: absent
    when:
+     - ansible_distribution in ('Ubuntu', 'Debian')
      - aptitude_status.stdout.find('ii') != -1
 
  - include: "upgrade.yml aptitude_present={{ False | bool }} upgrade_type={{ item.upgrade_type }} force_apt_get={{ item.force_apt_get }}"
@@ -63,6 +66,8 @@
    apt:
      pkg: aptitude
      state: present
+   when:
+     - ansible_distribution in ('Ubuntu', 'Debian')
 
  - include: "upgrade.yml aptitude_present={{ True | bool }} upgrade_type={{ item.upgrade_type }} force_apt_get={{ item.force_apt_get }}"
    when:
@@ -78,4 +83,5 @@
      pkg: aptitude
      state: absent
    when:
+     - ansible_distribution in ('Ubuntu', 'Debian')
      - aptitude_status.stdout.find('ii') == -1

--- a/test/integration/targets/apt/tasks/main.yml
+++ b/test/integration/targets/apt/tasks/main.yml
@@ -35,15 +35,13 @@
  - include: 'apt-builddep.yml'
    when: ansible_distribution in ('Ubuntu', 'Debian')
 
- - include: upgrade.yml upgrade_type=dist
+ - include: "upgrade.yml aptitude_present={{ True | bool }} upgrade_type=dist force_apt_get={{ False | bool }}"
    when: ansible_distribution in ('Ubuntu', 'Debian')
 
  - name: Check if aptitude is installed
    command: dpkg-query --show --showformat='${db:Status-Abbrev}' aptitude
    register: aptitude_status
    when: ansible_distribution in ('Ubuntu', 'Debian')
-
- - debug: var=aptitude_status.stdout
 
  - name: Remove aptitude, if installed, to test fall-back to apt-get
    apt:
@@ -66,7 +64,7 @@
      pkg: aptitude
      state: present
 
- - include: upgrade.yml upgrade_type={{ item.upgrade_type }} force_apt_get={{ item.force_apt_get }}
+ - include: "upgrade.yml aptitude_present={{ True | bool }} upgrade_type={{ item.upgrade_type }} force_apt_get={{ item.force_apt_get }}"
    when:
      - ansible_distribution in ('Ubuntu', 'Debian')
    with_items:

--- a/test/integration/targets/apt/tasks/main.yml
+++ b/test/integration/targets/apt/tasks/main.yml
@@ -15,73 +15,100 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
- - include: 'apt.yml'
-   when: ansible_distribution in ('Ubuntu', 'Debian')
+- block:
+  - name: Remove mysql which causes the upgrade tests to fail
+    block:
+      - service:
+          name: mysql
+          state: stopped
 
- - block:
-     - include: 'repo.yml'
-   always:
-     - apt_repository:
-         repo: "deb file:{{ repodir }} ./"
-         state: absent
-     - file:
-         name: "{{ repodir }}"
-         state: absent
-   when: ansible_distribution in ('Ubuntu', 'Debian')
+      - apt:
+          name: mysql*
+          state: absent
+          purge: yes
+          autoremove: yes
+          update_cache: yes
 
- - include: 'apt-multiarch.yml'
-   when:
-     - ansible_distribution in ('Ubuntu', 'Debian')
-     - ansible_userspace_architecture != apt_foreign_arch
+      - file:
+          name: "{{ item }}"
+          state: absent
+        with_items:
+         - /etc/mysql
+         - /var/log/mysql
+         - /var/lib/mysql
+    when: ansible_distribution_version is version('16.04', '==')
 
- - include: 'apt-builddep.yml'
-   when: ansible_distribution in ('Ubuntu', 'Debian')
+  # https://github.com/Microsoft/WSL/issues/143#issuecomment-209072634
+  - name: Fix udev so its upgrade works
+    script: fix-udev.sh
+    when: ansible_distribution_version is version('14.04', '==')
 
- - include: "upgrade.yml aptitude_present={{ True | bool }} upgrade_type=dist force_apt_get={{ False | bool }}"
-   when: ansible_distribution in ('Ubuntu', 'Debian')
+  - include: 'apt.yml'
 
- - name: Check if aptitude is installed
-   command: dpkg-query --show --showformat='${db:Status-Abbrev}' aptitude
-   register: aptitude_status
-   when: ansible_distribution in ('Ubuntu', 'Debian')
+  - block:
+      - include: 'repo.yml'
+    always:
+      - apt_repository:
+          repo: "deb file:{{ repodir }} ./"
+          state: absent
+      - file:
+          name: "{{ repodir }}"
+          state: absent
 
- - name: Remove aptitude, if installed, to test fall-back to apt-get
-   apt:
-     pkg: aptitude
-     state: absent
-   when:
-     - ansible_distribution in ('Ubuntu', 'Debian')
-     - aptitude_status.stdout.find('ii') != -1
+  - include: 'apt-multiarch.yml'
+    when:
+      - ansible_userspace_architecture != apt_foreign_arch
 
- - include: "upgrade.yml aptitude_present={{ False | bool }} upgrade_type={{ item.upgrade_type }} force_apt_get={{ item.force_apt_get }}"
-   when:
-     - ansible_distribution in ('Ubuntu', 'Debian')
-   with_items:
-     - { upgrade_type: safe, force_apt_get: False }
-     - { upgrade_type: full, force_apt_get: False }
-     - { upgrade_type: safe, force_apt_get: True }
-     - { upgrade_type: full, force_apt_get: True }
+  - include: 'apt-builddep.yml'
 
- - name: (Re-)Install aptitude, run same tests again
-   apt:
-     pkg: aptitude
-     state: present
-   when:
-     - ansible_distribution in ('Ubuntu', 'Debian')
+  - include: "upgrade.yml aptitude_present={{ True | bool }} upgrade_type=dist force_apt_get={{ False | bool }}"
 
- - include: "upgrade.yml aptitude_present={{ True | bool }} upgrade_type={{ item.upgrade_type }} force_apt_get={{ item.force_apt_get }}"
-   when:
-     - ansible_distribution in ('Ubuntu', 'Debian')
-   with_items:
-     - { upgrade_type: safe, force_apt_get: False }
-     - { upgrade_type: full, force_apt_get: False }
-     - { upgrade_type: safe, force_apt_get: True }
-     - { upgrade_type: full, force_apt_get: True }
+  - name: Check if aptitude is installed
+    command: dpkg-query --show --showformat='${db:Status-Abbrev}' aptitude
+    register: aptitude_status
+    when: ansible_distribution in ('Ubuntu', 'Debian')
 
- - name: Remove aptitude if not originally present
-   apt:
-     pkg: aptitude
-     state: absent
-   when:
-     - ansible_distribution in ('Ubuntu', 'Debian')
-     - aptitude_status.stdout.find('ii') == -1
+  - name: Remove aptitude, if installed, to test fall-back to apt-get
+    apt:
+      pkg: aptitude
+      state: absent
+    when:
+      - aptitude_status.stdout.find('ii') != -1
+
+  - include: "upgrade.yml aptitude_present={{ False | bool }} upgrade_type={{ item.upgrade_type }} force_apt_get={{ item.force_apt_get }}"
+    with_items:
+      - { upgrade_type: safe, force_apt_get: False }
+      - { upgrade_type: full, force_apt_get: False }
+      - { upgrade_type: safe, force_apt_get: True }
+      - { upgrade_type: full, force_apt_get: True }
+
+  - name: (Re-)Install aptitude, run same tests again
+    apt:
+      pkg: aptitude
+      state: present
+
+  - include: "upgrade.yml aptitude_present={{ True | bool }} upgrade_type={{ item.upgrade_type }} force_apt_get={{ item.force_apt_get }}"
+    with_items:
+      - { upgrade_type: safe, force_apt_get: False }
+      - { upgrade_type: full, force_apt_get: False }
+      - { upgrade_type: safe, force_apt_get: True }
+      - { upgrade_type: full, force_apt_get: True }
+
+  - name: Remove aptitude if not originally present
+    apt:
+      pkg: aptitude
+      state: absent
+    when:
+      - aptitude_status.stdout.find('ii') == -1
+
+  - name: Install mysql-server back since we uninstalled it to make upgrades work
+    apt:
+      name: mysql-server
+      state: present
+    environment:
+      noninteractive_env:
+        debian_frontend: noninteractive
+    when: ansible_distribution_version is version ('16.04', '==')
+
+  when:
+    - ansible_distribution in ('Ubuntu', 'Debian')

--- a/test/integration/targets/apt/tasks/main.yml
+++ b/test/integration/targets/apt/tasks/main.yml
@@ -66,7 +66,6 @@
   - name: Check if aptitude is installed
     command: dpkg-query --show --showformat='${db:Status-Abbrev}' aptitude
     register: aptitude_status
-    when: ansible_distribution in ('Ubuntu', 'Debian')
 
   - name: Remove aptitude, if installed, to test fall-back to apt-get
     apt:

--- a/test/integration/targets/apt/tasks/upgrade.yml
+++ b/test/integration/targets/apt/tasks/upgrade.yml
@@ -1,4 +1,14 @@
 ---
+- name: Remove packages that cause the upgrade below to fail, they need manual intervention to upgrade
+  apt:
+    name: "{{ pkg }}"
+    state: absent
+  with_items:
+    - mysql-server-5.7
+    - mysql-server
+  loop_control:
+    loop_var: pkg
+
 #### Tests for upgrade/download functions in modules/packaging/os/apt.py ####
 - name: download and install old version of hello
   apt: "deb=https://launchpad.net/ubuntu/+archive/primary/+files/hello_{{ hello_old_version }}_amd64.deb"
@@ -7,41 +17,35 @@
   shell: dpkg -s hello | grep Version | awk '{print $2}'
   register: hello_version
 
-- debug: var=hello_version
-
 - name: ensure the correct version of hello has been installed
   assert:
     that:
       - "{{ hello_version.stdout }}=={{ hello_old_version }}"
 
-- name: "(upgrade type: {{upgrade_type}}) upgrade packages to latest version, force_apt_get: {{force_apt_get|default(False)}}"
+- name: "(upgrade type: {{upgrade_type}}) upgrade packages to latest version, force_apt_get: {{force_apt_get}}"
   apt:
     upgrade: "{{ upgrade_type }}"
-    force_apt_get: "{{ force_apt_get | default(False) }}"
+    force_apt_get: "{{ force_apt_get }}"
   register: upgrade_result
 
 - name: check hello version
   shell: dpkg -s hello | grep Version | awk '{print $2}'
   register: hello_version
 
-- debug: var=upgrade_result.warnings|default([])
-- debug: var=aptitude_present
-- debug: var=force_apt_get
-
 - name: check that warning is not given when force_apt_get set
   assert:
     that:
-      - "'Could not find aptitude. Using apt-get instead' not in upgrade_result.warnings | default([])"
+      - "'warnings' not in upgrade_result"
   when:
-    - force_apt_get | default(False)
+    - force_apt_get
 
 - name: check that warning is given when aptitude not found and force_apt_get not set
   assert:
     that:
-      - "'Could not find aptitude. Using apt-get instead' in upgrade_result.warnings"
+      - "'Could not find aptitude. Using apt-get instead' in upgrade_result.warnings[0]"
   when:
-    - not aptitude_present|default(True)
-    - not force_apt_get|default(False)
+    - not aptitude_present
+    - not force_apt_get
 
 - name: check that old version upgraded correctly
   assert:
@@ -52,7 +56,7 @@
 - name: "(upgrade type: {{upgrade_type}}) upgrade packages to latest version (Idempotant)"
   apt:
     upgrade: "{{ upgrade_type }}"
-    force_apt_get: "{{ force_apt_get | default(False) }}"
+    force_apt_get: "{{ force_apt_get }}"
   register: second_upgrade_result
 
 - name: check that nothing has changed (Idempotant)

--- a/test/integration/targets/apt/tasks/upgrade.yml
+++ b/test/integration/targets/apt/tasks/upgrade.yml
@@ -1,14 +1,4 @@
 ---
-- name: Remove packages that cause the upgrade below to fail, they need manual intervention to upgrade
-  apt:
-    name: "{{ pkg }}"
-    state: absent
-  with_items:
-    - mysql-server-5.7
-    - mysql-server
-  loop_control:
-    loop_var: pkg
-
 #### Tests for upgrade/download functions in modules/packaging/os/apt.py ####
 - name: download and install old version of hello
   apt: "deb=https://launchpad.net/ubuntu/+archive/primary/+files/hello_{{ hello_old_version }}_amd64.deb"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
`apt` tests are currently disabled in CI since they are broken, this fixes them.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
apt tests

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION