### PR TITLE
Add support for CA SAAM sesu prompt

### DIFF
--- a/lib/ansible/playbook/play_context.py
+++ b/lib/ansible/playbook/play_context.py
@@ -51,6 +51,7 @@ __all__ = ['PlayContext']
 
 # TODO: needs to be configurable
 b_SU_PROMPT_LOCALIZATIONS = [
+    to_bytes('Please enter your password'),
     to_bytes('Password'),
     to_bytes('암호'),
     to_bytes('パスワード'),


### PR DESCRIPTION
##### SUMMARY

Add support for "computer associates technologies" SAAM
    add waiting message for Privilege escalation with "sesu"

##### COMPONENT NAME
play_context.py

##### ANSIBLE VERSION
 2.5

##### ADDITIONAL INFORMATION
https://docops.ca.com/ca-privileged-identity-management/12-8/en/reference/reference-guide/sesu-utility-substitute-user/
