### PR TITLE
[doc] config intro: add link to searched locations

### DIFF
--- a/docs/docsite/rst/installation_guide/intro_configuration.rst
+++ b/docs/docsite/rst/installation_guide/intro_configuration.rst
@@ -17,6 +17,7 @@ Configuration file
 
 Certain settings in Ansible are adjustable via a configuration file (ansible.cfg).
 The stock configuration should be sufficient for most users, but there may be reasons you would want to change them.
+Paths where configuration file is searched are listed in :ref:`reference documentation<ansible_configuration_settings_locations>`.
 
 .. _getting_the_latest_configuration:
 

--- a/docs/templates/config.rst.j2
+++ b/docs/templates/config.rst.j2
@@ -13,6 +13,7 @@ Ansible supports a few ways of providing configuration variables, mainly through
 Starting at Ansible 2.4 the ``ansible-config`` utility allows users to see all the configuration settings available, their defaults, how to set them and
 where their current value comes from. See :doc:ansible-config for more information.
 
+.. _ansible_configuration_settings_locations:
 
 The configuration file
 ======================


### PR DESCRIPTION
##### SUMMARY
`Configuring Ansible` section: add a link to documentation reference which provides list of searched paths for `ansible.cfg`. A screenshot of the rendered documentation:
![screenshot_2018-05-02_17-30-37](https://user-images.githubusercontent.com/1356830/39533315-0840f280-4e2f-11e8-9b5d-a5f66debb815.png)


##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
installation_guide

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0 (devel 9577cef3ba) last updated 2018/05/02 15:46:31 (GMT +200)
```