### PR TITLE
FIX: Removing superfluous bloc wrongly introduced in 2b7799f817e8.

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters.rst
@@ -130,8 +130,6 @@ Flatten only the first level of a list (akin to the `items` lookup)::
     {{ [3, [4, [2]] ]|flatten(level=1) }}
 
 
-To get the minimum value from list of numbers::
-
 .. _set_theory_filters:
 
 Set Theory Filters


### PR DESCRIPTION
##### SUMMARY

Just removing a bloc that was introduced probably a copy/past by error.

##### ISSUE TYPE
 - Docs Pull Request

