### PR TITLE
Fix rpm_key test on Fedora 27.

### DIFF
--- a/test/integration/targets/rpm_key/tasks/rpm_key.yaml
+++ b/test/integration/targets/rpm_key/tasks/rpm_key.yaml
@@ -47,7 +47,7 @@
 - name: confirm that signature check failed
   assert:
     that:
-      - "'MISSING KEYS' in sl_check.stdout"
+      - "'MISSING KEYS' in sl_check.stdout or 'SIGNATURES NOT OK' in sl_check.stdout"
       - "sl_check.failed"
 
 - name: remove EPEL GPG key from keyring (idempotent)
@@ -91,7 +91,7 @@
 
 - name: confirm that signature check succeeded
   assert:
-    that: "'rsa sha1 (md5) pgp md5 OK' in sl_check.stdout"
+    that: "'rsa sha1 (md5) pgp md5 OK' in sl_check.stdout or 'digests signatures OK' in sl_check.stdout"
 
 - name: remove GPG key from url
   rpm_key:
@@ -106,7 +106,7 @@
 - name: confirm that signature check failed
   assert:
     that:
-      - "'MISSING KEYS' in sl_check.stdout"
+      - "'MISSING KEYS' in sl_check.stdout or 'SIGNATURES NOT OK' in sl_check.stdout"
       - "sl_check.failed"
 
 - name: add GPG key from url
@@ -120,7 +120,7 @@
 
 - name: confirm that signature check succeeded
   assert:
-    that: "'rsa sha1 (md5) pgp md5 OK' in sl_check.stdout"
+    that: "'rsa sha1 (md5) pgp md5 OK' in sl_check.stdout or 'digests signatures OK' in sl_check.stdout"
 
 - name: remove all keys from key ring
   shell: "rpm -q  gpg-pubkey | xargs rpm -e"
@@ -136,7 +136,7 @@
 
 - name: confirm that signature check succeeded
   assert:
-    that: "'rsa sha1 (md5) pgp md5 OK' in sl_check.stdout"
+    that: "'rsa sha1 (md5) pgp md5 OK' in sl_check.stdout or 'digests signatures OK' in sl_check.stdout"
 
 #
 # Cleanup


### PR DESCRIPTION
##### SUMMARY

Fix rpm_key test on Fedora 27.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

rpm_key integration test

##### ANSIBLE VERSION

```
ansible 2.6.0 (test-fix 8a63999cf1) last updated 2018/04/05 08:29:57 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
