### PR TITLE
Allow filtering of instances by labels in GCE dynamic inventory #38391

### DIFF
--- a/contrib/inventory/gce.ini
+++ b/contrib/inventory/gce.ini
@@ -54,6 +54,9 @@ gce_zone =
 # example: Uncomment to only return inventory with the http-server or https-server tag
 #instance_tags = http-server,https-server
 
+# Filter inventory based on instance labels. Leave undefined to return instances regardless of labels.
+# example: Uncomment to only return inventory with the {"env": "dev", "type": "webserver"} label.
+#instance_labels = type_webserver,env_dev
 
 [inventory]
 # The 'inventory_ip_type' parameter specifies whether 'ansible_ssh_host' should

--- a/contrib/inventory/gce.py
+++ b/contrib/inventory/gce.py
@@ -517,13 +517,15 @@ class GceInventory(object):
                 else:
                     groups[tag] = [name]
 
+            # Skip grouping node by labels if node doesn't have any labels
             labels = node.extra['labels']
-            for lab_key, lab_value in labels.items():
-                label = 'label_%s_%s' % (lab_key, lab_value)
-                if label in groups:
-                    groups[label].append(name)
-                else:
-                    groups[label] = [name]
+            if labels is not None:
+                for lab_key, lab_value in labels.items():
+                    label = 'label_%s_%s' % (lab_key, lab_value)
+                    if label in groups:
+                        groups[label].append(name)
+                    else:
+                        groups[label] = [name]
 
             net = node.extra['networkInterfaces'][0]['network'].split('/')[-1]
             net = 'network_%s' % net


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Parameter ``--instance-labels`` allows to filter instances by labels. It's possible to use multiple labels separated by ",". 
The same labels can be used in playbooks.
Key:Value should be used as key_value.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
gce.py
gce.ini

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0
  config file = None
  configured module search path = [u'/home/ubuntu/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/ubuntu/.local/lib/python2.7/site-packages/ansible
  executable location = /home/ubuntu/.local/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Requires ``apache-libcloud 2.3.0``
```
/gce.py --list --instance-labels env_dev --pretty
{
  "10.132.0.3": [
    "cassandra-test-2"
  ],
,...
        "gce_image": "ubuntu-1604-xenial-v20180222",
        "gce_labels": {
          "env": "stage",
          "name": "db2",
          "type": "database"
        },
...
  "g1-small": [
    "cassandra-test-2"
  ],
  "label_env_stage": [
    "cassandra-test-2"
  ],
  "label_name_db2": [
    "cassandra-test-2"
  ],
  "label_type_database": [
    "cassandra-test-2"
  ],
```
