### PR TITLE
Some more fixes for the docs :ref: disambiguation

### DIFF
--- a/docs/bin/plugin_formatter.py
+++ b/docs/bin/plugin_formatter.py
@@ -560,6 +560,7 @@ These modules are currently shipped with Ansible, but will most likely be shippe
                          'modules': data['modules'],
                          'slug': data['slug'],
                          'module_info': plugin_info,
+                         'plugin_type': plugin_type
                          }
         text = templates['support_list'].render(template_data)
         write_data(text, output_dir, data['output'])

--- a/docs/docsite/rst/user_guide/intro_adhoc.rst
+++ b/docs/docsite/rst/user_guide/intro_adhoc.rst
@@ -94,12 +94,12 @@ specify that all of the time.  We'll use ``-m`` in later examples to
 run some other :doc:`modules`.
 
 .. note::
-   The :ref:`command module <module_command>` does not support extended shell syntax like piping and
+   The :ref:`command module <command_module>` does not support extended shell syntax like piping and
    redirects (although shell variables will always work). If your command requires shell-specific
    syntax, use the `shell` module instead. Read more about the differences on the
    :ref:`working_with_modules` page.
 
-Using the :ref:`shell module <module_shell>` looks like this::
+Using the :ref:`shell module <shell_module>` looks like this::
 
     $ ansible raleigh -m shell -a 'echo $TERM'
 

--- a/docs/templates/list_of_CATEGORY_plugins.rst.j2
+++ b/docs/templates/list_of_CATEGORY_plugins.rst.j2
@@ -25,7 +25,7 @@
 .. toctree:: :maxdepth: 1
 
 {% for module in info['_modules'] | sort %}
-  :ref:`@{ module }@`{% if module_info[module]['deprecated'] %} **(D)**{% endif%} -- @{ module_info[module]['doc']['short_description'] }@
+  :ref:`@{ module }@_@{ plugin_type }@`{% if module_info[module]['deprecated'] %} **(D)**{% endif%} -- @{ module_info[module]['doc']['short_description'] }@
 {% endfor %}
 
 {% endfor %}


### PR DESCRIPTION
The big one is that we needed to set plugin_type when we processed the by_support template.

Also added to list_of_CATEGORY_plugins page (which might not be used)
and corrected a place where I did module_name instead of name_module

##### ISSUE TYPE
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
various docs

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel 2.5
```
