### PR TITLE
include_* details in porting_guide_2.5.rst 

### DIFF
--- a/docs/docsite/rst/porting_guides/porting_guide_2.5.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.5.rst
@@ -27,8 +27,7 @@ static ``import_*`` would be inherited by the tasks within.
 
 This separation was only partially implemented in Ansible version 2.4. As of Ansible version 2.5, this work is complete and the separation now behaves as designed; attributes applied to an ``include_*`` task will not be inherited by the tasks within.
 
-To achieve an outcome similar to how Ansible worked prior to version 2.5, playbooks
-should use an explicit application of the attribute on the needed tasks, or use blocks to apply the attribute to many tasks. Another option is to use a static ``import_*`` when possible instead of a dynamic task.
+To achieve an outcome similar to how Ansible worked prior to version 2.5, playbooks should use an explicit application of the attribute on the needed tasks, or use blocks to apply the attribute to many tasks. Another option is to use a static ``import_*`` when possible instead of a dynamic task.
 
 **OLD** In Ansible 2.4:
 
@@ -38,6 +37,17 @@ should use an explicit application of the attribute on the needed tasks, or use 
       tags:
         - distro_include
 
+Included file:
+
+.. code-block:: yaml
+
+    - block:
+        - debug:
+            msg: "In included file"
+
+        - apt:
+            name: nginx
+            state: latest
 
 **NEW** In Ansible 2.5:
 
@@ -62,6 +72,8 @@ Included file:
             state: latest
       tags:
         - distro_include
+
+The relevant change in those examples is, that in Ansible 2.5, the included file defines the tag ``distro_include`` again. The tag is not inherited automatically.
 
 Deprecated
 ==========


### PR DESCRIPTION
The example regarding `include_*` is a bit unclear. First it seems like the v2.4 and v2.5 examples are the same. So I attempted to make the relevant change in the examples more obvious.

+label: docsite_pr

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE

 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
