### PR TITLE
Fix junos transport check

### DIFF
--- a/lib/ansible/plugins/action/junos.py
+++ b/lib/ansible/plugins/action/junos.py
@@ -57,8 +57,7 @@ class ActionModule(_ActionModule):
             pc.network_os = 'junos'
             pc.remote_addr = provider['host'] or self._play_context.remote_addr
 
-            if (provider['transport'] == 'cli' and self._task.action not in CLI_SUPPORTED_MODULES) or \
-                    (provider['transport'] == 'netconf' and self._task.action == 'junos_netconf'):
+            if provider['transport'] == 'cli' and self._task.action not in CLI_SUPPORTED_MODULES:
                 return {'failed': True, 'msg': "Transport type '%s' is not valid for '%s' module. "
                                                "Please see http://docs.ansible.com/ansible/latest/network/user_guide/platform_junos.html"
                                                % (provider['transport'], self._task.action)}


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
For connection=local check only if the transport value in
the provider is cli and the respective module support cli
transport. If not report back an appropriate error message.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
junos_netconf
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
