### PR TITLE
elb_target_group: only drain all elb targets if targets is an empty list and modify_targets is true

### DIFF
--- a/lib/ansible/modules/cloud/amazon/elb_target_group.py
+++ b/lib/ansible/modules/cloud/amazon/elb_target_group.py
@@ -480,7 +480,7 @@ def create_or_update_target_group(connection, module):
 
         # Do we need to modify targets?
         if module.params.get("purge_targets"):
-            if module.params.get("targets") == []:
+            if module.params.get("targets"):
                 params['Targets'] = module.params.get("targets")
 
                 # get list of current target instances. I can't see anything like a describe targets in the doco so

--- a/lib/ansible/modules/cloud/amazon/elb_target_group.py
+++ b/lib/ansible/modules/cloud/amazon/elb_target_group.py
@@ -539,7 +539,7 @@ def create_or_update_target_group(connection, module):
                         status_achieved, registered_instances = wait_for_status(connection, module, tg['TargetGroupArn'], instances_to_remove, 'unused')
                         if not status_achieved:
                             module.fail_json(msg='Error waiting for target deregistration - please check the AWS console')
-            elif module.get.params("targets") is None or elif module.get.params("targets") = []:
+            elif module.get.params("targets") is not None:
                 try:
                     current_targets = connection.describe_target_health(TargetGroupArn=tg['TargetGroupArn'])
                 except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:

--- a/lib/ansible/modules/cloud/amazon/elb_target_group.py
+++ b/lib/ansible/modules/cloud/amazon/elb_target_group.py
@@ -121,7 +121,7 @@ options:
   targets:
     description:
       - A list of targets to assign to the target group.  The list should be an Id and a Port parameter.
-        Defaults to None.  See the Examples for detail. 
+        Defaults to None.  See the Examples for detail.
         Prior to 2.6, all targets were drained if targets was None and I(purge_targets) was True.  As of 2.6,
         to drain all targets, this option must be set to an empty list to use in conjustion with I(purge_targets).
     required: false

--- a/lib/ansible/modules/cloud/amazon/elb_target_group.py
+++ b/lib/ansible/modules/cloud/amazon/elb_target_group.py
@@ -120,8 +120,8 @@ options:
     version_added: 2.5
   targets:
     description:
-      - A list of targets to assign to the target group. This parameter defaults to an empty list. Unless you set the 'purge_targets' parameter then
-        all existing targets will be removed from the group. The list should be an Id and a Port parameter. See the Examples for detail.
+      - A list of targets to assign to the target group.  The list should be an Id and a Port parameter.
+        Defaults to 'None.'  See the Examples for detail. 
     required: false
   unhealthy_threshold_count:
     description:
@@ -537,7 +537,7 @@ def create_or_update_target_group(connection, module):
                         status_achieved, registered_instances = wait_for_status(connection, module, tg['TargetGroupArn'], instances_to_remove, 'unused')
                         if not status_achieved:
                             module.fail_json(msg='Error waiting for target deregistration - please check the AWS console')
-            else:
+            elif module.get.parames("targets") is None:
                 try:
                     current_targets = connection.describe_target_health(TargetGroupArn=tg['TargetGroupArn'])
                 except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:

--- a/lib/ansible/modules/cloud/amazon/elb_target_group.py
+++ b/lib/ansible/modules/cloud/amazon/elb_target_group.py
@@ -121,7 +121,9 @@ options:
   targets:
     description:
       - A list of targets to assign to the target group.  The list should be an Id and a Port parameter.
-        Defaults to 'None.'  See the Examples for detail. 
+        Defaults to None.  See the Examples for detail. 
+        Prior to 2.6, all targets were drained if targets was None and I(purge_targets) was True.  As of 2.6,
+        to drain all targets, this option must be set to an empty list to use in conjustion with I(purge_targets).
     required: false
   unhealthy_threshold_count:
     description:
@@ -537,7 +539,7 @@ def create_or_update_target_group(connection, module):
                         status_achieved, registered_instances = wait_for_status(connection, module, tg['TargetGroupArn'], instances_to_remove, 'unused')
                         if not status_achieved:
                             module.fail_json(msg='Error waiting for target deregistration - please check the AWS console')
-            elif module.get.parames("targets") is None:
+            elif module.get.params("targets") is None or elif module.get.params("targets") = []:
                 try:
                     current_targets = connection.describe_target_health(TargetGroupArn=tg['TargetGroupArn'])
                 except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:

--- a/lib/ansible/modules/cloud/amazon/elb_target_group.py
+++ b/lib/ansible/modules/cloud/amazon/elb_target_group.py
@@ -57,7 +57,7 @@ options:
     description:
       - Whether or not to alter existing targets in the group to match what is passed with the module
     required: false
-    default: yes
+    default: no
   name:
     description:
       - The name of the target group.
@@ -670,7 +670,7 @@ def main():
             health_check_interval=dict(type='int'),
             health_check_timeout=dict(type='int'),
             healthy_threshold_count=dict(type='int'),
-            modify_targets=dict(default=True, type='bool'),
+            modify_targets=dict(default=False, type='bool'),
             name=dict(required=True),
             port=dict(type='int'),
             protocol=dict(choices=['http', 'https', 'tcp', 'HTTP', 'HTTPS', 'TCP']),


### PR DESCRIPTION
… targets

##### SUMMARY
~The current default of 'True' is dangerous because you would not expect to change targets unless you *want* to change targets.  It is safer to change this to false and prevent unexpected default assumptions.~ This was the first approach. Rather than changing a default, now check if targets is an empty list. Now if targets and modify_targets options are omitted from the play all targets are not drained.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
elb_target_group.py

##### ANSIBLE VERSION
2.5+


##### ADDITIONAL INFORMATION
Related to https://github.com/ansible/ansible/issues/39709
