### PR TITLE
fix for when status codes are provided as a comma separated list

### DIFF
--- a/lib/ansible/modules/windows/win_uri.ps1
+++ b/lib/ansible/modules/windows/win_uri.ps1
@@ -264,8 +264,11 @@ if ($return_content -or $dest) {
     }
 }
 
-if ($status_code -notcontains $response.StatusCode) {
-    Fail-Json -obj $result -message "Status code of request '$($response.StatusCode)' is not in list of valid status codes $status_code."
+# use numerical format of response status for comparison
+$resp_code = [System.Enum]::Format([System.Net.HttpStatusCode], $response.StatusCode, "d")
+
+if ($status_code -notcontains $resp_code) {
+    Fail-Json -obj $result -message "Status code of request '$resp_code' is not in list of valid status codes $status_code."
 }
 
 Exit-Json -obj $result

--- a/test/integration/targets/win_uri/tasks/test.yml
+++ b/test/integration/targets/win_uri/tasks/test.yml
@@ -250,7 +250,9 @@
 - name: validate status_codes are correct
   win_uri:
     url: http://{{httpbin_host}}/status/202
-    status_code: 202, 418
+    status_code:
+    - 202
+    - 418
     method: POST
     body: foo
   register: status_code_check
@@ -358,3 +360,35 @@
     - post_request_with_custom_headers.json.headers['Content-Type'] == "application/json"
     - post_request_with_custom_headers.json.headers['Test-Header'] == 'hello'
     - post_request_with_custom_headers.json.headers['Another-Header'] == 'world'
+
+- name: validate status codes as list of strings
+  win_uri:
+    url: https://httpbin.org/status/202
+    status_code:
+    - '202'
+    - '418'
+    method: POST
+    body: foo
+    return_content: yes
+  register: request_status_code_string
+
+- name: assert status codes as list of strings
+  assert:
+    that:
+    - not request_status_code_string.changed
+    - request_status_code_string.status_code == 202
+
+- name: validate status codes as comma separated list
+  win_uri:
+    url: https://httpbin.org/status/202
+    status_code: 202, 418
+    method: POST
+    body: foo
+    return_content: yes
+  register: request_status_code_comma
+
+- name: assert status codes as comma separated list
+  assert:
+    that:
+    - not request_status_code_comma.changed
+    - request_status_code_comma.status_code == 202

--- a/test/integration/targets/win_uri/tasks/test.yml
+++ b/test/integration/targets/win_uri/tasks/test.yml
@@ -250,8 +250,7 @@
 - name: validate status_codes are correct
   win_uri:
     url: http://{{httpbin_host}}/status/202
-    status_code:
-    - 202
+    status_code: 202, 418
     method: POST
     body: foo
   register: status_code_check


### PR DESCRIPTION
##### SUMMARY
If a comma separated list is provided for status_code, the comparison to the response code fails. This fix makes sure that the comparison will always be valid if only numerical status codes are provided per the documentation. 

##### ISSUE TYPE
 - Bugfix Pull Request


##### COMPONENT NAME
win_uri

##### ANSIBLE VERSION
```
ansible 2.6.0 (devel 7ea05a2d56) last updated 2018/03/27 21:37:38 (GMT -700)
  config file = None
  configured module search path = [u'/home/vagrant/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/vagrant/ansible/lib/ansible
  executable location = /home/vagrant/ansible/bin/ansible
  python version = 2.7.3 (default, Oct 26 2016, 21:01:49) [GCC 4.6.3]
```


##### ADDITIONAL INFORMATION
The root of the issue lies in the fact that a comma separated list is converted to an array of strings when passed as input. When the task result is converted to JSON, the HTTPStatusCode object is converted to the numerical code, but inside the module it resolves as the string representation (ex. 202 = 'Accepted'). 

Test:
```yaml
- name: validate status_codes are correct
  win_uri:
    url: http://{{httpbin_host}}/status/202
    status_code: 202, 418
    method: POST
    body: foo
  register: status_code_check
```
Before:
```
fatal: [win10]: FAILED! => {"access_control_allow_credentials": "true", "access_control_allow_origin": "*", "changed": false, "character_set": "utf-8", "connection": "keep-alive", "content_encoding": "", "content_length": "0", "content_type": "text/html; charset=utf-8", "cookies": [], "date": "Thu, 29 Mar 2018 04:33:58 GMT", "headers": ["Connection", "Access-Control-Allow-Origin", "Access-Control-Allow-Credentials", "X-Processed-Time", "Content-Length", "Content-Type", "Date", "Server", "Via", "X-Powered-By"], "is_from_cache": false, "is_mutually_authenticated": false, "last_modified": "2018-03-28T23:33:54.0161335-05:00", "method": "POST", "msg": "Status code of request 'Accepted' is not in list of valid status codes 202 418.", "protocol_version": {"Build": -1, "Major": 1, "MajorRevision": -1, "Minor": 1, "MinorRevision": -1, "Revision": -1}, "response_uri": "http://httpbin.org/status/202", "server": "meinheld/0.6.1", "status_code": 202, "status_description": "ACCEPTED", "supports_headers": true, "url": "http://httpbin.org/status/202", "via": "1.1 vegur", "x_powered_by": "Flask", "x_processed_time": "0"}

```
After:
```
ok: [win10] => {"access_control_allow_credentials": "true", "access_control_allow_origin": "*", "changed": false, "character_set": "utf-8", "connection": "keep-alive", "content_encoding": "", "content_length": "0", "content_type": "text/html; charset=utf-8", "cookies": [], "date": "Thu, 29 Mar 2018 04:36:27 GMT", "headers": ["Connection", "Access-Control-Allow-Origin", "Access-Control-Allow-Credentials", "X-Processed-Time", "Content-Length", "Content-Type", "Date", "Server", "Via", "X-Powered-By"], "is_from_cache": false, "is_mutually_authenticated": false, "last_modified": "2018-03-28T23:36:23.3346413-05:00", "method": "POST", "protocol_version": {"Build": -1, "Major": 1, "MajorRevision": -1, "Minor": 1, "MinorRevision": -1, "Revision": -1}, "response_uri": "http://httpbin.org/status/202", "server": "meinheld/0.6.1", "status_code": 202, "status_description": "ACCEPTED", "supports_headers": true, "url": "http://httpbin.org/status/202", "via": "1.1 vegur", "x_powered_by": "Flask", "x_processed_time": "0"}
```