### PR TITLE
[WIP] Support 'apply' to apply attributes to included tasks - Impl 2

### DIFF
--- a/lib/ansible/playbook/helpers.py
+++ b/lib/ansible/playbook/helpers.py
@@ -140,7 +140,7 @@ def load_list_of_tasks(ds, play, block=None, role=None, task_include=None, use_h
 
                 apply_attrs = task_ds.pop('apply', {})
 
-                if apply_attrs and 'include_tasks' not in task_ds:
+                if apply_attrs and action != 'include_tasks':
                     raise AnsibleParserError('Invalid params for include/import_tasks: apply', obj=task_ds)
                 elif apply_attrs:
                     apply_attrs['block'] = []
@@ -327,7 +327,7 @@ def load_list_of_tasks(ds, play, block=None, role=None, task_include=None, use_h
             elif action in ('include_role', 'import_role'):
                 apply_attrs = task_ds.pop('apply', {})
 
-                if apply_attrs and 'include_role' not in task_ds:
+                if apply_attrs and action != 'include_role':
                     raise AnsibleParserError('Invalid params for import_role: apply', obj=task_ds)
                 elif apply_attrs:
                     apply_attrs['block'] = []

--- a/lib/ansible/playbook/helpers.py
+++ b/lib/ansible/playbook/helpers.py
@@ -138,9 +138,26 @@ def load_list_of_tasks(ds, play, block=None, role=None, task_include=None, use_h
                 else:
                     include_class = TaskInclude
 
+                apply_attrs = task_ds.pop('apply', {})
+
+                if apply_attrs:
+                    apply_attrs['block'] = []
+                    p_block = Block.load(
+                        apply_attrs,
+                        play=play,
+                        parent_block=block,
+                        role=role,
+                        task_include=task_include,
+                        use_handlers=use_handlers,
+                        variable_manager=variable_manager,
+                        loader=loader,
+                    )
+                else:
+                    p_block = block
+
                 t = include_class.load(
                     task_ds,
-                    block=block,
+                    block=p_block,
                     role=role,
                     task_include=None,
                     variable_manager=variable_manager,
@@ -306,9 +323,26 @@ def load_list_of_tasks(ds, play, block=None, role=None, task_include=None, use_h
                     task_list.append(t)
 
             elif action in ('include_role', 'import_role'):
+                apply_attrs = task_ds.pop('apply', {})
+
+                if apply_attrs:
+                    apply_attrs['block'] = []
+                    p_block = Block.load(
+                        apply_attrs,
+                        play=play,
+                        parent_block=block,
+                        role=role,
+                        task_include=task_include,
+                        use_handlers=use_handlers,
+                        variable_manager=variable_manager,
+                        loader=loader,
+                    )
+                else:
+                    p_block = block
+
                 ir = IncludeRole.load(
                     task_ds,
-                    block=block,
+                    block=p_block,
                     role=role,
                     task_include=None,
                     variable_manager=variable_manager,

--- a/lib/ansible/playbook/helpers.py
+++ b/lib/ansible/playbook/helpers.py
@@ -140,7 +140,9 @@ def load_list_of_tasks(ds, play, block=None, role=None, task_include=None, use_h
 
                 apply_attrs = task_ds.pop('apply', {})
 
-                if apply_attrs:
+                if apply_attrs and 'include_tasks' not in task_ds:
+                    raise AnsibleParserError('Invalid params for include/import_tasks: apply', obj=task_ds)
+                elif apply_attrs:
                     apply_attrs['block'] = []
                     p_block = Block.load(
                         apply_attrs,
@@ -325,7 +327,9 @@ def load_list_of_tasks(ds, play, block=None, role=None, task_include=None, use_h
             elif action in ('include_role', 'import_role'):
                 apply_attrs = task_ds.pop('apply', {})
 
-                if apply_attrs:
+                if apply_attrs and 'include_role' not in task_ds:
+                    raise AnsibleParserError('Invalid params for import_role: apply', obj=task_ds)
+                elif apply_attrs:
                     apply_attrs['block'] = []
                     p_block = Block.load(
                         apply_attrs,

--- a/test/integration/targets/include_import/apply/import_apply.yml
+++ b/test/integration/targets/include_import/apply/import_apply.yml
@@ -1,0 +1,30 @@
+---
+- hosts: testhost
+  gather_facts: false
+  tasks:
+    - import_tasks: import_tasks.yml
+      apply:
+        tags:
+          - foo
+      tags:
+        - always
+
+    - assert:
+        that:
+          - include_tasks_result is defined
+      tags:
+        - always
+
+    - import_role:
+        name: import_role
+      apply:
+        tags:
+          - foo
+      tags:
+        - always
+
+    - assert:
+        that:
+          - include_role_result is defined
+      tags:
+        - always

--- a/test/integration/targets/include_import/apply/include_apply.yml
+++ b/test/integration/targets/include_import/apply/include_apply.yml
@@ -1,0 +1,30 @@
+---
+- hosts: testhost
+  gather_facts: false
+  tasks:
+    - include_tasks: include_tasks.yml
+      apply:
+        tags:
+          - foo
+      tags:
+        - always
+
+    - assert:
+        that:
+          - include_tasks_result is defined
+      tags:
+        - always
+
+    - include_role:
+        name: include_role
+      apply:
+        tags:
+          - foo
+      tags:
+        - always
+
+    - assert:
+        that:
+          - include_role_result is defined
+      tags:
+        - always

--- a/test/integration/targets/include_import/apply/include_tasks.yml
+++ b/test/integration/targets/include_import/apply/include_tasks.yml
@@ -1,0 +1,2 @@
+- set_fact:
+    include_tasks_result: true

--- a/test/integration/targets/include_import/apply/roles/include_role/tasks/main.yml
+++ b/test/integration/targets/include_import/apply/roles/include_role/tasks/main.yml
@@ -1,0 +1,2 @@
+- set_fact:
+    include_role_result: true

--- a/test/integration/targets/include_import/runme.sh
+++ b/test/integration/targets/include_import/runme.sh
@@ -67,3 +67,13 @@ ANSIBLE_STRATEGY='free' ansible-playbook undefined_var/playbook.yml  -i ../../in
 # Include path inheritance using host var for include file path
 ANSIBLE_STRATEGY='linear' ansible-playbook include_path_inheritance/playbook.yml  -i ../../inventory "$@"
 ANSIBLE_STRATEGY='free' ansible-playbook include_path_inheritance/playbook.yml  -i ../../inventory "$@"
+
+# include_ + apply (explicit inheritance)
+ANSIBLE_STRATEGY='linear' ansible-playbook apply/include_apply.yml -i ../../inventory "$@" --tags foo
+set +e
+OUT=$(ANSIBLE_STRATEGY='linear' ansible-playbook apply/import_apply.yml -i ../../inventory "$@" --tags foo 2>&1 | grep 'ERROR! Invalid params for include/import_tasks: apply')
+set -e
+if [[ -z "$OUT" ]]; then
+    echo "apply on import_tasks did not cause error"
+    exit 1
+fi


### PR DESCRIPTION
##### SUMMARY

This PR adds a new task keyword called `apply` that will allow included tasks to `inherit` explicitly provided attributes.

Examples:

```
---
- hosts: localhost
  gather_facts: false
  tasks:
    - include_tasks: include_me.yml
      apply:
        tags:
          - foo
      tags:
        - always

    - include_role:
        name: include_role
      apply:
        tags:
          - foo
      tags:
        - always
```


##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
lib/ansible/playbook/helpers.py


##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```