### PR TITLE
Encode xml data to utf8 standard (#34079)

### DIFF
--- a/lib/ansible/modules/network/dellos10/dellos10_facts.py
+++ b/lib/ansible/modules/network/dellos10/dellos10_facts.py
@@ -160,7 +160,7 @@ class Default(FactsBase):
     def populate(self):
         super(Default, self).populate()
         data = self.responses[0]
-        xml_data = ET.fromstring(data)
+        xml_data = ET.fromstring(data.encode('utf8'))
 
         self.facts['name'] = self.parse_name(xml_data)
         self.facts['version'] = self.parse_version(xml_data)
@@ -168,7 +168,7 @@ class Default(FactsBase):
         self.facts['hostname'] = self.parse_hostname(xml_data)
 
         data = self.responses[1]
-        xml_data = ET.fromstring(data)
+        xml_data = ET.fromstring(data.encode('utf8'))
 
         self.facts['servicetag'] = self.parse_servicetag(xml_data)
 
@@ -220,7 +220,7 @@ class Hardware(FactsBase):
         super(Hardware, self).populate()
         data = self.responses[0]
 
-        xml_data = ET.fromstring(data)
+        xml_data = ET.fromstring(data.encode('utf8'))
 
         self.facts['cpu_arch'] = self.parse_cpu_arch(xml_data)
 
@@ -277,7 +277,7 @@ class Interfaces(FactsBase):
         for line in int_show_data:
             if pattern in line:
                 if skip is False:
-                    xml_data = ET.fromstring(data)
+                    xml_data = ET.fromstring(data.encode('utf8'))
                     self.populate_interfaces(xml_data)
                     data = ''
                 else:
@@ -286,7 +286,7 @@ class Interfaces(FactsBase):
             data += line
 
         if skip is False:
-            xml_data = ET.fromstring(data)
+            xml_data = ET.fromstring(data.encode('utf8'))
             self.populate_interfaces(xml_data)
 
         self.facts['interfaces'] = self.intf_facts
@@ -299,7 +299,7 @@ class Interfaces(FactsBase):
         for line in lldp_data:
             if pattern in line:
                 if skip is False:
-                    xml_data = ET.fromstring(data)
+                    xml_data = ET.fromstring(data.encode('utf8'))
                     self.populate_neighbors(xml_data)
                     data = ''
                 else:
@@ -308,7 +308,7 @@ class Interfaces(FactsBase):
             data += line
 
         if skip is False:
-            xml_data = ET.fromstring(data)
+            xml_data = ET.fromstring(data.encode('utf8'))
             self.populate_neighbors(xml_data)
 
         self.facts['neighbors'] = self.lldp_facts


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Merged to devel https://github.com/ansible/ansible/pull/34079
(cherry picked from commit 5089122a323027bab30c11e5e0888aee8644a5d7)

In dellos10, response of few CLI commands are in XML format. Parsing that XML data throws below error.

Error snippet:
"ValueError: Unicode strings with encoding declaration are not supported. Please use bytes input or XML fragments without declaration."

Fix for the above error is to encode XML string data
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
modules/network/dellos10/dellos10_facts

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.4
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
