### PR TITLE
[ec2_ami] Ensure name or image_id is provided for state=present

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_ami.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_ami.py
@@ -656,7 +656,7 @@ def main():
         virtualization_type=dict(default='hvm'),
         root_device_name=dict(),
         delete_snapshot=dict(default=False, type='bool'),
-        name=dict(default=''),
+        name=dict(),
         wait=dict(type='bool', default=False),
         wait_timeout=dict(default=900, type='int'),
         description=dict(default=''),
@@ -679,6 +679,11 @@ def main():
             ['state', 'absent', ['image_id']],
         ]
     )
+
+    # Using a required_one_of=[['name', 'image_id']] overrides the message that should be provided by
+    # the required_if for state=absent, so check manually instead
+    if not any([module.params['image_id'], module.params['name']]):
+        module.fail_json(msg="one of the following is required: name, image_id")
 
     try:
         region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)

--- a/test/integration/targets/ec2_ami/tasks/main.yml
+++ b/test/integration/targets/ec2_ami/tasks/main.yml
@@ -87,6 +87,30 @@
 
     # ============================================================
 
+    - name: test clean failure if not providing image_id or name with state=present
+      ec2_ami:
+        ec2_region: '{{ec2_region}}'
+        ec2_access_key: '{{ec2_access_key}}'
+        ec2_secret_key: '{{ec2_secret_key}}'
+        security_token: '{{security_token}}'
+        instance_id: '{{ setup_instance.instance_ids[0] }}'
+        state: present
+        description: '{{ ec2_ami_description }}'
+        tags:
+          Name: '{{ ec2_ami_name }}_ami'
+        wait: yes
+        root_device_name: /dev/xvda
+      register: result
+      ignore_errors: yes
+
+    - name: assert error message is helpful
+      assert:
+        that:
+          - result.failed
+          - "result.msg == 'one of the following is required: name, image_id'"
+
+    # ============================================================
+
     - name: create an image from the instance
       ec2_ami:
         ec2_region: '{{ec2_region}}'
@@ -295,7 +319,6 @@
         security_token: '{{security_token}}'
         state: present
         image_id: '{{ result.image_id }}'
-        name: '{{ ec2_ami_name }}_ami'
         description: '{{ ec2_ami_description }}'
         tags:
           Name: '{{ ec2_ami_name }}_ami'


### PR DESCRIPTION
Add integration tests for backward compatibility and ensuring name or image_id is provided

Will cherry pick to https://github.com/ansible/ansible/pull/38585 for backporting.

##### SUMMARY
Follow up to https://github.com/ansible/ansible/pull/38514. 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/ec2_ami.py

##### ANSIBLE VERSION
```
2.6.0
```
