### PR TITLE
Resolves #39011

### DIFF
--- a/lib/ansible/modules/network/ios/ios_l2_interface.py
+++ b/lib/ansible/modules/network/ios/ios_l2_interface.py
@@ -146,7 +146,7 @@ def is_switchport(name, module):
 
 def interface_is_portchannel(name, module):
     if get_interface_type(name) == 'ethernet':
-        config = get_config(module, flags=[' | section interface'])
+        config = get_config(module, flags=[' | include interface'])
         if 'channel group' in config:
             return True
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This fix resolves issue #39011 by changing the show running-config
command to not use section but instead include in order to properly
capture the running-config on older devices that do not have the section
command available. I have tested this and it does indeed resolve this
issue.

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
ios_l2_interface

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0
  config file = None
  configured module search path = [u'/Users/larry/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.14 (default, Mar 10 2018, 00:01:04) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
