### PR TITLE
Enable check mode for docker_image_facts

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_image_facts.py
+++ b/lib/ansible/modules/cloud/docker/docker_image_facts.py
@@ -219,7 +219,8 @@ def main():
     )
 
     client = AnsibleDockerClient(
-        argument_spec=argument_spec
+        argument_spec=argument_spec,
+        supports_check_mode=True
     )
 
     results = dict(


### PR DESCRIPTION
##### SUMMARY

This module never changes anything. As such, there is no reason not to
just enable check mode.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
docker_image_facts

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.3.0
  config file = /Users/cbyrum/.ansible.cfg
  configured module search path = [u'/Users/cbyrum/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/cbyrum/src/cloudplatform/openstack-deploy/.tox/py27/lib/python2.7/site-packages/ansible
  executable location = /Users/cbyrum/src/cloudplatform/openstack-deploy/.tox/py27/bin/ansible
  python version = 2.7.10 (default, Feb  7 2017, 00:08:15) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.34)]
```


##### ADDITIONAL INFORMATION
This is pretty straight forward. A read-only module should always support check mode.
