### PR TITLE
Corrected typo under git practices

### DIFF
--- a/CODING_GUIDELINES.md
+++ b/CODING_GUIDELINES.md
@@ -290,9 +290,9 @@ In particular, metaclasses are probably not appropriate, however entertaining th
 Git Practices
 =============
 
-Pull requests cannot be accepted that contain merge commits.
+Pull requests cannot be accepted if they contain merge commits.
 
-Always do "git pull --rebase" and "git rebase" vs "git pull" or "git merge".
+Always do "git pull --rebase" and "git rebase" vs "git pull" or "git merge". See [rebasing a pull request](https://docs.ansible.com/ansible/latest/dev_guide/developing_rebasing.html) for more information.
 
 Always create a new branch for each pull request to avoid intermingling different features or fixes on the same branch.
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
I made edits to fix a typo in [CODING_GUIDELINES.md](https://github.com/ansible/ansible/blob/devel/CODING_GUIDELINES.md).

I changed:
'Pull requests cannot be accepted that contain merge commits'

to say:
'Pull requests cannot be accepted if they contain merge commits'

I also added a link to [rebasing a pull request](https://docs.ansible.com/ansible/latest/dev_guide/developing_rebasing.html) so people can more easily access information on how to do a PR.
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
Fixes #39585
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
CODING_GUIDELINES
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.2
```