### PR TITLE
Add ssh_connection retries to ansible.cfg example

### DIFF
--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -406,6 +406,11 @@
 # requires a tty by default. 
 #use_tty = True
 
+# Number of times to retry an SSH connection to a host, in case of UNREACHABLE.
+# For each retry attempt, there is an exponential backoff,
+# so after the first attempt there is 1s wait, then 2s, 4s etc. up to 30s (max).
+#retries = 3
+
 [persistent_connection]
 
 # Configures the persistent connection timeout value in seconds.  This value is


### PR DESCRIPTION
I add the `retries` option under [ssh_connection] as it was missing, and
some brief comments on the backoff logic.

##### SUMMARY
Change example ansible.cfg file to add ssh_connection `retries` parameter

##### ISSUE TYPE

 - Docs Pull Request

##### COMPONENT NAME
core

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.3.0
  config file = /Users/mralph/o2/infra-priority-stack/ansible/ansible.cfg
  configured module search path = [u'/Users/mralph/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/Cellar/ansible/2.4.3.0_4/libexec/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.14 (default, Mar 14 2018, 09:56:25) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```


##### ADDITIONAL INFORMATION
After change, ansible.cfg will have `retries` documented