### PR TITLE
Added nios_txt_record module

### DIFF
--- a/lib/ansible/modules/net_tools/nios/nios_txt_record.py
+++ b/lib/ansible/modules/net_tools/nios/nios_txt_record.py
@@ -1,0 +1,133 @@
+#!/usr/bin/python
+# Copyright (c) 2018 Red Hat, Inc.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = '''
+---
+module: nios_txt_record
+version_added: "2.7"
+author: "Corey Wanless"
+short_description: Configure Infoblox NIOS txt records
+description:
+  - Adds and/or removes instances of txt record objects from
+    Infoblox NIOS servers.  This module manages NIOS C(record:txt) objects
+    using the Infoblox WAPI interface over REST.
+requirements:
+  - infoblox_client
+extends_documentation_fragment: nios
+options:
+  name:
+    description:
+      - Specifies the fully qualified hostname to add or remove from
+        the system
+    required: true
+  view:
+    description:
+      - Sets the DNS view to associate this tst record with.  The DNS
+        view must already be configured on the system
+    required: true
+    default: default
+    aliases:
+      - dns_view
+  text:
+    description:
+      - Text associated with the record. It can contain up to 255 bytes
+        per substring, up to a total of 512 bytes. To enter leading,
+        trailing, or embedded spaces in the text, add quotes around the
+        text to preserve the spaces.
+  ttl:
+    description:
+      - Configures the TTL to be associated with this tst record
+  extattrs:
+    description:
+      - Allows for the configuration of Extensible Attributes on the
+        instance of the object.  This argument accepts a set of key / value
+        pairs for configuration.
+  comment:
+    description:
+      - Configures a text string comment to be associated with the instance
+        of this object.  The provided text string will be configured on the
+        object instance.
+  state:
+    description:
+      - Configures the intended state of the instance of the object on
+        the NIOS server.  When this value is set to C(present), the object
+        is configured on the device and when this value is set to C(absent)
+        the value is removed (if necessary) from the device.
+    default: present
+    choices:
+      - present
+      - absent
+'''
+
+EXAMPLES = '''
+    - name: Ensure a text Record Exists
+      nios_txt_record:
+        name: fqdn.txt.record.com
+        text: mytext
+        state: present
+        view: External
+        provider:
+          host: "{{ inventory_hostname_short }}"
+          username: admin
+          password: admin
+
+    - name: Ensure a text Record does not exist
+      nios_txt_record:
+        name: fqdn.txt.record.com
+        text: mytext
+        state: absent
+        view: External
+        provider:
+          host: "{{ inventory_hostname_short }}"
+          username: admin
+          password: admin
+'''
+
+RETURN = ''' # '''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.six import iteritems
+from ansible.module_utils.net_tools.nios.api import WapiModule
+
+
+def main():
+    ''' Main entry point for module execution
+    '''
+
+    ib_spec = dict(
+        name=dict(required=True, ib_req=True),
+        view=dict(default='default', aliases=['dns_view'], ib_req=True),
+        text=dict(type='str'),
+        ttl=dict(type='int'),
+        extattrs=dict(type='dict'),
+        comment=dict(),
+    )
+
+    argument_spec = dict(
+        provider=dict(required=True),
+        state=dict(default='present', choices=['present', 'absent'])
+    )
+
+    argument_spec.update(ib_spec)
+    argument_spec.update(WapiModule.provider_spec)
+
+    module = AnsibleModule(argument_spec=argument_spec,
+                           supports_check_mode=True)
+
+    wapi = WapiModule(module)
+    result = wapi.run('record:txt', ib_spec)
+
+    module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/test/integration/targets/nios_txt_record/aliases
+++ b/test/integration/targets/nios_txt_record/aliases
@@ -1,4 +1,4 @@
+shippable/cloud/group1
 posix/ci/cloud/group4/nios
 cloud/nios
 destructive
- 

--- a/test/integration/targets/nios_txt_record/aliases
+++ b/test/integration/targets/nios_txt_record/aliases
@@ -1,0 +1,4 @@
+posix/ci/cloud/group4/nios
+cloud/nios
+destructive
+ 

--- a/test/integration/targets/nios_txt_record/defaults/main.yaml
+++ b/test/integration/targets/nios_txt_record/defaults/main.yaml
@@ -1,0 +1,3 @@
+---
+testcase: "*"
+test_items: []

--- a/test/integration/targets/nios_txt_record/meta/main.yaml
+++ b/test/integration/targets/nios_txt_record/meta/main.yaml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_nios_tests

--- a/test/integration/targets/nios_txt_record/tasks/main.yml
+++ b/test/integration/targets/nios_txt_record/tasks/main.yml
@@ -1,0 +1,1 @@
+- include: nios_txt_record_idempotence.yml

--- a/test/integration/targets/nios_txt_record/tasks/nios_txt_record_idempotence.yml
+++ b/test/integration/targets/nios_txt_record/tasks/nios_txt_record_idempotence.yml
@@ -1,0 +1,80 @@
+- name: cleanup the parent object
+  nios_zone:
+    name: ansible.com
+    state: absent
+    provider: "{{ nios_provider }}"
+
+- name: create the parent object
+  nios_zone:
+    name: ansible.com
+    state: present
+    provider: "{{ nios_provider }}"
+
+- name: cleanup txt record
+  nios_txt_record:
+    name: txt.ansible.com
+    text: mytext  
+    state: absent
+    provider: "{{ nios_provider }}"
+
+- name: create txt record
+  nios_txt_record:
+    name: txt.ansible.com
+    text: mytext
+    state: present
+    provider: "{{ nios_provider }}"
+  register: txt_create1
+
+- name: create txt record
+  nios_txt_record:
+    name: txt.ansible.com
+    text: mytext
+    state: present
+    provider: "{{ nios_provider }}"
+  register: txt_create2
+
+- assert:
+    that:
+      - "txt_create1.changed"
+      - "not txt_create2.changed"
+
+- name: add a comment to an existing txt record
+  nios_txt_record:
+    name: txt.ansible.com
+    text: mytext
+    state: present
+    comment: mycomment
+    provider: "{{ nios_provider }}"
+  register: txt_update1
+
+- name: add a comment to an existing txt record
+  nios_txt_record:
+    name: txt.ansible.com
+    text: mytext
+    state: present
+    comment: mycomment
+    provider: "{{ nios_provider }}"
+  register: txt_update2
+
+- name: remove a txt record from the system
+  nios_txt_record:
+    name: txt.ansible.com
+    state: absent
+    provider: "{{ nios_provider }}"
+  register: txt_delete1
+
+- name: remove a txt record from the system
+  nios_txt_record:
+    name: txt.ansible.com
+    state: absent
+    provider: "{{ nios_provider }}"
+  register: txt_delete2
+
+- assert:
+    that:
+      - "txt_create1.changed"
+      - "not txt_create2.changed"
+      - "txt_update1.changed"
+      - "not txt_update2.changed"
+      - "txt_delete1.changed"
+      - "not txt_delete2.changed"


### PR DESCRIPTION
##### SUMMARY
This is adding support for managing Infoblox TXT Records.  This is helping us setup playbooks that enable letsencrypt dns challenge on an Infoblox platform.

##### ISSUE TYPE
 - New Module Pull Request

##### COMPONENT NAME
nios_txt_record

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0
  config file = None
  configured module search path = [u'/Users/wanlessc/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/Cellar/ansible/2.5.0/libexec/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 15:04:47) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
