### PR TITLE
nmap: inventory: fix version added

### DIFF
--- a/lib/ansible/plugins/inventory/nmap.py
+++ b/lib/ansible/plugins/inventory/nmap.py
@@ -7,7 +7,7 @@ __metaclass__ = type
 DOCUMENTATION = '''
     name: nmap
     plugin_type: inventory
-    version_added: "2.5"
+    version_added: "2.6"
     short_description: Uses nmap to find hosts to target
     description:
         - Uses a YAML configuration file with a valid YAML extension.


### PR DESCRIPTION
##### SUMMARY
nmap inventory was just merged for 2.6

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
nmap

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
