### PR TITLE
influxdb_query: fix use of common return results

### DIFF
--- a/lib/ansible/modules/database/influxdb/influxdb_query.py
+++ b/lib/ansible/modules/database/influxdb/influxdb_query.py
@@ -52,11 +52,11 @@ EXAMPLES = r'''
 
 - name: Print results from the query
   debug:
-    var: connection.results
+    var: connection.query_results
 '''
 
 RETURN = '''
-results:
+query_results:
   description: Result from the query
   returned: success
   type: list
@@ -96,7 +96,7 @@ def main():
     influx = AnsibleInfluxDBRead(module)
     query = module.params.get('query')
     results = influx.read_by_query(query)
-    module.exit_json(changed=True, results=results)
+    module.exit_json(changed=True, query_results=results)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
##### SUMMARY
module uses a common return name `results` for module return key, which causes an unexpected behaviour. Renaming the return, Fixes #38027 

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
influxdb_query

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
needs backport to 2.5