### PR TITLE
Fixes #38038 cloudfront_facts module returns only first page of response

### DIFF
--- a/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
+++ b/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
@@ -509,8 +509,12 @@ class CloudFrontServiceManager:
             else:
                 result = response.get(result_key)
             results.update(result)
-            args['NextToken'] = response.get('NextToken')
-            loop = args['NextToken'] is not None
+            args['Marker'] = response.get('NextMarker')
+            for key in response.keys():
+                if key.endswith('List'):
+                    args['Marker'] = response[key].get('NextMarker')
+                    break
+            loop = args['Marker'] is not None
         return results
 
     def keyed_list_helper(self, list_to_key):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This change fixes #38038.
`NextMarker` key appears to be in a `*List` key of `response` dict, not in `response` dict itself.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
cloudfront_facts.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0
  config file = None
  configured module search path = [u'/Users/gennadii_aleksandrov/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/gennadii_aleksandrov/Library/Python/2.7/lib/python/site-packages/ansible
  executable location = /Users/Gennadii_Aleksandrov/Library/Python/2.7/bin/ansible
  python version = 2.7.14 (default, Mar  9 2018, 23:57:12) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
This change introduces searching for `NextMarker` inside a first `result` dict key which ends with `List`. This lets pagination work as expected. Previously, `paginated_response()` returned only first page of API response because it was trying to get `NextMarker` from the top-level of `response` dict.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```