### PR TITLE
Fix for changing method only on specified interface

### DIFF
--- a/lib/ansible/modules/system/interfaces_file.py
+++ b/lib/ansible/modules/system/interfaces_file.py
@@ -305,7 +305,7 @@ def addOptionAfterLine(option, value, iface, lines, last_line_dict, iface_option
     # Changing method of interface is not an addition
     if option == 'method':
         for ln in lines:
-            if ln.get('line_type', '') == 'iface':
+            if ln.get('line_type', '') == 'iface' and ln.get('iface', '') == iface:
                 ln['line'] = re.sub(ln.get('params', {}).get('method', '') + '$', value, ln.get('line'))
                 ln['params']['method'] = value
         return lines

--- a/test/units/modules/system/interfaces_file/fixtures/golden_output/default_dhcp_change_method
+++ b/test/units/modules/system/interfaces_file/fixtures/golden_output/default_dhcp_change_method
@@ -1,0 +1,6 @@
+# The loopback network interface
+auto lo eth0
+iface lo inet loopback
+
+# The primary network interface
+iface eth0 inet manual

--- a/test/units/modules/system/interfaces_file/fixtures/golden_output/default_dhcp_change_method.json
+++ b/test/units/modules/system/interfaces_file/fixtures/golden_output/default_dhcp_change_method.json
@@ -1,0 +1,18 @@
+{
+    "eth0": {
+        "address_family": "inet",
+        "down": [],
+        "method": "manual",
+        "post-up": [],
+        "pre-up": [],
+        "up": []
+    },
+    "lo": {
+        "address_family": "inet",
+        "down": [],
+        "method": "loopback",
+        "post-up": [],
+        "pre-up": [],
+        "up": []
+    }
+}

--- a/test/units/modules/system/interfaces_file/fixtures/golden_output/servers.com_change_method
+++ b/test/units/modules/system/interfaces_file/fixtures/golden_output/servers.com_change_method
@@ -1,0 +1,58 @@
+ auto aggi
+ iface aggi inet static 
+ hwaddress ether 22:44:77:88:D5:96
+ address 10.44.15.196
+ netmask 255.255.255.248
+ mtu 1500
+ slaves int1 int2
+ bond_mode 4
+ bond_miimon 100
+ bond_downdelay 200
+ bond_updelay 200
+ bond_lacp_rate slow
+ bond_xmit_hash_policy layer3+4
+ post-up /sbin/ethtool -K aggi tx off tso off
+ 
+ auto agge
+ iface agge inet manual
+
+ auto br0
+ iface br0 inet static
+ bridge_ports agge
+ hwaddress ether 22:44:77:88:D5:98
+ address 188.44.133.76
+ netmask 255.255.255.248
+ gateway 188.44.133.75
+ slaves ext1 ext2
+ bond_mode 4
+ bond_miimon 100
+ bond_downdelay 200
+ bond_updelay 200
+ bond_lacp_rate slow
+ bond_xmit_hash_policy layer3+4
+ post-up /sbin/ethtool -K agge tx off tso off
+ 
+ up route add -net 10.0.0.0/8 gw 10.44.15.117 dev aggi
+ up route add -net 192.168.0.0/16 gw 10.44.15.117 dev aggi
+ up route add -net 188.44.208.0/21 gw 10.44.15.117 dev aggi
+ 
+ auto int1
+ iface int1 inet manual
+ bond-master aggi
+ 
+ auto int2
+ iface int2 inet manual
+ bond-master aggi
+ 
+ auto ext1
+ iface ext1 inet manual
+ bond-master agge
+ 
+ auto ext2
+ iface ext2 inet manual
+ bond-master agge
+ 
+ auto lo
+ iface lo inet loopback
+ 
+source /etc/network/interfaces.d/*.cfg

--- a/test/units/modules/system/interfaces_file/fixtures/golden_output/servers.com_change_method.exceptions.txt
+++ b/test/units/modules/system/interfaces_file/fixtures/golden_output/servers.com_change_method.exceptions.txt
@@ -1,0 +1,8 @@
+fail_json message: Error: interface eth0 not found
+options:
+{
+    "iface": "eth0",
+    "option": "method",
+    "state": "present",
+    "value": "manual"
+}

--- a/test/units/modules/system/interfaces_file/fixtures/golden_output/servers.com_change_method.json
+++ b/test/units/modules/system/interfaces_file/fixtures/golden_output/servers.com_change_method.json
@@ -1,0 +1,101 @@
+{
+    "agge": {
+        "address_family": "inet",
+        "down": [],
+        "method": "manual",
+        "post-up": [],
+        "pre-up": [],
+        "up": []
+    },
+    "aggi": {
+        "address": "10.44.15.196",
+        "address_family": "inet",
+        "bond_downdelay": "200",
+        "bond_lacp_rate": "slow",
+        "bond_miimon": "100",
+        "bond_mode": "4",
+        "bond_updelay": "200",
+        "bond_xmit_hash_policy": "layer3+4",
+        "down": [],
+        "hwaddress": "ether 22:44:77:88:D5:96",
+        "method": "static",
+        "mtu": "1500",
+        "netmask": "255.255.255.248",
+        "post-up": [
+            "/sbin/ethtool -K aggi tx off tso off"
+        ],
+        "pre-up": [],
+        "slaves": "int1 int2",
+        "up": []
+    },
+    "br0": {
+        "address": "188.44.133.76",
+        "address_family": "inet",
+        "bond_downdelay": "200",
+        "bond_lacp_rate": "slow",
+        "bond_miimon": "100",
+        "bond_mode": "4",
+        "bond_updelay": "200",
+        "bond_xmit_hash_policy": "layer3+4",
+        "bridge_ports": "agge",
+        "down": [],
+        "gateway": "188.44.133.75",
+        "hwaddress": "ether 22:44:77:88:D5:98",
+        "method": "static",
+        "netmask": "255.255.255.248",
+        "post-up": [
+            "/sbin/ethtool -K agge tx off tso off"
+        ],
+        "pre-up": [],
+        "slaves": "ext1 ext2",
+        "up": [
+            "route add -net 10.0.0.0/8 gw 10.44.15.117 dev aggi",
+            "route add -net 192.168.0.0/16 gw 10.44.15.117 dev aggi",
+            "route add -net 188.44.208.0/21 gw 10.44.15.117 dev aggi"
+        ]
+    },
+    "ext1": {
+        "address_family": "inet",
+        "bond-master": "agge",
+        "down": [],
+        "method": "manual",
+        "post-up": [],
+        "pre-up": [],
+        "up": []
+    },
+    "ext2": {
+        "address_family": "inet",
+        "bond-master": "agge",
+        "down": [],
+        "method": "manual",
+        "post-up": [],
+        "pre-up": [],
+        "up": []
+    },
+    "int1": {
+        "address_family": "inet",
+        "bond-master": "aggi",
+        "down": [],
+        "method": "manual",
+        "post-up": [],
+        "pre-up": [],
+        "up": []
+    },
+    "int2": {
+        "address_family": "inet",
+        "bond-master": "aggi",
+        "down": [],
+        "method": "manual",
+        "post-up": [],
+        "pre-up": [],
+        "up": []
+    },
+    "lo": {
+        "address_family": "inet",
+        "down": [],
+        "method": "loopback",
+        "post-up": [],
+        "pre-up": [],
+        "up": []
+    }
+}

--- a/test/units/modules/system/interfaces_file/test_interfaces_file.py
+++ b/test/units/modules/system/interfaces_file/test_interfaces_file.py
@@ -188,3 +188,35 @@ class TestInterfacesFileModule(unittest.TestCase):
                 self.compareInterfacesLinesToFile(lines, testfile, "%s_%s" % (testfile, testname))
                 self.compareInterfacesToFile(ifaces, testfile, "%s_%s.json" % (testfile, testname))
                 self.compareFileToBackup(path, backupp)
+
+    def test_change_method(self):
+        testcases = {
+            "change_method": [
+                {
+                    'iface': 'eth0',
+                    'option': 'method',
+                    'value': 'manual',
+                    'state': 'present',
+                }
+            ],
+        }
+        for testname, options_list in testcases.items():
+            for testfile in self.getTestFiles():
+                path = os.path.join(fixture_path, testfile)
+                lines, ifaces = interfaces_file.read_interfaces_file(module, path)
+                backupp = module.backup_local(path)
+                options = options_list[0]
+                fail_json_iterations = []
+                try:
+                    _, lines = interfaces_file.setInterfaceOption(module, lines, options['iface'], options['option'], options['value'], options['state'])
+                except AnsibleFailJson as e:
+                    fail_json_iterations.append("fail_json message: %s\noptions:\n%s" %
+                                                (str(e), json.dumps(options, sort_keys=True, indent=4, separators=(',', ': '))))
+                interfaces_file.write_changes(module, [d['line'] for d in lines if 'line' in d], path)
+
+                self.compareStringWithFile("\n=====\n".join(fail_json_iterations), "%s_%s.exceptions.txt" % (testfile, testname))
+
+                self.compareInterfacesLinesToFile(lines, testfile, "%s_%s" % (testfile, testname))
+                self.compareInterfacesToFile(ifaces, testfile, "%s_%s.json" % (testfile, testname))
+                # Restore backup
+                move(backupp, path)


### PR DESCRIPTION

##### SUMMARY
Properly fix the interface method change code so that only specified interface gets its method
changed, not all of them

Test added for interface method change

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
interfaces_file

##### ANSIBLE VERSION
```
ansible 2.6.0 (work 10cc45a2fb) last updated 2018/04/19 14:56:13 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/vagrant/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/vagrant/ansible/lib/ansible
  executable location = /home/vagrant/ansible/bin/ansible
  python version = 3.6.3 (default, Oct  3 2017, 21:45:48) [GCC 7.2.0]
```


##### ADDITIONAL INFORMATION
Before:

```
# The loopback network interface
auto lo eth0
iface lo inet manual

# The primary network interface
iface eth0 inet manual
```

After:

```
# The loopback network interface
auto lo eth0
iface lo inet loopback

# The primary network interface
iface eth0 inet manual
```