### PR TITLE
Load files once 

### DIFF
--- a/changelogs/fragments/load_files_once.yml
+++ b/changelogs/fragments/load_files_once.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - avoid uneeded reloading of plugin files https://github.com/ansible/ansible/pull/37648

--- a/lib/ansible/plugins/connection/__init__.py
+++ b/lib/ansible/plugins/connection/__init__.py
@@ -91,10 +91,15 @@ class ConnectionBase(AnsiblePlugin):
         else:
             shell_type = 'sh'
             shell_filename = os.path.basename(self._play_context.executable)
-            for shell in shell_loader.all():
-                if shell_filename in shell.COMPATIBLE_SHELLS:
-                    shell_type = shell.SHELL_FAMILY
-                    break
+            try:
+                shell = shell_loader.get(shell_filename)
+            except Exception:
+                shell = None
+            if shell is None:
+                for shell in shell_loader.all():
+                    if shell_filename in shell.COMPATIBLE_SHELLS:
+                        break
+            shell_type = shell.SHELL_FAMILY
 
         self._shell = shell_loader.get(shell_type)
         if not self._shell:

--- a/lib/ansible/vars/manager.py
+++ b/lib/ansible/vars/manager.py
@@ -241,6 +241,7 @@ class VariableManager:
                         inventory_dir = os.path.dirname(inventory_dir)
 
                     for plugin in vars_loader.all():
+
                         data = combine_vars(data, _get_plugin_vars(plugin, inventory_dir, entities))
                 return data
 
@@ -248,6 +249,7 @@ class VariableManager:
                 ''' merges all entities adjacent to play '''
                 data = {}
                 for plugin in vars_loader.all():
+
                     for path in basedirs:
                         data = combine_vars(data, _get_plugin_vars(plugin, path, entities))
                 return data


### PR DESCRIPTION
##### SUMMARY

avoids some repetitive loading
 - read config file only once
 - now cache the ini parser per file
 - optimize shell plugin loading

tried to 'optimize' vars_plugins loading but it creates issues with precedence,
probalby due to iterator not being reset, will look into it in subsequent fix/PR

(cherry picked from commit 42912e1ac88a142b14f7851a5cb9b4fc7e094db6)

backport of #37648

<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
plugin loader
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```