### PR TITLE
vdirect modules: fix 'import' sanity test

### DIFF
--- a/lib/ansible/modules/network/radware/vdirect_commit.py
+++ b/lib/ansible/modules/network/radware/vdirect_commit.py
@@ -328,10 +328,10 @@ class VdirectCommit(object):
 
 def main():
 
-    if not HAS_REST_CLIENT:
-        raise ImportError("The python vdirect-client module is required")
-
     module = AnsibleModule(argument_spec=meta_args)
+
+    if not HAS_REST_CLIENT:
+        module.fail_json(msg="The python vdirect-client module is required")
 
     try:
         vdirect_commit = VdirectCommit(module.params)

--- a/lib/ansible/modules/network/radware/vdirect_commit.py
+++ b/lib/ansible/modules/network/radware/vdirect_commit.py
@@ -155,15 +155,11 @@ FAILED = 'failed'
 NOT_PERFORMED = 'not performed'
 
 meta_args = dict(
-    vdirect_ip=dict(
-        required=True, fallback=(env_fallback, ['VDIRECT_IP']),
-        default=None),
-    vdirect_user=dict(
-        required=True, fallback=(env_fallback, ['VDIRECT_USER']),
-        default=None),
+    vdirect_ip=dict(required=True, fallback=(env_fallback, ['VDIRECT_IP'])),
+    vdirect_user=dict(required=True, fallback=(env_fallback, ['VDIRECT_USER'])),
     vdirect_password=dict(
         required=True, fallback=(env_fallback, ['VDIRECT_PASSWORD']),
-        default=None, no_log=True, type='str'),
+        no_log=True, type='str'),
     vdirect_secondary_ip=dict(
         required=False, fallback=(env_fallback, ['VDIRECT_SECONDARY_IP']),
         default=None),

--- a/lib/ansible/modules/network/radware/vdirect_file.py
+++ b/lib/ansible/modules/network/radware/vdirect_file.py
@@ -229,10 +229,10 @@ class VdirectFile(object):
 
 def main():
 
-    if not HAS_REST_CLIENT:
-        raise ImportError("The python vdirect-client module is required")
-
     module = AnsibleModule(argument_spec=meta_args)
+
+    if not HAS_REST_CLIENT:
+        module.fail_json(msg="The python vdirect-client module is required")
 
     try:
         vdirect_file = VdirectFile(module.params)

--- a/lib/ansible/modules/network/radware/vdirect_file.py
+++ b/lib/ansible/modules/network/radware/vdirect_file.py
@@ -131,15 +131,11 @@ WORKFLOW_TEMPLATE_CREATED_SUCCESS = 'Workflow template created'
 WORKFLOW_TEMPLATE_UPDATED_SUCCESS = 'Workflow template updated'
 
 meta_args = dict(
-    vdirect_ip=dict(
-        required=True, fallback=(env_fallback, ['VDIRECT_IP']),
-        default=None),
-    vdirect_user=dict(
-        required=True, fallback=(env_fallback, ['VDIRECT_USER']),
-        default=None),
+    vdirect_ip=dict(required=True, fallback=(env_fallback, ['VDIRECT_IP'])),
+    vdirect_user=dict(required=True, fallback=(env_fallback, ['VDIRECT_USER'])),
     vdirect_password=dict(
         required=True, fallback=(env_fallback, ['VDIRECT_PASSWORD']),
-        default=None, no_log=True, type='str'),
+        no_log=True, type='str'),
     vdirect_secondary_ip=dict(
         required=False, fallback=(env_fallback, ['VDIRECT_SECONDARY_IP']),
         default=None),
@@ -161,7 +157,7 @@ meta_args = dict(
     vdirect_http_port=dict(
         required=False, fallback=(env_fallback, ['VDIRECT_HTTP_PORT']),
         default=2188, type='int'),
-    file_name=dict(required=True, default=None)
+    file_name=dict(required=True)
 )
 
 

--- a/lib/ansible/modules/network/radware/vdirect_runnable.py
+++ b/lib/ansible/modules/network/radware/vdirect_runnable.py
@@ -309,11 +309,11 @@ class VdirectRunnable(object):
 
 def main():
 
-    if not HAS_REST_CLIENT:
-        raise ImportError("The python vdirect-client module is required")
-
     module = AnsibleModule(argument_spec=meta_args,
                            required_if=[['runnable_type', WORKFLOW_RUNNABLE_TYPE, ['action_name']]])
+
+    if not HAS_REST_CLIENT:
+        module.fail_json(msg="The python vdirect-client module is required")
 
     try:
         vdirect_runnable = VdirectRunnable(module.params)

--- a/lib/ansible/modules/network/radware/vdirect_runnable.py
+++ b/lib/ansible/modules/network/radware/vdirect_runnable.py
@@ -99,7 +99,7 @@ options:
      - Required if I(runnable_type=Workflow).
   parameters:
     description:
-     - Action parameters dictionary. In case of ConfigurationTemplate runnable type,
+     - Action parameters dictionary. In case of C(ConfigurationTemplate) runnable type,
      - the device connection details should always be passed as a parameter.
 
 requirements:

--- a/lib/ansible/modules/network/radware/vdirect_runnable.py
+++ b/lib/ansible/modules/network/radware/vdirect_runnable.py
@@ -86,8 +86,8 @@ options:
   runnable_type:
     description:
      - vDirect runnable type.
-     - May be ConfigurationTemplate, WorkflowTemplate or a Workflow.
     required: true
+    choices: ['ConfigurationTemplate', 'Workflow', 'WorkflowTemplate']
   runnable_name:
     description:
      - vDirect runnable name to run.
@@ -143,15 +143,11 @@ WORKFLOW_CREATION_SUCCESS = 'Workflow created.'
 WORKFLOW_ACTION_SUCCESS = 'Workflow action run completed.'
 
 meta_args = dict(
-    vdirect_ip=dict(
-        required=True, fallback=(env_fallback, ['VDIRECT_IP']),
-        default=None),
-    vdirect_user=dict(
-        required=True, fallback=(env_fallback, ['VDIRECT_USER']),
-        default=None),
+    vdirect_ip=dict(required=True, fallback=(env_fallback, ['VDIRECT_IP'])),
+    vdirect_user=dict(required=True, fallback=(env_fallback, ['VDIRECT_USER'])),
     vdirect_password=dict(
         required=True, fallback=(env_fallback, ['VDIRECT_PASSWORD']),
-        default=None, no_log=True, type='str'),
+        no_log=True, type='str'),
     vdirect_secondary_ip=dict(
         required=False, fallback=(env_fallback, ['VDIRECT_SECONDARY_IP']),
         default=None),
@@ -176,7 +172,7 @@ meta_args = dict(
     runnable_type=dict(
         required=True,
         choices=[CONFIGURATION_TEMPLATE_RUNNABLE_TYPE, WORKFLOW_TEMPLATE_RUNNABLE_TYPE, WORKFLOW_RUNNABLE_TYPE]),
-    runnable_name=dict(required=True, default=None),
+    runnable_name=dict(required=True),
     action_name=dict(required=False, default=None),
     parameters=dict(required=False, type='dict', default={})
 )

--- a/test/sanity/import/skip.txt
+++ b/test/sanity/import/skip.txt
@@ -1,6 +1,3 @@
 lib/ansible/modules/clustering/k8s/k8s_raw.py
 lib/ansible/modules/clustering/k8s/k8s_scale.py
 lib/ansible/modules/network/avi/avi_gslbservice_patch_member.py
-lib/ansible/modules/network/radware/vdirect_commit.py
-lib/ansible/modules/network/radware/vdirect_file.py
-lib/ansible/modules/network/radware/vdirect_runnable.py

--- a/test/sanity/import/skip.txt
+++ b/test/sanity/import/skip.txt
@@ -1,3 +1,0 @@
-lib/ansible/modules/clustering/k8s/k8s_raw.py
-lib/ansible/modules/clustering/k8s/k8s_scale.py
-lib/ansible/modules/network/avi/avi_gslbservice_patch_member.py

--- a/test/sanity/validate-modules/ignore.txt
+++ b/test/sanity/validate-modules/ignore.txt
@@ -1239,9 +1239,6 @@ lib/ansible/modules/network/panos/panos_security_rule.py E322
 lib/ansible/modules/network/panos/panos_security_rule.py E324
 lib/ansible/modules/network/panos/panos_security_rule.py E325
 lib/ansible/modules/network/panos/panos_security_rule.py E326
-lib/ansible/modules/network/radware/vdirect_commit.py E321
-lib/ansible/modules/network/radware/vdirect_file.py E321
-lib/ansible/modules/network/radware/vdirect_runnable.py E321
 lib/ansible/modules/network/sros/sros_config.py E323
 lib/ansible/modules/network/sros/sros_config.py E326
 lib/ansible/modules/network/vyos/vyos_interface.py E324


### PR DESCRIPTION
##### SUMMARY
`vdirect` modules: fix `import` sanity test

Error was:
  ```
$ ansible-test sanity --test import --python 3.6 
Sanity check using import with Python 3.6
ERROR: Found 1 import issue(s) on python 3.6 which need to be resolved:
ERROR: lib/ansible/modules/network/radware/vdirect_commit.py:332:0: ImportError: The python vdirect-client module is required
ERROR: The 1 sanity test(s) listed below (out of 1) failed. See error output above for details.
import --python 3.6
  ```

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
- vdirect_commit.py
- vdirect_file.py
- vdirect_runnable.py

##### ANSIBLE VERSION
```
ansible 2.6.0 (devel f75b7a9437) last updated 2018/05/04 00:50:49 (GMT +200)
```