### PR TITLE
elb_target_group: use port parameter as default for target port (#38578)

### DIFF
--- a/lib/ansible/modules/cloud/amazon/elb_target_group.py
+++ b/lib/ansible/modules/cloud/amazon/elb_target_group.py
@@ -502,7 +502,7 @@ def create_or_update_target_group(connection, module):
                     instances_to_add = []
                     for target in params['Targets']:
                         if target['Id'] in add_instances:
-                            instances_to_add.append({'Id': target['Id'], 'Port': int(target['Port'])})
+                            instances_to_add.append({'Id': target['Id'], 'Port': int(target.get('Port', module.params.get('port')))})
 
                     changed = True
                     try:


### PR DESCRIPTION
##### SUMMARY

The docs suggest that `port` parameter is the default port upon
which targets listen. As such, a target need only provide a `Port`
key to override the default.

(cherry picked from commit dc09ddfbd53b8af1f55366336cbae232c7b78621)

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
elb_target_group

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.1 (stable-2.5 ed473d792b) last updated 2018/04/19 13:36:42 (GMT +1000)
  config file = None
  configured module search path = [u'/home/will/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/will/src/ansible/lib/ansible
  executable location = /home/will/src/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 14 2018, 13:36:31) [GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]

```


##### ADDITIONAL INFORMATION
Backports #38578
