### PR TITLE
WIP - Don't call v2_runner_on_ok on include/include_task

### DIFF
--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -632,8 +632,8 @@ class StrategyBase:
                     if 'changed' in task_result._result and task_result._result['changed']:
                         self._tqm._stats.increment('changed', original_host.name)
 
-                # finally, send the ok for this task
-                self._tqm.send_callback('v2_runner_on_ok', task_result)
+                    # finally, send the ok for this task
+                    self._tqm.send_callback('v2_runner_on_ok', task_result)
 
             self._pending_results -= 1
             if original_host.name in self._blocked_hosts:

--- a/test/integration/targets/include_callbacks/aliases
+++ b/test/integration/targets/include_callbacks/aliases
@@ -1,0 +1,1 @@
+posix/ci/group1

--- a/test/integration/targets/include_callbacks/callback_plugins/test_callback.py
+++ b/test/integration/targets/include_callbacks/callback_plugins/test_callback.py
@@ -1,0 +1,202 @@
+"""Testing callback to record callback events and generalize the results for easier diffs."""
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import os
+
+from ansible.plugins.callback import CallbackBase
+
+
+class CallbackModule(CallbackBase):
+    CALLBACK_VERSION = 2.0
+    CALLBACK_TYPE = 'aggregate'
+    CALLBACK_NAME = 'test_callback'
+    CALLBACK_NEEDS_WHITELIST = False
+
+    def __init__(self):
+        super(CallbackModule, self).__init__()
+        self.path = os.environ.get('TEST_CALLBACK_PATH', os.path.abspath('test_callback.log'))
+        self.ignore = set(os.environ.get('TEST_CALLBACK_IGNORE', 'v2_on_any').split(','))
+        self.fd = open(self.path, 'w')
+
+    def v2_on_any(self, *args, **kwargs):
+        self.log('v2_on_any', kwargs, args)
+
+    def v2_runner_on_failed(self, result, ignore_errors=False):
+        self.log('v2_runner_on_failed', locals())
+
+    def v2_runner_on_ok(self, result):
+        self.log('v2_runner_on_ok', locals())
+
+    def v2_runner_on_skipped(self, result):
+        self.log('v2_runner_on_skipped', locals())
+
+    def v2_runner_on_unreachable(self, result):
+        self.log('v2_runner_on_unreachable', locals())
+
+    def v2_runner_on_async_poll(self, result):
+        self.log('v2_runner_on_async_poll', locals())
+
+    def v2_runner_on_async_ok(self, result):
+        self.log('v2_runner_on_async_ok', locals())
+
+    def v2_runner_on_async_failed(self, result):
+        self.log('v2_runner_on_async_failed', locals())
+
+    def v2_playbook_on_start(self, playbook):
+        self.log('v2_playbook_on_start', locals())
+
+    def v2_playbook_on_notify(self, handler, host):
+        self.log('v2_playbook_on_notify', locals())
+
+    def v2_playbook_on_no_hosts_matched(self):
+        self.log('v2_playbook_on_no_hosts_matched', locals())
+
+    def v2_playbook_on_no_hosts_remaining(self):
+        self.log('v2_playbook_on_no_hosts_remaining', locals())
+
+    def v2_playbook_on_task_start(self, task, is_conditional):
+        self.log('v2_playbook_on_task_start', locals())
+
+    def v2_playbook_on_cleanup_task_start(self, task):
+        self.log('v2_playbook_on_cleanup_task_start', locals())
+
+    def v2_playbook_on_handler_task_start(self, task):
+        self.log('v2_playbook_on_handler_task_start', locals())
+
+    def v2_playbook_on_vars_prompt(self, varname, private=True, prompt=None, encrypt=None, confirm=False, salt_size=None, salt=None, default=None):
+        self.log('v2_playbook_on_vars_prompt', locals())
+
+    def v2_playbook_on_import_for_host(self, result, imported_file):
+        self.log('v2_playbook_on_import_for_host', locals())
+
+    def v2_playbook_on_not_import_for_host(self, result, missing_file):
+        self.log('v2_playbook_on_not_import_for_host', locals())
+
+    def v2_playbook_on_play_start(self, play):
+        self.log('v2_playbook_on_play_start', locals())
+
+    def v2_playbook_on_stats(self, stats):
+        self.log('v2_playbook_on_stats', locals())
+
+    def v2_on_file_diff(self, result):
+        self.log('v2_on_file_diff', locals())
+
+    def v2_playbook_on_include(self, included_file):
+        self.log('v2_playbook_on_include', locals())
+
+    def v2_runner_item_on_ok(self, result):
+        self.log('v2_runner_item_on_ok', locals())
+
+    def v2_runner_item_on_failed(self, result):
+        self.log('v2_runner_item_on_failed', locals())
+
+    def v2_runner_item_on_skipped(self, result):
+        self.log('v2_runner_item_on_skipped', locals())
+
+    def v2_runner_retry(self, result):
+        self.log('v2_runner_retry', locals())
+
+    def log(self, name, kwargs, args=None):
+        if name in self.ignore:
+            return
+
+        kwargs = kwargs or {}
+
+        kwargs.pop('self', None)
+        result = kwargs.pop('result', None)
+
+        message = name
+
+        try:
+            if result and hasattr(result, '_task'):
+                task = result._task
+            else:
+                task = kwargs.pop('task', None)
+
+            if task and hasattr(task, '_uuid'):
+                task_uuid = task._uuid
+
+                if task_uuid:
+                    message += ' task_uuid=%s' % remap_uuid(task_uuid)
+
+            if task and hasattr(task, 'get_name'):
+                message += ' task_name="%s"' % task.get_name()
+
+            if result and hasattr(result, '_host'):
+                host = result._host
+
+                if host and hasattr(host, '_uuid'):
+                    message += ' host_uuid=%s' % remap_uuid(host._uuid)
+
+                if host and hasattr(host, 'name'):
+                    message += ' host_name=%s' % host.name
+
+            playbook = kwargs.pop('playbook', None)
+
+            if playbook and hasattr(playbook, '_file_name'):
+                message += ' filename="%s"' % relative_path(playbook._file_name)
+
+            play = kwargs.pop('play', None)
+
+            if play and hasattr(play, 'get_name'):
+                message += ' play_name="%s"' % play.get_name()
+
+            included_file = kwargs.pop('included_file', None)
+
+            if included_file and hasattr(included_file, '_filename'):
+                message += ' filename="%s"' % relative_path(included_file._filename)
+
+            stats = kwargs.pop('stats', None)
+
+            if stats and hasattr(stats, 'processed'):
+                message += ' hosts=%d' % len(stats.processed)
+
+            if kwargs:
+                message += ' %s' % ' '.join(['%s=%s' % (k, kwargs[k]) for k in sorted(kwargs)])
+
+            if args:
+                message += ' args=%s' % list(args)
+        except:
+            message += ' EXCEPTION'
+
+        self.write_log(message)
+
+    def write_log(self, message):
+        self.fd.write('%s\n' % message)
+
+
+REMAPPED_UUIDS = {}
+UUID_COUNTER = 0
+BASE_DIR = None
+
+base_dir = os.getcwd()
+
+while len(base_dir) >= 1:
+    if os.path.isfile(os.path.join(base_dir, 'shippable.yml')):
+        BASE_DIR = os.path.realpath(base_dir) + '/'
+        break
+
+    base_dir = os.path.dirname(base_dir)
+
+if not BASE_DIR:
+    raise Exception('unable to determine base_dir')
+
+
+def relative_path(path):
+    path = os.path.realpath(path)
+
+    if path.startswith(BASE_DIR):
+        path = path[len(BASE_DIR):]
+
+    return path
+
+
+def remap_uuid(uuid):
+    global UUID_COUNTER
+
+    if uuid not in REMAPPED_UUIDS:
+        UUID_COUNTER += 1
+        REMAPPED_UUIDS[uuid] = UUID_COUNTER
+
+    return REMAPPED_UUIDS[uuid]

--- a/test/integration/targets/include_callbacks/include_dynamic_failure.log
+++ b/test/integration/targets/include_callbacks/include_dynamic_failure.log
@@ -1,0 +1,5 @@
+v2_playbook_on_start filename="test/integration/targets/include_callbacks/include_dynamic_failure.yml"
+v2_playbook_on_play_start play_name="localhost"
+v2_playbook_on_task_start task_uuid=1 task_name="EXPECTED FAILURE include tasks file that does not exist" is_conditional=False
+v2_runner_on_failed task_uuid=1 task_name="EXPECTED FAILURE include tasks file that does not exist" host_uuid=2 host_name=localhost ignore_errors=False
+v2_playbook_on_stats hosts=1

--- a/test/integration/targets/include_callbacks/include_dynamic_failure.yml
+++ b/test/integration/targets/include_callbacks/include_dynamic_failure.yml
@@ -1,0 +1,7 @@
+- hosts: localhost
+  gather_facts: no
+  tasks:
+    - name: EXPECTED FAILURE include tasks file that does not exist
+      include: bogus.yml
+      static: no
+      when: yes

--- a/test/integration/targets/include_callbacks/include_dynamic_success.log
+++ b/test/integration/targets/include_callbacks/include_dynamic_success.log
@@ -1,0 +1,7 @@
+v2_playbook_on_start filename="test/integration/targets/include_callbacks/include_dynamic_success.yml"
+v2_playbook_on_play_start play_name="localhost"
+v2_playbook_on_task_start task_uuid=1 task_name="include tasks file that exists" is_conditional=False
+v2_playbook_on_include filename="test/integration/targets/include_callbacks/simple.yml"
+v2_playbook_on_task_start task_uuid=2 task_name="show message" is_conditional=False
+v2_runner_on_ok task_uuid=2 task_name="show message" host_uuid=3 host_name=localhost
+v2_playbook_on_stats hosts=1

--- a/test/integration/targets/include_callbacks/include_dynamic_success.yml
+++ b/test/integration/targets/include_callbacks/include_dynamic_success.yml
@@ -1,0 +1,7 @@
+- hosts: localhost
+  gather_facts: no
+  tasks:
+    - name: include tasks file that exists
+      include: simple.yml
+      static: no
+      when: yes

--- a/test/integration/targets/include_callbacks/include_failure.log
+++ b/test/integration/targets/include_callbacks/include_failure.log
@@ -1,0 +1,5 @@
+v2_playbook_on_start filename="test/integration/targets/include_callbacks/include_failure.yml"
+v2_playbook_on_play_start play_name="localhost"
+v2_playbook_on_task_start task_uuid=1 task_name="EXPECTED FAILURE include tasks file that does not exist" is_conditional=False
+v2_runner_on_failed task_uuid=1 task_name="EXPECTED FAILURE include tasks file that does not exist" host_uuid=2 host_name=localhost ignore_errors=False
+v2_playbook_on_stats hosts=1

--- a/test/integration/targets/include_callbacks/include_failure.yml
+++ b/test/integration/targets/include_callbacks/include_failure.yml
@@ -1,0 +1,5 @@
+- hosts: localhost
+  gather_facts: no
+  tasks:
+    - name: EXPECTED FAILURE include tasks file that does not exist
+      include: bogus.yml

--- a/test/integration/targets/include_callbacks/include_success.log
+++ b/test/integration/targets/include_callbacks/include_success.log
@@ -1,0 +1,5 @@
+v2_playbook_on_start filename="test/integration/targets/include_callbacks/include_success.yml"
+v2_playbook_on_play_start play_name="localhost"
+v2_playbook_on_task_start task_uuid=1 task_name="show message" is_conditional=False
+v2_runner_on_ok task_uuid=1 task_name="show message" host_uuid=2 host_name=localhost
+v2_playbook_on_stats hosts=1

--- a/test/integration/targets/include_callbacks/include_success.yml
+++ b/test/integration/targets/include_callbacks/include_success.yml
@@ -1,0 +1,5 @@
+- hosts: localhost
+  gather_facts: no
+  tasks:
+    - name: include tasks file that exists
+      include: simple.yml

--- a/test/integration/targets/include_callbacks/include_tasks_failure.log
+++ b/test/integration/targets/include_callbacks/include_tasks_failure.log
@@ -1,0 +1,5 @@
+v2_playbook_on_start filename="test/integration/targets/include_callbacks/include_tasks_failure.yml"
+v2_playbook_on_play_start play_name="localhost"
+v2_playbook_on_task_start task_uuid=1 task_name="EXPECTED FAILURE include tasks file that does not exist" is_conditional=False
+v2_runner_on_failed task_uuid=1 task_name="EXPECTED FAILURE include tasks file that does not exist" host_uuid=2 host_name=localhost ignore_errors=False
+v2_playbook_on_stats hosts=1

--- a/test/integration/targets/include_callbacks/include_tasks_failure.yml
+++ b/test/integration/targets/include_callbacks/include_tasks_failure.yml
@@ -1,0 +1,5 @@
+- hosts: localhost
+  gather_facts: no
+  tasks:
+    - name: EXPECTED FAILURE include tasks file that does not exist
+      include_tasks: bogus.yml

--- a/test/integration/targets/include_callbacks/include_tasks_success.log
+++ b/test/integration/targets/include_callbacks/include_tasks_success.log
@@ -1,0 +1,7 @@
+v2_playbook_on_start filename="test/integration/targets/include_callbacks/include_tasks_success.yml"
+v2_playbook_on_play_start play_name="localhost"
+v2_playbook_on_task_start task_uuid=1 task_name="include tasks file that exists" is_conditional=False
+v2_playbook_on_include filename="test/integration/targets/include_callbacks/simple.yml"
+v2_playbook_on_task_start task_uuid=2 task_name="show message" is_conditional=False
+v2_runner_on_ok task_uuid=2 task_name="show message" host_uuid=3 host_name=localhost
+v2_playbook_on_stats hosts=1

--- a/test/integration/targets/include_callbacks/include_tasks_success.yml
+++ b/test/integration/targets/include_callbacks/include_tasks_success.yml
@@ -1,0 +1,5 @@
+- hosts: localhost
+  gather_facts: no
+  tasks:
+    - name: include tasks file that exists
+      include_tasks: simple.yml

--- a/test/integration/targets/include_callbacks/runme.sh
+++ b/test/integration/targets/include_callbacks/runme.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -eux
+
+export ANSIBLE_HOSTS=../../inventory
+
+trap 'rm -f test_callback.log *.retry' EXIT
+
+ansible-playbook include_tasks_success.yml
+diff include_tasks_success.log test_callback.log
+
+ansible-playbook include_success.yml
+diff include_success.log test_callback.log
+
+ansible-playbook include_dynamic_success.yml
+diff include_dynamic_success.log test_callback.log
+
+# shellcheck disable=SC2015
+ansible-playbook include_tasks_failure.yml && exit 1 || true
+diff include_tasks_failure.log test_callback.log
+
+# shellcheck disable=SC2015
+ansible-playbook include_failure.yml && exit 1 || true
+diff include_failure.log test_callback.log
+
+# shellcheck disable=SC2015
+ansible-playbook include_dynamic_failure.yml && exit 1 || true
+diff include_dynamic_failure.log test_callback.log

--- a/test/integration/targets/include_callbacks/simple.yml
+++ b/test/integration/targets/include_callbacks/simple.yml
@@ -1,0 +1,2 @@
+- name: show message
+  debug: msg=hello


### PR DESCRIPTION
##### SUMMARY

Don't call the `v2_runner_on_ok` callback on `include` or `include_task`.
This avoids calling both `v2_runner_on_ok` and `v2_runner_on_failed` for imports that fail.

Before this change, include callbacks were:

- v2_runner_on_ok
- v2_playbook_on_include on success
- v2_runner_on_failed on failure

After this change, include callbacks are:

- v2_playbook_on_include on success
- v2_runner_on_failed on failure

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

`lib/ansible/plugins/strategy/__init__.py`

##### ANSIBLE VERSION

```
ansible 2.6.0 (no-redundant-include-callback 76c3db0ae9) last updated 2018/05/03 23:39:05 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```

##### ADDITIONAL INFORMATION

Integration tests have been added to verify the expected callbacks are made for includes.