### PR TITLE
Attempt 3: Prevent reparenting a block with itself

### DIFF
--- a/lib/ansible/playbook/block.py
+++ b/lib/ansible/playbook/block.py
@@ -69,6 +69,10 @@ class Block(Base, Become, Conditional, Taggable):
         '''object comparison based on _uuid'''
         return self._uuid == other._uuid
 
+    def __ne__(self, other):
+        '''object comparison based on _uuid'''
+        return self._uuid != other._uuid
+
     def get_vars(self):
         '''
         Blocks do not store variables directly, however they may be a member
@@ -174,20 +178,17 @@ class Block(Base, Become, Conditional, Taggable):
                 if task._parent:
                     new_task._parent = task._parent.copy(exclude_tasks=True)
                     # go up the parentage tree until we find an
-                    # object without a parent and make this new
-                    # block their parent
-                    cur_obj = new_task
-                    while cur_obj._parent:
-                        if cur_obj._parent:
-                            prev_obj = cur_obj
+                    # object without a parent or a parent that matches the new_block
+                    # and make this new block their parent.
+                    #
+                    # we start with new_task._parent, because new_task._parent is the same as new_block
+                    # but simply replacing it doesn't suffice, as we seem to lose important context, so we
+                    # must traverse farther
+                    cur_obj = new_task._parent
+                    while cur_obj._parent and cur_obj._parent != new_block:
                         cur_obj = cur_obj._parent
 
-                    # Ensure that we don't make the new_block the parent of itself
-                    if cur_obj != new_block:
-                        cur_obj._parent = new_block
-                    else:
-                        # prev_obj._parent is cur_obj, to allow for mutability we need to use prev_obj
-                        prev_obj._parent = new_block
+                    cur_obj._parent = new_block
                 else:
                     new_task._parent = new_block
                 new_task_list.append(new_task)


### PR DESCRIPTION
##### SUMMARY
Attempt 3: Prevent reparenting a block with itself

In https://github.com/ansible/ansible/pull/36075 I implemented a change to avoid reparenting a block with itself.  I overlooked the fact that my logic which used `!=` caused issues on py2, since `!=` does not use the inverse value of `__eq__` when `__ne__` was not defined.

As such this only really fixed the bug on python3.

Even with a change in logic or implementing `__ne__` we could only get a little further before a recursion error.

This change attempts to reparent without going too shallow or too deep in the parent chain.  The very original always went too deep, always reparenting unnecessarily, in #36075 we went nearly as deep.

Simply replacing `new_task._parent = new_block` led to missing context which caused existing tests to fail.

This PR will start with `new_task._parent` and (hopefully) reparent the correct item in the tree.

Using the reproducer in #38357 I was able to add 200 `include_role` tasks and succeed without an issue.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/playbook/block.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
2.6
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```