### PR TITLE
Remove provider (and transport, where applicable) from consideration when not using connection=local

### DIFF
--- a/lib/ansible/plugins/action/bigip.py
+++ b/lib/ansible/plugins/action/bigip.py
@@ -49,6 +49,7 @@ class ActionModule(_ActionModule):
             provider = self._task.args.get('provider', {})
             if any(provider.values()):
                 display.warning('provider is unnecessary when using network_cli and will be ignored')
+                del self._task.args['provider']
         elif self._play_context.connection == 'local':
             provider = load_provider(f5_provider_spec, self._task.args)
 

--- a/lib/ansible/plugins/action/dellos10.py
+++ b/lib/ansible/plugins/action/dellos10.py
@@ -49,6 +49,7 @@ class ActionModule(_ActionModule):
             provider = self._task.args.get('provider', {})
             if any(provider.values()):
                 display.warning('provider is unnecessary when using network_cli and will be ignored')
+                del self._task.args['provider']
         elif self._play_context.connection == 'local':
             provider = load_provider(dellos10_provider_spec, self._task.args)
             pc = copy.deepcopy(self._play_context)

--- a/lib/ansible/plugins/action/dellos6.py
+++ b/lib/ansible/plugins/action/dellos6.py
@@ -49,6 +49,7 @@ class ActionModule(_ActionModule):
             provider = self._task.args.get('provider', {})
             if any(provider.values()):
                 display.warning('provider is unnecessary when using network_cli and will be ignored')
+                del self._task.args['provider']
         elif self._play_context.connection == 'local':
             provider = load_provider(dellos6_provider_spec, self._task.args)
             pc = copy.deepcopy(self._play_context)

--- a/lib/ansible/plugins/action/dellos9.py
+++ b/lib/ansible/plugins/action/dellos9.py
@@ -49,6 +49,7 @@ class ActionModule(_ActionModule):
             provider = self._task.args.get('provider', {})
             if any(provider.values()):
                 display.warning('provider is unnecessary when using network_cli and will be ignored')
+                del self._task.args['provider']
         elif self._play_context.connection == 'local':
             provider = load_provider(dellos9_provider_spec, self._task.args)
             pc = copy.deepcopy(self._play_context)

--- a/lib/ansible/plugins/action/eos.py
+++ b/lib/ansible/plugins/action/eos.py
@@ -47,6 +47,10 @@ class ActionModule(_ActionModule):
             provider = self._task.args.get('provider', {})
             if any(provider.values()):
                 display.warning('provider is unnecessary when using network_cli and will be ignored')
+                del self._task.args['provider']
+            if self._task.args.get('transport'):
+                display.warning('transport is unnecessary when using network_cli and will be ignored')
+                del self._task.args['transport']
         elif self._play_context.connection == 'local':
             provider = load_provider(eos_provider_spec, self._task.args)
             transport = provider['transport'] or 'cli'

--- a/lib/ansible/plugins/action/ios.py
+++ b/lib/ansible/plugins/action/ios.py
@@ -47,6 +47,7 @@ class ActionModule(_ActionModule):
             provider = self._task.args.get('provider', {})
             if any(provider.values()):
                 display.warning('provider is unnecessary when using network_cli and will be ignored')
+                del self._task.args['provider']
         elif self._play_context.connection == 'local':
             provider = load_provider(ios_provider_spec, self._task.args)
             pc = copy.deepcopy(self._play_context)

--- a/lib/ansible/plugins/action/iosxr.py
+++ b/lib/ansible/plugins/action/iosxr.py
@@ -81,6 +81,7 @@ class ActionModule(_ActionModule):
             provider = self._task.args.get('provider', {})
             if any(provider.values()):
                 display.warning('provider is unnecessary when using {0} and will be ignored'.format(self._play_context.connection))
+                del self._task.args['provider']
         else:
             return {'failed': True, 'msg': 'Connection type %s is not valid for this module' % self._play_context.connection}
 

--- a/lib/ansible/plugins/action/junos.py
+++ b/lib/ansible/plugins/action/junos.py
@@ -89,6 +89,7 @@ class ActionModule(_ActionModule):
             provider = self._task.args.get('provider', {})
             if any(provider.values()):
                 display.warning('provider is unnecessary when using connection=%s and will be ignored' % self._play_context.connection)
+                del self._task.args['provider']
 
             if (self._play_context.connection == 'network_cli' and self._task.action not in CLI_SUPPORTED_MODULES) or \
                     (self._play_context.connection == 'netconf' and self._task.action == 'junos_netconf'):

--- a/lib/ansible/plugins/action/junos.py
+++ b/lib/ansible/plugins/action/junos.py
@@ -88,7 +88,7 @@ class ActionModule(_ActionModule):
         elif self._play_context.connection in ('netconf', 'network_cli'):
             provider = self._task.args.get('provider', {})
             if any(provider.values()):
-                display.warning('provider is unnecessary when using connection=%s and will be ignored' % self._play_context.connection)
+                display.warning('provider is unnecessary when using %s and will be ignored' % self._play_context.connection)
                 del self._task.args['provider']
 
             if (self._play_context.connection == 'network_cli' and self._task.action not in CLI_SUPPORTED_MODULES) or \

--- a/lib/ansible/plugins/action/net_base.py
+++ b/lib/ansible/plugins/action/net_base.py
@@ -96,6 +96,7 @@ class ActionModule(ActionBase):
             provider = self._task.args.get('provider', {})
             if any(provider.values()):
                 display.warning('provider is unnecessary when using connection=%s and will be ignored' % play_context.connection)
+                del self._task.args['provider']
 
         if play_context.connection == 'network_cli':
             # make sure we are in the right cli context which should be

--- a/lib/ansible/plugins/action/net_base.py
+++ b/lib/ansible/plugins/action/net_base.py
@@ -95,7 +95,7 @@ class ActionModule(ActionBase):
         else:
             provider = self._task.args.get('provider', {})
             if any(provider.values()):
-                display.warning('provider is unnecessary when using connection=%s and will be ignored' % play_context.connection)
+                display.warning('provider is unnecessary when using %s and will be ignored' % play_context.connection)
                 del self._task.args['provider']
 
         if play_context.connection == 'network_cli':

--- a/lib/ansible/plugins/action/nxos.py
+++ b/lib/ansible/plugins/action/nxos.py
@@ -47,6 +47,10 @@ class ActionModule(_ActionModule):
             provider = self._task.args.get('provider', {})
             if any(provider.values()):
                 display.warning('provider is unnecessary when using network_cli and will be ignored')
+                del self._task.args['provider']
+            if self._task.args.get('transport'):
+                display.warning('transport is unnecessary when using network_cli and will be ignored')
+                del self._task.args['transport']
         elif self._play_context.connection == 'local':
             provider = load_provider(nxos_provider_spec, self._task.args)
             transport = provider['transport'] or 'cli'

--- a/lib/ansible/plugins/action/sros.py
+++ b/lib/ansible/plugins/action/sros.py
@@ -43,6 +43,7 @@ class ActionModule(_ActionModule):
             provider = self._task.args.get('provider', {})
             if any(provider.values()):
                 display.warning('provider is unnecessary when using network_cli and will be ignored')
+                del self._task.args['provider']
         elif self._play_context.connection == 'local':
             provider = load_provider(sros_provider_spec, self._task.args)
 

--- a/lib/ansible/plugins/action/vyos.py
+++ b/lib/ansible/plugins/action/vyos.py
@@ -47,6 +47,7 @@ class ActionModule(_ActionModule):
             provider = self._task.args.get('provider', {})
             if any(provider.values()):
                 display.warning('provider is unnecessary when using network_cli and will be ignored')
+                del self._task.args['provider']
         elif self._play_context.connection == 'local':
             provider = load_provider(vyos_provider_spec, self._task.args)
             pc = copy.deepcopy(self._play_context)

--- a/test/integration/targets/eos_smoke/tests/cli/misc_tests.yaml
+++ b/test/integration/targets/eos_smoke/tests/cli/misc_tests.yaml
@@ -23,4 +23,15 @@
         provider: "{{ cli }}"
       become: no
 
+    # Test that transport values are properly ignored
+    - name: wrong transport specified
+      eos_command:
+          commands: show version
+          transport: eapi
+
+    - name: wrong transport specified in provider
+      eos_command:
+          commands: show version
+          provider: "{{ eapi }}"
+
   when: "ansible_connection != 'local'"

--- a/test/integration/targets/nxos_smoke/tests/cli/misc_tests.yaml
+++ b/test/integration/targets/nxos_smoke/tests/cli/misc_tests.yaml
@@ -1,0 +1,17 @@
+---
+- debug: msg="START cli/misc_tests.yaml on connection={{ ansible_connection }}"
+
+
+- block:
+    # Test that transport values are properly ignored
+    - name: wrong transport specified
+      eos_command:
+          commands: show version
+          transport: nxapi
+
+    - name: wrong transport specified in provider
+      eos_command:
+          commands: show version
+          provider: "{{ nxapi }}"
+
+  when: "ansible_connection != 'local'"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
Actually ignore provider by removing it from task args.

This helps the confusing case where using `connection: network_cli` yet also specifying `provider: {{eapi}}`, for example

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
network

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6
```