### PR TITLE
Change version added to 2.5.1 for script module stderr toggle feature

### DIFF
--- a/lib/ansible/plugins/inventory/script.py
+++ b/lib/ansible/plugins/inventory/script.py
@@ -21,7 +21,7 @@ DOCUMENTATION = '''
            - name: ANSIBLE_INVENTORY_PLUGIN_SCRIPT_CACHE
       always_show_stderr:
         description: Toggle display of stderr even when script was successful
-        version_added: "2.6"
+        version_added: "2.5.1"
         default: True
         type: boolean
         ini:


### PR DESCRIPTION
##### SUMMARY

A bugfix backported to 2.5 (#38177) also contained a new toggle option. The release manager (@nitzmahone ) approved backporting this added feature to the dot release. Updating `devel` to accurately reflect when the fetaure was added.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Docs Pull Request

##### COMPONENT NAME
`lib/ansible/plugins/inventory/script.py`

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6
```
