### PR TITLE
win_setup: fix for machine sid to work in domains with lots of users

### DIFF
--- a/lib/ansible/modules/windows/setup.ps1
+++ b/lib/ansible/modules/windows/setup.ps1
@@ -29,16 +29,24 @@ Function Get-MachineSid {
     # only accessible by the Local System account. This method get's the local
     # admin account (ends with -500) and lops it off to get the machine sid.
 
+    $admins_sid = "S-1-5-32-544"
+    $admin_group = ([Security.Principal.SecurityIdentifier]$admins_sid).Translate([Security.Principal.NTAccount]).Value 
+
     Add-Type -AssemblyName System.DirectoryServices.AccountManagement
     $principal_context = New-Object -TypeName System.DirectoryServices.AccountManagement.PrincipalContext([System.DirectoryServices.AccountManagement.ContextType]::Machine)
-    $user_principal = New-Object -TypeName System.DirectoryServices.AccountManagement.UserPrincipal($principal_context)
-    $searcher = New-Object -TypeName System.DirectoryServices.AccountManagement.PrincipalSearcher($user_principal)
-    $users = $searcher.FindAll() | Where-Object { $_.Sid -like "*-500" }
+    $group_principal = New-Object -TypeName System.DirectoryServices.AccountManagement.GroupPrincipal($principal_context, $admin_group)
+    $searcher = New-Object -TypeName System.DirectoryServices.AccountManagement.PrincipalSearcher($group_principal)
+    $groups = $searcher.FindOne()
 
     $machine_sid = $null
-    if ($users -ne $null) {
-        $machine_sid = $users.Sid.AccountDomainSid.Value
+    foreach ($user in $groups.Members) {
+        $user_sid = $user.Sid
+        if ($user_sid.Value.EndsWith("-500")) {
+            $machine_sid = $user_sid.AccountDomainSid.Value
+            break
+        }
     }
+
     return $machine_sid
 }
 


### PR DESCRIPTION
##### SUMMARY
The machine sid logic would take a long time if run in a domain environment that has a high latency between the host and the DC. This PR changes the logic so that it only searches the local administrators group which has a well known SID and finds the builtin admin account from there.

Fixes https://github.com/ansible/ansible/issues/38427
May Fix https://github.com/ansible/ansible/issues/38257

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
setup.ps1

##### ANSIBLE VERSION
```
devel
```