### PR TITLE
[AWS] report boto3/botocore versions during `fail_json_aws`

### DIFF
--- a/lib/ansible/module_utils/aws/core.py
+++ b/lib/ansible/module_utils/aws/core.py
@@ -188,7 +188,8 @@ class AnsibleAWSModule(object):
         """
         if not HAS_BOTO3:
             return 'NaN', 'NaN'
-        import boto3, botocore
+        import boto3
+        import botocore
         return boto3.__version__, botocore.__version__
 
 

--- a/lib/ansible/module_utils/aws/core.py
+++ b/lib/ansible/module_utils/aws/core.py
@@ -169,11 +169,27 @@ class AnsibleAWSModule(object):
         except AttributeError:
             response = None
 
+        boto3_version, botocore_version = self._gather_versions()
         if response is None:
-            self._module.fail_json(msg=message, exception=last_traceback)
+            self._module.fail_json(msg=message, exception=last_traceback,
+                                   boto3_version=boto3_version,
+                                   botocore_version=botocore_version)
         else:
             self._module.fail_json(msg=message, exception=last_traceback,
+                                   boto3_version=boto3_version,
+                                   botocore_version=botocore_version,
                                    **camel_dict_to_snake_dict(response))
+
+    def _gather_versions(self):
+        """Gather AWS SDK dependency versions
+
+        Returns (str, str) of boto3 and botocore versions
+        Returns ('NaN', 'NaN') if neither are installed
+        """
+        if not HAS_BOTO3:
+            return 'NaN', 'NaN'
+        import boto3, botocore
+        return boto3.__version__, botocore.__version__
 
 
 class _RetryingBotoClientWrapper(object):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

When modules call `fail_json_aws` and boto3 is installed, gather the
boto3 and botocore versions so that any new AWS module issues will
include the user's boto3 installation info. This will make debugging
issues where features aren't available yet easier.

For example, it would have made it easier to determine the source of https://github.com/ansible/ansible/pull/39085


<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
AnsibleAWSModule

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0 (export-boto-version-on-fail 2edfef8ade) last updated 2018/04/25 10:31:59 (GMT -400)
  config file = None
  configured module search path = [u'/home/ryansb/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /tmp/ansible/lib/ansible
  executable location = /tmp/ansible/bin/ansible
  python version = 2.7.12 (default, Sep 27 2016, 18:08:33) [GCC 6.2.1 20160916 (Red Hat 6.2.1-2)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
fatal: [localhost]: FAILED! => {                                                                         
    "boto3_version": "1.6.11",                                           
    "botocore_version": "1.9.11",                                                                        
    "changed": false,           
    "invocation": { 
      "module_args": {  
            "aws_access_key": null,                                                                      
            "aws_secret_key": null,                     
            "cidr_block": [                                                                              
                "20.0.0.0/24"                                                                            
            ],                  
            "dhcp_opts_id": null,                   
            "dns_hostnames": true,
            "dns_support": true,
            "ec2_url": null,
            "multi_ok": false,
            "name": "ansible-test-hornet-45732673",
            "profile": null,
            "purge_cidrs": false,
            "region": "us-east-1",
            "security_token": null,
            "state": "present",
            "tags": null,
            "tenancy": "default",
            "validate_certs": true
        }
    },
    "msg": "Failed to describe VPCs: Unable to locate credentials"
}
```

