### PR TITLE
Update win_get_url.py to show ftp examples

### DIFF
--- a/lib/ansible/modules/windows/win_get_url.py
+++ b/lib/ansible/modules/windows/win_get_url.py
@@ -15,9 +15,9 @@ DOCUMENTATION = r'''
 ---
 module: win_get_url
 version_added: "1.7"
-short_description: Fetches a file from a given URL
+short_description: Fetches a file from a given URL or FTP
 description:
-- Fetches a file from a URL and saves it locally.
+- Fetches a file from a URL or FTP and saves it locally.
 - For non-Windows targets, use the M(get_url) module instead.
 author:
 - Paul Durivage (@angstwad)
@@ -124,6 +124,14 @@ EXAMPLES = r'''
     proxy_url: http://10.0.0.1:8080
     proxy_username: username
     proxy_password: password
+
+# Attention here: MS doesn't allow format ftp://username:password@ftp.yourserver.com/earthrise.jpg
+- name: Download earthrise.jpg from FTP server to specified path
+  win_get_url:
+    url: ftp://ftp.yourserver.com/earthrise.jpg
+    dest: C:\earthrise.jpg
+    url_username: username
+    url_password: password
 '''
 
 RETURN = r'''


### PR DESCRIPTION
Adding examples how to use win_get_url with FTP

+label: docsite_pr

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Adding examples how to use win_get_url with FTP
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
win_get_url

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0
  config file = None
  configured module search path = [u'/Users/mateus/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mateus/Library/Python/2.7/lib/python/site-packages/ansible
  executable location = /Users/mateus//Library/Python/2.7/bin/ansible
  python version = 2.7.14 (default, Sep 25 2017, 09:53:22) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.37)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
