### PR TITLE
Fix interface method change

### DIFF
--- a/lib/ansible/modules/system/interfaces_file.py
+++ b/lib/ansible/modules/system/interfaces_file.py
@@ -302,6 +302,14 @@ def setInterfaceOption(module, lines, iface, option, raw_value, state):
 
 
 def addOptionAfterLine(option, value, iface, lines, last_line_dict, iface_options):
+    # Changing method of interface is not an addition
+    if option == 'method':
+        for ln in lines:
+            if ln.get('line_type', '') == 'iface':
+                ln['line'] = re.sub(ln.get('params', {}).get('method', '') + '$', value, ln.get('line'))
+                ln['params']['method'] = value
+        return lines
+
     last_line = last_line_dict['line']
     prefix_start = last_line.find(last_line.split()[0])
     suffix_start = last_line.rfind(last_line.split()[-1]) + len(last_line.split()[-1])


### PR DESCRIPTION
##### SUMMARY
Fixes [#38692](https://github.com/ansible/ansible/issues/38692)

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
interfaces_file

##### ANSIBLE VERSION
```
ansible 2.6.0 (work e2aa1155ba) last updated 2018/04/19 09:51:12 (GMT +200)
  config file = None
  configured module search path = [u'/Users/olivierbourdon/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/olivierbourdon/Documents/WORK/OpenNext/TECH/CODE/ANSIBLE/0-REF-ansible/lib/ansible
  executable location = /Users/olivierbourdon/Documents/WORK/OpenNext/TECH/CODE/ANSIBLE/0-REF-ansible/bin/ansible
  python version = 2.7.14 (default, Sep 22 2017, 00:06:07) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```


##### ADDITIONAL INFORMATION
Before:
```
iface eth0 inet dhcp
    address 192.168.178.111
    netmask 255.255.255.0
   method static
```

After:
```
iface eth0 inet static
    address 192.168.178.111
    netmask 255.255.255.0
```