### PR TITLE
make aef test more predictable

### DIFF
--- a/test/integration/targets/any_errors_fatal/aliases
+++ b/test/integration/targets/any_errors_fatal/aliases
@@ -1,0 +1,1 @@
+posix/ci/group3

--- a/test/integration/targets/any_errors_fatal/on_includes.yml
+++ b/test/integration/targets/any_errors_fatal/on_includes.yml
@@ -1,9 +1,7 @@
 ---
 # based on https://github.com/ansible/ansible/issues/22924
 - name: Test any errors fatal
-  hosts: testhost
+  hosts: testhost,testhost2
   any_errors_fatal: True
   tasks:
      - include: test_fatal.yml
-       #  tags:
-       #   - any_errors_fatal_includes

--- a/test/integration/targets/any_errors_fatal/test_fatal.yml
+++ b/test/integration/targets/any_errors_fatal/test_fatal.yml
@@ -2,10 +2,11 @@
 - name: Setting the fact for 'test' to 'test value'
   set_fact:
     test: "test value"
-  when: "inventory_hostname == groups.all.0"
+  when: inventory_hostname == 'testhost2'
 
-- name: EXPECTED FAILURE echo jinja eval of a var that should not exist
-  shell: "echo {{ test }}"
+- name: EXPECTED FAILURE ejinja eval of a var that should not exist
+  debug: msg="{{ test }}"
 
-- debug:
+- name: testhost should never reach here as testhost2 failure above should end play
+  debug:
     msg: "any_errors_fatal_this_should_never_be_reached"


### PR DESCRIPTION
##### SUMMARY

also revert "Disable any_errors_fatal test."
This reverts commit 56189cc312ab1907ac91c7eac30620c4f9f21546.

fixes #38407



<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
test
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6
```