### PR TITLE
Fix aruba initial prompt issue

### DIFF
--- a/lib/ansible/plugins/connection/network_cli.py
+++ b/lib/ansible/plugins/connection/network_cli.py
@@ -312,7 +312,8 @@ class Connection(ConnectionBase):
         else:
             display.vvvv('unable to load cliconf for network_os %s' % network_os)
 
-        self.receive()
+        self.receive(prompts=self._terminal.terminal_initial_prompt, answer=self._terminal.terminal_initial_answer,
+                     newline=self._terminal.terminal_inital_prompt_newline)
 
         display.vvvv('firing event: on_open_shell()', host=self._play_context.remote_addr)
         self._terminal.on_open_shell()

--- a/lib/ansible/plugins/terminal/__init__.py
+++ b/lib/ansible/plugins/terminal/__init__.py
@@ -52,6 +52,15 @@ class TerminalBase(with_metaclass(ABCMeta, object)):
         re.compile(br'\x08.')
     ]
 
+    #: terminal initial prompt
+    terminal_initial_prompt = None
+
+    #: terminal initial answer
+    terminal_initial_answer = None
+
+    #: Send newline after prompt match
+    terminal_inital_prompt_newline = True
+
     def __init__(self, connection):
         self._connection = connection
 

--- a/lib/ansible/plugins/terminal/aruba.py
+++ b/lib/ansible/plugins/terminal/aruba.py
@@ -29,10 +29,18 @@ from ansible.plugins.terminal import TerminalBase
 
 class TerminalModule(TerminalBase):
 
+    ansi_re = [
+        # check ECMA-48 Section 5.4 (Control Sequences)
+        re.compile(br'(\x1b\[\?1h\x1b=)'),
+        re.compile(br'((?:\x9b|\x1b\x5b)[\x30-\x3f]*[\x20-\x2f]*[\x40-\x7e])'),
+        re.compile(br'\x08.')
+    ]
+
     terminal_stdout_re = [
         re.compile(br"[\r\n]?[\w]*\(.+\) ?#(?:\s*)$"),
         re.compile(br"[pP]assword:$"),
         re.compile(br"(?<=\s)[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?\s*#\s*$"),
+        re.compile(br"[\r\n]?[\w\+\-\.:\/\[\]]+(?:\([^\)]+\)){0,3}(?:[>#]) ?$"),
     ]
 
     terminal_stderr_re = [
@@ -46,6 +54,12 @@ class TerminalModule(TerminalBase):
         re.compile(br"[^\r\n]+ not found", re.I),
         re.compile(br"'[^']' +returned error code: ?\d+"),
     ]
+
+    terminal_initial_prompt = b'Press any key to continue'
+
+    terminal_initial_answer = b'\r'
+
+    terminal_inital_prompt_newline = False
 
     def on_open_shell(self):
         try:


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #33414

Issue a newline when the initial connection
results in a prompt and expects user input.
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
plugins/connection/network_cli.py
plugins/terminal/__init__.py
plugins/terminal/aruba.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
