### PR TITLE
Use HTTPS instead of HTTP for httpbin tests. (#39457)

### DIFF
--- a/test/integration/targets/get_url/aliases
+++ b/test/integration/targets/get_url/aliases
@@ -1,3 +1,2 @@
 destructive
 posix/ci/group1
-disabled

--- a/test/integration/targets/get_url/tasks/main.yml
+++ b/test/integration/targets/get_url/tasks/main.yml
@@ -14,7 +14,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# along with Ansible.  If not, see <https://www.gnu.org/licenses/>.
 
 - name: Determine if python looks like it will support modern ssl features like SNI
   command: "{{ ansible_python.executable }} -c 'from ssl import SSLContext'"
@@ -67,7 +67,7 @@
         - result.failed
 
 - name: test HTTP HEAD request for file in check mode
-  get_url: url="http://{{ httpbin_host }}/get" dest={{ output_dir }}/get_url_check.txt force=yes
+  get_url: url="https://{{ httpbin_host }}/get" dest={{ output_dir }}/get_url_check.txt force=yes
   check_mode: True
   register: result
 
@@ -78,7 +78,7 @@
     - '"OK" in result.msg'
 
 - name: test HTTP HEAD for nonexistent URL in check mode
-  get_url: url="http://{{ httpbin_host }}/DOESNOTEXIST" dest={{ output_dir }}/shouldnotexist.html force=yes
+  get_url: url="https://{{ httpbin_host }}/DOESNOTEXIST" dest={{ output_dir }}/shouldnotexist.html force=yes
   check_mode: True
   register: result
   ignore_errors: True
@@ -191,12 +191,12 @@
 
 - name: Test get_url with redirect
   get_url:
-    url: 'http://{{ httpbin_host }}/redirect/6'
+    url: 'https://{{ httpbin_host }}/redirect/6'
     dest: "{{ output_dir }}/redirect.json"
 
 - name: Test that setting file modes work
   get_url:
-    url: 'http://{{ httpbin_host }}/'
+    url: 'https://{{ httpbin_host }}/'
     dest: '{{ output_dir }}/test'
     mode: '0707'
   register: result
@@ -213,7 +213,7 @@
 
 - name: Test that setting file modes on an already downlaoded file work
   get_url:
-    url: 'http://{{ httpbin_host }}/'
+    url: 'https://{{ httpbin_host }}/'
     dest: '{{ output_dir }}/test'
     mode: '0070'
   register: result

--- a/test/integration/targets/uri/aliases
+++ b/test/integration/targets/uri/aliases
@@ -1,3 +1,2 @@
 destructive
 posix/ci/group1
-disabled

--- a/test/integration/targets/uri/tasks/main.yml
+++ b/test/integration/targets/uri/tasks/main.yml
@@ -14,7 +14,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# along with Ansible.  If not, see <https://www.gnu.org/licenses/>.
 
 - name: set role facts
   set_fact:
@@ -130,7 +130,7 @@
 
 - name: test redirect without follow_redirects
   uri:
-    url: 'http://{{ httpbin_host }}/redirect/2'
+    url: 'https://{{ httpbin_host }}/redirect/2'
     follow_redirects: 'none'
     status_code: 302
   register: result
@@ -138,7 +138,7 @@
 - name: Assert location header
   assert:
     that:
-      - 'result.location|default("") == "http://{{ httpbin_host }}/relative-redirect/1"'
+      - 'result.location|default("") == "https://{{ httpbin_host }}/relative-redirect/1"'
 
 - name: Check SSL with redirect
   uri:
@@ -164,20 +164,20 @@
 
 - name: test basic auth
   uri:
-    url: 'http://{{ httpbin_host }}/basic-auth/user/passwd'
+    url: 'https://{{ httpbin_host }}/basic-auth/user/passwd'
     user: user
     password: passwd
 
 - name: test basic forced auth
   uri:
-    url: 'http://{{ httpbin_host }}/hidden-basic-auth/user/passwd'
+    url: 'https://{{ httpbin_host }}/hidden-basic-auth/user/passwd'
     force_basic_auth: true
     user: user
     password: passwd
 
 - name: test digest auth
   uri:
-    url: 'http://{{ httpbin_host }}/digest-auth/auth/user/passwd'
+    url: 'https://{{ httpbin_host }}/digest-auth/auth/user/passwd'
     user: user
     password: passwd
     headers:
@@ -185,13 +185,13 @@
 
 - name: test PUT
   uri:
-    url: 'http://{{ httpbin_host }}/put'
+    url: 'https://{{ httpbin_host }}/put'
     method: PUT
     body: 'foo=bar'
 
 - name: test OPTIONS
   uri:
-    url: 'http://{{ httpbin_host }}/'
+    url: 'https://{{ httpbin_host }}/'
     method: OPTIONS
   register: result
 

--- a/test/integration/targets/win_uri/aliases
+++ b/test/integration/targets/win_uri/aliases
@@ -1,2 +1,1 @@
 windows/ci/group3
-disabled

--- a/test/integration/targets/win_uri/tasks/test.yml
+++ b/test/integration/targets/win_uri/tasks/test.yml
@@ -4,7 +4,7 @@
 
 - name: get request without return_content
   win_uri:
-    url: http://{{httpbin_host}}/get
+    url: https://{{httpbin_host}}/get
     return_content: no
   register: get_request_without_content
 
@@ -18,7 +18,7 @@
 
 - name: get request with xml content
   win_uri:
-    url: http://{{httpbin_host}}/xml
+    url: https://{{httpbin_host}}/xml
     return_content: yes
   register: get_request_with_xml_content
 
@@ -32,7 +32,7 @@
 
 - name: get request with binary content
   win_uri:
-    url: http://{{httpbin_host}}/image/png
+    url: https://{{httpbin_host}}/image/png
     return_content: yes
   register: get_request_with_binary_content
 
@@ -46,7 +46,7 @@
 
 - name: get request with return_content and dest (check mode)
   win_uri:
-    url: http://{{httpbin_host}}/get
+    url: https://{{httpbin_host}}/get
     return_content: yes
     dest: '{{test_uri_path}}\get.json'
   register: get_request_with_dest_check
@@ -67,7 +67,7 @@
 
 - name: get request with return_content and dest
   win_uri:
-    url: http://{{httpbin_host}}/get
+    url: https://{{httpbin_host}}/get
     return_content: yes
     dest: '{{test_uri_path}}\get.json'
   register: get_request_with_dest
@@ -90,7 +90,7 @@
 
 - name: get request with return_content and dest (idempotent)
   win_uri:
-    url: http://{{httpbin_host}}/get
+    url: https://{{httpbin_host}}/get
     return_content: yes
     dest: '{{test_uri_path}}\get.json'
   register: get_request_with_dest_again
@@ -102,7 +102,7 @@
 
 - name: test request with creates option should skip
   win_uri:
-    url: http://{{httpbin_host}}/get
+    url: https://{{httpbin_host}}/get
     creates: '{{test_uri_path}}\get.json'
   register: request_with_creates_skipped
 
@@ -114,7 +114,7 @@
 
 - name: test request with creates option should not skip
   win_uri:
-    url: http://{{httpbin_host}}/get
+    url: https://{{httpbin_host}}/get
     creates: '{{test_uri_path}}\fake.json'
   register: request_with_creates_not_skipped
 
@@ -126,7 +126,7 @@
 
 - name: post request with return_content, dest and different content
   win_uri:
-    url: http://{{httpbin_host}}/post
+    url: https://{{httpbin_host}}/post
     method: POST
     content_type: application/json
     body: '{"foo": "bar"}'
@@ -150,7 +150,7 @@
 
 - name: test redirect without follow_redirects
   win_uri:
-    url: http://{{httpbin_host}}/redirect/2
+    url: https://{{httpbin_host}}/redirect/2
     follow_redirects: none
     status_code: 302
   register: redirect_without_follow
@@ -164,7 +164,7 @@
 
 - name: test redirect with follow_redirects
   win_uri:
-    url: http://{{httpbin_host}}/redirect/2
+    url: https://{{httpbin_host}}/redirect/2
     follow_redirects: all
   register: redirect_with_follow
 
@@ -174,7 +174,7 @@
     - not redirect_with_follow.changed
     - redirect_with_follow.location is not defined
     - redirect_with_follow.status_code == 200
-    - redirect_with_follow.response_uri == 'http://{{httpbin_host}}/get'
+    - redirect_with_follow.response_uri == 'https://{{httpbin_host}}/get'
 
 - name: get request with redirect of TLS
   win_uri:
@@ -192,7 +192,7 @@
 
 - name: test basic auth
   win_uri:
-    url: http://{{httpbin_host}}/basic-auth/user/passwd
+    url: https://{{httpbin_host}}/basic-auth/user/passwd
     user: user
     password: passwd
   register: basic_auth
@@ -205,7 +205,7 @@
 
 - name: test basic auth with force auth
   win_uri:
-    url: http://{{httpbin_host}}/hidden-basic-auth/user/passwd
+    url: https://{{httpbin_host}}/hidden-basic-auth/user/passwd
     user: user
     password: passwd
     force_basic_auth: yes
@@ -219,7 +219,7 @@
 
 - name: test PUT
   win_uri:
-    url: http://{{httpbin_host}}/put
+    url: https://{{httpbin_host}}/put
     method: PUT
     body: foo=bar
     return_content: yes
@@ -234,7 +234,7 @@
 
 - name: test OPTIONS
   win_uri:
-    url: http://{{httpbin_host}}/
+    url: https://{{httpbin_host}}/
     method: OPTIONS
   register: option_request
 
@@ -249,7 +249,7 @@
 
 - name: validate status_codes are correct
   win_uri:
-    url: http://{{httpbin_host}}/status/202
+    url: https://{{httpbin_host}}/status/202
     status_code:
     - 202
     - 418
@@ -265,7 +265,7 @@
 
 - name: send JSON body with dict type
   win_uri:
-    url: http://{{httpbin_host}}/post
+    url: https://{{httpbin_host}}/post
     method: POST
     body:
       foo: bar
@@ -298,7 +298,7 @@
 
 - name: get request with custom headers
   win_uri:
-    url: http://{{httpbin_host}}/get
+    url: https://{{httpbin_host}}/get
     headers:
       Test-Header: hello
       Another-Header: world
@@ -317,14 +317,14 @@
 
 - name: get request with timeout
   win_uri:
-    url: http://{{httpbin_host}}/delay/10
+    url: https://{{httpbin_host}}/delay/10
     timeout: 5
   register: get_with_timeout_fail
   failed_when: '"The operation has timed out" not in get_with_timeout_fail.msg'
 
 - name: connect to fakepath that does not exist
   win_uri:
-    url: http://{{httpbin_host}}/fakepath
+    url: https://{{httpbin_host}}/fakepath
     status_code: 404
     return_content: yes
   register: invalid_path
@@ -342,7 +342,7 @@
 
 - name: post request with custom headers
   win_uri:
-    url: http://{{httpbin_host}}/post
+    url: https://{{httpbin_host}}/post
     method: POST
     headers:
       Test-Header: hello


### PR DESCRIPTION
##### SUMMARY

Use HTTPS instead of HTTP for httpbin tests. (#39457)

The httpbin.org site is now redirecting HTTP to HTTPS.

(cherry picked from commit b92ef8e54a50b98a58b1146890dad64eed04dc35)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

integration tests

##### ANSIBLE VERSION

```
ansible 2.5.2 (uri-test-fix-2.5 c6c1bcd590) last updated 2018/05/01 16:30:40 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
