### PR TITLE
Add fail_dependency to make troubleshooting easier

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -2309,6 +2309,13 @@ class AnsibleModule(object):
         self._return_formatted(kwargs)
         sys.exit(0)
 
+    def fail_dependency(self, msg):
+        ''' This is for reporting back failed dependencies along with the python executable
+        currently being used being.
+        '''
+
+        self.fail_json(msg=msg, python_executable=sys.executable)
+
     def fail_json(self, **kwargs):
         ''' return from the module, with an error message '''
 

--- a/lib/ansible/modules/net_tools/snmp_facts.py
+++ b/lib/ansible/modules/net_tools/snmp_facts.py
@@ -199,7 +199,7 @@ def main():
     m_args = module.params
 
     if not has_pysnmp:
-        module.fail_json(msg='Missing required pysnmp module (check docs)')
+        module.fail_dependency(msg='Missing required pysnmp module (check docs)')
 
     cmdGen = cmdgen.CommandGenerator()
 


### PR DESCRIPTION


##### SUMMARY
Some modules require Python packages which aren't installed by default,
on systems with multiple versions of Python it isn't always clear for
people which version of Python is actually executing the code. Mostly
this can be solved by setting the ansible_python_interpreter variable.

However, I think this would make it much easier for people to figure
out what the problem actually is.

##### ISSUE TYPE
 - Feature Pull Request


##### ANSIBLE VERSION
```
ansible 2.6.0 (fail_dependency 7dbce2e17e) last updated 2018/04/06 09:53:46 (GMT +200)
  config file = None
  configured module search path = [u'/Users/patrick/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/patrick/src/forks/ansible/lib/ansible
  executable location = /Users/patrick/src/forks/ansible/bin/ansible
  python version = 2.7.14 (default, Sep 25 2017, 09:53:22) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.37)]
```

@gundalow, we spoke about this a year ago or so. I keep getting questions about problems related to this. Would be nice to have this or something similar in place.