### PR TITLE
Please Update easy_install.py

### DIFF
--- a/lib/ansible/modules/packaging/language/easy_install.py
+++ b/lib/ansible/modules/packaging/language/easy_install.py
@@ -91,6 +91,13 @@ from ansible.module_utils.basic import AnsibleModule
 def install_package(module, name, easy_install, executable_arguments):
     cmd = '%s %s %s' % (easy_install, ' '.join(executable_arguments), name)
     rc, out, err = module.run_command(cmd)
+    if rc:
+        # split the error message into lines, check if line contains error, then check line does not contain error we wish to ignore.
+        error_lines = err.splitlines()
+        for line in error_lines:
+            if 'error' in line.lower():
+                if 'zip-safe: No such file or directory' not in line:
+                    module.fail_json(msg=err)
     return rc, out, err
 
 
@@ -99,8 +106,8 @@ def _is_package_installed(module, name, easy_install, executable_arguments):
     executable_arguments = executable_arguments[:]
     executable_arguments.append('--dry-run')
     rc, out, err = install_package(module, name, easy_install, executable_arguments)
-    if rc:
-        module.fail_json(msg=err)
+#    if rc:
+#        module.fail_json(msg=err)
     return 'Downloading' not in out
 
 


### PR DESCRIPTION
##### SUMMARY
This commit is a workaround to packages that generate a return code 1 because of the zip-safe flag error, this workaround adds additional validation on the rc check to ignore zip-safe error but still fail on any other error.

Details of problems encountered in below issue comment;
https://github.com/ansible/ansible/issues/37296#issuecomment-382777344 

upstream issue created below;
https://github.com/pypa/setuptools/issues/1334

##### ISSUE TYPE
 - Bugfix Pull Request


##### COMPONENT NAME
Module > easy_install.py

##### ANSIBLE VERSION
```
ansible 2.5.1
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /bin/ansible
  python version = 2.7.5 (default, Feb 20 2018, 09:19:12) [GCC 4.8.5 20150623 (Red Hat 4.8.5-28)]
```