### PR TITLE
Use network_inspect to check for existing network

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_network.py
+++ b/lib/ansible/modules/cloud/docker/docker_network.py
@@ -153,6 +153,7 @@ from ansible.module_utils.docker_common import AnsibleDockerClient, DockerBaseCl
 
 try:
     from docker import utils
+    from docker.errors import NotFound as DockerNotFound
     if HAS_DOCKER_PY_2 or HAS_DOCKER_PY_3:
         from docker.types import IPAMPool, IPAMConfig
 except:
@@ -207,14 +208,10 @@ class DockerNetworkManager(object):
             self.absent()
 
     def get_existing_network(self):
-        networks = self.client.networks(names=[self.parameters.network_name])
-        # check if a user is trying to find network by its Id
-        if not networks:
-            networks = self.client.networks(ids=[self.parameters.network_name])
-        if not networks:
+        try:
+            return self.client.inspect_network(self.parameters.network_name)
+        except DockerNotFound:
             return None
-        else:
-            return networks[0]
 
     def has_different_config(self, net):
         '''


### PR DESCRIPTION
##### SUMMARY

Use network_inspect to check for existing network. 

This will also include the `Containers` in the network when only supplying a `name` to the module (e.g., should you want to loop over a list of all containers running on a network).

##### ISSUE TYPE
My interest is in returning the attached containers when the module is run with only a `name`.

This should solve https://github.com/ansible/ansible/issues/29460 as well because `inspect_network` will take a name or an id.

##### COMPONENT NAME

`docker_network`

##### ANSIBLE VERSION

```
ansible 2.6.0 (docker-network-containers 8f1d4bf7e2) last updated 2018/03/26 17:07:29 (GMT -400)
  config file = None
  configured module search path = [u'/Users/tvon/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/tvon/dev/ansible/ansible/lib/ansible
  executable location = /Users/tvon/dev/ansible/ansible/bin/ansible
  python version = 2.7.14 (default, Nov  5 2017, 23:16:26) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.38)]
```
