### PR TITLE
module_utils/facts: override pkg_mgr for ALT Linux

### DIFF
--- a/lib/ansible/module_utils/facts/system/pkg_mgr.py
+++ b/lib/ansible/module_utils/facts/system/pkg_mgr.py
@@ -78,5 +78,10 @@ class PkgMgrFactCollector(BaseFactCollector):
             if os.path.exists(pkg['path']):
                 pkg_mgr_name = pkg['name']
 
+        if pkg_mgr_name == 'apt' and \
+                os.path.exists('/usr/bin/rpm') and \
+                not os.path.exists('/usr/bin/dpkg'):
+            pkg_mgr_name = 'apt_rpm'
+
         facts_dict['pkg_mgr'] = pkg_mgr_name
         return facts_dict


### PR DESCRIPTION
##### SUMMARY
Overrides `pkg_mgr` fact to `apt_rpm` if:
- found package manager is `apt`;
- `os_family` is `ALT` (which represents ALT Linux).

Fixes #37997

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
module_utils/facts

##### ANSIBLE VERSION
```
ansible 2.6.0 (fix-37997-apr_rpm-for-altlinux d45e258a4b) last updated 2018/03/27 21:11:58 (GMT +300)
  config file = /home/gross/.ansible.cfg
  configured module search path = ['/home/gross/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/gross/thirdparty/ansible/lib/ansible
  executable location = /home/gross/thirdparty/ansible/bin/ansible
  python version = 3.6.4 (default, Jan  5 2018, 02:35:40) [GCC 7.2.1 20171224]
```

##### ADDITIONAL INFORMATION
See #37997
