### PR TITLE
Add note about sefcontext doing no restorecon

### DIFF
--- a/lib/ansible/modules/system/sefcontext.py
+++ b/lib/ansible/modules/system/sefcontext.py
@@ -53,6 +53,8 @@ options:
     default: 'yes'
 notes:
 - The changes are persistent across reboots
+- The changes are not effective until you do a restorecon, even if
+  reload is set to yes
 requirements:
 - libselinux-python
 - policycoreutils-python

--- a/lib/ansible/modules/system/sefcontext.py
+++ b/lib/ansible/modules/system/sefcontext.py
@@ -53,8 +53,10 @@ options:
     default: 'yes'
 notes:
 - The changes are persistent across reboots
-- The changes are not effective until you do a restorecon, even if
-  reload is set to yes
+- The M(sefcontext) module does not modify existing files to the new
+  SELinux context(s), so it is advisable to first create the SELinux
+  file contexts before creating files, or run C(restorecon) manually
+  for the existing files that require the new SELinux file contexts.
 requirements:
 - libselinux-python
 - policycoreutils-python


### PR DESCRIPTION
To someone like me who is relatively new to SELinux, setting the `reload` option to `yes` might suggest that a `restorecon` is automatically executed after the `semanage` call, making the new file context effective immediately. I have found out that this is not the case and would like to clarify this to others.

+label: docsite_pr

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
sefcontext module

##### ANSIBLE VERSION
```
ansible 2.5.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/zeust/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Aug  4 2017, 00:39:18) [GCC 4.8.5 20150623 (Red Hat 4.8.5-16)]
```