### PR TITLE
Adding support for opensearch of documentation

### DIFF
--- a/docs/docsite/_static/opensearch.xml
+++ b/docs/docsite/_static/opensearch.xml
@@ -1,0 +1,9 @@
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/"
+                       xmlns:moz="http://www.mozilla.org/2006/browser/search/">
+  <ShortName>Ansible</ShortName>
+  <Description>Search Ansible Documentation</Description>
+  <InputEncoding>UTF-8</InputEncoding>
+  <Image width="16" height="16" type="image/x-icon">https://docs.ansible.com/favicon.ico</Image>
+  <Url type="text/html" method="get" template="https://docs.ansible.com/ansible/latest/search.html?q={searchTerms}&amp;ref=opensearch"/>
+  <moz:SearchForm>https://docs.ansible.com/ansible/latest/search.html</moz:SearchForm>
+</OpenSearchDescription>

--- a/docs/docsite/rst/conf.py
+++ b/docs/docsite/rst/conf.py
@@ -183,7 +183,7 @@ html_copy_source = False
 # If true, an OpenSearch description file will be output, and all pages will
 # contain a <link> tag referring to it.  The value of this option must be the
 # base URL from which the finished HTML is served.
-# html_use_opensearch = ''
+html_use_opensearch = 'https://docs.ansible.com/ansible/latest/'
 
 # If nonempty, this is the file name suffix for HTML files (e.g. ".xhtml").
 # html_file_suffix = ''


### PR DESCRIPTION
##### SUMMARY
I'm having trouble building docsite, but this should enable opensearch for Ansible documentation

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
