### PR TITLE
Modules that have a link to their own deprecated section need to use a different link syntax

### DIFF
--- a/docs/templates/plugin.rst.j2
+++ b/docs/templates/plugin.rst.j2
@@ -386,7 +386,7 @@ please refer to this `Knowledge Base article <https://access.redhat.com/articles
 
 {% else %}
 
-This module is flagged as **deprecated** and will be removed in version { deprecated['removed_in'] | default('') | string | convert_symbols_to_format }@. For more information see :ref:`DEPRECATED`.
+This module is flagged as **deprecated** and will be removed in version @{ deprecated['removed_in'] | default('') | string | convert_symbols_to_format }@. For more information see `DEPRECATED`_.
 
 {% endif %}
 


### PR DESCRIPTION

The :ref: syntax is for linking to targets which are defined for the
whole document tree.  `link`_ is for linking to targets which are inside
of the document.  We want the latter for deprecated sections because
otherwise we'd have to create namespaced link targets for them.

##### ISSUE TYPE

 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
any module docs which have a deprecated section

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel and 2.5
```
