### PR TITLE
issue:38167 add support for onyx version 3.6.6000 for onyx_linkagg

### DIFF
--- a/test/units/modules/network/onyx/test_onyx_linkagg.py
+++ b/test/units/modules/network/onyx/test_onyx_linkagg.py
@@ -26,15 +26,20 @@ class TestOnyxLinkaggModule(TestOnyxModule):
         self.mock_load_config = patch(
             'ansible.module_utils.network.onyx.onyx.load_config')
         self.load_config = self.mock_load_config.start()
+        self.mock_get_version = patch.object(
+            onyx_linkagg.OnyxLinkAggModule, "_get_os_version")
+        self.get_version = self.mock_get_version.start()
 
     def tearDown(self):
         super(TestOnyxLinkaggModule, self).tearDown()
         self.mock_get_config.stop()
         self.mock_load_config.stop()
+        self.mock_get_version.stop()
 
     def load_fixture(self, config_file):
         self.get_config.return_value = load_fixture(config_file)
         self.load_config.return_value = None
+        self.get_version.return_value = "3.6.5000"
 
     def load_port_channel_fixture(self):
         config_file = 'onyx_port_channel_show.cfg'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fix mlag summary json parsing for onyx version 3.6.6000 and above 
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Fixes #38167 
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
onyx_linkagg.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0 (issue/38167 16f20560b8) last updated 2018/04/02 18:27:30 (GMT +000)
  config file = None
  python version = 2.7.5 (default, Nov  6 2016, 00:28:07) [GCC 4.8.5 20150623 (Red Hat 4.8.5-11)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
