### PR TITLE
adds index page for roadmaps to support internal links

### DIFF
--- a/docs/docsite/rst/index.rst
+++ b/docs/docsite/rst/index.rst
@@ -95,8 +95,4 @@ Ansible releases a new major release of Ansible approximately every two months. 
    :maxdepth: 2
    :caption: Roadmaps
 
-   roadmap/ROADMAP_2_1.rst
-   roadmap/ROADMAP_2_2.rst
-   roadmap/ROADMAP_2_3.rst
-   roadmap/ROADMAP_2_4.rst
-   roadmap/ROADMAP_2_5.rst
+   roadmap/index.rst

--- a/docs/docsite/rst/roadmap/index.rst
+++ b/docs/docsite/rst/roadmap/index.rst
@@ -1,0 +1,14 @@
+.. _roadmaps:
+
+Ansible Roadmap
+===============
+
+The Ansible team develops a roadmap for each major Ansible release. The latest roadmap shows current work; older roadmaps provide a history of the project. 
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+   :caption: Ansible Release Roadmaps
+
+   ROADMAP*
+


### PR DESCRIPTION
##### SUMMARY
Adds an index page for roadmaps section of the docs. This page supports generic links to "roadmap" so we don't have to update incoming links with each new release. The TOC should also automatically update to include new pages as we add roadmaps for future releases. 

This should have been part of #39094 but I missed this file.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
docs.ansible.com

##### ANSIBLE VERSION
2.5
