### PR TITLE
Add "Interface" endpoint types to ec2_vpc_endpoint module

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_endpoint.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_endpoint.py
@@ -80,6 +80,10 @@ options:
     description:
       - One or more vpc endpoint ids to remove from the AWS account
     required: false
+  vpc_endpoint_type:
+    description:
+      - One of "Gateway" or "Interface". The default is "Gateway".
+    required: false
   client_token:
     description:
       - Optional client token to ensure idempotency
@@ -245,6 +249,10 @@ def create_vpc_endpoint(client, module):
     params['ServiceName'] = module.params.get('service')
     params['DryRun'] = module.check_mode
 
+    params['VpcEndpointType'] = module.params.get('vpc_endpoint_type')
+    if not params['VpcEndpointType']:
+        params['VpcEndpointType'] = "Gateway"
+
     if module.params.get('route_table_ids'):
         params['RouteTableIds'] = module.params.get('route_table_ids')
 
@@ -337,6 +345,7 @@ def main():
             wait_timeout=dict(type='int', default=320, required=False),
             route_table_ids=dict(type='list'),
             vpc_endpoint_id=dict(),
+            vpc_endpoint_type=dict(),
             client_token=dict(),
         )
     )

--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_endpoint.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_endpoint.py
@@ -76,6 +76,14 @@ options:
         is added to the route table with the destination of the endpoint if
         provided.
     required: false
+  subnet_ids:
+    description:
+      - List of one or more subnet ids to attach to the endpoint.
+    required: false
+  security_group_ids:
+    description:
+      - List of one or more security group ids to attach to the endpoint.
+    required: false
   vpc_endpoint_id:
     description:
       - One or more vpc endpoint ids to remove from the AWS account
@@ -256,6 +264,12 @@ def create_vpc_endpoint(client, module):
     if module.params.get('route_table_ids'):
         params['RouteTableIds'] = module.params.get('route_table_ids')
 
+    if module.params.get('subnet_ids'):
+        params['SubnetIds'] = module.params.get('subnet_ids')
+
+    if module.params.get('security_group_ids'):
+        params['SecurityGroupIds'] = module.params.get('security_group_ids')
+
     if module.params.get('client_token'):
         token_provided = True
         request_time = datetime.datetime.utcnow()
@@ -344,6 +358,8 @@ def main():
             wait=dict(type='bool', default=False),
             wait_timeout=dict(type='int', default=320, required=False),
             route_table_ids=dict(type='list'),
+            subnet_ids=dict(type='list'),
+            security_group_ids=dict(type='list'),
             vpc_endpoint_id=dict(),
             vpc_endpoint_type=dict(),
             client_token=dict(),

--- a/test/integration/targets/ec2_vpc_route_table/tasks/main.yml
+++ b/test/integration/targets/ec2_vpc_route_table/tasks/main.yml
@@ -582,10 +582,26 @@
       that:
         - endpoint_details.vpc_endpoints[0].route_table_ids[0] == recreate_private_table.route_table.route_table_id
 
+  - name: create a Kinesis VPC endpoint
+    ec2_vpc_endpoint:
+      state: present
+      vpc_id: "{{ vpc.vpc.id }}"
+      service: "com.amazonaws.{{ aws_region }}.kinesis-streams"
+      <<: *aws_connection_info
+    register: kinesis_vpc_endpoint
+
   always:
   #############################################################################
   # TEAR DOWN STARTS HERE
   #############################################################################
+  - name: remove the Kinesis VPC endpoint
+    ec2_vpc_endpoint:
+      state: absent
+      vpc_endpoint_id: "{{ kinesis_vpc_endpoint.result.vpc_endpoint_id }}"
+      <<: *aws_connection_info
+    when: kinesis_vpc_endpoint is defined
+    ignore_errors: yes
+
   - name: remove the VPC endpoint
     ec2_vpc_endpoint:
       state: absent


### PR DESCRIPTION
##### SUMMARY

The ec2_vpc_endpoint module can only create "Gateway" type endpoints.  Services
like Kinesis are "Interface" type endpoints.  This change adds support for
"Interface" endpoints.


##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME

  ec2_vpc_endpoint

<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
# ansible --version
ansible 2.5.0
  config file = /work/ansible/ansible.cfg
  configured module search path = ['u/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /work/venv/ansible/lib/python2.7/site-packages/ansible
  executable location = /work/venv/ansible/bin/ansible
  python version = 2.7.14 (default, Sep 25 2017, 09:53:22) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.37)]
#
```

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
# ansible-playbook endpoint-resources.yml

PLAY [Create resources] ********************************************************************

TASK [Collect VPC route table ids] ***************************************************************************
ok: [localhost]

TASK [Create Dynamo endpoint] ********************************************************************************
changed: [localhost]

# Won't work without this change.
TASK [Create Kinesis endpoint] *******************************************************************************
changed: [localhost]

PLAY RECAP ***************************************************************************************************
localhost                  : ok=3    changed=2    unreachable=0    failed=0

#
```