### PR TITLE
Removing stretch items for 2.6 roadmap

### DIFF
--- a/docs/docsite/rst/roadmap/ROADMAP_2_6.rst
+++ b/docs/docsite/rst/roadmap/ROADMAP_2_6.rst
@@ -51,18 +51,12 @@ Connection work
 * New connection plugin: eAPI `proposal#102 <https://github.com/ansible/proposals/issues/102>`_
 * New connection plugin: NX-API
 * Support for configurable options for network_cli & netconf
-* Stretch & tech preview: New connection plugin for gRPC
-* Stretch: netconf plugin for IOS
-* Stretch: netconf plugin for NXOS
 
 Modules
 =======
 
 * New ``cli_config`` - platform agnostic module for sending text based config over network_cli
 * New ``cli_command`` - platform agnostic command module
-* New ``netconf_get`` - implements the standard netconf get rpc
-* New ``netconf_config`` - implements the standard netconf edit/configure rpc 
-* New ``netconf_rpc`` - calls any playbook defined rpc on the remote device and returns the results
 * New ``network_get`` - platform agnostic module for pulling configuration via SCP/SFTP over network_cli
 * New ``network_put`` - platform agnostic module for pushing configuration via SCP/SFTP over network_cli
 


### PR DESCRIPTION
  * netconf modules
  * gRPC connection plugin

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Updating the 2.6 roadmap to reflect the actual 2.6 features getting delivered.

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
