### PR TITLE
Update ios_logging.py

### DIFF
--- a/lib/ansible/modules/network/ios/ios_logging.py
+++ b/lib/ansible/modules/network/ios/ios_logging.py
@@ -390,7 +390,7 @@ def main():
                            supports_check_mode=True)
 
     device_info = get_capabilities(module)
-    os_version = device_info['device_info']['network_os_version']
+    os_version = device_info['device_info']['network_os']
 
     warnings = list()
     check_args(module, warnings)


### PR DESCRIPTION
When calling get_capabilities(module), it is get back a dictionary that does not contain `network_os_version` but `network_os`
```
{u'network_api': u'cliconf', u'rpc': [u'get_config', u'edit_config', u'get_capabilities', u'get'], u'device_info': {u'network_os_model': u'IOSv () processor', u'network_os_hostname': u'lab2_user1', u'network_os': u'ios'}}
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
When calling get_capabilities(module), it is get back a dictionary that does not contain `network_os_version` but `network_os`

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
This does fix #39616 

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
ios_logging

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.2
  config file = /Labs/Lab_2/ansible.cfg
  configured module search path = [u'/Labs/ansible/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
BEFORE:

The full traceback is:
Traceback (most recent call last):
  File "/tmp/ansible_prcxOp/ansible_module_ios_logging.py", line 416, in <module>
    main()
  File "/tmp/ansible_prcxOp/ansible_module_ios_logging.py", line 393, in main
    os_version = device_info['device_info']['network_os_version']
KeyError: 'network_os_version'

fatal: [lab2_user1]: FAILED! => {
    "changed": false, 
    "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_prcxOp/ansible_module_ios_logging.py\", line 416, in <module>\n    main()\n  File \"/tmp/ansible_prcxOp/ansible_module_ios_logging.py\", line 393, in main\n    os_version = device_info['device_info']['network_os_version']\nKeyError: 'network_os_version'\n", 
    "module_stdout": "", 
    "msg": "MODULE FAILURE", 
    "rc": 1
}


AFTER:

changed: [lab2_user1] => {
    "changed": true, 
    "commands": [
        "logging console notifications", 
        "logging host 10.1.1.5", 
        "logging host 10.1.1.6"
    ], 
    "invocation": {
        "module_args": {
            "aggregate": [
                {
                    "dest": "console", 
                    "facility": null, 
                    "level": "notifications", 
                    "name": null, 
                    "size": null, 
                    "state": "present"
                }, 
                {
                    "dest": "buffered", 
                    "facility": null, 
                    "level": "debugging", 
                    "name": null, 
                    "size": 500000, 
                    "state": "present"
                }, 
                {
                    "dest": "host", 
                    "facility": null, 
                    "level": "notifications", 
                    "name": "10.1.1.5", 
                    "size": null, 
                    "state": "present"
                }, 
                {
                    "dest": "host", 
                    "facility": null, 
                    "level": "notifications", 
                    "name": "10.1.1.6", 
                    "size": null, 
                    "state": "present"
                }
            ], 
            "auth_pass": null, 
            "authorize": null, 
            "dest": null, 
            "facility": null, 
            "host": null, 
            "level": "debugging", 
            "name": null, 
            "password": null, 
            "port": null, 
            "provider": null, 
            "size": null, 
            "ssh_keyfile": null, 
            "state": "present", 
            "timeout": null, 
            "username": null
        }
    }
}

```