### PR TITLE
Typo in lookup flattened example

### DIFF
--- a/lib/ansible/plugins/lookup/flattened.py
+++ b/lib/ansible/plugins/lookup/flattened.py
@@ -22,7 +22,7 @@ DOCUMENTATION = """
 
 EXAMPLES = """
 - name: "'unnest' all elements into single list"
-  debug: msg="all in one list {{lookup('flatten', [1,2,3,[5,6]], [a,b,c], [[5,6,1,3], [34,a,b,c]])}}"
+  debug: msg="all in one list {{lookup('flattened', [1,2,3,[5,6]], [a,b,c], [[5,6,1,3], [34,a,b,c]])}}"
 """
 
 RETURN = """


### PR DESCRIPTION
##### SUMMARY

This PR fixes a small typo in the documentation example of the flattened lookup plugin, preventing a copy-paste of the example to work properly

##### ISSUE TYPE

 - Docs Pull Request

##### COMPONENT NAME

flattened lookup plugin

##### ANSIBLE VERSION
```
devel branch
```

##### ADDITIONAL INFORMATION
