### PR TITLE
lvg: don't fail if an unknown physical device is encountered

### DIFF
--- a/lib/ansible/modules/system/lvg.py
+++ b/lib/ansible/modules/system/lvg.py
@@ -158,7 +158,12 @@ def main():
 
         # get pv list
         pvs_cmd = module.get_bin_path('pvs', True)
-        rc, current_pvs, err = module.run_command("%s --noheadings -o pv_name,vg_name --separator ';'" % pvs_cmd)
+        if dev_list:
+            pvs_filter = ' || '. join(['pv_name = {0}'.format(x) for x in dev_list])
+            pvs_filter = "--select '%s'" % pvs_filter
+        else:
+            pvs_filter = ''
+        rc, current_pvs, err = module.run_command("%s --noheadings -o pv_name,vg_name --separator ';' %s" % (pvs_cmd, pvs_filter))
         if rc != 0:
             module.fail_json(msg="Failed executing pvs command.", rc=rc, err=err)
 


### PR DESCRIPTION
##### SUMMARY

Physical devices are listed using `pvs` command. Then, for `/dev/dm-*` devices `dmsetup` command is used to find `pv_name`.
An error occurs when `pvs` command list an unknown device:
```
{
  "changed": false,
  "err": "Device dm-0 not found\nCommand failed\n",
  "msg": "Failed executing dmsetup command.",
  "rc": 1
}
```

This failure can be avoided when the unknown device isn't used in module parameter 'pvs'.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lvg

##### ANSIBLE VERSION
```
ansible 2.6.0 (devel d1d15dd025) last updated 2018/04/08 02:28:45 (GMT +200)
```

##### ADDITIONAL INFORMATION
Output of `pvs` and `dmsetup` commands:
```
$ pvs --noheadings -o pv_name,vg_name --separator ';'
  /dev/dm-0;vg_var
  /dev/mapper/sdb3_backups;vg_data_backups
$ dmsetup info -C --noheadings -o name /dev/dm-0
Device dm-0 not found
```