### PR TITLE
remove properties from vars in include_role

### DIFF
--- a/lib/ansible/playbook/included_file.py
+++ b/lib/ansible/playbook/included_file.py
@@ -151,7 +151,7 @@ class IncludedFile:
                         for from_arg in new_task.FROM_ARGS:
                             if from_arg in include_variables:
                                 from_key = from_arg.replace('_from', '')
-                                new_task._from_files[from_key] = templar.template(include_variables[from_arg])
+                                new_task._from_files[from_key] = templar.template(include_variables.pop(from_arg))
 
                         inc_file = IncludedFile("role", include_variables, new_task, is_role=True)
 

--- a/lib/ansible/playbook/included_file.py
+++ b/lib/ansible/playbook/included_file.py
@@ -142,7 +142,7 @@ class IncludedFile:
                         inc_file = IncludedFile(include_file, include_variables, original_task)
                     else:
                         # template the included role's name here
-                        role_name = include_variables.get('name', include_variables.get('role', None))
+                        role_name = include_variables.pop('name', include_variables.pop('role', None))
                         if role_name is not None:
                             role_name = templar.template(role_name)
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
otherwise `name=` option will overwrite any `name`  .. same with `role`.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
include_role
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.4-2.6
```
