### PR TITLE
adds alias parameter to nios_host_record

### DIFF
--- a/lib/ansible/modules/net_tools/nios/nios_host_record.py
+++ b/lib/ansible/modules/net_tools/nios/nios_host_record.py
@@ -66,6 +66,12 @@ options:
         required: true
         aliases:
           - address
+  aliases:
+    version_added: "2.6"
+    description:
+      - Configures an optional list of additional aliases to add to the host
+        record. These are equivalent to CNAMEs but held within a host
+        record. Must be in list format.
   ttl:
     description:
       - Configures the TTL to be associated with this host record
@@ -97,6 +103,8 @@ EXAMPLES = '''
     name: host.ansible.com
     ipv4:
       - address: 192.168.10.1
+    aliases:
+      - cname.ansible.com
     state: present
     provider:
       host: "{{ inventory_hostname_short }}"
@@ -182,6 +190,7 @@ def main():
 
         ipv4addrs=dict(type='list', aliases=['ipv4'], elements='dict', options=ipv4addr_spec, transform=ipv4addrs),
         ipv6addrs=dict(type='list', aliases=['ipv6'], elements='dict', options=ipv6addr_spec, transform=ipv6addrs),
+        aliases=dict(type='list'),
 
         ttl=dict(type='int'),
 


### PR DESCRIPTION
##### SUMMARY

Adds support for the "aliases" parameter to the nios_host_record module. The aliases parameter allows the addition of CNAME records in an Infoblox host record. This was requested in https://github.com/ansible/ansible/issues/38209.

##### ISSUE TYPE

 - Feature Pull Request

##### COMPONENT NAME

nios_host_record.py

##### ANSIBLE VERSION

```
ansible 2.6.0 (add-alias-to-host 266f0057fe) last updated 2018/04/28 11:22:58 (GMT -700)
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/brampling/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/brampling/Dropbox/src/ansibledev/ansible/lib/ansible
  executable location = /home/brampling/Dropbox/src/ansibledev/ansible/bin/ansible
  python version = 3.6.3 (default, Oct  3 2017, 21:45:48) [GCC 7.2.0]
```

##### ADDITIONAL INFORMATION

N/A