### PR TITLE
Fix ios integration test failures in CI

### DIFF
--- a/test/integration/targets/ios_interface/tests/cli/intent.yaml
+++ b/test/integration/targets/ios_interface/tests/cli/intent.yaml
@@ -5,8 +5,6 @@
   ios_interface:
     name: "{{ test_interface }}"
     state: up
-    tx_rate: ge(0)
-    rx_rate: ge(0)
     provider: "{{ cli }}"
   register: result
 
@@ -18,8 +16,6 @@
   ios_interface:
     name: "{{ test_interface }}"
     state: down
-    tx_rate: gt(0)
-    rx_rate: lt(0)
     provider: "{{ cli }}"
   ignore_errors: yes
   register: result
@@ -28,8 +24,6 @@
     that:
       - "result.failed == true"
       - "'state eq(down)' in result.failed_conditions"
-      - "'tx_rate gt(0)' in result.failed_conditions"
-      - "'rx_rate lt(0)' in result.failed_conditions"
 
 - name: Config + intent
   ios_interface:

--- a/test/integration/targets/ios_smoke/tests/cli/common_utils.yaml
+++ b/test/integration/targets/ios_smoke/tests/cli/common_utils.yaml
@@ -103,8 +103,6 @@
   ios_interface:
     name: "{{ test_interface }}"
     state: up
-    tx_rate: ge(0)
-    rx_rate: ge(0)
     provider: "{{ cli }}"
   register: result
 
@@ -116,8 +114,6 @@
   ios_interface:
     name: "{{ test_interface }}"
     state: down
-    tx_rate: gt(0)
-    rx_rate: lt(0)
     provider: "{{ cli }}"
   ignore_errors: yes
   register: result
@@ -126,8 +122,6 @@
     that:
       - "result.failed == true"
       - "'state eq(down)' in result.failed_conditions"
-      - "'tx_rate gt(0)' in result.failed_conditions"
-      - "'rx_rate lt(0)' in result.failed_conditions"
 
 - name: Config + intent
   ios_interface:
@@ -154,7 +148,5 @@
     that:
       - "result.failed == true"
       - "'state eq(up)' in result.failed_conditions"
-
-
 
 - debug: msg="END ios_smoke cli/common_utils.yaml on connection={{ ansible_connection }}"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fix ios integration test failures in CI. Since the packet transfer and receive rate
on the interface is not determined to remove the tx_rate and rx_rate test conditions
to prevent intermittent failure.
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Test Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
ios_interface/tests/cli/intent.yaml

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
