### PR TITLE
nmcli: check NMClient, NetworkManager availability

### DIFF
--- a/lib/ansible/modules/net_tools/nmcli.py
+++ b/lib/ansible/modules/net_tools/nmcli.py
@@ -467,7 +467,7 @@ try:
 
     from gi.repository import NetworkManager, NMClient
     HAVE_NM_CLIENT = True
-except ImportError:
+except (ImportError, ValueError):
     HAVE_NM_CLIENT = False
 
 from ansible.module_utils.basic import AnsibleModule


### PR DESCRIPTION
##### SUMMARY
This fix adds check for NMClient, NetworkManager availability
while using require_version API.

Fixes: #38042

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/net_tools/nmcli.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6devel
```