### PR TITLE
[do not merge] Add new test for switching off detached head

### DIFF
--- a/test/integration/targets/git/tasks/specific-revision.yml
+++ b/test/integration/targets/git/tasks/specific-revision.yml
@@ -42,6 +42,17 @@
     that:
       - 'git_result.stdout == "4e739a34719654db7b04896966e2354e1256ea5d"'
 
+- name: SPECIFIC-REVISION | update to HEAD from detached HEAD state
+  git:
+    repo: "{{ repo_dir }}/format1"
+    dest: "{{ checkout_dir }}"
+    version: HEAD
+  register: git_result
+
+- assert:
+    that:
+      - git_result is changed
+
 # Test a revision not available under refs/heads/ or refs/tags/
 
 - name: SPECIFIC-REVISION | attempt to get unavailable revision


### PR DESCRIPTION
This is in support of https://github.com/ansible/ansible/pull/38879

I want to get a clean run of the Ansible CI, so that I can verify that this new task produces the _exact_ error that I'm expecting.

A mocked local test yields

```
TASK [SPECIFIC-REVISION | update to HEAD from detached HEAD state] *****************************************************************************************************************
fatal: [localhost]: FAILED! => {"changed": false, "cmd": "/usr/local/bin/git reset --hard origin/c1b69a96653cd16a130dd5cb264a6bee8a91662a --", "msg": "Failed to checkout branch c1b69a96653cd16a130dd5cb264a6bee8a91662a", "rc": 128, "stderr": "fatal: Failed to resolve 'origin/c1b69a96653cd16a130dd5cb264a6bee8a91662a' as a valid revision.\n", "stderr_lines": ["fatal: Failed to resolve 'origin/c1b69a96653cd16a130dd5cb264a6bee8a91662a' as a valid revision."], "stdout": "", "stdout_lines": []}
```