### PR TITLE
Fix #38745 - set user/group on temp file

### DIFF
--- a/lib/ansible/modules/files/copy.py
+++ b/lib/ansible/modules/files/copy.py
@@ -302,6 +302,9 @@ def main():
     original_basename = module.params.get('original_basename', None)
     validate = module.params.get('validate', None)
     follow = module.params['follow']
+    mode = module.params['mode']
+    owner = module.params['owner']
+    group = module.params['group']
     remote_src = module.params['remote_src']
     checksum = module.params['checksum']
 
@@ -397,9 +400,12 @@ def main():
                 if validate:
                     # if we have a mode, make sure we set it on the temporary
                     # file source as some validations may require it
-                    # FIXME: should we do the same for owner/group here too?
                     if mode is not None:
                         module.set_mode_if_different(src, mode, False)
+                    if owner is not None:
+                        module.set_owner_if_different(src, owner, False)
+                    if group is not None:
+                        module.set_group_if_different(src, group, False)
                     if "%s" not in validate:
                         module.fail_json(msg="validate must contain %%s: %s" % (validate))
                     (rc, out, err) = module.run_command(validate % src)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #38745 - template module now sets target owner/group on temporary file.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
copy.py, used by template module
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.2.0
  config file = /home/bbrzezinski@pracuj.local/ansible/ansible.cfg
  configured module search path = [u'/home/bbrzezinski@pracuj.local/ansible/custom_modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Aug  4 2017, 00:39:18) [GCC 4.8.5 20150623 (Red Hat 4.8.5-16)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
