### PR TITLE
Use new vcenter simulator container location.

### DIFF
--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -156,7 +156,13 @@ def find_datastore_by_name(content, datastore_name):
 
 def find_dvs_by_name(content, switch_name):
 
-    vmware_distributed_switches = get_all_objs(content, [vim.dvs.VmwareDistributedVirtualSwitch])
+    # https://github.com/vmware/govmomi/issues/879
+    # https://github.com/ansible/ansible/pull/31798#issuecomment-336936222
+    try:
+        vmware_distributed_switches = get_all_objs(content, [vim.dvs.VmwareDistributedVirtualSwitch])
+    except IndexError:
+        vmware_distributed_switches = get_all_objs(content, [vim.DistributedVirtualSwitch])
+
     for dvs in vmware_distributed_switches:
         if dvs.name == switch_name:
             return dvs

--- a/test/runner/lib/cloud/vcenter.py
+++ b/test/runner/lib/cloud/vcenter.py
@@ -40,7 +40,7 @@ class VcenterProvider(CloudProvider):
         super(VcenterProvider, self).__init__(args, config_extension='.ini')
 
         # The simulator must be pinned to a specific version to guarantee CI passes with the version used.
-        self.image = 'ansible/ansible:vcenter-simulator@sha256:1a92e84f477ae4c45f9070a5419a0fc2b46abaecdb5bc396826741bca65ce028'
+        self.image = 'quay.io/ansible/vcenter-test-container:1.0.1'
         self.container_name = ''
 
     def filter(self, targets, exclude):


### PR DESCRIPTION
##### SUMMARY

Use new vcenter simulator container location.

Includes a fix to vmware module_utils necessary for tests to pass with the test container, which originated in https://github.com/ansible/ansible/pull/31798 as part of test container updates.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test vcenter plugin

##### ANSIBLE VERSION

```
ansible 2.4.4.0 (pin-vcenter-2.4 7355f063f0) last updated 2018/04/16 15:43:58 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
