### PR TITLE
[WIP] Generalize connection command running and I/O for all connection types

### DIFF
--- a/lib/ansible/plugins/connection/__init__.py
+++ b/lib/ansible/plugins/connection/__init__.py
@@ -8,13 +8,17 @@ __metaclass__ = type
 import fcntl
 import gettext
 import os
+import pty
 import shlex
+import subprocess
 from abc import abstractmethod, abstractproperty
 from functools import wraps
 
 from ansible import constants as C
+from ansible.compat import selectors
 from ansible.errors import AnsibleError
-from ansible.module_utils.six import string_types
+from ansible.module_utils.six import PY3, string_types, text_type, binary_type
+from ansible.module_utils.six.moves import shlex_quote
 from ansible.module_utils._text import to_bytes, to_text
 from ansible.plugins import AnsiblePlugin
 from ansible.plugins.loader import shell_loader
@@ -266,6 +270,330 @@ class ConnectionBase(AnsiblePlugin):
     def check_missing_password(self, b_output):
         b_missing_password = to_bytes(gettext.dgettext(self._play_context.become_method, C.BECOME_MISSING_STRINGS[self._play_context.become_method]))
         return b_missing_password and b_missing_password in b_output
+
+    def _send_initial_data(self, fh, in_data):
+        '''
+        Writes initial data to the stdin filehandle of the subprocess and closes
+        it. (The handle must be closed; otherwise, for example, "sftp -b -" will
+        just hang forever waiting for more commands.)
+        '''
+
+        display.debug('Sending initial data')
+
+        try:
+            fh.write(to_bytes(in_data))
+            fh.close()
+        except (OSError, IOError):
+            raise AnsibleConnectionFailure('Data could not be sent to remote host. Make sure this host is reachable using the configured connection method.')
+
+        display.debug('Sent initial data (%d bytes)' % len(in_data))
+
+    def _bare_run(self, cmd, in_data, executable=None, sudoable=True, external_fds=None):
+        '''
+        Starts the command and communicates with it until it ends.
+        '''
+
+        # Start the given command. If we don't need to pipeline data, we can try
+        # to use a pseudo-tty. If we are pipelining data, or can't create a pty,
+        # we fall back to using plain old pipes.
+
+        p = None
+
+        use_shell = False
+        if isinstance(cmd, (text_type, binary_type)):
+            cmd = to_bytes(cmd)
+            display_cmd = shlex_quote(to_text(cmd))
+            use_shell = True
+        else:
+            cmd = list(map(to_bytes, cmd))
+            display_cmd = list(map(shlex_quote, map(to_text, cmd)))
+
+        display.vvv(u'EXEC {0}'.format(display_cmd), host=getattr(self, 'host', None))
+
+        if not in_data:
+            try:
+                # Make sure stdin is a proper pty to avoid tcgetattr errors
+                master, slave = pty.openpty()
+                if PY3 and self._play_context.password and external_fds is not None:
+                    p = subprocess.Popen(cmd, shell=use_shell, executable=executable, stdin=slave, stdout=subprocess.PIPE, stderr=subprocess.PIPE, pass_fds=external_fds)
+                else:
+                    p = subprocess.Popen(cmd, shell=use_shell, executable=executable, stdin=slave, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                stdin = os.fdopen(master, 'wb', 0)
+                os.close(slave)
+            except (OSError, IOError):
+                p = None
+
+        if not p:
+            if PY3 and self._play_context.password:
+                p = subprocess.Popen(cmd, shell=use_shell, executable=executable, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, pass_fds=external_fds)
+            else:
+                p = subprocess.Popen(cmd, shell=use_shell, executable=executable, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            stdin = p.stdin
+
+        # If we are using external password authentication (ie. sshpass),
+        # write the password into the external pipe provided.
+
+        if self._play_context.password and external_fds is not None:
+            os.close(external_fds[0])
+            try:
+                os.write(external_fds[1], to_bytes(self._play_context.password) + b'\n')
+            except OSError as e:
+                # Ignore broken pipe errors if the external process has exited.
+                if e.errno != errno.EPIPE or p.poll() is None:
+                    raise
+            os.close(external_fds[1])
+
+        #
+        # I/O state machine
+        #
+
+        # Now we read and accumulate output from the running process until it
+        # exits. Depending on the circumstances, we may also need to write an
+        # escalation password and/or pipelined input to the process.
+
+        states = [
+            'awaiting_prompt', 'awaiting_escalation', 'ready_to_send', 'awaiting_exit'
+        ]
+
+        # Are we requesting privilege escalation? Right now, we may be invoked
+        # to execute sftp/scp with sudoable=True, but we can request escalation
+        # only when using ssh. Otherwise we can send initial data straightaway.
+
+        state = states.index('ready_to_send')
+        if self._play_context.become and sudoable:
+            if self._play_context.prompt:
+                # We're requesting escalation with a password, so we have to
+                # wait for a password prompt.
+                state = states.index('awaiting_prompt')
+                display.debug(u'Initial state: %s: %s' % (states[state], self._play_context.prompt))
+            elif self._play_context.success_key:
+                # We're requesting escalation without a password, so we have to
+                # detect success/failure before sending any initial data.
+                state = states.index('awaiting_escalation')
+                display.debug(u'Initial state: %s: %s' % (states[state], self._play_context.success_key))
+
+        # We store accumulated stdout and stderr output from the process here,
+        # but strip any privilege escalation prompt/confirmation lines first.
+        # Output is accumulated into tmp_*, complete lines are extracted into
+        # an array, then checked and removed or copied to stdout or stderr. We
+        # set any flags based on examining the output in self._flags.
+
+        b_stdout = b_stderr = b''
+        b_tmp_stdout = b_tmp_stderr = b''
+
+        self._flags = dict(
+            become_prompt=False, become_success=False,
+            become_error=False, become_nopasswd_error=False
+        )
+
+        # select timeout should be longer than the connect timeout, otherwise
+        # they will race each other when we can't connect, and the connect
+        # timeout usually fails
+        timeout = 2 + self._play_context.timeout
+        for fd in (p.stdout, p.stderr):
+            fcntl.fcntl(fd, fcntl.F_SETFL, fcntl.fcntl(fd, fcntl.F_GETFL) | os.O_NONBLOCK)
+
+        # TODO: bcoca would like to use SelectSelector() when open
+        # filehandles is low, then switch to more efficient ones when higher.
+        # select is faster when filehandles is low.
+        selector = selectors.DefaultSelector()
+        selector.register(p.stdout, selectors.EVENT_READ)
+        selector.register(p.stderr, selectors.EVENT_READ)
+
+        # If we can send initial data without waiting for anything, we do so
+        # before we start polling
+        if states[state] == 'ready_to_send' and in_data:
+            self._send_initial_data(stdin, in_data)
+            state += 1
+
+        try:
+            while True:
+                poll = p.poll()
+                events = selector.select(timeout)
+
+                # We pay attention to timeouts only while negotiating a prompt.
+
+                if not events:
+                    # We timed out
+                    if state <= states.index('awaiting_escalation'):
+                        # If the process has already exited, then it's not really a
+                        # timeout; we'll let the normal error handling deal with it.
+                        if poll is not None:
+                            break
+                        self._terminate_process(p)
+                        raise AnsibleError('Timeout (%ds) waiting for privilege escalation prompt: %s' % (timeout, to_native(b_stdout)))
+
+                # Read whatever output is available on stdout and stderr, and stop
+                # listening to the pipe if it's been closed.
+
+                for key, event in events:
+                    if key.fileobj == p.stdout:
+                        b_chunk = p.stdout.read()
+                        if b_chunk == b'':
+                            # stdout has been closed, stop watching it
+                            selector.unregister(p.stdout)
+                            # When ssh has ControlMaster (+ControlPath/Persist) enabled, the
+                            # first connection goes into the background and we never see EOF
+                            # on stderr. If we see EOF on stdout, lower the select timeout
+                            # to reduce the time wasted selecting on stderr if we observe
+                            # that the process has not yet existed after this EOF. Otherwise
+                            # we may spend a long timeout period waiting for an EOF that is
+                            # not going to arrive until the persisted connection closes.
+                            timeout = 1
+                        b_tmp_stdout += b_chunk
+                        display.debug("stdout chunk (state=%s):\n>>>%s<<<\n" % (state, to_text(b_chunk)))
+                    elif key.fileobj == p.stderr:
+                        b_chunk = p.stderr.read()
+                        if b_chunk == b'':
+                            # stderr has been closed, stop watching it
+                            selector.unregister(p.stderr)
+                        b_tmp_stderr += b_chunk
+                        display.debug("stderr chunk (state=%s):\n>>>%s<<<\n" % (state, to_text(b_chunk)))
+
+                # We examine the output line-by-line until we have negotiated any
+                # privilege escalation prompt and subsequent success/error message.
+                # Afterwards, we can accumulate output without looking at it.
+
+                if state < states.index('ready_to_send'):
+                    if b_tmp_stdout:
+                        b_output, b_unprocessed = self._examine_output('stdout', states[state], b_tmp_stdout, sudoable)
+                        b_stdout += b_output
+                        b_tmp_stdout = b_unprocessed
+
+                    if b_tmp_stderr:
+                        b_output, b_unprocessed = self._examine_output('stderr', states[state], b_tmp_stderr, sudoable)
+                        b_stderr += b_output
+                        b_tmp_stderr = b_unprocessed
+                else:
+                    b_stdout += b_tmp_stdout
+                    b_stderr += b_tmp_stderr
+                    b_tmp_stdout = b_tmp_stderr = b''
+
+                # If we see a privilege escalation prompt, we send the password.
+                # (If we're expecting a prompt but the escalation succeeds, we
+                # didn't need the password and can carry on regardless.)
+
+                if states[state] == 'awaiting_prompt':
+                    if self._flags['become_prompt']:
+                        display.debug('Sending become_pass in response to prompt')
+                        stdin.write(to_bytes(self._play_context.become_pass) + b'\n')
+                        # On python3 stdin is a BufferedWriter, and we don't have a guarantee
+                        # that the write will happen without a flush
+                        stdin.flush()
+                        self._flags['become_prompt'] = False
+                        state += 1
+                    elif self._flags['become_success']:
+                        state += 1
+
+                # We've requested escalation (with or without a password), now we
+                # wait for an error message or a successful escalation.
+
+                if states[state] == 'awaiting_escalation':
+                    if self._flags['become_success']:
+                        display.debug('Escalation succeeded')
+                        self._flags['become_success'] = False
+                        state += 1
+                    elif self._flags['become_error']:
+                        display.debug('Escalation failed')
+                        self._terminate_process(p)
+                        self._flags['become_error'] = False
+                        raise AnsibleError('Incorrect %s password' % self._play_context.become_method)
+                    elif self._flags['become_nopasswd_error']:
+                        display.debug('Escalation requires password')
+                        self._terminate_process(p)
+                        self._flags['become_nopasswd_error'] = False
+                        raise AnsibleError('Missing %s password' % self._play_context.become_method)
+                    elif self._flags['become_prompt']:
+                        # This shouldn't happen, because we should see the "Sorry,
+                        # try again" message first.
+                        display.debug('Escalation prompt repeated')
+                        self._terminate_process(p)
+                        self._flags['become_prompt'] = False
+                        raise AnsibleError('Incorrect %s password' % self._play_context.become_method)
+
+                # Once we're sure that the privilege escalation prompt, if any, has
+                # been dealt with, we can send any initial data and start waiting
+                # for output.
+
+                if states[state] == 'ready_to_send':
+                    if in_data:
+                        self._send_initial_data(stdin, in_data)
+                    state += 1
+
+                # Now we're awaiting_exit: has the child process exited? If it has,
+                # and we've read all available output from it, we're done.
+
+                if poll is not None:
+                    if not selector.get_map() or not events:
+                        break
+                    # We should not see further writes to the stdout/stderr file
+                    # descriptors after the process has closed, set the select
+                    # timeout to gather any last writes we may have missed.
+                    timeout = 0
+                    continue
+
+                # If the process has not yet exited, but we've already read EOF from
+                # its stdout and stderr (and thus no longer watching any file
+                # descriptors), we can just wait for it to exit.
+
+                elif not selector.get_map():
+                    p.wait()
+                    break
+
+                # Otherwise there may still be outstanding data to read.
+        finally:
+            selector.close()
+            # close stdin after process is terminated and stdout/stderr are read
+            # completely (see also issue #848)
+            stdin.close()
+
+        return (p.returncode, b_stdout, b_stderr)
+
+    def _examine_output(self, source, state, b_chunk, sudoable):
+        '''
+        Takes a string, extracts complete lines from it, tests to see if they
+        are a prompt, error message, etc., and sets appropriate flags in self.
+        Prompt and success lines are removed.
+
+        Returns the processed (i.e. possibly-edited) output and the unprocessed
+        remainder (to be processed with the next chunk) as strings.
+        '''
+
+        output = []
+        for b_line in b_chunk.splitlines(True):
+            display_line = to_text(b_line).rstrip('\r\n')
+            suppress_output = False
+
+            # display.debug("Examining line (source=%s, state=%s): '%s'" % (source, state, display_line))
+            if self._play_context.prompt and self.check_password_prompt(b_line):
+                display.debug("become_prompt: (source=%s, state=%s): '%s'" % (source, state, display_line))
+                self._flags['become_prompt'] = True
+                suppress_output = True
+            elif self._play_context.success_key and self.check_become_success(b_line):
+                display.debug("become_success: (source=%s, state=%s): '%s'" % (source, state, display_line))
+                self._flags['become_success'] = True
+                suppress_output = True
+            elif sudoable and self.check_incorrect_password(b_line):
+                display.debug("become_error: (source=%s, state=%s): '%s'" % (source, state, display_line))
+                self._flags['become_error'] = True
+            elif sudoable and self.check_missing_password(b_line):
+                display.debug("become_nopasswd_error: (source=%s, state=%s): '%s'" % (source, state, display_line))
+                self._flags['become_nopasswd_error'] = True
+
+            if not suppress_output:
+                output.append(b_line)
+
+        # The chunk we read was most likely a series of complete lines, but just
+        # in case the last line was incomplete (and not a prompt, which we would
+        # have removed from the output), we retain it to be processed with the
+        # next chunk.
+
+        remainder = b''
+        if output and not output[-1].endswith(b'\n'):
+            remainder = output[-1]
+            output = output[:-1]
+
+        return b''.join(output), remainder
 
     def connection_lock(self):
         f = self._play_context.connection_lockfd

--- a/lib/ansible/plugins/connection/local.py
+++ b/lib/ansible/plugins/connection/local.py
@@ -75,66 +75,8 @@ class Connection(ConnectionBase):
         super(Connection, self).exec_command(cmd, in_data=in_data, sudoable=sudoable)
 
         display.debug("in local.exec_command()")
-
         executable = C.DEFAULT_EXECUTABLE.split()[0] if C.DEFAULT_EXECUTABLE else None
-
-        display.vvv(u"EXEC {0}".format(to_text(cmd)), host=self._play_context.remote_addr)
-        display.debug("opening command with Popen()")
-
-        if isinstance(cmd, (text_type, binary_type)):
-            cmd = to_bytes(cmd)
-        else:
-            cmd = map(to_bytes, cmd)
-
-        p = subprocess.Popen(
-            cmd,
-            shell=isinstance(cmd, (text_type, binary_type)),
-            executable=executable,  # cwd=...
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-        )
-        display.debug("done running command with Popen()")
-
-        if self._play_context.prompt and sudoable:
-            fcntl.fcntl(p.stdout, fcntl.F_SETFL, fcntl.fcntl(p.stdout, fcntl.F_GETFL) | os.O_NONBLOCK)
-            fcntl.fcntl(p.stderr, fcntl.F_SETFL, fcntl.fcntl(p.stderr, fcntl.F_GETFL) | os.O_NONBLOCK)
-            selector = selectors.DefaultSelector()
-            selector.register(p.stdout, selectors.EVENT_READ)
-            selector.register(p.stderr, selectors.EVENT_READ)
-
-            become_output = b''
-            try:
-                while not self.check_become_success(become_output) and not self.check_password_prompt(become_output):
-                    events = selector.select(self._play_context.timeout)
-                    if not events:
-                        stdout, stderr = p.communicate()
-                        raise AnsibleError('timeout waiting for privilege escalation password prompt:\n' + to_native(become_output))
-
-                    for key, event in events:
-                        if key.fileobj == p.stdout:
-                            chunk = p.stdout.read()
-                        elif key.fileobj == p.stderr:
-                            chunk = p.stderr.read()
-
-                    if not chunk:
-                        stdout, stderr = p.communicate()
-                        raise AnsibleError('privilege output closed while waiting for password prompt:\n' + to_native(become_output))
-                    become_output += chunk
-            finally:
-                selector.close()
-
-            if not self.check_become_success(become_output):
-                p.stdin.write(to_bytes(self._play_context.become_pass, errors='surrogate_or_strict') + b'\n')
-            fcntl.fcntl(p.stdout, fcntl.F_SETFL, fcntl.fcntl(p.stdout, fcntl.F_GETFL) & ~os.O_NONBLOCK)
-            fcntl.fcntl(p.stderr, fcntl.F_SETFL, fcntl.fcntl(p.stderr, fcntl.F_GETFL) & ~os.O_NONBLOCK)
-
-        display.debug("getting output with communicate()")
-        stdout, stderr = p.communicate(in_data)
-        display.debug("done communicating")
-
-        display.debug("done with local.exec_command()")
-        return (p.returncode, stdout, stderr)
+        return self._bare_run(cmd, in_data=in_data, executable=executable, sudoable=sudoable)
 
     def put_file(self, in_path, out_path):
         ''' transfer a file from local to local '''

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -207,7 +207,6 @@ from functools import wraps
 from ansible import constants as C
 from ansible.errors import AnsibleError, AnsibleConnectionFailure, AnsibleFileNotFound
 from ansible.errors import AnsibleOptionsError
-from ansible.compat import selectors
 from ansible.module_utils.six import PY3, text_type, binary_type
 from ansible.module_utils.six.moves import shlex_quote
 from ansible.module_utils._text import to_bytes, to_native, to_text
@@ -305,6 +304,7 @@ class Connection(ConnectionBase):
         self.user = self._play_context.remote_user
         self.control_path = C.ANSIBLE_SSH_CONTROL_PATH
         self.control_path_dir = C.ANSIBLE_SSH_CONTROL_PATH_DIR
+        self.sshpass_pipe = None
 
     # The connection is created by running ssh/scp/sftp from the exec_command,
     # put_file, and fetch_file methods, so we don't need to do any connection
@@ -516,23 +516,6 @@ class Connection(ConnectionBase):
 
         return b_command
 
-    def _send_initial_data(self, fh, in_data):
-        '''
-        Writes initial data to the stdin filehandle of the subprocess and closes
-        it. (The handle must be closed; otherwise, for example, "sftp -b -" will
-        just hang forever waiting for more commands.)
-        '''
-
-        display.debug('Sending initial data')
-
-        try:
-            fh.write(to_bytes(in_data))
-            fh.close()
-        except (OSError, IOError):
-            raise AnsibleConnectionFailure('SSH Error: data could not be sent to remote host "%s". Make sure this host can be reached over ssh' % self.host)
-
-        display.debug('Sent initial data (%d bytes)' % len(in_data))
-
     # Used by _run() to kill processes on failures
     @staticmethod
     def _terminate_process(p):
@@ -542,339 +525,33 @@ class Connection(ConnectionBase):
         except (OSError, IOError):
             pass
 
-    # This is separate from _run() because we need to do the same thing for stdout
-    # and stderr.
-    def _examine_output(self, source, state, b_chunk, sudoable):
-        '''
-        Takes a string, extracts complete lines from it, tests to see if they
-        are a prompt, error message, etc., and sets appropriate flags in self.
-        Prompt and success lines are removed.
+    @_ssh_retry
+    def _run(self, cmd, in_data, sudoable=True, checkrc=True):
+        """Wrapper around _bare_run that retries the connection
+        """
 
-        Returns the processed (i.e. possibly-edited) output and the unprocessed
-        remainder (to be processed with the next chunk) as strings.
-        '''
-
-        output = []
-        for b_line in b_chunk.splitlines(True):
-            display_line = to_text(b_line).rstrip('\r\n')
-            suppress_output = False
-
-            # display.debug("Examining line (source=%s, state=%s): '%s'" % (source, state, display_line))
-            if self._play_context.prompt and self.check_password_prompt(b_line):
-                display.debug("become_prompt: (source=%s, state=%s): '%s'" % (source, state, display_line))
-                self._flags['become_prompt'] = True
-                suppress_output = True
-            elif self._play_context.success_key and self.check_become_success(b_line):
-                display.debug("become_success: (source=%s, state=%s): '%s'" % (source, state, display_line))
-                self._flags['become_success'] = True
-                suppress_output = True
-            elif sudoable and self.check_incorrect_password(b_line):
-                display.debug("become_error: (source=%s, state=%s): '%s'" % (source, state, display_line))
-                self._flags['become_error'] = True
-            elif sudoable and self.check_missing_password(b_line):
-                display.debug("become_nopasswd_error: (source=%s, state=%s): '%s'" % (source, state, display_line))
-                self._flags['become_nopasswd_error'] = True
-
-            if not suppress_output:
-                output.append(b_line)
-
-        # The chunk we read was most likely a series of complete lines, but just
-        # in case the last line was incomplete (and not a prompt, which we would
-        # have removed from the output), we retain it to be processed with the
-        # next chunk.
-
-        remainder = b''
-        if output and not output[-1].endswith(b'\n'):
-            remainder = output[-1]
-            output = output[:-1]
-
-        return b''.join(output), remainder
-
-    def _bare_run(self, cmd, in_data, sudoable=True, checkrc=True):
-        '''
-        Starts the command and communicates with it until it ends.
-        '''
-
-        display_cmd = list(map(shlex_quote, map(to_text, cmd)))
-        display.vvv(u'SSH: EXEC {0}'.format(u' '.join(display_cmd)), host=self.host)
-
-        # Start the given command. If we don't need to pipeline data, we can try
-        # to use a pseudo-tty (ssh will have been invoked with -tt). If we are
-        # pipelining data, or can't create a pty, we fall back to using plain
-        # old pipes.
-
-        p = None
-
-        if isinstance(cmd, (text_type, binary_type)):
-            cmd = to_bytes(cmd)
-        else:
-            cmd = list(map(to_bytes, cmd))
-
-        if not in_data:
-            try:
-                # Make sure stdin is a proper pty to avoid tcgetattr errors
-                master, slave = pty.openpty()
-                if PY3 and self._play_context.password:
-                    # pylint: disable=unexpected-keyword-arg
-                    p = subprocess.Popen(cmd, stdin=slave, stdout=subprocess.PIPE, stderr=subprocess.PIPE, pass_fds=self.sshpass_pipe)
-                else:
-                    p = subprocess.Popen(cmd, stdin=slave, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-                stdin = os.fdopen(master, 'wb', 0)
-                os.close(slave)
-            except (OSError, IOError):
-                p = None
-
-        if not p:
-            if PY3 and self._play_context.password:
-                # pylint: disable=unexpected-keyword-arg
-                p = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, pass_fds=self.sshpass_pipe)
-            else:
-                p = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            stdin = p.stdin
-
-        # If we are using SSH password authentication, write the password into
-        # the pipe we opened in _build_command.
-
-        if self._play_context.password:
-            os.close(self.sshpass_pipe[0])
-            try:
-                os.write(self.sshpass_pipe[1], to_bytes(self._play_context.password) + b'\n')
-            except OSError as e:
-                # Ignore broken pipe errors if the sshpass process has exited.
-                if e.errno != errno.EPIPE or p.poll() is None:
-                    raise
-            os.close(self.sshpass_pipe[1])
-
-        #
-        # SSH state machine
-        #
-
-        # Now we read and accumulate output from the running process until it
-        # exits. Depending on the circumstances, we may also need to write an
-        # escalation password and/or pipelined input to the process.
-
-        states = [
-            'awaiting_prompt', 'awaiting_escalation', 'ready_to_send', 'awaiting_exit'
-        ]
-
-        # Are we requesting privilege escalation? Right now, we may be invoked
-        # to execute sftp/scp with sudoable=True, but we can request escalation
-        # only when using ssh. Otherwise we can send initial data straightaway.
-
-        state = states.index('ready_to_send')
-        if b'ssh' in cmd and sudoable:
-            if self._play_context.prompt:
-                # We're requesting escalation with a password, so we have to
-                # wait for a password prompt.
-                state = states.index('awaiting_prompt')
-                display.debug(u'Initial state: %s: %s' % (states[state], self._play_context.prompt))
-            elif self._play_context.become and self._play_context.success_key:
-                # We're requesting escalation without a password, so we have to
-                # detect success/failure before sending any initial data.
-                state = states.index('awaiting_escalation')
-                display.debug(u'Initial state: %s: %s' % (states[state], self._play_context.success_key))
-
-        # We store accumulated stdout and stderr output from the process here,
-        # but strip any privilege escalation prompt/confirmation lines first.
-        # Output is accumulated into tmp_*, complete lines are extracted into
-        # an array, then checked and removed or copied to stdout or stderr. We
-        # set any flags based on examining the output in self._flags.
-
-        b_stdout = b_stderr = b''
-        b_tmp_stdout = b_tmp_stderr = b''
-
-        self._flags = dict(
-            become_prompt=False, become_success=False,
-            become_error=False, become_nopasswd_error=False
-        )
-
-        # select timeout should be longer than the connect timeout, otherwise
-        # they will race each other when we can't connect, and the connect
-        # timeout usually fails
-        timeout = 2 + self._play_context.timeout
-        for fd in (p.stdout, p.stderr):
-            fcntl.fcntl(fd, fcntl.F_SETFL, fcntl.fcntl(fd, fcntl.F_GETFL) | os.O_NONBLOCK)
-
-        # TODO: bcoca would like to use SelectSelector() when open
-        # filehandles is low, then switch to more efficient ones when higher.
-        # select is faster when filehandles is low.
-        selector = selectors.DefaultSelector()
-        selector.register(p.stdout, selectors.EVENT_READ)
-        selector.register(p.stderr, selectors.EVENT_READ)
-
-        # If we can send initial data without waiting for anything, we do so
-        # before we start polling
-        if states[state] == 'ready_to_send' and in_data:
-            self._send_initial_data(stdin, in_data)
-            state += 1
-
-        try:
-            while True:
-                poll = p.poll()
-                events = selector.select(timeout)
-
-                # We pay attention to timeouts only while negotiating a prompt.
-
-                if not events:
-                    # We timed out
-                    if state <= states.index('awaiting_escalation'):
-                        # If the process has already exited, then it's not really a
-                        # timeout; we'll let the normal error handling deal with it.
-                        if poll is not None:
-                            break
-                        self._terminate_process(p)
-                        raise AnsibleError('Timeout (%ds) waiting for privilege escalation prompt: %s' % (timeout, to_native(b_stdout)))
-
-                # Read whatever output is available on stdout and stderr, and stop
-                # listening to the pipe if it's been closed.
-
-                for key, event in events:
-                    if key.fileobj == p.stdout:
-                        b_chunk = p.stdout.read()
-                        if b_chunk == b'':
-                            # stdout has been closed, stop watching it
-                            selector.unregister(p.stdout)
-                            # When ssh has ControlMaster (+ControlPath/Persist) enabled, the
-                            # first connection goes into the background and we never see EOF
-                            # on stderr. If we see EOF on stdout, lower the select timeout
-                            # to reduce the time wasted selecting on stderr if we observe
-                            # that the process has not yet existed after this EOF. Otherwise
-                            # we may spend a long timeout period waiting for an EOF that is
-                            # not going to arrive until the persisted connection closes.
-                            timeout = 1
-                        b_tmp_stdout += b_chunk
-                        display.debug("stdout chunk (state=%s):\n>>>%s<<<\n" % (state, to_text(b_chunk)))
-                    elif key.fileobj == p.stderr:
-                        b_chunk = p.stderr.read()
-                        if b_chunk == b'':
-                            # stderr has been closed, stop watching it
-                            selector.unregister(p.stderr)
-                        b_tmp_stderr += b_chunk
-                        display.debug("stderr chunk (state=%s):\n>>>%s<<<\n" % (state, to_text(b_chunk)))
-
-                # We examine the output line-by-line until we have negotiated any
-                # privilege escalation prompt and subsequent success/error message.
-                # Afterwards, we can accumulate output without looking at it.
-
-                if state < states.index('ready_to_send'):
-                    if b_tmp_stdout:
-                        b_output, b_unprocessed = self._examine_output('stdout', states[state], b_tmp_stdout, sudoable)
-                        b_stdout += b_output
-                        b_tmp_stdout = b_unprocessed
-
-                    if b_tmp_stderr:
-                        b_output, b_unprocessed = self._examine_output('stderr', states[state], b_tmp_stderr, sudoable)
-                        b_stderr += b_output
-                        b_tmp_stderr = b_unprocessed
-                else:
-                    b_stdout += b_tmp_stdout
-                    b_stderr += b_tmp_stderr
-                    b_tmp_stdout = b_tmp_stderr = b''
-
-                # If we see a privilege escalation prompt, we send the password.
-                # (If we're expecting a prompt but the escalation succeeds, we
-                # didn't need the password and can carry on regardless.)
-
-                if states[state] == 'awaiting_prompt':
-                    if self._flags['become_prompt']:
-                        display.debug('Sending become_pass in response to prompt')
-                        stdin.write(to_bytes(self._play_context.become_pass) + b'\n')
-                        # On python3 stdin is a BufferedWriter, and we don't have a guarantee
-                        # that the write will happen without a flush
-                        stdin.flush()
-                        self._flags['become_prompt'] = False
-                        state += 1
-                    elif self._flags['become_success']:
-                        state += 1
-
-                # We've requested escalation (with or without a password), now we
-                # wait for an error message or a successful escalation.
-
-                if states[state] == 'awaiting_escalation':
-                    if self._flags['become_success']:
-                        display.vvv('Escalation succeeded')
-                        self._flags['become_success'] = False
-                        state += 1
-                    elif self._flags['become_error']:
-                        display.vvv('Escalation failed')
-                        self._terminate_process(p)
-                        self._flags['become_error'] = False
-                        raise AnsibleError('Incorrect %s password' % self._play_context.become_method)
-                    elif self._flags['become_nopasswd_error']:
-                        display.vvv('Escalation requires password')
-                        self._terminate_process(p)
-                        self._flags['become_nopasswd_error'] = False
-                        raise AnsibleError('Missing %s password' % self._play_context.become_method)
-                    elif self._flags['become_prompt']:
-                        # This shouldn't happen, because we should see the "Sorry,
-                        # try again" message first.
-                        display.vvv('Escalation prompt repeated')
-                        self._terminate_process(p)
-                        self._flags['become_prompt'] = False
-                        raise AnsibleError('Incorrect %s password' % self._play_context.become_method)
-
-                # Once we're sure that the privilege escalation prompt, if any, has
-                # been dealt with, we can send any initial data and start waiting
-                # for output.
-
-                if states[state] == 'ready_to_send':
-                    if in_data:
-                        self._send_initial_data(stdin, in_data)
-                    state += 1
-
-                # Now we're awaiting_exit: has the child process exited? If it has,
-                # and we've read all available output from it, we're done.
-
-                if poll is not None:
-                    if not selector.get_map() or not events:
-                        break
-                    # We should not see further writes to the stdout/stderr file
-                    # descriptors after the process has closed, set the select
-                    # timeout to gather any last writes we may have missed.
-                    timeout = 0
-                    continue
-
-                # If the process has not yet exited, but we've already read EOF from
-                # its stdout and stderr (and thus no longer watching any file
-                # descriptors), we can just wait for it to exit.
-
-                elif not selector.get_map():
-                    p.wait()
-                    break
-
-                # Otherwise there may still be outstanding data to read.
-        finally:
-            selector.close()
-            # close stdin after process is terminated and stdout/stderr are read
-            # completely (see also issue #848)
-            stdin.close()
+        (returncode, b_stdout, b_stderr) = self._bare_run(cmd, in_data, sudoable=sudoable, external_fds=self.sshpass_pipe)
 
         if C.HOST_KEY_CHECKING:
-            if cmd[0] == b"sshpass" and p.returncode == 6:
+            if cmd[0] == b"sshpass" and returncode == 6:
                 raise AnsibleError('Using a SSH password instead of a key is not possible because Host Key checking is enabled and sshpass does not support '
                                    'this.  Please add this host\'s fingerprint to your known_hosts file to manage this host.')
 
         controlpersisterror = b'Bad configuration option: ControlPersist' in b_stderr or b'unknown configuration option: ControlPersist' in b_stderr
-        if p.returncode != 0 and controlpersisterror:
+        if returncode != 0 and controlpersisterror:
             raise AnsibleError('using -c ssh on certain older ssh versions may not support ControlPersist, set ANSIBLE_SSH_ARGS="" '
                                '(or ssh_args in [ssh_connection] section of the config file) before running again')
 
         # If we find a broken pipe because of ControlPersist timeout expiring (see #16731),
         # we raise a special exception so that we can retry a connection.
         controlpersist_broken_pipe = b'mux_client_hello_exchange: write packet: Broken pipe' in b_stderr
-        if p.returncode == 255 and controlpersist_broken_pipe:
+        if returncode == 255 and controlpersist_broken_pipe:
             raise AnsibleControlPersistBrokenPipeError('SSH Error: data could not be sent because of ControlPersist broken pipe.')
 
-        if p.returncode == 255 and in_data and checkrc:
+        if returncode == 255 and in_data and checkrc:
             raise AnsibleConnectionFailure('SSH Error: data could not be sent to remote host "%s". Make sure this host can be reached over ssh' % self.host)
 
-        return (p.returncode, b_stdout, b_stderr)
-
-    @_ssh_retry
-    def _run(self, cmd, in_data, sudoable=True, checkrc=True):
-        """Wrapper around _bare_run that retries the connection
-        """
-        return self._bare_run(cmd, in_data, sudoable=sudoable, checkrc=checkrc)
+        return returncode, b_stdout, b_stderr
 
     @_ssh_retry
     def _file_transport_command(self, in_path, out_path, sftp_action):
@@ -916,14 +593,14 @@ class Connection(ConnectionBase):
                 cmd = self._build_command('sftp', to_bytes(host))
                 in_data = u"{0} {1} {2}\n".format(sftp_action, shlex_quote(in_path), shlex_quote(out_path))
                 in_data = to_bytes(in_data, nonstring='passthru')
-                (returncode, stdout, stderr) = self._bare_run(cmd, in_data, checkrc=False)
+                (returncode, stdout, stderr) = self._bare_run(cmd, in_data, external_fds=self.sshpass_pipe)
             elif method == 'scp':
                 if sftp_action == 'get':
                     cmd = self._build_command('scp', u'{0}:{1}'.format(host, shlex_quote(in_path)), out_path)
                 else:
                     cmd = self._build_command('scp', in_path, u'{0}:{1}'.format(host, shlex_quote(out_path)))
                 in_data = None
-                (returncode, stdout, stderr) = self._bare_run(cmd, in_data, checkrc=False)
+                (returncode, stdout, stderr) = self._bare_run(cmd, in_data, external_fds=self.sshpass_pipe)
             elif method == 'piped':
                 if sftp_action == 'get':
                     # we pass sudoable=False to disable pty allocation, which


### PR DESCRIPTION
This is the first pass at trying to get the guts of the I/O handling moved from being ssh-specific to a more generalized implementation other connection plugins can use to take advantage of the better state handling for become escalations.