### PR TITLE
Ensure SGs in default VPCs get default egress rule

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_group.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_group.py
@@ -941,7 +941,7 @@ def main():
                     # If rule already exists, don't later delete it
                     changed, ip_permission = authorize_ip("out", changed, client, group, groupRules, ipv6,
                                                           ip_permission, module, rule, "ipv6")
-        elif vpc_id is not None:
+        elif 'VpcId' in group:
             # when no egress rules are specified and we're in a VPC,
             # we add in a default allow all out rule, which was the
             # default behavior before egress rules were added

--- a/test/integration/targets/ec2_group/tasks/main.yml
+++ b/test/integration/targets/ec2_group/tasks/main.yml
@@ -422,6 +422,8 @@
         that:
         - 'result.changed'
         - 'result.group_id.startswith("sg-")'
+        - 'result.ip_permissions|length == 1'
+        - 'result.ip_permissions_egress|length == 1'
 
     # ============================================================
     - name: add same rule to the existing group  (expected changed=false)
@@ -464,6 +466,7 @@
           - result.ip_permissions|length == 2
           - result.ip_permissions[0].user_id_group_pairs or
             result.ip_permissions[1].user_id_group_pairs
+          - 'result.ip_permissions_egress[0].ip_protocol == "-1"'
 
     # ============================================================
     - name: test ip rules convert port numbers from string to int (expected changed=true)
@@ -489,6 +492,9 @@
         that:
            - 'result.changed'
            - 'result.group_id.startswith("sg-")'
+           - 'result.ip_permissions|length == 1'
+           - 'result.ip_permissions_egress[0].ip_protocol == "tcp"'
+
 
     # ============================================================
     - name: test group rules convert port numbers from string to int (expected changed=true)


### PR DESCRIPTION
##### SUMMARY

SGs created when a VPC ID was not specified would not necessarily
get the default egress rule, even when no explicit egress rules
were set.

Add some checks for egress rules in results from existing tests

Fixes #37963 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ec2_group

##### ANSIBLE VERSION
```
ansible 2.6.0 (devel 0ee275ca64) last updated 2018/03/28 11:18:16 (GMT +1000)
  config file = None
  configured module search path = [u'/home/will/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/will/src/ansible/lib/ansible
  executable location = /home/will/src/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 14 2018, 13:36:31) [GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]
```


##### ADDITIONAL INFORMATION
Should be backported to 2.5