### PR TITLE
Fix ec2_vpc_subnet for boto versions that do not accept the WaiterCon…

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_subnet.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_subnet.py
@@ -579,7 +579,7 @@ def main():
         module.fail_json(msg="assign_instances_ipv6 is True but ipv6_cidr is None or an empty string")
 
     if LooseVersion(botocore.__version__) < "1.7.0":
-        module.warn("boto3 >= 1.4.7 (or botocore >= 1.7.0) is required to use wait_timeout for custom wait times")
+        module.warn("botocore >= 1.7.0 is required to use wait_timeout for custom wait times")
 
     region, ec2_url, aws_connect_params = get_aws_connection_info(module, boto3=True)
     connection = boto3_conn(module, conn_type='client', resource='ec2', region=region, endpoint=ec2_url, **aws_connect_params)

--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_subnet.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_subnet.py
@@ -205,6 +205,7 @@ subnet:
 
 import time
 import traceback
+from distutils.version import LooseVersion
 
 try:
     import botocore
@@ -253,16 +254,17 @@ def describe_subnets_with_backoff(client, **params):
     return client.describe_subnets(**params)
 
 
-def wait_config(wait_timeout, start_time):
-    remaining_wait_timeout = int(wait_timeout + start_time - time.time())
-    return {'Delay': 5, 'MaxAttempts': remaining_wait_timeout // 5}
+def waiter_params(module, params, start_time):
+    if LooseVersion(botocore.__version__) >= "1.7.0":
+        remaining_wait_timeout = int(module.params['wait_timeout'] + start_time - time.time())
+        params['WaiterConfig'] = {'Delay': 5, 'MaxAttempts': remaining_wait_timeout // 5}
+    return params
 
 
 def handle_waiter(conn, module, waiter_name, params, start_time):
-    params['WaiterConfig'] = wait_config(module.params['wait_timeout'], start_time)
     try:
         get_waiter(conn, waiter_name).wait(
-            **params
+            **waiter_params(module, params, start_time)
         )
     except botocore.exceptions.WaiterError as e:
         module.fail_json_aws(e, "Failed to wait for updates to complete")
@@ -295,8 +297,7 @@ def create_subnet(conn, module, vpc_id, cidr, ipv6_cidr=None, az=None, start_tim
         handle_waiter(conn, module, 'subnet_exists', {'SubnetIds': [subnet['id']]}, start_time)
         try:
             conn.get_waiter('subnet_available').wait(
-                SubnetIds=[subnet['id']],
-                WaiterConfig=wait_config(wait_timeout, start_time)
+                **waiter_params(module, {'SubnetIds': [subnet['id']]}, start_time)
             )
             subnet['state'] = 'available'
         except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
@@ -576,6 +577,9 @@ def main():
 
     if module.params.get('assign_instances_ipv6') and not module.params.get('ipv6_cidr'):
         module.fail_json(msg="assign_instances_ipv6 is True but ipv6_cidr is None or an empty string")
+
+    if LooseVersion(botocore.__version__) < "1.7.0":
+        module.warn("boto3 >= 1.4.7 (or botocore >= 1.7.0) is required to use wait_timeout for custom wait times")
 
     region, ec2_url, aws_connect_params = get_aws_connection_info(module, boto3=True)
     connection = boto3_conn(module, conn_type='client', resource='ec2', region=region, endpoint=ec2_url, **aws_connect_params)


### PR DESCRIPTION
…fig parameter

##### SUMMARY
WaiterConfig requires botocore >= 1.7.0.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/ec2_vpc_subnet.py

##### ANSIBLE VERSION
```
2.6.0
```
