### PR TITLE
Add junos connection type check for junos_netconf

### DIFF
--- a/lib/ansible/plugins/action/junos.py
+++ b/lib/ansible/plugins/action/junos.py
@@ -90,7 +90,8 @@ class ActionModule(_ActionModule):
             if any(provider.values()):
                 display.warning('provider is unnecessary when using connection=%s and will be ignored' % self._play_context.connection)
 
-            if self._play_context.connection == 'network_cli' and self._task.action not in CLI_SUPPORTED_MODULES:
+            if (self._play_context.connection == 'network_cli' and self._task.action not in CLI_SUPPORTED_MODULES) or \
+                    (self._play_context.connection == 'netconf' and self._task.action == 'junos_netconf'):
                 return {'failed': True, 'msg': "Connection type '%s' is not valid for '%s' module. "
                                                "Please see http://docs.ansible.com/ansible/latest/network/user_guide/platform_junos.html"
                                                % (self._play_context.connection, self._task.action)}


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
junos_netconf works only with connection=network_cli
Add check to report appropriate error if any other
connection type is used.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
junos_netconf

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
