### PR TITLE
win_copy: backport 2.5 preserve local tmp path when sending multiple files

### DIFF
--- a/changelogs/fragments/win_copy-preserve-tmp-folder.yaml
+++ b/changelogs/fragments/win_copy-preserve-tmp-folder.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+- win_copy - Preserve the local tmp folder instead of deleting it so future tasks can use it
+  https://github.com/ansible/ansible/pull/37964

--- a/lib/ansible/plugins/action/win_copy.py
+++ b/lib/ansible/plugins/action/win_copy.py
@@ -11,6 +11,7 @@ import base64
 import json
 import os
 import os.path
+import shutil
 import tempfile
 import traceback
 import zipfile
@@ -320,12 +321,10 @@ class ActionModule(ActionBase):
             )
         )
         copy_args.pop('content', None)
-        os.remove(zip_path)
-
         module_return = self._execute_module(module_name='copy',
                                              module_args=copy_args,
                                              task_vars=task_vars)
-        os.removedirs(os.path.dirname(zip_path))
+        shutil.rmtree(os.path.dirname(zip_path))
         return module_return
 
     def run(self, tmp=None, task_vars=None):

--- a/test/integration/targets/win_copy/tasks/main.yml
+++ b/test/integration/targets/win_copy/tasks/main.yml
@@ -5,6 +5,16 @@
     state: directory
   delegate_to: localhost
 
+# removes the cached zip module from the previous task so we can replicate
+# the below issue where win_copy would delete DEFAULT_LOCAL_TMP if it
+# had permission to
+# https://github.com/ansible/ansible/issues/35613
+- name: clear the local ansiballz cache
+  file:
+    path: "{{lookup('config', 'DEFAULT_LOCAL_TMP')}}/ansiballz_cache"
+    state: absent
+  delegate_to: localhost
+
 - name: create test folder
   win_file:
     path: '{{test_win_copy_path}}'


### PR DESCRIPTION
##### SUMMARY
Will preserve the local tmp path when sending over a zip file, previously the code would have continued up the tree and delete each parent folder until an error was reached and this would cause issues further down the line.

Backport of https://github.com/ansible/ansible/pull/37964

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
win_copy

##### ANSIBLE VERSION
```
2.5
```