### PR TITLE
ovirt: FCP storage domains don't have to have target

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_storage_domains.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_storage_domains.py
@@ -356,6 +356,9 @@ class StorageDomainModule(BaseModule):
             return [(lun_id, storage.get('target')) for lun_id in lun_ids]
         elif storage.get('target_lun_map'):
             return [(target_map.get('lun_id'), target_map.get('target')) for target_map in storage.get('target_lun_map')]
+        else:
+            lun_ids = storage.get('lun_id') if isinstance(storage.get('lun_id'), list) else [(storage.get('lun_id'))]
+            return [(lun_id, None) for lun_id in lun_ids]
 
     def build_entity(self):
         storage_type = self._get_storage_type()


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Previously it was possible to add FCP storage domain which didn't have any target, when adding support for `target_map` we broke this functionality. This patch fixes it.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
ovirt_storage_domains

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
