### PR TITLE
Adding module for Digital Ocean Spaces

### DIFF
--- a/lib/ansible/modules/cloud/digital_ocean/digital_ocean_space.py
+++ b/lib/ansible/modules/cloud/digital_ocean/digital_ocean_space.py
@@ -1,0 +1,180 @@
+#!/usr/bin/python
+
+# Copyright: (c) 2018, Aaron Smith <ajsmith10381@gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = '''
+---
+module: digital_ocean_space
+short_description: Manage spaces in DigitalOcean.
+description:
+    - Create and remove spaces in DigitalOcean.
+author: "Aaron Smith (@slapula)"
+version_added: "2.6"
+options:
+  name:
+    description:
+     - The name of the space.
+    required: true
+  state:
+    description:
+     - Whether the space should be present or absent.
+    default: present
+    choices: ['present', 'absent']
+  region:
+    description:
+    - Region where the space will reside.
+  canned_acl:
+    description:
+    - Canned ACL to apply to the bucket.
+    default: private
+    choices: ['private', 'public-read']
+  access_id:
+    description:
+    - Access ID used for authentication with Digital Ocean Spaces API.
+    default: DO_ACCESS_KEY_ID
+  secret_key:
+    description:
+    - Secret key used for authentication with Digital Ocean Spaces API.
+    default: DO_SECRET_ACCESS_KEY
+extends_documentation_fragment: digital_ocean.documentation
+notes:
+  - Two environment variables are used for authentication with the Digital Ocean
+    Spaces API.  They are DO_ACCESS_KEY_ID and DO_SECRET_ACCESS_KEY.  You can
+    create this key pair in the Digital Ocean control panel.
+'''
+
+
+EXAMPLES = '''
+- name: create a space
+  digital_ocean_space:
+    name: cool_example_space
+    state: present
+
+- name: remove a space
+  digital_ocean_space:
+    name: cool_example_space
+    state: absent
+
+- name: use API credentials stored in ansible-vault
+  digital_ocean_space:
+    name: cool_example_space
+    state: present
+    access_id: "{{ super_secure_access_id_stored_in_vault }}"
+    secret_key: "{{ super_secure_secret_key_also_stored_in_vault }}"
+
+'''
+
+
+RETURN = ''' # '''
+
+import os
+import boto3
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.digital_ocean import DigitalOceanHelper
+from ansible.module_utils._text import to_native
+
+
+def space_exists(client, module):
+    space_name = module.params.get('name')
+    try:
+        client.head_bucket(Bucket=space_name)
+        return True
+    except:
+        return False
+
+
+def create_space(client, module, result):
+    space_name = module.params.get('name')
+    canned_acl = module.params.get('canned_acl')
+    try:
+        response = client.create_bucket(
+            Bucket=space_name,
+            ACL=canned_acl
+        )
+        result['changed'] = True
+        return result
+    except:
+        module.fail_json(msg="Failed to create space: {0}".format(space_name))
+
+
+def update_space(client, module, result):
+    space_name = module.params.get('name')
+    canned_acl = module.params.get('canned_acl')
+    try:
+        response = client.put_bucket_acl(
+            Bucket=space_name,
+            ACL=canned_acl
+        )
+        result['changed'] = True
+        return result
+    except:
+        module.fail_json(msg="Failed to update space ACL: {0}".format(space_name))
+
+
+def delete_space(client, module, result):
+    space_name = module.params.get('name')
+    try:
+        response = client.delete_bucket(Bucket=space_name)
+        result['changed'] = True
+        return result
+    except:
+        module.fail_json(msg="Failed to delete space: {0}".format(space_name))
+
+
+def main():
+    argument_spec = DigitalOceanHelper.digital_ocean_argument_spec()
+    argument_spec.update(
+        name=dict(type='str', required=True),
+        state=dict(type='str', default='present'),
+        region=dict(type='str', default='nyc3'),
+        canned_acl=dict(type='str', default='private'),
+        access_id=dict(type='str', default=os.environ['DO_ACCESS_KEY_ID']),
+        secret_key=dict(type='str', default=os.environ['DO_SECRET_ACCESS_KEY']),
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+    )
+
+    result = {
+        'changed': False
+    }
+
+    desired_state = module.params.get('state')
+    region = module.params.get('region')
+    access_id = module.params.get('access_id')
+    secret_key = module.params.get('secret_key')
+
+    session = boto3.session.Session()
+    client = session.client('s3',
+                            region_name=region,
+                            endpoint_url="https://{0}.digitaloceanspaces.com".format(region),
+                            aws_access_key_id=access_id,
+                            aws_secret_access_key=secret_key)
+
+    if desired_state == 'present':
+        if not space_exists(client, module):
+            create_space(client, module, result)
+        if space_exists(client, module):
+            update_space(client, module, result)
+
+    if desired_state == 'absent':
+        if space_exists(client, module):
+            delete_space(client, module, result)
+
+    module.exit_json(changed=result['changed'])
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/cloud/digital_ocean/digital_ocean_space.py
+++ b/lib/ansible/modules/cloud/digital_ocean/digital_ocean_space.py
@@ -32,6 +32,7 @@ options:
   region:
     description:
     - Region where the space will reside.
+    default: 'nyc3'
   canned_acl:
     description:
     - Canned ACL to apply to the bucket.
@@ -39,12 +40,12 @@ options:
     choices: ['private', 'public-read']
   access_id:
     description:
-    - Access ID used for authentication with Digital Ocean Spaces API.
-    default: DO_ACCESS_KEY_ID
+    - Access ID used for authentication with Digital Ocean Spaces API (Default is DO_ACCESS_KEY_ID).
+    default: ''
   secret_key:
     description:
-    - Secret key used for authentication with Digital Ocean Spaces API.
-    default: DO_SECRET_ACCESS_KEY
+    - Secret key used for authentication with Digital Ocean Spaces API (Default is DO_SECRET_ACCESS_KEY).
+    default: ''
 extends_documentation_fragment: digital_ocean.documentation
 notes:
   - Two environment variables are used for authentication with the Digital Ocean
@@ -77,6 +78,7 @@ EXAMPLES = '''
 RETURN = ''' # '''
 
 import os
+import boto3
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.aws.core import AnsibleAWSModule
@@ -135,9 +137,9 @@ def main():
     argument_spec = DigitalOceanHelper.digital_ocean_argument_spec()
     argument_spec.update(
         name=dict(type='str', required=True),
-        state=dict(type='str', default='present'),
+        state=dict(type='str', choices=['present', 'absent'], default='present'),
         region=dict(type='str', default='nyc3'),
-        canned_acl=dict(type='str', default='private'),
+        canned_acl=dict(type='str', choices=['private', 'public-read'], default='private'),
         access_id=dict(type='str', default=os.getenv('DO_ACCESS_KEY_ID', '')),
         secret_key=dict(type='str', default=os.getenv('DO_SECRET_ACCESS_KEY', '')),
     )

--- a/lib/ansible/modules/cloud/digital_ocean/digital_ocean_space.py
+++ b/lib/ansible/modules/cloud/digital_ocean/digital_ocean_space.py
@@ -78,7 +78,6 @@ EXAMPLES = '''
 RETURN = ''' # '''
 
 import os
-import boto3
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.aws.core import AnsibleAWSModule
@@ -144,7 +143,7 @@ def main():
         secret_key=dict(type='str', default=os.getenv('DO_SECRET_ACCESS_KEY', '')),
     )
 
-    module = AnsibleModule(
+    module = AnsibleAWSModule(
         argument_spec=argument_spec,
         supports_check_mode=True,
     )
@@ -158,8 +157,7 @@ def main():
     access_id = module.params.get('access_id')
     secret_key = module.params.get('secret_key')
 
-    session = boto3.session.Session()
-    client = session.client('s3',
+    client = module.client('s3',
                             region_name=region,
                             endpoint_url="https://{0}.digitaloceanspaces.com".format(region),
                             aws_access_key_id=access_id,

--- a/lib/ansible/modules/cloud/digital_ocean/digital_ocean_space.py
+++ b/lib/ansible/modules/cloud/digital_ocean/digital_ocean_space.py
@@ -19,6 +19,7 @@ description:
     - Create and remove spaces in DigitalOcean.
 author: "Aaron Smith (@slapula)"
 version_added: "2.6"
+requirements: [ 'botocore', 'boto3' ]
 options:
   name:
     description:
@@ -46,7 +47,10 @@ options:
     description:
     - Secret key used for authentication with Digital Ocean Spaces API (Default is DO_SECRET_ACCESS_KEY).
     default: ''
-extends_documentation_fragment: digital_ocean.documentation
+extends_documentation_fragment:
+    - digital_ocean.documentation
+    - aws
+    - ec2
 notes:
   - Two environment variables are used for authentication with the Digital Ocean
     Spaces API.  They are DO_ACCESS_KEY_ID and DO_SECRET_ACCESS_KEY.  You can
@@ -157,11 +161,13 @@ def main():
     access_id = module.params.get('access_id')
     secret_key = module.params.get('secret_key')
 
-    client = module.client('s3',
-                            region_name=region,
-                            endpoint_url="https://{0}.digitaloceanspaces.com".format(region),
-                            aws_access_key_id=access_id,
-                            aws_secret_access_key=secret_key)
+    client = module.client(
+        's3',
+        region_name=region,
+        endpoint_url="https://{0}.digitaloceanspaces.com".format(region),
+        aws_access_key_id=access_id,
+        aws_secret_access_key=secret_key
+    )
 
     if desired_state == 'present':
         if not space_exists(client, module):

--- a/lib/ansible/modules/cloud/digital_ocean/digital_ocean_space.py
+++ b/lib/ansible/modules/cloud/digital_ocean/digital_ocean_space.py
@@ -50,7 +50,6 @@ options:
 extends_documentation_fragment:
     - digital_ocean.documentation
     - aws
-    - ec2
 notes:
   - Two environment variables are used for authentication with the Digital Ocean
     Spaces API.  They are DO_ACCESS_KEY_ID and DO_SECRET_ACCESS_KEY.  You can

--- a/lib/ansible/modules/cloud/digital_ocean/digital_ocean_space.py
+++ b/lib/ansible/modules/cloud/digital_ocean/digital_ocean_space.py
@@ -77,9 +77,9 @@ EXAMPLES = '''
 RETURN = ''' # '''
 
 import os
-import boto3
 
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.aws.core import AnsibleAWSModule
 from ansible.module_utils.digital_ocean import DigitalOceanHelper
 from ansible.module_utils._text import to_native
 
@@ -138,8 +138,8 @@ def main():
         state=dict(type='str', default='present'),
         region=dict(type='str', default='nyc3'),
         canned_acl=dict(type='str', default='private'),
-        access_id=dict(type='str', default=os.environ['DO_ACCESS_KEY_ID']),
-        secret_key=dict(type='str', default=os.environ['DO_SECRET_ACCESS_KEY']),
+        access_id=dict(type='str', default=os.getenv('DO_ACCESS_KEY_ID', '')),
+        secret_key=dict(type='str', default=os.getenv('DO_SECRET_ACCESS_KEY', '')),
     )
 
     module = AnsibleModule(


### PR DESCRIPTION
##### SUMMARY
Digital Ocean introduced a new feature called Spaces somewhat recently and it serves as an object store (much like S3).  You can read more about it here: [An Introduction to Digital Ocean Spaces](https://www.digitalocean.com/community/tutorials/an-introduction-to-digitalocean-spaces).  In fact, their documentation says that they are basically trying to mirror the S3 api as closely as possible.  This means that you can interact with the Spaces API with libraries like boto3 without much refactoring.  Pretty cool.  Anyway, this is my attempt at adding Spaces support to Ansible.

##### ISSUE TYPE
 - New Module Pull Request

##### COMPONENT NAME
`digital_ocean_space`

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.1.0
  config file = None
  configured module search path = [u'/Users/asmith/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/asmith/.pyenv/versions/2.7.13/lib/python2.7/site-packages/ansible
  executable location = /Users/asmith/.pyenv/versions/2.7.13/bin/ansible
  python version = 2.7.13 (default, Sep  8 2017, 15:16:38) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```
