### PR TITLE
Add "modularity" support to the DNF ansible module.

### DIFF
--- a/lib/ansible/modules/packaging/os/dnf.py
+++ b/lib/ansible/modules/packaging/os/dnf.py
@@ -645,11 +645,11 @@ def main():
     _ensure_dnf(module)
 
     if params['modularity'] is not None:
-        global __modularity
-        if __modularity_available and params['modularity']:
-            __modularity = True
+        global _modularity
+        if _modularity_available and params['modularity']:
+            _modularity = True
         else:
-            __modularity = False
+            _modularity = False
 
     # Check if autoremove is called correctly
     if params['autoremove'] is not None:

--- a/lib/ansible/modules/packaging/os/dnf.py
+++ b/lib/ansible/modules/packaging/os/dnf.py
@@ -193,6 +193,7 @@ _modularity = _modularity_available
 # Needed for the FIXUP code
 import fnmatch
 
+
 def _ensure_dnf(module):
     if not HAS_DNF:
         if PY2:
@@ -321,11 +322,9 @@ def _mark_package_install(module, base, pkg_spec):
         module.fail_json(msg="No package {0} available.".format(pkg_spec))
 
 
-
 # FIXME: This is because the DNF API seem to just abort inside hawkey with
 #        various input. Including things like installed modules passed to
 #        install. This is all bad.
-
 
 def _mod_match_profiles(prefix, profiles, ui):
     if fnmatch.fnmatch(prefix, ui):

--- a/lib/ansible/modules/packaging/os/dnf.py
+++ b/lib/ansible/modules/packaging/os/dnf.py
@@ -612,6 +612,11 @@ def ensure(module, base, state, names, autoremove):
         for package in base.transaction.remove_set:
             response['results'].append("Removed: {0}".format(package))
 
+        # We need to do this so that DNF writes the files into modules.d
+        # generic ansible shutdown doesn't always trigger the correct things.
+        base.close()
+        del base
+
         if failures:
             module.fail_json(msg='Failed to install some of the '
                                  'specified packages',


### PR DESCRIPTION
##### SUMMARY
Add "modularity" support to the DNF ansible module.

Allows the user to install/remove/upgrade/enable/disable Fedora modules.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
modules/packaging/os/dnf

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0
```


##### ADDITIONAL INFORMATION
This should be reviewed by @ignatenkobrain as he owns the module.