### PR TITLE
win_reboot: backport warning message arguments

### DIFF
--- a/changelogs/fragments/win_reboot-warning-message-fix.yaml
+++ b/changelogs/fragments/win_reboot-warning-message-fix.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+- win_reboot - fix deprecated warning message to show version in correct spot
+  https://github.com/ansible/ansible/pull/37898

--- a/lib/ansible/plugins/action/win_reboot.py
+++ b/lib/ansible/plugins/action/win_reboot.py
@@ -85,7 +85,7 @@ class ActionModule(ActionBase):
         }
         for arg, version in deprecated_args.items():
             if self._task.args.get(arg) is not None:
-                display.warning("Since Ansible %s, %s is no longer used with win_reboot" % (arg, version))
+                display.warning("Since Ansible %s, %s is no longer used with win_reboot" % (version, arg))
 
         if self._task.args.get('connect_timeout') is not None:
             connect_timeout = int(self._task.args.get('connect_timeout', self.DEFAULT_CONNECT_TIMEOUT))


### PR DESCRIPTION
##### SUMMARY
Fix arg ordering on win_reboot deprecated warning message.

Backport of https://github.com/ansible/ansible/pull/37898

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
win_reboot

##### ANSIBLE VERSION
```
2.5
```