### PR TITLE
Changed vmware documentation to include esxi host in the variable description

### DIFF
--- a/lib/ansible/utils/module_docs_fragments/vmware.py
+++ b/lib/ansible/utils/module_docs_fragments/vmware.py
@@ -9,20 +9,20 @@ class ModuleDocFragment(object):
 options:
     hostname:
       description:
-      - The hostname or IP address of the vSphere vCenter.
+      - The hostname or IP address of the vSphere vCenter or ESXi server.
       - If the value is not specified in the task, the value of environment variable C(VMWARE_HOST) will be used instead.
       - Environment variable supported added in version 2.6.
       required: False
     username:
       description:
-      - The username of the vSphere vCenter.
+      - The username of the vSphere vCenter or ESXi server.
       - If the value is not specified in the task, the value of environment variable C(VMWARE_USER) will be used instead.
       - Environment variable supported added in version 2.6.
       required: False
       aliases: ['user', 'admin']
     password:
       description:
-      - The password of the vSphere vCenter.
+      - The password of the vSphere vCenter or ESXi server.
       - If the value is not specified in the task, the value of environment variable C(VMWARE_PASSWORD) will be used instead.
       - Environment variable supported added in version 2.6.
       required: False


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Changed the documentation of the hostname, username, password variables to show that they are applicable to an esxi host also, like the port variable.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/ansible/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Aug  4 2017, 00:39:18) [GCC 4.8.5 20150623 (Red Hat 4.8.5-16)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
