### PR TITLE
Remove redundant import from netapp module_utils

### DIFF
--- a/lib/ansible/module_utils/netapp.py
+++ b/lib/ansible/module_utils/netapp.py
@@ -22,9 +22,7 @@ try:
 except ImportError:
     import simplejson as json
 
-from ansible.module_utils.api import basic_auth_argument_spec
 from ansible.module_utils.six.moves.urllib.error import HTTPError
-from ansible.module_utils.api import basic_auth_argument_spec
 from ansible.module_utils.urls import open_url
 from ansible.module_utils.api import basic_auth_argument_spec
 


### PR DESCRIPTION
##### SUMMARY
Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/netapp.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6devel
```