### PR TITLE
Extreme Networks SLXOS Config Module

### DIFF
--- a/lib/ansible/module_utils/network/slxos/slxos.py
+++ b/lib/ansible/module_utils/network/slxos/slxos.py
@@ -105,3 +105,44 @@ def run_commands(module, commands):
         responses.append(out)
 
     return responses
+
+
+def get_config(module):
+    """Get switch configuration
+
+    Gets the described device's current configuration. If a configuration has
+    already been retrieved it will return the previously obtained configuration.
+
+    Args:
+        module: A valid AnsibleModule instance.
+
+    Returns:
+        A string containing the configuration.
+    """
+    if not hasattr(module, 'device_configs'):
+        module.device_configs = {}
+    elif module.device_configs != {}:
+        return module.device_configs
+
+    connection = get_connection(module)
+    out = connection.get_config()
+    cfg = to_text(out, errors='surrogate_then_replace').strip()
+    module.device_configs = cfg
+    return cfg
+
+
+def load_config(module, commands):
+    """Apply a list of commands to a device.
+
+    Given a list of commands apply them to the device to modify the
+    configuration in bulk.
+
+    Args:
+        module: A valid AnsibleModule instance.
+        commands: Iterable of command strings.
+
+    Returns:
+        None
+    """
+    connection = get_connection(module)
+    connection.edit_config(commands)

--- a/lib/ansible/modules/network/slxos/slxos_config.py
+++ b/lib/ansible/modules/network/slxos/slxos_config.py
@@ -105,17 +105,6 @@ options:
         as the delimiting character.  This only applies to the
         configuration action.
     default: "@"
-  force:
-    description:
-      - The force argument instructs the module to not consider the
-        current devices running-config.  When set to true, this will
-        cause the module to push the contents of I(src) into the device
-        without first checking if already configured.
-      - Note this argument should be considered deprecated.  To achieve
-        the equivalent, set the C(match=none) which is idempotent.  This argument
-        will be removed in Ansible 2.6.
-    type: bool
-    default: 'no'
   backup:
     description:
       - This argument will cause the module to create a full backup of
@@ -142,15 +131,6 @@ options:
         when getting the remote device running config.  When enabled,
         the module will get the current config by issuing the command
         C(show running-config all).
-    type: bool
-    default: 'no'
-  save:
-    description:
-      - The C(save) argument instructs the module to save the running-
-        config to the startup-config at the conclusion of the module
-        running.  If check mode is specified, this argument is ignored.
-      - This option is deprecated as of Ansible 2.4 and will be removed
-        in Ansible 2.8, use C(save_when) instead.
     type: bool
     default: 'no'
   save_when:
@@ -345,17 +325,10 @@ def main():
 
         diff_against=dict(choices=['startup', 'intended', 'running']),
         diff_ignore_lines=dict(type='list'),
-
-        # save is deprecated as of ans2.4, use save_when instead
-        save=dict(default=False, type='bool', removed_in_version='2.8'),
-
-        # force argument deprecated in ans2.2
-        force=dict(default=False, type='bool', removed_in_version='2.6')
     )
 
     mutually_exclusive = [('lines', 'src'),
-                          ('parents', 'src'),
-                          ('save', 'save_when')]
+                          ('parents', 'src')]
 
     required_if = [('match', 'strict', ['lines']),
                    ('match', 'exact', ['lines']),
@@ -420,7 +393,7 @@ def main():
 
     diff_ignore_lines = module.params['diff_ignore_lines']
 
-    if module.params['save_when'] == 'always' or module.params['save']:
+    if module.params['save_when'] == 'always':
         save_config(module, result)
     elif module.params['save_when'] == 'modified':
         output = run_commands(module, ['show running-config', 'show startup-config'])

--- a/lib/ansible/modules/network/slxos/slxos_config.py
+++ b/lib/ansible/modules/network/slxos/slxos_config.py
@@ -44,7 +44,6 @@ options:
         in the device running-config.  Be sure to note the configuration
         command syntax as some commands are automatically modified by the
         device config parser.
-    required: false
     default: null
     aliases: ['commands']
   parents:
@@ -53,7 +52,6 @@ options:
         the commands should be checked against.  If the parents argument
         is omitted, the commands are checked against the set of top
         level or global commands.
-    required: false
     default: null
   src:
     description:
@@ -62,7 +60,6 @@ options:
         either be the full path on the Ansible control host or a relative
         path from the playbook or role root directory.  This argument is mutually
         exclusive with I(lines), I(parents).
-    required: false
     default: null
   before:
     description:
@@ -71,7 +68,6 @@ options:
         the opportunity to perform configuration commands prior to pushing
         any changes without affecting how the set of commands are matched
         against the system.
-    required: false
     default: null
   after:
     description:
@@ -79,7 +75,6 @@ options:
         stack if a change needs to be made.  Just like with I(before) this
         allows the playbook designer to append a set of commands to be
         executed after the command set.
-    required: false
     default: null
   match:
     description:
@@ -91,7 +86,6 @@ options:
         must be an equal match.  Finally, if match is set to I(none), the
         module will not attempt to compare the source configuration with
         the running configuration on the remote device.
-    required: false
     default: line
     choices: ['line', 'strict', 'exact', 'none']
   replace:
@@ -102,7 +96,6 @@ options:
         mode.  If the replace argument is set to I(block) then the entire
         command block is pushed to the device in configuration mode if any
         line is not correct.
-    required: false
     default: line
     choices: ['line', 'block']
   multiline_delimiter:
@@ -111,7 +104,6 @@ options:
         element to the SLX-OS device.  It specifies the character to use
         as the delimiting character.  This only applies to the
         configuration action.
-    required: false
     default: "@"
   force:
     description:
@@ -131,7 +123,6 @@ options:
         changes are made.  The backup file is written to the C(backup)
         folder in the playbook root directory.  If the directory does not
         exist, it is created.
-    required: false
     default: no
     type: bool
   running_config:
@@ -143,7 +134,6 @@ options:
         every task in a playbook.  The I(running_config) argument allows the
         implementer to pass in the configuration to use as the base
         config for comparison.
-    required: false
     default: null
     aliases: ['config']
   defaults:
@@ -178,7 +168,6 @@ options:
         I(never), the running-config will never be copied to the
         startup-config.  If the argument is set to I(changed), then the running-config
         will only be copied to the startup-config if the task has made a change.
-    required: false
     default: never
     choices: ['always', 'never', 'modified', 'changed']
   diff_against:
@@ -193,7 +182,6 @@ options:
       - When this option is configured as I(running), the module will
         return the before and after diff of the running-config with respect
         to any changes made to the device configuration.
-    required: false
     choices: ['running', 'startup', 'intended']
   diff_ignore_lines:
     description:
@@ -201,7 +189,6 @@ options:
         ignored during the diff.  This is used for lines in the configuration
         that are automatically updated by the system.  This argument takes
         a list of regular expressions or exact line matches.
-    required: false
   intended_config:
     description:
       - The C(intended_config) provides the master configuration that
@@ -211,7 +198,6 @@ options:
         of the current device's configuration against.  When specifying this
         argument, the task should also modify the C(diff_against) value and
         set it to I(intended).
-    required: false
 """
 
 EXAMPLES = """

--- a/lib/ansible/modules/network/slxos/slxos_config.py
+++ b/lib/ansible/modules/network/slxos/slxos_config.py
@@ -1,0 +1,499 @@
+#!/usr/bin/python
+#
+# (c) 2018 Extreme Networks Inc.
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+from __future__ import (absolute_import, division, print_function)
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = """
+---
+module: slxos_config
+version_added: "2.6"
+author: "Lindsay Hill (@LindsayHill)"
+short_description: Manage Extreme Networks SLX-OS configuration sections
+description:
+  - Extreme SLX-OS configurations use a simple block indent file syntax
+    for segmenting configuration into sections.  This module provides
+    an implementation for working with SLX-OS configuration sections in
+    a deterministic way.
+notes:
+  - Tested against SLX-OS 17s.1.02
+options:
+  lines:
+    description:
+      - The ordered set of commands that should be configured in the
+        section.  The commands must be the exact same commands as found
+        in the device running-config.  Be sure to note the configuration
+        command syntax as some commands are automatically modified by the
+        device config parser.
+    required: false
+    default: null
+    aliases: ['commands']
+  parents:
+    description:
+      - The ordered set of parents that uniquely identify the section or hierarchy
+        the commands should be checked against.  If the parents argument
+        is omitted, the commands are checked against the set of top
+        level or global commands.
+    required: false
+    default: null
+  src:
+    description:
+      - Specifies the source path to the file that contains the configuration
+        or configuration template to load.  The path to the source file can
+        either be the full path on the Ansible control host or a relative
+        path from the playbook or role root directory.  This argument is mutually
+        exclusive with I(lines), I(parents).
+    required: false
+    default: null
+  before:
+    description:
+      - The ordered set of commands to push on to the command stack if
+        a change needs to be made.  This allows the playbook designer
+        the opportunity to perform configuration commands prior to pushing
+        any changes without affecting how the set of commands are matched
+        against the system.
+    required: false
+    default: null
+  after:
+    description:
+      - The ordered set of commands to append to the end of the command
+        stack if a change needs to be made.  Just like with I(before) this
+        allows the playbook designer to append a set of commands to be
+        executed after the command set.
+    required: false
+    default: null
+  match:
+    description:
+      - Instructs the module on the way to perform the matching of
+        the set of commands against the current device config.  If
+        match is set to I(line), commands are matched line by line.  If
+        match is set to I(strict), command lines are matched with respect
+        to position.  If match is set to I(exact), command lines
+        must be an equal match.  Finally, if match is set to I(none), the
+        module will not attempt to compare the source configuration with
+        the running configuration on the remote device.
+    required: false
+    default: line
+    choices: ['line', 'strict', 'exact', 'none']
+  replace:
+    description:
+      - Instructs the module on the way to perform the configuration
+        on the device.  If the replace argument is set to I(line) then
+        the modified lines are pushed to the device in configuration
+        mode.  If the replace argument is set to I(block) then the entire
+        command block is pushed to the device in configuration mode if any
+        line is not correct.
+    required: false
+    default: line
+    choices: ['line', 'block']
+  multiline_delimiter:
+    description:
+      - This argument is used when pushing a multiline configuration
+        element to the SLX-OS device.  It specifies the character to use
+        as the delimiting character.  This only applies to the
+        configuration action.
+    required: false
+    default: "@"
+  force:
+    description:
+      - The force argument instructs the module to not consider the
+        current devices running-config.  When set to true, this will
+        cause the module to push the contents of I(src) into the device
+        without first checking if already configured.
+      - Note this argument should be considered deprecated.  To achieve
+        the equivalent, set the C(match=none) which is idempotent.  This argument
+        will be removed in Ansible 2.6.
+    type: bool
+    default: 'no'
+  backup:
+    description:
+      - This argument will cause the module to create a full backup of
+        the current C(running-config) from the remote device before any
+        changes are made.  The backup file is written to the C(backup)
+        folder in the playbook root directory.  If the directory does not
+        exist, it is created.
+    required: false
+    default: no
+    type: bool
+  running_config:
+    description:
+      - The module, by default, will connect to the remote device and
+        retrieve the current running-config to use as a base for comparing
+        against the contents of source.  There are times when it is not
+        desirable to have the task get the current running-config for
+        every task in a playbook.  The I(running_config) argument allows the
+        implementer to pass in the configuration to use as the base
+        config for comparison.
+    required: false
+    default: null
+    aliases: ['config']
+  defaults:
+    description:
+      - This argument specifies whether or not to collect all defaults
+        when getting the remote device running config.  When enabled,
+        the module will get the current config by issuing the command
+        C(show running-config all).
+    type: bool
+    default: 'no'
+    version_added: "2.2"
+  save:
+    description:
+      - The C(save) argument instructs the module to save the running-
+        config to the startup-config at the conclusion of the module
+        running.  If check mode is specified, this argument is ignored.
+      - This option is deprecated as of Ansible 2.4 and will be removed
+        in Ansible 2.8, use C(save_when) instead.
+    type: bool
+    default: 'no'
+    version_added: "2.2"
+  save_when:
+    description:
+      - When changes are made to the device running-configuration, the
+        changes are not copied to non-volatile storage by default.  Using
+        this argument will change that before.  If the argument is set to
+        I(always), then the running-config will always be copied to the
+        startup-config and the I(modified) flag will always be set to
+        True.  If the argument is set to I(modified), then the running-config
+        will only be copied to the startup-config if it has changed since
+        the last save to startup-config.  If the argument is set to
+        I(never), the running-config will never be copied to the
+        startup-config.  If the argument is set to I(changed), then the running-config
+        will only be copied to the startup-config if the task has made a change.
+    required: false
+    default: never
+    choices: ['always', 'never', 'modified', 'changed']
+  diff_against:
+    description:
+      - When using the C(ansible-playbook --diff) command line argument
+        the module can generate diffs against different sources.
+      - When this option is configure as I(startup), the module will return
+        the diff of the running-config against the startup-config.
+      - When this option is configured as I(intended), the module will
+        return the diff of the running-config against the configuration
+        provided in the C(intended_config) argument.
+      - When this option is configured as I(running), the module will
+        return the before and after diff of the running-config with respect
+        to any changes made to the device configuration.
+    required: false
+    choices: ['running', 'startup', 'intended']
+  diff_ignore_lines:
+    description:
+      - Use this argument to specify one or more lines that should be
+        ignored during the diff.  This is used for lines in the configuration
+        that are automatically updated by the system.  This argument takes
+        a list of regular expressions or exact line matches.
+    required: false
+  intended_config:
+    description:
+      - The C(intended_config) provides the master configuration that
+        the node should conform to and is used to check the final
+        running-config against.   This argument will not modify any settings
+        on the remote device and is strictly used to check the compliance
+        of the current device's configuration against.  When specifying this
+        argument, the task should also modify the C(diff_against) value and
+        set it to I(intended).
+    required: false
+"""
+
+EXAMPLES = """
+- name: configure top level configuration
+  slxos_config:
+    lines: hostname {{ inventory_hostname }}
+
+- name: configure interface settings
+  slxos_config:
+    lines:
+      - description test interface
+      - ip address 172.31.1.1/24
+    parents: interface Ethernet 0/1
+
+- name: configure multiple interfaces
+  slxos_config:
+    lines:
+      - lacp timeout long
+    parents: "{{ item }}"
+  with_items:
+    - interface Ethernet 0/1
+    - interface Ethernet 0/2
+
+- name: load new acl into device
+  slxos_config:
+    lines:
+      - seq 10 permit ip host 1.1.1.1 any log
+      - seq 20 permit ip host 2.2.2.2 any log
+      - seq 30 permit ip host 3.3.3.3 any log
+      - seq 40 permit ip host 4.4.4.4 any log
+      - seq 50 permit ip host 5.5.5.5 any log
+    parents: ip access-list extended test
+    before: no ip access-list extended test
+    match: exact
+
+- name: check the running-config against master config
+  slxos_config:
+    diff_against: intended
+    intended_config: "{{ lookup('file', 'master.cfg') }}"
+
+- name: check the startup-config against the running-config
+  slxos_config:
+    diff_against: startup
+    diff_ignore_lines:
+      - ntp clock .*
+
+- name: save running to startup when modified
+  slxos_config:
+    save_when: modified
+"""
+
+RETURN = """
+updates:
+  description: The set of commands that will be pushed to the remote device
+  returned: always
+  type: list
+  sample: ['switch-attributes hostname foo', 'router ospf', 'area 0']
+commands:
+  description: The set of commands that will be pushed to the remote device
+  returned: always
+  type: list
+  sample: ['switch-attributes hostname foo', 'router ospf', 'area 0']
+backup_path:
+  description: The full path to the backup file
+  returned: when backup is yes
+  type: string
+  sample: /playbooks/ansible/backup/slxos_config.2018-02-12@18:26:34
+"""
+import re
+import time
+
+from ansible.module_utils.network.slxos.slxos import run_commands, get_config, load_config
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.network.common.parsing import Conditional
+from ansible.module_utils.network.common.config import NetworkConfig, dumps
+from ansible.module_utils.six import iteritems
+
+__metaclass__ = type
+
+
+def check_args(module, warnings):
+    if module.params['multiline_delimiter']:
+        if len(module.params['multiline_delimiter']) != 1:
+            module.fail_json(msg='multiline_delimiter value can only be a '
+                                 'single character')
+
+
+def get_running_config(module, current_config=None):
+    contents = module.params['running_config']
+    if not contents:
+        if current_config:
+            contents = current_config.config_text
+        else:
+            contents = get_config(module)
+    return NetworkConfig(indent=1, contents=contents)
+
+
+def get_candidate(module):
+    candidate = NetworkConfig(indent=1)
+
+    if module.params['src']:
+        src = module.params['src']
+        candidate.load(src)
+
+    elif module.params['lines']:
+        parents = module.params['parents'] or list()
+        candidate.add(module.params['lines'], parents=parents)
+
+    return candidate
+
+
+def save_config(module, result):
+    result['changed'] = True
+    if not module.check_mode:
+        command = {"command": "copy running-config startup-config",
+                   "prompt": "This operation will modify your startup configuration. Do you want to continue", "answer": "y"}
+        run_commands(module, command)
+    else:
+        module.warn('Skipping command `copy running-config startup-config` '
+                    'due to check_mode.  Configuration not copied to '
+                    'non-volatile storage')
+
+
+def main():
+    """ main entry point for module execution
+    """
+    argument_spec = dict(
+        src=dict(type='path'),
+
+        lines=dict(aliases=['commands'], type='list'),
+        parents=dict(type='list'),
+
+        before=dict(type='list'),
+        after=dict(type='list'),
+
+        match=dict(default='line', choices=['line', 'strict', 'exact', 'none']),
+        replace=dict(default='line', choices=['line', 'block']),
+        multiline_delimiter=dict(default='@'),
+
+        running_config=dict(aliases=['config']),
+        intended_config=dict(),
+
+        defaults=dict(type='bool', default=False),
+        backup=dict(type='bool', default=False),
+
+        save_when=dict(choices=['always', 'never', 'modified', 'changed'], default='never'),
+
+        diff_against=dict(choices=['startup', 'intended', 'running']),
+        diff_ignore_lines=dict(type='list'),
+
+        # save is deprecated as of ans2.4, use save_when instead
+        save=dict(default=False, type='bool', removed_in_version='2.8'),
+
+        # force argument deprecated in ans2.2
+        force=dict(default=False, type='bool', removed_in_version='2.6')
+    )
+
+    mutually_exclusive = [('lines', 'src'),
+                          ('parents', 'src'),
+                          ('save', 'save_when')]
+
+    required_if = [('match', 'strict', ['lines']),
+                   ('match', 'exact', ['lines']),
+                   ('replace', 'block', ['lines']),
+                   ('diff_against', 'intended', ['intended_config'])]
+
+    module = AnsibleModule(argument_spec=argument_spec,
+                           mutually_exclusive=mutually_exclusive,
+                           required_if=required_if,
+                           supports_check_mode=True)
+
+    result = {'changed': False}
+
+    warnings = list()
+    check_args(module, warnings)
+    result['warnings'] = warnings
+
+    config = None
+
+    if module.params['backup'] or (module._diff and module.params['diff_against'] == 'running'):
+        contents = get_config(module)
+        config = NetworkConfig(indent=1, contents=contents)
+        if module.params['backup']:
+            result['__backup__'] = contents
+
+    if any((module.params['lines'], module.params['src'])):
+        match = module.params['match']
+        replace = module.params['replace']
+        path = module.params['parents']
+
+        candidate = get_candidate(module)
+
+        if match != 'none':
+            config = get_running_config(module, config)
+            path = module.params['parents']
+            configobjs = candidate.difference(config, path=path, match=match, replace=replace)
+        else:
+            configobjs = candidate.items
+
+        if configobjs:
+            commands = dumps(configobjs, 'commands').split('\n')
+
+            if module.params['before']:
+                commands[:0] = module.params['before']
+
+            if module.params['after']:
+                commands.extend(module.params['after'])
+
+            result['commands'] = commands
+            result['updates'] = commands
+
+            # send the configuration commands to the device and merge
+            # them with the current running config
+            if not module.check_mode:
+                if commands:
+                    load_config(module, commands)
+
+            result['changed'] = True
+
+    running_config = None
+    startup_config = None
+
+    diff_ignore_lines = module.params['diff_ignore_lines']
+
+    if module.params['save_when'] == 'always' or module.params['save']:
+        save_config(module, result)
+    elif module.params['save_when'] == 'modified':
+        output = run_commands(module, ['show running-config', 'show startup-config'])
+
+        running_config = NetworkConfig(indent=1, contents=output[0], ignore_lines=diff_ignore_lines)
+        startup_config = NetworkConfig(indent=1, contents=output[1], ignore_lines=diff_ignore_lines)
+
+        if running_config.sha1 != startup_config.sha1:
+            save_config(module, result)
+    elif module.params['save_when'] == 'changed' and result['changed']:
+        save_config(module, result)
+
+    if module._diff:
+        if not running_config:
+            output = run_commands(module, 'show running-config')
+            contents = output[0]
+        else:
+            contents = running_config.config_text
+
+        # recreate the object in order to process diff_ignore_lines
+        running_config = NetworkConfig(indent=1, contents=contents, ignore_lines=diff_ignore_lines)
+
+        if module.params['diff_against'] == 'running':
+            if module.check_mode:
+                module.warn("unable to perform diff against running-config due to check mode")
+                contents = None
+            else:
+                contents = config.config_text
+
+        elif module.params['diff_against'] == 'startup':
+            if not startup_config:
+                output = run_commands(module, 'show startup-config')
+                contents = output[0]
+            else:
+                contents = startup_config.config_text
+
+        elif module.params['diff_against'] == 'intended':
+            contents = module.params['intended_config']
+
+        if contents is not None:
+            base_config = NetworkConfig(indent=1, contents=contents, ignore_lines=diff_ignore_lines)
+
+            if running_config.sha1 != base_config.sha1:
+                if module.params['diff_against'] == 'intended':
+                    before = running_config
+                    after = base_config
+                elif module.params['diff_against'] in ('startup', 'running'):
+                    before = base_config
+                    after = running_config
+
+                result.update({
+                    'changed': True,
+                    'diff': {'before': str(before), 'after': str(after)}
+                })
+
+    module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/network/slxos/slxos_config.py
+++ b/lib/ansible/modules/network/slxos/slxos_config.py
@@ -144,7 +144,6 @@ options:
         C(show running-config all).
     type: bool
     default: 'no'
-    version_added: "2.2"
   save:
     description:
       - The C(save) argument instructs the module to save the running-
@@ -154,7 +153,6 @@ options:
         in Ansible 2.8, use C(save_when) instead.
     type: bool
     default: 'no'
-    version_added: "2.2"
   save_when:
     description:
       - When changes are made to the device running-configuration, the

--- a/test/units/module_utils/network/slxos/test_slxos.py
+++ b/test/units/module_utils/network/slxos/test_slxos.py
@@ -129,3 +129,21 @@ class TestPluginCLIConfSLXOS(unittest.TestCase):
         module.slxos_connection.get.assert_has_calls(calls)
 
         self.assertEqual(responses, run_command_responses)
+
+    @patch('ansible.module_utils.network.slxos.slxos.Connection')
+    def test_load_config(self, connection):
+        """ Test load_config
+        """
+        module = MagicMock()
+
+        commands = [
+            'what does it take',
+            'to be',
+            'number one?',
+            'two is not a winner',
+            'and three nobody remember',
+        ]
+
+        slxos.load_config(module, commands)
+
+        module.slxos_connection.edit_config.assert_called_once_with(commands)

--- a/test/units/modules/network/slxos/fixtures/slxos_config_config.cfg
+++ b/test/units/modules/network/slxos/fixtures/slxos_config_config.cfg
@@ -1,0 +1,12 @@
+!
+hostname router
+!
+interface GigabitEthernet0/0
+ ip address 1.2.3.4 255.255.255.0
+ description test string
+!
+interface GigabitEthernet0/1
+ ip address 6.7.8.9 255.255.255.0
+ description test string
+ shutdown
+!

--- a/test/units/modules/network/slxos/fixtures/slxos_config_src.cfg
+++ b/test/units/modules/network/slxos/fixtures/slxos_config_src.cfg
@@ -1,0 +1,11 @@
+!
+hostname foo
+!
+interface GigabitEthernet0/0
+ no ip address
+!
+interface GigabitEthernet0/1
+ ip address 6.7.8.9 255.255.255.0
+ description test string
+ shutdown
+!

--- a/test/units/modules/network/slxos/test_slxos_config.py
+++ b/test/units/modules/network/slxos/test_slxos_config.py
@@ -1,0 +1,205 @@
+#
+# (c) 2018 Extreme Networks Inc.
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.compat.tests.mock import patch
+from ansible.modules.network.slxos import slxos_config
+from units.modules.utils import set_module_args
+from .slxos_module import TestSlxosModule, load_fixture
+
+
+class TestSlxosConfigModule(TestSlxosModule):
+
+    module = slxos_config
+
+    def setUp(self):
+        super(TestSlxosConfigModule, self).setUp()
+
+        self.mock_get_config = patch('ansible.modules.network.slxos.slxos_config.get_config')
+        self.get_config = self.mock_get_config.start()
+
+        self.mock_load_config = patch('ansible.modules.network.slxos.slxos_config.load_config')
+        self.load_config = self.mock_load_config.start()
+
+        self.mock_run_commands = patch('ansible.modules.network.slxos.slxos_config.run_commands')
+        self.run_commands = self.mock_run_commands.start()
+
+    def tearDown(self):
+        super(TestSlxosConfigModule, self).tearDown()
+        self.mock_get_config.stop()
+        self.mock_load_config.stop()
+        self.mock_run_commands.stop()
+
+    def load_fixtures(self, commands=None):
+        config_file = 'slxos_config_config.cfg'
+        self.get_config.return_value = load_fixture(config_file)
+        self.load_config.return_value = None
+
+    def test_slxos_config_unchanged(self):
+        src = load_fixture('slxos_config_config.cfg')
+        set_module_args(dict(src=src))
+        self.execute_module()
+
+    def test_slxos_config_src(self):
+        src = load_fixture('slxos_config_src.cfg')
+        set_module_args(dict(src=src))
+        commands = ['hostname foo', 'interface GigabitEthernet0/0',
+                    'no ip address']
+        self.execute_module(changed=True, commands=commands)
+
+    def test_slxos_config_backup(self):
+        set_module_args(dict(backup=True))
+        result = self.execute_module()
+        self.assertIn('__backup__', result)
+
+    def test_slxos_config_save_always(self):
+        self.run_commands.return_value = "Hostname foo"
+        set_module_args(dict(save_when='always'))
+        self.execute_module(changed=True)
+        self.assertEqual(self.run_commands.call_count, 1)
+        self.assertEqual(self.get_config.call_count, 0)
+        self.assertEqual(self.load_config.call_count, 0)
+        args = self.run_commands.call_args[0][1]
+        self.assertIn('copy running-config startup-config', args['command'])
+
+    def test_slxos_config_save_changed_true(self):
+        src = load_fixture('slxos_config_src.cfg')
+        set_module_args(dict(src=src, save_when='changed'))
+        commands = ['hostname foo', 'interface GigabitEthernet0/0', 'no ip address']
+        self.execute_module(changed=True, commands=commands)
+        self.assertEqual(self.run_commands.call_count, 1)
+        self.assertEqual(self.get_config.call_count, 1)
+        self.assertEqual(self.load_config.call_count, 1)
+        args = self.run_commands.call_args[0][1]
+        self.assertIn('copy running-config startup-config', args['command'])
+
+    def test_slxos_config_save_changed_false(self):
+        set_module_args(dict(save_when='changed'))
+        self.execute_module(changed=False)
+        self.assertEqual(self.run_commands.call_count, 0)
+        self.assertEqual(self.get_config.call_count, 0)
+        self.assertEqual(self.load_config.call_count, 0)
+
+    def test_slxos_config_save(self):
+        self.run_commands.return_value = "hostname foo"
+        set_module_args(dict(save=True))
+        self.execute_module(changed=True)
+        self.assertEqual(self.run_commands.call_count, 1)
+        self.assertEqual(self.get_config.call_count, 0)
+        self.assertEqual(self.load_config.call_count, 0)
+        args = self.run_commands.call_args[0][1]
+        self.assertIn('copy running-config startup-config', args['command'])
+
+    def test_slxos_config_lines_wo_parents(self):
+        set_module_args(dict(lines=['hostname foo']))
+        commands = ['hostname foo']
+        self.execute_module(changed=True, commands=commands)
+
+    def test_slxos_config_lines_w_parents(self):
+        set_module_args(dict(lines=['shutdown'], parents=['interface GigabitEthernet0/0']))
+        commands = ['interface GigabitEthernet0/0', 'shutdown']
+        self.execute_module(changed=True, commands=commands)
+
+    def test_slxos_config_before(self):
+        set_module_args(dict(lines=['hostname foo'], before=['test1', 'test2']))
+        commands = ['test1', 'test2', 'hostname foo']
+        self.execute_module(changed=True, commands=commands, sort=False)
+
+    def test_slxos_config_after(self):
+        set_module_args(dict(lines=['hostname foo'], after=['test1', 'test2']))
+        commands = ['hostname foo', 'test1', 'test2']
+        self.execute_module(changed=True, commands=commands, sort=False)
+
+    def test_slxos_config_before_after_no_change(self):
+        set_module_args(dict(lines=['hostname router'],
+                             before=['test1', 'test2'],
+                             after=['test3', 'test4']))
+        self.execute_module()
+
+    def test_slxos_config_config(self):
+        config = 'hostname localhost'
+        set_module_args(dict(lines=['hostname router'], config=config))
+        commands = ['hostname router']
+        self.execute_module(changed=True, commands=commands)
+
+    def test_slxos_config_replace_block(self):
+        lines = ['description test string', 'test string']
+        parents = ['interface GigabitEthernet0/0']
+        set_module_args(dict(lines=lines, replace='block', parents=parents))
+        commands = parents + lines
+        self.execute_module(changed=True, commands=commands)
+
+    def test_slxos_config_match_none(self):
+        lines = ['hostname router']
+        set_module_args(dict(lines=lines, match='none'))
+        self.execute_module(changed=True, commands=lines)
+
+    def test_slxos_config_match_none(self):
+        lines = ['ip address 1.2.3.4 255.255.255.0', 'description test string']
+        parents = ['interface GigabitEthernet0/0']
+        set_module_args(dict(lines=lines, parents=parents, match='none'))
+        commands = parents + lines
+        self.execute_module(changed=True, commands=commands, sort=False)
+
+    def test_slxos_config_match_strict(self):
+        lines = ['ip address 1.2.3.4 255.255.255.0', 'description test string',
+                 'shutdown']
+        parents = ['interface GigabitEthernet0/0']
+        set_module_args(dict(lines=lines, parents=parents, match='strict'))
+        commands = parents + ['shutdown']
+        self.execute_module(changed=True, commands=commands, sort=False)
+
+    def test_slxos_config_match_exact(self):
+        lines = ['ip address 1.2.3.4 255.255.255.0', 'description test string',
+                 'shutdown']
+        parents = ['interface GigabitEthernet0/0']
+        set_module_args(dict(lines=lines, parents=parents, match='exact'))
+        commands = parents + lines
+        self.execute_module(changed=True, commands=commands, sort=False)
+
+    def test_slxos_config_src_and_lines_fails(self):
+        args = dict(src='foo', lines='foo')
+        set_module_args(args)
+        self.execute_module(failed=True)
+
+    def test_slxos_config_src_and_parents_fails(self):
+        args = dict(src='foo', parents='foo')
+        set_module_args(args)
+        self.execute_module(failed=True)
+
+    def test_slxos_config_match_exact_requires_lines(self):
+        args = dict(match='exact')
+        set_module_args(args)
+        self.execute_module(failed=True)
+
+    def test_slxos_config_match_strict_requires_lines(self):
+        args = dict(match='strict')
+        set_module_args(args)
+        self.execute_module(failed=True)
+
+    def test_slxos_config_replace_block_requires_lines(self):
+        args = dict(replace='block')
+        set_module_args(args)
+        self.execute_module(failed=True)
+
+    def test_slxos_config_replace_config_requires_src(self):
+        args = dict(replace='config')
+        set_module_args(args)
+        self.execute_module(failed=True)

--- a/test/units/modules/network/slxos/test_slxos_config.py
+++ b/test/units/modules/network/slxos/test_slxos_config.py
@@ -97,16 +97,6 @@ class TestSlxosConfigModule(TestSlxosModule):
         self.assertEqual(self.get_config.call_count, 0)
         self.assertEqual(self.load_config.call_count, 0)
 
-    def test_slxos_config_save(self):
-        self.run_commands.return_value = "hostname foo"
-        set_module_args(dict(save=True))
-        self.execute_module(changed=True)
-        self.assertEqual(self.run_commands.call_count, 1)
-        self.assertEqual(self.get_config.call_count, 0)
-        self.assertEqual(self.load_config.call_count, 0)
-        args = self.run_commands.call_args[0][1]
-        self.assertIn('copy running-config startup-config', args['command'])
-
     def test_slxos_config_lines_wo_parents(self):
         set_module_args(dict(lines=['hostname foo']))
         commands = ['hostname foo']


### PR DESCRIPTION
##### SUMMARY
This PR adds the Extreme Networks SLXOS Config module and supporting utilities and tests.

##### ISSUE TYPE
 - New Module Pull Request

##### COMPONENT NAME
`slxos_config`

##### ANSIBLE VERSION
```
⟩ ansible --version
ansible 2.6.0 (slxos-config 5c67f37569) last updated 2018/04/11 13:07:51 (GMT -500)
  config file = None
  configured module search path = [u'/Users/mstone/dev/stackstorm/ansible/library']
  ansible python module location = /Users/mstone/dev/stackstorm/ansible/lib/ansible
  executable location = /Users/mstone/dev/stackstorm/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 29 2018, 15:58:25) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```


##### ADDITIONAL INFORMATION
```
⟩ ansible-playbook --ask-pass -i hosts.yml config.yml
SSH password:
ERROR! no action detected in task. This often indicates a misspelled module name, or incorrect module path.

The error appears to have been in '/Users/mstone/dev/stackstorm/ansible-slxos/config.yml': line 7, column 7, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

  tasks:
    - name: run multiple commands on remote nodes
      ^ here
```

```
⟩ ansible-playbook --ask-pass -i hosts.yml config.yml
SSH password:

PLAY [dc2leaf2] ********************************************************************************************************************************************************************************************

TASK [run multiple commands on remote nodes] ***************************************************************************************************************************************************************
ok: [dc2leaf2]

PLAY RECAP *************************************************************************************************************************************************************************************************
dc2leaf2                   : ok=1    changed=0    unreachable=0    failed=0
```
