### PR TITLE
Fix for NameError in cnos.py

### DIFF
--- a/lib/ansible/module_utils/network/cnos/cnos.py
+++ b/lib/ansible/module_utils/network/cnos/cnos.py
@@ -35,8 +35,8 @@ import time
 import socket
 import re
 try:
-    import cnos_errorcodes
-    import cnos_devicerules
+    from ansible.module_utils.network.cnos import cnos_errorcodes
+    from ansible.module_utils.network.cnos import cnos_devicerules
     HAS_LIB = True
 except:
     HAS_LIB = False


### PR DESCRIPTION
Issue : NameError: global name ‘cnos_devicerules’ is not defined. while running cnos modules. 
Device Rule file validates the range and type of data going into each CLI based on device type it is executed against.
This has to be backported to 2.5

##### SUMMARY
While executing the playbooks involving cnos modules, there comes an error where the files cnos_devicerules.py and cnos_errorcodes.py are not available in pythonpath. To mitigate this the change has to be made in import statement.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/network/cnos/cnos.py

##### ANSIBLE VERSION
ansible 2.6.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible-2.6.0-py2.7.egg/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.6 (default, Nov 23 2017, 15:49:48) [GCC 4.8.4]

##### ADDITIONAL INFORMATION

This change has to be backported to Ansible 2.5 version as well.