### PR TITLE
keep track of original inventory hostname in play context

### DIFF
--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -813,6 +813,9 @@ class TaskExecutor:
 
     def _set_connection_options(self, variables, templar):
 
+        # Keep the pre-delegate values for these keys
+        PRESERVE_ORIG = ('inventory_hostname',)
+
         # create copy with delegation built in
         final_vars = combine_vars(variables, variables.get('ansible_delegated_vars', dict()).get(self._task.delegate_to, dict()))
 
@@ -822,7 +825,9 @@ class TaskExecutor:
         # create dict of 'templated vars'
         options = {'_extras': {}}
         for k in option_vars:
-            if k in final_vars:
+            if k in PRESERVE_ORIG:
+                options[k] = templar.template(variables[k])
+            elif k in final_vars:
                 options[k] = templar.template(final_vars[k])
 
         # add extras if plugin supports them

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -778,9 +778,6 @@ class TaskExecutor:
         correct connection object from the list of connection plugins
         '''
 
-        # set the original hostname in the play_context
-        self._play_context.task_inventory_hostname = variables.get('inventory_hostname', '')
-
         if self._task.delegate_to is not None:
             # since we're delegating, we don't want to use interpreter values
             # which would have been set for the original target host

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -778,6 +778,9 @@ class TaskExecutor:
         correct connection object from the list of connection plugins
         '''
 
+        # set the original hostname in the play_context
+        self._play_context.task_inventory_hostname = variables.get('inventory_hostname', '')
+
         if self._task.delegate_to is not None:
             # since we're delegating, we don't want to use interpreter values
             # which would have been set for the original target host

--- a/lib/ansible/playbook/play_context.py
+++ b/lib/ansible/playbook/play_context.py
@@ -134,7 +134,6 @@ class PlayContext(Base):
 
     # connection fields, some are inherited from Base:
     # (connection, port, remote_user, environment, no_log)
-    _task_inventory_hostname = FieldAttribute(isa='string')
     _remote_addr = FieldAttribute(isa='string')
     _password = FieldAttribute(isa='string')
     _timeout = FieldAttribute(isa='int', default=C.DEFAULT_TIMEOUT)

--- a/lib/ansible/playbook/play_context.py
+++ b/lib/ansible/playbook/play_context.py
@@ -134,6 +134,7 @@ class PlayContext(Base):
 
     # connection fields, some are inherited from Base:
     # (connection, port, remote_user, environment, no_log)
+    _task_inventory_hostname = FieldAttribute(isa='string')
     _remote_addr = FieldAttribute(isa='string')
     _password = FieldAttribute(isa='string')
     _timeout = FieldAttribute(isa='int', default=C.DEFAULT_TIMEOUT)


### PR DESCRIPTION
This change further enables the https://github.com/jctanner/ansible-vcr project to collect fixtures per host in
situations where the host context is totally lost due to delegation.

##### SUMMARY
This change further enables the ansible-vcr project to collect fixtures per host in
situations where the host context is totally lost due to delegation.

##### ISSUE TYPE

 - Feature Pull Request


##### COMPONENT NAME
task_executor

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6
```


