### PR TITLE
Create postgresql_slot.py

### DIFF
--- a/lib/ansible/modules/database/postgresql/postgresql_slot.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_slot.py
@@ -1,0 +1,203 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Copyright: Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+ANSIBLE_METADATA = {'metadata_version': '1.0',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+DOCUMENTATION = '''
+module: postgresql_slot
+short_description: Add or remove replication slots from a PostgreSQL database.
+description: Add or remove both physical and logical replication slots from a PostgreSQL database.
+version_added: "2.4"
+options:
+  name:
+    description:
+      - name of the slot to add or remove
+    required: true
+  type:
+    description:
+      - slots come in two distinct flavors: physical | logical
+    choices: [ "physical", "logical" ]
+    required: true  
+  db:
+    description:
+      - name of the database to add | remove only the logical slot to/from
+    required: false, only needed if type = logical
+  decoder:
+    description:
+      - all logical slots must indicate which decoder they're using
+    required: false, but if type = logical, defaults to "test_decoding"
+  login_user:
+    description:
+      - The username used to authenticate with
+  login_password:
+    description:
+      - The password used to authenticate with
+  login_host:
+    description:
+      - Host running the database
+    default: localhost
+  port:
+    description:
+      - Database port to connect to.
+    default: 5432
+  state:
+    description:
+      - The slot state
+    default: present
+    choices: [ "present", "absent" ]
+notes:
+   - The default authentication assumes that you are either logging in as or sudo'ing to the C(postgres) account on the host.
+   - This module uses I(psycopg2), a Python PostgreSQL database adapter. You must ensure that psycopg2 is installed on
+     the host before using this module. If the remote host is the PostgreSQL server (which is the default case), then PostgreSQL must also be installed
+     on the remote host. For Ubuntu-based systems, install the C(postgresql), C(libpq-dev), and C(python-psycopg2) packages on the remote host before using
+      this module.
+requirements: [ psycopg2 ]
+author: "John Scalia (@jscalia)"
+'''
+
+EXAMPLES = '''
+# Adds physical_slot_one to the cluster running on target host default port 5432
+- postgresql_slot:
+    name: physical_slot_one
+    state: present
+
+# Add a logical_slot_one to the database "acme" on target host default port 5432
+# Note that cluster must be already be configured with wal_level=logical and no effort is made to ensure the
+# decoder specified actually exists on the target host
+- postgresql_slot:
+    name: logical_slot_one
+    type: logical
+    state: present
+    decoder: custom_decoder_one
+'''
+import traceback
+
+try:
+    import psycopg2
+    import psycopg2.extras
+except ImportError:
+    postgresqldb_found = False
+else:
+    postgresqldb_found = True
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_native
+
+class NotSupportedError(Exception):
+    pass
+   
+# ===========================================
+# PostgreSQL module specific support methods.
+#
+
+def slot_exists(cursor, slot):
+    query = "SELECT * FROM pg_replication_slots WHERE slot_name='%s'" % slot
+    cursor.execute(query, {'slot': slot})
+    return cursor.rowcount == 1
+
+
+def slot_delete(cursor, slot):
+    if slot_exists(cursor, slot):
+        query = "SELECT pg_drop_replication_slot('%s')" % slot
+        cursor.execute(query)
+        return True
+    else:
+        return False
+
+
+def slot_create_physical(cursor, slot): 
+    if not slot_exists(cursor, slot):
+        query = "SELECT pg_create_physical_replication_slot('%s')" % slot
+        cursor.execute(query)
+        return True
+    else:
+        return False
+
+def slot_create_logical(cursor, slot, decoder):
+    if not slot_exists(cursor, slot):
+        query = "SELECT pg_create_logical_replication_slot('%s', '%s')" % (slot, decoder)
+        cursor.execute(query)
+        return True
+    else:
+        return False
+
+# ===========================================
+# Module execution.
+#
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            login_user=dict(default="postgres"),
+            login_password=dict(default="", no_log=True),
+            login_host=dict(default=""),
+            port=dict(default="5432"),
+            db=dict(required=False),
+            slot=dict(required=True, aliases=['name']),
+            type=dict(default="physical", choices=["physical", "logical"]),
+            decoder=dict(default="test_decoding"),
+            state=dict(default="present", choices=["absent", "present"]),
+        ),
+        supports_check_mode=True
+    )
+
+    if not postgresqldb_found:
+        module.fail_json(msg="the python psycopg2 module is required")
+
+    db = module.params["db"]
+    slot = module.params["slot"]
+    type = module.params["type"]
+    state = module.params["state"]
+    decoder = module.params["decoder"]
+    changed = False
+
+    # To use defaults values, keyword arguments must be absent, so
+    # check which values are empty and don't include in the **kw
+    # dictionary
+    params_map = {
+        "login_host": "host",
+        "login_user": "user",
+        "login_password": "password",
+        "port": "port"
+    }
+    kw = dict((params_map[k], v) for (k, v) in module.params.items()
+              if k in params_map and v != '')
+    try:
+        db_connection = psycopg2.connect(database=db, **kw)
+        # Enable autocommit so we can create databases
+        if psycopg2.__version__ >= '2.4.2':
+            db_connection.autocommit = True
+
+        cursor = db_connection.cursor(
+            cursor_factory=psycopg2.extras.DictCursor)
+         except Exception as e:
+        module.fail_json(msg="unable to connect to database: %s" % to_native(e), exception=traceback.format_exc())
+
+    try:
+        if module.check_mode:
+            if state == "present":
+                changed = not slot_exists(cursor, slot)
+            elif state == "absent":
+                changed = slot_exists(cursor, slot)
+        else:
+            if state == "absent":
+                changed = slot_delete(cursor, slot)
+            elif state == "present":
+                if type == "physical":
+                     changed = slot_create_physical(cursor, slot)
+                else:
+                     changed = slot_create_logical(cursor, slot, decoder)
+    except NotSupportedError as e:
+        module.fail_json(msg=to_native(e), exception=traceback.format_exc())
+    except Exception as e:
+        module.fail_json(msg="Database query failed: %s" % to_native(e), exception=traceback.format_exc())
+        
+    module.exit_json(changed=changed, db=db, slot=slot)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/database/postgresql/postgresql_slot.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_slot.py
@@ -86,12 +86,14 @@ except ImportError:
 else:
     postgresqldb_found = True
 
+    
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 
+
 class NotSupportedError(Exception):
     pass
-   
+
 # ===========================================
 # PostgreSQL module specific support methods.
 #

--- a/lib/ansible/modules/database/postgresql/postgresql_slot.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_slot.py
@@ -174,7 +174,7 @@ def main():
 
         cursor = db_connection.cursor(
             cursor_factory=psycopg2.extras.DictCursor)
-         except Exception as e:
+    except Exception as e:
         module.fail_json(msg="unable to connect to database: %s" % to_native(e), exception=traceback.format_exc())
 
     try:

--- a/lib/ansible/modules/database/postgresql/postgresql_slot.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_slot.py
@@ -22,7 +22,7 @@ options:
     description:
       - slots come in two distinct flavors: physical and logical
     choices: [ "physical", "logical" ]
-    required: true  
+    required: true
   db:
     description:
       - name of the database to add or remove the logical slot

--- a/lib/ansible/modules/database/postgresql/postgresql_slot.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_slot.py
@@ -20,17 +20,18 @@ options:
     required: true
   type:
     description:
-      - slots come in two distinct flavors: physical | logical
+      - slots come in two distinct flavors: physical and logical
     choices: [ "physical", "logical" ]
     required: true  
   db:
     description:
-      - name of the database to add | remove only the logical slot to/from
+      - name of the database to add or remove the logical slot
     required: false, only needed if type = logical
   decoder:
     description:
       - all logical slots must indicate which decoder they're using
-    required: false, but if type = logical, defaults to "test_decoding"
+    required: false
+    default: test_decoding
   login_user:
     description:
       - The username used to authenticate with


### PR DESCRIPTION
There are currently many modules for postgresql databases, but managing replication slots is not currently present. This module rectifies that omission. This is my first attempt at adding a module.

##### SUMMARY
<!--- Managing replication slots can currently only be performed using shell commands -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
 - New Module Pull Request

##### COMPONENT NAME
postgresql_slot

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0 (devel 4c5ac16447) last updated 2018/05/04 06:57:19 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/419635/ansible/lib/ansible
  executable location = /home/419635/ansible/bin/ansible
  python version = 2.7.5 (default, May  3 2017, 07:55:04) [GCC 4.8.5 20150623 (Red Hat 4.8.5-14)]
```


##### ADDITIONAL INFORMATION
This new module was adapted from the existing postgresql_ext module. I used that one as a model for creating this one. It has been tested on several government systems.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
