### PR TITLE
Fix when template paths contain non-ascii chars and using the path in…

### DIFF
--- a/changelogs/fragments/ansible-managed-encoding.yaml
+++ b/changelogs/fragments/ansible-managed-encoding.yaml
@@ -1,0 +1,5 @@
+---
+bugfixes:
+- template - Fix for encoding issues when a template path contains non-ascii
+  characters and using the template path in ansible_managed
+  (https://github.com/ansible/ansible/issues/27262)

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -72,7 +72,6 @@ JINJA2_OVERRIDE = '#jinja2:'
 
 
 def generate_ansible_template_vars(path):
-
     b_path = to_bytes(path)
     try:
         template_uid = pwd.getpwuid(os.stat(b_path).st_uid).pw_name
@@ -80,10 +79,10 @@ def generate_ansible_template_vars(path):
         template_uid = os.stat(b_path).st_uid
 
     temp_vars = {}
-    temp_vars['template_host'] = os.uname()[1]
-    temp_vars['template_path'] = b_path
+    temp_vars['template_host'] = to_text(os.uname()[1])
+    temp_vars['template_path'] = path
     temp_vars['template_mtime'] = datetime.datetime.fromtimestamp(os.path.getmtime(b_path))
-    temp_vars['template_uid'] = template_uid
+    temp_vars['template_uid'] = to_text(template_uid)
     temp_vars['template_fullpath'] = os.path.abspath(path)
     temp_vars['template_run_date'] = datetime.datetime.now()
 
@@ -93,7 +92,7 @@ def generate_ansible_template_vars(path):
         uid=temp_vars['template_uid'],
         file=temp_vars['template_path'],
     )
-    temp_vars['ansible_managed'] = time.strftime(managed_str, time.localtime(os.path.getmtime(b_path)))
+    temp_vars['ansible_managed'] = to_text(time.strftime(to_native(managed_str), time.localtime(os.path.getmtime(b_path))))
 
     return temp_vars
 

--- a/test/integration/targets/template/ansible_managed.cfg
+++ b/test/integration/targets/template/ansible_managed.cfg
@@ -1,0 +1,2 @@
+[defaults]
+ansible_managed=ansible_managed = Ansible managed: {file} modified on %Y-%m-%d %H:%M:%S by {uid} on {host}

--- a/test/integration/targets/template/ansible_managed.yml
+++ b/test/integration/targets/template/ansible_managed.yml
@@ -1,0 +1,12 @@
+---
+- hosts: testhost
+  gather_facts: False
+  tasks:
+  - file:
+      path: '{{ output_dir }}/café.txt'
+      state: 'absent'
+  # Smoketest that ansible_managed with non-ascii chars works:
+  # https://github.com/ansible/ansible/issues/27262
+  - template:
+      src: 'templates/café.j2'
+      dest: '{{ output_dir }}/café.txt'

--- a/test/integration/targets/template/runme.sh
+++ b/test/integration/targets/template/runme.sh
@@ -6,3 +6,6 @@ ANSIBLE_ROLES_PATH=../ ansible-playbook template.yml -i ../../inventory -e @../.
 
 # Test for #35571
 ansible testhost -i testhost, -m debug -a 'msg={{ hostvars["localhost"] }}' -e "vars1={{ undef }}" -e "vars2={{ vars1 }}"
+
+# Test for https://github.com/ansible/ansible/issues/27262
+ansible-playbook ansible_managed.yml -c  ansible_managed.cfg -i ../../inventory -e @../../integration_config.yml -v "$@"

--- a/test/integration/targets/template/tasks/main.yml
+++ b/test/integration/targets/template/tasks/main.yml
@@ -51,6 +51,24 @@
     that:
       - "template_result.changed == true"
 
+# Basic template with non-ascii names
+- name: Check that non-ascii source and dest work
+  template:
+    src: 'café.j2'
+    dest: '{{ output_dir }}/café.txt'
+  register: template_results
+
+- name: Check that the resulting file exists
+  stat:
+    path: '{{ output_dir }}/café.txt'
+  register: stat_results
+
+- name: Check that template created the right file
+  assert:
+    that:
+      - 'template_results is changed'
+      - 'stat_results.stat["exists"]'
+
 # test for import with context on jinja-2.9 See https://github.com/ansible/ansible/issues/20494
 - name: fill in a template using import with context ala issue 20494
   template: src=import_with_context.j2 dest={{output_dir}}/import_with_context.templated mode=0644

--- a/test/integration/targets/template/templates/café.j2
+++ b/test/integration/targets/template/templates/café.j2
@@ -1,0 +1,1 @@
+{{ ansible_managed }}


### PR DESCRIPTION
… ansible_managed

Fixes #27262

(cherry picked from commit 81b252915941616140a36ad8b97bd34521ff6f1a)

##### ISSUE TYPE

 - Bugfix Pull Request


##### COMPONENT NAME
lib/ansible/plugins/action/template.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```

