### PR TITLE
VMware: Use RFC 952 compliant hostname while customization

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -216,7 +216,7 @@ options:
     - ' - C(vlan) (integer): VLAN number for this interface.'
     - 'Optional parameters per entry (used for virtual hardware):'
     - ' - C(device_type) (string): Virtual network device (one of C(e1000), C(e1000e), C(pcnet32), C(vmxnet2), C(vmxnet3) (default), C(sriov)).'
-    - ' - C(mac) (string): Customize mac address.'
+    - ' - C(mac) (string): Customize MAC address.'
     - 'Optional parameters per entry (used for OS customization):'
     - ' - C(type) (string): Type of IP assignment (either C(dhcp) or C(static)).'
     - ' - C(ip) (string): Static IP address (implies C(type: static)).'
@@ -230,14 +230,15 @@ options:
     version_added: '2.3'
   customization:
     description:
-    - Parameters for OS customization when cloning from template.
+    - Parameters for OS customization when cloning from the template or the virtual machine.
     - All parameters and VMware object names are case sensitive.
-    - Linux based OS requires Perl to be installed.
+    - Linux based OS requires Perl to be installed for OS customization.
     - 'Common parameters (Linux/Windows):'
     - ' - C(dns_servers) (list): List of DNS servers to configure.'
-    - ' - C(dns_suffix) (list): List of domain suffixes, aka DNS search path (default: C(domain) parameter).'
+    - ' - C(dns_suffix) (list): List of domain suffixes, a.k.a. DNS search path (default: C(domain) parameter).'
     - ' - C(domain) (string): DNS domain name to use.'
     - ' - C(hostname) (string): Computer hostname (default: shorted C(name) parameter).'
+    - 'Allowed characters are alphanumeric (uppercase and lowercase) and minus, rest of the characters are dropped as per RFC 952.'
     - 'Parameters related to Windows customization:'
     - ' - C(autologon) (bool): Auto logon after VM customization (default: False).'
     - ' - C(autologoncount) (int): Number of autologon after reboot (default: 1).'
@@ -255,12 +256,12 @@ options:
   vapp_properties:
     description:
     - A list of vApp properties
-    - 'For full list of attibutes and types refer to: U(https://github.com/vmware/pyvmomi/blob/master/docs/vim/vApp/PropertyInfo.rst)'
+    - 'For full list of attributes and types refer to: U(https://github.com/vmware/pyvmomi/blob/master/docs/vim/vApp/PropertyInfo.rst)'
     - 'Basic attributes are:'
-    - ' - C(id) (string): Property id - required'
-    - ' - C(value) (string): Property value'
+    - ' - C(id) (string): Property id - required.'
+    - ' - C(value) (string): Property value.'
     - ' - C(type) (string): Value type, string type by default.'
-    - ' - C(operation): C(remove): This attribute is required only when removing properties'
+    - ' - C(operation): C(remove): This attribute is required only when removing properties.'
     version_added: '2.6'
 extends_documentation_fragment: vmware.documentation
 '''
@@ -1350,7 +1351,10 @@ class PyVmomiHelper(PyVmomi):
                 ident.domain = str(self.params['customization']['domain'])
 
             ident.hostName = vim.vm.customization.FixedName()
-            ident.hostName.name = str(self.params['customization'].get('hostname', self.params['name'].split('.')[0]))
+            hostname = str(self.params['customization'].get('hostname', self.params['name'].split('.')[0]))
+            # Remove all characters except alphanumeric and minus which is allowed by RFC 952
+            valid_hostname = re.sub(r"[^a-zA-Z0-9\-]", "", hostname)
+            ident.hostName.name = valid_hostname
 
         self.customspec = vim.vm.customization.Specification()
         self.customspec.nicSettingMap = adaptermaps


### PR DESCRIPTION
##### SUMMARY
VMware throws error if hostname provided by user is not RFC 952
compliant. Added minor documentation fixes.

Fixes: #24225, #27096

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/vmware/vmware_guest.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6devel
```