### PR TITLE
aci_rest: add support for templates in 'src' parameter via Action Plugin

### DIFF
--- a/lib/ansible/plugins/action/aci_rest.py
+++ b/lib/ansible/plugins/action/aci_rest.py
@@ -1,0 +1,69 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import os
+from ansible.plugins.action import ActionBase
+from ansible.module_utils._text import to_text
+
+
+class ActionModule(ActionBase):
+
+    def run(self, tmp=None, task_vars=None):
+
+        src = self._task.args.get('src', None)
+        if src:
+            try:
+                self._handle_template()
+            except (ValueError, AttributeError) as exc:
+                return dict(failed=True, msg=exc.message)
+        result = super(ActionModule, self).run(tmp=tmp, task_vars=task_vars)
+        module_args = self._task.args.copy()
+        module_return = self._execute_module(module_args=module_args,
+                                             task_vars=task_vars, tmp=tmp)
+        result.update(module_return)
+        return result
+
+    def _get_working_path(self):
+        cwd = self._loader.get_basedir()
+        if self._task._role is not None:
+            cwd = self._task._role._role_path
+        return cwd
+
+    def _handle_template(self):
+        src = self._task.args.get('src')
+        working_path = self._get_working_path()
+
+        if os.path.isabs(src):
+            source = src
+        else:
+            source = self._loader.path_dwim_relative(
+                working_path, 'templates', src)
+            if not source:
+                source = self._loader.path_dwim_relative(working_path, src)
+
+        if not os.path.exists(source):
+            raise ValueError('path specified in src not found')
+
+        try:
+            with open(source, 'r') as f:
+                template_data = to_text(f.read())
+        except IOError:
+            return dict(failed=True, msg='unable to load src file')
+
+        # Create a template search path in the following order:
+        # [working_path, self_role_path, dependent_role_paths, dirname(source)]
+        searchpath = [working_path]
+        if self._task._role is not None:
+            searchpath.append(self._task._role._role_path)
+            if hasattr(self._task, "_block:"):
+                dep_chain = self._task._block.get_dep_chain()
+                if dep_chain is not None:
+                    for role in dep_chain:
+                        searchpath.append(role._role_path)
+        searchpath.append(os.path.dirname(source))
+        self._templar.environment.loader.searchpath = searchpath
+
+        self._task.args['content'] = self._templar.template(template_data)
+        # Now we have our template processed - we do not need src parameter, so we load parsed template into
+        # the content parameter and delete the src one, as they are mutually exclusive
+        del self._task.args['src']


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Action plugin for aci_rest to allow templates for 'src' parameter. Feedback is appreciated.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
aci_rest.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0 (aci_rest_jinja2_ap 3c0af4a799) last updated 2018/03/30 10:00:04 (GMT +200)
  config file = None
  configured module search path = [u'/Users/rdavyden/Documents/ACI/ansible/library']
  ansible python module location = /Users/rdavyden/Documents/ACI/ansible/lib/ansible
  executable location = /Users/rdavyden/Documents/ACI/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 14:43:05) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
