### PR TITLE
Update nxos_vlan.py

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_vlan.py
+++ b/lib/ansible/modules/network/nxos/nxos_vlan.py
@@ -458,7 +458,7 @@ def parse_interfaces(module, vlan):
     vlan_int = []
     interfaces = vlan.get('vlanshowplist-ifidx')
     if interfaces:
-        for i in interfaces.split(','):
+        for i in interfaces:
             if 'eth' in i.lower() and '-' in i:
                 int_range = i.split('-')
                 stop = int((int_range)[1])


### PR DESCRIPTION
##### SUMMARY
fixes https://github.com/ansible/ansible/issues/39471

```interfaces = vlan.get('vlanshowplist-ifidx')```

This results in 'interfaces' being a list, however we then try to run:

```for i in interfaces.split(','): ```

Which causes a crash as a list cannot have a split applied.

##### ISSUE TYPE
 - Bugfix Pull Request


##### COMPONENT NAME
nxos_vlan
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.2
  config file = None
  configured module search path = [u'/home/mark/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION

Play:
```yaml
- name: map VLANs to VNIs
  nxos_vlan:
    vlan_id: "{{ item.value.vlan }}"
    mapped_vni: "{{ item.value.vni }}"
    name: "{{ item.key }}"
  with_dict: "{{ vni_segments }}"
```
Dictionary:
```
vni_segments:
  test1:
    vlan: 50
    vni: 5000
```
<!--- BEFORE CHANGE -->
```
TASK [create VLAN and map to VNI] *******************************************************************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: AttributeError: 'list' object has no attribute 'split'
failed: [N9K3] (item={'value': {u'vlan': 50, u'vni': 5000}, 'key': u'test1'}) => {"changed": false, "item": {"key": "test1", "value": {"vlan": 50, "vni": 5000}}, "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_qoyZSz/ansible_module_nxos_vlan.py\", line 615, in <module>\n    main()\n  File \"/tmp/ansible_qoyZSz/ansible_module_nxos_vlan.py\", line 593, in main\n    have = map_config_to_obj(module, os_platform)\n  File \"/tmp/ansible_qoyZSz/ansible_module_nxos_vlan.py\", line 512, in map_config_to_obj\n    obj = parse_vlan_options(module, os_platform, output, vlan)\n  File \"/tmp/ansible_qoyZSz/ansible_module_nxos_vlan.py\", line 497, in parse_vlan_options\n    obj['interfaces'] = parse_interfaces(module, vlan)\n  File \"/tmp/ansible_qoyZSz/ansible_module_nxos_vlan.py\", line 474, in parse_interfaces\n    for i in interfaces.split(','):\nAttributeError: 'list' object has no attribute 'split'\n", "module_stdout": "", "msg": "MODULE FAILURE", "rc": 1}
```

AFTER CHANGE
```
TASK [create VLAN and map to VNI] ********************************************************************************************************************************
ok: [N9K3] => (item={'value': {u'vlan': 50, u'vni': 5000}, 'key': u'test1'})
ok: [N9K3] => (item={'value': {u'subnet': u'10.0.0.1/24', u'vlan': 100, u'vni': 10000}, 'key': u'web'})
```