### PR TITLE
We need to save the basename into an attribute for calling code

### DIFF
--- a/lib/ansible/plugins/loader.py
+++ b/lib/ansible/plugins/loader.py
@@ -506,7 +506,7 @@ class PluginLoader:
             if not found_in_cache:
                 self._load_config_defs(basename, path)
 
-            self._update_object(obj, name, path)
+            self._update_object(obj, basename, path)
             yield obj
 
 


### PR DESCRIPTION
##### SUMMARY
Fix a bug in the data that we save into an attribute discovered by the new grafana plugin: https://github.com/ansible/ansible/pull/34246

Thanks to @rrey for finding this and proposing the fix

##### ISSUE TYPE
 - Bugfix Pull Request
 
##### COMPONENT NAME
lib/ansible/plugins/loader.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```
