### PR TITLE
Backport 34925 to 2.5 handle missing dmidecode 37911

### DIFF
--- a/lib/ansible/module_utils/facts/virtual/linux.py
+++ b/lib/ansible/module_utils/facts/virtual/linux.py
@@ -236,13 +236,15 @@ class LinuxVirtual(Virtual):
         # In older Linux Kernel versions, /sys filesystem is not available
         # dmidecode is the safest option to parse virtualization related values
         dmi_bin = self.module.get_bin_path('dmidecode')
-        (rc, out, err) = self.module.run_command('%s -s system-product-name' % dmi_bin)
-        if rc == 0:
-            # Strip out commented lines (specific dmidecode output)
-            vendor_name = ''.join([line.strip() for line in out.splitlines() if not line.startswith('#')])
-            if vendor_name in ['VMware Virtual Platform', 'VMware7,1']:
-                virtual_facts['virtualization_type'] = 'VMware'
-                virtual_facts['virtualization_role'] = 'guest'
+        # We still want to continue even if dmidecode is not available
+        if dmi_bin is not None:
+            (rc, out, err) = self.module.run_command('%s -s system-product-name' % dmi_bin)
+            if rc == 0:
+                # Strip out commented lines (specific dmidecode output)
+                vendor_name = ''.join([line.strip() for line in out.splitlines() if not line.startswith('#')])
+                if vendor_name.startwith('VMware'):
+                    virtual_facts['virtualization_type'] = 'VMware'
+                    virtual_facts['virtualization_role'] = 'guest'
 
         # If none of the above matches, return 'NA' for virtualization_type
         # and virtualization_role. This allows for proper grouping.


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Backport of 34925 to 2.5

```
   continue fact gathering even without dmidecode (#34925)
    
   * continue fact gathering even without dmidecode
    
    If dmidecode is not available we still wan to continue with fact
    gathering.
    On certain platforms dmidecode just won't work
    
    (cherry picked from commit cbe2915ba5236030ba560ba870b97f57e09bebe7)
    
    Fixes #37911
```

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
lib/ansible/module_utils/facts/virtual/linux.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (backport_34925_fix_dmidecode_37911 0ad783c381) last updated 2018/03/27 14:02:00 (GMT -400)
  config file = /home/adrian/src/ansible/ansible.cfg
  configured module search path = [u'/home/adrian/ansible/my-modules']
  ansible python module location = /home/adrian/src/ansible/lib/ansible
  executable location = /home/adrian/src/ansible/bin/ansible
  python version = 2.7.14 (default, Feb 27 2018, 20:43:24) [GCC 7.3.1 20180130 (Red Hat 7.3.1-2)]
```

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
