### PR TITLE
Warn if a sequence type is passed when expecting str

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1848,9 +1848,9 @@ class AnsibleModule(object):
     def _check_type_str(self, value):
         if isinstance(value, string_types):
             return value
-        # Note: This could throw a unicode error if value's __str__() method
-        # returns non-ascii.  Have to port utils.to_bytes() if that happens
-        return str(value)
+        if isinstance(value, (list, dict)):
+            self.warn("Parameter value %s is expected to be string but was %s" % (value, value.__class__.__name__))
+        return to_native(value)
 
     def _check_type_list(self, value):
         if isinstance(value, list):


### PR DESCRIPTION
##### SUMMARY
`_check_type_str` happily converts all values to `str`.
More validation would be helpful to avoid errors when
accidentally passing the wrong thing.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
basic.py

##### ANSIBLE VERSION
```
ansible 2.6.0 (warn_on_complex_types 3902b60d97) last updated 2018/04/05 09:12:11 (GMT +1000)
  config file = None
  configured module search path = [u'/home/will/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/will/src/ansible/lib/ansible
  executable location = /home/will/src/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 14 2018, 13:36:31) [GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]
```


##### ADDITIONAL INFORMATION
Helps to avoid problems like #38233