### PR TITLE
Update nxos_vlan.py

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_vlan.py
+++ b/lib/ansible/modules/network/nxos/nxos_vlan.py
@@ -458,7 +458,7 @@ def parse_interfaces(module, vlan):
     vlan_int = []
     interfaces = vlan.get('vlanshowplist-ifidx')
     if interfaces:
-        for i in interfaces.split(','):
+        for i in interfaces:
             if 'eth' in i.lower() and '-' in i:
                 int_range = i.split('-')
                 stop = int((int_range)[1])

--- a/lib/ansible/modules/network/nxos/nxos_vxlan_vtep_vni.py
+++ b/lib/ansible/modules/network/nxos/nxos_vxlan_vtep_vni.py
@@ -212,7 +212,7 @@ def state_present(module, existing, proposed, candidate):
         elif key == 'ingress-replication protocol' and value != existing_commands.get(key):
             evalue = existing_commands.get(key)
             dvalue = PARAM_TO_DEFAULT_KEYMAP.get('ingress_replication', 'default')
-            if value != dvalue:
+            if evalue != dvalue and evalue != None:
                 if evalue != dvalue:
                     commands.append('no {0} {1}'.format(key, evalue))
                 commands.append('{0} {1}'.format(key, value))


### PR DESCRIPTION
I was getting playbook failures of this form:
for i in interfaces.split(','):\nAttributeError: 'list' object has no attribute 'split'\n"
after upgrading 2.4-->2.5 
Removing the .split() function causes my playbook to work successfully.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - New Module Pull Request
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
