### PR TITLE
Change except Error when trying to get a missing option

### DIFF
--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -236,11 +236,11 @@ class ActionBase(with_metaclass(ABCMeta, object)):
 
         try:
             admin_users = self._connection._shell.get_option('admin_users') + [remote_user]
-        except KeyError:
+        except AnsibleError:
             admin_users = ['root', remote_user]  # plugin does not support admin_users
         try:
             remote_tmp = self._connection._shell.get_option('remote_tmp')
-        except KeyError:
+        except AnsibleError:
             remote_tmp = '~/ansible'
 
         # deal with tmpdir creation
@@ -405,7 +405,7 @@ class ActionBase(with_metaclass(ABCMeta, object)):
 
         try:
             admin_users = self._connection._shell.get_option('admin_users')
-        except KeyError:
+        except AnsibleError:
             admin_users = ['root']  # plugin does not support admin users
 
         if self._play_context.become and self._play_context.become_user and self._play_context.become_user not in admin_users + [remote_user]:

--- a/lib/ansible/plugins/shell/powershell.py
+++ b/lib/ansible/plugins/shell/powershell.py
@@ -21,12 +21,6 @@ DOCUMENTATION = '''
           key: remote_tmp
         vars:
         - name: ansible_remote_tmp
-      admin_users:
-        description:
-        - List of users to be expected to have admin privileges, this is unused
-          in the PowerShell plugin
-        type: list
-        default: []
       set_module_language:
         description:
         - Controls if we set the locale for moduels when executing on the


### PR DESCRIPTION
##### SUMMARY
When calling ActionBase `.get_option` and the option does not exist, it raises an AnsibleError not KeyError

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
action/__init__.py

##### ANSIBLE VERSION
```
devel
```
