### PR TITLE
puppet module is no longer updating persistent external facts

### DIFF
--- a/lib/ansible/modules/system/puppet.py
+++ b/lib/ansible/modules/system/puppet.py
@@ -110,16 +110,16 @@ def _get_facter_dir():
 def _write_structured_data(basedir, basename, data):
     if not os.path.exists(basedir):
         os.makedirs(basedir)
-        file_path = os.path.join(basedir, "{0}.json".format(basename))
-        # This is more complex than you might normally expect because we want to
-        # open the file with only u+rw set. Also, we use the stat constants
-        # because ansible still supports python 2.4 and the octal syntax changed
-        out_file = os.fdopen(
-            os.open(
-                file_path, os.O_CREAT | os.O_WRONLY,
-                stat.S_IRUSR | stat.S_IWUSR), 'w')
-        out_file.write(json.dumps(data).encode('utf8'))
-        out_file.close()
+    file_path = os.path.join(basedir, "{0}.json".format(basename))
+    # This is more complex than you might normally expect because we want to
+    # open the file with only u+rw set. Also, we use the stat constants
+    # because ansible still supports python 2.4 and the octal syntax changed
+    out_file = os.fdopen(
+        os.open(
+            file_path, os.O_CREAT | os.O_WRONLY,
+            stat.S_IRUSR | stat.S_IWUSR), 'w')
+    out_file.write(json.dumps(data).encode('utf8'))
+    out_file.close()
 
 
 def main():


### PR DESCRIPTION
##### ISSUE TYPE
 - Bug Report

##### COMPONENT NAME
puppet -> facts

##### ANSIBLE VERSION
```
ansible 2.5.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/fzimmermann/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.13 (default, Nov 24 2017, 17:33:09) [GCC 6.3.0 20170516]
```

##### CONFIGURATION
##### OS / ENVIRONMENT
N/A

##### SUMMARY
since https://github.com/ansible/ansible/commit/a2d34e914e169d08956ea807aab4d5539d31e8ce#diff-becb6bb32df45def0d94db13da194552R132
already created facts are no longer updated.
I will create a suitable merge-request to fix this issue.

##### STEPS TO REPRODUCE
use puppet facts and change some value in a later run.

##### EXPECTED RESULTS
facts are updated on system

##### ACTUAL RESULTS
facts are no (longer) updated

