### PR TITLE
Update EdgeOS modules to be community supported (#38112)

### DIFF
--- a/lib/ansible/modules/network/edgeos/edgeos_config.py
+++ b/lib/ansible/modules/network/edgeos/edgeos_config.py
@@ -9,7 +9,7 @@ __metaclass__ = type
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],
-                    'supported_by': 'network'}
+                    'supported_by': 'community'}
 
 DOCUMENTATION = """
 ---

--- a/lib/ansible/modules/network/edgeos/edgeos_facts.py
+++ b/lib/ansible/modules/network/edgeos/edgeos_facts.py
@@ -9,7 +9,7 @@ __metaclass__ = type
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],
-                    'supported_by': 'network'}
+                    'supported_by': 'community'}
 
 
 DOCUMENTATION = """


### PR DESCRIPTION
(cherry picked from commit a4c82d58421ac386db3d84d3cd9da16bf0387fce)

##### SUMMARY
Fixes #38109 
Backports marking EdgeOS modules as community-supported

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
Supported Network Modules Index

##### ANSIBLE VERSION
2.5
