### PR TITLE
vmware_guest: cast vlan to int or str when relevant

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -998,10 +998,10 @@ class PyVmomiHelper(PyVmomi):
                 dvps = self.cache.get_all_objs(self.content, [vim.dvs.DistributedVirtualPortgroup])
                 for dvp in dvps:
                     if hasattr(dvp.config.defaultPortConfig, 'vlan') and \
-                            dvp.config.defaultPortConfig.vlan.vlanId == network['vlan']:
+                            dvp.config.defaultPortConfig.vlan.vlanId == int(network['vlan']):
                         network['name'] = dvp.config.name
                         break
-                    if dvp.config.name == network['vlan']:
+                    if dvp.config.name == str(network['vlan']):
                         network['name'] = dvp.config.name
                         break
                 else:


### PR DESCRIPTION
##### SUMMARY

Fixes #38398 

<!--- Describe the change, including rationale and design decisions -->
- `network['vlan']` should be a VLAN ID
Integers passed around using jinja variable references are converted to strings (see #9362) and the #32738 PR will allow using 'NativeType' in ansible
Explicitly converting to integer will make the module works **as expected with or without** the NativeType support

- `network['vlan']` can also be a VLAN NAME (fallback)
Explicitly converting to string will make the module works **as expected with or without** the NativeType support

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->

`vmware_guest`

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.3.1.0
  config file = 
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, Jul 31 2017, 14:34:53) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->
Sample code creating the issue
```
- name: create vm
  vmware_guest:
    validate_certs: no
    state: poweredoff

    template: "{{ template_name }}"
    name:     "{{ inventory_hostname }}"
    folder:   "/{{ vm_folder | default(sandbox_path) }}"

    hostname: "{{ vcenter_url }}"
    username: "{{ vcenter_user }}"
    password: "{{ vcenter_password }}"

    cluster:       "{{ vcenter_cluster }}"
    resource_pool: "{{ vcenter_rp_name }}"
    datacenter:    "{{ vcenter_datacenter }}"

    hardware:
      scsi:      paravirtual
      memory_mb: "{{ vm_ram }}"
      num_cpus:  "{{ vm_nbcpu }}"

    networks:
      -
        type:    "vmxnet3"
        vlan:    "{{ vlan_id }}"                        # <-- the problem is here: jinja variable must be quoted and are therefore sent as string, but module waits for an integer.
        ip:      "{{ ansible_ssh_host }}"
        netmask: "{{ netmask }}"

    disk:
      -
        size_gb: "{{ vm_system_disk_size | mandatory }}"
        type: "{{ vm_disk_type }}"
        autoselect_datastore: yes
      -
        size_gb: "{{ vm_swap | default( vm_ram|int / 1024) | int }}"
        type: "{{ vm_disk_type }}"
        autoselect_datastore: yes
```
<!--- Paste verbatim command output below, e.g. before and after your change -->
Output before the fix ❌  : 
```
fatal: [dns1-ro1-b -> localhost]: FAILED! => {
    "changed": false, 
    "failed": true, 
    "invocation": {
        "module_args": {
            "annotation": null, 
            "cluster": "xxxxxxxxx", 
            "customization": {}, 
            "customvalues": [], 
            "datacenter": "xxxxxxxxx", 
            "disk": [
                {
                    "autoselect_datastore": true, 
                    "size_gb": "15", 
                    "type": "thin"
                }, 
                {
                    "autoselect_datastore": true, 
                    "size_gb": "4", 
                    "type": "thin"
                }, 
            ], 
            "esxi_hostname": null, 
            "folder": "/xxxxxxxxx", 
            "force": false, 
            "guest_id": null, 
            "hardware": {
                "memory_mb": "4096", 
                "num_cpus": "6", 
                "scsi": "paravirtual"
            }, 
            "hostname": "1.2.3.4", 
            "is_template": false, 
            "name": "dns1-ro1-b", 
            "name_match": "first", 
            "networks": [
                {
                    "ip": "2.3.4.5", 
                    "netmask": "255.255.255.128", 
                    "type": "vmxnet3", 
                    "vlan": "2251"
                }
            ], 
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
            "resource_pool": "xxxxxxxxx", 
            "state": "poweredoff", 
            "template": "xxxxxxxxx", 
            "template_src": "xxxxxxxxx", 
            "username": "xxxxxxxxx", 
            "uuid": null, 
            "validate_certs": false, 
            "wait_for_ip_address": false
        }
    }, 
    "msg": "VLAN '2251' does not exist"
}

```
Output after applying the PR ✔️  : 
```
changed: [dns1-ro1-b -> localhost] => {
    "changed": true, 
    "failed": false, 
    "instance": {
        "annotation": "", 
        "current_snapshot": null, 
        "customvalues": {}, 
        "guest_tools_status": "guestToolsNotRunning", 
        "guest_tools_version": null, 
        "hw_eth0": {
            "addresstype": "assigned", 
            "ipaddresses": null, 
            "label": "Network adapter 1", 
            "macaddress": "xx:xx:xx:xx:xx:xx", 
            "macaddress_dash": "xx-xx-xx-xx-xx-xx", 
            "summary": "DVSwitch: xx xx xx xx xx xx xx xx-xx xx xx xx xx xx xx xx"
        }, 
        "hw_guest_full_name": null, 
        "hw_guest_id": null, 
        "hw_interfaces": [
            "eth0"
        ], 
        "hw_memtotal_mb": 4096, 
        "hw_name": "xxxxxxxxx", 
        "hw_power_status": "poweredOff", 
        "hw_processor_count": 6, 
        "hw_product_uuid": "xxxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxx", 
        "ipv4": null, 
        "ipv6": null, 
        "module_hw": true, 
        "snapshots": []
    }, 
    "invocation": {
        "module_args": {
            "annotation": null, 
            "cluster": "xxxxxxxxx", 
            "customization": {}, 
            "customvalues": [], 
            "datacenter": "xxxxxxxxx", 
            "disk": [
                {
                    "autoselect_datastore": true, 
                    "size_gb": "15", 
                    "type": "thin"
                }, 
                {
                    "autoselect_datastore": true, 
                    "size_gb": "4", 
                    "type": "thin"
                }, 
            ], 
            "esxi_hostname": null, 
            "folder": "/xxxxxxxxx", 
            "force": false, 
            "guest_id": null, 
            "hardware": {
                "memory_mb": "4096", 
                "num_cpus": "6", 
                "scsi": "paravirtual"
            }, 
            "hostname": "1.2.3.4", 
            "is_template": false, 
            "name": "dns1-ro1-b", 
            "name_match": "first", 
            "networks": [
                {
                    "ip": "2.3.4.5", 
                    "netmask": "255.255.255.128", 
                    "type": "vmxnet3", 
                    "vlan": "2251"
                }
            ], 
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
            "resource_pool": "xxxxxxxxx", 
            "state": "poweredoff", 
            "template": "xxxxxxxxx", 
            "template_src": "xxxxxxxxx", 
            "username": "xxxxxxxxx", 
            "uuid": null, 
            "validate_certs": false, 
            "wait_for_ip_address": false
        }
    }
}

```