### PR TITLE
Fix formatting error in rst plugin template

### DIFF
--- a/docs/templates/plugin.rst.j2
+++ b/docs/templates/plugin.rst.j2
@@ -405,5 +405,5 @@ Author
 {%   if plugin_type == 'module' %}
     If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/@{ source }@?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.
 {% else %}
-    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/plugins/@{ plugin_type }@/@{ source }@_` to improve it.
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/plugins/@{ plugin_type }@/@{ source }@`_ to improve it.
 {% endif %}


### PR DESCRIPTION
##### SUMMARY
The hyperlink syntax used is wrong and the resulting
rendered documents have broken links.

##### ISSUE TYPE
 - Docs Pull Request

##### ANSIBLE VERSION
latest
