### PR TITLE
Updated 'quay.io/ansible/vcenter-test-container' image tag to '1.2.0'

### DIFF
--- a/test/runner/lib/cloud/vcenter.py
+++ b/test/runner/lib/cloud/vcenter.py
@@ -43,7 +43,7 @@ class VcenterProvider(CloudProvider):
         if os.environ.get('ANSIBLE_VCSIM_CONTAINER'):
             self.image = os.environ.get('ANSIBLE_VCSIM_CONTAINER')
         else:
-            self.image = 'quay.io/ansible/vcenter-test-container:1.0.1'
+            self.image = 'quay.io/ansible/vcenter-test-container:1.2.0'
         self.container_name = ''
 
     def filter(self, targets, exclude):


### PR DESCRIPTION
##### SUMMARY
Updated 'quay.io/ansible/vcenter-test-container' image tag to '1.2.0'

vcsim remains on commit 'dee49fa3694c5aff05e4b340b0686772f65c1fe1'

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
vcenter-test-container

##### ADDITIONAL INFORMATION
This completes the initial transition from an image base of 'fedora:26' to 'golang:1.10.1-alpine3.7'.