### PR TITLE
Connect via ssh using ansible_port (#39603)

### DIFF
--- a/test/integration/targets/vyos_user/tests/cli/auth.yaml
+++ b/test/integration/targets/vyos_user/tests/cli/auth.yaml
@@ -7,15 +7,15 @@
       state: present
       configured_password: pass123
 
-  - name: test login
+  - name: test login via ssh with new user
     expect:
-      command: "ssh auth_user@{{ ansible_ssh_host }} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no '/opt/vyatta/sbin/vyatta-cfg-cmd-wrapper show version'"
+      command: "ssh auth_user@{{ ansible_ssh_host }} -p {{ ansible_port }} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no '/opt/vyatta/sbin/vyatta-cfg-cmd-wrapper show version'"
       responses:
         (?i)password: "pass123"
 
-  - name: test login with invalid password (should fail)
+  - name: test login via ssh with invalid password (should fail)
     expect:
-      command: "ssh auth_user@{{ ansible_ssh_host }} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no '/opt/vyatta/sbin/vyatta-cfg-cmd-wrapper show version'"
+      command: "ssh auth_user@{{ ansible_ssh_host }} -p {{ ansible_port }} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no '/opt/vyatta/sbin/vyatta-cfg-cmd-wrapper show version'"
       responses:
         (?i)password: "badpass"
     ignore_errors: yes


### PR DESCRIPTION
##### SUMMARY

Depending on how we spin up the VM we use different ssh port. Honor that
in the vyos_user test
(cherry picked from commit 287f4ff37405e8aa45f565f260df721d99333fb6)


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
vyos_user

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
