### PR TITLE
Fix typo

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_inventory.rst
+++ b/docs/docsite/rst/dev_guide/developing_inventory.rst
@@ -19,7 +19,7 @@ When the dynamic inventory provider is called with the single argument ``--list`
 
     {
         "group001": {
-            "hosts": ["host001", "" "host002"],
+            "hosts": ["host001", "host002"],
             "vars": {
                 "var1": true
             },


### PR DESCRIPTION
Typo
+label: docsite_pr

##### SUMMARY
Fix a simple typo with empty quotes

##### ISSUE TYPE

 - Docs Pull Request

##### COMPONENT NAME

developing_inventory

##### ANSIBLE VERSION

```
ansible 2.6.0 (scaleway_inventory 9dd20a20be) last updated 2018/04/11 18:06:30 (GMT +200)
  config file = /Users/sieben/.ansible.cfg
  configured module search path = ['/Users/sieben/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/sieben/workspace/ansible/lib/ansible
  executable location = /Users/sieben/workspace/ansible/bin/ansible
  python version = 3.6.4 (v3.6.4:d48ecebad5, Dec 18 2017, 21:07:28) [GCC 4.2.1 (Apple Inc. build 5666) (dot 3)]
```