### PR TITLE
Update aliases on integration tests.

### DIFF
--- a/test/integration/targets/aws_waf_web_acl/aliases
+++ b/test/integration/targets/aws_waf_web_acl/aliases
@@ -3,3 +3,4 @@ aws_waf_facts
 aws_waf_web_acl
 aws_waf_web_match
 aws_waf_web_rule
+unsupported

--- a/test/integration/targets/azure_rm_deployment/aliases
+++ b/test/integration/targets/azure_rm_deployment/aliases
@@ -1,2 +1,3 @@
 cloud/azure
 destructive
+posix/ci/cloud/group2/azure

--- a/test/integration/targets/dpkg_selections/aliases
+++ b/test/integration/targets/dpkg_selections/aliases
@@ -1,3 +1,4 @@
+posix/ci/group1
 destructive
 skip/freebsd
 skip/osx

--- a/test/integration/targets/nuage_vspk/aliases
+++ b/test/integration/targets/nuage_vspk/aliases
@@ -1,1 +1,2 @@
+posix/ci/group1
 skip/python3

--- a/test/integration/targets/nuage_vspk/aliases
+++ b/test/integration/targets/nuage_vspk/aliases
@@ -1,2 +1,1 @@
-posix/ci/group1
 skip/python3

--- a/test/integration/targets/vmware_maintenancemode/aliases
+++ b/test/integration/targets/vmware_maintenancemode/aliases
@@ -1,2 +1,3 @@
+posix/ci/cloud/group1/vcenter
 cloud/vcenter
 destructive


### PR DESCRIPTION
##### SUMMARY

Update aliases on integration tests:

- Enable dpkg_selections test.
- ~Enable nuage_vspk test.~ The test [fails](https://app.shippable.com/github/ansible/ansible/runs/60015/28/tests) on centos6.
- Enable vmware_maintenancemode test.
- Enable azure_rm_deployment test.
- Mark aws_waf_web_acl test unsupported.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

various integration tests

##### ANSIBLE VERSION

```
ansible 2.6.0 (update-tests d506d7b57d) last updated 2018/04/03 23:21:17 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
