### PR TITLE
password_hash() should fail when invoked with bad parameters

### DIFF
--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -303,7 +303,7 @@ def get_encrypted_password(password, hashtype='sha512', salt=None):
 
         return encrypted
 
-    raise AnsibleFilterError("invalid hashtype: '{}'. Must be one of [{}]".format(hashtype, ", ".join([ "'{}'".format(key) for key in cryptmethod.keys()])))
+    raise AnsibleFilterError("invalid hashtype: '{0}'. Must be one of [{1}]".format(hashtype, ", ".join(["'{0}'".format(key) for key in cryptmethod.keys()])))
 
 
 def to_uuid(string):

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -303,7 +303,7 @@ def get_encrypted_password(password, hashtype='sha512', salt=None):
 
         return encrypted
 
-    return None
+    raise AnsibleFilterError("invalid hashtype: '{}'. Must be one of [{}]".format(hashtype, ", ".join([ "'{}'".format(key) for key in cryptmethod.keys()])))
 
 
 def to_uuid(string):

--- a/test/integration/targets/filters/tasks/main.yml
+++ b/test/integration/targets/filters/tasks/main.yml
@@ -185,3 +185,16 @@
           - flat_two == [1, 2, 3, 4, [5], 6, 7]
   vars:
     orig_list: [1, 2, [3, [4, [5]], 6], 7]
+
+- name: Invoke password_hash with a wrong algorithm
+  debug:
+    var: "'somestring' | password_hash('WRONG_ALGORITHM')"
+  register: _bad_password_hash_filter
+  ignore_errors: yes
+
+- name: Verify password_hash filter failed when invoked with wrong algorithm
+  assert:
+    that:
+      - _bad_password_hash_filter is failed
+      - "'invalid hashtype' in _bad_password_hash_filter.msg"
+    msg: "password_hash('WRONG_ALGORITHM') has to fail with 'invalid hashtype'"


### PR DESCRIPTION
##### SUMMARY
When invoked with an invalid parameter (i.e., a non-existing hashing algorithm), `password_hash` returns an empty string (`""`) without failing.
Since this filter is often used to set user password, **this can lead to locking out a user due to setting a different password than the intended one**.
If the oversight is caught at execution time with a clear error, it can be fixed easily by the developer.

This change:
- stops the play raising an `AnsibleFilterError` exception
- prints the offending parameter (i.e.: `WRONG_ALGO`)
- prints the list of the acceptable ones (i.e.: `['md5', 'blowfish', 'sha256', 'sha512']`), generating it from the code

Fixes #38149.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
`password_hash` jinja filter

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/xxx/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /mnt/md/tmp/ansible/lib/ansible
  executable location = /mnt/md/tmp/ansible/bin/ansible
  python version = 3.6.3 (default, Oct  3 2017, 21:45:48) [GCC 7.2.0]
```


##### ADDITIONAL INFORMATION
Example of an execution before the change:
```
$ ansible all -i "localhost," -c local -a "echo The hash is: \'{{ 'somestring' | password_hash('WRONG_ALGO') }}\'"
localhost | SUCCESS | rc=0 >>
The hash is: ''
```

Example of an execution after the change:
```
$ ansible all -i "localhost," -c local -a "echo The hash is: \'{{ 'somestring' | password_hash('WRONG_ALGO') }}\'"
localhost | FAILED | rc=-1 >>
invalid hashtype: 'WRONG_ALGO'. Must be one of ['md5', 'blowfish', 'sha256', 'sha512']
```
