### PR TITLE
Pass vars from import_playbook in early

### DIFF
--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -54,7 +54,7 @@ class Playbook:
         pb._load_playbook_data(file_name=file_name, variable_manager=variable_manager)
         return pb
 
-    def _load_playbook_data(self, file_name, variable_manager):
+    def _load_playbook_data(self, file_name, variable_manager, vars=None):
 
         if os.path.isabs(file_name):
             self._basedir = os.path.dirname(file_name)
@@ -103,7 +103,7 @@ class Playbook:
                     which = entry.get('import_playbook', entry.get('include', entry))
                     display.display("skipping playbook '%s' due to conditional test failure" % which, color=C.COLOR_SKIP)
             else:
-                entry_obj = Play.load(entry, variable_manager=variable_manager, loader=self._loader)
+                entry_obj = Play.load(entry, variable_manager=variable_manager, loader=self._loader, vars=vars)
                 self._entries.append(entry_obj)
 
         # we're done, so restore the old basedir in the loader

--- a/lib/ansible/playbook/base.py
+++ b/lib/ansible/playbook/base.py
@@ -486,9 +486,9 @@ class Base(with_metaclass(BaseMeta, object)):
         try:
             if isinstance(ds, dict):
                 _validate_variable_keys(ds)
-                return ds
+                return combine_vars(self.vars, ds)
             elif isinstance(ds, list):
-                all_vars = dict()
+                all_vars = self.vars
                 for item in ds:
                     if not isinstance(item, dict):
                         raise ValueError

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -101,13 +101,15 @@ class Play(Base, Taggable, Become):
         return self._attributes.get('name')
 
     @staticmethod
-    def load(data, variable_manager=None, loader=None):
+    def load(data, variable_manager=None, loader=None, vars=None):
         if ('name' not in data or data['name'] is None) and 'hosts' in data:
             if isinstance(data['hosts'], list):
                 data['name'] = ','.join(data['hosts'])
             else:
                 data['name'] = data['hosts']
         p = Play()
+        if vars:
+            p.vars = vars.copy()
         return p.load_data(data, variable_manager=variable_manager, loader=loader)
 
     def preprocess_data(self, ds):

--- a/lib/ansible/playbook/playbook_include.py
+++ b/lib/ansible/playbook/playbook_include.py
@@ -69,7 +69,7 @@ class PlaybookInclude(Base, Conditional, Taggable):
         if not os.path.isabs(file_name):
             file_name = os.path.join(basedir, file_name)
 
-        pb._load_playbook_data(file_name=file_name, variable_manager=variable_manager)
+        pb._load_playbook_data(file_name=file_name, variable_manager=variable_manager, vars=self.vars.copy())
 
         # finally, update each loaded playbook entry with any variables specified
         # on the included playbook and/or any tags which may have been set

--- a/test/integration/targets/include_import/playbook/playbook_needing_vars.yml
+++ b/test/integration/targets/include_import/playbook/playbook_needing_vars.yml
@@ -1,0 +1,6 @@
+---
+- hosts: testhost
+  gather_facts: no
+  tasks:
+    - import_role:
+        name: "{{ import_playbook_role_name }}"

--- a/test/integration/targets/include_import/playbook/roles/import_playbook_role/tasks/main.yml
+++ b/test/integration/targets/include_import/playbook/roles/import_playbook_role/tasks/main.yml
@@ -1,0 +1,2 @@
+- debug:
+    msg: in import_playbook_role

--- a/test/integration/targets/include_import/playbook/test_import_playbook.yml
+++ b/test/integration/targets/include_import/playbook/test_import_playbook.yml
@@ -14,3 +14,7 @@
   when: include_next_playbook
 
 - import_playbook: validate34.yml
+
+- import_playbook: playbook_needing_vars.yml
+  vars:
+    import_playbook_role_name: import_playbook_role


### PR DESCRIPTION
##### SUMMARY
Pass vars from import_playbook in early, as they may be needed to parse the imported plays. Fixes #33693

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/playbook

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```