### PR TITLE
support url scheme

### DIFF
--- a/lib/ansible/plugins/lookup/consul_kv.py
+++ b/lib/ansible/plugins/lookup/consul_kv.py
@@ -93,7 +93,7 @@ class LookupModule(LookupBase):
                 try:
                     url = os.environ['ANSIBLE_CONSUL_URL']
                     u = urlparse(url)
-                    consul_api = consul.Consul(host=u.hostname, port=u.port)
+                    consul_api = consul.Consul(host=u.hostname, port=u.port, scheme=u.scheme)
                 except KeyError:
                     port = kwargs.get('port', '8500')
                     host = kwargs.get('host', 'localhost')


### PR DESCRIPTION
##### SUMMARY
Add scheme support for the consul_kv lookup as it currently doesn't support https schemes

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
consul_kv plugin

##### ANSIBLE VERSION
```
ansible 2.6.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/jbakker/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/jbakker/git/other/ansible/.virtualenv/ansible/lib/python2.7/site-packages/ansible
  executable location = bin/ansible
  python version = 2.7.14 (default, Apr 16 2018, 20:08:15) [GCC 7.3.1 20180406]

```

##### ADDITIONAL INFORMATION
We expose the consul api through https, the consul_kv plugin currently only supports http, with this MR the scheme is parsed from the url