### PR TITLE
Backport fix for fw_offline/FW_VERSION globals in firewalld

### DIFF
--- a/lib/ansible/modules/system/firewalld.py
+++ b/lib/ansible/modules/system/firewalld.py
@@ -155,6 +155,8 @@ from ansible.module_utils.basic import AnsibleModule
 
 # globals
 module = None
+fw_offline = False
+FW_VERSION = None
 
 # Imports
 try:
@@ -165,7 +167,6 @@ try:
     from firewall.client import FirewallClient
     from firewall.client import FirewallClientZoneSettings
     fw = None
-    fw_offline = False
     import_failure = False
 
     try:


### PR DESCRIPTION
Signed-off-by: Adam Miller <admiller@redhat.com>

##### SUMMARY
Fixes #38161

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.2 (backport/2.5/fix-firewalld-globals db0e5eba9c) last updated 2018/04/26 16:17:23 (GMT -500)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/admiller/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/admiller/src/dev/ansible/lib/ansible
  executable location = /home/admiller/src/dev/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 14 2018, 13:36:31) [GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before Change
```
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: NameError: global name 'fw_offline' is not defined
localhost | FAILED! => {
    "changed": false,
    "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_zbEyG9/ansible_module_firewalld.py\", line 1018, in <module>\n    main()\n  File \"/tmp/ansible_zbEyG9/ansible_module_firewalld.py\", line 812, in main\n    if fw_offline:\nNameError: global name 'fw_offline' is not defined\n",
    "module_stdout": "",
    "msg": "MODULE FAILURE",
    "rc": 1
}
```
