### PR TITLE
manageiq_provider: don't send top-level null fields on creation

### DIFF
--- a/lib/ansible/modules/remote_management/manageiq/manageiq_provider.py
+++ b/lib/ansible/modules/remote_management/manageiq/manageiq_provider.py
@@ -745,24 +745,24 @@ class ManageIQProvider(object):
         # clean nulls, we do not send nulls to the api
         endpoints = delete_nulls(endpoints)
 
+        resource = dict(
+            name=name,
+            zone={'id': zone_id},
+            provider_region=provider_region,
+            host_default_vnc_port_start=host_default_vnc_port_start,
+            host_default_vnc_port_end=host_default_vnc_port_end,
+            subscription=subscription,
+            project=project,
+            uid_ems=uid_ems,
+            tenant_mapping_enabled=tenant_mapping_enabled,
+            api_version=api_version,
+            connection_configurations=endpoints,
+        )
+
         # try to create a new provider
         try:
             url = '%s/providers' % (self.api_url)
-            result = self.client.post(
-                url,
-                name=name,
-                type=supported_providers()[provider_type]['class_name'],
-                zone={'id': zone_id},
-                provider_region=provider_region,
-                host_default_vnc_port_start=host_default_vnc_port_start,
-                host_default_vnc_port_end=host_default_vnc_port_end,
-                subscription=subscription,
-                project=project,
-                uid_ems=uid_ems,
-                tenant_mapping_enabled=tenant_mapping_enabled,
-                api_version=api_version,
-                connection_configurations=endpoints,
-            )
+            result = self.client.post(url, type=supported_providers()[provider_type]['class_name'], **resource)
         except Exception as e:
             self.module.fail_json(msg="failed to create provider %s: %s" % (name, str(e)))
 

--- a/lib/ansible/modules/remote_management/manageiq/manageiq_provider.py
+++ b/lib/ansible/modules/remote_management/manageiq/manageiq_provider.py
@@ -694,7 +694,7 @@ class ManageIQProvider(object):
     def edit_provider(self, provider, name, provider_type, endpoints, zone_id, provider_region,
                       host_default_vnc_port_start, host_default_vnc_port_end,
                       subscription, project, uid_ems, tenant_mapping_enabled, api_version):
-        """ Edit a user from manageiq.
+        """ Edit a provider from manageiq.
 
         Returns:
             a short message describing the operation executed.
@@ -737,11 +737,10 @@ class ManageIQProvider(object):
     def create_provider(self, name, provider_type, endpoints, zone_id, provider_region,
                         host_default_vnc_port_start, host_default_vnc_port_end,
                         subscription, project, uid_ems, tenant_mapping_enabled, api_version):
-        """ Creates the user in manageiq.
+        """ Creates the provider in manageiq.
 
         Returns:
-            the created user id, name, created_on timestamp,
-            updated_on timestamp, userid and current_group_id.
+            a short message describing the operation executed.
         """
         # clean nulls, we do not send nulls to the api
         endpoints = delete_nulls(endpoints)

--- a/lib/ansible/modules/remote_management/manageiq/manageiq_provider.py
+++ b/lib/ansible/modules/remote_management/manageiq/manageiq_provider.py
@@ -742,9 +742,6 @@ class ManageIQProvider(object):
         Returns:
             a short message describing the operation executed.
         """
-        # clean nulls, we do not send nulls to the api
-        endpoints = delete_nulls(endpoints)
-
         resource = dict(
             name=name,
             zone={'id': zone_id},
@@ -758,6 +755,9 @@ class ManageIQProvider(object):
             api_version=api_version,
             connection_configurations=endpoints,
         )
+
+        # clean nulls, we do not send nulls to the api
+        resource = delete_nulls(resource)
 
         # try to create a new provider
         try:


### PR DESCRIPTION
##### SUMMARY
Fixes #38331.
Generally, it's safer not to send unnecessary nulls to manageiq API.
We were mostly omitting them, except top-level ones in provider creation. Specifically, openshift provider creation has been broken since #35043 by sending `api_version` field.

Also started refactoring that I promised @snecklifter, but for easier review only doing minimum necessary here, will followup with separate refactoring PR.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
`manageiq_provider` module.

##### ADDITIONAL INFORMATION
Recommend reviewing by commits, see commit messages for explanation of the fix.

Before:
```
fatal: [localhost]: FAILED! => {"changed": false, "msg": "failed to create provider cben2-master001.10.35.48.6.cmio.eng.lab.tlv.redhat.com: Api::BadRequestError: Could not create the new provider - OpenShift api_version cannot be modified"}
```
After:
```
ok: [localhost] => {
    "result": {
        "changed": true,
        "failed": false,
        "msg": "successfully created the provider cben2-master001.10.35.48.6.cmio.eng.lab.tlv.redhat.com: [{u'name': u'cben2-master001.10.35.48.6.cmio.eng.lab.tlv.redhat.com', u'tenant_id': u'1', u'enabled': True, u'tenant_mapping_enabled': False, u'created_on': u'2018-04-08T14:10:29Z', u'href': u'http://localhost:3000/api/providers/4', u'updated_on': u'2018-04-08T14:10:29Z', u'guid': u'cbe03394-d434-4d7d-aece-b8a42dddce19', u'type': u'ManageIQ::Providers::Openshift::ContainerManager', u'id': u'4', u'api_version': u'v1', u'zone_id': u'1'}]"
    }
}
```