### PR TITLE
issue:38321 fix onyx_config module failed while using python = 3.5 (#38343)

### DIFF
--- a/changelogs/fragments/onyx_config-py3-fix.yaml
+++ b/changelogs/fragments/onyx_config-py3-fix.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- Fix onyx_config action plugin when used on Python 3 https://github.com/ansible/ansible/pull/38343

--- a/lib/ansible/plugins/action/onyx_config.py
+++ b/lib/ansible/plugins/action/onyx_config.py
@@ -54,7 +54,7 @@ class ActionModule(_ActionModule):
 
         # strip out any keys that have two leading and two trailing
         # underscore characters
-        for key in result.keys():
+        for key in list(result.keys()):
             if PRIVATE_KEYS_RE.match(key):
                 del result[key]
 


### PR DESCRIPTION
Original PR https://github.com/ansible/ansible/pull/38343
(cherry picked from commit 0d79268a6d2b97eb670c7ee01e56e4f9ae7d6b27)

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

