### PR TITLE
Ensure that arguments for sub commands are properly indented in man pages

### DIFF
--- a/docs/templates/man.j2
+++ b/docs/templates/man.j2
@@ -52,7 +52,7 @@ ACTIONS
 
 {% if actions[action]['options'] %}
 {% for option in actions[action]['options']|sort(attribute='options') %}
-{% for switch in option['options'] if switch in actions[action]['option_names'] %}**{{switch}}**{% if option['arg'] %} '{{option['arg']}}'{% endif %}{% if not loop.last %}, {% endif %}{% endfor %}
+{% for switch in option['options'] if switch in actions[action]['option_names'] %}  **{{switch}}**{% if option['arg'] %} '{{option['arg']}}'{% endif %}{% if not loop.last %}, {% endif %}{% endfor %}
 
         {{ (option['desc']) }}
 {% endfor %}


### PR DESCRIPTION
##### SUMMARY
Ensure that arguments for sub commands are properly indented in man pages

Before:
```
       encrypt_string
              encrypt the supplied string using the provided vault secret

       --encrypt-vault-id 'ENCRYPT_VAULT_ID'
          the vault id used to encrypt (required if more than vault-id is pro-
          vided)

       --output
          output file name for encrypt or decrypt; use - for stdout
```

After:
```
       encrypt_string
              encrypt the supplied string using the provided vault secret

              --encrypt-vault-id 'ENCRYPT_VAULT_ID'
                 the vault id used to encrypt (required if more than  vault-id
                 is provided)

              --output
                 output file name for encrypt or decrypt; use - for stdout
```

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
docs/templates/man.j2

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```