### PR TITLE
Create operation doesn't accept ClientRequestToken parameter

### DIFF
--- a/lib/ansible/modules/cloud/amazon/cloudformation.py
+++ b/lib/ansible/modules/cloud/amazon/cloudformation.py
@@ -327,6 +327,9 @@ def create_stack(module, stack_params, cfn):
         else:
             module.fail_json(msg="termination_protection parameter requires botocore >= 1.7.18")
 
+    # Create operation doesn't accept ClientRequestToken parameter.
+    stack_params.pop('ClientRequestToken', None)
+
     try:
         cfn.create_stack(**stack_params)
         result = stack_operation(cfn, stack_params['StackName'], 'CREATE', stack_params.get('ClientRequestToken', None))


### PR DESCRIPTION
This fixes the following exception when trying to create a new
CloudFormation stack:

> Unknown parameter in input: "ClientRequestToken", must be one of:
> StackName, TemplateBody, TemplateURL, Parameters, DisableRollback,
> TimeoutInMinutes, NotificationARNs, Capabilities, ResourceTypes,
> RoleARN, OnFailure, StackPolicyBody, StackPolicyURL, Tags

This fix was tested with stable-2.5.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
cloudformation

##### ANSIBLE VERSION
```
ansible 2.5.0
```