### PR TITLE
Multiple ansible-test fixes.

### DIFF
--- a/test/runner/lib/config.py
+++ b/test/runner/lib/config.py
@@ -161,6 +161,7 @@ class IntegrationConfig(TestConfig):
         self.start_at = args.start_at  # type: str
         self.start_at_task = args.start_at_task  # type: str
         self.allow_destructive = args.allow_destructive if 'allow_destructive' in args else False  # type: bool
+        self.allow_root = args.allow_root  # type: bool
         self.retry_on_error = args.retry_on_error  # type: bool
         self.continue_on_error = args.continue_on_error  # type: bool
         self.debug_strategy = args.debug_strategy  # type: bool

--- a/test/runner/lib/config.py
+++ b/test/runner/lib/config.py
@@ -160,7 +160,7 @@ class IntegrationConfig(TestConfig):
 
         self.start_at = args.start_at  # type: str
         self.start_at_task = args.start_at_task  # type: str
-        self.allow_destructive = args.allow_destructive if 'allow_destructive' in args else False  # type: bool
+        self.allow_destructive = args.allow_destructive  # type: bool
         self.allow_root = args.allow_root  # type: bool
         self.retry_on_error = args.retry_on_error  # type: bool
         self.continue_on_error = args.continue_on_error  # type: bool

--- a/test/runner/lib/executor.py
+++ b/test/runner/lib/executor.py
@@ -1183,12 +1183,12 @@ def get_integration_local_filter(args, targets):
     """
     exclude = []
 
-    if os.getuid() != 0:
+    if not args.allow_root and os.getuid() != 0:
         skip = 'needs/root/'
         skipped = [target.name for target in targets if skip in target.aliases]
         if skipped:
             exclude.append(skip)
-            display.warning('Excluding tests marked "%s" which require running as root: %s'
+            display.warning('Excluding tests marked "%s" which require --allow-root or running as root: %s'
                             % (skip.rstrip('/'), ', '.join(skipped)))
 
     # consider explicit testing of destructive as though --allow-destructive was given

--- a/test/runner/lib/executor.py
+++ b/test/runner/lib/executor.py
@@ -1191,15 +1191,15 @@ def get_integration_local_filter(args, targets):
             display.warning('Excluding tests marked "%s" which require --allow-root or running as root: %s'
                             % (skip.rstrip('/'), ', '.join(skipped)))
 
-    # consider explicit testing of destructive as though --allow-destructive was given
-    include_destructive = any(target.startswith('destructive/') for target in args.include)
+    override_destructive = set(target for target in args.include if target.startswith('destructive/'))
 
-    if not args.allow_destructive and not include_destructive:
+    if not args.allow_destructive:
         skip = 'destructive/'
-        skipped = [target.name for target in targets if skip in target.aliases]
+        override = [target.name for target in targets if override_destructive & set(target.aliases)]
+        skipped = [target.name for target in targets if skip in target.aliases and target.name not in override]
         if skipped:
-            exclude.append(skip)
-            display.warning('Excluding tests marked "%s" which require --allow-destructive to run locally: %s'
+            exclude.extend(skipped)
+            display.warning('Excluding tests marked "%s" which require --allow-destructive or prefixing with "destructive/" to run locally: %s'
                             % (skip.rstrip('/'), ', '.join(skipped)))
 
     if args.python_version.startswith('3'):

--- a/test/runner/lib/executor.py
+++ b/test/runner/lib/executor.py
@@ -1233,12 +1233,14 @@ def get_integration_docker_filter(args, targets):
             display.warning('Excluding tests marked "%s" which require --docker-privileged to run under docker: %s'
                             % (skip.rstrip('/'), ', '.join(skipped)))
 
+    docker_image = args.docker.split('@')[0]  # strip SHA for proper tag comparison
+
     python_version = 2  # images are expected to default to python 2 unless otherwise specified
 
-    if args.docker.endswith('py3'):
+    if docker_image.endswith('py3'):
         python_version = 3  # docker images ending in 'py3' are expected to default to python 3
 
-    if args.docker.endswith(':default'):
+    if docker_image.endswith(':default'):
         python_version = 3  # docker images tagged 'default' are expected to default to python 3
 
     if args.python:  # specifying a numeric --python option overrides the default python

--- a/test/runner/lib/sanity/__init__.py
+++ b/test/runner/lib/sanity/__init__.py
@@ -220,7 +220,7 @@ class SanityCodeSmellTest(SanityTest):
         """
         :type args: SanityConfig
         :type targets: SanityTargets
-        :rtype: SanityResult
+        :rtype: TestResult
         """
         if self.path.endswith('.py'):
             cmd = [args.python_executable, self.path]
@@ -327,7 +327,7 @@ class SanitySingleVersion(SanityFunc):
         """
         :type args: SanityConfig
         :type targets: SanityTargets
-        :rtype: SanityResult
+        :rtype: TestResult
         """
         pass
 
@@ -340,7 +340,7 @@ class SanityMultipleVersion(SanityFunc):
         :type args: SanityConfig
         :type targets: SanityTargets
         :type python_version: str
-        :rtype: SanityResult
+        :rtype: TestResult
         """
         pass
 

--- a/test/runner/lib/sanity/ansible_doc.py
+++ b/test/runner/lib/sanity/ansible_doc.py
@@ -33,7 +33,7 @@ class AnsibleDocTest(SanityMultipleVersion):
         :type args: SanityConfig
         :type targets: SanityTargets
         :type python_version: str
-        :rtype: SanityResult
+        :rtype: TestResult
         """
         with open('test/sanity/ansible-doc/skip.txt', 'r') as skip_fd:
             skip_modules = set(skip_fd.read().splitlines())

--- a/test/runner/lib/sanity/compile.py
+++ b/test/runner/lib/sanity/compile.py
@@ -35,7 +35,7 @@ class CompileTest(SanityMultipleVersion):
         :type args: SanityConfig
         :type targets: SanityTargets
         :type python_version: str
-        :rtype: SanityResult
+        :rtype: TestResult
         """
         # optional list of regex patterns to exclude from tests
         skip_file = 'test/sanity/compile/python%s-skip.txt' % python_version

--- a/test/runner/lib/sanity/import.py
+++ b/test/runner/lib/sanity/import.py
@@ -41,7 +41,7 @@ class ImportTest(SanityMultipleVersion):
         :type args: SanityConfig
         :type targets: SanityTargets
         :type python_version: str
-        :rtype: SanityResult
+        :rtype: TestResult
         """
         with open('test/sanity/import/skip.txt', 'r') as skip_fd:
             skip_paths = skip_fd.read().splitlines()

--- a/test/runner/lib/sanity/pep8.py
+++ b/test/runner/lib/sanity/pep8.py
@@ -35,7 +35,7 @@ class Pep8Test(SanitySingleVersion):
         """
         :type args: SanityConfig
         :type targets: SanityTargets
-        :rtype: SanityResult
+        :rtype: TestResult
         """
         with open(PEP8_SKIP_PATH, 'r') as skip_fd:
             skip_paths = skip_fd.read().splitlines()

--- a/test/runner/lib/sanity/pslint.py
+++ b/test/runner/lib/sanity/pslint.py
@@ -39,7 +39,7 @@ class PslintTest(SanitySingleVersion):
         """
         :type args: SanityConfig
         :type targets: SanityTargets
-        :rtype: SanityResult
+        :rtype: TestResult
         """
         with open(PSLINT_SKIP_PATH, 'r') as skip_fd:
             skip_paths = skip_fd.read().splitlines()

--- a/test/runner/lib/sanity/pylint.py
+++ b/test/runner/lib/sanity/pylint.py
@@ -63,7 +63,7 @@ class PylintTest(SanitySingleVersion):
         """
         :type args: SanityConfig
         :type targets: SanityTargets
-        :rtype: SanityResult
+        :rtype: TestResult
         """
         if args.python_version in UNSUPPORTED_PYTHON_VERSIONS:
             display.warning('Skipping pylint on unsupported Python version %s.' % args.python_version)

--- a/test/runner/lib/sanity/rstcheck.py
+++ b/test/runner/lib/sanity/rstcheck.py
@@ -34,7 +34,7 @@ class RstcheckTest(SanitySingleVersion):
         """
         :type args: SanityConfig
         :type targets: SanityTargets
-        :rtype: SanityResult
+        :rtype: TestResult
         """
         if args.python_version in UNSUPPORTED_PYTHON_VERSIONS:
             display.warning('Skipping rstcheck on unsupported Python version %s.' % args.python_version)

--- a/test/runner/lib/sanity/sanity_docs.py
+++ b/test/runner/lib/sanity/sanity_docs.py
@@ -23,7 +23,7 @@ class SanityDocsTest(SanitySingleVersion):
         """
         :type args: SanityConfig
         :type targets: SanityTargets
-        :rtype: SanityResult
+        :rtype: TestResult
         """
         sanity_dir = 'docs/docsite/rst/dev_guide/testing/sanity'
         sanity_docs = set(part[0] for part in (os.path.splitext(name) for name in os.listdir(sanity_dir)) if part[1] == '.rst')

--- a/test/runner/lib/sanity/shellcheck.py
+++ b/test/runner/lib/sanity/shellcheck.py
@@ -32,7 +32,7 @@ class ShellcheckTest(SanitySingleVersion):
         """
         :type args: SanityConfig
         :type targets: SanityTargets
-        :rtype: SanityResult
+        :rtype: TestResult
         """
         with open('test/sanity/shellcheck/skip.txt', 'r') as skip_fd:
             skip_paths = set(skip_fd.read().splitlines())

--- a/test/runner/lib/sanity/validate_modules.py
+++ b/test/runner/lib/sanity/validate_modules.py
@@ -42,7 +42,7 @@ class ValidateModulesTest(SanitySingleVersion):
         """
         :type args: SanityConfig
         :type targets: SanityTargets
-        :rtype: SanityResult
+        :rtype: TestResult
         """
         with open(VALIDATE_SKIP_PATH, 'r') as skip_fd:
             skip_paths = skip_fd.read().splitlines()

--- a/test/runner/lib/sanity/yamllint.py
+++ b/test/runner/lib/sanity/yamllint.py
@@ -29,7 +29,7 @@ class YamllintTest(SanitySingleVersion):
         """
         :type args: SanityConfig
         :type targets: SanityTargets
-        :rtype: SanityResult
+        :rtype: TestResult
         """
         paths = [
             [i.path for i in targets.include if os.path.splitext(i.path)[1] in ('.yml', '.yaml')],

--- a/test/runner/test.py
+++ b/test/runner/test.py
@@ -225,6 +225,10 @@ def parse_args():
                              action='store_true',
                              help='allow destructive tests (--local and --tox only)')
 
+    integration.add_argument('--allow-root',
+                             action='store_true',
+                             help='allow tests requiring root when not root')
+
     integration.add_argument('--retry-on-error',
                              action='store_true',
                              help='retry failed test with increased verbosity')


### PR DESCRIPTION
##### SUMMARY

Multiple ansible-test fixes:

- Add ansible-test integration --allow-root option.
- Fix destructive target override.
- Fix bad type hint SanityResult -> TestResult.
- Fix skip/python3 filtering with --docker option.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.6.0 (at-fixes d19496f63e) last updated 2018/04/03 17:31:44 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
