### PR TITLE
ovirt_vms: Clarified graphical_console arguments.

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_vms.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_vms.py
@@ -538,7 +538,7 @@ options:
             - "Assign graphical console to the virtual machine."
             - "Graphical console is a dictionary which can have following values:"
             - "C(headless_mode) - If I(true) disable the graphics console for this virtual machine."
-            - "C(protocol) - Graphical protocol, one of I(VNC), I(SPICE), or both."
+            - "C(protocol) - Graphical protocol, a list of I(spice), I(vnc), or both."
         version_added: "2.5"
 notes:
     - If VM is in I(UNASSIGNED) or I(UNKNOWN) state before any operation, the module will fail.
@@ -809,6 +809,16 @@ EXAMPLES = '''
     usb_support: True
     serial_console: True
     quota_id: "{{ ovirt_quotas[0]['id'] }}"
+
+- name: Create a VM that has the console configured for both Spice and VNC
+  ovirt_vms:
+    name: myvm
+    template: mytemplate
+    cluster: mycluster
+    graphical_console:
+      protocol:
+        - spice
+        - vnc
 '''
 
 


### PR DESCRIPTION
##### SUMMARY
For protocol, it should be a list and all of the values are expected to be lowercase. An example is also added to show how to add both Spice and VNC consoles to a VM.

The current documentation confusingly says the options should be "SPICE",  "VNC", or both and it is not completely clear what format the variables should be in (it should be in a list).

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
ovirt_vms

##### ANSIBLE VERSION
2.5 and 2.6

##### ADDITIONAL INFORMATION
This only changes the documentation. If desired, I could also send a small patch to use `lower()` on the strings to make them lowercase (so they end-user can use any kind of capitalization they want). For now, this is just a simple documentation update.