### PR TITLE
nxos_interface: AttributeError: 'NoneType' object has no attribute 'group'

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_interface.py
+++ b/lib/ansible/modules/network/nxos/nxos_interface.py
@@ -602,15 +602,17 @@ def map_config_to_obj(want, module):
                     command = 'show run interface {0}'.format(obj['name'])
                     body = execute_show_command(command, module)[0]
 
-                    if 'speed' in body:
-                        obj['speed'] = re.search(r'speed (\d+)', body).group(1)
-                    else:
+                    speed_match = re.search(r'speed (\d+)', body)
+                    if speed_match is None:
                         obj['speed'] = 'auto'
-
-                    if 'duplex' in body:
-                        obj['duplex'] = re.search(r'duplex (\S+)', body).group(1)
                     else:
+                        obj['speed'] = speed_match.group(1)
+
+                    duplex_match = re.search(r'duplex (\S+)', body)
+                    if duplex_match is None:
                         obj['duplex'] = 'auto'
+                    else:
+                        obj['duplex'] = duplex_match.group(1)
 
                     if 'ip forward' in body:
                         obj['ip_forward'] = 'enable'


### PR DESCRIPTION
##### SUMMARY
This fixes an issue we recently encounteredi with nxos_interface:

```
Traceback (most recent call last):
  File "/tmp/ansible_JmLoba/ansible_module_nxos_interface.py", line 777, in main
    have = map_config_to_obj(want, module)
  File "/tmp/ansible_JmLoba/ansible_module_nxos_interface.py", line 606, in map_config_to_obj
    obj['speed'] = re.search(r'speed (\d+)', body).group(1)
AttributeError: 'NoneType' object has no attribute 'group'
```

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
nxos_interface

##### ANSIBLE VERSION
v2.6