### PR TITLE
Add elapsed return value to select modules

### DIFF
--- a/changelogs/fragments/add-elapsed-return-value-to-select-modules.yaml
+++ b/changelogs/fragments/add-elapsed-return-value-to-select-modules.yaml
@@ -1,0 +1,3 @@
+minor_changes:
+- Now emits 'elapsed' as a return value for get_url, uri and win_uri
+- Ensures 'elapsed' is always returned, when timed out or failed

--- a/lib/ansible/modules/net_tools/basics/uri.py
+++ b/lib/ansible/modules/net_tools/basics/uri.py
@@ -280,7 +280,7 @@ from ansible.module_utils.urls import fetch_url, url_argument_spec
 JSON_CANDIDATES = ('text', 'json', 'javascript')
 
 
-def write_file(module, url, dest, content):
+def write_file(module, url, dest, content, resp):
     # create a tempfile with some test content
     fd, tmpsrc = tempfile.mkstemp(dir=module.tmpdir)
     f = open(tmpsrc, 'wb')
@@ -289,7 +289,7 @@ def write_file(module, url, dest, content):
     except Exception as e:
         os.remove(tmpsrc)
         module.fail_json(msg="failed to create temporary content file: %s" % to_native(e),
-                         exception=traceback.format_exc())
+                         exception=traceback.format_exc(), **resp)
     f.close()
 
     checksum_src = None
@@ -298,10 +298,10 @@ def write_file(module, url, dest, content):
     # raise an error if there is no tmpsrc file
     if not os.path.exists(tmpsrc):
         os.remove(tmpsrc)
-        module.fail_json(msg="Source '%s' does not exist" % tmpsrc)
+        module.fail_json(msg="Source '%s' does not exist" % tmpsrc, **resp)
     if not os.access(tmpsrc, os.R_OK):
         os.remove(tmpsrc)
-        module.fail_json(msg="Source '%s' not readable" % tmpsrc)
+        module.fail_json(msg="Source '%s' not readable" % tmpsrc, **resp)
     checksum_src = module.sha1(tmpsrc)
 
     # check if there is no dest file
@@ -309,15 +309,15 @@ def write_file(module, url, dest, content):
         # raise an error if copy has no permission on dest
         if not os.access(dest, os.W_OK):
             os.remove(tmpsrc)
-            module.fail_json(msg="Destination '%s' not writable" % dest)
+            module.fail_json(msg="Destination '%s' not writable" % dest, **resp)
         if not os.access(dest, os.R_OK):
             os.remove(tmpsrc)
-            module.fail_json(msg="Destination '%s' not readable" % dest)
+            module.fail_json(msg="Destination '%s' not readable" % dest, **resp)
         checksum_dest = module.sha1(dest)
     else:
         if not os.access(os.path.dirname(dest), os.W_OK):
             os.remove(tmpsrc)
-            module.fail_json(msg="Destination dir '%s' not writable" % os.path.dirname(dest))
+            module.fail_json(msg="Destination dir '%s' not writable" % os.path.dirname(dest), **resp)
 
     if checksum_src != checksum_dest:
         try:
@@ -325,7 +325,7 @@ def write_file(module, url, dest, content):
         except Exception as e:
             os.remove(tmpsrc)
             module.fail_json(msg="failed to copy %s to %s: %s" % (tmpsrc, dest, to_native(e)),
-                             exception=traceback.format_exc())
+                             exception=traceback.format_exc(), **resp)
 
     os.remove(tmpsrc)
 
@@ -406,7 +406,7 @@ def uri(module, url, dest, body, body_format, method, headers, socket_timeout):
             })
             data = open(src, 'rb')
         except OSError:
-            module.fail_json(msg='Unable to open source file %s' % src, exception=traceback.format_exc())
+            module.fail_json(msg='Unable to open source file %s' % src, exception=traceback.format_exc(), elapsed=0)
     else:
         data = body
 
@@ -511,7 +511,7 @@ def main():
             try:
                 body = form_urlencoded(body)
             except ValueError as e:
-                module.fail_json(msg='failed to parse body as form_urlencoded: %s' % to_native(e))
+                module.fail_json(msg='failed to parse body as form_urlencoded: %s' % to_native(e), elapsed=0)
         if 'content-type' not in [header.lower() for header in dict_headers]:
             dict_headers['Content-Type'] = 'application/x-www-form-urlencoded'
 
@@ -552,7 +552,7 @@ def main():
         if resp['status'] == 304:
             resp['changed'] = False
         else:
-            write_file(module, url, dest, content)
+            write_file(module, url, dest, content, resp)
             # allow file attribute changes
             resp['changed'] = True
             module.params['path'] = dest

--- a/lib/ansible/modules/utilities/logic/wait_for.py
+++ b/lib/ansible/modules/utilities/logic/wait_for.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# (c) 2012, Jeroen Hoekx <jeroen@hoekx.be>
+# Copyright: (c) 2012, Jeroen Hoekx <jeroen@hoekx.be>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
@@ -467,18 +467,18 @@ def main():
         compiled_search_re = None
 
     if port and path:
-        module.fail_json(msg="port and path parameter can not both be passed to wait_for")
+        module.fail_json(msg="port and path parameter can not both be passed to wait_for", elapsed=0)
     if path and state == 'stopped':
-        module.fail_json(msg="state=stopped should only be used for checking a port in the wait_for module")
+        module.fail_json(msg="state=stopped should only be used for checking a port in the wait_for module", elapsed=0)
     if path and state == 'drained':
-        module.fail_json(msg="state=drained should only be used for checking a port in the wait_for module")
+        module.fail_json(msg="state=drained should only be used for checking a port in the wait_for module", elapsed=0)
     if module.params['exclude_hosts'] is not None and state != 'drained':
-        module.fail_json(msg="exclude_hosts should only be with state=drained")
+        module.fail_json(msg="exclude_hosts should only be with state=drained", elapsed=0)
     for _connection_state in module.params['active_connection_states']:
         try:
             get_connection_state_id(_connection_state)
         except:
-            module.fail_json(msg="unknown active_connection_state (%s) defined" % _connection_state)
+            module.fail_json(msg="unknown active_connection_state (%s) defined" % _connection_state, elapsed=0)
 
     start = datetime.datetime.utcnow()
 

--- a/lib/ansible/modules/utilities/logic/wait_for.py
+++ b/lib/ansible/modules/utilities/logic/wait_for.py
@@ -170,6 +170,14 @@ EXAMPLES = r'''
     ansible_connection: local
 '''
 
+RETURN = r'''
+elapsed:
+  description: The number of seconds that elapsed while waiting
+  returned: always
+  type: int
+  sample: 23
+'''
+
 import binascii
 import datetime
 import errno

--- a/lib/ansible/modules/utilities/logic/wait_for_connection.py
+++ b/lib/ansible/modules/utilities/logic/wait_for_connection.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# (c) 2017, Dag Wieers <dag@wieers.com>
+# Copyright: (c) 2017, Dag Wieers (@dagwieers) <dag@wieers.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function

--- a/lib/ansible/modules/windows/win_get_url.py
+++ b/lib/ansible/modules/windows/win_get_url.py
@@ -141,6 +141,11 @@ dest:
     returned: always
     type: string
     sample: C:\Users\RandomUser\earthrise.jpg
+elapsed:
+    description: The elapsed seconds between the start of poll and the end of the module.
+    returned: always
+    type: float
+    sample: 2.1406487
 url:
     description: requested url
     returned: always

--- a/lib/ansible/modules/windows/win_reboot.py
+++ b/lib/ansible/modules/windows/win_reboot.py
@@ -89,6 +89,6 @@ rebooted:
 elapsed:
   description: The number of seconds that elapsed waiting for the system to be rebooted.
   returned: always
-  type: int
-  sample: 23
+  type: float
+  sample: 23.2
 '''

--- a/lib/ansible/modules/windows/win_uri.py
+++ b/lib/ansible/modules/windows/win_uri.py
@@ -174,6 +174,11 @@ EXAMPLES = r'''
 '''
 
 RETURN = r'''
+elapsed:
+  description: The number of seconds that elapsed while performing the download
+  returned: always
+  type: float
+  sample: 23.2
 url:
   description: The Target URL
   returned: always

--- a/lib/ansible/modules/windows/win_wait_for.ps1
+++ b/lib/ansible/modules/windows/win_wait_for.ps1
@@ -23,6 +23,7 @@ $timeout = Get-AnsibleParam -obj $params -name "timeout" -type "int" -default 30
 
 $result = @{
     changed = $false
+    elapsed = 0
 }
 
 # validate the input with the various options
@@ -126,9 +127,8 @@ if ($path -eq $null -and $port -eq $null -and $state -ne "drained") {
         }
 
         if ($complete -eq $false) {
-            $elapsed_seconds = ((Get-Date) - $module_start).TotalSeconds
+            $result.elapsed = ((Get-Date) - $module_start).TotalSeconds
             $result.wait_attempts = $attempts
-            $result.elapsed = $elapsed_seconds
             if ($search_regex -eq $null) {
                 Fail-Json $result "timeout while waiting for file $path to be present"
             } else {
@@ -158,9 +158,8 @@ if ($path -eq $null -and $port -eq $null -and $state -ne "drained") {
         }
 
         if ($complete -eq $false) {
-            $elapsed_seconds = ((Get-Date) - $module_start).TotalSeconds
+            $result.elapsed = ((Get-Date) - $module_start).TotalSeconds
             $result.wait_attempts = $attempts
-            $result.elapsed = $elapsed_seconds
             if ($search_regex -eq $null) {
                 Fail-Json $result "timeout while waiting for file $path to be absent"
             } else {
@@ -185,9 +184,8 @@ if ($path -eq $null -and $port -eq $null -and $state -ne "drained") {
         }
 
         if ($complete -eq $false) {
-            $elapsed_seconds = ((Get-Date) - $module_start).TotalSeconds
+            $result.elapsed = ((Get-Date) - $module_start).TotalSeconds
             $result.wait_attempts = $attempts
-            $result.elapsed = $elapsed_seconds
             Fail-Json $result "timeout while waiting for $($hostname):$port to start listening"
         }
     } elseif ($state -in @("stopped","absent")) {
@@ -206,9 +204,8 @@ if ($path -eq $null -and $port -eq $null -and $state -ne "drained") {
         }
 
         if ($complete -eq $false) {
-            $elapsed_seconds = ((Get-Date) - $module_start).TotalSeconds
+            $result.elapsed = ((Get-Date) - $module_start).TotalSeconds
             $result.wait_attempts = $attempts
-            $result.elapsed = $elapsed_seconds
             Fail-Json $result "timeout while waiting for $($hostname):$port to stop listening"
         }
     } elseif ($state -eq "drained") {
@@ -247,15 +244,14 @@ if ($path -eq $null -and $port -eq $null -and $state -ne "drained") {
         }
 
         if ($complete -eq $false) {
-            $elapsed_seconds = ((Get-Date) - $module_start).TotalSeconds
+            $result.elapsed = ((Get-Date) - $module_start).TotalSeconds
             $result.wait_attempts = $attempts
-            $result.elapsed = $elapsed_seconds
             Fail-Json $result "timeout while waiting for $($hostname):$port to drain"
         }
     }
 }
 
-$result.wait_attempts = $attempts
 $result.elapsed = ((Get-Date) - $module_start).TotalSeconds
+$result.wait_attempts = $attempts
 
 Exit-Json $result


### PR DESCRIPTION
##### SUMMARY
It can be quite useful to know exactly how much time has elapsed downloading/waiting. This improves existing modules or updates documentation.

- This PR brings feature parity to **get_url** (from win_get_url).
- We ensure `elapsed` is always returned (also when it eventually fails/times out)
- We added `elapsed` to **uri** and **win_uri** (cfr. get_url) on the basis that it helps to troubleshoot network-related issues (which can happen at any time, so `--debug` or altering strategy is no option here).

This relates to #37957

##### ISSUE TYPE
 - Feature Pull Request
 - Docs Pull Request

##### COMPONENT NAME
get_url, uri, wait_for, win_get_url, win_reboot, win_uri

##### ANSIBLE VERSION
v2.6