### PR TITLE
ovirt: Update documentation to showcase that the Python SDK 4.2.4 is required.

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_auth.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_auth.py
@@ -102,14 +102,14 @@ options:
 
 requirements:
   - python >= 2.7
-  - ovirt-engine-sdk-python >= 4.0.0
+  - ovirt-engine-sdk-python >= 4.2.4
 notes:
   - "Everytime you use ovirt_auth module to obtain ticket, you need to also revoke the ticket,
      when you no longer need it, otherwise the ticket would be revoked by engine when it expires.
      For an example of how to achieve that, please take a look at I(examples) section."
   - "In order to use this module you have to install oVirt/RHV Python SDK.
      To ensure it's installed with correct version you can create the following task:
-     I(pip: name=ovirt-engine-sdk-python version=4.0.0)"
+     I(pip: name=ovirt-engine-sdk-python version=4.2.4)"
   - "Note that in oVirt/RHV 4.1 if you want to use a user which is not administrator
      you must enable the I(ENGINE_API_FILTER_BY_DEFAULT) variable in engine. In
      oVirt/RHV 4.2 and later it's enabled by default."

--- a/lib/ansible/utils/module_docs_fragments/ovirt.py
+++ b/lib/ansible/utils/module_docs_fragments/ovirt.py
@@ -72,5 +72,5 @@ requirements:
 notes:
   - "In order to use this module you have to install oVirt Python SDK.
      To ensure it's installed with correct version you can create the following task:
-     I(pip: name=ovirt-engine-sdk-python version=4.0.0)"
+     I(pip: name=ovirt-engine-sdk-python version=4.2.4)"
 '''

--- a/lib/ansible/utils/module_docs_fragments/ovirt_facts.py
+++ b/lib/ansible/utils/module_docs_fragments/ovirt_facts.py
@@ -60,5 +60,5 @@ requirements:
 notes:
   - "In order to use this module you have to install oVirt Python SDK.
      To ensure it's installed with correct version you can create the following task:
-     pip: name=ovirt-engine-sdk-python version=4.0.0"
+     pip: name=ovirt-engine-sdk-python version=4.2.4"
 '''


### PR DESCRIPTION
This is related to the GitHub PR#35841. Some documentation was missed and did not get updated with those patches.

https://github.com/ansible/ansible/pull/35841

##### SUMMARY
oVirt modules used to require the 4.0.0 Python SDK in Ansible 2.4. Starting in Ansible 2.5, 4.2.4 is required. That requirement was not updated in all of the related documentation.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
ovirt

##### ANSIBLE VERSION
2.6

##### ADDITIONAL INFORMATION
This should also be back-ported to 2.5.