### PR TITLE
ISSUE-37945 output not populated on failure

### DIFF
--- a/lib/ansible/modules/web_infrastructure/jenkins_script.py
+++ b/lib/ansible/modules/web_infrastructure/jenkins_script.py
@@ -115,7 +115,7 @@ def is_csrf_protection_enabled(module):
                            module.params['url'] + '/api/json',
                            method='GET')
     if info["status"] != 200:
-        module.fail_json(msg="HTTP error " + str(info["status"]) + " " + info["msg"])
+        module.fail_json(msg="HTTP error " + str(info["status"]) + " " + info["msg"], output='')
 
     content = to_native(resp.read())
     return json.loads(content).get('useCrumbs', False)
@@ -126,7 +126,7 @@ def get_crumb(module):
                            module.params['url'] + '/crumbIssuer/api/json',
                            method='GET')
     if info["status"] != 200:
-        module.fail_json(msg="HTTP error " + str(info["status"]) + " " + info["msg"])
+        module.fail_json(msg="HTTP error " + str(info["status"]) + " " + info["msg"], output='')
 
     content = to_native(resp.read())
     return json.loads(content)
@@ -148,14 +148,17 @@ def main():
 
     if module.params['user'] is not None:
         if module.params['password'] is None:
-            module.fail_json(msg="password required when user provided")
+            module.fail_json(msg="password required when user provided", output='')
         module.params['url_username'] = module.params['user']
         module.params['url_password'] = module.params['password']
         module.params['force_basic_auth'] = True
 
     if module.params['args'] is not None:
         from string import Template
-        script_contents = Template(module.params['script']).substitute(module.params['args'])
+        try:
+            script_contents = Template(module.params['script']).substitute(module.params['args'])
+        except KeyError as err:
+            module.fail_json(msg="Error with templating variable: %s" % err, output='')
     else:
         script_contents = module.params['script']
 

--- a/lib/ansible/modules/web_infrastructure/jenkins_script.py
+++ b/lib/ansible/modules/web_infrastructure/jenkins_script.py
@@ -172,12 +172,12 @@ def main():
                            timeout=module.params['timeout'])
 
     if info["status"] != 200:
-        module.fail_json(msg="HTTP error " + str(info["status"]) + " " + info["msg"])
+        module.fail_json(msg="HTTP error " + str(info["status"]) + " " + info["msg"], output='')
 
     result = to_native(resp.read())
 
     if 'Exception:' in result and 'at java.lang.Thread' in result:
-        module.fail_json(msg="script failed with stacktrace:\n " + result)
+        module.fail_json(msg="script failed with stacktrace:\n " + result, output='')
 
     module.exit_json(
         output=result,


### PR DESCRIPTION
This always includes output, but it is empty on failure.

##### SUMMARY
This always includes output in the dictionary returned.

To avoid duplicating data it is empty if there has been a failure, but this means that something like:
```
changed_when: project_library_status.output.find("project library") != -1
```
on a script does not give the confusing error of:
```
fatal: [run1]: FAILED! => {"msg": "The conditional check 'whitelist_status.output.find(\"signatures changed\") != -1' failed. The error was: error while evaluating conditional (whitelist_status.output.find(\"signatures changed\") != -1): 'dict object' has no attribute 'output'"}
```
when there is an exception thrown by jenkins running the script.

Fixes #37945 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
jenkins_script

##### ANSIBLE VERSION
```
ansible 2.4.3.0
  config file = /home/ja.hogarth/workspace/ynap/ansible/ansible_role_jenkins/ansible.cfg
  configured module search path = [u'/home/ja.hogarth/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.14 (default, Feb 17 2018, 10:42:17) [GCC 7.3.1 20180130 (Red Hat 7.3.1-2)]

```


##### ADDITIONAL INFORMATION

With the changes in place the following type of response is gained instead
```
fatal: [run1]: FAILED! => {"changed": false, "msg": "script failed with stacktrace:\n org.codehaus.groovy.control.MultipleCompilationErrorsException: startup failed:\nScript1.groovy: 11: unable to resolve class JsonSlurper \n @ line 11, column 16.\n   def req_sigs = new JsonSlurper().parseText(signatures_json)\n                  ^\n\n1 error\n\n\tat org.codehaus.groovy.control.ErrorCollector.failIfErrors(ErrorCollector.java:310)\n\tat org.codehaus.groovy.control.CompilationUnit.applyToSourceUnits(CompilationUnit.java:958)\n\tat org.codehaus.groovy.control.CompilationUnit.doPhaseOperation(CompilationUnit.java:605)\n\tat org.codehaus.groovy.control.CompilationUnit.compile(CompilationUnit.java:554)\n\tat groovy.lang.GroovyClassLoader.doParseClass(GroovyClassLoader.java:298)\n\tat groovy.lang.GroovyClassLoader.parseClass(GroovyClassLoader.java:268)\n\tat groovy.lang.GroovyShell.parseClass(GroovyShell.java:688)\n\tat groovy.lang.GroovyShell.parse(GroovyShell.java:700)\n\tat groovy.lang.GroovyShell.evaluate(GroovyShell.java:584)\n\tat groovy.lang.GroovyShell.evaluate(GroovyShell.java:623)\n\tat groovy.lang.GroovyShell.evaluate(GroovyShell.java:594)\n\tat hudson.util.RemotingDiagnostics$Script.call(RemotingDiagnostics.java:142)\n\tat hudson.util.RemotingDiagnostics$Script.call(RemotingDiagnostics.java:114)\n\tat hudson.remoting.LocalChannel.call(LocalChannel.java:45)\n\tat hudson.util.RemotingDiagnostics.executeGroovy(RemotingDiagnostics.java:111)\n\tat jenkins.model.Jenkins._doScript(Jenkins.java:4331)\n\tat jenkins.model.Jenkins.doScriptText(Jenkins.java:4309)\n\tat java.lang.invoke.MethodHandle.invokeWithArguments(MethodHandle.java:627)\n\tat org.kohsuke.stapler.Function$MethodFunction.invoke(Function.java:343)\n\tat org.kohsuke.stapler.Function.bindAndInvoke(Function.java:184)\n\tat org.kohsuke.stapler.Function.bindAndInvokeAndServeResponse(Function.java:117)\n\tat org.kohsuke.stapler.MetaClass$1.doDispatch(MetaClass.java:129)\n\tat org.kohsuke.stapler.NameBasedDispatcher.dispatch(NameBasedDispatcher.java:58)\n\tat org.kohsuke.stapler.Stapler.tryInvoke(Stapler.java:715)\n\tat org.kohsuke.stapler.Stapler.invoke(Stapler.java:845)\n\tat org.kohsuke.stapler.Stapler.invoke(Stapler.java:649)\n\tat org.kohsuke.stapler.Stapler.service(Stapler.java:238)\n\tat javax.servlet.http.HttpServlet.service(HttpServlet.java:790)\n\tat org.eclipse.jetty.servlet.ServletHolder.handle(ServletHolder.java:841)\n\tat org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1650)\n\tat hudson.util.PluginServletFilter$1.doFilter(PluginServletFilter.java:154)\n\tat hudson.security.HudsonPrivateSecurityRealm$5.doFilter(HudsonPrivateSecurityRealm.java:807)\n\tat hudson.util.PluginServletFilter$1.doFilter(PluginServletFilter.java:151)\n\tat org.jenkinsci.plugins.ssegateway.Endpoint$SSEListenChannelFilter.doFilter(Endpoint.java:225)\n\tat hudson.util.PluginServletFilter$1.doFilter(PluginServletFilter.java:151)\n\tat io.jenkins.blueocean.ResourceCacheControl.doFilter(ResourceCacheControl.java:134)\n\tat hudson.util.PluginServletFilter$1.doFilter(PluginServletFilter.java:151)\n\tat io.jenkins.blueocean.auth.jwt.impl.JwtAuthenticationFilter.doFilter(JwtAuthenticationFilter.java:61)\n\tat hudson.util.PluginServletFilter$1.doFilter(PluginServletFilter.java:151)\n\tat net.bull.javamelody.MonitoringFilter.doFilter(MonitoringFilter.java:237)\n\tat net.bull.javamelody.MonitoringFilter.doFilter(MonitoringFilter.java:214)\n\tat net.bull.javamelody.PluginMonitoringFilter.doFilter(PluginMonitoringFilter.java:88)\n\tat org.jvnet.hudson.plugins.monitoring.HudsonMonitoringFilter.doFilter(HudsonMonitoringFilter.java:114)\n\tat hudson.util.PluginServletFilter$1.doFilter(PluginServletFilter.java:151)\n\tat hudson.plugins.greenballs.GreenBallFilter.doFilter(GreenBallFilter.java:59)\n\tat hudson.util.PluginServletFilter$1.doFilter(PluginServletFilter.java:151)\n\tat hudson.util.PluginServletFilter.doFilter(PluginServletFilter.java:157)\n\tat org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1637)\n\tat hudson.security.csrf.CrumbFilter.doFilter(CrumbFilter.java:64)\n\tat org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1637)\n\tat hudson.security.ChainedServletFilter$1.doFilter(ChainedServletFilter.java:84)\n\tat hudson.security.UnwrapSecurityExceptionFilter.doFilter(UnwrapSecurityExceptionFilter.java:51)\n\tat hudson.security.ChainedServletFilter$1.doFilter(ChainedServletFilter.java:87)\n\tat jenkins.security.ExceptionTranslationFilter.doFilter(ExceptionTranslationFilter.java:117)\n\tat hudson.security.ChainedServletFilter$1.doFilter(ChainedServletFilter.java:87)\n\tat org.acegisecurity.providers.anonymous.AnonymousProcessingFilter.doFilter(AnonymousProcessingFilter.java:125)\n\tat hudson.security.ChainedServletFilter$1.doFilter(ChainedServletFilter.java:87)\n\tat org.acegisecurity.ui.rememberme.RememberMeProcessingFilter.doFilter(RememberMeProcessingFilter.java:142)\n\tat hudson.security.ChainedServletFilter$1.doFilter(ChainedServletFilter.java:87)\n\tat org.acegisecurity.ui.AbstractProcessingFilter.doFilter(AbstractProcessingFilter.java:271)\n\tat hudson.security.ChainedServletFilter$1.doFilter(ChainedServletFilter.java:87)\n\tat jenkins.security.BasicHeaderProcessor.success(BasicHeaderProcessor.java:140)\n\tat jenkins.security.BasicHeaderProcessor.doFilter(BasicHeaderProcessor.java:82)\n\tat hudson.security.ChainedServletFilter$1.doFilter(ChainedServletFilter.java:87)\n\tat org.acegisecurity.context.HttpSessionContextIntegrationFilter.doFilter(HttpSessionContextIntegrationFilter.java:249)\n\tat hudson.security.HttpSessionContextIntegrationFilter2.doFilter(HttpSessionContextIntegrationFilter2.java:67)\n\tat hudson.security.ChainedServletFilter$1.doFilter(ChainedServletFilter.java:87)\n\tat hudson.security.ChainedServletFilter.doFilter(ChainedServletFilter.java:90)\n\tat hudson.security.HudsonFilter.doFilter(HudsonFilter.java:171)\n\tat org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1637)\n\tat org.kohsuke.stapler.compression.CompressionFilter.doFilter(CompressionFilter.java:49)\n\tat org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1637)\n\tat hudson.util.CharacterEncodingFilter.doFilter(CharacterEncodingFilter.java:82)\n\tat org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1637)\n\tat org.kohsuke.stapler.DiagnosticThreadNameFilter.doFilter(DiagnosticThreadNameFilter.java:30)\n\tat org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1637)\n\tat org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:533)\n\tat org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:143)\n\tat org.eclipse.jetty.security.SecurityHandler.handle(SecurityHandler.java:524)\n\tat org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:132)\n\tat org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:190)\n\tat org.eclipse.jetty.server.session.SessionHandler.doHandle(SessionHandler.java:1595)\n\tat org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:188)\n\tat org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1253)\n\tat org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:168)\n\tat org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:473)\n\tat org.eclipse.jetty.server.session.SessionHandler.doScope(SessionHandler.java:1564)\n\tat org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:166)\n\tat org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1155)\n\tat org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:141)\n\tat org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:132)\n\tat org.eclipse.jetty.server.Server.handle(Server.java:564)\n\tat org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:317)\n\tat org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:251)\n\tat org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:279)\n\tat org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:110)\n\tat org.eclipse.jetty.io.ChannelEndPoint$2.run(ChannelEndPoint.java:124)\n\tat org.eclipse.jetty.util.thread.Invocable.invokePreferred(Invocable.java:128)\n\tat org.eclipse.jetty.util.thread.Invocable$InvocableExecutor.invoke(Invocable.java:222)\n\tat org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.doProduce(EatWhatYouKill.java:294)\n\tat org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.run(EatWhatYouKill.java:199)\n\tat winstone.BoundedExecutorService$1.run(BoundedExecutorService.java:77)\n\tat java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)\n\tat java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)\n\tat java.lang.Thread.run(Thread.java:748)\n", "output": ""}
```
