### PR TITLE
Increase possible wait time for nonmonotonic subnet attributes

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_subnet.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_subnet.py
@@ -508,7 +508,7 @@ def ensure_subnet_present(conn, module):
 
 
 def ensure_final_subnet(conn, module, subnet, start_time):
-    for rewait in range(0, 10):
+    for rewait in range(0, 30):
         map_public_correct = False
         assign_ipv6_correct = False
 
@@ -531,7 +531,7 @@ def ensure_final_subnet(conn, module, subnet, start_time):
         if map_public_correct and assign_ipv6_correct:
             break
 
-        time.sleep(3)
+        time.sleep(5)
         subnet = get_matching_subnet(conn, module, module.params['vpc_id'], module.params['cidr'])
 
     return subnet


### PR DESCRIPTION
##### SUMMARY
I am still running into irregular flaky tests because of these two attributes. Should I increase the time more than this?

Fixes #36083

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/ec2_vpc_subnet.py

##### ANSIBLE VERSION
```
2.6.0
```
