### PR TITLE
 Fixed issue of AD groups with hostname included

### DIFF
--- a/lib/ansible/modules/windows/win_group_membership.ps1
+++ b/lib/ansible/modules/windows/win_group_membership.ps1
@@ -133,7 +133,7 @@ function Get-GroupMember {
         $rootless_adspath = $current_member.Replace("WinNT://", "")
         $split_adspath = $rootless_adspath.Split("/")
 
-        if ($split_adspath -match $env:COMPUTERNAME) {
+        if ($split_adspath -match "^$env:COMPUTERNAME$") {
             # Local
             $parsed_member.domain = $env:COMPUTERNAME
             $parsed_member.username = $split_adspath[-1]


### PR DESCRIPTION
##### SUMMARY
Added a regex pattern for recognizing AD groups with hostname included in group name.
Without this change the playbook will throw an exception because it recognizes the AD group with the hostname in it as local group and trys to add this group over and over.

  failed: [yourhost.local] (item=LOCAL\la-yourhost) => {
    "added": [],
    "changed": false,
    "item": "LOCAL\\la-yourhost",
    "msg": "Exception calling \"Add\" with \"1\" argument(s): \"The specified account name is already a member of the group.\r\n\"",
    "name": "Administrators"
}

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
win_group_membership

##### ANSIBLE VERSION
```
ansible 2.4.2.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/users/myself/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /bin/ansible
  python version = 2.7.5 (default, May  3 2017, 07:55:04) [GCC 4.8.5 20150623 (Red Hat 4.8.5-14)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
