### PR TITLE
Allow ansible-inventory to work with inline vaulted variables

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -775,6 +775,9 @@ def _json_encode_fallback(obj):
         return list(obj)
     elif isinstance(obj, datetime.datetime):
         return obj.isoformat()
+    # handle AnsibleVaultEncryptedUnicode without needing to import non module_utils libraries:
+    elif hasattr(obj, '_ciphertext') and hasattr(obj, 'yaml_tag'):
+        return "%s %s" % (obj.yaml_tag, obj._ciphertext)
     raise TypeError("Cannot json serialize %s" % to_native(obj))
 
 


### PR DESCRIPTION
##### SUMMARY
ansible-inventory needs jsonify logic to cope with
AnsibleVaultEncryptedUnicode, otherwise you get a TypeError

Due to module_utils being unable to import other libraries, we
can't do a proper isinstance check so look for suitable attributes.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
module_utils/basic.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0 (devel c97e508806) last updated 2018/04/18 14:10:24 (GMT +1000)
  config file = /home/will/tmp/ansible/inline_vault/ansible.cfg
  configured module search path = [u'/home/will/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/will/src/ansible/lib/ansible
  executable location = /home/will/src/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 14 2018, 13:36:31) [GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]
```


##### ADDITIONAL INFORMATION
ansible.cfg
```
[defaults]
vault_password_file=vault_pass
inventory=inventory
```

```
echo opensesame > vault_pass
echo -n 'hello' | ansible-vault encrypt_string 
Reading plaintext input from stdin. (ctrl-d to end input)
!vault |
          $ANSIBLE_VAULT;1.1;AES256
          35633431306531613631343062326136343532663966383439613330656536623737636639643662
          3034323562373430366230313366353164333566346662310a303266663564383432663963376337
          65396539623831633535396361323462643037336166626262366631356461363434633963616562
          3931626531343732630a366662373736326266376536616231636366613934373137353337383531
          3935
```

inventory/hosts
```
[test]
test1
```

inventory/group_vars/test.yml
```
password: !vault |
          $ANSIBLE_VAULT;1.1;AES256
          35633431306531613631343062326136343532663966383439613330656536623737636639643662
          3034323562373430366230313366353164333566346662310a303266663564383432663963376337
          65396539623831633535396361323462643037336166626262366631356461363434633963616562
          3931626531343732630a366662373736326266376536616231636366613934373137353337383531
          3935
```

Before fix:
```
ansible-inventory --host test1
ERROR! Unexpected Exception, this is probably a bug: Cannot json serialize hello
```

After fix:
```
ansible-inventory --host test1
{
    "ansible_verbosity": 0, 
    "password": "!vault $ANSIBLE_VAULT;1.1;AES256\n35633431306531613631343062326136343532663966383439613330656536623737636639643662\n3034323562373430366230313366353164333566346662310a303266663564383432663963376337\n65396539623831633535396361323462643037336166626262366631356461363434633963616562\n3931626531343732630a366662373736326266376536616231636366613934373137353337383531\n3935\n"
}
```
