### PR TITLE
different doc anchors for modules & plugins

### DIFF
--- a/docs/templates/plugin.rst.j2
+++ b/docs/templates/plugin.rst.j2
@@ -1,6 +1,11 @@
 :source: @{ source }@
 
+{% if plugin_type == 'module' %}
+.. _@{ module }@:
+{% else %}
 .. _@{ plugin_type }@_@{ module }@:
+{% endif %}
+
 {% for alias in aliases %}
 .. _@{ alias }@:
 {% endfor %}

--- a/docs/templates/plugin.rst.j2
+++ b/docs/templates/plugin.rst.j2
@@ -1,11 +1,6 @@
 :source: @{ source }@
 
-{% if plugin_type == 'module' %}
-.. _@{ module }@:
-{% else %}
 .. _@{ plugin_type }@_@{ module }@:
-{% endif %}
-
 {% for alias in aliases %}
 .. _@{ alias }@:
 {% endfor %}

--- a/docs/templates/plugin.rst.j2
+++ b/docs/templates/plugin.rst.j2
@@ -1,6 +1,11 @@
 :source: @{ source }@
 
+{% if plugin_type == 'module' %}
 .. _@{ module }@:
+{% else %}
+.. _@{ plugin_type }@_@{ module }@:
+{% endif %}
+
 {% for alias in aliases %}
 .. _@{ alias }@:
 {% endfor %}


### PR DESCRIPTION
##### SUMMARY
Assigns different doc anchors (`.. _anchor_name`) to generated docs for modules and plugins. Without this change both https://docs.ansible.com/ansible/latest/plugins/lookup/file.html and https://docs.ansible.com/ansible/latest/modules/file_module.html get the anchor `.. _file`, and the link from https://docs.ansible.com/ansible/latest/modules/list_of_files_modules.html was picking up the wrong one, pointing to the plugin when it should point to the module. Same thing was happening for "template", which is also both a module and a plugin.

##### ISSUE TYPE
 - Docs Pull Request

##### ANSIBLE VERSION
2.5 and greater

##### ADDITIONAL INFORMATION
The issue was reported on Twitter today and relayed on the #docs channel by mphillips. 
