### PR TITLE
Azure Module Fixes with primary field and base-url

### DIFF
--- a/lib/ansible/module_utils/azure_rm_common.py
+++ b/lib/ansible/module_utils/azure_rm_common.py
@@ -874,6 +874,7 @@ class AzureRMModuleBase(object):
         if not base_url:
             # most things are resource_manager, don't make everyone specify
             base_url = self._cloud_environment.endpoints.resource_manager
+            client_kwargs['base_url'] = base_url
 
         # unversioned clients won't accept profile; only send it if necessary
         # clients without a version specified in the profile will use the default

--- a/lib/ansible/modules/cloud/azure/azure_rm_networkinterface.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_networkinterface.py
@@ -310,7 +310,6 @@ def nic_to_dict(nic):
             private_ip_address=config.private_ip_address,
             private_ip_allocation_method=config.private_ip_allocation_method,
             subnet=subnet_to_dict(config.subnet),
-            primary=config.primary,
             public_ip_address=dict(
                 id=config.public_ip_address.id,
                 name=azure_id_to_dict(config.public_ip_address.id).get('publicIPAddresses'),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
 When creating a Network Security Group in AzureStack using Ansible
       when looking at the code the base-url was shown as "none" - this caused the code to use
       the standard public azure base-url of "management.azure.com" - this caused ansible 
      not to work with AzureStack as the URL for AzureStack is not the public one. This address was
     set in the credentials file and caused other resources (public ip address, resource grouyp etc...) to
     be created OK but did not work for network security groups. After degugging I found that the
     local variable is set to the credientials fiule value in this case but the value is not passed to
     subsequent functions. This fixes this.

In Ansible 2.5 a new field has appeared under Azure Network Interface called primary.
According to the documentation this field is not mandatory but when running a playbook without this field errors have resulted. To get around this I include the field primary and set it to "True" - after this another error has resulted. THis subserquent error comes from the Python module stating that the "primary" field does not exist in the data structures that are used. To get around this I removed the line from the python module and this works. I think this may be a symptom of an issue elsewhere so not sure if this is the best fix.


<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.2
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Aug  4 2017, 00:39:18) [GCC 4.8.5 20150623 (Red Hat 4.8.5-16)]

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
```
