### PR TITLE
fix problem with CallbackBase getting __main__.cli.options

### DIFF
--- a/lib/ansible/plugins/callback/__init__.py
+++ b/lib/ansible/plugins/callback/__init__.py
@@ -37,11 +37,7 @@ except ImportError:
     from ansible.utils.display import Display
     global_display = Display()
 
-try:
-    from __main__ import cli
-except ImportError:
-    # using API w/o cli
-    cli = False
+import __main__
 
 __all__ = ["CallbackBase"]
 
@@ -60,8 +56,8 @@ class CallbackBase(AnsiblePlugin):
         else:
             self._display = global_display
 
-        if cli:
-            self._options = cli.options
+        if getattr(__main__, 'cli', False):
+            self._options = __main__.cli.options
         else:
             self._options = None
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
if you look at the 'default' callback, in v2_playbook_on_start, if self._display.verbosity > 3 and self._options is not None then it should print out the list of command line options, but it don't.  See example below.

At the top of 'callback/\_\_init__.py', there is an 'from \_\_main__ import cli'.  If this import succeeds, it creates a _new variable_ in this module with it's value set to be what it is in \_\_main__.cli at the point of the import, which is always None.  Later when bin/ansible changes it's variable 'cli' to an actual CLI, that change is not reflected in callback's variable 'cli', it stays None.

The fix for this is to import \_\_main__ instead of cli from \_\_main__.  Then use \_\_main__.cli.options.  The use of getattr is to cover the case that \_\_main__ doesn't have a 'cli' variable just as the 'try: except:' dealt with.  

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
CallbackBase

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0 (detached HEAD 2367130ba3) last updated 2018/04/17 14:50:29 (GMT -400)
  config file = /home/gavin/.ansible.cfg
  configured module search path = [u'/home/gavin/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/gavin/projects/ansible/ansible/lib/ansible
  executable location = /home/gavin/projects/ansible/ansible/ENV/bin/ansible
  python version = 2.7.14 (default, Mar 14 2018, 13:36:31) [GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before:
```
$ ansible-playbook -vvvv --check -l localhost ~/projects/ansible/playbooks/ansible-target.yml

...
...  lots of output elided
...

PLAYBOOK: ansible-target.yml ****************************************************************************
1 plays in /home/gavin/projects/ansible/playbooks/ansible-target.yml

PLAY [all] **********************************************************************************************

...
...  lots of output elided
...
```
After:
```
$ ansible-playbook -vvvv --check -l localhost ~/projects/ansible/playbooks/ansible-target.yml

...
... lots of output elided
...
PLAYBOOK: ansible-target.yml ****************************************************************************
become_method: sudo
become_user: root
check: True
connection: smart
forks: 5
inventory: [u'/home/gavin/ansible_hosts']
subset: localhost
tags: [u'all']
timeout: 10
verbosity: 4
1 plays in /home/gavin/projects/ansible/playbooks/ansible-target.yml

PLAY [all] **********************************************************************************************

...
... lots of output elided
...
```
