### PR TITLE
Need to convert filenames to byte strings before using them in APIs

### DIFF
--- a/changelogs/fragments/template-filename-encoding.yaml
+++ b/changelogs/fragments/template-filename-encoding.yaml
@@ -1,0 +1,5 @@
+---
+bugfixes:
+- template action plugin - fix the encoding of filenames to avoid tracebacks on
+  Python2 when characters that are not present in the user's locale are
+  present. (https://github.com/ansible/ansible/pull/39424)


### PR DESCRIPTION
Under a non-utf-8 locale (for instance, LC_ALL=C), passing a non-ascii
filename to many APIs will traceback.  Fix that by explicitly converting
to byte strings before passing to external APIs.

May fix #27262

(cherry picked from commit 2976b653ce0e8003e790a95014d9481769999294)

Add a changelog for filename encoding in template action fix

(cherry picked from commit d90c36e320eab9de197e814c8b948ee6017bf717)

##### ISSUE TYPE

 - Bugfix Pull Request


##### COMPONENT NAME
lib/ansible/plugins/action/template.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
stable-2.5
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
