### PR TITLE
Add a User-Agent string to the API request

### DIFF
--- a/lib/ansible/module_utils/scaleway.py
+++ b/lib/ansible/module_utils/scaleway.py
@@ -1,4 +1,5 @@
 import json
+import sys
 
 from ansible.module_utils.urls import fetch_url
 
@@ -33,9 +34,12 @@ class Response(object):
 
 class ScalewayAPI(object):
 
-    def __init__(self, module, headers, base_url):
+    def __init__(self, module, base_url, headers=None):
         self.module = module
-        self.headers = headers
+        self.headers = {'User-Agent': self.get_user_agent_string(module),
+                        'Content-type': 'application/json'}
+        if headers is not None:
+            self.headers.update(headers)
         self.base_url = base_url
 
     def _url_builder(self, path):
@@ -58,6 +62,10 @@ class ScalewayAPI(object):
             self.module.fail_json(msg=info['msg'])
 
         return Response(resp, info)
+
+    @staticmethod
+    def get_user_agent_string(module):
+        return "ansible %s Python %s" % (module.ansible_version, sys.version.split(' ')[0])
 
     def get(self, path, data=None, headers=None):
         return self.send('GET', path, data, headers)

--- a/lib/ansible/modules/cloud/scaleway/scaleway_compute.py
+++ b/lib/ansible/modules/cloud/scaleway/scaleway_compute.py
@@ -584,8 +584,7 @@ def core(module):
     }
 
     compute_api = ScalewayAPI(module=module,
-                              headers={'X-Auth-Token': api_token,
-                                       'Content-type': 'application/json'},
+                              headers={'X-Auth-Token': api_token},
                               base_url=SCALEWAY_LOCATION[region]["api_endpoint"])
 
     changed, summary = state_strategy[wished_server["state"]](compute_api=compute_api, wished_server=wished_server)

--- a/lib/ansible/modules/cloud/scaleway/scaleway_sshkey.py
+++ b/lib/ansible/modules/cloud/scaleway/scaleway_sshkey.py
@@ -109,8 +109,7 @@ def core(module):
     ssh_pub_key = module.params['ssh_pub_key']
     state = module.params["state"]
     account_api = ScalewayAPI(module,
-                              headers={'X-Auth-Token': api_token,
-                                       'Content-type': 'application/json'},
+                              headers={'X-Auth-Token': api_token},
                               base_url=module.params["base_url"])
     response = account_api.get('organizations')
 


### PR DESCRIPTION
##### SUMMARY

This PR adds a User-Agent header to each API request.

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

- scaleway_compute
- scaleway_sshkeys

##### ANSIBLE VERSION

```
$ ansible --version
ansible 2.6.0
  config file = None
  configured module search path = [u'/Users/sieben/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/site-packages/ansible-2.6.0-py2.7.egg/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.14 (default, Mar  9 2018, 23:57:12) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```