### PR TITLE
Removes outdated note regarding loops

### DIFF
--- a/lib/ansible/modules/packaging/os/yum.py
+++ b/lib/ansible/modules/packaging/os/yum.py
@@ -143,8 +143,6 @@ options:
     required: false
     version_added: "2.5"
 notes:
-  - When used with a `loop:` each package will be processed individually,
-    it is much more efficient to pass the list directly to the `name` option.
   - In versions prior to 1.9.2 this module installed and removed each package
     given to the yum module separately. This caused problems when packages
     specified by filename or url had to be installed or removed together. In


### PR DESCRIPTION
##### SUMMARY

the yum module uses "squashed" loops since ages. I wasn't able to figure out when exactly the squashed loops were introduced since it is not mentioned in the release notes. Certainly before Ansible 2.

Since documentation is version now, I think we safely can just drop this note.

##### ISSUE TYPE

 - Docs Pull Request

##### COMPONENT NAME

yum

+label: docsite_pr