### PR TITLE
Update docker_container documentation for links

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -159,6 +159,7 @@ options:
   links:
     description:
       - List of name aliases for linked containers in the format C(container_name:alias)
+        Setting this will force container to be restarted.
   log_driver:
     description:
       - Specify the logging driver. Docker uses json-file by default.

--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -158,8 +158,8 @@ options:
        - Dictionary of key value pairs.
   links:
     description:
-      - List of name aliases for linked containers in the format C(container_name:alias)
-        Setting this will force container to be restarted.
+      - List of name aliases for linked containers in the format C(container_name:alias).
+      - Setting this will force container to be restarted.
   log_driver:
     description:
       - Specify the logging driver. Docker uses json-file by default.


### PR DESCRIPTION
Quite new here, hope the process is right.

I discover that setting "links" argument will force restart of the container.

+label: docsite_pr

##### SUMMARY
Precise module behaviour.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
docker_container

##### ADDITIONAL INFORMATION
As links is a deprecated feature, I suggest no fix. 

Users should find another way to achieve their goal.

But doc should precise this behaviour, to avoid useless investigations.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
   links:
     description:
       - List of name aliases for linked containers in the format C(container_name:alias)
+        Setting this will force container to be restarted.
```