### PR TITLE
Don't pass keyword args as positional, include file_name

### DIFF
--- a/lib/ansible/plugins/action/include_vars.py
+++ b/lib/ansible/plugins/action/include_vars.py
@@ -236,7 +236,7 @@ class ActionModule(ActionBase):
             data = to_text(b_data, errors='surrogate_or_strict')
 
             self.show_content = show_content
-            data = self._loader.load(data, show_content)
+            data = self._loader.load(data, file_name=filename, show_content=show_content)
             if not data:
                 data = dict()
             if not isinstance(data, dict):


### PR DESCRIPTION
##### SUMMARY
Don't pass keyword args as positional, include file_name. Fixes #38190

Since this code path has existed, we have always been passing `show_content` as the `file_name` parameter.  When there was a YAML error, this caused us to try and open `True` as a file, which results in a hang.

This `open` is in `AnsibleError._get_error_lines_from_file`

At minimum this seems to only affect Mac, and does not affect Linux OSes.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/action/include_vars.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.4
2.5
2.6
```

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```