### PR TITLE
Ensure timezone tests reset system timezone to UTC

### DIFF
--- a/test/integration/targets/timezone/tasks/main.yml
+++ b/test/integration/targets/timezone/tasks/main.yml
@@ -1,15 +1,21 @@
-- name: set timezone to Etc/UTC
-  timezone:
-    name: Etc/UTC
+- block:
+    - name: Set timezone to Etc/UTC
+      timezone:
+        name: Etc/UTC
+      register: original_timezone
 
-- name: set timezone to Australia/Brisbane
-  timezone:
-    name: Australia/Brisbane
-  register: timezone_set
+    - name: Set timezone to Australia/Brisbane
+      timezone:
+        name: Australia/Brisbane
+      register: timezone_set
 
-- name: ensure timezone changed
-  assert:
-    that:
-      - timezone_set.changed
-      - timezone_set.diff.after.name == 'Australia/Brisbane'
-      - timezone_set.diff.before.name == 'Etc/UTC'
+    - name: Ensure timezone changed
+      assert:
+        that:
+          - timezone_set is changed
+          - timezone_set.diff.after.name == 'Australia/Brisbane'
+          - timezone_set.diff.before.name == 'Etc/UTC'
+  always:
+    - name: Restore original system timezone - {{ original_timezone.diff.before.name }}
+      timezone:
+        name: "{{ original_timezone.diff.before.name }}"

--- a/test/integration/targets/timezone/tasks/main.yml
+++ b/test/integration/targets/timezone/tasks/main.yml
@@ -1,9 +1,9 @@
-- block:
-    - name: Set timezone to Etc/UTC
-      timezone:
-        name: Etc/UTC
-      register: original_timezone
+- name: Set timezone to Etc/UTC
+  timezone:
+    name: Etc/UTC
+  register: original_timezone
 
+- block:
     - name: Set timezone to Australia/Brisbane
       timezone:
         name: Australia/Brisbane


### PR DESCRIPTION
##### SUMMARY

The `timezone` tests changes the system timezone and does not set it back to UTC. Since the test instances are long-lived, this could cause problems for subsequent tests.

This change puts the test inside a block to ensure the timezone is always reset even if the `timezone` test fails.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
`/test/integration/targets/timezone/tasks/main.yml`

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6
```
