### PR TITLE
Backport #38827 for 2.5 - Allow inheriting attrs from static parents

### DIFF
--- a/changelogs/fragments/include_inherit_from_static_parents.yaml
+++ b/changelogs/fragments/include_inherit_from_static_parents.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- dynamic includes - Allow inheriting attributes from static parents (https://github.com/ansible/ansible/pull/38827)

--- a/lib/ansible/playbook/base.py
+++ b/lib/ansible/playbook/base.py
@@ -171,8 +171,6 @@ class Base(with_metaclass(BaseMeta, object)):
         'su', 'su_user', 'su_pass', 'su_exe', 'su_flags',
     ]
 
-    _inheritable = True
-
     def __init__(self):
 
         # initialize the data loader and variable manager, which will be provided

--- a/lib/ansible/playbook/role_include.py
+++ b/lib/ansible/playbook/role_include.py
@@ -48,8 +48,6 @@ class IncludeRole(TaskInclude):
     OTHER_ARGS = ('private', 'allow_duplicates')  # assigned to matching property
     VALID_ARGS = tuple(frozenset(BASE + FROM_ARGS + OTHER_ARGS))  # all valid args
 
-    _inheritable = False
-
     # =================================================================================
     # ATTRIBUTES
 

--- a/lib/ansible/playbook/task_include.py
+++ b/lib/ansible/playbook/task_include.py
@@ -50,8 +50,6 @@ class TaskInclude(Task):
     @staticmethod
     def load(data, block=None, role=None, task_include=None, variable_manager=None, loader=None):
         t = TaskInclude(block=block, role=role, task_include=task_include)
-        if t.action == 'include_task':
-            t._inheritable = False
         return t.load_data(data, variable_manager=variable_manager, loader=loader)
 
     def copy(self, exclude_parent=False, exclude_tasks=False):

--- a/test/integration/targets/include_import/grandchild/block_include_tasks.yml
+++ b/test/integration/targets/include_import/grandchild/block_include_tasks.yml
@@ -1,0 +1,2 @@
+- command: "true"
+  register: block_include_result

--- a/test/integration/targets/include_import/grandchild/import.yml
+++ b/test/integration/targets/include_import/grandchild/import.yml
@@ -1,0 +1,1 @@
+- include_tasks: include_level_1.yml

--- a/test/integration/targets/include_import/grandchild/import_include_include_tasks.yml
+++ b/test/integration/targets/include_import/grandchild/import_include_include_tasks.yml
@@ -1,0 +1,2 @@
+- command: "true"
+  register: import_include_include_result

--- a/test/integration/targets/include_import/grandchild/include_level_1.yml
+++ b/test/integration/targets/include_import/grandchild/include_level_1.yml
@@ -1,0 +1,1 @@
+- include_tasks: import_include_include_tasks.yml

--- a/test/integration/targets/include_import/runme.sh
+++ b/test/integration/targets/include_import/runme.sh
@@ -41,3 +41,7 @@ ANSIBLE_STRATEGY='linear' ansible-playbook test_recursion.yml -i ../../inventory
 # https://github.com/ansible/ansible/issues/34782
 ANSIBLE_STRATEGY='linear' ansible-playbook nested.yml  -i ../../inventory "$@" --skip-tags never
 ANSIBLE_STRATEGY='free' ansible-playbook nested.yml  -i ../../inventory "$@" --skip-tags never
+
+# Inlcuded tasks should inherit attrs from non-dynamic blocks in parent chain
+# https://github.com/ansible/ansible/pull/38827
+ANSIBLE_STRATEGY='linear' ansible-playbook test_grandparent_inheritance.yml -i ../../inventory "$@"

--- a/test/integration/targets/include_import/test_grandparent_inheritance.yml
+++ b/test/integration/targets/include_import/test_grandparent_inheritance.yml
@@ -1,0 +1,29 @@
+---
+- hosts: testhost
+  gather_facts: false
+  tasks:
+    - debug:
+        var: inventory_hostname
+
+    - name: Test included tasks inherit from block
+      check_mode: true
+      block:
+        - include_tasks: grandchild/block_include_tasks.yml
+
+    - debug:
+        var: block_include_result
+
+    - assert:
+        that:
+          - block_include_result is skipped
+
+    - name: Test included tasks inherit deeply from import
+      import_tasks: grandchild/import.yml
+      check_mode: true
+
+    - debug:
+        var: import_include_include_result
+
+    - assert:
+        that:
+          - import_include_include_result is skipped


### PR DESCRIPTION
##### SUMMARY
Backport #38827 for 2.5 - Allow inheriting attrs from static parents

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/playbook/block.py
lib/ansible/playbook/task.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```