### PR TITLE
Integration Tests only: nxos_snmp_location

### DIFF
--- a/test/integration/targets/nxos_snmp_location/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_snmp_location/tests/common/sanity.yaml
@@ -5,19 +5,15 @@
 
 - name: Setup - Remove snmp_location if configured
   nxos_snmp_location: &remove
-    location: Test
+    location: Test 
     state: absent
-    timeout: 60
     provider: "{{ connection }}"
-  ignore_errors: yes
 
 - block:
-
-  - name: Configure snmp host
+  - name: Configure snmp location 
     nxos_snmp_location: &config
-      location: Test
+      location: Testing
       state: present
-      timeout: 60
       provider: "{{ connection }}"
     register: result
 
@@ -33,17 +29,36 @@
       that:
         - "result.changed == false"
 
-  always:
-  - name: Cleanup
+  - name: Change snmp location 
+    nxos_snmp_location: &config1
+      location: Test
+      state: present
+      provider: "{{ connection }}"
+    register: result
+
+  - assert: *true
+
+  - name: Idempotence Check
+    nxos_snmp_location: *config1
+    register: result
+
+  - assert: *false
+
+  - name: remove snmp location
     nxos_snmp_location: *remove
     register: result
 
   - assert: *true
 
-  - name: Cleanup Idempotence
+  - name: Remove Idempotence
     nxos_snmp_location: *remove
     register: result
 
   - assert: *false
+
+  always:
+  - name: Cleanup
+    nxos_snmp_location: *remove
+    register: result
 
   - debug: msg="END connection={{ ansible_connection }} nxos_snmp_location sanity test"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
IT cases for nxos_snmp_location

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - IT Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
nxos_snmp_location

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0 (devel 8c819dd9cb) last updated 2018/03/21 18:16:48 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /root/agents-ci/ansible/lib/ansible
  executable location = /root/agents-ci/ansible/bin/ansible
  python version = 2.7.6 (default, Oct 26 2016, 20:30:19) [GCC 4.8.4]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->
* This PR is for cleaning up nxos_snmp_location integration test cases, like removing timeouts, fixing typos etc.
* All tests pass on all platforms.
* There are no code changes.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
