### PR TITLE
Support omit removal from list within arguments

### DIFF
--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -55,7 +55,10 @@ def remove_omit(task_args, omit_token):
         if i[1] == omit_token:
             continue
         elif isinstance(i[1], (dict, list)):
-            new_args[i[0]] = remove_omit(i[1], omit_token)
+            try:
+                new_args[i[0]] = remove_omit(i[1], omit_token)
+            except IndexError:
+                new_args.append(remove_omit(i[1], omit_token))
         else:
             try:
                 new_args[i[0]] = i[1]

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -41,15 +41,26 @@ def remove_omit(task_args, omit_token):
     Remove args with a value equal to the ``omit_token`` recursively
     to align with now having suboptions in the argument_spec
     '''
-    new_args = {}
 
-    for i in iteritems(task_args):
+    if isinstance(task_args, dict):
+        loop = iteritems(task_args)
+        new_args = {}
+    elif isinstance(task_args, list):
+        loop = enumerate(task_args)
+        new_args = []
+    else:
+        raise TypeError('unsupported type (%r)' % type(task_args))
+
+    for i in loop:
         if i[1] == omit_token:
             continue
-        elif isinstance(i[1], dict):
+        elif isinstance(i[1], (dict, list)):
             new_args[i[0]] = remove_omit(i[1], omit_token)
         else:
-            new_args[i[0]] = i[1]
+            try:
+                new_args[i[0]] = i[1]
+            except IndexError:
+                new_args.append(i[1])
 
     return new_args
 

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -38,8 +38,9 @@ __all__ = ['TaskExecutor']
 
 def remove_omit(task_args, omit_token):
     '''
-    Remove args with a value equal to the ``omit_token`` recursively
-    to align with now having suboptions in the argument_spec
+    Recursively remove arguments with a value equal to the ``omit_token``
+
+    This function handles both dicts and lists
     '''
 
     if isinstance(task_args, dict):
@@ -51,19 +52,17 @@ def remove_omit(task_args, omit_token):
     else:
         raise TypeError('unsupported type (%r)' % type(task_args))
 
-    for i in loop:
-        if i[1] == omit_token:
+    for i, value in loop:
+        if value == omit_token:
             continue
-        elif isinstance(i[1], (dict, list)):
-            try:
-                new_args[i[0]] = remove_omit(i[1], omit_token)
-            except IndexError:
-                new_args.append(remove_omit(i[1], omit_token))
-        else:
-            try:
-                new_args[i[0]] = i[1]
-            except IndexError:
-                new_args.append(i[1])
+        elif isinstance(value, (dict, list)):
+            value = remove_omit(value, omit_token)
+
+        try:
+            new_args[i] = value
+        except IndexError:
+            # new_args is a list, likely empty, not supporting direct item assignment
+            new_args.append(value)
 
     return new_args
 

--- a/test/units/executor/test_task_executor.py
+++ b/test/units/executor/test_task_executor.py
@@ -499,7 +499,7 @@ class TestTaskExecutor(unittest.TestCase):
                     'remove': 'POPCORN',
                     'keep': 'not_popcorn',
                 },
-                'a_list': ['POPCORN'],
+                'a_list': ['POPCORN', 'not_popcorn'],
             },
             'a_list': ['POPCORN'],
         }
@@ -513,9 +513,12 @@ class TestTaskExecutor(unittest.TestCase):
                 'subsubdict': {
                     'keep': 'not_popcorn',
                 },
-                'a_list': ['POPCORN'],
+                'a_list': ['not_popcorn'],
             },
-            'a_list': ['POPCORN'],
+            'a_list': [],
         }
 
         self.assertEqual(remove_omit(data, omit_token), expected)
+
+        with self.assertRaises(TypeError):
+            remove_omit(True, omit_token)


### PR DESCRIPTION
##### SUMMARY

In the example of #39144 using `default(omit)` within `rsync_opts` could alleviate issues.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
lib/ansible/executor/task_executor.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```