### PR TITLE
Update intermediate_concepts.rst (#39500)

### DIFF
--- a/docs/docsite/rst/network/getting_started/intermediate_concepts.rst
+++ b/docs/docsite/rst/network/getting_started/intermediate_concepts.rst
@@ -66,15 +66,10 @@ GitHub Repos
 
 Ansible hosts module code, examples, demonstrations, and other content on GitHub. Anyone with a GitHub account is able to create Pull Requests (PRs) or issues on these repos:
 
-- `Network-Automation <https://github.com/network-automation>`_ is an open community for all things network automation
+- `Network-Automation <https://github.com/network-automation>`_ is an open community for all things network automation. Have an idea, some playbooks, or roles to share? Email ansible-network@redhat.com and we will add you as a contributor to the repository.
+
 - `Ansible <https://github.com/ansible/ansible>`_ is the main codebase, including code for network modules
 
-Email
---------
-
-Join the Ansible Network Community email list:
-
-- email ansible-network@redhat.com and we will get you added right away
 
 IRC
 --------


### PR DESCRIPTION
Updated  GitHub Repos section to better explain what ansible-network@redhat.com is for (not an email list, but adding to the network-automation github repo.
(cherry picked from commit 9773157da660628650ccc97b461b6de6b4d5dc9e)

##### SUMMARY
Fixes mistake in the Network section of the docs.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
docs.ansible.com

##### ANSIBLE VERSION
2.5
