### PR TITLE
lastpass filter: add example

### DIFF
--- a/lib/ansible/plugins/lookup/lastpass.py
+++ b/lib/ansible/plugins/lookup/lastpass.py
@@ -25,7 +25,9 @@ DOCUMENTATION = """
 """
 
 EXAMPLES = """
-# need one
+- name: get 'custom_field' from lastpass entry 'entry-name'
+  debug:
+    msg: "{{ lookup('lastpass', 'entry-name', field='custom_field') }}"
 """
 
 RETURN = """


### PR DESCRIPTION
##### SUMMARY
Add documentation example for lastpass filter.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
lastpass filter plugin

##### ANSIBLE VERSION
```
ansible 2.6.0 (lastpass-filter-doc cfe6f7a129) last updated 2018/04/09 15:19:55 (GMT +300)
  config file = None
  configured module search path = [u'/Users/dresnick/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/dresnick/src/ext/ansible/lib/ansible
  executable location = /Users/dresnick/src/ext/ansible/bin/ansible
  python version = 2.7.14 (default, Mar  9 2018, 23:57:12) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```

##### ADDITIONAL INFORMATION
