### PR TITLE
Datadog monitor fixes

### DIFF
--- a/lib/ansible/modules/monitoring/datadog_monitor.py
+++ b/lib/ansible/modules/monitoring/datadog_monitor.py
@@ -224,7 +224,7 @@ def _get_monitor(module):
     else:
         monitors = api.Monitor.get_all()
         for monitor in monitors:
-            if monitor['name'] == module.params['name']:
+            if monitor['name'] == _fix_template_vars(module.params['name']):
                 return monitor
     return {}
 
@@ -232,7 +232,9 @@ def _get_monitor(module):
 def _post_monitor(module, options):
     try:
         kwargs = dict(type=module.params['type'], query=module.params['query'],
-                      name=module.params['name'], message=_fix_template_vars(module.params['message']),
+                      name=_fix_template_vars(module.params['name']),
+                      message=_fix_template_vars(module.params['message']),
+                      escalation_message=_fix_template_vars(module.params['escalation_message']),
                       options=options)
         if module.params['tags'] is not None:
             kwargs['tags'] = module.params['tags']
@@ -254,7 +256,9 @@ def _equal_dicts(a, b, ignore_keys):
 def _update_monitor(module, monitor, options):
     try:
         kwargs = dict(id=monitor['id'], query=module.params['query'],
-                      name=module.params['name'], message=_fix_template_vars(module.params['message']),
+                      name=_fix_template_vars(module.params['name']),
+                      message=_fix_template_vars(module.params['message']),
+                      escalation_message=_fix_template_vars(module.params['escalation_message']),
                       options=options)
         if module.params['tags'] is not None:
             kwargs['tags'] = module.params['tags']


### PR DESCRIPTION
##### SUMMARY
Datadog allows adding variables to more fields than just the message; this fixes template vars in the `name` and `escalation_message` fields as well.

Additionally, the missing monitor field `evaluation_delay` was added.

If this is ever actually merged, the following open PRs can be closed:
#19377 (templates `name` but not `escalation_message`)
#21326 (templates `name` but not `escalation_message`)
#23011 (adds `evaluation_delay` field)
#32784 (adds `evaluation_delay` field)

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
`datadog_monitor`

##### ANSIBLE VERSION
```
ansible 2.6.0 (datadog-monitor-fixes 0b4864d14a) last updated 2018/04/09 14:44:41 (GMT +300)
  config file = None
  configured module search path = [u'/Users/dresnick/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/dresnick/src/ext/ansible/lib/ansible
  executable location = /Users/dresnick/src/ext/ansible/bin/ansible
  python version = 2.7.14 (default, Mar  9 2018, 23:57:12) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```

##### ADDITIONAL INFORMATION
