### PR TITLE
win_uri: backport 2.5 fix for when status codes are provided as a comma separated list

### DIFF
--- a/changelogs/fragments/win_uri-int-status-codes.yaml
+++ b/changelogs/fragments/win_uri-int-status-codes.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_uri - convert status code values to an int before validating them in server response (https://github.com/ansible/ansible/pull/38080)

--- a/lib/ansible/modules/windows/win_uri.ps1
+++ b/lib/ansible/modules/windows/win_uri.ps1
@@ -56,6 +56,17 @@ if ($use_basic_parsing) {
     Add-DeprecationWarning -obj $result -message "Since Ansible 2.5, use_basic_parsing does not change any behaviour, this option will be removed" -version 2.7
 }
 
+if ($status_code) {
+    $status_code = foreach ($code in $status_code) {
+        try {
+            [int]$code
+        }
+        catch [System.InvalidCastException] {
+            Fail-Json -obj $result -message "Failed to convert '$code' to an integer. Status codes must be provided in numeric format."
+        }
+    }
+}
+
 $client = [System.Net.WebRequest]::Create($url)
 $client.Method = $method
 $client.Timeout = $timeout * 1000
@@ -265,7 +276,7 @@ if ($return_content -or $dest) {
 }
 
 if ($status_code -notcontains $response.StatusCode) {
-    Fail-Json -obj $result -message "Status code of request '$($response.StatusCode)' is not in list of valid status codes $status_code."
+    Fail-Json -obj $result -message "Status code of request '$([int]$response.StatusCode)' is not in list of valid status codes $status_code : '$($response.StatusCode)'."
 }
 
 Exit-Json -obj $result

--- a/test/integration/targets/win_uri/tasks/test.yml
+++ b/test/integration/targets/win_uri/tasks/test.yml
@@ -252,6 +252,7 @@
     url: http://{{httpbin_host}}/status/202
     status_code:
     - 202
+    - 418
     method: POST
     body: foo
   register: status_code_check
@@ -359,3 +360,35 @@
     - post_request_with_custom_headers.json.headers['Content-Type'] == "application/json"
     - post_request_with_custom_headers.json.headers['Test-Header'] == 'hello'
     - post_request_with_custom_headers.json.headers['Another-Header'] == 'world'
+
+- name: validate status codes as list of strings
+  win_uri:
+    url: https://httpbin.org/status/202
+    status_code:
+    - '202'
+    - '418'
+    method: POST
+    body: foo
+    return_content: yes
+  register: request_status_code_string
+
+- name: assert status codes as list of strings
+  assert:
+    that:
+    - not request_status_code_string.changed
+    - request_status_code_string.status_code == 202
+
+- name: validate status codes as comma separated list
+  win_uri:
+    url: https://httpbin.org/status/202
+    status_code: 202, 418
+    method: POST
+    body: foo
+    return_content: yes
+  register: request_status_code_comma
+
+- name: assert status codes as comma separated list
+  assert:
+    that:
+    - not request_status_code_comma.changed
+    - request_status_code_comma.status_code == 202


### PR DESCRIPTION
##### SUMMARY
Fixes the status code parsing to convert the input list values to an int before validating them. Also fixes us the error message to show the actual response int value.

Backport of https://github.com/ansible/ansible/pull/38080

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
win_uri

##### ANSIBLE VERSION
```
2.5
```