### PR TITLE
fixes issue when netconf would report ios is not supported (#38155)

### DIFF
--- a/lib/ansible/plugins/connection/netconf.py
+++ b/lib/ansible/plugins/connection/netconf.py
@@ -157,8 +157,9 @@ except ImportError:
 
 logging.getLogger('ncclient').setLevel(logging.INFO)
 
-network_os_device_param_map = {
-    "nxos": "nexus"
+NETWORK_OS_DEVICE_PARAM_MAP = {
+    "nxos": "nexus",
+    "ios": "default"
 }
 
 
@@ -242,7 +243,7 @@ class Connection(ConnectionBase):
                 if network_os:
                     display.display('discovered network_os %s' % network_os, log_only=True)
 
-        device_params = {'name': (network_os_device_param_map.get(network_os) or network_os or 'default')}
+        device_params = {'name': (NETWORK_OS_DEVICE_PARAM_MAP.get(network_os) or network_os or 'default')}
 
         ssh_config = os.getenv('ANSIBLE_NETCONF_SSH_CONFIG', False)
         if ssh_config in BOOLEANS_TRUE:


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
* fixes issue when netconf would report ios is not supported

This change now will map ansible_network_os=ios to the correct netconf
plugin implementation.  This will resolve an error where the netconf
connection plugin will report that ios is unsupported.

(cherry picked from commit 91a748e33be75ab16f8f725e788e5649c436cb46)

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
netconf

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```