### PR TITLE
Use correct esxi host variable in vmware_cfg_backup

### DIFF
--- a/changelogs/fragments/38654-update_vmware_cfg_backup_variable_usage.yml
+++ b/changelogs/fragments/38654-update_vmware_cfg_backup_variable_usage.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- Changed hostname variable in order for the esxi host to be found when authentication against a vcenter was done.


### PR DESCRIPTION
##### SUMMARY
Fixed bug where hostname could not be found and minor documentation changes.

(cherry picked from commit 8f5320435f31b2462a36350888ca2833c65cbefc)

##### ISSUE TYPE
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
changelogs/fragments/38654-update_vmware_cfg_backup_variable_usage.yml
lib/ansible/modules/cloud/vmware/vmware_cfg_backup.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
Stable-2.5
```