### PR TITLE
synchronize module: Default rsync_opts to empty list

### DIFF
--- a/lib/ansible/modules/files/synchronize.py
+++ b/lib/ansible/modules/files/synchronize.py
@@ -366,7 +366,7 @@ def main():
             group=dict(type='bool'),
             set_remote_user=dict(type='bool', default=True),
             rsync_timeout=dict(type='int', default=0),
-            rsync_opts=dict(type='list'),
+            rsync_opts=dict(type='list', default=[]),
             ssh_args=dict(type='str'),
             partial=dict(type='bool', default=False),
             verify_host=dict(type='bool', default=False),


### PR DESCRIPTION
##### SUMMARY
Ensure that if rsync_opts is not set, it defaults to an empty list rather than `None`.

Otherwise python fails when it tries to iterate over `None`.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
synchronize
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0 (devel 79c5a34b0b) last updated 2018/04/06 16:49:43 (GMT +1000)
  config file = None
  configured module search path = [u'/home/will/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/will/src/ansible/lib/ansible
  executable location = /home/will/src/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 14 2018, 13:36:31) [GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]
```
