### PR TITLE
Fix typo in porting guides index page

### DIFF
--- a/docs/docsite/rst/porting_guides/porting_guides.rst
+++ b/docs/docsite/rst/porting_guides/porting_guides.rst
@@ -4,7 +4,9 @@
 Ansible Porting Guides
 **********************
 
-This section lists porting guides that can help you playbooks, plugins and other parts of your Ansible infrastructure from one version of Ansible to the next. Please note that this is not a complete list. If you believe any extra information would be useful in these pages, you can edit by clicking `Edit on GitHub` on the top right, or raising an issue.
+This section lists porting guides that can help you in updating playbooks, plugins and other parts of your Ansible infrastructure from one version of Ansible to the next.
+
+Please note that this is not a complete list. If you believe any extra information would be useful in these pages, you can edit by clicking `Edit on GitHub` on the top right, or raising an issue.
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
##### SUMMARY

`This section lists porting guides that can help you playbooks` to `This section lists porting guides that can help you in updating playbooks`

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
docs/docsite/rst/porting_guides/porting_guides.rst

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6devel
```