### PR TITLE
Fix get_cloud_platforms config usage.

### DIFF
--- a/test/runner/lib/cloud/__init__.py
+++ b/test/runner/lib/cloud/__init__.py
@@ -43,12 +43,13 @@ def initialize_cloud_plugins():
 
 def get_cloud_platforms(args, targets=None):
     """
-    :type args: IntegrationConfig
+    :type args: TestConfig
     :type targets: tuple[IntegrationTarget] | None
     :rtype: list[str]
     """
-    if args.list_targets:
-        return []
+    if isinstance(args, IntegrationConfig):
+        if args.list_targets:
+            return []
 
     if targets is None:
         cloud_platforms = set(args.metadata.cloud_config or [])


### PR DESCRIPTION
##### SUMMARY

Fix get_cloud_platforms config usage.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.6.0 (at-cloud-fix b1ccadd14f) last updated 2018/04/11 14:50:02 (GMT -700)
  config file = None
  configured module search path = ['/Users/mclay/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 3.6.4 (default, Mar 22 2018, 13:54:22) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
