### PR TITLE
[WIP] - set _ansible_remote_tmp to the value of remote_tmp if required

### DIFF
--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -236,11 +236,11 @@ class ActionBase(with_metaclass(ABCMeta, object)):
 
         try:
             admin_users = self._connection._shell.get_option('admin_users') + [remote_user]
-        except KeyError:
+        except AnsibleError:
             admin_users = ['root', remote_user]  # plugin does not support admin_users
         try:
             remote_tmp = self._connection._shell.get_option('remote_tmp')
-        except KeyError:
+        except AnsibleError:
             remote_tmp = '~/ansible'
 
         # deal with tmpdir creation
@@ -405,7 +405,7 @@ class ActionBase(with_metaclass(ABCMeta, object)):
 
         try:
             admin_users = self._connection._shell.get_option('admin_users')
-        except KeyError:
+        except AnsibleError:
             admin_users = ['root']  # plugin does not support admin users
 
         if self._play_context.become and self._play_context.become_user and self._play_context.become_user not in admin_users + [remote_user]:
@@ -650,7 +650,13 @@ class ActionBase(with_metaclass(ABCMeta, object)):
         module_args['_ansible_shell_executable'] = self._play_context.executable
 
         # make sure all commands use the designated temporary directory
-        module_args['_ansible_tmpdir'] = self._connection._shell.tmpdir
+        tmpdir = self._connection._shell.tmpdir
+        if tmpdir is None:
+            try:
+                tmpdir = self._connection._shell.get_option('remote_tmp')
+            except AnsibleError:
+                pass
+        module_args['_ansible_tmpdir'] = tmpdir
 
     def _update_connection_options(self, options, variables=None):
         ''' ensures connections have the appropriate information '''

--- a/lib/ansible/plugins/shell/powershell.py
+++ b/lib/ansible/plugins/shell/powershell.py
@@ -21,12 +21,6 @@ DOCUMENTATION = '''
           key: remote_tmp
         vars:
         - name: ansible_remote_tmp
-      admin_users:
-        description:
-        - List of users to be expected to have admin privileges, this is unused
-          in the PowerShell plugin
-        type: list
-        default: []
       set_module_language:
         description:
         - Controls if we set the locale for moduels when executing on the


### PR DESCRIPTION
##### SUMMARY
The `_ansible_remote_tmp` is only being supplied when using an action plugin that has set `_early_needs_tmp_path`. Any other cases this value is `None` and so the module use the default temp directory of `tempfile`

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
action/__init__.py

##### ANSIBLE VERSION
```
devel
```