### PR TITLE
Fixed rename functionality of na_cdot_qtree.

### DIFF
--- a/lib/ansible/modules/storage/netapp/na_cdot_qtree.py
+++ b/lib/ansible/modules/storage/netapp/na_cdot_qtree.py
@@ -47,6 +47,12 @@ options:
     - The name of the vserver to use.
     required: true
 
+  qtree_new_name:
+    description:
+    - The new name to rename the qtree.
+    required: false
+    version_added: '2.6'
+
 '''
 
 EXAMPLES = """
@@ -64,6 +70,7 @@ EXAMPLES = """
   na_cdot_qtree:
     state: present
     name: ansibleQTree
+    qtree_new_name: ansibleQTreeNew
     flexvol_name: ansibleVolume
     vserver: ansibleVServer
     hostname: "{{ netapp_hostname }}"
@@ -93,6 +100,7 @@ class NetAppCDOTQTree(object):
             name=dict(required=True, type='str'),
             flexvol_name=dict(type='str'),
             vserver=dict(required=True, type='str'),
+            qtree_new_name=dict(required=False, type='str', default=None),
         ))
 
         self.module = AnsibleModule(
@@ -110,6 +118,7 @@ class NetAppCDOTQTree(object):
         self.name = p['name']
         self.flexvol_name = p['flexvol_name']
         self.vserver = p['vserver']
+        self.new_name = p['qtree_new_name']
 
         if HAS_NETAPP_LIB is False:
             self.module.fail_json(msg="the python NetApp-Lib module is required")
@@ -171,7 +180,7 @@ class NetAppCDOTQTree(object):
 
     def rename_qtree(self):
         path = '/vol/%s/%s' % (self.flexvol_name, self.name)
-        new_path = '/vol/%s/%s' % (self.flexvol_name, self.name)
+        new_path = '/vol/%s/%s' % (self.flexvol_name, self.new_name)
         qtree_rename = netapp_utils.zapi.NaElement.create_node_with_children(
             'qtree-rename', **{'qtree': path,
                                'new-qtree-name': new_path})
@@ -197,7 +206,7 @@ class NetAppCDOTQTree(object):
                 changed = True
 
             elif self.state == 'present':
-                if self.name is not None and not self.name == \
+                if self.new_name is not None and not self.new_name == \
                         self.name:
                     changed = True
                     rename_qtree = True


### PR DESCRIPTION
Issue link: https://github.com/ansible/ansible/issues/39139

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Added new parameter "qtree_new_name" to pass the new name to rename the
qtree.
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
na_cdot_qtree.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible --version
ansible 2.5.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Aug  4 2017, 00:39:18) [GCC 4.8.5 20150623 (Red Hat 4.8.5-16)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
