### PR TITLE
nmcli: change default value of autoconnect

### DIFF
--- a/changelogs/fragments/38671-nmcli_autoconnect_value_correction.yaml
+++ b/changelogs/fragments/38671-nmcli_autoconnect_value_correction.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- nmcli change default value of autoconnect

--- a/lib/ansible/modules/net_tools/nmcli.py
+++ b/lib/ansible/modules/net_tools/nmcli.py
@@ -34,7 +34,7 @@ options:
             - Whether the device should exist or not, taking action if the state is different from what is stated.
     autoconnect:
         required: False
-        default: "yes"
+        default: True
         type: bool
         description:
             - Whether the connection should start on boot.
@@ -1210,7 +1210,7 @@ def main():
     # Parsing argument file
     module = AnsibleModule(
         argument_spec=dict(
-            autoconnect=dict(required=False, default=None, type='bool'),
+            autoconnect=dict(required=False, default=True, type='bool'),
             state=dict(required=True, choices=['present', 'absent'], type='str'),
             conn_name=dict(required=True, type='str'),
             master=dict(required=False, default=None, type='str'),


### PR DESCRIPTION
##### SUMMARY
There was discrepancy between documentation and actual code.

Fixes: #38671

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

(cherry picked from commit f1cd2542653dd8274025858fdaca057c285bd6d0)

##### ISSUE TYPE
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
lib/ansible/modules/net_tools/nmcli.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
Stable-2.5
```