### PR TITLE
Allow ec2_ami integration tests to run on PRs to the ec2_ami module b…

### DIFF
--- a/test/integration/targets/ec2_ami/aliases
+++ b/test/integration/targets/ec2_ami/aliases
@@ -1,4 +1,4 @@
 cloud/aws
 posix/ci/cloud/group4/aws
-disabled
+unstable
 ec2_ami_facts


### PR DESCRIPTION
…y marking it unstable instead of disabled

##### SUMMARY
Separating #39250 because getting 4 unstable tests to pass at once is hard.

##### ISSUE TYPE
 - Test Pull Request

##### COMPONENT NAME
test/integration/targets/ec2_ami/aliases

##### ANSIBLE VERSION
```
2.6.0
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
