### PR TITLE
Fix zabbix-template module error version comparison

### DIFF
--- a/lib/ansible/modules/monitoring/zabbix/zabbix_template.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_template.py
@@ -202,7 +202,7 @@ template_json:
     }
 '''
 
-from distutils.version import LooseVersion
+from pkg_resources import parse_version
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 import json
@@ -417,7 +417,7 @@ class Template(object):
             # old api version support here
             api_version = self._zapi.api_version()
             # updateExisting for application removed from zabbix api after 3.2
-            if LooseVersion(api_version) <= LooseVersion('3.2.x'):
+            if parse_version(api_version) <= parse_version('3.2.x'):
                 update_rules['applications']['updateExisting'] = True
 
             self._zapi.configuration.import_({

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_template.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_template.py
@@ -202,7 +202,7 @@ template_json:
     }
 '''
 
-from pkg_resources import parse_version
+from distutils.version import LooseVersion
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 import json
@@ -417,7 +417,8 @@ class Template(object):
             # old api version support here
             api_version = self._zapi.api_version()
             # updateExisting for application removed from zabbix api after 3.2
-            if parse_version(api_version) <= parse_version('3.2.x'):
+            if LooseVersion(api_version).version[:2] <= LooseVersion(
+                    '3.2').version:
                 update_rules['applications']['updateExisting'] = True
 
             self._zapi.configuration.import_({


### PR DESCRIPTION
##### SUMMARY
Fixes #39198

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
zabbix_template

##### ANSIBLE VERSION
```
ansible 2.5.1
  config file = None
  configured module search path = ['/Users/amatellanes/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/amatellanes/.virtualenvs/pipeline-downloads_ansible3/lib/python3.6/site-packages/ansible
  executable location = /Users/amatellanes/.virtualenvs/pipeline-downloads_ansible3/bin/ansible
  python version = 3.6.5 (default, Mar 30 2018, 06:41:53) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```


##### ADDITIONAL INFORMATION
Since integers and strings are non-comparable in Python 3, the following comparison will fail:

```
from distutils.version import LooseVersion

api_version = '3.2.10'
LooseVersion(api_version) < LooseVersion('3.2.x')
```

The traceback:

```
TypeError                                 Traceback (most recent call last)
<ipython-input-3-6897b32efdd1> in <module>()
      2 from distutils.version import LooseVersion
      3 api_version = '3.2.10'
----> 4 LooseVersion(api_version) < LooseVersion('3.2.x')

/usr/local/Cellar/python/3.6.5/Frameworks/Python.framework/Versions/3.6/lib/python3.6/distutils/version.py in __lt__(self, other)
     50
     51     def __lt__(self, other):
---> 52         c = self._cmp(other)
     53         if c is NotImplemented:
     54             return c

/usr/local/Cellar/python/3.6.5/Frameworks/Python.framework/Versions/3.6/lib/python3.6/distutils/version.py in _cmp(self, other)
    335         if self.version == other.version:
    336             return 0
--> 337         if self.version < other.version:
    338             return -1
    339         if self.version > other.version:

TypeError: '<' not supported between instances of 'int' and 'str'
```

By using [`pkg_resources`](http://setuptools.readthedocs.io/en/latest/index.html) module we can fix this error.