### PR TITLE
Allow set_fact to update in a loop

### DIFF
--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -593,10 +593,13 @@ class TaskExecutor:
                     failed_when_result = False
                 return failed_when_result
 
-            if 'ansible_facts' in result and self._task.action not in ('set_fact', 'include_vars'):
+            if 'ansible_facts' in result:
                 vars_copy.update(namespace_facts(result['ansible_facts']))
                 if C.INJECT_FACTS_AS_VARS:
-                    vars_copy.update(clean_facts(result['ansible_facts']))
+                    if self._task.action not in ('set_fact', 'include_vars'):
+                        vars_copy.update(clean_facts(result['ansible_facts']))
+                    else:
+                        vars_copy.update(result['ansible_facts'])
 
             # set the failed property if it was missing.
             if 'failed' not in result:
@@ -651,10 +654,13 @@ class TaskExecutor:
         if self._task.register:
             variables[self._task.register] = wrap_var(result)
 
-        if 'ansible_facts' in result and self._task.action not in ('set_fact', 'include_vars'):
+        if 'ansible_facts' in result:
             variables.update(namespace_facts(result['ansible_facts']))
             if C.INJECT_FACTS_AS_VARS:
-                variables.update(clean_facts(result['ansible_facts']))
+                if self._task.action not in ('set_fact', 'include_vars'):
+                    variables.update(clean_facts(result['ansible_facts']))
+                else:
+                    variables.update(result['ansible_facts'])
 
         # save the notification target in the result, if it was specified, as
         # this task may be running in a loop in which case the notification

--- a/test/integration/targets/set_fact/runme.sh
+++ b/test/integration/targets/set_fact/runme.sh
@@ -11,3 +11,4 @@ ANSIBLE_CACHE_PLUGIN=jsonfile ANSIBLE_CACHE_PLUGIN_CONNECTION="${MYTMPDIR}" ansi
 
 ANSIBLE_CACHE_PLUGIN=jsonfile ANSIBLE_CACHE_PLUGIN_CONNECTION="${MYTMPDIR}" ansible-playbook -i ../../inventory --flush-cache "$@" set_fact_no_cache.yml
 
+ansible-playbook -i ../../inventory "$@" set_fact_loop.yml

--- a/test/integration/targets/set_fact/set_fact_loop.yml
+++ b/test/integration/targets/set_fact/set_fact_loop.yml
@@ -1,0 +1,44 @@
+---
+- name: Run set_fact loop tests
+  hosts: localhost
+  tasks:
+    - name: debug items
+      debug:
+        var: item
+      loop:
+        - a
+        - b
+        - "{{ does_not_exist|default() }}"
+      when: item != ""
+
+    - name: set_fact loop with list
+      set_fact:
+        list_of_items: "{{ (list_of_items|default([])) + [item] }}"
+      loop:
+        - a
+        - b
+        - "{{ does_not_exist|default() }}"
+      when: item != ""
+
+    - name: assert that list_of_items is correct
+      assert:
+        that:
+          - "list_of_items == ['a', 'b']"
+          - "list_of_items|length == 2"
+
+    - name: set_fact loop with dict
+      set_fact:
+        dict_of_items: "{{ (dict_of_items|default({})) | combine({item.key: item.value }) }}"
+      # no idea how to do this with `loop`
+      with_dict:
+        a: b
+        b: d
+        c: "{{ does_not_exist|default() }}"
+      when: item.value != ""
+
+    - name: assert that dict_of_items is correct
+      assert:
+        that:
+          - "'a' in dict_of_items and dict_of_items.a == 'b'"
+          - "'b' in dict_of_items and dict_of_items.b == 'd'"
+          - "dict_of_items|length == 2"


### PR DESCRIPTION
##### SUMMARY
set_fact should be able to repeatedly update a variable in a loop

Fixes #38075 
Adds tests to avoid future regressions

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
set_fact

##### ANSIBLE VERSION
```
ansible 2.6.0 (devel 1c7b9e66b4) last updated 2018/04/05 12:23:13 (GMT +1000)
  config file = None
  configured module search path = [u'/home/will/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/will/src/ansible/lib/ansible
  executable location = /home/will/src/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 14 2018, 13:36:31) [GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]
```


##### ADDITIONAL INFORMATION
If this isn't quite right (and I haven't tested it against the #37535 case), then please at least just cherry pick the commit containing just the test!