### PR TITLE
Ensure we don't overwrite handlers from include_role when loading a play

### DIFF
--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -169,7 +169,11 @@ class Play(Base, Taggable, Become):
         Bare handlers outside of a block are given an implicit block.
         '''
         try:
-            return load_list_of_blocks(ds=ds, play=self, use_handlers=True, variable_manager=self._variable_manager, loader=self._loader)
+            return self._extend_value(
+                self.handlers,
+                load_list_of_blocks(ds=ds, play=self, use_handlers=True, variable_manager=self._variable_manager, loader=self._loader),
+                prepend=True
+            )
         except AssertionError as e:
             raise AnsibleParserError("A malformed block was encountered while loading handlers", obj=self._ds, orig_exc=e)
 


### PR DESCRIPTION
##### SUMMARY
Ensure we don't overwrite handlers from include_role when loading a play

Fixes #18140

In `IncludeRole.get_block_list` we add the handlers from a role directly to the play, later we run `_load_handlers` which, if the play has handlers of it's own, overwrites the handlers added from `include_role`.

I debated overloading what `FieldAttribute.extend` means, and adding some functionality into `load_data` to use that, but decided to just handle it in `_load_handlers`.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/playbook/play.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```