### PR TITLE
Return the tags of the task in the json callback results

### DIFF
--- a/lib/ansible/plugins/callback/json.py
+++ b/lib/ansible/plugins/callback/json.py
@@ -109,6 +109,7 @@ class CallbackModule(CallbackBase):
         task_result = result._result.copy()
         task_result.update(on_info)
         task_result['action'] = task.action
+        task_result['tags'] = task.tags
         self.results[-1]['tasks'][-1]['hosts'][host.name] = task_result
 
     def __getattribute__(self, name):


### PR DESCRIPTION
This returns the tags of the task in the json results. This is additional information to be returned and useful if you need to categorize your results based on the tags of the tasks.