### PR TITLE
Adding haversine filter - mathstuff.py

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters.rst
@@ -271,6 +271,10 @@ Square root, or the 5th::
     {{ myvar | root }}
     {{ myvar | root(5) }}
 
+Haversine, great-circle distance between two coordinates::
+
+    {{ 'm'|haversine('35.9914928','-78.907046', '-33.8523063', '151.2085984') }}
+
 Note that jinja2 already provides some like abs() and round().
 
 .. json_query_filter:

--- a/docs/docsite/rst/user_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters.rst
@@ -271,9 +271,15 @@ Square root, or the 5th::
     {{ myvar | root }}
     {{ myvar | root(5) }}
 
-Haversine, great-circle distance between two coordinates::
+Haversine, great-circle distance between two coordinates using a list::
 
-    {{ 'm'|haversine('35.9914928','-78.907046', '-33.8523063', '151.2085984') }}
+    # Returns a dict with distances m & km
+    {{ ['35.9914928','-78.907046','-33.8523063','151.2085984']|haversine }}
+
+Haversine, great-circle distance between two coordinates using a dict::
+
+    # Returns a dict with distances m & km
+    {{ { 'lat1': '35.9914928', 'lon1': '-78.907046', 'lat2': '-33.8523063', 'lon2': '151.2085984'}|haversine }}
 
 Note that jinja2 already provides some like abs() and round().
 

--- a/docs/docsite/rst/user_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters.rst
@@ -281,6 +281,13 @@ Haversine, great-circle distance between two coordinates using a dict::
     # Returns a dict with distances m & km
     {{ { 'lat1': '35.9914928', 'lon1': '-78.907046', 'lat2': '-33.8523063', 'lon2': '151.2085984'}|haversine }}
 
+Haversine distance specifying the unit of measure to return::
+
+    # Returns kilometers (km)
+    {{ ['35.9914928','-78.907046','-33.8523063','151.2085984','km']|haversine }}
+    # Returns miles (m)
+    {{ { 'lat1': '35.99', 'lon1': '-78.90', 'lat2': '-33.85', 'lon2': '151.20', 'unit': 'm'}|haversine }}
+
 Note that jinja2 already provides some like abs() and round().
 
 .. json_query_filter:

--- a/lib/ansible/plugins/filter/mathstuff.py
+++ b/lib/ansible/plugins/filter/mathstuff.py
@@ -114,15 +114,31 @@ def inversepower(x, base=2):
         raise errors.AnsibleFilterError('root() can only be used on numbers: %s' % str(e))
 
 
-def haversine(measurement, lat1, lon1, lat2, lon2):
+def haversine(coordinates):
     from math import radians, sin, cos, sqrt, asin
-
-    if measurement not in ["m", "km"]:
-        raise errors.AnsibleFilterError('haversine() can only be called with km or m')
 
     diameter = {
         'm': 7917.5,
         'km': 12742}
+
+    if isinstance(coordinates, list):
+        if (len(coordinates) == 4):
+            lat1 = coordinates[0]
+            lon1 = coordinates[1]
+            lat2 = coordinates[2]
+            lon2 = coordinates[3]
+        else:
+            raise errors.AnsibleFilterError('haversine() supplied list should contain 4 elements [lat1, lon1, lat2, lon2]. %s supplied.' % len(coordinates))
+    elif isinstance(coordinates, dict):
+        if all(k in coordinates for k in ('lat1', 'lon1', 'lat2', 'lon2')):
+            lat1 = coordinates.get('lat1')
+            lon1 = coordinates.get('lon1')
+            lat2 = coordinates.get('lat2')
+            lon2 = coordinates.get('lon2')
+        else:
+            raise errors.AnsibleFilterError('haversine() supplied dicts should contain 4 keys: lat1, lon1, lat2 and lon2')
+    else:
+        raise errors.AnsibleFilterError('haversine() only accepts a list or dict of coordinates.')
 
     try:
         lat1 = float(lat1)
@@ -143,7 +159,10 @@ def haversine(measurement, lat1, lon1, lat2, lon2):
     except Exception as e:
         raise errors.AnsibleFilterError('haversine() something went wrong: %s' % str(e))
 
-    return round(diameter[measurement] / 2 * c, 2)
+    return {
+        'km': round(diameter['km'] / 2 * c, 2),
+        'm': round(diameter['m'] / 2 * c, 2)
+    }
 
 
 def human_readable(size, isbits=False, unit=None):

--- a/lib/ansible/plugins/filter/mathstuff.py
+++ b/lib/ansible/plugins/filter/mathstuff.py
@@ -114,6 +114,29 @@ def inversepower(x, base=2):
         raise errors.AnsibleFilterError('root() can only be used on numbers: %s' % str(e))
 
 
+def haversine(measurement, lat1, lon1, lat2, lon2):
+    from math import radians, sin, cos, sqrt, asin
+    diameter = {
+        'm': 7917.5,
+        'km': 12742}
+
+    try:
+        dlat = radians(float(lat2) - float(lat1))
+        dlon = radians(float(lon2) - float(lon1))
+        lat1 = radians(float(lat1))
+        lat2 = radians(float(lat2))
+
+        a = sin(dlat / 2) ** 2 + cos(lat1) * cos(lat2) * sin(dlon / 2) ** 2
+        c = 2 * asin(sqrt(a))
+    except (ValueError, TypeError) as e:
+        raise errors.AnsibleFilterError('haversine() only accepts floats: %s' % str(e))
+
+    if measurement in diameter:
+        return round(diameter[measurement] / 2 * c, 2)
+    else:
+        raise errors.AnsibleFilterError('haversine() can only be called with km or m')
+
+
 def human_readable(size, isbits=False, unit=None):
     ''' Return a human readable string '''
     try:
@@ -209,6 +232,9 @@ class FilterModule(object):
             # zip
             'zip': zip,
             'zip_longest': zip_longest,
+
+            # haversine
+            'haversine': haversine,
 
         }
 

--- a/lib/ansible/plugins/filter/mathstuff.py
+++ b/lib/ansible/plugins/filter/mathstuff.py
@@ -116,25 +116,34 @@ def inversepower(x, base=2):
 
 def haversine(measurement, lat1, lon1, lat2, lon2):
     from math import radians, sin, cos, sqrt, asin
+
+    if measurement not in ["m", "km"]:
+        raise errors.AnsibleFilterError('haversine() can only be called with km or m')
+
     diameter = {
         'm': 7917.5,
         'km': 12742}
 
     try:
-        dlat = radians(float(lat2) - float(lat1))
-        dlon = radians(float(lon2) - float(lon1))
-        lat1 = radians(float(lat1))
-        lat2 = radians(float(lat2))
+        lat1 = float(lat1)
+        lon1 = float(lon1)
+        lat2 = float(lat2)
+        lon2 = float(lon2)
+    except ValueError as e:
+        raise errors.AnsibleFilterError('haversine() only accepts floats: %s' % str(e))
+
+    try:
+        dlat = radians(lat2 - lat1)
+        dlon = radians(lon2 - lon1)
+        lat1 = radians(lat1)
+        lat2 = radians(lat2)
 
         a = sin(dlat / 2) ** 2 + cos(lat1) * cos(lat2) * sin(dlon / 2) ** 2
         c = 2 * asin(sqrt(a))
-    except (ValueError, TypeError) as e:
-        raise errors.AnsibleFilterError('haversine() only accepts floats: %s' % str(e))
+    except Exception as e:
+        raise errors.AnsibleFilterError('haversine() something went wrong: %s' % str(e))
 
-    if measurement in diameter:
-        return round(diameter[measurement] / 2 * c, 2)
-    else:
-        raise errors.AnsibleFilterError('haversine() can only be called with km or m')
+    return round(diameter[measurement] / 2 * c, 2)
 
 
 def human_readable(size, isbits=False, unit=None):

--- a/lib/ansible/plugins/filter/mathstuff.py
+++ b/lib/ansible/plugins/filter/mathstuff.py
@@ -124,6 +124,7 @@ def haversine(coordinates):
     if isinstance(coordinates, list):
         if (len(coordinates) == 4):
             lat1, lon1, lat2, lon2 = coordinates
+            unit = None
         elif (len(coordinates) == 5):
             lat1, lon1, lat2, lon2, unit = coordinates
         else:
@@ -148,11 +149,9 @@ def haversine(coordinates):
     except ValueError as e:
         raise errors.AnsibleFilterError('haversine() only accepts floats: %s' % str(e))
 
-    try:
-        if ('unit' in locals() and unit is not None):
-            assert unit in ['m', 'km']
-    except AssertionError:
-        raise errors.AnsibleFilterError('haversine() unit must be m or km if defined')
+    if (unit is not None):
+        if unit not in ['m', 'km']:
+            raise errors.AnsibleFilterError('haversine() unit must be m or km if defined')
 
     try:
         dlat = radians(lat2 - lat1)
@@ -165,7 +164,7 @@ def haversine(coordinates):
     except Exception as e:
         raise errors.AnsibleFilterError('haversine() something went wrong: %s' % str(e))
 
-    if ('unit' in locals() and unit is not None):
+    if (unit is not None):
         return round(diameter[unit] / 2 * c, 2)
     else:
         return {

--- a/test/units/plugins/filter/test_mathstuff.py
+++ b/test/units/plugins/filter/test_mathstuff.py
@@ -109,19 +109,32 @@ class TestPower:
 class TestHaversine:
     def test_haversine_non_number(self):
         with pytest.raises(AnsibleFilterError, message='haversine() only accepts floats'):
-            ms.haversine('km', 'a', 'b', 'c', 'd')
+            ms.haversine(['a', 'b', 'c', 'd'])
 
         with pytest.raises(AnsibleFilterError, message='haversine() only accepts floats'):
-            ms.haversine('m', 'a', 'b', 'c', 'd')
+            ms.haversine({'lon1': 'a', 'lat1': 'b', 'lon2': 'c', 'lat2': 'd'})
 
-        with pytest.raises(AnsibleFilterError, message='haversine() can only be called with km or m'):
-            ms.haversine('z', '35.9914928', '-78.907046', '-33.8523063', '151.2085984')
+        with pytest.raises(AnsibleFilterError, message='haversine() supplied list should contain 4 elements for lat1, lon1, lat2 and lon2.'):
+            ms.haversine(['35.9914928', '-78.907046', '-33.8523063'])
+
+        with pytest.raises(AnsibleFilterError, message='haversine() supplied list should contain 4 elements for lat1, lon1, lat2 and lon2.'):
+            ms.haversine(['11.44', '43.44', '35.9914928', '-78.907046', '-33.8523063'])
+
+        with pytest.raises(AnsibleFilterError, message='haversine() supplied dicts should contain 4 keys: lat1, lon1, lat2 and lon2'):
+            ms.haversine({'lon1': '-78.907046', 'lat1': '35.9914928'})
 
     def test_km(self):
-        assert ms.haversine('km', '35.9914928', '-78.907046', '-33.8523063', '151.2085984') == 15490.46
+        assert ms.haversine(['35.9914928', '-78.907046', '-33.8523063', '151.2085984']).get('km') == 15490.46
 
     def test_m(self):
-        assert ms.haversine('m', '35.9914928', '-78.907046', '-33.8523063', '151.2085984') == 9625.31
+        assert ms.haversine({'lat1': '35.9914928', 'lon1': '-78.907046', 'lat2': '-33.8523063', 'lon2': '151.2085984'}).get('m') == 9625.31
+
+    def test_order(self):
+        assert ms.haversine({'lon2': '151.2085984', 'lat1': '35.9914928', 'lon1': '-78.907046', 'lat2': '-33.8523063'}).get('m') == 9625.31
+
+    def test_compare_both(self):
+        assert (ms.haversine({'lat1': '-78.907046', 'lon1': '35.9914928', 'lon2': '-33.8523063', 'lat2': '151.2085984'}).get('m') ==
+                ms.haversine(['-78.907046', '35.9914928', '151.2085984', '-33.8523063']).get('m'))
 
 
 class TestInversePower:

--- a/test/units/plugins/filter/test_mathstuff.py
+++ b/test/units/plugins/filter/test_mathstuff.py
@@ -106,6 +106,24 @@ class TestPower:
         assert ms.power(10, 3) == 1000
 
 
+class TestHaversine:
+    def test_haversine_non_number(self):
+        with pytest.raises(AnsibleFilterError, message='haversine() only accepts floats'):
+            ms.haversine('km', 'a', 'b', 'c', 'd')
+
+        with pytest.raises(AnsibleFilterError, message='haversine() only accepts floats'):
+            ms.haversine('m', 'a', 'b', 'c', 'd')
+
+        with pytest.raises(AnsibleFilterError, message='haversine() can only be called with km or m'):
+            ms.haversine('z', '35.9914928','-78.907046', '-33.8523063', '151.2085984')
+
+    def test_km(self):
+        assert ms.haversine('km', '35.9914928', '-78.907046', '-33.8523063', '151.2085984') == 15490.46
+
+    def test_m(self):
+        assert ms.haversine('m', '35.9914928', '-78.907046', '-33.8523063', '151.2085984') == 9625.31
+
+
 class TestInversePower:
     def test_root_non_number(self):
         with pytest.raises(AnsibleFilterError, message='root() can only be used on numbers: a float is required'):

--- a/test/units/plugins/filter/test_mathstuff.py
+++ b/test/units/plugins/filter/test_mathstuff.py
@@ -115,7 +115,7 @@ class TestHaversine:
             ms.haversine('m', 'a', 'b', 'c', 'd')
 
         with pytest.raises(AnsibleFilterError, message='haversine() can only be called with km or m'):
-            ms.haversine('z', '35.9914928','-78.907046', '-33.8523063', '151.2085984')
+            ms.haversine('z', '35.9914928', '-78.907046', '-33.8523063', '151.2085984')
 
     def test_km(self):
         assert ms.haversine('km', '35.9914928', '-78.907046', '-33.8523063', '151.2085984') == 15490.46

--- a/test/units/plugins/filter/test_mathstuff.py
+++ b/test/units/plugins/filter/test_mathstuff.py
@@ -123,8 +123,17 @@ class TestHaversine:
         with pytest.raises(AnsibleFilterError, message='haversine() supplied dicts should contain 4 keys: lat1, lon1, lat2 and lon2'):
             ms.haversine({'lon1': '-78.907046', 'lat1': '35.9914928'})
 
+        with pytest.raises(AnsibleFilterError, message='haversine() unit must be m or km if defined'):
+            ms.haversine(['35.9914928', '-78.907046', '-33.8523063', '151.2085984', 'z'])
+
+        with pytest.raises(AnsibleFilterError, message='haversine() unit must be m or km if defined'):
+            ms.haversine({'lon2': '151.2085984', 'lat1': '35.9914928', 'lon1': '-78.907046', 'lat2': '-33.8523063', 'unit': 'z'})
+
     def test_km(self):
         assert ms.haversine(['35.9914928', '-78.907046', '-33.8523063', '151.2085984']).get('km') == 15490.46
+
+    def test_only_km(self):
+        assert ms.haversine(['35.9914928', '-78.907046', '-33.8523063', '151.2085984', 'km']) == 15490.46
 
     def test_m(self):
         assert ms.haversine({'lat1': '35.9914928', 'lon1': '-78.907046', 'lat2': '-33.8523063', 'lon2': '151.2085984'}).get('m') == 9625.31

--- a/test/units/plugins/filter/test_mathstuff.py
+++ b/test/units/plugins/filter/test_mathstuff.py
@@ -107,7 +107,7 @@ class TestPower:
 
 
 class TestHaversine:
-    def test_haversine_non_number(self):
+    def test_haversine_errors(self):
         with pytest.raises(AnsibleFilterError, message='haversine() only accepts floats'):
             ms.haversine(['a', 'b', 'c', 'd'])
 


### PR DESCRIPTION
##### SUMMARY
Haversine is a formula to calculate the great-circle distance between two coordinates.

This will help when wanting to determine the distance between coordinates, especially in a `when:` statement.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->

##### ANSIBLE VERSION

```
ansible 2.6.0 (haversine_filter 1391e2b082) last updated 2018/04/21 18:02:55 (GMT +1100)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/johni/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/johni/ansible/hacking/ansible/lib/ansible
  executable location = /home/johni/ansible/hacking/ansible/bin/ansible
  python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

Example playbook:
```
- hosts: localhost
  tasks:
    - name: Haversine distance between two lon/lat co-ordinates via list
      debug:
        msg: "{{ ['35.9914928','-78.907046','-33.8523063','151.2085984']|haversine }}"

    - name: Haversine distance between two lon/lat co-ordinates via list requesting km
      debug:
        msg: "{{ ['35.9914928','-78.907046','-33.8523063','151.2085984', 'km']|haversine }}"

    - name: Haversine distance between two lon/lat co-ordinates via dict
      debug:
        msg: "{{ { 'lat1': '35.9914928', 'lon1': '-78.907046', 'lat2': '-33.8523063', 'lon2': '151.2085984'}|haversine }}"

    - name: Haversine distance between two lon/lat co-ordinates via dict requesting m
      debug:
        msg: "{{ { 'lat1': '35.9914928', 'lon1': '-78.907046', 'lat2': '-33.8523063', 'lon2': '151.2085984', 'unit': 'm'}|haversine }}"

    - name: Haversine distance between two lon/lat co-ordinates via list (zeros)
      debug:
        msg: "{{ ['0','0','0','0']|haversine }}"

    - name: Fail due to bad value
      debug:
        msg: "{{ ['0','0','0','a']|haversine }}"
      ignore_errors: yes

    - name: Fail due to missing value
      debug:
        msg: "{{ ['0','0']|haversine }}"
      ignore_errors: yes

```

And example results:

```
$ ansible-playbook only_filter.yml

PLAY [localhost] *********************************************************************************************************************************************

TASK [Gathering Facts] ***************************************************************************************************************************************
ok: [localhost]

TASK [Haversine distance between two lon/lat co-ordinates via list] ******************************************************************************************
ok: [localhost] => {
    "msg": {
        "km": 15490.46, 
        "m": 9625.31
    }
}

TASK [Haversine distance between two lon/lat co-ordinates via list requesting km] ****************************************************************************
ok: [localhost] => {
    "msg": "15490.46"
}

TASK [Haversine distance between two lon/lat co-ordinates via dict] ******************************************************************************************
ok: [localhost] => {
    "msg": {
        "km": 15490.46, 
        "m": 9625.31
    }
}

TASK [Haversine distance between two lon/lat co-ordinates via dict requesting m] *****************************************************************************
ok: [localhost] => {
    "msg": "9625.31"
}

TASK [Haversine distance between two lon/lat co-ordinates via list (zeros)] **********************************************************************************
ok: [localhost] => {
    "msg": {
        "km": 0.0, 
        "m": 0.0
    }
}

TASK [Fail due to bad value] *********************************************************************************************************************************
fatal: [localhost]: FAILED! => {"msg": "haversine() only accepts floats: could not convert string to float: a"}
...ignoring

TASK [Fail due to missing value] *****************************************************************************************************************************
fatal: [localhost]: FAILED! => {"msg": "haversine() supplied list should contain 4 elements [lat1, lon1, lat2, lon2]. 2 supplied."}
...ignoring

PLAY RECAP ***************************************************************************************************************************************************
localhost                  : ok=8    changed=0    unreachable=0    failed=0   
```