### PR TITLE
Fix ~ vs. ~username expansion

### DIFF
--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -567,11 +567,14 @@ class ActionBase(with_metaclass(ABCMeta, object)):
         split_path = path.split(os.path.sep, 1)
         expand_path = split_path[0]
 
-        if sudoable and expand_path == '~' and self._play_context.become and self._play_context.become_user:
-            expand_path = '~%s' % self._play_context.become_user
-        else:
-            # use remote user instead, if none set default to current user
-            expand_path = '~%s' % self._play_context.remote_user or self._connection.default_user or ''
+        # We translate '~' to '~username' here, and then expand '~username'
+        # remotely.
+
+        if expand_path == '~':
+            username = self._play_context.remote_user or self._connection.default_user or ''
+            if sudoable and self._play_context.become and self._play_context.become_user:
+                username = self._play_context.become_user
+            expand_path = '~%s' % username
 
         # use shell to construct appropriate command and execute
         cmd = self._connection._shell.expand_user(expand_path)


### PR DESCRIPTION
##### SUMMARY

We used to translate '\~' based on become_user, but in cc1c7c6 that was
extended to using remote_user for non-sudoable tasks. The new code was,
however, inappropriately applied to '\~' and '~x' alike, which broke:

    - copy: src=x dest=~foo/x
      become_user: foo
      become: yes

The ~foo/x was incorrectly treated as if it were ~/x, and translated to
~remote_user/x instead of ~foo/x.

Fixes #39281

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
core

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0 (devel e9270fb100) last updated 2018/05/01 08:08:18 (GMT +550)
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->
