### PR TITLE
Fix problem that default installed gem version can not be got

### DIFF
--- a/lib/ansible/modules/packaging/language/gem.py
+++ b/lib/ansible/modules/packaging/language/gem.py
@@ -150,7 +150,9 @@ def get_installed_versions(module, remote=False):
         if match:
             versions = match.group(1)
             for version in versions.split(', '):
-                installed_versions.append(version.split()[0])
+                version_match = re.match(r"\s*(?:default:\s+)?(\S+)", version)
+                if version_match:
+                    installed_versions.append(version_match.group(1))
     return installed_versions
 
 


### PR DESCRIPTION
##### SUMMARY
This fix problem that default installed gem version can't be got.

Below are possible gem version patterns.

```
bundler (default: 1.16.1)
power_assert (0.2.2)
json (2.1.0, 2.0.0, default: 1.8.1)
libv8 (3.16.14.15 x86_64-linux)
```

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/packaging/language/gem.py

##### ANSIBLE VERSION
```
ansible 2.5.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/vagrant/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/vagrant/.pyenv/versions/3.6.4/lib/python3.6/site-packages/ansible
  executable location = /home/vagrant/.pyenv/versions/3.6.4/bin/ansible
  python version = 3.6.4 (default, Apr  2 2018, 16:27:15) [GCC 4.8.5 20150623 (Red Hat 4.8.5-16)]
```


##### ADDITIONAL INFORMATION
When updating to the latest rubygems, bundler will be entered.
The version of Gem installed by this update will be of the form deafult: x.x.x.
However, in case of the current Ansible module, this style is not supported.
As with this pull request, if you extract the version from the divided string, this problem will be gone.

For this problem, the following error occurs.

```
failed: [default] (item=2.2.1) => {"changed": false, "cmd": "/home/vagrant/.rbenv/versions/2.2.1/bin/gem install --version 1.16.1 --no-user-install --no-document bundler", "item": "2.2.1", "msg": "ERROR:  Error installing bundler:\n\t\"bundle\" from bundler conflicts with /home/vagrant/.rbenv/versions/2.2.1/bin/bundle", "rc": 1, "stderr": "ERROR:  Error installing bundler:\n\t\"bundle\" from bundler conflicts with /home/vagrant/.rbenv/versions/2.2.1/bin/bundle\n", "stderr_lines": ["ERROR:  Error installing bundler:", "\t\"bundle\" from bundler conflicts with /home/vagrant/.rbenv/versions/2.2.1/bin/bundle"], "stdout": "", "stdout_lines": []}
```

The below is the definition of the task.

```yaml
- name: check rbenv 
  stat: path={{ rbenv_path }}
  register: rbenv
- name: download rbenv
  git: repo={{ rbenv_url }} dest={{ rbenv_path }}
- name: download rbenv-build
  git: repo={{ rbenv_build_url }} dest="{{ rbenv_path }}/plugins/ruby-build"
- name: download rbenv-update
  git: repo={{ rbenv_update_url }} dest="{{ rbenv_path }}/plugins/rbenv-update"
- name: set rbenv variables
  register: result
  shell: echo 'export PATH="${HOME}/.rbenv/shims:${HOME}/.rbenv/bin:${PATH}"' >> ${HOME}/.bashrc
  when: not rbenv.stat.exists
- name: rbenv update
  shell: '{{ rbenv_path }}/bin/rbenv update'
  changed_when: false
- name: install ruby
  shell: |
    if [ "$({{ rbenv_path }}/bin/rbenv versions 2>&1 | grep {{ item }})" == "" ]; then
      echo 'Installing ruby {{ item }}'
      {{ rbenv_path }}/bin/rbenv install {{ item }}
    fi
  with_items: '{{ ruby_versions }}'
  register: ruby_installer_result
  changed_when: '"Installing ruby" in ruby_installer_result.stdout'
# NOTE: Update to the latest Rubygems. Currently 2.7.6 is the latest.
- name: update rubygems
  shell: "{{ rbenv_path }}/versions/{{ item }}/bin/gem update --system"
  environment:
    RBENV_VERSION: "{{ item }}"
    RBENV_ROOT: "{{ rbenv_path }}"
  with_items: '{{ ruby_versions }}'
  register: rubygems_result
  changed_when: '"Latest version already installed" not in rubygems_result.stdout'
# NOTE: ↓ Error (ruby_version 2.2.1)
- name: install bundler
  gem: name=bundler state=latest user_install=no executable="{{ rbenv_path }}/versions/{{ item }}/bin/gem"
  environment:
    RBENV_VERSION: "{{ item }}"
    RBENV_ROOT: "{{ rbenv_path }}"
  with_items: '{{ ruby_versions }}'
```

The below is the variable to use.

```yaml
rbenv_url: https://github.com/rbenv/rbenv.git
rbenv_build_url: https://github.com/sstephenson/ruby-build.git
rbenv_update_url: https://github.com/rkh/rbenv-update.git
rbenv_path: /home/vagrant/.rbenv
ruby_versions: [2.2.1, 2.5.1]
```