### PR TITLE
Adding multiple project support for GCE

### DIFF
--- a/contrib/inventory/gce.ini
+++ b/contrib/inventory/gce.ini
@@ -29,6 +29,7 @@
 # (See ansible/test/gce_tests.py comments for full install instructions)
 #
 # Author: Eric Johnson <erjohnso@google.com>
+# Contributors: John Roach <johnroach1985@gmail.com>
 
 [gce]
 # GCE Service Account configuration information can be stored in the
@@ -41,6 +42,8 @@ libcloud_secrets =
 
 # If you are not going to use a 'secrets.py' file, you can set the necessary
 # authorization parameters here.
+# You can add multiple gce projects to by using a comma separated list. Make
+# sure that the service account used has permissions on said projects.
 gce_service_account_email_address =
 gce_service_account_pem_file_path =
 gce_project_id =

--- a/contrib/inventory/gce.py
+++ b/contrib/inventory/gce.py
@@ -70,8 +70,9 @@ Examples:
   $ contrib/inventory/gce.py --host my_instance
 
 Author: Eric Johnson <erjohnso@google.com>
-Contributors: Matt Hite <mhite@hotmail.com>, Tom Melendez <supertom@google.com>
-Version: 0.0.3
+Contributors: Matt Hite <mhite@hotmail.com>, Tom Melendez <supertom@google.com>,
+              John Roach <johnroach1985@gmail.com>
+Version: 0.0.4
 '''
 
 try:
@@ -167,7 +168,7 @@ class GceInventory(object):
         # Read settings and parse CLI arguments
         self.parse_cli_args()
         self.config = self.get_config()
-        self.driver = self.get_gce_driver()
+        self.drivers = self.get_gce_drivers()
         self.ip_type = self.get_inventory_options()
         if self.ip_type:
             self.ip_type = self.ip_type.lower()
@@ -277,9 +278,9 @@ class GceInventory(object):
         ip_type = os.environ.get('INVENTORY_IP_TYPE', ip_type)
         return ip_type
 
-    def get_gce_driver(self):
-        """Determine the GCE authorization settings and return a
-        libcloud driver.
+    def get_gce_drivers(self):
+        """Determine the GCE authorization settings and return a list of
+        libcloud drivers.
         """
         # Attempt to get GCE params from a configuration file, if one
         # exists.
@@ -325,12 +326,16 @@ class GceInventory(object):
         kwargs['project'] = os.environ.get('GCE_PROJECT', kwargs['project'])
         kwargs['datacenter'] = os.environ.get('GCE_ZONE', kwargs['datacenter'])
 
-        # Retrieve and return the GCE driver.
-        gce = get_driver(Provider.GCE)(*args, **kwargs)
-        gce.connection.user_agent_append(
-            '%s/%s' % (USER_AGENT_PRODUCT, USER_AGENT_VERSION),
-        )
-        return gce
+        gce_drivers = []
+        projects = kwargs['project'].split(',')
+        for project in projects:
+            kwargs['project'] = project
+            gce = get_driver(Provider.GCE)(*args, **kwargs)
+            gce.connection.user_agent_append(
+                '%s/%s' % (USER_AGENT_PRODUCT, USER_AGENT_VERSION),
+            )
+            gce_drivers.append(gce)
+        return gce_drivers
 
     def parse_env_zones(self):
         '''returns a list of comma separated zones parsed from the GCE_ZONE environment variable.
@@ -420,9 +425,10 @@ class GceInventory(object):
         all_nodes = []
         params, more_results = {'maxResults': 500}, True
         while more_results:
-            self.driver.connection.gce_params = params
-            all_nodes.extend(self.driver.list_nodes())
-            more_results = 'pageToken' in params
+            for driver in self.drivers:
+                driver.connection.gce_params = params
+                all_nodes.extend(driver.list_nodes())
+                more_results = 'pageToken' in params
         return all_nodes
 
     def group_instances(self, zones=None):


### PR DESCRIPTION
##### SUMMARY
GCE deployments can span across multiple projects either because such projects are maintained by different teams or the need to keep projects separated per domain for ease of maintainability. 

This code change allows such a deployment topology to be supported while not breaking backward compatibility.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
gce inventory tool

##### ANSIBLE VERSION
```
ansible 2.5.0
  config file = None
  configured module search path = [u'/Users/jroach/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Library/Python/2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.10 (default, Oct  6 2017, 22:29:07) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.31)]
```


##### ADDITIONAL INFORMATION
As per the new version of gce.ini comments; you can add multiple projects to a comma-delimited list. This should work as long as the service account has the correct permissions.
