### PR TITLE
lvg: Allow unit to be specified for pesize (Fixes #38103)

### DIFF
--- a/lib/ansible/modules/system/lvg.py
+++ b/lib/ansible/modules/system/lvg.py
@@ -32,7 +32,9 @@ options:
     - The module will take care of running pvcreate if needed.
   pesize:
     description:
-    - The size of the physical extent in megabytes. Must be a power of 2.
+    - The size of the physical extent. pesize must be a power of 2, or
+      multiple of 128KiB. Since version 2.6, pesize can be optionally suffixed
+      by a UNIT (k/K/m/M/g/G), default unit is megabyte.
     default: 4
   pv_options:
     description:
@@ -62,6 +64,12 @@ EXAMPLES = '''
     vg: vg.services
     pvs: /dev/sda1
     pesize: 32
+
+- name: Create a volume group on top of /dev/sdb with physical extent size = 128KiB
+  lvg:
+    vg: vg.services
+    pvs: /dev/sdb
+    pesize: 128K
 
 # If, for example, we already have VG vg.services on top of /dev/sdb1,
 # this VG will be extended by /dev/sdc5.  Or if vg.services was created on
@@ -124,7 +132,7 @@ def main():
         argument_spec=dict(
             vg=dict(type='str', required=True),
             pvs=dict(type='list'),
-            pesize=dict(type='int', default=4),
+            pesize=dict(type='str', default=4),
             pv_options=dict(type='str', default=''),
             vg_options=dict(type='str', default=''),
             state=dict(type='str', default='present', choices=['absent', 'present']),
@@ -200,7 +208,7 @@ def main():
                     else:
                         module.fail_json(msg="Creating physical volume '%s' failed" % current_dev, rc=rc, err=err)
                 vgcreate_cmd = module.get_bin_path('vgcreate')
-                rc, _, err = module.run_command([vgcreate_cmd] + vgoptions + ['-s', str(pesize), vg] + dev_list)
+                rc, _, err = module.run_command([vgcreate_cmd] + vgoptions + ['-s', pesize, vg] + dev_list)
                 if rc == 0:
                     changed = True
                 else:


### PR DESCRIPTION
##### SUMMARY
Change the type of the pesize argument for lvg module to string.

Currently pesize allows only integers for the size and the unit allowed is Megabyte.
However, vgcreate allows units to be k|K, m|M, g|G, ... which gives a lot of flexibility for the user. 

This change makes the module more flexible, and allows the user to specify the unit.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
lvg

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
[sac@dhcp35-44 ansible]$ ansible --version
ansible 2.6.0 (issue-38103 dd4b9994c7) last updated 2018/05/03 15:50:35 (GMT +550)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/sac/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/sac/work/ansible/lib/ansible
  executable location = /home/sac/work/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 14 2018, 13:36:31) [GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]
[sac@dhcp35-44 ansible]$ 

```


##### ADDITIONAL INFORMATION
Playbook:
```
   - name: Create volume group
      lvg:
        state: present
        vg: pe_size_test
        pvs: /dev/vdb,/dev/vdc
        pesize: 128K
```

Before change

```
PLAY [Create a volume group] *********************************************************************************************************************

TASK [Create volume group] ***********************************************************************************************************************
fatal: [10.70.43.249]: FAILED! => {"changed": false, "msg": "argument pesize is of type <type 'str'> and we were unable to convert to int: invalid literal for int() with base 10: '128K'"}
        to retry, use: --limit @/home/sac/work/scratch/ansible_bugs/vg_create.retry

PLAY RECAP ***************************************************************************************************************************************
10.70.43.249               : ok=0    changed=0    unreachable=0    failed=1   

```

After change
```
PLAY [Create a volume group] *********************************************************************************************************************

TASK [Create volume group] ***********************************************************************************************************************
changed: [10.70.43.249]

PLAY RECAP ***************************************************************************************************************************************
10.70.43.249               : ok=1    changed=1    unreachable=0    failed=0   
```