### PR TITLE
[cloud] backport of #38018 - ensure SGs in default VPCs get default egress rule (#38018)

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_group.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_group.py
@@ -941,7 +941,7 @@ def main():
                     # If rule already exists, don't later delete it
                     changed, ip_permission = authorize_ip("out", changed, client, group, groupRules, ipv6,
                                                           ip_permission, module, rule, "ipv6")
-        elif vpc_id is not None:
+        elif 'VpcId' in group:
             # when no egress rules are specified and we're in a VPC,
             # we add in a default allow all out rule, which was the
             # default behavior before egress rules were added

--- a/test/integration/targets/ec2_group/tasks/main.yml
+++ b/test/integration/targets/ec2_group/tasks/main.yml
@@ -422,6 +422,8 @@
         that:
         - 'result.changed'
         - 'result.group_id.startswith("sg-")'
+        - 'result.ip_permissions|length == 1'
+        - 'result.ip_permissions_egress|length == 1'
 
     # ============================================================
     - name: add same rule to the existing group  (expected changed=false)
@@ -464,6 +466,7 @@
           - result.ip_permissions|length == 2
           - result.ip_permissions[0].user_id_group_pairs or
             result.ip_permissions[1].user_id_group_pairs
+          - 'result.ip_permissions_egress[0].ip_protocol == "-1"'
 
     # ============================================================
     - name: test ip rules convert port numbers from string to int (expected changed=true)
@@ -489,6 +492,9 @@
         that:
            - 'result.changed'
            - 'result.group_id.startswith("sg-")'
+           - 'result.ip_permissions|length == 1'
+           - 'result.ip_permissions_egress[0].ip_protocol == "tcp"'
+
 
     # ============================================================
     - name: test group rules convert port numbers from string to int (expected changed=true)


### PR DESCRIPTION
##### SUMMARY
SGs created when a VPC ID was not specified would not necessarily
get the default egress rule, even when no explicit egress rules
were set.

Add some checks for egress rules in results from existing tests

(cherry picked from commit 98b29f8ad633e05060ec4044a6e7a622f27b4c5f)

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/ec2_group.py

##### ANSIBLE VERSION
```
ansible 2.5.0 (backport/2.5/38018 4a8e87599c) last updated 2018/03/28 17:42:40 (GMT -400)
  config file = None
  configured module search path = [u'/Users/shertel/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/shertel/ansible/lib/ansible
  executable location = /Users/shertel/ansible/bin/ansible
  python version = 2.7 (r27:82500, Mar 28 2018, 12:11:51) [GCC 4.2.1 Compatible Apple LLVM 7.3.0 (clang-703.0.31)]
```