### PR TITLE
Return correct version on installed VyOS

### DIFF
--- a/lib/ansible/modules/network/vyos/vyos_facts.py
+++ b/lib/ansible/modules/network/vyos/vyos_facts.py
@@ -135,7 +135,7 @@ class Default(FactsBase):
         self.facts['hostname'] = self.responses[1]
 
     def parse_version(self, data):
-        match = re.search(r'Version:\s*(\S+)', data)
+        match = re.search(r'Version:\s*(.*)', data)
         if match:
             return match.group(1)
 

--- a/test/units/modules/network/vyos/test_vyos_facts.py
+++ b/test/units/modules/network/vyos/test_vyos_facts.py
@@ -63,7 +63,7 @@ class TestVyosFactsModule(TestVyosModule):
         facts = result.get('ansible_facts')
         self.assertEqual(len(facts), 5)
         self.assertEqual(facts['ansible_net_hostname'].strip(), 'vyos01')
-        self.assertEqual(facts['ansible_net_version'], 'VyOS')
+        self.assertEqual(facts['ansible_net_version'], 'VyOS 1.1.7')
 
     def test_vyos_facts_not_all(self):
         set_module_args(dict(gather_subset='!all'))
@@ -71,7 +71,7 @@ class TestVyosFactsModule(TestVyosModule):
         facts = result.get('ansible_facts')
         self.assertEqual(len(facts), 5)
         self.assertEqual(facts['ansible_net_hostname'].strip(), 'vyos01')
-        self.assertEqual(facts['ansible_net_version'], 'VyOS')
+        self.assertEqual(facts['ansible_net_version'], 'VyOS 1.1.7')
 
     def test_vyos_facts_exclude_most(self):
         set_module_args(dict(gather_subset=['!neighbors', '!config']))
@@ -79,7 +79,7 @@ class TestVyosFactsModule(TestVyosModule):
         facts = result.get('ansible_facts')
         self.assertEqual(len(facts), 5)
         self.assertEqual(facts['ansible_net_hostname'].strip(), 'vyos01')
-        self.assertEqual(facts['ansible_net_version'], 'VyOS')
+        self.assertEqual(facts['ansible_net_version'], 'VyOS 1.1.7')
 
     def test_vyos_facts_invalid_subset(self):
         set_module_args(dict(gather_subset='cereal'))


### PR DESCRIPTION
Previously existing regexp will shows only "VyOS" without numeric output of router version.
For example: from  "Version:      VyOS 1.1.6" only VyOS will be written in ansible_net_version variable
For more informative output numeric value should be returned as well

##### SUMMARY
Previously existing regexp will shows only "VyOS" without numeric output of router version.
For example: from  "Version:      VyOS 1.1.6" only VyOS will be written in ansible_net_version variable
For more informative output numeric value should be returned as well

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
vyos_facts

##### ANSIBLE VERSION
```
ansible 2.5.1
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/murmanov/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION
Below you can see before and after outputs

```
ok: [nn-vpn.int] => {
    "ansible_facts": {
        "ansible_net_gather_subset": [
            "neighbors", 
            "default"
        ], 
        "ansible_net_hostname": "nn-vpn", 
        "ansible_net_model": "VMware", 
        "ansible_net_serialnum": "VMware-56", 
        "ansible_net_version": "VyOS"
    }, 
    "changed": false, 
    "invocation": {
        "module_args": {
            "gather_subset": [
                "!config"
            ], 
            "host": null, 
            "password": null, 
            "port": null, 
            "provider": null, 
            "ssh_keyfile": null, 
            "timeout": null, 
            "username": null
        }
    }
}

################# After ####################

ok: [nn-vpn.int] => {
    "ansible_facts": {
        "ansible_net_gather_subset": [
            "neighbors", 
            "default"
        ], 
        "ansible_net_hostname": "nn-vpn", 
        "ansible_net_model": "VMware", 
        "ansible_net_serialnum": "VMware-56", 
        "ansible_net_version": "VyOS 1.1.6"
    }, 
    "changed": false, 
    "invocation": {
        "module_args": {
            "gather_subset": [
                "!config"
            ], 
            "host": null, 
            "password": null, 
            "port": null, 
            "provider": null, 
            "ssh_keyfile": null, 
            "timeout": null, 
            "username": null
        }
    }
}

```
