### PR TITLE
Add error handling for junos in case wrong connection type

### DIFF
--- a/lib/ansible/plugins/action/junos.py
+++ b/lib/ansible/plugins/action/junos.py
@@ -59,7 +59,9 @@ class ActionModule(_ActionModule):
 
             if (provider['transport'] == 'cli' and self._task.action not in CLI_SUPPORTED_MODULES) or \
                     (provider['transport'] == 'netconf' and self._task.action == 'junos_netconf'):
-                return {'failed': True, 'msg': "Transport type '%s' is not valid for '%s' module" % (provider['transport'], self._task.action)}
+                return {'failed': True, 'msg': "Transport type '%s' is not valid for '%s' module. "
+                                               "Please see http://docs.ansible.com/ansible/latest/network/user_guide/platform_junos.html"
+                                               % (provider['transport'], self._task.action)}
 
             if self._task.action == 'junos_netconf' or (provider['transport'] == 'cli' and self._task.action == 'junos_command'):
                 pc.connection = 'network_cli'
@@ -90,7 +92,9 @@ class ActionModule(_ActionModule):
                 display.warning('provider is unnecessary when using connection=%s and will be ignored' % self._play_context.connection)
 
             if self._play_context.connection == 'network_cli' and self._task.action not in CLI_SUPPORTED_MODULES:
-                return {'failed': True, 'msg': "Connection type '%s' is not valid for '%s' module" % (self._play_context.connection, self._task.action)}
+                return {'failed': True, 'msg': "Connection type '%s' is not valid for '%s' module. "
+                                               "Please see http://docs.ansible.com/ansible/latest/network/user_guide/platform_junos.html"
+                                               % (self._play_context.connection, self._task.action)}
 
         if (self._play_context.connection == 'local' and pc.connection == 'network_cli') or self._play_context.connection == 'network_cli':
             # make sure we are in the right cli context which should be

--- a/lib/ansible/plugins/action/junos.py
+++ b/lib/ansible/plugins/action/junos.py
@@ -37,6 +37,7 @@ except ImportError:
     from ansible.utils.display import Display
     display = Display()
 
+CLI_SUPPORTED_MODULES = ['junos_netconf', 'junos_command']
 
 class ActionModule(_ActionModule):
 
@@ -54,6 +55,11 @@ class ActionModule(_ActionModule):
             pc = copy.deepcopy(self._play_context)
             pc.network_os = 'junos'
             pc.remote_addr = provider['host'] or self._play_context.remote_addr
+
+            if (provider['transport'] == 'cli' and self._task.action not in CLI_SUPPORTED_MODULES) or \
+                    (provider['transport'] == 'netconf' and self._task.action == 'junos_netconf'):
+                return {'failed': True, 'msg': "Transport type '%s' is not valid for '%s' module" % (provider['transport'], self._task.action)}
+
             if self._task.action == 'junos_netconf' or (provider['transport'] == 'cli' and self._task.action == 'junos_command'):
                 pc.connection = 'network_cli'
                 pc.port = int(provider['port'] or self._play_context.port or 22)
@@ -81,8 +87,9 @@ class ActionModule(_ActionModule):
             provider = self._task.args.get('provider', {})
             if any(provider.values()):
                 display.warning('provider is unnecessary when using connection=%s and will be ignored' % self._play_context.connection)
-        else:
-            return {'failed': True, 'msg': 'Connection type %s is not valid for this module' % self._play_context.connection}
+
+            if self._play_context.connection == 'network_cli' and self._task.action not in CLI_SUPPORTED_MODULES:
+                return {'failed': True, 'msg': "Connection type '%s' is not valid for '%s' module" % (self._play_context.connection, self._task.action)}
 
         if (self._play_context.connection == 'local' and pc.connection == 'network_cli') or self._play_context.connection == 'network_cli':
             # make sure we are in the right cli context which should be

--- a/lib/ansible/plugins/action/junos.py
+++ b/lib/ansible/plugins/action/junos.py
@@ -39,6 +39,7 @@ except ImportError:
 
 CLI_SUPPORTED_MODULES = ['junos_netconf', 'junos_command']
 
+
 class ActionModule(_ActionModule):
 
     def run(self, tmp=None, task_vars=None):


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #37990

If a junos module doesn't support given connection/transport type
return an appropriate error message.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
plugins/action/junos.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before:
```
fatal: [an-vsrx-02]: FAILED! => {
    "changed": false,
    "module_stderr": "Traceback (most recent call last):\n  File 
<--snip-->
\"/var/folders/bp/pf3l672j2s79st6d4ps6q7200000gn/T/ansible_N3vNTq/ansible_modlib.zip/ansible/module_utils/network/common/netconf.py\", line 102, in parse_rpc_error\nansible.module_utils.connection.ConnectionError: None\n",
    "module_stdout": "",
    "msg": "MODULE FAILURE",
    "rc": 1
}
```
After:
```
For connection=network_cli
fatal: [vsrx]: FAILED! => {
    "changed": false,
    "msg": "Connection type 'network_cli' is not valid for 'junos_facts' module"
}

For transport=cli
fatal: [vsrx]: FAILED! => {
    "changed": false,
    "msg": "Transport type 'cli' is not valid for 'junos_facts' module"
}
```