### PR TITLE
added edr parameter to GSLB VServer module

### DIFF
--- a/lib/ansible/modules/network/netscaler/netscaler_gslb_vserver.py
+++ b/lib/ansible/modules/network/netscaler/netscaler_gslb_vserver.py
@@ -285,6 +285,13 @@ options:
             - 'disabled'
         description:
             - "Enable logging appflow flow information."
+            
+    edr:
+        choices:
+            - 'enabled'
+            - 'disabled'
+        description:
+            - "Send clients an empty DNS response when the GSLB virtual server is DOWN."
 
     domain_bindings:
         description:
@@ -741,6 +748,13 @@ def main():
                 'disabled',
             ]
         ),
+        edr=dict(
+            type='str',
+            choices=[
+                'enabled',
+                'disabled',
+            ]
+        ),
         domainname=dict(type='str'),
         cookie_domain=dict(type='str'),
     )
@@ -815,6 +829,7 @@ def main():
         'sothreshold',
         'sobackupaction',
         'appflowlog',
+        'edr',
         'cookie_domain',
     ]
 
@@ -849,6 +864,7 @@ def main():
         'disableprimaryondown': [lambda v: v.upper()],
         'sopersistence': [lambda v: v.upper()],
         'appflowlog': [lambda v: v.upper()],
+        'edr': [lambda v: v.upper()],
     }
 
     # Instantiate config proxy

--- a/lib/ansible/modules/network/netscaler/netscaler_gslb_vserver.py
+++ b/lib/ansible/modules/network/netscaler/netscaler_gslb_vserver.py
@@ -20,7 +20,7 @@ short_description: Configure gslb vserver entities in Netscaler.
 description:
     - Configure gslb vserver entities in Netscaler.
 
-version_added: "2.4.0"
+version_added: "2.6"
 
 author: George Nikolopoulos (@giorgos-nikolopoulos)
 

--- a/lib/ansible/modules/network/netscaler/netscaler_gslb_vserver.py
+++ b/lib/ansible/modules/network/netscaler/netscaler_gslb_vserver.py
@@ -20,7 +20,7 @@ short_description: Configure gslb vserver entities in Netscaler.
 description:
     - Configure gslb vserver entities in Netscaler.
 
-version_added: "2.6"
+version_added: "2.4.0"
 
 author: George Nikolopoulos (@giorgos-nikolopoulos)
 

--- a/lib/ansible/modules/network/netscaler/netscaler_gslb_vserver.py
+++ b/lib/ansible/modules/network/netscaler/netscaler_gslb_vserver.py
@@ -285,7 +285,7 @@ options:
             - 'disabled'
         description:
             - "Enable logging appflow flow information."
-            
+
     edr:
         choices:
             - 'enabled'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
The parameter to change the EDR configuration setting is not currently present in the netscaler_gslb_vserver module. Therefore, would have to use the netscaler_nitro_requests separately to modify it. This change has included the parameter within the module itself.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
netscaler_gslb_vserver

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0 (devel 9350b5ec22)
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```