### PR TITLE
Fixes #38085 - cloudfront_invalidation doesn't work for the first invalidation ever

### DIFF
--- a/lib/ansible/modules/cloud/amazon/cloudfront_invalidation.py
+++ b/lib/ansible/modules/cloud/amazon/cloudfront_invalidation.py
@@ -181,7 +181,7 @@ class CloudFrontInvalidationServiceManager(object):
         # find all invalidations for the distribution
         try:
             paginator = self.client.get_paginator('list_invalidations')
-            invalidations = paginator.paginate(DistributionId=distribution_id).build_full_result()['InvalidationList'].get('Items', [])
+            invalidations = paginator.paginate(DistributionId=distribution_id).build_full_result().get('InvalidationList', {}).get('Items', [])
             invalidation_ids = [inv['Id'] for inv in invalidations]
         except (BotoCoreError, ClientError) as e:
             self.module.fail_json_aws(e, msg="Error listing CloudFront invalidations.")


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #38085 - cloudfront_invalidation doesn't work for the first invalidation ever
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
`get_invalidation()` now uses `.get()` on a `paginator.paginate(DistributionId=distribution_id).build_full_result()` dict object instead of attempting to read a key right away. This avoids `KeyError` if `build_full_result()` returns empty dict (true if there are no previous invalidations for the given distribution).
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
cloudfront_invalidation
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0
  config file = None
  configured module search path = [u'/Users/gennadii_aleksandrov/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/gennadii_aleksandrov/Library/Python/2.7/lib/python/site-packages/ansible
  executable location = /Users/Gennadii_Aleksandrov/Library/Python/2.7/bin/ansible
  python version = 2.7.14 (default, Mar  9 2018, 23:57:12) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```