### PR TITLE
JBoss modules

### DIFF
--- a/lib/ansible/module_utils/jboss.py
+++ b/lib/ansible/module_utils/jboss.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+
+# (c) 2017, Ansible by Red Hat, inc
+#
+# This file is part of Ansible by Red Hat
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import env_fallback
+
+
+JBOSS_COMMON_ARGS = dict(
+    username=dict(type='str', fallback=(env_fallback, ['JBOSS_MANAGEMENT_USER'])),
+    password=dict(no_log=True, type='str', fallback=(env_fallback, ['JBOSS_MANAGEMENT_PASSWORD'])),
+    host=dict(type='str', fallback=(env_fallback, ['JBOSS_MANAGEMENT_HOST'])),
+    port=dict(type='int', fallback=(env_fallback, ['JBOSS_MANAGEMENT_PORT'])),
+    timeout=dict(type='int', default=300),
+    operation_headers=dict(type='dict', require=False))
+
+
+class JBossAnsibleModule(AnsibleModule):
+
+    def __init__(self, argument_spec, supports_check_mode):
+        argument_spec.update(JBOSS_COMMON_ARGS)
+
+        AnsibleModule.__init__(self, argument_spec=argument_spec, supports_check_mode=supports_check_mode)

--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -820,7 +820,7 @@ def open_url(url, data=None, headers=None, method=None, use_proxy=True,
              force=False, last_mod_time=None, timeout=10, validate_certs=True,
              url_username=None, url_password=None, http_agent=None,
              force_basic_auth=False, follow_redirects='urllib2',
-             client_cert=None, client_key=None, cookies=None):
+             client_cert=None, client_key=None, cookies=None, auth_realm=None):
     '''
     Sends a request via HTTP(S) or FTP using urllib2 (Python2) or urllib (Python3)
 
@@ -859,7 +859,7 @@ def open_url(url, data=None, headers=None, method=None, use_proxy=True,
             passman = urllib_request.HTTPPasswordMgrWithDefaultRealm()
 
             # this creates a password manager
-            passman.add_password(None, netloc, username, password)
+            passman.add_password(auth_realm, netloc, username, password)
 
             # because we have put None at the start it will always
             # use this username/password combination for  urls

--- a/lib/ansible/modules/web_infrastructure/jboss/jboss_command.py
+++ b/lib/ansible/modules/web_infrastructure/jboss/jboss_command.py
@@ -1,0 +1,134 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2017, Ansible by Red Hat, inc
+#
+# This file is part of Ansible by Red Hat
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'metadata_version': '1.1'}
+
+DOCUMENTATION = '''
+---
+module: jboss_command
+short_description: Execute JBoss commands using Management API.
+description:
+    - Uses DMR Model to send commands over Management API.
+author: "Jairo Junior (@jairojunior)"
+version_added: 2.6
+options:
+    name:
+      description: Name of the operation to be executed.
+      required: true
+      aliases: [operation]
+    path:
+      description: Path in JBoss-CLI syntax to execute the operation.
+      required: false
+      aliases: [target]
+    parameters:
+      description: Parameters of the operation.
+      required: false
+    ignore_failed_outcome:
+      description: Whether it should ignore non sucessful outcomes.
+      required: false
+      default: false
+      type: bool
+extends_documentation_fragment: jboss
+'''
+
+EXAMPLES = '''
+---
+# Read datasource state
+- jboss_command:
+    operation: read-attribute
+    path: "java:jboss/datasources/petshopDSXA"
+    parameters:
+        name: enable
+  register: check_enabled
+
+# Enable if it's not already
+- jboss_command:
+    operation: enable
+    path: "java:jboss/datasources/petshopDSXA"
+  when: check_enabled.meta.result == true
+
+# Check server-state
+- jboss_command:
+    operation: read-attribute
+    parameters:
+    name: server-state
+  changed_when: False
+  register: server_state
+
+# Reload if necessary
+- jboss_cli:
+    operation: reload
+  when: server_state.meta.result == "reload-required"
+'''
+
+RETURN = '''
+---
+meta:
+    description: Management API response
+    returned: success
+    type: dict
+    sample: "{'outcome': 'success', 'response-headers': {'process-state': 'reload-required'}}"
+'''
+
+try:
+    from jboss.client import Client
+    from jboss.exceptions import AuthError
+    from jboss.exceptions import OperationError
+    HAS_JBOSS_PY = True
+except ImportError:
+    HAS_JBOSS_PY = False
+
+from ansible.module_utils.jboss import JBossAnsibleModule
+
+
+def main():
+    module = JBossAnsibleModule(
+        argument_spec=dict(
+            name=dict(aliases=['operation'], required=True, type='str'),
+            path=dict(aliases=['target'], required=False, type='str'),
+            parameters=dict(required=False, type='dict', default=dict()),
+            ignore_failed_outcome=dict(required=False, type='bool', default=False),
+        ),
+        supports_check_mode=False
+    )
+
+    if not HAS_JBOSS_PY:
+        module.fail_json(msg='jboss-py required for this module')
+
+    client = Client.from_config(module.params)
+
+    try:
+        output = client.execute(operation=module.params['name'],
+                                parameters=module.params['parameters'],
+                                ignore_failed_outcome=module.params['ignore_failed_outcome'],
+                                path=module.params['path'])
+
+        module.exit_json(changed=True, meta=output)
+    except (AuthError, OperationError) as err:
+        module.fail_json(msg=str(err))
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/web_infrastructure/jboss/jboss_deployment.py
+++ b/lib/ansible/modules/web_infrastructure/jboss/jboss_deployment.py
@@ -1,0 +1,175 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+
+# (c) 2017, Ansible by Red Hat, inc
+#
+# This file is part of Ansible by Red Hat
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'metadata_version': '1.1'}
+
+DOCUMENTATION = '''
+---
+module: jboss_deployment
+short_description: Manage JBoss deployments
+description:
+    - Manages JBoss deployments through Management API, using local or remote artifacts and ensuring deployed content checksum matches source file checksum.
+author: "Jairo Junior (@jairojunior)"
+version_added: 2.6
+options:
+    name:
+      description: Name of deployment unit.
+      required: true
+    state:
+      description: Whether the deployment should be present or absent.
+      required: false
+      default: present
+      choices: [present, absent]
+    src:
+      description: Local or remote path of deployment file.
+      required: false
+    server_group:
+      description: Target server group. (Domain mode only)
+      required: false
+extends_documentation_fragment: jboss
+'''
+
+EXAMPLES = '''
+# Undeploy hawt.io
+- jboss_deployment:
+    name: hawtio.war
+    state: absent
+
+# Deploy hawt.io (uploads src from local)
+- jboss_deployment:
+    name: hawtio.war
+    src: /opt/hawtio.war
+    state: present
+
+# Deploy app.jar (already present in remote host)
+- jboss_deployment:
+    name: app.jar
+    state: present
+    src: /tmp/app.jar
+'''
+
+RETURN = '''
+---
+meta:
+    description: Management API response
+    returned: success
+    type: dict
+    sample: "{'outcome': 'success', 'response-headers': {'process-state': 'reload-required'}}"
+'''
+
+
+try:
+    from jboss.client import Client
+    from jboss.exceptions import AuthError
+    from jboss.exceptions import OperationError
+    HAS_JBOSS_PY = True
+except ImportError:
+    HAS_JBOSS_PY = False
+
+from ansible.module_utils.jboss import JBossAnsibleModule
+
+
+def read_deployment(client, name):
+    exists, result = client.read('/deployment=' + name)
+
+    if exists:
+        bytes_value = result['content'][0]['hash']['BYTES_VALUE']
+        result = bytes_value.decode('base64').encode('hex')
+
+    return exists, result
+
+
+def present(module, client, name, exists, current_checksum):
+    src = module.params['src']
+    checksum_src = module.sha1(src)
+    server_group = module.params['server_group']
+
+    if exists:
+        if current_checksum == checksum_src:
+            module.exit_json(changed=False,
+                             meta='Deployment {0} exists with {1}'.format(name, current_checksum))
+
+        if not module.check_mode:
+            module.exit_json(changed=True,
+                             meta=client.update_deploy(name, src, server_group),
+                             msg='Update deployment {0} content with {1}. Previous content checksum {2}'.format(name, checksum_src, current_checksum))
+
+        module.exit_json(changed=True, diff=dict(before=current_checksum, after=checksum_src))
+
+    if not module.check_mode:
+        module.exit_json(changed=True,
+                         meta=client.deploy(name, src, server_group),
+                         msg='Deployed {0}'.format(name))
+
+    module.exit_json(changed=True, diff=dict(before='', after=checksum_src))
+
+
+def absent(module, client, name, exists):
+    server_group = module.params['server_group']
+
+    if exists:
+        if not module.check_mode:
+            module.exit_json(changed=True,
+                             meta=client.undeploy(name, server_group),
+                             msg='Undeployed {0}'.format(name))
+
+        module.exit_json(changed=True, msg='Deployment exists')
+
+    module.exit_json(changed=False, msg='Deployment {0} is absent'.format(name))
+
+
+def main():
+    module = JBossAnsibleModule(
+        argument_spec=dict(
+            name=dict(required=True, type='str'),
+            state=dict(choices=['present', 'absent'], default='present'),
+            src=dict(required=False, type='str'),
+            server_group=dict(required=False, type='str'),
+        ),
+        supports_check_mode=True
+    )
+
+    if not HAS_JBOSS_PY:
+        module.fail_json(msg='jboss-py required for this module')
+
+    client = Client.from_config(module.params)
+
+    try:
+        name = module.params['name']
+        state = module.params['state']
+
+        exists, current_checksum = read_deployment(client, name)
+
+        if state == 'present':
+            present(module, client, name, exists, current_checksum)
+        else:
+            absent(module, client, name, exists)
+    except (AuthError, OperationError) as err:
+        module.fail_json(msg=str(err))
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/web_infrastructure/jboss/jboss_resource.py
+++ b/lib/ansible/modules/web_infrastructure/jboss/jboss_resource.py
@@ -1,0 +1,188 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2017, Ansible by Red Hat, inc
+#
+# This file is part of Ansible by Red Hat
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'metadata_version': '1.1'}
+
+DOCUMENTATION = '''
+---
+module: jboss_resource
+short_description: Manage JBoss configuration (datasources, queues, https, etc)
+description:
+    - Manages JBoss configuration/resources (i.e. Management Model) through Management API.
+    - Locally or remote, ensuring resource state matches specified attributes.
+author: "Jairo Junior (@jairojunior)"
+version_added: 2.6
+options:
+    name:
+      description: Name of the configuration resource using JBoss-CLI path expression.
+      required: true
+      aliases: [path]
+    state:
+      description: Whether the resource should be present or absent.
+      required: false
+      default: present
+      choices: [present, absent]
+    attributes:
+      description: Attributes defining the state of configuration resource.
+      required: false
+extends_documentation_fragment: jboss
+'''
+
+EXAMPLES = '''
+# Configure a datasource
+- jboss_resource:
+    name: "/subsystem=datasources/data-source=DemoDS"
+    state: present
+    attributes:
+    driver-name: h2
+    connection-url: "jdbc:h2:mem:demo;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE"
+    jndi-name: "java:jboss/datasources/DemoDS"
+    user-name: sa
+    password: sa
+    min-pool-size: 20
+    max-pool-size: 40
+
+# TLSRealm
+- jboss_resource:
+    name: "/core-service=management/security-realm=TLSRealm"
+
+# Server identity
+- jboss_resource:
+    name: "/core-service=management/security-realm=TLSRealm/server-identity=ssl"
+    attributes:
+    keystore-path: jboss.jks
+    keystore-relative-to: /etc/pki/java
+    keystore-password: changeit
+    alias: demo
+    key-password: changeit
+
+# HTTPS Listener
+- jboss_resource:
+    name: "/subsystem=undertow/server=default-server/https-listener=https"
+    attributes:
+    socket-binding: https
+    security-realm: TLSRealm
+    enabled: true
+'''
+
+RETURN = '''
+---
+meta:
+    description: Management API response
+    returned: success
+    type: dict
+    sample: "{'outcome': 'success', 'response-headers': {'process-state': 'reload-required'}}"
+'''
+
+try:
+    from jboss.client import Client
+    from jboss.exceptions import AuthError
+    from jboss.exceptions import OperationError
+    HAS_JBOSS_PY = True
+except ImportError:
+    HAS_JBOSS_PY = False
+
+from ansible.module_utils.jboss import JBossAnsibleModule
+
+
+def diff(current, desired):
+    attributes_diff = {}
+
+    for key, value in desired.items():
+        if not current[key] == value:
+            attributes_diff[key] = value
+
+    return attributes_diff
+
+
+def present(module, client, path, desired_attributes, exists, current_attributes):
+    if exists:
+        changed_attributes = diff(current_attributes, desired_attributes)
+
+        if not changed_attributes:
+            module.exit_json(changed=False,
+                             msg='{0} exists with {1}'.format(path, current_attributes))
+
+        if not module.check_mode:
+            module.exit_json(changed=True,
+                             msg='Updated {0} of {1}'.format(changed_attributes, path),
+                             meta=client.update(path, changed_attributes))
+
+        module.exit_json(changed=True,
+                         diff=dict(before=current_attributes, after=desired_attributes))
+
+    if not module.check_mode:
+        module.exit_json(changed=True,
+                         meta=client.add(path, desired_attributes),
+                         msg='Added {0} with {1}'.format(path, desired_attributes))
+
+    module.exit_json(changed=True,
+                     diff=dict(before=current_attributes, after=desired_attributes))
+
+
+def absent(module, client, path, exists):
+    if exists:
+        if not module.check_mode:
+            module.exit_json(changed=True,
+                             msg='Removed ' + path,
+                             meta=client.remove(path))
+
+        module.exit_json(changed=True, msg='Resouce exists')
+
+    module.exit_json(changed=False, msg=path + ' is absent')
+
+
+def main():
+    module = JBossAnsibleModule(
+        argument_spec=dict(
+            name=dict(aliases=['path'], required=True, type='str'),
+            state=dict(choices=['present', 'absent'], default='present'),
+            attributes=dict(required=False, type='dict', default=dict()),
+        ),
+        supports_check_mode=True
+    )
+
+    if not HAS_JBOSS_PY:
+        module.fail_json(msg='jboss-py required for this module')
+
+    client = Client.from_config(module.params)
+
+    try:
+        path = module.params['name']
+        attributes = module.params['attributes']
+        state = module.params['state']
+
+        exists, current_attributes = client.read(path)
+
+        if state == 'present':
+            present(module, client, path, attributes, exists, current_attributes)
+        else:
+            absent(module, client, path, exists)
+    except (AuthError, OperationError) as err:
+        module.fail_json(msg=str(err))
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/utils/module_docs_fragments/jboss.py
+++ b/lib/ansible/utils/module_docs_fragments/jboss.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+
+# (c) 2017, Ansible by Red Hat, inc
+#
+# This file is part of Ansible by Red Hat
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+
+class ModuleDocFragment(object):
+    DOCUMENTATION = '''
+options:
+    username:
+      description:
+        - JBoss Management User. This option can be omitted if the environment variable C(JBOSS_MANAGEMENT_USER) is set.
+    password:
+      description:
+        - JBoss Management Password. This option can be omitted if the environment variable C(JBOSS_MANAGEMENT_PASSWORD) is set.
+    host:
+      description:
+        - JBoss Management Host. This option can be omitted if the environment variable C(JBOSS_MANAGEMENT_HOST) is set.
+    port:
+      description:
+        - JBoss Management Port. This option can be omitted if the environment variable C(JBOSS_MANAGEMENT_PORT) is set.
+    timeout:
+      description:
+        - HTTP Request timeout.
+      default: 300
+    operation_headers:
+      description:
+        - Special headers that help control how the operation executes.
+notes:
+    - Requires jboss-py Python package on the host.
+requirements:
+    - jboss-py >= 1.0.0
+'''

--- a/test/integration/targets/jboss_command/aliases
+++ b/test/integration/targets/jboss_command/aliases
@@ -1,0 +1,4 @@
+destructive
+posix/ci/group1
+skip/osx
+skip/freebsd

--- a/test/integration/targets/jboss_command/meta/main.yml
+++ b/test/integration/targets/jboss_command/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - setup_jboss

--- a/test/integration/targets/jboss_command/tasks/main.yml
+++ b/test/integration/targets/jboss_command/tasks/main.yml
@@ -1,0 +1,18 @@
+---
+- name: Read datasource
+  jboss_command:
+    operation: read-resource
+    path: "/subsystem=datasources/data-source=ExampleDS"
+  environment:
+    JBOSS_MANAGEMENT_USER: ansible
+    JBOSS_MANAGEMENT_PASSWORD: ansible
+    JBOSS_MANAGEMENT_HOST: "127.0.0.1"
+    JBOSS_MANAGEMENT_PORT: 9990
+  register: result
+
+- name: assert output message that hawtio was deployed
+  assert:
+    that:
+       - "result.changed == true"
+       - "result.meta.outcome == 'success'"
+       - "result.meta.result['jndi-name'] == 'java:jboss/datasources/ExampleDS'"

--- a/test/integration/targets/jboss_deployment/aliases
+++ b/test/integration/targets/jboss_deployment/aliases
@@ -1,0 +1,4 @@
+destructive
+posix/ci/group1
+skip/osx
+skip/freebsd

--- a/test/integration/targets/jboss_deployment/meta/main.yml
+++ b/test/integration/targets/jboss_deployment/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - setup_jboss

--- a/test/integration/targets/jboss_deployment/tasks/main.yml
+++ b/test/integration/targets/jboss_deployment/tasks/main.yml
@@ -1,0 +1,25 @@
+---
+- name: Download hawt.io
+  get_url:
+    url: http://central.maven.org/maven2/io/hawt/hawtio-web/1.5.0/hawtio-web-1.5.0.war
+    dest: /opt/hawtio.war
+    mode: 0655
+    checksum: sha256:fddd0f2320d79ad16a29b557e30fc94bba0ec4f3e51ee2377dd42d9ff0cfb78f
+
+- name: Deploy hawt.io
+  jboss_deployment:
+    name: hawtio.war
+    state: present
+    src: /opt/hawtio.war
+  environment:
+    JBOSS_MANAGEMENT_USER: ansible
+    JBOSS_MANAGEMENT_PASSWORD: ansible
+    JBOSS_MANAGEMENT_HOST: "127.0.0.1"
+    JBOSS_MANAGEMENT_PORT: 9990
+  register: result
+
+- name: assert output message that hawtio was deployed
+  assert:
+    that:
+       - "result.changed == true"
+       - "result.msg == 'Deployed hawtio.war'"

--- a/test/integration/targets/jboss_resource/aliases
+++ b/test/integration/targets/jboss_resource/aliases
@@ -1,0 +1,4 @@
+destructive
+posix/ci/group1
+skip/osx
+skip/freebsd

--- a/test/integration/targets/jboss_resource/meta/main.yml
+++ b/test/integration/targets/jboss_resource/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - setup_jboss

--- a/test/integration/targets/jboss_resource/tasks/main.yml
+++ b/test/integration/targets/jboss_resource/tasks/main.yml
@@ -1,0 +1,25 @@
+---
+- name: Configure datasource
+  jboss_resource:
+    name: "/subsystem=datasources/data-source=DemoDS"
+    state: present
+    attributes:
+      driver-name: h2
+      connection-url: "jdbc:h2:mem:demo;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE"
+      jndi-name: "java:jboss/datasources/DemoDS"
+      user-name: sa
+      password: sa
+      min-pool-size: 12
+      max-pool-size: 25
+  environment:
+    JBOSS_MANAGEMENT_USER: ansible
+    JBOSS_MANAGEMENT_PASSWORD: ansible
+    JBOSS_MANAGEMENT_HOST: "127.0.0.1"
+    JBOSS_MANAGEMENT_PORT: 9990
+  register: result
+
+- name: assert output message that hawtio was deployed
+  assert:
+    that:
+       - "result.changed == true"
+       - "'Added /subsystem=datasources/data-source=DemoDS' in result.msg"

--- a/test/integration/targets/setup_jboss/defaults/main.yml
+++ b/test/integration/targets/setup_jboss/defaults/main.yml
@@ -1,0 +1,7 @@
+---
+jboss_home: /opt/wildfly
+jboss_user: wildfly
+jboss_group: wildfly
+jboss_install_src: http://download.jboss.org/wildfly/10.1.0.Final/wildfly-10.1.0.Final.tar.gz
+jboss_mgmt_user: ansible
+jboss_mgmt_password: ansible

--- a/test/integration/targets/setup_jboss/tasks/main.yml
+++ b/test/integration/targets/setup_jboss/tasks/main.yml
@@ -1,0 +1,64 @@
+---
+- name: Download JDK
+  get_url:
+    url: http://download.oracle.com/otn-pub/java/jdk/8u131-b11/d54c1d3a095b4ff2b6607d096fa80163/jdk-8u131-linux-x64.tar.gz
+    headers: "Cookie:oraclelicense=accept-securebackup-cookie"
+    dest: /tmp/jdk-8u131-linux-x64.tar.gz
+
+- name: Extract JDK tarball
+  unarchive:
+    src: /tmp/jdk-8u131-linux-x64.tar.gz
+    dest: /opt
+    creates: /opt/jdk1.8.0_131/
+    remote_src: yes
+
+- name: JBoss OS user
+  user:
+    name: "{{ jboss_user }}"
+
+- name: JBoss OS group
+  group:
+    name: "{{ jboss_group }}"
+
+- name: JBoss home dir
+  file:
+    path: "{{ jboss_home }}"
+    owner: "{{ jboss_user }}"
+    group: "{{ jboss_group }}"
+    state: directory
+    mode: 0755
+
+- name: Download and Extract Tarball
+  unarchive:
+    src: "{{ jboss_install_src }}"
+    dest: "{{ jboss_home }}"
+    extra_opts:
+      - "--no-same-owner"
+      - "--no-same-permissions"
+      - "--strip-components=1"
+    creates: "{{ jboss_home }}/jboss-modules.jar"
+    owner: "{{ jboss_user }}"
+    group: "{{ jboss_group }}"
+    remote_src: yes
+
+- name: Management Realm user
+  lineinfile:
+    path: "{{ jboss_home }}/standalone/configuration/mgmt-users.properties"
+    line: "{{ jboss_mgmt_user }}={{ [jboss_mgmt_user, 'ManagementRealm', jboss_mgmt_password] | join(':') | hash('md5') }}"
+    regexp: "^{{ jboss_mgmt_user }}="
+
+- name: Start JBoss
+  shell: "nohup {{ jboss_home }}/bin/standalone.sh &"
+  become: yes
+  become_user: "{{ jboss_user }}"
+  environment:
+    JAVA_HOME: /opt/jdk1.8.0_131
+
+- name: jboss-py
+  pip:
+    name: "git+https://github.com/jairojunior/jboss-py.git@master#egg=jboss-py"
+
+- name: Wait for management interface to become available
+  wait_for:
+    port: 9990
+    delay: 10


### PR DESCRIPTION
##### SUMMARY

This PR is composed of three remote management module for JBoss: jboss_deployment, jboss_resource and jboss_command

The rationale behind using Management API as opposed to traditional JBoss-CLI [1] approach is to reduce the burden of the module user to Manage JBoss's resources by introducing a declarative approach that is idempotent by nature (at least for jboss_deployment and jboss_resource).

There is already a jboss module in web_infrastructure [2] to perform deploys, but it's limited to standalone mode and it leverages deployment scanner, so it basically copy the file to deployment directory, hence it did not provide any feedback for module users regarding deployment success or failure.

I developed a showcase role [3] to develop these modules. There are a few examples there and it's fully functional. Molecule is converging twice to check for idempotence. At first I was planning to test everything using testinfra, but I found out that Ansible uses a different test approach that I am still getting to know.

The module dependency [4] was developed by me and has a pretty decent test coverage. Not sure if it could be part of Ansible codebase, or if it really should be in a separated package.

##### ISSUE TYPE
 - New Module Pull Request

##### COMPONENT NAME
modules/web_infrastructure/jboss

##### ANSIBLE VERSION
```
2.6.0
```

[1] https://github.com/jairojunior/wildfly-ha-tcpgossip-vagrant-puppet/blob/master/wildfly-rolling-deployment.yml#L24

[2] http://docs.ansible.com/ansible/jboss_module.html

[3] https://github.com/jairojunior/ansible-role-jboss

[4] https://github.com/jairojunior/jboss-py

##### CORE CHANGES

This PR changes `open_url` behavior to use a user provided Authentication Realm. A better way to handle this would be to guess this realm based on the first request, as other libraries do.
