### PR TITLE
Subversion: checking out with existing content

### DIFF
--- a/lib/ansible/modules/source_control/subversion.py
+++ b/lib/ansible/modules/source_control/subversion.py
@@ -50,6 +50,7 @@ options:
         svn checkout --force; if force is specified then existing files with different content are reverted
     type: bool
     default: "no"
+    version_added: "2.6"
   username:
     description:
       - C(--username) parameter passed to svn.

--- a/lib/ansible/modules/source_control/subversion.py
+++ b/lib/ansible/modules/source_control/subversion.py
@@ -44,6 +44,12 @@ options:
         Prior to 1.9 the default was C(yes).
     type: bool
     default: "no"
+  in_place:
+    description:
+      - If the directory exists, then the working copy will be checked-out over-the-top using
+        svn checkout --force; if force is specified then existing files with different content are reverted
+    type: bool
+    default: "no"
   username:
     description:
       - C(--username) parameter passed to svn.
@@ -140,9 +146,13 @@ class Subversion(object):
         rc = self._exec(["info", self.dest], check_rc=False)
         return rc == 0
 
-    def checkout(self):
+    def checkout(self, force=False):
         '''Creates new svn working directory if it does not already exist.'''
-        self._exec(["checkout", "-r", self.revision, self.repo, self.dest])
+        cmd = ["checkout"]
+        if force:
+            cmd.append("--force")
+        cmd.extend(["-r", self.revision, self.repo, self.dest])
+        self._exec(cmd)
 
     def export(self, force=False):
         '''Export svn repo to directory'''
@@ -214,6 +224,7 @@ def main():
             checkout=dict(type='bool', default=True),
             update=dict(type='bool', default=True),
             switch=dict(type='bool', default=True),
+            in_place=dict(type='bool', default=False),
         ),
         supports_check_mode=True,
     )
@@ -229,6 +240,7 @@ def main():
     switch = module.params['switch']
     checkout = module.params['checkout']
     update = module.params['update']
+    in_place = module.params['in_place']
 
     # We screenscrape a huge amount of svn commands so use C locale anytime we
     # call run_command()
@@ -271,6 +283,12 @@ def main():
             else:
                 module.fail_json(msg="ERROR: modified files exist in the repository.")
         svn.update()
+    elif in_place:
+        before = None
+        svn.checkout(force=True)
+        local_mods = svn.has_local_mods()
+        if local_mods and force:
+            svn.revert()
     else:
         module.fail_json(msg="ERROR: %s folder already exists, but its not a subversion repository." % (dest,))
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

If the directory exists, we want the ability to checkout into it and use the content as existing files; equivalent to `svn checkout --force`

This forms part of our workflow for quite a few things (we keep `/etc/nagios` in subversion for example and check it out on servers; yet when the package is installed it creates default config which we want to replace).


I was expecting the force option to do this, however I understand why it doesn't do that currently. I was debating with changing the meaning of force to include this behaviour, however I've opted for a seperate flag for now for backwards compatibility. This does mean that config with `force: no` and `in_place: yes` is potentially non-idempotent in the situation where an existing file has differing content from the working copy as the `in_place` checkout will succeed, yet the next playbook run will fail due to modified files.


<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
Subversion

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.3.1.0
  config file =
  configured module search path = Default w/o overrides
  python version = 2.7.9 (default, Jun 29 2016, 13:08:31) [GCC 4.9.2]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
