### PR TITLE
minor accuracy fix

### DIFF
--- a/changelogs/fragments/doc_fix.yml
+++ b/changelogs/fragments/doc_fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - minor doc fix https://github.com/ansible/ansible/pull/39111

--- a/docs/docsite/rst/user_guide/playbooks_tests.rst
+++ b/docs/docsite/rst/user_guide/playbooks_tests.rst
@@ -74,7 +74,7 @@ The ``version`` test can also be used to evaluate the ``ansible_distribution_ver
 
     {{ ansible_distribution_version is version('12.04', '>=') }}
 
-If ``ansible_distribution_version`` is greater than or equal to 12, this test returns True, otherwise False.
+If ``ansible_distribution_version`` is greater than or equal to 12.04, this test returns True, otherwise False.
 
 The ``version`` test accepts the following operators::
 


### PR DESCRIPTION
##### SUMMARY
Don't round the parameter 12.04 in the explanatory paragraph unless `version()` rounds the parameter

(cherry picked from commit 5cf544e03e5f833e1614fa940849976550d55448)
(cherry picked from commit 56967497d57abbf6ea62515b1776f1180072d274)

backpor tof #39111 

<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
- Docs

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
docs
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```
