### PR TITLE
Add a 'finished' test for async jobs

### DIFF
--- a/test/integration/targets/async/tasks/main.yml
+++ b/test/integration/targets/async/tasks/main.yml
@@ -33,13 +33,14 @@
         - "'cmd' in async_result"
         - "'delta' in async_result"
         - "'end' in async_result"
-        - "'finished' in async_result or async_result.finished == 1"
         - "'rc' in async_result"
         - "'start' in async_result"
         - "'stderr' in async_result"
         - "'stdout' in async_result"
         - "'stdout_lines' in async_result"
-        - "async_result.rc == 0"
+        - async_result.rc == 0
+        - async_result.finished == 1
+        - async_result is finished
 
 - name: test async without polling
   command: sleep 5
@@ -54,7 +55,8 @@
     that:
         - "'ansible_job_id' in async_result"
         - "'started' in async_result"
-        - "'finished' not in async_result or async_result.finished == 0"
+        - async_result.finished == 0
+        - async_result is not finished
 
 - name: test skipped task handling
   command: /bin/true
@@ -79,7 +81,7 @@
 - name: 'check on task started as a "fire-and-forget"'
   async_status: jid={{ fnf_task.ansible_job_id }}
   register: fnf_result
-  until: fnf_result.finished
+  until: fnf_result is finished
   retries: 10
   delay: 1
 
@@ -87,6 +89,7 @@
   assert:
     that:
     - fnf_result.finished
+    - fnf_result is finished
 
 - name: test graceful module failure
   async_test:
@@ -101,7 +104,8 @@
     that:
     - async_result.ansible_job_id is match('\d+\.\d+')
     - async_result.finished == 1
-    - async_result is changed == false
+    - async_result is finished
+    - async_result is not changed
     - async_result is failed
     - async_result.msg == 'failed gracefully'
 
@@ -118,8 +122,11 @@
     that:
     - async_result.ansible_job_id is match('\d+\.\d+')
     - async_result.finished == 1
+    - async_result is finished
     - async_result.changed == false
-    - async_result is failed == true
+    - async_result is not changed
+    - async_result.failed == true
+    - async_result is failed
     - async_result.stderr is search('failing via exception', multiline=True)
 
 - name: test leading junk before JSON
@@ -134,7 +141,9 @@
     that:
     - async_result.ansible_job_id is match('\d+\.\d+')
     - async_result.finished == 1
+    - async_result is finished
     - async_result.changed == true
+    - async_result is changed
     - async_result is successful
 
 - name: test trailing junk after JSON
@@ -149,6 +158,21 @@
     that:
     - async_result.ansible_job_id is match('\d+\.\d+')
     - async_result.finished == 1
+    - async_result is finished
     - async_result.changed == true
+    - async_result is changed
     - async_result is successful
     - async_result.warnings[0] is search('trailing junk after module output')
+
+# NOTE: This should report a warning that cannot be tested
+- name: test async properties on non-async task
+  command: sleep 1
+  register: non_async_result
+
+- name: validate response
+  assert:
+    that:
+    - non_async_result is successful
+    - non_async_result is changed
+    - non_async_result is finished
+    - "'ansible_job_id' not in non_async_result"


### PR DESCRIPTION
##### SUMMARY
This provides a more convenient way for testing (async) jobs.

When used with a non-async job it will report a warning so the user is
aware that he may be doing something incorrect.

Since the 'finished' result value is an integer (!), the test is turning
this in a proper boolean. Both these tests would never finish successfully.
```yaml
until: job.finished == true
until: job.finished == false
```
As it requires this:
```yaml
until: job.finished == 1
```

But now this works as expected
```yaml
until: job is finished
```

PS I don't think it makes sense to also add a `finished` filter, as we want to move to tests for everything.
PS2 I would prefer to backport this it is also available in newer v2.5 (and possibly v2.4) releases. Just so we can recommend using this instead.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
core

##### ANSIBLE VERSION
v2.6