### PR TITLE
vmware_guest: Added a flag to indicate the network is a distributed virtual switch

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -629,6 +629,12 @@ class PyVmomiCache(object):
 
         return objects
 
+    def get_dvs(self, network):
+        if network not in self.networks:
+            self.networks[network] = self.find_obj(self.content, [vim.dvs.DistributedVirtualPortgroup], network)
+
+        return self.networks[network]
+
     def get_network(self, network):
         if network not in self.networks:
             self.networks[network] = self.find_obj(self.content, [vim.Network], network)
@@ -1042,6 +1048,9 @@ class PyVmomiHelper(PyVmomi):
                 self.module.fail_json(msg="Device MAC address '%s' is invalid."
                                           " Please provide correct MAC address." % network['mac'])
 
+            if 'dvs' not in network:
+                network['dvs'] = False
+
             network_devices.append(network)
 
         return network_devices
@@ -1105,7 +1114,12 @@ class PyVmomiHelper(PyVmomi):
                 nic.operation = vim.vm.device.VirtualDeviceSpec.Operation.add
                 nic_change_detected = True
 
-            if hasattr(self.cache.get_network(network_name), 'portKeys'):
+            if network_devices[key]['dvs']:
+                network = self.cache.get_dvs(network_name)
+            else:
+                network = self.cache.get_network(network_name)
+
+            if hasattr(network, 'portKeys'):
                 # VDS switch
                 pg_obj = find_obj(self.content, [vim.dvs.DistributedVirtualPortgroup], network_name)
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Added a flag to indicate a network is Distributed Virtual Switch and not a vswitch.
This is required if there is a vswitch network with the same name as a DVS network.
The flag will allow the selection of the DVS network over the vswitch network, or vice versa.

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
vmware_guest

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0
  config file = /home/itmxg01/ansible/vmware-provisioning/ansible.cfg
  configured module search path = [u'/home/itmxg01/ansible/vmware-provisioning/library']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.14 (default, Jan  5 2018, 10:41:29) [GCC 7.2.1 20171224]

```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
