### PR TITLE
Add NSX-T Logical Switch support in vmware_guest

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -1122,7 +1122,7 @@ class PyVmomiHelper(PyVmomi):
                 nic.device.backing = vim.vm.device.VirtualEthernetCard.OpaqueNetworkBackingInfo()
                 nic.device.backing.opaqueNetworkType = 'nsx.LogicalSwitch'
                 nic.device.backing.opaqueNetworkId = self.cache.get_network(network_name).summary.opaqueNetworkId
-                nic.device.deviceInfo.summary = 'nsx.LogicalSwitch: %s'%(self.cache.get_network(network_name).summary.opaqueNetworkId)
+                nic.device.deviceInfo.summary = 'nsx.LogicalSwitch: %s' % (self.cache.get_network(network_name).summary.opaqueNetworkId)
 
             else:
                 # vSwitch

--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -1116,6 +1116,14 @@ class PyVmomiHelper(PyVmomi):
                 dvs_port_connection.switchUuid = pg_obj.config.distributedVirtualSwitch.uuid
                 nic.device.backing = vim.vm.device.VirtualEthernetCard.DistributedVirtualPortBackingInfo()
                 nic.device.backing.port = dvs_port_connection
+
+            elif isinstance(self.cache.get_network(network_name), vim.OpaqueNetwork):
+                # NSX-T Logical Switch
+                nic.device.backing = vim.vm.device.VirtualEthernetCard.OpaqueNetworkBackingInfo()
+                nic.device.backing.opaqueNetworkType = 'nsx.LogicalSwitch'
+                nic.device.backing.opaqueNetworkId = self.cache.get_network(network_name).summary.opaqueNetworkId
+                nic.device.deviceInfo.summary = 'nsx.LogicalSwitch: %s'%(self.cache.get_network(network_name).summary.opaqueNetworkId)
+
             else:
                 # vSwitch
                 if not isinstance(nic.device.backing, vim.vm.device.VirtualEthernetCard.NetworkBackingInfo):


### PR DESCRIPTION
##### SUMMARY
Fixes #37975 

It is a simple change. Previously the module checks:
```
if it is distribute vSwitch portgroup:
    attach to DVS portgroup
else:
    attach to VSS portgroup
```
Now the code looks like:
```
if it is distribute vSwitch portgroup:
    attach to DVS portgroup
elif it is nsx-t logical switch:
    attach to nsx-t logical switch
else:
    attach to VSS portgroup
```

##### ISSUE TYPE
 - Bugfix Pull Request
 

##### COMPONENT NAME
vmware_guest

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
(venv) YSIMEONOV-PRO15:ansible ysimeonov$ ansible --version
ansible 2.6.0 (devel b8c8fe079b) last updated 2018/03/27 09:04:41 (GMT +200)
  config file = None
  configured module search path = ['/Users/ysimeonov/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/ysimeonov/commitansible/ansible/lib/ansible
  executable location = /Users/ysimeonov/commitansible/ansible/bin/ansible
  python version = 3.6.4 (default, Mar  1 2018, 18:36:50) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
(venv) YSIMEONOV-PRO15:ansible ysimeonov$
```


##### ADDITIONAL INFORMATION
After amending  vmware_guest.py I tested connecting to nsx-t logical switch and it works.
I also tested connecting to Standard vSwitch portgroup and Distributed vSwitch portgroup, just to ensure that there is no break in the previous behaviour and it works! 
