### PR TITLE
Make remote_tmp work

### DIFF
--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -691,6 +691,10 @@ class ActionBase(with_metaclass(ABCMeta, object)):
         if module_args is None:
             module_args = self._task.args
 
+        if self._connection._shell.tmpdir is None:
+            self._make_tmp_path()
+        tmpdir = self._connection._shell.tmpdir
+
         self._update_module_args(module_name, module_args, task_vars)
 
         # FUTURE: refactor this along with module build process to better encapsulate "smart wrapper" functionality
@@ -699,15 +703,8 @@ class ActionBase(with_metaclass(ABCMeta, object)):
         if not shebang and module_style != 'binary':
             raise AnsibleError("module (%s) is missing interpreter line" % module_name)
 
-        tmpdir = self._connection._shell.tmpdir
         remote_module_path = None
-
         if not self._is_pipelining_enabled(module_style, wrap_async):
-            # we might need remote tmp dir
-            if tmpdir is None:
-                self._make_tmp_path()
-                tmpdir = self._connection._shell.tmpdir
-
             remote_module_filename = self._connection._shell.get_remote_filename(module_path)
             remote_module_path = self._connection._shell.join_path(tmpdir, remote_module_filename)
 


### PR DESCRIPTION
* With universal tempdir, we always have to create a remote_tmp because we
  do not know if the module needs it or not.  So we can no longer depend
  on pipelining disabling the need for a tempdir
* We need to ensure we have a tempdir much earlier because we need to
  know that value in order to construct the module's parameters.

##### ISSUE TYPE

 - Bugfix Pull Request


##### COMPONENT NAME
lib/ansible/plugins/action/__init__.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel 2.5
```
