### PR TITLE
Add missing IAM policy for cloudfront

### DIFF
--- a/hacking/aws_config/setup-iam.yml
+++ b/hacking/aws_config/setup-iam.yml
@@ -26,6 +26,7 @@
 
     - name: Get aws account ID
       aws_caller_facts:
+        profile: "{{ profile|default(omit) }}"
       register: aws_caller_facts
 
     - name: Set aws_account_fact

--- a/hacking/aws_config/testing_policies/cloudfront-policy.json
+++ b/hacking/aws_config/testing_policies/cloudfront-policy.json
@@ -7,6 +7,7 @@
             "Action": [
                 "cloudfront:CreateDistribution",
                 "cloudfront:CreateDistributionWithTags",
+                "cloudfront:CreateCloudFrontOriginAccessIdentity",
                 "cloudfront:DeleteDistribution",
                 "cloudfront:GetDistribution",
                 "cloudfront:GetStreamingDistribution",


### PR DESCRIPTION
##### SUMMARY

Cloudfront needs CreateOriginAccessIdentity

Add profile parameter to setup-iam.yml. Could arguably just use
AWS_PROFILE but given that other tasks are using profile, should
be consistent.


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
cloudfront_distribution

##### ANSIBLE VERSION
```
ansible 2.6.0 (devel 63a8ae94a7) last updated 2018/04/04 10:36:04 (GMT +1000)
  config file = None
  configured module search path = [u'/Users/will/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/will/src/ansible/lib/ansible
  executable location = /Users/will/src/ansible/bin/ansible
  python version = 2.7.14 (default, Mar  9 2018, 23:57:12) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
