### PR TITLE
Fixing choices for transport option in gluster_volume module

### DIFF
--- a/lib/ansible/modules/system/gluster_volume.py
+++ b/lib/ansible/modules/system/gluster_volume.py
@@ -56,7 +56,7 @@ options:
     description:
       - Transport type for volume.
     default: tcp
-    choices: [ rdma, tcp, tcp,rdma ]
+    choices: [ tcp, rdma, 'tcp,rdma' ]
   bricks:
     description:
       - Brick paths on servers. Multiple brick paths can be separated by commas.

--- a/test/sanity/validate-modules/ignore.txt
+++ b/test/sanity/validate-modules/ignore.txt
@@ -1668,7 +1668,6 @@ lib/ansible/modules/system/firewalld.py E324
 lib/ansible/modules/system/firewalld.py E325
 lib/ansible/modules/system/firewalld.py E326
 lib/ansible/modules/system/gluster_volume.py E322
-lib/ansible/modules/system/gluster_volume.py E326
 lib/ansible/modules/system/group.py E325
 lib/ansible/modules/system/iptables.py E325
 lib/ansible/modules/system/iptables.py E326


### PR DESCRIPTION
##### SUMMARY
This PR is fixing choices for `transport` option in the `gluster_volume` module. It's adding quotes around one of the values without which the documentation shows the values twice.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
`gluster_volume`

##### ANSIBLE VERSION
```
ansible 2.5.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.14 (default, Jan  5 2018, 10:41:29) [GCC 7.2.1 20171224]
```

##### ADDITIONAL INFORMATION
None