### PR TITLE
Remove unstable from azure_rm_storageblob test.

### DIFF
--- a/test/integration/targets/azure_rm_storageblob/aliases
+++ b/test/integration/targets/azure_rm_storageblob/aliases
@@ -1,4 +1,3 @@
 cloud/azure
 posix/ci/cloud/group2/azure
 destructive
-unstable


### PR DESCRIPTION
##### SUMMARY

Remove unstable from azure_rm_storageblob test.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

azure_rm_storageblob integration test

##### ANSIBLE VERSION

```
ansible 2.5.2 (test-fix-2.5 04b811255a) last updated 2018/05/02 10:21:59 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
