### PR TITLE
Enable nuage_vspk tests for Python 2.7.

### DIFF
--- a/test/integration/targets/nuage_vspk/aliases
+++ b/test/integration/targets/nuage_vspk/aliases
@@ -1,3 +1,2 @@
 posix/ci/group1
 skip/python3
-disabled

--- a/test/integration/targets/nuage_vspk/tasks/main.yml
+++ b/test/integration/targets/nuage_vspk/tasks/main.yml
@@ -15,3 +15,4 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  when: "ansible_python_version is version('2.7', '>=')"


### PR DESCRIPTION
##### SUMMARY

Enable nuage_vspk tests for Python 2.7.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

nuage_vspk integration tests

##### ANSIBLE VERSION

```
ansible 2.6.0 (nuage-tests 14a31eb4c8) last updated 2018/05/03 14:30:57 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
