### PR TITLE
Use HTTPS instead of HTTP for httpbin tests. (#39457)

### DIFF
--- a/test/integration/targets/get_url/aliases
+++ b/test/integration/targets/get_url/aliases
@@ -1,1 +1,2 @@
 destructive
+posix/ci/group1

--- a/test/integration/targets/get_url/tasks/main.yml
+++ b/test/integration/targets/get_url/tasks/main.yml
@@ -14,7 +14,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# along with Ansible.  If not, see <https://www.gnu.org/licenses/>.
 
 - name: Determine if python looks like it will support modern ssl features like SNI
   command: "{{ ansible_python.executable }} -c 'from ssl import SSLContext'"
@@ -66,7 +66,7 @@
         - result.failed
 
 - name: test HTTP HEAD request for file in check mode
-  get_url: url="http://{{ httpbin_host }}/get" dest={{ output_dir }}/get_url_check.txt force=yes
+  get_url: url="https://{{ httpbin_host }}/get" dest={{ output_dir }}/get_url_check.txt force=yes
   check_mode: True
   register: result
 
@@ -77,7 +77,7 @@
     - '"OK" in result.msg'
 
 - name: test HTTP HEAD for nonexistent URL in check mode
-  get_url: url="http://{{ httpbin_host }}/DOESNOTEXIST" dest={{ output_dir }}/shouldnotexist.html force=yes
+  get_url: url="https://{{ httpbin_host }}/DOESNOTEXIST" dest={{ output_dir }}/shouldnotexist.html force=yes
   check_mode: True
   register: result
   ignore_errors: True
@@ -190,12 +190,12 @@
 
 - name: Test get_url with redirect
   get_url:
-    url: 'http://{{ httpbin_host }}/redirect/6'
+    url: 'https://{{ httpbin_host }}/redirect/6'
     dest: "{{ output_dir }}/redirect.json"
 
 - name: Test that setting file modes work
   get_url:
-    url: 'http://{{ httpbin_host }}/'
+    url: 'https://{{ httpbin_host }}/'
     dest: '{{ output_dir }}/test'
     mode: '0707'
   register: result
@@ -212,7 +212,7 @@
 
 - name: Test that setting file modes on an already downlaoded file work
   get_url:
-    url: 'http://{{ httpbin_host }}/'
+    url: 'https://{{ httpbin_host }}/'
     dest: '{{ output_dir }}/test'
     mode: '0070'
   register: result

--- a/test/integration/targets/uri/aliases
+++ b/test/integration/targets/uri/aliases
@@ -1,1 +1,2 @@
 destructive
+posix/ci/group1

--- a/test/integration/targets/uri/tasks/main.yml
+++ b/test/integration/targets/uri/tasks/main.yml
@@ -14,7 +14,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# along with Ansible.  If not, see <https://www.gnu.org/licenses/>.
 
 - name: set role facts
   set_fact:
@@ -130,7 +130,7 @@
 
 - name: test redirect without follow_redirects
   uri:
-    url: 'http://{{ httpbin_host }}/redirect/2'
+    url: 'https://{{ httpbin_host }}/redirect/2'
     follow_redirects: 'none'
     status_code: 302
   register: result
@@ -138,7 +138,7 @@
 - name: Assert location header
   assert:
     that:
-      - 'result.location|default("") == "http://{{ httpbin_host }}/relative-redirect/1"'
+      - 'result.location|default("") == "https://{{ httpbin_host }}/relative-redirect/1"'
 
 - name: Check SSL with redirect
   uri:
@@ -164,20 +164,20 @@
 
 - name: test basic auth
   uri:
-    url: 'http://{{ httpbin_host }}/basic-auth/user/passwd'
+    url: 'https://{{ httpbin_host }}/basic-auth/user/passwd'
     user: user
     password: passwd
 
 - name: test basic forced auth
   uri:
-    url: 'http://{{ httpbin_host }}/hidden-basic-auth/user/passwd'
+    url: 'https://{{ httpbin_host }}/hidden-basic-auth/user/passwd'
     force_basic_auth: true
     user: user
     password: passwd
 
 - name: test digest auth
   uri:
-    url: 'http://{{ httpbin_host }}/digest-auth/auth/user/passwd'
+    url: 'https://{{ httpbin_host }}/digest-auth/auth/user/passwd'
     user: user
     password: passwd
     headers:
@@ -185,13 +185,13 @@
 
 - name: test PUT
   uri:
-    url: 'http://{{ httpbin_host }}/put'
+    url: 'https://{{ httpbin_host }}/put'
     method: PUT
     body: 'foo=bar'
 
 - name: test OPTIONS
   uri:
-    url: 'http://{{ httpbin_host }}/'
+    url: 'https://{{ httpbin_host }}/'
     method: OPTIONS
   register: result
 


### PR DESCRIPTION
##### SUMMARY

Use HTTPS instead of HTTP for httpbin tests. (#39457)

The httpbin.org site is now redirecting HTTP to HTTPS.

(cherry picked from commit b92ef8e54a50b98a58b1146890dad64eed04dc35)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

integration tests

##### ANSIBLE VERSION

```
ansible 2.4.4.0 (uri-test-fix-2.4 fc606f9548) last updated 2018/05/01 16:37:43 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
