### PR TITLE
Improved performance for single host case

### DIFF
--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -313,7 +313,11 @@ class StrategyBase:
 
                     worker_prc = WorkerProcess(self._final_q, task_vars, host, task, play_context, self._loader, self._variable_manager, shared_loader_obj)
                     self._workers[self._cur_worker][0] = worker_prc
-                    worker_prc.start()
+                    if len(self._workers) > 1:
+                        worker_prc.start()
+                    else:
+                        # this hack bypasses the forking of a sub-process if there is only one worker; reduces the execution time
+                        worker_prc.run()
                     display.debug("worker is %d (out of %d available)" % (self._cur_worker + 1, len(self._workers)))
                     queued = True
                 self._cur_worker += 1


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
As long as there is only one host to reach (eg localhost), the task queue contains only one worker; hence, it is not necessary to detach a sub-process to handle the task in the background (since the only thing to do in the meantime is to wait until the queue is drained).
In such situation, one can easily save the time needed to fork the sub-process. It may constitutes a saving of several seconds on a playbook containing hundreds of tasks (especially if many of them are skipped).
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request