### PR TITLE
VMware: handle permission denied while reading facts

### DIFF
--- a/changelogs/fragments/37056-vmware_guest_no_permission.yaml
+++ b/changelogs/fragments/37056-vmware_guest_no_permission.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- Adds exception handling which is raised when user does not have correct set of permissions/privileges to read virtual machine facts.

--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -305,8 +305,14 @@ def gather_vm_facts(content, vm):
 
     # facts that may or may not exist
     if vm.summary.runtime.host:
-        host = vm.summary.runtime.host
-        facts['hw_esxi_host'] = host.summary.config.name
+        try:
+            host = vm.summary.runtime.host
+            facts['hw_esxi_host'] = host.summary.config.name
+        except vim.fault.NoPermission:
+            # User does not have read permission for the host system,
+            # proceed without this value. This value does not contribute or hamper
+            # provisioning or power management operations.
+            pass
     if vm.summary.runtime.dasVmProtection:
         facts['hw_guest_ha_state'] = vm.summary.runtime.dasVmProtection.dasProtected
 


### PR DESCRIPTION
##### SUMMARY
This fix adds exception handling which is raised when user
does not have correct set of permissions/privileges to read virtual machine
facts especially host system configuration.

Fixes: #37056

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>
(cherry picked from commit efc3f4f824402fd7033c53c954a57b693b61f76d)

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/37056-vmware_guest_no_permission.yaml
lib/ansible/module_utils/vmware.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
Stable-2.5
```