### PR TITLE
ec2_instance: add a retry to run_instance to help with ec2 consistency and iam role

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_instance.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_instance.py
@@ -600,6 +600,7 @@ import re
 import uuid
 import string
 import textwrap
+import time
 from collections import namedtuple
 
 try:
@@ -1313,7 +1314,7 @@ def ensure_present(existing_matches, changed, ec2, state):
             )
     try:
         instance_spec = build_run_instance_spec(module.params)
-        instance_response = AWSRetry.jittered_backoff()(ec2.run_instances)(**instance_spec)
+        instance_response = run_instances(ec2, **instance_spec)
         instances = instance_response['Instances']
         instance_ids = [i['InstanceId'] for i in instances]
 
@@ -1338,6 +1339,20 @@ def ensure_present(existing_matches, changed, ec2, state):
         )
     except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as e:
         module.fail_json_aws(e, msg="Failed to create new EC2 instance")
+
+
+@AWSRetry.jittered_backoff()
+def run_instances(ec2, **instance_spec):
+    try:
+        return ec2.run_instances(**instance_spec)
+    except botocore.exceptions.ClientError as e:
+        if e.response['Error']['Code'] == 'InvalidParameterValue' and "Invalid IAM Instance Profile ARN" in e.response['Error']['Message']:
+            # If the instance profile has just been created, it takes some time to be visible by ec2
+            # So we wait 10 second and retry the run_instances
+            time.sleep(10)
+            return ec2.run_instances(**instance_spec)
+        else:
+            raise e
 
 
 def main():

--- a/test/integration/targets/ec2_instance/tasks/iam_instance_role.yml
+++ b/test/integration/targets/ec2_instance/tasks/iam_instance_role.yml
@@ -19,9 +19,6 @@
         <<: *aws_connection_info
       register: iam_role
 
-    - name: Wait for IAM role to be available, otherwise the next step will fail (Invalid IAM Instance Profile name)
-      command: sleep 10
-
     - name: Make instance with an instance_role
       ec2_instance:
         name: "{{ resource_prefix }}-test-default-vpc"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Following discussion on https://github.com/ansible/ansible/pull/37465#issuecomment-378283378

The current problem occurs when creating an instance with an iam role immediately after this role has been created in iam. It is not yet visible to ec2 when creating the instance.

This PR adds a retry to the `run_instance` method, with the matching error code and error message

Thanks to this fix, we were able to remove the *sleep* task in the integration test
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
ec2_instance

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6.0
```


