### PR TITLE
Disambiguates autogenerated module docs - fixes #38439.

### DIFF
--- a/docs/docsite/rst/installation_guide/intro_configuration.rst
+++ b/docs/docsite/rst/installation_guide/intro_configuration.rst
@@ -33,7 +33,7 @@ An `example file is available on Github <https://raw.github.com/ansible/ansible/
 
 For more details and a full listing of available configurations go to :ref:`configuration_settings`. Starting with Ansible version 2.4, you can use the :ref:`ansible-config` command line utility to list your available options and inspect the current values.
 
-For in-depth details, see :ref:`config`.
+For in-depth details, see :ref:`ansible_configuration_settings`.
 
 
 Environmental configuration
@@ -42,7 +42,8 @@ Environmental configuration
 Ansible also allows configuration of settings using environment variables.
 If these environment variables are set, they will override any setting loaded from the configuration file.
 
-You can get a full listing of available environment variables from :doc:`_config`.
+You can get a full listing of available environment variables from :ref:`ansible_configuration_settings`.
+
 
 .. _command_line_configuration:
 

--- a/docs/docsite/rst/plugins/callback.rst
+++ b/docs/docsite/rst/plugins/callback.rst
@@ -50,13 +50,13 @@ or for my custom callback:
 
   stdout_callback = mycallback
 
-This only affects :doc:`../ansible-playbook` by default.
+This only affects :ref:`ansible-playbook` by default.
 
 Managing AdHoc
 ``````````````
 
-The :doc:`ansible <../ansible>` AdHoc command specifically uses a different callback plugin for stdout,
-so there is an extra setting in :doc:`ansible.cfg <../config>` you need to add to use the stdout callback defined above:
+The :ref:`ansible` ad hoc command specifically uses a different callback plugin for stdout,
+so there is an extra setting in :ref:`ansible_configuration_settings` you need to add to use the stdout callback defined above:
 
 .. code-block:: ini
 
@@ -87,19 +87,21 @@ Use ``ansible-doc -t callback <plugin name>`` to see specific documents and exam
 
 .. seealso::
 
-   :doc:`../playbooks`
-       An introduction to playbooks
+   :doc:`action`
+       Ansible Action plugins
+   :doc:`cache`
+       Ansible cache plugins
+   :doc:`connection`
+       Ansible connection plugins
    :doc:`inventory`
        Ansible inventory plugins
-   :doc:`../playbooks_filters`
-       Jinja2 filter plugins
-   :doc:`../playbooks_tests`
-       Jinja2 test plugins
-   :doc:`../playbooks_lookups`
-       Jinja2 lookup plugins
+   :doc:`shell`
+       Ansible Shell plugins
+   :doc:`strategy`
+       Ansible Strategy plugins
    :doc:`vars`
-       Ansible vars plugins
-   `User Mailing List <http://groups.google.com/group/ansible-devel>`_
+       Ansible Vars plugins
+   `User Mailing List <https://groups.google.com/forum/#!forum/ansible-devel>`_
        Have a question?  Stop by the google group!
-   `irc.freenode.net <http://irc.freenode.net>`_
+   `webchat.freenode.net <https://webchat.freenode.net>`_
        #ansible IRC chat channel

--- a/docs/docsite/rst/user_guide/intro_adhoc.rst
+++ b/docs/docsite/rst/user_guide/intro_adhoc.rst
@@ -94,11 +94,12 @@ specify that all of the time.  We'll use ``-m`` in later examples to
 run some other :doc:`modules`.
 
 .. note::
-   The :ref:`command` module does not support extended shell syntax like piping and redirects (although
-   shell variables will always work). If your command requires shell-specific syntax, use the `shell` module
-   instead. Read more about the differences on the :ref:`working_with_modules` page.
+   The :ref:`command module <module_command>` does not support extended shell syntax like piping and
+   redirects (although shell variables will always work). If your command requires shell-specific
+   syntax, use the `shell` module instead. Read more about the differences on the
+   :ref:`working_with_modules` page.
 
-Using the :ref:`shell` module looks like this::
+Using the :ref:`shell module <module_shell>` looks like this::
 
     $ ansible raleigh -m shell -a 'echo $TERM'
 

--- a/docs/templates/config.rst.j2
+++ b/docs/templates/config.rst.j2
@@ -1,3 +1,5 @@
+.. _ansible_configuration_settings:
+
 {% set name = 'Ansible Configuration Settings' -%}
 {% set name_slug = 'config' -%}
 

--- a/docs/templates/list_of_CATEGORY_modules.rst.j2
+++ b/docs/templates/list_of_CATEGORY_modules.rst.j2
@@ -11,7 +11,7 @@
 {% if category['_modules'] %}
 
 {% for module in category['_modules'] | sort %}
-  * :ref:`@{ module }@`{% if module_info[module]['deprecated'] %} **(D)**{% endif%} 
+  * :ref:`@{ module }@_@{ plugin_type }@`{% if module_info[module]['deprecated'] %} **(D)**{% endif%} 
 {% endfor %}
 {% endif %}
 
@@ -25,7 +25,7 @@
 
 
 {% for module in info['_modules'] | sort %}
-  * :ref:`@{ module }@`{% if module_info[module]['deprecated'] %} **(D)**{% endif%} 
+  * :ref:`@{ module }@_@{ plugin_type }@`{% if module_info[module]['deprecated'] %} **(D)**{% endif%} 
 {% endfor %}
 
 {% endfor %}

--- a/docs/templates/modules_by_support.rst.j2
+++ b/docs/templates/modules_by_support.rst.j2
@@ -4,7 +4,7 @@ Modules Maintained by the @{ maintainers }@
 ``````````````````````````@{ '`' * maintainers | length }@
 
 {% for module in modules | sort %}
-  * :ref:`@{ module }@`{% if module_info[module]['deprecated'] %} **(D)**{% endif%} 
+  * :ref:`@{ module }@_@{plugin_type}@`{% if module_info[module]['deprecated'] %} **(D)**{% endif%} 
 {% endfor %}
 
 .. note::

--- a/docs/templates/plugin.rst.j2
+++ b/docs/templates/plugin.rst.j2
@@ -1,6 +1,6 @@
 :source: @{ source }@
 
-.. _@{ module }@:
+.. _@{ module }@_@{ plugin_type }@:
 {% for alias in aliases %}
 .. _@{ alias }@:
 {% endfor %}


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This attempts to fix #38439 by disambiguating autogenerated module docs by appending the module type to the file name. 
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - New Module Pull Request
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
