### PR TITLE
Add ability to filter EC2 instances via shell environment

### DIFF
--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -32,6 +32,13 @@ the AWS_PROFILE variable:
 
 For more details, see: http://docs.pythonboto.org/en/latest/boto_config_tut.html
 
+You can filter for specific EC2 instances by creating an environment variable
+named EC2_INSTANCE_FILTERS, which has the same format as the instance_filters
+entry documented in ec2.ini.  For example, to find all hosts whose name begins
+with 'webserver', one might use:
+
+    export EC2_INSTANCE_FILTERS='tag:Name=webserver*'
+
 When run against a specific host, this script returns the following variables:
  - ec2_ami_launch_index
  - ec2_architecture
@@ -494,8 +501,8 @@ class Ec2Inventory(object):
         # Instance filters (see boto and EC2 API docs). Ignore invalid filters.
         self.ec2_instance_filters = []
 
-        if config.has_option('ec2', 'instance_filters'):
-            filters = config.get('ec2', 'instance_filters')
+        if config.has_option('ec2', 'instance_filters') or 'EC2_INSTANCE_FILTERS' in os.environ:
+            filters = os.getenv('EC2_INSTANCE_FILTERS', config.get('ec2', 'instance_filters') if config.has_option('ec2', 'instance_filters') else '')
 
             if self.stack_filters and '&' in filters:
                 self.fail_with_error("AND filters along with stack_filter enabled is not supported.\n")


### PR DESCRIPTION
##### SUMMARY
In some cases it's far easier to filter EC2 instances via environment variable, rather than by
modifying the .ini file; for example, when creating a separate job for each environment.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
EC2 external inventory script

##### ANSIBLE VERSION
```
ansible 2.5.1
  config file = /Users/ubantda/workspace/PVTOOLS/ansible-ec2host/ansible.cfg
  configured module search path = [u'/Users/ubantda/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/Cellar/python/2.7.14_3/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/ansible
  executable location = /usr/local/Cellar/python/2.7.14_3/Frameworks/Python.framework/Versions/2.7/bin/ansible
  python version = 2.7.14 (default, Feb  6 2018, 20:03:13) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```

