### PR TITLE
adds FAQ TOC entry, links & examples to modules

### DIFF
--- a/docs/docsite/rst/network/index.rst
+++ b/docs/docsite/rst/network/index.rst
@@ -32,6 +32,7 @@ For documentation on using a particular network module, consult the :doc:`list o
    :caption: User Guide
 
    user_guide/index
+   user_guide/faq
    user_guide/network_best_practices_2.5
    user_guide/network_debug_troubleshooting
    user_guide/network_working_with_command_output

--- a/lib/ansible/modules/network/eos/eos_config.py
+++ b/lib/ansible/modules/network/eos/eos_config.py
@@ -239,7 +239,7 @@ EXAMPLES = """
 
 - name: for idempotency, use full-form commands
   eos_config:
-	lines:
+    lines:
 	  # - shut
 	  - shutdown
 	# parents: int eth1/1

--- a/lib/ansible/modules/network/eos/eos_config.py
+++ b/lib/ansible/modules/network/eos/eos_config.py
@@ -44,6 +44,8 @@ options:
         in the device running-config.  Be sure to note the configuration
         command syntax as some commands are automatically modified by the
         device config parser.
+      - Abbreviated commands in lines are NOT idempotent, see 
+        L(Network FAQ,../network/user_guide/faq.html).
     aliases: ['commands']
   parents:
     description:
@@ -234,6 +236,15 @@ EXAMPLES = """
   eos_config:
     diff_against: intended
     intended_config: "{{ lookup('file', 'master.cfg') }}"
+
+- name: for idempotency, use full-form commands
+  eos_config:
+	lines:
+	  # - shut
+	  - shutdown
+	# parents: int eth1/1
+	parents: interface Ethernet1/1
+
 """
 
 RETURN = """

--- a/lib/ansible/modules/network/eos/eos_config.py
+++ b/lib/ansible/modules/network/eos/eos_config.py
@@ -44,8 +44,6 @@ options:
         in the device running-config.  Be sure to note the configuration
         command syntax as some commands are automatically modified by the
         device config parser.
-      - Abbreviated commands in lines are NOT idempotent, see
-        L(Network FAQ,../network/user_guide/faq.html).
     aliases: ['commands']
   parents:
     description:
@@ -205,6 +203,8 @@ options:
         argument, the task should also modify the C(diff_against) value and
         set it to I(intended).
     version_added: "2.4"
+notes:
+  - Abbreviated commands are NOT idempotent, see L(Network FAQ,../network/user_guide/faq.html).
 """
 
 EXAMPLES = """
@@ -242,9 +242,8 @@ EXAMPLES = """
     lines:
       # - shut
       - shutdown
-    # parents: int eth1/1
-    parents: interface Ethernet1/1
-
+    # parents: int eth1
+    parents: interface Ethernet1
 """
 
 RETURN = """

--- a/lib/ansible/modules/network/eos/eos_config.py
+++ b/lib/ansible/modules/network/eos/eos_config.py
@@ -204,7 +204,8 @@ options:
         set it to I(intended).
     version_added: "2.4"
 notes:
-  - Abbreviated commands are NOT idempotent, see L(Network FAQ,../network/user_guide/faq.html).
+  - Abbreviated commands are NOT idempotent, see
+    L(Network FAQ,../network/user_guide/faq.html#why-do-the-config-modules-always-return-changed-true-with-abbreviated-commands).
 """
 
 EXAMPLES = """

--- a/lib/ansible/modules/network/eos/eos_config.py
+++ b/lib/ansible/modules/network/eos/eos_config.py
@@ -44,7 +44,7 @@ options:
         in the device running-config.  Be sure to note the configuration
         command syntax as some commands are automatically modified by the
         device config parser.
-      - Abbreviated commands in lines are NOT idempotent, see 
+      - Abbreviated commands in lines are NOT idempotent, see
         L(Network FAQ,../network/user_guide/faq.html).
     aliases: ['commands']
   parents:

--- a/lib/ansible/modules/network/eos/eos_config.py
+++ b/lib/ansible/modules/network/eos/eos_config.py
@@ -240,10 +240,10 @@ EXAMPLES = """
 - name: for idempotency, use full-form commands
   eos_config:
     lines:
-	  # - shut
-	  - shutdown
-	# parents: int eth1/1
-	parents: interface Ethernet1/1
+      # - shut
+      - shutdown
+    # parents: int eth1/1
+    parents: interface Ethernet1/1
 
 """
 

--- a/lib/ansible/modules/network/eos/eos_config.py
+++ b/lib/ansible/modules/network/eos/eos_config.py
@@ -36,6 +36,8 @@ description:
 extends_documentation_fragment: eos
 notes:
   - Tested against EOS 4.15
+  - Abbreviated commands are NOT idempotent, see
+    L(Network FAQ,../network/user_guide/faq.html#why-do-the-config-modules-always-return-changed-true-with-abbreviated-commands).
 options:
   lines:
     description:
@@ -203,9 +205,6 @@ options:
         argument, the task should also modify the C(diff_against) value and
         set it to I(intended).
     version_added: "2.4"
-notes:
-  - Abbreviated commands are NOT idempotent, see
-    L(Network FAQ,../network/user_guide/faq.html#why-do-the-config-modules-always-return-changed-true-with-abbreviated-commands).
 """
 
 EXAMPLES = """

--- a/lib/ansible/modules/network/ios/ios_config.py
+++ b/lib/ansible/modules/network/ios/ios_config.py
@@ -43,6 +43,8 @@ options:
         in the device running-config.  Be sure to note the configuration
         command syntax as some commands are automatically modified by the
         device config parser.
+      - Abbreviated commands in lines are NOT idempotent, see 
+        L(Network FAQ,../network/user_guide/faq.html).
     aliases: ['commands']
   parents:
     description:
@@ -261,6 +263,15 @@ EXAMPLES = """
 - name: save running to startup when modified
   ios_config:
     save_when: modified
+
+- name: for idempotency, use full-form commands
+  ios_config:
+	lines:
+	  # - shut
+	  - shutdown
+	# parents: int gig1/0/11
+	parents: interface GigabitEthernet1/0/11
+
 """
 
 RETURN = """

--- a/lib/ansible/modules/network/ios/ios_config.py
+++ b/lib/ansible/modules/network/ios/ios_config.py
@@ -267,10 +267,10 @@ EXAMPLES = """
 - name: for idempotency, use full-form commands
   ios_config:
     lines:
-	  # - shut
-	  - shutdown
-	# parents: int gig1/0/11
-	parents: interface GigabitEthernet1/0/11
+      # - shut
+      - shutdown
+    # parents: int gig1/0/11
+    parents: interface GigabitEthernet1/0/11
 
 """
 

--- a/lib/ansible/modules/network/ios/ios_config.py
+++ b/lib/ansible/modules/network/ios/ios_config.py
@@ -35,6 +35,8 @@ description:
 extends_documentation_fragment: ios
 notes:
   - Tested against IOS 15.6
+  - Abbreviated commands are NOT idempotent, see
+    L(Network FAQ,../network/user_guide/faq.html#why-do-the-config-modules-always-return-changed-true-with-abbreviated-commands).
 options:
   lines:
     description:
@@ -200,9 +202,6 @@ options:
         argument, the task should also modify the C(diff_against) value and
         set it to I(intended).
     version_added: "2.4"
-notes:
-  - Abbreviated commands are NOT idempotent, see 
-    L(Network FAQ,../network/user_guide/faq.html#why-do-the-config-modules-always-return-changed-true-with-abbreviated-commands).
 """
 
 EXAMPLES = """

--- a/lib/ansible/modules/network/ios/ios_config.py
+++ b/lib/ansible/modules/network/ios/ios_config.py
@@ -43,8 +43,6 @@ options:
         in the device running-config.  Be sure to note the configuration
         command syntax as some commands are automatically modified by the
         device config parser.
-      - Abbreviated commands in lines are NOT idempotent, see
-        L(Network FAQ,../network/user_guide/faq.html).
     aliases: ['commands']
   parents:
     description:
@@ -202,6 +200,8 @@ options:
         argument, the task should also modify the C(diff_against) value and
         set it to I(intended).
     version_added: "2.4"
+notes:
+  - Abbreviated commands are NOT idempotent, see L(Network FAQ,../network/user_guide/faq.html).
 """
 
 EXAMPLES = """
@@ -271,7 +271,6 @@ EXAMPLES = """
       - shutdown
     # parents: int gig1/0/11
     parents: interface GigabitEthernet1/0/11
-
 """
 
 RETURN = """

--- a/lib/ansible/modules/network/ios/ios_config.py
+++ b/lib/ansible/modules/network/ios/ios_config.py
@@ -266,7 +266,7 @@ EXAMPLES = """
 
 - name: for idempotency, use full-form commands
   ios_config:
-	lines:
+    lines:
 	  # - shut
 	  - shutdown
 	# parents: int gig1/0/11

--- a/lib/ansible/modules/network/ios/ios_config.py
+++ b/lib/ansible/modules/network/ios/ios_config.py
@@ -43,7 +43,7 @@ options:
         in the device running-config.  Be sure to note the configuration
         command syntax as some commands are automatically modified by the
         device config parser.
-      - Abbreviated commands in lines are NOT idempotent, see 
+      - Abbreviated commands in lines are NOT idempotent, see
         L(Network FAQ,../network/user_guide/faq.html).
     aliases: ['commands']
   parents:

--- a/lib/ansible/modules/network/ios/ios_config.py
+++ b/lib/ansible/modules/network/ios/ios_config.py
@@ -201,7 +201,8 @@ options:
         set it to I(intended).
     version_added: "2.4"
 notes:
-  - Abbreviated commands are NOT idempotent, see L(Network FAQ,../network/user_guide/faq.html).
+  - Abbreviated commands are NOT idempotent, see 
+    L(Network FAQ,../network/user_guide/faq.html#why-do-the-config-modules-always-return-changed-true-with-abbreviated-commands).
 """
 
 EXAMPLES = """

--- a/lib/ansible/modules/network/iosxr/iosxr_config.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_config.py
@@ -37,7 +37,7 @@ options:
         in the device running-config.  Be sure to note the configuration
         command syntax as some commands are automatically modified by the
         device config parser.
-      - Abbreviated commands in lines are NOT idempotent, see 
+      - Abbreviated commands in lines are NOT idempotent, see
         L(Network FAQ,../network/user_guide/faq.html).
     aliases: ['commands']
   parents:

--- a/lib/ansible/modules/network/iosxr/iosxr_config.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_config.py
@@ -37,8 +37,6 @@ options:
         in the device running-config.  Be sure to note the configuration
         command syntax as some commands are automatically modified by the
         device config parser.
-      - Abbreviated commands in lines are NOT idempotent, see
-        L(Network FAQ,../network/user_guide/faq.html).
     aliases: ['commands']
   parents:
     description:
@@ -134,6 +132,8 @@ options:
     type: bool
     default: 'no'
     version_added: "2.4"
+notes:
+  - Abbreviated commands are NOT idempotent, see L(Network FAQ,../network/user_guide/faq.html).
 """
 
 EXAMPLES = """
@@ -159,9 +159,8 @@ EXAMPLES = """
     lines:
       # - shut
       - shutdown
-    # parents: int g0/0/0/0
-    parents: interface GigabitEthernet0/0/0/0
-
+    # parents: int g0/0/0/1
+    parents: interface GigabitEthernet0/0/0/1
 """
 
 RETURN = """

--- a/lib/ansible/modules/network/iosxr/iosxr_config.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_config.py
@@ -156,7 +156,7 @@ EXAMPLES = """
 
 - name: for idempotency, use full-form commands
   iosxr_config:
-	lines:
+    lines:
 	  # - shut
 	  - shutdown
 	# parents: int g0/0/0/0

--- a/lib/ansible/modules/network/iosxr/iosxr_config.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_config.py
@@ -133,7 +133,8 @@ options:
     default: 'no'
     version_added: "2.4"
 notes:
-  - Abbreviated commands are NOT idempotent, see L(Network FAQ,../network/user_guide/faq.html).
+  - Abbreviated commands are NOT idempotent, see
+    L(Network FAQ,../network/user_guide/faq.html#why-do-the-config-modules-always-return-changed-true-with-abbreviated-commands).
 """
 
 EXAMPLES = """

--- a/lib/ansible/modules/network/iosxr/iosxr_config.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_config.py
@@ -27,6 +27,8 @@ extends_documentation_fragment: iosxr
 notes:
   - Tested against IOS XRv 6.1.2
   - This module does not support netconf connection
+  - Abbreviated commands are NOT idempotent, see
+    L(Network FAQ,../network/user_guide/faq.html#why-do-the-config-modules-always-return-changed-true-with-abbreviated-commands).
   - Avoid service disrupting changes (viz. Management IP) from config replace.
   - Do not use C(end) in the replace config file.
 options:
@@ -132,9 +134,6 @@ options:
     type: bool
     default: 'no'
     version_added: "2.4"
-notes:
-  - Abbreviated commands are NOT idempotent, see
-    L(Network FAQ,../network/user_guide/faq.html#why-do-the-config-modules-always-return-changed-true-with-abbreviated-commands).
 """
 
 EXAMPLES = """

--- a/lib/ansible/modules/network/iosxr/iosxr_config.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_config.py
@@ -157,10 +157,10 @@ EXAMPLES = """
 - name: for idempotency, use full-form commands
   iosxr_config:
     lines:
-	  # - shut
-	  - shutdown
-	# parents: int g0/0/0/0
-	parents: interface GigabitEthernet0/0/0/0
+      # - shut
+      - shutdown
+    # parents: int g0/0/0/0
+    parents: interface GigabitEthernet0/0/0/0
 
 """
 

--- a/lib/ansible/modules/network/iosxr/iosxr_config.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_config.py
@@ -37,6 +37,8 @@ options:
         in the device running-config.  Be sure to note the configuration
         command syntax as some commands are automatically modified by the
         device config parser.
+      - Abbreviated commands in lines are NOT idempotent, see 
+        L(Network FAQ,../network/user_guide/faq.html).
     aliases: ['commands']
   parents:
     description:
@@ -151,6 +153,15 @@ EXAMPLES = """
     src: config.cfg
     replace: config
     backup: yes
+
+- name: for idempotency, use full-form commands
+  iosxr_config:
+	lines:
+	  # - shut
+	  - shutdown
+	# parents: int g0/0/0/0
+	parents: interface GigabitEthernet0/0/0/0
+
 """
 
 RETURN = """

--- a/lib/ansible/modules/network/junos/junos_config.py
+++ b/lib/ansible/modules/network/junos/junos_config.py
@@ -160,7 +160,7 @@ EXAMPLES = """
 
 - name: for idempotency, use full-form commands
   junos_config:
-	lines:
+    lines:
 	  # - shut
 	  - shutdown
 	# parents: int eth1/1

--- a/lib/ansible/modules/network/junos/junos_config.py
+++ b/lib/ansible/modules/network/junos/junos_config.py
@@ -32,8 +32,6 @@ options:
         lines to push into the remote device.  Each line must start with
         either C(set) or C(delete).  This argument is mutually exclusive
         with the I(src) argument.
-      - Abbreviated commands in lines are NOT idempotent, see
-        L(Network FAQ,../network/user_guide/faq.html).
   src:
     description:
       - The I(src) argument provides a path to the configuration file
@@ -128,6 +126,7 @@ requirements:
 notes:
   - This module requires the netconf system service be enabled on
     the remote device being managed.
+  - Abbreviated commands are NOT idempotent, see L(Network FAQ,../network/user_guide/faq.html).
   - Loading JSON-formatted configuration I(json) is supported
     starting in Junos OS Release 16.1 onwards.
   - Tested against vSRX JUNOS version 15.1X49-D15.4, vqfx-10000 JUNOS Version 15.1X53-D60.4.
@@ -161,11 +160,8 @@ EXAMPLES = """
 - name: for idempotency, use full-form commands
   junos_config:
     lines:
-      # - shut
-      - shutdown
-    # parents: int eth1/1
-    parents: interface Ethernet1/1
-
+      # - set int ge-0/0/1 unit 0 desc "Test interface"
+      - set interfaces ge-0/0/1 unit 0 description "Test interface"
 """
 
 RETURN = """

--- a/lib/ansible/modules/network/junos/junos_config.py
+++ b/lib/ansible/modules/network/junos/junos_config.py
@@ -161,10 +161,10 @@ EXAMPLES = """
 - name: for idempotency, use full-form commands
   junos_config:
     lines:
-	  # - shut
-	  - shutdown
-	# parents: int eth1/1
-	parents: interface Ethernet1/1
+      # - shut
+      - shutdown
+    # parents: int eth1/1
+    parents: interface Ethernet1/1
 
 """
 

--- a/lib/ansible/modules/network/junos/junos_config.py
+++ b/lib/ansible/modules/network/junos/junos_config.py
@@ -32,6 +32,8 @@ options:
         lines to push into the remote device.  Each line must start with
         either C(set) or C(delete).  This argument is mutually exclusive
         with the I(src) argument.
+      - Abbreviated commands in lines are NOT idempotent, see 
+        L(Network FAQ,../network/user_guide/faq.html).
   src:
     description:
       - The I(src) argument provides a path to the configuration file
@@ -155,6 +157,15 @@ EXAMPLES = """
 - name: confirm a previous commit
   junos_config:
     confirm_commit: yes
+
+- name: for idempotency, use full-form commands
+  junos_config:
+	lines:
+	  # - shut
+	  - shutdown
+	# parents: int eth1/1
+	parents: interface Ethernet1/1
+
 """
 
 RETURN = """

--- a/lib/ansible/modules/network/junos/junos_config.py
+++ b/lib/ansible/modules/network/junos/junos_config.py
@@ -126,7 +126,8 @@ requirements:
 notes:
   - This module requires the netconf system service be enabled on
     the remote device being managed.
-  - Abbreviated commands are NOT idempotent, see L(Network FAQ,../network/user_guide/faq.html).
+  - Abbreviated commands are NOT idempotent, see
+    L(Network FAQ,../network/user_guide/faq.html#why-do-the-config-modules-always-return-changed-true-with-abbreviated-commands).
   - Loading JSON-formatted configuration I(json) is supported
     starting in Junos OS Release 16.1 onwards.
   - Tested against vSRX JUNOS version 15.1X49-D15.4, vqfx-10000 JUNOS Version 15.1X53-D60.4.

--- a/lib/ansible/modules/network/junos/junos_config.py
+++ b/lib/ansible/modules/network/junos/junos_config.py
@@ -32,7 +32,7 @@ options:
         lines to push into the remote device.  Each line must start with
         either C(set) or C(delete).  This argument is mutually exclusive
         with the I(src) argument.
-      - Abbreviated commands in lines are NOT idempotent, see 
+      - Abbreviated commands in lines are NOT idempotent, see
         L(Network FAQ,../network/user_guide/faq.html).
   src:
     description:

--- a/lib/ansible/modules/network/nxos/nxos_config.py
+++ b/lib/ansible/modules/network/nxos/nxos_config.py
@@ -248,7 +248,7 @@ EXAMPLES = """
 
 - name: for idempotency, use full-form commands
   nxos_config:
-	lines:
+    lines:
 	  # - shut
 	  - shutdown
 	# parents: int eth1/1

--- a/lib/ansible/modules/network/nxos/nxos_config.py
+++ b/lib/ansible/modules/network/nxos/nxos_config.py
@@ -205,7 +205,8 @@ options:
         set it to I(intended).
     version_added: "2.4"
 notes:
-  - Abbreviated commands in lines are NOT idempotent, see L(Network FAQ,../network/user_guide/faq.html).
+  - Abbreviated commands are NOT idempotent, see
+    L(Network FAQ,../network/user_guide/faq.html#why-do-the-config-modules-always-return-changed-true-with-abbreviated-commands).
 """
 
 EXAMPLES = """

--- a/lib/ansible/modules/network/nxos/nxos_config.py
+++ b/lib/ansible/modules/network/nxos/nxos_config.py
@@ -42,8 +42,6 @@ options:
         in the device running-config.  Be sure to note the configuration
         command syntax as some commands are automatically modified by the
         device config parser.
-      - Abbreviated commands in lines are NOT idempotent, see
-        L(Network FAQ,../network/user_guide/faq.html).
     aliases: ['commands']
   parents:
     description:
@@ -206,6 +204,8 @@ options:
         argument, the task should also modify the C(diff_against) value and
         set it to I(intended).
     version_added: "2.4"
+notes:
+  - Abbreviated commands in lines are NOT idempotent, see L(Network FAQ,../network/user_guide/faq.html).
 """
 
 EXAMPLES = """
@@ -253,7 +253,6 @@ EXAMPLES = """
       - shutdown
     # parents: int eth1/1
     parents: interface Ethernet1/1
-
 """
 
 RETURN = """

--- a/lib/ansible/modules/network/nxos/nxos_config.py
+++ b/lib/ansible/modules/network/nxos/nxos_config.py
@@ -249,10 +249,10 @@ EXAMPLES = """
 - name: for idempotency, use full-form commands
   nxos_config:
     lines:
-	  # - shut
-	  - shutdown
-	# parents: int eth1/1
-	parents: interface Ethernet1/1
+      # - shut
+      - shutdown
+    # parents: int eth1/1
+    parents: interface Ethernet1/1
 
 """
 

--- a/lib/ansible/modules/network/nxos/nxos_config.py
+++ b/lib/ansible/modules/network/nxos/nxos_config.py
@@ -42,7 +42,7 @@ options:
         in the device running-config.  Be sure to note the configuration
         command syntax as some commands are automatically modified by the
         device config parser.
-      - Abbreviated commands in lines are NOT idempotent, see 
+      - Abbreviated commands in lines are NOT idempotent, see
         L(Network FAQ,../network/user_guide/faq.html).
     aliases: ['commands']
   parents:

--- a/lib/ansible/modules/network/nxos/nxos_config.py
+++ b/lib/ansible/modules/network/nxos/nxos_config.py
@@ -42,6 +42,8 @@ options:
         in the device running-config.  Be sure to note the configuration
         command syntax as some commands are automatically modified by the
         device config parser.
+      - Abbreviated commands in lines are NOT idempotent, see 
+        L(Network FAQ,../network/user_guide/faq.html).
     aliases: ['commands']
   parents:
     description:
@@ -243,6 +245,14 @@ EXAMPLES = """
   nxos_config:
     replace_src: config.txt
     replace: config
+
+- name: for idempotency, use full-form commands
+  nxos_config:
+	lines:
+	  # - shut
+	  - shutdown
+	# parents: int eth1/1
+	parents: interface Ethernet1/1
 
 """
 

--- a/lib/ansible/modules/network/vyos/vyos_config.py
+++ b/lib/ansible/modules/network/vyos/vyos_config.py
@@ -42,6 +42,8 @@ options:
       - The ordered set of configuration lines to be managed and
         compared with the existing configuration on the remote
         device.
+      - Abbreviated commands in lines are NOT idempotent, see 
+        L(Network FAQ,../network/user_guide/faq.html).
   src:
     description:
       - The C(src) argument specifies the path to the source config
@@ -100,6 +102,15 @@ EXAMPLES = """
   vyos_config:
     src: vyos.cfg
     backup: yes
+
+- name: for idempotency, use full-form commands
+  nxos_config:
+	lines:
+	  # - shut
+	  - shutdown
+	# parents: int eth1/1
+	parents: interface Ethernet1/1
+
 """
 
 RETURN = """

--- a/lib/ansible/modules/network/vyos/vyos_config.py
+++ b/lib/ansible/modules/network/vyos/vyos_config.py
@@ -105,7 +105,7 @@ EXAMPLES = """
 
 - name: for idempotency, use full-form commands
   nxos_config:
-	lines:
+    lines:
 	  # - shut
 	  - shutdown
 	# parents: int eth1/1

--- a/lib/ansible/modules/network/vyos/vyos_config.py
+++ b/lib/ansible/modules/network/vyos/vyos_config.py
@@ -42,7 +42,7 @@ options:
       - The ordered set of configuration lines to be managed and
         compared with the existing configuration on the remote
         device.
-      - Abbreviated commands in lines are NOT idempotent, see 
+      - Abbreviated commands in lines are NOT idempotent, see
         L(Network FAQ,../network/user_guide/faq.html).
   src:
     description:

--- a/lib/ansible/modules/network/vyos/vyos_config.py
+++ b/lib/ansible/modules/network/vyos/vyos_config.py
@@ -87,7 +87,8 @@ options:
     type: bool
     default: 'no'
 notes:
-  - Abbreviated commands are NOT idempotent, see L(Network FAQ,../network/user_guide/faq.html).
+  - Abbreviated commands are NOT idempotent, see
+    L(Network FAQ,../network/user_guide/faq.html#why-do-the-config-modules-always-return-changed-true-with-abbreviated-commands).
 """
 
 EXAMPLES = """

--- a/lib/ansible/modules/network/vyos/vyos_config.py
+++ b/lib/ansible/modules/network/vyos/vyos_config.py
@@ -106,10 +106,10 @@ EXAMPLES = """
 - name: for idempotency, use full-form commands
   nxos_config:
     lines:
-	  # - shut
-	  - shutdown
-	# parents: int eth1/1
-	parents: interface Ethernet1/1
+      # - shut
+      - shutdown
+    # parents: int eth1/1
+    parents: interface Ethernet1/1
 
 """
 

--- a/lib/ansible/modules/network/vyos/vyos_config.py
+++ b/lib/ansible/modules/network/vyos/vyos_config.py
@@ -36,6 +36,8 @@ description:
 extends_documentation_fragment: vyos
 notes:
   - Tested against VYOS 1.1.7
+  - Abbreviated commands are NOT idempotent, see
+    L(Network FAQ,../network/user_guide/faq.html#why-do-the-config-modules-always-return-changed-true-with-abbreviated-commands).
 options:
   lines:
     description:
@@ -86,9 +88,6 @@ options:
         active configuration is saved.
     type: bool
     default: 'no'
-notes:
-  - Abbreviated commands are NOT idempotent, see
-    L(Network FAQ,../network/user_guide/faq.html#why-do-the-config-modules-always-return-changed-true-with-abbreviated-commands).
 """
 
 EXAMPLES = """

--- a/lib/ansible/modules/network/vyos/vyos_config.py
+++ b/lib/ansible/modules/network/vyos/vyos_config.py
@@ -42,8 +42,6 @@ options:
       - The ordered set of configuration lines to be managed and
         compared with the existing configuration on the remote
         device.
-      - Abbreviated commands in lines are NOT idempotent, see
-        L(Network FAQ,../network/user_guide/faq.html).
   src:
     description:
       - The C(src) argument specifies the path to the source config
@@ -88,6 +86,8 @@ options:
         active configuration is saved.
     type: bool
     default: 'no'
+notes:
+  - Abbreviated commands are NOT idempotent, see L(Network FAQ,../network/user_guide/faq.html).
 """
 
 EXAMPLES = """
@@ -104,13 +104,10 @@ EXAMPLES = """
     backup: yes
 
 - name: for idempotency, use full-form commands
-  nxos_config:
+  vyos_config:
     lines:
-      # - shut
-      - shutdown
-    # parents: int eth1/1
-    parents: interface Ethernet1/1
-
+      # - set int eth eth2 description 'OUTSIDE'
+      - set interface ethernet eth2 description 'OUTSIDE'
 """
 
 RETURN = """


### PR DESCRIPTION
##### SUMMARY
- On platforms Ansible supports, adds examples to Network `*_config` module docs illustrating the effect of abbreviations on idempotency.
- On platforms Ansible supports, links to the Network FAQ page, which discusses abbreviations and idempotency, from the `lines` sections of the `*_config` module docs.
- Adds TOC link to the Network FAQ page.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
Network Documentation

##### ANSIBLE VERSION
2.5

##### ADDITIONAL INFORMATION
You can view generated versions of the six pages here:
https://acozine.github.io/html/modules/eos_config_module.html
https://acozine.github.io/html/modules/ios_config_module.html
https://acozine.github.io/html/modules/iosxr_config_module.html
https://acozine.github.io/html/modules/nxos_config_module.html
https://acozine.github.io/html/modules/vyos_config_module.html
