### PR TITLE
 cs_ip_address: add a "tags" parameter to ensure idempotency

### DIFF
--- a/test/integration/targets/cs_ip_address/aliases
+++ b/test/integration/targets/cs_ip_address/aliases
@@ -1,0 +1,2 @@
+cloud/cs
+posix/ci/cloud/group1/cs

--- a/test/integration/targets/cs_ip_address/meta/main.yml
+++ b/test/integration/targets/cs_ip_address/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - cs_common

--- a/test/integration/targets/cs_ip_address/tasks/main.yml
+++ b/test/integration/targets/cs_ip_address/tasks/main.yml
@@ -1,0 +1,212 @@
+---
+- name: setup ensure the test network is absent
+  cs_network:
+    name: ipaddr_test_network
+    state: absent
+    zone: "{{ cs_common_zone_adv }}"
+
+- name: setup create the test network
+  cs_network:
+    name: ipaddr_test_network
+    network_offering: DefaultIsolatedNetworkOfferingWithSourceNatService
+    state: present
+    zone: "{{ cs_common_zone_adv }}"
+  register: base_network
+- name: setup verify create the test network
+  assert:
+    that:
+    - base_network is successful
+
+- name: setup clean ip_address with tags
+  cs_ip_address:
+    state: absent
+    tags:
+      - key: unique_id
+        value: "adacd65e-7868-5ebf-9f8b-e6e0ea779861"
+    network: ipaddr_test_network
+    zone: "{{ cs_common_zone_adv }}"
+
+- name: setup associate ip_address for SNAT
+  cs_ip_address:
+    network: ipaddr_test_network
+    zone: "{{ cs_common_zone_adv }}"
+  register: ip_address_snat
+
+- name: test associate ip_address in check mode
+  cs_ip_address:
+    network: ipaddr_test_network
+    zone: "{{ cs_common_zone_adv }}"
+  check_mode: true
+  register: ip_address
+- name: verify test associate ip_address in check mode
+  assert:
+    that:
+    - ip_address is successful
+    - ip_address is changed
+
+- name: test associate ip_address
+  cs_ip_address:
+    network: ipaddr_test_network
+    zone: "{{ cs_common_zone_adv }}"
+  register: ip_address
+- name: verify test associate ip_address
+  assert:
+    that:
+    - ip_address is successful
+    - ip_address is changed
+    - ip_address.ip_address is defined
+
+- name: test associate ip_address with tags in check mode
+  cs_ip_address:
+    network: ipaddr_test_network
+    tags:
+      - key: unique_id
+        value: "adacd65e-7868-5ebf-9f8b-e6e0ea779861"
+    zone: "{{ cs_common_zone_adv }}"
+  register: ip_address_tag
+  check_mode: true
+- name: verify test associate ip_address with tags in check mode
+  assert:
+    that:
+    - ip_address_tag is successful
+    - ip_address_tag is changed
+
+- name: test associate ip_address with tags
+  cs_ip_address:
+    network: ipaddr_test_network
+    tags:
+      - key: unique_id
+        value: "adacd65e-7868-5ebf-9f8b-e6e0ea779861"
+    zone: "{{ cs_common_zone_adv }}"
+  register: ip_address_tag
+- name: verify test associate ip_address with tags
+  assert:
+    that:
+    - ip_address_tag is successful
+    - ip_address_tag is changed
+    - ip_address_tag.ip_address is defined
+    - ip_address_tag.tags.0.key == "unique_id"
+    - ip_address_tag.tags.0.value == "adacd65e-7868-5ebf-9f8b-e6e0ea779861"
+
+- name: test associate ip_address with tags idempotence
+  cs_ip_address:
+    network: ipaddr_test_network
+    tags:
+      - key: unique_id
+        value: "adacd65e-7868-5ebf-9f8b-e6e0ea779861"
+    zone: "{{ cs_common_zone_adv }}"
+  register: ip_address_tag
+- name: verify test associate ip_address with tags idempotence
+  assert:
+    that:
+    - ip_address_tag is successful
+    - ip_address_tag is not changed
+    - ip_address_tag.ip_address is defined
+    - ip_address_tag.state == "Allocated"
+    - ip_address_tag.tags.0.key == "unique_id"
+    - ip_address_tag.tags.0.value == "adacd65e-7868-5ebf-9f8b-e6e0ea779861"
+
+- name: test disassiociate ip_address with missing param ip_address
+  cs_ip_address:
+    state: absent
+    network: ipaddr_test_network
+    zone: "{{ cs_common_zone_adv }}"
+  ignore_errors: true
+  register: ip_address_err
+- name: verify test disassiociate ip_address with missing param ip_address
+  assert:
+    that:
+    - ip_address_err is failed
+    - 'ip_address_err.msg == "state is absent but any of the following are missing: ip_address, tags"'
+
+- name: test disassociate ip_address in check mode
+  cs_ip_address:
+    state: absent
+    ip_address: "{{ ip_address.ip_address }}"
+    network: ipaddr_test_network
+    zone: "{{ cs_common_zone_adv }}"
+  check_mode: true
+  register: ip_address
+- name: verify test disassociate ip_address in check mode
+  assert:
+    that:
+    - ip_address is successful
+    - ip_address is changed
+
+- name: test disassociate ip_address
+  cs_ip_address:
+    state: absent
+    ip_address: "{{ ip_address.ip_address }}"
+    network: ipaddr_test_network
+    zone: "{{ cs_common_zone_adv }}"
+  register: ip_address
+- name: verify test disassociate ip_address
+  assert:
+    that:
+    - ip_address is successful
+    - ip_address is changed
+
+- name: test disassociate ip_address idempotence
+  cs_ip_address:
+    state: absent
+    ip_address: "{{ ip_address.ip_address }}"
+    network: ipaddr_test_network
+    zone: "{{ cs_common_zone_adv }}"
+  register: ip_address
+- name: verify test disassociate ip_address idempotence
+  assert:
+    that:
+    - ip_address is successful
+    - ip_address is not changed
+
+- name: test disassociate ip_address with tags with check mode
+  cs_ip_address:
+    state: absent
+    tags:
+      - key: unique_id
+        value: "adacd65e-7868-5ebf-9f8b-e6e0ea779861"
+    network: ipaddr_test_network
+    zone: "{{ cs_common_zone_adv }}"
+  check_mode: true
+  register: ip_address
+- name: verify test disassociate ip_address with tags in check mode
+  assert:
+    that:
+    - ip_address is successful
+    - ip_address is changed
+
+- name: test disassociate ip_address with tags
+  cs_ip_address:
+    state: absent
+    tags:
+      - key: unique_id
+        value: "adacd65e-7868-5ebf-9f8b-e6e0ea779861"
+    network: ipaddr_test_network
+    zone: "{{ cs_common_zone_adv }}"
+  register: ip_address
+- name: verify test disassociate ip_address with tags
+  assert:
+    that:
+    - ip_address is successful
+    - ip_address is changed
+
+- name: test disassociate ip_address with tags idempotence
+  cs_ip_address:
+    state: absent
+    tags:
+      - key: unique_id
+        value: "adacd65e-7868-5ebf-9f8b-e6e0ea779861"
+    network: ipaddr_test_network
+    zone: "{{ cs_common_zone_adv }}"
+  register: ip_address
+- name: verify test disassociate ip_address with tags idempotence
+  assert:
+    that:
+    - ip_address is successful
+    - ip_address is not changed
+
+- name: clean the test network
+  cs_network:
+    name: ipaddr_test_network
+    state: absent
+    zone: "{{ cs_common_zone_adv }}"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Due to Cloudstack API limitations, the calls related to IP addresses aren't idempotent.
This implies implementing some complex mechanisms in playbooks that manage public access to Cloudstack deployments.

However, resources tagging can be used to uniquely identify IP addresses.

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
lib/ansible/modules/cloud/cloudstack/cs_ip_address.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
