### PR TITLE
Enable vmware_datastore_maintenancemode test.

### DIFF
--- a/test/integration/targets/vmware_datastore_maintenancemode/aliases
+++ b/test/integration/targets/vmware_datastore_maintenancemode/aliases
@@ -1,4 +1,3 @@
 cloud/vcenter
 destructive
 posix/ci/cloud/group4/vcenter
-disabled


### PR DESCRIPTION
##### SUMMARY

Enable vmware_datastore_maintenancemode test.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

vmware_datastore_maintenancemode integration test

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0 (enable-test 309b13ca33) last updated 2018/04/17 16:36:56 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
