### PR TITLE
Integration Tests only: nxos_acl_interface

### DIFF
--- a/test/integration/targets/nxos_acl_interface/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_acl_interface/tests/common/sanity.yaml
@@ -16,11 +16,21 @@
     provider: "{{ connection }}"
   ignore_errors: yes
 
+- name: "Setup: Put interface into no switch port mode"
+  nxos_config:
+    commands:
+      - "no switchport"
+    parents:
+      - "interface {{ intname }}"
+    match: none
+    provider: "{{ connection }}"
+  ignore_errors: yes
+
 - name: "Setup: Cleanup possibly existing acl"
   nxos_acl: &remove
     name: ANSIBLE_ACL
     seq: 10
-    state: absent
+    state: delete_acl
     provider: "{{ connection }}"
   ignore_errors: yes
 
@@ -112,9 +122,9 @@
     nxos_config: *default
     ignore_errors: yes
 
+  always:
   - name: Remove possible configured ACL
     nxos_acl: *remove
     ignore_errors: yes
 
-  always:
   - debug: msg="END connection={{ ansible_connection }} nxos_acl_interface sanity test"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
IT cases for nxos_acl_interface
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - IT Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
nxos_acl_interface
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0 (devel 8c819dd9cb) last updated 2018/03/21 18:16:48 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /root/agents-ci/ansible/lib/ansible
  executable location = /root/agents-ci/ansible/bin/ansible
  python version = 2.7.6 (default, Oct 26 2016, 20:30:19) [GCC 4.8.4]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
* On some older platforms, the default for interface is switchport and this needs to be changed to 'no switchport' before the integration tests can be run, otherwise, they fail. The IT cases are enhanced to take care of these differences. 
* Also the cleanup of acl is not done properly and it is leaving some residue and this is done as well.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
```
