### PR TITLE
azure: fix creation of TXT dns record sets

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_dnsrecordset.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_dnsrecordset.py
@@ -211,7 +211,7 @@ RECORD_ARGSPECS = dict(
         target=dict(type='str', required=True, aliases=['entry'])
     ),
     TXT=dict(
-        value=dict(type='str', required=True, aliases=['entry'])
+        value=dict(type='list', required=True, aliases=['entry'])
     ),
     # FUTURE: ensure all record types are supported (see https://github.com/Azure/azure-sdk-for-python/tree/master/azure-mgmt-dns/azure/mgmt/dns/models)
 )
@@ -375,7 +375,11 @@ class AzureRMRecordSet(AzureRMModuleBase):
 def gethash(self):
     if not getattr(self, '_cachedhash', None):
         spec = inspect.getargspec(self.__init__)
-        valuetuple = tuple([getattr(self, x, None) for x in spec.args if x != 'self'])
+        valuetuple = tuple(
+            map(lambda v: v if not isinstance(v, list) else str(v), [
+                getattr(self, x, None) for x in spec.args if x != 'self'
+            ])
+        )
         self._cachedhash = hash(valuetuple)
     return self._cachedhash
 

--- a/test/integration/targets/azure_rm_dnsrecordset/tasks/main.yml
+++ b/test/integration/targets/azure_rm_dnsrecordset/tasks/main.yml
@@ -158,6 +158,26 @@
     that: 
       - results.changed
 
+- name: create TXT records in a new record set
+  azure_rm_dnsrecordset:
+    resource_group: "{{ resource_group }}"
+    relative_name: "_txt.{{ domain_name }}.com"
+    zone_name: "{{ domain_name }}.com"
+    record_type: TXT
+    state: present
+    records:
+      - entry: "v=spf1 a -all"
+      - entry: "foo"
+      - entry:
+          - "bar"
+          - "baz"
+  register: results
+
+- name: Assert that TXT record set was created
+  assert:
+    that:
+      - results.changed
+
 - name: Delete DNS zone
   azure_rm_dnszone:
     resource_group: "{{ resource_group }}"


### PR DESCRIPTION
##### SUMMARY
As per `azure.mgmt.dns.models.txt_record.TxtRecord`, expected value for a
record is of type `[str]`. Fix TXT argspec to specify type as `list`
instead of `str`.

Fixes #37581 

Reference: https://docs.microsoft.com/en-us/python/api/azure.mgmt.dns.models.txtrecord?view=azure-python

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
azure.azure_rm_dnsrecordset

##### ANSIBLE VERSION
```
ansible 2.5.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/abn/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.14 (default, Mar 14 2018, 13:36:31) [GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]
```

##### ADDITIONAL INFORMATION
N/A