### PR TITLE
docker: Allow publishing of ports with the same number but different protocol

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -1019,6 +1019,8 @@ class TaskParameters(DockerBaseClass):
                     protocol = 'tcp'
                     port = int(publish_port)
                 for exposed_port in exposed:
+                    if exposed_port[1] != protocol:
+                        continue
                     if isinstance(exposed_port[0], string_types) and '-' in exposed_port[0]:
                         start_port, end_port = exposed_port[0].split('-')
                         if int(start_port) <= port <= int(end_port):
@@ -1210,7 +1212,7 @@ class Container(DockerBaseClass):
 
         # "ExposedPorts": null returns None type & causes AttributeError - PR #5517
         if config.get('ExposedPorts') is not None:
-            expected_exposed = [re.sub(r'/.+$', '', p) for p in config.get('ExposedPorts', dict()).keys()]
+            expected_exposed = [self._normalize_port(p) for p in config.get('ExposedPorts', dict()).keys()]
         else:
             expected_exposed = []
 
@@ -1625,10 +1627,10 @@ class Container(DockerBaseClass):
         self.log('_get_expected_exposed')
         image_ports = []
         if image:
-            image_ports = [re.sub(r'/.+$', '', p) for p in (image['ContainerConfig'].get('ExposedPorts') or {}).keys()]
+            image_ports = [self._normalize_port(p) for p in (image['ContainerConfig'].get('ExposedPorts') or {}).keys()]
         param_ports = []
         if self.parameters.ports:
-            param_ports = [str(p[0]) for p in self.parameters.ports]
+            param_ports = [str(p[0]) + '/' + p[1] for p in self.parameters.ports]
         result = list(set(image_ports + param_ports))
         self.log(result, pretty_print=True)
         return result
@@ -1668,6 +1670,11 @@ class Container(DockerBaseClass):
         for key, value in getattr(self.parameters, param_name).items():
             results.append("%s%s%s" % (key, join_with, value))
         return results
+
+    def _normalize_port(self, port):
+        if '/' not in port:
+            return port + '/tcp'
+        return port
 
 
 class ContainerManager(DockerBaseClass):

--- a/test/units/modules/cloud/docker/test_docker_container.py
+++ b/test/units/modules/cloud/docker/test_docker_container.py
@@ -1,0 +1,19 @@
+import unittest
+
+from ansible.modules.cloud.docker.docker_container import TaskParameters
+
+
+class TestTaskParameters(unittest.TestCase):
+    """Unit tests for TaskParameters."""
+
+    def test_parse_exposed_ports_tcp_udp(self):
+        """
+        Ensure _parse_exposed_ports does not cancel ports with the same
+        number but different protocol.
+        """
+        task_params = TaskParameters.__new__(TaskParameters)
+        task_params.exposed_ports = None
+        result = task_params._parse_exposed_ports([80, '443', '443/udp'])
+        self.assertTrue((80, 'tcp') in result)
+        self.assertTrue((443, 'tcp') in result)
+        self.assertTrue((443, 'udp') in result)


### PR DESCRIPTION
##### SUMMARY

This change fixes an issue where the `docker_container` module does not publish a `udp` port if a `tcp` port of the same number has already been defined. The existing logic to make sure ports are not exposed twice did not take protocol into account when checking for duplicate exposed ports.

In addition, this change also causes `docker_container` to compare the full `PORT/PROTOCOL` string, as opposed to only `PORT` when deciding if a container's configuration has changed.

Fixes #27367

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
`ansible.modules.cloud.docker.docker_container`

##### ANSIBLE VERSION

```
ansible 2.6.0
  config file = None
  configured module search path = ['/home/sharp/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python3.6/dist-packages/ansible-2.6.0-py3.6.egg/ansible
  executable location = /usr/local/bin/ansible
  python version = 3.6.3 (default, Oct  3 2017, 21:45:48) [GCC 7.2.0]
```


##### ADDITIONAL INFORMATION

Example configuration below. QUIC is a protocol enabled over UDP port 443.
```
- name: Create caddy container with QUIC enabled
  docker_container:
    name: caddy-quic
    image: yourfavoritecaddyrepo/caddy
    command: ["-quic", "--conf", "/etc/caddy/Caddyfile", "--log", "stdout"]
    published_ports:
      - "80:80"
      - "443:443"
      - "443:443/udp"
    volumes:
      - "/etc/caddy/:/etc/caddy/:ro"
```
