### PR TITLE
corrects links to 'list_of' pages (#39161)

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_modules_in_groups.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_in_groups.rst
@@ -33,7 +33,7 @@ Although it's tempting to get straight into coding, there are a few things to be
 Naming Convention
 `````````````````
 
-As you may have noticed when looking under ``lib/ansible/modules/`` we support up to two directories deep (but no deeper), e.g. `databases/mysql`. This is used to group files on disk as well as group related modules into categories and topics the Module Index, for example: :ref:`list_of_database_modules`.
+As you may have noticed when looking under ``lib/ansible/modules/`` we support up to two directories deep (but no deeper), e.g. `databases/mysql`. This is used to group files on disk as well as group related modules into categories and topics the Module Index, for example: :ref:`database_modules`.
 
 The directory name should represent the *product* or *OS* name, not the company name.
 

--- a/docs/docsite/rst/network/getting_started/basic_concepts.rst
+++ b/docs/docsite/rst/network/getting_started/basic_concepts.rst
@@ -24,7 +24,7 @@ A list of managed nodes. An inventory file is also sometimes called a "hostfile"
 Modules
 ================================================================================
 
-The units of code Ansible executes. Each module has a particular use, from administering users on a specific type of database to managing VLAN interfaces on a specific type of network device. You can invoke a single module with a task, or invoke several different modules in a playbook. For an idea of how many modules Ansible includes, take a look at the :doc:`list of all modules<../../modules/modules_by_category>` or the :doc:`list of network modules<../../modules/list_of_network_modules>`.
+The units of code Ansible executes. Each module has a particular use, from administering users on a specific type of database to managing VLAN interfaces on a specific type of network device. You can invoke a single module with a task, or invoke several different modules in a playbook. For an idea of how many modules Ansible includes, take a look at the :doc:`list of all modules<../../modules/modules_by_category>` or the :ref:`list of network modules<network_modules>`.
 
 Tasks
 ================================================================================

--- a/docs/docsite/rst/network/index.rst
+++ b/docs/docsite/rst/network/index.rst
@@ -11,7 +11,7 @@ Ansible Network modules extend the benefits of simple, powerful, agentless autom
 
 If you're new to Ansible, or new to using Ansible for network management, start with the Getting Started Guide.
 
-For documentation on using a particular network module, consult the :doc:`list of all network modules<../modules/list_of_network_modules>`. Some network modules are maintained by the Ansible community - here's a list of :doc:`network modules maintained by the Ansible Network Team<../modules/network_maintained>`.
+For documentation on using a particular network module, consult the :ref:`list of all network modules<network_modules>`. Some network modules are maintained by the Ansible community - here's a list of :ref:`network modules maintained by the Ansible Network Team<network_supported>`.
 
 .. toctree::
    :maxdepth: 3

--- a/docs/docsite/rst/scenario_guides/guide_aci.rst
+++ b/docs/docsite/rst/scenario_guides/guide_aci.rst
@@ -65,7 +65,7 @@ For instance ensuring that a specific tenant exists, is done using the following
         description: Customer XYZ
         state: present
 
-A complete list of existing ACI modules is available for the latest stable release on the :ref:`list of network modules <list_of_network_modules>`. You can also view the `current development version <http://docs.ansible.com/ansible/devel/modules/list_of_network_modules.html#aci>`_.
+A complete list of existing ACI modules is available for the latest stable release on the :ref:`list of network modules <network_modules>`. You can also view the `current development version <http://docs.ansible.com/ansible/devel/modules/list_of_network_modules.html#aci>`_.
 
 Querying ACI configuration
 ..........................

--- a/docs/docsite/rst/user_guide/windows_dsc.rst
+++ b/docs/docsite/rst/user_guide/windows_dsc.rst
@@ -387,7 +387,7 @@ Setup IIS Website
        An introduction to playbooks
    :doc:`playbooks_best_practices`
        Best practices advice
-   `List of Windows Modules :ref:`<list_of_windows_modules>`
+   `List of Windows Modules :ref:`<windows_modules>`
        Windows specific module list, all implemented in PowerShell
    `User Mailing List <http://groups.google.com/group/ansible-project>`_
        Have a question?  Stop by the google group!

--- a/docs/docsite/rst/user_guide/windows_faq.rst
+++ b/docs/docsite/rst/user_guide/windows_faq.rst
@@ -122,7 +122,7 @@ Python and most of them do not work on Windows.
 
 Because of this, there are dedicated Windows modules that are written in
 PowerShell and are meant to be run on Windows hosts. A list of these modules
-can be found :ref:`here <list_of_windows_modules>`.
+can be found :ref:`here <windows_modules>`.
 
 In addition, the following Ansible Core modules/action-plugins work with Windows:
 

--- a/docs/docsite/rst/user_guide/windows_setup.rst
+++ b/docs/docsite/rst/user_guide/windows_setup.rst
@@ -447,7 +447,7 @@ Windows host.
        An introduction to playbooks
    :doc:`playbooks_best_practices`
        Best practices advice
-   :ref:`List of Windows Modules <list_of_windows_modules>`
+   :ref:`List of Windows Modules <windows_modules>`
        Windows specific module list, all implemented in PowerShell
    `User Mailing List <http://groups.google.com/group/ansible-project>`_
        Have a question?  Stop by the google group!

--- a/docs/docsite/rst/user_guide/windows_usage.rst
+++ b/docs/docsite/rst/user_guide/windows_usage.rst
@@ -483,7 +483,7 @@ guides for Windows modules differ substantially from those for standard standard
        An introduction to playbooks
    :doc:`playbooks_best_practices`
        Best practices advice
-   :ref:`List of Windows Modules <list_of_windows_modules>`
+   :ref:`List of Windows Modules <windows_modules>`
        Windows specific module list, all implemented in PowerShell
    `User Mailing List <http://groups.google.com/group/ansible-project>`_
        Have a question?  Stop by the google group!

--- a/docs/docsite/rst/user_guide/windows_winrm.rst
+++ b/docs/docsite/rst/user_guide/windows_winrm.rst
@@ -767,7 +767,7 @@ Some of these limitations can be mitigated by doing one of the following:
        An introduction to playbooks
    :doc:`playbooks_best_practices`
        Best practices advice
-   :ref:`List of Windows Modules <list_of_windows_modules>`
+   :ref:`List of Windows Modules <windows_modules>`
        Windows specific module list, all implemented in PowerShell
    `User Mailing List <http://groups.google.com/group/ansible-project>`_
        Have a question?  Stop by the google group!


### PR DESCRIPTION
##### SUMMARY
The titles and URLs of the list pages use "list of X modules" - for example:
http://docs.ansible.com/ansible/latest/modules/list_of_network_modules.html

However, the anchors added to those pages omit the "list of" - for example, if you generate the webdocs and open docs/docsite/rst/modules/list_of_network_modules.rst you'll see its anchor is:
.. _network_modules:

This PR corrects :ref: links to those pages from elsewhere in the docsite, and eliminates undefined label rST warnings.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
docs.ansible.com

##### ANSIBLE VERSION
2.5

