### PR TITLE
win_regedit: backport 2.5 stabilise tests

### DIFF
--- a/changelogs/fragments/win_regedit-hive-unload.yaml
+++ b/changelogs/fragments/win_regedit-hive-unload.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_regedit - wait for garbage collection to finish before trying to unload the hive in case handles didn't unload in time (https://github.com/ansible/ansible/pull/38912)

--- a/lib/ansible/modules/windows/win_regedit.ps1
+++ b/lib/ansible/modules/windows/win_regedit.ps1
@@ -562,6 +562,7 @@ $key_prefix[$path]
 } finally {
     if ($hive) {
         [GC]::Collect()
+        [GC]::WaitForPendingFinalizers()
         try {
             [Ansible.RegistryUtil]::UnloadHive("ANSIBLE")
         } catch [System.ComponentModel.Win32Exception] {

--- a/test/integration/targets/win_regedit/tasks/tests.yml
+++ b/test/integration/targets/win_regedit/tasks/tests.yml
@@ -537,7 +537,6 @@
     $prop = Get-ItemProperty -Path HKLM:\ANSIBLE\NewKey -Name TestProp -ErrorAction SilentlyContinue
     if ($prop) {
       $prop.TestProp
-      $prop.Close()
     }
     &reg.exe unload HKLM\ANSIBLE > $null
     exit 0
@@ -565,7 +564,6 @@
     $prop = Get-ItemProperty -Path HKLM:\ANSIBLE\NewKey -Name TestProp -ErrorAction SilentlyContinue
     if ($prop) {
       $prop.TestProp
-      $prop.Close()
     }
     &reg.exe unload HKLM\ANSIBLE > $null
     exit 0
@@ -607,7 +605,6 @@
     $prop = Get-ItemProperty -Path HKLM:\ANSIBLE\NewKey -Name TestProp -ErrorAction SilentlyContinue
     if ($prop) {
       $prop.TestProp
-      $prop.Close()
     }
     &reg.exe unload HKLM\ANSIBLE > $null
     exit 0
@@ -633,7 +630,6 @@
     $prop = Get-ItemProperty -Path HKLM:\ANSIBLE\NewKey -Name TestProp -ErrorAction SilentlyContinue
     if ($prop) {
       $prop.TestProp
-      $prop.Close()
     }
     &reg.exe unload HKLM\ANSIBLE > $null
     exit 0
@@ -662,7 +658,7 @@
   win_regedit:
     path: '{{test_win_regedit_hive_key}}'
     state: absent
-    delete_yes: yes
+    delete_key: yes
     hive: C:\Users\Default\NTUSER.dat
   register: remove_key_in_hive_check
   check_mode: yes
@@ -688,7 +684,7 @@
   win_regedit:
     path: '{{test_win_regedit_hive_key}}'
     state: absent
-    delete_yes: yes
+    delete_key: yes
     hive: C:\Users\Default\NTUSER.dat
   register: remove_key_in_hive
 
@@ -713,7 +709,7 @@
   win_regedit:
     path: '{{test_win_regedit_hive_key}}'
     state: absent
-    delete_yes: yes
+    delete_key: yes
     hive: C:\Users\Default\NTUSER.dat
   register: remove_key_in_hive_again
 


### PR DESCRIPTION
##### SUMMARY
We should wait until the finalizer of the IDisposable objects are finished before trying to unload the registry hive. This should stop the issue where the handle is still being finalised when trying to unload the hive causing an access is denied exception.

Backport of https://github.com/ansible/ansible/pull/38912

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
win_regedit

##### ANSIBLE VERSION
```
2.5
```