### PR TITLE
Check error values before proceeding in postgresql_db

### DIFF
--- a/lib/ansible/modules/database/postgresql/postgresql_db.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_db.py
@@ -460,6 +460,9 @@ def main():
                 module.fail_json(msg=to_native(e), exception=traceback.format_exc())
 
         elif state in ("dump", "restore"):
+            if not db_exists(cursor, db) and state == "dump":
+                module.fail_json(
+                    msg="database \"{db}\" does not exist".format(db=db))
             method = state == "dump" and db_dump or db_restore
             try:
                 rc, stdout, stderr, cmd = method(module, target, target_opts, db, **kw)


### PR DESCRIPTION
* postgresql_db dump does not fail on FATAL error when using compression

##### SUMMARY

Fixed postgresql_db dump does not fail on FATAL error when using compression #39412

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

- lib/ansible/modules/database/postgresql/postgresql_db.py

##### ANSIBLE VERSION

- 2.6

##### ADDITIONAL INFORMATION

- None