### PR TITLE
Remove the _config.rst file from installation_guide

### DIFF
--- a/docs/docsite/rst/installation_guide/_config.rst
+++ b/docs/docsite/rst/installation_guide/_config.rst
@@ -1,3 +1,0 @@
-.. This is a hack to allow doc references to files in other subdirectories.
-
-.. include:: ../reference_appendices/config.rst

--- a/docs/docsite/rst/installation_guide/intro_configuration.rst
+++ b/docs/docsite/rst/installation_guide/intro_configuration.rst
@@ -42,7 +42,7 @@ Environmental configuration
 Ansible also allows configuration of settings using environment variables.
 If these environment variables are set, they will override any setting loaded from the configuration file.
 
-You can get a full listing of available environment variables from :doc:`_config`.
+You can get a full listing of available environment variables from :ref:`configuration_settings`.
 
 .. _command_line_configuration:
 

--- a/docs/templates/config.rst.j2
+++ b/docs/templates/config.rst.j2
@@ -1,3 +1,5 @@
+.. _configuration_settings:
+
 {% set name = 'Ansible Configuration Settings' -%}
 {% set name_slug = 'config' -%}
 


### PR DESCRIPTION
##### SUMMARY

The _config.rst file causes 163 duplicate label warning
messages - removing it and the link to it causes no
additional problems


##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
docs

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0 (devel e10e0d42d8) last updated 2018/04/09 21:15:12 (GMT +1000)
  config file = None
  configured module search path = [u'/Users/will/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/will/src/ansible/lib/ansible
  executable location = /Users/will/src/ansible/bin/ansible
  python version = 2.7.14 (default, Mar  9 2018, 23:57:12) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```


##### ADDITIONAL INFORMATION
Small sample of warning messages:

```
/Users/will/src/ansible/docs/docsite/rst/reference_appendices/config.rst:895: WARNING: duplicate label default_local_tmp, other instance in /Users/will/src/ansible/docs/docsite/rst/installation_guide/_config.rst
/Users/will/src/ansible/docs/docsite/rst/reference_appendices/config.rst:1734: WARNING: duplicate label inventory_ignore_patterns, other instance in /Users/will/src/ansible/docs/docsite/rst/installation_guide/_config.rst
/Users/will/src/ansible/docs/docsite/rst/reference_appendices/config.rst:1588: WARNING: duplicate label enable_task_debugger, other instance in /Users/will/src/ansible/docs/docsite/rst/installation_guide/_config.rst
/Users/will/src/ansible/docs/docsite/rst/reference_appendices/config.rst:1796: WARNING: duplicate label paramiko_host_key_auto_add, other instance in /Users/will/src/ansible/docs/docsite/rst/installation_guide/_config.rst
/Users/will/src/ansible/docs/docsite/rst/reference_appendices/config.rst:1818: WARNING: duplicate label persistent_command_timeout, other instance in /Users/will/src/ansible/docs/docsite/rst/installation_guide/_config.rst
```

