### PR TITLE
doc for _config backup argument (#38650)

### DIFF
--- a/lib/ansible/modules/network/eos/eos_config.py
+++ b/lib/ansible/modules/network/eos/eos_config.py
@@ -131,9 +131,8 @@ options:
         folder in the playbook root directory or role root directory, if
         playbook is part of an ansible role. If the directory does not exist,
         it is created.
-    required: false
-    default: no
     type: bool
+    default: 'no'
     version_added: "2.2"
   running_config:
     description:

--- a/lib/ansible/modules/network/ios/ios_config.py
+++ b/lib/ansible/modules/network/ios/ios_config.py
@@ -136,9 +136,8 @@ options:
         folder in the playbook root directory or role root directory, if
         playbook is part of an ansible role. If the directory does not exist,
         it is created.
-    required: false
-    default: no
     type: bool
+    default: 'no'
     version_added: "2.2"
   running_config:
     description:

--- a/lib/ansible/modules/network/iosxr/iosxr_config.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_config.py
@@ -133,9 +133,8 @@ options:
         folder in the playbook root directory or role root directory, if
         playbook is part of an ansible role. If the directory does not exist,
         it is created.
-    required: false
-    default: no
-    choices: ['yes', 'no']
+    type: bool
+    default: 'no'
     version_added: "2.2"
   comment:
     description:

--- a/lib/ansible/modules/network/junos/junos_config.py
+++ b/lib/ansible/modules/network/junos/junos_config.py
@@ -108,9 +108,8 @@ options:
         folder in the playbook root directory or role root directory, if
         playbook is part of an ansible role. If the directory does not exist,
         it is created.
-    required: false
-    default: no
-    choices: ['yes', 'no']
+    type: bool
+    default: 'no'
     version_added: "2.2"
   update:
     description:

--- a/lib/ansible/modules/network/nxos/nxos_config.py
+++ b/lib/ansible/modules/network/nxos/nxos_config.py
@@ -137,9 +137,8 @@ options:
         folder in the playbook root directory or role root directory, if
         playbook is part of an ansible role. If the directory does not exist,
         it is created.
-    required: false
-    default: false
     type: bool
+    default: 'no'
     version_added: "2.2"
   running_config:
     description:

--- a/lib/ansible/modules/network/vyos/vyos_config.py
+++ b/lib/ansible/modules/network/vyos/vyos_config.py
@@ -73,9 +73,8 @@ options:
         in the playbook root directory or role root directory, if
         playbook is part of an ansible role. If the directory does not
         exist, it is created.
-    required: false
-    default: false
-    choices: ['yes', 'no']
+    type: bool
+    default: 'no'
   comment:
     description:
       - Allows a commit description to be specified to be included


### PR DESCRIPTION
(cherry-picked from commit 6de49f0)

##### SUMMARY
Refines module docs for network *_config modules, explaining that when executing 
backups, the backup directory will be created if it does not exist.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
network module docs

##### ANSIBLE VERSION
2.5
