### PR TITLE
Fix zabbix_host for Zabbix Server versions < 3.0

### DIFF
--- a/lib/ansible/modules/monitoring/zabbix/zabbix_host.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_host.py
@@ -509,27 +509,27 @@ class Host(object):
             if proposed_inventory != host['inventory']:
                 return True
 
-        if tls_accept is not None:
+        if tls_accept is not None and 'tls_accept' in host:
             if int(host['tls_accept']) != tls_accept:
                 return True
 
-        if tls_psk_identity is not None:
+        if tls_psk_identity is not None and 'tls_psk_identity' in host:
             if host['tls_psk_identity'] != tls_psk_identity:
                 return True
 
-        if tls_psk is not None:
+        if tls_psk is not None and 'tls_psk' in host:
             if host['tls_psk'] != tls_psk:
                 return True
 
-        if tls_issuer is not None:
+        if tls_issuer is not None and 'tls_issuer' in host:
             if host['tls_issuer'] != tls_issuer:
                 return True
 
-        if tls_subject is not None:
+        if tls_subject is not None and 'tls_subject' in host:
             if host['tls_subject'] != tls_subject:
                 return True
 
-        if tls_connect is not None:
+        if tls_connect is not None and 'tls_connect' in host:
             if int(host['tls_connect']) != tls_connect:
                 return True
         if ipmi_authtype is not None:


### PR DESCRIPTION
##### SUMMARY
The tls_* parameters are not present in Zabbix Server versions prior to
3.0. Thus the API response does not contain these keys and the
zabbix_host module failed. This commit adds checks if the parameters are
present in the API response and otherwise just completely ignores these
parameters. The documentation already states that they are not supported
for Zabbix Server versions below 3.0.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
zabbix_host

##### ANSIBLE VERSION
```
devel
```
