### PR TITLE
[aws_s3] Fix uploading src option on the target machine to a bucket

### DIFF
--- a/lib/ansible/plugins/action/aws_s3.py
+++ b/lib/ansible/plugins/action/aws_s3.py
@@ -43,11 +43,14 @@ class ActionModule(ActionBase):
             new_module_args = self._task.args.copy()
             if source:
                 source = os.path.expanduser(source)
-                try:
-                    source = self._loader.get_real_file(self._find_needle('files', source))
-                    new_module_args['src'] = source
-                except AnsibleError as e:
-                    raise AnsibleActionFail(to_text(e))
+
+                # For backward compatibility check if the file exists on the remote; it should take precedence
+                if not self._remote_file_exists(source):
+                    try:
+                        source = self._loader.get_real_file(self._find_needle('files', source))
+                        new_module_args['src'] = source
+                    except AnsibleError as e:
+                        raise AnsibleActionFail(to_text(e))
 
             # execute the aws_s3 module now, with the updated args
             result.update(self._execute_module(module_args=new_module_args, task_vars=task_vars))

--- a/lib/ansible/plugins/action/aws_s3.py
+++ b/lib/ansible/plugins/action/aws_s3.py
@@ -20,7 +20,7 @@ __metaclass__ = type
 
 import os
 
-from ansible.errors import AnsibleError, AnsibleAction, AnsibleActionFail
+from ansible.errors import AnsibleError, AnsibleAction, AnsibleActionFail, AnsibleFileNotFound
 from ansible.module_utils._text import to_text
 from ansible.plugins.action import ActionBase
 
@@ -48,6 +48,9 @@ class ActionModule(ActionBase):
                 if not self._remote_file_exists(source):
                     try:
                         source = self._loader.get_real_file(self._find_needle('files', source))
+                        new_module_args['src'] = source
+                    except AnsibleFileNotFound as e:
+                        # module handles error message for nonexistent files
                         new_module_args['src'] = source
                     except AnsibleError as e:
                         raise AnsibleActionFail(to_text(e))


### PR DESCRIPTION
##### SUMMARY
This re-enables uploading remote files (which worked prior to 4d58d16793962fb7186defa3f1a4db90a2aa2a69). Fixes https://github.com/ansible/ansible/issues/38656.
2.5 backport candidate.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/action/aws_s3.py

##### ANSIBLE VERSION
```
2.6
```