### PR TITLE
Allow the galaxy client to fetch from a url in role version data

### DIFF
--- a/lib/ansible/galaxy/api.py
+++ b/lib/ansible/galaxy/api.py
@@ -203,7 +203,7 @@ class GalaxyAPI(object):
         """
 
         try:
-            url = '%s/roles/%d/%s/?page_size=50' % (self.baseurl, int(role_id), related)
+            url = '%s/roles/%s/%s/?page_size=50' % (self.baseurl, role_id, related)
             data = self.__call_galaxy(url)
             results = data['results']
             done = (data.get('next_link', None) is None)

--- a/lib/ansible/galaxy/role.py
+++ b/lib/ansible/galaxy/role.py
@@ -167,7 +167,7 @@ class GalaxyRole(object):
 
     def fetch(self, role_data):
         """
-        Downloads the archived role from github to a temp location
+        Downloads the archived role to a temp location based on role data
         """
         if role_data:
 
@@ -241,6 +241,11 @@ class GalaxyRole(object):
                         raise AnsibleError("- the specified version (%s) of %s was not found in the list of available versions (%s)." % (self.version,
                                                                                                                                          self.name,
                                                                                                                                          role_versions))
+
+                # check if there's a source link for our role_version
+                for role_version in role_versions:
+                    if role_version['name'] == self.version and 'source' in role_version:
+                        self.src = role_version['source']
 
                 tmp_file = self.fetch(role_data)
 


### PR DESCRIPTION
Ping @bmbouter @chouseknecht @maxamillion @alikins

#### SUMMARY

Currently if the ansible-galaxy client fetches a role from a galaxy server, it then fetches the role files from Github. This change allows a galaxy server to provide an alternate source url that points to an archive that contains the role version. This is essential for https://github.com/pulp/pulp_ansible which provides both a galaxy-compatible api and also hosts the role files (as opposed to using Github).

#### ISSUE TYPE

* Feature Pull Request

#### COMPONENT NAME

`lib/ansible/galaxy`

#### ANSIBLE VERSION

2.5