### PR TITLE
Update dnsmadeeasy.py

### DIFF
--- a/lib/ansible/modules/net_tools/dnsmadeeasy.py
+++ b/lib/ansible/modules/net_tools/dnsmadeeasy.py
@@ -240,6 +240,7 @@ EXAMPLES = '''
     account_key: key
     account_secret: secret
     domain: my.com
+    record_type: A
     state: absent
     record_name: test
 


### PR DESCRIPTION
If you omit the record type on state absent you will get "record_type not yet supported". Although in my experience so far, if you put the record type it still fails to remove the record but it doesn't crash. (#38730)
+label: docsite_pr

##### SUMMARY
Fixed omission in example for dns made easy module

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
dnsmadeasy

##### ANSIBLE VERSION
N/A

##### ADDITIONAL INFORMATION
N/A
