### PR TITLE
Backport Azure SecurityRule to use kwargs (#37695)

### DIFF
--- a/lib/ansible/module_utils/azure_rm_common.py
+++ b/lib/ansible/module_utils/azure_rm_common.py
@@ -747,17 +747,41 @@ class AzureRMModuleBase(object):
             if os_type == 'Linux':
                 # add an inbound SSH rule
                 parameters.security_rules = [
-                    self.network_models.SecurityRule('Tcp', '*', '*', 'Allow', 'Inbound', description='Allow SSH Access',
-                                                     source_port_range='*', destination_port_range='22', priority=100, name='SSH')
+                    self.network_models.SecurityRule(protocol='Tcp',
+                                                     source_address_prefix='*',
+                                                     destination_address_prefix='*',
+                                                     access='Allow',
+                                                     direction='Inbound',
+                                                     description='Allow SSH Access',
+                                                     source_port_range='*',
+                                                     destination_port_range='22',
+                                                     priority=100,
+                                                     name='SSH')
                 ]
                 parameters.location = location
             else:
                 # for windows add inbound RDP and WinRM rules
                 parameters.security_rules = [
-                    self.network_models.SecurityRule('Tcp', '*', '*', 'Allow', 'Inbound', description='Allow RDP port 3389',
-                                                     source_port_range='*', destination_port_range='3389', priority=100, name='RDP01'),
-                    self.network_models.SecurityRule('Tcp', '*', '*', 'Allow', 'Inbound', description='Allow WinRM HTTPS port 5986',
-                                                     source_port_range='*', destination_port_range='5986', priority=101, name='WinRM01'),
+                    self.network_models.SecurityRule(protocol='Tcp',
+                                                     source_address_prefix='*',
+                                                     destination_address_prefix='*',
+                                                     access='Allow',
+                                                     direction='Inbound',
+                                                     description='Allow RDP port 3389',
+                                                     source_port_range='*',
+                                                     destination_port_range='3389',
+                                                     priority=100,
+                                                     name='RDP01'),
+                    self.network_models.SecurityRule(protocol='Tcp',
+                                                     source_address_prefix='*',
+                                                     destination_address_prefix='*',
+                                                     access='Allow',
+                                                     direction='Inbound',
+                                                     description='Allow WinRM HTTPS port 5986',
+                                                     source_port_range='*',
+                                                     destination_port_range='5986',
+                                                     priority=101,
+                                                     name='WinRM01'),
                 ]
         else:
             # Open custom ports


### PR DESCRIPTION
(cherry picked from commit ca225d6da0bcace7240fdf364f55051cb61ea3ef)

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
azure_rm_common.py


##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

If I install `azure-mgmt-network==2.0.0rc` package

`File \"/tmp/ansible_GbPZin/ansible_modlib.zip/ansible/module_utils/azure_rm_common.py\", line 751, in create_default_securitygroup\nTypeError: __init__() takes exactly 1 argument (11 given)\`

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```