### PR TITLE
ec2_metric_alarm: TreatMissingData feature (attempt #3)

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_metric_alarm.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_metric_alarm.py
@@ -60,6 +60,10 @@ options:
           - 'LessThanThreshold'
           - 'GreaterThanThreshold'
           - 'GreaterThanOrEqualToThreshold'
+          - '<='
+          - '<'
+          - '>'
+          - '>='
     threshold:
         description:
           - Sets the min/max bound for triggering the alarm
@@ -134,7 +138,7 @@ options:
           - 'ignore'
           - 'missing'
         default: 'missing'
-        version_added: "2.5"
+        version_added: "2.6"
 extends_documentation_fragment:
     - aws
     - ec2


### PR DESCRIPTION
##### SUMMARY

This introduces option for `TreatMissingData` in `ec2_metric_alarm` module.

There is alread pull request for this, but it was abandoned by the author. I rebased it and made sure things works correctly (as reported by someone from the community in referenced issues).

Existing pull request: #23407 #33086
Issues:

#28160
#23493

##### ISSUE TYPE

* Feature Pull Request

##### COMPONENT NAME
ec2_metric_alarm module

##### ANSIBLE VERSION

```
ansible --version
ansible 2.5.0
  config file = None
  python version = 2.7.14 (default, Sep 25 2017, 09:53:22) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.37)]
```