### PR TITLE
split tag value with comma and add to separate group

### DIFF
--- a/contrib/inventory/azure_rm.py
+++ b/contrib/inventory/azure_rm.py
@@ -736,9 +736,9 @@ class AzureInventory(object):
                     self._inventory[safe_value] = []
                 self._inventory[safe_key].append(host_name)
                 self._inventory[safe_value].append(host_name)
-                if re.search(r',', values):
-                    for value in values.split(","):
-                        safe_value = safe_key + '_' + self._to_safe(value)
+                if re.search(r',', value):
+                    for token in value.split(","):
+                        safe_value = safe_key + '_' + self._to_safe(token)
                         if not self._inventory.get(safe_value):
                             self._inventory[safe_value] = []
                         self._inventory[safe_value].append(host_name)

--- a/contrib/inventory/azure_rm.py
+++ b/contrib/inventory/azure_rm.py
@@ -736,6 +736,12 @@ class AzureInventory(object):
                     self._inventory[safe_value] = []
                 self._inventory[safe_key].append(host_name)
                 self._inventory[safe_value].append(host_name)
+                if re.search(r',', values):
+                    for value in values.split(","):
+                        safe_value = safe_key + '_' + self._to_safe(value)
+                        if not self._inventory.get(safe_value):
+                            self._inventory[safe_value] = []
+                        self._inventory[safe_value].append(host_name)
 
     def _json_format_dict(self, pretty=False):
         # convert inventory to json
@@ -834,6 +840,8 @@ class AzureInventory(object):
             if arg_value and tag_obj.get(arg_key, None) == arg_value:
                 matches += 1
             elif not arg_value and tag_obj.get(arg_key, None) is not None:
+                matches += 1
+            elif arg_value and arg_value in tag_obj.get(arg_key, "").split(","):
                 matches += 1
         if matches == len(tag_args):
             return True


### PR DESCRIPTION
Support to have multiple comma separated values for a tag.

##### SUMMARY
This provides an option for a VM tag value to have comma separated list which will be split and added as individual inventory group

e.g: role:elasticsearch,elasticsearch-data

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
azure_rm.py

##### ANSIBLE VERSION
```
2.x
```


##### ADDITIONAL INFORMATION
e.g:

tags for vm1:
  role: elasticsearch, ealsticsearch-data

groups before changes
```
"role_elasticsearch_ealsticsearch-data": [
    "vm1"
  ]
```
groups after changes
```
"role_elasticsearch_ealsticsearch-data": [
    "vm1"
  ],
"role_elasticsearch": [
    "vm1"
  ],
"role_ealsticsearch-data": [
    "vm1"
  ]
```
