### PR TITLE
Use the computed role name instead of 'role'

### DIFF
--- a/lib/ansible/playbook/included_file.py
+++ b/lib/ansible/playbook/included_file.py
@@ -160,7 +160,7 @@ class IncludedFile:
                                 from_key = from_arg.replace('_from', '')
                                 new_task._from_files[from_key] = templar.template(include_variables[from_arg])
 
-                        inc_file = IncludedFile("role", include_variables, new_task, is_role=True)
+                        inc_file = IncludedFile(role_name, include_variables, new_task, is_role=True)
 
                     try:
                         pos = included_files.index(inc_file)

--- a/test/integration/inventory
+++ b/test/integration/inventory
@@ -1,6 +1,6 @@
 [local]
 testhost ansible_ssh_host=127.0.0.1 ansible_connection=local host_var_role_name=role3
-testhost2 ansible_ssh_host=127.0.0.1 ansible_connection=local
+testhost2 ansible_ssh_host=127.0.0.1 ansible_connection=local host_var_role_name=role2
 # For testing delegate_to
 testhost3 ansible_ssh_host=127.0.0.3
 testhost4 ansible_ssh_host=127.0.0.4

--- a/test/integration/targets/include_import/role/test_include_role.yml
+++ b/test/integration/targets/include_import/role/test_include_role.yml
@@ -1,5 +1,5 @@
 - name: Test include_role
-  hosts: testhost
+  hosts: testhost,testhost2
 
   vars:
     run_role: yes
@@ -85,9 +85,26 @@
       include_role:
         name: "{{ role_name }}"
 
+    - name: wipe role results
+      set_fact:
+        _role2_result: ~
+        _role3_result: ~
+
     - name: Test using a host variable for role name
       include_role:
         name: "{{ host_var_role_name }}"
+
+    - name: assert that host varible for role name calls 2 diff roles
+      assert:
+        that:
+          - _role2_result is not none
+      when: inventory_hostname == 'testhost2'
+
+    - name: assert that host varible for role name calls 2 diff roles
+      assert:
+        that:
+          - _role3_result is not none
+      when: inventory_hostname == 'testhost'
 
     - name: Pass variable to role
       include_role:


### PR DESCRIPTION
##### SUMMARY
Use the computed role name instead of 'role'. Fixes #38838

Before this change the `__eq__` check in `IncludedFile` cannot properly differentiate between 2 role names computed using host vars, since the `filename` was always `"role"`, instead of utilizing the computed role name.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/playbook/included_file.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```