### PR TITLE
fixes broken links in Amazon module docs (#39248)

### DIFF
--- a/lib/ansible/modules/cloud/amazon/_ec2_vpc.py
+++ b/lib/ansible/modules/cloud/amazon/_ec2_vpc.py
@@ -22,7 +22,7 @@ deprecated:
   removed_in: "2.5"
   why: Replaced by dedicated modules.
   alternative: Use M(ec2_vpc_net) along with supporting modules including M(ec2_vpc_igw), M(ec2_vpc_route_table), M(ec2_vpc_subnet),
-               M(ec2_vpc_dhcp_options), M(ec2_vpc_nat_gateway), M(ec2_vpc_nacl).
+               M(ec2_vpc_dhcp_option), M(ec2_vpc_nat_gateway), M(ec2_vpc_nacl).
 options:
   cidr_block:
     description:

--- a/lib/ansible/modules/cloud/amazon/aws_s3.py
+++ b/lib/ansible/modules/cloud/amazon/aws_s3.py
@@ -28,7 +28,7 @@ description:
       deleting both objects and buckets, retrieving objects as files or strings and generating download links.
       This module has a dependency on boto3 and botocore.
 notes:
-   - In 2.4, this module has been renamed from M(s3) into M(aws_s3).
+   - In 2.4, this module has been renamed from C(s3) into M(aws_s3).
 version_added: "1.1"
 options:
   aws_access_key:


### PR DESCRIPTION
(cherry picked from commit 0d38c80395bff5c4f2e97e5c71676c3997c812cb)

##### SUMMARY
As part of making all rST warnings fatal on Shippable, we are eliminating warnings from the docs build. This PR addresses two of these, both in the Amazon module docs:

The documentation for the aws_s3 module contains a link to its old name, triggering a WARNING: undefined label error. This PR retains the text but removes the link.
The documentation for the ec2_vpc module refers to the deprecated ec2_vps_dhcp_options module (instead of the current version, which has no s on option). This PR redirects that link to the current module name.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
docs.ansible.com

##### ANSIBLE VERSION
2.5
