### PR TITLE
Add docs to `AnsibleAWSModule.client` retry settings

### DIFF
--- a/lib/ansible/module_utils/aws/core.py
+++ b/lib/ansible/module_utils/aws/core.py
@@ -38,12 +38,25 @@ The 'AnsibleAWSModule' module provides similar, but more restricted,
 interfaces to the normal Ansible module.  It also includes the
 additional methods for connecting to AWS using the standard module arguments
 
-      m.resource('lambda') # - get an AWS connection as a boto3 resource.
+    m.resource('lambda') # - get an AWS connection as a boto3 resource.
 
 or
 
-      m.client('sts') # - get an AWS connection as a boto3 client.
+    m.client('sts') # - get an AWS connection as a boto3 client.
 
+To make use of AWSRetry easier, it can now be wrapped around any call from a
+module-created client. To add retries to a client, create a client:
+
+    m.client('ec2', retry_decorator=AWSRetry.jittered_backoff(retries=10))
+
+Any calls from that client can be made to use the decorator passed at call-time
+using the `aws_retry` argument. By default, no retries are used.
+
+    ec2 = m.client('ec2', retry_decorator=AWSRetry.jittered_backoff(retries=10))
+    ec2.describe_instances(InstanceIds=['i-123456789'], aws_retry=True)
+
+The call will be retried the specified number of times, so the calling functions
+don't need to be wrapped in the backoff decorator.
 
 """
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

AWSModule clients now have a feature to wrap all calls in AWSRetry automatically. This feature was undocumented when it was merged. This PR adds docs on how to use the retry to avoid needing to wrap module code in retries. 

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
AWS module_utils

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
