### PR TITLE
Add support for dzdo flags Fixes #38766

### DIFF
--- a/lib/ansible/playbook/play_context.py
+++ b/lib/ansible/playbook/play_context.py
@@ -551,9 +551,9 @@ class PlayContext(Base):
                 exe = self.become_exe or 'dzdo'
                 if self.become_pass:
                     prompt = '[dzdo via ansible, key=%s] password: ' % randbits
-                    becomecmd = '%s -p %s -u %s %s' % (exe, shlex_quote(prompt), self.become_user, command)
+                    becomecmd = '%s %s -p %s -u %s %s' % (exe, flags, shlex_quote(prompt), self.become_user, command)
                 else:
-                    becomecmd = '%s -u %s %s' % (exe, self.become_user, command)
+                    becomecmd = '%s %s -u %s %s' % (exe, flags, self.become_user, command)
 
             elif self.become_method == 'pmrun':
 

--- a/test/units/playbook/test_play_context.py
+++ b/test/units/playbook/test_play_context.py
@@ -119,6 +119,7 @@ def test_play_context_make_become_cmd(parser):
     ksu_exe = 'ksu'
     ksu_flags = ''
     dzdo_exe = 'dzdo'
+    dzdo_flags = ''
 
     cmd = play_context.make_become_cmd(cmd=default_cmd, executable=default_exe)
     assert cmd == default_cmd
@@ -167,11 +168,11 @@ def test_play_context_make_become_cmd(parser):
 
     play_context.become_method = 'dzdo'
     cmd = play_context.make_become_cmd(cmd=default_cmd, executable="/bin/bash")
-    assert cmd == """%s -u %s %s -c 'echo %s; %s'""" % (dzdo_exe, play_context.become_user, default_exe, play_context.success_key, default_cmd)
+    assert cmd == """%s %s -u %s %s -c 'echo %s; %s'""" % (dzdo_exe, dzdo_flags, play_context.become_user, default_exe, play_context.success_key, default_cmd)
 
     play_context.become_pass = 'testpass'
     play_context.become_method = 'dzdo'
     cmd = play_context.make_become_cmd(cmd=default_cmd, executable="/bin/bash")
-    assert (cmd == """%s -p %s -u %s %s -c 'echo %s; %s'""" % (dzdo_exe, shlex_quote(play_context.prompt),
-                                                               play_context.become_user, default_exe,
-                                                               play_context.success_key, default_cmd))
+    assert (cmd == """%s %s -p %s -u %s %s -c 'echo %s; %s'""" % (dzdo_exe, dzdo_flags, shlex_quote(play_context.prompt),
+                                                                  play_context.become_user, default_exe,
+                                                                  play_context.success_key, default_cmd))


### PR DESCRIPTION
##### SUMMARY
Add Flags to the dzdo become method
Fixes #38685 

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME
play_context

##### ANSIBLE VERSION
2.5.0


##### ADDITIONAL INFORMATION
The `dzdo` Become method does not currently accept flags set in `become_flags` - this pull request simply adds the flags to the `becomecmd`s for `dzdo`


