### PR TITLE
Add returning values to the rds_subnet_group module

### DIFF
--- a/lib/ansible/modules/cloud/amazon/rds_subnet_group.py
+++ b/lib/ansible/modules/cloud/amazon/rds_subnet_group.py
@@ -105,6 +105,7 @@ def get_subnet_group_info(subnet_group):
         status=subnet_group.status
     )
 
+
 def create_result(changed, subnet_group=None):
     if subnet_group is None:
         return dict(
@@ -115,6 +116,7 @@ def create_result(changed, subnet_group=None):
             changed=changed,
             subnet_group=get_subnet_group_info(subnet_group)
         )
+
 
 def main():
     argument_spec = ec2_argument_spec()

--- a/lib/ansible/modules/cloud/amazon/rds_subnet_group.py
+++ b/lib/ansible/modules/cloud/amazon/rds_subnet_group.py
@@ -57,6 +57,34 @@ EXAMPLES = '''
     name: norwegian-blue
 '''
 
+RETURN = '''
+subnet_group:
+    description: Dictionary of DB subnet group values
+    returned: I(state=present)
+    type: complex
+    contains:
+        name:
+            description: The name of the DB subnet group
+            returned: I(state=present)
+            type: string
+        description:
+            description: The description of the DB subnet group
+            returned: I(state=present)
+            type: string
+        vpc_id:
+            description: The VpcId of the DB subnet group
+            returned: I(state=present)
+            type: string
+        subnet_ids:
+            description: Contains a list of Subnet IDs
+            returned: I(state=present)
+            type: array
+        status:
+            description: The status of the DB subnet group
+            returned: I(state=present)
+            type: string
+'''
+
 try:
     import boto.rds
     from boto.exception import BotoServerError
@@ -67,6 +95,26 @@ except ImportError:
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ec2 import HAS_BOTO, connect_to_aws, ec2_argument_spec, get_aws_connection_info
 
+
+def get_subnet_group_info(subnet_group):
+    return dict(
+        name=subnet_group.name,
+        description=subnet_group.description,
+        vpc_id=subnet_group.vpc_id,
+        subnet_ids=subnet_group.subnet_ids,
+        status=subnet_group.status
+    )
+
+def create_result(changed, subnet_group=None):
+    if subnet_group is None:
+        return dict(
+            changed=changed
+        )
+    else:
+        return dict(
+            changed=changed,
+            subnet_group=get_subnet_group_info(subnet_group)
+        )
 
 def main():
     argument_spec = ec2_argument_spec()
@@ -108,8 +156,8 @@ def main():
         module.fail_json(msg=e.error_message)
 
     try:
-        changed = False
         exists = False
+        result = create_result(False)
 
         try:
             matching_groups = conn.get_all_db_subnet_groups(group_name, max_records=100)
@@ -121,11 +169,11 @@ def main():
         if state == 'absent':
             if exists:
                 conn.delete_db_subnet_group(group_name)
-                changed = True
+                result = create_result(True)
         else:
             if not exists:
                 new_group = conn.create_db_subnet_group(group_name, desc=group_description, subnet_ids=group_subnets)
-                changed = True
+                result = create_result(True, new_group)
             else:
                 # Sort the subnet groups before we compare them
                 matching_groups[0].subnet_ids.sort()
@@ -134,11 +182,13 @@ def main():
                         matching_groups[0].description != group_description or
                         matching_groups[0].subnet_ids != group_subnets):
                     changed_group = conn.modify_db_subnet_group(group_name, description=group_description, subnet_ids=group_subnets)
-                    changed = True
+                    result = create_result(True, changed_group)
+                else:
+                    result = create_result(False, matching_groups[0])
     except BotoServerError as e:
         module.fail_json(msg=e.error_message)
 
-    module.exit_json(changed=changed)
+    module.exit_json(**result)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
##### SUMMARY

Returning attribute values of DB subnet group is very useful for writing subsequent tasks.

##### ISSUE TYPE

 - Feature Pull Request

##### COMPONENT NAME

rds_subnet_group

##### ANSIBLE VERSION

```
$ ansible --version
ansible 2.6.0 (devel e6299298f9) last updated 2018/04/20 20:41:58 (GMT +900)
  config file = None
  configured module search path = [u'/Users/krdlab/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/krdlab/.provisioning/dev/projects/misc/krdlab/ansible/lib/ansible
  executable location = /Users/krdlab/.provisioning/dev/projects/misc/krdlab/ansible/bin/ansible
  python version = 2.7.11 (default, Oct 20 2016, 16:27:36) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
