### PR TITLE
Add memory_usage callback plugin used to profile memory

### DIFF
--- a/lib/ansible/plugins/callback/memory_usage.py
+++ b/lib/ansible/plugins/callback/memory_usage.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+# (c) 2018, Hideki Saito <saito@fgrep.org>
+# GNU General Public License v3.0+
+#  (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.plugins.callback import CallbackBase
+
+import psutil as ps
+
+DOCUMENTATION = '''
+    callback: memory_usage
+    callback_type: aggregate
+    requirements:
+        - whitelist in configuration
+        - ps_utils
+    short_description: Show memory usage of tasks and handlers
+    version_added: "2.6"
+    description:
+        - This is an ansible callback plugin that profiling memory usage
+        - This plugin measures and displays simple memory usage information
+        - It is implemented as a decorator in task and handler execution
+'''
+
+
+def _convert_unit(usage):
+    """
+    Convert memory usage to MiB
+    """
+    mib = usage / 1024 / 1024
+    return mib
+
+
+def profiling(f=None):
+    """
+    Decorator that will run the function and print a line-by-line profile
+    """
+    def wrapper(*args, **kwargs):
+        proc = ps.Process()
+        val = f(*args, **kwargs)
+        results = []
+        rss, vms, pfaults, pageins = proc.memory_info()
+        print(
+            "Memory Usage: rss({rss:.4f})MiB vms({vms:.4f})MiB "
+            "pfaults({pfaults:d}) pageins({pageins:d}) @{func}"
+            .format(
+                rss=_convert_unit(rss),
+                vms=_convert_unit(vms),
+                pfaults=pfaults,
+                pageins=pageins,
+                func=f.__name__))
+        return val
+
+    return wrapper
+
+
+class CallbackModule(CallbackBase):
+    """
+    This callback module tells you how long your plays ran for.
+    """
+    CALLBACK_VERSION = 2.0
+    CALLBACK_TYPE = 'aggregate'
+    CALLBACK_NAME = 'memory_usage'
+    CALLBACK_NEEDS_WHITELIST = True
+
+    def __init__(self):
+        super(CallbackModule, self).__init__()
+
+    @profiling
+    def v2_playbook_on_start(self, playbook):
+        pass
+
+    @profiling
+    def v2_playbook_on_task_start(self, task, is_conditional):
+        pass
+
+    @profiling
+    def v2_playbook_on_handler_task_start(self, task):
+        pass
+
+#
+# [EOF]
+#

--- a/test/runner/requirements/units.txt
+++ b/test/runner/requirements/units.txt
@@ -28,3 +28,6 @@ pyfmg
 
 # requirement for aci_rest module
 xmljson
+
+# requirement for memory_usage callback module
+psutil


### PR DESCRIPTION
* Add memory_usage plugin used to profile memory in each tasks

##### SUMMARY
memory_usage plugin is using python psutil module and it shows memory usage information of each tasks and handlers.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
- lib/ansible/plugins/callback/memory_usage.py

##### ANSIBLE VERSION
```
Devel
```

##### REQUIREMENTS
- psutil

##### Configuration
```
[defaults]
callback_whitelist = memory_usage
```

##### Example output of Playbook
```
$ ansible-playbook -i inventory test.yml
Memory Usage: rss(46.4727)MiB vms(4237.7969)MiB pfaults(16557) pageins(0) @v2_playbook_on_start

PLAY [all] ******************************************************************************************

TASK [Gathering Facts] ******************************************************************************
Memory Usage: rss(47.8867)MiB vms(4242.8203)MiB pfaults(17095) pageins(0) @v2_playbook_on_task_start
ok: [127.0.0.1]

TASK [include_role] *********************************************************************************
Memory Usage: rss(48.2539)MiB vms(4243.0703)MiB pfaults(18763) pageins(0) @v2_playbook_on_task_start

TASK [test : ping] **********************************************************************************
Memory Usage: rss(48.3281)MiB vms(4243.0703)MiB pfaults(20443) pageins(0) @v2_playbook_on_task_start
ok: [127.0.0.1] => {"changed": false, "failed": false, "ping": "pong"}

PLAY RECAP ******************************************************************************************
127.0.0.1                  : ok=2    changed=0    unreachable=0    failed=0
```
