### PR TITLE
Adding module for AWS Config service

### DIFF
--- a/lib/ansible/modules/cloud/amazon/aws_config.py
+++ b/lib/ansible/modules/cloud/amazon/aws_config.py
@@ -1,0 +1,669 @@
+#!/usr/bin/python
+
+# Copyright: (c) 2018, Aaron Smith <ajsmith10381@gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = r'''
+---
+module: aws_config
+short_description: Manage AWS Config resources
+description:
+    - Module manages AWS Config resources
+    - Supported resource types include rules, configuration recorders, delivery channels, aggregation_authorizations, and configuration_aggregators.
+version_added: "2.6"
+requirements: [ 'botocore', 'boto3' ]
+author:
+    - "Aaron Smith (@slapula)"
+options:
+  name:
+    description:
+    - The name of the AWS Config resource.
+    required: true
+  state:
+    description:
+    - Whether the Config rule should be present or absent.
+    default: present
+    choices: ['present', 'absent']
+  resource_type:
+    description:
+    - The type of AWS Config resource you are manipulating.
+    required: true
+    choices: ['rule', 'delivery_channel', 'configuration_recorder', 'aggregation_authorization', 'configuration_aggregator']
+  description:
+    description:
+    - The description that you provide for the AWS Config rule.
+    - Resource type `rule`
+  scope:
+    description:
+    - Defines which resources can trigger an evaluation for the rule.
+    - Resource type `rule`
+    required: true
+    suboptions:
+      compliance_types:
+        description:
+        - The resource types of only those AWS resources that you want to trigger an evaluation for the rule.
+          You can only specify one type if you also specify a resource ID for `compliance_id`.
+      compliance_id:
+        description:
+        - The ID of the only AWS resource that you want to trigger an evaluation for the rule. If you specify a resource ID,
+          you must specify one resource type for `compliance_types`.
+      tag_key:
+        description:
+        - The tag key that is applied to only those AWS resources that you want to trigger an evaluation for the rule.
+      tag_value:
+        description:
+        - The tag value applied to only those AWS resources that you want to trigger an evaluation for the rule.
+          If you specify a value for `tag_value`, you must also specify a value for `tag_key`.
+  source:
+    description:
+    - Provides the rule owner (AWS or customer), the rule identifier, and the notifications that cause the function to
+      evaluate your AWS resources.
+    - Resource type `rule`
+    suboptions:
+      owner:
+        description:
+        - The resource types of only those AWS resources that you want to trigger an evaluation for the rule.
+          You can only specify one type if you also specify a resource ID for `compliance_id`.
+      identifier:
+        description:
+        - The ID of the only AWS resource that you want to trigger an evaluation for the rule.
+          If you specify a resource ID, you must specify one resource type for `compliance_types`.
+      details:
+        description:
+        - Provides the source and type of the event that causes AWS Config to evaluate your AWS resources.
+        - This parameter expects a list of dictionaries.  Each dictionary expects the following key/value pairs.
+        - Key `EventSource` The source of the event, such as an AWS service, that triggers AWS Config to evaluate your AWS resources.
+        - Key `MessageType` The type of notification that triggers AWS Config to run an evaluation for a rule.
+        - Key `MaximumExecutionFrequency` The frequency at which you want AWS Config to run evaluations for a custom rule with a periodic trigger.
+  input_parameters:
+    description:
+    - A string, in JSON format, that is passed to the AWS Config rule Lambda function.
+    - Resource type `rule`
+  execution_frequency:
+    description:
+    - The maximum frequency with which AWS Config runs evaluations for a rule.
+    - Resource type `rule`
+    choices: ['One_Hour', 'Three_Hours', 'Six_Hours', 'Twelve_Hours', 'TwentyFour_Hours']
+  role_arn:
+    description:
+    - Amazon Resource Name (ARN) of the IAM role used to describe the AWS resources associated with the account.
+    - Resource type `configuration_recorder`
+  recording_group:
+    description:
+    - Specifies the types of AWS resources for which AWS Config records configuration changes.
+    - Resource type `configuration_recorder`
+    suboptions:
+      all_supported:
+        description:
+        - Specifies whether AWS Config records configuration changes for every supported type of regional resource.
+        - If you set this option to `true`, when AWS Config adds support for a new type of regional resource, it starts
+          recording resources of that type automatically.
+        - If you set this option to `true`, you cannot enumerate a list of `resource_types`.
+      include_global_types:
+        description:
+        - Specifies whether AWS Config includes all supported types of global resources (for example, IAM resources)
+          with the resources that it records.
+        - Before you can set this option to `true`, you must set the allSupported option to `true`.
+        - If you set this option to `true`, when AWS Config adds support for a new type of global resource, it starts recording
+          resources of that type automatically.
+        - The configuration details for any global resource are the same in all regions. To prevent duplicate configuration items,
+          you should consider customizing AWS Config in only one region to record global resources.
+      resource_types:
+        description:
+        - A list that specifies the types of AWS resources for which AWS Config records configuration changes (for example,
+          `AWS::EC2::Instance` or `AWS::CloudTrail::Trail`).
+        - Before you can set this option to `true`, you must set the `all_supported` option to `false`.
+  s3_bucket:
+    description:
+    - The name of the Amazon S3 bucket to which AWS Config delivers configuration snapshots and configuration history files.
+    - Resource type `delivery_channel`
+  s3_prefix:
+    description:
+    - The prefix for the specified Amazon S3 bucket.
+    - Resource type `delivery_channel`
+  sns_topic_arn:
+    description:
+    - The Amazon Resource Name (ARN) of the Amazon SNS topic to which AWS Config sends notifications about configuration changes.
+    - Resource type `delivery_channel`
+  delivery_frequency:
+    description:
+    - The frequency with which AWS Config delivers configuration snapshots.
+    - Resource type `delivery_channel`
+    choices: ['One_Hour', 'Three_Hours', 'Six_Hours', 'Twelve_Hours', 'TwentyFour_Hours']
+  authorized_account_id:
+    description:
+    - The 12-digit account ID of the account authorized to aggregate data.
+    - Resource type `aggregation_authorization`
+  authorized_aws_region:
+    description:
+    - The region authorized to collect aggregated data.
+    - Resource type `aggregation_authorization`
+  account_sources:
+    description:
+    - The 12-digit account ID of the account authorized to aggregate data.
+    - Resource type `configuration_aggregator`
+  organization_source:
+    description:
+    - The region authorized to collect aggregated data.
+    - Resource type `configuration_aggregator`
+    suboptions:
+      role_arn:
+        description:
+        - ARN of the IAM role used to retreive AWS Organization details associated with the aggregator account.
+      aws_regions:
+        description:
+        - The source regions being aggregated.
+      all_aws_regions:
+        description:
+        - If true, aggreagate existing AWS Config regions and future regions.
+extends_documentation_fragment:
+  - aws
+  - ec2
+'''
+
+EXAMPLES = r'''
+- name: Create Configuration Recorder for AWS Config
+  aws_config:
+    name: test_configuration_recorder
+    state: present
+    resource_type: configuration_recorder
+    role_arn: 'arn:aws:iam::123456789012:role/AwsConfigRecorder'
+    recording_group:
+        all_supported: true
+        include_global_types: true
+        resource_types: []
+
+- name: Create Delivery Channel for AWS Config
+  aws_config:
+    name: test_delivery_channel
+    state: present
+    resource_type: delivery_channel
+    s3_bucket: 'test_aws_config_bucket'
+    s3_prefix: "/*"
+    sns_topic_arn: 'arn:aws:sns:us-east-1:123456789012:aws_config_topic:1234ab56-cdef-7g89-01hi-2jk34l5m67no'
+    delivery_frequency: 'Twelve_Hours'
+
+- name: Create Config Rule for AWS Config
+  aws_config:
+    name: test_config_rule
+    state: present
+    resource_type: rule
+    description: 'This AWS Config rule checks for public write access on S3 buckets'
+    scope:
+        compliance_types:
+            - 'AWS::S3::Bucket'
+    source:
+        owner: aws
+        identifier: 'S3_BUCKET_PUBLIC_WRITE_PROHIBITED'
+
+'''
+
+RETURN = r'''#'''
+
+
+try:
+    import botocore
+    from botocore.exceptions import BotoCoreError, ClientError
+except ImportError:
+    pass  # handled by AnsibleAWSModule
+
+from ansible.module_utils.aws.core import AnsibleAWSModule
+from ansible.module_utils.ec2 import boto3_conn, get_aws_connection_info, AWSRetry
+from ansible.module_utils.ec2 import camel_dict_to_snake_dict, boto3_tag_list_to_ansible_dict
+
+
+def resource_exists(client, module, resource_type, params):
+    if resource_type == 'configuration_recorder':
+        try:
+            client.describe_configuration_recorders(
+                ConfigurationRecorderNames=[params['name']]
+            )
+            return True
+        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError):
+            return False
+
+    if resource_type == 'delivery_channel':
+        try:
+            client.describe_delivery_channels(
+                DeliveryChannelNames=[params['name']]
+            )
+            return True
+        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError):
+            return False
+
+    if resource_type == 'rule':
+        try:
+            client.describe_config_rules(
+                ConfigRuleNames=[params['ConfigRuleName']]
+            )
+            return True
+        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError):
+            return False
+
+    if resource_type == 'aggregation_authorization':
+        try:
+            current_authorizations = client.describe_aggregation_authorizations()['AggregationAuthorizations']
+            authorization_exists = next(
+                (item for item in current_authorizations if item["AuthorizedAccountId"] == params['AuthorizedAccountId']),
+                None
+            )
+            if authorization_exists:
+                return True
+        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError):
+            return False
+
+    if resource_type == 'configuration_aggregator':
+        try:
+            client.describe_configuration_aggregators(
+                ConfigurationAggregatorNames=[params['name']]
+            )
+            return True
+        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError):
+            return False
+
+    return False
+
+
+def create_resource(client, module, resource_type, params, result):
+    if resource_type == 'configuration_recorder':
+        try:
+            response = client.put_configuration_recorder(
+                ConfigurationRecorder=params
+            )
+            result['changed'] = True
+            return result
+        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+            module.fail_json_aws(e, msg="Couldn't create AWS Config configuration recorder")
+
+    if resource_type == 'delivery_channel':
+        try:
+            response = client.put_delivery_channel(
+                DeliveryChannel=params
+            )
+            result['changed'] = True
+            return result
+        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+            module.fail_json_aws(e, msg="Couldn't create AWS Config delivery channel")
+
+    if resource_type == 'rule':
+        try:
+            response = client.put_config_rule(
+                ConfigRule=params
+            )
+            result['changed'] = True
+            return result
+        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+            module.fail_json_aws(e, msg="Couldn't create AWS Config rule")
+
+    if resource_type == 'aggregation_authorization':
+        try:
+            response = client.put_aggregation_authorization(
+                AuthorizedAccountId=params['AuthorizedAccountId'],
+                AuthorizedAwsRegion=params['AuthorizedAwsRegion']
+            )
+            result['changed'] = True
+            return result
+        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+            module.fail_json_aws(e, msg="Couldn't create AWS Aggregation authorization")
+
+    if resource_type == 'configuration_aggregator':
+        try:
+            response = client.put_configuration_aggregator(
+                ConfigurationAggregatorName=params['ConfigurationAggregatorName'],
+                AccountAggregationSources=params['AccountAggregationSources'],
+                OrganizationAggregationSource=params['OrganizationAggregationSource']
+            )
+            result['changed'] = True
+            return result
+        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+            module.fail_json_aws(e, msg="Couldn't create AWS Config configuration aggregator")
+
+    return result
+
+
+def update_resource(client, module, resource_type, params, result):
+    if resource_type == 'configuration_recorder':
+        current_params = client.describe_configuration_recorders(
+            ConfigurationRecorderNames=[params['name']]
+        )
+
+        if params != current_params['ConfigurationRecorders'][0]:
+            try:
+                response = client.put_configuration_recorder(
+                    ConfigurationRecorder=params
+                )
+                result['changed'] = True
+                return result
+            except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+                module.fail_json_aws(e, msg="Couldn't update AWS Config configuration recorder")
+
+    if resource_type == 'delivery_channel':
+        current_params = client.describe_delivery_channels(
+            DeliveryChannelNames=[params['name']]
+        )
+
+        if params != current_params['DeliveryChannels'][0]:
+            try:
+                response = client.put_delivery_channel(
+                    DeliveryChannel=params
+                )
+                result['changed'] = True
+                return result
+            except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+                module.fail_json_aws(e, msg="Couldn't create AWS Config delivery channel")
+
+    if resource_type == 'rule':
+        current_params = client.describe_config_rules(
+            ConfigRuleNames=[params['ConfigRuleName']]
+        )
+
+        del current_params['ConfigRules'][0]['ConfigRuleArn']
+        del current_params['ConfigRules'][0]['ConfigRuleId']
+
+        if params != current_params['ConfigRules'][0]:
+            try:
+                response = client.put_config_rule(
+                    ConfigRule=params
+                )
+                result['changed'] = True
+                return result
+            except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+                module.fail_json_aws(e, msg="Couldn't create AWS Config rule")
+
+    if resource_type == 'aggregation_authorization':
+        current_authorizations = client.describe_aggregation_authorizations()['AggregationAuthorizations']
+        current_params = next(
+            (item for item in current_authorizations if item["AuthorizedAccountId"] == params['AuthorizedAccountId']),
+            None
+        )
+
+        del current_params['AggregationAuthorizationArn']
+        del current_params['CreationTime']
+
+        if params != current_params:
+            try:
+                response = client.put_aggregation_authorization(
+                    AuthorizedAccountId=params['AuthorizedAccountId'],
+                    AuthorizedAwsRegion=params['AuthorizedAwsRegion']
+                )
+                result['changed'] = True
+                return result
+            except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+                module.fail_json_aws(e, msg="Couldn't create AWS Aggregation authorization")
+
+    if resource_type == 'configuration_aggregator':
+        current_params = client.describe_configuration_aggregators(
+            ConfigurationAggregatorNames=[params['name']]
+        )
+
+        del current_params['ConfigurationAggregatorArn']
+        del current_params['CreationTime']
+        del current_params['LastUpdatedTime']
+
+        if params != current_params['ConfigurationAggregators'][0]:
+            try:
+                response = client.put_configuration_aggregator(
+                    ConfigurationAggregatorName=params['ConfigurationAggregatorName'],
+                    AccountAggregationSources=params['AccountAggregationSources'],
+                    OrganizationAggregationSource=params['OrganizationAggregationSource']
+                )
+                result['changed'] = True
+                return result
+            except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+                module.fail_json_aws(e, msg="Couldn't create AWS Config configuration aggregator")
+
+    return result
+
+
+def delete_resource(client, module, resource_type, params, result):
+    if resource_type == 'configuration_recorder':
+        try:
+            response = client.delete_configuration_recorder(
+                ConfigurationRecorderName=params['name']
+            )
+            result['changed'] = True
+            return result
+        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+            module.fail_json_aws(e, msg="Couldn't delete AWS Config configuration recorder")
+
+    if resource_type == 'delivery_channel':
+        try:
+            response = client.delete_delivery_channel(
+                DeliveryChannelName=params['name']
+            )
+            result['changed'] = True
+            return result
+        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+            module.fail_json_aws(e, msg="Couldn't delete AWS Config delivery channel")
+
+    if resource_type == 'rule':
+        try:
+            response = client.delete_config_rule(
+                ConfigRuleName=params['ConfigRuleName']
+            )
+            result['changed'] = True
+            return result
+        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+            module.fail_json_aws(e, msg="Couldn't delete AWS Config rule")
+
+    if resource_type == 'aggregation_authorization':
+        try:
+            response = client.delete_aggregation_authorization(
+                AuthorizedAccountId=params['AuthorizedAccountId'],
+                AuthorizedAwsRegion=params['AuthorizedAwsRegion']
+            )
+            result['changed'] = True
+            return result
+        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+            module.fail_json_aws(e, msg="Couldn't delete AWS Aggregation authorization")
+
+    if resource_type == 'configuration_aggregator':
+        try:
+            response = client.delete_configuration_aggregator(
+                ConfigurationAggregatorName=params['ConfigurationAggregatorName']
+            )
+            result['changed'] = True
+            return result
+        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+            module.fail_json_aws(e, msg="Couldn't delete AWS Config configuration aggregator")
+
+    return result
+
+
+def main():
+    requirements = [
+        ('resource_type', 'rule', ['source']),
+        ('resource_type', 'delivery_channel', ['s3_bucket']),
+        ('resource_type', 'configuration_recorder', ['role_arn'])
+    ]
+
+    module = AnsibleAWSModule(
+        argument_spec={
+            'name': dict(type='str', required=True),
+            'state': dict(type='str', choices=['present', 'absent'], default='present'),
+            'resource_type': dict(
+                type='str',
+                choices=[
+                    'rule',
+                    'delivery_channel',
+                    'configuration_recorder',
+                    'aggregation_authorization'
+                ],
+                required=True
+            ),
+            'description': dict(type='str'),
+            'scope': dict(type='dict'),
+            'source': dict(type='dict'),
+            'input_parameters': dict(type='str'),
+            'execution_frequency': dict(type='str', choices=['One_Hour', 'Three_Hours', 'Six_Hours', 'Twelve_Hours', 'TwentyFour_Hours']),
+            's3_bucket': dict(type='str'),
+            's3_prefix': dict(type='str'),
+            'sns_topic_arn': dict(type='str'),
+            'delivery_frequency': dict(type='str', choices=['One_Hour', 'Three_Hours', 'Six_Hours', 'Twelve_Hours', 'TwentyFour_Hours']),
+            'role_arn': dict(type='str'),
+            'recording_group': dict(type='dict'),
+            'authorized_account_id': dict(type='str'),
+            'authorized_aws_region': dict(type='str'),
+            'account_sources': dict(type='list'),
+            'organization_source': dict(type='dict')
+        },
+        supports_check_mode=False,
+        required_if=requirements,
+    )
+
+    result = {
+        'changed': False
+    }
+
+    name = module.params.get('name')
+    resource_type = module.params.get('resource_type')
+    state = module.params.get('state')
+
+    if resource_type == 'rule':
+        params = {}
+        if name:
+            params['ConfigRuleName'] = name
+        if module.params.get('description'):
+            params['Description'] = module.params.get('description')
+        if module.params.get('scope'):
+            params['Scope'] = {}
+            if module.params.get('scope').get('compliance_types'):
+                params['Scope'].update({
+                    'ComplianceResourceTypes': module.params.get('scope').get('compliance_types')
+                })
+            if module.params.get('scope').get('tag_key'):
+                params['Scope'].update({
+                    'TagKey': module.params.get('scope').get('tag_key')
+                })
+            if module.params.get('scope').get('tag_value'):
+                params['Scope'].update({
+                    'TagValue': module.params.get('scope').get('tag_value')
+                })
+            if module.params.get('scope').get('compliance_id'):
+                params['Scope'].update({
+                    'ComplianceResourceId': module.params.get('scope').get('compliance_id')
+                })
+        if module.params.get('source'):
+            params['Source'] = {}
+            if module.params.get('source').get('owner'):
+                params['Source'].update({
+                    'Owner': module.params.get('source').get('owner')
+                })
+            if module.params.get('source').get('identifier'):
+                params['Source'].update({
+                    'SourceIdentifier': module.params.get('source').get('identifier')
+                })
+            if module.params.get('source').get('details'):
+                params['Source'].update({
+                    'SourceDetails': module.params.get('source').get('details')
+                })
+        if module.params.get('input_parameters'):
+            params['InputParameters'] = module.params.get('input_parameters')
+        if module.params.get('execution_frequency'):
+            params['MaximumExecutionFrequency'] = module.params.get('execution_frequency')
+        params['ConfigRuleState'] = 'ACTIVE'
+
+    if resource_type == 'delivery_channel':
+        params = {}
+        if name:
+            params['name'] = name
+        if module.params.get('s3_bucket'):
+            params['s3BucketName'] = module.params.get('s3_bucket')
+        if module.params.get('s3_prefix'):
+            params['s3KeyPrefix'] = module.params.get('s3_prefix')
+        if module.params.get('sns_topic_arn'):
+            params['snsTopicARN'] = module.params.get('sns_topic_arn')
+        if module.params.get('s3_prefix'):
+            params['s3KeyPrefix'] = module.params.get('s3_prefix')
+        if module.params.get('delivery_frequency'):
+            params['configSnapshotDeliveryProperties'] = {
+                'deliveryFrequency': module.params.get('delivery_frequency')
+            }
+
+    if resource_type == 'configuration_recorder':
+        params = {}
+        if name:
+            params['name'] = name
+        if module.params.get('role_arn'):
+            params['roleARN'] = module.params.get('role_arn')
+        if module.params.get('recording_group'):
+            params['recordingGroup'] = {}
+            if module.params.get('recording_group').get('all_supported'):
+                params['recordingGroup'].update({
+                    'allSupported': module.params.get('recording_group').get('all_supported')
+                })
+            if module.params.get('recording_group').get('include_global_types'):
+                params['recordingGroup'].update({
+                    'includeGlobalResourceTypes': module.params.get('recording_group').get('include_global_types')
+                })
+            if module.params.get('recording_group').get('resource_types'):
+                params['recordingGroup'].update({
+                    'resourceTypes': module.params.get('recording_group').get('resource_types')
+                })
+
+    if resource_type == 'aggregation_authorization':
+        params = {}
+        if module.params.get('authorized_account_id'):
+            params['AuthorizedAccountId'] = module.params.get('authorized_account_id')
+        if module.params.get('authorized_aws_region'):
+            params['AuthorizedAwsRegion'] = module.params.get('authorized_aws_region')
+
+    if resource_type == 'configuration_aggregator':
+        params = {}
+        if module.params.get('name'):
+            params['ConfigurationAggregatorName'] = module.params.get('name')
+        if module.params.get('account_sources'):
+            params['AccountAggregationSources'] = []
+            for i in module.params.get('account_sources'):
+                tmp_dict = {}
+                if i.get('account_ids'):
+                    tmp_dict['AccountIds'] = i.get('account_ids')
+                if i.get('aws_regions'):
+                    tmp_dict['AwsRegions'] = i.get('aws_regions')
+                if i.get('all_aws_regions'):
+                    tmp_dict['AllAwsRegions'] = i.get('all_aws_regions')
+                params['AccountAggregationSources'].append(tmp_dict)
+        if module.params.get('organization_source'):
+            params['OrganizationAggregationSource'] = {}
+            if module.params.get('organization_source').get('role_arn'):
+                params['OrganizationAggregationSource'].update({
+                    'RoleArn': module.params.get('organization_source').get('role_arn')
+                })
+            if module.params.get('organization_source').get('aws_regions'):
+                params['OrganizationAggregationSource'].update({
+                    'AwsRegions': module.params.get('organization_source').get('aws_regions')
+                })
+            if module.params.get('organization_source').get('all_aws_regions'):
+                params['OrganizationAggregationSourcep'].update({
+                    'AllAwsRegions': module.params.get('organization_source').get('all_aws_regions')
+                })
+
+    region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
+    client = boto3_conn(module, conn_type='client', resource='config', region=region, endpoint=ec2_url, **aws_connect_kwargs)
+
+    resource_status = resource_exists(client, module, resource_type, params)
+
+    if state == 'present':
+        if not resource_status:
+            create_resource(client, module, resource_type, params, result)
+        if resource_status:
+            update_resource(client, module, resource_type, params, result)
+
+    if state == 'absent':
+        if resource_status:
+            delete_resource(client, module, resource_type, params, result)
+
+    module.exit_json(changed=result['changed'])
+
+
+if __name__ == '__main__':
+    main()

--- a/test/integration/targets/aws_config/aliases
+++ b/test/integration/targets/aws_config/aliases
@@ -1,0 +1,2 @@
+cloud/aws
+posix/ci/cloud/group4/aws

--- a/test/integration/targets/aws_config/defaults/main.yaml
+++ b/test/integration/targets/aws_config/defaults/main.yaml
@@ -1,0 +1,2 @@
+---
+config_s3_bucket: 'test-aws-config-bucket'

--- a/test/integration/targets/aws_config/files/config-trust-policy.json
+++ b/test/integration/targets/aws_config/files/config-trust-policy.json
@@ -1,0 +1,13 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "config.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}

--- a/test/integration/targets/aws_config/tasks/main.yaml
+++ b/test/integration/targets/aws_config/tasks/main.yaml
@@ -1,0 +1,459 @@
+---
+- block:
+
+    # ============================================================
+    # Prerequisites
+    # ============================================================
+    - name: set connection information for all tasks
+      set_fact:
+        aws_connection_info: &aws_connection_info
+          aws_access_key: "{{ aws_access_key }}"
+          aws_secret_key: "{{ aws_secret_key }}"
+          region: "{{ aws_region }}"
+      no_log: true
+
+    - name: ensure IAM role exists
+      iam_role:
+        <<: *aws_connection_info
+        name: AwsConfigRecorderTestRole
+        assume_role_policy_document: "{{ lookup('file','config-trust-policy.json') }}"
+        state: present
+        create_instance_profile: no
+        managed_policy:
+        - 'arn:aws:iam::aws:policy/service-role/AWSConfigRole'
+      register: config_iam_role
+
+    - name: ensure SNS topic exists
+      sns_topic:
+        <<: *aws_connection_info
+        name: AwsConfigDeliveryChannelTestTopic
+        state: present
+        subscriptions:
+          - endpoint: "rando_email_address@rando.com"
+            protocol: "email"
+      register: config_sns_topic
+
+    - name: ensure S3 bucket exists
+      s3_bucket:
+        <<: *aws_connection_info
+        name: "{{ config_s3_bucket | to_uuid }}"
+
+    - name: ensure S3 access for IAM role
+      iam_policy:
+        <<: *aws_connection_info
+        iam_type: role
+        iam_name: AwsConfigRecorderTestRole
+        policy_name: AwsConfigRecorderTestRoleS3Policy
+        state: present
+        policy_json: "{{ lookup( 'template', 'config-s3-policy.json.j2') }}"
+
+    # ============================================================
+    # Module requirement testing
+    # ============================================================
+    - name: test with no parameters
+      aws_config:
+      register: output
+      ignore_errors: true
+
+    - name: assert failure when called with no parameters
+      assert:
+        that:
+           - output.failed
+           - 'output.msg.startswith("missing required arguments: name")'
+
+    - name: test with no name parameter
+      aws_config:
+        state: present
+      register: output
+      ignore_errors: true
+
+    - name: assert failure when called with no name parameter
+      assert:
+        that:
+           - output.failed
+           - 'output.msg.startswith("missing required arguments: name")'
+
+    - name: test with no resource_type parameter
+      aws_config:
+        name: random_name
+        state: present
+      register: output
+      ignore_errors: true
+
+    - name: assert failure when called with no resource_type parameter
+      assert:
+        that:
+           - output.failed
+           - 'output.msg.startswith("missing required arguments: resource_type")'
+
+    - name: test resource_type rule with no source parameter
+      aws_config:
+        name: random_name
+        state: present
+        resource_type: rule
+      register: output
+      ignore_errors: true
+
+    - name: assert failure when called with no source parameter
+      assert:
+        that:
+           - output.failed
+           - 'output.msg.startswith("resource_type is rule but all of the following are missing: source")'
+
+    - name: test resource_type delivery_channel with no s3_bucket parameter
+      aws_config:
+        name: random_name
+        state: present
+        resource_type: delivery_channel
+      register: output
+      ignore_errors: true
+
+    - name: assert failure when called with no s3_bucket parameter
+      assert:
+        that:
+           - output.failed
+           - 'output.msg.startswith("resource_type is delivery_channel but all of the following are missing: s3_bucket")'
+
+    - name: test resource_type configuration_recorder with no role_arn parameter
+      aws_config:
+        name: random_name
+        state: present
+        resource_type: configuration_recorder
+      register: output
+      ignore_errors: true
+
+    - name: assert failure when called with no role_arn parameter
+      assert:
+        that:
+           - output.failed
+           - 'output.msg.startswith("resource_type is configuration_recorder but all of the following are missing: role_arn")'
+
+    - name: test resource_type configuration_recorder with no recording_group parameter
+      aws_config:
+        name: random_name
+        state: present
+        resource_type: configuration_recorder
+        role_arn: 'arn:aws:iam::123456789012:role/AwsConfigRecorder'
+      register: output
+      ignore_errors: true
+
+    - name: assert failure when called with no recording_group parameter
+      assert:
+        that:
+           - output.failed
+           - 'output.msg.startswith("resource_type is configuration_recorder but all of the following are missing: recording_group")'
+
+    - name: test resource_type aggregation_authorization with no authorized_account_id parameter
+      aws_config:
+        name: random_name
+        state: present
+        resource_type: aggregation_authorization
+      register: output
+      ignore_errors: true
+
+    - name: assert failure when called with no authorized_account_id parameter
+      assert:
+        that:
+           - output.failed
+           - 'output.msg.startswith("resource_type is aggregation_authorization but all of the following are missing: authorized_account_id")'
+
+    - name: test resource_type aggregation_authorization with no authorized_aws_region parameter
+      aws_config:
+        name: random_name
+        state: present
+        resource_type: aggregation_authorization
+        authorized_account_id: '123456789012'
+      register: output
+      ignore_errors: true
+
+    - name: assert failure when called with no authorized_aws_region parameter
+      assert:
+        that:
+           - output.failed
+           - 'output.msg.startswith("resource_type is aggregation_authorization but all of the following are missing: authorized_aws_region")'
+
+    - name: test resource_type configuration_aggregator with no account_sources parameter
+      aws_config:
+        name: random_name
+        state: present
+        resource_type: configuration_aggregator
+      register: output
+      ignore_errors: true
+
+    - name: assert failure when called with no account_sources parameter
+      assert:
+        that:
+           - output.failed
+           - 'output.msg.startswith("resource_type is configuration_aggregator but all of the following are missing: account_sources")'
+
+    - name: test resource_type configuration_aggregator with no organization_source parameter
+      aws_config:
+        name: random_name
+        state: present
+        resource_type: configuration_aggregator
+        account_sources: []
+      register: output
+      ignore_errors: true
+
+    - name: assert failure when called with no organization_source parameter
+      assert:
+        that:
+           - output.failed
+           - 'output.msg.startswith("resource_type is configuration_aggregator but all of the following are missing: organization_source")'
+
+    # ============================================================
+    # Creation testing
+    # ============================================================
+    - name: Create Configuration Recorder for AWS Config
+      aws_config:
+        <<: *aws_connection_info
+        name: test_configuration_recorder
+        state: present
+        resource_type: configuration_recorder
+        role_arn: "{{ config_iam_role.arn }}"
+        recording_group:
+            all_supported: true
+            include_global_types: true
+      register: output
+
+    - assert:
+        that:
+          - output.changed
+
+    - name: Create Delivery Channel for AWS Config
+      aws_config:
+        <<: *aws_connection_info
+        name: test_delivery_channel
+        state: present
+        resource_type: delivery_channel
+        s3_bucket: "{{ config_s3_bucket | to_uuid }}"
+        sns_topic_arn: "{{ config_sns_topic.sns_arn }}"
+        delivery_frequency: 'Twelve_Hours'
+      register: output
+
+    - assert:
+        that:
+          - output.changed
+
+    - name: Create Config Rule for AWS Config
+      aws_config:
+        <<: *aws_connection_info
+        name: test_config_rule
+        state: present
+        resource_type: rule
+        description: 'This AWS Config rule checks for public write access on S3 buckets'
+        scope:
+            compliance_types:
+                - 'AWS::S3::Bucket'
+        source:
+            owner: AWS
+            identifier: 'S3_BUCKET_PUBLIC_WRITE_PROHIBITED'
+      register: output
+
+    - assert:
+        that:
+          - output.changed
+
+    # ============================================================
+    # Update testing
+    # ============================================================
+    - name: Update Configuration Recorder
+      aws_config:
+        <<: *aws_connection_info
+        name: test_configuration_recorder
+        state: present
+        resource_type: configuration_recorder
+        role_arn: "{{ config_iam_role.arn }}"
+        recording_group:
+            all_supported: false
+            include_global_types: false
+            resource_types:
+              - 'AWS::S3::Bucket'
+      register: output
+
+    - assert:
+        that:
+          - output.changed
+
+    - name: Update Delivery Channel
+      aws_config:
+        <<: *aws_connection_info
+        name: test_delivery_channel
+        state: present
+        resource_type: delivery_channel
+        s3_bucket: "{{ config_s3_bucket | to_uuid }}"
+        sns_topic_arn: "{{ config_sns_topic.sns_arn }}"
+        delivery_frequency: 'TwentyFour_Hours'
+      register: output
+
+    - assert:
+        that:
+          - output.changed
+
+    - name: Update Config Rule
+      aws_config:
+        <<: *aws_connection_info
+        name: test_config_rule
+        state: present
+        resource_type: rule
+        description: 'This AWS Config rule checks for public write access on S3 buckets'
+        scope:
+            compliance_types:
+                - 'AWS::S3::Bucket'
+        source:
+            owner: AWS
+            identifier: 'S3_BUCKET_PUBLIC_READ_PROHIBITED'
+      register: output
+
+    - assert:
+        that:
+          - output.changed
+
+    # ============================================================
+    # Read testing
+    # ============================================================
+    - name: Don't update Configuration Recorder
+      aws_config:
+        <<: *aws_connection_info
+        name: test_configuration_recorder
+        state: present
+        resource_type: configuration_recorder
+        role_arn: "{{ config_iam_role.arn }}"
+        recording_group:
+            all_supported: false
+            include_global_types: false
+            resource_types:
+              - 'AWS::S3::Bucket'
+      register: output
+
+    - assert:
+        that:
+          - not output.changed
+
+    - name: Don't update Delivery Channel
+      aws_config:
+        <<: *aws_connection_info
+        name: test_delivery_channel
+        state: present
+        resource_type: delivery_channel
+        s3_bucket: "{{ config_s3_bucket | to_uuid }}"
+        sns_topic_arn: "{{ config_sns_topic.sns_arn }}"
+        delivery_frequency: 'TwentyFour_Hours'
+      register: output
+
+    - assert:
+        that:
+          - not output.changed
+
+    - name: Don't update Config Rule
+      aws_config:
+        <<: *aws_connection_info
+        name: test_config_rule
+        state: present
+        resource_type: rule
+        description: 'This AWS Config rule checks for public write access on S3 buckets'
+        scope:
+            compliance_types:
+                - 'AWS::S3::Bucket'
+        source:
+            owner: AWS
+            identifier: 'S3_BUCKET_PUBLIC_READ_PROHIBITED'
+      register: output
+
+    - assert:
+        that:
+          - not output.changed
+
+  always:
+    # ============================================================
+    # Destroy testing
+    # ============================================================
+    - name: Destroy Configuration Recorder
+      aws_config:
+        <<: *aws_connection_info
+        name: test_configuration_recorder
+        state: absent
+        resource_type: configuration_recorder
+        role_arn: "{{ config_iam_role.arn }}"
+        recording_group:
+            all_supported: false
+            include_global_types: false
+            resource_types:
+              - 'AWS::S3::Bucket'
+      register: output
+      ignore_errors: yes
+
+#    - assert:
+#        that:
+#          - output.changed
+
+    - name: Destroy Delivery Channel
+      aws_config:
+        <<: *aws_connection_info
+        name: test_delivery_channel
+        state: absent
+        resource_type: delivery_channel
+        s3_bucket: "{{ config_s3_bucket | to_uuid }}"
+        sns_topic_arn: "{{ config_sns_topic.sns_arn }}"
+        delivery_frequency: 'TwentyFour_Hours'
+      register: output
+      ignore_errors: yes
+
+#    - assert:
+#        that:
+#          - output.changed
+
+    - name: Destroy Config Rule
+      aws_config:
+        <<: *aws_connection_info
+        name: test_config_rule
+        state: absent
+        resource_type: rule
+        description: 'This AWS Config rule checks for public write access on S3 buckets'
+        scope:
+            compliance_types:
+                - 'AWS::S3::Bucket'
+        source:
+            owner: AWS
+            identifier: 'S3_BUCKET_PUBLIC_READ_PROHIBITED'
+      register: output
+      ignore_errors: yes
+
+#    - assert:
+#        that:
+#          - output.changed
+
+    # ============================================================
+    # Clean up prerequisites
+    # ============================================================
+    - name: remove S3 access from IAM role
+      iam_policy:
+        <<: *aws_connection_info
+        iam_type: role
+        iam_name: AwsConfigRecorderTestRole
+        policy_name: AwsConfigRecorderTestRoleS3Policy
+        state: absent
+        policy_json: "{{ lookup( 'template', 'config-s3-policy.json.j2') }}"
+      ignore_errors: yes
+
+    - name: remove IAM role
+      iam_role:
+        <<: *aws_connection_info
+        name: AwsConfigRecorderTestRole
+        state: absent
+      ignore_errors: yes
+
+    - name: remove SNS topic
+      sns_topic:
+        <<: *aws_connection_info
+        name: AwsConfigDeliveryChannelTestTopic
+        state: absent
+      ignore_errors: yes
+
+    - name: remove S3 bucket
+      s3_bucket:
+        <<: *aws_connection_info
+        name: "{{ config_s3_bucket | to_uuid }}"
+        state: absent
+        force: yes
+      ignore_errors: yes

--- a/test/integration/targets/aws_config/templates/config-s3-policy.json.j2
+++ b/test/integration/targets/aws_config/templates/config-s3-policy.json.j2
@@ -1,0 +1,23 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Action": "sns:Publish",
+            "Resource": "{{ config_sns_topic.sns_arn }}",
+            "Effect": "Allow",
+            "Sid": "PublishToSNS"
+        },
+        {
+            "Action": "s3:PutObject",
+            "Resource": "arn:aws:s3:::{{ config_s3_bucket }}/*",
+            "Effect": "Allow",
+            "Sid": "AllowPutS3Object"
+        },
+        {
+            "Action": "s3:GetBucketAcl",
+            "Resource": "arn:aws:s3:::{{ config_s3_bucket }}",
+            "Effect": "Allow",
+            "Sid": "AllowGetS3Acl"
+        }
+    ]
+}


### PR DESCRIPTION
##### SUMMARY
This is my attempt to add support for the AWS Config service.  This module supports creating/updating/deleting a number of the service's essential resources: rules, configuration recorders, delivery channels, etc.  I believe I've covered most of the bases here so any feedback would be much appreciated.  I have also included integration tests that cover most of what I think should be tested. Again,  I could use some help fleshing that out as well.

##### ISSUE TYPE
 - New Module Pull Request

##### COMPONENT NAME
`aws_config`

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.1.0
  config file = None
  configured module search path = [u'/Users/asmith/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/asmith/.pyenv/versions/2.7.13/lib/python2.7/site-packages/ansible
  executable location = /Users/asmith/.pyenv/versions/2.7.13/bin/ansible
  python version = 2.7.13 (default, Sep  8 2017, 15:16:38) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
