### PR TITLE
netscaler (multiple modules): Add capability to proxy module calls through a MAS node

### DIFF
--- a/lib/ansible/modules/network/netscaler/netscaler_cs_action.py
+++ b/lib/ansible/modules/network/netscaler/netscaler_cs_action.py
@@ -170,18 +170,19 @@ def main():
     # Fallthrough to rest of execution
     client = get_nitro_client(module)
 
-    try:
-        client.login()
-    except nitro_exception as e:
-        msg = "nitro exception during login. errorcode=%s, message=%s" % (str(e.errorcode), e.message)
-        module.fail_json(msg=msg)
-    except Exception as e:
-        if str(type(e)) == "<class 'requests.exceptions.ConnectionError'>":
-            module.fail_json(msg='Connection error %s' % str(e))
-        elif str(type(e)) == "<class 'requests.exceptions.SSLError'>":
-            module.fail_json(msg='SSL Error %s' % str(e))
-        else:
-            module.fail_json(msg='Unexpected error during login %s' % str(e))
+    if not module.params['mas_proxy_call']:
+        try:
+            client.login()
+        except nitro_exception as e:
+            msg = "nitro exception during login. errorcode=%s, message=%s" % (str(e.errorcode), e.message)
+            module.fail_json(msg=msg)
+        except Exception as e:
+            if str(type(e)) == "<class 'requests.exceptions.ConnectionError'>":
+                module.fail_json(msg='Connection error %s' % str(e))
+            elif str(type(e)) == "<class 'requests.exceptions.SSLError'>":
+                module.fail_json(msg='SSL Error %s' % str(e))
+            else:
+                module.fail_json(msg='Unexpected error during login %s' % str(e))
 
     readwrite_attrs = [
         'name',
@@ -279,7 +280,9 @@ def main():
         msg = "nitro exception errorcode=%s, message=%s" % (str(e.errorcode), e.message)
         module.fail_json(msg=msg, **module_result)
 
-    client.logout()
+    if not module.params['mas_proxy_call']:
+        client.logout()
+
     module.exit_json(**module_result)
 
 

--- a/lib/ansible/modules/network/netscaler/netscaler_cs_policy.py
+++ b/lib/ansible/modules/network/netscaler/netscaler_cs_policy.py
@@ -184,18 +184,19 @@ def main():
     # Fallthrough to rest of execution
     client = get_nitro_client(module)
 
-    try:
-        client.login()
-    except nitro_exception as e:
-        msg = "nitro exception during login. errorcode=%s, message=%s" % (str(e.errorcode), e.message)
-        module.fail_json(msg=msg)
-    except Exception as e:
-        if str(type(e)) == "<class 'requests.exceptions.ConnectionError'>":
-            module.fail_json(msg='Connection error %s' % str(e))
-        elif str(type(e)) == "<class 'requests.exceptions.SSLError'>":
-            module.fail_json(msg='SSL Error %s' % str(e))
-        else:
-            module.fail_json(msg='Unexpected error during login %s' % str(e))
+    if not module.params['mas_proxy_call']:
+        try:
+            client.login()
+        except nitro_exception as e:
+            msg = "nitro exception during login. errorcode=%s, message=%s" % (str(e.errorcode), e.message)
+            module.fail_json(msg=msg)
+        except Exception as e:
+            if str(type(e)) == "<class 'requests.exceptions.ConnectionError'>":
+                module.fail_json(msg='Connection error %s' % str(e))
+            elif str(type(e)) == "<class 'requests.exceptions.SSLError'>":
+                module.fail_json(msg='SSL Error %s' % str(e))
+            else:
+                module.fail_json(msg='Unexpected error during login %s' % str(e))
 
     readwrite_attrs = [
         'policyname',
@@ -278,7 +279,9 @@ def main():
         msg = "nitro exception errorcode=%s, message=%s" % (str(e.errorcode), e.message)
         module.fail_json(msg=msg, **module_result)
 
-    client.logout()
+    if not module.params['mas_proxy_call']:
+        client.logout()
+
     module.exit_json(**module_result)
 
 

--- a/lib/ansible/modules/network/netscaler/netscaler_cs_vserver.py
+++ b/lib/ansible/modules/network/netscaler/netscaler_cs_vserver.py
@@ -1059,18 +1059,19 @@ def main():
     # Fallthrough to rest of execution
     client = get_nitro_client(module)
 
-    try:
-        client.login()
-    except nitro_exception as e:
-        msg = "nitro exception during login. errorcode=%s, message=%s" % (str(e.errorcode), e.message)
-        module.fail_json(msg=msg)
-    except Exception as e:
-        if str(type(e)) == "<class 'requests.exceptions.ConnectionError'>":
-            module.fail_json(msg='Connection error %s' % str(e))
-        elif str(type(e)) == "<class 'requests.exceptions.SSLError'>":
-            module.fail_json(msg='SSL Error %s' % str(e))
-        else:
-            module.fail_json(msg='Unexpected error during login %s' % str(e))
+    if not module.params['mas_proxy_call']:
+        try:
+            client.login()
+        except nitro_exception as e:
+            msg = "nitro exception during login. errorcode=%s, message=%s" % (str(e.errorcode), e.message)
+            module.fail_json(msg=msg)
+        except Exception as e:
+            if str(type(e)) == "<class 'requests.exceptions.ConnectionError'>":
+                module.fail_json(msg='Connection error %s' % str(e))
+            elif str(type(e)) == "<class 'requests.exceptions.SSLError'>":
+                module.fail_json(msg='SSL Error %s' % str(e))
+            else:
+                module.fail_json(msg='Unexpected error during login %s' % str(e))
 
     readwrite_attrs = [
         'name',
@@ -1299,7 +1300,9 @@ def main():
         msg = "nitro exception errorcode=%s, message=%s" % (str(e.errorcode), e.message)
         module.fail_json(msg=msg, **module_result)
 
-    client.logout()
+    if not module.params['mas_proxy_call']:
+        client.logout()
+
     module.exit_json(**module_result)
 
 

--- a/lib/ansible/modules/network/netscaler/netscaler_gslb_service.py
+++ b/lib/ansible/modules/network/netscaler/netscaler_gslb_service.py
@@ -516,18 +516,19 @@ def main():
     # Fallthrough to rest of execution
     client = get_nitro_client(module)
 
-    try:
-        client.login()
-    except nitro_exception as e:
-        msg = "nitro exception during login. errorcode=%s, message=%s" % (str(e.errorcode), e.message)
-        module.fail_json(msg=msg)
-    except Exception as e:
-        if str(type(e)) == "<class 'requests.exceptions.ConnectionError'>":
-            module.fail_json(msg='Connection error %s' % str(e))
-        elif str(type(e)) == "<class 'requests.exceptions.SSLError'>":
-            module.fail_json(msg='SSL Error %s' % str(e))
-        else:
-            module.fail_json(msg='Unexpected error during login %s' % str(e))
+    if not module.params['mas_proxy_call']:
+        try:
+            client.login()
+        except nitro_exception as e:
+            msg = "nitro exception during login. errorcode=%s, message=%s" % (str(e.errorcode), e.message)
+            module.fail_json(msg=msg)
+        except Exception as e:
+            if str(type(e)) == "<class 'requests.exceptions.ConnectionError'>":
+                module.fail_json(msg='Connection error %s' % str(e))
+            elif str(type(e)) == "<class 'requests.exceptions.SSLError'>":
+                module.fail_json(msg='SSL Error %s' % str(e))
+            else:
+                module.fail_json(msg='Unexpected error during login %s' % str(e))
 
     readwrite_attrs = [
         'servicename',
@@ -687,7 +688,9 @@ def main():
         msg = "nitro exception errorcode=%s, message=%s" % (str(e.errorcode), e.message)
         module.fail_json(msg=msg, **module_result)
 
-    client.logout()
+    if not module.params['mas_proxy_call']:
+        client.logout()
+
     module.exit_json(**module_result)
 
 

--- a/lib/ansible/modules/network/netscaler/netscaler_gslb_site.py
+++ b/lib/ansible/modules/network/netscaler/netscaler_gslb_site.py
@@ -293,18 +293,19 @@ def main():
     # Fallthrough to rest of execution
     client = get_nitro_client(module)
 
-    try:
-        client.login()
-    except nitro_exception as e:
-        msg = "nitro exception during login. errorcode=%s, message=%s" % (str(e.errorcode), e.message)
-        module.fail_json(msg=msg)
-    except Exception as e:
-        if str(type(e)) == "<class 'requests.exceptions.ConnectionError'>":
-            module.fail_json(msg='Connection error %s' % str(e))
-        elif str(type(e)) == "<class 'requests.exceptions.SSLError'>":
-            module.fail_json(msg='SSL Error %s' % str(e))
-        else:
-            module.fail_json(msg='Unexpected error during login %s' % str(e))
+    if not module.params['mas_proxy_call']:
+        try:
+            client.login()
+        except nitro_exception as e:
+            msg = "nitro exception during login. errorcode=%s, message=%s" % (str(e.errorcode), e.message)
+            module.fail_json(msg=msg)
+        except Exception as e:
+            if str(type(e)) == "<class 'requests.exceptions.ConnectionError'>":
+                module.fail_json(msg='Connection error %s' % str(e))
+            elif str(type(e)) == "<class 'requests.exceptions.SSLError'>":
+                module.fail_json(msg='SSL Error %s' % str(e))
+            else:
+                module.fail_json(msg='Unexpected error during login %s' % str(e))
 
     readwrite_attrs = [
         'sitename',
@@ -415,7 +416,9 @@ def main():
         msg = "nitro exception errorcode=%s, message=%s" % (str(e.errorcode), e.message)
         module.fail_json(msg=msg, **module_result)
 
-    client.logout()
+    if not module.params['mas_proxy_call']:
+        client.logout()
+
     module.exit_json(**module_result)
 
 

--- a/lib/ansible/modules/network/netscaler/netscaler_gslb_vserver.py
+++ b/lib/ansible/modules/network/netscaler/netscaler_gslb_vserver.py
@@ -777,18 +777,19 @@ def main():
     # Fallthrough to rest of execution
     client = get_nitro_client(module)
 
-    try:
-        client.login()
-    except nitro_exception as e:
-        msg = "nitro exception during login. errorcode=%s, message=%s" % (str(e.errorcode), e.message)
-        module.fail_json(msg=msg)
-    except Exception as e:
-        if str(type(e)) == "<class 'requests.exceptions.ConnectionError'>":
-            module.fail_json(msg='Connection error %s' % str(e))
-        elif str(type(e)) == "<class 'requests.exceptions.SSLError'>":
-            module.fail_json(msg='SSL Error %s' % str(e))
-        else:
-            module.fail_json(msg='Unexpected error during login %s' % str(e))
+    if not module.params['mas_proxy_call']:
+        try:
+            client.login()
+        except nitro_exception as e:
+            msg = "nitro exception during login. errorcode=%s, message=%s" % (str(e.errorcode), e.message)
+            module.fail_json(msg=msg)
+        except Exception as e:
+            if str(type(e)) == "<class 'requests.exceptions.ConnectionError'>":
+                module.fail_json(msg='Connection error %s' % str(e))
+            elif str(type(e)) == "<class 'requests.exceptions.SSLError'>":
+                module.fail_json(msg='SSL Error %s' % str(e))
+            else:
+                module.fail_json(msg='Unexpected error during login %s' % str(e))
 
     readwrite_attrs = [
         'name',
@@ -946,7 +947,9 @@ def main():
         msg = "nitro exception errorcode=%s, message=%s" % (str(e.errorcode), e.message)
         module.fail_json(msg=msg, **module_result)
 
-    client.logout()
+    if not module.params['mas_proxy_call']:
+        client.logout()
+
     module.exit_json(**module_result)
 
 

--- a/lib/ansible/modules/network/netscaler/netscaler_lb_monitor.py
+++ b/lib/ansible/modules/network/netscaler/netscaler_lb_monitor.py
@@ -1148,18 +1148,19 @@ def main():
     # Fallthrough to rest of execution
     client = get_nitro_client(module)
 
-    try:
-        client.login()
-    except nitro_exception as e:
-        msg = "nitro exception during login. errorcode=%s, message=%s" % (str(e.errorcode), e.message)
-        module.fail_json(msg=msg)
-    except Exception as e:
-        if str(type(e)) == "<class 'requests.exceptions.ConnectionError'>":
-            module.fail_json(msg='Connection error %s' % str(e))
-        elif str(type(e)) == "<class 'requests.exceptions.SSLError'>":
-            module.fail_json(msg='SSL Error %s' % str(e))
-        else:
-            module.fail_json(msg='Unexpected error during login %s' % str(e))
+    if not module.params['mas_proxy_call']:
+        try:
+            client.login()
+        except nitro_exception as e:
+            msg = "nitro exception during login. errorcode=%s, message=%s" % (str(e.errorcode), e.message)
+            module.fail_json(msg=msg)
+        except Exception as e:
+            if str(type(e)) == "<class 'requests.exceptions.ConnectionError'>":
+                module.fail_json(msg='Connection error %s' % str(e))
+            elif str(type(e)) == "<class 'requests.exceptions.SSLError'>":
+                module.fail_json(msg='SSL Error %s' % str(e))
+            else:
+                module.fail_json(msg='Unexpected error during login %s' % str(e))
 
     # Instantiate lb monitor object
     readwrite_attrs = [
@@ -1371,7 +1372,8 @@ def main():
         msg = "nitro exception errorcode=%s, message=%s" % (str(e.errorcode), e.message)
         module.fail_json(msg=msg, **module_result)
 
-    client.logout()
+    if not module.params['mas_proxy_call']:
+        client.logout()
 
     module.exit_json(**module_result)
 

--- a/lib/ansible/modules/network/netscaler/netscaler_lb_vserver.py
+++ b/lib/ansible/modules/network/netscaler/netscaler_lb_vserver.py
@@ -1645,18 +1645,19 @@ def main():
     # Fallthrough to rest of execution
     client = get_nitro_client(module)
 
-    try:
-        client.login()
-    except nitro_exception as e:
-        msg = "nitro exception during login. errorcode=%s, message=%s" % (str(e.errorcode), e.message)
-        module.fail_json(msg=msg)
-    except Exception as e:
-        if str(type(e)) == "<class 'requests.exceptions.ConnectionError'>":
-            module.fail_json(msg='Connection error %s' % str(e))
-        elif str(type(e)) == "<class 'requests.exceptions.SSLError'>":
-            module.fail_json(msg='SSL Error %s' % str(e))
-        else:
-            module.fail_json(msg='Unexpected error during login %s' % str(e))
+    if not module.params['mas_proxy_call']:
+        try:
+            client.login()
+        except nitro_exception as e:
+            msg = "nitro exception during login. errorcode=%s, message=%s" % (str(e.errorcode), e.message)
+            module.fail_json(msg=msg)
+        except Exception as e:
+            if str(type(e)) == "<class 'requests.exceptions.ConnectionError'>":
+                module.fail_json(msg='Connection error %s' % str(e))
+            elif str(type(e)) == "<class 'requests.exceptions.SSLError'>":
+                module.fail_json(msg='SSL Error %s' % str(e))
+            else:
+                module.fail_json(msg='Unexpected error during login %s' % str(e))
 
     readwrite_attrs = [
         'name',
@@ -1932,7 +1933,9 @@ def main():
         msg = "nitro exception errorcode=%s, message=%s" % (str(e.errorcode), e.message)
         module.fail_json(msg=msg, **module_result)
 
-    client.logout()
+    if not module.params['mas_proxy_call']:
+        client.logout()
+
     module.exit_json(**module_result)
 
 

--- a/lib/ansible/modules/network/netscaler/netscaler_lb_vserver.py
+++ b/lib/ansible/modules/network/netscaler/netscaler_lb_vserver.py
@@ -1097,9 +1097,9 @@ def get_actual_service_bindings(client, module):
         else:
             raise
 
-    bindigs_list = lbvserver_service_binding.get(client, module.params['name'])
+    bindings_list = lbvserver_service_binding.get(client, module.params['name'])
 
-    for item in bindigs_list:
+    for item in bindings_list:
         key = item.servicename
         bindings[key] = item
 
@@ -1119,9 +1119,9 @@ def get_actual_servicegroup_bindings(client, module):
         else:
             raise
 
-    bindigs_list = lbvserver_servicegroup_binding.get(client, module.params['name'])
+    bindings_list = lbvserver_servicegroup_binding.get(client, module.params['name'])
 
-    for item in bindigs_list:
+    for item in bindings_list:
         key = item.servicegroupname
         bindings[key] = item
 

--- a/lib/ansible/modules/network/netscaler/netscaler_nitro_request.py
+++ b/lib/ansible/modules/network/netscaler/netscaler_nitro_request.py
@@ -302,12 +302,15 @@ class NitroAPICaller(object):
     _argument_spec = dict(
         nsip=dict(
             fallback=(env_fallback, ['NETSCALER_NSIP']),
+            aliases=['mas_ip'],
         ),
         nitro_user=dict(
             fallback=(env_fallback, ['NETSCALER_NITRO_USER']),
+            aliases=['mas_user'],
         ),
         nitro_pass=dict(
             fallback=(env_fallback, ['NETSCALER_NITRO_PASS']),
+            aliases=['mas_pass'],
             no_log=True
         ),
         nitro_protocol=dict(
@@ -321,6 +324,7 @@ class NitroAPICaller(object):
         ),
         nitro_auth_token=dict(
             type='str',
+            aliases=['mas_auth_token'],
             no_log=True
         ),
         resource=dict(type='str'),
@@ -458,6 +462,7 @@ class NitroAPICaller(object):
         self._module_result['changed'] = False
         self._module_result.update(kwargs)
         self._module_result['msg'] = msg
+        self._module_result['headers'] = self._headers
         self._module.fail_json(**self._module_result)
 
     def main(self):

--- a/lib/ansible/modules/network/netscaler/netscaler_save_config.py
+++ b/lib/ansible/modules/network/netscaler/netscaler_save_config.py
@@ -149,18 +149,19 @@ def main():
     # Fallthrough to rest of execution
     client = get_nitro_client(module)
 
-    try:
-        client.login()
-    except nitro_exception as e:
-        msg = "nitro exception during login. errorcode=%s, message=%s" % (str(e.errorcode), e.message)
-        module.fail_json(msg=msg)
-    except Exception as e:
-        if str(type(e)) == "<class 'requests.exceptions.ConnectionError'>":
-            module.fail_json(msg='Connection error %s' % str(e))
-        elif str(type(e)) == "<class 'requests.exceptions.SSLError'>":
-            module.fail_json(msg='SSL Error %s' % str(e))
-        else:
-            module.fail_json(msg='Unexpected error during login %s' % str(e))
+    if not module.params['mas_proxy_call']:
+        try:
+            client.login()
+        except nitro_exception as e:
+            msg = "nitro exception during login. errorcode=%s, message=%s" % (str(e.errorcode), e.message)
+            module.fail_json(msg=msg)
+        except Exception as e:
+            if str(type(e)) == "<class 'requests.exceptions.ConnectionError'>":
+                module.fail_json(msg='Connection error %s' % str(e))
+            elif str(type(e)) == "<class 'requests.exceptions.SSLError'>":
+                module.fail_json(msg='SSL Error %s' % str(e))
+            else:
+                module.fail_json(msg='Unexpected error during login %s' % str(e))
 
     try:
         log('Saving configuration')
@@ -169,7 +170,9 @@ def main():
         msg = "nitro exception errorcode=" + str(e.errorcode) + ",message=" + e.message
         module.fail_json(msg=msg, **module_result)
 
-    client.logout()
+    if not module.params['mas_proxy_call']:
+        client.logout()
+
     module.exit_json(**module_result)
 
 

--- a/lib/ansible/modules/network/netscaler/netscaler_server.py
+++ b/lib/ansible/modules/network/netscaler/netscaler_server.py
@@ -253,18 +253,20 @@ def main():
     # Fallthrough to rest of execution
 
     client = get_nitro_client(module)
-    try:
-        client.login()
-    except nitro_exception as e:
-        msg = "nitro exception during login. errorcode=%s, message=%s" % (str(e.errorcode), e.message)
-        module.fail_json(msg=msg)
-    except Exception as e:
-        if str(type(e)) == "<class 'requests.exceptions.ConnectionError'>":
-            module.fail_json(msg='Connection error %s' % str(e))
-        elif str(type(e)) == "<class 'requests.exceptions.SSLError'>":
-            module.fail_json(msg='SSL Error %s' % str(e))
-        else:
-            module.fail_json(msg='Unexpected error during login %s' % str(e))
+
+    if not module.params['mas_proxy_call']:
+        try:
+            client.login()
+        except nitro_exception as e:
+            msg = "nitro exception during login. errorcode=%s, message=%s" % (str(e.errorcode), e.message)
+            module.fail_json(msg=msg)
+        except Exception as e:
+            if str(type(e)) == "<class 'requests.exceptions.ConnectionError'>":
+                module.fail_json(msg='Connection error %s' % str(e))
+            elif str(type(e)) == "<class 'requests.exceptions.SSLError'>":
+                module.fail_json(msg='SSL Error %s' % str(e))
+            else:
+                module.fail_json(msg='Unexpected error during login %s' % str(e))
 
     # Instantiate Server Config object
     readwrite_attrs = [
@@ -394,7 +396,9 @@ def main():
         msg = "nitro exception errorcode=%s, message=%s" % (str(e.errorcode), e.message)
         module.fail_json(msg=msg, **module_result)
 
-    client.logout()
+    if not module.params['mas_proxy_call']:
+        client.logout()
+
     module.exit_json(**module_result)
 
 

--- a/lib/ansible/modules/network/netscaler/netscaler_service.py
+++ b/lib/ansible/modules/network/netscaler/netscaler_service.py
@@ -719,18 +719,19 @@ def main():
 
     client = get_nitro_client(module)
 
-    try:
-        client.login()
-    except nitro_exception as e:
-        msg = "nitro exception during login. errorcode=%s, message=%s" % (str(e.errorcode), e.message)
-        module.fail_json(msg=msg)
-    except Exception as e:
-        if str(type(e)) == "<class 'requests.exceptions.ConnectionError'>":
-            module.fail_json(msg='Connection error %s' % str(e))
-        elif str(type(e)) == "<class 'requests.exceptions.SSLError'>":
-            module.fail_json(msg='SSL Error %s' % str(e))
-        else:
-            module.fail_json(msg='Unexpected error during login %s' % str(e))
+    if not module.params['mas_proxy_call']:
+        try:
+            client.login()
+        except nitro_exception as e:
+            msg = "nitro exception during login. errorcode=%s, message=%s" % (str(e.errorcode), e.message)
+            module.fail_json(msg=msg)
+        except Exception as e:
+            if str(type(e)) == "<class 'requests.exceptions.ConnectionError'>":
+                module.fail_json(msg='Connection error %s' % str(e))
+            elif str(type(e)) == "<class 'requests.exceptions.SSLError'>":
+                module.fail_json(msg='SSL Error %s' % str(e))
+            else:
+                module.fail_json(msg='Unexpected error during login %s' % str(e))
 
     # Fallthrough to rest of execution
 
@@ -944,7 +945,9 @@ def main():
         msg = "nitro exception errorcode=%s, message=%s" % (str(e.errorcode), e.message)
         module.fail_json(msg=msg, **module_result)
 
-    client.logout()
+    if not module.params['mas_proxy_call']:
+        client.logout()
+
     module.exit_json(**module_result)
 
 

--- a/lib/ansible/modules/network/netscaler/netscaler_servicegroup.py
+++ b/lib/ansible/modules/network/netscaler/netscaler_servicegroup.py
@@ -831,18 +831,19 @@ def main():
     # Fallthrough to rest of execution
     client = get_nitro_client(module)
 
-    try:
-        client.login()
-    except nitro_exception as e:
-        msg = "nitro exception during login. errorcode=%s, message=%s" % (str(e.errorcode), e.message)
-        module.fail_json(msg=msg)
-    except Exception as e:
-        if str(type(e)) == "<class 'requests.exceptions.ConnectionError'>":
-            module.fail_json(msg='Connection error %s' % str(e))
-        elif str(type(e)) == "<class 'requests.exceptions.SSLError'>":
-            module.fail_json(msg='SSL Error %s' % str(e))
-        else:
-            module.fail_json(msg='Unexpected error during login %s' % str(e))
+    if not module.params['mas_proxy_call']:
+        try:
+            client.login()
+        except nitro_exception as e:
+            msg = "nitro exception during login. errorcode=%s, message=%s" % (str(e.errorcode), e.message)
+            module.fail_json(msg=msg)
+        except Exception as e:
+            if str(type(e)) == "<class 'requests.exceptions.ConnectionError'>":
+                module.fail_json(msg='Connection error %s' % str(e))
+            elif str(type(e)) == "<class 'requests.exceptions.SSLError'>":
+                module.fail_json(msg='SSL Error %s' % str(e))
+            else:
+                module.fail_json(msg='Unexpected error during login %s' % str(e))
 
     # Instantiate service group configuration object
     readwrite_attrs = [
@@ -1034,7 +1035,9 @@ def main():
         msg = "nitro exception errorcode=" + str(e.errorcode) + ",message=" + e.message
         module.fail_json(msg=msg, **module_result)
 
-    client.logout()
+    if not module.params['mas_proxy_call']:
+        client.logout()
+
     module.exit_json(**module_result)
 
 

--- a/lib/ansible/modules/network/netscaler/netscaler_ssl_certkey.py
+++ b/lib/ansible/modules/network/netscaler/netscaler_ssl_certkey.py
@@ -237,18 +237,19 @@ def main():
     # Fallthrough to rest of execution
     client = get_nitro_client(module)
 
-    try:
-        client.login()
-    except nitro_exception as e:
-        msg = "nitro exception during login. errorcode=%s, message=%s" % (str(e.errorcode), e.message)
-        module.fail_json(msg=msg)
-    except Exception as e:
-        if str(type(e)) == "<class 'requests.exceptions.ConnectionError'>":
-            module.fail_json(msg='Connection error %s' % str(e))
-        elif str(type(e)) == "<class 'requests.exceptions.SSLError'>":
-            module.fail_json(msg='SSL Error %s' % str(e))
-        else:
-            module.fail_json(msg='Unexpected error during login %s' % str(e))
+    if not module.params['mas_proxy_call']:
+        try:
+            client.login()
+        except nitro_exception as e:
+            msg = "nitro exception during login. errorcode=%s, message=%s" % (str(e.errorcode), e.message)
+            module.fail_json(msg=msg)
+        except Exception as e:
+            if str(type(e)) == "<class 'requests.exceptions.ConnectionError'>":
+                module.fail_json(msg='Connection error %s' % str(e))
+            elif str(type(e)) == "<class 'requests.exceptions.SSLError'>":
+                module.fail_json(msg='SSL Error %s' % str(e))
+            else:
+                module.fail_json(msg='Unexpected error during login %s' % str(e))
 
     readwrite_attrs = [
         'certkey',
@@ -363,7 +364,9 @@ def main():
         msg = "nitro exception errorcode=%s, message=%s" % (str(e.errorcode), e.message)
         module.fail_json(msg=msg, **module_result)
 
-    client.logout()
+    if not module.params['mas_proxy_call']:
+        client.logout()
+
     module.exit_json(**module_result)
 
 

--- a/lib/ansible/utils/module_docs_fragments/netscaler.py
+++ b/lib/ansible/utils/module_docs_fragments/netscaler.py
@@ -6,17 +6,20 @@ options:
         description:
             - The ip address of the netscaler appliance where the nitro API calls will be made.
             - "The port can be specified with the colon (:). E.g. 192.168.1.1:555."
+        aliases: mas_ip
         required: True
 
     nitro_user:
         description:
             - The username with which to authenticate to the netscaler node.
-        required: True
+        required: False
+        aliases: mas_user
 
     nitro_pass:
         description:
             - The password with which to authenticate to the netscaler node.
-        required: True
+        required: False
+        aliases: mas_pass
 
     nitro_protocol:
         choices: [ 'http', 'https' ]
@@ -49,6 +52,26 @@ options:
             - The module will not save the configuration on the netscaler node if it made no changes.
         type: bool
         default: true
+
+    mas_proxy_call:
+        description:
+            - If true the underlying NITRO API calls made by the module will be proxied through a MAS node to the target Netscaler instance.
+            - When true you must also define the following options: I(nitro_auth_token), I(instance_ip).
+        type: bool
+        default: false
+        version_added: "2.6.0"
+
+    nitro_auth_token:
+        description:
+            - The authentication token provided by a login operation.
+        aliases: mas_auth_token
+        version_added: "2.6.0"
+
+    instance_ip:
+        description:
+            - The target Netscaler instance ip address to which all underlying NITRO API calls will be proxied to.
+            - It is meaningful only when having set C(mas_proxy_call) to C(true)
+        version_added: "2.6.0"
 notes:
   - For more information on using Ansible to manage Citrix NetScaler Network devices see U(https://www.ansible.com/ansible-netscaler).
 '''

--- a/test/units/modules/network/netscaler/test_netscaler_nitro_request.py
+++ b/test/units/modules/network/netscaler/test_netscaler_nitro_request.py
@@ -79,7 +79,8 @@ class TestNetscalerNitroRequestModule(TestModule):
             call.fail_json(
                 changed=False,
                 failed=True,
-                msg='Cannot define both authentication token and username/password'
+                msg='Cannot define both authentication token and username/password',
+                headers={'Cookie': 'NITRO_AUTH_TOKEN=##DDASKLFDJ', 'X-NITRO-PASS': 'nsroot', 'Content-Type': 'application/json', 'X-NITRO-USER': 'nsroot'}
             )
         ]
         module_mock = Mock(return_value=mock_module_instance)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
The Netscaler Management and Analytics System, MAS for short, has the capability to proxy NITRO API calls to Netscaler instances it manages. ( [MAS documentation](https://docs.citrix.com/en-us/netscaler-mas/netscaler-management-and-analytics-service.html) )

Until now Netscaler modules needed to connect to the Netscaler node they configured.

With this update the capability is added to execute the modules in a mode that proxies the underlying NITRO API calls through a MAS node.

This capability is added for all existing Netscaler modules.

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
lib/ansible/module_utils/network/netscaler/netscaler.py
lib/ansible/modules/network/netscaler/netscaler_cs_action.py
lib/ansible/modules/network/netscaler/netscaler_cs_policy.py
lib/ansible/modules/network/netscaler/netscaler_cs_vserver.py
lib/ansible/modules/network/netscaler/netscaler_gslb_service.py
lib/ansible/modules/network/netscaler/netscaler_gslb_site.py
lib/ansible/modules/network/netscaler/netscaler_gslb_vserver.py
lib/ansible/modules/network/netscaler/netscaler_lb_monitor.py
lib/ansible/modules/network/netscaler/netscaler_lb_vserver.py
lib/ansible/modules/network/netscaler/netscaler_nitro_request.py
lib/ansible/modules/network/netscaler/netscaler_save_config.py
lib/ansible/modules/network/netscaler/netscaler_server.py
lib/ansible/modules/network/netscaler/netscaler_service.py
lib/ansible/modules/network/netscaler/netscaler_servicegroup.py
lib/ansible/modules/network/netscaler/netscaler_ssl_certkey.py
lib/ansible/utils/module_docs_fragments/netscaler.py
test/units/modules/network/netscaler/test_netscaler_nitro_request.py


##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0 (mas_proxy_calls 0c52b77f56) last updated 2018/04/23 19:02:06 (GMT +300)
  config file = /home/georgen/.ansible.cfg
  configured module search path = ['/home/georgen/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/georgen/repos/ansible_fork/lib/ansible
  executable location = /home/georgen/repos/ansible_fork/bin/ansible
  python version = 3.5.2 (default, Nov 23 2017, 16:37:01) [GCC 5.4.0 20160609]

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->
The MAS capability is mainly implemented in the nitro module utilities file ( lib/ansible/module_utils/network/netscaler/netscaler.py ).

Changes to the rest of the modules are trivial to adjust them for the new options added.
