### PR TITLE
control from task 'args in task name'

### DIFF
--- a/lib/ansible/playbook/handler.py
+++ b/lib/ansible/playbook/handler.py
@@ -58,4 +58,3 @@ class Handler(Task):
         ''' return the name of the handler, never display args'''
 
         return super(Handler, self).get_name(display_args=False)
-

--- a/lib/ansible/playbook/handler.py
+++ b/lib/ansible/playbook/handler.py
@@ -53,3 +53,9 @@ class Handler(Task):
         result = super(Handler, self).serialize()
         result['is_handler'] = True
         return result
+
+    def get_name(self, display_args=False):
+        ''' return the name of the handler, never display args'''
+
+        return super(Handler, self).get_name(display_args=False)
+

--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -109,6 +109,9 @@ class Task(Base, Conditional, Taggable, Become):
             path = "%s:%s" % (self._parent._play._ds._data_source, self._parent._play._ds._line_number)
         return path
 
+    def get_args_string(self):
+        return u', '.join(u'%s=%s' % a for a in self.args.items())
+
     def get_name(self, display_args=True):
         ''' return the name of the task '''
 
@@ -125,20 +128,19 @@ class Task(Base, Conditional, Taggable, Become):
             else:
                 name = u"%s" % (self.action,)
 
-        '''
-         args can be specified as no_log in several places: in the task or in the argument spec.
-         We can check whether the task is no_log but the argument spec can't be because
-         that is only run on the target machine and we haven't run it thereyet at this time.
-
-         So we give people a config option to affect display of the args so that they can secure this
-         if they feel that their stdout is insecure (shoulder surfing, logging stdout straight to a file, etc).
-        '''
         if display_args and not self.no_log and C.DISPLAY_ARGS_TO_STDOUT:
-            args = u', '.join(u'%s=%s' % a for a in self.args.items())
+            '''
+             args can be specified as no_log in several places: in the task or in the argument spec.
+             We can check whether the task is no_log but the argument spec can't be because
+             that is only run on the target machine and we haven't run it thereyet at this time.
+
+             So we give people a config option to affect display of the args so that they can secure this
+             if they feel that their stdout is insecure (shoulder surfing, logging stdout straight to a file, etc).
+            '''
+            args = self.get_args_string()
             name += u' %s' % args
 
         return name
-
 
     def _merge_kv(self, ds):
         if ds is None:

--- a/lib/ansible/plugins/callback/default.py
+++ b/lib/ansible/plugins/callback/default.py
@@ -138,20 +138,7 @@ class CallbackModule(CallbackBase):
             self._print_task_banner(task)
 
     def _print_task_banner(self, task):
-        # args can be specified as no_log in several places: in the task or in
-        # the argument spec.  We can check whether the task is no_log but the
-        # argument spec can't be because that is only run on the target
-        # machine and we haven't run it thereyet at this time.
-        #
-        # So we give people a config option to affect display of the args so
-        # that they can secure this if they feel that their stdout is insecure
-        # (shoulder surfing, logging stdout straight to a file, etc).
-        args = ''
-        if not task.no_log and C.DISPLAY_ARGS_TO_STDOUT:
-            args = u', '.join(u'%s=%s' % a for a in task.args.items())
-            args = u' %s' % args
-
-        self._display.banner(u"TASK [%s%s]" % (task.get_name().strip(), args))
+        self._display.banner(u"TASK [%s]" % (task.get_name().strip()))
         if self._display.verbosity >= 2:
             path = task.get_path()
             if path:


### PR DESCRIPTION
##### SUMMARY

- having each callback do this or not made it inconsistent
- handlers should not do this as they are matched by 'name w/o args' and would be confusing


<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
tasks
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5-2.6

```