### PR TITLE
azure_rm_storageaccount: fix broken import

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_storageaccount.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_storageaccount.py
@@ -147,7 +147,7 @@ except ImportError:
     # This is handled in azure_rm_common
     pass
 
-from ansible.module_utils.azure_rm_common import AZURE_SUCCESS_STATE, AzureRMModuleBase
+from ansible.module_utils.azure_rm_common import AZURE_SUCCESS_STATE, AzureRMModuleBase, HAS_AZURE
 
 
 class AzureRMStorageAccount(AzureRMModuleBase):
@@ -167,8 +167,9 @@ class AzureRMStorageAccount(AzureRMModuleBase):
             access_tier=dict(type='str', choices=['Hot', 'Cool'])
         )
 
-        for key in self.storage_models.SkuName:
-            self.module_arg_spec['account_type']['choices'].append(getattr(key, 'value'))
+        if HAS_AZURE:
+            for key in self.storage_models.SkuName:
+                self.module_arg_spec['account_type']['choices'].append(getattr(key, 'value'))
 
         self.results = dict(
             changed=False,

--- a/test/sanity/import/skip.txt
+++ b/test/sanity/import/skip.txt
@@ -1,4 +1,3 @@
-lib/ansible/modules/cloud/azure/azure_rm_storageaccount.py
 lib/ansible/modules/cloud/webfaction/webfaction_site.py
 lib/ansible/modules/clustering/k8s/k8s_raw.py
 lib/ansible/modules/clustering/k8s/k8s_scale.py


### PR DESCRIPTION
##### SUMMARY
`azure_rm_storageaccount` module: fix broken import

Fix this error:
```
Traceback (most recent call last):
  File "lib/ansible/modules/cloud/azure/azure_rm_storageaccount.py", line 452, in <module>
    main()
  File "lib/ansible/modules/cloud/azure/azure_rm_storageaccount.py", line 449, in main
    AzureRMStorageAccount()
  File "lib/ansible/modules/cloud/azure/azure_rm_storageaccount.py", line 170, in __init__
    for key in self.storage_models.SkuName:
  File "src/ansible/ansible.git/lib/ansible/module_utils/azure_rm_common.py", line 921, in storage_models
    return StorageManagementClient.models("2017-10-01")
NameError: name 'StorageManagementClient' is not defined
```

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
azure_rm_storageaccount

##### ANSIBLE VERSION
```
ansible 2.6.0 (devel 7437d6fdc4) last updated 2018/04/22 20:21:59 (GMT +200)
```