### PR TITLE
Backport #38194 for 2.4 - include_vars error fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,7 +134,8 @@ Ansible Changes By Release
 * fix required args for nxos_snapshot: https://github.com/ansible/ansible/pull/37232
 * Properly check that nxos_snapshot parameters that are required in certain circumstances are present:
   https://github.com/ansible/ansible/pull/37232
-
+* Call DataLoader.load with the correct signature to prevent hang on error processing in include_vars
+  (https://github.com/ansible/ansible/pull/38194)
 
 <a id="2.4.3"></a>
 

--- a/lib/ansible/plugins/action/include_vars.py
+++ b/lib/ansible/plugins/action/include_vars.py
@@ -234,7 +234,7 @@ class ActionModule(ActionBase):
             data = to_text(b_data, errors='surrogate_or_strict')
 
             self.show_content = show_content
-            data = self._loader.load(data, show_content)
+            data = self._loader.load(data, file_name=filename, show_content=show_content)
             if not data:
                 data = dict()
             if not isinstance(data, dict):


### PR DESCRIPTION
##### SUMMARY
Backport #38194 for 2.4 - include_vars error fix

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/action/include_vars.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
