### PR TITLE
updated status of infoblox modules

### DIFF
--- a/lib/ansible/modules/net_tools/nios/nios_dns_view.py
+++ b/lib/ansible/modules/net_tools/nios/nios_dns_view.py
@@ -6,8 +6,8 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'community'}
+                    'status': ['stable'],
+                    'supported_by': 'certified'}
 
 
 DOCUMENTATION = '''

--- a/lib/ansible/modules/net_tools/nios/nios_host_record.py
+++ b/lib/ansible/modules/net_tools/nios/nios_host_record.py
@@ -6,8 +6,8 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'community'}
+                    'status': ['stable'],
+                    'supported_by': 'certified'}
 
 
 DOCUMENTATION = '''

--- a/lib/ansible/modules/net_tools/nios/nios_network.py
+++ b/lib/ansible/modules/net_tools/nios/nios_network.py
@@ -6,8 +6,8 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'community'}
+                    'status': ['stable'],
+                    'supported_by': 'certified'}
 
 
 DOCUMENTATION = '''

--- a/lib/ansible/modules/net_tools/nios/nios_network_view.py
+++ b/lib/ansible/modules/net_tools/nios/nios_network_view.py
@@ -6,8 +6,8 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'community'}
+                    'status': ['stable'],
+                    'supported_by': 'certified'}
 
 
 DOCUMENTATION = '''

--- a/lib/ansible/modules/net_tools/nios/nios_zone.py
+++ b/lib/ansible/modules/net_tools/nios/nios_zone.py
@@ -6,8 +6,8 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'community'}
+                    'status': ['stable'],
+                    'supported_by': 'certified'}
 
 
 DOCUMENTATION = '''


### PR DESCRIPTION
##### SUMMARY
Updating the module metadata for Infoblox modules to reflect correct status. Will be back ported to 2.5.x

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->

nios/*

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0 (infoblox_status_change ad4977167f) last updated 2018/05/02 10:46:22 (GMT -700)
  config file = None
  configured module search path = [u'/home/thaumos/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/thaumos/ansible/lib/ansible
  executable location = /home/thaumos/ansible/bin/ansible
  python version = 2.7.12 (default, Nov 20 2017, 18:23:56) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->
NA
<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
