### PR TITLE
Exit admin mode properly on iosxr_config

### DIFF
--- a/lib/ansible/module_utils/network/iosxr/iosxr.py
+++ b/lib/ansible/module_utils/network/iosxr/iosxr.py
@@ -426,6 +426,8 @@ def load_config(module, command_filter, commit=False, replace=False,
         elif commit:
             commit_config(module, comment=comment)
             conn.edit_config('end')
+            if admin:
+                conn.edit_config('exit')
         else:
             conn.discard_changes()
 


### PR DESCRIPTION
Fixes #38811

When using 'admin' in iosxr-config, we need to pass an end
to config terminal session but also pass exit so we exit admin
mode.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
iosxr_config

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0 (devel 8bfc92fb27) last updated 2018/05/02 12:59:05 (GMT +200)
```

