### PR TITLE
Fix fetching ios default running config (#39475)

### DIFF
--- a/changelogs/fragments/ios_get_config_fix.yaml
+++ b/changelogs/fragments/ios_get_config_fix.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- ios_config - Fix ios get_config to fetch config without defaults (https://github.com/ansible/ansible/pull/39475)

--- a/lib/ansible/plugins/cliconf/ios.py
+++ b/lib/ansible/plugins/cliconf/ios.py
@@ -56,12 +56,14 @@ class Cliconf(CliconfBase):
     def get_config(self, source='running', format='text', flags=None):
         if source not in ('running', 'startup'):
             return self.invalid_params("fetching configuration from %s is not supported" % source)
+
+        if not flags:
+            flags = []
+
         if source == 'running':
             cmd = 'show running-config '
-            if not flags:
-                flags = ['all']
         else:
-            cmd = 'show startup-config'
+            cmd = 'show startup-config '
 
         cmd += ' '.join(to_list(flags))
         cmd = cmd.strip()


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
If default option is enable in that case only
add 'all' or 'full' flag
(cherry picked from commit eb5e15e7e0dc60d53aea6370d9a45a47e3632b2e)

Update changelog
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
plugins/cliconf/ios.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
