### PR TITLE
Improve deprecation message for ec2_vpc_dhcp_options modules

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_dhcp_option.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_dhcp_option.py
@@ -274,6 +274,11 @@ def main():
     )
 
     module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
+    if module._name == 'ec2_vpc_dhcp_options':
+        module.deprecate("The 'ec2_vpc_dhcp_options' module has been renamed "
+                         "'ec2_vpc_dhcp_option' (option is no longer plural)",
+                         version=2.8)
+
     params = module.params
     found = False
     changed = False

--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_dhcp_option_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_dhcp_option_facts.py
@@ -126,6 +126,10 @@ def main():
 
     module = AnsibleModule(argument_spec=argument_spec,
                            supports_check_mode=True)
+    if module._name == 'ec2_vpc_dhcp_options_facts':
+        module.deprecate("The 'ec2_vpc_dhcp_options_facts' module has been renamed "
+                         "'ec2_vpc_dhcp_option_facts' (option is no longer plural)",
+                         version=2.8)
 
     # Validate Requirements
     if not HAS_BOTO3:


### PR DESCRIPTION
##### SUMMARY
Make it clear to user why ec2_vpc_dhcp_options and
ec2_vpc_dhcp_options_facts have been deprecated

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
ec2_vpc_dhcp_option

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0 (devel 8bc7af2e34) last updated 2018/04/09 08:13:05 (GMT +1000)
  config file = None
  configured module search path = [u'/home/will/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/will/src/ansible/lib/ansible
  executable location = /home/will/src/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 14 2018, 13:36:31) [GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]

```


##### ADDITIONAL INFORMATION

Before
```
[DEPRECATION WARNING]: ec2_vpc_dhcp_options is kept for backwards compatibility but 
usage is discouraged. The module documentation details page may explain 
more about this rationale.. This feature will be removed in a future release. 
Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
```

(the module documentation page does not explain any more about this rationale at all)

After
```
[DEPRECATION WARNING]: The 'ec2_vpc_dhcp_options_facts' module has been renamed
'ec2_vpc_dhcp_option_facts' (option is no longer plural). This feature will 
be removed in version 2.8. Deprecation warnings can be disabled by setting
deprecation_warnings=False in ansible.cfg.
```
