### PR TITLE
Add 'hidden' option to user module for Darwin/OS X

### DIFF
--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -38,6 +38,12 @@ options:
     uid:
         description:
             - Optionally sets the I(UID) of the user.
+    hidden:
+        required: false
+        type: boolean
+        description:
+            - Darwin/OS X only, optionally hide the user from the login window and system preferences.
+            - The default will be 'True' if the I(system) option is used.
     non_unique:
         description:
             - Optionally when used with the -u option, this option allows to
@@ -265,6 +271,7 @@ class User(object):
         self.state = module.params['state']
         self.name = module.params['name']
         self.uid = module.params['uid']
+        self.hidden     = module.params['hidden']
         self.non_unique = module.params['non_unique']
         self.seuser = module.params['seuser']
         self.group = module.params['group']
@@ -1511,6 +1518,7 @@ class DarwinUser(User):
         ('shell', 'UserShell'),
         ('uid', 'UniqueID'),
         ('group', 'PrimaryGroupID'),
+        ('hidden', 'IsHidden'),
     ]
 
     def _get_dscl(self):
@@ -2134,6 +2142,8 @@ def main():
             shell=dict(type='str'),
             password=dict(type='str', no_log=True),
             login_class=dict(type='str'),
+            # following options are specific to macOS
+            hidden=dict(type='bool'),
             # following options are specific to selinux
             seuser=dict(type='str'),
             # following options are specific to userdel

--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -40,7 +40,7 @@ options:
             - Optionally sets the I(UID) of the user.
     hidden:
         required: false
-        type: boolean
+        type: bool
         description:
             - Darwin/OS X only, optionally hide the user from the login window and system preferences.
             - The default will be 'True' if the I(system) option is used.

--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -44,6 +44,7 @@ options:
         description:
             - Darwin/OS X only, optionally hide the user from the login window and system preferences.
             - The default will be 'True' if the I(system) option is used.
+        version_added: "2.6"
     non_unique:
         description:
             - Optionally when used with the -u option, this option allows to
@@ -271,7 +272,7 @@ class User(object):
         self.state = module.params['state']
         self.name = module.params['name']
         self.uid = module.params['uid']
-        self.hidden     = module.params['hidden']
+        self.hidden = module.params['hidden']
         self.non_unique = module.params['non_unique']
         self.seuser = module.params['seuser']
         self.group = module.params['group']
@@ -1520,6 +1521,23 @@ class DarwinUser(User):
         ('group', 'PrimaryGroupID'),
         ('hidden', 'IsHidden'),
     ]
+
+    def __init__(self, module):
+
+        super(DarwinUser, self).__init__(module)
+
+        # make the user hidden if option is set or deffer to system option
+        if self.hidden is None:
+            if self.system:
+                self.hidden = 1
+        elif self.hidden:
+            self.hidden = 1
+        else:
+            self.hidden = 0
+
+        # add hidden to processing if set
+        if self.hidden is not None:
+            self.fields.append(('hidden', 'IsHidden'))
 
     def _get_dscl(self):
         return [self.module.get_bin_path('dscl', True), self.dscl_directory]


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
cleanup of #21525

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
user
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6
```