### PR TITLE
task_executor send the task as a kwarg to connections

### DIFF
--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -798,7 +798,7 @@ class TaskExecutor:
             conn_type,
             self._play_context,
             self._new_stdin,
-            task=self._task,
+            task_uuid=self._task._uuid,
             ansible_playbook_pid=to_text(os.getppid())
         )
 

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -794,7 +794,7 @@ class TaskExecutor:
 
         conn_type = self._play_context.connection
 
-        connection = self._shared_loader_obj.connection_loader.get(conn_type, self._play_context, self._new_stdin, ansible_playbook_pid=to_text(os.getppid()))
+        connection = self._shared_loader_obj.connection_loader.get(conn_type, self._play_context, self._new_stdin, task=self._task, ansible_playbook_pid=to_text(os.getppid()))
         if not connection:
             raise AnsibleError("the connection plugin '%s' was not found" % conn_type)
 

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -794,7 +794,14 @@ class TaskExecutor:
 
         conn_type = self._play_context.connection
 
-        connection = self._shared_loader_obj.connection_loader.get(conn_type, self._play_context, self._new_stdin, task=self._task, ansible_playbook_pid=to_text(os.getppid()))
+        connection = self._shared_loader_obj.connection_loader.get(
+            conn_type,
+            self._play_context,
+            self._new_stdin,
+            task=self._task,
+            ansible_playbook_pid=to_text(os.getppid())
+        )
+
         if not connection:
             raise AnsibleError("the connection plugin '%s' was not found" % conn_type)
 


### PR DESCRIPTION
##### SUMMARY
This allows connection plugins to retrieve context about the task. It further enables https://github.com/jctanner/ansible-vcr to not rely on a callback plugin to log the task info into an intermediate file.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
taskexecutor

##### ANSIBLE VERSION

```
2.6
```



