### PR TITLE
Add missing parameters.  Fixes TypeError exception

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_ami.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_ami.py
@@ -626,9 +626,9 @@ def get_image_by_id(module, connection, image_id):
                 result['ProductCodes'] = connection.describe_image_attribute(Attribute='productCodes', ImageId=image_id)['ProductCodes']
             except botocore.exceptions.ClientError as e:
                 if e.response['Error']['Code'] != 'InvalidAMIID.Unavailable':
-                    module.fail_json_aws(e, msg="Error retrieving image attributes" % image_id)
+                    module.fail_json_aws(e, msg="Error retrieving image attributes %s" % image_id)
             except botocore.exceptions.BotoCoreError as e:
-                module.fail_json_aws(e, msg="Error retrieving image attributes" % image_id)
+                module.fail_json_aws(e, msg="Error retrieving image attributes %s" % image_id)
             return result
         module.fail_json(msg="Invalid number of instances (%s) found for image_id: %s." % (str(len(images)), image_id))
     except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as e:


### PR DESCRIPTION
##### SUMMARY
Exceptions thrown when ec2_ami fails to create an image due to bad permissions (or other errors).  Attribute missing in string formatting throws exception.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ec2_ami

##### ANSIBLE VERSION
```
ansible --version
ansible 2.5.1
  config file = None
  configured module search path = [u'/home/ec2-user/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible-2.5.1-py2.7.egg/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Feb 20 2018, 09:19:12) [GCC 4.8.5 20150623 (Red Hat 4.8.5-28)]
```


##### ADDITIONAL INFORMATION
Stack trace from error:

```
Traceback (most recent call last):
  File "/home/ec2-user/.ansible/tmp/ansible-tmp-1524256826.73-122688373381022/debug_dir/ansible_module_ec2_ami.py", line 704, in <module>
    main()
  File "/home/ec2-user/.ansible/tmp/ansible-tmp-1524256826.73-122688373381022/debug_dir/ansible_module_ec2_ami.py", line 700, in main
    create_image(module, connection)
  File "/home/ec2-user/.ansible/tmp/ansible-tmp-1524256826.73-122688373381022/debug_dir/ansible_module_ec2_ami.py", line 491, in create_image
    **get_ami_info(get_image_by_id(module, connection, image_id)))
  File "/home/ec2-user/.ansible/tmp/ansible-tmp-1524256826.73-122688373381022/debug_dir/ansible_module_ec2_ami.py", line 632, in get_image_by_id
    module.fail_json_aws(e, msg="Error retrieving image attributes" % image_id)
TypeError: not all arguments converted during string formatting
```
