### PR TITLE
BACKPORT: ansible_password & ansible_ssh_pass are the ENV variable (#38035)

### DIFF
--- a/lib/ansible/plugins/connection/netconf.py
+++ b/lib/ansible/plugins/connection/netconf.py
@@ -67,7 +67,8 @@ options:
       - Configures the user password used to authenticate to the remote device
         when first establishing the SSH connection.
     vars:
-      - name: ansible_pass
+      - name: ansible_password
+      - name: ansible_ssh_pass
   private_key_file:
     description:
       - The private SSH key or certificate file used to to authenticate to the

--- a/lib/ansible/plugins/connection/network_cli.py
+++ b/lib/ansible/plugins/connection/network_cli.py
@@ -62,7 +62,8 @@ options:
       - Configures the user password used to authenticate to the remote device
         when first establishing the SSH connection.
     vars:
-      - name: ansible_pass
+      - name: ansible_password
+      - name: ansible_ssh_pass
   private_key_file:
     description:
       - The private SSH key or certificate file used to to authenticate to the


### PR DESCRIPTION
##### SUMMARY
* ansible_ssh_pass is the ENV variable

(cherry picked from commit a4e932ee9fa76b8a65736cfac22b9906da7e7634)



##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
