### PR TITLE
Replace the hard-coded temp path in gunicorn module

### DIFF
--- a/lib/ansible/modules/web_infrastructure/gunicorn.py
+++ b/lib/ansible/modules/web_infrastructure/gunicorn.py
@@ -130,14 +130,6 @@ def main():
         'user': '-u',
     }
 
-    # temporary files in case no option provided
-    tmp_error_log = '/tmp/gunicorn.temp.error.log'
-    tmp_pid_file = '/tmp/gunicorn.temp.pid'
-
-    # remove temp file if exists
-    remove_tmp_file(tmp_pid_file)
-    remove_tmp_file(tmp_error_log)
-
     module = AnsibleModule(
         argument_spec=dict(
             app=dict(required=True, type='str', aliases=['name']),
@@ -152,6 +144,14 @@ def main():
                         ),
         )
     )
+
+    # temporary files in case no option provided
+    tmp_error_log = os.path.join(module.tmpdir, 'gunicorn.temp.error.log')
+    tmp_pid_file = os.path.join(module.tmpdir, 'gunicorn.temp.pid')
+
+    # remove temp file if exists
+    remove_tmp_file(tmp_pid_file)
+    remove_tmp_file(tmp_error_log)
 
     # obtain app name and venv
     params = module.params


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
The gunicorn module has a hard-coded reference to '/tmp' which may
or may not be the actual temp directory for an operating system.

This patch replaces '/tmp' with module.tmpdir which should
resolve to the correct temp directory for the OS.

Fixes Issue #36953

Signed-off-by: Eric Brown <browne@vmware.com>
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
https://github.com/ansible/ansible/blob/devel/lib/ansible/modules/web_infrastructure/gunicorn.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0
  config file = None
  configured module search path = [u'/Users/browne/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Library/Python/2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.10 (default, Feb  7 2017, 00:08:15) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.34)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
