### PR TITLE
Add start and end timestamp to task and play result in json callback

### DIFF
--- a/lib/ansible/plugins/callback/json.py
+++ b/lib/ansible/plugins/callback/json.py
@@ -64,7 +64,9 @@ class CallbackModule(CallbackBase):
                 'id': str(task._uuid)
             },
             'hosts': {},
-            'start': '%sZ' % datetime.datetime.utcnow().isoformat()
+            'duration': {
+                'start': '%sZ' % datetime.datetime.utcnow().isoformat()
+            }
         }
 
     def v2_playbook_on_play_start(self, play):
@@ -113,7 +115,7 @@ class CallbackModule(CallbackBase):
         task_result['action'] = task.action
         self.results[-1]['tasks'][-1]['hosts'][host.name] = task_result
         end_time = '%sZ' % datetime.datetime.utcnow().isoformat()
-        self.results[-1]['tasks'][-1]['end'] = end_time
+        self.results[-1]['tasks'][-1]['duration']['end'] = end_time
 
     def __getattribute__(self, name):
         """Return ``_record_task_result`` partial with a dict containing skipped/failed if necessary"""

--- a/lib/ansible/plugins/callback/json.py
+++ b/lib/ansible/plugins/callback/json.py
@@ -64,7 +64,7 @@ class CallbackModule(CallbackBase):
                 'id': str(task._uuid)
             },
             'hosts': {},
-            'start': datetime.datetime.utcnow().isoformat()
+            'start': '%sZ' % datetime.datetime.utcnow().isoformat()
         }
 
     def v2_playbook_on_play_start(self, play):
@@ -112,7 +112,7 @@ class CallbackModule(CallbackBase):
         task_result.update(on_info)
         task_result['action'] = task.action
         self.results[-1]['tasks'][-1]['hosts'][host.name] = task_result
-        end_time = datetime.datetime.utcnow().isoformat()
+        end_time = '%sZ' % datetime.datetime.utcnow().isoformat()
         self.results[-1]['tasks'][-1]['end'] = end_time
 
     def __getattribute__(self, name):

--- a/lib/ansible/plugins/callback/json.py
+++ b/lib/ansible/plugins/callback/json.py
@@ -29,6 +29,7 @@ DOCUMENTATION = '''
         type: bool
 '''
 
+import datetime
 import json
 
 from functools import partial
@@ -62,7 +63,8 @@ class CallbackModule(CallbackBase):
                 'name': task.get_name(),
                 'id': str(task._uuid)
             },
-            'hosts': {}
+            'hosts': {},
+            'start': datetime.datetime.utcnow().isoformat()
         }
 
     def v2_playbook_on_play_start(self, play):
@@ -110,6 +112,8 @@ class CallbackModule(CallbackBase):
         task_result.update(on_info)
         task_result['action'] = task.action
         self.results[-1]['tasks'][-1]['hosts'][host.name] = task_result
+        end_time = datetime.datetime.utcnow().isoformat()
+        self.results[-1]['tasks'][-1]['end'] = end_time
 
     def __getattribute__(self, name):
         """Return ``_record_task_result`` partial with a dict containing skipped/failed if necessary"""


### PR DESCRIPTION
##### SUMMARY
Currently, the timestamp information is only provided directly by a few
Ansible modules (e.g. the command module, which shows the runtime of a
command per host result).
This change adds an 'overall' time information to all executed tasks. The
delta between both timestamps shows how long it took a task to finish
across all hosts/nodes.

Update: This information is now also available for plays.

This patch is also proposed for zuul and can be found here:
https://review.openstack.org/#/c/563888

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
lib/ansible/plugins/callback/json.py

##### ANSIBLE VERSION
```
2.6devel
```
