### PR TITLE
Attempt 4: Prevent reparenting a block with itself

### DIFF
--- a/lib/ansible/executor/play_iterator.py
+++ b/lib/ansible/executor/play_iterator.py
@@ -524,7 +524,7 @@ class PlayIterator:
             if state.tasks_child_state:
                 state.tasks_child_state = self._insert_tasks_into_state(state.tasks_child_state, task_list)
             else:
-                target_block = state._blocks[state.cur_block].copy(exclude_parent=True)
+                target_block = state._blocks[state.cur_block].copy()
                 before = target_block.block[:state.cur_regular_task]
                 after = target_block.block[state.cur_regular_task:]
                 target_block.block = before + task_list + after
@@ -533,7 +533,7 @@ class PlayIterator:
             if state.rescue_child_state:
                 state.rescue_child_state = self._insert_tasks_into_state(state.rescue_child_state, task_list)
             else:
-                target_block = state._blocks[state.cur_block].copy(exclude_parent=True)
+                target_block = state._blocks[state.cur_block].copy()
                 before = target_block.rescue[:state.cur_rescue_task]
                 after = target_block.rescue[state.cur_rescue_task:]
                 target_block.rescue = before + task_list + after
@@ -542,7 +542,7 @@ class PlayIterator:
             if state.always_child_state:
                 state.always_child_state = self._insert_tasks_into_state(state.always_child_state, task_list)
             else:
-                target_block = state._blocks[state.cur_block].copy(exclude_parent=True)
+                target_block = state._blocks[state.cur_block].copy()
                 before = target_block.always[:state.cur_always_task]
                 after = target_block.always[state.cur_always_task:]
                 target_block.always = before + task_list + after

--- a/lib/ansible/playbook/block.py
+++ b/lib/ansible/playbook/block.py
@@ -177,18 +177,19 @@ class Block(Base, Become, Conditional, Taggable):
                 new_task = task.copy(exclude_parent=True)
                 if task._parent:
                     new_task._parent = task._parent.copy(exclude_tasks=True)
-                    # go up the parentage tree until we find an
-                    # object without a parent or a parent that matches the new_block
-                    # and make this new block their parent.
-                    #
-                    # we start with new_task._parent, because new_task._parent is the same as new_block
-                    # but simply replacing it doesn't suffice, as we seem to lose important context, so we
-                    # must traverse farther
-                    cur_obj = new_task._parent
-                    while cur_obj._parent and cur_obj._parent != new_block:
-                        cur_obj = cur_obj._parent
+                    if task._parent == new_block:
+                        # If task._parent is the same as new_block, just replace it
+                        new_task._parent = new_block
+                    else:
+                        # task may not be a direct child of new_block, ensure new_task carries the correct parent
+                        # and then search for the correct place to insert new_block
+                        new_task._parent = task._parent
 
-                    cur_obj._parent = new_block
+                        cur_obj = new_task._parent
+                        while cur_obj._parent and cur_obj._parent != new_block:
+                            cur_obj = cur_obj._parent
+
+                        cur_obj._parent = new_block
                 else:
                     new_task._parent = new_block
                 new_task_list.append(new_task)

--- a/lib/ansible/playbook/block.py
+++ b/lib/ansible/playbook/block.py
@@ -175,6 +175,9 @@ class Block(Base, Become, Conditional, Taggable):
             new_task_list = []
             for task in task_list:
                 new_task = task.copy(exclude_parent=True)
+                # Ensure new_block has a parent, so that we maintain context
+                if not new_block._parent and task._parent._parent:
+                    new_block._parent = task._parent._parent.copy(exclude_tasks=True)
                 if task._parent:
                     new_task._parent = task._parent.copy(exclude_tasks=True)
                     if task._parent == new_block:

--- a/lib/ansible/playbook/block.py
+++ b/lib/ansible/playbook/block.py
@@ -175,9 +175,6 @@ class Block(Base, Become, Conditional, Taggable):
             new_task_list = []
             for task in task_list:
                 new_task = task.copy(exclude_parent=True)
-                # Ensure new_block has a parent, so that we maintain context
-                if not new_block._parent and task._parent._parent:
-                    new_block._parent = task._parent._parent.copy(exclude_tasks=True)
                 if task._parent:
                     new_task._parent = task._parent.copy(exclude_tasks=True)
                     if task._parent == new_block:
@@ -205,7 +202,7 @@ class Block(Base, Become, Conditional, Taggable):
 
         new_me._parent = None
         if self._parent and not exclude_parent:
-            new_me._parent = self._parent.copy(exclude_tasks=exclude_tasks)
+            new_me._parent = self._parent.copy(exclude_tasks=True)
 
         if not exclude_tasks:
             new_me.block = _dupe_task_list(self.block or [], new_me)

--- a/lib/ansible/playbook/block.py
+++ b/lib/ansible/playbook/block.py
@@ -184,10 +184,7 @@ class Block(Base, Become, Conditional, Taggable):
                         # If task._parent is the same as new_block, just replace it
                         new_task._parent = new_block
                     else:
-                        # task may not be a direct child of new_block, ensure new_task carries the correct parent
-                        # and then search for the correct place to insert new_block
-                        new_task._parent = task._parent
-
+                        # task may not be a direct child of new_block, search for the correct place to insert new_block
                         cur_obj = new_task._parent
                         while cur_obj._parent and cur_obj._parent != new_block:
                             cur_obj = cur_obj._parent

--- a/lib/ansible/playbook/block.py
+++ b/lib/ansible/playbook/block.py
@@ -69,6 +69,10 @@ class Block(Base, Become, Conditional, Taggable):
         '''object comparison based on _uuid'''
         return self._uuid == other._uuid
 
+    def __ne__(self, other):
+        '''object comparison based on _uuid'''
+        return self._uuid != other._uuid
+
     def get_vars(self):
         '''
         Blocks do not store variables directly, however they may be a member
@@ -174,20 +178,17 @@ class Block(Base, Become, Conditional, Taggable):
                 if task._parent:
                     new_task._parent = task._parent.copy(exclude_tasks=True)
                     # go up the parentage tree until we find an
-                    # object without a parent and make this new
-                    # block their parent
-                    cur_obj = new_task
-                    while cur_obj._parent:
-                        if cur_obj._parent:
-                            prev_obj = cur_obj
+                    # object without a parent or a parent that matches the new_block
+                    # and make this new block their parent.
+                    #
+                    # we start with new_task._parent, because new_task._parent is the same as new_block
+                    # but simply replacing it doesn't suffice, as we seem to lose important context, so we
+                    # must traverse farther
+                    cur_obj = new_task._parent
+                    while cur_obj._parent and cur_obj._parent != new_block:
                         cur_obj = cur_obj._parent
 
-                    # Ensure that we don't make the new_block the parent of itself
-                    if cur_obj != new_block:
-                        cur_obj._parent = new_block
-                    else:
-                        # prev_obj._parent is cur_obj, to allow for mutability we need to use prev_obj
-                        prev_obj._parent = new_block
+                    cur_obj._parent = new_block
                 else:
                     new_task._parent = new_block
                 new_task_list.append(new_task)

--- a/lib/ansible/playbook/role/__init__.py
+++ b/lib/ansible/playbook/role/__init__.py
@@ -410,9 +410,7 @@ class Role(Base, Become, Conditional, Taggable):
             block_list.extend(dep_blocks)
 
         for idx, task_block in enumerate(self._task_blocks):
-            new_task_block = task_block.copy(exclude_parent=True)
-            if task_block._parent:
-                new_task_block._parent = task_block._parent.copy()
+            new_task_block = task_block.copy()
             new_task_block._dep_chain = new_dep_chain
             new_task_block._play = play
             if idx == len(self._task_blocks) - 1:


### PR DESCRIPTION
##### SUMMARY
In https://github.com/ansible/ansible/pull/36075 I implemented a change to avoid reparenting a block with itself.  I overlooked the fact that my logic which used `!=` caused issues on py2, since `!=` does not use the inverse value of `__eq__` when `__ne__` was not defined.

As such this only really fixed the bug on python3.

Even with a change in logic or implementing `__ne__` we could only get a little further before a recursion error.

Instead of the change in https://github.com/ansible/ansible/pull/38690 where we try to limit the depth, this change tries to more intelligently place `new_block` in the most common case where `task._parent == new_block`.

This change allows for even more dynamic includes to be used than any previous attempt.

Some important notes here:

1. The use of `exclude_parent=True` when calling `Block.copy` caused issues with losing context in this method
1. Along with the above description, previously `task._parent` was always left as `new_task._parent = task._parent.copy(exclude_tasks=True)`, and in such a case, we would loop to the very end of the parent chain and insert `new_block` so that parent chain would start with the original block and end with `new_block` effectively making a really weird parent chain, meaning the above didn't matter.
1. Not excluding parent on `Block.copy` does slow things down a little, but in general this method allows for much higher recursion, so we get a little slower execution, with higher recursion limits, as we should never be duplicating a parent in the lineage.  Additionally, excluding tasks when including the parent, gets us back much of the slow down, without negative side effect.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/playbook/block.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.4
2.5
2.6
```

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```