### PR TITLE
winrm: backport 2.5 added flag handler for kinit to request forwardable ticket when delegation is set

### DIFF
--- a/changelogs/fragments/winrm_kinit-delegation.yaml
+++ b/changelogs/fragments/winrm_kinit-delegation.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- winrm - when managing Kerberos tickets in Ansible, get a forwardable ticket if delegation is set (https://github.com/ansible/ansible/pull/37815)


### PR DESCRIPTION
##### SUMMARY
When managing Kerberos tickets ourselves, run kinit with the `-f` flag to retrieve a forwardable ticket if `ansible_winrm_kerberos_delegation` is set to `yes`.

Backport of https://github.com/ansible/ansible/pull/37815

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
winrm

##### ANSIBLE VERSION
```
2.5
```