### PR TITLE
make aef test more predictable

### DIFF
--- a/test/integration/targets/any_errors_fatal/on_includes.yml
+++ b/test/integration/targets/any_errors_fatal/on_includes.yml
@@ -1,9 +1,7 @@
 ---
 # based on https://github.com/ansible/ansible/issues/22924
 - name: Test any errors fatal
-  hosts: testhost
+  hosts: testhost,testhost2
   any_errors_fatal: True
   tasks:
      - include: test_fatal.yml
-       #  tags:
-       #   - any_errors_fatal_includes

--- a/test/integration/targets/any_errors_fatal/test_fatal.yml
+++ b/test/integration/targets/any_errors_fatal/test_fatal.yml
@@ -2,10 +2,11 @@
 - name: Setting the fact for 'test' to 'test value'
   set_fact:
     test: "test value"
-  when: "inventory_hostname == groups.all.0"
+  when: inventory_hostname == 'testhost2'
 
-- name: EXPECTED FAILURE echo jinja eval of a var that should not exist
-  shell: "echo {{ test }}"
+- name: EXPECTED FAILURE ejinja eval of a var that should not exist
+  debug: msg="{{ test }}"
 
-- debug:
+- name: testhost should never reach here as testhost2 failure above should end play
+  debug:
     msg: "any_errors_fatal_this_should_never_be_reached"


### PR DESCRIPTION
##### SUMMARY

revert "Disable any_errors_fatal test."
This reverts commit 56189cc312ab1907ac91c7eac30620c4f9f21546.

fixes #38407

(cherry picked from commit 3c996d0f745c84a50533478014144401629574d6)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

any_errors_fatal integration test

##### ANSIBLE VERSION

```
ansible 2.5.0 (test-fix 2268a2e7c4) last updated 2018/04/19 09:09:08 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
