### PR TITLE
Remove `ResponseMetadata` key from aws_caller_facts

### DIFF
--- a/lib/ansible/modules/cloud/amazon/aws_caller_facts.py
+++ b/lib/ansible/modules/cloud/amazon/aws_caller_facts.py
@@ -72,6 +72,7 @@ def main():
 
     try:
         caller_identity = client.get_caller_identity()
+        caller_identity.pop('ResponseMetadata', None)
         module.exit_json(
             changed=False,
             **camel_dict_to_snake_dict(caller_identity)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

The `aws_caller_facts` module is supposed to grab the user ID, ARN, and account of the caller, but because it doesn't post-process that result, it includes boto3 request information in the returned value. 

This module is new in 2.6, so existing users can't be relying on the return structure yet. 

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
aws_caller_facts

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
# before
ok: [localhost] =>        
  i_am:                   
    account: '509803855674'
    arn: arn:aws:iam::509803855674:user/ryansb  
    changed: false
    failed: false 
    response_metadata:    
      http_headers:
        content-length: '403' 
        content-type: text/xml  
        date: Fri, 20 Apr 2018 20:27:28 GMT 
        x-amzn-requestid: 3f162cf6-44d9-11e8-bc7c-5bf6b9f8d526  
      http_status_code: 200
      request_id: 3f162cf6-44d9-11e8-bc7c-5bf6b9f8d526       
      retry_attempts: 0   
    user_id: AIDAIYSN33VO5EOC4REPC 

# after
ok: [localhost] =>
  i_am:
    account: '509803855674'         
    arn: arn:aws:iam::509803855674:user/ryansb      
    changed: false        
    failed: false         
    user_id: AIDAIYSN33VO5EOC4REPC 

```
