### PR TITLE
Attempt 2: Prevent reparenting a block with itself

### DIFF
--- a/lib/ansible/playbook/block.py
+++ b/lib/ansible/playbook/block.py
@@ -183,11 +183,11 @@ class Block(Base, Become, Conditional, Taggable):
                         cur_obj = cur_obj._parent
 
                     # Ensure that we don't make the new_block the parent of itself
-                    if cur_obj != new_block:
-                        cur_obj._parent = new_block
-                    else:
+                    if cur_obj == new_block:
                         # prev_obj._parent is cur_obj, to allow for mutability we need to use prev_obj
                         prev_obj._parent = new_block
+                    else:
+                        cur_obj._parent = new_block
                 else:
                     new_task._parent = new_block
                 new_task_list.append(new_task)


### PR DESCRIPTION
##### SUMMARY
In https://github.com/ansible/ansible/pull/36075 I implemented a change to avoid reparenting a block with itself.  I overlooked the fact that my logic which used `!=` caused issues on py2, since `!=` does not use the inverse value of `__eq__` when `__ne__` was not defined.

As such this only really fixed the bug on python3.

Partially addresses https://github.com/ansible/ansible/issues/38357

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/playbook/block.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
2.6
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```