### PR TITLE
Fixes for multiline doc descriptions breaking rst formatting

### DIFF
--- a/docs/bin/plugin_formatter.py
+++ b/docs/bin/plugin_formatter.py
@@ -117,7 +117,7 @@ def html_ify(text):
     t = _CONST.sub(r"<code>\1</code>", t)
     t = _RULER.sub(r"<hr/>", t)
 
-    return t
+    return t.strip()
 
 
 def rst_fmt(text, fmt):

--- a/docs/templates/plugin.rst.j2
+++ b/docs/templates/plugin.rst.j2
@@ -325,10 +325,10 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
                 <td>
                     <div class="cell-border">
                         {% if value.description is string %}
-                            <div>@{ value.description | html_ify }@</div>
+                            <div>@{ value.description | html_ify |indent(4)}@</div>
                         {% else %}
                             {% for desc in value.description %}
-                                <div>@{ desc | html_ify }@</div>
+                                <div>@{ desc | html_ify |indent(4)}@</div>
                             {% endfor %}
                         {% endif %}
                         <br/>


### PR DESCRIPTION
* strip whitespace to preserve indent level
* Make sure to indent subsequent lines of indentation


##### ISSUE TYPE
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
Various module docs

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel 2.5
```


##### ADDITIONAL INFORMATION
This fixes all block-quote-missing-blank-line warnings.

Probably fixes some other warnings as well as it fixes html being interpreted as rst in various module docs.