### PR TITLE
backport ec2_vpc_route_table fixes and custom waiter from PRs 35975/36922/37356

### DIFF
--- a/changelogs/fragments/ec2_vpc_route_table_waiters.yaml
+++ b/changelogs/fragments/ec2_vpc_route_table_waiters.yaml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - Add a custom waiter for the ec2_vpc_route_table module that waits for a route table to exist
+  - Wait for route table to be present before attempting to use it

--- a/lib/ansible/module_utils/aws/waiters.py
+++ b/lib/ansible/module_utils/aws/waiters.py
@@ -1,0 +1,52 @@
+# Copyright: (c) 2018, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+try:
+    import botocore.waiter as core_waiter
+except ImportError:
+    pass  # caught by HAS_BOTO3
+
+
+ec2_data = {
+    "version": 2,
+    "waiters": {
+        "RouteTableExists": {
+            "delay": 5,
+            "maxAttempts": 40,
+            "operation": "DescribeRouteTables",
+            "acceptors": [
+                {
+                    "matcher": "path",
+                    "expected": True,
+                    "argument": "length(RouteTables[]) > `0`",
+                    "state": "success"
+                },
+                {
+                    "matcher": "error",
+                    "expected": "InvalidRouteTableID.NotFound",
+                    "state": "retry"
+                }
+            ]
+        }
+    }
+}
+
+
+def model_for(name):
+    ec2_models = core_waiter.WaiterModel(waiter_config=ec2_data)
+    return ec2_models.get_waiter(name)
+
+
+waiters_by_name = {
+    ('EC2', 'route_table_exists'): lambda ec2: core_waiter.Waiter(
+        'route_table_exists',
+        model_for('RouteTableExists'),
+        ec2.describe_route_tables)
+}
+
+
+def get_waiter(client, waiter_name):
+    try:
+        return waiters_by_name[(client.__class__.__name__, waiter_name)](client)
+    except KeyError:
+        raise NotImplementedError("Waiter {0} could not be found for client {1}. Available waiters: {2}".format(
+            waiter_name, type(client), ', '.join(repr(k) for k in waiters_by_name.keys())))

--- a/lib/ansible/module_utils/aws/waiters.py
+++ b/lib/ansible/module_utils/aws/waiters.py
@@ -24,7 +24,7 @@ ec2_data = {
                     "matcher": "error",
                     "expected": "InvalidRouteTableID.NotFound",
                     "state": "retry"
-                }
+                },
             ]
         }
     }
@@ -40,7 +40,9 @@ waiters_by_name = {
     ('EC2', 'route_table_exists'): lambda ec2: core_waiter.Waiter(
         'route_table_exists',
         model_for('RouteTableExists'),
-        ec2.describe_route_tables)
+        core_waiter.NormalizedOperationMethod(
+            ec2.describe_route_tables
+        ))
 }
 
 


### PR DESCRIPTION
##### SUMMARY
This is a partial fix as ec2_vpc_route_table has not been fully stabilized on devel yet. This does improve some things, however, and will allow the subnet fixes to be backported since they added to the custom waiters added in this PR. There will be another PR to fix additional instabilities with the ec2_vpc_route_table module.

(cherry picked from commit 8fb31ac)
(cherry picked from commit a40bce2)
(cherry picked from commit c9e8aca)

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/aws/waiters.py
lib/ansible/modules/cloud/amazon/ec2_vpc_route_table.py
test/integration/targets/ec2_vpc_route_table/tasks/main.yml

##### ANSIBLE VERSION
```
2.5.2
```