### PR TITLE
Adding more facts to dellos9_facts module

### DIFF
--- a/lib/ansible/modules/network/dellos9/dellos9_facts.py
+++ b/lib/ansible/modules/network/dellos9/dellos9_facts.py
@@ -189,7 +189,7 @@ class Default(FactsBase):
 
         data = self.responses[2]
         self.facts['hostname'] = self.parse_hostname(data)
-        
+
         data = self.responses[3]
         self.facts['stack'] = self.parse_stack(data)
 
@@ -215,7 +215,7 @@ class Default(FactsBase):
         match = re.search(r'image file is "(.+)"', data)
         if match:
             return match.group(1)
-    
+  
     def parse_stack(self, data):
         match = re.search(r'^Topology:\s*(.+)', data, re.M)
         if match:
@@ -230,8 +230,7 @@ class Default(FactsBase):
         match = re.findall(r'\s+\S+\s+\S+\s+(\w{14})\s+\S+', data, re.M)
         if match:
             self.facts['stack_serialnums'] = match
-
-
+            
     def parse_serialnum(self, data):
         for line in data.split('\n'):
             if line.startswith('*'):
@@ -239,7 +238,7 @@ class Default(FactsBase):
                     r'\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)', line, re.M)
                 if match:
                     return match.group(3)
-
+                  
                   
 class Hardware(FactsBase):
 


### PR DESCRIPTION
This change will give an option to check stacked configurations for DellOS9 switches as well as gathering serial numbers from all systems configured in stack

##### SUMMARY
This change required to gather more detailed information from Force10 switches aggregated in  stack

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
dellos9_facts

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.1
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/murmanov/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->
Basically I've added new facts which can be helpful sometimes
<!--- Paste verbatim command output below, e.g. before and after your change -->
```
        "ansible_net_stack": "Daisy chain", 
        "ansible_net_stack_serialnums": [
            "CN2829851B0244", 
            "CN2829851B0148"
        ], 
        "ansible_net_system_members": [
            "  0   Management   online         MXL-10/40GbE", 
            "  1   Standby      online         MXL-10/40GbE"
        ], 

```
