### PR TITLE
Use a temp directory that is more likely to exist

### DIFF
--- a/docs/docsite/rst/user_guide/windows_setup.rst
+++ b/docs/docsite/rst/user_guide/windows_setup.rst
@@ -35,7 +35,7 @@ This is an example of how to run this script from PowerShell:
 .. code-block:: guess
 
     $url = "https://raw.githubusercontent.com/jborean93/ansible-windows/master/scripts/Upgrade-PowerShell.ps1"
-    $file = "$env:TEMP\Upgrade-PowerShell.ps1"
+    $file = "$env:temp\Upgrade-PowerShell.ps1"
     $username = "Administrator"
     $password = "Password"
 
@@ -93,7 +93,7 @@ The following PowerShell command will install the hotfix:
 .. code-block:: guess
 
     $url = "https://raw.githubusercontent.com/jborean93/ansible-windows/master/scripts/Install-WMF3Hotfix.ps1"
-    $file = "$env:SystemDrive\temp\Install-WMF3Hotfix.ps1"
+    $file = "$env:temp\Install-WMF3Hotfix.ps1"
 
     (New-Object -TypeName System.Net.WebClient).DownloadFile($url, $file)
     powershell.exe -ExecutionPolicy ByPass -File $file -Verbose
@@ -116,7 +116,7 @@ To use this script, run the following in PowerShell:
 .. code-block:: guess
 
     $url = "https://raw.githubusercontent.com/ansible/ansible/devel/examples/scripts/ConfigureRemotingForAnsible.ps1"
-    $file = "$env:SystemDrive\temp\ConfigureRemotingForAnsible.ps1"
+    $file = "$env:temp\ConfigureRemotingForAnsible.ps1"
 
     (New-Object -TypeName System.Net.WebClient).DownloadFile($url, $file)
 


### PR DESCRIPTION
##### SUMMARY

`env:SystemDrive\temp` does not necessarily exist

`env:temp` is much more likely to exist. Use that

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
windows_setup

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0 (devel c9fb054bc8) last updated 2018/04/12 10:55:24 (GMT +1000)
  config file = None
  configured module search path = [u'/home/will/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/will/src/ansible/lib/ansible
  executable location = /home/will/src/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 14 2018, 13:36:31) [GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]

```
