### PR TITLE
Fix typo in if statement in snmp_facts module.

### DIFF
--- a/lib/ansible/modules/net_tools/snmp_facts.py
+++ b/lib/ansible/modules/net_tools/snmp_facts.py
@@ -319,7 +319,7 @@ def main():
             if v.ifMtu in current_oid:
                 ifIndex = int(current_oid.rsplit('.', 1)[-1])
                 results['ansible_interfaces'][ifIndex]['mtu'] = current_val
-            if v.ifMtu in current_oid:
+            if v.ifSpeed in current_oid:
                 ifIndex = int(current_oid.rsplit('.', 1)[-1])
                 results['ansible_interfaces'][ifIndex]['speed'] = current_val
             if v.ifPhysAddress in current_oid:

--- a/lib/ansible/modules/network/ios/ios_facts.py
+++ b/lib/ansible/modules/network/ios/ios_facts.py
@@ -40,7 +40,7 @@ options:
     description:
       - When supplied, this argument will restrict the facts collected
         to a given subset.  Possible values for this argument include
-        all, hardware, config, interfaces and neighbors.  Can specify a list of
+        all, hardware, config, and interfaces.  Can specify a list of
         values to include a larger subset.  Values can also be used
         with an initial C(M(!)) to specify that a specific subset should
         not be collected.
@@ -133,8 +133,6 @@ ansible_net_interfaces:
   description: A hash of all interfaces running on the system
   returned: when interfaces is configured
   type: dict
-
-# neighbors
 ansible_net_neighbors:
   description: The list of LLDP neighbors from the remote device
   returned: when interfaces is configured
@@ -257,7 +255,8 @@ class Interfaces(FactsBase):
     COMMANDS = [
         'show interfaces',
         'show ip interface',
-        'show ipv6 interface'
+        'show ipv6 interface',
+        'show lldp'
     ]
 
     def populate(self):
@@ -280,6 +279,12 @@ class Interfaces(FactsBase):
         if data:
             data = self.parse_interfaces(data)
             self.populate_ipv6_interfaces(data)
+
+        data = self.responses[3]
+        if data:
+            neighbors = self.run(['show lldp neighbors detail'])
+            if neighbors:
+                self.facts['neighbors'] = self.parse_neighbors(neighbors[0])
 
     def populate_interfaces(self, interfaces):
         facts = dict()
@@ -333,6 +338,20 @@ class Interfaces(FactsBase):
             self.facts['all_ipv4_addresses'].append(address)
         else:
             self.facts['all_ipv6_addresses'].append(address)
+
+    def parse_neighbors(self, neighbors):
+        facts = dict()
+        for entry in neighbors.split('------------------------------------------------'):
+            if entry == '':
+                continue
+            intf = self.parse_lldp_intf(entry)
+            if intf not in facts:
+                facts[intf] = list()
+            fact = dict()
+            fact['host'] = self.parse_lldp_host(entry)
+            fact['port'] = self.parse_lldp_port(entry)
+            facts[intf].append(fact)
+        return facts
 
     def parse_interfaces(self, data):
         parsed = dict()
@@ -400,36 +419,6 @@ class Interfaces(FactsBase):
         if match:
             return match.group(1)
 
-
-class Neighbors(FactsBase):
-
-    COMMANDS = [
-        'show lldp'
-    ]
-
-    def populate(self):
-        super(Neighbors, self).populate()
-
-        data = self.responses[0]
-        if data:
-            neighbors = self.run(['show lldp neighbors detail'])
-            if neighbors:
-                self.facts['neighbors'] = self.parse_neighbors(neighbors[0])
-
-    def parse_neighbors(self, neighbors):
-        facts = dict()
-        for entry in neighbors.split('------------------------------------------------'):
-            if entry == '':
-                continue
-            intf = self.parse_lldp_intf(entry)
-            if intf not in facts:
-                facts[intf] = list()
-            fact = dict()
-            fact['host'] = self.parse_lldp_host(entry)
-            fact['port'] = self.parse_lldp_port(entry)
-            facts[intf].append(fact)
-        return facts
-
     def parse_lldp_intf(self, data):
         match = re.search(r'^Local Intf: (.+)$', data, re.M)
         if match:
@@ -451,7 +440,6 @@ FACT_SUBSETS = dict(
     hardware=Hardware,
     interfaces=Interfaces,
     config=Config,
-    neighbors=Neighbors,
 )
 
 VALID_SUBSETS = frozenset(FACT_SUBSETS.keys())

--- a/lib/ansible/modules/network/ios/ios_facts.py
+++ b/lib/ansible/modules/network/ios/ios_facts.py
@@ -133,7 +133,7 @@ ansible_net_interfaces:
   description: A hash of all interfaces running on the system
   returned: when interfaces is configured
   type: dict
-  
+
 # neighbors
 ansible_net_neighbors:
   description: The list of LLDP neighbors from the remote device
@@ -399,23 +399,23 @@ class Interfaces(FactsBase):
         match = re.search(r'^(?:.+) is (.+),', data, re.M)
         if match:
             return match.group(1)
-        
-        
+
+
 class Neighbors(FactsBase):
 
     COMMANDS = [
         'show lldp'
     ]
-    
+
     def populate(self):
         super(Neighbors, self).populate()
-        
+
         data = self.responses[0]
         if data:
             neighbors = self.run(['show lldp neighbors detail'])
             if neighbors:
                 self.facts['neighbors'] = self.parse_neighbors(neighbors[0])
-                
+
     def parse_neighbors(self, neighbors):
         facts = dict()
         for entry in neighbors.split('------------------------------------------------'):


### PR DESCRIPTION
##### SUMMARY
There is a typo in the *snmp_facts* module that wrongly assigns the MTU value as the interface speed.
This change corrects the relevant `if` statement.

There is no open issue for this bug.

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
snmp_facts module.

##### ANSIBLE VERSION
```
ansible 2.6.0
  config file = None
  configured module search path = [u'/home/mjuenemann/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/mjuenemann/.virtualenvs/ansible-devel/lib/python2.7/site-packages/ansible-2.6.0-py2.7.egg/ansible
  executable location = /home/mjuenemann/.virtualenvs/ansible-devel/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION
Before change: `speed` is equal to `mtu`.
```
  ansible_facts:
    ansible_all_ipv4_addresses:
    - 10.1.1.27
    ansible_interfaces:
      '1':
        adminstatus: up
        description: ''
        ifindex: '1'
        mac: 002155f86ec4
        mtu: '1500'
        name: FastEthernet0
        operstatus: up
        speed: '1500'
```
After change: `speed` is now correct.
```
  ansible_facts:
    ansible_all_ipv4_addresses:
    - 10.1.1.27
    ansible_interfaces:
      '1':
        adminstatus: up
        description: ''
        ifindex: '1'
        mac: 002155f86ec4
        mtu: '1500'
        name: FastEthernet0
        operstatus: up
        speed: '100000000'
```