### PR TITLE
Allow empty list of names in pip module

### DIFF
--- a/lib/ansible/modules/packaging/language/pip.py
+++ b/lib/ansible/modules/packaging/language/pip.py
@@ -491,9 +491,13 @@ def main():
         if name:
             for pkg in name:
                 cmd += ' %s' % _get_full_name(pkg, version)
+        elif requirements:
+            cmd += ' -r %s' % requirements
         else:
-            if requirements:
-                cmd += ' -r %s' % requirements
+            module.exit_json(
+                changed=False,
+                warnings=["No valid name or requirements file found."],
+            )
 
         if module.check_mode:
             if extra_args or requirements or state == 'latest' or not name:

--- a/test/integration/targets/pip/tasks/pip.yml
+++ b/test/integration/targets/pip/tasks/pip.yml
@@ -208,3 +208,14 @@
   assert:
     that:
       - "venv_chdir.changed"
+
+# ansible#38785
+- name: allow empty list of packages
+  pip:
+    name: []
+  register: pip_install_empty
+
+- name: ensure empty install is successful
+  assert:
+    that:
+      - not pip_install_empty.changed


### PR DESCRIPTION
##### SUMMARY
Fixes #38785 

pip 10 gives exit code 1 for empty argument lists (pip < 10 gave exit 0), see also https://github.com/pypa/pip/pull/4210.

To still allow playbooks to pass when giving empty lists, don't call
pip in that case, but show a warning.

##### ISSUE TYPE
 Bugfix Pull Request

##### COMPONENT NAME
pip

##### ANSIBLE VERSION
devel