### PR TITLE
Restore seboolean and sefcontext tests on RHEL.

### DIFF
--- a/test/integration/targets/seboolean/aliases
+++ b/test/integration/targets/seboolean/aliases
@@ -1,3 +1,2 @@
 needs/root
 posix/ci/group2
-skip/rhel

--- a/test/integration/targets/seboolean/tasks/seboolean.yml
+++ b/test/integration/targets/seboolean/tasks/seboolean.yml
@@ -15,6 +15,12 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
+- name: install requirements for RHEL
+  package:
+    name: policycoreutils-python
+  when:
+    - ansible_distribution == 'RedHat'
+
 - name: Cleanup
   shell: setsebool -P httpd_can_network_connect 0
 ##########################################################################################

--- a/test/integration/targets/sefcontext/aliases
+++ b/test/integration/targets/sefcontext/aliases
@@ -1,3 +1,2 @@
 needs/root
 posix/ci/group2
-skip/rhel

--- a/test/integration/targets/sefcontext/tasks/sefcontext.yml
+++ b/test/integration/targets/sefcontext/tasks/sefcontext.yml
@@ -15,6 +15,12 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
+- name: install requirements for RHEL
+  package:
+    name: policycoreutils-python
+  when:
+    - ansible_distribution == 'RedHat'
+
 - name: Ensure we start with a clean state
   sefcontext:
     path: '/tmp/foo/bar(/.*)?'


### PR DESCRIPTION
##### SUMMARY

Restore seboolean and sefcontext tests on RHEL.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

seboolean and sefcontext integration tests

##### ANSIBLE VERSION

```
ansible 2.6.0 (test-fix 6557919ae1) last updated 2018/04/17 14:00:49 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
