### PR TITLE
[2.5] cloudstack: fix do not rely on APIs list queries for names (#37910)

### DIFF
--- a/lib/ansible/modules/cloud/cloudstack/cs_configuration.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_configuration.py
@@ -228,7 +228,9 @@ class AnsibleCloudStackConfiguration(AnsibleCloudStack):
         configurations = self.query_api('listConfigurations', **args)
         if not configurations:
             self.module.fail_json(msg="Configuration %s not found." % args['name'])
-        configuration = configurations['configuration'][0]
+        for config in configurations['configuration']:
+            if args['name'] == config['name']:
+                configuration = config
         return configuration
 
     def get_value(self):


### PR DESCRIPTION
(cherry picked from commit abae7a49f7341fe5ec5980383fba28f818b7b07e)

##### SUMMARY
fix do not rely on list queries for names

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
cs_configuration

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
