### PR TITLE
Work-around for issue #38425

### DIFF
--- a/lib/ansible/modules/network/ios/ios_facts.py
+++ b/lib/ansible/modules/network/ios/ios_facts.py
@@ -133,7 +133,7 @@ ansible_net_interfaces:
   description: A hash of all interfaces running on the system
   returned: when interfaces is configured
   type: dict
-  
+
 # neighbors
 ansible_net_neighbors:
   description: The list of LLDP neighbors from the remote device
@@ -399,23 +399,23 @@ class Interfaces(FactsBase):
         match = re.search(r'^(?:.+) is (.+),', data, re.M)
         if match:
             return match.group(1)
-        
-        
+
+
 class Neighbors(FactsBase):
 
     COMMANDS = [
         'show lldp'
     ]
-    
+
     def populate(self):
         super(Neighbors, self).populate()
-        
+
         data = self.responses[0]
         if data:
             neighbors = self.run(['show lldp neighbors detail'])
             if neighbors:
                 self.facts['neighbors'] = self.parse_neighbors(neighbors[0])
-                
+
     def parse_neighbors(self, neighbors):
         facts = dict()
         for entry in neighbors.split('------------------------------------------------'):


### PR DESCRIPTION
##### SUMMARY
Work-around for #38425 

Older versions of Cisco IOS do not support LLDP and the command `show lldp neighbors` produces an error as described in #38425 

This change creates a separate 'neighbors' subset for the *ios_facts* module. This allows to exclude collecting LLDP neighbor information from the facts gathering process, avoiding the error described in #38425 . 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ios_facts

##### ANSIBLE VERSION
```
ansible 2.6.0
  config file = None
  configured module search path = [u'/home/mjuenemann/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/mjuenemann/.virtualenvs/ansible-devel/lib/python2.7/site-packages/ansible-2.6.0-py2.7.egg/ansible
  executable location = /home/mjuenemann/.virtualenvs/ansible-devel/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION
Example of work-around for IOS releases that do not support LLDP.
```
- name: getting ios facts
  ios_facts:
    gather_subset: "!neighbors"
```
