### PR TITLE
fixed data disk issue crash

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine_scaleset.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine_scaleset.py
@@ -522,7 +522,7 @@ class AzureRMVirtualMachineScaleSet(AzureRMModuleBase):
                     vmss_dict['sku']['capacity'] = self.capacity
 
                 if self.data_disks and \
-                   len(self.data_disks) != len(vmss_dict['properties']['virtualMachineProfile']['storageProfile']['dataDisks']):
+                   len(self.data_disks) != len(vmss_dict['properties']['virtualMachineProfile']['storageProfile'].get('dataDisks', [])):
                     self.log('CHANGED: virtual machine scale set {0} - Data Disks'.format(self.name))
                     differences.append('Data Disks')
                     changed = True


### PR DESCRIPTION
##### SUMMARY
Fixes crash when trying to update VMMS with no data disks by adding data disk.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
azure_rm_virtualmachine_scaleset

##### ANSIBLE VERSION
2.5

##### ADDITIONAL INFORMATION

