### PR TITLE
Fixes 30786 - add server response to the failure

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_stack.py
+++ b/lib/ansible/modules/cloud/openstack/os_stack.py
@@ -168,7 +168,10 @@ def _create_stack(module, stack, cloud, shade):
         else:
             module.fail_json(msg="Failure in creating stack: {0}".format(stack))
     except shade.OpenStackCloudException as e:
-        module.fail_json(msg=str(e))
+        if hasattr(e, 'response'):
+            module.fail_json(msg=str(e), response=e.response.json())
+        else:
+            module.fail_json(msg=str(e))
 
 
 def _update_stack(module, stack, cloud, shade):
@@ -188,7 +191,10 @@ def _update_stack(module, stack, cloud, shade):
             module.fail_json(msg="Failure in updating stack: %s" %
                              stack['stack_status_reason'])
     except shade.OpenStackCloudException as e:
-        module.fail_json(msg=str(e))
+        if hasattr(e, 'response'):
+            module.fail_json(msg=str(e), response=e.response.json())
+        else:
+            module.fail_json(msg=str(e))
 
 
 def _system_state_change(module, stack, cloud):

--- a/lib/ansible/modules/cloud/openstack/os_stack.py
+++ b/lib/ansible/modules/cloud/openstack/os_stack.py
@@ -149,6 +149,7 @@ stack:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.openstack import openstack_full_argument_spec, openstack_module_kwargs, openstack_cloud_from_module
+from ansible.module_utils._text import to_native
 
 
 def _create_stack(module, stack, cloud, shade):
@@ -169,9 +170,9 @@ def _create_stack(module, stack, cloud, shade):
             module.fail_json(msg="Failure in creating stack: {0}".format(stack))
     except shade.OpenStackCloudException as e:
         if hasattr(e, 'response'):
-            module.fail_json(msg=str(e), response=e.response.json())
+            module.fail_json(msg=to_native(e), response=e.response.json())
         else:
-            module.fail_json(msg=str(e))
+            module.fail_json(msg=to_native(e))
 
 
 def _update_stack(module, stack, cloud, shade):
@@ -192,9 +193,9 @@ def _update_stack(module, stack, cloud, shade):
                              stack['stack_status_reason'])
     except shade.OpenStackCloudException as e:
         if hasattr(e, 'response'):
-            module.fail_json(msg=str(e), response=e.response.json())
+            module.fail_json(msg=to_native(e), response=e.response.json())
         else:
-            module.fail_json(msg=str(e))
+            module.fail_json(msg=to_native(e))
 
 
 def _system_state_change(module, stack, cloud):
@@ -266,7 +267,7 @@ def main():
                     module.fail_json(msg='delete stack failed for stack: %s' % name)
             module.exit_json(changed=changed)
     except shade.OpenStackCloudException as e:
-        module.fail_json(msg=str(e))
+        module.fail_json(msg=to_native(e))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
##### SUMMARY
If an exception occurred during the stack create/update (not the stack validation, but execution. Normally server responds, that stack failed) a server response is the only source of failure information. Without it is it not possible to clarify the reason for stack failure (of course except of going to heat and looking for events)

Fixes #30786 



##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
openstack.os_stack

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.1
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/gtema/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.14 (default, Mar 14 2018, 13:36:31) [GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]

```


##### ADDITIONAL INFORMATION
detailed information in the bug report: https://github.com/ansible/ansible/issues/30786
