### PR TITLE
Updating tower_job_template.py

### DIFF
--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_template.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_template.py
@@ -25,36 +25,35 @@ description:
 options:
     name:
       description:
-        - Name to use for the job_template.
+        - Name to use for the job template.
       required: True
     description:
       description:
         - Description to use for the job template.
     job_type:
       description:
-        - The job_type to use for the job template.
+        - The job type to use for the job template.
       required: True
       choices: ["run", "check", "scan"]
     inventory:
       description:
-        - Inventory to use for the job template.
+        - Name of the inventory to use for the job template.
     project:
       description:
-        - Project to use for the job template.
+        - Name of the project to use for the job template.
       required: True
     playbook:
       description:
-        - Playbook to use for the job template.
+        - Path to the playbook to use for the job template within the project provided.
       required: True
-    machine_credential:
+    credential:
       description:
-        - Machine_credential to use for the job template.
-    cloud_credential:
+        - Name of the credential to use for the job template.
+      version_added: 2.6
+    vault_credential:
       description:
-        - Cloud_credential to use for the job template.
-    network_credential:
-      description:
-        - The network_credential to use for the job template.
+        - Name of the vault credential to use for the job template.
+      version_added: 2.6
     forks:
       description:
         - The number of parallel or simultaneous processes to use while executing the playbook.
@@ -63,23 +62,52 @@ options:
         - A host pattern to further constrain the list of hosts managed or affected by the playbook
     verbosity:
       description:
-        - Control the output level Ansible produces as the playbook runs.
-      choices: ["verbose", "debug"]
-    job_tags:
-      description:
-        - The job_tags to use for the job template.
-    skip_tags:
-      description:
-        - The skip_tags to use for the job template.
-    host_config_key:
-      description:
-        - Allow provisioning callbacks using this host config key.
+        - Control the output level Ansible produces as the playbook runs. 0 - Normal, 1 - Verbose, 2 - More Verbose, 3 - Debug, 4 - Connection Debug.
+      choices: [0, 1, 2, 3, 4]
+      default: 0
     extra_vars_path:
       description:
         - Path to the C(extra_vars) YAML file.
+    job_tags:
+      description:
+        - Comma separated list of the tags to use for the job template.
+    force_handlers_enabled:
+      description:
+        - Enable forcing playbook handlers to run even if a task fails.
+      version_added: 2.6
+      type: bool
+      default: 'no'
+    skip_tags:
+      description:
+        - Comma separated list of the tags to skip for the job template.
+    start_at_task:
+      description:
+        - Start the playbook at the task matching this name.
+      version_added: 2.6
+    fact_caching_enabled:
+      description:
+        - Enable use of fact caching for the job template.
+      version_added: 2.6
+      type: bool
+      default: 'no'
+    host_config_key:
+      description:
+        - Allow provisioning callbacks using this host config key.
+    ask_diff_mode:
+      description:
+        - Prompt user to enable diff mode (show changes) to files when supported by modules.
+      version_added: 2.6
+      type: bool
+      default: 'no'
     ask_extra_vars:
       description:
-        - Prompt user for C(extra_vars) on launch.
+        - Prompt user for (extra_vars) on launch.
+      type: bool
+      default: 'no'
+    ask_limit:
+      description:
+        - Prompt user for a limit on launch.
+      version_added: 2.6
       type: bool
       default: 'no'
     ask_tags:
@@ -87,9 +115,21 @@ options:
         - Prompt user for job tags on launch.
       type: bool
       default: 'no'
+    ask_skip_tags:
+      description:
+        - Prompt user for job tags to skip on launch.
+      version_added: 2.6
+      type: bool
+      default: 'no'
     ask_job_type:
       description:
         - Prompt user for job type on launch.
+      type: bool
+      default: 'no'
+    ask_verbosity:
+      description:
+        - Prompt user to choose a verbosity level on launch.
+      version_added: 2.6
       type: bool
       default: 'no'
     ask_inventory:
@@ -102,9 +142,21 @@ options:
         - Prompt user for credential on launch.
       type: bool
       default: 'no'
+    survey_enabled:
+      description:
+        - Enable a survey on the job template.
+      version_added: 2.6
+      type: bool
+      default: 'no'
     become_enabled:
       description:
         - Activate privilege escalation.
+      type: bool
+      default: 'no'
+    concurrent_jobs_enabled:
+      description:
+        - Allow simultaneous runs of the job template.
+      version_added: 2.6
       type: bool
       default: 'no'
     state:
@@ -119,13 +171,13 @@ extends_documentation_fragment: tower
 EXAMPLES = '''
 - name: Create tower Ping job template
   tower_job_template:
-    name: Ping
-    job_type: run
-    inventory: Local
-    project: Demo
-    playbook: ping.yml
-    machine_credential: Local
-    state: present
+    name: "Ping"
+    job_type: "run"
+    inventory: "Local"
+    project: "Demo"
+    playbook: "ping.yml"
+    credential: "Local"
+    state: "present"
     tower_config_file: "~/tower_cli.cfg"
 '''
 
@@ -147,11 +199,19 @@ def update_fields(p):
     '''
     params = p.copy()
     field_map = {
+        'fact_caching_enabled': 'use_fact_cache',
+        'ask_diff_mode': 'ask_diff_mode_on_launch',
         'ask_extra_vars': 'ask_variables_on_launch',
         'ask_limit': 'ask_limit_on_launch',
         'ask_tags': 'ask_tags_on_launch',
+        'ask_skip_tags': 'ask_skip_tags_on_launch',
+        'ask_verbosity': 'ask_verbosity_on_launch',
+        'ask_inventory': 'ask_inventory_on_launch',
+        'ask_credential': 'ask_credential_on_launch',
         'ask_job_type': 'ask_job_type_on_launch',
-        'machine_credential': 'credential',
+        'diff_mode_enabled': 'diff_mode',
+        'concurrent_jobs_enabled': 'allow_simultaneous',
+        'force_handlers_enabled': 'force_handlers',
     }
 
     params_update = {}
@@ -172,9 +232,8 @@ def update_resources(module, p):
     identity_map = {
         'project': 'name',
         'inventory': 'name',
-        'machine_credential': 'name',
-        'network_credential': 'name',
-        'cloud_credential': 'name',
+        'credential': 'name',
+        'vault_credential': 'name',
     }
     for k, v in identity_map.items():
         try:
@@ -191,28 +250,37 @@ def main():
     argument_spec = tower_argument_spec()
     argument_spec.update(dict(
         name=dict(required=True),
-        description=dict(),
+        description=dict(default=''),
         job_type=dict(choices=['run', 'check', 'scan'], required=True),
-        inventory=dict(),
+        inventory=dict(default=''),
         project=dict(required=True),
         playbook=dict(required=True),
-        machine_credential=dict(),
-        cloud_credential=dict(),
-        network_credential=dict(),
+        credential=dict(default=''),
+        vault_credential=dict(default=''),
         forks=dict(type='int'),
-        limit=dict(),
-        verbosity=dict(choices=['verbose', 'debug']),
-        job_tags=dict(),
-        skip_tags=dict(),
-        host_config_key=dict(),
+        limit=dict(default=''),
+        verbosity=dict(type='int', choices=[0, 1, 2, 3, 4], default=0),
         extra_vars_path=dict(type='path', required=False),
+        job_tags=dict(default=''),
+        force_handlers_enabled=dict(type='bool', default=False),
+        skip_tags=dict(default=''),
+        start_at_task=dict(default=''),
+        timeout=dict(type='int', default=0),
+        fact_caching_enabled=dict(type='bool', default=False),
+        host_config_key=dict(default=''),
+        ask_diff_mode=dict(type='bool', default=False),
         ask_extra_vars=dict(type='bool', default=False),
         ask_limit=dict(type='bool', default=False),
         ask_tags=dict(type='bool', default=False),
+        ask_skip_tags=dict(type='bool', default=False),
         ask_job_type=dict(type='bool', default=False),
+        ask_verbosity=dict(type='bool', default=False),
         ask_inventory=dict(type='bool', default=False),
         ask_credential=dict(type='bool', default=False),
+        survey_enabled=dict(type='bool', default=False),
         become_enabled=dict(type='bool', default=False),
+        diff_mode_enabled=dict(type='bool', default=False),
+        concurrent_jobs_enabled=dict(type='bool', default=False),
         state=dict(choices=['present', 'absent'], default='present'),
     ))
 

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_template.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_template.py
@@ -49,11 +49,11 @@ options:
     credential:
       description:
         - Name of the credential to use for the job template.
-      version_added: 2.6
+      version_added: 2.7
     vault_credential:
       description:
         - Name of the vault credential to use for the job template.
-      version_added: 2.6
+      version_added: 2.7
     forks:
       description:
         - The number of parallel or simultaneous processes to use while executing the playbook.
@@ -74,7 +74,7 @@ options:
     force_handlers_enabled:
       description:
         - Enable forcing playbook handlers to run even if a task fails.
-      version_added: 2.6
+      version_added: 2.7
       type: bool
       default: 'no'
     skip_tags:
@@ -83,11 +83,11 @@ options:
     start_at_task:
       description:
         - Start the playbook at the task matching this name.
-      version_added: 2.6
+      version_added: 2.7
     fact_caching_enabled:
       description:
         - Enable use of fact caching for the job template.
-      version_added: 2.6
+      version_added: 2.7
       type: bool
       default: 'no'
     host_config_key:
@@ -96,7 +96,7 @@ options:
     ask_diff_mode:
       description:
         - Prompt user to enable diff mode (show changes) to files when supported by modules.
-      version_added: 2.6
+      version_added: 2.7
       type: bool
       default: 'no'
     ask_extra_vars:
@@ -107,7 +107,7 @@ options:
     ask_limit:
       description:
         - Prompt user for a limit on launch.
-      version_added: 2.6
+      version_added: 2.7
       type: bool
       default: 'no'
     ask_tags:
@@ -118,7 +118,7 @@ options:
     ask_skip_tags:
       description:
         - Prompt user for job tags to skip on launch.
-      version_added: 2.6
+      version_added: 2.7
       type: bool
       default: 'no'
     ask_job_type:
@@ -129,7 +129,7 @@ options:
     ask_verbosity:
       description:
         - Prompt user to choose a verbosity level on launch.
-      version_added: 2.6
+      version_added: 2.7
       type: bool
       default: 'no'
     ask_inventory:
@@ -145,7 +145,7 @@ options:
     survey_enabled:
       description:
         - Enable a survey on the job template.
-      version_added: 2.6
+      version_added: 2.7
       type: bool
       default: 'no'
     become_enabled:
@@ -156,7 +156,7 @@ options:
     concurrent_jobs_enabled:
       description:
         - Allow simultaneous runs of the job template.
-      version_added: 2.6
+      version_added: 2.7
       type: bool
       default: 'no'
     state:

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_template.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_template.py
@@ -241,6 +241,9 @@ def update_resources(module, p):
                 key = 'credential' if '_credential' in k else k
                 result = tower_cli.get_resource(key).get(**{v: params[k]})
                 params[k] = result['id']
+            elif k in params:
+                # unset empty parameters to avoid ValueError: invalid literal for int() with base 10: ''
+                del(params[k])
         except (exc.NotFound) as excinfo:
             module.fail_json(msg='Failed to update job template: {0}'.format(excinfo), changed=False)
     return params

--- a/test/integration/targets/tower_job_template/tasks/main.yml
+++ b/test/integration/targets/tower_job_template/tasks/main.yml
@@ -44,7 +44,7 @@
     project: Job Template Test Project
     inventory: Demo Inventory
     playbook: hello_world.yml
-    machine_credential: Demo Credential
+    credential: Demo Credential
     job_type: run
     state: present
   register: result


### PR DESCRIPTION
##### SUMMARY
The main purpose is to get several key features functioning properly, namely ask_credential, which wasn't mapped correctly in the python code.

Added several features that the API supports:
vault_credential - ability to specify named vault_credential.
verbosity - Updated verbosity to have a default of '0' (normal output) and updated python documentation.
force_handlers_enabled - Allows forcing job handlers to always run.
start_at_task - Allows starting a playbook at a named task.
timeout - Allows specifying a timeout for the playbook.  Defaults to '0'.
fact_caching_enabled - Allows enabling fact caching on the job template.
ask_diff_mode - Allows prompting to run the job template in diff mode.
ask_skip_tags - Allows prompting for tags to skip at job launch.
ask_verbosity - Allows prompting for verbosity level at job launch.
ask_credential - Fixed mapping to ask_credential_on_launch.
survey_enabled - Enables the survey on the job template (something else would have to create the spec.)
diff_mode_enabled - Allows enabling diff mode on the job template.
credential - Getting rid of machine_credential, network_credential, and cloud_credential as the current code only takes in the last mapped item, which was cloud_credential.  All 3 mapped to credential, and there was no logic or need for this, as there's no distinction in the job template between the 3 types.  The job template only cares about the name of the credential.
concurrent_jobs_enabled - Allows enabling concurrent (simultaneous) job runs on the job template.


<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
tower_job_template

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/ahuffman/git/ansible-tiaa-onboarding/roles/tower-job-template/library']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /bin/ansible
  python version = 2.7.14 (default, Mar 14 2018, 13:36:31) [GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
Fixing ask_credential to actually work and not throw an error, and adding multiple features available via the UI and API.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
TOWER_JOB_TEMPLATE    (/usr/lib/python2.7/site-packages/ansible/modules/web_infrastructure/ansible_tower/tower_job_template.py)

        Create, update, or destroy Ansible Tower job templates. See https://www.ansible.com/tower for an overview.

OPTIONS (= is mandatory):

- ask_credential
        Prompt user for credential on launch.
        [Default: False]

- ask_extra_vars
        Prompt user for extra_vars on launch.
        [Default: False]

- ask_inventory
        Propmt user for inventory on launch.
        [Default: False]

- ask_job_type
        Prompt user for job type on launch.
        [Default: False]

- ask_tags
        Prompt user for job tags on launch.
        [Default: False]

- become_enabled
        Should become_enabled.
        [Default: False]

- cloud_credential
        Cloud_credential to use for the job_template.
        [Default: None]

- description
        Description to use for the job_template.
        [Default: None]

- extra_vars_path
        Path to the extra_vars yaml file.
        [Default: None]

- forks
        The number of parallel or simultaneous processes to use while executing the playbook.
        [Default: None]

- host_config_key
        Allow provisioning callbacks using this host config key.
        [Default: None]

- inventory
        Inventory to use for the job_template.
        [Default: None]

- job_tags
        The job_tags to use for the job_template.
        [Default: None]

= job_type
        The job_type to use for the job_template.
        (Choices: run, check, scan)

- limit
        A host pattern to further constrain the list of hosts managed or affected by the playbook
        [Default: None]

- machine_credential
        Machine_credential to use for the job_template.
        [Default: None]

= name
        Name to use for the job_template.


- network_credential
        The network_credential to use for the job_template.
        [Default: None]

= playbook
        Playbook to use for the job_template.


= project
        Project to use for the job_template.


- skip_tags
        The skip_tags to use for the job_template.
        [Default: None]

- state
        Desired state of the resource.
        (Choices: present, absent)[Default: present]

- tower_config_file
        Path to the Tower config file. See notes.
        [Default: None]

- tower_host
        URL to your Tower instance.
        [Default: None]

- tower_password
        Password for your Tower instance.
        [Default: None]

- tower_username
        Username for your Tower instance.
        [Default: None]

- tower_verify_ssl
        Dis/allow insecure connections to Tower. If `no', SSL certificates will not be validated. This should only be used on personally
        controlled sites using self-signed certificates.
        [Default: True]

- verbosity
        Control the output level Ansible produces as the playbook runs.
        (Choices: verbose, debug)[Default: None]


NOTES:
      * If no `config_file' is provided we will attempt to use the tower-cli library defaults to find your Tower host information.
      * `config_file' should contain Tower configuration in the following format host=hostname username=username password=password

REQUIREMENTS:  ansible-tower-cli >= 3.0.2

AUTHOR: Wayne Witzel III (@wwitzel3)
        METADATA:
          status:
          - preview
          supported_by: community
        

EXAMPLES:
- name: Create tower Ping job template
  tower_job_template:
    name: Ping
    job_type: run
    inventory: Local
    project: Demo
    playbook: ping.yml
    machine_credential: Local
    state: present
    tower_config_file: "~/tower_cli.cfg"

TOWER_JOB_TEMPLATE    (/home/ahuffman/git/ansible-1/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_template.py)

        Create, update, or destroy Ansible Tower job templates. See https://www.ansible.com/tower for an overview.

OPTIONS (= is mandatory):

- ask_credential
        Prompt user for credential on launch.
        [Default: no]
        type: bool

- ask_diff_mode
        Prompt user to enable diff mode (show changes) to files when supported by modules.
        [Default: no]
        type: bool

- ask_extra_vars
        Prompt user for (extra_vars) on launch.
        [Default: no]
        type: bool

- ask_inventory
        Propmt user for inventory on launch.
        [Default: no]
        type: bool

- ask_job_type
        Prompt user for job type on launch.
        [Default: no]
        type: bool

- ask_limit
        Prompt user for a limit on launch.
        [Default: no]
        type: bool

- ask_skip_tags
        Prompt user for job tags to skip on launch.
        [Default: no]
        type: bool

- ask_tags
        Prompt user for job tags on launch.
        [Default: no]
        type: bool

- ask_verbosity
        Prompt user to choose a verbosity level on launch.
        [Default: no]
        type: bool

- become_enabled
        Activate privilege escalation.
        [Default: no]
        type: bool

- concurrent_jobs_enabled
        Allow simultaneous runs of the job template.
        [Default: no]
        type: bool

- credential
        Name of the credential to use for the job template.
        [Default: (null)]

- description
        Description to use for the job template.
        [Default: (null)]

- extra_vars_path
        Path to the `extra_vars' YAML file.
        [Default: (null)]

- fact_caching_enabled
        Enable use of fact caching for the job template.
        [Default: no]
        type: bool

- force_handlers_enabled
        Enable forcing playbook handlers to run even if a task fails.
        [Default: no]
        type: bool

- forks
        The number of parallel or simultaneous processes to use while executing the playbook.
        [Default: (null)]

- host_config_key
        Allow provisioning callbacks using this host config key.
        [Default: (null)]

- inventory
        Name of the inventory to use for the job template.
        [Default: (null)]

- job_tags
        Comma separated list of the tags to use for the job template.
        [Default: (null)]

= job_type
        The job type to use for the job template.
        (Choices: run, check, scan)

- limit
        A host pattern to further constrain the list of hosts managed or affected by the playbook
        [Default: (null)]

= name
        Name to use for the job template.


= playbook
        Path to the playbook to use for the job template within the project provided.


= project
        Name of the project to use for the job template.


- skip_tags
        Comma separated list of the tags to skip for the job template.
        [Default: (null)]

- start_at_task
        Start the playbook at the task matching this name.
        [Default: (null)]

- state
        Desired state of the resource.
        (Choices: present, absent)[Default: present]

- survey_enabled
        Enable a survey on the job template.
        [Default: no]
        type: bool

- tower_config_file
        Path to the Tower config file. See notes.
        [Default: None]

- tower_host
        URL to your Tower instance.
        [Default: None]

- tower_password
        Password for your Tower instance.
        [Default: None]

- tower_username
        Username for your Tower instance.
        [Default: None]

- tower_verify_ssl
        Dis/allow insecure connections to Tower. If `no', SSL certificates will not be validated. This should only be used on personally
        controlled sites using self-signed certificates.
        [Default: True]

- vault_credential
        Name of the vault credential to use for the job template.
        [Default: (null)]

- verbosity
        Control the output level Ansible produces as the playbook runs. 0 - Normal, 1 - Verbose, 2 - More Verbose, 3 - Debug, 4 -
        Connection Debug.
        (Choices: 0, 1, 2, 3, 4)[Default: 0]


NOTES:
      * If no `config_file' is provided we will attempt to use the tower-cli library defaults to find your Tower host information.
      * `config_file' should contain Tower configuration in the following format host=hostname username=username password=password

REQUIREMENTS:  ansible-tower-cli >= 3.0.2

AUTHOR: Wayne Witzel III (@wwitzel3)
        METADATA:
          status:
          - preview
          supported_by: community
        

EXAMPLES:
- name: Create tower Ping job template
  tower_job_template:
    name: "Ping"
    job_type: "run"
    inventory: "Local"
    project: "Demo"
    playbook: "ping.yml"
    credential: "Local"
    state: "present"
    tower_config_file: "~/tower_cli.cfg"

```
