### PR TITLE
use show run instead of section pipeline ios_l2_interface

### DIFF
--- a/lib/ansible/modules/network/ios/ios_l2_interface.py
+++ b/lib/ansible/modules/network/ios/ios_l2_interface.py
@@ -146,10 +146,9 @@ def is_switchport(name, module):
 
 def interface_is_portchannel(name, module):
     if get_interface_type(name) == 'ethernet':
-        config = get_config(module, flags=[' | section interface'])
-        if 'channel group' in config:
+        config = run_commands(module, ['show run interface {0}'.format(name)])[0]
+        if any(c in config for c in ['channel group', 'channel-group']):
             return True
-
     return False
 
 


### PR DESCRIPTION
Signed-off-by: Trishna Guha <trishnaguha17@gmail.com>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
fixes https://github.com/ansible/ansible/issues/39011
`| section` isn't supported in older IOS devices, use `show run interface` instead. 
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
modules/network/ios/ios_l2_interface.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel, 2.5
```