### PR TITLE
Update the cloudstack test container reference.

### DIFF
--- a/test/runner/lib/cloud/cs.py
+++ b/test/runner/lib/cloud/cs.py
@@ -53,7 +53,7 @@ class CsCloudProvider(CloudProvider):
         super(CsCloudProvider, self).__init__(args, config_extension='.ini')
 
         # The simulator must be pinned to a specific version to guarantee CI passes with the version used.
-        self.image = 'ansible/ansible:cloudstack-simulator@sha256:885aedb7f34ce7114eaa383a2541ede93c4f8cb543c05edf90b694def67b1a6a'
+        self.image = 'quay.io/ansible/cloudstack-test-container:1.0.0'
         self.container_name = ''
         self.endpoint = ''
         self.host = ''


### PR DESCRIPTION
##### SUMMARY

Update the cloudstack test container reference.

(cherry picked from commit ac1fbbeabc9aaac0c845849260719072e5f6506a)

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

test/runner/lib/cloud/cs.py

##### ANSIBLE VERSION

```
ansible 2.5.1 (cloudstack-2.5 37ffdced4d) last updated 2018/04/25 11:30:51 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
