### PR TITLE
Added empty default for name parameter

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_ami.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_ami.py
@@ -656,7 +656,7 @@ def main():
         virtualization_type=dict(default='hvm'),
         root_device_name=dict(),
         delete_snapshot=dict(default=False, type='bool'),
-        name=dict(),
+        name=dict(default=''),
         wait=dict(type='bool', default=False),
         wait_timeout=dict(default=900, type='int'),
         description=dict(default=''),

--- a/lib/ansible/modules/cloud/amazon/ec2_ami.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_ami.py
@@ -677,7 +677,6 @@ def main():
         argument_spec=argument_spec,
         required_if=[
             ['state', 'absent', ['image_id']],
-            ['state', 'present', ['name']],
         ]
     )
 


### PR DESCRIPTION
Fix for issue #38482 

##### SUMMARY
Adds a default empty value to the name parameter after the move to boto3 - to fix a bug

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ec2_ami

##### ANSIBLE VERSION
```
ansible 2.5.0
  config file = None
  configured module search path = [u'/Users/msaidelk/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/msaidelk/venv/lib/python2.7/site-packages/ansible
  executable location = /Users/msaidelk/venv/bin/ansible
  python version = 2.7.10 (default, Jul 15 2017, 17:16:57) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.31)]
```


##### ADDITIONAL INFORMATION
See issue #38482 