### PR TITLE
Fix building from ubuntu1404 Dockerfile

### DIFF
--- a/test/utils/docker/ubuntu1404/Dockerfile
+++ b/test/utils/docker/ubuntu1404/Dockerfile
@@ -54,6 +54,7 @@ RUN apt-get update -y && \
     && \
     apt-get clean
 
+RUN pip install pip --upgrade
 RUN pip install --upgrade pycrypto cryptography
 
 # helpful things taken from the ubuntu-upstart Dockerfile:
@@ -92,7 +93,6 @@ RUN ssh-keygen -q -t rsa -N '' -f /root/.ssh/id_rsa && \
     cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys && \
     for key in /etc/ssh/ssh_host_*_key.pub; do echo "localhost $(cat ${key})" >> /root/.ssh/known_hosts; done
 VOLUME /sys/fs/cgroup /run/lock /run /tmp
-RUN pip install pip --upgrade
 RUN pip install coverage junit-xml
 ENV container=docker
 CMD ["/sbin/init"]


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes build failing with `cryptography requires setuptools 18.5`
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
test/utils/docker/ubuntu1404/Dockerfile

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION