### PR TITLE
Fix #26755 by ensuring that the first nic in the nic list is primary

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
@@ -819,7 +819,11 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
                     if set(current_nics) != set(network_interfaces):
                         self.log('CHANGED: virtual machine {0} - network interfaces are different.'.format(self.name))
                         differences.append('Network Interfaces')
-                        updated_nics = [dict(id=id) for id in network_interfaces]
+                        updated_nics = [
+                          dict(id=id, primary=True)
+                          if i is 0 else 
+                          dict(id=id, primary=False) 
+                          for i, id in enumerate(network_interfaces)]
                         vm_dict['properties']['networkProfile']['networkInterfaces'] = updated_nics
                         changed = True
 
@@ -928,7 +932,11 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
                     if not self.short_hostname:
                         self.short_hostname = self.name
 
-                    nics = [self.compute_models.NetworkInterfaceReference(id=id) for id in network_interfaces]
+                    nics = [
+                      self.compute_models.NetworkInterfaceReference(id=id, primary=True)
+                      if i is 0 else
+                      self.compute_models.NetworkInterfaceReference(id=id, primary=False)
+                      for i, id in enumerate(network_interfaces)]
 
                     # os disk
                     if self.managed_disk_type:
@@ -1057,9 +1065,10 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
 
                     self.log("Update virtual machine {0}".format(self.name))
                     self.results['actions'].append('Updated VM {0}'.format(self.name))
-
-                    nics = [self.compute_models.NetworkInterfaceReference(id=interface['id'])
-                            for interface in vm_dict['properties']['networkProfile']['networkInterfaces']]
+                    nics = [
+                      self.compute_models.NetworkInterfaceReference(id=interface['id'], primary=True) if i is 0 else 
+                      self.compute_models.NetworkInterfaceReference(id=interface['id'], primary=False)
+                            for i, interface in enumerate(vm_dict['properties']['networkProfile']['networkInterfaces'])]
 
                     # os disk
                     if not vm_dict['properties']['storageProfile']['osDisk'].get('managedDisk'):

--- a/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
@@ -819,11 +819,8 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
                     if set(current_nics) != set(network_interfaces):
                         self.log('CHANGED: virtual machine {0} - network interfaces are different.'.format(self.name))
                         differences.append('Network Interfaces')
-                        updated_nics = [
-                          dict(id=id, primary=True)
-                          if i is 0 else 
-                          dict(id=id, primary=False) 
-                          for i, id in enumerate(network_interfaces)]
+                        updated_nics = [dict(id=id, primary=(i is 0))
+                                        for i, id in enumerate(network_interfaces)]
                         vm_dict['properties']['networkProfile']['networkInterfaces'] = updated_nics
                         changed = True
 
@@ -932,11 +929,8 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
                     if not self.short_hostname:
                         self.short_hostname = self.name
 
-                    nics = [
-                      self.compute_models.NetworkInterfaceReference(id=id, primary=True)
-                      if i is 0 else
-                      self.compute_models.NetworkInterfaceReference(id=id, primary=False)
-                      for i, id in enumerate(network_interfaces)]
+                    nics = [self.compute_models.NetworkInterfaceReference(id=id, primary=(i is 0))
+                            for i, id in enumerate(network_interfaces)]
 
                     # os disk
                     if self.managed_disk_type:
@@ -1065,9 +1059,7 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
 
                     self.log("Update virtual machine {0}".format(self.name))
                     self.results['actions'].append('Updated VM {0}'.format(self.name))
-                    nics = [
-                      self.compute_models.NetworkInterfaceReference(id=interface['id'], primary=True) if i is 0 else 
-                      self.compute_models.NetworkInterfaceReference(id=interface['id'], primary=False)
+                    nics = [self.compute_models.NetworkInterfaceReference(id=interface['id'], primary=(i is 0))
                             for i, interface in enumerate(vm_dict['properties']['networkProfile']['networkInterfaces'])]
 
                     # os disk

--- a/test/integration/targets/azure_rm_virtualmachine/tasks/virtualmachine.yml
+++ b/test/integration/targets/azure_rm_virtualmachine/tasks/virtualmachine.yml
@@ -1,9 +1,14 @@
-- name: Delete virtual machine
+- name: Delete virtual machines
   azure_rm_virtualmachine:
       resource_group: "{{ resource_group }}"
-      name: testvm002
+      name: "{{ vms }}"
       state: absent
       vm_size: Standard_A0
+  loop:
+    - testvm002
+    - testvm003
+  loop_control:
+    loop_var: vms
   register: output
 
 - name: Create storage account name
@@ -59,7 +64,7 @@
           priority: 110
           direction: Inbound
 
-- name: Create NIC
+- name: Create NIC for single nic VM
   azure_rm_networkinterface:
       resource_group: "{{ resource_group }}"
       name: testvm001
@@ -68,20 +73,8 @@
       public_ip_name: testvm001
       security_group: testvm001
 
-- name: Create second NIC
-  azure_rm_networkinterface:
-      resource_group: "{{ resource_group }}"
-      name: testvm002
-      virtual_network: testvm001
-      subnet: testvm001
-      security_group: testvm001
-
-- name: Create virtual machine
+- name: Create virtual machine with a single NIC
   register: output
-  vars:
-    niclist:
-      - testvm001
-      - testvm002
   azure_rm_virtualmachine:
       resource_group: "{{ resource_group }}"
       name: testvm002
@@ -93,7 +86,7 @@
       admin_password: Password123!
       short_hostname: testvm
       os_type: Linux
-      network_interfaces: "{{ niclist }}"
+      network_interfaces: testvm001
       availability_set: "avbs{{ resource_group | hash('md5') | truncate(7, True, '') }}"
       image:
         offer: UbuntuServer
@@ -185,7 +178,7 @@
           - "azure_vm.powerstate in ['starting', 'running']"
           - output.changed
 
-- name: Should be idempotent
+- name: Should be idempotent with a single NIC
   vars:
     niclist:
       - testvm001
@@ -266,6 +259,82 @@
       name: testvmnoip
       state: absent
       vm_size: Standard_A0
+
+- name: Create NICs for dual nic VM
+  azure_rm_networkinterface:
+      resource_group: "{{ resource_group }}"
+      name: "{{ item }}"
+      virtual_network: testvm001
+      subnet: testvm001
+      security_group: testvm001
+  loop:
+    - testvm011
+    - testvm012
+
+- name: Create virtual machine with two NICs
+  register: output
+  vars:
+    niclist:
+      - testvm011
+      - testvm012
+  azure_rm_virtualmachine:
+      resource_group: "{{ resource_group }}"
+      name: testvm003
+      vm_size: Standard_A0
+      storage_account: "{{ storage_account }}"
+      storage_container: testvm001
+      storage_blob: testvm003.vhd
+      admin_username: adminuser
+      admin_password: Password123!
+      short_hostname: testvm
+      os_type: Linux
+      network_interfaces: "{{ niclist }}"
+      availability_set: "avbs{{ resource_group | hash('md5') | truncate(7, True, '') }}"
+      image:
+        offer: UbuntuServer
+        publisher: Canonical
+        sku: 16.04-LTS
+        version: latest
+
+- assert:
+      that:
+        - azure_vm.properties.availabilitySet.id
+
+- name: Should be idempotent with a dual NICs
+  vars:
+    niclist:
+      - testvm011
+      - testvm012
+  azure_rm_virtualmachine:
+      resource_group: "{{ resource_group }}"
+      name: testvm003
+      vm_size: Standard_A0
+      storage_account: "{{ storage_account }}"
+      storage_container: testvm001
+      storage_blob: testvm003.vhd
+      admin_username: adminuser
+      admin_password: Password123!
+      short_hostname: testvm
+      os_type: Linux
+      network_interfaces: "{{ niclist }}"
+      availability_set: "avbs{{ resource_group | hash('md5') | truncate(7, True, '') }}"
+      image:
+        offer: UbuntuServer
+        publisher: Canonical
+        sku: 16.04-LTS
+        version: latest
+  register: output
+
+- assert:
+      that: not output.changed
+
+- name: Delete dual NIC VM
+  azure_rm_virtualmachine:
+      resource_group: "{{ resource_group }}"
+      name: testvm003
+      state: absent
+      vm_size: Standard_A0
+  register: output
 
 # TODO: Until we have a module to create/delete images this is the best tests
 # I can do

--- a/test/integration/targets/azure_rm_virtualmachine/tasks/virtualmachine.yml
+++ b/test/integration/targets/azure_rm_virtualmachine/tasks/virtualmachine.yml
@@ -197,7 +197,7 @@
       os_type: Linux
       network_interfaces:
                           - testvm001
-                          - testvm002]
+                          - testvm002
       image:
         offer: UbuntuServer
         publisher: Canonical

--- a/test/integration/targets/azure_rm_virtualmachine/tasks/virtualmachine.yml
+++ b/test/integration/targets/azure_rm_virtualmachine/tasks/virtualmachine.yml
@@ -78,6 +78,10 @@
 
 - name: Create virtual machine
   register: output
+  vars:
+    niclist:
+      - testvm001
+      - testvm002
   azure_rm_virtualmachine:
       resource_group: "{{ resource_group }}"
       name: testvm002
@@ -89,9 +93,7 @@
       admin_password: Password123!
       short_hostname: testvm
       os_type: Linux
-      network_interfaces:
-                          - testvm001
-                          - testvm002
+      network_interfaces: niclist
       availability_set: "avbs{{ resource_group | hash('md5') | truncate(7, True, '') }}"
       image:
         offer: UbuntuServer
@@ -184,6 +186,10 @@
           - output.changed
 
 - name: Should be idempotent
+  vars:
+    niclist:
+      - testvm001
+      - testvm002
   azure_rm_virtualmachine:
       resource_group: "{{ resource_group }}"
       name: testvm002
@@ -195,9 +201,7 @@
       admin_password: Password123!
       short_hostname: testvm
       os_type: Linux
-      network_interfaces:
-                          - testvm001
-                          - testvm002
+      network_interfaces: niclist
       image:
         offer: UbuntuServer
         publisher: Canonical

--- a/test/integration/targets/azure_rm_virtualmachine/tasks/virtualmachine.yml
+++ b/test/integration/targets/azure_rm_virtualmachine/tasks/virtualmachine.yml
@@ -68,6 +68,14 @@
       public_ip_name: testvm001
       security_group: testvm001
 
+- name: Create second NIC
+  azure_rm_networkinterface:
+      resource_group: "{{ resource_group }}"
+      name: testvm002
+      virtual_network: testvm001
+      subnet: testvm001
+      security_group: testvm001
+
 - name: Create virtual machine
   register: output
   azure_rm_virtualmachine:
@@ -81,7 +89,9 @@
       admin_password: Password123!
       short_hostname: testvm
       os_type: Linux
-      network_interfaces: testvm001
+      network_interfaces:
+                          - testvm001
+                          - testvm002
       availability_set: "avbs{{ resource_group | hash('md5') | truncate(7, True, '') }}"
       image:
         offer: UbuntuServer
@@ -185,7 +195,9 @@
       admin_password: Password123!
       short_hostname: testvm
       os_type: Linux
-      network_interfaces: testvm001
+      network_interfaces:
+                          - testvm001
+                          - testvm002]
       image:
         offer: UbuntuServer
         publisher: Canonical

--- a/test/integration/targets/azure_rm_virtualmachine/tasks/virtualmachine.yml
+++ b/test/integration/targets/azure_rm_virtualmachine/tasks/virtualmachine.yml
@@ -179,10 +179,6 @@
           - output.changed
 
 - name: Should be idempotent with a single NIC
-  vars:
-    niclist:
-      - testvm001
-      - testvm002
   azure_rm_virtualmachine:
       resource_group: "{{ resource_group }}"
       name: testvm002
@@ -194,7 +190,7 @@
       admin_password: Password123!
       short_hostname: testvm
       os_type: Linux
-      network_interfaces: "{{ niclist }}"
+      network_interfaces: testvm001
       image:
         offer: UbuntuServer
         publisher: Canonical

--- a/test/integration/targets/azure_rm_virtualmachine/tasks/virtualmachine.yml
+++ b/test/integration/targets/azure_rm_virtualmachine/tasks/virtualmachine.yml
@@ -93,7 +93,7 @@
       admin_password: Password123!
       short_hostname: testvm
       os_type: Linux
-      network_interfaces: niclist
+      network_interfaces: "{{ niclist }}"
       availability_set: "avbs{{ resource_group | hash('md5') | truncate(7, True, '') }}"
       image:
         offer: UbuntuServer
@@ -201,7 +201,7 @@
       admin_password: Password123!
       short_hostname: testvm
       os_type: Linux
-      network_interfaces: niclist
+      network_interfaces: "{{ niclist }}"
       image:
         offer: UbuntuServer
         publisher: Canonical


### PR DESCRIPTION
… set to True, and all other nics have primary set to False.

##### SUMMARY
Fixes #26755 by ensuring that the first nic in the nic list has primary set as True, and all other nics have primary set to False.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
azure_rm_virtualmachine

##### ANSIBLE VERSION
```
2.6.0
```

