### PR TITLE
Fix non-working blkio_weight parameter

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -809,6 +809,7 @@ class TaskParameters(DockerBaseClass):
         if not HAS_DOCKER_PY_3:
             create_params['cpu_shares'] = 'cpu_shares'
             create_params['volume_driver'] = 'volume_driver'
+            create_params['blkio_weight'] = 'blkio_weight'
 
         result = dict(
             host_config=self._host_config(),
@@ -906,6 +907,7 @@ class TaskParameters(DockerBaseClass):
             # cpu_shares and volume_driver moved to create_host_config in > 3
             host_config_params['cpu_shares'] = 'cpu_shares'
             host_config_params['volume_driver'] = 'volume_driver'
+            host_config_params['blkio_weight'] = 'blkio_weight'
 
         params = dict()
         for key, value in host_config_params.items():
@@ -1363,6 +1365,7 @@ class Container(DockerBaseClass):
             cpuset_cpus=host_config.get('CpusetCpus'),
             cpuset_mems=host_config.get('CpusetMems'),
             cpu_shares=host_config.get('CpuShares'),
+            blkio_weight=host_config.get('BlkioWeight'),
             kernel_memory=host_config.get("KernelMemory"),
             memory=host_config.get('Memory'),
             memory_reservation=host_config.get('MemoryReservation'),


### PR DESCRIPTION
##### SUMMARY
blkio_weight parameter of docker_container module is currently not working in Ansible 2.4 and 2.5.
This patch fixes it.
##### ISSUE TYPE
 - Bugfix Pull Request
##### COMPONENT NAME
docker_container module
