### PR TITLE
avoids rst error on exos_command module docs

### DIFF
--- a/lib/ansible/modules/network/exos/exos_command.py
+++ b/lib/ansible/modules/network/exos/exos_command.py
@@ -37,7 +37,7 @@ description:
     module to wait for a specific condition before returning or timing out if
     the condition is not met.
   - This module does not support running configuration commands.
-    Please use M(exos_config) to configure EXOS devices.
+    We expect to release an exos_config module soon to configure EXOS devices.
 notes:
   - If a command sent to the device requires answering a prompt, it is possible
     to pass a dict containing I(command), I(answer) and I(prompt). See examples.


### PR DESCRIPTION
##### SUMMARY
As part of making all rST warnings fatal on Shippable, we are eliminating warnings from the docs build.

The documentation for the `exos_command` module refers to a module that does not exist yet. Once you've created the second module, we encourage you to add the link back into this documentation.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
exos_command module

##### ANSIBLE VERSION
2.5

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
