### PR TITLE
Prevent pip module to fail if chdir is set without virtualenv

### DIFF
--- a/lib/ansible/modules/packaging/language/pip.py
+++ b/lib/ansible/modules/packaging/language/pip.py
@@ -383,7 +383,7 @@ def main():
     env = module.params['virtualenv']
 
     venv_created = False
-    if chdir:
+    if chdir and env:
         env = os.path.join(chdir, env)
 
     if umask and not isinstance(umask, int):


### PR DESCRIPTION
##### SUMMARY
If chdir is set, but virtualenv is not, pip fails when trying to path.join them.
This is a trivial fix to prevent just this.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
packgaging/languages/pip

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.2
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/<...>/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.15 (default, May  1 2018, 05:55:50) [GCC 7.3.0]
```


##### ADDITIONAL INFORMATION
command:
```
$ ansible localhost -m pip -a "chdir=/tmp/tilt name=pip"
```
before:
```
 [WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'

An exception occurred during task execution. To see the full traceback, use -vvv. The error was: AttributeError: 'NoneType' object has no attribute 'startswith'
localhost | FAILED! => {
    "changed": false, 
    "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_pj1nYB/ansible_module_pip.py\", line 562, in <module>\n    main()\n  File \"/tmp/ansible_pj1nYB/ansible_module_pip.py\", line 387, in main\n    env = os.path.join(chdir, env)\n  File \"/home/matthiasd/.virtualenvs/ansible/lib/python2.7/posixpath.py\", line 68, in join\n    if b.startswith('/'):\nAttributeError: 'NoneType' object has no attribute 'startswith'\n", 
    "module_stdout": "", 
    "msg": "MODULE FAILURE", 
    "rc": 1
}
```
after:
```
 [WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'

localhost | SUCCESS => {
    "changed": false, 
    "cmd": "/home/matthiasd/.virtualenvs/ansible/bin/pip2 install pip", 
    "name": [
        "pip"
    ], 
    "requirements": null, 
    "state": "present", 
    "stderr": "", 
    "stderr_lines": [], 
    "stdout": "Requirement already satisfied: pip in /home/matthiasd/.virtualenvs/ansible/lib/python2.7/site-packages\n", 
    "stdout_lines": [
        "Requirement already satisfied: pip in /home/matthiasd/.virtualenvs/ansible/lib/python2.7/site-packages"
    ], 
    "version": null, 
    "virtualenv": null
}
```