### PR TITLE
Fix changelog order in the rpm spec file

### DIFF
--- a/packaging/rpm/ansible.spec
+++ b/packaging/rpm/ansible.spec
@@ -153,16 +153,16 @@ rm -rf %{buildroot}
 * Mon Sep 18 2017 Ansible, Inc. <info@ansible.com> - 2.4.0.0-1
 - Release 2.4.0.0-1
 
-* Fri Aug 04 2017 Ansible, Inc. <info@ansible.com> - 2.3.2.0-1
+* Fri Aug  4 2017 Ansible, Inc. <info@ansible.com> - 2.3.2.0-1
 - Release 2.3.2.0-1
 
-* Thu Jun 01 2017 Ansible, Inc. <info@ansible.com> - 2.3.1.0-1
-- Release 2.3.1.0-1
-
-* Thu Jun 01 2017 Ansible, Inc. <info@ansible.com> - 2.1.6.0-1
+* Thu Jun  1 2017 Ansible, Inc. <info@ansible.com> - 2.1.6.0-1
 - Release 2.1.6.0-1
 
-* Tue May 09 2017 Ansible, Inc. <info@ansible.com> - 2.2.3.0-1
+* Thu Jun  1 2017 Ansible, Inc. <info@ansible.com> - 2.3.1.0-1
+- Release 2.3.1.0-1
+
+* Tue May  9 2017 Ansible, Inc. <info@ansible.com> - 2.2.3.0-1
 - Release 2.2.3.0-1
 
 * Wed Apr 12 2017 Ansible, Inc. <info@ansible.com> - 2.3.0.0-1
@@ -180,7 +180,7 @@ rm -rf %{buildroot}
 * Mon Jan 16 2017 Ansible, Inc. <info@ansible.com> - 2.1.4.0-1
 - Release 2.1.4.0-1
 
-* Fri Nov 04 2016 Ansible, Inc. <info@ansible.com> - 2.1.3.0-1
+* Fri Nov  4 2016 Ansible, Inc. <info@ansible.com> - 2.1.3.0-1
 - Release 2.1.3.0-1
 
 * Mon Oct 31 2016 Ansible, Inc. <info@ansible.com> - 2.2.0.0-1
@@ -207,10 +207,10 @@ rm -rf %{buildroot}
 * Tue Jan 12 2016 Ansible, Inc. <info@ansible.com> - 2.0.0.0-1
 - Release 2.0.0.0-1
 
-* Fri Oct 09 2015 Ansible, Inc. <info@ansible.com> - 1.9.4
+* Fri Oct  9 2015 Ansible, Inc. <info@ansible.com> - 1.9.4
 - Release 1.9.4
 
-* Thu Sep 03 2015 Ansible, Inc. <info@ansible.com> - 1.9.3
+* Thu Sep  3 2015 Ansible, Inc. <info@ansible.com> - 1.9.3
 - Release 1.9.3
 
 * Wed Jun 24 2015 Ansible, Inc. <info@ansible.com> - 1.9.2
@@ -228,7 +228,7 @@ rm -rf %{buildroot}
 * Tue Feb 17 2015 Ansible, Inc. <info@ansible.com> - 1.8.3
 - Release 1.8.3
 
-* Thu Dec 04 2014 Michael DeHaan <michael@ansible.com> - 1.8.2
+* Thu Dec  4 2014 Michael DeHaan <michael@ansible.com> - 1.8.2
 - Release 1.8.2
 
 * Wed Nov 26 2014 Michael DeHaan <michael@ansible.com> - 1.8.1
@@ -243,7 +243,7 @@ rm -rf %{buildroot}
 * Thu Aug 14 2014 Michael DeHaan <michael@ansible.com> - 1.7.1
 - Release 1.7.1
 
-* Wed Aug 06 2014 Michael DeHaan <michael@ansible.com> - 1.7.0
+* Wed Aug  6 2014 Michael DeHaan <michael@ansible.com> - 1.7.0
 - Release 1.7.0
 
 * Fri Jul 25 2014 Michael DeHaan <michael@ansible.com> - 1.6.10
@@ -258,7 +258,7 @@ rm -rf %{buildroot}
 * Mon Jul 21 2014 Michael DeHaan <michael@ansible.com> - 1.6.7
 - Release 1.6.7
 
-* Tue Jul 01 2014 Michael DeHaan <michael@ansible.com> - 1.6.6
+* Tue Jul  1 2014 Michael DeHaan <michael@ansible.com> - 1.6.6
 - Release 1.6.6
 
 * Wed Jun 25 2014 Michael DeHaan <michael@ansible.com> - 1.6.5
@@ -267,22 +267,22 @@ rm -rf %{buildroot}
 * Wed Jun 25 2014 Michael DeHaan <michael@ansible.com> - 1.6.4
 - Release 1.6.4
 
-* Mon Jun 09 2014 Michael DeHaan <michael@ansible.com> - 1.6.3
+* Mon Jun  9 2014 Michael DeHaan <michael@ansible.com> - 1.6.3
 - Release 1.6.3
 
 * Fri May 23 2014 Michael DeHaan <michael@ansible.com> - 1.6.2
 - Release 1.6.2
 
-* Wed May 07 2014 Michael DeHaan <michael@ansible.com> - 1.6.1
+* Wed May  7 2014 Michael DeHaan <michael@ansible.com> - 1.6.1
 - Release 1.6.1
 
-* Mon May 05 2014 Michael DeHaan <michael@ansible.com> - 1.6.0
+* Mon May  5 2014 Michael DeHaan <michael@ansible.com> - 1.6.0
 - Release 1.6.0
 
 * Fri Apr 18 2014 Michael DeHaan <michael@ansible.com> - 1.5.5
 - Release 1.5.5
 
-* Tue Apr 01 2014 Michael DeHaan <michael@ansible.com> - 1.5.4
+* Tue Apr  1 2014 Michael DeHaan <michael@ansible.com> - 1.5.4
 - Release 1.5.4
 
 * Thu Mar 13 2014 Michael DeHaan <michael@ansible.com> - 1.5.3
@@ -298,42 +298,42 @@ rm -rf %{buildroot}
 - Release 1.5.0
 
 * Fri Feb 28 2014 Michael DeHaan <michael.dehaan@gmail.com> - 1.5-0
-* Release 1.5
+- Release 1.5
 
 * Wed Feb 12 2014 Michael DeHaan <michael.dehaan@gmail.com> - 1.4.5
-* Release 1.4.5
+- Release 1.4.5
 
-* Mon Jan 06 2014 Michael DeHaan <michael.dehaan@gmail.com> - 1.4.4
-* Release 1.4.4
+* Mon Jan  6 2014 Michael DeHaan <michael.dehaan@gmail.com> - 1.4.4
+- Release 1.4.4
 
 * Fri Dec 20 2013 Michael DeHaan <michael.dehaan@gmail.com> - 1.4.3
-* Release 1.4.3
+- Release 1.4.3
 
 * Wed Dec 18 2013 Michael DeHaan <michael.dehaan@gmail.com> - 1.4.2
-* Release 1.4.2
+- Release 1.4.2
 
 * Wed Nov 27 2013 Michael DeHaan <michael.dehaan@gmail.com> - 1.4-1
-* Release 1.4.1
+- Release 1.4.1
 
 * Thu Nov 21 2013 Michael DeHaan <michael.dehaan@gmail.com> - 1.4-0
-* Release 1.4.0
+- Release 1.4.0
 
 * Fri Sep 13 2013 Michael DeHaan <michael.dehaan@gmail.com> - 1.3-0
-* Release 1.3.0
+- Release 1.3.0
 
-* Fri Jul 05 2013 Michael DeHaan <michael.dehaan@gmail.com> - 1.2-2
-* Release 1.2.2
+* Fri Jul  5 2013 Michael DeHaan <michael.dehaan@gmail.com> - 1.2-2
+- Release 1.2.2
 
-* Thu Jul 04 2013 Michael DeHaan <michael.dehaan@gmail.com> - 1.2-1
-* Release 1.2.1
+* Thu Jul  4 2013 Michael DeHaan <michael.dehaan@gmail.com> - 1.2-1
+- Release 1.2.1
 
 * Mon Jun 10 2013 Michael DeHaan <michael.dehaan@gmail.com> - 1.2-0
-* Release 1.2
+- Release 1.2
 
-* Tue Apr 2 2013 Michael DeHaan <michael.dehaan@gmail.com> - 1.1-0
-* Release 1.1
+* Tue Apr  2 2013 Michael DeHaan <michael.dehaan@gmail.com> - 1.1-0
+- Release 1.1
 
-* Fri Feb 1 2013 Michael DeHaan <michael.dehaan@gmail.com> - 1.0-0
+* Fri Feb  1 2013 Michael DeHaan <michael.dehaan@gmail.com> - 1.0-0
 - Release 1.0
 
 * Fri Nov 30 2012 Michael DeHaan <michael.dehaan@gmail.com> - 0.9-0
@@ -342,13 +342,13 @@ rm -rf %{buildroot}
 * Fri Oct 19 2012 Michael DeHaan <michael.dehaan@gmail.com> - 0.8-0
 - Release of 0.8
 
-* Mon Aug 6 2012 Michael DeHaan <michael.dehaan@gmail.com> - 0.7-0
+* Mon Aug  6 2012 Michael DeHaan <michael.dehaan@gmail.com> - 0.7-0
 - Release of 0.7
 
-* Mon Aug 6 2012 Michael DeHaan <michael.dehaan@gmail.com> - 0.6-0
+* Mon Aug  6 2012 Michael DeHaan <michael.dehaan@gmail.com> - 0.6-0
 - Release of 0.6
 
-* Wed Jul 4 2012 Michael DeHaan <michael.dehaan@gmail.com> - 0.5-0
+* Wed Jul  4 2012 Michael DeHaan <michael.dehaan@gmail.com> - 0.5-0
 - Release of 0.5
 
 * Wed May 23 2012 Michael DeHaan <michael.dehaan@gmail.com> - 0.4-0


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fix changelog order in the rpm spec file
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
RPM Spec file
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
rpmbuild failed to build due to bogus timeline in the changelog. Use chronological order instead of version order.
Single digit date must not have a 0 before but a space instead
<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
