### PR TITLE
Fixes #38318 changed the -D to --one-database for import

### DIFF
--- a/lib/ansible/modules/database/mysql/mysql_db.py
+++ b/lib/ansible/modules/database/mysql/mysql_db.py
@@ -265,7 +265,7 @@ def db_import(module, host, user, password, db_name, target, all_databases, port
         cmd.append("--host=%s" % shlex_quote(host))
         cmd.append("--port=%i" % port)
     if not all_databases:
-        cmd.append("-D")
+        cmd.append("--one-database")
         cmd.append(shlex_quote(''.join(db_name)))
 
     comp_prog_path = None


### PR DESCRIPTION


##### SUMMARY

Fixes #38318 - The mysql_db module needs to use the --one-database flag for imports

The import option does not limit the import to a single database if you specified a single database.  It will always change all databases that are specified in the import.

Changed ```lib/ansible/modules/database/mysql/mysql_db.py```

The mysql_db module is using the mysql -D flag (--database), which only specifies the database to target:

https://dev.mysql.com/doc/refman/5.7/en/mysql-command-options.html#option_mysql_database

>     --database=db_name, -D db_name
> 
>     The database to use. This is useful primarily in an option file.
> 

Instead of the --one-database option:

https://dev.mysql.com/doc/refman/5.7/en/mysql-command-options.html#option_mysql_one-database

>     --one-database, -o
> 
>     Ignore statements except those that occur while the default database is the one named on the command line. This option is rudimentary and should be used with care. Statement filtering is based only on USE statements.
> 
> 
>     Initially, mysql executes statements in the input because specifying a database db_name on the command line is equivalent to inserting USE db_name at the beginning of the input. Then, for each USE statement encountered, mysql accepts or rejects following statements depending on whether the database named is the one on the command line. The content of the statements is immaterial.
> 

