### PR TITLE
The ssh change note has been removed

### DIFF
--- a/docs/docsite/rst/scenario_guides/guide_rax.rst
+++ b/docs/docsite/rst/scenario_guides/guide_rax.rst
@@ -123,8 +123,6 @@ Here's what it would look like in a playbook, assuming the parameters were defin
 
 The rax module returns data about the nodes it creates, like IP addresses, hostnames, and login passwords.  By registering the return value of the step, it is possible used this data to dynamically add the resulting hosts to inventory (temporarily, in memory). This facilitates performing configuration actions on the hosts in a follow-on task.  In the following example, the servers that were successfully created using the above task are dynamically added to a group called "raxhosts", with each nodes hostname, IP address, and root password being added to the inventory.
 
-.. include:: ../rst_common/ansible_ssh_changes_note.rst
-
 .. code-block:: yaml
 
     - name: Add the instances we created (by public IP) to the group 'raxhosts'


### PR DESCRIPTION
Since the note was about 2.0 versus 1.x, this has been removed.  The
file implementing it is gone so we need to stop referencing it.


##### ISSUE TYPE
 - Bugfix Pull Request
 - Docs Pull Request

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel 2.5
```
