### PR TITLE
keycloak_client: fix ansible diff/changed (sorting, null-values)

### DIFF
--- a/lib/ansible/modules/identity/keycloak/keycloak_client.py
+++ b/lib/ansible/modules/identity/keycloak/keycloak_client.py
@@ -722,13 +722,20 @@ def main():
     changeset = dict()
 
     for client_param in client_params:
-        # lists in the Keycloak API are sorted
         new_param_value = module.params.get(client_param)
+
+        # some lists in the Keycloak API are sorted, some are not.
         if isinstance(new_param_value, list):
-            try:
-                new_param_value = sorted(new_param_value)
-            except TypeError:
-                pass
+            if client_param in ['attributes']:
+                try:
+                    new_param_value = sorted(new_param_value)
+                except TypeError:
+                    pass
+        # Unfortunately, the ansible argument spec checker introduces variables with null values when
+        # they are not specified
+        if client_param == 'protocol_mappers':
+            new_param_value = map(lambda x: {k: v for (k, v) in x.items() if x[k] is not None}, new_param_value)
+
         changeset[camel(client_param)] = new_param_value
 
     # Whether creating or updating a client, take the before-state and merge the changeset into it

--- a/lib/ansible/modules/identity/keycloak/keycloak_client.py
+++ b/lib/ansible/modules/identity/keycloak/keycloak_client.py
@@ -734,7 +734,7 @@ def main():
         # Unfortunately, the ansible argument spec checker introduces variables with null values when
         # they are not specified
         if client_param == 'protocol_mappers':
-            new_param_value = map(lambda x: {k: v for (k, v) in x.items() if x[k] is not None}, new_param_value)
+            new_param_value = map(lambda x: dict((k, v) for (k, v) in x.items() if x[k] is not None), new_param_value)
 
         changeset[camel(client_param)] = new_param_value
 

--- a/lib/ansible/modules/identity/keycloak/keycloak_client.py
+++ b/lib/ansible/modules/identity/keycloak/keycloak_client.py
@@ -734,7 +734,7 @@ def main():
         # Unfortunately, the ansible argument spec checker introduces variables with null values when
         # they are not specified
         if client_param == 'protocol_mappers':
-            new_param_value = map(lambda x: dict((k, v) for (k, v) in x.items() if x[k] is not None), new_param_value)
+            new_param_value = [dict((k, v) for k, v in x.items() if x[k] is not None) for x in new_param_value]
 
         changeset[camel(client_param)] = new_param_value
 


### PR DESCRIPTION
##### SUMMARY

This PR fixes two things related to diff output on keycloak_client: not all lists in the API are returned sorted (currently it seems "attributes" is the only one that is), so we need compare unsorted lists to figure out a diff.
Another problem is the usage of the ansible argument spec to check protocol_mapper contents -- if a key is not supplied as an option, the ansible checker adds a None-value to the dict being checked. The API, on the otherhand, just skips values that are not defined. Thus we remove null-values from the list to be sent to the API (and checked in before/after for diff).

This should not affect usage of the module other than when -D is used. 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
keycloak_client

##### ANSIBLE VERSION
2.6.0