### PR TITLE
Remove unstable marker from rabbitmq_user test.

### DIFF
--- a/test/integration/targets/rabbitmq_user/aliases
+++ b/test/integration/targets/rabbitmq_user/aliases
@@ -3,4 +3,3 @@ posix/ci/group1
 skip/osx
 skip/freebsd
 skip/rhel
-unstable


### PR DESCRIPTION
##### SUMMARY

Remove unstable marker from rabbitmq_user test.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

rabbitmq_user integration test

##### ANSIBLE VERSION

```
ansible 2.6.0 (test-update 260f576ef6) last updated 2018/05/02 09:54:31 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
