### PR TITLE
Fixes #22204 by adding GCE accelerator support

### DIFF
--- a/lib/ansible/modules/cloud/google/gce.py
+++ b/lib/ansible/modules/cloud/google/gce.py
@@ -354,7 +354,7 @@ def get_instance_info(inst):
 
     if 'guestAccelerators' in inst.extra:
         guestAccelerators = inst.extra['guestAccelerators'][0]
-        accelerators = '{}:{}'.format(
+        accelerators = '%s:%d' % (
             guestAccelerators['acceleratorType'], guestAccelerators['acceleratorCount'])
 
     return ({

--- a/lib/ansible/modules/cloud/google/gce.py
+++ b/lib/ansible/modules/cloud/google/gce.py
@@ -164,7 +164,6 @@ notes:
   - Either I(instance_names) or I(name) is required.
   - JSON credentials strongly preferred.
 author: "Eric Johnson (@erjohnso) <erjohnso@google.com>, Tom Melendez (@supertom) <supertom@google.com>"
-contributor: "Bairen Yi <byi@connect.ust.hk>"
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/cloud/google/gce.py
+++ b/lib/ansible/modules/cloud/google/gce.py
@@ -495,11 +495,8 @@ def create_instances(module, gce, instance_names, number, lc_zone):
     if subnetwork is not None:
         gce_args['ex_subnetwork'] = subnetwork
     if accelerators is not None:
-        if (len(accelerators) != 1):
-            module.fail_json(
-                msg='Mixed accelerator types are not supported', changed=False)
-        gce_args['ex_accelerator_type'] = accelerators[0].split(':')[0]
-        gce_args['ex_accelerator_count'] = int(accelerators[0].split(':')[1])
+        gce_args['ex_accelerator_type'] = accelerators.split(':')[0]
+        gce_args['ex_accelerator_count'] = int(accelerators.split(':')[1])
         gce_args['ex_on_host_maintenance'] = 'TERMINATE'
 
     if isinstance(instance_names, str) and not number:

--- a/lib/ansible/modules/cloud/google/gce.py
+++ b/lib/ansible/modules/cloud/google/gce.py
@@ -662,7 +662,7 @@ def main():
             disk_auto_delete=dict(type='bool', default=True),
             disk_size=dict(type='int', default=10),
             preemptible=dict(type='bool', default=None),
-            accelerators=dict(type='list'),
+            accelerators=dict(),
         ),
         mutually_exclusive=[('instance_names', 'name')]
     )

--- a/lib/ansible/modules/cloud/google/gce_instance_template.py
+++ b/lib/ansible/modules/cloud/google/gce_instance_template.py
@@ -138,13 +138,20 @@ options:
     version_added: "2.4"
     description:
       - Region that subnetwork resides in. (Required for subnetwork to successfully complete)
+  accelerators:
+    description:
+       - the type and number of accelerators to attach to the instance
+       - (see `gcloud compute accelerator-types list` for available types)
+    version_added: "2.6"
+
 requirements:
     - "python >= 2.6"
     - "apache-libcloud >= 0.13.3, >= 0.17.0 if using JSON credentials,
-      >= 0.20.0 if using preemptible option"
+      >= 0.20.0 if using preemptible option, >= 2.4.0 if using accelerators"
 notes:
   - JSON credentials strongly preferred.
 author: "Gwenael Pellen (@GwenaelPellenArkeup) <gwenael.pellen@arkeup.com>"
+contributor: "Bairen Yi <byi@connect.ust.hk>"
 '''
 
 EXAMPLES = '''
@@ -279,6 +286,7 @@ def create_instance_template(module, gce):
     metadata = module.params.get('metadata')
     description = module.params.get('description')
     disks_gce_struct = module.params.get('disks_gce_struct')
+    accelerators = module.params.get('accelerators')
     changed = False
 
     # args of ex_create_instancetemplate
@@ -301,7 +309,9 @@ def create_instance_template(module, gce):
         metadata=None,
         description=None,
         disks_gce_struct=None,
-        nic_gce_struct=None
+        nic_gce_struct=None,
+        accelerator_type=None,
+        accelerator_count=None,
     )
 
     gce_args['name'] = name
@@ -403,6 +413,11 @@ def create_instance_template(module, gce):
 
     if description is not None:
         gce_args['description'] = description
+
+    if accelerators is not None:
+        gce_args['accelerator_type'] = accelerators[0].split(':')[0]
+        gce_args['accelerator_count'] = int(accelerators[0].split(':')[1])
+        gce_args['on_host_maintenance'] = 'TERMINATE'
 
     instance = None
     try:

--- a/lib/ansible/modules/cloud/google/gce_instance_template.py
+++ b/lib/ansible/modules/cloud/google/gce_instance_template.py
@@ -151,7 +151,6 @@ requirements:
 notes:
   - JSON credentials strongly preferred.
 author: "Gwenael Pellen (@GwenaelPellenArkeup) <gwenael.pellen@arkeup.com>"
-contributor: "Bairen Yi <byi@connect.ust.hk>"
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/cloud/google/gce_instance_template.py
+++ b/lib/ansible/modules/cloud/google/gce_instance_template.py
@@ -563,7 +563,8 @@ def main():
             pem_file=dict(type='path'),
             credentials_file=dict(type='path'),
             subnetwork_region=dict(),
-            disks_gce_struct=dict(type='list')
+            disks_gce_struct=dict(type='list'),
+            accelerators=dict(),
         ),
         mutually_exclusive=[['source', 'image']],
         required_one_of=[['image', 'image_family']],

--- a/lib/ansible/modules/cloud/google/gce_instance_template.py
+++ b/lib/ansible/modules/cloud/google/gce_instance_template.py
@@ -414,8 +414,8 @@ def create_instance_template(module, gce):
         gce_args['description'] = description
 
     if accelerators is not None:
-        gce_args['accelerator_type'] = accelerators[0].split(':')[0]
-        gce_args['accelerator_count'] = int(accelerators[0].split(':')[1])
+        gce_args['accelerator_type'] = accelerators.split(':')[0]
+        gce_args['accelerator_count'] = int(accelerators.split(':')[1])
         gce_args['on_host_maintenance'] = 'TERMINATE'
 
     instance = None


### PR DESCRIPTION
This CL adds a parameter `accelerators` for `gce` and `gce_instance_template`.

It works like `accelerators: {{ accelerator_type }}:{{ accelerator_count }}`, e.g. 

```accelerators: nvidia-tesla-k80:4```

The type of this param is string instead of list, as no mixed accelerators are permitted on GCE for now.

@erjohnso @supertom Any comments?