### PR TITLE
Update bigip_configsync_action.py

### DIFF
--- a/lib/ansible/modules/network/f5/bigip_configsync_action.py
+++ b/lib/ansible/modules/network/f5/bigip_configsync_action.py
@@ -62,7 +62,7 @@ author:
 
 EXAMPLES = r'''
 - name: Sync configuration from device to group
-  bigip_configsync_actions:
+  bigip_configsync_action:
     device_group: foo-group
     sync_device_to_group: yes
     server: lb.mydomain.com
@@ -72,7 +72,7 @@ EXAMPLES = r'''
   delegate_to: localhost
 
 - name: Sync configuration from most recent device to the current host
-  bigip_configsync_actions:
+  bigip_configsync_action:
     device_group: foo-group
     sync_most_recent_to_device: yes
     server: lb.mydomain.com
@@ -82,7 +82,7 @@ EXAMPLES = r'''
   delegate_to: localhost
 
 - name: Perform an initial sync of a device to a new device group
-  bigip_configsync_actions:
+  bigip_configsync_action:
     device_group: new-device-group
     sync_device_to_group: yes
     server: lb.mydomain.com


### PR DESCRIPTION
In Ansible 2.5 the module is renamed to bigip_configsync_action instead of bigip_configsync_actions. I updated the examples. 

 label: docsite_pr

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
bigip_configsync_action

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
10:39 $ ansible --version
ansible 2.5.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
In Ansible 2.5 the module is renamed to bigip_configsync_action instead of bigip_configsync_actions. I updated the examples. 
```
