### PR TITLE
fix capitalization on os_project_access examples

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_project_access.py
+++ b/lib/ansible/modules/cloud/openstack/os_project_access.py
@@ -57,7 +57,7 @@ requirements:
 
 EXAMPLES = '''
 - name: "Enable access to tiny flavor to your tenant."
-  os_project_Access:
+  os_project_access:
     cloud: mycloud
     state: present
     target_project_id: f0f1f2f3f4f5f67f8f9e0e1
@@ -66,7 +66,7 @@ EXAMPLES = '''
 
 
 - name: "Disable access to the given flavor to project"
-  os_project_Access:
+  os_project_access:
     cloud: mycloud
     state: absent
     target_project_id: f0f1f2f3f4f5f67f8f9e0e1


### PR DESCRIPTION
##### SUMMARY
Fix small typo in examples for new openstack module os_project_access.py, where upper case A has been used instead of lower

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
os_project_access.py

##### ANSIBLE VERSION
```
ansible 2.5.0
  config file = None
  configured module search path = [u'/Users/buckleyd/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/buckleyd/.virtualenvs/ansible_25/lib/python2.7/site-packages/ansible
  executable location = /Users/buckleyd/.virtualenvs/ansible_25/bin/ansible
  python version = 2.7.10 (default, Oct 23 2015, 19:19:21) [GCC 4.2.1 Compatible Apple LLVM 7.0.0 (clang-700.0.59.5)]
```
