### PR TITLE
Fix in eos get_config cliconf api

### DIFF
--- a/lib/ansible/plugins/cliconf/eos.py
+++ b/lib/ansible/plugins/cliconf/eos.py
@@ -51,13 +51,12 @@ class Cliconf(CliconfBase):
         lookup = {'running': 'running-config', 'startup': 'startup-config'}
         if source not in lookup:
             return self.invalid_params("fetching configuration from %s is not supported" % source)
-        if format == 'text':
-            cmd = b'show %s ' % lookup[source]
-        else:
-            cmd = b'show %s | %s' % (lookup[source], format)
 
-        flags = [] if flags is None else flags
-        cmd += ' '.join(flags)
+        cmd = b'show %s ' % lookup[source]
+        if format and format is not 'text':
+            cmd += b'| %s ' % format
+
+        cmd += ' '.join(to_list(flags))
         cmd = cmd.strip()
         return self.send_command(cmd)
 


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
If format is passed as None to get_config api, wrong command is
genereted ie. `show running-configuration | None | section interface`.
Add format type in command only if format value is either not `text`
or not `None`.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
plugins/cliconf/eos.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
