### PR TITLE
Add error handling for junos in case wrong connection type (#38023)

### DIFF
--- a/lib/ansible/plugins/action/junos.py
+++ b/lib/ansible/plugins/action/junos.py
@@ -37,6 +37,8 @@ except ImportError:
     from ansible.utils.display import Display
     display = Display()
 
+CLI_SUPPORTED_MODULES = ['junos_netconf', 'junos_command']
+
 
 class ActionModule(_ActionModule):
 
@@ -54,6 +56,13 @@ class ActionModule(_ActionModule):
             pc = copy.deepcopy(self._play_context)
             pc.network_os = 'junos'
             pc.remote_addr = provider['host'] or self._play_context.remote_addr
+
+            if (provider['transport'] == 'cli' and self._task.action not in CLI_SUPPORTED_MODULES) or \
+                    (provider['transport'] == 'netconf' and self._task.action == 'junos_netconf'):
+                return {'failed': True, 'msg': "Transport type '%s' is not valid for '%s' module. "
+                                               "Please see http://docs.ansible.com/ansible/latest/network/user_guide/platform_junos.html"
+                                               % (provider['transport'], self._task.action)}
+
             if self._task.action == 'junos_netconf' or (provider['transport'] == 'cli' and self._task.action == 'junos_command'):
                 pc.connection = 'network_cli'
                 pc.port = int(provider['port'] or self._play_context.port or 22)
@@ -81,8 +90,11 @@ class ActionModule(_ActionModule):
             provider = self._task.args.get('provider', {})
             if any(provider.values()):
                 display.warning('provider is unnecessary when using connection=%s and will be ignored' % self._play_context.connection)
-        else:
-            return {'failed': True, 'msg': 'Connection type %s is not valid for this module' % self._play_context.connection}
+
+            if self._play_context.connection == 'network_cli' and self._task.action not in CLI_SUPPORTED_MODULES:
+                return {'failed': True, 'msg': "Connection type '%s' is not valid for '%s' module. "
+                                               "Please see http://docs.ansible.com/ansible/latest/network/user_guide/platform_junos.html"
+                                               % (self._play_context.connection, self._task.action)}
 
         if (self._play_context.connection == 'local' and pc.connection == 'network_cli') or self._play_context.connection == 'network_cli':
             # make sure we are in the right cli context which should be


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
* Add error handling for junos in case wrong connection type
Fixes #37990
If a junos module doesn't support given connection/transport type
return an appropriate error message.

* Fix CI issues
* Fix review comment
(cherry picked from commit 3a4fc4af085f605fbb1b84057c831cb406a30c86)
Merged to devel https://github.com/ansible/ansible/pull/38023
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
plugins/action/junos.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
