### PR TITLE
Add troubleshooting URL for persistent socket path related issue

### DIFF
--- a/changelogs/fragments/persistent_socket_path_troubleshoot_url.yml
+++ b/changelogs/fragments/persistent_socket_path_troubleshoot_url.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- Add url to troubleshoot persistent socket path related issues https://github.com/ansible/ansible/pull/38542

--- a/lib/ansible/module_utils/connection.py
+++ b/lib/ansible/module_utils/connection.py
@@ -111,8 +111,10 @@ class Connection(object):
         req = request_builder(name, *args, **kwargs)
         reqid = req['id']
 
+        troubleshoot = 'http://docs.ansible.com/ansible/latest/network/user_guide/network_debug_troubleshooting.html#category-socket-path-issue'
+
         if not os.path.exists(self.socket_path):
-            raise ConnectionError('socket_path does not exist or cannot be found')
+            raise ConnectionError('socket_path does not exist or cannot be found. Please check %s' % troubleshoot)
 
         try:
             data = json.dumps(req)
@@ -120,7 +122,8 @@ class Connection(object):
             response = json.loads(out)
 
         except socket.error as e:
-            raise ConnectionError('unable to connect to socket', err=to_text(e, errors='surrogate_then_replace'), exception=traceback.format_exc())
+            raise ConnectionError('unable to connect to socket. Please check %s' % troubleshoot, err=to_text(e, errors='surrogate_then_replace'),
+                                  exception=traceback.format_exc())
 
         if response['id'] != reqid:
             raise ConnectionError('invalid json-rpc id received')


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->


* Add troubleshooting URL for persistent socket path related issue

socket path timeout related error messages are not displayed on the
console as the ansible-connection process does not have access to it.
Until this is fixed need to point to troubleshooting URL so that
users can take corrective actions.

* Fix CI issue

* Update changelog fragments
(cherry picked from commit 53d3e7e306770d403841ee0215c91aa9e3999885)
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
module_utils/connection.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
