### PR TITLE
 win_updates: backport 2.5 fix when failed is not present in output 

### DIFF
--- a/lib/ansible/plugins/action/win_updates.py
+++ b/lib/ansible/plugins/action/win_updates.py
@@ -189,10 +189,12 @@ class ActionModule(ActionBase):
         # if the module failed to run at all then changed won't be populated
         # so we just return the result as is
         # https://github.com/ansible/ansible/issues/38232
-        if result['failed']:
+        failed = result.get('failed', False)
+        if "updates" not in result.keys() or failed:
+            result['failed'] = True
             return result
 
-        changed = result['changed']
+        changed = result.get('changed', False)
         updates = result.get('updates', dict())
         filtered_updates = result.get('filtered_updates', dict())
         found_update_count = result.get('found_update_count', 0)
@@ -241,7 +243,7 @@ class ActionModule(ActionBase):
                 result.pop('msg', None)
                 # rerun the win_updates module after the reboot is complete
                 result = self._run_win_updates(new_module_args, task_vars)
-                if result['failed']:
+                if result.get('failed', False):
                     return result
 
                 result_updates = result.get('updates', dict())


### PR DESCRIPTION
##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/38856, no changelog needed as the faulty change was never in a release.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
win_updates

##### ANSIBLE VERSION
```
2.5
```