### PR TITLE
Letsencrypt: improving documentation on second run

### DIFF
--- a/lib/ansible/modules/web_infrastructure/letsencrypt.py
+++ b/lib/ansible/modules/web_infrastructure/letsencrypt.py
@@ -24,15 +24,18 @@ description:
       free, automated, and open certificate authority (CA), run for the
       public's benefit. For details see U(https://letsencrypt.org). The current
       implementation supports the http-01 and dns-01 challenges."
-   - "To use this module, it has to be executed at least twice. Either as two
-      different tasks in the same run or during multiple runs."
+   - "To use this module, it has to be executed twice. Either as two
+      different tasks in the same run or during two runs. Note that the output
+      of the first run needs to be recorded and passed to the second run as the
+      module argument C(data)."
    - "Between these two tasks you have to fulfill the required steps for the
       chosen challenge by whatever means necessary. For http-01 that means
       creating the necessary challenge file on the destination webserver. For
       dns-01 the necessary dns record has to be created.
       It is I(not) the responsibility of this module to perform these steps."
    - "For details on how to fulfill these challenges, you might have to read through
-      U(https://tools.ietf.org/html/draft-ietf-acme-acme-09#section-8)"
+      U(https://tools.ietf.org/html/draft-ietf-acme-acme-09#section-8).
+      Also, consider the examples provided for this module."
    - "Although the defaults are chosen so that the module can be used with
       the Let's Encrypt CA, the module can be used with any service using the ACME
       v1 or v2 protocol."
@@ -124,9 +127,10 @@ options:
     aliases: ['src']
   data:
     description:
-      - "The data to validate ongoing challenges."
+      - "The data to validate ongoing challenges. This must be specified for
+         the second run of the module only."
       - "The value that must be used here will be provided by a previous use
-         of this module."
+         of this module. See the examples for more details."
       - "I(Note): the C(data) option was marked as C(no_log) up to
          Ansible 2.5. From Ansible 2.6 on, it is no longer marked this way
          as it causes error messages to be come unusable, and C(data) does


### PR DESCRIPTION
##### SUMMARY
As @apple4ever noted in #37884, the module's documentation is unclear w.r.t. that the second run of the `letsencrypt` module needs the data provided by the first run. (This is a result of adding ACME v2 support, and that the old behavior could cause certificates to be issued more than once.)

##### ISSUE TYPE
Docs Pull Request

##### COMPONENT NAME
letsencrypt

##### ANSIBLE VERSION
2.5.0
