### PR TITLE
vyos_interface require multiple network nodes to run

### DIFF
--- a/test/integration/targets/vyos_interface/tests/cli/intent.yaml
+++ b/test/integration/targets/vyos_interface/tests/cli/intent.yaml
@@ -9,15 +9,12 @@
 - name: Detect if we have existing lldp neighbors configured
   vyos_command:
     commands:
-      - show lldp neighbors
+      - show lldp neighbors detail
   register: neighbors_out
-
-- debug:
-    var: neighbors_out
 
 - name: Should we run lldp tests?
   set_fact:
-    run_lldp_tests: "'Gi0/0' in neighbors_out.stdout[0]"
+  t  run_lldp_tests: "'PortDescr:    eth0' in neighbors_out.stdout[0]"
 
 - name: Enable LLDP service
   vyos_lldp:
@@ -51,7 +48,7 @@
   vyos_interface:
     name: eth0
     neighbors:
-    - port: Gi0/0
+    - port: eth0
   when: run_lldp_tests
   register: result
 
@@ -131,7 +128,7 @@
     aggregate:
     - name: eth0
       neighbors:
-      - port: Gi0/0
+      - port: eth0
   when: run_lldp_tests
   register: result
 
@@ -145,7 +142,7 @@
     aggregate:
     - name: eth0
       neighbors:
-      - port: Gi0/0
+      - port: eth0
       - port: dummy_port
         host: dummy_host
   ignore_errors: yes

--- a/test/integration/targets/vyos_interface/tests/cli/intent.yaml
+++ b/test/integration/targets/vyos_interface/tests/cli/intent.yaml
@@ -1,11 +1,35 @@
 ---
-- debug: msg="START cli/intent.yaml on connection={{ ansible_connection }}"
+- debug: msg="START cli/intent.yaml on connection={{ ansible_connection }}" #"
 
-- name: Run vyos lsmod command
+# To be able to run the lldp test we need to have a neighbor configured to talk to
+# In DCI & Zuul we (currently) only spin up a single network VM, so we can't configure a neighbor
+# In the future when we have multi-network-nodes running we can run these tests again
+# https://github.com/ansible/ansible/issues/39667
+
+- name: Detect if we have existing lldp neighbors configured
   vyos_command:
     commands:
-      - lsmod
-  register: lsmod_out
+      - show lldp neighbors
+  register: neighbors_out
+
+- debug:
+    var: neighbors_out
+
+- name: Should we run lldp tests?
+  set_fact:
+    # run_lldp_tests: "'eth0' in neighbors_out.stdout[0]"
+    run_lldp_tests: False
+
+- name: Enable LLDP service
+  vyos_lldp:
+    state: present
+  when: run_lldp_tests
+
+- name: Create LLDP configuration
+  vyos_lldp_interface:
+    name: eth1
+    state: present
+  when: run_lldp_tests
 
 - name: Setup (interface is up)
   vyos_interface:
@@ -29,13 +53,13 @@
     name: eth0
     neighbors:
     - port: eth0
-  when: "'virtio_net' not in lsmod_out.stdout[0]"
+  when: run_lldp_tests
   register: result
 
 - assert:
     that:
       - "result.failed == false"
-  when: "'virtio_net' not in lsmod_out.stdout[0]"
+  when: run_lldp_tests
 
 - name: Check intent arguments (failed condition)
   vyos_interface:
@@ -56,7 +80,7 @@
     - port: dummy_port
       host: dummy_host
   ignore_errors: yes
-  when: "'virtio_net' not in lsmod_out.stdout[0]"
+  when: run_lldp_tests
   register: result
 
 - assert:
@@ -64,7 +88,7 @@
       - "result.failed == true"
       - "'host dummy_host' in result.failed_conditions"
       - "'port dummy_port' in result.failed_conditions"
-  when: "'virtio_net' not in lsmod_out.stdout[0]"
+  when: run_lldp_tests
 
 - name: Config + intent
   vyos_interface:
@@ -109,13 +133,13 @@
     - name: eth0
       neighbors:
       - port: eth0
-  when: "'virtio_net' not in lsmod_out.stdout[0]"
+  when: run_lldp_tests
   register: result
 
 - assert:
     that:
       - "result.failed == false"
-  when: "'virtio_net' not in lsmod_out.stdout[0]"
+  when: run_lldp_tests
 
 - name: Check lldp neighbors intent aggregate arguments (failed)
   vyos_interface:
@@ -126,7 +150,7 @@
       - port: dummy_port
         host: dummy_host
   ignore_errors: yes
-  when: "'virtio_net' not in lsmod_out.stdout[0]"
+  when: run_lldp_tests
   register: result
 
 - assert:
@@ -134,4 +158,4 @@
       - "result.failed == true"
       - "'host dummy_host' in result.failed_conditions"
       - "'port dummy_port' in result.failed_conditions"
-  when: "'virtio_net' not in lsmod_out.stdout[0]"
+  when: run_lldp_tests

--- a/test/integration/targets/vyos_interface/tests/cli/intent.yaml
+++ b/test/integration/targets/vyos_interface/tests/cli/intent.yaml
@@ -17,8 +17,7 @@
 
 - name: Should we run lldp tests?
   set_fact:
-    # run_lldp_tests: "'eth0' in neighbors_out.stdout[0]"
-    run_lldp_tests: False
+    run_lldp_tests: "'Gi0/0' in neighbors_out.stdout[0]"
 
 - name: Enable LLDP service
   vyos_lldp:
@@ -52,7 +51,7 @@
   vyos_interface:
     name: eth0
     neighbors:
-    - port: eth0
+    - port: Gi0/0
   when: run_lldp_tests
   register: result
 
@@ -132,7 +131,7 @@
     aggregate:
     - name: eth0
       neighbors:
-      - port: eth0
+      - port: Gi0/0
   when: run_lldp_tests
   register: result
 
@@ -146,7 +145,7 @@
     aggregate:
     - name: eth0
       neighbors:
-      - port: eth0
+      - port: Gi0/0
       - port: dummy_port
         host: dummy_host
   ignore_errors: yes

--- a/test/integration/targets/vyos_interface/tests/cli/intent.yaml
+++ b/test/integration/targets/vyos_interface/tests/cli/intent.yaml
@@ -14,7 +14,7 @@
 
 - name: Should we run lldp tests?
   set_fact:
-  t  run_lldp_tests: "'PortDescr:    eth0' in neighbors_out.stdout[0]"
+    run_lldp_tests: "'PortDescr:    eth0' in neighbors_out.stdout[0]"
 
 - name: Enable LLDP service
   vyos_lldp:


### PR DESCRIPTION
##### SUMMARY

We don't have the ability to run these currently, so disable them.
The original logic was also incorrect, the tests don't pass on lab, DCI
nor single instance nodepool, so disable

https://github.com/ansible/ansible/issues/39667 tracks getting these
enabled again

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
vyos_interface

##### ANSIBLE VERSION
```
2.5
```
