### PR TITLE
Fix broken docs link.

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_loops.rst
+++ b/docs/docsite/rst/user_guide/playbooks_loops.rst
@@ -72,7 +72,7 @@ If you have a list of hashes, you can reference subkeys using things like::
         - { name: 'testuser1', groups: 'wheel' }
         - { name: 'testuser2', groups: 'root' }
 
-Also be aware that when combining :ref:`when: playbooks_conditionals` with a loop, the ``when:`` statement is processed separately for each item.
+Also be aware that when combining :doc:`playbooks_conditionals` with a loop, the ``when:`` statement is processed separately for each item.
 See :ref:`the_when_statement` for an example.
 
 


### PR DESCRIPTION
##### SUMMARY

Fix broken docs link.

This link was already fixed in https://github.com/ansible/ansible/pull/38375 for devel. That PR could not be included in stable-2.5 because it documented a new feature for the 2.6 release.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

docs

##### ANSIBLE VERSION

```
ansible 2.5.2 (docs-fix-2.5 23b3992d62) last updated 2018/04/30 15:33:05 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
