### PR TITLE
Use updated task, instead of original, non-merged included_file._task

### DIFF
--- a/changelogs/fragments/includes.yaml
+++ b/changelogs/fragments/includes.yaml
@@ -14,3 +14,4 @@ bugfixes:
 - dynamic includes - Allow inheriting attributes from static parents (https://github.com/ansible/ansible/pull/38827)
 - include_role/import_role - improved performance and recursion depth (https://github.com/ansible/ansible/pull/36470)
 - include_role/import_role - Fix parameter templating (https://github.com/ansible/ansible/pull/36372)
+- dynamic includes - Use the copied and merged task for calculating task vars (https://github.com/ansible/ansible/pull/39762)

--- a/lib/ansible/plugins/strategy/linear.py
+++ b/lib/ansible/plugins/strategy/linear.py
@@ -363,7 +363,7 @@ class StrategyModule(StrategyBase):
                             for new_block in new_blocks:
                                 task_vars = self._variable_manager.get_vars(
                                     play=iterator._play,
-                                    task=included_file._task,
+                                    task=new_block._parent
                                 )
                                 display.debug("filtering new block on tags")
                                 final_block = new_block.filter_tagged_tasks(play_context, task_vars)


### PR DESCRIPTION
##### SUMMARY
Use updated task, instead of original, non-merged included_file._task. Fixes #39637

Before this change, we were using `included_file._task` in our call to `get_vars`.  However, what is missing here, is that `included_file._args` aren't merged into `included_file._task.vars`.  `_args` is merged into `vars` in `_copy_included_file` which is then later used as the parent of the new block.

Use `new_block._parent` instead, which is the merged copy.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/strategy/linear.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```