### PR TITLE
fix nxos_igmp_interface issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,8 @@ Ansible Changes By Release
 ### Major Changes
 
 ### Deprecations (to be removed in 2.10)
-* `oif_prefix` and `oif_source` properties are deprecated in the nxos_igmp_interface
-  module.  Use the `oif_ps` parameter with a dictionary of prefix and source
-  to values instead.
+* In the `nxos_igmp_interface` module, `oif_prefix` and `oif_source` properties are deprecated.
+  Use the `oif_ps` parameter with a dictionary of prefix and source to values instead.
 
 See [Porting Guide](http://docs.ansible.com/ansible/devel/porting_guides/porting_guides.html) for more information
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Ansible Changes By Release
 ### Major Changes
 
 ### Deprecations (to be removed in 2.10)
+* `oif_prefix` and `oif_source` properties are deprecated in the nxos_igmp_interface
+  module.  Use the `oif_ps` parameter with a dictionary of prefix and source
+  to values instead.
 
 See [Porting Guide](http://docs.ansible.com/ansible/devel/porting_guides/porting_guides.html) for more information
 

--- a/docs/docsite/rst/porting_guides/porting_guide_2.6.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.6.rst
@@ -22,7 +22,7 @@ No notable changes.
 Deprecated
 ==========
 
-* In the `nxos_igmp_interface` module, `oif_prefix` and `oif_source` properties are deprecated. Use
+* In the :ref:`nxos_mtu <nxos_igmp_interface>` module, `oif_prefix` and `oif_source` properties are deprecated. Use
   `ois_ps` parameter with a dictionary of prefix and source to values instead.
 
 Modules

--- a/docs/docsite/rst/porting_guides/porting_guide_2.6.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.6.rst
@@ -22,7 +22,7 @@ No notable changes.
 Deprecated
 ==========
 
-* In the :ref:`nxos_mtu <nxos_igmp_interface>` module, `oif_prefix` and `oif_source` properties are deprecated. Use
+* In the :ref:`nxos_igmp_interface <nxos_igmp_interface>` module, `oif_prefix` and `oif_source` properties are deprecated. Use
   `ois_ps` parameter with a dictionary of prefix and source to values instead.
 
 Modules

--- a/docs/docsite/rst/porting_guides/porting_guide_2.6.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.6.rst
@@ -22,7 +22,8 @@ No notable changes.
 Deprecated
 ==========
 
-No notable changes.
+* In the `nxos_igmp_interface` module, `oif_prefix` and `oif_source` properties are deprecated. Use
+  `ois_ps` parameter with a dictionary of prefix and source to values instead.
 
 Modules
 =======

--- a/lib/ansible/modules/network/nxos/nxos_igmp_interface.py
+++ b/lib/ansible/modules/network/nxos/nxos_igmp_interface.py
@@ -153,6 +153,7 @@ EXAMPLES = '''
 - nxos_igmp_interface:
     interface: ethernet1/32
     startup_query_interval: 30
+    oif_ps: [{'prefix': '238.2.2.6'}, {'source': '1.1.1.1', 'prefix': '238.2.2.5'}]
     state: present
 '''
 RETURN = '''
@@ -160,22 +161,25 @@ proposed:
     description: k/v pairs of parameters passed into module
     returned: always
     type: dict
-    sample: {"startup_query_count": "30"}
+    sample: {"startup_query_count": "30",
+             "oif_ps": [{'prefix': '238.2.2.6'}, {'source': '1.1.1.1', 'prefix': '238.2.2.5'}]}
 existing:
-    description: k/v pairs of existing BGP configuration
+    description: k/v pairs of existing igmp_interface configuration
     returned: always
     type: dict
-    sample: {"startup_query_count": "2"}
+    sample: {"startup_query_count": "2", "oif_ps": []}
 end_state:
-    description: k/v pairs of BGP configuration after module execution
+    description: k/v pairs of igmp interface configuration after module execution
     returned: always
     type: dict
-    sample: {"startup_query_count": "30"}
+    sample: {"startup_query_count": "30",
+             "oif_ps": [{'prefix': '238.2.2.6'}, {'source': '1.1.1.1', 'prefix': '238.2.2.5'}]}
 updates:
     description: commands sent to the device
     returned: always
     type: list
-    sample: ["interface Ethernet1/32", "ip igmp startup-query-count 30"]
+    sample: ["interface Ethernet1/32", "ip igmp startup-query-count 30",
+             "ip igmp static-oif 238.2.2.6", "ip igmp static-oif 238.2.2.5 source 1.1.1.1"]
 changed:
     description: check to see if a change was made on the device
     returned: always

--- a/lib/ansible/modules/network/nxos/nxos_igmp_interface.py
+++ b/lib/ansible/modules/network/nxos/nxos_igmp_interface.py
@@ -109,7 +109,6 @@ options:
               Reports are always sent for nonlink local groups.
               By default, reports are not sent for link local groups.
         type: bool
-        default: 'false'
     immediate_leave:
         description:
             - Enables the device to remove the group entry from the multicast
@@ -119,7 +118,6 @@ options:
               device does not send group-specific queries.
               The default is disabled.
         type: bool
-        default: 'false'
     oif_routemap:
         description:
             - Configure a routemap for static outgoing interface (OIF) or
@@ -139,7 +137,8 @@ options:
               prefix if source is not needed. The specified values will be configured
               on the device and if any previous prefix/sources exist, they will be removed.
               Keyword 'default' is also accpted which removes all existing prefix/sources.
-              ex: [{'prefix': '238.2.2.6'}, {'source': '1.1.1.1', 'prefix': '238.2.2.5'}]
+              See below for example
+              [{'prefix': '238.2.2.6'}, {'source': '1.1.1.1', 'prefix': '238.2.2.5'}]
     restart:
         description:
             - Restart IGMP. This is NOT idempotent as this is action only.
@@ -147,7 +146,7 @@ options:
     state:
         description:
             - Manages desired state of the resource.
-        default: present
+        default: 'present'
         choices: ['present', 'absent', 'default']
 '''
 EXAMPLES = '''

--- a/lib/ansible/modules/network/nxos/nxos_igmp_interface.py
+++ b/lib/ansible/modules/network/nxos/nxos_igmp_interface.py
@@ -57,7 +57,7 @@ options:
     version:
         description:
             - IGMP version. It can be 2 or 3 or keyword 'default'.
-        choices: ['2', '3']
+        choices: ['2', '3', 'default']
     startup_query_interval:
         description:
             - Query interval used when the IGMP process starts up.
@@ -124,12 +124,12 @@ options:
               keyword 'default'.
     oif_prefix:
         description:
-            - Configure a prefix for static outgoing interface (OIF). This
-              argument is deprecated, please use oif_ps instead.
+            - This argument is deprecated, please use oif_ps instead.
+              Configure a prefix for static outgoing interface (OIF).
     oif_source:
         description:
-            - Configure a source for static outgoing interface (OIF). This
-              argument is deprecated, please use oif_ps instead.
+            - This argument is deprecated, please use oif_ps instead.
+              Configure a source for static outgoing interface (OIF).
     oif_ps:
         description:
             - Configure prefixes and sources for static outgoing interface (OIF). This
@@ -155,7 +155,7 @@ EXAMPLES = '''
     startup_query_interval: 30
     oif_ps:
       - { 'prefix': '238.2.2.6' }
-      - {'source': '1.1.1.1', 'prefix': '238.2.2.5'}
+      - { 'source': '1.1.1.1', 'prefix': '238.2.2.5'}
     state: present
 '''
 RETURN = '''

--- a/lib/ansible/modules/network/nxos/nxos_igmp_interface.py
+++ b/lib/ansible/modules/network/nxos/nxos_igmp_interface.py
@@ -46,7 +46,8 @@ notes:
     - Route-map check not performed (same as CLI) check when configuring
       route-map with 'static-oif'
     - If restart is set to true with other params set, the restart will happen
-      last, i.e. after the configuration takes place.
+      last, i.e. after the configuration takes place. However, 'restart' itself
+      is not idempotent as it is an action and not configuration.
 options:
     interface:
         description:
@@ -55,48 +56,51 @@ options:
         required: true
     version:
         description:
-            - IGMP version. It can be 2 or 3.
+            - IGMP version. It can be 2 or 3 or keyword 'default'.
         choices: ['2', '3']
     startup_query_interval:
         description:
             - Query interval used when the IGMP process starts up.
-              The range is from 1 to 18000. The default is 31.
+              The range is from 1 to 18000 or keyword 'default'.
+              The default is 31.
     startup_query_count:
         description:
             - Query count used when the IGMP process starts up.
-              The range is from 1 to 10. The default is 2.
+              The range is from 1 to 10 or keyword 'default'.
+              The default is 2.
     robustness:
         description:
-            - Sets the robustness variable. Values can range from 1 to 7.
-              The default is 2.
+            - Sets the robustness variable. Values can range from 1 to 7 or
+              keyword 'default'. The default is 2.
     querier_timeout:
         description:
             - Sets the querier timeout that the software uses when deciding
               to take over as the querier. Values can range from 1 to 65535
-              seconds. The default is 255 seconds.
+              seconds or keyword 'default'. The default is 255 seconds.
     query_mrt:
         description:
             - Sets the response time advertised in IGMP queries.
-              Values can range from 1 to 25 seconds. The default is 10 seconds.
+              Values can range from 1 to 25 seconds or keyword 'default'.
+              The default is 10 seconds.
     query_interval:
         description:
             - Sets the frequency at which the software sends IGMP host query
-              messages. Values can range from 1 to 18000 seconds.
-              The default is 125 seconds.
+              messages. Values can range from 1 to 18000 seconds or keyword
+              'default'. The default is 125 seconds.
     last_member_qrt:
         description:
             - Sets the query interval waited after sending membership reports
               before the software deletes the group state. Values can range
-              from 1 to 25 seconds. The default is 1 second.
+              from 1 to 25 seconds or keyword 'default'. The default is 1 second.
     last_member_query_count:
         description:
             - Sets the number of times that the software sends an IGMP query
               in response to a host leave message.
-              Values can range from 1 to 5. The default is 2.
+              Values can range from 1 to 5 or keyword 'default'. The default is 2.
     group_timeout:
         description:
             - Sets the group membership timeout for IGMPv2.
-              Values can range from 3 to 65,535 seconds.
+              Values can range from 3 to 65,535 seconds or keyword 'default'.
               The default is 260 seconds.
     report_llg:
         description:
@@ -105,7 +109,7 @@ options:
               Reports are always sent for nonlink local groups.
               By default, reports are not sent for link local groups.
         type: bool
-        default: 'no'
+        default: 'false'
     immediate_leave:
         description:
             - Enables the device to remove the group entry from the multicast
@@ -115,10 +119,11 @@ options:
               device does not send group-specific queries.
               The default is disabled.
         type: bool
-        default: 'no'
+        default: 'false'
     oif_routemap:
         description:
-            - Configure a routemap for static outgoing interface (OIF).
+            - Configure a routemap for static outgoing interface (OIF) or
+              keyword 'default'.
     oif_prefix:
         description:
             - Configure a prefix for static outgoing interface (OIF).
@@ -127,13 +132,13 @@ options:
             - Configure a source for static outgoing interface (OIF).
     restart:
         description:
-            - Restart IGMP.
+            - Restart IGMP. This is NOT idempotent as this is action only.
         type: bool
     state:
         description:
             - Manages desired state of the resource.
         default: present
-        choices: ['present', 'default']
+        choices: ['present', 'absent', 'default']
 '''
 EXAMPLES = '''
 - nxos_igmp_interface:
@@ -146,54 +151,22 @@ proposed:
     description: k/v pairs of parameters passed into module
     returned: always
     type: dict
-    sample: {"asn": "65535", "router_id": "1.1.1.1", "vrf": "test"}
+    sample: {"startup_query_count": "30"}
 existing:
     description: k/v pairs of existing BGP configuration
     returned: always
     type: dict
-    sample: {"asn": "65535", "bestpath_always_compare_med": false,
-            "bestpath_aspath_multipath_relax": false,
-            "bestpath_compare_neighborid": false,
-            "bestpath_compare_routerid": false,
-            "bestpath_cost_community_ignore": false,
-            "bestpath_med_confed": false,
-            "bestpath_med_missing_as_worst": false,
-            "bestpath_med_non_deterministic": false, "cluster_id": "",
-            "confederation_id": "", "confederation_peers": "",
-            "graceful_restart": true, "graceful_restart_helper": false,
-            "graceful_restart_timers_restart": "120",
-            "graceful_restart_timers_stalepath_time": "300", "local_as": "",
-            "log_neighbor_changes": false, "maxas_limit": "",
-            "neighbor_down_fib_accelerate": false, "reconnect_interval": "60",
-            "router_id": "11.11.11.11", "suppress_fib_pending": false,
-            "timer_bestpath_limit": "", "timer_bgp_hold": "180",
-            "timer_bgp_keepalive": "60", "vrf": "test"}
+    sample: {"startup_query_count": "2"}
 end_state:
     description: k/v pairs of BGP configuration after module execution
     returned: always
     type: dict
-    sample: {"asn": "65535", "bestpath_always_compare_med": false,
-            "bestpath_aspath_multipath_relax": false,
-            "bestpath_compare_neighborid": false,
-            "bestpath_compare_routerid": false,
-            "bestpath_cost_community_ignore": false,
-            "bestpath_med_confed": false,
-            "bestpath_med_missing_as_worst": false,
-            "bestpath_med_non_deterministic": false, "cluster_id": "",
-            "confederation_id": "", "confederation_peers": "",
-            "graceful_restart": true, "graceful_restart_helper": false,
-            "graceful_restart_timers_restart": "120",
-            "graceful_restart_timers_stalepath_time": "300", "local_as": "",
-            "log_neighbor_changes": false, "maxas_limit": "",
-            "neighbor_down_fib_accelerate": false, "reconnect_interval": "60",
-            "router_id": "1.1.1.1",  "suppress_fib_pending": false,
-            "timer_bestpath_limit": "", "timer_bgp_hold": "180",
-            "timer_bgp_keepalive": "60", "vrf": "test"}
+    sample: {"startup_query_count": "30"}
 updates:
     description: commands sent to the device
     returned: always
     type: list
-    sample: ["router bgp 65535", "vrf test", "router-id 1.1.1.1"]
+    sample: ["interface Ethernet1/32", "ip igmp startup-query-count 30"]
 changed:
     description: check to see if a change was made on the device
     returned: always
@@ -369,7 +342,7 @@ def get_igmp_interface(module, interface):
     return igmp
 
 
-def config_igmp_interface(delta, found_both, found_prefix):
+def config_igmp_interface(delta, existing, found_both, found_prefix):
     CMDS = {
         'version': 'ip igmp version {0}',
         'startup_query_interval': 'ip igmp startup-query-interval {0}',
@@ -390,6 +363,7 @@ def config_igmp_interface(delta, found_both, found_prefix):
 
     commands = []
     command = None
+    def_vals = get_igmp_interface_defaults()
 
     for key, value in delta.items():
         if key == 'oif_source' or found_both or found_prefix:
@@ -401,8 +375,18 @@ def config_igmp_interface(delta, found_both, found_prefix):
             else:
                 command = CMDS.get('oif_prefix').format(
                     delta.get('oif_prefix'))
+        elif key == 'oif_routemap':
+            if value == 'default':
+                if existing.get(key):
+                    command = 'no ' + CMDS.get(key).format('dummy')
+            else:
+                command = CMDS.get(key).format(value)
         elif value:
-            command = CMDS.get(key).format(value)
+            if value == 'default':
+                if def_vals.get(key) != existing.get(key):
+                    command = CMDS.get(key).format(def_vals.get(key))
+            else:
+                command = CMDS.get(key).format(value)
         elif not value:
             command = 'no {0}'.format(CMDS.get(key).format(value))
 
@@ -447,7 +431,7 @@ def config_default_igmp_interface(existing, delta, found_both, found_prefix):
     proposed = get_igmp_interface_defaults()
     delta = dict(set(proposed.items()).difference(existing.items()))
     if delta:
-        command = config_igmp_interface(delta, found_both, found_prefix)
+        command = config_igmp_interface(delta, existing, found_both, found_prefix)
 
         if command:
             for each in command:
@@ -459,10 +443,9 @@ def config_default_igmp_interface(existing, delta, found_both, found_prefix):
 def config_remove_oif(existing, existing_oif_prefix_source):
     commands = []
     command = None
-    if existing.get('routemap'):
-        command = 'no ip igmp static-oif route-map {0}'.format(
-            existing.get('routemap'))
-    if existing_oif_prefix_source:
+    if existing.get('oif_routemap'):
+        commands.append('no ip igmp static-oif route-map {0}'.format('dummy'))
+    elif existing_oif_prefix_source:
         for each in existing_oif_prefix_source:
             if each.get('prefix') and each.get('source'):
                 command = 'no ip igmp static-oif {0} source {1} '.format(
@@ -516,9 +499,8 @@ def main():
     oif_source = module.params['oif_source']
     oif_routemap = module.params['oif_routemap']
 
-    if oif_source:
-        if not oif_prefix:
-            module.fail_json(msg='oif_prefix required when setting oif_source')
+    if oif_source and not oif_prefix:
+        module.fail_json(msg='oif_prefix required when setting oif_source')
 
     intf_type = get_interface_type(interface)
     if get_interface_mode(interface, intf_type, module) == 'layer2':
@@ -609,7 +591,7 @@ def main():
 
     if state == 'present':
         if delta:
-            command = config_igmp_interface(delta, found_both, found_prefix)
+            command = config_igmp_interface(delta, existing, found_both, found_prefix)
             if command:
                 commands.append(command)
 
@@ -631,9 +613,6 @@ def main():
         if command:
             commands.append(command)
 
-    if module.params['restart']:
-        commands.append('restart igmp')
-
     cmds = []
     results = {}
     if commands:
@@ -648,6 +627,10 @@ def main():
             end_state = get_igmp_interface(module, interface)
             if 'configure' in cmds:
                 cmds.pop(0)
+
+    if module.params['restart']:
+        cmd = {'command': 'restart igmp', 'output': 'text'}
+        run_commands(module, cmd)
 
     results['proposed'] = proposed
     results['existing'] = existing_copy

--- a/lib/ansible/modules/network/nxos/nxos_igmp_interface.py
+++ b/lib/ansible/modules/network/nxos/nxos_igmp_interface.py
@@ -137,6 +137,7 @@ options:
               prefix if source is not needed. The specified values will be configured
               on the device and if any previous prefix/sources exist, they will be removed.
               Keyword 'default' is also accpted which removes all existing prefix/sources.
+        version_added: 2.6
     restart:
         description:
             - Restart IGMP. This is NOT idempotent as this is action only.

--- a/lib/ansible/modules/network/nxos/nxos_igmp_interface.py
+++ b/lib/ansible/modules/network/nxos/nxos_igmp_interface.py
@@ -155,7 +155,7 @@ EXAMPLES = '''
     startup_query_interval: 30
     oif_ps:
       - { 'prefix': '238.2.2.6' }
-      - { 'source': '1.1.1.1', 'prefix': '238.2.2.5'}
+      - { 'source': '192.168.0.1', 'prefix': '238.2.2.5'}
     state: present
 '''
 RETURN = '''
@@ -164,7 +164,7 @@ proposed:
     returned: always
     type: dict
     sample: {"startup_query_count": "30",
-             "oif_ps": [{'prefix': '238.2.2.6'}, {'source': '1.1.1.1', 'prefix': '238.2.2.5'}]}
+             "oif_ps": [{'prefix': '238.2.2.6'}, {'source': '192.168.0.1', 'prefix': '238.2.2.5'}]}
 existing:
     description: k/v pairs of existing igmp_interface configuration
     returned: always
@@ -175,13 +175,13 @@ end_state:
     returned: always
     type: dict
     sample: {"startup_query_count": "30",
-             "oif_ps": [{'prefix': '238.2.2.6'}, {'source': '1.1.1.1', 'prefix': '238.2.2.5'}]}
+             "oif_ps": [{'prefix': '238.2.2.6'}, {'source': '192.168.0.1', 'prefix': '238.2.2.5'}]}
 updates:
     description: commands sent to the device
     returned: always
     type: list
     sample: ["interface Ethernet1/32", "ip igmp startup-query-count 30",
-             "ip igmp static-oif 238.2.2.6", "ip igmp static-oif 238.2.2.5 source 1.1.1.1"]
+             "ip igmp static-oif 238.2.2.6", "ip igmp static-oif 238.2.2.5 source 192.168.0.1"]
 changed:
     description: check to see if a change was made on the device
     returned: always

--- a/lib/ansible/modules/network/nxos/nxos_igmp_interface.py
+++ b/lib/ansible/modules/network/nxos/nxos_igmp_interface.py
@@ -137,16 +137,15 @@ options:
               prefix if source is not needed. The specified values will be configured
               on the device and if any previous prefix/sources exist, they will be removed.
               Keyword 'default' is also accpted which removes all existing prefix/sources.
-              See below for example
-              [{'prefix': '238.2.2.6'}, {'source': '1.1.1.1', 'prefix': '238.2.2.5'}]
     restart:
         description:
             - Restart IGMP. This is NOT idempotent as this is action only.
         type: bool
+        default: False
     state:
         description:
             - Manages desired state of the resource.
-        default: 'present'
+        default: present
         choices: ['present', 'absent', 'default']
 '''
 EXAMPLES = '''

--- a/lib/ansible/modules/network/nxos/nxos_igmp_interface.py
+++ b/lib/ansible/modules/network/nxos/nxos_igmp_interface.py
@@ -153,7 +153,9 @@ EXAMPLES = '''
 - nxos_igmp_interface:
     interface: ethernet1/32
     startup_query_interval: 30
-    oif_ps: [{'prefix': '238.2.2.6'}, {'source': '1.1.1.1', 'prefix': '238.2.2.5'}]
+    oif_ps:
+      - { 'prefix': '238.2.2.6' }
+      - {'source': '1.1.1.1', 'prefix': '238.2.2.5'}
     state: present
 '''
 RETURN = '''
@@ -462,7 +464,7 @@ def config_default_igmp_interface(existing, delta):
     proposed = get_igmp_interface_defaults()
     delta = dict(set(proposed.items()).difference(existing.items()))
     if delta:
-        command = config_igmp_interface(delta, existing, None)
+        command = config_igmp_interface(delta, existing, existing_oif_prefix_source=None)
 
         if command:
             for each in command:
@@ -537,13 +539,12 @@ def main():
     oif_routemap = module.params['oif_routemap']
     oif_ps = module.params['oif_ps']
 
-    if not oif_ps:
-        if oif_source and not oif_prefix:
-            module.fail_json(msg='oif_prefix required when setting oif_source')
-        elif oif_source and oif_prefix:
-            oif_ps = [{'source': oif_source, 'prefix': oif_prefix}]
-        elif not oif_source and oif_prefix:
-            oif_ps = [{'prefix': oif_prefix}]
+    if oif_source and not oif_prefix:
+        module.fail_json(msg='oif_prefix required when setting oif_source')
+    elif oif_source and oif_prefix:
+        oif_ps = [{'source': oif_source, 'prefix': oif_prefix}]
+    elif not oif_source and oif_prefix:
+        oif_ps = [{'prefix': oif_prefix}]
 
     intf_type = get_interface_type(interface)
     if get_interface_mode(interface, intf_type, module) == 'layer2':

--- a/test/integration/targets/nxos_igmp_interface/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_igmp_interface/tests/common/sanity.yaml
@@ -83,7 +83,10 @@
       last_member_qrt: default
       last_member_query_count: default
       group_timeout: default
-      oif_ps: [{'prefix': '238.2.2.6'}, {'prefix': '238.2.2.5'}, {'source': '1.1.1.1', 'prefix': '238.2.2.5'}]
+      oif_ps:
+        - {'prefix': '238.2.2.6'}
+        - {'prefix': '238.2.2.5'}
+        - {'source': '1.1.1.1', 'prefix': '238.2.2.5'}
       state: present
       provider: "{{ connection }}"
     register: result

--- a/test/integration/targets/nxos_igmp_interface/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_igmp_interface/tests/common/sanity.yaml
@@ -6,11 +6,22 @@
 # Select interface for test
 - set_fact: intname="{{ nxos_int1 }}"
 
+- set_fact: restart="true"
+  when: platform is not match("N35")
+
 - name: "Enable feature PIM"
   nxos_feature:
     feature: pim
     state: enabled
     provider: "{{ connection }}"
+  ignore_errors: yes
+
+- name: Put interface in default mode
+  nxos_config:
+    commands:
+    - "default interface {{ intname }}"
+    provider: "{{ connection }}"
+    match: none
   ignore_errors: yes
 
 - block:
@@ -39,7 +50,8 @@
       last_member_query_count: 4
       report_llg: true
       immediate_leave: true
-      restart: false
+      group_timeout: 300
+      oif_routemap: abcd
       state: present
       provider: "{{ connection }}"
     register: result
@@ -56,10 +68,42 @@
       that:
         - "result.changed == false"
 
+  - name: Configure igmp interface with some default values
+    nxos_igmp_interface: &sdef
+      interface: "{{ intname }}"
+      version: default
+      startup_query_interval: default
+      startup_query_count: default
+      robustness: default
+      querier_timeout: default
+      query_mrt: default
+      query_interval: default
+      last_member_qrt: default
+      last_member_query_count: default
+      group_timeout: default
+      oif_routemap: default
+      state: present
+      provider: "{{ connection }}"
+    register: result
+
+  - assert: *true
+
+  - name: "Check Idempotence - Configure igmp interface with some default values"
+    nxos_igmp_interface: *sdef
+    register: result
+
+  - assert: *false
+
+  - name: restart igmp
+    nxos_igmp_interface: &restart
+      interface: "{{ intname }}"
+      restart: "{{restart|default(omit)}}"
+      provider: "{{ connection }}"
+
   - name: Configure igmp interface with default value
     nxos_igmp_interface: &default
       interface: "{{ intname }}"
-      state: default
+      state: absent
       provider: "{{ connection }}"
     register: result
 

--- a/test/integration/targets/nxos_igmp_interface/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_igmp_interface/tests/common/sanity.yaml
@@ -51,7 +51,9 @@
       report_llg: true
       immediate_leave: true
       group_timeout: 300
-      oif_routemap: abcd
+      # deprecated
+      oif_prefix: 239.255.255.2
+      oif_source: 1.1.1.1
       state: present
       provider: "{{ connection }}"
     register: result
@@ -81,7 +83,7 @@
       last_member_qrt: default
       last_member_query_count: default
       group_timeout: default
-      oif_routemap: default
+      oif_ps: [{'prefix': '238.2.2.6'}, {'prefix': '238.2.2.5'}, {'source': '1.1.1.1', 'prefix': '238.2.2.5'}]
       state: present
       provider: "{{ connection }}"
     register: result
@@ -100,8 +102,59 @@
       restart: "{{restart|default(omit)}}"
       provider: "{{ connection }}"
 
-  - name: Configure igmp interface with default value
+  - name: Configure igmp interface with default oif_ps
+    nxos_igmp_interface: &defoif
+      interface: "{{ intname }}"
+      oif_ps: default
+      state: present
+      provider: "{{ connection }}"
+    register: result
+
+  - assert: *true
+
+  - name: "Check Idempotence - Configure igmp interface with default oif_ps"
+    nxos_igmp_interface: *defoif
+    register: result
+
+  - assert: *false
+
+  - name: Configure igmp interface with oif_routemap
+    nxos_igmp_interface: &orm
+      interface: "{{ intname }}"
+      version: 3
+      startup_query_interval: 60
+      startup_query_count: 5
+      robustness: 6
+      oif_routemap: abcd
+      state: present
+      provider: "{{ connection }}"
+    register: result
+
+  - assert: *true
+
+  - name: "Check Idempotence - Configure igmp interface with oif_routemap"
+    nxos_igmp_interface: *orm
+    register: result
+
+  - assert: *false
+
+  - name: Configure igmp interface with default state
     nxos_igmp_interface: &default
+      interface: "{{ intname }}"
+      state: default
+      provider: "{{ connection }}"
+    register: result
+
+  - assert: *true
+
+  - name: "Check Idempotence - Configure igmp interface with default state"
+    nxos_igmp_interface: *default
+    register: result
+
+  - assert: *false
+
+  - name: Configure igmp interface with absent state
+    nxos_igmp_interface: &absent
       interface: "{{ intname }}"
       state: absent
       provider: "{{ connection }}"
@@ -109,15 +162,15 @@
 
   - assert: *true
 
-  - name: "Check Idempotence - Configure igmp interface with default value"
-    nxos_igmp_interface: *default
+  - name: "Check Idempotence - Configure igmp interface with absent state"
+    nxos_igmp_interface: *absent
     register: result
 
   - assert: *false
 
   always:
-  - name: Configure igmp interface with default value
-    nxos_igmp_interface: *default
+  - name: Configure igmp interface with absent state
+    nxos_igmp_interface: *absent
     register: result
 
   - name: Put interface in default mode

--- a/test/sanity/validate-modules/ignore.txt
+++ b/test/sanity/validate-modules/ignore.txt
@@ -1343,6 +1343,7 @@ lib/ansible/modules/network/nxos/nxos_evpn_global.py E325
 lib/ansible/modules/network/nxos/nxos_evpn_global.py E326
 lib/ansible/modules/network/nxos/nxos_file_copy.py E324
 lib/ansible/modules/network/nxos/nxos_gir.py E326
+lib/ansible/modules/network/nxos/nxos_igmp_interface.py E326
 lib/ansible/modules/network/nxos/nxos_interface.py E324
 lib/ansible/modules/network/nxos/nxos_lldp.py E326
 lib/ansible/modules/network/nxos/nxos_logging.py E325

--- a/test/sanity/validate-modules/ignore.txt
+++ b/test/sanity/validate-modules/ignore.txt
@@ -1343,7 +1343,6 @@ lib/ansible/modules/network/nxos/nxos_evpn_global.py E325
 lib/ansible/modules/network/nxos/nxos_evpn_global.py E326
 lib/ansible/modules/network/nxos/nxos_file_copy.py E324
 lib/ansible/modules/network/nxos/nxos_gir.py E326
-lib/ansible/modules/network/nxos/nxos_igmp_interface.py E326
 lib/ansible/modules/network/nxos/nxos_interface.py E324
 lib/ansible/modules/network/nxos/nxos_lldp.py E326
 lib/ansible/modules/network/nxos/nxos_logging.py E325


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #38750 and #38753
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
nxos_igmp_interface

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0 (devel fed20b825f) last updated 2018/02/15 12:51:12 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /root/agents-ci/ansible/lib/ansible
  executable location = /root/agents-ci/ansible/bin/ansible
  python version = 2.7.6 (default, Oct 26 2016, 20:30:19) [GCC 4.8.4]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
* This PR fixes #38750 and #38753 
* Deprecates oif_prefix and oif_source but maintains backward compatibility
* Introduces oif_ps as a new parameter to add/remove multiple prefix/sources.
* Documentation corrections are made
* Integration tests are enhanced for coverage and platform dependencies
* All tests pass on all platforms
<!--- Paste verbatim command output below, e.g. before and after your change -->
```
```
