### PR TITLE
Install git in pip tests

### DIFF
--- a/test/integration/targets/pip/tasks/pip.yml
+++ b/test/integration/targets/pip/tasks/pip.yml
@@ -18,6 +18,11 @@
 
 # FIXME: replace the python test package
 
+- name: install git, needed for repo installs
+  package:
+    name: git
+    state: present
+
 # first some tests installed system-wide
 # verify things were not installed to start with
 

--- a/test/integration/targets/pip/tasks/pip.yml
+++ b/test/integration/targets/pip/tasks/pip.yml
@@ -22,6 +22,7 @@
   package:
     name: git
     state: present
+  when: ansible_distribution != "MacOSX"
 
 # first some tests installed system-wide
 # verify things were not installed to start with


### PR DESCRIPTION
##### SUMMARY
Install git in the pip tests. Fixes the tests, which currently fail on rhel/freebsd due to git missing.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
pip

##### ANSIBLE VERSION
devel

##### ADDITIONAL INFORMATION
