### PR TITLE
Add retry to ec2_metadata_facts query

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_metadata_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_metadata_facts.py
@@ -448,12 +448,12 @@ class Ec2Metadata(object):
     def _fetch(self, url):
         response, info = fetch_url(self.module, url, force=True)
 
-        if not info.get('msg', '').startswith('OK'):
+        if info.get('status') not in (200, 404):
             time.sleep(3)
             # request went bad, retry once then raise
             self.module.warn('Retrying query to metadata service. First attempt failed: {0}'.format(info['msg']))
             response, info = fetch_url(self.module, url, force=True)
-            if not info.get('msg', '').startswith('OK'):
+            if info.get('status') not in (200, 404):
                 # fail out now
                 self.module.fail_json(msg='Failed to retrieve metadata from AWS: {0}'.format(info['msg']), response=info)
         if response:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
In the fetch step for the EC2 metadata, add a retry in case the metadata service is throttled or unavailable. Currently, EC2 metadata service issues show up as a KeyError, which isn't very intuitive or helpful. 

Fixes #38902 

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
ec2_metadata_facts

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```

cc/ @roadmapper 
