### PR TITLE
win_updates: backport 2.5 handle failure on module load

### DIFF
--- a/changelogs/fragments/win_updates_handle-module-failures.yaml
+++ b/changelogs/fragments/win_updates_handle-module-failures.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+- win_updates - handle if the module fails to load and return the error message
+  https://github.com/ansible/ansible/pull/38363

--- a/lib/ansible/plugins/action/win_updates.py
+++ b/lib/ansible/plugins/action/win_updates.py
@@ -186,6 +186,12 @@ class ActionModule(ActionBase):
         new_module_args.pop('reboot_timeout', None)
         result = self._run_win_updates(new_module_args, task_vars)
 
+        # if the module failed to run at all then changed won't be populated
+        # so we just return the result as is
+        # https://github.com/ansible/ansible/issues/38232
+        if result['failed']:
+            return result
+
         changed = result['changed']
         updates = result.get('updates', dict())
         filtered_updates = result.get('filtered_updates', dict())
@@ -235,6 +241,8 @@ class ActionModule(ActionBase):
                 result.pop('msg', None)
                 # rerun the win_updates module after the reboot is complete
                 result = self._run_win_updates(new_module_args, task_vars)
+                if result['failed']:
+                    return result
 
                 result_updates = result.get('updates', dict())
                 result_filtered_updates = result.get('filtered_updates', dict())


### PR DESCRIPTION
##### SUMMARY
If the win_updates action plugin fails to run the module, become doesn't work and so on. This will pick up the failure and return it back to the user instead of hiding it.

Backport of https://github.com/ansible/ansible/pull/38363

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
win_updates

##### ANSIBLE VERSION
```
2.5
```