### PR TITLE
Fix gathering facts in run_once play

### DIFF
--- a/lib/ansible/executor/play_iterator.py
+++ b/lib/ansible/executor/play_iterator.py
@@ -169,6 +169,9 @@ class PlayIterator:
             fact_path = self._play.fact_path
 
         setup_block = Block(play=self._play)
+        # Gathering facts with run_once would copy the facts from one host to
+        # the others.
+        setup_block.run_once = False
         setup_task = Task(block=setup_block)
         setup_task.action = 'setup'
         setup_task.name = 'Gathering Facts'

--- a/test/integration/targets/gathering_facts/runme.sh
+++ b/test/integration/targets/gathering_facts/runme.sh
@@ -5,3 +5,5 @@ set -eux
 # ANSIBLE_CACHE_PLUGINS=cache_plugins/ ANSIBLE_CACHE_PLUGIN=none ansible-playbook test_gathering_facts.yml -i ../../inventory -v "$@"
 ansible-playbook test_gathering_facts.yml -i ../../inventory -v "$@"
 #ANSIBLE_CACHE_PLUGIN=base ansible-playbook test_gathering_facts.yml -i ../../inventory -v "$@"
+
+ANSIBLE_GATHERING=smart ansible-playbook test_run_once.yml -i ../../inventory -v "$@"

--- a/test/integration/targets/gathering_facts/test_run_once.yml
+++ b/test/integration/targets/gathering_facts/test_run_once.yml
@@ -1,0 +1,28 @@
+---
+- hosts: facthost1
+  gather_facts: no
+  tasks:
+    - name: install test local facts
+      copy:
+        src: uuid.fact
+        dest: /etc/ansible/facts.d/
+        mode: 0755
+
+- hosts: facthost1,facthost2
+  gather_facts: yes
+  run_once: yes
+  tasks:
+    - block:
+      - name: 'Check the same host is used'
+        assert:
+          that: 'hostvars.facthost1.ansible_fqdn == hostvars.facthost2.ansible_fqdn'
+          msg: 'This test requires 2 inventory hosts referring to the same host.'
+      - name: "Check that run_once doesn't prevent fact gathering (#39453)"
+        assert:
+          that: 'hostvars.facthost1.ansible_local.uuid != hostvars.facthost2.ansible_local.uuid'
+          msg: "{{ 'Same value for ansible_local.uuid on both hosts: ' ~ hostvars.facthost1.ansible_local.uuid }}"
+      always:
+        - name: remove test local facts
+          file:
+            path: /etc/ansible/facts.d/uuid.fact
+            state: absent

--- a/test/integration/targets/gathering_facts/uuid.fact
+++ b/test/integration/targets/gathering_facts/uuid.fact
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+
+import json
+import uuid
+
+
+# return a random string
+print(json.dumps(str(uuid.uuid4())))


### PR DESCRIPTION

##### SUMMARY
When facts have to be gathered in a play with run_once==True, the facts are gathered on only one host and copied to the others.
This may cause facts such as `ansible_fqdn` to be the same on all the hosts.

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
Fixes #39312

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/executor/play_iterator.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0 (devel c8a9b411bc) last updated 2018/04/27 22:35:51 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/kael/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/kael/dev/ansible/lib/ansible
  executable location = /home/kael/dev/ansible/venv/bin/ansible
  python version = 3.6.5rc1 (default, Mar 14 2018, 06:54:23) [GCC 7.3.0]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
