### PR TITLE
doc: index_var: fix version added

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_loops.rst
+++ b/docs/docsite/rst/user_guide/playbooks_loops.rst
@@ -285,7 +285,7 @@ Another option to loop control is ``pause``, which allows you to control the tim
       loop_control:
         pause: 3
 
-.. versionadded:: 2.7
+.. versionadded:: 2.5
 
 If you need to keep track of where you are in a loop, you can use the ``index_var`` option to loop control to specify a variable name to contain the current loop index.::
 


### PR DESCRIPTION
##### SUMMARY
e9b0a4ccb42854329b33b06624379c6122b67bd7 is present since v2.5.0b1

Example given in the documentation works well with Ansible 2.5:
```
$ ansible --version
ansible 2.5.0 (stable-2.5 2604832858) last updated 2018/03/27 10:39:36 (GMT +200)
$ cat test.yml
- hosts: all
  gather_facts: no
  tasks:
  - name: count our fruit
    debug:
      msg: "{{ item }} with index {{ my_idx }}"
    loop:
      - apple
      - banana
      - pear
    loop_control:
      index_var: my_idx
 $ ansible-playbook -i localhost, test.yml

PLAY [all] ***

TASK [count our fruit] ***
ok: [localhost] => (item=apple) => {
    "msg": "apple with index 0",
    "my_idx": 0
}
ok: [localhost] => (item=banana) => {
    "msg": "banana with index 1",
    "my_idx": 1
}
ok: [localhost] => (item=pear) => {
    "msg": "pear with index 2",
    "my_idx": 2
}

PLAY RECAP ***
localhost                  : ok=1    changed=0    unreachable=0    failed=0   
```

Must be backported to 2.5.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
doc

##### ANSIBLE VERSION
```
ansible 2.6.0 (devel 135d343254) last updated 2018/03/27 10:36:19 (GMT +200)
```