### PR TITLE
Fixed bug to set hostTypeIndex correctly at the time of netapp_e_host create

### DIFF
--- a/lib/ansible/modules/storage/netapp/netapp_e_host.py
+++ b/lib/ansible/modules/storage/netapp/netapp_e_host.py
@@ -288,7 +288,7 @@ class Host(object):
     def create_host(self):
         post_body = dict(
             name=self.name,
-            host_type=dict(index=self.host_type_index),
+            hostType=dict(index=self.host_type_index),
             groupId=self.group_id,
             ports=self.ports
         )


### PR DESCRIPTION
Issue link: https://github.com/ansible/ansible/issues/39143



##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Corrected post_body making by replacing host_type with hostType while creating
host.
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
netapp_e_host.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible --version
ansible 2.5.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Aug  4 2017, 00:39:18) [GCC 4.8.5 20150623 (Red Hat 4.8.5-16)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
