### PR TITLE
VMware: correct documentation for datacenter

### DIFF
--- a/changelogs/fragments/38290-doc_update_vmware_guest_find.yaml
+++ b/changelogs/fragments/38290-doc_update_vmware_guest_find.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- Update documentation related to datacenter in vmware_guest_find module. Mark datacenter as optional.

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_find.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_find.py
@@ -30,22 +30,21 @@ requirements:
     - PyVmomi
 options:
    name:
-        description:
-            - Name of the VM to work with.
-            - This is required if uuid is not supplied.
+     description:
+     - Name of the VM to work with.
+     - This is required if C(uuid) parameter is not supplied.
    uuid:
-        description:
-            - UUID of the instance to manage if known, this is VMware's BIOS UUID.
-            - This is required if name is not supplied.
+     description:
+     - UUID of the instance to manage if known, this is VMware's BIOS UUID.
+     - This is required if C(name) parameter is not supplied.
    datacenter:
-        description:
-            - Destination datacenter for the find operation.
-            - Deprecated in 2.5, will be removed in 2.9 release.
-        required: True
+     description:
+     - Destination datacenter for the find operation.
+     - Deprecated in 2.5, will be removed in 2.9 release.
 extends_documentation_fragment: vmware.documentation
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 - name: Find Guest's Folder using name
   vmware_guest_find:
     hostname: 192.168.1.209
@@ -70,6 +69,9 @@ folders:
     description: List of folders for user specified virtual machine
     returned: on success
     type: list
+    sample: [
+        '/DC0/vm',
+    ]
 """
 
 
@@ -77,9 +79,7 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 from ansible.module_utils.vmware import PyVmomi, get_all_objs, vmware_argument_spec
 
-
 try:
-    import pyVmomi
     from pyVmomi import vim
 except ImportError:
     pass
@@ -88,8 +88,6 @@ except ImportError:
 class PyVmomiHelper(PyVmomi):
     def __init__(self, module):
         super(PyVmomiHelper, self).__init__(module)
-        self.datacenter = None
-        self.folders = None
         self.name = self.params['name']
         self.uuid = self.params['uuid']
 
@@ -114,11 +112,13 @@ def main():
     argument_spec.update(
         name=dict(type='str'),
         uuid=dict(type='str'),
-        datacenter=dict(removed_in_version=2.9, type='str', required=True)
+        datacenter=dict(removed_in_version=2.9, type='str')
     )
 
     module = AnsibleModule(argument_spec=argument_spec,
-                           required_one_of=[['name', 'uuid']])
+                           required_one_of=[['name', 'uuid']],
+                           mutually_exclusive=[['name', 'uuid']],
+                           )
 
     pyv = PyVmomiHelper(module)
     # Check if the VM exists before continuing


### PR DESCRIPTION
##### SUMMARY
This fixes documentation related to datacenter in vmware_guest_find
module.

Fixes: #38290

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>
(cherry picked from commit 2367130ba3761925928f39961d5281a4d27854bc)

##### ISSUE TYPE
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
changelogs/fragments/38290-doc_update_vmware_guest_find.yaml
lib/ansible/modules/cloud/vmware/vmware_guest_find.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
Stable-2.5
```