### PR TITLE
Slack Callback fix integration with stable-2.5

### DIFF
--- a/lib/ansible/plugins/callback/slack.py
+++ b/lib/ansible/plugins/callback/slack.py
@@ -152,7 +152,7 @@ class CallbackModule(CallbackBase):
                 invocation_items.append('Extra Vars: %s' %
                                         ' '.join(extra_vars))
 
-            title.append('by *%s*' % self.get_options('remote_user'))
+            title.append('by *%s*' % self.get_option('remote_user'))
 
         title.append('\n\n*%s*' % self.playbook_name)
         msg_items = [' '.join(title)]


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
`get_options` is an undefined method from CallbackBase

As a result, remove the trailing `s` letter.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
- slack callback plugin
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```

Relates to:  #38268
