### PR TITLE
win_copy: added fix for win_copy deleting local tmp folder

### DIFF
--- a/lib/ansible/plugins/action/win_copy.py
+++ b/lib/ansible/plugins/action/win_copy.py
@@ -11,6 +11,7 @@ import base64
 import json
 import os
 import os.path
+import shutil
 import tempfile
 import traceback
 import zipfile
@@ -320,12 +321,10 @@ class ActionModule(ActionBase):
             )
         )
         copy_args.pop('content', None)
-        os.remove(zip_path)
-
         module_return = self._execute_module(module_name='copy',
                                              module_args=copy_args,
                                              task_vars=task_vars)
-        os.removedirs(os.path.dirname(zip_path))
+        shutil.rmtree(os.path.dirname(zip_path))
         return module_return
 
     def run(self, tmp=None, task_vars=None):

--- a/test/integration/targets/win_copy/tasks/main.yml
+++ b/test/integration/targets/win_copy/tasks/main.yml
@@ -5,6 +5,16 @@
     state: directory
   delegate_to: localhost
 
+# removes the cached zip module from the previous task so we can replicate
+# the below issue where win_copy would delete DEFAULT_LOCAL_TMP if it
+# had permission to
+# https://github.com/ansible/ansible/issues/35613
+- name: clear the local ansiballz cache
+  file:
+    path: "{{lookup('config', 'DEFAULT_LOCAL_TMP')}}/ansiballz_cache"
+    state: absent
+  delegate_to: localhost
+
 - name: create test folder
   win_file:
     path: '{{test_win_copy_path}}'


### PR DESCRIPTION
##### SUMMARY
When win_copy copies multiple files it can sometimes delete the local tmp folder that should be used by multiple modules. This means any further modules that need to access this local tmp folder will fail.

We never came across this in `ansible-test` as we ran a Python module on localhost which causes the ansiballz cache to stop win_copy from successfully deleting this folder. This PR also adds a step in the test to remove this cache after it was created to check this behaviour.

Fixes https://github.com/ansible/ansible/issues/35613

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
win_copy

##### ANSIBLE VERSION
```
devel
2.5
2.4
```