### PR TITLE
Fix mysql-server install/upgrade on Ubuntu 16.04.

### DIFF
--- a/test/integration/targets/docker_secret/tasks/Ubuntu.yml
+++ b/test/integration/targets/docker_secret/tasks/Ubuntu.yml
@@ -29,8 +29,29 @@
 - name: Add Docker repo
   shell: add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"  
 
-- name: Install Docker CE
-  apt:
-    name: docker-ce
-    state: present
-    update_cache: yes
+- block:
+    - name: Prevent service restart
+      copy:
+        content: exit 101
+        dest: /usr/sbin/policy-rc.d
+        backup: yes
+        mode: 0755
+      register: policy_rc_d
+
+    - name: Install Docker CE
+      apt:
+        name: docker-ce
+        state: present
+        update_cache: yes
+  always:
+    - name: Restore /usr/sbin/policy-rc.d (if needed)
+      command: mv {{ policy_rc_d.backup_file }} /usr/sbin/policy-rc.d
+      when:
+        - "'backup_file' in policy_rc_d"
+
+    - name: Remove /usr/sbin/policy-rc.d (if needed)
+      file:
+        path: /usr/sbin/policy-rc.d
+        state: absent
+      when:
+        - "'backup_file' not in policy_rc_d"

--- a/test/runner/setup/docker.sh
+++ b/test/runner/setup/docker.sh
@@ -2,6 +2,9 @@
 
 set -eu
 
+# Required for newer mysql-server packages to install/upgrade on Ubuntu 16.04.
+rm -f /usr/sbin/policy-rc.d
+
 # Support images with only python3 installed.
 if [ ! -f /usr/bin/python ] && [ -f /usr/bin/python3 ]; then
     ln -s /usr/bin/python3 /usr/bin/python


### PR DESCRIPTION
##### SUMMARY

Fix mysql-server install/upgrade on Ubuntu 16.04.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.6.0 (ci-fix 7d52e7a242) last updated 2018/04/24 09:43:42 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
