### PR TITLE
[AWS cloudfront_distribution] Update minimum protocol versions (#38644)

### DIFF
--- a/lib/ansible/modules/cloud/amazon/cloudfront_distribution.py
+++ b/lib/ansible/modules/cloud/amazon/cloudfront_distribution.py
@@ -1319,7 +1319,10 @@ class CloudFrontValidationManager(object):
         ])
         self.__valid_viewer_certificate_minimum_protocol_versions = set([
             'SSLv3',
-            'TLSv1'
+            'TLSv1',
+            'TLSv1_2016',
+            'TLSv1.1_2016',
+            'TLSv1.2_2018'
         ])
         self.__valid_viewer_certificate_certificate_sources = set([
             'cloudfront',


### PR DESCRIPTION
##### SUMMARY
As per docs, the current set of values is

```
'SSLv3'|'TLSv1'|'TLSv1_2016'|'TLSv1.1_2016'|'TLSv1.2_2018'
```

Fixes #38642

(cherry picked from commit 6b970348b15d3c8fba93d307a9bfd3bbf1aa0e0c)

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
cloudfront_distribution

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.1 (stable-2.5 ed473d792b) last updated 2018/04/19 13:36:42 (GMT +1000)
  config file = None
  configured module search path = [u'/home/will/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/will/src/ansible/lib/ansible
  executable location = /home/will/src/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 14 2018, 13:36:31) [GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]
```


##### ADDITIONAL INFORMATION
Backport from #38644