### PR TITLE
GCE: Fix AttributeError in ex_create_multiple_nodes API

### DIFF
--- a/lib/ansible/modules/cloud/google/gce.py
+++ b/lib/ansible/modules/cloud/google/gce.py
@@ -495,7 +495,8 @@ def create_instances(module, gce, instance_names, number, lc_zone):
                 try:
                     n = gce.ex_get_node(n.name, lc_zone)
                 except ResourceNotFoundError:
-                    pass
+                    module.fail_json(msg='Unexpected error attempting to create ' +
+                                         'instance %s, error: %s' % (instance_names, resp))
             else:
                 # Assure that at least one node has been created to set changed=True
                 changed = True


### PR DESCRIPTION
Currently there is no way we could get detailed error message for each instance that failed to create when calling `ex_create_multiple_nodes`. 

We mistakenly thought that it fails only because the instances have been created, which is not always the case as reported in #31063. 

Now when we cannot find created instances, we fail the task.