### PR TITLE
WIP: PostgresSQL: allows to escape identifiers and use it with postgresql_user

### DIFF
--- a/lib/ansible/module_utils/postgres.py
+++ b/lib/ansible/module_utils/postgres.py
@@ -27,12 +27,91 @@
 # LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 # USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+__metaclass__ = type
+
 try:
     import psycopg2
     import psycopg2.extras
+    import psycopg2.extensions
     HAS_PSYCOPG2 = True
 except ImportError:
     HAS_PSYCOPG2 = False
+
+import ctypes
+import ctypes.util
+import re
+import string
+
+from ansible.module_utils._text import to_bytes, to_native
+
+try:
+    # quote_ident is available since Psycopg 2.7
+    from psycopg2.extensions import quote_ident
+    HAS_PSYCOPG2_QUOTE_IDENT = True
+except ImportError:
+    HAS_PSYCOPG2_QUOTE_IDENT = False
+
+
+class unionPthreadMutex(ctypes.Union):
+    _pack_ = True
+    _fields_ = [
+        ('__size', ctypes.c_char * 40),  # sizeof(struct___pthread_mutex_s)
+        ('__align', ctypes.c_int64),
+        ('PADDING_0', ctypes.c_ubyte * 32),
+    ]
+
+
+class structConnectionObject(ctypes.Structure):
+    _pack_ = True
+    _fields_ = [
+        ('ob_refcnt', ctypes.c_int64),
+        ('ob_type', ctypes.c_void_p),
+        ('lock', unionPthreadMutex),
+        ('dsn', ctypes.c_void_p),
+        ('critical', ctypes.c_void_p),
+        ('encoding', ctypes.c_void_p),
+        ('closed', ctypes.c_int64),
+        ('mark', ctypes.c_int64),
+        ('status', ctypes.c_int32),
+        ('PADDING_0', ctypes.c_ubyte * 4),
+        ('tpc_xid', ctypes.c_void_p),
+        ('async', ctypes.c_int64),
+        ('protocol', ctypes.c_int32),
+        ('server_version', ctypes.c_int32),
+        ('pgconn', ctypes.c_void_p),
+        # fields after pgconn can be ignored
+    ]
+
+try:
+    libpq = ctypes.cdll.LoadLibrary(ctypes.util.find_library('pq'))
+    libpq.PQescapeIdentifier.argtypes = (ctypes.c_void_p, ctypes.c_char_p, ctypes.c_size_t)
+    libpq.PQescapeIdentifier.restype = ctypes.c_void_p
+    libpq.PQfreemem.argtypes = (ctypes.c_void_p,)
+    libpq.PQfreemem.restype = None
+
+    HAS_LIBPQ_QUOTE_IDENT = True
+except AttributeError:
+    HAS_LIBPQ_QUOTE_IDENT = False
+
+
+if not HAS_LIBPQ_QUOTE_IDENT:
+    class UnquotedIdentifier(object):
+        """Allow unquoted identifiers only
+        See https://www.postgresql.org/docs/current/static/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS
+        """
+        EXTENSION_PATTERN = r'[^\W\d][\w_\$]+$'
+
+        def __init__(self, identifier):
+            self.identifier = identifier
+
+        def getquoted(self):
+            if re.match(self.EXTENSION_PATTERN, self.identifier):
+                return self.identifier
+            else:
+                raise Exception('%r is not a valid identifier' % self.identifier)
+
+    if HAS_PSYCOPG2:
+        psycopg2.extensions.register_adapter(UnquotedIdentifier, lambda identifier: identifier)
 
 
 class LibraryError(Exception):
@@ -59,3 +138,51 @@ def postgres_common_argument_spec():
         ssl_mode=dict(default='prefer', choices=['disable', 'allow', 'prefer', 'require', 'verify-ca', 'verify-full']),
         ssl_rootcert=dict(),
     )
+
+
+class EscapeIdentifierCursor(object):
+    """Escape identifiers using psycopg2.extensions.quote_ident if available,
+    else try with libpq.PQescapeIdentifier. If both are not available,
+    identifiers are not escaped."""
+
+    __metaclass__ = type
+
+    def execute(self, query, vars=None, identifiers=None):
+        """Replace string.Template placeholder ${...} by identifiers if any"""
+        if identifiers:
+            query = string.Template(query)
+            if HAS_PSYCOPG2_QUOTE_IDENT:
+                query = query.substitute(dict((name, quote_ident(value, self)) for name, value in identifiers.items()))
+            elif HAS_LIBPQ_QUOTE_IDENT:
+                query = query.substitute(dict((name, self.escape_identifier(value)) for name, value in identifiers.items()))
+            else:
+                if vars is None:
+                    vars = {}
+                if identifiers:
+                    self.module.warn('Unable to escape identifiers')
+                query = query.substitute(dict((name, '%%(%s)s' % name) for name in identifiers.keys()))
+                vars.update(dict((name, UnquotedIdentifier(value)) for name, value in identifiers.items()))
+
+        return super(EscapeIdentifierCursor, self).execute(query, vars=vars)
+
+    def escape_identifier(self, identifier):
+        if HAS_PSYCOPG2_QUOTE_IDENT or not HAS_LIBPQ_QUOTE_IDENT:
+            raise AssertionError("psycopg2.extensions.quote_ident available (%s) or libpq isn't (%s)" % (HAS_PSYCOPG2_QUOTE_IDENT, HAS_LIBPQ_QUOTE_IDENT))
+        _connection = ctypes.cast(ctypes.c_void_p(id(self.connection)), ctypes.POINTER(structConnectionObject)).contents
+        escaped = libpq.PQescapeIdentifier(_connection.pgconn, ctypes.c_char_p(to_bytes(identifier)), ctypes.c_size_t(len(identifier)))
+        try:
+            return to_native(ctypes.cast(escaped, ctypes.c_char_p).value)
+        finally:
+            if escaped is not None:
+                libpq.PQfreemem(escaped)
+
+
+def escape_identifier_cursor(module, cursor=None):
+    """Create a cursor allowing to escape identifiers: 'cursor.execute' method
+    accepts an identifier dictionary. When not empty, string.Template
+    placeholders ${...} in query will be replaced by escaped identifiers.
+
+    Usage: connection.cursor(cursor_factory=escape_identifier_cursor(module, cursor=psycopg2.extras.DictCursor)"""
+    if cursor is None:
+        cursor = psycopg2.extensions.cursor
+    return type("Cursor", (EscapeIdentifierCursor, cursor), {'module': module})

--- a/lib/ansible/modules/database/postgresql/postgresql_user.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_user.py
@@ -196,13 +196,12 @@ try:
     import psycopg2
     import psycopg2.extras
 except ImportError:
-    postgresqldb_found = False
-else:
-    postgresqldb_found = True
+    pass
 
+from ansible.module_utils._text import to_bytes, to_native
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.database import pg_quote_identifier, SQLParseError
-from ansible.module_utils._text import to_bytes, to_native
+from ansible.module_utils.postgres import ensure_libs, LibraryError
 from ansible.module_utils.six import iteritems
 
 
@@ -743,7 +742,9 @@ def main():
     sslrootcert = module.params["ssl_rootcert"]
     conn_limit = module.params["conn_limit"]
 
-    if not postgresqldb_found:
+    try:
+        ensure_libs()
+    except LibraryError:
         module.fail_json(msg="the python psycopg2 module is required")
 
     # To use defaults values, keyword arguments must be absent, so

--- a/test/integration/targets/postgresql/defaults/main.yml
+++ b/test/integration/targets/postgresql/defaults/main.yml
@@ -3,6 +3,6 @@
 db_name: 'ansible_db'
 db_user1: 'ansible_db_user1'
 db_user2: 'ansible_db_user2'
-db_user3: 'ansible_db_user3'
+db_user3: 'ansible.db.user3' # use identifiers with one dot and two dots (#22568)
 
 tmp_dir: '/tmp'

--- a/test/integration/targets/postgresql/tasks/main.yml
+++ b/test/integration/targets/postgresql/tasks/main.yml
@@ -754,6 +754,11 @@
     that:
       - "result.stdout_lines[-1] == '(0 rows)'"
 
+- import_tasks: postgresql_user_role_with_dots.yml
+  # RHEL/CentOS 6: psycopg2.extensions.quote_ident and PQescapeIdentifier aren't available,
+  # only unquoted identifiers are allowed
+  when: "ansible_distribution not in ['RedHat', 'CentOS'] or ansible_distribution_version is version('7', '>=')"
+
 # dump/restore tests per format
 # ============================================================
 - include: state_dump_restore.yml test_fixture=user file=dbdata.sql

--- a/test/integration/targets/postgresql/tasks/postgresql_user_role_with_dots.yml
+++ b/test/integration/targets/postgresql/tasks/postgresql_user_role_with_dots.yml
@@ -1,0 +1,48 @@
+###################################
+# Create a role containing two dots
+# nor db_user1 neither db_user2 can be used since only
+# postgresql_user module handles role with dots
+#
+- name: Create a user with dots in name
+  postgresql_user:
+    name: "{{ db_user3 }}"
+    state: "present"
+    encrypted: 'yes'
+    password: "md55c8ccfd9d6711fc69a7eae647fc54f51"
+    login_user: "{{ db_user1 }}"
+    login_password: "password"
+    login_host: "localhost"
+    db: postgres
+
+- name: Check that it was created
+  become: True
+  become_user: "{{ pg_user }}"
+  shell: echo "select * from pg_user where usename='{{ db_user3 }}';" | psql -d postgres
+  register: result
+
+- assert:
+    that:
+      - "result.stdout_lines[-1] == '(1 row)'"
+
+- name: Remove user
+  postgresql_user:
+    name: "{{ db_user3 }}"
+    state: 'absent'
+    priv: "ALL"
+    login_user: "{{ db_user1 }}"
+    login_password: "password"
+    login_host: "localhost"
+    db: postgres
+
+- name: Check that they were removed
+  become: True
+  become_user: "{{ pg_user }}"
+  shell: echo "select * from pg_user where usename='{{ db_user3 }}';" | psql -d postgres
+  register: result
+
+- assert:
+    that:
+      - "result.stdout_lines[-1] == '(0 rows)'"
+#
+# end of test of role name with dots
+####################################

--- a/test/integration/targets/setup_postgresql_db/tasks/main.yml
+++ b/test/integration/targets/setup_postgresql_db/tasks/main.yml
@@ -23,7 +23,9 @@
   ignore_errors: True
 
 - name: remove old db (RedHat or Suse)
-  command: rm -rf "{{ pg_dir }}"
+  file:
+    state: absent
+    path: "{{ pg_dir }}"
   ignore_errors: True
   when: ansible_os_family == "RedHat" or ansible_os_family == "Suse"
 

--- a/test/units/module_utils/test_postgresql.py
+++ b/test/units/module_utils/test_postgresql.py
@@ -1,18 +1,25 @@
 # Copyright (c) 2017 Ansible Project
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+import json
 import sys
 
 from ansible.compat.tests import unittest
 from ansible.compat.tests.mock import patch, MagicMock
 
+from ansible.module_utils import basic
 from ansible.module_utils.six.moves import builtins
-from ansible.module_utils._text import to_native
+from ansible.module_utils._text import to_native, to_bytes
 
 
 import pprint
 
 realimport = builtins.__import__
+
+
+class MockCursor(object):
+    def execute(self, query, vars=None):
+        return query
 
 
 class TestPostgres(unittest.TestCase):
@@ -33,6 +40,7 @@ class TestPostgres(unittest.TestCase):
         mod = builtins.__import__('ansible.module_utils.postgres')
 
         self.assertFalse(mod.module_utils.postgres.HAS_PSYCOPG2)
+        self.assertFalse(mod.module_utils.postgres.HAS_PSYCOPG2_QUOTE_IDENT)
 
         with self.assertRaises(mod.module_utils.postgres.LibraryError) as context:
             mod.module_utils.postgres.ensure_libs(sslrootcert=None)
@@ -50,6 +58,7 @@ class TestPostgres(unittest.TestCase):
         mod = builtins.__import__('ansible.module_utils.postgres')
 
         self.assertTrue(mod.module_utils.postgres.HAS_PSYCOPG2)
+        self.assertTrue(mod.module_utils.postgres.HAS_PSYCOPG2_QUOTE_IDENT)
 
         ensure_ret = mod.module_utils.postgres.ensure_libs(sslrootcert=None)
         self.assertFalse(ensure_ret)
@@ -73,3 +82,54 @@ class TestPostgres(unittest.TestCase):
         with self.assertRaises(mod.module_utils.postgres.LibraryError) as context:
             mod.module_utils.postgres.ensure_libs(sslrootcert='yes')
         self.assertIn('psycopg2 must be at least 2.4.3 in order to use', to_native(context.exception))
+
+    @patch.object(builtins, '__import__')
+    def test_escape_identifier_cursor(self, mock_import):
+        self._psycopg2_mock = MagicMock()
+        self._psycopg2_mock.__version__ = '2.4.1'
+        self._psycopg2_mock.quote_ident.return_value = 'quote_ident'
+
+        def _mock_import(name, *args, **kwargs):
+            if 'psycopg2' in name:
+                return self._psycopg2_mock
+            return realimport(name, *args, **kwargs)
+
+        # module.warning required needed for escape_identifier_cursor
+        args = json.dumps({'ANSIBLE_MODULE_ARGS': {}})
+        basic._ANSIBLE_ARGS = to_bytes(args)
+        module = basic.AnsibleModule({})
+
+        self.clear_modules(['psycopg2.extras', 'psycopg2.extensions', 'psycopg2', 'ansible.module_utils.postgres'])
+        mock_import.side_effect = _mock_import
+        mod = builtins.__import__('ansible.module_utils.postgres')
+
+        klass = mod.module_utils.postgres.escape_identifier_cursor(module, MockCursor)
+        cursor = klass()
+
+        with patch.object(cursor, 'escape_identifier', return_value='escape_identifier',
+                          autospec=True) as mock_escape_identifier:
+
+            mod.module_utils.postgres.HAS_PSYCOPG2 = True
+            mod.module_utils.postgres.HAS_LIBPQ_QUOTE_IDENT = False
+            mod.module_utils.postgres.HAS_PSYCOPG2_QUOTE_IDENT = False
+            ret = cursor.execute('select * from ${table}', identifiers={'table': 'users'})
+            self.assertEqual(self._psycopg2_mock.quote_ident.call_count, 0)
+            self.assertEqual(mock_escape_identifier.call_count, 0)
+            self.assertEqual(mock_escape_identifier.call_count, 0)
+            self.assertEqual(ret, 'select * from %(table)s')
+
+            mod.module_utils.postgres.HAS_PSYCOPG2 = True
+            mod.module_utils.postgres.HAS_LIBPQ_QUOTE_IDENT = True
+            mod.module_utils.postgres.HAS_PSYCOPG2_QUOTE_IDENT = True
+            ret = cursor.execute('select * from ${table}', identifiers={'table': 'users'})
+            self.assertEqual(self._psycopg2_mock.quote_ident.call_count, 1)
+            self.assertEqual(mock_escape_identifier.call_count, 0)
+            self.assertEqual(ret, 'select * from quote_ident')
+
+            mod.module_utils.postgres.HAS_PSYCOPG2 = True
+            mod.module_utils.postgres.HAS_PSYCOPG2_QUOTE_IDENT = False
+            mod.module_utils.postgres.HAS_LIBPQ_QUOTE_IDENT = True
+            ret = cursor.execute('select * from ${table}', identifiers={'table': 'users'})
+            self.assertEqual(self._psycopg2_mock.quote_ident.call_count, 1)
+            self.assertEqual(mock_escape_identifier.call_count, 1)
+            self.assertEqual(ret, 'select * from escape_identifier')


### PR DESCRIPTION
##### SUMMARY
Allow to escape PostgreSQL identifiers:
- either using `psycopg2.extensions.quote_ident` (available since 2.7)
- or using `PQescapeIdentifier` from `libpq` (available since 9.0).

When both are unavailable (for example with CentOS 6), only [unquoted identifiers](https://www.postgresql.org/docs/current/static/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS) are allowed: when a dot is used, behavior is roughly the same as the current one: module fails.

Closes #22568.

**Usage**:

  ```
  from ansible.module_utils.postgres import escape_identifier_cursor
  cursor = db_connection.cursor(cursor_factory=escape_identifier_cursor(module, cursor=psycopg2.extras.DictCursor))
  query = 'DROP USER ${user}'
  cursor.execute(query, identifiers={'user': user})
  ```

**Tests provided**:
- tests for `postgresql_user` module
- tests for from `ansible.module_utils.postgres.escape_identifier_cursor`

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
postgresql_user

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0 (devel 93fc99c576) last updated 2018/04/02 02:20:53 (GMT +200)
```

##### ADDITIONAL INFORMATION
`ansible.module_utils.postgres.escape_identifier_cursor` should be used instead of [`ansible.module_utils.database.pg_quote_identifier`](https://github.com/ansible/ansible/blob/70bcc5ed453751fa5138be2994b30d2014a55ec5/lib/ansible/module_utils/database.py#L113) in every PosgreSQL modules.

Feedback/review was unsuccessfully asked there : #30828.