### PR TITLE
Work-around for get-pip.py install failure.

### DIFF
--- a/test/runner/setup/remote.sh
+++ b/test/runner/setup/remote.sh
@@ -22,7 +22,7 @@ if [ "${platform}" = "freebsd" ]; then
          sleep 10
     done
 
-    pip --version 2>/dev/null || curl --silent --show-error https://bootstrap.pypa.io/get-pip.py | python
+    pip --version 2>/dev/null || curl --silent --show-error https://bootstrap.pypa.io/get-pip.py | python - --force-reinstall
 elif [ "${platform}" = "rhel" ]; then
     while true; do
         yum install -y \
@@ -36,7 +36,7 @@ elif [ "${platform}" = "rhel" ]; then
          sleep 10
     done
 
-    pip --version 2>/dev/null || curl --silent --show-error https://bootstrap.pypa.io/get-pip.py | python
+    pip --version 2>/dev/null || curl --silent --show-error https://bootstrap.pypa.io/get-pip.py | python - --force-reinstall
 fi
 
 if [ "${platform}" = "freebsd" ] || [ "${platform}" = "osx" ]; then


### PR DESCRIPTION
##### SUMMARY

Work-around for get-pip.py install failure.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.6.0 (pip-workaround d4551a6d88) last updated 2018/04/14 12:44:41 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
