### PR TITLE
VMware: Check device type explicitly

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -1088,7 +1088,8 @@ class PyVmomiHelper(PyVmomi):
                     nic_change_detected = True
                 if 'device_type' in network_devices[key]:
                     device = self.device_helper.get_device(network_devices[key]['device_type'], network_name)
-                    if nic.device != device:
+                    device_class = type(device)
+                    if not isinstance(nic.device, device_class):
                         self.module.fail_json(msg="Changing the device type is not possible when interface is already present. "
                                                   "The failing device type is %s" % network_devices[key]['device_type'])
                 # Changing mac address has no effect when editing interface

--- a/test/integration/targets/vmware_guest/tasks/main.yml
+++ b/test/integration/targets/vmware_guest/tasks/main.yml
@@ -34,3 +34,4 @@
 #- include: template_d1_c1_f0.yml
 - include: vapp_d1_c1_f0.yml
 - include: disk_size_d1_c1_f0.yml
+- include: network_with_device.yml

--- a/test/integration/targets/vmware_guest/tasks/network_with_device.yml
+++ b/test/integration/targets/vmware_guest/tasks/network_with_device.yml
@@ -1,0 +1,97 @@
+# Test code for the vmware_guest module.
+# Copyright: (c) 2018, Abhijeet Kasurde <akasurde@redhat.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# Testcase to check #38605
+- name: Wait for Flask controller to come up online
+  wait_for:
+    host: "{{ vcsim }}"
+    port: 5000
+    state: started
+
+- name: kill vcsim
+  uri:
+    url: http://{{ vcsim }}:5000/killall
+- name: start vcsim with no folders
+  uri:
+    url: http://{{ vcsim }}:5000/spawn?datacenter=1&cluster=1&folder=0
+  register: vcsim_instance
+
+- name: Wait for Flask controller to come up online
+  wait_for:
+    host: "{{ vcsim }}"
+    port: 443
+    state: started
+
+- name: get a list of VMS from vcsim
+  uri:
+    url: http://{{ vcsim }}:5000/govc_find?filter=VM
+  register: vmlist
+
+- debug: var=vcsim_instance
+
+- debug: var=vmlist
+
+- set_fact:
+   vm1: "{{ vmlist['json'][0] }}"
+
+- debug: var=vm1
+
+- set_fact:
+    vm_name: "VM_{{ 10000 | random }}"
+
+- name: Deploy VM {{ vm1 | basename }}
+  vmware_guest:
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    validate_certs: False
+    datacenter: "{{ (vm1|basename).split('_')[0] }}"
+    state: poweredon
+    folder: "{{ vm1 | dirname }}"
+    name: "{{ vm_name }}"
+    disk:
+      - size: 10mb
+        autoselect_datastore: yes
+    guest_id: rhel7_64guest
+    hardware:
+      memory_mb: 512
+      num_cpus: 1
+    networks:
+      - name: "DC0_DVPG0"
+        device_type: "vmxnet3"
+  register: vm_result
+
+- debug: var=vm_result
+
+- assert:
+    that:
+      - "vm_result.changed"
+
+- name: Deploy VM {{ vm1 | basename }} again
+  vmware_guest:
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    validate_certs: False
+    datacenter: "{{ (vm1|basename).split('_')[0] }}"
+    state: poweredon
+    folder: "{{ vm1 | dirname }}"
+    name: "{{ vm_name }}"
+    disk:
+      - size: 10mb
+        autoselect_datastore: yes
+    guest_id: rhel7_64guest
+    hardware:
+      memory_mb: 512
+      num_cpus: 1
+    networks:
+      - name: "DC0_DVPG0"
+        device_type: "vmxnet3"
+  register: vm_result_again
+
+- debug: var=vm_result_again
+
+- assert:
+    that:
+      - "not vm_result_again.changed"

--- a/test/integration/targets/vmware_guest/tasks/network_with_device.yml
+++ b/test/integration/targets/vmware_guest/tasks/network_with_device.yml
@@ -58,7 +58,7 @@
       memory_mb: 512
       num_cpus: 1
     networks:
-      - name: "DC0_DVPG0"
+      - name: 'VM Network'
         device_type: "vmxnet3"
   register: vm_result
 
@@ -86,7 +86,7 @@
       memory_mb: 512
       num_cpus: 1
     networks:
-      - name: "DC0_DVPG0"
+      - name: 'VM Network'
         device_type: "vmxnet3"
   register: vm_result_again
 


### PR DESCRIPTION
##### SUMMARY
Check datatype of device instead of comparing them directly in
vmware_guest. Also, added testcases to check this behavior.

Fixes: #38605

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/vmware/vmware_guest.py
test/integration/targets/vmware_guest/tasks/main.yml
test/integration/targets/vmware_guest/tasks/network_with_device.yml

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6devel
```