### PR TITLE
fix empty error triggered by single \n

### DIFF
--- a/changelogs/fragments/fix_spurious_stderr.yml
+++ b/changelogs/fragments/fix_spurious_stderr.yml
@@ -1,0 +1,2 @@
+bugfixes:
+ - dont emit empty error due to \n https://github.com/ansible/ansible/pull/39019

--- a/lib/ansible/plugins/inventory/script.py
+++ b/lib/ansible/plugins/inventory/script.py
@@ -104,7 +104,10 @@ class InventoryModule(BaseInventoryPlugin, Cacheable):
                 (stdout, stderr) = sp.communicate()
 
                 path = to_native(path)
-                err = to_native(stderr or "") + "\n"
+                err = to_native(stderr or "")
+
+                if err and not err.endswith('\n'):
+                    err += '\n'
 
                 if sp.returncode != 0:
                     raise AnsibleError("Inventory script (%s) had an execution error: %s " % (path, err))


### PR DESCRIPTION
##### SUMMARY

backport of #39019

(cherry picked from commit 01e7f44e0df4b11ddd8d6a5e32e249da4324901b)


<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
inventory
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```
