### PR TITLE
rabbitmq_user: 'node' parameter: add default value

### DIFF
--- a/lib/ansible/modules/messaging/rabbitmq_user.py
+++ b/lib/ansible/modules/messaging/rabbitmq_user.py
@@ -143,7 +143,7 @@ class RabbitMqUser(object):
     def _exec(self, args, run_in_check_mode=False):
         if not self.module.check_mode or run_in_check_mode:
             cmd = [self._rabbitmqctl, '-q']
-            if self.node is not None:
+            if self.node:
                 cmd.extend(['-n', self.node])
             rc, out, err = self.module.run_command(cmd + args, check_rc=True)
             return out.splitlines()
@@ -245,7 +245,7 @@ def main():
         read_priv=dict(default='^$'),
         force=dict(default='no', type='bool'),
         state=dict(default='present', choices=['present', 'absent']),
-        node=dict(default=None),
+        node=dict(default='rabbit'),
         update_password=dict(default='on_create', choices=['on_create', 'always'])
     )
     module = AnsibleModule(

--- a/test/integration/targets/rabbitmq_user/tasks/main.yml
+++ b/test/integration/targets/rabbitmq_user/tasks/main.yml
@@ -1,4 +1,10 @@
 ---
 
-- include: tests.yml
-  when: ansible_distribution == 'Ubuntu'
+- when: ansible_distribution == 'Ubuntu'
+  block:
+
+  - import_tasks: tests.yml
+
+  - import_tasks: tests.yml
+    environment:
+      RABBITMQ_NODENAME: test

--- a/test/integration/targets/setup_rabbitmq/tasks/ubuntu.yml
+++ b/test/integration/targets/setup_rabbitmq/tasks/ubuntu.yml
@@ -33,11 +33,3 @@
 
 - name: Start RabbitMQ service
   service: name=rabbitmq-server state=started
-  when: ansible_distribution_release == 'trusty'
-
-# This is an ugly workaround!
-# There is a problem to run services via systemd inside docker containers (https://github.com/moby/moby/issues/2296):
-# systemctl command fails with the error 'Failed to connect to bus: No such file or directory'
-- name: Start RabbitMQ service
-  command: /etc/init.d/rabbitmq-server start
-  when: ansible_distribution_release == 'xenial'

--- a/test/sanity/validate-modules/ignore.txt
+++ b/test/sanity/validate-modules/ignore.txt
@@ -587,7 +587,6 @@ lib/ansible/modules/messaging/rabbitmq_exchange.py E326
 lib/ansible/modules/messaging/rabbitmq_policy.py E324
 lib/ansible/modules/messaging/rabbitmq_queue.py E324
 lib/ansible/modules/messaging/rabbitmq_queue.py E327
-lib/ansible/modules/messaging/rabbitmq_user.py E324
 lib/ansible/modules/monitoring/airbrake_deployment.py E324
 lib/ansible/modules/monitoring/bigpanda.py E322
 lib/ansible/modules/monitoring/bigpanda.py E324


### PR DESCRIPTION
##### SUMMARY
`rabbitmq_user` module documentation states that the default value for `node` parameter is `rabbit`. However in `argument_spec`, there isn't any default value specified. This leads to an error when the `RABBITMQ_NODENAME` environment variable is set.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
rabbitmq_user

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0 (devel 45e4dfda3d) last updated 2018/03/31 02:21:43 (GMT +200)
```

##### ADDITIONAL INFORMATION
Fix should be backported to 2.5.