### PR TITLE
docs: Document disabling diff on task level

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_checkmode.rst
+++ b/docs/docsite/rst/user_guide/playbooks_checkmode.rst
@@ -98,3 +98,18 @@ Since the diff feature produces a large amount of output, it is best used when c
 
     ansible-playbook foo.yml --check --diff --limit foo.example.com
 
+.. versionadded:: 2.4
+
+The ``--diff`` option can leak sensitive information. Therefore reporting changes can be disabled for tasks by specifying ``diff: no`` in case they deal with secrets.
+
+Example::
+
+  tasks:
+    - name: this task will not report a diff when the file changes
+      template:
+        src: secret.conf.j2
+        dest: /etc/secret.conf
+        owner: root
+        group: root
+        mode: '0600'
+      diff: no

--- a/docs/docsite/rst/user_guide/playbooks_checkmode.rst
+++ b/docs/docsite/rst/user_guide/playbooks_checkmode.rst
@@ -100,7 +100,7 @@ Since the diff feature produces a large amount of output, it is best used when c
 
 .. versionadded:: 2.4
 
-The ``--diff`` option can leak sensitive information. Therefore reporting changes can be disabled for tasks by specifying ``diff: no`` in case they deal with secrets.
+The ``--diff`` option can reveal sensitive information. This option can disabled for tasks by specifying ``diff: no``. 
 
 Example::
 


### PR DESCRIPTION
##### SUMMARY
This change improves the documentation for the `--diff` command line argument.

Tasks that deal with secrets may leak sensitive information when running in Check Mode. This change updates the documentation explaining that the diff can be deactivated on task level.

The feature was requested in #14860 and got introduced in Ansible 2.4 with #28581. But it has not been added to the documentation yet.

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->

`playbooks_checkmode.rst`

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0
```

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
validated with:
MODULES=playbooks_checkmode make webdocs
```