### PR TITLE
use actual ssh executable as it might not be ssh

### DIFF
--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -677,7 +677,7 @@ class Connection(ConnectionBase):
         # only when using ssh. Otherwise we can send initial data straightaway.
 
         state = states.index('ready_to_send')
-        if b'ssh' in cmd and sudoable:
+        if to_bytes(self.get_option('ssh_executable')) in cmd and sudoable:
             if self._play_context.prompt:
                 # We're requesting escalation with a password, so we have to
                 # wait for a password prompt.


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
fixes issues with alternate ssh executables, the condition just meant to avoid sftp/scp

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
connection/ssh
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.4-2.6
```
