### PR TITLE
Trim parameter documentation when generating docs

### DIFF
--- a/docs/templates/plugin.rst.j2
+++ b/docs/templates/plugin.rst.j2
@@ -345,10 +345,10 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
                 <td>@{ value.returned | html_ify }@</td>
                 <td>
                     {% if value.description is string %}
-                        <div>@{ value.description | html_ify |indent(4)}@</div>
+                        <div>@{ value.description | html_ify |indent(4) | trim}@</div>
                     {% else %}
                         {% for desc in value.description %}
-                            <div>@{ desc | html_ify |indent(4)}@</div>
+                            <div>@{ desc | html_ify |indent(4) | trim}@</div>
                         {% endfor %}
                     {% endif %}
                     <br/>


### PR DESCRIPTION
##### SUMMARY
While the HTML produced is perfectly valid, without the `trim` filter,
a lot of warnings are emitted (700 lines of warnings out of 2812 are
eliminated by this change)

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
docs

##### ANSIBLE VERSION
```
ansible 2.6.0 (devel e10e0d42d8) last updated 2018/04/09 21:15:12 (GMT +1000)
  config file = None
  configured module search path = [u'/Users/will/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/will/src/ansible/lib/ansible
  executable location = /Users/will/src/ansible/bin/ansible
  python version = 2.7.14 (default, Mar  9 2018, 23:57:12) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```


##### ADDITIONAL INFORMATION
A small example from the logs (the redshift_facts module produces 100+ lines alone!)
```
/Users/will/src/ansible/docs/docsite/rst/modules/aws_caller_facts_module.rst:269: WARNING: Explicit markup ends without a blank line; unexpected unindent.
/Users/will/src/ansible/docs/docsite/rst/modules/aws_caller_facts_module.rst:271: WARNING: Unexpected indentation.
/Users/will/src/ansible/docs/docsite/rst/modules/aws_caller_facts_module.rst:274: WARNING: Block quote ends without a blank line; unexpected unindent.
/Users/will/src/ansible/docs/docsite/rst/modules/aws_caller_facts_module.rst:275: WARNING: Block quote ends without a blank line; unexpected unindent.
/Users/will/src/ansible/docs/docsite/rst/modules/aws_caller_facts_module.rst:276: WARNING: Block quote ends without a blank line; unexpected unindent.
/Users/will/src/ansible/docs/docsite/rst/modules/aws_caller_facts_module.rst:278: WARNING: Block quote ends without a blank line; unexpected unindent.
```
