### PR TITLE
Add docker_config module

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_config.py
+++ b/lib/ansible/modules/cloud/docker/docker_config.py
@@ -280,7 +280,9 @@ def main():
     client = AnsibleDockerClient(
         argument_spec=argument_spec,
         supports_check_mode=True,
-        required_if=required_if
+        required_if=required_if,
+        min_docker_version='2.6.0',
+        min_docker_api_version='1.30',
     )
 
     results = dict(

--- a/lib/ansible/modules/cloud/docker/docker_config.py
+++ b/lib/ansible/modules/cloud/docker/docker_config.py
@@ -285,7 +285,6 @@ def main():
 
     results = dict(
         changed=False,
-        config_id=''
     )
 
     ConfigManager(client, results)()

--- a/lib/ansible/modules/cloud/docker/docker_config.py
+++ b/lib/ansible/modules/cloud/docker/docker_config.py
@@ -1,0 +1,285 @@
+#!/usr/bin/python
+#
+# Copyright 2016 Red Hat | Ansible
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = '''
+---
+module: docker_config
+
+short_description: Manage docker configs.
+
+version_added: "2.6"
+
+description:
+     - Create and remove Docker configs in a Swarm environment. Similar to `docker config create` and `docker config rm`.
+     - Adds to the metadata of new configs 'ansible_key', an encrypted hash representation of the data, which is then used
+     - in future runs to test if a config has changed.
+     - If 'ansible_key is not present, then a config will not be updated unless the C(force) option is set.
+     - Updates to configs are performed by removing the config and creating it again.
+options:
+  data:
+    description:
+      - String. The value of the config. Required when state is C(present).
+    required: false
+  labels:
+    description:
+      - "A map of key:value meta data, where both the I(key) and I(value) are expected to be a string."
+      - If new meta data is provided, or existing meta data is modified, the config will be updated by removing it and creating it again.
+    required: false
+  force:
+    description:
+      - Use with state C(present) to always remove and recreate an existing config.
+      - If I(true), an existing config will be replaced, even if it has not changed.
+    default: false
+    type: bool
+  name:
+    description:
+      - The name of the config.
+    required: true
+  state:
+    description:
+      - Set to C(present), if the config should exist, and C(absent), if it should not.
+    required: false
+    default: present
+    choices:
+      - absent
+      - present
+
+extends_documentation_fragment:
+    - docker
+
+requirements:
+  - "docker-py >= 2.6.0"
+  - "Docker API >= 1.30"
+
+author:
+  - Chris Houseknecht (@chouseknecht)
+  - John Hu (@ushuz)
+'''
+
+EXAMPLES = '''
+
+- name: Create config foo
+  docker_config:
+    name: foo
+    data: Hello World!
+    state: present
+
+- name: Change the config data
+  docker_config:
+    name: foo
+    data: Goodnight everyone!
+    labels:
+      bar: baz
+      one: '1'
+    state: present
+
+- name: Add a new label
+  docker_config:
+    name: foo
+    data: Goodnight everyone!
+    labels:
+      bar: baz
+      one: '1'
+      # Adding a new label will cause a remove/create of the config
+      two: '2'
+    state: present
+
+- name: No change
+  docker_config:
+    name: foo
+    data: Goodnight everyone!
+    labels:
+      bar: baz
+      one: '1'
+      # Even though 'two' is missing, there is no change to the existing config
+    state: present
+
+- name: Update an existing label
+  docker_config:
+    name: foo
+    data: Goodnight everyone!
+    labels:
+      bar: monkey   # Changing a label will cause a remove/create of the config
+      one: '1'
+    state: present
+
+- name: Force the removal/creation of the config
+  docker_config:
+    name: foo
+    data: Goodnight everyone!
+    force: yes
+    state: present
+
+- name: Remove config foo
+  docker_config:
+    name: foo
+    state: absent
+'''
+
+RETURN = '''
+config_id:
+  description:
+    - The ID assigned by Docker to the config object.
+  returned: success
+  type: string
+  sample: 'hzehrmyjigmcp2gb6nlhmjqcv'
+'''
+
+import hashlib
+
+try:
+    from docker.errors import APIError
+except ImportError:
+    # missing docker-py handled in ansible.module_utils.docker
+    pass
+
+from ansible.module_utils.docker_common import AnsibleDockerClient, DockerBaseClass
+from ansible.module_utils._text import to_native, to_bytes
+
+
+class ConfigManager(DockerBaseClass):
+
+    def __init__(self, client, results):
+
+        super(ConfigManager, self).__init__()
+
+        self.client = client
+        self.results = results
+        self.check_mode = self.client.check_mode
+
+        parameters = self.client.module.params
+        self.name = parameters.get('name')
+        self.state = parameters.get('state')
+        self.data = parameters.get('data')
+        self.labels = parameters.get('labels')
+        self.force = parameters.get('force')
+        self.data_key = None
+
+    def __call__(self):
+        if self.state == 'present':
+            self.data_key = hashlib.sha224(to_bytes(self.data)).hexdigest()
+            self.present()
+        elif self.state == 'absent':
+            self.absent()
+
+    def get_config(self):
+        ''' Find an existing config. '''
+        try:
+            configs = self.client.configs(filters={'name': self.name})
+        except APIError as exc:
+            self.client.fail("Error accessing config %s: %s" % (self.name, to_native(exc)))
+
+        for config in configs:
+            if config['Spec']['Name'] == self.name:
+                return config
+        return None
+
+    def create_config(self):
+        ''' Create a new config '''
+        config_id = None
+        # We can't see the data after creation, so adding a label we can use for idempotency check
+        labels = {
+            'ansible_key': self.data_key
+        }
+        if self.labels:
+            labels.update(self.labels)
+
+        try:
+            if not self.check_mode:
+                config_id = self.client.create_config(self.name, self.data, labels=labels)
+        except APIError as exc:
+            self.client.fail("Error creating config: %s" % to_native(exc))
+
+        if isinstance(config_id, dict):
+            config_id = config_id['ID']
+
+        return config_id
+
+    def present(self):
+        ''' Handles state == 'present', creating or updating the config '''
+        config = self.get_config()
+        if config:
+            self.results['config_id'] = config['ID']
+            data_changed = False
+            attrs = config.get('Spec', {})
+            if attrs.get('Labels', {}).get('ansible_key'):
+                if attrs['Labels']['ansible_key'] != self.data_key:
+                    data_changed = True
+            labels_changed = False
+            if self.labels and attrs.get('Labels'):
+                # check if user requested a label change
+                for label in attrs['Labels']:
+                    if self.labels.get(label) and self.labels[label] != attrs['Labels'][label]:
+                        labels_changed = True
+                # check if user added a label
+            labels_added = False
+            if self.labels:
+                if attrs.get('Labels'):
+                    for label in self.labels:
+                        if label not in attrs['Labels']:
+                            labels_added = True
+                else:
+                    labels_added = True
+            if data_changed or labels_added or labels_changed or self.force:
+                # if something changed or force, delete and re-create the config
+                self.absent()
+                config_id = self.create_config()
+                self.results['changed'] = True
+                self.results['config_id'] = config_id
+        else:
+            self.results['changed'] = True
+            self.results['config_id'] = self.create_config()
+
+    def absent(self):
+        ''' Handles state == 'absent', removing the config '''
+        config = self.get_config()
+        if config:
+            try:
+                if not self.check_mode:
+                    self.client.remove_config(config['ID'])
+            except APIError as exc:
+                self.client.fail("Error removing config %s: %s" % (self.name, to_native(exc)))
+            self.results['changed'] = True
+
+
+def main():
+    argument_spec = dict(
+        name=dict(type='str', required=True),
+        state=dict(type='str', choices=['absent', 'present'], default='present'),
+        data=dict(type='str'),
+        labels=dict(type='dict'),
+        force=dict(type='bool', default=False)
+    )
+
+    required_if = [
+        ('state', 'present', ['data'])
+    ]
+
+    client = AnsibleDockerClient(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+        required_if=required_if
+    )
+
+    results = dict(
+        changed=False,
+        config_id=''
+    )
+
+    ConfigManager(client, results)()
+    client.module.exit_json(**results)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/cloud/docker/docker_config.py
+++ b/lib/ansible/modules/cloud/docker/docker_config.py
@@ -23,8 +23,8 @@ version_added: "2.8"
 description:
      - Create and remove Docker configs in a Swarm environment. Similar to C(docker config create) and C(docker config rm).
      - Adds to the metadata of new configs 'ansible_key', an encrypted hash representation of the data, which is then used
-       in future runs to test if a config has changed.
-     - If 'ansible_key' is not present, then a config will not be updated unless the C(force) option is set.
+       in future runs to test if a config has changed. If 'ansible_key' is not present, then a config will not be updated
+       unless the C(force) option is set.
      - Updates to configs are performed by removing the config and creating it again.
 options:
   data:

--- a/lib/ansible/modules/cloud/docker/docker_config.py
+++ b/lib/ansible/modules/cloud/docker/docker_config.py
@@ -62,15 +62,12 @@ extends_documentation_fragment:
     - docker
 
 requirements:
+  - "python >= 2.7"
   - "docker >= 2.6.0"
   - "Please note that the L(docker-py,https://pypi.org/project/docker-py/) Python
      module has been superseded by L(docker,https://pypi.org/project/docker/)
      (see L(here,https://github.com/docker/docker-py/issues/1310) for details).
-     For Python 2.6, C(docker-py) must be used. Otherwise, it is recommended to
-     install the C(docker) Python module. Note that both modules should I(not)
-     be installed at the same time. Also note that when both modules are installed
-     and one of them is uninstalled, the other might no longer function and a
-     reinstall of it is required."
+     Version 2.6.0 or newer is only available with the C(docker) module."
   - "Docker API >= 1.30"
 
 author:

--- a/lib/ansible/modules/cloud/docker/docker_config.py
+++ b/lib/ansible/modules/cloud/docker/docker_config.py
@@ -77,10 +77,10 @@ author:
 
 EXAMPLES = '''
 
-- name: Create config foo
+- name: Create config foo (from a file on the control machine)
   docker_config:
     name: foo
-    data: Hello World!
+    data: "{{ lookup('file', '/path/to/config/file') }}"
     state: present
 
 - name: Change the config data

--- a/lib/ansible/modules/cloud/docker/docker_swarm.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm.py
@@ -136,7 +136,7 @@ extends_documentation_fragment:
     - docker
 requirements:
     - python >= 2.7
-    - "docker-py >= 2.6.0"
+    - "docker >= 2.6.0"
     - "Please note that the L(docker-py,https://pypi.org/project/docker-py/) Python
        module has been superseded by L(docker,https://pypi.org/project/docker/)
        (see L(here,https://github.com/docker/docker-py/issues/1310) for details).

--- a/test/integration/targets/docker_config/aliases
+++ b/test/integration/targets/docker_config/aliases
@@ -1,0 +1,4 @@
+shippable/posix/group2
+skip/osx
+skip/freebsd
+destructive

--- a/test/integration/targets/docker_config/handlers/main.yml
+++ b/test/integration/targets/docker_config/handlers/main.yml
@@ -1,0 +1,3 @@
+- name: disable_swarm 
+  command: docker swarm leave --force
+  ignore_errors: yes

--- a/test/integration/targets/docker_config/handlers/main.yml
+++ b/test/integration/targets/docker_config/handlers/main.yml
@@ -1,3 +1,0 @@
-- name: disable_swarm 
-  command: docker swarm leave --force
-  ignore_errors: yes

--- a/test/integration/targets/docker_config/meta/main.yml
+++ b/test/integration/targets/docker_config/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - setup_docker

--- a/test/integration/targets/docker_config/tasks/main.yml
+++ b/test/integration/targets/docker_config/tasks/main.yml
@@ -1,2 +1,7 @@
+- name: Check Docker API version
+  command: "{{ ansible_python.executable }} -c 'import docker; print(docker.from_env().version()["ApiVersion"])'"
+  register: docker_api_version
+  ignore_errors: yes
+
 - include_tasks: test_docker_config.yml
-  when: ansible_os_family != 'RedHat' or ansible_distribution_major_version != '6'
+  when: docker_api_version.rc == 0 and docker_api_version.stdout is version('1.30', '>=')

--- a/test/integration/targets/docker_config/tasks/main.yml
+++ b/test/integration/targets/docker_config/tasks/main.yml
@@ -1,0 +1,2 @@
+- include_tasks: test_docker_config.yml
+  when: ansible_os_family != 'RedHat' or ansible_distribution_major_version != '6'

--- a/test/integration/targets/docker_config/tasks/main.yml
+++ b/test/integration/targets/docker_config/tasks/main.yml
@@ -1,5 +1,5 @@
 - name: Check Docker API version
-  command: "{{ ansible_python.executable }} -c 'import docker; print(docker.from_env().version()["ApiVersion"])'"
+  command: "{{ ansible_python.executable }} -c 'import docker; print(docker.from_env().version()[\"ApiVersion\"])'"
   register: docker_api_version
   ignore_errors: yes
 

--- a/test/integration/targets/docker_config/tasks/test_docker_config.yml
+++ b/test/integration/targets/docker_config/tasks/test_docker_config.yml
@@ -1,0 +1,97 @@
+- name: Check if already in swarm
+  shell: docker node ls 2>&1 | grep 'docker swarm init'
+  register: output
+  ignore_errors: yes
+
+- name: Enable swarm mode
+  command: docker swarm init
+  when: output.rc == 0
+  notify: disable_swarm
+
+- name: Parameter name should be required
+  docker_config:
+    state: present
+  ignore_errors: yes
+  register: output
+
+- name: assert failure when called with no name
+  assert:
+    that:
+       - 'output.failed'
+       - 'output.msg == "missing required arguments: name"'
+
+- name: Test parameters
+  docker_config:
+    name: foo
+    state: present
+  ignore_errors: yes
+  register: output
+
+- name: assert failure when called with no data
+  assert:
+    that:
+       - 'output.failed'
+       - 'output.msg == "state is present but all of the following are missing: data"'
+
+- name: Create config
+  docker_config:
+    name: db_password
+    data: opensesame!
+    state: present
+  register: output
+
+- name: Create variable config_id
+  set_fact:
+    config_id: "{{ output.config_id }}"
+
+- name: Inspect config
+  command: "docker config inspect {{ config_id }}"
+  register: inspect
+
+- debug: var=inspect
+
+- name: assert config creation succeeded
+  assert:
+    that:
+       - "'db_password' in inspect.stdout"
+       - "'ansible_key' in inspect.stdout"
+
+- name: Create config again
+  docker_config:
+    name: db_password
+    data: opensesame!
+    state: present
+  register: output
+
+- name: assert create config is idempotent
+  assert:
+    that:
+       - not output.changed
+
+- name: Update config
+  docker_config:
+    name: db_password
+    data: newpassword!
+    state: present
+  register: output
+
+- name: assert config was updated
+  assert:
+    that:
+       - output.changed
+       - output.config_id != config_id
+
+- name: Remove config
+  docker_config:
+    name: db_password
+    state: absent
+
+- name: Check that config is removed
+  command: "docker config inspect {{ config_id }}"
+  register: output
+  ignore_errors: yes
+
+- name: assert config was removed
+  assert:
+    that:
+      - output.failed

--- a/test/integration/targets/docker_config/tasks/test_docker_config.yml
+++ b/test/integration/targets/docker_config/tasks/test_docker_config.yml
@@ -1,12 +1,12 @@
-- name: Check if already in swarm
-  shell: docker node ls 2>&1 | grep 'docker swarm init'
-  register: output
-  ignore_errors: yes
+- name: Make sure we're not already using Docker swarm
+  docker_swarm:
+    state: absent
+    force: true
 
-- name: Enable swarm mode
-  command: docker swarm init
-  when: output.rc == 0
-  notify: disable_swarm
+- name: Create a Swarm cluster
+  docker_swarm:
+    state: present
+    advertise_addr: "{{ansible_default_ipv4.address}}"
 
 - name: Parameter name should be required
   docker_config:
@@ -95,3 +95,8 @@
   assert:
     that:
       - output.failed
+
+- name: Remove a Swarm cluster
+  docker_swarm:
+    state: absent
+    force: true

--- a/test/integration/targets/docker_config/tasks/test_docker_config.yml
+++ b/test/integration/targets/docker_config/tasks/test_docker_config.yml
@@ -96,6 +96,17 @@
     that:
       - output.failed
 
+- name: Remove config
+  docker_config:
+    name: db_password
+    state: absent
+  register: output
+
+- name: assert remove config is idempotent
+  assert:
+    that:
+      - not output.changed
+
 - name: Remove a Swarm cluster
   docker_swarm:
     state: absent


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Add a new module `docker_config` for managing Docker configs objects. It is based on the `docker_secret` module introduced by #26469, as Docker secrets and configs are quite similar.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New Module Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
lib/ansible/modules/cloud/docker/docker_config.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0
  config file = /path/to/ansible.cfg
  configured module search path = [u'/path/to/libraries']
  ansible python module location = /home/ushuz/.pyenv/versions/2.7.14/lib/python2.7/site-packages/ansible
  executable location = /home/ushuz/.pyenv/versions/2.7.14/bin/ansible
  python version = 2.7.14 (default, Nov 27 2017, 16:11:13) [GCC 4.8.4]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
As configs have almost identical Docker API as secrets, I just renamed various `[Ss]ecret` in `docker_secret` module to `[Cc]onfig`, and voila `docker_config`. It should be working perfectly just like `docker_secret` module as long as low-level Docker API don't change dramatically.

And the usage is just the same as `docker_secret` module.
