### PR TITLE
abs test overwrites built-in jinja2 abs filter

### DIFF
--- a/lib/ansible/plugins/test/files.py
+++ b/lib/ansible/plugins/test/files.py
@@ -40,7 +40,6 @@ class TestModule(object):
 
             # path testing
             'is_abs': isabs,
-            'abs': isabs,
             'is_same_file': samefile,
             'same_file': samefile,
             'is_mount': ismount,


### PR DESCRIPTION
The abs test for absolute paths overwrites the built-in Jinja2 abs
filter, preventing the absolute value of numbers from being taken and
breaking existing code which makes use of the absolute value filter.

##### SUMMARY
The abs test for absolute paths overwrites the built-in Jinja2 abs
filter, preventing the absolute value of numbers from being taken and
breaking existing code which makes use of the absolute value filter.

##### ISSUE TYPE
Bugfix Pull Request

##### COMPONENT NAME
abs test

##### ANSIBLE VERSION
affects 2.5.0 and devel


##### ADDITIONAL INFORMATION

ansible -m debug -a 'msg="{{ -4 | abs }}"' localhost

localhost | FAILED! => {
    "msg": "Unexpected templating type error occurred on ({{ -4 | abs }}): expected str, bytes or os.PathLike object, not int"

