### PR TITLE
add instanceUuid (also called PersistentId) in vmware utils

### DIFF
--- a/changelogs/fragments/vmware_gather_facts_instance_uuid.yaml
+++ b/changelogs/fragments/vmware_gather_facts_instance_uuid.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- Updated virtual machine facts with instanceUUID which is unique for each VM irrespective of name and BIOS UUID.

--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -291,6 +291,7 @@ def gather_vm_facts(content, vm):
         'hw_guest_ha_state': None,
         'hw_is_template': vm.config.template,
         'hw_folder': None,
+        'instance_uuid': vm.config.instanceUuid,
         'guest_tools_status': _get_vm_prop(vm, ('guest', 'toolsRunningStatus')),
         'guest_tools_version': _get_vm_prop(vm, ('guest', 'toolsVersion')),
         'guest_question': vm.summary.runtime.question,


### PR DESCRIPTION
##### SUMMARY
(cherry picked from commit 0cdba9ff70c76af49e5cce2c9a16705cc0718a64)

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/vmware_gather_facts_instance_uuid.yaml
lib/ansible/module_utils/vmware.py

##### ANSIBLE VERSION
```
Stable-2.5
```