### PR TITLE
Integrate bug/docs report and FR issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,5 +1,5 @@
 ---
-name: Bug report
+name: 🐛 Bug report
 about: Create a report to help us improve
 
 ---

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,61 @@
+---
+name: Bug report
+about: Create a report to help us improve
+
+---
+
+<!---
+Verify first that your issue/request is not already reported on GitHub.
+THIS FORM WILL BE READ BY A MACHINE, COMPLETE ALL SECTIONS AS DESCRIBED.
+Also test if the latest release, and devel branch are affected too.
+ALWAYS add information AFTER (OUTSIDE) these html comments.
+Otherwise it may end up being automatically closed by our bot. -->
+
+##### ISSUE TYPE
+ - Bug Report
+
+##### COMPONENT NAME
+<!--- Insert, BELOW THIS COMMENT, the name of the module, plugin, task or feature.
+Do not include extra details here, e.g. "vyos_command" not "the network module vyos_command" or the full path-->
+
+##### ANSIBLE VERSION
+<!--- Paste, BELOW THIS COMMENT, verbatim output from "ansible --version" between quotes below -->
+```
+
+```
+
+##### CONFIGURATION
+<!--- If using Ansible 2.4 or above, paste, BELOW THIS COMMENT, the results of "ansible-config dump --only-changed"
+Otherwise, mention any settings you have changed/added/removed in ansible.cfg
+(or using the ANSIBLE_* environment variables).-->
+
+##### OS / ENVIRONMENT
+<!--- Mention, BELOW THIS COMMENT, the OS you are running Ansible from, and the OS you are
+managing, or say "N/A" for anything that is not platform-specific.
+Also mention the specific version of what you are trying to control,
+e.g. if this is a network bug the version of firmware on the network device.-->
+
+##### SUMMARY
+<!--- Explain the problem briefly -->
+
+##### STEPS TO REPRODUCE
+<!--- For bugs, show exactly how to reproduce the problem, using a minimal test-case.
+For new features, show how the feature would be used. -->
+
+<!--- Paste example playbooks or commands between quotes below -->
+```yaml
+
+```
+
+<!--- You can also paste gist.github.com links for larger files -->
+
+##### EXPECTED RESULTS
+<!--- What did you expect to happen when running the steps above? -->
+
+##### ACTUAL RESULTS
+<!--- What actually happened? If possible run with extra verbosity (-vvvv) -->
+
+<!--- Paste verbatim command output between quotes below -->
+```
+
+```

--- a/.github/ISSUE_TEMPLATE/documentation_report.md
+++ b/.github/ISSUE_TEMPLATE/documentation_report.md
@@ -1,5 +1,5 @@
 ---
-name: Documentation Report
+name: 📝 Documentation Report
 about: Ask us about docs
 
 ---

--- a/.github/ISSUE_TEMPLATE/documentation_report.md
+++ b/.github/ISSUE_TEMPLATE/documentation_report.md
@@ -1,0 +1,61 @@
+---
+name: Documentation Report
+about: Ask us about docs
+
+---
+
+<!---
+Verify first that your issue/request is not already reported on GitHub.
+THIS FORM WILL BE READ BY A MACHINE, COMPLETE ALL SECTIONS AS DESCRIBED.
+Also test if the latest release, and devel branch are affected too.
+ALWAYS add information AFTER (OUTSIDE) these html comments.
+Otherwise it may end up being automatically closed by our bot. -->
+
+##### ISSUE TYPE
+ - Documentation Report
+
+##### COMPONENT NAME
+<!--- Insert, BELOW THIS COMMENT, the name of the module, plugin, task or feature.
+Do not include extra details here, e.g. "vyos_command" not "the network module vyos_command" or the full path-->
+
+##### ANSIBLE VERSION
+<!--- Paste, BELOW THIS COMMENT, verbatim output from "ansible --version" between quotes below -->
+```
+
+```
+
+##### CONFIGURATION
+<!--- If using Ansible 2.4 or above, paste, BELOW THIS COMMENT, the results of "ansible-config dump --only-changed"
+Otherwise, mention any settings you have changed/added/removed in ansible.cfg
+(or using the ANSIBLE_* environment variables).-->
+
+##### OS / ENVIRONMENT
+<!--- Mention, BELOW THIS COMMENT, the OS you are running Ansible from, and the OS you are
+managing, or say "N/A" for anything that is not platform-specific.
+Also mention the specific version of what you are trying to control,
+e.g. if this is a network bug the version of firmware on the network device.-->
+
+##### SUMMARY
+<!--- Explain the problem briefly -->
+
+##### STEPS TO REPRODUCE
+<!--- For bugs, show exactly how to reproduce the problem, using a minimal test-case.
+For new features, show how the feature would be used. -->
+
+<!--- Paste example playbooks or commands between quotes below -->
+```yaml
+
+```
+
+<!--- You can also paste gist.github.com links for larger files -->
+
+##### EXPECTED RESULTS
+<!--- What did you expect to happen when running the steps above? -->
+
+##### ACTUAL RESULTS
+<!--- What actually happened? If possible run with extra verbosity (-vvvv) -->
+
+<!--- Paste verbatim command output between quotes below -->
+```
+
+```

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,5 +1,5 @@
 ---
-name: Feature request
+name: ✨ Feature request
 about: Suggest an idea for this project
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,61 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+
+---
+
+<!---
+Verify first that your issue/request is not already reported on GitHub.
+THIS FORM WILL BE READ BY A MACHINE, COMPLETE ALL SECTIONS AS DESCRIBED.
+Also test if the latest release, and devel branch are affected too.
+ALWAYS add information AFTER (OUTSIDE) these html comments.
+Otherwise it may end up being automatically closed by our bot. -->
+
+##### ISSUE TYPE
+ - Feature Idea
+
+##### COMPONENT NAME
+<!--- Insert, BELOW THIS COMMENT, the name of the module, plugin, task or feature.
+Do not include extra details here, e.g. "vyos_command" not "the network module vyos_command" or the full path-->
+
+##### ANSIBLE VERSION
+<!--- Paste, BELOW THIS COMMENT, verbatim output from "ansible --version" between quotes below -->
+```
+
+```
+
+##### CONFIGURATION
+<!--- If using Ansible 2.4 or above, paste, BELOW THIS COMMENT, the results of "ansible-config dump --only-changed"
+Otherwise, mention any settings you have changed/added/removed in ansible.cfg
+(or using the ANSIBLE_* environment variables).-->
+
+##### OS / ENVIRONMENT
+<!--- Mention, BELOW THIS COMMENT, the OS you are running Ansible from, and the OS you are
+managing, or say "N/A" for anything that is not platform-specific.
+Also mention the specific version of what you are trying to control,
+e.g. if this is a network bug the version of firmware on the network device.-->
+
+##### SUMMARY
+<!--- Explain the problem briefly -->
+
+##### STEPS TO REPRODUCE
+<!--- For bugs, show exactly how to reproduce the problem, using a minimal test-case.
+For new features, show how the feature would be used. -->
+
+<!--- Paste example playbooks or commands between quotes below -->
+```yaml
+
+```
+
+<!--- You can also paste gist.github.com links for larger files -->
+
+##### EXPECTED RESULTS
+<!--- What did you expect to happen when running the steps above? -->
+
+##### ACTUAL RESULTS
+<!--- What actually happened? If possible run with extra verbosity (-vvvv) -->
+
+<!--- Paste verbatim command output between quotes below -->
+```
+
+```


### PR DESCRIPTION
##### SUMMARY
GitHub has publicly released feature of having several different templates for different issue types a few days ago. It looks pretty neat and is going to help users have issue type pre-sellected when creating issue. Bot flow is unaffected by this change.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
‒

##### ANSIBLE VERSION
‒

##### ADDITIONAL INFORMATION
Ref: maintainers/early-access-feedback#139 (accessible only to EAP members)
Example project with this feature enabled: https://github.com/aio-libs/multidict/issues/new/choose
Example 2: https://github.com/babel/babel/issues/new/choose

// successor of #39727