### PR TITLE
protect against plugins using verify incorrectly

### DIFF
--- a/changelogs/fragments/protect_bad_verify.yml
+++ b/changelogs/fragments/protect_bad_verify.yml
@@ -1,0 +1,2 @@
+bugfixes:
+ - protect against bad plugin verify method https://github.com/ansible/ansible/pull/36591

--- a/lib/ansible/inventory/manager.py
+++ b/lib/ansible/inventory/manager.py
@@ -257,8 +257,13 @@ class InventoryManager(object):
                 plugin_name = to_native(getattr(plugin, '_load_name', getattr(plugin, '_original_path', '')))
                 display.debug(u'Attempting to use plugin %s (%s)' % (plugin_name, plugin._original_path))
 
-                # initialize
-                if plugin.verify_file(source):
+                # initialize and figure out if plugin wants to attempt parsing this file
+                try:
+                    plugin_wants = bool(plugin.verify_file(source))
+                except Exception:
+                    plugin_wants = False
+
+                if plugin_wants:
                     try:
                         # in case plugin fails 1/2 way we dont want partial inventory
                         plugin.parse(self._inventory, self._loader, source, cache=cache)


### PR DESCRIPTION
##### SUMMARY
assume false on any errors

(cherry picked from commit ef40e5e3b21fe05df3ed5691360ea51ce84a66c2)

backport of #36591


<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
inventory plugins
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```
