### PR TITLE
nios lookup errors out when there are no results #37970

### DIFF
--- a/lib/ansible/plugins/lookup/nios.py
+++ b/lib/ansible/plugins/lookup/nios.py
@@ -110,6 +110,6 @@ class LookupModule(LookupBase):
         res = wapi.get_object(obj_type, filter_data, return_fields=return_fields)
         if res is not None:
             for obj in res:
-                 if 'extattrs' in obj:
-                     obj['extattrs'] = flatten_extattrs(obj['extattrs'])
+                if 'extattrs' in obj:
+                    obj['extattrs'] = flatten_extattrs(obj['extattrs'])
         return res

--- a/lib/ansible/plugins/lookup/nios.py
+++ b/lib/ansible/plugins/lookup/nios.py
@@ -108,7 +108,8 @@ class LookupModule(LookupBase):
         provider = kwargs.pop('provider', {})
         wapi = WapiLookup(provider)
         res = wapi.get_object(obj_type, filter_data, return_fields=return_fields)
-        for obj in res:
-            if 'extattrs' in obj:
-                obj['extattrs'] = flatten_extattrs(obj['extattrs'])
+        if res is not None:
+          for obj in res:
+              if 'extattrs' in obj:
+                  obj['extattrs'] = flatten_extattrs(obj['extattrs'])
         return res

--- a/lib/ansible/plugins/lookup/nios.py
+++ b/lib/ansible/plugins/lookup/nios.py
@@ -109,7 +109,7 @@ class LookupModule(LookupBase):
         wapi = WapiLookup(provider)
         res = wapi.get_object(obj_type, filter_data, return_fields=return_fields)
         if res is not None:
-          for obj in res:
-              if 'extattrs' in obj:
-                  obj['extattrs'] = flatten_extattrs(obj['extattrs'])
+            for obj in res:
+                 if 'extattrs' in obj:
+                     obj['extattrs'] = flatten_extattrs(obj['extattrs'])
         return res

--- a/lib/ansible/plugins/lookup/nios.py
+++ b/lib/ansible/plugins/lookup/nios.py
@@ -112,4 +112,6 @@ class LookupModule(LookupBase):
             for obj in res:
                 if 'extattrs' in obj:
                     obj['extattrs'] = flatten_extattrs(obj['extattrs'])
+        else:
+            res = []
         return res


### PR DESCRIPTION
##### SUMMARY
When using the nios lookup feature. If a lookup has no results it fails out. with "'NoneType' object is not iterable"

##### ISSUE TYPE
Bug Report

##### COMPONENT NAME
nios_lookup

##### ANSIBLE VERSION
ansible 2.6.0 (devel 2d0547c411)
python version = 2.7.14 (default, Mar 10 2018, 00:01:04) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]


##### ADDITIONAL INFORMATION
OS / ENVIRONMENT
MAC 10.12.6

```
