### PR TITLE
Fixes F5 conventions and adds features

### DIFF
--- a/lib/ansible/modules/network/f5/bigip_user.py
+++ b/lib/ansible/modules/network/f5/bigip_user.py
@@ -24,7 +24,7 @@ description:
     Your other parameters will be ignored in this case. Changing the C(root)
     password is not an idempotent operation. Therefore, it will change it
     every time this module attempts to change it.
-version_added: "2.4"
+version_added: 2.4
 options:
   full_name:
     description:
@@ -70,7 +70,7 @@ options:
       - C(always) will allow to update passwords if the user chooses to do so.
         C(on_create) will only set the password for newly created users. When
         C(username_credential) is C(root), this value will be forced to C(always).
-    default: on_create
+    default: always
     choices:
       - always
       - on_create
@@ -196,30 +196,23 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.basic import env_fallback
 from distutils.version import LooseVersion
 
-HAS_DEVEL_IMPORTS = False
-
 try:
-    # Sideband repository used for dev
     from library.module_utils.network.f5.bigip import HAS_F5SDK
     from library.module_utils.network.f5.bigip import F5Client
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import AnsibleF5Parameters
     from library.module_utils.network.f5.common import cleanup_tokens
-    from library.module_utils.network.f5.common import fqdn_name
     from library.module_utils.network.f5.common import f5_argument_spec
     try:
         from library.module_utils.network.f5.common import iControlUnexpectedHTTPError
     except ImportError:
         HAS_F5SDK = False
-    HAS_DEVEL_IMPORTS = True
 except ImportError:
-    # Upstream Ansible
     from ansible.module_utils.network.f5.bigip import HAS_F5SDK
     from ansible.module_utils.network.f5.bigip import F5Client
     from ansible.module_utils.network.f5.common import F5ModuleError
     from ansible.module_utils.network.f5.common import AnsibleF5Parameters
     from ansible.module_utils.network.f5.common import cleanup_tokens
-    from ansible.module_utils.network.f5.common import fqdn_name
     from ansible.module_utils.network.f5.common import f5_argument_spec
     try:
         from ansible.module_utils.network.f5.common import iControlUnexpectedHTTPError

--- a/lib/ansible/modules/network/f5/bigip_vcmp_guest.py
+++ b/lib/ansible/modules/network/f5/bigip_vcmp_guest.py
@@ -20,7 +20,7 @@ description:
   - Manages vCMP guests on a BIG-IP. This functionality only exists on
     actual hardware and must be enabled by provisioning C(vcmp) with the
     C(bigip_provision) module.
-version_added: "2.5"
+version_added: 2.5
 options:
   name:
     description:
@@ -68,6 +68,7 @@ options:
     description:
       - When C(state) is C(absent), will additionally delete the virtual disk associated
         with the vCMP guest. By default, this value is C(no).
+    type: bool
     default: no
   mgmt_address:
     description:
@@ -179,33 +180,30 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.basic import env_fallback
 from collections import namedtuple
 
-HAS_DEVEL_IMPORTS = False
-
 try:
-    # Sideband repository used for dev
     from library.module_utils.network.f5.bigip import HAS_F5SDK
     from library.module_utils.network.f5.bigip import F5Client
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import AnsibleF5Parameters
     from library.module_utils.network.f5.common import cleanup_tokens
-    from library.module_utils.network.f5.common import fqdn_name
+    from library.module_utils.network.f5.common import fq_name
     from library.module_utils.network.f5.common import f5_argument_spec
     try:
         from library.module_utils.network.f5.common import iControlUnexpectedHTTPError
+        from f5.utils.responses.handlers import Stats
     except ImportError:
         HAS_F5SDK = False
-    HAS_DEVEL_IMPORTS = True
 except ImportError:
-    # Upstream Ansible
     from ansible.module_utils.network.f5.bigip import HAS_F5SDK
     from ansible.module_utils.network.f5.bigip import F5Client
     from ansible.module_utils.network.f5.common import F5ModuleError
     from ansible.module_utils.network.f5.common import AnsibleF5Parameters
     from ansible.module_utils.network.f5.common import cleanup_tokens
-    from ansible.module_utils.network.f5.common import fqdn_name
+    from ansible.module_utils.network.f5.common import fq_name
     from ansible.module_utils.network.f5.common import f5_argument_spec
     try:
         from ansible.module_utils.network.f5.common import iControlUnexpectedHTTPError
+        from f5.utils.responses.handlers import Stats
     except ImportError:
         HAS_F5SDK = False
 
@@ -214,11 +212,6 @@ try:
     HAS_NETADDR = True
 except ImportError:
     HAS_NETADDR = False
-
-try:
-    from f5.utils.responses.handlers import Stats
-except ImportError:
-    HAS_F5SDK = False
 
 
 class Parameters(AnsibleF5Parameters):
@@ -245,11 +238,6 @@ class Parameters(AnsibleF5Parameters):
         'vlans', 'mgmt_network', 'mgmt_address', 'initial_image', 'mgmt_route',
         'state'
     ]
-
-    def _fqdn_name(self, value):
-        if value is not None and not value.startswith('/'):
-            return '/{0}/{1}'.format(self.partition, value)
-        return value
 
     def to_return(self):
         result = {}
@@ -318,7 +306,7 @@ class Parameters(AnsibleF5Parameters):
     def vlans(self):
         if self._values['vlans'] is None:
             return None
-        result = [self._fqdn_name(x) for x in self._values['vlans']]
+        result = [fq_name(self.partition, x) for x in self._values['vlans']]
         result.sort()
         return result
 
@@ -438,11 +426,6 @@ class ModuleManager(object):
                 msg=warning['msg'],
                 version=warning['version']
             )
-
-    def _fqdn_name(self, value):
-        if value is not None and not value.startswith('/'):
-            return '/{0}/{1}'.format(self.partition, value)
-        return value
 
     def present(self):
         if self.exists():

--- a/lib/ansible/modules/network/f5/bigip_vlan.py
+++ b/lib/ansible/modules/network/f5/bigip_vlan.py
@@ -18,7 +18,7 @@ module: bigip_vlan
 short_description: Manage VLANs on a BIG-IP system
 description:
   - Manage VLANs on a BIG-IP system
-version_added: "2.2"
+version_added: 2.2
 options:
   description:
     description:
@@ -71,6 +71,17 @@ options:
         specifies that the default CMP hash uses L4 ports.
       - When creating a new VLAN, if this parameter is not specified, the default
         of C(default) is used.
+    choices:
+      - default
+      - destination-address
+      - source-address
+      - dst-ip
+      - src-ip
+      - dest
+      - destination
+      - source
+      - dst
+      - src
     version_added: 2.5
   dag_tunnel:
     description:
@@ -82,6 +93,9 @@ options:
         of C(outer) is used.
       - This parameter is not supported on Virtual Editions of BIG-IP.
     version_added: 2.5
+    choices:
+      - inner
+      - outer
   dag_round_robin:
     description:
       - Specifies whether some of the stateless traffic on the VLAN should be
@@ -187,27 +201,22 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.basic import env_fallback
 
 try:
-    # Sideband repository used for dev
     from library.module_utils.network.f5.bigip import HAS_F5SDK
     from library.module_utils.network.f5.bigip import F5Client
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import AnsibleF5Parameters
     from library.module_utils.network.f5.common import cleanup_tokens
-    from library.module_utils.network.f5.common import fqdn_name
     from library.module_utils.network.f5.common import f5_argument_spec
     try:
         from library.module_utils.network.f5.common import iControlUnexpectedHTTPError
     except ImportError:
         HAS_F5SDK = False
-    HAS_DEVEL_IMPORTS = True
 except ImportError:
-    # Upstream Ansible
     from ansible.module_utils.network.f5.bigip import HAS_F5SDK
     from ansible.module_utils.network.f5.bigip import F5Client
     from ansible.module_utils.network.f5.common import F5ModuleError
     from ansible.module_utils.network.f5.common import AnsibleF5Parameters
     from ansible.module_utils.network.f5.common import cleanup_tokens
-    from ansible.module_utils.network.f5.common import fqdn_name
     from ansible.module_utils.network.f5.common import f5_argument_spec
     try:
         from ansible.module_utils.network.f5.common import iControlUnexpectedHTTPError

--- a/test/sanity/validate-modules/ignore.txt
+++ b/test/sanity/validate-modules/ignore.txt
@@ -1172,10 +1172,7 @@ lib/ansible/modules/network/f5/bigip_static_route.py E325
 lib/ansible/modules/network/f5/bigip_sys_global.py E326
 lib/ansible/modules/network/f5/bigip_ucs.py E325
 lib/ansible/modules/network/f5/bigip_ucs.py E326
-lib/ansible/modules/network/f5/bigip_user.py E324
-lib/ansible/modules/network/f5/bigip_vcmp_guest.py E325
 lib/ansible/modules/network/f5/bigip_virtual_server.py E326
-lib/ansible/modules/network/f5/bigip_vlan.py E326
 lib/ansible/modules/network/f5/bigiq_regkey_license.py E325
 lib/ansible/modules/network/fortimanager/fmgr_script.py E324
 lib/ansible/modules/network/fortios/fortios_address.py E324

--- a/test/units/modules/network/f5/test_bigip_user.py
+++ b/test/units/modules/network/f5/test_bigip_user.py
@@ -21,11 +21,11 @@ from ansible.compat.tests.mock import patch
 from ansible.module_utils.basic import AnsibleModule
 
 try:
-    from library.bigip_user import Parameters
-    from library.bigip_user import ModuleManager
-    from library.bigip_user import ArgumentSpec
-    from library.bigip_user import UnparitionedManager
-    from library.bigip_user import PartitionedManager
+    from library.modules.bigip_user import Parameters
+    from library.modules.bigip_user import ModuleManager
+    from library.modules.bigip_user import ArgumentSpec
+    from library.modules.bigip_user import UnparitionedManager
+    from library.modules.bigip_user import PartitionedManager
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import iControlUnexpectedHTTPError
     from test.unit.modules.utils import set_module_args

--- a/test/units/modules/network/f5/test_bigip_vcmp_guest.py
+++ b/test/units/modules/network/f5/test_bigip_vcmp_guest.py
@@ -21,9 +21,9 @@ from ansible.compat.tests.mock import patch
 from ansible.module_utils.basic import AnsibleModule
 
 try:
-    from library.bigip_vcmp_guest import Parameters
-    from library.bigip_vcmp_guest import ModuleManager
-    from library.bigip_vcmp_guest import ArgumentSpec
+    from library.modules.bigip_vcmp_guest import Parameters
+    from library.modules.bigip_vcmp_guest import ModuleManager
+    from library.modules.bigip_vcmp_guest import ArgumentSpec
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import iControlUnexpectedHTTPError
     from test.unit.modules.utils import set_module_args

--- a/test/units/modules/network/f5/test_bigip_virtual_address.py
+++ b/test/units/modules/network/f5/test_bigip_virtual_address.py
@@ -20,9 +20,9 @@ from ansible.compat.tests.mock import patch
 from ansible.module_utils.basic import AnsibleModule
 
 try:
-    from library.bigip_virtual_address import Parameters
-    from library.bigip_virtual_address import ModuleManager
-    from library.bigip_virtual_address import ArgumentSpec
+    from library.modules.bigip_virtual_address import Parameters
+    from library.modules.bigip_virtual_address import ModuleManager
+    from library.modules.bigip_virtual_address import ArgumentSpec
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import iControlUnexpectedHTTPError
     from test.unit.modules.utils import set_module_args

--- a/test/units/modules/network/f5/test_bigip_vlan.py
+++ b/test/units/modules/network/f5/test_bigip_vlan.py
@@ -20,10 +20,10 @@ from ansible.compat.tests.mock import patch
 from ansible.module_utils.basic import AnsibleModule
 
 try:
-    from library.bigip_vlan import ApiParameters
-    from library.bigip_vlan import ModuleParameters
-    from library.bigip_vlan import ModuleManager
-    from library.bigip_vlan import ArgumentSpec
+    from library.modules.bigip_vlan import ApiParameters
+    from library.modules.bigip_vlan import ModuleParameters
+    from library.modules.bigip_vlan import ModuleManager
+    from library.modules.bigip_vlan import ArgumentSpec
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import iControlUnexpectedHTTPError
     from test.unit.modules.utils import set_module_args


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
This patch fixes a number of convention changes in F5 modules.
Additionally, it adds some features to bigip vlan and other modules

* add support for virtual address names
* add traffic group to virtual address

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
* bigip_user
* bigip_vlan
* bigip_vcmp_guest
* bigip_virtual_address

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0
  config file = None
  configured module search path = ['/root/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python3.6/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 3.6.4 (default, Mar 14 2018, 17:49:05) [GCC 4.9.2]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
