### PR TITLE
Fix eos_vlan associated interface check

### DIFF
--- a/lib/ansible/modules/network/eos/eos_vlan.py
+++ b/lib/ansible/modules/network/eos/eos_vlan.py
@@ -245,10 +245,10 @@ def map_params_to_obj(module):
                     item[key] = module.params[key]
 
             if item.get('interfaces'):
-                item['interfaces'] = [intf.replace(" ", "").lower() for intf in item.get('interfaces') if intf]
+                item['interfaces'] = [intf.replace(" ", "") for intf in item.get('interfaces') if intf]
 
             if item.get('associated_interfaces'):
-                item['associated_interfaces'] = [intf.replace(" ", "").lower() for intf in item.get('associated_interfaces') if intf]
+                item['associated_interfaces'] = [intf.replace(" ", "") for intf in item.get('associated_interfaces') if intf]
 
             d = item.copy()
             d['vlan_id'] = str(d['vlan_id'])
@@ -259,8 +259,8 @@ def map_params_to_obj(module):
             'vlan_id': str(module.params['vlan_id']),
             'name': module.params['name'],
             'state': module.params['state'],
-            'interfaces': [intf.replace(" ", "").lower() for intf in module.params['interfaces']] if module.params['interfaces'] else [],
-            'associated_interfaces': [intf.replace(" ", "").lower() for intf in
+            'interfaces': [intf.replace(" ", "") for intf in module.params['interfaces']] if module.params['interfaces'] else [],
+            'associated_interfaces': [intf.replace(" ", "") for intf in
                                       module.params['associated_interfaces']] if module.params['associated_interfaces'] else []
 
         })

--- a/lib/ansible/modules/network/eos/eos_vlan.py
+++ b/lib/ansible/modules/network/eos/eos_vlan.py
@@ -45,14 +45,14 @@ options:
     required: true
   interfaces:
     description:
-      - List of interfaces that should be associated to the VLAN. The name of interface
-        should be in expanded format and not abbreviated.
+      - List of interfaces that should be associated to the VLAN. The name of interface is
+        case sensitive and should be in expanded format and not abbreviated.
   associated_interfaces:
     description:
       - This is a intent option and checks the operational state of the for given vlan C(name)
-        for associated interfaces. The name of interface should be in expanded format and not abbreviated.
-        If the value in the C(associated_interfaces) does not match with the operational state of vlan
-        interfaces on device it will result in failure.
+        for associated interfaces. The name of interface is case sensitive and should be in
+        expanded format and not abbreviated. If the value in the C(associated_interfaces)
+        does not match with the operational state of vlan interfaces on device it will result in failure.
     version_added: "2.5"
   delay:
     description:

--- a/test/integration/targets/eos_vlan/tests/cli/basic.yaml
+++ b/test/integration/targets/eos_vlan/tests/cli/basic.yaml
@@ -137,9 +137,9 @@
     that:
       - "result.changed == true"
       - "'vlan 4000' in result.commands"
-      - "'interface ethernet1' in result.commands"
+      - "'interface Ethernet1' in result.commands"
       - "'switchport access vlan 4000' in result.commands"
-      - "'interface ethernet2' in result.commands"
+      - "'interface Ethernet2' in result.commands"
       - "'switchport access vlan 4000' in result.commands"
       # Ensure sessions contains epoc. Will fail after 18th May 2033
       - "'ansible_1' in result.session_name"
@@ -149,8 +149,8 @@
     vlan_id: 4000
     state: present
     interfaces:
-      - ethernet 1   # interface name modified to test case insensitive and space scenario
-      - ethernet 2   # interface name modified to test case insensitive and space scenario
+      - Ethernet 1   # interface name space scenario
+      - Ethernet 2   # interface name space scenario
     authorize: yes
     provider: "{{ cli }}"
   become: yes
@@ -194,7 +194,7 @@
     that:
       - "result.changed == true"
       - "'vlan 4000' in result.commands"
-      - "'interface ethernet2' in result.commands"
+      - "'interface Ethernet2' in result.commands"
       - "'no switchport access vlan 4000' in result.commands"
       # Ensure sessions contains epoc. Will fail after 18th May 2033
       - "'ansible_1' in result.session_name"
@@ -204,7 +204,7 @@
     vlan_id: 4000
     state: present
     interfaces:
-      - ethernet 1 # interface name modified to handle case insensitive and space scenario
+      - Ethernet 1 # space scenario
     authorize: yes
     provider: "{{ cli }}"
   become: yes


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
*  Fix eos_vlan associated interface check by comparing
   the interface in want and have by converting the name
   to lower

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
eos_vlan

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
