### PR TITLE
Fix pep8 and pylint errors in ovirt_permissions_facts.py

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_permissions_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_permissions_facts.py
@@ -94,10 +94,14 @@ from ansible.module_utils.ovirt import (
 def _permissions_service(connection, module):
     if module.params['user_name']:
         service = connection.system_service().users_service()
-        entity = next(iter(service.list(search='usrname={}'.format(
-                    '{}@{}'.format(module.params['user_name'], module.params['authz_name'])
+        entity = next(
+            iter(
+                service.list(
+                    search='usrname={0}'.format(
+                        '{0}@{1}'.format(module.params['user_name'], module.params['authz_name'])
+                    )
                 )
-            )),
+            ),
             None
         )
     else:


### PR DESCRIPTION
##### SUMMARY
Fix E126, E123 pep8 errors, and ansible-format-automatic-specification pylint error
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/ovirt/ovirt_permissions_facts.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```