### PR TITLE
firewalld: fix AttributeError: 'AnsibleModule' object has no attribute 'fail'

### DIFF
--- a/lib/ansible/modules/system/firewalld.py
+++ b/lib/ansible/modules/system/firewalld.py
@@ -829,7 +829,7 @@ def main():
 
     # Verify required params are provided
     if immediate and fw_offline:
-        module.fail(msg='firewall is not currently running, unable to perform immediate actions without a running firewall daemon')
+        module.fail_json(msg='firewall is not currently running, unable to perform immediate actions without a running firewall daemon')
 
     changed = False
     msgs = []


### PR DESCRIPTION
##### SUMMARY

```
Error was:
  File "/tmp/ansible_qY_BMb/ansible_module_firewalld.py", line 703, in <module>
    main()
  File "/tmp/ansible_qY_BMb/ansible_module_firewalld.py", line 548, in main
    module.fail(msg='firewall is not currently running, unable to perform immediate actions without a running firewall daemon')
AttributeError: 'AnsibleModule' object has no attribute 'fail'
```

Should be backported in 2.5.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
firewalld

##### ANSIBLE VERSION
```
ansible 2.6.0 (devel a8953fcac4) last updated 2018/04/07 19:18:31 (GMT +200)
```