### PR TITLE
Add support for NRDP notifications

### DIFF
--- a/lib/ansible/plugins/callback/nrdp.py
+++ b/lib/ansible/plugins/callback/nrdp.py
@@ -135,9 +135,6 @@ class CallbackModule(CallbackBase):
                 data=urlencode(body),
                 method='POST',
                 validate_certs=False)
-#            if not response.ok:
-#                self._display.warning("NRDP callback cannot send result.")
-#            self._display.warning(response.read())
             return response.read()
         except Exception as ex:
             self._display.warning("NRDP callback cannot send result {0}".format(ex))

--- a/lib/ansible/plugins/callback/nrdp.py
+++ b/lib/ansible/plugins/callback/nrdp.py
@@ -25,6 +25,14 @@ DOCUMENTATION = '''
             ini:
                 - section: callback_nrdp
                   key: url
+        validate_nrdp_certs:
+            description: (bool) validate the SSL certificate of the nrdp server. (For HTTPS url)
+            env:
+                - name: NRDP_VALIDATE_CERTS
+            ini:
+                - section: callback_nrdp
+                  key: validate_nrdp_certs
+            default: False
         token:
             description: token to be allowed to push nrdp events
             required: True
@@ -91,6 +99,7 @@ class CallbackModule(CallbackBase):
         self.token = self.get_option('token')
         self.hostname = self.get_option('hostname')
         self.servicename = self.get_option('servicename')
+        self.validate_nrdp_certs = self.get_option('validate_nrdp_certs')
 
         if (self.url or self.token or self.hostname or
                 self.servicename) is None:
@@ -134,7 +143,7 @@ class CallbackModule(CallbackBase):
             response = open_url(self.url,
                 data=urlencode(body),
                 method='POST',
-                validate_certs=False)
+                validate_certs=self.validate_nrdp_certs)
             return response.read()
         except Exception as ex:
             self._display.warning("NRDP callback cannot send result {0}".format(ex))

--- a/lib/ansible/plugins/callback/nrdp.py
+++ b/lib/ansible/plugins/callback/nrdp.py
@@ -15,7 +15,7 @@ DOCUMENTATION = '''
         - this callback send playbook result to nagios
         - nagios shall use NRDP to recive passive events
         - the passive check is sent to a dedicated host/service for ansible
-    version_added: 2.7
+    version_added: 2.8
     options:
         url:
             description: url of the nrdp server

--- a/lib/ansible/plugins/callback/nrdp.py
+++ b/lib/ansible/plugins/callback/nrdp.py
@@ -133,7 +133,7 @@ class CallbackModule(CallbackBase):
         xmldata += "</checkresult>\n"
         xmldata += "</checkresults>\n"
 
-        body={
+        body = {
             'cmd': 'submitcheck',
             'token': self.token,
             'XMLDATA': bytes(xmldata)
@@ -141,9 +141,9 @@ class CallbackModule(CallbackBase):
 
         try:
             response = open_url(self.url,
-                data=urlencode(body),
-                method='POST',
-                validate_certs=self.validate_nrdp_certs)
+                                data=urlencode(body),
+                                method='POST',
+                                validate_certs=self.validate_nrdp_certs)
             return response.read()
         except Exception as ex:
             self._display.warning("NRDP callback cannot send result {0}".format(ex))

--- a/lib/ansible/plugins/callback/nrdp.py
+++ b/lib/ansible/plugins/callback/nrdp.py
@@ -155,8 +155,8 @@ class CallbackModule(CallbackBase):
             stat = stats.summarize(host)
             gstats += "'%s_ok'=%d '%s_changed'=%d \
                        '%s_unreachable'=%d '%s_failed'=%d " % \
-                        (host, stat['ok'], host, stat['changed'],
-                         host, stat['unreachable'], host, stat['failures'])
+                (host, stat['ok'], host, stat['changed'],
+                 host, stat['unreachable'], host, stat['failures'])
             # Critical when failed tasks or unreachable host
             critical += stat['failures']
             critical += stat['unreachable']

--- a/lib/ansible/plugins/callback/nrdp.py
+++ b/lib/ansible/plugins/callback/nrdp.py
@@ -1,0 +1,171 @@
+# -*- coding: utf-8 -*-
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+DOCUMENTATION = '''
+    callback: nrdp
+    type: notification
+    author: "Remi VERCHERE (@rverchere)"
+    short_description: post task result to a nagios server through nrdp
+    description:
+        - this callback send playbook result to nagios
+        - nagios shall use NRDP to recive passive events
+        - the passive check is sent to a dedicated host/service for ansible
+    version_added: 2.5
+    requirements:
+        - requests
+    options:
+        url:
+            description: url of the nrdp server
+            required: True
+            env:
+                - name : NRDP_URL
+        token:
+            description: token to be allowed to push nrdp events
+            required: True
+            env:
+                - name: NRDP_TOKEN
+        hostname:
+            description: hostname where the passive check is linked to
+            required: True
+            env:
+                - name : NRDP_ANSIBLE_HOSTNAME
+        servicename:
+            description: service where the passive check is linked to
+            required: True
+            env:
+                - name : NRDP_ANSIBLE_SERVICENAME
+'''
+
+import os
+
+try:
+    import requests
+    HAS_REQUESTS = True
+except ImportError:
+    HAS_REQUESTS = False
+
+from ansible.plugins.callback import CallbackBase
+
+class CallbackModule(CallbackBase):
+    '''
+    send ansible-playbook to Nagios server using nrdp protocol
+    '''
+
+    CALLBACK_VERSION = 2.0
+    CALLBACK_TYPE = 'notification'
+    CALLBACK_NAME = 'nrdp'
+    CALLBACK_NEEDS_WHITELIST = True
+
+    # Nagios states
+    OK = 0
+    WARNING = 1
+    CRITICAL = 2
+    UNKNOWN = 3
+
+    def __init__(self):
+        super(CallbackModule, self).__init__()
+
+        if not HAS_REQUESTS:
+            self._display.warning(
+                "The required python requests library is not installed."
+                " The NRDP callback plugin is disabled.")
+            self.disabled = True
+
+        self.url = os.getenv("NRDP_URL")
+        if not self.url.endswith('/'):
+            self.url += '/'
+        self.token = os.getenv("NRDP_TOKEN")
+        self.hostname = os.getenv("NRDP_ANSIBLE_HOSTNAME")
+        self.servicename = os.getenv("NRDP_ANSIBLE_SERVICENAME")
+
+        if (self.url or self.token or self.hostname or
+                self.servicename) is None:
+            self._display.warning("NRDP callback wants the NRDP_URL,"
+                " NRDP_TOKEN, NRDP_ANSIBLE_HOSTNAME, NRDP_ANSIBLE_SERVICENAME"
+                " environment variables'."
+                " The NRDP callback plugin is disabled.")
+            self.disabled = True
+
+        self.play = None
+
+    def _send_nrdp(self, state, msg):
+        '''
+        nrpd service check send XMLDATA like this:
+        <?xml version='1.0'?>
+            <checkresults>
+                <checkresult type='service'>
+                    <hostname>somehost</hostname>
+                    <servicename>someservice</servicename>
+                    <state>1</state>
+                    <output>WARNING: Danger Will Robinson!|perfdata</output>
+                </checkresult>
+            </checkresults>
+        '''
+        xmldata = "<?xml version='1.0'?>\n"
+        xmldata += "<checkresults>\n"
+        xmldata += "<checkresult type='service'>\n"
+        xmldata += "<hostname>%s</hostname>\n" % self.hostname
+        xmldata += "<servicename>%s</servicename>\n" % self.servicename
+        xmldata += "<state>%d</state>\n" % state
+        xmldata += "<output>%s</output>\n" % msg
+        xmldata += "</checkresult>\n"
+        xmldata += "</checkresults>\n"
+
+        try:
+            # disable urllib3 and ssl warnings
+            if hasattr(requests.packages.urllib3, 'disable_warnings'):
+                requests.packages.urllib3.disable_warnings()
+            response = requests.post(
+                self.url,
+                data={
+                    'cmd': 'submitcheck',
+                    'token': self.token,
+                    'XMLDATA': bytes(xmldata)
+                },
+                verify=False,
+                stream=False
+            )
+            if not response.ok:
+                self._display.warning("NRDP callback cannot send result.")
+        except:
+            self._display.warning("NRDP callback cannot send result.")
+
+    def v2_playbook_on_play_start(self, play):
+        '''
+        Display Playbook and play start messages
+        '''
+        self.play = play
+
+    def v2_playbook_on_stats(self, stats):
+        '''
+        Display info about playbook statistics
+        '''
+        name = self.play
+        gstats = ""
+        hosts = sorted(stats.processed.keys())
+        critical = warning = 0
+        for host in hosts:
+            stat = stats.summarize(host)
+            gstats += "'%s_ok'=%d '%s_changed'=%d \
+                      '%s_unreachable'=%d '%s_failed'=%d " % \
+                        (host, stat['ok'], host, stat['changed'],
+                         host, stat['unreachable'], host, stat['failures'])
+            # Critical when failed tasks or unreachable host
+            critical += stat['failures']
+            critical += stat['unreachable']
+            # Warning when changed tasks
+            warning += stat['changed']
+
+        msg = "%s|%s" % (name, gstats)
+        if critical:
+            # Send Critical
+            self._send_nrdp(self.CRITICAL, msg)
+        elif warning:
+            # Send Warning
+            self._send_nrdp(self.WARNING, msg)
+        else:
+            # Send OK
+            self._send_nrdp(self.OK, msg)

--- a/lib/ansible/plugins/callback/nrdp.py
+++ b/lib/ansible/plugins/callback/nrdp.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+# (c) 2018 Remi Verchere <remi@verchere.fr>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 # Make coding more python3-ish
 from __future__ import (absolute_import, division, print_function)
@@ -49,6 +51,7 @@ except ImportError:
 
 from ansible.plugins.callback import CallbackBase
 
+
 class CallbackModule(CallbackBase):
     '''
     send ansible-playbook to Nagios server using nrdp protocol
@@ -84,9 +87,10 @@ class CallbackModule(CallbackBase):
         if (self.url or self.token or self.hostname or
                 self.servicename) is None:
             self._display.warning("NRDP callback wants the NRDP_URL,"
-                " NRDP_TOKEN, NRDP_ANSIBLE_HOSTNAME, NRDP_ANSIBLE_SERVICENAME"
-                " environment variables'."
-                " The NRDP callback plugin is disabled.")
+                                  " NRDP_TOKEN, NRDP_ANSIBLE_HOSTNAME,"
+                                  " NRDP_ANSIBLE_SERVICENAME"
+                                  " environment variables'."
+                                  " The NRDP callback plugin is disabled.")
             self.disabled = True
 
         self.play = None
@@ -150,7 +154,7 @@ class CallbackModule(CallbackBase):
         for host in hosts:
             stat = stats.summarize(host)
             gstats += "'%s_ok'=%d '%s_changed'=%d \
-                      '%s_unreachable'=%d '%s_failed'=%d " % \
+                       '%s_unreachable'=%d '%s_failed'=%d " % \
                         (host, stat['ok'], host, stat['changed'],
                          host, stat['unreachable'], host, stat['failures'])
             # Critical when failed tasks or unreachable host

--- a/lib/ansible/plugins/callback/nrdp.py
+++ b/lib/ansible/plugins/callback/nrdp.py
@@ -15,7 +15,7 @@ DOCUMENTATION = '''
         - this callback send playbook result to nagios
         - nagios shall use NRDP to recive passive events
         - the passive check is sent to a dedicated host/service for ansible
-    version_added: 2.6
+    version_added: 2.7
     requirements:
         - requests
     options:

--- a/lib/ansible/plugins/callback/nrdp.py
+++ b/lib/ansible/plugins/callback/nrdp.py
@@ -15,7 +15,7 @@ DOCUMENTATION = '''
         - this callback send playbook result to nagios
         - nagios shall use NRDP to recive passive events
         - the passive check is sent to a dedicated host/service for ansible
-    version_added: 2.5
+    version_added: 2.6
     requirements:
         - requests
     options:


### PR DESCRIPTION
##### SUMMARY

Adding callback that sends ansible-playbook result to a Nagios server using NRDP.

All of the information is sent as one service for one host. This service is dedicated for ansible results.

The Nagios states are:

* CRITICAL: one of the playbook tasks failed or host is unreachable
* WARNING: one of playbook tasts changed
* OK: every playbook tasks are ok

Performance data are splitted by hosts and result type (ok, changed, unreachable, failed).

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME

nrdp callback

##### ANSIBLE VERSION
```
ansible 2.5.1
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/rverchere/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.15rc1 (default, Apr 15 2018, 21:51:34) [GCC 7.3.0]
```

##### ADDITIONAL INFORMATION

You must have a working Nagios server using NRDP to accept remote events.<br/>
You also must have a servicename defined for playbook results.

The callback uses environment variables to send results:

* `NRDP_URL` : nrdp url (i.e. `http://192.168.1.10/nrdp/`)
* `NRDP_TOKEN`: nrdp token to allow post data
* `NRDP_ANSIBLE_HOSTNAME`: hostname for the Nagios check
* `NRDP_ANSIBLE_SERVICENAME`: servicename for the Nagios check
