### PR TITLE
Modules to link relatively to docs

### DIFF
--- a/lib/ansible/modules/utilities/logic/import_role.py
+++ b/lib/ansible/modules/utilities/logic/import_role.py
@@ -24,7 +24,7 @@ description:
     between other tasks of the play.
   - Most keywords, loops and conditionals will only be applied to the imported tasks, not to this statement itself. If
     you want the opposite behavior, use M(include_role) instead. To better understand the difference you can read
-    U(https://docs.ansible.com/ansible/latest/playbooks_reuse_includes.html).
+    the L(Including and Importing Guide,../user_guide/playbooks_reuse_includes.html).
 version_added: "2.4"
 options:
   name:

--- a/lib/ansible/modules/utilities/logic/set_fact.py
+++ b/lib/ansible/modules/utilities/logic/set_fact.py
@@ -24,7 +24,7 @@ description:
     - These variables will be available to subsequent plays during an ansible-playbook run, but will not be saved across executions even if you use
       a fact cache.
     - Per the standard Ansible variable precedence rules, many other types of variables have a higher priority, so this value may be overridden.
-      See L(Variable Precedence guide,../user_guide/playbooks_variables.html#variable-precedence-where-should-i-put-a-variable) for more information.
+      See L(Variable Precedence Guide,../user_guide/playbooks_variables.html#variable-precedence-where-should-i-put-a-variable) for more information.
     - This module is also supported for Windows targets.
 options:
   key_value:

--- a/lib/ansible/modules/utilities/logic/set_fact.py
+++ b/lib/ansible/modules/utilities/logic/set_fact.py
@@ -24,7 +24,7 @@ description:
     - These variables will be available to subsequent plays during an ansible-playbook run, but will not be saved across executions even if you use
       a fact cache.
     - Per the standard Ansible variable precedence rules, many other types of variables have a higher priority, so this value may be overridden.
-      See U(http://docs.ansible.com/ansible/playbooks_variables.html#variable-precedence-where-should-i-put-a-variable) for more information.
+      See L(Variable Precedence guide,../user_guide/playbooks_variables.html#variable-precedence-where-should-i-put-a-variable) for more information.
     - This module is also supported for Windows targets.
 options:
   key_value:

--- a/lib/ansible/utils/module_docs_fragments/cloudstack.py
+++ b/lib/ansible/utils/module_docs_fragments/cloudstack.py
@@ -56,6 +56,6 @@ notes:
     Optionally multiple credentials and endpoints can be specified using ini sections in C(cloudstack.ini).
     Use the argument C(api_region) to select the section name, default section is C(cloudstack).
     See https://github.com/exoscale/cs for more information.
-  - A detailed guide about cloudstack modules can be found on http://docs.ansible.com/ansible/guide_cloudstack.html.
+  - A detailed guide about cloudstack modules can be found in the L(CloudStack Cloud Guide,../scenario_guides/guide_cloudstack.html).
   - This module supports check mode.
 '''


### PR DESCRIPTION
##### SUMMARY
`L()` allows relative links, so if a person is on `/devel/` or `/2.5/` version of docs they will stay there


##### ISSUE TYPE
 - Docs Pull Request

