### PR TITLE
removes broken link to old module name (#39249)

### DIFF
--- a/lib/ansible/modules/notification/say.py
+++ b/lib/ansible/modules/notification/say.py
@@ -21,7 +21,7 @@ short_description: Makes a computer to speak.
 description:
    - makes a computer speak! Amuse your friends, annoy your coworkers!
 notes:
-   - In 2.5, this module has been renamed from M(osx_say) into M(say).
+   - In 2.5, this module has been renamed from C(osx_say) to M(say).
    - If you like this module, you may also be interested in the osx_say callback plugin.
 options:
   msg:


### PR DESCRIPTION
##### SUMMARY
As part of making all rST warnings fatal on Shippable, we are eliminating warnings from the docs build. This PR addresses one of these:

The documentation for the say module contains a link to its old name, triggering a WARNING: undefined label error. This PR retains the text but removes the link.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
docs.ansible.com

##### ANSIBLE VERSION
2.5
