### PR TITLE
Ensure handlers have proper parent

### DIFF
--- a/lib/ansible/playbook/helpers.py
+++ b/lib/ansible/playbook/helpers.py
@@ -333,10 +333,10 @@ def load_list_of_tasks(ds, play, block=None, role=None, task_include=None, use_h
 
                     # uses compiled list from object
                     blocks, _ = ir.get_block_list(variable_manager=variable_manager, loader=loader)
-                    t = task_list.extend(blocks)
+                    task_list.extend(blocks)
                 else:
                     # passes task object itself for latter generation of list
-                    t = task_list.append(ir)
+                    task_list.append(ir)
             else:
                 if use_handlers:
                     t = Handler.load(task_ds, block=block, role=role, task_include=task_include, variable_manager=variable_manager, loader=loader)

--- a/lib/ansible/playbook/role_include.py
+++ b/lib/ansible/playbook/role_include.py
@@ -96,6 +96,8 @@ class IncludeRole(TaskInclude):
 
         # updated available handlers in play
         handlers = actual_role.get_handler_blocks(play=myplay)
+        for h in handlers:
+            h._parent = self
         myplay.handlers = myplay.handlers + handlers
         return blocks, handlers
 

--- a/test/integration/targets/include_import/role/test_import_role.yml
+++ b/test/integration/targets/include_import/role/test_import_role.yml
@@ -136,3 +136,8 @@
         - name: Include role inside always
           import_role:
             name: role3
+
+    - name: Test delegate_to handler is delegated
+      import_role:
+        name: delegated_handler
+      delegate_to: localhost

--- a/test/integration/targets/include_import/roles/delegated_handler/handlers/main.yml
+++ b/test/integration/targets/include_import/roles/delegated_handler/handlers/main.yml
@@ -1,0 +1,4 @@
+- name: delegated assert handler
+  assert:
+    that:
+      - ansible_delegated_vars is defined

--- a/test/integration/targets/include_import/roles/delegated_handler/tasks/main.yml
+++ b/test/integration/targets/include_import/roles/delegated_handler/tasks/main.yml
@@ -1,0 +1,3 @@
+- command: "true"
+  notify:
+    - delegated assert handler


### PR DESCRIPTION
##### SUMMARY
This PR ensures that handlers have the correct parent.  This change does for handlers what tasks already had done.

This ensures that things like the following apply to handlers:

```
- import_role:
    name: thing
  delegate_to: localhost
```

Fixes #36518 

Additionally, on a small note, `task_list.extend` is in place and returns nothing, don't assign to `t`.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```