### PR TITLE
[terraform] Disable input prompts during Terraform init/plan/apply

### DIFF
--- a/lib/ansible/modules/cloud/misc/terraform.py
+++ b/lib/ansible/modules/cloud/misc/terraform.py
@@ -133,7 +133,7 @@ import traceback
 from ansible.module_utils.basic import AnsibleModule
 
 DESTROY_ARGS = ('destroy', '-no-color', '-force')
-APPLY_ARGS = ('apply', '-no-color', '-auto-approve=true')
+APPLY_ARGS = ('apply', '-no-color', '-input=false', '-auto-approve=true')
 module = None
 
 
@@ -159,7 +159,7 @@ def _state_args(state_file):
 
 
 def init_plugins(bin_path, project_path):
-    command = [bin_path, 'init']
+    command = [bin_path, 'init', '-input=false']
     rc, out, err = module.run_command(command, cwd=project_path)
     if rc != 0:
         module.fail_json(msg="Failed to initialize Terraform modules:\r\n{0}".format(err))
@@ -169,7 +169,7 @@ def build_plan(bin_path, project_path, variables_args, state_file, plan_path=Non
     if plan_path is None:
         f, plan_path = tempfile.mkstemp(suffix='.tfplan')
 
-    command = [bin_path, 'plan', '-no-color', '-detailed-exitcode', '-out', plan_path]
+    command = [bin_path, 'plan', '-input=false', '-no-color', '-detailed-exitcode', '-out', plan_path]
     command.extend(_state_args(state_file))
 
     rc, out, err = module.run_command(command + variables_args, cwd=project_path)


### PR DESCRIPTION
Per Hashicorp's [guidelines][1] for automated use of terraform CLI, this PR
adds the `-input=false` option to all the commands executed in the
module. If input is required, this causes a hard failure that will
become a module failure.

[1]: https://www.terraform.io/guides/running-terraform-in-automation.html

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
terraform

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
