### PR TITLE
Use $(MAKE) instead of raw "make"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -340,12 +340,12 @@ deb-src-upload: deb-src
 
 .PHONY: epub
 epub:
-	(cd docs/docsite/; CPUS=$(CPUS) make epub)
+	(cd docs/docsite/; CPUS=$(CPUS) $(MAKE) epub)
 
 # for arch or gentoo, read instructions in the appropriate 'packaging' subdirectory directory
 .PHONY: webdocs
 webdocs:
-	(cd docs/docsite/; CPUS=$(CPUS) make docs)
+	(cd docs/docsite/; CPUS=$(CPUS) $(MAKE) docs)
 
 .PHONY: generate_rst
 generate_rst: lib/ansible/cli/*.py
@@ -354,7 +354,7 @@ generate_rst: lib/ansible/cli/*.py
 
 
 docs: generate_rst
-	make $(MANPAGES)
+	$(MAKE) $(MANPAGES)
 
 .PHONY: alldocs
 alldocs: docs webdocs

--- a/docs/docsite/Makefile
+++ b/docs/docsite/Makefile
@@ -108,7 +108,7 @@ staticmin:
 	cat _themes/srtd/static/css/theme.css | sed -e 's/^[ 	]*//g; s/[ 	]*$$//g; s/\([:{;,]\) /\1/g; s/ {/{/g; s/\/\*.*\*\///g; /^$$/d' | sed -e :a -e '$$!N; s/\n\(.\)/\1/; ta' > _themes/srtd/static/css/theme.min.css
 
 epub:
-	(CPUS=$(CPUS) make -f Makefile.sphinx epub)
+	(CPUS=$(CPUS) $(MAKE) -f Makefile.sphinx epub)
 
 htmlsingle: assertrst
 	sphinx-build -j $(CPUS) -b html -d $(BUILDDIR)/doctrees ./rst $(BUILDDIR)/html rst/$(rst)


### PR DESCRIPTION
This Makefile uses non-standard constructs. As such it can only be
parsed by GNU make, which is often installed as 'gmake' instead of
'make'. Using $(MAKE) ensures the same version of make gets called that
is used to execute the top level.