### PR TITLE
docs/keywords: Clarify `async` a bit

### DIFF
--- a/docs/docsite/keyword_desc.yml
+++ b/docs/docsite/keyword_desc.yml
@@ -6,7 +6,7 @@ args: "*DEPRECATED*, A secondary way to add arguments into a task. Takes a dicti
 always: List of tasks, in a block, that execute no matter if there is an error in the block or not.
 always_run: "*DEPRECATED*, forces a task to run even in check mode. Use :term:`check_mode` directive instead."
 any_errors_fatal: Force any un-handled task errors on any host to propagate to all hosts and end the play.
-async: Run a task asyncronouslly if the C(action) supports this.
+async: Run a task asynchronously if the C(action) supports this; value is maximum runtime in seconds.
 become: Boolean that controls if privilege escalation is used or not on :term:`Task` execution.
 become_flags: A string of flag(s) to pass to the privilege escalation program when :term:`become` is True.
 become_method: Which method of privilege escalation to use (such as sudo or su).


### PR DESCRIPTION
I hastily did a copy/paste of the `async` example and it took me
a while to understand that `async` specified a maximum runtime in seconds.
The docs are actually mostly clear on this, but I made this PR while
reading the code.

This also fixes the spelling of "asynchronously".
