### PR TITLE
avoids not-in-toc errors with :orphan:

### DIFF
--- a/docs/templates/plugin.rst.j2
+++ b/docs/templates/plugin.rst.j2
@@ -1,5 +1,10 @@
 :source: @{ source }@
 
+{# avoids rST "isn't included in any toctree" errors for module docs #}
+{% if plugin_type == 'module' %}
+:orphan:
+{% endif %}
+
 .. _@{ module }@_@{ plugin_type }@:
 {% for alias in aliases %}
 .. _@{ alias }@:


### PR DESCRIPTION
##### SUMMARY
This is part of our push to get rid of rst_warning errors in the docs build. By including `:orphan:` on the top of each module doc page, we eliminate one error per module.
Fixes #39108.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
docs.ansible.com

##### ANSIBLE VERSION
2.5

##### ADDITIONAL INFORMATION
Related to #39030 
