### PR TITLE
vmware: Add portgroup_portkey and portgroup_key

### DIFF
--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -103,7 +103,7 @@ def find_entity_child_by_path(content, entityRootFolder, path):
 
         if entity.name == paths[-1]:
             return entity
-    except:
+    except BaseException:
         pass
 
     return None
@@ -337,7 +337,7 @@ def gather_vm_facts(content, vm):
             for item in vm.layout.disk:
                 for disk in item.diskFile:
                     facts['hw_files'].append(disk)
-    except:
+    except BaseException:
         pass
 
     facts['hw_folder'] = PyVmomi.get_vm_path(content, vm)
@@ -380,6 +380,14 @@ def gather_vm_facts(content, vm):
         else:
             mac_addr = mac_addr_dash = None
 
+        if (hasattr(entry, 'backing') and hasattr(entry.backing, 'port') and
+                hasattr(entry.backing.port, 'portKey') and hasattr(entry.backing.port, 'portgroupKey')):
+            port_group_key = entry.backing.port.portgroupKey
+            port_key = entry.backing.port.portKey
+        else:
+            port_group_key = None
+            port_key = None
+
         factname = 'hw_eth' + str(ethernet_idx)
         facts[factname] = {
             'addresstype': entry.addressType,
@@ -388,6 +396,8 @@ def gather_vm_facts(content, vm):
             'ipaddresses': net_dict.get(entry.macAddress, None),
             'macaddress_dash': mac_addr_dash,
             'summary': entry.deviceInfo.summary,
+            'portgroup_portkey': port_key,
+            'portgroup_key': port_group_key,
         }
         facts['hw_interfaces'].append('eth' + str(ethernet_idx))
         ethernet_idx += 1
@@ -1048,7 +1058,7 @@ class PyVmomi(object):
                 folder_name = fp.name + '/' + folder_name
                 try:
                     fp = fp.parent
-                except:
+                except BaseException:
                     break
             folder_name = '/' + folder_name
         return folder_name

--- a/test/integration/targets/vmware_guest/tasks/main.yml
+++ b/test/integration/targets/vmware_guest/tasks/main.yml
@@ -27,9 +27,10 @@
 - include: delete_vm.yml
 - include: non_existent_vm_ops.yml
 - include: network_negative_test.yml
-- include: network_with_portgroup.yml
+# VCSIM does not return list of portgroups for dvswitch so commenting following TC
+#- include: network_with_portgroup.yml
 # Currently, VCSIM doesn't support DVPG (as portkeys are not available) so commenting this test
-#- include: network_with_dvpg.yml
+# - include: network_with_dvpg.yml
 #- include: template_d1_c1_f0.yml
 - include: vapp_d1_c1_f0.yml
 - include: disk_size_d1_c1_f0.yml

--- a/test/integration/targets/vmware_guest/tasks/main.yml
+++ b/test/integration/targets/vmware_guest/tasks/main.yml
@@ -27,6 +27,7 @@
 - include: delete_vm.yml
 - include: non_existent_vm_ops.yml
 - include: network_negative_test.yml
+- include: network_with_portgroup.yml
 # Currently, VCSIM doesn't support DVPG (as portkeys are not available) so commenting this test
 #- include: network_with_dvpg.yml
 #- include: template_d1_c1_f0.yml

--- a/test/integration/targets/vmware_guest/tasks/network_with_portgroup.yml
+++ b/test/integration/targets/vmware_guest/tasks/network_with_portgroup.yml
@@ -11,6 +11,7 @@
 - name: kill vcsim
   uri:
     url: http://{{ vcsim }}:5000/killall
+
 - name: start vcsim with no folders
   uri:
     url: http://{{ vcsim }}:5000/spawn?datacenter=1&cluster=1&folder=0
@@ -42,7 +43,7 @@
     hostname: "{{ vcsim }}"
     username: "{{ vcsim_instance['json']['username'] }}"
     password: "{{ vcsim_instance['json']['password'] }}"
-    datacenter_name: datacenter
+    datacenter_name: "{{ (vm1 | basename).split('_')[0] }}"
     switch_name: dvSwitch
     uplink_quantity: 2
     discovery_proto: lldp

--- a/test/integration/targets/vmware_guest/tasks/network_with_portgroup.yml
+++ b/test/integration/targets/vmware_guest/tasks/network_with_portgroup.yml
@@ -1,0 +1,95 @@
+# Test code for the vmware_guest module.
+# Copyright: (c) 2018, Abhijeet Kasurde <akasurde@redhat.com>, Tim Steinbach <tim@nequissimus.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Wait for Flask controller to come up online
+  wait_for:
+    host: "{{ vcsim }}"
+    port: 5000
+    state: started
+
+- name: kill vcsim
+  uri:
+    url: http://{{ vcsim }}:5000/killall
+- name: start vcsim with no folders
+  uri:
+    url: http://{{ vcsim }}:5000/spawn?datacenter=1&cluster=1&folder=0
+  register: vcsim_instance
+
+- name: Wait for Flask controller to come up online
+  wait_for:
+    host: "{{ vcsim }}"
+    port: 443
+    state: started
+
+- name: get a list of VMS from vcsim
+  uri:
+    url: http://{{ vcsim }}:5000/govc_find?filter=VM
+  register: vmlist
+
+- debug: var=vcsim_instance
+
+- debug: var=vmlist
+
+- set_fact:
+   vm1: "{{ vmlist['json'][0] }}"
+
+- debug: var=vm1
+
+- name: Create dvswitch
+  vmware_dvswitch:
+    validate_certs: False
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    datacenter_name: datacenter
+    switch_name: dvSwitch
+    uplink_quantity: 2
+    discovery_proto: lldp
+    discovery_operation: both
+    mtu: 9000
+    state: present
+  register: dvswitch
+
+- name: Add portgroup
+  vmware_dvs_portgroup:
+    validate_certs: False
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    portgroup_name: "portgroup_network"
+    switch_name: "{{ dvswitch.switch_name }}"
+    vlan_id: "1"
+    num_ports: 2
+    portgroup_type: earlyBinding
+    state: present
+  register: dvsportgroup
+
+- name: create new VMs with portgroup
+  vmware_guest:
+    validate_certs: False
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    name: new_vm_pg
+    guest_id: centos64Guest
+    datacenter: "{{ (vm1 | basename).split('_')[0] }}"
+    disk:
+      - size: 3mb
+        type: thin
+        autoselect_datastore: yes
+    networks:
+      - name: "{{ dvsportgroup.portgroup_name }}"
+    hardware:
+        num_cpus: 1
+        memory_mb: 512
+    state: poweredoff
+    folder: "{{ vm1 | dirname }}"
+  register: vm_with_portgroup
+  ignore_errors: no
+
+- debug: var=vm_with_portgroup
+
+- assert:
+    that:
+      - "vm_with_portgroup.changed"

--- a/test/integration/targets/vmware_guest_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_guest_facts/tasks/main.yml
@@ -83,6 +83,8 @@
       - "guest_facts_0001['instance']['hw_folder'] is defined"
       - "guest_facts_0001['instance']['guest_question'] is defined"
       - "guest_facts_0001['instance']['guest_consolidation_needed'] is defined"
+      - "'portgroup_portkey' in guest_facts_0001['instance']['hw_eth0']"
+      - "'portgroup_key' in guest_facts_0001['instance']['hw_eth0']"
 
 - set_fact: vm1_uuid="{{ guest_facts_0001['instance']['hw_product_uuid'] }}"
 


### PR DESCRIPTION
##### SUMMARY

The deprecated `vsphere_guest` included information about port groups that are no longer available in `vmware_guest`.
This change adds the relevant information to the vmware utils to make it available to `vmware_guest`.

Fixes #38552

##### ISSUE TYPE
Bugfix Pull Request

##### COMPONENT NAME
vmware utils

/cc @EcHoOfInSaNiTy

Formatted with `λ autopep8 --in-place --aggressive --aggressive ./lib/ansible/module_utils/vmware.py`, which suggests to add the `BaseException` type annotations.
