### PR TITLE
fixing security group instability

### DIFF
--- a/test/integration/targets/azure_rm_securitygroup/aliases
+++ b/test/integration/targets/azure_rm_securitygroup/aliases
@@ -1,3 +1,4 @@
 cloud/azure
 destructive
 azure_rm_securitygroup_facts
+posix/ci/cloud/group2/azure

--- a/test/integration/targets/azure_rm_securitygroup/tasks/main.yml
+++ b/test/integration/targets/azure_rm_securitygroup/tasks/main.yml
@@ -119,7 +119,7 @@
       that:
           - output.ansible_facts.azure_securitygroups | length == 1
 
-- name: Gather facts for all accounts
+- name: Gather facts for all security group in the resource group
   azure_rm_securitygroup_facts:
       resource_group: "{{ resource_group }}"
   register: output
@@ -128,16 +128,16 @@
       that:
           - output.ansible_facts.azure_securitygroups | length > 0
 
-- name: Delete all security groups
+- name: Delete security group
   azure_rm_securitygroup:
       resource_group: "{{ resource_group }}"
-      name: "{{ item.name }}"
+      name: mysecgroup
       state: absent
-  with_items: "{{ output.ansible_facts.azure_securitygroups }}"
 
-- name: Should have no security groups remaining
+- name: Security group should be deleted
   azure_rm_securitygroup_facts:
       resource_group: "{{ resource_group }}"
+      name: mysecgroup
   register: output
 
 - assert:

--- a/test/integration/targets/azure_rm_securitygroup/tasks/main.yml
+++ b/test/integration/targets/azure_rm_securitygroup/tasks/main.yml
@@ -117,7 +117,7 @@
 
 - assert:
       that:
-          - azure_securitygroups | length == 1
+          - output.ansible_facts.azure_securitygroups | length == 1
 
 - name: Gather facts for all accounts
   azure_rm_securitygroup_facts:
@@ -126,14 +126,14 @@
 
 - assert:
       that:
-          - azure_securitygroups | length > 0
+          - output.ansible_facts.azure_securitygroups | length > 0
 
 - name: Delete all security groups
   azure_rm_securitygroup:
       resource_group: "{{ resource_group }}"
       name: "{{ item.name }}"
       state: absent
-  with_items: "{{ azure_securitygroups }}"
+  with_items: "{{ output.ansible_facts.azure_securitygroups }}"
 
 - name: Should have no security groups remaining
   azure_rm_securitygroup_facts:
@@ -142,4 +142,4 @@
 
 - assert:
       that:
-          - azure_securitygroups | length == 0
+          - output.ansible_facts.azure_securitygroups | length == 0


### PR DESCRIPTION
##### SUMMARY
Fixing nsg test instability

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME

azure_rm_securitygroup

##### ANSIBLE VERSION
2.5

##### ADDITIONAL INFORMATION
Test was using same facts variable as azure_rm_networkinterface test and it was causing interference between tests.
