### PR TITLE
yaml callback fails on python3

### DIFF
--- a/lib/ansible/plugins/callback/yaml.py
+++ b/lib/ansible/plugins/callback/yaml.py
@@ -47,7 +47,7 @@ def my_represent_scalar(self, tag, value, style=None):
             # ...no trailing space
             value = value.rstrip()
             # ...and non-printable characters
-            value = filter(lambda x: x in string.printable, value)
+            value = ''.join(x for x in value if x in string.printable)
             # ...tabs prevent blocks from expanding
             value = value.expandtabs()
             # ...and odd bits of whitespace


### PR DESCRIPTION
##### SUMMARY
When the URI module returns complex JSON objects, the YAML callback
fails while trying to represent these objects.  The problem arises
because the filter method returns an iterator in Python 3, rather than a
str object.  Therefore, the str method expandtabs() is not available,
and the callback fails with the following error:

[WARNING]: Failure using method (v2_runner_on_failed) in callback plugin (<ansible.plugins.callback.yaml.CallbackModule object at 0x7f7c7ed8aa20>): 'filter' object has no attribute 'expandtabs'

##### ISSUE TYPE
Bugfix Pull Request


##### COMPONENT NAME
yaml callback

##### ANSIBLE VERSION
Affects 2.5.0 and devel.


##### ADDITIONAL INFORMATION
Issue can be replicated by running this playbook:

- hosts: localhost
  gather_facts: false
  tasks:
    - uri:
        url: https://jsonplaceholder.typicode.com/posts

ansible-playbook tmp.yml -v