### PR TITLE
Expose verbosity as a var, dedupe attr list

### DIFF
--- a/lib/ansible/utils/vars.py
+++ b/lib/ansible/utils/vars.py
@@ -146,16 +146,19 @@ def load_extra_vars(loader, options):
 def load_options_vars(options, version):
 
     options_vars = {'ansible_version': version}
-    aliases = {'check': 'check_mode',
-               'diff': 'diff_mode',
-               'inventory': 'inventory_sources',
-               'subset': 'limit',
-               'tags': 'run_tags'}
+    attrs = {'check': 'check_mode',
+             'diff': 'diff_mode',
+             'forks': 'forks',
+             'inventory': 'inventory_sources',
+             'skip_tags': 'skip_tags',
+             'subset': 'limit',
+             'tags': 'run_tags',
+             'verbosity': 'verbosity'}
 
-    for attr in ('check', 'diff', 'forks', 'inventory', 'skip_tags', 'subset', 'tags'):
+    for attr, alias in attrs.items():
         opt = getattr(options, attr, None)
         if opt is not None:
-            options_vars['ansible_%s' % aliases.get(attr, attr)] = opt
+            options_vars['ansible_%s' % alias] = opt
 
     return options_vars
 


### PR DESCRIPTION
##### SUMMARY
Expose verbosity as a var, dedupe attr list. Fixes #36170 

For deduping attr list, instead of potentially duplicating the attr in aliases and in a tuple for looping, just put everything in the mapping, and use that for iteration.

The should prevent mistakes and omissions in the future.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
lib/ansible/utils/vars.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```