### PR TITLE
Use https for links to ansible.com domains.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,13 @@ Ansible Changes By Release
 
 ## 2.6 "Heartbreaker" - ACTIVE DEVELOPMENT
 
-[Porting Guide](http://docs.ansible.com/ansible/devel/porting_guides/porting_guides.html)
+[Porting Guide](https://docs.ansible.com/ansible/devel/porting_guides/porting_guides.html)
 
 ### Major Changes
 
 ### Deprecations (to be removed in 2.10)
 
-See [Porting Guide](http://docs.ansible.com/ansible/devel/porting_guides/porting_guides.html) for more information
+See [Porting Guide](https://docs.ansible.com/ansible/devel/porting_guides/porting_guides.html) for more information
 
 ### Minor Changes
 * Removed restriction from protocol in cloudflare_dns module to allow other protocols than tcp and udp to be specified.
@@ -125,7 +125,7 @@ See [Porting Guide](https://docs.ansible.com/ansible/devel/porting_guides/portin
 * network_cli
 * netconf
 
-While neither is technically a new plugin, these connections may now be used directly with network modules. See [Network Best Practices for Ansible 2.5](http://docs.ansible.com/ansible/devel/network_best_practices_2.5.html) for more details.
+While neither is technically a new plugin, these connections may now be used directly with network modules. See [Network Best Practices for Ansible 2.5](https://docs.ansible.com/ansible/devel/network_best_practices_2.5.html) for more details.
 
 #### Filters
 * parse_xml
@@ -1356,7 +1356,7 @@ While neither is technically a new plugin, these connections may now be used dir
 
 ## 2.3 "Ramble On" - 2017-04-12
 
-Moving to Ansible 2.3 guide http://docs.ansible.com/ansible/porting_guide_2.3.html
+Moving to Ansible 2.3 guide https://docs.ansible.com/ansible/porting_guide_2.3.html
 
 ### Major Changes
 * Documented and renamed the previously released 'single var vaulting' feature, allowing user to use vault encryption for single variables in a normal YAML vars file.
@@ -2131,7 +2131,7 @@ Module fixes:
 * Added a new strategy `debug`, which allows per-task debugging of playbooks, for more details see https://docs.ansible.com/ansible/playbooks_debugger.html
 * Added a new option for tasks: `loop_control`. This currently only supports one option - `loop_var`, which allows a different loop variable from `item` to be used.
 * Added the ability to filter facts returned by the fact gathering setup step using the `gather_subset` option on the play or in the ansible.cfg configuration file.
-  See http://docs.ansible.com/ansible/intro_configuration.html#gathering for details on the format of the option.
+  See https://docs.ansible.com/ansible/intro_configuration.html#gathering for details on the format of the option.
 * Added the ability to send per-item callbacks, rather than a batch update (this more closely resembles the behavior of Ansible 1.x).
 * Added facility for modules to send back 'diff' for display when ansible is called with --diff, updated several modules to return this info
 * Added ansible-console tool, a REPL shell that allows running adhoc tasks against a chosen inventory (based on  https://github.com/dominis/ansible-shell)

--- a/CODING_GUIDELINES.md
+++ b/CODING_GUIDELINES.md
@@ -20,7 +20,7 @@ PEP 8 and basic style checks
   * [PEP 8](https://www.python.org/dev/peps/pep-0008/) is a great Python style guide, which you should read.
   * PEP 8 must not be strictly followed in all aspects, but most of it is good advice.
   * The line is limited to 160 characters.
-  * To run checks for things we care about, use [ansible-test](http://docs.ansible.com/ansible/dev_guide/testing_pep8.html#running-locally).
+  * To run checks for things we care about, use [ansible-test](https://docs.ansible.com/ansible/dev_guide/testing_pep8.html#running-locally).
   * Similarly, additional checks can be made with "make pyflakes".
   * There is no need to submit code changes for PEP 8 and pyflakes fixes, as these break attribution history.  Project leadership will make these periodically.
   * Do not submit pull requests that simply adjust whitespace in the code.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,19 +5,19 @@ Hi! Nice to see you here!
 
 ## QUESTIONS ?
 
-Please see the [community guide](http://docs.ansible.com/ansible/latest/community/index.html) for information on how to ask questions on the [mailing lists](http://docs.ansible.com/ansible/latest/community/communication.html#mailing-list-information) and IRC.
+Please see the [community guide](https://docs.ansible.com/ansible/latest/community/index.html) for information on how to ask questions on the [mailing lists](https://docs.ansible.com/ansible/latest/community/communication.html#mailing-list-information) and IRC.
 
 The GitHub issue tracker is not the best place for questions for various reasons, but both IRC and the mailing list are very helpful places for those things, as the community page explains best.
 
 
 ## CONTRIBUTING ?
 
-Please see the [community guide](http://docs.ansible.com/ansible/latest/community/index.html) for information regarding the contribution process. Important license agreement information is also included on that page.
+Please see the [community guide](https://docs.ansible.com/ansible/latest/community/index.html) for information regarding the contribution process. Important license agreement information is also included on that page.
 
 
 ## BUG TO REPORT ?
 
-First and foremost, also check the [community guide](http://docs.ansible.com/ansible/latest/community/index.html).
+First and foremost, also check the [community guide](https://docs.ansible.com/ansible/latest/community/index.html).
 
 You can report bugs or make enhancement requests at the [Ansible GitHub issue page](http://github.com/ansible/ansible/issues/new) by filling out the issue template that will be presented.
 

--- a/MODULE_GUIDELINES.md
+++ b/MODULE_GUIDELINES.md
@@ -1,3 +1,3 @@
 # Module Maintainer Guidelines
 
-The Ansible Module Maintainer Guidelines can now be found in the [official Ansible community guide](http://docs.ansible.com/ansible/latest/community/maintainers.html).
+The Ansible Module Maintainer Guidelines can now be found in the [official Ansible community guide](https://docs.ansible.com/ansible/latest/community/maintainers.html).

--- a/README.rst
+++ b/README.rst
@@ -95,6 +95,6 @@ See `COPYING <COPYING>`_ to see the full text.
 .. |PyPI version| image:: https://img.shields.io/pypi/v/ansible.svg
    :target: https://pypi.org/project/ansible
 .. |Docs badge| image:: https://img.shields.io/badge/docs-latest-brightgreen.svg
-   :target: http://docs.ansible.com/ansible
+   :target: https://docs.ansible.com/ansible
 .. |Build Status| image:: https://api.shippable.com/projects/573f79d02a8192902e20e34b/badge?branch=devel
    :target: https://app.shippable.com/projects/573f79d02a8192902e20e34b

--- a/ROADMAP.rst
+++ b/ROADMAP.rst
@@ -14,4 +14,4 @@ These roadmaps are the team's *best guess* roadmaps based on the Ansible team's 
 - AnsibleFest conferences.
 - IRC Freenode channel: #ansible-devel (this one may have things lost in lots of conversation, so a caution).
 
-Ansible Roadmaps can be found `here <http://docs.ansible.com/ansible/devel/roadmap/>`_.
+Ansible Roadmaps can be found `here <https://docs.ansible.com/ansible/devel/roadmap/>`_.

--- a/docs/docsite/README.md
+++ b/docs/docsite/README.md
@@ -1,7 +1,7 @@
 Homepage and documentation source for Ansible
 =============================================
 
-This project hosts the source behind [docs.ansible.com](http://docs.ansible.com/)
+This project hosts the source behind [docs.ansible.com](https://docs.ansible.com/)
 
 Contributions to the documentation are welcome. To make changes, submit a pull request that changes the reStructuredText files in the `rst/` directory only, and the core team can do a docs build and push the static files.
 
@@ -18,4 +18,4 @@ Note that module documentation can actually be [generated from a DOCUMENTATION d
 To install sphinx and the required theme, install pip and then "pip install sphinx sphinx_rtd_theme"
 
 [file issues]: https://github.com/ansible/ansible/issues
-[module-docs]: http://docs.ansible.com/developing_modules.html#documenting-your-module
+[module-docs]: https://docs.ansible.com/developing_modules.html#documenting-your-module

--- a/docs/docsite/rst/dev_guide/developing_api.rst
+++ b/docs/docsite/rst/dev_guide/developing_api.rst
@@ -15,7 +15,7 @@ write plugins, and you can plug in inventory data from external data sources.  T
 gives a basic overview and examples of the Ansible execution and playbook API.
 
 If you would like to use Ansible programmatically from a language other than Python, trigger events asynchronously, 
-or have access control and logging demands, please see the `Ansible Tower documentation <http://docs.ansible.com/ansible-tower/>`_.
+or have access control and logging demands, please see the `Ansible Tower documentation <https://docs.ansible.com/ansible-tower/>`_.
 
 .. note:: Because Ansible relies on forking processes, this API is not thread safe.
 

--- a/docs/docsite/rst/dev_guide/style_guide/_themes/srtd/footer.html
+++ b/docs/docsite/rst/dev_guide/style_guide/_themes/srtd/footer.html
@@ -13,7 +13,7 @@
   <hr/>
 
   <p>
-  &copy; Copyright 2015 <a href="http://ansible.com">Ansible, Inc.</a>.
+  &copy; Copyright 2015 <a href="https://ansible.com">Ansible, Inc.</a>.
 
   {%- if last_updated %}
     {% trans last_updated=last_updated|e %}Last updated on {{ last_updated }}.{% endtrans %}

--- a/docs/docsite/rst/dev_guide/style_guide/_themes/srtd/layout.html
+++ b/docs/docsite/rst/dev_guide/style_guide/_themes/srtd/layout.html
@@ -197,11 +197,11 @@
 
 <!-- AnsibleFest and free eBook preview stuff -->
 <center>
-<a href="http://www.ansible.com/tower?utm_source=docs">
-<img src="http://www.ansible.com/hubfs/Docs_Ads/TowerDocs.png">
+<a href="https://www.ansible.com/tower?utm_source=docs">
+<img src="https://www.ansible.com/hubfs/Docs_Ads/TowerDocs.png">
 </a>
 <a href="https://www.eventbrite.com/e/ansiblefest-nyc-2015-tickets-16058031003">
-<img src="http://www.ansible.com/hubfs/Docs_Ads/Untitled_design_1.png">
+<img src="https://www.ansible.com/hubfs/Docs_Ads/Untitled_design_1.png">
 </a>
 <br/>&nbsp;<br/>
 <br/>&nbsp;<br/>

--- a/docs/docsite/rst/installation_guide/intro_installation.rst
+++ b/docs/docsite/rst/installation_guide/intro_installation.rst
@@ -277,7 +277,7 @@ Readers that use virtualenv can also install Ansible under virtualenv, though we
 Tarballs of Tagged Releases
 +++++++++++++++++++++++++++
 
-Packaging Ansible or wanting to build a local package yourself, but don't want to do a git checkout?  Tarballs of releases are available on the `Ansible downloads <http://releases.ansible.com/ansible>`_ page.
+Packaging Ansible or wanting to build a local package yourself, but don't want to do a git checkout?  Tarballs of releases are available on the `Ansible downloads <https://releases.ansible.com/ansible>`_ page.
 
 These releases are also tagged in the `git repository <https://github.com/ansible/ansible/releases>`_ with the release version.
 

--- a/docs/docsite/rst/network/getting_started/intermediate_concepts.rst
+++ b/docs/docsite/rst/network/getting_started/intermediate_concepts.rst
@@ -49,8 +49,8 @@ Text
 
 Read more about Ansible for Network Automation:
 
-- Network Automation on the `Ansible website <http://ansible.com/overview/networking>`_
-- Ansible Network `Blog posts <http://ansible.com/blog/topic/networks>`_
+- Network Automation on the `Ansible website <https://ansible.com/overview/networking>`_
+- Ansible Network `Blog posts <https://ansible.com/blog/topic/networks>`_
 
 Events (on Video and in Person)
 --------------------------------

--- a/docs/docsite/rst/scenario_guides/guide_aci.rst
+++ b/docs/docsite/rst/scenario_guides/guide_aci.rst
@@ -65,7 +65,7 @@ For instance ensuring that a specific tenant exists, is done using the following
         description: Customer XYZ
         state: present
 
-A complete list of existing ACI modules is available for the latest stable release on the :ref:`list of network modules <list_of_network_modules>`. You can also view the `current development version <http://docs.ansible.com/ansible/devel/modules/list_of_network_modules.html#aci>`_.
+A complete list of existing ACI modules is available for the latest stable release on the :ref:`list of network modules <list_of_network_modules>`. You can also view the `current development version <https://docs.ansible.com/ansible/devel/modules/list_of_network_modules.html#aci>`_.
 
 Querying ACI configuration
 ..........................

--- a/docs/templates/man.j2
+++ b/docs/templates/man.j2
@@ -67,7 +67,7 @@ INVENTORY
 
 Ansible stores the hosts it can potentially operate on in an inventory.
 This can be an YAML file, ini-like file, a script, directory, list, etc.
-For additional options, see the documentation on http://docs.ansible.com/.
+For additional options, see the documentation on https://docs.ansible.com/.
 
 {% endif %}
 ENVIRONMENT
@@ -119,6 +119,6 @@ SEE ALSO
 {% for other in cli_list|sort %}{% if other != cli %}**ansible{% if other != 'adhoc' %}-{{other}}{% endif %}** (1){% if not loop.last %}, {% endif %}{% endif %}{% endfor %}
 
 Extensive documentation is available in the documentation site:
-<http://docs.ansible.com>.
+<https://docs.ansible.com>.
 IRC and mailing list info can be found in file CONTRIBUTING.md,
 available in: <https://github.com/ansible/ansible>

--- a/examples/DOCUMENTATION.yml
+++ b/examples/DOCUMENTATION.yml
@@ -3,7 +3,7 @@
 # aliases) you can use the word 'null', or an empty list, [], where
 # appropriate.
 #
-# See http://docs.ansible.com/ansible/dev_guide/developing_modules_documenting.html for more information
+# See https://docs.ansible.com/ansible/dev_guide/developing_modules_documenting.html for more information
 #
 module: modulename
 short_description: This is a sentence describing the module

--- a/hacking/metadata-tool.py
+++ b/hacking/metadata-tool.py
@@ -177,7 +177,7 @@ def parse_assigned_metadata(csvfile):
         :4: deprecated
         :5: removed
 
-        http://docs.ansible.com/ansible/latest/dev_guide/developing_modules_documenting.html#ansible-metadata-block
+        https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_documenting.html#ansible-metadata-block
     """
     with open(csvfile, 'rb') as f:
         for record in csv.reader(f):

--- a/lib/ansible/cli/vault.py
+++ b/lib/ansible/cli/vault.py
@@ -14,7 +14,7 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
 # ansible-vault is a script that encrypts/decrypts YAML files. See
-# http://docs.ansible.com/playbooks_vault.html for more details.
+# https://docs.ansible.com/playbooks_vault.html for more details.
 
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type

--- a/lib/ansible/module_utils/connection.py
+++ b/lib/ansible/module_utils/connection.py
@@ -111,7 +111,7 @@ class Connection(object):
         req = request_builder(name, *args, **kwargs)
         reqid = req['id']
 
-        troubleshoot = 'http://docs.ansible.com/ansible/latest/network/user_guide/network_debug_troubleshooting.html#category-socket-path-issue'
+        troubleshoot = 'https://docs.ansible.com/ansible/latest/network/user_guide/network_debug_troubleshooting.html#category-socket-path-issue'
 
         if not os.path.exists(self.socket_path):
             raise ConnectionError('socket_path does not exist or cannot be found. Please check %s' % troubleshoot)

--- a/lib/ansible/modules/cloud/amazon/GUIDELINES.md
+++ b/lib/ansible/modules/cloud/amazon/GUIDELINES.md
@@ -158,7 +158,7 @@ connection = boto3_conn(module, conn_type='client', resource='ec2', region=regio
 
 ### Common Documentation Fragments for Connection Parameters
 
-There are two [common documentation fragments](http://docs.ansible.com/ansible/latest/dev_guide/developing_modules_documenting.html#documentation-fragments)
+There are two [common documentation fragments](https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_documenting.html#documentation-fragments)
 that should be included into almost all AWS modules:
 
 * `aws` - contains the common boto connection parameters
@@ -518,8 +518,8 @@ affect the module are detected. At a minimum this should cover the key API calls
 documented return values are present in the module result.
 
 For general information on running the integration tests see the [Integration Tests page of the
-Module Development Guide](http://docs.ansible.com/ansible/latest/dev_guide/testing_integration.html).
-Particularly the [cloud test configuration section](http://docs.ansible.com/ansible/latest/dev_guide/testing_integration.html#other-configuration-for-cloud-tests)
+Module Development Guide](https://docs.ansible.com/ansible/latest/dev_guide/testing_integration.html).
+Particularly the [cloud test configuration section](https://docs.ansible.com/ansible/latest/dev_guide/testing_integration.html#other-configuration-for-cloud-tests)
 
 The integration tests for your module should be added in `test/integration/targets/MODULE_NAME`.
 
@@ -567,7 +567,7 @@ for every call, it's preferrable to use [YAML Anchors](http://blog.daemonl.com/2
 
 ### AWS Permissions for Integration Tests
 
-As explained in the [Integration Test guide](http://docs.ansible.com/ansible/latest/dev_guide/testing_integration.html#iam-policies-for-aws)
+As explained in the [Integration Test guide](https://docs.ansible.com/ansible/latest/dev_guide/testing_integration.html#iam-policies-for-aws)
 there are defined IAM policies in `hacking/aws_config/testing_policies/` that contain the necessary permissions
 to run the AWS integration test.
 

--- a/lib/ansible/modules/cloud/ovirt/README.rst
+++ b/lib/ansible/modules/cloud/ovirt/README.rst
@@ -47,7 +47,7 @@ New module development
 ----------------------
 
 Please read 
-`link <http://docs.ansible.com/ansible/dev_guide/developing_modules.html#how-to-develop-a-module>`__,
+`link <https://docs.ansible.com/ansible/dev_guide/developing_modules.html#how-to-develop-a-module>`__,
 first to know what common properties, functions and features every module must
 have.
 

--- a/lib/ansible/modules/net_tools/basics/get_url.py
+++ b/lib/ansible/modules/net_tools/basics/get_url.py
@@ -24,7 +24,7 @@ description:
        the target host, requests will be sent through that proxy. This
        behaviour can be overridden by setting a variable for this task
        (see `setting the environment
-       <http://docs.ansible.com/playbooks_environment.html>`_),
+       <https://docs.ansible.com/playbooks_environment.html>`_),
        or by using the use_proxy option.
      - HTTP redirects can redirect from HTTP to HTTPS so you should be sure that
        your proxy environment for both protocols is correct.

--- a/lib/ansible/modules/notification/pushbullet.py
+++ b/lib/ansible/modules/notification/pushbullet.py
@@ -68,7 +68,7 @@ EXAMPLES = '''
     device: Chrome
     push_type: link
     title: Ansible Documentation
-    body: http://docs.ansible.com/
+    body: https://docs.ansible.com/
 
 # Sends a push notification to a channel
 - pushbullet:

--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -88,7 +88,7 @@ options:
         description:
             - Optionally set the user's password to this crypted value.
             - On Darwin/OS X systems, this value has to be cleartext. Beware of security issues.
-            - See U(http://docs.ansible.com/ansible/faq.html#how-do-i-generate-crypted-passwords-for-the-user-module)
+            - See U(https://docs.ansible.com/ansible/faq.html#how-do-i-generate-crypted-passwords-for-the-user-module)
               for details on various ways to generate these password values.
     state:
         description:

--- a/lib/ansible/modules/utilities/logic/async_status.py
+++ b/lib/ansible/modules/utilities/logic/async_status.py
@@ -32,7 +32,7 @@ options:
     choices: [ "status", "cleanup" ]
     default: "status"
 notes:
-    - See also U(http://docs.ansible.com/playbooks_async.html)
+    - See also U(https://docs.ansible.com/playbooks_async.html)
     - This module is also supported for Windows targets.
 author:
     - "Ansible Core Team"

--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -228,7 +228,7 @@ class Task(Base, Conditional, Taggable, Become):
                 # as we will remove this at some point in the future.
                 if action in ('include', 'include_tasks') and k not in self._valid_attrs and k not in self.DEPRECATED_ATTRIBUTES:
                     display.deprecated("Specifying include variables at the top-level of the task is deprecated."
-                                       " Please see:\nhttp://docs.ansible.com/ansible/playbooks_roles.html#task-include-files-and-encouraging-reuse\n\n"
+                                       " Please see:\nhttps://docs.ansible.com/ansible/playbooks_roles.html#task-include-files-and-encouraging-reuse\n\n"
                                        " for currently supported syntax regarding included files and variables", version="2.7")
                     new_ds['vars'][k] = v
                 elif k in self._valid_attrs:

--- a/lib/ansible/plugins/action/junos.py
+++ b/lib/ansible/plugins/action/junos.py
@@ -59,7 +59,7 @@ class ActionModule(_ActionModule):
 
             if provider['transport'] == 'cli' and self._task.action not in CLI_SUPPORTED_MODULES:
                 return {'failed': True, 'msg': "Transport type '%s' is not valid for '%s' module. "
-                                               "Please see http://docs.ansible.com/ansible/latest/network/user_guide/platform_junos.html"
+                                               "Please see https://docs.ansible.com/ansible/latest/network/user_guide/platform_junos.html"
                                                % (provider['transport'], self._task.action)}
 
             if self._task.action == 'junos_netconf' or (provider['transport'] == 'cli' and self._task.action == 'junos_command'):
@@ -93,7 +93,7 @@ class ActionModule(_ActionModule):
             if (self._play_context.connection == 'network_cli' and self._task.action not in CLI_SUPPORTED_MODULES) or \
                     (self._play_context.connection == 'netconf' and self._task.action == 'junos_netconf'):
                 return {'failed': True, 'msg': "Connection type '%s' is not valid for '%s' module. "
-                                               "Please see http://docs.ansible.com/ansible/latest/network/user_guide/platform_junos.html"
+                                               "Please see https://docs.ansible.com/ansible/latest/network/user_guide/platform_junos.html"
                                                % (self._play_context.connection, self._task.action)}
 
         if (self._play_context.connection == 'local' and pc.connection == 'network_cli') or self._play_context.connection == 'network_cli':

--- a/packaging/port/sysutils/ansible/Makefile
+++ b/packaging/port/sysutils/ansible/Makefile
@@ -4,7 +4,7 @@ PORTNAME=	ansible
 PORTVERSION=	2.1
 PORTREVISION=	1
 CATEGORIES=	python net-mgmt sysutils
-MASTER_SITES=	http://releases.ansible.com/ansible/
+MASTER_SITES=	https://releases.ansible.com/ansible/
 DISTNAME=	${PORTNAME}-${PORTVERSION}
 
 MAINTAINER=	bcoca@ansible.com

--- a/packaging/rpm/ansible.spec
+++ b/packaging/rpm/ansible.spec
@@ -12,7 +12,7 @@ Url:       https://www.ansible.com
 Summary:   SSH-based application deployment, configuration management, and IT orchestration platform
 License:   GPLv3+
 Group:     Development/Libraries
-Source:    http://releases.ansible.com/ansible/%{name}-%{version}.tar.gz
+Source:    https://releases.ansible.com/ansible/%{name}-%{version}.tar.gz
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot
 %{!?__python2: %global __python2 /usr/bin/python2.6}
 %{!?python_sitelib: %global python_sitelib %(%{__python2} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")}

--- a/test/integration/targets/vault/faux-editor.py
+++ b/test/integration/targets/vault/faux-editor.py
@@ -14,7 +14,7 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
 # ansible-vault is a script that encrypts/decrypts YAML files. See
-# http://docs.ansible.com/playbooks_vault.html for more details.
+# https://docs.ansible.com/playbooks_vault.html for more details.
 
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type

--- a/test/integration/targets/vault/password-script.py
+++ b/test/integration/targets/vault/password-script.py
@@ -14,7 +14,7 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
 # ansible-vault is a script that encrypts/decrypts YAML files. See
-# http://docs.ansible.com/playbooks_vault.html for more details.
+# https://docs.ansible.com/playbooks_vault.html for more details.
 
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type

--- a/test/legacy/Makefile
+++ b/test/legacy/Makefile
@@ -1,7 +1,7 @@
 # This Makefile is for legacy integration tests.
 # Most new tests should be implemented using ansible-test.
 # Existing tests are slowly being migrated to ansible-test.
-# See: http://docs.ansible.com/ansible/dev_guide/testing_integration.html
+# See: https://docs.ansible.com/ansible/dev_guide/testing_integration.html
 
 TEST_DIR ?= ~/ansible_testing
 INVENTORY ?= inventory

--- a/test/legacy/roles/cnos_backup/README.md
+++ b/test/legacy/roles/cnos_backup/README.md
@@ -13,7 +13,7 @@ For more details, see [Lenovo modules for Ansible: cnos_backup](http://systemx.l
 ---
 <add role requirements information below>
 
-- Ansible version 2.2 or later ([Ansible installation documentation](http://docs.ansible.com/ansible/intro_installation.html))
+- Ansible version 2.2 or later ([Ansible installation documentation](https://docs.ansible.com/ansible/intro_installation.html))
 - Lenovo switches running CNOS version 10.2.1.0 or later
 - an SSH connection to the Lenovo switch (SSH must be enabled on the network device)
 

--- a/test/legacy/roles/cnos_bgp/README.md
+++ b/test/legacy/roles/cnos_bgp/README.md
@@ -15,7 +15,7 @@ For more details, see [Lenovo modules for Ansible: cnos_bgp](http://systemx.leno
 ---
 <add role requirements information below>
 
-- Ansible version 2.2 or later ([Ansible installation documentation](http://docs.ansible.com/ansible/intro_installation.html))
+- Ansible version 2.2 or later ([Ansible installation documentation](https://docs.ansible.com/ansible/intro_installation.html))
 - Lenovo switches running CNOS version 10.2.1.0 or later
 - an SSH connection to the Lenovo switch (SSH must be enabled on the network device)
 

--- a/test/legacy/roles/cnos_command/README.md
+++ b/test/legacy/roles/cnos_command/README.md
@@ -15,7 +15,7 @@ For more details, see [Lenovo modules for Ansible: cnos_command](http://systemx.
 ---
 <add role requirements information below>
 
-- Ansible version 2.2 or later ([Ansible installation documentation](http://docs.ansible.com/ansible/intro_installation.html))
+- Ansible version 2.2 or later ([Ansible installation documentation](https://docs.ansible.com/ansible/intro_installation.html))
 - Lenovo switches running CNOS version 10.2.1.0 or later
 - an SSH connection to the Lenovo switch (SSH must be enabled on the network device)
 

--- a/test/legacy/roles/cnos_conditional_command/README.md
+++ b/test/legacy/roles/cnos_conditional_command/README.md
@@ -20,7 +20,7 @@ For more details, see [Lenovo modules for Ansible: cnos_conditional_command](htt
 ---
 <add role requirements information below>
 
-- Ansible version 2.2 or later ([Ansible installation documentation](http://docs.ansible.com/ansible/intro_installation.html))
+- Ansible version 2.2 or later ([Ansible installation documentation](https://docs.ansible.com/ansible/intro_installation.html))
 - Lenovo switches running CNOS version 10.2.1.0 or later
 - an SSH connection to the Lenovo switch (SSH must be enabled on the network device)
 

--- a/test/legacy/roles/cnos_conditional_template/README.md
+++ b/test/legacy/roles/cnos_conditional_template/README.md
@@ -21,7 +21,7 @@ For more details, see [Lenovo modules for Ansible: cnos_conditional_template](ht
 ---
 <add role requirements information below>
 
-- Ansible version 2.2 or later ([Ansible installation documentation](http://docs.ansible.com/ansible/intro_installation.html))
+- Ansible version 2.2 or later ([Ansible installation documentation](https://docs.ansible.com/ansible/intro_installation.html))
 - Lenovo switches running CNOS version 10.2.1.0 or later
 - an SSH connection to the Lenovo switch (SSH must be enabled on the network device)
 

--- a/test/legacy/roles/cnos_ethernet/README.md
+++ b/test/legacy/roles/cnos_ethernet/README.md
@@ -15,7 +15,7 @@ For more details, see [Lenovo modules for Ansible: cnos_interface](http://system
 ---
 <add role requirements information below>
 
-- Ansible version 2.2 or later ([Ansible installation documentation](http://docs.ansible.com/ansible/intro_installation.html))
+- Ansible version 2.2 or later ([Ansible installation documentation](https://docs.ansible.com/ansible/intro_installation.html))
 - Lenovo switches running CNOS version 10.2.1.0 or later
 - an SSH connection to the Lenovo switch (SSH must be enabled on the network device)
 

--- a/test/legacy/roles/cnos_facts/README.md
+++ b/test/legacy/roles/cnos_facts/README.md
@@ -13,7 +13,7 @@ For more details, see [Lenovo modules for Ansible: cnos_facts](http://systemx.le
 ---
 <add role requirements information below>
 
-- Ansible version 2.2 or later ([Ansible installation documentation](http://docs.ansible.com/ansible/intro_installation.html))
+- Ansible version 2.2 or later ([Ansible installation documentation](https://docs.ansible.com/ansible/intro_installation.html))
 - Lenovo switches running CNOS version 10.2.1.0 or later
 - an SSH connection to the Lenovo switch (SSH must be enabled on the network device)
 

--- a/test/legacy/roles/cnos_image/README.md
+++ b/test/legacy/roles/cnos_image/README.md
@@ -17,7 +17,7 @@ For more details, see [Lenovo modules for Ansible: cnos_image](http://systemx.le
 ---
 <add role requirements information below>
 
-- Ansible version 2.2 or later ([Ansible installation documentation](http://docs.ansible.com/ansible/intro_installation.html))
+- Ansible version 2.2 or later ([Ansible installation documentation](https://docs.ansible.com/ansible/intro_installation.html))
 - Lenovo switches running CNOS version 10.2.1.0 or later
 - an SSH connection to the Lenovo switch (SSH must be enabled on the network device)
 

--- a/test/legacy/roles/cnos_portchannel/README.md
+++ b/test/legacy/roles/cnos_portchannel/README.md
@@ -15,7 +15,7 @@ For more details, see [Lenovo modules for Ansible: cnos_portchannel](http://syst
 ---
 <add role requirements information below>
 
-- Ansible version 2.2 or later ([Ansible installation documentation](http://docs.ansible.com/ansible/intro_installation.html))
+- Ansible version 2.2 or later ([Ansible installation documentation](https://docs.ansible.com/ansible/intro_installation.html))
 - Lenovo switches running CNOS version 10.2.1.0 or later
 - an SSH connection to the Lenovo switch (SSH must be enabled on the network device)
 

--- a/test/legacy/roles/cnos_rollback/README.md
+++ b/test/legacy/roles/cnos_rollback/README.md
@@ -17,7 +17,7 @@ For more details, see [Lenovo modules for Ansible: cnos_rollback](http://systemx
 ---
 <add role requirements information below>
 
-- Ansible version 2.2 or later ([Ansible installation documentation](http://docs.ansible.com/ansible/intro_installation.html))
+- Ansible version 2.2 or later ([Ansible installation documentation](https://docs.ansible.com/ansible/intro_installation.html))
 - Lenovo switches running CNOS version 10.2.1.0 or later
 - an SSH connection to the Lenovo switch (SSH must be enabled on the network device)
 

--- a/test/legacy/roles/cnos_save/README.md
+++ b/test/legacy/roles/cnos_save/README.md
@@ -13,7 +13,7 @@ For more details, see [Lenovo modules for Ansible: cnos_save](http://systemx.len
 ---
 <add role requirements information below>
 
-- Ansible version 2.2 or later ([Ansible installation documentation](http://docs.ansible.com/ansible/intro_installation.html))
+- Ansible version 2.2 or later ([Ansible installation documentation](https://docs.ansible.com/ansible/intro_installation.html))
 - Lenovo switches running CNOS version 10.2.1.0 or later
 - an SSH connection to the Lenovo switch (SSH must be enabled on the network device)
 

--- a/test/legacy/roles/cnos_showrun/README.md
+++ b/test/legacy/roles/cnos_showrun/README.md
@@ -13,7 +13,7 @@ For more details, see [Lenovo modules for Ansible: cnos_showrun](http://systemx.
 ---
 <add role requirements information below>
 
-- Ansible version 2.2 or later ([Ansible installation documentation](http://docs.ansible.com/ansible/intro_installation.html))
+- Ansible version 2.2 or later ([Ansible installation documentation](https://docs.ansible.com/ansible/intro_installation.html))
 - Lenovo switches running CNOS version 10.2.1.0 or later
 - an SSH connection to the Lenovo switch (SSH must be enabled on the network device)
 

--- a/test/legacy/roles/cnos_template/README.md
+++ b/test/legacy/roles/cnos_template/README.md
@@ -15,7 +15,7 @@ For more details, see [Lenovo modules for Ansible: cnos_template](http://systemx
 ---
 <add role requirements information below>
 
-- Ansible version 2.2 or later ([Ansible installation documentation](http://docs.ansible.com/ansible/intro_installation.html))
+- Ansible version 2.2 or later ([Ansible installation documentation](https://docs.ansible.com/ansible/intro_installation.html))
 - Lenovo switches running CNOS version 10.2.1.0 or later
 - an SSH connection to the Lenovo switch (SSH must be enabled on the network device)
 

--- a/test/legacy/roles/cnos_vlag/README.md
+++ b/test/legacy/roles/cnos_vlag/README.md
@@ -15,7 +15,7 @@ For more details, see [Lenovo modules for Ansible: cnos_vlag](http://systemx.len
 ---
 <add role requirements information below>
 
-- Ansible version 2.2 or later ([Ansible installation documentation](http://docs.ansible.com/ansible/intro_installation.html))
+- Ansible version 2.2 or later ([Ansible installation documentation](https://docs.ansible.com/ansible/intro_installation.html))
 - Lenovo switches running CNOS version 10.2.1.0 or later
 - an SSH connection to the Lenovo switch (SSH must be enabled on the network device)
 

--- a/test/legacy/roles/cnos_vlan/README.md
+++ b/test/legacy/roles/cnos_vlan/README.md
@@ -15,7 +15,7 @@ For more details, see [Lenovo modules for Ansible: cnos_vlan](http://systemx.len
 ---
 <add role requirements information below>
 
-- Ansible version 2.2 or later ([Ansible installation documentation](http://docs.ansible.com/ansible/intro_installation.html))
+- Ansible version 2.2 or later ([Ansible installation documentation](https://docs.ansible.com/ansible/intro_installation.html))
 - Lenovo switches running CNOS version 10.2.1.0 or later
 - an SSH connection to the Lenovo switch (SSH must be enabled on the network device)
 


### PR DESCRIPTION
##### SUMMARY

Use https for links to ansible.com domains.

##### ISSUE TYPE

Docs Pull Request

##### COMPONENT NAME

docs

##### ANSIBLE VERSION

```
ansible 2.6.0 (https-ansible-links d4092feada) last updated 2018/04/22 07:23:54 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
