### PR TITLE
Added an option to change the root directory apk installs to

### DIFF
--- a/lib/ansible/modules/packaging/os/apk.py
+++ b/lib/ansible/modules/packaging/os/apk.py
@@ -61,8 +61,8 @@ options:
   root:
     description:
       - Install the packages to the specified directory
-        type: str
-        default: ""
+    type: str
+    default: ""
     version_added: "2.5"
 notes:
   - '"name" and "upgrade" are mutually exclusive.'

--- a/lib/ansible/modules/packaging/os/apk.py
+++ b/lib/ansible/modules/packaging/os/apk.py
@@ -134,8 +134,8 @@ EXAMPLES = '''
 
 # Install package to directory
 - apk:
-  name: foo
-  root: /tmp
+      name: foo
+      root: /tmp
 '''
 
 RETURN = '''

--- a/lib/ansible/modules/packaging/os/apk.py
+++ b/lib/ansible/modules/packaging/os/apk.py
@@ -333,9 +333,9 @@ def main():
     if p['repository']:
         for r in p['repository']:
             APK_PATH = "%s --repository %s --repositories-file /dev/null" % (APK_PATH, r)
-            
+
     if p['root']:
-      APK_PATH = "%s --root %s" % (APK_PATH, p['root'])
+        APK_PATH = "%s --root %s" % (APK_PATH, p['root'])
 
     # normalize the state parameter
     if p['state'] in ['present', 'installed']:

--- a/lib/ansible/modules/packaging/os/apk.py
+++ b/lib/ansible/modules/packaging/os/apk.py
@@ -58,6 +58,12 @@ options:
       - Upgrade all installed packages to their latest version.
     type: bool
     default: 'no'
+  root:
+    description:
+      - Install the packages to the specified directory
+        type: str
+        default: ""
+    version_added: "2.5"
 notes:
   - '"name" and "upgrade" are mutually exclusive.'
   - When used with a `loop:` each package will be processed individually, it is much more efficient to pass the list directly to the `name` option.
@@ -125,6 +131,11 @@ EXAMPLES = '''
     state: latest
     update_cache: yes
     repository: http://dl-3.alpinelinux.org/alpine/edge/main
+
+# Install package to directory
+- apk:
+  name: foo
+  root: /tmp
 '''
 
 RETURN = '''
@@ -303,6 +314,7 @@ def main():
             update_cache=dict(default='no', type='bool'),
             upgrade=dict(default='no', type='bool'),
             available=dict(default='no', type='bool'),
+            root=dict(default="", type='str')
         ),
         required_one_of=[['name', 'update_cache', 'upgrade']],
         mutually_exclusive=[['name', 'upgrade']],
@@ -321,6 +333,9 @@ def main():
     if p['repository']:
         for r in p['repository']:
             APK_PATH = "%s --repository %s --repositories-file /dev/null" % (APK_PATH, r)
+            
+    if p['root']:
+      APK_PATH = "%s --root %s" % (APK_PATH, p['root'])
 
     # normalize the state parameter
     if p['state'] in ['present', 'installed']:

--- a/lib/ansible/modules/packaging/os/apk.py
+++ b/lib/ansible/modules/packaging/os/apk.py
@@ -61,9 +61,8 @@ options:
   root:
     description:
       - Install the packages to the specified directory
-    type: str
     default: ""
-    version_added: "2.5"
+    version_added: "2.6"
 notes:
   - '"name" and "upgrade" are mutually exclusive.'
   - When used with a `loop:` each package will be processed individually, it is much more efficient to pass the list directly to the `name` option.


### PR DESCRIPTION
##### SUMMARY
I needed to set up a chroot with busybox in it.
The best way to do so it to use apk to install busybox in a different root.
This PR adds that capability.
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
apk
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.1
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/omer/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.14 (default, Sep 23 2017, 22:06:14) [GCC 7.2.0]
```


##### ADDITIONAL INFORMATION
None
