### PR TITLE
Fix swap allocation in ansible-test for docker

### DIFF
--- a/test/runner/lib/delegation.py
+++ b/test/runner/lib/delegation.py
@@ -219,7 +219,7 @@ def delegate_docker(args, exclude, require):
             if args.docker_memory:
                 test_options.extend([
                     '--memory=%d' % args.docker_memory,
-                    '--memory-swap=0',
+                    '--memory-swap=%d' % args.docker_memory,
                 ])
 
             docker_socket = '/var/run/docker.sock'


### PR DESCRIPTION
##### SUMMARY

I apparently did not read the docs close enough about the `--memory-swap` flag when I added `--docker-memory`.

My intent was to disable swap, restricting to the explicit amount of memory supplied.

The docs read:

>       --memory-swap bytes              Swap limit equal to memory plus swap: '-1' to enable unlimited swap

I set this value of `0` which appears to have no impact.

Setting both `--memory` and `--memory-swap` to the same value achieve the proper results.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
test/runner/lib/delegation.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```