### PR TITLE
Name tasks in ini_file module

### DIFF
--- a/lib/ansible/modules/files/ini_file.py
+++ b/lib/ansible/modules/files/ini_file.py
@@ -103,7 +103,8 @@ EXAMPLES = '''
     mode: 0600
     backup: yes
 
-- ini_file:
+- name: Ensure "temperature=cold is in section "[drinks]" in specified file
+  ini_file:
     path: /etc/anotherconf
     section: drinks
     option: temperature


### PR DESCRIPTION
One of Ansible best practices is "Always Name Tasks".

This should include tasks in examples as well so people can learn
what is the right way to use it.

##### SUMMARY
Doc fix of ini_file module

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
ini_file

```

```
