### PR TITLE
Update 2.6 roadmap dates.

### DIFF
--- a/docs/docsite/rst/roadmap/ROADMAP_2_6.rst
+++ b/docs/docsite/rst/roadmap/ROADMAP_2_6.rst
@@ -2,17 +2,22 @@
 Ansible 2.6
 ===========
 
-**Core Engine Freeze:** Mid May 2018
-
-**Core and Curated Module Freeze:** Mid May 2018
-
-**Community Module Freeze:** Late May 2018
-
-**Release Candidate:** Mid June 2018
-
-**Target:** June/July 2018
-
 .. contents:: Topics
+
+Release Schedule
+----------------
+
+Proposed
+========
+
+- 2018-05-17 Core Freeze (Core Engine and Non-Community Modules)
+- 2018-05-17 Alpha Release 1
+- 2018-05-24 Alpha Release 2
+- 2018-05-25 Community Freeze (Community Modules)
+- 2018-05-31 Release Candidate 1
+- 2018-06-07 Release Candidate 2
+- 2018-06-14 Release Candidate 3
+- 2018-06-28 Final Release
 
 Engine improvements
 -------------------

--- a/docs/docsite/rst/roadmap/ROADMAP_2_6.rst
+++ b/docs/docsite/rst/roadmap/ROADMAP_2_6.rst
@@ -14,6 +14,7 @@ Proposed
 - 2018-05-17 Alpha Release 1
 - 2018-05-24 Alpha Release 2
 - 2018-05-25 Community Freeze (Community Modules)
+- 2018-05-31 Branch stable-2.6
 - 2018-05-31 Release Candidate 1
 - 2018-06-07 Release Candidate 2
 - 2018-06-14 Release Candidate 3


### PR DESCRIPTION
##### SUMMARY

Update 2.6 roadmap dates.

##### ISSUE TYPE

Docs Pull Request

##### COMPONENT NAME

roadmap

##### ANSIBLE VERSION

```
ansible 2.6.0 (roadmap c40d70b483) last updated 2018/05/01 13:42:20 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
