### PR TITLE
Fix redhat_subscription.py documentation typographical error

### DIFF
--- a/lib/ansible/modules/packaging/os/redhat_subscription.py
+++ b/lib/ansible/modules/packaging/os/redhat_subscription.py
@@ -69,7 +69,7 @@ options:
     auto_attach:
         description:
             - Upon successful registration, auto-consume available subscriptions
-            - Added in favor of depracated autosubscribe in 2.5.
+            - Added in favor of deprecated autosubscribe in 2.5.
         type: bool
         default: 'no'
         version_added: "2.5"


### PR DESCRIPTION
 fixed small typo of "depracated" to "deprecated" in `redhat_subscription` module website documentation

+label: docsite_pr

##### SUMMARY
simple fix of misspelling in `redhat_subscription` module web documentation

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
`redhat_subscription` module documentation typo

##### ANSIBLE VERSION
N/A

##### ADDITIONAL INFORMATION
N/A
