### PR TITLE
Add missing > to fix 'edit this document' link

### DIFF
--- a/docs/templates/plugin.rst.j2
+++ b/docs/templates/plugin.rst.j2
@@ -407,5 +407,5 @@ Author
 {%   if plugin_type == 'module' %}
     If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/@{ source }@?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.
 {% else %}
-    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/plugins/@{ plugin_type }@/@{ source }@`_ to improve it.
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/plugins/@{ plugin_type }@/@{ source }@>`_ to improve it.
 {% endif %}


### PR DESCRIPTION
##### SUMMARY
Broken link for non-modules


Fixes
`The test ansible-test sanity --test docs-build [explain] failed with 132 errors:`

```
docs/docsite/rst/plugins/cache/jsonfile.rst:137:0: warning: Unknown target name: "edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/plugins/cache/jsonfile.py".
docs/docsite/rst/plugins/cache/memcached.rst:144:0: warning: Unknown target name: "edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/plugins/cache/memcached.py".
docs/docsite/rst/plugins/cache/memory.rst:43:0: warning: Unknown target name: "edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/plugins/cache/memory.py".
docs/docsite/rst/plugins/cache/mongodb.rst:147:0: warning: Unknown target name: "edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/plugins/cache/mongodb.py".
d
```

##### ISSUE TYPE
 - Docs Pull Request

