### PR TITLE
Set bond options to free text.

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_host_networks.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_host_networks.py
@@ -170,12 +170,15 @@ def get_bond_options(opt_str):
         We need to maintain this type strings, for the __compare_options method,
         for easier comparision.
         """
-        return [
-            'Active-Backup',
-            'Load balance (balance-xor)',
-            None,
-            'Dynamic link aggregation (802.3ad)',
-        ][mode_number]
+        modes = [
+        'Active-Backup',
+        'Load balance (balance-xor)',
+        None,
+        'Dynamic link aggregation (802.3ad)',
+        ]
+        if (not 0 < mode_number <= mode_number-1):
+            return None
+        return modes[mode_number-1]
     
     opt_dict = {}
     for item in opt_str.split():
@@ -195,7 +198,7 @@ def get_bond_options(opt_str):
     options.append(
         otypes.Option(
             name='mode',
-            type=get_type_name(mode_number - 1),
+            type=get_type_name(mode_number),
             value=str(mode_number)
         )
     )


### PR DESCRIPTION
##### SUMMARY
Users should not be confined to certain bond options based on bond mode.

This change allows users to pass free text containing bond mode & options rather be confined to pre-set bond options based on mode.
