### PR TITLE
Fixes to improve ios_system idempotency Fixes: #38301

### DIFF
--- a/lib/ansible/modules/network/ios/ios_system.py
+++ b/lib/ansible/modules/network/ios/ios_system.py
@@ -254,7 +254,7 @@ def parse_hostname(config):
 
 
 def parse_domain_name(config):
-    match = re.findall(r'^ip domain name (?:vrf (\S+) )*(\S+)', config, re.M)
+    match = re.findall(r'^ip domain[- ]name (?:vrf (\S+) )*(\S+)', config, re.M)
     matches = list()
     for vrf, name in match:
         if not vrf:
@@ -264,7 +264,7 @@ def parse_domain_name(config):
 
 
 def parse_domain_search(config):
-    match = re.findall(r'^ip domain list (?:vrf (\S+) )*(\S+)', config, re.M)
+    match = re.findall(r'^ip domain[- ]list (?:vrf (\S+) )*(\S+)', config, re.M)
     matches = list()
     for vrf, name in match:
         if not vrf:
@@ -285,7 +285,7 @@ def parse_name_servers(config):
 
 
 def parse_lookup_source(config):
-    match = re.search(r'ip domain lookup source-interface (\S+)', config, re.M)
+    match = re.search(r'ip domain[- ]lookup source-interface (\S+)', config, re.M)
     if match:
         return match.group(1)
 
@@ -297,7 +297,7 @@ def map_config_to_obj(module):
         'domain_name': parse_domain_name(config),
         'domain_search': parse_domain_search(config),
         'lookup_source': parse_lookup_source(config),
-        'lookup_enabled': 'no ip domain lookup' not in config,
+        'lookup_enabled': 'no ip domain lookup' not in config and 'no ip domain-lookup' not in config,
         'name_servers': parse_name_servers(config)
     }
 


### PR DESCRIPTION
Added detection of additional formatting for domain_name, domain_search,
lookup_source, and lookup_enabled on some software versions. In each
case they failed to detect existing commands with a '-' in it.

Fixes: #38301

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
IOS has multiple formats for specific commands, depending on the version, that were not considered in the ios_system module. 
ip domain name == ip domain-name
ip domain list == ip domain-list
ip domain lookup source-interface == ip domain-lookup source-interface
no ip domain lookup == no ip domain-lookup

I modified the regular expression for 3 of the above to allow either "-" or " ". for the fourth, I added a second check to align with the existing code which was not using a regular expression check. 

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
ios_system

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0
  config file = /nas/ansible/lab/ansible.cfg
  configured module search path = [u'/home/cisco/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Aug  4 2017, 00:39:18) [GCC 4.8.5 20150623 (Red Hat 4.8.5-16)]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
#### Test Plays
- name: Configure system domain details
  ios_system:
    domain_name: "test.mylab.com"
    lookup_source: "Vlan100"
    domain_search: "test.com"

- name: Configure system domain details again
  ios_system:
    domain_name: "test.mylab.com"
    lookup_source: "Vlan100"
    domain_search: "test.com"

- name: Configure system domain details
  ios_system:
    domain_name: "{{ domain_name }}"
    lookup_enabled: no

- name: Configure system domain details again
  ios_system:
    domain_name: "{{ domain_name }}"
    lookup_enabled: no

<!--- Paste verbatim command output below, e.g. before and after your change -->
#### Output
```
Before: 
PLAY [Enforce base Lab config] ****************************************************************************************************************************************************

TASK [ios_baseline_3850 : Configure system domain details] ************************************************************************************************************************
changed: [1.2.3.4] => {"changed": true, "commands": ["ip domain lookup source-interface Vlan100", "ip domain name test.mylab.com", "ip domain list test.com"]}

TASK [ios_baseline_3850 : Configure system domain details again] ******************************************************************************************************************
changed: [1.2.3.4] => {"changed": true, "commands": ["ip domain lookup source-interface Vlan100", "ip domain name test.mylab.com", "ip domain list test.com"]}

TASK [ios_baseline_3850 : Configure system domain details] ************************************************************************************************************************
changed: [1.2.3.4] => {"changed": true, "commands": ["no ip domain lookup", "ip domain name test.mylab.com"]}

TASK [ios_baseline_3850 : Configure system domain details again] ******************************************************************************************************************
changed: [1.2.3.4] => {"changed": true, "commands": ["no ip domain lookup", "ip domain name test.mylab.com"]}


After: 
PLAY [Enforce base Lab config] ****************************************************************************************************************************************************

TASK [ios_baseline_3850 : Configure system domain details] ************************************************************************************************************************
changed: [1.2.3.4] => {"changed": true, "commands": ["ip domain lookup source-interface Vlan100"]}

TASK [ios_baseline_3850 : Configure system domain details again] ******************************************************************************************************************
ok: [1.2.3.4] => {"changed": false, "commands": []}

TASK [ios_baseline_3850 : Configure system domain details] ************************************************************************************************************************
changed: [1.2.3.4] => {"changed": true, "commands": ["no ip domain lookup"]}

TASK [ios_baseline_3850 : Configure system domain details again] ******************************************************************************************************************
ok: [1.2.3.4] => {"changed": false, "commands": []}


```
