### PR TITLE
Ansible.ModuleUtils.FileUtil - Add ability to test non file system provider paths

### DIFF
--- a/lib/ansible/module_utils/powershell/Ansible.ModuleUtils.FileUtil.psm1
+++ b/lib/ansible/module_utils/powershell/Ansible.ModuleUtils.FileUtil.psm1
@@ -19,6 +19,10 @@ Function Test-AnsiblePath {
         $file_attributes = [System.IO.File]::GetAttributes($Path)
     } catch [System.IO.FileNotFoundException], [System.IO.DirectoryNotFoundException] {
         return $false
+    } catch [NotSupportedException] {
+        # When testing a path like Cert:\LocalMachine\My, System.IO.File will
+        # not work, we just revert back to using Test-Path for this
+        return Test-Path -Path $Path
     }
 
     if ([Int32]$file_attributes -eq -1) {

--- a/test/integration/targets/win_module_utils/library/file_util_test.ps1
+++ b/test/integration/targets/win_module_utils/library/file_util_test.ps1
@@ -62,6 +62,7 @@ Assert-Equals -actual $actual -expected $true
 
 # Test-AnsiblePath Normal file
 $actual = Test-AnsiblePath -Path C:\Windows\System32\kernel32.dll
+Assert-Equals -actual $actual -expected $true
 
 # Test-AnsiblePath fails with wildcard
 $failed = $false
@@ -72,6 +73,18 @@ try {
     Assert-Equals -actual $_.Exception.Message -expected "Exception calling `"GetAttributes`" with `"1`" argument(s): `"Illegal characters in path.`""
 }
 Assert-Equals -actual $failed -expected $true
+
+# Test-AnsiblePath on non file PS Provider object
+$actual = Test-AnsiblePath -Path Cert:\LocalMachine\My
+Assert-Equals -actual $actual -expected $true
+
+# Test-AnsiblePath on environment variable
+$actual = Test-AnsiblePath -Path env:SystemDrive
+Assert-Equals -actual $actual -expected $true
+
+# Test-AnsiblePath on environment variable that does not exist
+$actual = Test-AnsiblePath -Path env:FakeEnvValue
+Assert-Equals -actual $actual -expected $false
 
 # Get-AnsibleItem doesn't exist with -ErrorAction SilentlyContinue param
 $actual = Get-AnsibleItem -Path C:\fakefile -ErrorAction SilentlyContinue


### PR DESCRIPTION
##### SUMMARY
Adds the ability to use `Test-AnsiblePath` to test out paths with non file system providers. This brings the `Test-AnsiblePath` more on par with the `Test-Path` cmdlet.

Fixes https://github.com/ansible/ansible/issues/39072

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
module_utils/powershell/Ansible.ModuleUtils.FileUtil.psm1

##### ANSIBLE VERSION
```
devel
```
