### PR TITLE
VMware: correct comparison for guest_id

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -699,7 +699,8 @@ class PyVmomiHelper(PyVmomi):
         if vm_creation and self.params['guest_id'] is None:
             self.module.fail_json(msg="guest_id attribute is mandatory for VM creation")
 
-        if self.params['guest_id'] and (vm_obj is None or self.params['guest_id'] != vm_obj.summary.config.guestId):
+        if self.params['guest_id'] and \
+                (vm_obj is None or self.params['guest_id'].lower() != vm_obj.summary.config.guestId.lower()):
             self.change_detected = True
             self.configspec.guestId = self.params['guest_id']
 


### PR DESCRIPTION
##### SUMMARY
This fix corrects the comparison of system generated guest_id with
user provided guest_id. Module used to report change even if the
guest_ids were same. For example, user provided guest id rhel7_64guest
and VMware returned guest id rhel7_64Guest are logically same but
 lexicographically different and due to this module use to report
change even if there is no change applied.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/vmware/vmware_guest.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6devel
```