### PR TITLE
Mark unsupported integration tests.

### DIFF
--- a/test/integration/targets/azure_rm_acs/aliases
+++ b/test/integration/targets/azure_rm_acs/aliases
@@ -1,2 +1,3 @@
 cloud/azure
 destructive
+unsupported

--- a/test/integration/targets/cloudfront_distribution/aliases
+++ b/test/integration/targets/cloudfront_distribution/aliases
@@ -1,1 +1,2 @@
 cloud/aws
+unsupported

--- a/test/integration/targets/connection_buildah/aliases
+++ b/test/integration/targets/connection_buildah/aliases
@@ -1,2 +1,3 @@
 needs/root
 non_local
+unsupported

--- a/test/integration/targets/connection_docker/aliases
+++ b/test/integration/targets/connection_docker/aliases
@@ -1,1 +1,2 @@
 non_local
+unsupported

--- a/test/integration/targets/connection_jail/aliases
+++ b/test/integration/targets/connection_jail/aliases
@@ -1,0 +1,1 @@
+unsupported

--- a/test/integration/targets/connection_libvirt_lxc/aliases
+++ b/test/integration/targets/connection_libvirt_lxc/aliases
@@ -1,0 +1,1 @@
+unsupported

--- a/test/integration/targets/connection_lxc/aliases
+++ b/test/integration/targets/connection_lxc/aliases
@@ -1,0 +1,1 @@
+unsupported

--- a/test/integration/targets/connection_lxd/aliases
+++ b/test/integration/targets/connection_lxd/aliases
@@ -1,1 +1,2 @@
 non_local
+unsupported

--- a/test/integration/targets/ec2_asg/aliases
+++ b/test/integration/targets/ec2_asg/aliases
@@ -1,1 +1,2 @@
 cloud/aws
+unsupported

--- a/test/integration/targets/ec2_instance/aliases
+++ b/test/integration/targets/ec2_instance/aliases
@@ -1,1 +1,2 @@
 cloud/aws
+unsupported

--- a/test/integration/targets/ecs_cluster/aliases
+++ b/test/integration/targets/ecs_cluster/aliases
@@ -3,3 +3,4 @@ ecs_service_facts
 ecs_task
 ecs_taskdefinition
 ecs_taskdefinition_facts
+unsupported

--- a/test/integration/targets/elb_target/aliases
+++ b/test/integration/targets/elb_target/aliases
@@ -1,1 +1,2 @@
 cloud/aws
+unsupported

--- a/test/integration/targets/gcp_compute_address/aliases
+++ b/test/integration/targets/gcp_compute_address/aliases
@@ -1,1 +1,2 @@
 cloud/gcp
+unsupported

--- a/test/integration/targets/gcp_dns_managed_zone/aliases
+++ b/test/integration/targets/gcp_dns_managed_zone/aliases
@@ -1,1 +1,2 @@
 cloud/gcp
+unsupported

--- a/test/integration/targets/java_cert/aliases
+++ b/test/integration/targets/java_cert/aliases
@@ -1,0 +1,1 @@
+unsupported

--- a/test/integration/targets/synchronize-buildah/aliases
+++ b/test/integration/targets/synchronize-buildah/aliases
@@ -1,2 +1,3 @@
 non_local
 needs/root
+unsupported

--- a/test/integration/targets/ucs_ip_pool/aliases
+++ b/test/integration/targets/ucs_ip_pool/aliases
@@ -4,3 +4,4 @@
 # ucs_hostname: 172.16.143.136
 # ucs_username: admin
 # ucs_password: password
+unsupported

--- a/test/integration/targets/ucs_lan_connectivity/aliases
+++ b/test/integration/targets/ucs_lan_connectivity/aliases
@@ -4,3 +4,4 @@
 # ucs_hostname: 172.16.143.136
 # ucs_username: admin
 # ucs_password: password
+unsupported

--- a/test/integration/targets/ucs_mac_pool/aliases
+++ b/test/integration/targets/ucs_mac_pool/aliases
@@ -4,3 +4,4 @@
 # ucs_hostname: 172.16.143.136
 # ucs_username: admin
 # ucs_password: password
+unsupported

--- a/test/integration/targets/ucs_san_connectivity/aliases
+++ b/test/integration/targets/ucs_san_connectivity/aliases
@@ -4,3 +4,4 @@
 # ucs_hostname: 172.16.143.136
 # ucs_username: admin
 # ucs_password: password
+unsupported

--- a/test/integration/targets/ucs_vhba_template/aliases
+++ b/test/integration/targets/ucs_vhba_template/aliases
@@ -4,3 +4,4 @@
 # ucs_hostname: 172.16.143.136
 # ucs_username: admin
 # ucs_password: password
+unsupported

--- a/test/integration/targets/ucs_vlans/aliases
+++ b/test/integration/targets/ucs_vlans/aliases
@@ -4,3 +4,4 @@
 # ucs_hostname: 172.16.143.136
 # ucs_username: admin
 # ucs_password: password
+unsupported

--- a/test/integration/targets/ucs_vnic_template/aliases
+++ b/test/integration/targets/ucs_vnic_template/aliases
@@ -4,3 +4,4 @@
 # ucs_hostname: 172.16.143.136
 # ucs_username: admin
 # ucs_password: password
+unsupported

--- a/test/integration/targets/ucs_vsans/aliases
+++ b/test/integration/targets/ucs_vsans/aliases
@@ -4,3 +4,4 @@
 # ucs_hostname: 172.16.143.136
 # ucs_username: admin
 # ucs_password: password
+unsupported

--- a/test/integration/targets/ucs_wwn_pool/aliases
+++ b/test/integration/targets/ucs_wwn_pool/aliases
@@ -4,3 +4,4 @@
 # ucs_hostname: 172.16.143.136
 # ucs_username: admin
 # ucs_password: password
+unsupported

--- a/test/integration/targets/win_domain_group/aliases
+++ b/test/integration/targets/win_domain_group/aliases
@@ -1,0 +1,1 @@
+unsupported


### PR DESCRIPTION
##### SUMMARY

Add `unsupported` alias to tests which are not currently supported by CI.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

integration tests

##### ANSIBLE VERSION

```
ansible 2.6.0 (unsupported-tests 3eb434f023) last updated 2018/04/03 18:58:10 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
