### PR TITLE
warn about assign_public_ip immutability only if explicitly set

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2.py
+++ b/lib/ansible/modules/cloud/amazon/ec2.py
@@ -134,7 +134,6 @@ options:
     description:
       - when provisioning within vpc, assign a public IP address. Boto library must be 2.13.0+
     type: bool
-    default: 'no'
   private_ip:
     version_added: "1.2"
     description:
@@ -1560,7 +1559,7 @@ def warn_if_public_ip_assignment_changed(module, instance):
 
     # Check that public ip assignment is the same and warn if not
     public_dns_name = getattr(instance, 'public_dns_name', None)
-    if (assign_public_ip or public_dns_name) and (not public_dns_name or not assign_public_ip):
+    if (assign_public_ip or public_dns_name) and (not public_dns_name or assign_public_ip is False):
         module.warn("Unable to modify public ip assignment to {0} for instance {1}. "
                     "Whether or not to assign a public IP is determined during instance creation.".format(assign_public_ip, instance.id))
 
@@ -1590,7 +1589,7 @@ def main():
             user_data=dict(),
             instance_tags=dict(type='dict'),
             vpc_subnet_id=dict(),
-            assign_public_ip=dict(type='bool', default=False),
+            assign_public_ip=dict(type='bool'),
             private_ip=dict(),
             instance_profile_name=dict(),
             instance_ids=dict(type='list', aliases=['instance_id']),


### PR DESCRIPTION
##### SUMMARY
Change assign_public_ip to default to None rather than False so
that we can detect whether the value is being explicitly set or
not, and only warn if it is explicitly set to False for something
with a public_dns_name

Fixes #37985


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ec2

##### ANSIBLE VERSION
```
ansible 2.6.0 (devel 0214a85382) last updated 2018/03/21 15:11:32 (GMT +1000)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/will/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/will/src/ansible/lib/ansible
  executable location = /home/will/src/ansible/bin/ansible
  python version = 2.7.14 (default, Feb 27 2018, 20:43:24) [GCC 7.3.1 20180130 (Red Hat 7.3.1-2)]

```


##### ADDITIONAL INFORMATION
This bug is not present in the ec2_instance module which is the future replacement for the ec2 module.