### PR TITLE
Fix returned landscape value when using Python 3

### DIFF
--- a/lib/ansible/modules/monitoring/spectrum_device.py
+++ b/lib/ansible/modules/monitoring/spectrum_device.py
@@ -224,7 +224,7 @@ def get_device(device_ip):
     model_address = model.find('./*[@id="0x12d7f"]').text
 
     # derive the landscape handler from the model handler of the device
-    model_landscape = "0x%x" % int(int(model_handle, 16) / 0x100000 * 0x100000)
+    model_landscape = "0x%x" % int(int(model_handle, 16) // 0x100000 * 0x100000)
 
     device = dict(
         model_handle=model_handle,
@@ -264,7 +264,7 @@ def add_device():
     model = root.find('ca:model', namespace)
 
     model_handle = model.get('mh')
-    model_landscape = "0x%x" % int(int(model_handle, 16) / 0x100000 * 0x100000)
+    model_landscape = "0x%x" % int(int(model_handle, 16) // 0x100000 * 0x100000)
 
     device = dict(
         model_handle=model_handle,


### PR DESCRIPTION
##### SUMMARY
When using Python 3 to run ansible the calculated landscape value is wrong

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
spectrum_device

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0
```


