### PR TITLE
Fix broken links in module documentation

### DIFF
--- a/lib/ansible/modules/cloud/amazon/aws_batch_compute_environment.py
+++ b/lib/ansible/modules/cloud/amazon/aws_batch_compute_environment.py
@@ -12,8 +12,8 @@ module: aws_batch_compute_environment
 short_description: Manage AWS Batch Compute Environments
 description:
     - This module allows the management of AWS Batch Compute Environments.
-      It is idempotent and supports "Check" mode.  Use module M(batch_compute_environment) to manage the compute
-      environment, M(batch_job_queue) to manage job queues, M(batch_job_definition) to manage job definitions.
+      It is idempotent and supports "Check" mode.  Use module M(aws_batch_compute_environment) to manage the compute
+      environment, M(aws_batch_job_queue) to manage job queues, M(aws_batch_job_definition) to manage job definitions.
 
 version_added: "2.5"
 

--- a/lib/ansible/modules/cloud/amazon/aws_batch_job_definition.py
+++ b/lib/ansible/modules/cloud/amazon/aws_batch_job_definition.py
@@ -12,8 +12,8 @@ module: aws_batch_job_definition
 short_description: Manage AWS Batch Job Definitions
 description:
     - This module allows the management of AWS Batch Job Definitions.
-      It is idempotent and supports "Check" mode.  Use module M(batch_compute_environment) to manage the compute
-      environment, M(batch_job_queue) to manage job queues, M(batch_job_definition) to manage job definitions.
+      It is idempotent and supports "Check" mode.  Use module M(aws_batch_compute_environment) to manage the compute
+      environment, M(aws_batch_job_queue) to manage job queues, M(aws_batch_job_definition) to manage job definitions.
 
 version_added: "2.5"
 

--- a/lib/ansible/modules/cloud/amazon/aws_batch_job_queue.py
+++ b/lib/ansible/modules/cloud/amazon/aws_batch_job_queue.py
@@ -12,8 +12,8 @@ module: aws_batch_job_queue
 short_description: Manage AWS Batch Job Queues
 description:
     - This module allows the management of AWS Batch Job Queues.
-      It is idempotent and supports "Check" mode.  Use module M(batch_compute_environment) to manage the compute
-      environment, M(batch_job_queue) to manage job queues, M(batch_job_definition) to manage job definitions.
+      It is idempotent and supports "Check" mode.  Use module M(aws_batch_compute_environment) to manage the compute
+      environment, M(aws_batch_job_queue) to manage job queues, M(aws_batch_job_definition) to manage job definitions.
 
 version_added: "2.5"
 

--- a/lib/ansible/modules/cloud/amazon/lambda_policy.py
+++ b/lib/ansible/modules/cloud/amazon/lambda_policy.py
@@ -15,7 +15,7 @@ description:
     - This module allows the management of AWS Lambda policy statements.
       It is idempotent and supports "Check" mode.  Use module M(lambda) to manage the lambda
       function itself, M(lambda_alias) to manage function aliases, M(lambda_event) to manage event source mappings
-      such as Kinesis streams, M(lambda_invoke) to execute a lambda function and M(lambda_facts) to gather facts
+      such as Kinesis streams, M(execute_lambda) to execute a lambda function and M(lambda_facts) to gather facts
       relating to one or more lambda functions.
 
 version_added: "2.4"

--- a/lib/ansible/modules/windows/win_dsc.py
+++ b/lib/ansible/modules/windows/win_dsc.py
@@ -19,7 +19,7 @@ description:
 - Requires PowerShell version 5.0 or newer.
 - Most of the options for this module are dynamic and will vary depending on
   the DSC Resource specified in I(resource_name).
-- See :doc:`windows_dsc` for more information on how to use this module.
+- See :doc:`/user_guide/windows_dsc` for more information on how to use this module.
 options:
   resource_name:
     description:


### PR DESCRIPTION
##### SUMMARY
* Reflect updated names of the aws_batch_job modules
* Remove mention of `lambda_invoke` module which has yet to make it to
  Ansible.
* Update broken rst link in win_dsc module


##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
docs

##### ANSIBLE VERSION

```
ansible 2.6.0 (devel e10e0d42d8) last updated 2018/04/09 21:15:12 (GMT +1000)
  config file = None
  configured module search path = [u'/Users/will/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/will/src/ansible/lib/ansible
  executable location = /Users/will/src/ansible/bin/ansible
  python version = 2.7.14 (default, Mar  9 2018, 23:57:12) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
