### PR TITLE
add user password lock option to user module

### DIFF
--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -175,10 +175,10 @@ options:
         version_added: "1.9"
     password_lock:
         description:
-            - Lock the password (usermod -L ) by adding a '!' at the beginning of the password user entry.
+            - Lock the password (usermod -L ). 
+              WARNING : implementation differs on different platforms, this option does not always mean the user cannot login via other methods.
               This option does not disable the user, only lock the password.
         type: bool
-        default: 'no'
         version_added: "2.6"
     local:
         description:
@@ -530,6 +530,8 @@ class User(object):
 
         if self.password_lock:
             cmd.append('-L')
+        elif self.password_lock is not None:
+              cmd.append('-U')
 
         if self.update_password == 'always' and self.password is not None and info[1] != self.password:
             cmd.append('-p')

--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -954,7 +954,7 @@ class FreeBsdUser(User):
                 cmd.append(self.uid)
             return self.execute_command(cmd)
         elif self.password_lock is not None:
-             cmd = [
+            cmd = [
                 self.module.get_bin_path('pw', True),
                 'unlock',
                 '-n',

--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -175,7 +175,7 @@ options:
         version_added: "1.9"
     password_lock:
         description:
-            - Lock the password (usermod -L ) by adding a '!' at the beginning of the password user entry. 
+            - Lock the password (usermod -L ) by adding a '!' at the beginning of the password user entry.
               This option does not disable the user, only lock the password.
         type: bool
         default: 'no'

--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -175,7 +175,7 @@ options:
         version_added: "1.9"
     password_lock:
         description:
-            - Lock the password (usermod -L ). 
+            - Lock the password (usermod -L ).
               WARNING implementation differs on different platforms, this option does not always mean the user cannot login via other methods.
               This option does not disable the user, only lock the password.
         type: bool

--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -176,7 +176,7 @@ options:
     password_lock:
         description:
             - Lock the password (usermod -L ). 
-              WARNING : implementation differs on different platforms, this option does not always mean the user cannot login via other methods.
+              WARNING implementation differs on different platforms, this option does not always mean the user cannot login via other methods.
               This option does not disable the user, only lock the password.
         type: bool
         version_added: "2.6"
@@ -531,7 +531,7 @@ class User(object):
         if self.password_lock:
             cmd.append('-L')
         elif self.password_lock is not None:
-              cmd.append('-U')
+            cmd.append('-U')
 
         if self.update_password == 'always' and self.password is not None and info[1] != self.password:
             cmd.append('-p')


### PR DESCRIPTION
##### SUMMARY

This adds password lock feature (lock -l command) tu user module.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
module : user 

##### ANSIBLE VERSION
```
ansible 2.4.3.0
```


##### ADDITIONAL INFORMATION

I have not written tests for this feature, because i don't know if it can be useful

fixes #29466