### PR TITLE
Ansible.ModuleUtils.FileUtil: catch DirectoryNotFoundException when testing a path

### DIFF
--- a/lib/ansible/module_utils/powershell/Ansible.ModuleUtils.FileUtil.psm1
+++ b/lib/ansible/module_utils/powershell/Ansible.ModuleUtils.FileUtil.psm1
@@ -17,7 +17,7 @@ Function Test-AnsiblePath {
     # Replacement for Test-Path
     try {
         $file_attributes = [System.IO.File]::GetAttributes($Path)
-    } catch [System.IO.FileNotFoundException] {
+    } catch [System.IO.FileNotFoundException], [System.IO.DirectoryNotFoundException] {
         return $false
     }
 

--- a/test/integration/targets/win_module_utils/library/file_util_test.ps1
+++ b/test/integration/targets/win_module_utils/library/file_util_test.ps1
@@ -48,6 +48,14 @@ if ($pagefile) {
 $actual = Test-AnsiblePath -Path C:\fakefile
 Assert-Equals -actual $actual -expected $false
 
+# Test-AnsiblePath Directory that doesn't exist
+$actual = Test-AnsiblePath -Path C:\fakedirectory
+Assert-Equals -actual $actual -expected $false
+
+# Test-AnsiblePath file in non-existant directory
+$actual = Test-AnsiblePath -Path C:\fakedirectory\fakefile.txt
+Assert-Equals -actual $actual -expected $false
+
 # Test-AnsiblePath Normal directory
 $actual = Test-AnsiblePath -Path C:\Windows
 Assert-Equals -actual $actual -expected $true

--- a/test/integration/targets/win_shell/tasks/main.yml
+++ b/test/integration/targets/win_shell/tasks/main.yml
@@ -144,6 +144,19 @@
     that:
     - statout.stat.exists == true
 
+# https://github.com/ansible/ansible/issues/37967
+- name: test creates with file in missing directory
+  win_shell: echo hi
+  args:
+    creates: c:\fakefolder\fakefolder2\fakefile.txt
+  register: shellout
+
+- name: validate result
+  assert:
+    that:
+    - shellout.skipped is not defined
+    - shellout.changed
+
 - name: run with removes, should remove
   win_shell: Remove-Item c:\testfile.txt
   args:


### PR DESCRIPTION
##### SUMMARY
The `Test-AnsiblePath` cmdlet did not catch `DirectoryNotFoundException` which would fire if the parent directory did not exist when testing the path. We add the catch and return `$false` in these cases as the path in question would not exist in those cases.

Fixes https://github.com/ansible/ansible/issues/37967

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
module_utils/powershell/Ansible.ModuleUtils.FileUtil

##### ANSIBLE VERSION
```
devel
2.5
```