### PR TITLE
s3_bucket: add encryption capabilities to the module

### DIFF
--- a/hacking/aws_config/testing_policies/storage-policy.json
+++ b/hacking/aws_config/testing_policies/storage-policy.json
@@ -11,6 +11,7 @@
                 "s3:GetBucketRequestPayment",
                 "s3:GetBucketTagging",
                 "s3:GetBucketVersioning",
+                "s3:GetEncryptionConfiguration",
                 "s3:GetObject",
                 "s3:ListBucket",
                 "s3:PutBucketAcl",
@@ -18,6 +19,7 @@
                 "s3:PutBucketRequestPayment",
                 "s3:PutBucketTagging",
                 "s3:PutBucketVersioning",
+                "s3:PutEncryptionConfiguration",
                 "s3:PutObject",
                 "s3:PutObjectAcl"
             ],
@@ -26,6 +28,12 @@
                 "arn:aws:s3:::ansible-test-*",
                 "arn:aws:s3:::ansible-test-*/*"
             ]
+        },
+        {
+            "Sid": "AllowS3AnsibleListTestBuckets",
+            "Action": "s3:ListAllMyBuckets",
+            "Effect": "Allow",
+            "Resource": "*"
         }
     ]
 }

--- a/lib/ansible/modules/cloud/amazon/s3_bucket.py
+++ b/lib/ansible/modules/cloud/amazon/s3_bucket.py
@@ -70,7 +70,9 @@ options:
     type: bool
   encryption:
     description:
-      - Describes the default server-side encryption to apply to new objects in the bucket. If none is specified, the default encryption will be applied.
+      - Describes the default server-side encryption to apply to new objects in the bucket.
+        If the argument is not specified, the default encryption will be applied when creating the bucket.
+        In order to remove the server-side encryption, the encryption needs to be set to 'none' explicitely.
     choices: [ 'none', 'AES256', 'aws:kms' ]
     version_added: "2.6"
   encryption_key_id:
@@ -255,10 +257,13 @@ def create_or_update_bucket(s3_client, module, location):
             changed = True
 
     # Encryption
-    try:
-        current_encryption = get_bucket_encryption(s3_client, name)
-    except (ClientError, BotoCoreError) as e:
-        module.fail_json_aws(e, msg="Failed to get bucket encryption")
+    if hasattr(s3_client, "get_bucket_encryption"):
+        try:
+            current_encryption = get_bucket_encryption(s3_client, name)
+        except (ClientError, BotoCoreError) as e:
+            module.fail_json_aws(e, msg="Failed to get bucket encryption")
+    elif encryption is not None:
+        module.fail_json(msg="Using bucket encryption requires botocore version >= 1.7.41")
 
     if encryption is not None:
         current_encryption_algorithm = current_encryption.get('SSEAlgorithm') if current_encryption else None
@@ -584,8 +589,8 @@ def main():
             tags=dict(required=False, default=None, type='dict'),
             versioning=dict(default=None, type='bool'),
             ceph=dict(default='no', type='bool'),
-            encryption=dict(type='str', default=None, choices=['none', 'AES256', 'aws:kms']),
-            encryption_key_id=dict(type='str')
+            encryption=dict(choices=['none', 'AES256', 'aws:kms']),
+            encryption_key_id=dict()
         )
     )
 

--- a/lib/ansible/modules/cloud/amazon/s3_bucket.py
+++ b/lib/ansible/modules/cloud/amazon/s3_bucket.py
@@ -68,6 +68,14 @@ options:
     description:
       - Whether versioning is enabled or disabled (note that once versioning is enabled, it can only be suspended)
     type: bool
+  encryption:
+    description:
+      - Describes the default server-side encryption to apply to new objects in the bucket. If none is specified, the default encryption will be applied.
+    choices: [ 'none', 'AES256', 'aws:kms' ]
+    version_added: "2.6"
+  encryption_key_id:
+    description: KMS master key ID to use for the default encryption. This parameter is allowed if encryption is aws:kms.
+    version_added: "2.6"
 extends_documentation_fragment:
     - aws
     - ec2
@@ -128,6 +136,8 @@ def create_or_update_bucket(s3_client, module, location):
     requester_pays = module.params.get("requester_pays")
     tags = module.params.get("tags")
     versioning = module.params.get("versioning")
+    encryption = module.params.get("encryption")
+    encryption_key_id = module.params.get("encryption_key_id")
     changed = False
 
     try:
@@ -244,8 +254,35 @@ def create_or_update_bucket(s3_client, module, location):
             current_tags_dict = tags
             changed = True
 
+    # Encryption
+    try:
+        current_encryption = get_bucket_encryption(s3_client, name)
+    except (ClientError, BotoCoreError) as e:
+        module.fail_json_aws(e, msg="Failed to get bucket encryption")
+
+    if encryption is not None:
+        current_encryption_algorithm = current_encryption.get('SSEAlgorithm') if current_encryption else None
+        current_encryption_key = current_encryption.get('KMSMasterKeyID') if current_encryption else None
+        if encryption == 'none' and current_encryption_algorithm is not None:
+            try:
+                delete_bucket_encryption(s3_client, name)
+            except (BotoCoreError, ClientError) as e:
+                module.fail_json_aws(e, msg="Failed to delete bucket encryption")
+            current_encryption = wait_encryption_is_applied(module, s3_client, name, None)
+            changed = True
+        elif encryption != 'none' and (encryption != current_encryption_algorithm) or (encryption == 'aws:kms' and current_encryption_key != encryption_key_id):
+            expected_encryption = {'SSEAlgorithm': encryption}
+            if encryption == 'aws:kms':
+                expected_encryption.update({'KMSMasterKeyID': encryption_key_id})
+            try:
+                put_bucket_encryption(s3_client, name, expected_encryption)
+            except (BotoCoreError, ClientError) as e:
+                module.fail_json_aws(e, msg="Failed to set bucket encryption")
+            current_encryption = wait_encryption_is_applied(module, s3_client, name, expected_encryption)
+            changed = True
+
     module.exit_json(changed=changed, name=name, versioning=versioning_return_value,
-                     requester_pays=requester_pays, policy=current_policy, tags=current_tags_dict)
+                     requester_pays=requester_pays, policy=current_policy, tags=current_tags_dict, encryption=current_encryption)
 
 
 def bucket_exists(s3_client, bucket_name):
@@ -324,8 +361,31 @@ def put_bucket_versioning(s3_client, bucket_name, required_versioning):
 
 
 @AWSRetry.exponential_backoff(max_delay=120, catch_extra_error_codes=['NoSuchBucket'])
+def get_bucket_encryption(s3_client, bucket_name):
+    try:
+        result = s3_client.get_bucket_encryption(Bucket=bucket_name)
+        return result.get('ServerSideEncryptionConfiguration').get('Rules')[0].get('ApplyServerSideEncryptionByDefault')
+    except ClientError as e:
+        if e.response['Error']['Code'] == 'ServerSideEncryptionConfigurationNotFoundError':
+            return None
+        else:
+            raise e
+
+
+@AWSRetry.exponential_backoff(max_delay=120, catch_extra_error_codes=['NoSuchBucket'])
+def put_bucket_encryption(s3_client, bucket_name, encryption):
+    server_side_encryption_configuration = {'Rules': [{'ApplyServerSideEncryptionByDefault': encryption}]}
+    s3_client.put_bucket_encryption(Bucket=bucket_name, ServerSideEncryptionConfiguration=server_side_encryption_configuration)
+
+
+@AWSRetry.exponential_backoff(max_delay=120, catch_extra_error_codes=['NoSuchBucket'])
 def delete_bucket_tagging(s3_client, bucket_name):
     s3_client.delete_bucket_tagging(Bucket=bucket_name)
+
+
+@AWSRetry.exponential_backoff(max_delay=120, catch_extra_error_codes=['NoSuchBucket'])
+def delete_bucket_encryption(s3_client, bucket_name):
+    s3_client.delete_bucket_encryption(Bucket=bucket_name)
 
 
 @AWSRetry.exponential_backoff(max_delay=120)
@@ -372,6 +432,19 @@ def wait_payer_is_applied(module, s3_client, bucket_name, expected_payer, should
         module.fail_json(msg="Bucket request payment failed to apply in the excepted time")
     else:
         return None
+
+
+def wait_encryption_is_applied(module, s3_client, bucket_name, expected_encryption):
+    for dummy in range(0, 12):
+        try:
+            encryption = get_bucket_encryption(s3_client, bucket_name)
+        except (BotoCoreError, ClientError) as e:
+            module.fail_json_aws(e, msg="Failed to get updated encryption for bucket")
+        if encryption != expected_encryption:
+            time.sleep(5)
+        else:
+            return encryption
+    module.fail_json(msg="Bucket encryption failed to apply in the excepted time")
 
 
 def wait_versioning_is_applied(module, s3_client, bucket_name, required_versioning):
@@ -510,11 +583,13 @@ def main():
             state=dict(default='present', type='str', choices=['present', 'absent']),
             tags=dict(required=False, default=None, type='dict'),
             versioning=dict(default=None, type='bool'),
-            ceph=dict(default='no', type='bool')
+            ceph=dict(default='no', type='bool'),
+            encryption=dict(type='str', default=None, choices=['none', 'AES256', 'aws:kms']),
+            encryption_key_id=dict(type='str')
         )
     )
 
-    module = AnsibleAWSModule(argument_spec=argument_spec)
+    module = AnsibleAWSModule(argument_spec=argument_spec, required_if=[['encryption', 'aws:kms', ['encryption_key_id']]])
 
     region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
 

--- a/test/integration/targets/s3_bucket/tasks/main.yml
+++ b/test/integration/targets/s3_bucket/tasks/main.yml
@@ -272,7 +272,60 @@
     - assert:
         that:
           - not output.changed
+    # ============================================================
+    - name: Create bucket with AES256 encryption
+      s3_bucket:
+        name: "{{ resource_prefix }}.testbucket.encrypt.ansible"
+        state: present
+        encryption: "AES256"
+        <<: *aws_connection_info
+      register: output
 
+    - assert:
+        that:
+          - output.changed
+          - output.name == '{{ resource_prefix }}.testbucket.encrypt.ansible'
+          - output.encryption
+          - output.encryption.SSEAlgorithm == 'AES256'
+
+    - name: Update bucket with same encryption config
+      s3_bucket:
+        name: "{{ resource_prefix }}.testbucket.encrypt.ansible"
+        state: present
+        encryption: "AES256"
+        <<: *aws_connection_info
+      register: output
+
+    - assert:
+        that:
+          - not output.changed
+          - output.encryption
+          - output.encryption.SSEAlgorithm == 'AES256'
+
+    - name: Disable encryption from bucket
+      s3_bucket:
+        name: "{{ resource_prefix }}.testbucket.encrypt.ansible"
+        state: present
+        encryption: "none"
+        <<: *aws_connection_info
+      register: output
+
+    - assert:
+        that:
+          - output.changed
+          - not output.encryption
+
+    # ============================================================
+    - name: Delete s3_bucket
+      s3_bucket:
+        name: "{{ resource_prefix }}.testbucket.encrypt.ansible"
+        state: absent
+        <<: *aws_connection_info
+      register: output
+
+    - assert:
+        that:
+          - output.changed
   # ============================================================
   always:
     - name: Ensure all buckets are deleted
@@ -285,3 +338,4 @@
         - "{{ resource_prefix }}-testbucket-ansible"
         - "{{ resource_prefix }}-testbucket-ansible-complex"
         - "{{ resource_prefix }}.testbucket.ansible"
+        - "{{ resource_prefix }}.testbucket.encrypt.ansible"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Add parameters to enable default encryption on a s3 bucket

* `encryption`: `AES256` or `aws:kms`
* `encryption_key_id`: kms key id when `aws:kms` is used
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Fixes #35110

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
s3_bucket

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
I've added integration test for AES256. For aws:kms, I have tested it on my account, but since ansible does not provide a module to create kms key I was not able to add it to the integration test suite.
