### PR TITLE
uri: Avoid false traceback in common scenarios

### DIFF
--- a/lib/ansible/modules/net_tools/basics/uri.py
+++ b/lib/ansible/modules/net_tools/basics/uri.py
@@ -564,10 +564,8 @@ def main():
         ukey = key.replace("-", "_").lower()
         uresp[ukey] = value
 
-    try:
+    if 'location' in uresp:
         uresp['location'] = absolute_location(url, uresp['location'])
-    except KeyError:
-        pass
 
     # Default content_encoding to try
     content_encoding = 'utf-8'

--- a/lib/ansible/modules/net_tools/basics/uri.py
+++ b/lib/ansible/modules/net_tools/basics/uri.py
@@ -261,12 +261,13 @@ import datetime
 import json
 import os
 import shutil
+import sys
 import tempfile
 import traceback
 
 from collections import Mapping, Sequence
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.six import iteritems, string_types
+from ansible.module_utils.six import PY2, iteritems, string_types
 from ansible.module_utils.six.moves.urllib.parse import urlencode, urlsplit
 from ansible.module_utils._text import to_native, to_text
 from ansible.module_utils.urls import fetch_url, url_argument_spec
@@ -579,7 +580,8 @@ def main():
                 js = json.loads(u_content)
                 uresp['json'] = js
             except:
-                pass
+                if PY2:
+                    sys.exc_clear()  # Avoid false positive traceback in fail_json() on Python 2
     else:
         u_content = to_text(content, encoding=content_encoding)
 


### PR DESCRIPTION
##### SUMMARY
So I was confused by the fact that the **uri** module, when not
returning an acceptable HTTP status code, also returns:

    The full traceback is:
      File "/tmp/ansible_UQwiI4/ansible_module_uri.py", line 471, in main
        uresp['location'] = absolute_location(url, uresp['location'])

or

    The full traceback is:
      File "/tmp/ansible_9tOvt1/ansible_module_uri.py", line 581, in main
        js = json.loads(u_content)
      File "/usr/lib64/python2.7/json/__init__.py", line 338, in loads
        return _default_decoder.decode(s)
      File "/usr/lib64/python2.7/json/decoder.py", line 366, in decode
        obj, end = self.raw_decode(s, idx=_w(s, 0).end())
      File "/usr/lib64/python2.7/json/decoder.py", line 384, in raw_decode
        raise ValueError("No JSON object could be decoded")

While the actual error was:

    Status code was 400 and not [201]: HTTP Error 400:

This is caused by [this code](https://github.com/ansible/ansible/blob/devel/lib/ansible/module_utils/basic.py#L2390). Personally I would disable that piece because it is almost always wrong and confusing.

I also wonder why that message ends abruptly. I would have expected
`HTTP Error 400: Bad Request` which would be more useful.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
uri

##### ANSIBLE VERSION
v2.6 and earlier