### PR TITLE
win_pester: move away from public repo to source test files

### DIFF
--- a/test/integration/targets/win_pester/aliases
+++ b/test/integration/targets/win_pester/aliases
@@ -1,2 +1,1 @@
 windows/ci/group2
-unstable

--- a/test/integration/targets/win_pester/defaults/main.yml
+++ b/test/integration/targets/win_pester/defaults/main.yml
@@ -1,12 +1,2 @@
 ---
-local_test_files:
-  - files/test01.test.ps1
-  - files/test02.test.ps1
-remote_test_files:
-  - test01.test.ps1
-  - test02.test.ps1
-fake_remote_test_file: C:\Pester\fake_test.test.ps1
-fake_remote_folder: C:\Fake_Pester
-remote_test_folder: 
-  - C:\Pester\
-  - C:\Pester
+test_win_pester_path: C:\ansible\win_pester

--- a/test/integration/targets/win_pester/tasks/main.yml
+++ b/test/integration/targets/win_pester/tasks/main.yml
@@ -1,117 +1,51 @@
 ---
-- name: Get facts
-  setup:
-
-- name: Add Pester module
-  win_psmodule:
-    name: Pester
-    state: present
-  when: ansible_powershell_version >= 5
-
-- name: Add Pester module with Chocolatey
-  win_chocolatey:
-    name: Pester
-    state: present
-  when: ansible_powershell_version < 5
-
-- name: Copy test file(s)
-  win_copy:
-    src: "{{ item }}"
-    dest: "{{ remote_test_folder[0] }}"
-  with_items: "{{local_test_files}}"
-
-- name: Run Pester test(s) specifying a fake test file
-  win_pester:
-    path: "{{ fake_remote_test_file }}"
-  register: result
-  ignore_errors: yes
-
-- name: Assert result
-  assert:
-    that: 
-      - result.failed == true
-
-- name: Run Pester test(s) specifying a fake folder
-  win_pester:
-    path: "{{ fake_remote_folder }}"
-  register: result
-  ignore_errors: yes
-
-- name: Assert result
-  assert:
-    that: 
-      - result.failed == true
-
-- name: Run Pester test(s) specifying a test file and a higher pester version
-  win_pester:
-    path: "{{ remote_test_folder[0] }}{{ remote_test_files[0] }}"
-    minimum_version: 6.0.0
-  register: result
-  ignore_errors: yes
-
-- name: Assert result
-  assert:
-    that: 
-      - result.failed == true
-
-- name: Run Pester test(s) specifying a test file
-  win_pester:
-    path: "{{ remote_test_folder[0] }}{{ remote_test_files[0] }}"
-  register: result
-
-- name: Assert result
-  assert:
-    that: 
-      - result.failed == false
-      - result.output.TotalCount == 1
-
-- name: Run Pester test(s) specifying a test file and with a minimum mandatory Pester version
-  win_pester:
-    path: "{{ remote_test_folder[0] }}{{ remote_test_files[0] }}"
-    minimum_version: 3.0.0
-  register: result
-
-- name: Assert result
-  assert:
-    that: 
-      - result.failed == false
-      - result.output.TotalCount == 1
-
-- name: Run Pester test(s) located in a folder. Folder path end with '\'
-  win_pester:
-    path: "{{ remote_test_folder[0] }}"
-  register: result
-
-- name: Assert result 
-  assert:
-    that: 
-      - result.failed == false
-      - result.output.TotalCount == 2
-
-- name: Run Pester test(s) located in a folder. Folder path does not end with '\' 
-  win_pester:
-    path: "{{ remote_test_folder[1] }}"
-  register: result
-
-- name: Assert result 
-  assert:
-    that: 
-      - result.failed == false
-      - result.output.TotalCount == 2
-
-- name: Run Pester test(s) located in a folder and with a minimum mandatory Pester version
-  win_pester:
-    path: "{{ remote_test_folder[0] }}"
-    minimum_version: 3.0.0
-  register: result
-
-- name: Assert result 
-  assert:
-    that: 
-      - result.failed == false
-      - result.output.TotalCount == 2
-
-- name: Delete test folder
+- name: create test folder
   win_file:
-    path: "{{ remote_test_folder[0] }}"
-    state: absent
+    path: '{{test_win_pester_path}}\Modules'
+    state: directory
+
+- name: download Pester module from S3 bucket
+  win_get_url:
+    # this was downloaded straight off the Pester GitHub release page and uploaded to the S3 bucket
+    # https://github.com/pester/Pester/releases 
+    url: 'https://s3.amazonaws.com/ansible-ci-files/test/integration/roles/test_win_pester/Pester-4.3.1.zip'
+    dest: '{{test_win_pester_path}}\Pester-4.3.1.zip'
+
+- name: unzip Pester module
+  win_unzip:
+    src: '{{test_win_pester_path}}\Pester-4.3.1.zip'
+    dest: '{{test_win_pester_path}}\Modules'
+
+- name: rename extracted zip to match module name
+  win_shell: Rename-Item -Path '{{test_win_pester_path}}\Modules\Pester-4.3.1' -NewName Pester
+
+- name: add custom Pester location to the PSModulePath
+  win_path:
+    name: PSModulePath
+    scope: machine
+    state: present
+    elements:
+    - '{{test_win_pester_path}}\Modules'
+
+- name: copy test files
+  win_copy:
+    src: files/
+    dest: '{{test_win_pester_path}}\'
+
+- block:
+  - name: run Pester tests
+    include_tasks: test.yml
+
+  always:
+  - name: remove custom pester location on the PSModulePath
+    win_path:
+      name: PSModulePath
+      scope: machine
+      state: absent
+      elements:
+      - '{{test_win_pester_path}}\Modules'
+    
+  - name: delete test folder
+    win_file:
+      path: '{{test_win_pester_path}}'
+      state: absent

--- a/test/integration/targets/win_pester/tasks/test.yml
+++ b/test/integration/targets/win_pester/tasks/test.yml
@@ -1,0 +1,81 @@
+---
+- name: Run Pester test(s) specifying a fake test file
+  win_pester:
+    path: '{{test_win_pester_path}}\fakefile.ps1'
+  register: fake_file
+  failed_when: '"Cannot find file or directory: ''" + test_win_pester_path + "\\fakefile.ps1'' as it does not exist" not in fake_file.msg'
+
+- name: Run Pester test(s) specifying a fake folder
+  win_pester:
+    path: '{{test_win_pester_path }}\fakedir'
+  register: fake_folder
+  failed_when: '"Cannot find file or directory: ''" + test_win_pester_path + "\\fakedir'' as it does not exist" not in fake_folder.msg'
+
+- name: Run Pester test(s) specifying a test file and a higher pester version
+  win_pester:
+    path: '{{test_win_pester_path}}\test01.test.ps1'
+    minimum_version: '6.0.0'
+  register: invalid_version
+  failed_when: '"Pester version is not greater or equal to 6.0.0" not in invalid_version.msg'
+
+- name: Run Pester test(s) specifying a test file
+  win_pester:
+    path: '{{test_win_pester_path}}\test01.test.ps1'
+  register: file_result
+
+- name: assert Run Pester test(s) specify a test file
+  assert:
+    that:
+    - file_result.changed
+    - not file_result.failed
+    - file_result.output.TotalCount == 1
+
+- name: Run Pester test(s) specifying a test file and with a minimum mandatory Pester version
+  win_pester:
+    path: '{{test_win_pester_path}}\test01.test.ps1'
+    minimum_version: 3.0.0
+  register: file_result_with_version
+
+- name: assert Run Pester test(s) specifying a test file and a minimum mandatory Pester version
+  assert:
+    that:
+    - file_result_with_version.changed
+    - not file_result_with_version.failed
+    - file_result_with_version.output.TotalCount == 1
+
+- name: Run Pester test(s) located in a folder. Folder path end with '\'
+  win_pester:
+    path: '{{test_win_pester_path}}\'
+  register: dir_with_ending_slash
+
+- name: assert Run Pester test(s) located in a folder. Folder path end with '\'
+  assert:
+    that:
+    - dir_with_ending_slash.changed
+    - not dir_with_ending_slash.failed
+    - dir_with_ending_slash.output.TotalCount == 2
+
+- name: Run Pester test(s) located in a folder. Folder path does not end with '\' 
+  win_pester:
+    path: '{{test_win_pester_path}}'
+  register: dir_without_ending_slash
+
+- name: assert Run Pester test(s) located in a folder. Folder does not end with '\'
+  assert:
+    that:
+    - dir_without_ending_slash.changed
+    - not dir_without_ending_slash.failed
+    - dir_without_ending_slash.output.TotalCount == 2
+
+- name: Run Pester test(s) located in a folder and with a minimum mandatory Pester version
+  win_pester:
+    path: '{{test_win_pester_path}}'
+    minimum_version: 3.0.0
+  register: dir_with_version
+
+- name: assert Run Pester test(s) located in a folder and with a minimum mandatory Pester version
+  assert:
+    that:
+    - dir_with_version.changed
+    - not dir_with_version.failed
+    - dir_with_version.output.TotalCount == 2


### PR DESCRIPTION
##### SUMMARY
Original win_pester test, installed Pester either through Chocolatey or the the PS Gallery which isn't always available and let to unstable tests. This change now installs Pester manually and sources the files from an S3 bucket we control. This should fix the stability issues with the test.

Fixes https://github.com/ansible/ansible/issues/38716

##### ISSUE TYPE
 - Test Pull Request

##### COMPONENT NAME
win_pester

##### ANSIBLE VERSION
```
devel
```