### PR TITLE
Fixes #30599 Ini_file module: Options within no section managed

### DIFF
--- a/lib/ansible/modules/files/ini_file.py
+++ b/lib/ansible/modules/files/ini_file.py
@@ -170,8 +170,21 @@ def do_ini(module, filename, section=None, option=None, value=None,
         ini_lines[-1] += '\n'
         changed = True
 
-    # append a fake section line to simplify the logic
+    # append fake section lines to simplify the logic
+    # At top:
+    # Fake random section to do not match any other in the file
+    # Using commit hash as fake section name
+    fake_section_name = "ad01e11446efb704fcdbdb21f2c43757423d91c5"
+
+    # Insert it at the beginning
+    ini_lines.insert(0, '[%s]' % fake_section_name)
+
+    # At botton:
     ini_lines.append('[')
+
+    # If no section is defined, fake section is used
+    if not section:
+        section = fake_section_name
 
     within_section = not section
     section_start = 0
@@ -240,6 +253,7 @@ def do_ini(module, filename, section=None, option=None, value=None,
                         break
 
     # remove the fake section line
+    del ini_lines[0]
     del ini_lines[-1:]
 
     if not within_section and option and state == 'present':

--- a/test/integration/targets/ini_file/tasks/main.yml
+++ b/test/integration/targets/ini_file/tasks/main.yml
@@ -251,3 +251,92 @@
       - result10.changed == True
       - result10.msg == 'option changed'
       - content10 == expected10
+
+- name: Ensure "hate=coke" is created within no section
+  ini_file:
+    section:
+    path: "{{ output_file }}"
+    option: hate
+    value: coke
+  register: result11
+
+- name: set expected content and get current ini file content
+  set_fact:
+    expected11: "hate = coke"
+    content11: "{{ lookup('file', output_file) }}"
+
+- name: assert 'changed' is true and content is OK (no section)
+  assert:
+    that:
+      - result11 is changed
+      - result11.msg == 'option added'
+      - content11 == expected11
+
+- name: Ensure "hate=coke" is modified as "hate=water" within no section
+  ini_file:
+    path: "{{ output_file }}"
+    option: hate
+    value: water
+    section:
+  register: result12
+
+- name: set expected content and get current ini file content
+  set_fact:
+    expected12: "hate = water"
+
+    content12: "{{ lookup('file', output_file) }}"
+
+- name: assert 'changed' is true and content is OK (no section)
+  assert:
+    that:
+      - result12 is changed
+      - result12.msg == 'option changed'
+      - content12 == expected12
+
+- name: remove option 'hate' within no section
+  ini_file:
+    section:
+    path: "{{ output_file }}"
+    option: hate
+    state: absent
+  register: result13
+
+- name: get current ini file content
+  set_fact:
+    content13: "{{ lookup('file', output_file) }}"
+
+- name: assert changed (no section)
+  assert:
+    that:
+      - result13 is changed
+      - result13.msg == 'option changed'
+      - content13 == ""
+
+- name: Check add option without section before existing section
+  block:
+    - name: Add option with section
+      ini_file:
+        path: "{{ output_file }}"
+        section: drinks
+        option: hate
+        value: water
+    - name: Add option without section
+      ini_file:
+        path: "{{ output_file }}"
+        section:
+        option: like
+        value: tea
+
+- name: set expected content and get current ini file content
+  set_fact:
+    expected14: |-
+      like = tea
+
+      [drinks]
+      hate = water
+    content14: "{{ lookup('file', output_file) }}"
+
+- name: Verify content of ini file is as expected
+  assert:
+    that:
+      - content14 == expected14

--- a/test/integration/targets/ini_file/tasks/main.yml
+++ b/test/integration/targets/ini_file/tasks/main.yml
@@ -252,6 +252,12 @@
       - result10.msg == 'option changed'
       - content10 == expected10
 
+- name: Clean test file
+  copy:
+    content: ""
+    dest: "{{ output_file }}"
+    force: yes
+
 - name: Ensure "hate=coke" is created within no section
   ini_file:
     section:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
Fixes #30599
Options within no sections aren't included, deleted or modified. These are just unmanged. This pull request solves this.

The fix consists in creating a fake section at the beginning of the execution and remove it just before the file is written. This way options with or without sections are treated in the same way, heving a consisten behaviour. Furthermore, creating fake sections is something that was already being done in the module.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
- ini_file

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0 (devel a5491cac8c) last updated 2018/04/18 20:57:17 (GMT +200)
  config file = /home/jdani/.ansible.cfg
  configured module search path = [u'/home/jdani/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/jdani/freak/devel/ansible/ansible/lib/ansible
  executable location = /home/jdani/freak/devel/ansible/ansible/bin/ansible
  python version = 2.7.14 (default, Sep 23 2017, 22:06:14) [GCC 7.2.0]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
