### PR TITLE
Cache task_vars to speed up IncludedFile.process_include_results

### DIFF
--- a/lib/ansible/playbook/included_file.py
+++ b/lib/ansible/playbook/included_file.py
@@ -54,6 +54,7 @@ class IncludedFile:
     @staticmethod
     def process_include_results(results, iterator, loader, variable_manager):
         included_files = []
+        task_vars_cache = {}
 
         for res in results:
 
@@ -73,7 +74,11 @@ class IncludedFile:
                     if 'skipped' in include_result and include_result['skipped'] or 'failed' in include_result and include_result['failed']:
                         continue
 
-                    task_vars = variable_manager.get_vars(play=iterator._play, host=original_host, task=original_task)
+                    cache_key = (iterator._play, original_host, original_task)
+                    try:
+                        task_vars = task_vars_cache[cache_key]
+                    except KeyError:
+                        task_vars = task_vars_cache[cache_key] = variable_manager.get_vars(play=iterator._play, host=original_host, task=original_task)
                     templar = Templar(loader=loader, variables=task_vars)
 
                     include_variables = include_result.get('include_variables', dict())


### PR DESCRIPTION
##### SUMMARY
Cache task_vars to speed up IncludedFile.process_include_results

`process_include_results` can be slow.  When profiling a loop on an `include_tasks` I noticed that the majority of the time spent were calls to `get_vars`.  This PR aims to cache them to improve performance.


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/playbook/included_file.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION

Some perf stats from cProfile:

before:
```
TASK [include_tasks] *************************************************************************************************************************************************************
         2195754 function calls (2184229 primitive calls) in 2.094 seconds

   Ordered by: cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.010    0.010    2.098    2.098 included_file.py:70(process_include_results)
      461    0.027    0.000    1.955    0.004 manager.py:154(get_vars)
    10603    0.077    0.000    0.946    0.000 loader.py:423(all)
      461    0.009    0.000    0.778    0.002 manager.py:430(_get_magic_variables)
```



after:
```
TASK [include_tasks] *************************************************************************************************************************************************************
         156118 function calls (156093 primitive calls) in 0.112 seconds

   Ordered by: cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.005    0.005    0.112    0.112 included_file.py:70(process_include_results)
      461    0.020    0.000    0.056    0.000 {method 'index' of 'list' objects}
   106030    0.035    0.000    0.035    0.000 included_file.py:64(__eq__)
      461    0.002    0.000    0.022    0.000 dataloader.py:177(path_dwim)
```

The above done using:

```
---
- hosts: localhost
  gather_facts: false
  tasks:
    - include_tasks: include_me.yml
      with_sequence: start=0 end=460
```