### PR TITLE
Add backup option to passwordstore lookup (and improve doc)

### DIFF
--- a/changelogs/fragments/passwordstore-lookup-backup.yaml
+++ b/changelogs/fragments/passwordstore-lookup-backup.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - passwordstore - Add backup option when overwriting password (off by default)

--- a/lib/ansible/plugins/lookup/passwordstore.py
+++ b/lib/ansible/plugins/lookup/passwordstore.py
@@ -201,7 +201,9 @@ class LookupModule(LookupBase):
         # generate new password, insert old lines from current result and return new password
         newpass = self.get_newpass()
         datetime = time.strftime("%d/%m/%Y %H:%M:%S")
-        msg = newpass + '\n' + '\n'.join(self.passoutput[1:]) + '\n'
+        msg = newpass + '\n'
+        if self.passoutput[1:]:
+            msg += '\n'.join(self.passoutput[1:]) + '\n'
         if self.paramvals['backup']:
             msg += "lookup_pass: old password was {0} (Updated on {1})\n".format(self.password, datetime)
         try:

--- a/lib/ansible/plugins/lookup/passwordstore.py
+++ b/lib/ansible/plugins/lookup/passwordstore.py
@@ -55,24 +55,30 @@ DOCUMENTATION = """
 EXAMPLES = """
 # Debug is used for examples, BAD IDEA to show passwords on screen
 - name: Basic lookup. Fails if example/test doesn't exist
-  debug: msg="{{ lookup('passwordstore', 'example/test')}}"
+  debug:
+    msg: "{{ lookup('passwordstore', 'example/test')}}"
 
 - name: Create pass with random 16 character password. If password exists just give the password
-  debug: var=mypassword
+  debug:
+    var: mypassword
   vars:
     mypassword: "{{ lookup('passwordstore', 'example/test create=true')}}"
 
 - name: Different size password
-  debug: msg="{{ lookup('passwordstore', 'example/test create=true length=42')}}"
+  debug:
+    msg: "{{ lookup('passwordstore', 'example/test create=true length=42')}}"
 
 - name: Create password and overwrite the password if it exists. As a bonus, this module includes the old password inside the pass file
-  debug: msg="{{ lookup('passwordstore', 'example/test create=true overwrite=true')}}"
+  debug:
+    msg: "{{ lookup('passwordstore', 'example/test create=true overwrite=true')}}"
 
 - name: Return the value for user in the KV pair user, username
-  debug: msg="{{ lookup('passwordstore', 'example/test subkey=user')}}"
+  debug:
+    msg: "{{ lookup('passwordstore', 'example/test subkey=user')}}"
 
 - name: Return the entire password file content
-  set_fact: passfilecontent="{{ lookup('passwordstore', 'example/test returnall=true')}}"
+  set_fact:
+    passfilecontent: "{{ lookup('passwordstore', 'example/test returnall=true')}}"
 """
 
 RETURN = """

--- a/lib/ansible/plugins/lookup/passwordstore.py
+++ b/lib/ansible/plugins/lookup/passwordstore.py
@@ -22,28 +22,28 @@ DOCUMENTATION = """
         description: location of the password store
         default: '~/.password-store'
       directory:
-        description: directory of the password store
+        description: The directory of the password store.
         env:
           - name: PASSWORD_STORE_DIR
       create:
-        description: flag to create the password
+        description: Create the password if it does not already exist.
         type: bool
         default: 'no'
       overwrite:
-        description: flag to overwrite the password
+        description: Override the password if it does already exist.
         type: bool
         default: 'no'
       returnall:
-        description: flag to return all the contents of the password store
+        description: Return all the content of the password, not only the first line.
         type: bool
         default: 'no'
       subkey:
-        description: subkey to return
+        description: Return a specific subkey of the password.
         default: password
       userpass:
-        description: user password
+        description: Specify a password to save, instead of a generated one.
       length:
-        description: password length
+        description: The length of the generated password
         type: integer
         default: 16
       backup:

--- a/lib/ansible/plugins/lookup/passwordstore.py
+++ b/lib/ansible/plugins/lookup/passwordstore.py
@@ -30,7 +30,7 @@ DOCUMENTATION = """
         type: bool
         default: 'no'
       overwrite:
-        description: Override the password if it does already exist.
+        description: Overwrite the password if it does already exist.
         type: bool
         default: 'no'
       returnall:

--- a/lib/ansible/plugins/lookup/passwordstore.py
+++ b/lib/ansible/plugins/lookup/passwordstore.py
@@ -47,7 +47,7 @@ DOCUMENTATION = """
         type: integer
         default: 16
       backup:
-        description: Backup the previous password in a subkey
+        description: Used with C(overwrite=yes). Backup the previous password in a subkey.
         type: bool
         default: 'no'
 """

--- a/lib/ansible/plugins/lookup/passwordstore.py
+++ b/lib/ansible/plugins/lookup/passwordstore.py
@@ -50,6 +50,7 @@ DOCUMENTATION = """
         description: Used with C(overwrite=yes). Backup the previous password in a subkey.
         type: bool
         default: 'no'
+        version_added: 2.6
 """
 EXAMPLES = """
 # Debug is used for examples, BAD IDEA to show passwords on screen

--- a/lib/ansible/plugins/lookup/passwordstore.py
+++ b/lib/ansible/plugins/lookup/passwordstore.py
@@ -50,7 +50,7 @@ DOCUMENTATION = """
         description: Used with C(overwrite=yes). Backup the previous password in a subkey.
         type: bool
         default: 'no'
-        version_added: 2.6
+        version_added: 2.7
 """
 EXAMPLES = """
 # Debug is used for examples, BAD IDEA to show passwords on screen


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This MR adds the ability to configure the backup of old passwords in the passwordstore lookup. Previously, the lookup always saved old passwords in the `lookup_pass` subkey of the password. With this MR, this is disabled by default (as Password Store provide git integration) and can be re-enabled with the `backup=true` parameter.
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
passwordstore

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0 (passwordstore 05672a582d) last updated 2018/05/03 14:57:08 (GMT +200)
  config file = /home/stephane/.ansible.cfg
  configured module search path = ['/home/stephane/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/stephane/git/sparunakian/ansible/lib/ansible
  executable location = /home/stephane/git/sparunakian/ansible/bin/ansible
  python version = 3.6.5 (default, Apr 14 2018, 13:17:30) [GCC 7.3.1 20180406]
```