### PR TITLE
Update yarn.py: set name_version even w/o version

### DIFF
--- a/lib/ansible/modules/packaging/language/yarn.py
+++ b/lib/ansible/modules/packaging/language/yarn.py
@@ -167,16 +167,16 @@ class Yarn(object):
         self.production = kwargs['production']
         self.ignore_scripts = kwargs['ignore_scripts']
 
-        # Specify a version of package if version arg passed in
-        self.name_version = None
+        self.name_version = self.name
 
         if kwargs['executable']:
             self.executable = kwargs['executable'].split(' ')
         else:
             self.executable = [module.get_bin_path('yarn', True)]
 
+        # Append a version of package if version arg passed in
         if kwargs['version'] and self.name is not None:
-            self.name_version = self.name + '@' + str(self.version)
+            self.name_version += '@' + str(self.version)
 
     def _exec(self, args, run_in_check_mode=False, check_rc=True):
         if not self.module.check_mode or (self.module.check_mode and run_in_check_mode):


### PR DESCRIPTION
##### SUMMARY

Otherwise, 
```
  yarn:
    name: myPackage
    state: present
    global: yes
```
results to:
```
FAILED! => {"changed": false, "cmd": "/usr/local/bin/yarn global install --non-interactive --no-emoji", "msg": "error An unexpected error occurred: \"Invalid subcommand. Try \\\"add, bin, dir, ls, list, remove, upgrade, upgrade-interactive\\\"\".", "rc": 1, [...]
```

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
yarn

##### ANSIBLE VERSION

```
ansible 2.6.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.14 (default, Dec 14 2017, 15:51:29) [GCC 6.4.0]
```


