### PR TITLE
Backport #37083 for 2.5 - IncludedFile comparison fix for free strategy

### DIFF
--- a/changelogs/fragments/include_comparison.yaml
+++ b/changelogs/fragments/include_comparison.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- dynamic includes - Fix IncludedFile comparison for free strategy (https://github.com/ansible/ansible/pull/37083)

--- a/lib/ansible/playbook/included_file.py
+++ b/lib/ansible/playbook/included_file.py
@@ -46,7 +46,7 @@ class IncludedFile:
             self._hosts.append(host)
 
     def __eq__(self, other):
-        return other._filename == self._filename and other._args == self._args
+        return other._filename == self._filename and other._args == self._args and other._task._parent._uuid == self._task._parent._uuid
 
     def __repr__(self):
         return "%s (%s): %s" % (self._filename, self._args, self._hosts)

--- a/test/units/playbook/test_included_file.py
+++ b/test/units/playbook/test_included_file.py
@@ -21,7 +21,8 @@ __metaclass__ = type
 
 import os
 
-from ansible.compat.tests import unittest
+import pytest
+
 from ansible.compat.tests.mock import MagicMock
 from units.mock.loader import DictDataLoader
 
@@ -32,70 +33,122 @@ from ansible.executor import task_result
 from ansible.playbook.included_file import IncludedFile
 
 
-class TestIncludedFile(unittest.TestCase):
-    def test(self):
-        filename = 'somefile.yml'
+@pytest.fixture
+def mock_iterator():
+    mock_iterator = MagicMock(name='MockIterator')
+    mock_iterator._play = MagicMock(name='MockPlay')
+    return mock_iterator
 
-        inc_file = IncludedFile(filename=filename, args=[], task=None)
 
-        self.assertIsInstance(inc_file, IncludedFile)
-        self.assertEquals(inc_file._filename, filename)
-        self.assertEquals(inc_file._args, [])
-        self.assertEquals(inc_file._task, None)
+@pytest.fixture
+def mock_variable_manager():
+    # TODO: can we use a real VariableManager?
+    mock_variable_manager = MagicMock(name='MockVariableManager')
+    mock_variable_manager.get_vars.return_value = dict()
+    return mock_variable_manager
 
-    def test_process_include_results(self):
-        hostname = "testhost1"
-        hostname2 = "testhost2"
 
-        parent_task_ds = {'debug': 'msg=foo'}
-        parent_task = Task()
-        parent_task.load(parent_task_ds)
+def test_included_file_instantiation():
+    filename = 'somefile.yml'
 
-        task_ds = {'include': 'include_test.yml'}
-        task_include = TaskInclude()
-        loaded_task = task_include.load(task_ds, task_include=parent_task)
+    inc_file = IncludedFile(filename=filename, args=[], task=None)
 
-        child_task_ds = {'include': 'other_include_test.yml'}
-        child_task_include = TaskInclude()
-        loaded_child_task = child_task_include.load(child_task_ds, task_include=loaded_task)
+    assert isinstance(inc_file, IncludedFile)
+    assert inc_file._filename == filename
+    assert inc_file._args == []
+    assert inc_file._task is None
 
-        return_data = {'include': 'include_test.yml'}
-        # The task in the TaskResult has to be a TaskInclude so it has a .static attr
-        result1 = task_result.TaskResult(host=hostname, task=loaded_task, return_data=return_data)
 
-        return_data = {'include': 'other_include_test.yml'}
-        result2 = task_result.TaskResult(host=hostname2, task=loaded_child_task, return_data=return_data)
-        results = [result1, result2]
+def test_process_include_results(mock_iterator, mock_variable_manager):
+    hostname = "testhost1"
+    hostname2 = "testhost2"
 
-        fake_loader = DictDataLoader({'include_test.yml': "",
-                                      'other_include_test.yml': ""})
+    parent_task_ds = {'debug': 'msg=foo'}
+    parent_task = Task.load(parent_task_ds)
 
-        mock_tqm = MagicMock(name='MockTaskQueueManager')
+    task_ds = {'include': 'include_test.yml'}
+    loaded_task = TaskInclude.load(task_ds, task_include=parent_task)
 
-        mock_play = MagicMock(name='MockPlay')
+    return_data = {'include': 'include_test.yml'}
+    # The task in the TaskResult has to be a TaskInclude so it has a .static attr
+    result1 = task_result.TaskResult(host=hostname, task=loaded_task, return_data=return_data)
+    result2 = task_result.TaskResult(host=hostname2, task=loaded_task, return_data=return_data)
+    results = [result1, result2]
 
-        mock_iterator = MagicMock(name='MockIterator')
-        mock_iterator._play = mock_play
+    fake_loader = DictDataLoader({'include_test.yml': ""})
 
-        mock_inventory = MagicMock(name='MockInventory')
-        mock_inventory._hosts_cache = dict()
+    res = IncludedFile.process_include_results(results, mock_iterator, fake_loader, mock_variable_manager)
+    assert isinstance(res, list)
+    assert len(res) == 1
+    assert res[0]._filename == os.path.join(os.getcwd(), 'include_test.yml')
+    assert res[0]._hosts == ['testhost1', 'testhost2']
+    assert res[0]._args == {}
 
-        def _get_host(host_name):
-            return None
 
-        mock_inventory.get_host.side_effect = _get_host
+def test_process_include_diff_files(mock_iterator, mock_variable_manager):
+    hostname = "testhost1"
+    hostname2 = "testhost2"
 
-        # TODO: can we use a real VariableManager?
-        mock_variable_manager = MagicMock(name='MockVariableManager')
-        mock_variable_manager.get_vars.return_value = dict()
+    parent_task_ds = {'debug': 'msg=foo'}
+    parent_task = Task.load(parent_task_ds)
 
-        res = IncludedFile.process_include_results(results, mock_iterator, fake_loader, mock_variable_manager)
-        self.assertIsInstance(res, list)
-        self.assertEquals(res[0]._filename, os.path.join(os.getcwd(), 'include_test.yml'))
-        self.assertEquals(res[1]._filename, os.path.join(os.getcwd(), 'other_include_test.yml'))
+    task_ds = {'include': 'include_test.yml'}
+    loaded_task = TaskInclude.load(task_ds, task_include=parent_task)
 
-        self.assertEquals(res[0]._hosts, ['testhost1'])
-        self.assertEquals(res[1]._hosts, ['testhost2'])
+    child_task_ds = {'include': 'other_include_test.yml'}
+    loaded_child_task = TaskInclude.load(child_task_ds, task_include=loaded_task)
 
-        self.assertEquals(res[0]._args, {})
-        self.assertEquals(res[1]._args, {})
+    return_data = {'include': 'include_test.yml'}
+    # The task in the TaskResult has to be a TaskInclude so it has a .static attr
+    result1 = task_result.TaskResult(host=hostname, task=loaded_task, return_data=return_data)
+
+    return_data = {'include': 'other_include_test.yml'}
+    result2 = task_result.TaskResult(host=hostname2, task=loaded_child_task, return_data=return_data)
+    results = [result1, result2]
+
+    fake_loader = DictDataLoader({'include_test.yml': "",
+                                  'other_include_test.yml': ""})
+
+    res = IncludedFile.process_include_results(results, mock_iterator, fake_loader, mock_variable_manager)
+    assert isinstance(res, list)
+    assert res[0]._filename == os.path.join(os.getcwd(), 'include_test.yml')
+    assert res[1]._filename == os.path.join(os.getcwd(), 'other_include_test.yml')
+
+    assert res[0]._hosts == ['testhost1']
+    assert res[1]._hosts == ['testhost2']
+
+    assert res[0]._args == {}
+    assert res[1]._args == {}
+
+
+def test_process_include_simulate_free(mock_iterator, mock_variable_manager):
+    hostname = "testhost1"
+    hostname2 = "testhost2"
+
+    parent_task_ds = {'debug': 'msg=foo'}
+    parent_task1 = Task.load(parent_task_ds)
+    parent_task2 = Task.load(parent_task_ds)
+
+    task_ds = {'include': 'include_test.yml'}
+    loaded_task1 = TaskInclude.load(task_ds, task_include=parent_task1)
+    loaded_task2 = TaskInclude.load(task_ds, task_include=parent_task2)
+
+    return_data = {'include': 'include_test.yml'}
+    # The task in the TaskResult has to be a TaskInclude so it has a .static attr
+    result1 = task_result.TaskResult(host=hostname, task=loaded_task1, return_data=return_data)
+    result2 = task_result.TaskResult(host=hostname2, task=loaded_task2, return_data=return_data)
+    results = [result1, result2]
+
+    fake_loader = DictDataLoader({'include_test.yml': ""})
+
+    res = IncludedFile.process_include_results(results, mock_iterator, fake_loader, mock_variable_manager)
+    assert isinstance(res, list)
+    assert len(res) == 2
+    assert res[0]._filename == os.path.join(os.getcwd(), 'include_test.yml')
+    assert res[1]._filename == os.path.join(os.getcwd(), 'include_test.yml')
+
+    assert res[0]._hosts == ['testhost1']
+    assert res[1]._hosts == ['testhost2']
+
+    assert res[0]._args == {}
+    assert res[1]._args == {}


### PR DESCRIPTION
##### SUMMARY

Backport #37083 for 2.5 - IncludedFile comparison fix for free strategy
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/playbook/included_file.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
