### PR TITLE
Backport #39764 for 2.5 - async_status environment

### DIFF
--- a/changelogs/fragments/async_status_env.yaml
+++ b/changelogs/fragments/async_status_env.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- async - Ensure that the implicit async_status gets the env from a task with async (https://github.com/ansible/ansible/pull/39764)

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -703,7 +703,7 @@ class TaskExecutor:
         # that (with a sleep for "poll" seconds between each retry) until the
         # async time limit is exceeded.
 
-        async_task = Task().load(dict(action='async_status jid=%s' % async_jid))
+        async_task = Task().load(dict(action='async_status jid=%s' % async_jid, environment=self._task.environment))
 
         # FIXME: this is no longer the case, normal takes care of all, see if this can just be generalized
         # Because this is an async task, the action handler is async. However,


### PR DESCRIPTION
##### SUMMARY
Backport #39764 for 2.5 - async_status environment

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/executor/task_executor.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
