### PR TITLE
Fix grafana CALLBACK_VERSION

### DIFF
--- a/lib/ansible/plugins/callback/grafana_annotations.py
+++ b/lib/ansible/plugins/callback/grafana_annotations.py
@@ -149,7 +149,7 @@ class CallbackModule(CallbackBase):
     and put the plugin in <path_to_callback_plugins_folder>
     """
 
-    CALLBACK_VERSION = 1.0
+    CALLBACK_VERSION = 2.0
     CALLBACK_TYPE = 'aggregate'
     CALLBACK_NAME = 'grafana_annotations'
     CALLBACK_NEEDS_WHITELIST = True


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This prevents displaying the following on every ansible run:
```
 [WARNING]: Grafana URL was not provided. The Grafana URL can be provided using the `GRAFANA_URL`
environment variable.
                                                    
[DEPRECATION WARNING]: minimal callback, does not support setting 'options', it will work for now,  but 
this will be required in the future and should be updated,  see the 2.4 porting guide for details.. This                                                                                                           
 feature will be removed in version 2.9. Deprecation warnings can be disabled by setting 
deprecation_warnings=False in ansible.cfg.
```

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
grafana_annotations

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION