### PR TITLE
Allow ec2_group integration tests to run on PRs to the ec2_group modu…

### DIFF
--- a/test/integration/targets/ec2_group/aliases
+++ b/test/integration/targets/ec2_group/aliases
@@ -1,3 +1,3 @@
 cloud/aws
 posix/ci/cloud/group4/aws
-disabled
+unstable


### PR DESCRIPTION
…le by marking it unstable instead of disabled

##### SUMMARY
Separating https://github.com/ansible/ansible/pull/39250 because getting 4 unstable tests to pass at once is hard.

##### ISSUE TYPE
 - Test Pull Request

##### COMPONENT NAME
test/integration/targets/ec2_group/aliases

##### ANSIBLE VERSION
```
2.6.0
```
