### PR TITLE
Pull persistent connection parameters via get_option

### DIFF
--- a/bin/ansible-connection
+++ b/bin/ansible-connection
@@ -141,7 +141,8 @@ class ConnectionProcess(object):
             self.shutdown()
 
     def connect_timeout(self, signum, frame):
-        display.display('persistent connection idle timeout triggered, timeout value is %s secs' % self.connection.get_option('persistent_connect_timeout'), log_only=True)
+        display.display('persistent connection idle timeout triggered, timeout value is %s secs'
+                        % self.connection.get_option('persistent_connect_timeout'), log_only=True)
         self.shutdown()
 
     def command_timeout(self, signum, frame):

--- a/bin/ansible-connection
+++ b/bin/ansible-connection
@@ -107,7 +107,7 @@ class ConnectionProcess(object):
             while self.connection.connected:
                 signal.signal(signal.SIGALRM, self.connect_timeout)
                 signal.signal(signal.SIGTERM, self.handler)
-                signal.alarm(C.PERSISTENT_CONNECT_TIMEOUT)
+                signal.alarm(self.connection.get_option('persistent_connect_timeout'))
 
                 self.exception = None
                 (s, addr) = self.sock.accept()
@@ -141,7 +141,7 @@ class ConnectionProcess(object):
             self.shutdown()
 
     def connect_timeout(self, signum, frame):
-        display.display('persistent connection idle timeout triggered, timeout value is %s secs' % C.PERSISTENT_CONNECT_TIMEOUT, log_only=True)
+        display.display('persistent connection idle timeout triggered, timeout value is %s secs' % self.connection.get_option('persistent_connect_timeout'), log_only=True)
         self.shutdown()
 
     def command_timeout(self, signum, frame):

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -810,7 +810,7 @@ class TaskExecutor:
         self._play_context.set_options_from_plugin(connection)
 
         if any(((connection.supports_persistence and C.USE_PERSISTENT_CONNECTIONS), connection.force_persistence)):
-            self._play_context.timeout = C.PERSISTENT_COMMAND_TIMEOUT
+            self._play_context.timeout = connection.get_option('persistent_command_timeout')
             display.vvvv('attempting to start connection', host=self._play_context.remote_addr)
             display.vvvv('using connection plugin %s' % connection.transport, host=self._play_context.remote_addr)
             socket_path = self._start_connection()

--- a/lib/ansible/plugins/action/eos.py
+++ b/lib/ansible/plugins/action/eos.py
@@ -66,7 +66,7 @@ class ActionModule(_ActionModule):
                 pc.remote_user = provider['username'] or self._play_context.connection_user
                 pc.password = provider['password'] or self._play_context.password
                 pc.private_key_file = provider['ssh_keyfile'] or self._play_context.private_key_file
-                pc.timeout = int(provider['timeout'] or C.PERSISTENT_COMMAND_TIMEOUT)
+                pc.timeout = int(provider['timeout']) if provider['timeout'] else None
                 pc.become = provider['authorize'] or False
                 if pc.become:
                     pc.become_method = 'enable'
@@ -74,6 +74,9 @@ class ActionModule(_ActionModule):
 
                 display.vvv('using connection plugin %s (was local)' % pc.connection, pc.remote_addr)
                 connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin)
+
+                if connection._play_context.timeout is None:
+                    connection._play_context.timeout = connection.get_option('persistent_command_timeout')
 
                 socket_path = connection.run()
                 display.vvvv('socket_path: %s' % socket_path, pc.remote_addr)

--- a/lib/ansible/plugins/action/ios.py
+++ b/lib/ansible/plugins/action/ios.py
@@ -58,7 +58,7 @@ class ActionModule(_ActionModule):
             pc.remote_user = provider['username'] or self._play_context.connection_user
             pc.password = provider['password'] or self._play_context.password
             pc.private_key_file = provider['ssh_keyfile'] or self._play_context.private_key_file
-            pc.timeout = int(provider['timeout'] or C.PERSISTENT_COMMAND_TIMEOUT)
+            pc.timeout = int(provider['timeout']) if provider['timeout'] else None
             pc.become = provider['authorize'] or False
             if pc.become:
                 pc.become_method = 'enable'
@@ -66,6 +66,9 @@ class ActionModule(_ActionModule):
 
             display.vvv('using connection plugin %s (was local)' % pc.connection, pc.remote_addr)
             connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin)
+
+            if connection._play_context.timeout is None:
+                connection._play_context.timeout = connection.get_option('persistent_command_timeout')
 
             socket_path = connection.run()
             display.vvvv('socket_path: %s' % socket_path, pc.remote_addr)

--- a/lib/ansible/plugins/action/iosxr.py
+++ b/lib/ansible/plugins/action/iosxr.py
@@ -61,10 +61,13 @@ class ActionModule(_ActionModule):
             pc.port = int(provider['port'] or self._play_context.port or 22)
             pc.remote_user = provider['username'] or self._play_context.connection_user
             pc.password = provider['password'] or self._play_context.password
-            pc.timeout = int(provider['timeout'] or C.PERSISTENT_COMMAND_TIMEOUT)
+            pc.timeout = int(provider['timeout']) if provider['timeout'] else None
 
             display.vvv('using connection plugin %s (was local)' % pc.connection, pc.remote_addr)
             connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin)
+
+            if connection._play_context.timeout is None:
+                connection._play_context.timeout = connection.get_option('persistent_command_timeout')
 
             socket_path = connection.run()
             display.vvvv('socket_path: %s' % socket_path, pc.remote_addr)

--- a/lib/ansible/plugins/action/junos.py
+++ b/lib/ansible/plugins/action/junos.py
@@ -72,10 +72,13 @@ class ActionModule(_ActionModule):
             pc.remote_user = provider['username'] or self._play_context.connection_user
             pc.password = provider['password'] or self._play_context.password
             pc.private_key_file = provider['ssh_keyfile'] or self._play_context.private_key_file
-            pc.timeout = int(provider['timeout'] or C.PERSISTENT_COMMAND_TIMEOUT)
+            pc.timeout = int(provider['timeout']) if provider['timeout'] else None
 
             display.vvv('using connection plugin %s (was local)' % pc.connection, pc.remote_addr)
             connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin)
+
+            if connection._play_context.timeout is None:
+                connection._play_context.timeout = connection.get_option('persistent_command_timeout')
 
             socket_path = connection.run()
             display.vvvv('socket_path: %s' % socket_path, pc.remote_addr)

--- a/lib/ansible/plugins/action/nxos.py
+++ b/lib/ansible/plugins/action/nxos.py
@@ -66,7 +66,7 @@ class ActionModule(_ActionModule):
                 pc.remote_user = provider['username'] or self._play_context.connection_user
                 pc.password = provider['password'] or self._play_context.password
                 pc.private_key_file = provider['ssh_keyfile'] or self._play_context.private_key_file
-                pc.timeout = int(provider['timeout'] or C.PERSISTENT_COMMAND_TIMEOUT)
+                pc.timeout = int(provider['timeout']) if provider['timeout'] else None
                 pc.become = provider['authorize'] or False
                 if pc.become:
                     pc.become_method = 'enable'
@@ -74,6 +74,9 @@ class ActionModule(_ActionModule):
 
                 display.vvv('using connection plugin %s (was local)' % pc.connection, pc.remote_addr)
                 connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin)
+
+                if connection._play_context.timeout is None:
+                    connection._play_context.timeout = connection.get_option('persistent_command_timeout')
 
                 socket_path = connection.run()
                 display.vvvv('socket_path: %s' % socket_path, pc.remote_addr)

--- a/lib/ansible/plugins/action/vyos.py
+++ b/lib/ansible/plugins/action/vyos.py
@@ -53,17 +53,20 @@ class ActionModule(_ActionModule):
             pc = copy.deepcopy(self._play_context)
             pc.connection = 'network_cli'
             pc.network_os = 'vyos'
-            connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin)
-
             pc.remote_addr = provider['host'] or self._play_context.remote_addr
             pc.port = int(provider['port'] or self._play_context.port or 22)
             pc.remote_user = provider['username'] or self._play_context.connection_user
             pc.password = provider['password'] or self._play_context.password
             pc.private_key_file = provider['ssh_keyfile'] or self._play_context.private_key_file
-            pc.timeout = int(provider['timeout'] or connection.get_option('persistent_command_timeout'))
+            pc.timeout = int(provider['timeout']) if provider['timeout'] else None
 
             display.vvv('using connection plugin %s (was local)' % pc.connection, pc.remote_addr)
+            connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin)
 
+            if connection._play_context.timeout is None:
+                connection._play_context.timeout = connection.get_option('persistent_command_timeout')
+
+            import q;q(connection._play_context.timeout)
             socket_path = connection.run()
             display.vvvv('socket_path: %s' % socket_path, pc.remote_addr)
             if not socket_path:

--- a/lib/ansible/plugins/action/vyos.py
+++ b/lib/ansible/plugins/action/vyos.py
@@ -66,7 +66,6 @@ class ActionModule(_ActionModule):
             if connection._play_context.timeout is None:
                 connection._play_context.timeout = connection.get_option('persistent_command_timeout')
 
-            import q;q(connection._play_context.timeout)
             socket_path = connection.run()
             display.vvvv('socket_path: %s' % socket_path, pc.remote_addr)
             if not socket_path:

--- a/lib/ansible/plugins/action/vyos.py
+++ b/lib/ansible/plugins/action/vyos.py
@@ -53,15 +53,16 @@ class ActionModule(_ActionModule):
             pc = copy.deepcopy(self._play_context)
             pc.connection = 'network_cli'
             pc.network_os = 'vyos'
+            connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin)
+
             pc.remote_addr = provider['host'] or self._play_context.remote_addr
             pc.port = int(provider['port'] or self._play_context.port or 22)
             pc.remote_user = provider['username'] or self._play_context.connection_user
             pc.password = provider['password'] or self._play_context.password
             pc.private_key_file = provider['ssh_keyfile'] or self._play_context.private_key_file
-            pc.timeout = int(provider['timeout'] or C.PERSISTENT_COMMAND_TIMEOUT)
+            pc.timeout = int(provider['timeout'] or connection.get_option('persistent_command_timeout'))
 
             display.vvv('using connection plugin %s (was local)' % pc.connection, pc.remote_addr)
-            connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin)
 
             socket_path = connection.run()
             display.vvvv('socket_path: %s' % socket_path, pc.remote_addr)

--- a/lib/ansible/plugins/connection/network_cli.py
+++ b/lib/ansible/plugins/connection/network_cli.py
@@ -151,8 +151,8 @@ options:
         close
     default: 10
     ini:
-      section: persistent_connection
-      key: persistent_command_timeout
+      - section: persistent_connection
+        key: command_timeout
     env:
       - name: ANSIBLE_PERSISTENT_COMMAND_TIMEOUT
 """
@@ -298,7 +298,7 @@ class Connection(ConnectionBase):
         display.vvvv('ssh connection done, setting terminal', host=self._play_context.remote_addr)
 
         self._ssh_shell = ssh.ssh.invoke_shell()
-        self._ssh_shell.settimeout(self._play_context.timeout)
+        self._ssh_shell.settimeout(self.get_option('persistent_command_timeout'))
 
         network_os = self._play_context.network_os
         if not network_os:

--- a/lib/ansible/plugins/connection/paramiko_ssh.py
+++ b/lib/ansible/plugins/connection/paramiko_ssh.py
@@ -114,8 +114,16 @@ DOCUMENTATION = """
             version_added: '2.5'
           - name: ansible_paramiko_host_key_checking
             version_added: '2.5'
+      use_persistent_connections:
+        description: 'Toggles the use of persistence for connections'
+        type: boolean
+        default: False
+        env:
+          - name: ANSIBLE_USE_PERSISTENT_CONNECTIONS
+        ini:
+          - section: defaults
+            key: use_persistent_connections
 # TODO:
-#C.USE_PERSISTENT_CONNECTIONS:
 #timeout=self._play_context.timeout,
 """
 
@@ -188,7 +196,7 @@ class MyAddPolicy(object):
             fingerprint = hexlify(key.get_fingerprint())
             ktype = key.get_name()
 
-            if C.USE_PERSISTENT_CONNECTIONS or self.connection.force_persistence:
+            if self.connection.get_option('use_persistent_connections') or self.connection.force_persistence:
                 # don't print the prompt string since the user cannot respond
                 # to the question anyway
                 raise AnsibleError(AUTHENTICITY_MSG[1:92] % (hostname, ktype, fingerprint))

--- a/lib/ansible/plugins/connection/persistent.py
+++ b/lib/ansible/plugins/connection/persistent.py
@@ -22,10 +22,12 @@ options:
         close
     default: 10
     ini:
-      section: persistent_connection
-      key: persistent_command_timeout
+      - section: persistent_connection
+        key: command_timeout
     env:
       - name: ANSIBLE_PERSISTENT_COMMAND_TIMEOUT
+    vars:
+      - name: ansible_persistent_command_timeout
 """
 import os
 import pty

--- a/lib/ansible/plugins/connection/persistent.py
+++ b/lib/ansible/plugins/connection/persistent.py
@@ -26,8 +26,6 @@ options:
         key: command_timeout
     env:
       - name: ANSIBLE_PERSISTENT_COMMAND_TIMEOUT
-    vars:
-      - name: ansible_persistent_command_timeout
 """
 import os
 import pty

--- a/lib/ansible/plugins/connection/persistent.py
+++ b/lib/ansible/plugins/connection/persistent.py
@@ -6,12 +6,26 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 DOCUMENTATION = """
-    author: Ansible Core Team
-    connection: persistent
-    short_description: Use a persistent unix socket for connection
+author: Ansible Core Team
+connection: persistent
+short_description: Use a persistent unix socket for connection
+description:
+  - This is a helper plugin to allow making other connections persistent.
+version_added: "2.3"
+options:
+  persistent_command_timeout:
+    type: int
     description:
-        - This is a helper plugin to allow making other connections persistent.
-    version_added: "2.3"
+      - Configures, in seconds, the amount of time to wait for a command to
+        return from the remote device.  If this timer is exceeded before the
+        command returns, the connection plugin will raise an exception and
+        close
+    default: 10
+    ini:
+      section: persistent_connection
+      key: persistent_command_timeout
+    env:
+      - name: ANSIBLE_PERSISTENT_COMMAND_TIMEOUT
 """
 import os
 import pty

--- a/test/units/plugins/connection/test_network_cli.py
+++ b/test/units/plugins/connection/test_network_cli.py
@@ -31,6 +31,7 @@ from ansible.compat.tests.mock import patch, MagicMock
 from ansible.errors import AnsibleConnectionFailure
 from ansible.playbook.play_context import PlayContext
 from ansible.plugins.connection import network_cli
+from ansible.plugins.loader import connection_loader
 
 
 class TestConnectionClass(unittest.TestCase):
@@ -40,7 +41,7 @@ class TestConnectionClass(unittest.TestCase):
         pc = PlayContext()
         new_stdin = StringIO()
 
-        conn = network_cli.Connection(pc, new_stdin)
+        conn = connection_loader.get('network_cli', pc, '/dev/null')
         conn.ssh = MagicMock()
         conn.receive = MagicMock()
         conn._terminal = MagicMock()
@@ -52,7 +53,7 @@ class TestConnectionClass(unittest.TestCase):
         pc = PlayContext()
         new_stdin = StringIO()
 
-        conn = network_cli.Connection(pc, new_stdin)
+        conn = connection_loader.get('network_cli', pc, '/dev/null')
         conn.ssh = MagicMock()
         conn.receive = MagicMock()
         conn._terminal = MagicMock()
@@ -65,7 +66,7 @@ class TestConnectionClass(unittest.TestCase):
         pc = PlayContext()
         new_stdin = StringIO()
 
-        conn = network_cli.Connection(pc, new_stdin)
+        conn = connection_loader.get('network_cli', pc, '/dev/null')
         pc.network_os = 'ios'
 
         conn.ssh = MagicMock()


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Pull persistent connection paramters via get_option
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
Fixes #38580

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
persistent

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0 (persistent_connection_config_manager_opts 16812cfbf1) last updated 2018/04/26 17:31:27 (GMT +200)

```
