### PR TITLE
Add extra_specs to os_subnet module

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_subnet.py
+++ b/lib/ansible/modules/cloud/openstack/os_subnet.py
@@ -95,6 +95,12 @@ options:
    availability_zone:
      description:
        - Ignored. Present for backwards compatibility
+   extra_specs:
+     description:
+        - Dictionary with extra key/value pairs passed to the API
+     required: false
+     default: None
+     version_added: "2.6"
 requirements:
     - "python >= 2.6"
     - "shade"
@@ -231,6 +237,7 @@ def main():
         ipv6_ra_mode=dict(default=None, choice=ipv6_mode_choices),
         ipv6_address_mode=dict(default=None, choice=ipv6_mode_choices),
         use_default_subnetpool=dict(default=False, type='bool'),
+        extra_specs=dict(required=False, default=dict(), type='dict'),
         state=dict(default='present', choices=['absent', 'present']),
         project=dict(default=None)
     )
@@ -256,6 +263,7 @@ def main():
     ipv6_a_mode = module.params['ipv6_address_mode']
     use_default_subnetpool = module.params['use_default_subnetpool']
     project = module.params.pop('project')
+    extra_specs = module.params['extra_specs']
 
     min_version = None
     if use_default_subnetpool:
@@ -310,7 +318,8 @@ def main():
                     host_routes=host_routes,
                     ipv6_ra_mode=ipv6_ra_mode,
                     ipv6_address_mode=ipv6_a_mode,
-                    tenant_id=project_id)
+                    tenant_id=project_id,
+                    **extra_specs)
                 if use_default_subnetpool:
                     kwargs['use_default_subnetpool'] = use_default_subnetpool
                 subnet = cloud.create_subnet(network_name, cidr, **kwargs)

--- a/lib/ansible/modules/cloud/openstack/os_subnet.py
+++ b/lib/ansible/modules/cloud/openstack/os_subnet.py
@@ -99,7 +99,7 @@ options:
      description:
         - Dictionary with extra key/value pairs passed to the API
      required: false
-     default: None
+     default: {}
      version_added: "2.6"
 requirements:
     - "python >= 2.6"
@@ -237,7 +237,7 @@ def main():
         ipv6_ra_mode=dict(default=None, choice=ipv6_mode_choices),
         ipv6_address_mode=dict(default=None, choice=ipv6_mode_choices),
         use_default_subnetpool=dict(default=False, type='bool'),
-        extra_specs=dict(required=False, default=None, type='dict'),
+        extra_specs=dict(required=False, default=dict(), type='dict'),
         state=dict(default='present', choices=['absent', 'present']),
         project=dict(default=None)
     )
@@ -263,7 +263,7 @@ def main():
     ipv6_a_mode = module.params['ipv6_address_mode']
     use_default_subnetpool = module.params['use_default_subnetpool']
     project = module.params.pop('project')
-    extra_specs = module.params['extra_specs'] or dict()
+    extra_specs = module.params['extra_specs']
 
     min_version = None
     if use_default_subnetpool:

--- a/lib/ansible/modules/cloud/openstack/os_subnet.py
+++ b/lib/ansible/modules/cloud/openstack/os_subnet.py
@@ -237,7 +237,7 @@ def main():
         ipv6_ra_mode=dict(default=None, choice=ipv6_mode_choices),
         ipv6_address_mode=dict(default=None, choice=ipv6_mode_choices),
         use_default_subnetpool=dict(default=False, type='bool'),
-        extra_specs=dict(required=False, default=dict(), type='dict'),
+        extra_specs=dict(required=False, default=None, type='dict'),
         state=dict(default='present', choices=['absent', 'present']),
         project=dict(default=None)
     )
@@ -263,7 +263,7 @@ def main():
     ipv6_a_mode = module.params['ipv6_address_mode']
     use_default_subnetpool = module.params['use_default_subnetpool']
     project = module.params.pop('project')
-    extra_specs = module.params['extra_specs']
+    extra_specs = module.params['extra_specs'] or dict()
 
     min_version = None
     if use_default_subnetpool:

--- a/lib/ansible/modules/cloud/openstack/os_subnet.py
+++ b/lib/ansible/modules/cloud/openstack/os_subnet.py
@@ -318,8 +318,10 @@ def main():
                     host_routes=host_routes,
                     ipv6_ra_mode=ipv6_ra_mode,
                     ipv6_address_mode=ipv6_a_mode,
-                    tenant_id=project_id,
-                    **extra_specs)
+                    tenant_id=project_id)
+                if any(spec in kwargs for spec in extra_specs):
+                    raise ValueError('Duplicate key in extra_specs')
+                kwargs = dict(kwargs, **extra_specs)
                 if use_default_subnetpool:
                     kwargs['use_default_subnetpool'] = use_default_subnetpool
                 subnet = cloud.create_subnet(network_name, cidr, **kwargs)

--- a/lib/ansible/modules/cloud/openstack/os_subnet.py
+++ b/lib/ansible/modules/cloud/openstack/os_subnet.py
@@ -320,8 +320,10 @@ def main():
                     ipv6_ra_mode=ipv6_ra_mode,
                     ipv6_address_mode=ipv6_a_mode,
                     tenant_id=project_id)
-                if any(spec in kwargs for spec in extra_specs):
-                    raise ValueError('Duplicate key in extra_specs')
+                dup_args = set(kwargs.keys()) & set(extra_specs.keys())
+                if dup_args:
+                    raise ValueError('Duplicate key(s) {0} in extra_specs'
+                                     .format(list(dup_args)))
                 kwargs = dict(kwargs, **extra_specs)
                 if use_default_subnetpool:
                     kwargs['use_default_subnetpool'] = use_default_subnetpool

--- a/lib/ansible/modules/cloud/openstack/os_subnet.py
+++ b/lib/ansible/modules/cloud/openstack/os_subnet.py
@@ -308,6 +308,7 @@ def main():
         if state == 'present':
             if not subnet:
                 kwargs = dict(
+                    cidr=cidr,
                     ip_version=ip_version,
                     enable_dhcp=enable_dhcp,
                     subnet_name=subnet_name,
@@ -324,7 +325,7 @@ def main():
                 kwargs = dict(kwargs, **extra_specs)
                 if use_default_subnetpool:
                     kwargs['use_default_subnetpool'] = use_default_subnetpool
-                subnet = cloud.create_subnet(network_name, cidr, **kwargs)
+                subnet = cloud.create_subnet(network_name, **kwargs)
                 changed = True
             else:
                 if _needs_update(subnet, module, cloud):

--- a/lib/ansible/modules/cloud/openstack/os_subnet.py
+++ b/lib/ansible/modules/cloud/openstack/os_subnet.py
@@ -100,7 +100,7 @@ options:
         - Dictionary with extra key/value pairs passed to the API
      required: false
      default: {}
-     version_added: "2.6"
+     version_added: "2.7"
 requirements:
     - "python >= 2.6"
     - "shade"

--- a/lib/ansible/modules/cloud/openstack/os_subnet.py
+++ b/lib/ansible/modules/cloud/openstack/os_subnet.py
@@ -324,9 +324,9 @@ def main():
                 if dup_args:
                     raise ValueError('Duplicate key(s) {0} in extra_specs'
                                      .format(list(dup_args)))
-                kwargs = dict(kwargs, **extra_specs)
                 if use_default_subnetpool:
                     kwargs['use_default_subnetpool'] = use_default_subnetpool
+                kwargs = dict(kwargs, **extra_specs)
                 subnet = cloud.create_subnet(network_name, **kwargs)
                 changed = True
             else:


### PR DESCRIPTION
##### SUMMARY

This change removes the parameter limitation on `os_subnet` module for Neutron subnet creation.

This way, any key value passed via `extra_specs` argument is included in shade's API call.

##### ISSUE TYPE

 - Feature Pull Request

##### COMPONENT NAME

os_subnet

##### ANSIBLE VERSION

```
ansible 2.6.0 (devel eb162bdf7f) last updated 2018/02/26 14:25:07 (GMT +100)
  config file = None
  configured module search path = [u'/github/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /github/ansible/lib/ansible
  executable location = /github/.virtualenvs/ansible_devel/bin/ansible
  python version = 2.7.13 (default, Apr  4 2017, 08:47:57) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.38)]
```

##### ADDITIONAL INFORMATION

The use case here is that some third party neutron plugins actually extend the API, and this would allow us to still use the `os_subnet` module to pass those parameters.
If we add specific parameters to the module, it becomes coupled with those plugins, and sometimes those plugins are vendor specific.

~~This change relies on `shade` changes proposed here: [https://review.openstack.org/#/c/563134](https://review.openstack.org/#/c/563134)~~ (Abandoned)

This change relies on `openstacksdk` changes proposed here: [https://review.openstack.org/#/c/625920/](https://review.openstack.org/#/c/625920/)
