### PR TITLE
mail callback: Exception info less important

### DIFF
--- a/lib/ansible/plugins/callback/mail.py
+++ b/lib/ansible/plugins/callback/mail.py
@@ -155,14 +155,14 @@ class CallbackModule(CallbackBase):
             subject = self.itemsubject
         elif result._result.get('failed_when_result') is True:
             subject = "Failed due to 'failed_when' condition"
-        elif result._result.get('exception'):
-            subject = self.subject_msg(result._result['exception'], failtype, -1)
         elif result._result.get('msg'):
             subject = self.subject_msg(result._result['msg'], failtype, 0)
         elif result._result.get('stderr'):
             subject = self.subject_msg(result._result['stderr'], failtype, -1)
         elif result._result.get('stdout'):
             subject = self.subject_msg(result._result['stdout'], failtype, -1)
+        elif result._result.get('exception'):  # Unrelated exceptions are added to output :-/
+            subject = self.subject_msg(result._result['exception'], failtype, -1)
         else:
             subject = '%s: %s' % (failtype, result._task.name or result._task.action)
 
@@ -193,12 +193,12 @@ class CallbackModule(CallbackBase):
             body += self.body_blob(result._result['msg'], 'message')
 
         # Add stdout / stderr / exception / warnings / deprecations
-        if result._result.get('exception'):
-            body += self.body_blob(result._result['exception'], 'exception')
         if result._result.get('stdout'):
             body += self.body_blob(result._result['stdout'], 'standard output')
         if result._result.get('stderr'):
             body += self.body_blob(result._result['stderr'], 'error output')
+        if result._result.get('exception'):  # Unrelated exceptions are added to output :-/
+            body += self.body_blob(result._result['exception'], 'exception')
         if result._result.get('warnings'):
             for i in range(len(result._result.get('warnings'))):
                 body += self.body_blob(result._result['warnings'][i], 'exception %d' % (i + 1))
@@ -231,4 +231,3 @@ class CallbackModule(CallbackBase):
         # Pass item information to task failure
         self.itemsubject = result._result['msg']
         self.itembody += self.body_blob(json.dumps(result._result, indent=4), "failed item dump '%(item)s'" % result._result)
-#        self.itembody += self.body_blob(json.dumps(dir(result), indent=4), "failed full dump '%(item)s'" % result._result)


### PR DESCRIPTION
##### SUMMARY
So it seems on failure the last raised (but handled) exception is being
added to the task failure result, which makes it often unrelated to the
actual failure.

Since we assumed the exception was always related, using the exception
information for the subject is plain wrong (and let me to debug
completely unrelated ghost issues).

Also the exception details are now moved back in the output. Maybe we
should not show it unless there's no other information ? But at least it
should not be the mail's subject.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
mail callback

##### ANSIBLE VERSION
v2.6 and earlier