### PR TITLE
win_exec_wrapper: fix tests after recent change

### DIFF
--- a/test/integration/targets/win_exec_wrapper/aliases
+++ b/test/integration/targets/win_exec_wrapper/aliases
@@ -1,1 +1,2 @@
-windows/ci/group2
+windows/ci/group1
+windows/ci/smoketest

--- a/test/integration/targets/win_exec_wrapper/tasks/main.yml
+++ b/test/integration/targets/win_exec_wrapper/tasks/main.yml
@@ -32,7 +32,7 @@
     - '"This module cannot run as it requires a minimum PowerShell version of 20.0.0.0, actual was " in invalid_ps_version.msg'
 
 - name: test out environment block for task
-  win_shell: set | more
+  win_shell: set
   args:
     executable: cmd.exe
   environment:


### PR DESCRIPTION
##### SUMMARY
Test was using `| more` when it wasn't needed. While this may have worked before a recent change stops this from working and in a WinRM context it isn't needed at all.

Fixes https://github.com/ansible/ansible/issues/38494

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
win_exec_wrapper

##### ANSIBLE VERSION
```
devel
2.5
```