### PR TITLE
synchronize: fix the mixture of quoting and passing of lists to run_command

### DIFF
--- a/lib/ansible/modules/files/synchronize.py
+++ b/lib/ansible/modules/files/synchronize.py
@@ -505,7 +505,7 @@ def main():
             cmd.append('--link-dest=%s' % link_path)
 
     changed_marker = '<<CHANGED>>'
-    cmd.append('--out-format=' + changed_marker + '%i %n%L')
+    cmd.append('--out-format=\'' + changed_marker + '%i %n%L\'')
 
     # expand the paths
     if '@' not in source:

--- a/lib/ansible/modules/files/synchronize.py
+++ b/lib/ansible/modules/files/synchronize.py
@@ -478,7 +478,7 @@ def main():
         cmd.append('--rsh=%s' % ssh_cmd_str)
 
     if rsync_path:
-        cmd.append('--rsync-path=\'%s\'' % rsync_path)
+        cmd.append('--rsync-path=%s' % rsync_path)
 
     if rsync_opts:
         cmd.extend(' '.join(rsync_opts))
@@ -499,7 +499,7 @@ def main():
             cmd.append('--link-dest=%s' % link_path)
 
     changed_marker = '<<CHANGED>>'
-    cmd.append('--out-format=\'' + changed_marker + '%i %n%L\'')
+    cmd.append('--out-format=' + changed_marker + '%i %n%L')
 
     # expand the paths
     if '@' not in source:

--- a/lib/ansible/modules/files/synchronize.py
+++ b/lib/ansible/modules/files/synchronize.py
@@ -481,7 +481,7 @@ def main():
         cmd.append('--rsync-path=%s' % rsync_path)
 
     if rsync_opts:
-        cmd.extend(' '.join(rsync_opts))
+        cmd.append(' '.join(rsync_opts))
 
     if partial:
         cmd.append('--partial')

--- a/lib/ansible/modules/files/synchronize.py
+++ b/lib/ansible/modules/files/synchronize.py
@@ -516,7 +516,7 @@ def main():
     cmd.append(source)
     cmd.append(dest)
     cmdstr = ' '.join(cmd)
-    (rc, out, err) = module.run_command(cmd)
+    (rc, out, err) = module.run_command(cmdstr)
     if rc:
         return module.fail_json(msg=err, rc=rc, cmd=cmdstr)
 

--- a/lib/ansible/modules/files/synchronize.py
+++ b/lib/ansible/modules/files/synchronize.py
@@ -481,7 +481,7 @@ def main():
         cmd.append('--rsync-path=%s' % rsync_path)
 
     if rsync_opts:
-        cmd.append(' '.join(rsync_opts))
+        cmd.extend(rsync_opts)
 
     if partial:
         cmd.append('--partial')

--- a/lib/ansible/modules/files/synchronize.py
+++ b/lib/ansible/modules/files/synchronize.py
@@ -475,13 +475,13 @@ def main():
         ssh_cmd_str = ' '.join(shlex_quote(arg) for arg in ssh_cmd)
         if ssh_args:
             ssh_cmd_str += ' %s' % ssh_args
-        cmd.append('--rsh=\'%s\'' % ssh_cmd_str)
+        cmd.append('--rsh=%s' % ssh_cmd_str)
 
     if rsync_path:
         cmd.append('--rsync-path=\'%s\'' % rsync_path)
 
     if rsync_opts:
-        cmd.extend(rsync_opts)
+        cmd.extend(' '.join(rsync_opts))
 
     if partial:
         cmd.append('--partial')
@@ -510,7 +510,7 @@ def main():
     cmd.append(source)
     cmd.append(dest)
     cmdstr = ' '.join(cmd)
-    (rc, out, err) = module.run_command(cmdstr)
+    (rc, out, err) = module.run_command(cmd)
     if rc:
         return module.fail_json(msg=err, rc=rc, cmd=cmdstr)
 

--- a/lib/ansible/modules/files/synchronize.py
+++ b/lib/ansible/modules/files/synchronize.py
@@ -306,14 +306,8 @@ EXAMPLES = '''
 
 import os
 
-# Python3 compat. six.moves.shlex_quote will be available once we're free to
-# upgrade beyond six-1.4 module-side.
-try:
-    from shlex import quote as shlex_quote
-except ImportError:
-    from pipes import quote as shlex_quote
-
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.six.moves import shlex_quote
 
 
 client_addr = None

--- a/lib/ansible/modules/files/synchronize.py
+++ b/lib/ansible/modules/files/synchronize.py
@@ -484,7 +484,7 @@ def main():
         cmd.append('--rsh=\'%s\'' % ssh_cmd_str)
 
     if rsync_path:
-        cmd.append('--rsync-path=%s' % rsync_path)
+        cmd.append('--rsync-path=\'%s\'' % rsync_path)
 
     if rsync_opts:
         cmd.extend(rsync_opts)


### PR DESCRIPTION
##### SUMMARY
synchronize passes lists to run_command now, and some options needed to be single elements in the list instead of multiple.

##### ISSUE TYPE

 - Bugfix Pull Request


##### COMPONENT NAME
synchronize.py

##### ANSIBLE VERSION
```
2.6
```
