### PR TITLE
openssl_certificate: Handle dump() in check_mode

### DIFF
--- a/lib/ansible/modules/crypto/openssl_certificate.py
+++ b/lib/ansible/modules/crypto/openssl_certificate.py
@@ -423,6 +423,7 @@ class SelfSignedCertificate(Certificate):
         self.notAfter = module.params['selfsigned_notAfter']
         self.digest = module.params['selfsigned_digest']
         self.version = module.params['selfsigned_version']
+        self.serial_number = randint(1000, 99999)
         self.csr = crypto_utils.load_certificate_request(self.csr_path)
         self.privatekey = crypto_utils.load_privatekey(
             self.privatekey_path, self.privatekey_passphrase
@@ -442,7 +443,7 @@ class SelfSignedCertificate(Certificate):
 
         if not self.check(module, perms_required=False) or self.force:
             cert = crypto.X509()
-            cert.set_serial_number(randint(1000, 99999))
+            cert.set_serial_number(self.serial_number)
             if self.notBefore:
                 cert.set_notBefore(self.notBefore)
             else:
@@ -474,17 +475,29 @@ class SelfSignedCertificate(Certificate):
         if module.set_fs_attributes_if_different(file_args, False):
             self.changed = True
 
-    def dump(self):
+    def dump(self, check_mode=False):
 
         result = {
             'changed': self.changed,
             'filename': self.path,
             'privatekey': self.privatekey_path,
-            'csr': self.csr_path,
-            'notBefore': self.cert.get_notBefore(),
-            'notAfter': self.cert.get_notAfter(),
-            'serial_number': self.cert.get_serial_number(),
+            'csr': self.csr_path
         }
+
+        if check_mode:
+            now = datetime.datetime.utcnow()
+            ten = now.replace(now.year + 10)
+            result.update({
+                'notBefore': self.notBefore if self.notBefore else now.strftime("%Y%m%d%H%M%SZ"),
+                'notAfter': self.notAfter if self.notAfter else ten.strftime("%Y%m%d%H%M%SZ"),
+                'serial_number': self.serial_number,
+            })
+        else:
+            result.update({
+                'notBefore': self.cert.get_notBefore(),
+                'notAfter': self.cert.get_notAfter(),
+                'serial_number': self.cert.get_serial_number(),
+            })
 
         return result
 
@@ -708,7 +721,7 @@ class AssertOnlyCertificate(Certificate):
 
         return parent_check and assertonly_check
 
-    def dump(self):
+    def dump(self, check_mode=False):
 
         result = {
             'changed': self.changed,
@@ -773,7 +786,7 @@ class AcmeCertificate(Certificate):
         if module.set_fs_attributes_if_different(file_args, False):
             self.changed = True
 
-    def dump(self):
+    def dump(self, check_mode=False):
 
         result = {
             'changed': self.changed,
@@ -859,7 +872,7 @@ def main():
     if module.params['state'] == 'present':
 
         if module.check_mode:
-            result = certificate.dump()
+            result = certificate.dump(check_mode=True)
             result['changed'] = module.params['force'] or not certificate.check(module)
             module.exit_json(**result)
 
@@ -870,7 +883,7 @@ def main():
     else:
 
         if module.check_mode:
-            result = certificate.dump()
+            result = certificate.dump(check_mode=True)
             result['changed'] = os.path.exists(module.params['path'])
             module.exit_json(**result)
 

--- a/test/integration/targets/openssl_certificate/tasks/main.yml
+++ b/test/integration/targets/openssl_certificate/tasks/main.yml
@@ -28,6 +28,15 @@
         selfsigned_digest: sha256
       register: selfsigned_certificate_idempotence
 
+    - name: Generate selfsigned certificate (check mode)
+      openssl_certificate:
+        path: '{{ output_dir }}/cert.pem'
+        csr_path: '{{ output_dir }}/csr.csr'
+        privatekey_path: '{{ output_dir }}/privatekey.pem'
+        provider: selfsigned
+        selfsigned_digest: sha256
+      check_mode: yes
+
     - name: Check selfsigned certificate
       openssl_certificate:
         path: '{{ output_dir }}/cert.pem'


### PR DESCRIPTION
##### SUMMARY

Currently, when ones run the module in check_mode it tries to retrieve
values from the actual certificate generated in the generate() function.

Since in check_mode we call dump() without calling generate(), self.cert
is None, leading to self.cert.get_notBefore(), self.cert.get_notAfter()
and self.cert.get_serial_number() raising an error.

>  NoneType' object has no attribute 'get_notBefore'

The solution is to have two way to handle dump() method, whether its run
in check_mode=True or check_mode=False leading to different way the
information is retrieved.

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

 - openssl_certificate

##### ANSIBLE VERSION

 - devel

##### ADDITIONAL INFORMATION

Fixes: https://github.com/ansible/ansible/issues/37867