### PR TITLE
Fixes #29818: chkconfig localizes messages, ansible fails to recognise

### DIFF
--- a/lib/ansible/modules/system/service.py
+++ b/lib/ansible/modules/system/service.py
@@ -248,7 +248,10 @@ class Service(object):
                 cmd = [to_bytes(c, errors='surrogate_or_strict') for c in shlex.split(cmd)]
             # In either of the above cases, pass a list of byte strings to Popen
 
-            p = subprocess.Popen(cmd, shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE, preexec_fn=lambda: os.close(pipe[1]))
+            # chkconfig localizes messages and we're screen scraping so make
+            # sure we use the C locale
+            lang_env = dict(LANG='C', LC_ALL='C', LC_MESSAGES='C')
+            p = subprocess.Popen(cmd, shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=lang_env, preexec_fn=lambda: os.close(pipe[1]))
             stdout = b("")
             stderr = b("")
             fds = [p.stdout, p.stderr]


### PR DESCRIPTION
##### SUMMARY
In the particular case of executin "chkconfig --list NAME", ansible
checks the stderr looking for a particular english message.
This message is different in other languages, Spanish for example
(although it have been corrected in the latests versions).

This change forces the locale so messages are consistent.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/system/service.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
master branch
```