### PR TITLE
Add note about the dangers of ANSIBLE_DEBUG

### DIFF
--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -494,9 +494,10 @@ DEFAULT_DEBUG:
   name: Debug mode
   default: False
   description:
-    - "Toggles debug output in Ansible, VERY verbose and can hinder
-      multiprocessing.  Debug output also can also include secret information
-      despite no_log settings which means it should not be used in production."
+    - "Toggles debug output in Ansible. This is *very* verbose and can hinder
+      multiprocessing.  Debug output can also include secret information
+      despite no_log settings being enabled, which means debug mode should not be used in 
+      production."
   env: [{name: ANSIBLE_DEBUG}]
   ini:
   - {key: debug, section: defaults}

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -493,7 +493,10 @@ DEFAULT_CONNECTION_PLUGIN_PATH:
 DEFAULT_DEBUG:
   name: Debug mode
   default: False
-  description: Toggles debug output in Ansible, VERY verbose and can hinder multiprocessing.
+  description:
+    - "Toggles debug output in Ansible, VERY verbose and can hinder
+      multiprocessing.  Debug output also can also include secret information
+      despite no_log settings which means it should not be used in production."
   env: [{name: ANSIBLE_DEBUG}]
   ini:
   - {key: debug, section: defaults}


### PR DESCRIPTION
##### SUMMARY
ANSIBLE_DEBUG can show data marked no_log.  This is expected but only documented in the FAQ.  Add that warning to the documentation for ANSIBLE_DEBUG in config.

##### ISSUE TYPE

 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel 2.5
```


##### ADDITIONAL INFORMATION
Discovered this while exploring this ansible proposal https://github.com/ansible/proposals/issues/109
