### PR TITLE
fix for security group description crash

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_securitygroup.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_securitygroup.py
@@ -400,7 +400,7 @@ def compare_rules(r, rule):
         matched = True
         if rule.get('description', None) != r['description']:
             changed = True
-            r['description'] = rule['description']
+            r['description'] = rule.get('description', None)
         if rule['protocol'] != r['protocol']:
             changed = True
             r['protocol'] = rule['protocol']


### PR DESCRIPTION
##### SUMMARY

Fixes a crash when existing description is not empty, and description not specified in task.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
azure_rm_securitygroup

##### ANSIBLE VERSION
2.5

##### ADDITIONAL INFORMATION
