### PR TITLE
Restore docker_secret test on RHEL.

### DIFF
--- a/test/integration/targets/docker_secret/aliases
+++ b/test/integration/targets/docker_secret/aliases
@@ -1,5 +1,4 @@
 posix/ci/group2
 skip/osx
 skip/freebsd
-skip/rhel
 destructive

--- a/test/integration/targets/docker_secret/tasks/test_secrets.yml
+++ b/test/integration/targets/docker_secret/tasks/test_secrets.yml
@@ -3,7 +3,7 @@
     state: present 
     name: "{{ item }}"
   with_items:
-    - docker>=2.1.0
+    - docker==2.1.0
 
 - name: Check if already in swarm
   shell: docker node ls 2>&1 | grep 'docker swarm init'


### PR DESCRIPTION
##### SUMMARY

Restore docker_secret test on RHEL.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

docker_secret integration test

##### ANSIBLE VERSION

```
ansible 2.6.0 (docker-secret-rhel e72a84c314) last updated 2018/04/17 13:45:12 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
