### PR TITLE
Fix encoding issue when parsing plugin examples

### DIFF
--- a/changelogs/fragments/encoding-docs-plugin-parsing.yaml
+++ b/changelogs/fragments/encoding-docs-plugin-parsing.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- Fix an encoding issue when parsing the examples from a plugins' documentation

--- a/lib/ansible/parsing/plugin_docs.py
+++ b/lib/ansible/parsing/plugin_docs.py
@@ -8,6 +8,7 @@ __metaclass__ = type
 import ast
 import yaml
 
+from ansible.module_utils._text import to_text
 from ansible.parsing.metadata import extract_metadata
 from ansible.parsing.yaml.loader import AnsibleLoader
 
@@ -61,7 +62,7 @@ def read_docstring(filename, verbose=True, ignore_errors=True):
                                 data[varkey] = AnsibleLoader(child.value.s, file_name=filename).get_single_data()
                             else:
                                 # not yaml, should be a simple string
-                                data[varkey] = child.value.s
+                                data[varkey] = to_text(child.value.s)
                         display.debug('assigned :%s' % varkey)
 
         # Metadata is per-file and a dict rather than per-plugin/function and yaml


### PR DESCRIPTION
This caused a non-fatal traceback when building, for example, the module
documentation for the debug module.


##### ISSUE TYPE

 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel 2.5
```