### PR TITLE
Fix unset 'ansible_virtualization_role' fact

### DIFF
--- a/lib/ansible/module_utils/facts/virtual/linux.py
+++ b/lib/ansible/module_utils/facts/virtual/linux.py
@@ -242,7 +242,7 @@ class LinuxVirtual(Virtual):
             if rc == 0:
                 # Strip out commented lines (specific dmidecode output)
                 vendor_name = ''.join([line.strip() for line in out.splitlines() if not line.startswith('#')])
-                if vendor_name.startwith('VMware'):
+                if vendor_name.startswith('VMware'):
                     virtual_facts['virtualization_type'] = 'VMware'
                     virtual_facts['virtualization_role'] = 'guest'
                     return virtual_facts


### PR DESCRIPTION
##### SUMMARY
Error was: `AttributeError("'str' object has no attribute 'startwith'",)` resulting in `ansible_virtualization_role` being not set.

Fixes #39138

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/facts/virtual/linux.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0 (devel ac754c736f) last updated 2018/04/27 16:24:14 (GMT +200)
```

##### ADDITIONAL INFORMATION
Present in 2.5.1 (ae0a9a5e9cfab4f910ca15861787cccc3c9bb600), should be backported in 2.5.2.

Bug wasn't caught by the CI because integration tests don't use `real` hardware (moreover bug only occurs when `kvm`/`vboxdrv` modules aren't loaded).