### PR TITLE
VMware: Set default network type as 'dhcp'

### DIFF
--- a/changelogs/fragments/38466-vmware_guest_set_dhcp_as_default.yaml
+++ b/changelogs/fragments/38466-vmware_guest_set_dhcp_as_default.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- Set default network type as 'dhcp' if user has not specified any.

--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -209,7 +209,7 @@ options:
     - ' - C(device_type) (string): Virtual network device (one of C(e1000), C(e1000e), C(pcnet32), C(vmxnet2), C(vmxnet3) (default), C(sriov)).'
     - ' - C(mac) (string): Customize mac address.'
     - 'Optional parameters per entry (used for OS customization):'
-    - ' - C(type) (string): Type of IP assignment (either C(dhcp) or C(static)).'
+    - ' - C(type) (string): Type of IP assignment (either C(dhcp) or C(static)). C(dhcp) is default.'
     - ' - C(ip) (string): Static IP address (implies C(type: static)).'
     - ' - C(netmask) (string): Static netmask required for C(ip).'
     - ' - C(gateway) (string): Static gateway.'
@@ -936,6 +936,9 @@ class PyVmomiHelper(PyVmomi):
                 # network type as 'static'
                 if 'ip' in network or 'netmask' in network:
                     network['type'] = 'static'
+                else:
+                    # User wants network type as 'dhcp'
+                    network['type'] = 'dhcp'
 
             if network.get('type') == 'static':
                 if 'ip' in network and 'netmask' not in network:

--- a/test/integration/targets/vmware_guest/tasks/network_negative_test.yml
+++ b/test/integration/targets/vmware_guest/tasks/network_negative_test.yml
@@ -61,7 +61,7 @@
 
 - debug: var=non_existent_network
 
-- name: assert that no changes were made
+- name: assert that no changes were not made
   assert:
     that:
         - "not non_existent_network.changed"
@@ -94,7 +94,7 @@
 
 - debug: var=no_netmask
 
-- name: assert that no changes were made
+- name: assert that no changes were not made
   assert:
     that:
         - "not no_netmask.changed"
@@ -127,7 +127,7 @@
 
 - debug: var=no_ip
 
-- name: assert that changes were made
+- name: assert that changes were not made
   assert:
     that:
         - "not no_ip.changed"
@@ -160,7 +160,7 @@
 
 - debug: var=no_network_name
 
-- name: assert that no changes were made
+- name: assert that no changes were not made
   assert:
     that:
         - "not no_network_name.changed"
@@ -193,7 +193,7 @@
 
 - debug: var=no_network
 
-- name: assert that changes were made
+- name: assert that changes were not made
   assert:
     that:
         - "not no_network.changed"
@@ -227,7 +227,7 @@
 
 - debug: var=invalid_device_type
 
-- name: assert that changes were made
+- name: assert that changes were not made
   assert:
     that:
         - "not invalid_device_type.changed"
@@ -262,7 +262,7 @@
 
 - debug: var=invalid_mac
 
-- name: assert that changes were made
+- name: assert that changes were not made
   assert:
     that:
         - "not invalid_mac.changed"
@@ -298,7 +298,7 @@
 
 - debug: var=invalid_network_type
 
-- name: assert that changes were made
+- name: assert that changes were not made
   assert:
     that:
         - "not invalid_network_type.changed"
@@ -334,8 +334,38 @@
 
 - debug: var=invalid_dhcp_network_type
 
-- name: assert that changes were made
+- name: assert that changes were not made
   assert:
     that:
         - "not invalid_dhcp_network_type.changed"
         - "\"Static IP information provided for network\" in invalid_dhcp_network_type.msg"
+
+- name: create new VMs with no network type which set network type as "DHCP"
+  vmware_guest:
+    validate_certs: False
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    name: new_vm_no_nw_type
+    guest_id: centos64Guest
+    datacenter: "{{ (vm1 | basename).split('_')[0] }}"
+    disk:
+      - size: 3mb
+        type: thin
+        autoselect_datastore: yes
+    networks:
+      - name: "VM Network"
+    hardware:
+        num_cpus: 3
+        memory_mb: 512
+    state: poweredoff
+    folder: "{{ vm1 | dirname }}"
+  register: no_network_type
+  ignore_errors: yes
+
+- debug: var=no_network_type
+
+- name: assert that changes were made
+  assert:
+    that:
+        - "no_network_type.changed"


### PR DESCRIPTION
##### SUMMARY
If user does not specify any network type then set network type
to dhcp. There are additional checks around 'ip', 'netmask' and
'type' in network spec.

Fixes: #38466

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>
(cherry picked from commit 9b139baacbe247b6bbc6ec5de57032de61c5de71)

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/38466-vmware_guest_set_dhcp_as_default.yaml
lib/ansible/modules/cloud/vmware/vmware_guest.py
test/integration/targets/vmware_guest/tasks/network_negative_test.yml

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
Stable-2.5
```