### PR TITLE
Fix misuse of 'self' in lib/ansible/module_utils/network/eos/eos.py. …

### DIFF
--- a/lib/ansible/module_utils/network/eos/eos.py
+++ b/lib/ansible/module_utils/network/eos/eos.py
@@ -232,7 +232,7 @@ class Cli:
 
         if not all((bool(use_session), self.supports_sessions)):
             if commit:
-                return self.configure(self, commands)
+                return self.configure(commands)
             else:
                 self._module.warn("EOS can not check config without config session")
                 result = {'changed': True}

--- a/lib/ansible/module_utils/network/eos/eos.py
+++ b/lib/ansible/module_utils/network/eos/eos.py
@@ -420,7 +420,7 @@ class Eapi:
 
         if not all((bool(use_session), self.supports_sessions)):
             if commit:
-                return self.configure(self, config)
+                return self.configure(config)
             else:
                 self._module.warn("EOS can not check config without config session")
                 result = {'changed': True}


### PR DESCRIPTION
Fixes #27630

##### SUMMARY
There seems to be a slight error in `ansible/lib/ansible/module_utils/network/eos/eos.py` in the method `load_config`.

As you can see from the snippet below in the old code, when `configure` is called (an instance method of CLI), `self` is given as an argument. This is causing an error (see issue number #27630) because `configure` only takes two arguments. This commit removes `self` from the arguments of load_config.

Old code:
```
def load_config(self, commands, commit=False, replace=False):
        ...
        if not all((bool(use_session), self.supports_sessions)):
            if commit:
                return self.configure(self, commands)
            else:
                self._module.warn("EOS can not check config without config session")
                result = {'changed': True}
                return result
        ....
```
New code:
```
def load_config(self, commands, commit=False, replace=False):
        ...
        if not all((bool(use_session), self.supports_sessions)):
            if commit:
                return self.configure(commands)
            else:
                self._module.warn("EOS can not check config without config session")
                result = {'changed': True}
                return result
        ....
```

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
`ansible/lib/ansible/module_utils/network/eos/eos.py`

##### ANSIBLE VERSION
```
ansible 2.4.2.0
  config file = /Users/xbbnllu/.ansible.cfg
  configured module search path = [u'/Users/xbbnllu/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/ansible
  executable location = ./bin/ansible
  python version = 2.7.13 (v2.7.13:a06454b1afa1, Dec 17 2016, 12:39:47) [GCC 4.2.1 (Apple Inc. build 5666) (dot 3)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
[bugfix/misuse_of_self_in_eos_module_util 2a22085b2b] Fix misuse of 'self' in lib/ansible/module_utils/network/eos/eos.py. Method load_config
 1 file changed, 1 insertion(+), 1 deletion(-)

```
