### PR TITLE
postgresql_privs: Support FOREIGN DATA WRAPPER and FOREIGN SERVER

### DIFF
--- a/changelogs/fragments/38803-postgresql_privs_fdw_and_fs_obj_types.yaml
+++ b/changelogs/fragments/38803-postgresql_privs_fdw_and_fs_obj_types.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "postgresql_privs - introduces support for FOREIGN DATA WRAPPER and FOREIGN SERVER as object types in postgresql_privs module. (https://github.com/ansible/ansible/issues/38801)"

--- a/lib/ansible/modules/database/postgresql/postgresql_privs.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_privs.py
@@ -41,7 +41,7 @@ options:
     description:
       - Type of database object to set privileges on.
       - The `default_prives` choice is available starting at version 2.7.
-      - The 'foreign_data_wrapper' and 'foreign_server' object types are available from Ansible version '2.7'.
+      - The 'foreign_data_wrapper' and 'foreign_server' object types are available from Ansible version '2.8'.
     default: table
     choices: [table, sequence, function, database,
               schema, language, tablespace, group,
@@ -271,6 +271,23 @@ EXAMPLES = """
     objs: TYPES
     privs: USAGE
     type: default_privs
+    role: reader
+
+# Available since version 2.8
+# GRANT ALL PRIVILEGES ON FOREIGN DATA WRAPPER fdw TO reader
+- postgresql_privs:
+    db: test
+    objs: fdw
+    privs: ALL
+    type: foreign_data_wrapper
+    role: reader
+
+# GRANT ALL PRIVILEGES ON FOREIGN SERVER fdw_server TO reader
+- postgresql_privs:
+    db: test
+    objs: fdw_server
+    privs: ALL
+    type: foreign_server
     role: reader
 
 """

--- a/lib/ansible/modules/database/postgresql/postgresql_privs.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_privs.py
@@ -41,6 +41,7 @@ options:
     description:
       - Type of database object to set privileges on.
       - The `default_prives` choice is available starting at version 2.7.
+      - The 'foreign_data_wrapper' and 'foreign_server' object types are available from Ansible version '2.7'.
     default: table
     choices: [table, sequence, function, database,
               schema, language, tablespace, group,

--- a/test/integration/targets/postgresql/tasks/main.yml
+++ b/test/integration/targets/postgresql/tasks/main.yml
@@ -777,6 +777,9 @@
 # Test postgresql_tablespace module
 - include: postgresql_tablespace.yml
 
+# Test postgresql_privs
+- include: postgresql_privs.yml
+
 # dump/restore tests per format
 # ============================================================
 - include: state_dump_restore.yml test_fixture=user file=dbdata.sql

--- a/test/integration/targets/postgresql/tasks/postgresql_privs.yml
+++ b/test/integration/targets/postgresql/tasks/postgresql_privs.yml
@@ -42,6 +42,12 @@
     objs: dummy
     db: "{{ db_name }}"
     login_user: "{{ pg_user }}"
+  register: result
+  ignore_errors: yes
+
+- assert:
+    that:
+      - "result.changed == true"
 
 - name: Get foreign data wrapper privileges
   become: True
@@ -58,6 +64,69 @@
       - "fdw_result.stdout_lines[-1] == '(1 row)'"
       - "'fdw_test' in fdw_result.stdout_lines[-2]"
 
+- name: Grant foreign data wrapper privileges second time
+  postgresql_privs:
+    state: present
+    type: foreign_data_wrapper
+    roles: fdw_test
+    privs: ALL
+    objs: dummy
+    db: "{{ db_name }}"
+    login_user: "{{ pg_user }}"
+  register: result
+  ignore_errors: yes
+
+- assert:
+    that:
+      - "result.changed == false"
+
+- name: Revoke foreign data wrapper privileges
+  postgresql_privs:
+    state: absent
+    type: foreign_data_wrapper
+    roles: fdw_test
+    privs: ALL
+    objs: dummy
+    db: "{{ db_name }}"
+    login_user: "{{ pg_user }}"
+  register: result
+  ignore_errors: yes
+
+- assert:
+    that:
+      - "result.changed == true"
+
+- name: Get foreign data wrapper privileges
+  become: True
+  become_user: "{{ pg_user }}"
+  shell: echo "{{ fdw_query }}" | psql -d "{{ db_name }}"
+  vars:
+    fdw_query: >
+      SELECT fdwacl FROM pg_catalog.pg_foreign_data_wrapper
+      WHERE fdwname = ANY (ARRAY['dummy']) ORDER BY fdwname
+  register: fdw_result
+
+- assert:
+    that:
+      - "fdw_result.stdout_lines[-1] == '(1 row)'"
+      - "'fdw_test' not in fdw_result.stdout_lines[-2]"
+
+- name: Revoke foreign data wrapper privileges for second time
+  postgresql_privs:
+    state: absent
+    type: foreign_data_wrapper
+    roles: fdw_test
+    privs: ALL
+    objs: dummy
+    db: "{{ db_name }}"
+    login_user: "{{ pg_user }}"
+  register: result
+  ignore_errors: yes
+
+- assert:
+    that:
+      - "result.changed == false"
+
 - name: Grant foreign server privileges
   postgresql_privs:
     state: present
@@ -67,6 +136,12 @@
     objs: dummy_server
     db: "{{ db_name }}"
     login_user: "{{ pg_user }}"
+  register: result
+  ignore_errors: yes
+
+- assert:
+    that:
+      - "result.changed == true"
 
 - name: Get foreign server privileges
   become: True
@@ -82,6 +157,69 @@
     that:
       - "fs_result.stdout_lines[-1] == '(1 row)'"
       - "'fdw_test' in fs_result.stdout_lines[-2]"
+
+- name: Grant foreign server privileges for second time
+  postgresql_privs:
+    state: present
+    type: foreign_server
+    roles: fdw_test
+    privs: ALL
+    objs: dummy_server
+    db: "{{ db_name }}"
+    login_user: "{{ pg_user }}"
+  register: result
+  ignore_errors: yes
+
+- assert:
+    that:
+      - "result.changed == false"
+
+- name: Revoke foreign server privileges
+  postgresql_privs:
+    state: absent
+    type: foreign_server
+    roles: fdw_test
+    privs: ALL
+    objs: dummy_server
+    db: "{{ db_name }}"
+    login_user: "{{ pg_user }}"
+  register: result
+  ignore_errors: yes
+
+- assert:
+    that:
+      - "result.changed == true"
+
+- name: Get foreign server privileges
+  become: True
+  become_user: "{{ pg_user }}"
+  shell: echo "{{ fdw_query }}" | psql -d "{{ db_name }}"
+  vars:
+    fdw_query: >
+      SELECT srvacl FROM pg_catalog.pg_foreign_server
+      WHERE srvname = ANY (ARRAY['dummy_server']) ORDER BY srvname
+  register: fs_result
+
+- assert:
+    that:
+      - "fs_result.stdout_lines[-1] == '(1 row)'"
+      - "'fdw_test' not in fs_result.stdout_lines[-2]"
+
+- name: Revoke foreign server privileges for second time
+  postgresql_privs:
+    state: absent
+    type: foreign_server
+    roles: fdw_test
+    privs: ALL
+    objs: dummy_server
+    db: "{{ db_name }}"
+    login_user: "{{ pg_user }}"
+  register: result
+  ignore_errors: yes
+
+- assert:
+    that:
+      - "result.changed == false"
 
 - name: Cleanup
   become: True
@@ -99,4 +237,3 @@
     state: absent
     name: "{{ db_name }}"
     login_user: "{{ pg_user }}"
-  register: result

--- a/test/integration/targets/postgresql/tasks/postgresql_privs.yml
+++ b/test/integration/targets/postgresql/tasks/postgresql_privs.yml
@@ -1,0 +1,102 @@
+---
+
+######################################################
+# Test foreign data wrapper and foreign server privs #
+######################################################
+
+- name: Create DB
+  become_user: "{{ pg_user }}"
+  become: True
+  postgresql_db:
+    state: present
+    name: "{{ db_name }}"
+    login_user: "{{ pg_user }}"
+  register: result
+
+- name: Create test role
+  become: True
+  become_user: "{{ pg_user }}"
+  shell: echo "CREATE ROLE fdw_test" | psql -d "{{ db_name }}"
+
+- name: Create fdw extension
+  become: True
+  become_user: "{{ pg_user }}"
+  shell: echo "CREATE EXTENSION postgres_fdw" | psql -d "{{ db_name }}"
+
+- name: Create foreign data wrapper
+  become: True
+  become_user: "{{ pg_user }}"
+  shell: echo "CREATE FOREIGN DATA WRAPPER dummy" | psql -d "{{ db_name }}"
+
+- name: Create foreign server
+  become: True
+  become_user: "{{ pg_user }}"
+  shell: echo "CREATE SERVER dummy_server FOREIGN DATA WRAPPER dummy" | psql -d "{{ db_name }}"
+
+- name: Grant foreign data wrapper privileges
+  postgresql_privs:
+    state: present
+    type: foreign_data_wrapper
+    roles: fdw_test
+    privs: ALL
+    objs: dummy
+    db: "{{ db_name }}"
+    login_user: "{{ pg_user }}"
+
+- name: Get foreign data wrapper privileges
+  become: True
+  become_user: "{{ pg_user }}"
+  shell: echo "{{ fdw_query }}" | psql -d "{{ db_name }}"
+  vars:
+    fdw_query: >
+      SELECT fdwacl FROM pg_catalog.pg_foreign_data_wrapper
+      WHERE fdwname = ANY (ARRAY['dummy']) ORDER BY fdwname
+  register: fdw_result
+
+- assert:
+    that:
+      - "fdw_result.stdout_lines[-1] == '(1 row)'"
+      - "'fdw_test' in fdw_result.stdout_lines[-2]"
+
+- name: Grant foreign server privileges
+  postgresql_privs:
+    state: present
+    type: foreign_server
+    roles: fdw_test
+    privs: ALL
+    objs: dummy_server
+    db: "{{ db_name }}"
+    login_user: "{{ pg_user }}"
+
+- name: Get foreign server privileges
+  become: True
+  become_user: "{{ pg_user }}"
+  shell: echo "{{ fdw_query }}" | psql -d "{{ db_name }}"
+  vars:
+    fdw_query: >
+      SELECT srvacl FROM pg_catalog.pg_foreign_server
+      WHERE srvname = ANY (ARRAY['dummy_server']) ORDER BY srvname
+  register: fs_result
+
+- assert:
+    that:
+      - "fs_result.stdout_lines[-1] == '(1 row)'"
+      - "'fdw_test' in fs_result.stdout_lines[-2]"
+
+- name: Cleanup
+  become: True
+  become_user: "{{ pg_user }}"
+  shell: echo "{{ item }}" | psql -d "{{ db_name }}"
+  with_items:
+    - DROP ROLE fdw_test
+    - DROP FOREIGN DATA WRAPPER dummy
+    - DROP SERVER dummy_server
+
+- name: Destroy DB
+  become_user: "{{ pg_user }}"
+  become: True
+  postgresql_db:
+    state: absent
+    name: "{{ db_name }}"
+    login_user: "{{ pg_user }}"
+  register: result


### PR DESCRIPTION
##### SUMMARY

This introduces support for `FOREIGN DATA WRAPPER` and `FOREIGN SERVER` as object types in `postgresql_privs` module.

Issues:
#38801 

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
postgresql_privs

##### ANSIBLE VERSION
```
ansible 2.6.0
  config file = /etc/ansible/ansible.cfg
  python version = 2.7.13 (default, Nov 24 2017, 17:33:09) [GCC 6.3.0 20170516]

```
