### PR TITLE
Only template values in vars_prompt rather than all vars

### DIFF
--- a/lib/ansible/executor/playbook_executor.py
+++ b/lib/ansible/executor/playbook_executor.py
@@ -102,13 +102,14 @@ class PlaybookExecutor:
                     # clear any filters which may have been applied to the inventory
                     self._inventory.remove_restriction()
 
-                    # Create a temporary copy of the play here, so we can run post_validate
-                    # on it without the templating changes affecting the original object.
-                    # Doing this before vars_prompt to allow for using variables in prompt.
+                    # Create a temporary copy of the play here, so we can template varibales
+                    # in vars_prompt fields without the templating changes affecting the original object.
+                    # This allows variables to be used in vars_prompt fields.
                     all_vars = self._variable_manager.get_vars(play=play)
                     templar = Templar(loader=self._loader, variables=all_vars)
+                    templated_vars_prompt = templar.template(play.vars_prompt)
                     new_play = play.copy()
-                    new_play.post_validate(templar)
+                    setattr(new_play, 'vars_prompt', templated_vars_prompt)
 
                     if play.vars_prompt:
                         for var in new_play.vars_prompt:


### PR DESCRIPTION
##### SUMMARY

This allows the use of variables in vars_prompt fields but allows variables entered in the prompt to affect play vars rather than throwing an undefined error.

Fixes #37984


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
`playbook_executor.py`

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6
```
