### PR TITLE
Fix deprecated warnings

### DIFF
--- a/lib/ansible/modules/monitoring/grafana_dashboard.py
+++ b/lib/ansible/modules/monitoring/grafana_dashboard.py
@@ -103,11 +103,12 @@ slug:
   sample: foo
 '''
 
-import base64
 import json
-import os
+import base64
+
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.urls import fetch_url
+from ansible.module_utils._text import to_bytes
 
 __metaclass__ = type
 
@@ -162,7 +163,7 @@ def grafana_create_dashboard(module, data):
     if 'grafana_api_key' in data and data['grafana_api_key']:
         headers['Authorization'] = "Bearer %s" % data['grafana_api_key']
     else:
-        auth = base64.encodestring('%s:%s' % (data['grafana_user'], data['grafana_password'])).replace('\n', '')
+        auth = base64.b64encode(to_bytes('%s:%s' % (data['grafana_user'], data['grafana_password'])).replace('\n', ''))
         headers['Authorization'] = 'Basic %s' % auth
         grafana_switch_organisation(module, data['grafana_url'], data['org_id'], headers)
 
@@ -220,7 +221,7 @@ def grafana_delete_dashboard(module, data):
     if 'grafana_api_key' in data and data['grafana_api_key']:
         headers['Authorization'] = "Bearer %s" % data['grafana_api_key']
     else:
-        auth = base64.encodestring('%s:%s' % (data['grafana_user'], data['grafana_password'])).replace('\n', '')
+        auth = base64.b64encode(to_bytes('%s:%s' % (data['grafana_user'], data['grafana_password'])).replace('\n', ''))
         headers['Authorization'] = 'Basic %s' % auth
         grafana_switch_organisation(module, data['grafana_url'], data['org_id'], headers)
 
@@ -253,7 +254,7 @@ def grafana_export_dashboard(module, data):
     if 'grafana_api_key' in data and data['grafana_api_key']:
         headers['Authorization'] = "Bearer %s" % data['grafana_api_key']
     else:
-        auth = base64.encodestring('%s:%s' % (data['grafana_user'], data['grafana_password'])).replace('\n', '')
+        auth = base64.b64encode(to_bytes('%s:%s' % (data['grafana_user'], data['grafana_password'])).replace('\n', ''))
         headers['Authorization'] = 'Basic %s' % auth
         grafana_switch_organisation(module, data['grafana_url'], data['org_id'], headers)
 

--- a/lib/ansible/modules/monitoring/grafana_datasource.py
+++ b/lib/ansible/modules/monitoring/grafana_datasource.py
@@ -249,11 +249,12 @@ after:
         "withCredentials": false }
 '''
 
-import base64
 import json
-import os
+import base64
+
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.urls import fetch_url
+from ansible.module_utils._text import to_bytes
 
 __metaclass__ = type
 
@@ -362,7 +363,7 @@ def grafana_create_datasource(module, data):
     if 'grafana_api_key' in data and data['grafana_api_key'] is not None:
         headers['Authorization'] = "Bearer %s" % data['grafana_api_key']
     else:
-        auth = base64.encodestring('%s:%s' % (data['grafana_user'], data['grafana_password'])).replace('\n', '')
+        auth = base64.b64encode(to_bytes('%s:%s' % (data['grafana_user'], data['grafana_password'])).replace('\n', ''))
         headers['Authorization'] = 'Basic %s' % auth
         grafana_switch_organisation(module, data['grafana_url'], data['org_id'], headers)
 
@@ -422,7 +423,7 @@ def grafana_delete_datasource(module, data):
     if 'grafana_api_key' in data and data['grafana_api_key']:
         headers['Authorization'] = "Bearer %s" % data['grafana_api_key']
     else:
-        auth = base64.encodestring('%s:%s' % (data['grafana_user'], data['grafana_password'])).replace('\n', '')
+        auth = base64.b64encode(to_bytes('%s:%s' % (data['grafana_user'], data['grafana_password'])).replace('\n', ''))
         headers['Authorization'] = 'Basic %s' % auth
         grafana_switch_organisation(module, data['grafana_url'], data['org_id'], headers)
 

--- a/lib/ansible/modules/monitoring/pagerduty.py
+++ b/lib/ansible/modules/monitoring/pagerduty.py
@@ -134,19 +134,20 @@ EXAMPLES = '''
     service: '{{ pd_window.result.maintenance_window.id }}'
 '''
 
-import base64
 import datetime
 import json
+import base64
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.urls import fetch_url
+from ansible.module_utils._text import to_bytes
 
 
 def auth_header(user, passwd, token):
     if token:
         return "Token token=%s" % token
 
-    auth = base64.encodestring('%s:%s' % (user, passwd)).replace('\n', '')
+    auth = base64.b64encode(to_bytes('%s:%s' % (user, passwd)).replace('\n', ''))
     return "Basic %s" % auth
 
 

--- a/lib/ansible/modules/network/citrix/_netscaler.py
+++ b/lib/ansible/modules/network/citrix/_netscaler.py
@@ -88,14 +88,14 @@ EXAMPLES = '''
     action: disable
 '''
 
-import base64
 import json
 import socket
 import traceback
+import base64
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six.moves.urllib.parse import urlencode
-from ansible.module_utils._text import to_native
+from ansible.module_utils._text import to_native, to_bytes
 from ansible.module_utils.urls import fetch_url
 
 
@@ -115,7 +115,7 @@ class netscaler(object):
         if not len(data_json):
             data_json = None
 
-        auth = base64.encodestring('%s:%s' % (self._nsc_user, self._nsc_pass)).replace('\n', '').strip()
+        auth = base64.b64encode(to_bytes('%s:%s' % (self._nsc_user, self._nsc_pass)).replace('\n', '').strip())
         headers = {
             'Authorization': 'Basic %s' % auth,
             'Content-Type': 'application/x-www-form-urlencoded',

--- a/lib/ansible/modules/source_control/github_hooks.py
+++ b/lib/ansible/modules/source_control/github_hooks.py
@@ -80,15 +80,16 @@ EXAMPLES = '''
   delegate_to: localhost
 '''
 
-import base64
 import json
+import base64
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.urls import fetch_url
+from ansible.module_utils._text import to_bytes
 
 
 def request(module, url, user, oauthkey, data='', method='GET'):
-    auth = base64.encodestring('%s:%s' % (user, oauthkey)).replace('\n', '')
+    auth = base64.b64encode(to_bytes('%s:%s' % (user, oauthkey)).replace('\n', ''))
     headers = {
         'Authorization': 'Basic %s' % auth,
     }


### PR DESCRIPTION
##### SUMMARY

- `base64.encodestring` is deprecated. https://docs.python.org/3/library/base64.html#base64.encodestring 

##### ISSUE TYPE

 - Bugfix Pull Request

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
$ ansible --version
ansible 2.6.0 (fix_deprecated cbdae1b688) last updated 2018/04/06 11:13:21 (GMT +200)
  config file = None
  configured module search path = [u'/Users/sieben/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/sieben/workspace/ansible/lib/ansible
  executable location = /Users/sieben/workspace/ansible/bin/ansible
  python version = 2.7.14 (default, Mar  9 2018, 23:57:12) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
