### PR TITLE
Update httptester container reference.

### DIFF
--- a/test/runner/test.py
+++ b/test/runner/test.py
@@ -584,7 +584,7 @@ def add_extra_docker_options(parser, integration=True):
 
     docker.add_argument('--docker-util',
                         metavar='IMAGE',
-                        default='ansible/ansible@sha256:00f26e1d1909315ab1038751fc9397dd3cf7655604ba3b68fccda754c8630e50',  # httptester
+                        default='quay.io/ansible/http-test-container:1.0.0',
                         help='docker utility image to provide test services')
 
     docker.add_argument('--docker-privileged',


### PR DESCRIPTION
##### SUMMARY

Update httptester container reference.

(cherry picked from commit 35748e52285fa56f0b0e475a1fa51b0da793afc5)

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.5.0 (update-2.5 21a4662dae) last updated 2018/04/17 20:51:20 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
