### PR TITLE
Fix openssl_certificate test for newer openssl.

### DIFF
--- a/test/integration/targets/openssl_certificate/tests/validate.yml
+++ b/test/integration/targets/openssl_certificate/tests/validate.yml
@@ -7,7 +7,7 @@
   register: cert_modulus
 
 - name: Validate certificate (test - issuer value)
-  shell: 'openssl x509 -noout  -in {{ output_dir}}/cert.pem -text | grep "Issuer" | sed "s/.*: \(.*\)/\1/g"'
+  shell: 'openssl x509 -noout  -in {{ output_dir}}/cert.pem -text | grep "Issuer" | sed "s/.*: \(.*\)/\1/g; s/ //g;"'
   register: cert_issuer
 
 


### PR DESCRIPTION
##### SUMMARY

Fix openssl_certificate test for newer openssl.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

openssl_certificate integration test

##### ANSIBLE VERSION

```
ansible 2.6.0 (test-fix 9367accaa9) last updated 2018/04/04 14:34:57 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
