### PR TITLE
Remove support for SSLv2 in test suite

### DIFF
--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -893,7 +893,8 @@ def open_url(url, data=None, headers=None, method=None, use_proxy=True,
     if HAS_SSLCONTEXT and not validate_certs:
         # In 2.7.9, the default context validates certificates
         context = SSLContext(ssl.PROTOCOL_SSLv23)
-        context.options |= ssl.OP_NO_SSLv2
+        if ssl.OP_NO_SSLv2:
+            context.options |= ssl.OP_NO_SSLv2
         context.options |= ssl.OP_NO_SSLv3
         context.verify_mode = ssl.CERT_NONE
         context.check_hostname = False

--- a/test/units/module_utils/urls/test_open_url.py
+++ b/test/units/module_utils/urls/test_open_url.py
@@ -217,7 +217,8 @@ def test_open_url_no_validate_certs(urlopen_mock, install_opener_mock):
     assert ssl_handler is not None
     context = ssl_handler._context
     assert context.protocol == ssl.PROTOCOL_SSLv23
-    assert context.options & ssl.OP_NO_SSLv2
+    if ssl.OP_NO_SSLv2:
+        assert context.options & ssl.OP_NO_SSLv2
     assert context.options & ssl.OP_NO_SSLv3
     assert context.verify_mode == ssl.CERT_NONE
     assert context.check_hostname is False


### PR DESCRIPTION
##### SUMMARY

When running the test test/units/module_utils/urls/test_open_url.py
test_open_url_no_validate_certs, the test fails because of the SSLv2
check. (Fedora 27/OpenSSL 1.1.0g)

By reading the openssl man page[1], one can see that support for SSLv2
has been removed.

> Support for SSLv2 and the corresponding SSLv2_method(),
> SSLv2_server_method() and SSLv2_client_method() functions where removed
> in OpenSSL 1.1.0.
>
> SSLv23_method(), SSLv23_server_method() and SSLv23_client_method() were
> deprecated and the preferred TLS_method(), TLS_server_method() and
> TLS_client_method() functions were introduced in OpenSSL 1.1.0.

Hence this commit remove the uses of this flag.

[1] https://www.openssl.org/docs/man1.1.0/ssl/SSLv23_method.html

<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

  - tests

##### ANSIBLE VERSION

  - devel

##### ADDITIONAL INFORMATION

  - N/A