### PR TITLE
Remove boolean check for underscore in IAM role

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_metadata_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_metadata_facts.py
@@ -456,7 +456,7 @@ class Ec2Metadata(object):
         new_fields = {}
         for key, value in fields.items():
             split_fields = key[len(uri):].split('/')
-            if len(split_fields) == 3 and split_fields[0:2] == ['iam', 'security-credentials'] and '_' not in split_fields[2]:
+            if len(split_fields) == 3 and split_fields[0:2] == ['iam', 'security-credentials']:
                 new_fields[self._prefix % "iam-instance-profile-role"] = split_fields[2]
             if len(split_fields) > 1 and split_fields[1]:
                 new_key = "-".join(split_fields)


### PR DESCRIPTION
Underscore is a valid character in an IAM role

##### SUMMARY
Fixes part of #38658. Remove an unnecessary check that improperly removed IAM roles with underscores.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ec2_metadata_facts

##### ANSIBLE VERSION
```
ansible 2.5.0.0
```
