### PR TITLE
plugins: filter: ipaddr: Add AddrFormatError exeption when hwaddr value is not macaddr

### DIFF
--- a/test/support/network-integration/collections/ansible_collections/ansible/netcommon/plugins/filter/ipaddr.py
+++ b/test/support/network-integration/collections/ansible_collections/ansible/netcommon/plugins/filter/ipaddr.py
@@ -1112,6 +1112,8 @@ def hwaddr(value, query="", alias="hwaddr"):
 
     try:
         v = netaddr.EUI(value)
+    except netaddr.AddrFormatError:
+        return False
     except Exception:
         if query and query != "bool":
             raise errors.AnsibleFilterError(


### PR DESCRIPTION
##### SUMMARY
netaddr.AddrFormatError is not handled by `hwaddr()` filter.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->

`ansible/lib/ansible/plugins/filter/ipaddr.py`

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.3.0
  config file = /home/k0ste/ansible-fork/ansible.cfg
  configured module search path = [u'/home/k0ste/ansible/my_modules', u'/home/k0ste/ceph-ansible/library']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.14 (default, Jan  5 2018, 10:41:29) [GCC 7.2.1 20171224]
```


##### ADDITIONAL INFORMATION

###### Test data: 

```yaml
---
- name: hwaddr validation
  become: false
  gather_facts: false
  remote_user: k0ste
  no_log: false
  strategy: linear
  hosts: localhost
  vars:
    maddr: 'd0:50:99:1c:78:'
  tasks:
  - assert:
      that: "vars['maddr'] | hwaddr()"
      msg: "'maddr' is not maddr"
```
###### Expected results:

msg: `vars['maddr']` is not maddr.

###### Actual results:

```python
PLAY [hwaddr validation] *******************************************************************************************************************************************************************************************

TASK [assert] ******************************************************************************************************************************************************************************************************
fatal: [localhost]: FAILED! => {"msg": "The conditional check 'vars['maddr'] | hwaddr()' failed. The error was: local variable 'v' referenced before assignment"}

PLAY RECAP *********************************************************************************************************************************************************************************************************
localhost                  : ok=0    changed=0    unreachable=0    failed=1   
```

###### Fixed via this PR:

```python
PLAY [hwaddr validation] *******************************************************************************************************************************************************************************************

TASK [assert] ******************************************************************************************************************************************************************************************************
fatal: [localhost]: FAILED! => {"msg": "The conditional check 'vars['maddr'] | hwaddr()' failed. The error was: hwaddr: not a hardware address: d0:50:99:1c:78:"}

PLAY RECAP *********************************************************************************************************************************************************************************************************
localhost                  : ok=0    changed=0    unreachable=0    failed=1   
```