### PR TITLE
Add BGP ASN to ec2_vpc_vgw.py. Fixes #38484

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_vgw.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_vgw.py
@@ -41,6 +41,9 @@ options:
   vpc_id:
     description:
         - the vpc-id of a vpc to attach or detach
+  asn:
+    description:
+        - the BGP ASN of the amazon side
   wait_timeout:
     description:
         - number of seconds to wait for status during vpc attach and detach

--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_vgw.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_vgw.py
@@ -202,9 +202,10 @@ def detach_vgw(client, module, vpn_gateway_id, vpc_id=None):
 def create_vgw(client, module):
     params = dict()
     params['Type'] = module.params.get('type')
+    params['AmazonSideAsn'] = module.params.get('asn')
 
     try:
-        response = client.create_vpn_gateway(Type=params['Type'])
+        response = client.create_vpn_gateway(Type=params['Type'], AmazonSideAsn=params['AmazonSideAsn'])
     except botocore.exceptions.ClientError as e:
         module.fail_json(msg=to_native(e), exception=traceback.format_exc())
 
@@ -544,6 +545,7 @@ def main():
         name=dict(),
         vpn_gateway_id=dict(),
         vpc_id=dict(),
+        asn=dict(type='int'),
         wait_timeout=dict(type='int', default=320),
         type=dict(default='ipsec.1', choices=['ipsec.1']),
         tags=dict(default=None, required=False, type='dict', aliases=['resource_tags']),

--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_vgw.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_vgw.py
@@ -44,6 +44,7 @@ options:
   asn:
     description:
         - the BGP ASN of the amazon side
+    version_added: "2.6"
   wait_timeout:
     description:
         - number of seconds to wait for status during vpc attach and detach


### PR DESCRIPTION
##### SUMMARY
Added ability to specify Amazon side BGP ASN in ec2_vpc_vgw module

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
ec2_vpc_vgw

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
$ ansible --version
ansible 2.5.0
  config file = /Users/johndow/.ansible.cfg
  configured module search path = [u'/Library/Python/2.7/site-packages/napalm_ansible/modules']
  ansible python module location = /Library/Python/2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.10 (default, Jul 15 2017, 17:16:57) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.31)]

```