### PR TITLE
Skip self._parent on dynamic, defer grandparent for attr lookup

### DIFF
--- a/lib/ansible/playbook/base.py
+++ b/lib/ansible/playbook/base.py
@@ -174,8 +174,6 @@ class Base(with_metaclass(BaseMeta, object)):
         'su', 'su_user', 'su_pass', 'su_exe', 'su_flags',
     ]
 
-    _inheritable = True
-
     def __init__(self):
 
         # initialize the data loader and variable manager, which will be provided

--- a/lib/ansible/playbook/role_include.py
+++ b/lib/ansible/playbook/role_include.py
@@ -48,8 +48,6 @@ class IncludeRole(TaskInclude):
     OTHER_ARGS = ('private', 'allow_duplicates')  # assigned to matching property
     VALID_ARGS = tuple(frozenset(BASE + FROM_ARGS + OTHER_ARGS))  # all valid args
 
-    _inheritable = False
-
     # =================================================================================
     # ATTRIBUTES
 

--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -433,7 +433,7 @@ class Task(Base, Conditional, Taggable, Become):
             if _parent and (value is None or extend):
                 if getattr(_parent, 'statically_loaded', True):
                     # vars are always inheritable, other attributes might not be for the partent but still should be for other ancestors
-                    if attr != 'vars' and getattr(_parent, '_inheritable', True) and hasattr(_parent, '_get_parent_attribute'):
+                    if attr != 'vars' and hasattr(_parent, '_get_parent_attribute'):
                         parent_value = _parent._get_parent_attribute(attr)
                     else:
                         parent_value = _parent._attributes.get(attr, None)

--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -423,13 +423,20 @@ class Task(Base, Conditional, Taggable, Become):
         prepend = self._valid_attrs[attr].prepend
         try:
             value = self._attributes[attr]
-            if self._parent and (value is None or extend):
-                if getattr(self._parent, 'statically_loaded', True):
+            # If parent is static, we can grab attrs from the parent
+            # otherwise, defer to the grandparent
+            if getattr(self._parent, 'statically_loaded', True):
+                _parent = self._parent
+            else:
+                _parent = self._parent._parent
+
+            if _parent and (value is None or extend):
+                if getattr(_parent, 'statically_loaded', True):
                     # vars are always inheritable, other attributes might not be for the partent but still should be for other ancestors
-                    if attr != 'vars' and getattr(self._parent, '_inheritable', True) and hasattr(self._parent, '_get_parent_attribute'):
-                        parent_value = self._parent._get_parent_attribute(attr)
+                    if attr != 'vars' and getattr(_parent, '_inheritable', True) and hasattr(_parent, '_get_parent_attribute'):
+                        parent_value = _parent._get_parent_attribute(attr)
                     else:
-                        parent_value = self._parent._attributes.get(attr, None)
+                        parent_value = _parent._attributes.get(attr, None)
 
                     if extend:
                         value = self._extend_value(value, parent_value, prepend)

--- a/lib/ansible/playbook/task_include.py
+++ b/lib/ansible/playbook/task_include.py
@@ -50,8 +50,6 @@ class TaskInclude(Task):
     @staticmethod
     def load(data, block=None, role=None, task_include=None, variable_manager=None, loader=None):
         t = TaskInclude(block=block, role=role, task_include=task_include)
-        if t.action == 'include_task':
-            t._inheritable = False
         return t.load_data(data, variable_manager=variable_manager, loader=loader)
 
     def copy(self, exclude_parent=False, exclude_tasks=False):

--- a/test/integration/targets/include_import/grandchild/block_include_tasks.yml
+++ b/test/integration/targets/include_import/grandchild/block_include_tasks.yml
@@ -1,0 +1,2 @@
+- command: "true"
+  register: block_include_result

--- a/test/integration/targets/include_import/grandchild/import.yml
+++ b/test/integration/targets/include_import/grandchild/import.yml
@@ -1,0 +1,1 @@
+- include_tasks: include_level_1.yml

--- a/test/integration/targets/include_import/grandchild/import_include_include_tasks.yml
+++ b/test/integration/targets/include_import/grandchild/import_include_include_tasks.yml
@@ -1,0 +1,2 @@
+- command: "true"
+  register: import_include_include_result

--- a/test/integration/targets/include_import/grandchild/include_level_1.yml
+++ b/test/integration/targets/include_import/grandchild/include_level_1.yml
@@ -1,0 +1,1 @@
+- include_tasks: import_include_include_tasks.yml

--- a/test/integration/targets/include_import/runme.sh
+++ b/test/integration/targets/include_import/runme.sh
@@ -55,3 +55,7 @@ gen_task_files
 ANSIBLE_STRATEGY='linear' ansible-playbook test_copious_include_tasks.yml  -i ../../inventory "$@" --skip-tags never
 ANSIBLE_STRATEGY='free' ansible-playbook test_copious_include_tasks.yml  -i ../../inventory "$@" --skip-tags never
 rm -f tasks/hello/*.yml
+
+# Inlcuded tasks should inherit attrs from non-dynamic blocks in parent chain
+# https://github.com/ansible/ansible/pull/38827
+ANSIBLE_STRATEGY='linear' ansible-playbook test_grandparent_inheritance.yml -i ../../inventory "$@"

--- a/test/integration/targets/include_import/test_grandparent_inheritance.yml
+++ b/test/integration/targets/include_import/test_grandparent_inheritance.yml
@@ -1,0 +1,29 @@
+---
+- hosts: testhost
+  gather_facts: false
+  tasks:
+    - debug:
+        var: inventory_hostname
+
+    - name: Test included tasks inherit from block
+      check_mode: true
+      block:
+        - include_tasks: grandchild/block_include_tasks.yml
+
+    - debug:
+        var: block_include_result
+
+    - assert:
+        that:
+          - block_include_result is skipped
+
+    - name: Test included tasks inherit deeply from import
+      import_tasks: grandchild/import.yml
+      check_mode: true
+
+    - debug:
+        var: import_include_include_result
+
+    - assert:
+        that:
+          - import_include_include_result is skipped


### PR DESCRIPTION
##### SUMMARY

Skip self._parent on dynamic, defer grandparent for attr lookup.

This solves the problem where we should look up the tree for attrs on static objects, when constructing attrs for tasks within dynamic.

Examples:

Block:
```
# delegate_to: localhost should be applied to tasks within the include as the attr is not applied to the include itself
- delegate_to: localhost
  block:
    - include_tasks: include_me.yml
```

import->include:
```
- import_tasks: import_me.yml
  delegate_to: localhost
```
```
# delegate_to: localhost should apply to tasks within include_tasks
- include_tasks: include_me.yml
```

This PR also backs out the `_inheritable` changes from https://github.com/ansible/ansible/commit/8e6ebae8bda

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/playbook/block.py
lib/ansible/playbook/task.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```