### PR TITLE
Namespace the aliases ref target by plugin type

### DIFF
--- a/docs/templates/plugin.rst.j2
+++ b/docs/templates/plugin.rst.j2
@@ -2,7 +2,7 @@
 
 .. _@{ module }@_@{ plugin_type }@:
 {% for alias in aliases %}
-.. _@{ alias }@:
+.. _@{ alias }@_@{ plugin_type }@:
 {% endfor %}
 
 {% if short_description %}


### PR DESCRIPTION
##### SUMMARY
Aliases for plugins need to be namespaced in the same way as the canonical plugin name.

##### ISSUE TYPE
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
module and plugin docs

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel 2.5
```
