### PR TITLE
[aws] Retry creation of tags when DHCP optionset is not found

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_dhcp_option.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_dhcp_option.py
@@ -201,6 +201,18 @@ def get_resource_tags(vpc_conn, resource_id):
     return dict((t.name, t.value) for t in vpc_conn.get_all_tags(filters={'resource-id': resource_id}))
 
 
+def retry_not_found(to_call, *args, **kwargs):
+    start_time = time()
+    while time() < start_time + 300:
+        try:
+            return to_call(*args, **kwargs)
+        except EC2ResponseError as e:
+            if e.error_code == 'InvalidDhcpOptionID.NotFound':
+                sleep(3)
+                continue
+            raise e
+
+
 def ensure_tags(module, vpc_conn, resource_id, tags, add_only, check_mode):
     try:
         cur_tags = get_resource_tags(vpc_conn, resource_id)
@@ -209,11 +221,11 @@ def ensure_tags(module, vpc_conn, resource_id, tags, add_only, check_mode):
 
         to_delete = dict((k, cur_tags[k]) for k in cur_tags if k not in tags)
         if to_delete and not add_only:
-            vpc_conn.delete_tags(resource_id, to_delete, dry_run=check_mode)
+            retry_not_found(vpc_conn.delete_tags, resource_id, to_delete, dry_run=check_mode)
 
         to_add = dict((k, tags[k]) for k in tags if k not in cur_tags)
         if to_add:
-            vpc_conn.create_tags(resource_id, to_add, dry_run=check_mode)
+            retry_not_found(vpc_conn.create_tags, resource_id, to_add, dry_run=check_mode)
 
         latest_tags = get_resource_tags(vpc_conn, resource_id)
         return {'changed': True, 'tags': latest_tags}
@@ -363,16 +375,10 @@ def main():
             # wait for dhcp option to be accessible
             found_dhcp_opt = False
             start_time = time()
-            while time() < start_time + 300:
-                try:
-                    found_dhcp_opt = connection.get_all_dhcp_options(dhcp_options_ids=[dhcp_option.id])
-                except EC2ResponseError as e:
-                    if e.error_code == 'InvalidDhcpOptionID.NotFound':
-                        sleep(3)
-                    else:
-                        module.fail_json(msg="Failed to describe DHCP options", exception=traceback.format_exc)
-                else:
-                    break
+            try:
+                found_dhcp_opt = retry_not_found(connection.get_all_dhcp_options, dhcp_options_ids=[dhcp_option.id])
+            except EC2ResponseError as e:
+                module.fail_json(msg="Failed to describe DHCP options", exception=traceback.format_exc)
             if not found_dhcp_opt:
                 module.fail_json(msg="Failed to wait for {0} to be available.".format(dhcp_option.id))
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Resolve desync in tag creation when DHCP optionset exists, but the tag service is not yet aware of it. 

https://github.com/ansible/ansible/issues/36063#issuecomment-379834220

Fixes #36063
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
ec2_vpc_dhcp_option

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
