### PR TITLE
Fix spelling of lookup

### DIFF
--- a/lib/ansible/modules/cloud/smartos/vmadm.py
+++ b/lib/ansible/modules/cloud/smartos/vmadm.py
@@ -690,7 +690,7 @@ def main():
         uuid = get_vm_uuid(module, p['name'])
         # Bit of a chicken and egg problem here for VMs with state == deleted.
         # If they're going to be removed in this play, we have to lookup the
-        # uuid. If they're already deleted there's nothing to looup.
+        # uuid. If they're already deleted there's nothing to lookup.
         # So if state == deleted and get_vm_uuid() returned '', the VM is already
         # deleted and there's nothing else to do.
         if uuid is None and vm_state == 'deleted':

--- a/lib/ansible/plugins/lookup/_redis_kv.py
+++ b/lib/ansible/plugins/lookup/_redis_kv.py
@@ -14,7 +14,7 @@ DOCUMENTATION = """
         version: '2.9'
         alternative: new 'redis' lookup
     description:
-      - this looup returns a list of items given to it, if any of the top level items is also a list it will flatten it, but it will not recurse
+      - this lookup returns a list of items given to it, if any of the top level items is also a list it will flatten it, but it will not recurse
     requirements:
       - redis (python library https://github.com/andymccurdy/redis-py/)
     options:

--- a/lib/ansible/plugins/lookup/items.py
+++ b/lib/ansible/plugins/lookup/items.py
@@ -10,7 +10,7 @@ DOCUMENTATION = """
     version_added: historical
     short_description: list of items
     description:
-      - this looup returns a list of items given to it, if any of the top level items is also a list it will flatten it, but it will not recurse
+      - this lookup returns a list of items given to it, if any of the top level items is also a list it will flatten it, but it will not recurse
     notes:
       - this is the standard lookup used for loops in most examples
       - check out the 'flattened' lookup for recursive flattening

--- a/lib/ansible/plugins/lookup/redis.py
+++ b/lib/ansible/plugins/lookup/redis.py
@@ -12,7 +12,7 @@ DOCUMENTATION = """
     version_added: "2.5"
     short_description: fetch data from Redis
     description:
-      - This looup returns a list of results from a Redis DB corresponding to a list of items given to it
+      - This lookup returns a list of results from a Redis DB corresponding to a list of items given to it
     requirements:
       - redis (python library https://github.com/andymccurdy/redis-py/)
     options:


### PR DESCRIPTION
##### SUMMARY
Correct spelling of "lookup" in the plugins and module that had a missing `k`.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
vmadm cloud module
items lookup plugin
redis lookup plugin
redis_kv lookup plugin

##### ANSIBLE VERSION
```
2.6.0 0.0.devel
```


##### ADDITIONAL INFORMATION
N/A