### PR TITLE
k8s inventory: add pod nodeport

### DIFF
--- a/lib/ansible/module_utils/k8s/inventory.py
+++ b/lib/ansible/module_utils/k8s/inventory.py
@@ -212,7 +212,8 @@ class K8sInventoryHelper(object):
             ports = [{'name': port.name,
                       'port': port.port,
                       'protocol': port.protocol,
-                      'targetPort': port.target_port} for port in service.spec.ports]
+                      'targetPort': port.target_port,
+                      'nodePort': port.node_port} for port in service.spec.ports]
 
             # add hostvars
             self.inventory.set_variable(service_name, 'object_type', 'service')


### PR DESCRIPTION
Node port field is not populated on K8S pods, and it's certainely the most useful port to use in pod when we need to interact with ansible outside of the cluster

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
k8s inventory

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5.1.0
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before
```
"ports": [
            {
                "name": "searx-http",
                "port": 8888,
                "protocol": "TCP",
                "targetPort": 8888
            }
        ],
```

After
```
"ports": [
            {
                "name": "searx-http",
                "nodePort": 55487,
                "port": 8888,
                "protocol": "TCP",
                "targetPort": 8888
            }
        ],
```
