### PR TITLE
ec2_snapshot_copy: WaitError and ClientError exception handling

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_snapshot_copy.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_snapshot_copy.py
@@ -143,9 +143,9 @@ def copy_snapshot(module, ec2):
             )
 
     except WaiterError as we:
-        module.fail_json(msg='An error occurred (%s) waiting for the snapshot to become available. (%s)' % (we.message, we.reason))
+        module.fail_json(msg='An error occurred waiting for the snapshot to become available. (%s)' % str(we), exception=traceback.format_exc())
     except ClientError as ce:
-        module.fail_json(msg=ce.message, exception=traceback.format_exc(), **camel_dict_to_snake_dict(ce.response))
+        module.fail_json(msg=str(ce), exception=traceback.format_exc(), **camel_dict_to_snake_dict(ce.response))
 
     module.exit_json(changed=True, snapshot_id=snapshot_id)
 


### PR DESCRIPTION
##### SUMMARY
Fix issue #37834 - Error while raising WaitError exception in copy_snapshot() ('reason' is not a valid attribute)

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ec2_snapshot_copy

##### ANSIBLE VERSION
ansible 2.4.2.0

##### ADDITIONAL INFORMATION

```python
>>> from botocore.exceptions import WaiterError
>>> dir(WaiterError)
['__class__', '__delattr__', '__dict__', '__doc__', '__format__', '__getattribute__',
 '__getitem__', '__getslice__', '__hash__', '__init__', '__module__', '__new__',
 '__reduce__', '__reduce_ex__', '__repr__', '__setattr__', '__setstate__', '__sizeof__',
 '__str__', '__subclasshook__', '__unicode__', '__weakref__', 'args', 'fmt',  'message']
```