### PR TITLE
Clarifications of parameters in yum_repo module

### DIFF
--- a/lib/ansible/modules/packaging/os/yum_repository.py
+++ b/lib/ansible/modules/packaging/os/yum_repository.py
@@ -68,7 +68,7 @@ options:
     default: 75
   description:
     description:
-      - A human readable string describing the repository. Note that it corresponds to the "name" parameter in the yum repo file.
+      - A human readable string describing the repository. This option corresponds to the "name" property in the repo file.
       - This parameter is only required if I(state) is set to C(present).
   enabled:
     description:
@@ -200,7 +200,7 @@ options:
     default: 21600
   name:
     description:
-      - Unique repository ID. In relation to the yum file, it's the ID of the section of the repository
+      - Unique repository ID. This option builds the section name of the repository in the .ini repo file.
       - This parameter is only required if I(state) is set to C(present) or
         C(absent).
     required: true

--- a/lib/ansible/modules/packaging/os/yum_repository.py
+++ b/lib/ansible/modules/packaging/os/yum_repository.py
@@ -68,7 +68,7 @@ options:
     default: 75
   description:
     description:
-      - A human readable string describing the repository.
+      - A human readable string describing the repository. Note that it corresponds to the "name" parameter in the yum repo file.
       - This parameter is only required if I(state) is set to C(present).
   enabled:
     description:
@@ -200,7 +200,7 @@ options:
     default: 21600
   name:
     description:
-      - Unique repository ID.
+      - Unique repository ID. In relation to the yum file, it's the ID of the section of the repository
       - This parameter is only required if I(state) is set to C(present) or
         C(absent).
     required: true

--- a/lib/ansible/modules/packaging/os/yum_repository.py
+++ b/lib/ansible/modules/packaging/os/yum_repository.py
@@ -200,7 +200,7 @@ options:
     default: 21600
   name:
     description:
-      - Unique repository ID. This option builds the section name of the repository in the .ini repo file.
+      - Unique repository ID. This option builds the section name of the repository in the repo file.
       - This parameter is only required if I(state) is set to C(present) or
         C(absent).
     required: true


### PR DESCRIPTION
Added a note defining where the "name" parameter of the module will appear in the repo file and note explaining that the description parameter of the module is actually the name parameter in the repo file. It might help people transform their existing yum repository files in ansible managed repos.
+label: docsite_pr

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
yum_repository module

##### ANSIBLE VERSION
```
ansible 2.4.2.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.6/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.6.6 (r266:84292, Aug 18 2016, 15:13:37) [GCC 4.4.7 20120313 (Red Hat 4.4.7-17)]
```