### PR TITLE
Use HTTPS instead of HTTP for httpbin tests.

### DIFF
--- a/test/integration/targets/get_url/aliases
+++ b/test/integration/targets/get_url/aliases
@@ -1,3 +1,2 @@
 destructive
 posix/ci/group1
-disabled

--- a/test/integration/targets/get_url/tasks/main.yml
+++ b/test/integration/targets/get_url/tasks/main.yml
@@ -14,7 +14,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# along with Ansible.  If not, see <https://www.gnu.org/licenses/>.
 
 - name: Determine if python looks like it will support modern ssl features like SNI
   command: "{{ ansible_python.executable }} -c 'from ssl import SSLContext'"
@@ -67,7 +67,7 @@
         - result.failed
 
 - name: test HTTP HEAD request for file in check mode
-  get_url: url="http://{{ httpbin_host }}/get" dest={{ output_dir }}/get_url_check.txt force=yes
+  get_url: url="https://{{ httpbin_host }}/get" dest={{ output_dir }}/get_url_check.txt force=yes
   check_mode: True
   register: result
 
@@ -78,7 +78,7 @@
     - '"OK" in result.msg'
 
 - name: test HTTP HEAD for nonexistent URL in check mode
-  get_url: url="http://{{ httpbin_host }}/DOESNOTEXIST" dest={{ output_dir }}/shouldnotexist.html force=yes
+  get_url: url="https://{{ httpbin_host }}/DOESNOTEXIST" dest={{ output_dir }}/shouldnotexist.html force=yes
   check_mode: True
   register: result
   ignore_errors: True
@@ -191,12 +191,12 @@
 
 - name: Test get_url with redirect
   get_url:
-    url: 'http://{{ httpbin_host }}/redirect/6'
+    url: 'https://{{ httpbin_host }}/redirect/6'
     dest: "{{ output_dir }}/redirect.json"
 
 - name: Test that setting file modes work
   get_url:
-    url: 'http://{{ httpbin_host }}/'
+    url: 'https://{{ httpbin_host }}/'
     dest: '{{ output_dir }}/test'
     mode: '0707'
   register: result
@@ -213,7 +213,7 @@
 
 - name: Test that setting file modes on an already downlaoded file work
   get_url:
-    url: 'http://{{ httpbin_host }}/'
+    url: 'https://{{ httpbin_host }}/'
     dest: '{{ output_dir }}/test'
     mode: '0070'
   register: result

--- a/test/integration/targets/uri/aliases
+++ b/test/integration/targets/uri/aliases
@@ -1,3 +1,2 @@
 destructive
 posix/ci/group1
-disabled

--- a/test/integration/targets/uri/tasks/main.yml
+++ b/test/integration/targets/uri/tasks/main.yml
@@ -14,7 +14,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# along with Ansible.  If not, see <https://www.gnu.org/licenses/>.
 
 - name: set role facts
   set_fact:
@@ -130,7 +130,7 @@
 
 - name: test redirect without follow_redirects
   uri:
-    url: 'http://{{ httpbin_host }}/redirect/2'
+    url: 'https://{{ httpbin_host }}/redirect/2'
     follow_redirects: 'none'
     status_code: 302
   register: result
@@ -138,7 +138,7 @@
 - name: Assert location header
   assert:
     that:
-      - 'result.location|default("") == "http://{{ httpbin_host }}/relative-redirect/1"'
+      - 'result.location|default("") == "https://{{ httpbin_host }}/relative-redirect/1"'
 
 - name: Check SSL with redirect
   uri:
@@ -164,20 +164,20 @@
 
 - name: test basic auth
   uri:
-    url: 'http://{{ httpbin_host }}/basic-auth/user/passwd'
+    url: 'https://{{ httpbin_host }}/basic-auth/user/passwd'
     user: user
     password: passwd
 
 - name: test basic forced auth
   uri:
-    url: 'http://{{ httpbin_host }}/hidden-basic-auth/user/passwd'
+    url: 'https://{{ httpbin_host }}/hidden-basic-auth/user/passwd'
     force_basic_auth: true
     user: user
     password: passwd
 
 - name: test digest auth
   uri:
-    url: 'http://{{ httpbin_host }}/digest-auth/auth/user/passwd'
+    url: 'https://{{ httpbin_host }}/digest-auth/auth/user/passwd'
     user: user
     password: passwd
     headers:
@@ -185,13 +185,13 @@
 
 - name: test PUT
   uri:
-    url: 'http://{{ httpbin_host }}/put'
+    url: 'https://{{ httpbin_host }}/put'
     method: PUT
     body: 'foo=bar'
 
 - name: test OPTIONS
   uri:
-    url: 'http://{{ httpbin_host }}/'
+    url: 'https://{{ httpbin_host }}/'
     method: OPTIONS
   register: result
 

--- a/test/integration/targets/uri/tasks/redirect-all.yml
+++ b/test/integration/targets/uri/tasks/redirect-all.yml
@@ -1,6 +1,6 @@
 - name: Test HTTP 301 using HEAD
   uri:
-    url: http://{{ httpbin_host }}/redirect-to?status_code=301&url=http://{{ httpbin_host }}/anything
+    url: https://{{ httpbin_host }}/redirect-to?status_code=301&url=https://{{ httpbin_host }}/anything
     follow_redirects: all
     return_content: yes
     method: HEAD
@@ -12,11 +12,11 @@
     - http_301_head.json is not defined
     - http_301_head.redirected == true
     - http_301_head.status == 200
-    - http_301_head.url == 'http://{{ httpbin_host }}/anything'
+    - http_301_head.url == 'https://{{ httpbin_host }}/anything'
 
 - name: Test HTTP 301 using GET
   uri:
-    url: http://{{ httpbin_host }}/redirect-to?status_code=301&url=http://{{ httpbin_host }}/anything
+    url: https://{{ httpbin_host }}/redirect-to?status_code=301&url=https://{{ httpbin_host }}/anything
     follow_redirects: all
     return_content: yes
     method: GET
@@ -27,15 +27,15 @@
     - http_301_get is successful
     - http_301_get.json.data == ''
     - http_301_get.json.method == 'GET'
-    - http_301_get.json.url == 'http://{{ httpbin_host }}/anything'
+    - http_301_get.json.url == 'https://{{ httpbin_host }}/anything'
     - http_301_get.redirected == true
     - http_301_get.status == 200
-    - http_301_get.url == 'http://{{ httpbin_host }}/anything'
+    - http_301_get.url == 'https://{{ httpbin_host }}/anything'
 
 # NOTE: The HTTP POST turns into an HTTP GET
 - name: Test HTTP 301 using POST
   uri:
-    url: http://{{ httpbin_host }}/redirect-to?status_code=301&url=http://{{ httpbin_host }}/anything
+    url: https://{{ httpbin_host }}/redirect-to?status_code=301&url=https://{{ httpbin_host }}/anything
     follow_redirects: all
     return_content: yes
     method: POST
@@ -48,14 +48,14 @@
     - http_301_post is successful
     - http_301_post.json.data == ''
     - http_301_post.json.method == 'GET'
-    - http_301_post.json.url == 'http://{{ httpbin_host }}/anything'
+    - http_301_post.json.url == 'https://{{ httpbin_host }}/anything'
     - http_301_post.redirected == true
     - http_301_post.status == 200
-    - http_301_post.url == 'http://{{ httpbin_host }}/anything'
+    - http_301_post.url == 'https://{{ httpbin_host }}/anything'
 
 - name: Test HTTP 302 using HEAD
   uri:
-    url: http://{{ httpbin_host }}/redirect-to?status_code=302&url=http://{{ httpbin_host }}/anything
+    url: https://{{ httpbin_host }}/redirect-to?status_code=302&url=https://{{ httpbin_host }}/anything
     follow_redirects: all
     return_content: yes
     method: HEAD
@@ -67,11 +67,11 @@
     - http_302_head.json is not defined
     - http_302_head.redirected == true
     - http_302_head.status == 200
-    - http_302_head.url == 'http://{{ httpbin_host }}/anything'
+    - http_302_head.url == 'https://{{ httpbin_host }}/anything'
 
 - name: Test HTTP 302 using GET
   uri:
-    url: http://{{ httpbin_host }}/redirect-to?status_code=302&url=http://{{ httpbin_host }}/anything
+    url: https://{{ httpbin_host }}/redirect-to?status_code=302&url=https://{{ httpbin_host }}/anything
     follow_redirects: all
     return_content: yes
     method: GET
@@ -82,15 +82,15 @@
     - http_302_get is successful
     - http_302_get.json.data == ''
     - http_302_get.json.method == 'GET'
-    - http_302_get.json.url == 'http://{{ httpbin_host }}/anything'
+    - http_302_get.json.url == 'https://{{ httpbin_host }}/anything'
     - http_302_get.redirected == true
     - http_302_get.status == 200
-    - http_302_get.url == 'http://{{ httpbin_host }}/anything'
+    - http_302_get.url == 'https://{{ httpbin_host }}/anything'
 
 # NOTE: The HTTP POST turns into an HTTP GET
 - name: Test HTTP 302 using POST
   uri:
-    url: http://{{ httpbin_host }}/redirect-to?status_code=302&url=http://{{ httpbin_host }}/anything
+    url: https://{{ httpbin_host }}/redirect-to?status_code=302&url=https://{{ httpbin_host }}/anything
     follow_redirects: all
     return_content: yes
     method: POST
@@ -103,14 +103,14 @@
     - http_302_post is successful
     - http_302_post.json.data == ''
     - http_302_post.json.method == 'GET'
-    - http_302_post.json.url == 'http://{{ httpbin_host }}/anything'
+    - http_302_post.json.url == 'https://{{ httpbin_host }}/anything'
     - http_302_post.redirected == true
     - http_302_post.status == 200
-    - http_302_post.url == 'http://{{ httpbin_host }}/anything'
+    - http_302_post.url == 'https://{{ httpbin_host }}/anything'
 
 - name: Test HTTP 303 using HEAD
   uri:
-    url: http://{{ httpbin_host }}/redirect-to?status_code=303&url=http://{{ httpbin_host }}/anything
+    url: https://{{ httpbin_host }}/redirect-to?status_code=303&url=https://{{ httpbin_host }}/anything
     follow_redirects: all
     return_content: yes
     method: HEAD
@@ -122,11 +122,11 @@
     - http_303_head.json is not defined
     - http_303_head.redirected == true
     - http_303_head.status == 200
-    - http_303_head.url == 'http://{{ httpbin_host }}/anything'
+    - http_303_head.url == 'https://{{ httpbin_host }}/anything'
 
 - name: Test HTTP 303 using GET
   uri:
-    url: http://{{ httpbin_host }}/redirect-to?status_code=303&url=http://{{ httpbin_host }}/anything
+    url: https://{{ httpbin_host }}/redirect-to?status_code=303&url=https://{{ httpbin_host }}/anything
     follow_redirects: all
     return_content: yes
     method: GET
@@ -137,15 +137,15 @@
     - http_303_get is successful
     - http_303_get.json.data == ''
     - http_303_get.json.method == 'GET'
-    - http_303_get.json.url == 'http://{{ httpbin_host }}/anything'
+    - http_303_get.json.url == 'https://{{ httpbin_host }}/anything'
     - http_303_get.redirected == true
     - http_303_get.status == 200
-    - http_303_get.url == 'http://{{ httpbin_host }}/anything'
+    - http_303_get.url == 'https://{{ httpbin_host }}/anything'
 
 # NOTE: The HTTP POST turns into an HTTP GET
 - name: Test HTTP 303 using POST
   uri:
-    url: http://{{ httpbin_host }}/redirect-to?status_code=303&url=http://{{ httpbin_host }}/anything
+    url: https://{{ httpbin_host }}/redirect-to?status_code=303&url=https://{{ httpbin_host }}/anything
     follow_redirects: all
     return_content: yes
     method: POST
@@ -158,14 +158,14 @@
     - http_303_post is successful
     - http_303_post.json.data == ''
     - http_303_post.json.method == 'GET'
-    - http_303_post.json.url == 'http://{{ httpbin_host }}/anything'
+    - http_303_post.json.url == 'https://{{ httpbin_host }}/anything'
     - http_303_post.redirected == true
     - http_303_post.status == 200
-    - http_303_post.url == 'http://{{ httpbin_host }}/anything'
+    - http_303_post.url == 'https://{{ httpbin_host }}/anything'
 
 - name: Test HTTP 307 using HEAD
   uri:
-    url: http://{{ httpbin_host }}/redirect-to?status_code=307&url=http://{{ httpbin_host }}/anything
+    url: https://{{ httpbin_host }}/redirect-to?status_code=307&url=https://{{ httpbin_host }}/anything
     follow_redirects: all
     return_content: yes
     method: HEAD
@@ -177,11 +177,11 @@
     - http_307_head.json is not defined
     - http_307_head.redirected == true
     - http_307_head.status == 200
-    - http_307_head.url == 'http://{{ httpbin_host }}/anything'
+    - http_307_head.url == 'https://{{ httpbin_host }}/anything'
 
 - name: Test HTTP 307 using GET
   uri:
-    url: http://{{ httpbin_host }}/redirect-to?status_code=307&url=http://{{ httpbin_host }}/anything
+    url: https://{{ httpbin_host }}/redirect-to?status_code=307&url=https://{{ httpbin_host }}/anything
     follow_redirects: all
     return_content: yes
     method: GET
@@ -192,14 +192,14 @@
     - http_307_get is successful
     - http_307_get.json.data == ''
     - http_307_get.json.method == 'GET'
-    - http_307_get.json.url == 'http://{{ httpbin_host }}/anything'
+    - http_307_get.json.url == 'https://{{ httpbin_host }}/anything'
     - http_307_get.redirected == true
     - http_307_get.status == 200
-    - http_307_get.url == 'http://{{ httpbin_host }}/anything'
+    - http_307_get.url == 'https://{{ httpbin_host }}/anything'
 
 - name: Test HTTP 307 using POST
   uri:
-    url: http://{{ httpbin_host }}/redirect-to?status_code=307&url=http://{{ httpbin_host }}/anything
+    url: https://{{ httpbin_host }}/redirect-to?status_code=307&url=https://{{ httpbin_host }}/anything
     follow_redirects: all
     return_content: yes
     method: POST
@@ -212,14 +212,14 @@
     - http_307_post is successful
     - http_307_post.json.json.foo == 'bar'
     - http_307_post.json.method == 'POST'
-    - http_307_post.json.url == 'http://{{ httpbin_host }}/anything'
+    - http_307_post.json.url == 'https://{{ httpbin_host }}/anything'
     - http_307_post.redirected == true
     - http_307_post.status == 200
-    - http_307_post.url == 'http://{{ httpbin_host }}/anything'
+    - http_307_post.url == 'https://{{ httpbin_host }}/anything'
 
 - name: Test HTTP 308 using HEAD
   uri:
-    url: http://{{ httpbin_host }}/redirect-to?status_code=308&url=http://{{ httpbin_host }}/anything
+    url: https://{{ httpbin_host }}/redirect-to?status_code=308&url=https://{{ httpbin_host }}/anything
     follow_redirects: all
     return_content: yes
     method: HEAD
@@ -231,11 +231,11 @@
     - http_308_head.json is undefined
     - http_308_head.redirected == true
     - http_308_head.status == 200
-    - http_308_head.url == 'http://{{ httpbin_host }}/anything'
+    - http_308_head.url == 'https://{{ httpbin_host }}/anything'
 
 - name: Test HTTP 308 using GET
   uri:
-    url: http://{{ httpbin_host }}/redirect-to?status_code=308&url=http://{{ httpbin_host }}/anything
+    url: https://{{ httpbin_host }}/redirect-to?status_code=308&url=https://{{ httpbin_host }}/anything
     follow_redirects: all
     return_content: yes
     method: GET
@@ -246,14 +246,14 @@
     - http_308_get is successful
     - http_308_get.json.data == ''
     - http_308_get.json.method == 'GET'
-    - http_308_get.json.url == 'http://{{ httpbin_host }}/anything'
+    - http_308_get.json.url == 'https://{{ httpbin_host }}/anything'
     - http_308_get.redirected == true
     - http_308_get.status == 200
-    - http_308_get.url == 'http://{{ httpbin_host }}/anything'
+    - http_308_get.url == 'https://{{ httpbin_host }}/anything'
 
 - name: Test HTTP 308 using POST
   uri:
-    url: http://{{ httpbin_host }}/redirect-to?status_code=308&url=http://{{ httpbin_host }}/anything
+    url: https://{{ httpbin_host }}/redirect-to?status_code=308&url=https://{{ httpbin_host }}/anything
     follow_redirects: all
     return_content: yes
     method: POST
@@ -266,7 +266,7 @@
     - http_308_post is successful
     - http_308_post.json.json.foo == 'bar'
     - http_308_post.json.method == 'POST'
-    - http_308_post.json.url == 'http://{{ httpbin_host }}/anything'
+    - http_308_post.json.url == 'https://{{ httpbin_host }}/anything'
     - http_308_post.redirected == true
     - http_308_post.status == 200
-    - http_308_post.url == 'http://{{ httpbin_host }}/anything'
+    - http_308_post.url == 'https://{{ httpbin_host }}/anything'

--- a/test/integration/targets/uri/tasks/redirect-none.yml
+++ b/test/integration/targets/uri/tasks/redirect-none.yml
@@ -1,6 +1,6 @@
 - name: Test HTTP 301 using HEAD
   uri:
-    url: http://{{ httpbin_host }}/redirect-to?status_code=301&url=http://{{ httpbin_host }}/anything
+    url: https://{{ httpbin_host }}/redirect-to?status_code=301&url=https://{{ httpbin_host }}/anything
     follow_redirects: none
     return_content: yes
     method: HEAD
@@ -11,15 +11,15 @@
     that:
     - http_301_head is failure
     - http_301_head.json is not defined
-    - http_301_head.location == 'http://{{ httpbin_host }}/anything'
+    - http_301_head.location == 'https://{{ httpbin_host }}/anything'
     - "http_301_head.msg == 'Status code was 301 and not [200]: HTTP Error 301: MOVED PERMANENTLY'"
     - http_301_head.redirected == false
     - http_301_head.status == 301
-    - http_301_head.url == 'http://{{ httpbin_host }}/redirect-to?status_code=301&url=http://{{ httpbin_host }}/anything'
+    - http_301_head.url == 'https://{{ httpbin_host }}/redirect-to?status_code=301&url=https://{{ httpbin_host }}/anything'
 
 - name: Test HTTP 301 using GET
   uri:
-    url: http://{{ httpbin_host }}/redirect-to?status_code=301&url=http://{{ httpbin_host }}/anything
+    url: https://{{ httpbin_host }}/redirect-to?status_code=301&url=https://{{ httpbin_host }}/anything
     follow_redirects: none
     return_content: yes
     method: GET
@@ -30,15 +30,15 @@
     that:
     - http_301_get is failure
     - http_301_get.json is not defined
-    - http_301_get.location == 'http://{{ httpbin_host }}/anything'
+    - http_301_get.location == 'https://{{ httpbin_host }}/anything'
     - "http_301_get.msg == 'Status code was 301 and not [200]: HTTP Error 301: MOVED PERMANENTLY'"
     - http_301_get.redirected == false
     - http_301_get.status == 301
-    - http_301_get.url == 'http://{{ httpbin_host }}/redirect-to?status_code=301&url=http://{{ httpbin_host }}/anything'
+    - http_301_get.url == 'https://{{ httpbin_host }}/redirect-to?status_code=301&url=https://{{ httpbin_host }}/anything'
 
 - name: Test HTTP 301 using POST
   uri:
-    url: http://{{ httpbin_host }}/redirect-to?status_code=301&url=http://{{ httpbin_host }}/anything
+    url: https://{{ httpbin_host }}/redirect-to?status_code=301&url=https://{{ httpbin_host }}/anything
     follow_redirects: none
     return_content: yes
     method: POST
@@ -51,15 +51,15 @@
     that:
     - http_301_post is failure
     - http_301_post.json is not defined
-    - http_301_post.location == 'http://{{ httpbin_host }}/anything'
+    - http_301_post.location == 'https://{{ httpbin_host }}/anything'
     - "http_301_post.msg == 'Status code was 301 and not [200]: HTTP Error 301: MOVED PERMANENTLY'"
     - http_301_post.redirected == false
     - http_301_post.status == 301
-    - http_301_post.url == 'http://{{ httpbin_host }}/redirect-to?status_code=301&url=http://{{ httpbin_host }}/anything'
+    - http_301_post.url == 'https://{{ httpbin_host }}/redirect-to?status_code=301&url=https://{{ httpbin_host }}/anything'
 
 - name: Test HTTP 302 using HEAD
   uri:
-    url: http://{{ httpbin_host }}/redirect-to?status_code=302&url=http://{{ httpbin_host }}/anything
+    url: https://{{ httpbin_host }}/redirect-to?status_code=302&url=https://{{ httpbin_host }}/anything
     follow_redirects: none
     return_content: yes
     method: HEAD
@@ -70,15 +70,15 @@
     that:
     - http_302_head is failure
     - http_302_head.json is not defined
-    - http_302_head.location == 'http://{{ httpbin_host }}/anything'
+    - http_302_head.location == 'https://{{ httpbin_host }}/anything'
     - "http_302_head.msg == 'Status code was 302 and not [200]: HTTP Error 302: FOUND'"
     - http_302_head.redirected == false
     - http_302_head.status == 302
-    - http_302_head.url == 'http://{{ httpbin_host }}/redirect-to?status_code=302&url=http://{{ httpbin_host }}/anything'
+    - http_302_head.url == 'https://{{ httpbin_host }}/redirect-to?status_code=302&url=https://{{ httpbin_host }}/anything'
 
 - name: Test HTTP 302 using GET
   uri:
-    url: http://{{ httpbin_host }}/redirect-to?status_code=302&url=http://{{ httpbin_host }}/anything
+    url: https://{{ httpbin_host }}/redirect-to?status_code=302&url=https://{{ httpbin_host }}/anything
     follow_redirects: none
     return_content: yes
     method: GET
@@ -89,15 +89,15 @@
     that:
     - http_302_get is failure
     - http_302_get.json is not defined
-    - http_302_get.location == 'http://{{ httpbin_host }}/anything'
+    - http_302_get.location == 'https://{{ httpbin_host }}/anything'
     - "http_302_get.msg == 'Status code was 302 and not [200]: HTTP Error 302: FOUND'"
     - http_302_get.redirected == false
     - http_302_get.status == 302
-    - http_302_get.url == 'http://{{ httpbin_host }}/redirect-to?status_code=302&url=http://{{ httpbin_host }}/anything'
+    - http_302_get.url == 'https://{{ httpbin_host }}/redirect-to?status_code=302&url=https://{{ httpbin_host }}/anything'
 
 - name: Test HTTP 302 using POST
   uri:
-    url: http://{{ httpbin_host }}/redirect-to?status_code=302&url=http://{{ httpbin_host }}/anything
+    url: https://{{ httpbin_host }}/redirect-to?status_code=302&url=https://{{ httpbin_host }}/anything
     follow_redirects: none
     return_content: yes
     method: POST
@@ -110,15 +110,15 @@
     that:
     - http_302_post is failure
     - http_302_post.json is not defined
-    - http_302_post.location == 'http://{{ httpbin_host }}/anything'
+    - http_302_post.location == 'https://{{ httpbin_host }}/anything'
     - "http_302_post.msg == 'Status code was 302 and not [200]: HTTP Error 302: FOUND'"
     - http_302_post.redirected == false
     - http_302_post.status == 302
-    - http_302_post.url == 'http://{{ httpbin_host }}/redirect-to?status_code=302&url=http://{{ httpbin_host }}/anything'
+    - http_302_post.url == 'https://{{ httpbin_host }}/redirect-to?status_code=302&url=https://{{ httpbin_host }}/anything'
 
 - name: Test HTTP 303 using HEAD
   uri:
-    url: http://{{ httpbin_host }}/redirect-to?status_code=303&url=http://{{ httpbin_host }}/anything
+    url: https://{{ httpbin_host }}/redirect-to?status_code=303&url=https://{{ httpbin_host }}/anything
     follow_redirects: none
     return_content: yes
     method: HEAD
@@ -129,15 +129,15 @@
     that:
     - http_303_head is failure
     - http_303_head.json is not defined
-    - http_303_head.location == 'http://{{ httpbin_host }}/anything'
+    - http_303_head.location == 'https://{{ httpbin_host }}/anything'
     - "http_303_head.msg == 'Status code was 303 and not [200]: HTTP Error 303: SEE OTHER'"
     - http_303_head.redirected == false
     - http_303_head.status == 303
-    - http_303_head.url == 'http://{{ httpbin_host }}/redirect-to?status_code=303&url=http://{{ httpbin_host }}/anything'
+    - http_303_head.url == 'https://{{ httpbin_host }}/redirect-to?status_code=303&url=https://{{ httpbin_host }}/anything'
 
 - name: Test HTTP 303 using GET
   uri:
-    url: http://{{ httpbin_host }}/redirect-to?status_code=303&url=http://{{ httpbin_host }}/anything
+    url: https://{{ httpbin_host }}/redirect-to?status_code=303&url=https://{{ httpbin_host }}/anything
     follow_redirects: none
     return_content: yes
     method: GET
@@ -148,15 +148,15 @@
     that:
     - http_303_get is failure
     - http_303_get.json is not defined
-    - http_303_get.location == 'http://{{ httpbin_host }}/anything'
+    - http_303_get.location == 'https://{{ httpbin_host }}/anything'
     - "http_303_get.msg == 'Status code was 303 and not [200]: HTTP Error 303: SEE OTHER'"
     - http_303_get.redirected == false
     - http_303_get.status == 303
-    - http_303_get.url == 'http://{{ httpbin_host }}/redirect-to?status_code=303&url=http://{{ httpbin_host }}/anything'
+    - http_303_get.url == 'https://{{ httpbin_host }}/redirect-to?status_code=303&url=https://{{ httpbin_host }}/anything'
 
 - name: Test HTTP 303 using POST
   uri:
-    url: http://{{ httpbin_host }}/redirect-to?status_code=303&url=http://{{ httpbin_host }}/anything
+    url: https://{{ httpbin_host }}/redirect-to?status_code=303&url=https://{{ httpbin_host }}/anything
     follow_redirects: none
     return_content: yes
     method: POST
@@ -169,15 +169,15 @@
     that:
     - http_303_post is failure
     - http_303_post.json is not defined
-    - http_303_post.location == 'http://{{ httpbin_host }}/anything'
+    - http_303_post.location == 'https://{{ httpbin_host }}/anything'
     - "http_303_post.msg == 'Status code was 303 and not [200]: HTTP Error 303: SEE OTHER'"
     - http_303_post.redirected == false
     - http_303_post.status == 303
-    - http_303_post.url == 'http://{{ httpbin_host }}/redirect-to?status_code=303&url=http://{{ httpbin_host }}/anything'
+    - http_303_post.url == 'https://{{ httpbin_host }}/redirect-to?status_code=303&url=https://{{ httpbin_host }}/anything'
 
 - name: Test HTTP 307 using HEAD
   uri:
-    url: http://{{ httpbin_host }}/redirect-to?status_code=307&url=http://{{ httpbin_host }}/anything
+    url: https://{{ httpbin_host }}/redirect-to?status_code=307&url=https://{{ httpbin_host }}/anything
     follow_redirects: none
     return_content: yes
     method: HEAD
@@ -188,15 +188,15 @@
     that:
     - http_307_head is failure
     - http_307_head.json is not defined
-    - http_307_head.location == 'http://{{ httpbin_host }}/anything'
+    - http_307_head.location == 'https://{{ httpbin_host }}/anything'
     - "http_307_head.msg == 'Status code was 307 and not [200]: HTTP Error 307: TEMPORARY REDIRECT'"
     - http_307_head.redirected == false
     - http_307_head.status == 307
-    - http_307_head.url == 'http://{{ httpbin_host }}/redirect-to?status_code=307&url=http://{{ httpbin_host }}/anything'
+    - http_307_head.url == 'https://{{ httpbin_host }}/redirect-to?status_code=307&url=https://{{ httpbin_host }}/anything'
 
 - name: Test HTTP 307 using GET
   uri:
-    url: http://{{ httpbin_host }}/redirect-to?status_code=307&url=http://{{ httpbin_host }}/anything
+    url: https://{{ httpbin_host }}/redirect-to?status_code=307&url=https://{{ httpbin_host }}/anything
     follow_redirects: none
     return_content: yes
     method: GET
@@ -207,15 +207,15 @@
     that:
     - http_307_get is failure
     - http_307_get.json is not defined
-    - http_307_get.location == 'http://{{ httpbin_host }}/anything'
+    - http_307_get.location == 'https://{{ httpbin_host }}/anything'
     - "http_307_get.msg == 'Status code was 307 and not [200]: HTTP Error 307: TEMPORARY REDIRECT'"
     - http_307_get.redirected == false
     - http_307_get.status == 307
-    - http_307_get.url == 'http://{{ httpbin_host }}/redirect-to?status_code=307&url=http://{{ httpbin_host }}/anything'
+    - http_307_get.url == 'https://{{ httpbin_host }}/redirect-to?status_code=307&url=https://{{ httpbin_host }}/anything'
 
 - name: Test HTTP 307 using POST
   uri:
-    url: http://{{ httpbin_host }}/redirect-to?status_code=307&url=http://{{ httpbin_host }}/anything
+    url: https://{{ httpbin_host }}/redirect-to?status_code=307&url=https://{{ httpbin_host }}/anything
     follow_redirects: none
     return_content: yes
     method: POST
@@ -228,16 +228,16 @@
     that:
     - http_307_post is failure
     - http_307_post.json is not defined
-    - http_307_post.location == 'http://{{ httpbin_host }}/anything'
+    - http_307_post.location == 'https://{{ httpbin_host }}/anything'
     - "http_307_post.msg == 'Status code was 307 and not [200]: HTTP Error 307: TEMPORARY REDIRECT'"
     - http_307_post.redirected == false
     - http_307_post.status == 307
-    - http_307_post.url == 'http://{{ httpbin_host }}/redirect-to?status_code=307&url=http://{{ httpbin_host }}/anything'
+    - http_307_post.url == 'https://{{ httpbin_host }}/redirect-to?status_code=307&url=https://{{ httpbin_host }}/anything'
 
 # NOTE: This is a bug, fixed in https://github.com/ansible/ansible/pull/36809
 - name: Test HTTP 308 using HEAD
   uri:
-    url: http://{{ httpbin_host }}/redirect-to?status_code=308&url=http://{{ httpbin_host }}/anything
+    url: https://{{ httpbin_host }}/redirect-to?status_code=308&url=https://{{ httpbin_host }}/anything
     follow_redirects: none
     return_content: yes
     method: GET
@@ -248,16 +248,16 @@
     that:
     - http_308_head is failure
     - http_308_head.json is not defined
-    - http_308_head.location == 'http://{{ httpbin_host }}/anything'
+    - http_308_head.location == 'https://{{ httpbin_host }}/anything'
     - "http_308_head.msg == 'Status code was 308 and not [200]: HTTP Error 308: UNKNOWN'"
     - http_308_head.redirected == false
     - http_308_head.status == 308
-    - http_308_head.url == 'http://{{ httpbin_host }}/redirect-to?status_code=308&url=http://{{ httpbin_host }}/anything'
+    - http_308_head.url == 'https://{{ httpbin_host }}/redirect-to?status_code=308&url=https://{{ httpbin_host }}/anything'
 
 # NOTE: This is a bug, fixed in https://github.com/ansible/ansible/pull/36809
 - name: Test HTTP 308 using GET
   uri:
-    url: http://{{ httpbin_host }}/redirect-to?status_code=308&url=http://{{ httpbin_host }}/anything
+    url: https://{{ httpbin_host }}/redirect-to?status_code=308&url=https://{{ httpbin_host }}/anything
     follow_redirects: none
     return_content: yes
     method: GET
@@ -268,15 +268,15 @@
     that:
     - http_308_get is failure
     - http_308_get.json is not defined
-    - http_308_get.location == 'http://{{ httpbin_host }}/anything'
+    - http_308_get.location == 'https://{{ httpbin_host }}/anything'
     - "http_308_get.msg == 'Status code was 308 and not [200]: HTTP Error 308: UNKNOWN'"
     - http_308_get.redirected == false
     - http_308_get.status == 308
-    - http_308_get.url == 'http://{{ httpbin_host }}/redirect-to?status_code=308&url=http://{{ httpbin_host }}/anything'
+    - http_308_get.url == 'https://{{ httpbin_host }}/redirect-to?status_code=308&url=https://{{ httpbin_host }}/anything'
 
 - name: Test HTTP 308 using POST
   uri:
-    url: http://{{ httpbin_host }}/redirect-to?status_code=308&url=http://{{ httpbin_host }}/anything
+    url: https://{{ httpbin_host }}/redirect-to?status_code=308&url=https://{{ httpbin_host }}/anything
     follow_redirects: none
     return_content: yes
     method: POST
@@ -289,8 +289,8 @@
     that:
     - http_308_post is failure
     - http_308_post.json is not defined
-    - http_308_post.location == 'http://{{ httpbin_host }}/anything'
+    - http_308_post.location == 'https://{{ httpbin_host }}/anything'
     - "http_308_post.msg == 'Status code was 308 and not [200]: HTTP Error 308: UNKNOWN'"
     - http_308_post.redirected == false
     - http_308_post.status == 308
-    - http_308_post.url == 'http://{{ httpbin_host }}/redirect-to?status_code=308&url=http://{{ httpbin_host }}/anything'
+    - http_308_post.url == 'https://{{ httpbin_host }}/redirect-to?status_code=308&url=https://{{ httpbin_host }}/anything'

--- a/test/integration/targets/uri/tasks/redirect-safe.yml
+++ b/test/integration/targets/uri/tasks/redirect-safe.yml
@@ -1,6 +1,6 @@
 - name: Test HTTP 301 using HEAD
   uri:
-    url: http://{{ httpbin_host }}/redirect-to?status_code=301&url=http://{{ httpbin_host }}/anything
+    url: https://{{ httpbin_host }}/redirect-to?status_code=301&url=https://{{ httpbin_host }}/anything
     follow_redirects: safe
     return_content: yes
     method: HEAD
@@ -12,11 +12,11 @@
     - http_301_head.json is not defined
     - http_301_head.redirected == true
     - http_301_head.status == 200
-    - http_301_head.url == 'http://{{ httpbin_host }}/anything'
+    - http_301_head.url == 'https://{{ httpbin_host }}/anything'
 
 - name: Test HTTP 301 using GET
   uri:
-    url: http://{{ httpbin_host }}/redirect-to?status_code=301&url=http://{{ httpbin_host }}/anything
+    url: https://{{ httpbin_host }}/redirect-to?status_code=301&url=https://{{ httpbin_host }}/anything
     follow_redirects: safe
     return_content: yes
     method: GET
@@ -27,14 +27,14 @@
     - http_301_get is successful
     - http_301_get.json.data == ''
     - http_301_get.json.method == 'GET'
-    - http_301_get.json.url == 'http://{{ httpbin_host }}/anything'
+    - http_301_get.json.url == 'https://{{ httpbin_host }}/anything'
     - http_301_get.redirected == true
     - http_301_get.status == 200
-    - http_301_get.url == 'http://{{ httpbin_host }}/anything'
+    - http_301_get.url == 'https://{{ httpbin_host }}/anything'
 
 - name: Test HTTP 301 using POST
   uri:
-    url: http://{{ httpbin_host }}/redirect-to?status_code=301&url=http://{{ httpbin_host }}/anything
+    url: https://{{ httpbin_host }}/redirect-to?status_code=301&url=https://{{ httpbin_host }}/anything
     follow_redirects: safe
     return_content: yes
     method: POST
@@ -47,15 +47,15 @@
     that:
     - http_301_post is failure
     - http_301_post.json is not defined
-    - http_301_post.location == 'http://{{ httpbin_host }}/anything'
+    - http_301_post.location == 'https://{{ httpbin_host }}/anything'
     - "http_301_post.msg == 'Status code was 301 and not [200]: HTTP Error 301: MOVED PERMANENTLY'"
     - http_301_post.redirected == false
     - http_301_post.status == 301
-    - http_301_post.url == 'http://{{ httpbin_host }}/redirect-to?status_code=301&url=http://{{ httpbin_host }}/anything'
+    - http_301_post.url == 'https://{{ httpbin_host }}/redirect-to?status_code=301&url=https://{{ httpbin_host }}/anything'
 
 - name: Test HTTP 302 using HEAD
   uri:
-    url: http://{{ httpbin_host }}/redirect-to?status_code=302&url=http://{{ httpbin_host }}/anything
+    url: https://{{ httpbin_host }}/redirect-to?status_code=302&url=https://{{ httpbin_host }}/anything
     follow_redirects: safe
     return_content: yes
     method: HEAD
@@ -67,11 +67,11 @@
     - http_302_head.json is not defined
     - http_302_head.redirected == true
     - http_302_head.status == 200
-    - http_302_head.url == 'http://{{ httpbin_host }}/anything'
+    - http_302_head.url == 'https://{{ httpbin_host }}/anything'
 
 - name: Test HTTP 302 using GET
   uri:
-    url: http://{{ httpbin_host }}/redirect-to?status_code=302&url=http://{{ httpbin_host }}/anything
+    url: https://{{ httpbin_host }}/redirect-to?status_code=302&url=https://{{ httpbin_host }}/anything
     follow_redirects: safe
     return_content: yes
     method: GET
@@ -82,14 +82,14 @@
     - http_302_get is successful
     - http_302_get.json.data == ''
     - http_302_get.json.method == 'GET'
-    - http_302_get.json.url == 'http://{{ httpbin_host }}/anything'
+    - http_302_get.json.url == 'https://{{ httpbin_host }}/anything'
     - http_302_get.redirected == true
     - http_302_get.status == 200
-    - http_302_get.url == 'http://{{ httpbin_host }}/anything'
+    - http_302_get.url == 'https://{{ httpbin_host }}/anything'
 
 - name: Test HTTP 302 using POST
   uri:
-    url: http://{{ httpbin_host }}/redirect-to?status_code=302&url=http://{{ httpbin_host }}/anything
+    url: https://{{ httpbin_host }}/redirect-to?status_code=302&url=https://{{ httpbin_host }}/anything
     follow_redirects: safe
     return_content: yes
     method: POST
@@ -102,15 +102,15 @@
     that:
     - http_302_post is failure
     - http_302_post.json is not defined
-    - http_302_post.location == 'http://{{ httpbin_host }}/anything'
+    - http_302_post.location == 'https://{{ httpbin_host }}/anything'
     - "http_302_post.msg == 'Status code was 302 and not [200]: HTTP Error 302: FOUND'"
     - http_302_post.redirected == false
     - http_302_post.status == 302
-    - http_302_post.url == 'http://{{ httpbin_host }}/redirect-to?status_code=302&url=http://{{ httpbin_host }}/anything'
+    - http_302_post.url == 'https://{{ httpbin_host }}/redirect-to?status_code=302&url=https://{{ httpbin_host }}/anything'
 
 - name: Test HTTP 303 using HEAD
   uri:
-    url: http://{{ httpbin_host }}/redirect-to?status_code=303&url=http://{{ httpbin_host }}/anything
+    url: https://{{ httpbin_host }}/redirect-to?status_code=303&url=https://{{ httpbin_host }}/anything
     follow_redirects: safe
     return_content: yes
     method: HEAD
@@ -122,11 +122,11 @@
     - http_303_head.json is not defined
     - http_303_head.redirected == true
     - http_303_head.status == 200
-    - http_303_head.url == 'http://{{ httpbin_host }}/anything'
+    - http_303_head.url == 'https://{{ httpbin_host }}/anything'
 
 - name: Test HTTP 303 using GET
   uri:
-    url: http://{{ httpbin_host }}/redirect-to?status_code=303&url=http://{{ httpbin_host }}/anything
+    url: https://{{ httpbin_host }}/redirect-to?status_code=303&url=https://{{ httpbin_host }}/anything
     follow_redirects: safe
     return_content: yes
     method: GET
@@ -137,14 +137,14 @@
     - http_303_get is successful
     - http_303_get.json.data == ''
     - http_303_get.json.method == 'GET'
-    - http_303_get.json.url == 'http://{{ httpbin_host }}/anything'
+    - http_303_get.json.url == 'https://{{ httpbin_host }}/anything'
     - http_303_get.redirected == true
     - http_303_get.status == 200
-    - http_303_get.url == 'http://{{ httpbin_host }}/anything'
+    - http_303_get.url == 'https://{{ httpbin_host }}/anything'
 
 - name: Test HTTP 303 using POST
   uri:
-    url: http://{{ httpbin_host }}/redirect-to?status_code=303&url=http://{{ httpbin_host }}/anything
+    url: https://{{ httpbin_host }}/redirect-to?status_code=303&url=https://{{ httpbin_host }}/anything
     follow_redirects: safe
     return_content: yes
     method: POST
@@ -157,15 +157,15 @@
     that:
     - http_303_post is failure
     - http_303_post.json is not defined
-    - http_303_post.location == 'http://{{ httpbin_host }}/anything'
+    - http_303_post.location == 'https://{{ httpbin_host }}/anything'
     - "http_303_post.msg == 'Status code was 303 and not [200]: HTTP Error 303: SEE OTHER'"
     - http_303_post.redirected == false
     - http_303_post.status == 303
-    - http_303_post.url == 'http://{{ httpbin_host }}/redirect-to?status_code=303&url=http://{{ httpbin_host }}/anything'
+    - http_303_post.url == 'https://{{ httpbin_host }}/redirect-to?status_code=303&url=https://{{ httpbin_host }}/anything'
 
 - name: Test HTTP 307 using HEAD
   uri:
-    url: http://{{ httpbin_host }}/redirect-to?status_code=307&url=http://{{ httpbin_host }}/anything
+    url: https://{{ httpbin_host }}/redirect-to?status_code=307&url=https://{{ httpbin_host }}/anything
     follow_redirects: safe
     return_content: yes
     method: HEAD
@@ -177,11 +177,11 @@
     - http_307_head.json is not defined
     - http_307_head.redirected == true
     - http_307_head.status == 200
-    - http_307_head.url == 'http://{{ httpbin_host }}/anything'
+    - http_307_head.url == 'https://{{ httpbin_host }}/anything'
 
 - name: Test HTTP 307 using GET
   uri:
-    url: http://{{ httpbin_host }}/redirect-to?status_code=307&url=http://{{ httpbin_host }}/anything
+    url: https://{{ httpbin_host }}/redirect-to?status_code=307&url=https://{{ httpbin_host }}/anything
     follow_redirects: safe
     return_content: yes
     method: GET
@@ -192,14 +192,14 @@
     - http_307_get is successful
     - http_307_get.json.data == ''
     - http_307_get.json.method == 'GET'
-    - http_307_get.json.url == 'http://{{ httpbin_host }}/anything'
+    - http_307_get.json.url == 'https://{{ httpbin_host }}/anything'
     - http_307_get.redirected == true
     - http_307_get.status == 200
-    - http_307_get.url == 'http://{{ httpbin_host }}/anything'
+    - http_307_get.url == 'https://{{ httpbin_host }}/anything'
 
 - name: Test HTTP 307 using POST
   uri:
-    url: http://{{ httpbin_host }}/redirect-to?status_code=307&url=http://{{ httpbin_host }}/anything
+    url: https://{{ httpbin_host }}/redirect-to?status_code=307&url=https://{{ httpbin_host }}/anything
     follow_redirects: safe
     return_content: yes
     method: POST
@@ -212,15 +212,15 @@
     that:
     - http_307_post is failure
     - http_307_post.json is not defined
-    - http_307_post.location == 'http://{{ httpbin_host }}/anything'
+    - http_307_post.location == 'https://{{ httpbin_host }}/anything'
     - "http_307_post.msg == 'Status code was 307 and not [200]: HTTP Error 307: TEMPORARY REDIRECT'"
     - http_307_post.redirected == false
     - http_307_post.status == 307
-    - http_307_post.url == 'http://{{ httpbin_host }}/redirect-to?status_code=307&url=http://{{ httpbin_host }}/anything'
+    - http_307_post.url == 'https://{{ httpbin_host }}/redirect-to?status_code=307&url=https://{{ httpbin_host }}/anything'
 
 - name: Test HTTP 308 using HEAD
   uri:
-    url: http://{{ httpbin_host }}/redirect-to?status_code=308&url=http://{{ httpbin_host }}/anything
+    url: https://{{ httpbin_host }}/redirect-to?status_code=308&url=https://{{ httpbin_host }}/anything
     follow_redirects: safe
     return_content: yes
     method: HEAD
@@ -232,11 +232,11 @@
     - http_308_head.json is not defined
     - http_308_head.redirected == true
     - http_308_head.status == 200
-    - http_308_head.url == 'http://{{ httpbin_host }}/anything'
+    - http_308_head.url == 'https://{{ httpbin_host }}/anything'
 
 - name: Test HTTP 308 using GET
   uri:
-    url: http://{{ httpbin_host }}/redirect-to?status_code=308&url=http://{{ httpbin_host }}/anything
+    url: https://{{ httpbin_host }}/redirect-to?status_code=308&url=https://{{ httpbin_host }}/anything
     follow_redirects: safe
     return_content: yes
     method: GET
@@ -247,14 +247,14 @@
     - http_308_get is successful
     - http_308_get.json.data == ''
     - http_308_get.json.method == 'GET'
-    - http_308_get.json.url == 'http://{{ httpbin_host }}/anything'
+    - http_308_get.json.url == 'https://{{ httpbin_host }}/anything'
     - http_308_get.redirected == true
     - http_308_get.status == 200
-    - http_308_get.url == 'http://{{ httpbin_host }}/anything'
+    - http_308_get.url == 'https://{{ httpbin_host }}/anything'
 
 - name: Test HTTP 308 using POST
   uri:
-    url: http://{{ httpbin_host }}/redirect-to?status_code=308&url=http://{{ httpbin_host }}/anything
+    url: https://{{ httpbin_host }}/redirect-to?status_code=308&url=https://{{ httpbin_host }}/anything
     follow_redirects: safe
     return_content: yes
     method: POST
@@ -267,8 +267,8 @@
     that:
     - http_308_post is failure
     - http_308_post.json is not defined
-    - http_308_post.location == 'http://{{ httpbin_host }}/anything'
+    - http_308_post.location == 'https://{{ httpbin_host }}/anything'
     - "http_308_post.msg == 'Status code was 308 and not [200]: HTTP Error 308: UNKNOWN'"
     - http_308_post.redirected == false
     - http_308_post.status == 308
-    - http_308_post.url == 'http://{{ httpbin_host }}/redirect-to?status_code=308&url=http://{{ httpbin_host }}/anything'
+    - http_308_post.url == 'https://{{ httpbin_host }}/redirect-to?status_code=308&url=https://{{ httpbin_host }}/anything'

--- a/test/integration/targets/uri/tasks/redirect-urllib2.yml
+++ b/test/integration/targets/uri/tasks/redirect-urllib2.yml
@@ -1,7 +1,7 @@
 # NOTE: The HTTP HEAD turns into an HTTP GET
 - name: Test HTTP 301 using HEAD
   uri:
-    url: http://{{ httpbin_host }}/redirect-to?status_code=301&url=http://{{ httpbin_host }}/anything
+    url: https://{{ httpbin_host }}/redirect-to?status_code=301&url=https://{{ httpbin_host }}/anything
     follow_redirects: urllib2
     return_content: yes
     method: HEAD
@@ -12,14 +12,14 @@
     - http_301_head is successful
     - http_301_head.json.data == ''
     - http_301_head.json.method == 'GET'
-    - http_301_head.json.url == 'http://{{ httpbin_host }}/anything'
+    - http_301_head.json.url == 'https://{{ httpbin_host }}/anything'
     - http_301_head.redirected == true
     - http_301_head.status == 200
-    - http_301_head.url == 'http://{{ httpbin_host }}/anything'
+    - http_301_head.url == 'https://{{ httpbin_host }}/anything'
 
 - name: Test HTTP 301 using GET
   uri:
-    url: http://{{ httpbin_host }}/redirect-to?status_code=301&url=http://{{ httpbin_host }}/anything
+    url: https://{{ httpbin_host }}/redirect-to?status_code=301&url=https://{{ httpbin_host }}/anything
     follow_redirects: urllib2
     return_content: yes
     method: GET
@@ -30,15 +30,15 @@
     - http_301_get is successful
     - http_301_get.json.data == ''
     - http_301_get.json.method == 'GET'
-    - http_301_get.json.url == 'http://{{ httpbin_host }}/anything'
+    - http_301_get.json.url == 'https://{{ httpbin_host }}/anything'
     - http_301_get.redirected == true
     - http_301_get.status == 200
-    - http_301_get.url == 'http://{{ httpbin_host }}/anything'
+    - http_301_get.url == 'https://{{ httpbin_host }}/anything'
 
 # NOTE: The HTTP POST turns into an HTTP GET
 - name: Test HTTP 301 using POST
   uri:
-    url: http://{{ httpbin_host }}/redirect-to?status_code=301&url=http://{{ httpbin_host }}/anything
+    url: https://{{ httpbin_host }}/redirect-to?status_code=301&url=https://{{ httpbin_host }}/anything
     follow_redirects: urllib2
     return_content: yes
     method: POST
@@ -51,15 +51,15 @@
     - http_301_post is successful
     - http_301_post.json.data == ''
     - http_301_post.json.method == 'GET'
-    - http_301_post.json.url == 'http://{{ httpbin_host }}/anything'
+    - http_301_post.json.url == 'https://{{ httpbin_host }}/anything'
     - http_301_post.redirected == true
     - http_301_post.status == 200
-    - http_301_post.url == 'http://{{ httpbin_host }}/anything'
+    - http_301_post.url == 'https://{{ httpbin_host }}/anything'
 
 # NOTE: The HTTP HEAD turns into an HTTP GET
 - name: Test HTTP 302 using HEAD
   uri:
-    url: http://{{ httpbin_host }}/redirect-to?status_code=302&url=http://{{ httpbin_host }}/anything
+    url: https://{{ httpbin_host }}/redirect-to?status_code=302&url=https://{{ httpbin_host }}/anything
     follow_redirects: urllib2
     return_content: yes
     method: HEAD
@@ -70,14 +70,14 @@
     - http_302_head is successful
     - http_302_head.json.data == ''
     - http_302_head.json.method == 'GET'
-    - http_302_head.json.url == 'http://{{ httpbin_host }}/anything'
+    - http_302_head.json.url == 'https://{{ httpbin_host }}/anything'
     - http_302_head.redirected == true
     - http_302_head.status == 200
-    - http_302_head.url == 'http://{{ httpbin_host }}/anything'
+    - http_302_head.url == 'https://{{ httpbin_host }}/anything'
 
 - name: Test HTTP 302 using GET
   uri:
-    url: http://{{ httpbin_host }}/redirect-to?status_code=302&url=http://{{ httpbin_host }}/anything
+    url: https://{{ httpbin_host }}/redirect-to?status_code=302&url=https://{{ httpbin_host }}/anything
     follow_redirects: urllib2
     return_content: yes
     method: GET
@@ -88,15 +88,15 @@
     - http_302_get is successful
     - http_302_get.json.data == ''
     - http_302_get.json.method == 'GET'
-    - http_302_get.json.url == 'http://{{ httpbin_host }}/anything'
+    - http_302_get.json.url == 'https://{{ httpbin_host }}/anything'
     - http_302_get.redirected == true
     - http_302_get.status == 200
-    - http_302_get.url == 'http://{{ httpbin_host }}/anything'
+    - http_302_get.url == 'https://{{ httpbin_host }}/anything'
 
 # NOTE: The HTTP POST turns into an HTTP GET
 - name: Test HTTP 302 using POST
   uri:
-    url: http://{{ httpbin_host }}/redirect-to?status_code=302&url=http://{{ httpbin_host }}/anything
+    url: https://{{ httpbin_host }}/redirect-to?status_code=302&url=https://{{ httpbin_host }}/anything
     follow_redirects: urllib2
     return_content: yes
     method: POST
@@ -109,15 +109,15 @@
     - http_302_post is successful
     - http_302_post.json.data == ''
     - http_302_post.json.method == 'GET'
-    - http_302_post.json.url == 'http://{{ httpbin_host }}/anything'
+    - http_302_post.json.url == 'https://{{ httpbin_host }}/anything'
     - http_302_post.redirected == true
     - http_302_post.status == 200
-    - http_302_post.url == 'http://{{ httpbin_host }}/anything'
+    - http_302_post.url == 'https://{{ httpbin_host }}/anything'
 
 # NOTE: The HTTP HEAD turns into an HTTP GET
 - name: Test HTTP 303 using HEAD
   uri:
-    url: http://{{ httpbin_host }}/redirect-to?status_code=303&url=http://{{ httpbin_host }}/anything
+    url: https://{{ httpbin_host }}/redirect-to?status_code=303&url=https://{{ httpbin_host }}/anything
     follow_redirects: urllib2
     return_content: yes
     method: HEAD
@@ -128,14 +128,14 @@
     - http_303_head is successful
     - http_303_head.json.data == ''
     - http_303_head.json.method == 'GET'
-    - http_303_head.json.url == 'http://{{ httpbin_host }}/anything'
+    - http_303_head.json.url == 'https://{{ httpbin_host }}/anything'
     - http_303_head.redirected == true
     - http_303_head.status == 200
-    - http_303_head.url == 'http://{{ httpbin_host }}/anything'
+    - http_303_head.url == 'https://{{ httpbin_host }}/anything'
 
 - name: Test HTTP 303 using GET
   uri:
-    url: http://{{ httpbin_host }}/redirect-to?status_code=303&url=http://{{ httpbin_host }}/anything
+    url: https://{{ httpbin_host }}/redirect-to?status_code=303&url=https://{{ httpbin_host }}/anything
     follow_redirects: urllib2
     return_content: yes
     method: GET
@@ -146,15 +146,15 @@
     - http_303_get is successful
     - http_303_get.json.data == ''
     - http_303_get.json.method == 'GET'
-    - http_303_get.json.url == 'http://{{ httpbin_host }}/anything'
+    - http_303_get.json.url == 'https://{{ httpbin_host }}/anything'
     - http_303_get.redirected == true
     - http_303_get.status == 200
-    - http_303_get.url == 'http://{{ httpbin_host }}/anything'
+    - http_303_get.url == 'https://{{ httpbin_host }}/anything'
 
 # NOTE: The HTTP POST turns into an HTTP GET
 - name: Test HTTP 303 using POST
   uri:
-    url: http://{{ httpbin_host }}/redirect-to?status_code=303&url=http://{{ httpbin_host }}/anything
+    url: https://{{ httpbin_host }}/redirect-to?status_code=303&url=https://{{ httpbin_host }}/anything
     follow_redirects: urllib2
     return_content: yes
     method: POST
@@ -167,15 +167,15 @@
     - http_303_post is successful
     - http_303_post.json.data == ''
     - http_303_post.json.method == 'GET'
-    - http_303_post.json.url == 'http://{{ httpbin_host }}/anything'
+    - http_303_post.json.url == 'https://{{ httpbin_host }}/anything'
     - http_303_post.redirected == true
     - http_303_post.status == 200
-    - http_303_post.url == 'http://{{ httpbin_host }}/anything'
+    - http_303_post.url == 'https://{{ httpbin_host }}/anything'
 
 # NOTE: The HTTP HEAD turns into an HTTP GET
 - name: Test HTTP 307 using HEAD
   uri:
-    url: http://{{ httpbin_host }}/redirect-to?status_code=307&url=http://{{ httpbin_host }}/anything
+    url: https://{{ httpbin_host }}/redirect-to?status_code=307&url=https://{{ httpbin_host }}/anything
     follow_redirects: urllib2
     return_content: yes
     method: HEAD
@@ -186,14 +186,14 @@
     - http_307_head is successful
     - http_307_head.json.data == ''
     - http_307_head.json.method == 'GET'
-    - http_307_head.json.url == 'http://{{ httpbin_host }}/anything'
+    - http_307_head.json.url == 'https://{{ httpbin_host }}/anything'
     - http_307_head.redirected == true
     - http_307_head.status == 200
-    - http_307_head.url == 'http://{{ httpbin_host }}/anything'
+    - http_307_head.url == 'https://{{ httpbin_host }}/anything'
 
 - name: Test HTTP 307 using GET
   uri:
-    url: http://{{ httpbin_host }}/redirect-to?status_code=307&url=http://{{ httpbin_host }}/anything
+    url: https://{{ httpbin_host }}/redirect-to?status_code=307&url=https://{{ httpbin_host }}/anything
     follow_redirects: urllib2
     return_content: yes
     method: GET
@@ -204,15 +204,15 @@
     - http_307_get is successful
     - http_307_get.json.data == ''
     - http_307_get.json.method == 'GET'
-    - http_307_get.json.url == 'http://{{ httpbin_host }}/anything'
+    - http_307_get.json.url == 'https://{{ httpbin_host }}/anything'
     - http_307_get.redirected == true
     - http_307_get.status == 200
-    - http_307_get.url == 'http://{{ httpbin_host }}/anything'
+    - http_307_get.url == 'https://{{ httpbin_host }}/anything'
 
 # FIXME: This is fixed in https://github.com/ansible/ansible/pull/36809
 - name: Test HTTP 307 using POST
   uri:
-    url: http://{{ httpbin_host }}/redirect-to?status_code=307&url=http://{{ httpbin_host }}/anything
+    url: https://{{ httpbin_host }}/redirect-to?status_code=307&url=https://{{ httpbin_host }}/anything
     follow_redirects: urllib2
     return_content: yes
     method: POST
@@ -225,16 +225,16 @@
     that:
     - http_307_post is failure
     - http_307_post.json is not defined
-    - http_307_post.location == 'http://{{ httpbin_host }}/anything'
+    - http_307_post.location == 'https://{{ httpbin_host }}/anything'
     - "http_307_post.msg == 'Status code was 307 and not [200]: HTTP Error 307: TEMPORARY REDIRECT'"
     - http_307_post.redirected == false
     - http_307_post.status == 307
-    - http_307_post.url == 'http://{{ httpbin_host }}/redirect-to?status_code=307&url=http://{{ httpbin_host }}/anything'
+    - http_307_post.url == 'https://{{ httpbin_host }}/redirect-to?status_code=307&url=https://{{ httpbin_host }}/anything'
 
 # FIXME: This is fixed in https://github.com/ansible/ansible/pull/36809
 - name: Test HTTP 308 using HEAD
   uri:
-    url: http://{{ httpbin_host }}/redirect-to?status_code=308&url=http://{{ httpbin_host }}/anything
+    url: https://{{ httpbin_host }}/redirect-to?status_code=308&url=https://{{ httpbin_host }}/anything
     follow_redirects: urllib2
     return_content: yes
     method: GET
@@ -245,16 +245,16 @@
     that:
     - http_308_head is failure
     - http_308_head.json is not defined
-    - http_308_head.location == 'http://{{ httpbin_host }}/anything'
+    - http_308_head.location == 'https://{{ httpbin_host }}/anything'
     - "http_308_head.msg == 'Status code was 308 and not [200]: HTTP Error 308: UNKNOWN'"
     - http_308_head.redirected == false
     - http_308_head.status == 308
-    - http_308_head.url == 'http://{{ httpbin_host }}/redirect-to?status_code=308&url=http://{{ httpbin_host }}/anything'
+    - http_308_head.url == 'https://{{ httpbin_host }}/redirect-to?status_code=308&url=https://{{ httpbin_host }}/anything'
 
 # FIXME: This is fixed in https://github.com/ansible/ansible/pull/36809
 - name: Test HTTP 308 using GET
   uri:
-    url: http://{{ httpbin_host }}/redirect-to?status_code=308&url=http://{{ httpbin_host }}/anything
+    url: https://{{ httpbin_host }}/redirect-to?status_code=308&url=https://{{ httpbin_host }}/anything
     follow_redirects: urllib2
     return_content: yes
     method: GET
@@ -265,16 +265,16 @@
     that:
     - http_308_get is failure
     - http_308_get.json is not defined
-    - http_308_get.location == 'http://{{ httpbin_host }}/anything'
+    - http_308_get.location == 'https://{{ httpbin_host }}/anything'
     - "http_308_get.msg == 'Status code was 308 and not [200]: HTTP Error 308: UNKNOWN'"
     - http_308_get.redirected == false
     - http_308_get.status == 308
-    - http_308_get.url == 'http://{{ httpbin_host }}/redirect-to?status_code=308&url=http://{{ httpbin_host }}/anything'
+    - http_308_get.url == 'https://{{ httpbin_host }}/redirect-to?status_code=308&url=https://{{ httpbin_host }}/anything'
 
 # FIXME: This is fixed in https://github.com/ansible/ansible/pull/36809
 - name: Test HTTP 308 using POST
   uri:
-    url: http://{{ httpbin_host }}/redirect-to?status_code=308&url=http://{{ httpbin_host }}/anything
+    url: https://{{ httpbin_host }}/redirect-to?status_code=308&url=https://{{ httpbin_host }}/anything
     follow_redirects: urllib2
     return_content: yes
     method: POST
@@ -287,8 +287,8 @@
     that:
     - http_308_post is failure
     - http_308_post.json is not defined
-    - http_308_post.location == 'http://{{ httpbin_host }}/anything'
+    - http_308_post.location == 'https://{{ httpbin_host }}/anything'
     - "http_308_post.msg == 'Status code was 308 and not [200]: HTTP Error 308: UNKNOWN'"
     - http_308_post.redirected == false
     - http_308_post.status == 308
-    - http_308_post.url == 'http://{{ httpbin_host }}/redirect-to?status_code=308&url=http://{{ httpbin_host }}/anything'
+    - http_308_post.url == 'https://{{ httpbin_host }}/redirect-to?status_code=308&url=https://{{ httpbin_host }}/anything'

--- a/test/integration/targets/win_uri/aliases
+++ b/test/integration/targets/win_uri/aliases
@@ -1,2 +1,1 @@
 windows/ci/group3
-disabled

--- a/test/integration/targets/win_uri/tasks/test.yml
+++ b/test/integration/targets/win_uri/tasks/test.yml
@@ -4,7 +4,7 @@
 
 - name: get request without return_content
   win_uri:
-    url: http://{{httpbin_host}}/get
+    url: https://{{httpbin_host}}/get
     return_content: no
   register: get_request_without_content
 
@@ -18,7 +18,7 @@
 
 - name: get request with xml content
   win_uri:
-    url: http://{{httpbin_host}}/xml
+    url: https://{{httpbin_host}}/xml
     return_content: yes
   register: get_request_with_xml_content
 
@@ -32,7 +32,7 @@
 
 - name: get request with binary content
   win_uri:
-    url: http://{{httpbin_host}}/image/png
+    url: https://{{httpbin_host}}/image/png
     return_content: yes
   register: get_request_with_binary_content
 
@@ -46,7 +46,7 @@
 
 - name: get request with return_content and dest (check mode)
   win_uri:
-    url: http://{{httpbin_host}}/get
+    url: https://{{httpbin_host}}/get
     return_content: yes
     dest: '{{test_uri_path}}\get.json'
   register: get_request_with_dest_check
@@ -67,7 +67,7 @@
 
 - name: get request with return_content and dest
   win_uri:
-    url: http://{{httpbin_host}}/get
+    url: https://{{httpbin_host}}/get
     return_content: yes
     dest: '{{test_uri_path}}\get.json'
   register: get_request_with_dest
@@ -90,7 +90,7 @@
 
 - name: get request with return_content and dest (idempotent)
   win_uri:
-    url: http://{{httpbin_host}}/get
+    url: https://{{httpbin_host}}/get
     return_content: yes
     dest: '{{test_uri_path}}\get.json'
   register: get_request_with_dest_again
@@ -102,7 +102,7 @@
 
 - name: test request with creates option should skip
   win_uri:
-    url: http://{{httpbin_host}}/get
+    url: https://{{httpbin_host}}/get
     creates: '{{test_uri_path}}\get.json'
   register: request_with_creates_skipped
 
@@ -114,7 +114,7 @@
 
 - name: test request with creates option should not skip
   win_uri:
-    url: http://{{httpbin_host}}/get
+    url: https://{{httpbin_host}}/get
     creates: '{{test_uri_path}}\fake.json'
   register: request_with_creates_not_skipped
 
@@ -126,7 +126,7 @@
 
 - name: post request with return_content, dest and different content
   win_uri:
-    url: http://{{httpbin_host}}/post
+    url: https://{{httpbin_host}}/post
     method: POST
     content_type: application/json
     body: '{"foo": "bar"}'
@@ -150,7 +150,7 @@
 
 - name: test redirect without follow_redirects
   win_uri:
-    url: http://{{httpbin_host}}/redirect/2
+    url: https://{{httpbin_host}}/redirect/2
     follow_redirects: none
     status_code: 302
   register: redirect_without_follow
@@ -164,7 +164,7 @@
 
 - name: test redirect with follow_redirects
   win_uri:
-    url: http://{{httpbin_host}}/redirect/2
+    url: https://{{httpbin_host}}/redirect/2
     follow_redirects: all
   register: redirect_with_follow
 
@@ -174,7 +174,7 @@
     - not redirect_with_follow.changed
     - redirect_with_follow.location is not defined
     - redirect_with_follow.status_code == 200
-    - redirect_with_follow.response_uri == 'http://{{httpbin_host}}/get'
+    - redirect_with_follow.response_uri == 'https://{{httpbin_host}}/get'
 
 - name: get request with redirect of TLS
   win_uri:
@@ -192,7 +192,7 @@
 
 - name: test basic auth
   win_uri:
-    url: http://{{httpbin_host}}/basic-auth/user/passwd
+    url: https://{{httpbin_host}}/basic-auth/user/passwd
     user: user
     password: passwd
   register: basic_auth
@@ -205,7 +205,7 @@
 
 - name: test basic auth with force auth
   win_uri:
-    url: http://{{httpbin_host}}/hidden-basic-auth/user/passwd
+    url: https://{{httpbin_host}}/hidden-basic-auth/user/passwd
     user: user
     password: passwd
     force_basic_auth: yes
@@ -219,7 +219,7 @@
 
 - name: test PUT
   win_uri:
-    url: http://{{httpbin_host}}/put
+    url: https://{{httpbin_host}}/put
     method: PUT
     body: foo=bar
     return_content: yes
@@ -234,7 +234,7 @@
 
 - name: test OPTIONS
   win_uri:
-    url: http://{{httpbin_host}}/
+    url: https://{{httpbin_host}}/
     method: OPTIONS
   register: option_request
 
@@ -249,7 +249,7 @@
 
 - name: validate status_codes are correct
   win_uri:
-    url: http://{{httpbin_host}}/status/202
+    url: https://{{httpbin_host}}/status/202
     status_code:
     - 202
     - 418
@@ -265,7 +265,7 @@
 
 - name: send JSON body with dict type
   win_uri:
-    url: http://{{httpbin_host}}/post
+    url: https://{{httpbin_host}}/post
     method: POST
     body:
       foo: bar
@@ -298,7 +298,7 @@
 
 - name: get request with custom headers
   win_uri:
-    url: http://{{httpbin_host}}/get
+    url: https://{{httpbin_host}}/get
     headers:
       Test-Header: hello
       Another-Header: world
@@ -317,14 +317,14 @@
 
 - name: get request with timeout
   win_uri:
-    url: http://{{httpbin_host}}/delay/10
+    url: https://{{httpbin_host}}/delay/10
     timeout: 5
   register: get_with_timeout_fail
   failed_when: '"The operation has timed out" not in get_with_timeout_fail.msg'
 
 - name: connect to fakepath that does not exist
   win_uri:
-    url: http://{{httpbin_host}}/fakepath
+    url: https://{{httpbin_host}}/fakepath
     status_code: 404
     return_content: yes
   register: invalid_path
@@ -342,7 +342,7 @@
 
 - name: post request with custom headers
   win_uri:
-    url: http://{{httpbin_host}}/post
+    url: https://{{httpbin_host}}/post
     method: POST
     headers:
       Test-Header: hello


### PR DESCRIPTION
##### SUMMARY

Use HTTPS instead of HTTP for httpbin tests.

The httpbin.org site is now redirecting HTTP to HTTPS.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

win_uri, uri, get_url integration tests

##### ANSIBLE VERSION

```
ansible 2.6.0 (httpbin-fix fcf0add01d) last updated 2018/04/27 15:51:24 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
