### PR TITLE
Added Support for vault credentials

### DIFF
--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_template.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_template.py
@@ -55,6 +55,9 @@ options:
     network_credential:
       description:
         - The network_credential to use for the job template.
+    vault_credential:
+      description:
+        - The vault_credential to use for the job template.
     forks:
       description:
         - The number of parallel or simultaneous processes to use while executing the playbook.
@@ -175,6 +178,7 @@ def update_resources(module, p):
         'machine_credential': 'name',
         'network_credential': 'name',
         'cloud_credential': 'name',
+        'vault_credential': 'name',
     }
     for k, v in identity_map.items():
         try:
@@ -199,6 +203,7 @@ def main():
         machine_credential=dict(),
         cloud_credential=dict(),
         network_credential=dict(),
+        vault_credential=dict(),
         forks=dict(type='int'),
         limit=dict(),
         verbosity=dict(choices=['verbose', 'debug']),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This adds support for vault credentials inside the tower_job_template module.
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
tower_job_template
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.2
  config file = None
  configured module search path = [u'/Users/wanlessc/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/Cellar/ansible/2.5.2/libexec/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 15:04:47) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->
I had a need to support adding a vault credential to a job template through this module.  So, I went ahead and added it.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
