### PR TITLE
Add the ability to specify an install_dir to the gem module

### DIFF
--- a/changelogs/fragments/gem-custom-home.yaml
+++ b/changelogs/fragments/gem-custom-home.yaml
@@ -1,0 +1,2 @@
+new_features:
+  - gem - add ability to specify a custom directory for installing gems (https://github.com/ansible/ansible/pull/38195)

--- a/lib/ansible/modules/packaging/language/gem.py
+++ b/lib/ansible/modules/packaging/language/gem.py
@@ -189,6 +189,7 @@ def uninstall(module):
     if module.check_mode:
         return
     cmd = get_rubygems_path(module)
+    environ = get_rubygems_environ(module)
     cmd.append('uninstall')
     if module.params['install_dir']:
         cmd.extend(['--install-dir', module.params['install_dir']])
@@ -199,7 +200,7 @@ def uninstall(module):
         cmd.append('--all')
         cmd.append('--executable')
     cmd.append(module.params['name'])
-    module.run_command(cmd, check_rc=True)
+    module.run_command(cmd, environ_update=environ, check_rc=True)
 
 
 def install(module):

--- a/test/integration/targets/gem/tasks/main.yml
+++ b/test/integration/targets/gem/tasks/main.yml
@@ -46,7 +46,7 @@
   assert:
     that:
       - install_gem_result is changed
-      - current_gems.stdout | search('gist\s+\([0-9.]+\)')
+      - current_gems.stdout is search('gist\s+\([0-9.]+\)')
 
 - name: Remove a gem
   gem:
@@ -62,7 +62,7 @@
   assert:
     that:
       - remove_gem_results is changed
-      - not current_gems.stdout | search('gist\s+\([0-9.]+\)')
+      - current_gems.stdout is not search('gist\s+\([0-9.]+\)')
 
 
 # Check cutom gem directory
@@ -85,7 +85,7 @@
   assert:
     that:
       - install_gem_result is changed
-      - gem_search.files[0].path | search('gist-[0-9.]+')
+      - gem_search.files[0].path is search('gist-[0-9.]+')
   ignore_errors: yes
 
 - name: Remove a gem in a custom directory

--- a/test/integration/targets/gem/tasks/main.yml
+++ b/test/integration/targets/gem/tasks/main.yml
@@ -66,6 +66,24 @@
 
 
 # Check cutom gem directory
+- name: Install gem in a custom directory with incorrect options
+  gem:
+    name: gist
+    state: present
+    install_dir: "{{ output_dir }}/gems"
+  ignore_errors: yes
+  register: install_gem_fail_result
+
+- debug:
+    var: install_gem_fail_result
+  tags: debug
+
+- name: Ensure previous task failed
+  assert:
+    that:
+      - install_gem_fail_result is failed
+      - install_gem_fail_result.msg == 'install_dir requires user_install=false'
+
 - name: Install a gem in a custom directory
   gem:
     name: gist

--- a/test/integration/targets/gem/tasks/main.yml
+++ b/test/integration/targets/gem/tasks/main.yml
@@ -25,31 +25,86 @@
         - 'default.yml'
       paths: '../vars'
 
-- name: install dependencies for test
-  package: name={{ package_item }} state=present
-  with_items: "{{ test_packages }}"
-  loop_control:
-    loop_var: package_item
+- name: Install dependencies for test
+  package:
+    name: "{{ item }}"
+    state: present
+  loop: "{{ test_packages }}"
   when: ansible_distribution != "MacOSX"
 
-- name: remove a gem
-  gem: name=gist state=absent
+- name: Install a gem
+  gem:
+    name: gist
+    state: present
+  register: install_gem_result
 
-- name: verify gist is not installed
-  shell: gem list | egrep '^gist '
-  register: uninstall
-  failed_when: "uninstall.rc != 1"
+- name: List gems
+  command: gem list
+  register: current_gems
 
-- name: install a gem
-  gem: name=gist state=present
-  register: gem_result
-
-- name: verify module output properties
+- name: Ensure gem was installed
   assert:
     that:
-        - "'name' in gem_result"
-        - "'changed' in gem_result"
-        - "'state' in gem_result"
+      - install_gem_result is changed
+      - current_gems.stdout | search('gist\s+\([0-9.]+\)')
 
-- name: verify gist is installed
-  shell: gem list | egrep '^gist '
+- name: Remove a gem
+  gem:
+    name: gist
+    state: absent
+  register: remove_gem_results
+
+- name: List gems
+  command: gem list
+  register: current_gems
+
+- name: Verify gem is not installed
+  assert:
+    that:
+      - remove_gem_results is changed
+      - not current_gems.stdout | search('gist\s+\([0-9.]+\)')
+
+
+# Check cutom gem directory
+- name: Install a gem in a custom directory
+  gem:
+    name: gist
+    state: present
+    user_install: no
+    install_dir: "{{ output_dir }}/gems"
+  register: install_gem_result
+
+- name: Find gems in custom directory
+  find:
+    paths: "{{ output_dir }}/gems/gems"
+    file_type: directory
+    contains: gist
+  register: gem_search
+
+- name: Ensure gem was installed in custom directory
+  assert:
+    that:
+      - install_gem_result is changed
+      - gem_search.files[0].path | search('gist-[0-9.]+')
+  ignore_errors: yes
+
+- name: Remove a gem in a custom directory
+  gem:
+    name: gist
+    state: absent
+    user_install: no
+    install_dir: "{{ output_dir }}/gems"
+  register: install_gem_result
+
+- name: Find gems in custom directory
+  find:
+    paths: "{{ output_dir }}/gems/gems"
+    file_type: directory
+    contains: gist
+  register: gem_search
+
+- name: Ensure gem was removed in custom directory
+  assert:
+    that:
+      - install_gem_result is changed
+      - gem_search.files | length == 0

--- a/test/units/modules/packaging/language/test_gem.py
+++ b/test/units/modules/packaging/language/test_gem.py
@@ -1,0 +1,87 @@
+# Copyright (c) 2018 Antoine Catton
+# MIT License (see licenses/MIT-license.txt or https://opensource.org/licenses/MIT)
+import copy
+import json
+
+import pytest
+
+from ansible.modules.packaging.language import gem
+from units.modules.utils import AnsibleExitJson, AnsibleFailJson, ModuleTestCase, set_module_args
+
+
+class TestGem(ModuleTestCase):
+    def setUp(self):
+        super(TestGem, self).setUp()
+        self.rubygems_path = ['/usr/bin/gem']
+        self.mocker.patch(
+            'ansible.modules.packaging.language.gem.get_rubygems_path',
+            lambda module: copy.deepcopy(self.rubygems_path),
+        )
+
+    @pytest.fixture(autouse=True)
+    def _mocker(self, mocker):
+        self.mocker = mocker
+
+    def patch_installed_versions(self, versions):
+        """Mocks the versions of the installed package"""
+
+        target = 'ansible.modules.packaging.language.gem.get_installed_versions'
+
+        def new(module, remote=False):
+            return versions
+
+        return self.mocker.patch(target, new)
+
+    def patch_rubygems_version(self, version=None):
+        target = 'ansible.modules.packaging.language.gem.get_rubygems_version'
+
+        def new(module):
+            return version
+
+        return self.mocker.patch(target, new)
+
+    def patch_run_command(self):
+        target = 'ansible.module_utils.basic.AnsibleModule.run_command'
+        return self.mocker.patch(target)
+
+    def test_fails_when_user_install_and_install_dir_are_combined(self):
+        set_module_args({
+            'name': 'dummy',
+            'user_install': True,
+            'install_dir': '/opt/dummy',
+        })
+
+        with pytest.raises(AnsibleFailJson) as exc:
+            gem.main()
+
+        result = exc.value.args[0]
+        assert result['failed']
+        assert result['msg'] == "install_dir requires user_install=false"
+
+    def test_passes_install_dir_to_gem(self):
+        # XXX: This test is extremely fragile, and makes assuptions about the module code, and how
+        #      functions are run.
+        #      If you start modifying the code of the module, you might need to modify what this
+        #      test mocks. The only thing that matters is the assertion that this 'gem install' is
+        #      invoked with '--install-dir'.
+
+        set_module_args({
+            'name': 'dummy',
+            'user_install': False,
+            'install_dir': '/opt/dummy',
+        })
+
+        self.patch_rubygems_version()
+        self.patch_installed_versions([])
+        run_command = self.patch_run_command()
+
+        with pytest.raises(AnsibleExitJson) as exc:
+            gem.main()
+
+        result = exc.value.args[0]
+        assert result['changed']
+        assert run_command.called
+
+        args = run_command.call_args[0]
+        command = args[0]
+        assert '--install-dir /opt/dummy' in ' '.join(command)


### PR DESCRIPTION
##### SUMMARY

Some system administrator want to separate some gem installation from the rest
of the system. A good example is `gem install --install-dir /opt/fluentd fluentd`.

This pull request allows users of the `gem` module in Ansible to specify a
directory where the gem is going to be installed.

In addition to the future, this adds partial tests for the module in question.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
module: `packaging.languages.gem`

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0 (add-install-dir-to-gem 8e1c0ce4d6) last updated 2018/04/03 00:31:31 (GMT +200)
  config file = None
  configured module search path = ['<home>/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = <localdev>/ansible/lib/ansible
  executable location = <localdev>/ansible/.ansible/bin/ansible
  python version = 3.6.4 (default, Mar 13 2018, 18:16:01) [GCC 7.3.1 20180130 (Red Hat 7.3.1-2)]
```


##### ADDITIONAL INFORMATION
N/A