### PR TITLE
facts: Detecting NVME partitions under Linux

### DIFF
--- a/lib/ansible/module_utils/facts/hardware/linux.py
+++ b/lib/ansible/module_utils/facts/hardware/linux.py
@@ -615,7 +615,7 @@ class LinuxHardware(Hardware):
 
             d['partitions'] = {}
             for folder in os.listdir(sysdir):
-                m = re.search("(" + diskname + r"\d+)", folder)
+                m = re.search("(" + diskname + r"[p]*\d+)", folder)
                 if m:
                     part = {}
                     partname = m.group(1)


### PR DESCRIPTION
##### SUMMARY
In the current state of the code, the nvme partitions are returned as empty as in :
        "ansible_devices": {
            "nvme0n1": {
                "model": "SAMSUNG MZVLW256HEHP-000L7",
                "partitions": {},

The parsing of the /sys/block/<diskname> try to find a disk named like :
    <diskname><x> as in sda1 for sda

But in the nvme context, the partition of nvme0n1 is named nvme0n1p1.
This add a possible 'p' between the diskname and the partname.

This patch simply add the option of having a 'p' between the diskname
and the partname.

The patch works on my host :
                "model": "INTEL SSDPEDMD400G4",
                "partitions": {
                    "nvme0n1p1": {
                         ...
                        "size": "93.13 GB",
                    }

Fixes #38742
Signed-off-by: Erwan Velu <erwan@redhat.com>

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
fact

##### ANSIBLE VERSION
ansible 2.6.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/erwan/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Aug  4 2017, 00:39:18) [GCC 4.8.5 20150623 (Red Hat 4.8.5-16)]



##### ADDITIONAL INFORMATION
Before, there is no partitions for my nvme device, after it does show it.

 "nvme0n1": {
                "holders": [], 
                "host": "Non-Volatile memory controller: Intel Corporation PCIe Data Center SSD (rev 01)", 
                "links": {
                    "ids": [
                        "nvme-INTEL_SSDPEDMD400G4_CVFT623300HY400BGN", 
                        "nvme-nvme.8086-43564654363233333030485934303042474e-494e54454c205353445045444d443430304734-00000001"
                    ], 
                    "labels": [], 
                    "masters": [], 
                    "uuids": []
                }, 
                "model": "INTEL SSDPEDMD400G4", 
                "partitions": {}
                }, 



 "nvme0n1": {
                "holders": [], 
                "host": "Non-Volatile memory controller: Intel Corporation PCIe Data Center SSD (rev 01)", 
                "links": {
                    "ids": [
                        "nvme-INTEL_SSDPEDMD400G4_CVFT623300HY400BGN", 
                        "nvme-nvme.8086-43564654363233333030485934303042474e-494e54454c205353445045444d443430304734-00000001"
                    ], 
                    "labels": [], 
                    "masters": [], 
                    "uuids": []
                }, 
                "model": "INTEL SSDPEDMD400G4", 
                "partitions": {
                    "nvme0n1p1": {
                        "holders": [], 
                        "links": {
                            "ids": [
                                "lvm-pv-uuid-XN7bf3-l0QX-CEAi-cnWl-3QL5-FmeI-DhpLTO", 
                                "nvme-INTEL_SSDPEDMD400G4_CVFT623300HY400BGN-part1", 
                                "nvme-nvme.8086-43564654363233333030485934303042474e-494e54454c205353445045444d443430304734-00000001-part1"
                            ], 
                            "labels": [], 
                            "masters": [], 
                            "uuids": []
                        }, 
                        "sectors": "195312467", 
                        "sectorsize": 512, 
                        "size": "93.13 GB", 
                        "start": "34", 
                        "uuid": null
                    }
                }, 
