### PR TITLE
Feature/alphanumeric password in passwordstore

### DIFF
--- a/lib/ansible/plugins/lookup/passwordstore.py
+++ b/lib/ansible/plugins/lookup/passwordstore.py
@@ -51,6 +51,11 @@ DOCUMENTATION = """
         type: bool
         default: 'no'
         version_added: 2.7
+      nosymbols:
+        description: use alphanumeric characters
+        type: bool
+        default: 'no'
+        version_added: 2.7
 """
 EXAMPLES = """
 # Debug is used for examples, BAD IDEA to show passwords on screen
@@ -71,6 +76,9 @@ EXAMPLES = """
 - name: Create password and overwrite the password if it exists. As a bonus, this module includes the old password inside the pass file
   debug:
     msg: "{{ lookup('passwordstore', 'example/test create=true overwrite=true')}}"
+
+- name: Create an alphanumeric password
+  debug: msg="{{ lookup('passwordstore', 'example/test create=true nosymbols=true) }}"
 
 - name: Return the value for user in the KV pair user, username
   debug:
@@ -96,6 +104,7 @@ from ansible.errors import AnsibleError, AnsibleAssertionError
 from ansible.module_utils._text import to_bytes, to_native, to_text
 from ansible.utils.encrypt import random_password
 from ansible.plugins.lookup import LookupBase
+from ansible import constants as C
 
 
 # backhacked check_output with input for python 2.7
@@ -155,7 +164,7 @@ class LookupModule(LookupBase):
                 raise AnsibleError(e)
             # check and convert values
             try:
-                for key in ['create', 'returnall', 'overwrite', 'backup']:
+                for key in ['create', 'returnall', 'overwrite', 'backup', 'nosymbols']:
                     if not isinstance(self.paramvals[key], bool):
                         self.paramvals[key] = util.strtobool(self.paramvals[key])
             except (ValueError, AssertionError) as e:
@@ -198,10 +207,15 @@ class LookupModule(LookupBase):
         return True
 
     def get_newpass(self):
+        if self.paramvals['nosymbols']:
+            chars = C.DEFAULT_PASSWORD_CHARS[:62]
+        else:
+            chars = C.DEFAULT_PASSWORD_CHARS
+
         if self.paramvals['userpass']:
             newpass = self.paramvals['userpass']
         else:
-            newpass = random_password(length=self.paramvals['length'])
+            newpass = random_password(length=self.paramvals['length'], chars=chars)
         return newpass
 
     def update_password(self):
@@ -250,6 +264,7 @@ class LookupModule(LookupBase):
             'create': False,
             'returnall': False,
             'overwrite': False,
+            'nosymbols': False,
             'userpass': '',
             'length': 16,
             'backup': False,

--- a/lib/ansible/plugins/lookup/passwordstore.py
+++ b/lib/ansible/plugins/lookup/passwordstore.py
@@ -55,7 +55,7 @@ DOCUMENTATION = """
         description: use alphanumeric characters
         type: bool
         default: 'no'
-        version_added: 2.7
+        version_added: 2.8
 """
 EXAMPLES = """
 # Debug is used for examples, BAD IDEA to show passwords on screen


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Added a switch in order to allow for exclusively alphanumeric passwords to be generated
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
lookup passwordstore

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/madonius/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.14 (default, Jan  5 2018, 10:41:29) [GCC 7.2.1 20171224]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
