### PR TITLE
fix all cases with pause and ctrl+c

### DIFF
--- a/lib/ansible/plugins/action/pause.py
+++ b/lib/ansible/plugins/action/pause.py
@@ -159,6 +159,14 @@ class ActionModule(ActionBase):
 
             if fd is not None:
                 if isatty(fd):
+
+                    # grab actual Ctrl+C sequence
+                    try:
+                        intr = termios.tcgetattr(fd)[6][termios.VINTR]
+                    except Exception:
+                        # unsupported/not present, use default
+                        intr =  b'\x03'  # value for Ctrl+C
+
                     old_settings = termios.tcgetattr(fd)
                     tty.setraw(fd)
 
@@ -184,11 +192,12 @@ class ActionModule(ActionBase):
                     # are read in below
                     termios.tcflush(stdin, termios.TCIFLUSH)
 
+
             while True:
                 try:
                     if fd is not None:
                         key_pressed = stdin.read(1)
-                        if key_pressed == b'\x03':  # value for Ctrl+C
+                        if key_pressed == intr:  # value for Ctrl+C
                             raise KeyboardInterrupt
 
                     if not seconds:

--- a/lib/ansible/plugins/action/pause.py
+++ b/lib/ansible/plugins/action/pause.py
@@ -178,7 +178,7 @@ class ActionModule(ActionBase):
                     if not seconds:
                         new_settings = termios.tcgetattr(fd)
                         new_settings[0] = new_settings[0] | termios.ICRNL
-                        if seconds or 'prompt' in self._task.args:
+                        if 'prompt' in self._task.args:
                             new_settings[3] = new_settings[3] | termios.ICANON
                         termios.tcsetattr(fd, termios.TCSANOW, new_settings)
 

--- a/lib/ansible/plugins/action/pause.py
+++ b/lib/ansible/plugins/action/pause.py
@@ -188,7 +188,7 @@ class ActionModule(ActionBase):
                 try:
                     if fd is not None:
                         key_pressed = stdin.read(1)
-                        if key_pressed == b'\x03': # value for Ctrl+C
+                        if key_pressed == b'\x03':  # value for Ctrl+C
                             raise KeyboardInterrupt
 
                     if not seconds:

--- a/lib/ansible/plugins/action/pause.py
+++ b/lib/ansible/plugins/action/pause.py
@@ -177,16 +177,15 @@ class ActionModule(ActionBase):
                     # See man termios for details on these flags
                     if not seconds:
                         new_settings = termios.tcgetattr(fd)
-                        new_settings[0] = new_settings[0] | termios.ICRNL
                         if 'prompt' in self._task.args:
+                            new_settings[0] = new_settings[0] | termios.ICRNL
                             new_settings[3] = new_settings[3] | termios.ICANON
-                        termios.tcsetattr(fd, termios.TCSANOW, new_settings)
 
                         if echo:
-                            # Enable ECHO since tty.setraw() disables it
-                            new_settings = termios.tcgetattr(fd)
+                            # Enable ECHO based on option, since tty.setraw() disables it
                             new_settings[3] = new_settings[3] | termios.ECHO
-                            termios.tcsetattr(fd, termios.TCSANOW, new_settings)
+
+                        termios.tcsetattr(fd, termios.TCSANOW, new_settings)
 
                     # flush the buffer to make sure no previous key presses
                     # are read in below

--- a/lib/ansible/plugins/action/pause.py
+++ b/lib/ansible/plugins/action/pause.py
@@ -165,7 +165,7 @@ class ActionModule(ActionBase):
                         intr = termios.tcgetattr(fd)[6][termios.VINTR]
                     except Exception:
                         # unsupported/not present, use default
-                        intr =  b'\x03'  # value for Ctrl+C
+                        intr = b'\x03'  # value for Ctrl+C
 
                     old_settings = termios.tcgetattr(fd)
                     tty.setraw(fd)
@@ -190,7 +190,6 @@ class ActionModule(ActionBase):
                     # flush the buffer to make sure no previous key presses
                     # are read in below
                     termios.tcflush(stdin, termios.TCIFLUSH)
-
 
             while True:
                 try:
@@ -248,3 +247,5 @@ class ActionModule(ActionBase):
                 return False
             elif key_pressed.lower() == b'c':
                 return True
+            else:
+                display.display("Invalid keypress detected, please press 'C' to continue or 'A' to abort \r")


### PR DESCRIPTION
##### SUMMARY

now ctrl+c works in most scenarios:
 - naked:
	`- pause:`
 - with prompt
	`- pause: prompt=hi`
 - time wait
	`- pause: seconds=60`
 - time wait with prompt
	`- pause: seconds=60 prompt=hi`

fixes #35372


<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
pause
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5-2.6
```