### PR TITLE
facts: remove duplicate device vendor and model assignment

### DIFF
--- a/lib/ansible/module_utils/facts/hardware/linux.py
+++ b/lib/ansible/module_utils/facts/hardware/linux.py
@@ -602,9 +602,6 @@ class LinuxHardware(Hardware):
                     if serial:
                         d['serial'] = serial.group(1)
 
-            for key in ['vendor', 'model']:
-                d[key] = get_file_content(sysdir + "/device/" + key)
-
             for key, test in [('removable', '/removable'),
                               ('support_discard', '/queue/discard_granularity'),
                               ]:


### PR DESCRIPTION
Signed-off-by: Alfredo Deza <adeza@redhat.com>

##### SUMMARY
The `hardware/linux.py` facts is re-assigning the vendor and model for a device. This is not needed as it is already taken care of a few lines above (line 592 and 593)

##### ISSUE TYPE
 - Bugfix Pull Request


##### COMPONENT NAME
linux (module_utils/facts/hardware/linux.py)


##### ANSIBLE VERSION
```
 ansible --version
ansible 2.6.0 (linux-fact-cleanup e594a4c9e7) last updated 2018/04/27 09:22:13 (GMT -400)
  config file = /Users/alfredo/.ansible.cfg
  configured module search path = [u'/Users/alfredo/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/alfredo/python/ansible/lib/ansible
  executable location = /Users/alfredo/.virtualenvs/ansible/bin/ansible
  python version = 2.7.8 (v2.7.8:ee879c0ffa11, Jun 29 2014, 21:07:35) [GCC 4.2.1 (Apple Inc. build 5666) (dot 3)]

```

