### PR TITLE
ansible_ssh_pass is the ENV variable

### DIFF
--- a/lib/ansible/plugins/connection/netconf.py
+++ b/lib/ansible/plugins/connection/netconf.py
@@ -66,7 +66,7 @@ options:
       - Configures the user password used to authenticate to the remote device
         when first establishing the SSH connection.
     vars:
-      - name: ansible_pass
+      - name: ansible_ssh_pass
   private_key_file:
     description:
       - The private SSH key or certificate file used to to authenticate to the

--- a/lib/ansible/plugins/connection/netconf.py
+++ b/lib/ansible/plugins/connection/netconf.py
@@ -67,6 +67,7 @@ options:
         when first establishing the SSH connection.
     vars:
       - name: ansible_ssh_pass
+      - name: ansible_password
   private_key_file:
     description:
       - The private SSH key or certificate file used to to authenticate to the

--- a/lib/ansible/plugins/connection/netconf.py
+++ b/lib/ansible/plugins/connection/netconf.py
@@ -66,8 +66,8 @@ options:
       - Configures the user password used to authenticate to the remote device
         when first establishing the SSH connection.
     vars:
-      - name: ansible_ssh_pass
       - name: ansible_password
+      - name: ansible_ssh_pass
   private_key_file:
     description:
       - The private SSH key or certificate file used to to authenticate to the

--- a/lib/ansible/plugins/connection/network_cli.py
+++ b/lib/ansible/plugins/connection/network_cli.py
@@ -61,8 +61,8 @@ options:
       - Configures the user password used to authenticate to the remote device
         when first establishing the SSH connection.
     vars:
-      - name: ansible_ssh_pass
       - name: ansible_password
+      - name: ansible_ssh_pass
   private_key_file:
     description:
       - The private SSH key or certificate file used to to authenticate to the

--- a/lib/ansible/plugins/connection/network_cli.py
+++ b/lib/ansible/plugins/connection/network_cli.py
@@ -62,6 +62,7 @@ options:
         when first establishing the SSH connection.
     vars:
       - name: ansible_ssh_pass
+      - name: ansible_password
   private_key_file:
     description:
       - The private SSH key or certificate file used to to authenticate to the

--- a/lib/ansible/plugins/connection/network_cli.py
+++ b/lib/ansible/plugins/connection/network_cli.py
@@ -61,7 +61,7 @@ options:
       - Configures the user password used to authenticate to the remote device
         when first establishing the SSH connection.
     vars:
-      - name: ansible_pass
+      - name: ansible_ssh_pass
   private_key_file:
     description:
       - The private SSH key or certificate file used to to authenticate to the


### PR DESCRIPTION
##### SUMMARY
Correct environment variable name.

Confusion may have occurred as the `_ssh` part of was removed from `ansible_ssh_user`, `ansible_ssh_host`, and `ansible_ssh_port`

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
network_cli

##### ANSIBLE VERSION
```
2.5.0
```

