### PR TITLE
 Update TaskInclude _raw_params with the expanded/templated path to file

### DIFF
--- a/lib/ansible/playbook/included_file.py
+++ b/lib/ansible/playbook/included_file.py
@@ -144,6 +144,8 @@ class IncludedFile:
                                 include_file = loader.path_dwim(include_result['include'])
 
                         include_file = templar.template(include_file)
+                        # Update the task args to reflect the expanded/templated path
+                        original_task.args['_raw_params'] = include_file
                         inc_file = IncludedFile(include_file, include_variables, original_task)
                     else:
                         # template the included role's name here

--- a/test/integration/targets/include_import/include_path_inheritance/one/include_me.yml
+++ b/test/integration/targets/include_import/include_path_inheritance/one/include_me.yml
@@ -1,0 +1,2 @@
+- debug:
+    msg: one

--- a/test/integration/targets/include_import/include_path_inheritance/playbook.yml
+++ b/test/integration/targets/include_import/include_path_inheritance/playbook.yml
@@ -1,0 +1,14 @@
+- hosts: testhost:testhost2
+  tasks:
+    - set_fact:
+        include_me: one
+      when: inventory_hostname == ansible_play_hosts[0]
+
+    - set_fact:
+        include_me: two
+      when: inventory_hostname == ansible_play_hosts[1]
+
+    - debug:
+        var: include_me
+
+    - include_tasks: '{{ include_me }}/include_me.yml'

--- a/test/integration/targets/include_import/include_path_inheritance/two/include_me.yml
+++ b/test/integration/targets/include_import/include_path_inheritance/two/include_me.yml
@@ -1,0 +1,2 @@
+- debug:
+    msg: two

--- a/test/integration/targets/include_import/runme.sh
+++ b/test/integration/targets/include_import/runme.sh
@@ -63,3 +63,7 @@ ANSIBLE_STRATEGY='linear' ansible-playbook test_grandparent_inheritance.yml -i .
 # undefined_var
 ANSIBLE_STRATEGY='linear' ansible-playbook undefined_var/playbook.yml  -i ../../inventory "$@"
 ANSIBLE_STRATEGY='free' ansible-playbook undefined_var/playbook.yml  -i ../../inventory "$@"
+
+# Include path inheritance using host var for include file path
+ANSIBLE_STRATEGY='linear' ansible-playbook include_path_inheritance/playbook.yml  -i ../../inventory "$@"
+ANSIBLE_STRATEGY='free' ansible-playbook include_path_inheritance/playbook.yml  -i ../../inventory "$@"


### PR DESCRIPTION
##### SUMMARY

Update TaskInclude _raw_params with the expanded/templated path to file

Fixes https://github.com/ansible/ansible/issues/34665

Before this change, if a parent include used a hostvar in the path for the included file, an `AnsibleUndefinedVariable` error would happen, due to `ansible.playbook.helpers.load_list_of_tasks` not having host context.

This PR resolves this by updating `_raw_params` of `TaskInclude`s as their results are processed, so that `load_list_of_tasks` has an expanded/templated path.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/playbook/included_file.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
2.6
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```