### PR TITLE
Enable xml integration test.

### DIFF
--- a/test/integration/targets/xml/aliases
+++ b/test/integration/targets/xml/aliases
@@ -1,3 +1,2 @@
 destructive
 posix/ci/group1
-disabled


### PR DESCRIPTION
##### SUMMARY

Enable xml integration test.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

xml integration test

##### ANSIBLE VERSION

```
ansible 2.6.0 (enable-xml-test 22421785fc) last updated 2018/05/02 11:22:04 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
