### PR TITLE
Add firewalld Rich Rule port forwarding example

### DIFF
--- a/lib/ansible/modules/system/firewalld.py
+++ b/lib/ansible/modules/system/firewalld.py
@@ -133,6 +133,17 @@ EXAMPLES = '''
     zone: custom
     state: present
     permanent: true
+
+- name: Redirect port 443 to 8443 with Rich Rule
+  firewalld:
+    rich_rule: rule family={{ item }} forward-port port=443 protocol=tcp to-port=8443
+    zone:      public
+    permanent: true
+    immediate: true
+    state:     enabled
+  with_items:
+    - ipv4
+    - ipv6
 '''
 
 from ansible.module_utils.basic import AnsibleModule


### PR DESCRIPTION
Example provided by Mike Cardwell (@mikehardenize) in an issue
comment 28349#issuecomment-385354551

Signed-off-by: Adam Miller <admiller@redhat.com>

##### SUMMARY
Add an example of using a Rich Rule to create port forward via firewalld to the module documentation

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
firewalld

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0 (firewalld-docs f118beb676) last updated 2018/04/30 17:32:59 (GMT -500)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/admiller/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/admiller/src/dev/ansible/lib/ansible
  executable location = /home/admiller/src/dev/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 14 2018, 13:36:31) [GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]
```

