### PR TITLE
Ensure remove files work when file was already removed

### DIFF
--- a/changelogs/fragments/file-succeed-if-already-absent.yaml
+++ b/changelogs/fragments/file-succeed-if-already-absent.yaml
@@ -1,0 +1,5 @@
+---
+bugfixes:
+- file module - Eliminate an error if we're asked to remove a file but
+  something removes it while we are processing the request
+  (https://github.com/ansible/ansible/pull/39466)


### PR DESCRIPTION
Backport

If a file disappears when you are removing it, this will ensure it
doesn't fail and continues as expected.

(cherry picked from commit 6a08b16c37e67dd9cfb5804593c7ed4c783fa8f5)

Add changelog for file removal race

(cherry picked from commit 7c9122a89d1d66d60a44eb4f1ecdbccef2447df9)


##### ISSUE TYPE

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```
