### PR TITLE
README.md was renamed.  Fix deb build reference to the README

### DIFF
--- a/packaging/debian/docs
+++ b/packaging/debian/docs
@@ -1,1 +1,1 @@
-README.md
+README.rst


### PR DESCRIPTION


##### ISSUE TYPE

 - Bugfix Pull Request


##### COMPONENT NAME
debian build process

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```