### PR TITLE
VMware: report failure if no snapshot exists on VM

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest_snapshot.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_snapshot.py
@@ -280,7 +280,7 @@ class PyVmomiHelper(PyVmomi):
 
     def rename_snapshot(self, vm):
         if vm.snapshot is None:
-            self.module.exit_json(msg="virtual machine - %s doesn't have any"
+            self.module.fail_json(msg="virtual machine - %s doesn't have any"
                                       " snapshots" % (self.module.params.get('uuid') or self.module.params.get('name')))
 
         snap_obj = self.get_snapshots_by_name_recursively(vm.snapshot.rootSnapshotList,
@@ -304,8 +304,12 @@ class PyVmomiHelper(PyVmomi):
 
     def remove_or_revert_snapshot(self, vm):
         if vm.snapshot is None:
+            vm_name = (self.module.params.get('uuid') or self.module.params.get('name'))
+            if self.module.params.get('state') == 'revert':
+                self.module.fail_json(msg="virtual machine - %s does not"
+                                          " have any snapshots to revert to." % vm_name)
             self.module.exit_json(msg="virtual machine - %s doesn't have any"
-                                      " snapshots" % (self.module.params.get('uuid') or self.module.params.get('name')))
+                                      " snapshots to remove." % vm_name)
 
         snap_obj = self.get_snapshots_by_name_recursively(vm.snapshot.rootSnapshotList,
                                                           self.module.params["snapshot_name"])


### PR DESCRIPTION
##### SUMMARY
This fix add correct reporting of failure if VM does not contain
any snapshots for following operations - rename, remove and revert.

Fixes: #37906

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/vmware/vmware_guest_snapshot.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6devel
```