### PR TITLE
Passing environmental variable to task definition

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ecs_taskdefinition.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_taskdefinition.py
@@ -122,10 +122,10 @@ EXAMPLES = '''
           awslogs-group: ecs
           awslogs-region: us-west-2
       environment:
-         -  name: FAASOS_ENV
-            value: dev
-         -  name: VERSION
-            value: 1.5
+      -  name: FAASOS_ENV
+         value: dev
+      -  name: VERSION
+         value: 1.5
     - name: busybox
       command:
         - >

--- a/lib/ansible/modules/cloud/amazon/ecs_taskdefinition.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_taskdefinition.py
@@ -122,10 +122,10 @@ EXAMPLES = '''
           awslogs-group: ecs
           awslogs-region: us-west-2
       environment:
-      -  name: FAASOS_ENV
-         value: dev
-      -  name: VERSION
-         value: 1.5
+      - name: FAASOS_ENV
+        value: dev
+      - name: VERSION
+        value: 1.5
     - name: busybox
       command:
         - >

--- a/lib/ansible/modules/cloud/amazon/ecs_taskdefinition.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_taskdefinition.py
@@ -122,10 +122,10 @@ EXAMPLES = '''
           awslogs-group: ecs
           awslogs-region: us-west-2
       environment:
-         -  name: "FAASOS_ENV"
-            value: "dev"
-         -  name: "VERSION"
-            value: "1.5"
+         -  name: FAASOS_ENV
+            value: dev
+         -  name: VERSION
+            value: 1.5
     - name: busybox
       command:
         - >

--- a/lib/ansible/modules/cloud/amazon/ecs_taskdefinition.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_taskdefinition.py
@@ -121,6 +121,11 @@ EXAMPLES = '''
         options:
           awslogs-group: ecs
           awslogs-region: us-west-2
+      environment:
+         -  name: "FAASOS_ENV"
+            value: "dev"
+         -  name: "VERSION"
+            value: "1.5"
     - name: busybox
       command:
         - >


### PR DESCRIPTION
This will pass the environmental variable to the "docker run" command.

Docker File Changes:
CMD FAASOS_ENV=$FAASOS_ENV node code/index.js

Docker Run Example: 
ubuntu@panther:~$ docker run -it -e "FAASOS_ENV=dev" api-gateway /bin/sh
/app # echo $FAASOS_ENV
dev

Task Definition Json Snippet:
      "environment": [
        {
          "name": "FAASOS_ENV",
          "value": "dev"
        },
        {
          "name": "Version",
          "value": "1.5"
        }
      ],
+label: docsite_pr

##### SUMMARY
This will help the user to pass the multiple environmental variables to the task definition which is used to execute the docker run command.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
ECS Task Definition

##### ANSIBLE VERSION
```
ansible 2.5.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/ubuntu/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.12 (default, Nov 20 2017, 18:23:56) [GCC 5.4.0 20160609]
```
