### PR TITLE
Added empty default for name parameter

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_ami.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_ami.py
@@ -656,7 +656,7 @@ def main():
         virtualization_type=dict(default='hvm'),
         root_device_name=dict(),
         delete_snapshot=dict(default=False, type='bool'),
-        name=dict(),
+        name=dict(default=''),
         wait=dict(type='bool', default=False),
         wait_timeout=dict(default=900, type='int'),
         description=dict(default=''),

--- a/lib/ansible/modules/cloud/amazon/ec2_ami.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_ami.py
@@ -656,7 +656,7 @@ def main():
         virtualization_type=dict(default='hvm'),
         root_device_name=dict(),
         delete_snapshot=dict(default=False, type='bool'),
-        name=dict(default=''),
+        name=dict(),
         wait=dict(type='bool', default=False),
         wait_timeout=dict(default=900, type='int'),
         description=dict(default=''),
@@ -679,6 +679,11 @@ def main():
             ['state', 'absent', ['image_id']],
         ]
     )
+
+    # Using a required_one_of=[['name', 'image_id']] overrides the message that should be provided by
+    # the required_if for state=absent, so check manually instead
+    if not any([module.params['image_id'], module.params['name']]):
+        module.fail_json(msg="one of the following is required: name, image_id")
 
     try:
         region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)

--- a/lib/ansible/modules/cloud/amazon/ec2_ami.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_ami.py
@@ -677,7 +677,6 @@ def main():
         argument_spec=argument_spec,
         required_if=[
             ['state', 'absent', ['image_id']],
-            ['state', 'present', ['name']],
         ]
     )
 

--- a/test/integration/targets/ec2_ami/tasks/main.yml
+++ b/test/integration/targets/ec2_ami/tasks/main.yml
@@ -87,6 +87,30 @@
 
     # ============================================================
 
+    - name: test clean failure if not providing image_id or name with state=present
+      ec2_ami:
+        ec2_region: '{{ec2_region}}'
+        ec2_access_key: '{{ec2_access_key}}'
+        ec2_secret_key: '{{ec2_secret_key}}'
+        security_token: '{{security_token}}'
+        instance_id: '{{ setup_instance.instance_ids[0] }}'
+        state: present
+        description: '{{ ec2_ami_description }}'
+        tags:
+          Name: '{{ ec2_ami_name }}_ami'
+        wait: yes
+        root_device_name: /dev/xvda
+      register: result
+      ignore_errors: yes
+
+    - name: assert error message is helpful
+      assert:
+        that:
+          - result.failed
+          - "result.msg == 'one of the following is required: name, image_id'"
+
+    # ============================================================
+
     - name: create an image from the instance
       ec2_ami:
         ec2_region: '{{ec2_region}}'
@@ -295,7 +319,6 @@
         security_token: '{{security_token}}'
         state: present
         image_id: '{{ result.image_id }}'
-        name: '{{ ec2_ami_name }}_ami'
         description: '{{ ec2_ami_description }}'
         tags:
           Name: '{{ ec2_ami_name }}_ami'


### PR DESCRIPTION
##### SUMMARY
Fix for issue #38482


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ec2_ami

##### ANSIBLE VERSION
```
ansible 2.5.0
  config file = None
  configured module search path = [u'/Users/msaidelk/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/msaidelk/venv/lib/python2.7/site-packages/ansible
  executable location = /Users/msaidelk/venv/bin/ansible
  python version = 2.7.10 (default, Jul 15 2017, 17:16:57) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.31)]
```


##### ADDITIONAL INFORMATION
See issue #38482
Submitted based instructions from #38514

Cherry picked the fix and backported...