### PR TITLE
Allow ec2_vpc_route_table integration tests to run on Prs to the ec2_…

### DIFF
--- a/test/integration/targets/ec2_vpc_route_table/aliases
+++ b/test/integration/targets/ec2_vpc_route_table/aliases
@@ -1,3 +1,3 @@
 cloud/aws
 posix/ci/cloud/group4/aws
-disabled
+unstable


### PR DESCRIPTION
…vpc_route_table module by marking it unstable instead of disabled

##### SUMMARY
Separating #39250 because getting 4 unstable tests to pass at once is hard.

##### ISSUE TYPE
 - Test Pull Request

##### COMPONENT NAME
test/integration/targets/ec2_vpc_route_table/aliases

##### ANSIBLE VERSION
```
2.6.0
```