### PR TITLE
Backport/2.5/37287  Eos :do not push config to device if check_mode is enabled

### DIFF
--- a/changelogs/fragments/36980-eos_check_mode_without_config_session.yaml
+++ b/changelogs/fragments/36980-eos_check_mode_without_config_session.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- EOS can not check configuration without use of config session (ANSIBLE_EOS_USE_SESSIONS=0). Fix is to throw error when hiting into this exception case. Configs would neither be checked nor be played on the eos device.

--- a/test/integration/targets/eos_config/tests/cli/check_mode.yaml
+++ b/test/integration/targets/eos_config/tests/cli/check_mode.yaml
@@ -37,4 +37,33 @@
    that:
      - "config.session not in result.stdout[0].sessions"
 
+- name: invalid configuration in check mode + no config session
+  eos_config:
+     lines:
+         - ip address 119.31.1.1 255.255.255.256
+     parents: interface Loopback911
+  check_mode: 1
+  environment:
+    ANSIBLE_EOS_USE_SESSIONS: 0
+  register: result
+  ignore_errors: yes
+
+- assert:
+   that:
+   - "result.changed == true"
+
+- name: valid configuration in check mode + no config session
+  eos_config:
+     lines:
+         - ip address 119.31.1.1 255.255.255.255
+     parents: interface Loopback911
+  check_mode: yes
+  register: result
+  environment:
+    ANSIBLE_EOS_USE_SESSIONS: 0
+
+- assert:
+   that:
+   - "result.changed == true"
+
 - debug: msg="END cli/check_mode.yaml on connection={{ ansible_connection }}"


### PR DESCRIPTION
Backport/2.5/37287  Eos :do not push config to device if check_mode is enabled