### PR TITLE
Update kibana_plugin.py

### DIFF
--- a/lib/ansible/modules/database/misc/kibana_plugin.py
+++ b/lib/ansible/modules/database/misc/kibana_plugin.py
@@ -44,11 +44,11 @@ options:
     plugin_bin:
         description:
             - Location of the plugin binary
-        default: /opt/kibana/bin/kibana
+        default: /usr/share/kibana/bin/kibana-plugin
     plugin_dir:
         description:
             - Your configured plugin directory specified in Kibana
-        default: /opt/kibana/installedPlugins/
+        default: /usr/share/kibana/plugins
     version:
         description:
             - Version of the plugin to be installed.
@@ -115,8 +115,8 @@ from ansible.module_utils.basic import AnsibleModule
 
 
 PACKAGE_STATE_MAP = dict(
-    present="--install",
-    absent="--remove"
+    present="install",
+    absent="remove"
 )
 
 
@@ -196,8 +196,8 @@ def main():
             state=dict(default="present", choices=PACKAGE_STATE_MAP.keys()),
             url=dict(default=None),
             timeout=dict(default="1m"),
-            plugin_bin=dict(default="/opt/kibana/bin/kibana", type="path"),
-            plugin_dir=dict(default="/opt/kibana/installedPlugins/", type="path"),
+            plugin_bin=dict(default="/usr/share/kibana/bin/kibana-plugin", type="path"),
+            plugin_dir=dict(default="/usr/share/kibana/plugins/", type="path"),
             version=dict(default=None),
             force=dict(default="no", type="bool")
         ),


### PR DESCRIPTION
<!--- Your description here -->
The default path for all parts of elaticsearch in 5.x and up is "/usr/share/<service>", ex. /usr/share/kibana/
+label: docsite_pr

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - New Module Pull Request
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
