### PR TITLE
Fetch ios default config is defaults is enabled

### DIFF
--- a/lib/ansible/modules/network/ios/ios_config.py
+++ b/lib/ansible/modules/network/ios/ios_config.py
@@ -351,13 +351,13 @@ def load_banners(module, banners):
         run_commands(module, ['\n'])
 
 
-def get_running_config(module, current_config=None):
+def get_running_config(module, current_config=None, flags=None):
     contents = module.params['running_config']
+
     if not contents:
         if not module.params['defaults'] and current_config:
             contents, banners = extract_banners(current_config.config_text)
         else:
-            flags = get_defaults_flag(module) if module.params['defaults'] else []
             contents = get_config(module, flags=flags)
     contents, banners = extract_banners(contents)
     return NetworkConfig(indent=1, contents=contents), banners
@@ -445,9 +445,10 @@ def main():
     result['warnings'] = warnings
 
     config = None
+    flags = get_defaults_flag(module) if module.params['defaults'] else []
 
     if module.params['backup'] or (module._diff and module.params['diff_against'] == 'running'):
-        contents = get_config(module)
+        contents = get_config(module, flags=flags)
         config = NetworkConfig(indent=1, contents=contents)
         if module.params['backup']:
             result['__backup__'] = contents
@@ -460,7 +461,7 @@ def main():
         candidate, want_banners = get_candidate(module)
 
         if match != 'none':
-            config, have_banners = get_running_config(module, config)
+            config, have_banners = get_running_config(module, config, flags=flags)
             path = module.params['parents']
             configobjs = candidate.difference(config, path=path, match=match, replace=replace)
         else:


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
If default option is eanbled fetch the current
running configuration by adding `all` or `full`
flag
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
ios_config

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
