### PR TITLE
VMware: Allow user to select disk_mode

### DIFF
--- a/test/integration/targets/vmware_guest/tasks/disk_mode_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/disk_mode_d1_c1_f0.yml
@@ -30,7 +30,7 @@
 - debug: var=vcsim_instance
 - debug: var=vmlist
 
-- name: create new VMs with invalid disk size
+- name: create new VMs with invalid disk mode
   vmware_guest:
     validate_certs: False
     hostname: "{{ vcsim }}"
@@ -60,7 +60,7 @@
     that:
         - "disk_mode_d1_c1_f0.results|map(attribute='changed')|unique|list == [false]"
 
-- name: create new VMs with valid disk size
+- name: create new VMs with valid disk mode
   vmware_guest:
     validate_certs: False
     hostname: "{{ vcsim }}"
@@ -88,3 +88,33 @@
   assert:
     that:
         - "disk_mode_d1_c1_f0_2.results|map(attribute='changed')|unique|list == [true]"
+
+# TODO: vcsim does not support reconfiguration of disk mode, fails with types.InvalidDeviceSpec
+#- name: create new VMs with valid disk mode again
+#  vmware_guest:
+#    validate_certs: False
+#    hostname: "{{ vcsim }}"
+#    username: "{{ vcsim_instance['json']['username'] }}"
+#    password: "{{ vcsim_instance['json']['password'] }}"
+#    name: "{{ 'newvm_' + item|basename }}"
+#    guest_id: centos64Guest
+#    datacenter: "{{ (item|basename).split('_')[0] }}"
+#    hardware:
+#        num_cpus: 1
+#        memory_mb: 512
+#    disk:
+#        - size: 1gb
+#          type: eagerzeroedthick
+#          autoselect_datastore: True
+#          disk_mode: 'independent_persistent'
+#    state: poweredoff
+#    folder: "{{ item|dirname }}"
+#  with_items: "{{ vmlist['json'] }}"
+#  register: disk_mode_d1_c1_f0_2
+
+#- debug: var=disk_mode_d1_c1_f0_2
+
+#- name: assert that changes were not made
+#  assert:
+#    that:
+#        - "disk_mode_d1_c1_f0_2.results|map(attribute='changed')|unique|list == [false]"

--- a/test/integration/targets/vmware_guest/tasks/disk_mode_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/disk_mode_d1_c1_f0.yml
@@ -1,0 +1,90 @@
+# Test code for the vmware_guest module.
+# Copyright: (c) 2018, Abhijeet Kasurde <akasurde@redhat.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Wait for Flask controller to come up online
+  wait_for:
+    host: "{{ vcsim }}"
+    port: 5000
+    state: started
+
+- name: kill vcsim
+  uri:
+    url: http://{{ vcsim }}:5000/killall
+- name: start vcsim with no folders
+  uri:
+    url: http://{{ vcsim }}:5000/spawn?datacenter=1&cluster=1&folder=0
+  register: vcsim_instance
+
+- name: Wait for Flask controller to come up online
+  wait_for:
+    host: "{{ vcsim }}"
+    port: 443
+    state: started
+
+- name: get a list of VMS from vcsim
+  uri:
+    url: http://{{ vcsim }}:5000/govc_find?filter=VM
+  register: vmlist
+
+- debug: var=vcsim_instance
+- debug: var=vmlist
+
+- name: create new VMs with invalid disk size
+  vmware_guest:
+    validate_certs: False
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    name: "{{ 'newvm_' + item|basename }}"
+    guest_id: centos64Guest
+    datacenter: "{{ (item|basename).split('_')[0] }}"
+    hardware:
+        num_cpus: 1
+        memory_mb: 512
+    disk:
+        - size: 1gb
+          type: eagerzeroedthick
+          autoselect_datastore: True
+          disk_mode: 'invalid_disk_mode'
+    state: poweredoff
+    folder: "{{ item|dirname }}"
+  with_items: "{{ vmlist['json'] }}"
+  register: disk_mode_d1_c1_f0
+  ignore_errors: True
+
+- debug: var=disk_mode_d1_c1_f0
+
+- name: assert that changes were not made
+  assert:
+    that:
+        - "disk_mode_d1_c1_f0.results|map(attribute='changed')|unique|list == [false]"
+
+- name: create new VMs with valid disk size
+  vmware_guest:
+    validate_certs: False
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    name: "{{ 'newvm_' + item|basename }}"
+    guest_id: centos64Guest
+    datacenter: "{{ (item|basename).split('_')[0] }}"
+    hardware:
+        num_cpus: 1
+        memory_mb: 512
+    disk:
+        - size: 1gb
+          type: eagerzeroedthick
+          autoselect_datastore: True
+          disk_mode: 'independent_persistent'
+    state: poweredoff
+    folder: "{{ item|dirname }}"
+  with_items: "{{ vmlist['json'] }}"
+  register: disk_mode_d1_c1_f0_2
+
+- debug: var=disk_mode_d1_c1_f0_2
+
+- name: assert that changes were made
+  assert:
+    that:
+        - "disk_mode_d1_c1_f0_2.results|map(attribute='changed')|unique|list == [true]"

--- a/test/integration/targets/vmware_guest/tasks/main.yml
+++ b/test/integration/targets/vmware_guest/tasks/main.yml
@@ -29,3 +29,4 @@
 - include: vapp_d1_c1_f0.yml
 - include: disk_size_d1_c1_f0.yml
 - include: network_with_device.yml
+- include: disk_mode_d1_c1_f0.yml


### PR DESCRIPTION
##### SUMMARY
This fix allows user to select disk modes for given disk configuration
in the given VM.

Fixes: #37749

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/vmware/vmware_guest.py
test/integration/targets/vmware_guest/tasks/disk_mode_d1_c1_f0.yml
test/integration/targets/vmware_guest/tasks/main.yml

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6devel
```