### PR TITLE
Update call method for parse_cli_textfsm

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters.rst
@@ -461,7 +461,7 @@ The network filters also support parsing the output of a CLI command using the
 TextFSM library.  To parse the CLI output with TextFSM use the following
 filter::
 
-  {{ output | parse_cli_textfsm('path/to/fsm') }}
+  {{ output.stdout[0] | parse_cli_textfsm('path/to/fsm') }}
 
 Use of the TextFSM filter requires the TextFSM library to be installed.
 


### PR DESCRIPTION
+label: docsite_pr

##### SUMMARY
Call parse_cli_textfsm with the stdout[0] subset of "output" so existing TextFSM templates work without further modification.


##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
User guide

##### ANSIBLE VERSION
```
ansible 2.5.0
```