### PR TITLE
win_copy: backport 2.4 preserve local tmp path when sending multiple files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 Ansible Changes By Release
 ==========================
 
+<a id="2.4.5"></a>
+
+## 2.4.5 "Dancing Days" - TBD
+
+### Bugfixes
+
+* Fix win_copy to preserve the global Ansible local tmp path instead of
+  deleting it when dealing with multiple files
+  (https://github.com/ansible/ansible/pull/37964)
+
+
 <a id="2.4.4"></a>
 
 ## 2.4.4 "Dancing Days" - 2018-04-04

--- a/lib/ansible/plugins/action/win_copy.py
+++ b/lib/ansible/plugins/action/win_copy.py
@@ -11,6 +11,7 @@ import base64
 import json
 import os
 import os.path
+import shutil
 import tempfile
 import traceback
 import zipfile
@@ -320,11 +321,10 @@ class ActionModule(ActionBase):
             )
         )
         copy_args.pop('content', None)
-        os.remove(zip_path)
-        os.removedirs(os.path.dirname(zip_path))
 
         module_return = self._execute_module(module_args=copy_args, task_vars=task_vars)
         self._remove_tmp_path(tmp_path)
+        shutil.rmtree(os.path.dirname(zip_path))
         return module_return
 
     def run(self, tmp=None, task_vars=None):


### PR DESCRIPTION
##### SUMMARY
Will preserve the local tmp path when sending over a zip file, previously the code would have continued up the tree and delete each parent folder until an error was reached and this would cause issues further down the line.

Backport of https://github.com/ansible/ansible/pull/37964

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
win_copy

##### ANSIBLE VERSION
```
2.4
```