### PR TITLE
Fix documentation for aws_ssm and aws_ssm_parameter_store

### DIFF
--- a/lib/ansible/modules/cloud/amazon/aws_ssm_parameter_store.py
+++ b/lib/ansible/modules/cloud/amazon/aws_ssm_parameter_store.py
@@ -105,8 +105,8 @@ EXAMPLES = '''
     value: "Test1234"
     overwrite_value: "always"
 
-- name: recommend to use with ssm lookup plugin
-  debug: msg="{{ lookup('ssm', 'hello') }}"
+- name: recommend to use with aws_ssm lookup plugin
+  debug: msg="{{ lookup('aws_ssm', 'hello') }}"
 '''
 
 RETURN = '''

--- a/lib/ansible/plugins/lookup/aws_ssm.py
+++ b/lib/ansible/plugins/lookup/aws_ssm.py
@@ -19,7 +19,7 @@ requirements:
   - botocore
 short_description: Get the value for a SSM parameter or all parameters under a path.
 description:
-  - Get the value for an Amazon Simple Systems Manager parameter or a heirarchy of parameters.
+  - Get the value for an Amazon Simple Systems Manager parameter or a hierarchy of parameters.
     The first argument you pass the lookup can either be a parameter name or a hierarchy of
     parameters. Hierarchies start with a forward slash and end with the parameter name. Up to
     5 layers may be specified.
@@ -62,16 +62,16 @@ EXAMPLES = '''
   debug: msg="{{ lookup('aws_ssm', 'Hello' ) }}"
 
 - name: lookup ssm parameter store in nominated region
-  debug: msg="{{ lookup('aws_ssm', 'Hello', region=us-east-2 ) }}"
+  debug: msg="{{ lookup('aws_ssm', 'Hello', region='us-east-2' ) }}"
 
 - name: lookup ssm parameter store without decrypted
   debug: msg="{{ lookup('aws_ssm', 'Hello', decrypt=False ) }}"
 
 - name: lookup ssm parameter store in nominated aws profile
-  debug: msg="{{ lookup('aws_ssm', 'Hello', aws_profile=myprofile ) }}"
+  debug: msg="{{ lookup('aws_ssm', 'Hello', aws_profile='myprofile' ) }}"
 
 - name: lookup ssm parameter store with all options.
-  debug: msg="{{ lookup('aws_ssm', 'Hello', decrypt=false, region=us-east-2, aws_profile=myprofile') }}"
+  debug: msg="{{ lookup('aws_ssm', 'Hello', decrypt=false, region='us-east-2', aws_profile='myprofile') }}"
 
 - name: lookup a key which doesn't exist, returns ""
   debug: msg="{{ lookup('aws_ssm', 'NoKey') }}"
@@ -88,10 +88,10 @@ EXAMPLES = '''
   debug: msg="{{ "the secret was:" ~ temp_secret | default('couldn\'t access secret') }}"
 
 - name: return a dictionary of ssm parameters from a hierarchy path
-  debug: msg="{{ lookup('aws_ssm', '/PATH/to/params', region=ap-southeast-2, bypath=true, recursive=true' ) }}"
+  debug: msg="{{ lookup('aws_ssm', '/PATH/to/params', region='ap-southeast-2', bypath=true, recursive=true ) }}"
 
 - name: return a dictionary of ssm parameters from a hierarchy path with shortened names (param instead of /PATH/to/param)
-  debug: msg="{{ lookup('aws_ssm', '/PATH/to/params', region=ap-southeast-2, shortnames=true, bypath=true, recursive=true ) }}"
+  debug: msg="{{ lookup('aws_ssm', '/PATH/to/params', region='ap-southeast-2', shortnames=true, bypath=true, recursive=true ) }}"
 
 - name: Iterate over a parameter hierarchy
   debug: msg='key contains {{item.Name}} with value {{item.Value}} '


### PR DESCRIPTION
label: docsite_pr

##### SUMMARY

As I read the `aws_ssm` lookup plugin and the `aws_ssm_parameter_store` module documentations, I spot a few typos. This PR is about those simple fixes in the examples.


##### ISSUE TYPE

 - Docs Pull Request

##### COMPONENT NAME

- aws_ssm lookup plugin
- aws_ssm_parameter_store module

##### ANSIBLE VERSION
```
ansible 2.5.0
  config file = None
  configured module search path = [u'/home/sebastien/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.13 (default, Nov 24 2017, 17:33:09) [GCC 6.3.0 20170516]
```

