### PR TITLE
Fix docs build warnings.

### DIFF
--- a/docs/docsite/rst/plugins/action.rst
+++ b/docs/docsite/rst/plugins/action.rst
@@ -30,11 +30,6 @@ Plugin List
 You can use ``ansible-doc -t cache -l`` to see the list of available plugins.
 Use ``ansible-doc -t cache <plugin name>`` to see specific documentation and examples.
 
-.. toctree:: :maxdepth: 1
-    :glob:
-
-    action/*
-
 .. seealso::
 
    :doc:`cache`


### PR DESCRIPTION
##### SUMMARY

Fix docs build warnings.

##### ISSUE TYPE

Docs Pull Request

##### COMPONENT NAME

docs

##### ANSIBLE VERSION

```
ansible 2.6.0 (docs-fixes 13912f96c4) last updated 2018/04/19 13:24:00 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
