### PR TITLE
Remove duplicated "instead" word

### DIFF
--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -171,7 +171,7 @@ def tests_as_filters_warning(name, func):
     @wraps(func)
     def wrapper(*args, **kwargs):
         display.deprecated(
-            'Using tests as filters is deprecated. Instead of using `result|%(name)s` instead use '
+            'Using tests as filters is deprecated. Instead of using `result|%(name)s` use '
             '`result is %(name)s`' % dict(name=name),
             version='2.9'
         )

--- a/test/units/template/test_tests_as_filters_warning.py
+++ b/test/units/template/test_tests_as_filters_warning.py
@@ -16,14 +16,14 @@ def test_tests_as_filters_warning(mocker):
     # Call successful test, ensure the message is correct
     filters['successful']({})
     display.deprecated.assert_called_once_with(
-        'Using tests as filters is deprecated. Instead of using `result|successful` instead use `result is successful`', version='2.9'
+        'Using tests as filters is deprecated. Instead of using `result|successful` use `result is successful`', version='2.9'
     )
 
     # Call success test, ensure the message is correct
     display.deprecated.reset_mock()
     filters['success']({})
     display.deprecated.assert_called_once_with(
-        'Using tests as filters is deprecated. Instead of using `result|success` instead use `result is success`', version='2.9'
+        'Using tests as filters is deprecated. Instead of using `result|success` use `result is success`', version='2.9'
     )
 
     # Call bool filter, ensure no deprecation message was displayed


### PR DESCRIPTION
##### SUMMARY
Too many "instead" words, we should avoid the 2nd in:

> [DEPRECATION WARNING]: Using tests as filters is deprecated. Instead of using `result|search` instead use `result is search`. This feature will be removed in version 2.9.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
Core

##### ANSIBLE VERSION
Affects 2.5+

