### PR TITLE
Detect separate git dir and set git config path value appropriately

### DIFF
--- a/lib/ansible/modules/source_control/git.py
+++ b/lib/ansible/modules/source_control/git.py
@@ -1028,6 +1028,7 @@ def main():
                     raise ValueError('.git file has invalid git dir reference format')
                 if not os.path.isdir(os.environ['GIT_DIR']):
                     raise TypeError('%s is not a directory' % os.environ['GIT_DIR'])
+                gitconfig = os.path.join(os.environ['GIT_DIR'], 'config')
             except (TypeError, ValueError) as err:
                 """``.git`` file does not have a valid format for detached Git dir."""
                 module.fail_json(

--- a/lib/ansible/modules/source_control/git.py
+++ b/lib/ansible/modules/source_control/git.py
@@ -1019,6 +1019,14 @@ def main():
         dest = os.path.abspath(dest)
         if bare:
             gitconfig = os.path.join(dest, 'config')
+        elif os.path.isfile(os.path.join(dest, '.git')):
+            with open(os.path.join(dest, '.git'), 'r') as gitfile:
+                data = gitfile.read()
+            match = re.match('gitdir: (.+)$', data)
+            if match:
+                separate_git_dir = match.group(1)
+                os.environ['GIT_DIR'] = separate_git_dir
+                gitconfig = os.path.join(separate_git_dir, 'config')
         else:
             gitconfig = os.path.join(dest, '.git', 'config')
 

--- a/lib/ansible/modules/source_control/git.py
+++ b/lib/ansible/modules/source_control/git.py
@@ -600,7 +600,8 @@ def get_repo_path(dest, bare):
         repo_path = dest
     else:
         repo_path = os.path.join(dest, '.git')
-    # Check if the .git is a file. If it is a file, it means that we are in a submodule structure.
+    # Check if the .git is a file. If it is a file, it means that the repository is in external directory respective to the working copy (e.g. we are in a
+    # submodule structure).
     if os.path.isfile(repo_path):
         with open(repo_path, 'r') as gitfile:
             data = gitfile.read()

--- a/lib/ansible/modules/source_control/git.py
+++ b/lib/ansible/modules/source_control/git.py
@@ -603,7 +603,6 @@ def get_repo_path(module, dest, bare):
     # Check if the .git is a file. If it is a file, it means that we are in a submodule structure.
     if os.path.isfile(repo_path):
         try:
-            git_conf = open(repo_path, 'rb')
             with open(repo_path, 'r') as gitfile:
                 data = gitfile.read()
             ref_prefix, gitdir = data.rstrip().split('gitdir: ', 1)

--- a/lib/ansible/modules/source_control/git.py
+++ b/lib/ansible/modules/source_control/git.py
@@ -595,35 +595,26 @@ def is_not_a_branch(git_path, module, dest):
     return False
 
 
-def get_repo_path(module, dest, bare):
+def get_repo_path(dest, bare):
     if bare:
         repo_path = dest
     else:
         repo_path = os.path.join(dest, '.git')
     # Check if the .git is a file. If it is a file, it means that we are in a submodule structure.
     if os.path.isfile(repo_path):
-        try:
-            with open(repo_path, 'r') as gitfile:
-                data = gitfile.read()
-            ref_prefix, gitdir = data.rstrip().split('gitdir: ', 1)
-            if ref_prefix:
-                raise ValueError('.git file has invalid git dir reference format')
+        with open(repo_path, 'r') as gitfile:
+            data = gitfile.read()
+        ref_prefix, gitdir = data.rstrip().split('gitdir: ', 1)
+        if ref_prefix:
+            raise ValueError('.git file has invalid git dir reference format')
 
-            # There is a possibility the .git file to have an absolute path.
-            if os.path.isabs(gitdir):
-                repo_path = gitdir
-            else:
-                repo_path = os.path.join(repo_path.split('.git')[0], gitdir)
-            if not os.path.isdir(repo_path):
-                raise ValueError('%s is not a directory' % repo_path)
-        except (IOError, AttributeError, ValueError) as err:
-            # No repo path found
-            """``.git`` file does not have a valid format for detached Git dir."""
-            module.fail_json(
-                msg='Current repo does not have a valid reference to a '
-                'separate Git dir or it refers to the invalid path',
-                details=str(err),
-            )
+        # There is a possibility the .git file to have an absolute path.
+        if os.path.isabs(gitdir):
+            repo_path = gitdir
+        else:
+            repo_path = os.path.join(repo_path.split('.git')[0], gitdir)
+        if not os.path.isdir(repo_path):
+            raise ValueError('%s is not a directory' % repo_path)
     return repo_path
 
 
@@ -635,7 +626,16 @@ def get_head_branch(git_path, module, dest, remote, bare=False):
     associated with.  In the case of a detached HEAD, this will look
     up the branch in .git/refs/remotes/<remote>/HEAD.
     '''
-    repo_path = get_repo_path(module, dest, bare)
+    try:
+        repo_path = get_repo_path(dest, bare)
+    except (IOError, ValueError) as err:
+        # No repo path found
+        """``.git`` file does not have a valid format for detached Git dir."""
+        module.fail_json(
+            msg='Current repo does not have a valid reference to a '
+            'separate Git dir or it refers to the invalid path',
+            details=str(err),
+        )
     # Read .git/HEAD for the name of the branch.
     # If we're in a detached HEAD state, look up the branch associated with
     # the remote HEAD in .git/refs/remotes/<remote>/HEAD
@@ -1025,7 +1025,16 @@ def main():
         module.fail_json(msg="the destination directory must be specified unless clone=no")
     elif dest:
         dest = os.path.abspath(dest)
-        repo_path = get_repo_path(module, dest, bare)
+        try:
+            repo_path = get_repo_path(dest, bare)
+        except (IOError, ValueError) as err:
+            # No repo path found
+            """``.git`` file does not have a valid format for detached Git dir."""
+            module.fail_json(
+                msg='Current repo does not have a valid reference to a '
+                'separate Git dir or it refers to the invalid path',
+                details=str(err),
+            )
         gitconfig = os.path.join(repo_path, 'config')
 
     # create a wrapper script and export

--- a/lib/ansible/modules/source_control/git.py
+++ b/lib/ansible/modules/source_control/git.py
@@ -1023,12 +1023,12 @@ def main():
             with open(os.path.join(dest, '.git'), 'r') as gitfile:
                 data = gitfile.read()
             try:
-                ref_prefix, os.environ['GIT_DIR'] = data.split('gitdir: ', 1)
+                ref_prefix, separate_git_dir = data.rstrip().split('gitdir: ', 1)
                 if ref_prefix:
                     raise ValueError('.git file has invalid git dir reference format')
-                if not os.path.isdir(os.environ['GIT_DIR']):
-                    raise TypeError('%s is not a directory' % os.environ['GIT_DIR'])
-                gitconfig = os.path.join(os.environ['GIT_DIR'], 'config')
+                if not os.path.isdir(separate_git_dir):
+                    raise TypeError('%s is not a directory' % separate_git_dir)
+                gitconfig = os.path.join(separate_git_dir, 'config')
             except (TypeError, ValueError) as err:
                 """``.git`` file does not have a valid format for detached Git dir."""
                 module.fail_json(

--- a/test/integration/targets/git/tasks/main.yml
+++ b/test/integration/targets/git/tasks/main.yml
@@ -36,3 +36,8 @@
 - include_tasks: reset-origin.yml
 - include_tasks: ambiguous-ref.yml
 - include_tasks: archive.yml
+- include_tasks: separate-git-dir.yml
+  when:
+    - not gpg_version.stderr
+    - gpg_version.stdout
+    - git_version.stdout is version("1.7.5", '>=')

--- a/test/integration/targets/git/tasks/main.yml
+++ b/test/integration/targets/git/tasks/main.yml
@@ -38,6 +38,4 @@
 - include_tasks: archive.yml
 - include_tasks: separate-git-dir.yml
   when:
-    - not gpg_version.stderr
-    - gpg_version.stdout
     - git_version.stdout is version("1.7.5", '>=')

--- a/test/integration/targets/git/tasks/separate-git-dir.yml
+++ b/test/integration/targets/git/tasks/separate-git-dir.yml
@@ -1,0 +1,18 @@
+# test code for repositories with separate git dir updating
+# see https://github.com/ansible/ansible/pull/38016
+# see https://github.com/ansible/ansible/issues/30034
+
+- name: SEPARATE-GIT-DIR | clear checkout_dir
+  file:
+    state: absent
+    path: '{{ checkout_dir }}'
+
+- name: SEPARATE-GIT-DIR | clone with a separate git dir
+  command: git clone {{ repo_format1 }} git --separate-git-dir=separate.git
+  args:
+    chdir: "{{ output_dir }}"
+
+- name: SEPARATE-GIT-DIR | update repo the usual way
+  git:
+    repo: "{{ repo_format1 }}"
+    dest: "{{ checkout_dir }}"

--- a/test/integration/targets/git/tasks/separate-git-dir.yml
+++ b/test/integration/targets/git/tasks/separate-git-dir.yml
@@ -16,3 +16,47 @@
   git:
     repo: "{{ repo_format1 }}"
     dest: "{{ checkout_dir }}"
+
+- name: SEPARATE-GIT-DIR | set git dir to non-existent dir
+  shell: "echo gitdir: /dev/null/non-existent-dir > .git"
+  args:
+    chdir: "{{ checkout_dir }}"
+
+- name: SEPARATE-GIT-DIR | update repo the usual way
+  git:
+    repo: "{{ repo_format1 }}"
+    dest: "{{ checkout_dir }}"
+  ignore_errors: yes
+  register: result
+
+- name: SEPARATE-GIT-DIR | check update has failed
+  assert:
+    that:
+      - result is failed
+
+- name: SEPARATE-GIT-DIR | set .git file to bad format
+  shell: "echo some text  gitdir: {{ checkout_dir }} > .git"
+  args:
+    chdir: "{{ checkout_dir }}"
+
+- name: SEPARATE-GIT-DIR | update repo the usual way
+  git:
+    repo: "{{ repo_format1 }}"
+    dest: "{{ checkout_dir }}"
+  ignore_errors: yes
+  register: result
+
+- name: SEPARATE-GIT-DIR | check update has failed
+  assert:
+    that:
+      - result is failed
+
+- name: SEPARATE-GIT-DIR | clear separate git dir
+  file:
+    state: absent
+    path: '{{ output_dir }}/separate.git'
+
+- name: SEPARATE-GIT-DIR | clear checkout_dir
+  file:
+    state: absent
+    path: '{{ checkout_dir }}'

--- a/test/integration/targets/git/tasks/separate-git-dir.yml
+++ b/test/integration/targets/git/tasks/separate-git-dir.yml
@@ -7,10 +7,12 @@
     state: absent
     path: '{{ checkout_dir }}'
 
+- name: create a tempdir for separate git dir
+  local_action: shell mktemp -du
+  register: tempdir
+
 - name: SEPARATE-GIT-DIR | clone with a separate git dir
-  command: git clone {{ repo_format1 }} git --separate-git-dir=separate.git
-  args:
-    chdir: "{{ output_dir }}"
+  command: git clone {{ repo_format1 }} {{ checkout_dir }} --separate-git-dir={{ tempdir.stdout }}
 
 - name: SEPARATE-GIT-DIR | update repo the usual way
   git:
@@ -54,7 +56,7 @@
 - name: SEPARATE-GIT-DIR | clear separate git dir
   file:
     state: absent
-    path: '{{ output_dir }}/separate.git'
+    path: "{{ tempdir.stdout }}"
 
 - name: SEPARATE-GIT-DIR | clear checkout_dir
   file:


### PR DESCRIPTION
##### SUMMARY

fixes #30034 

Detects a separate git tree configuration in the working tree  and sets `$GIT_DIR` environment variable to that value

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
git.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.0.0.2
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```



