### PR TITLE
Update httptester docs.

### DIFF
--- a/docs/docsite/rst/dev_guide/testing_httptester.rst
+++ b/docs/docsite/rst/dev_guide/testing_httptester.rst
@@ -17,54 +17,7 @@ HTTP Testing endpoint which provides the following capabilities:
 * SNI
 
 
-Source files can be found at `test/utils/docker/httptester/ <https://github.com/ansible/ansible/tree/devel/test/utils/docker/httptester>`_
-
-Building
-========
-
-Docker
-------
-
-Both ways of building ``docker`` utilize the ``nginx:alpine`` image, but can
-be customized for ``Fedora``, ``Red Hat``, ``CentOS``, ``Ubuntu``,
-``Debian`` and other variants of ``Alpine``
-
-When utilizing ``packer`` or configuring with ``ansible-playbook``,
-the services will not automatically start on launch, and will have to be
-manually started using::
-
-    cd test/utils/docker/httptester
-    ./services.sh
-
-Such as when starting a docker container::
-
-    cd test/utils/docker/httptester
-    docker run -ti --rm -p 80:80 -p 443:443 --name httptester ansible/ansible:httptester /services.sh
-
-docker build
-------------
-
-::
-
-    cd test/utils/docker/httptester
-    docker build -t ansible/ansible:httptester .
-
-packer
-------
-
-The ``packer`` build will use ``ansible-playbook`` to perform the
-configuration, and will tag the image as ``ansible/ansible:httptester``::
-
-    cd test/utils/docker/httptester
-    packer build packer.json
-
-Ansible
-=======
-
-::
-    cd test/utils/docker/httptester
-    ansible-playbook -i hosts -v httptester.yml
-
+Source files can be found in the `http-test-container <https://github.com/ansible/http-test-container>`_ repository.
 
 Extending httptester
 ====================


### PR DESCRIPTION
##### SUMMARY

Update httptester docs.

##### ISSUE TYPE

Docs Pull Request

##### COMPONENT NAME

docs

##### ANSIBLE VERSION

```
ansible 2.6.0 (docs-cleanup-httptester e0e79ab0fc) last updated 2018/04/17 14:30:22 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
