### PR TITLE
Setting default for gpgcheck in yum_repository

### DIFF
--- a/lib/ansible/modules/packaging/os/yum_repository.py
+++ b/lib/ansible/modules/packaging/os/yum_repository.py
@@ -108,6 +108,7 @@ options:
       - Tells yum whether or not it should perform a GPG signature check on
         packages.
     type: bool
+    default: 'no'
   gpgkey:
     description:
       - A URL pointing to the ASCII-armored GPG key file for the repository.


### PR DESCRIPTION
##### SUMMARY

This PR is adding missing default value into the documentation of the `yum_repository` module which was previously removed in the PR #36267. The doc generator assigns `no` value to non-defined `default` so it makes sense to add the `default` back with the `no` value.

##### ISSUE TYPE
Docs Pull Request

##### COMPONENT NAME
`yum_repository`

##### ANSIBLE VERSION
```
ansible 2.5.2
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.14 (default, Apr 16 2018, 20:08:15) [GCC 7.3.1 20180406]
```

##### ADDITIONAL INFORMATION

None