### PR TITLE
Adding digital_ocean_space alias for s3_bucket module

### DIFF
--- a/lib/ansible/modules/cloud/amazon/s3_bucket.py
+++ b/lib/ansible/modules/cloud/amazon/s3_bucket.py
@@ -137,7 +137,7 @@ except ImportError:
     pass  # handled by AnsibleAWSModule
 
 
-def create_or_update_bucket(s3_client, module, location):
+def create_or_update_bucket(s3_client, location):
 
     policy = module.params.get("policy")
     name = module.params.get("name")

--- a/lib/ansible/modules/cloud/amazon/s3_bucket.py
+++ b/lib/ansible/modules/cloud/amazon/s3_bucket.py
@@ -21,9 +21,11 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = '''
 ---
 module: s3_bucket
-short_description: Manage S3 buckets in AWS, Ceph, Walrus and FakeS3
+short_description: Manage S3 buckets in AWS, DigitalOcean, Ceph, Walrus and FakeS3
 description:
-    - Manage S3 buckets in AWS, Ceph, Walrus and FakeS3
+    - Manage S3 buckets in AWS, DigitalOcean, Ceph, Walrus and FakeS3
+    - DigitalOcean Spaces support is available through the `digital_ocean_space` module name or setting `s3_url` parameter to a DigitalOcean endpoint.
+      (ex. `https://ams3.digitaloceanspaces.com`)
 version_added: "2.0"
 requirements: [ boto3 ]
 author: "Rob White (@wimnat)"
@@ -43,7 +45,7 @@ options:
       - The JSON policy as a string.
   s3_url:
     description:
-      - S3 URL endpoint for usage with Ceph, Eucalyptus and fakes3 etc.
+      - S3 URL endpoint for usage with DigitalOcean, Ceph, Eucalyptus and fakes3 etc.
       - Assumes AWS if not specified.
       - For Walrus, use FQDN of the endpoint without scheme nor path.
     aliases: [ S3_URL ]
@@ -110,6 +112,11 @@ EXAMPLES = '''
     tags:
       example: tag1
       another: tag2
+
+# Create a simple DigitalOcean Spaces bucket using their provided regional endpoint
+- digital_ocean_space:
+    name: mydobucket
+    s3_url: 'https://nyc3.digitaloceanspaces.com'
 
 '''
 

--- a/lib/ansible/modules/cloud/amazon/s3_bucket.py
+++ b/lib/ansible/modules/cloud/amazon/s3_bucket.py
@@ -112,7 +112,7 @@ EXAMPLES = '''
       another: tag2
 
 # Create a simple DigitalOcean Spaces bucket using their provided regional endpoint
-- digital_ocean_space:
+- s3_bucket:
     name: mydobucket
     s3_url: 'https://nyc3.digitaloceanspaces.com'
 

--- a/lib/ansible/modules/cloud/amazon/s3_bucket.py
+++ b/lib/ansible/modules/cloud/amazon/s3_bucket.py
@@ -24,8 +24,6 @@ module: s3_bucket
 short_description: Manage S3 buckets in AWS, DigitalOcean, Ceph, Walrus and FakeS3
 description:
     - Manage S3 buckets in AWS, DigitalOcean, Ceph, Walrus and FakeS3
-    - DigitalOcean Spaces support is available through the `digital_ocean_space` module name or setting `s3_url` parameter to a DigitalOcean endpoint.
-      (ex. `https://ams3.digitaloceanspaces.com`)
 version_added: "2.0"
 requirements: [ boto3 ]
 author: "Rob White (@wimnat)"

--- a/lib/ansible/modules/cloud/amazon/s3_bucket.py
+++ b/lib/ansible/modules/cloud/amazon/s3_bucket.py
@@ -137,7 +137,7 @@ except ImportError:
     pass  # handled by AnsibleAWSModule
 
 
-def create_or_update_bucket(s3_client, location):
+def create_or_update_bucket(s3_client, module, location):
 
     policy = module.params.get("policy")
     name = module.params.get("name")
@@ -156,7 +156,7 @@ def create_or_update_bucket(s3_client, location):
 
     if not bucket_is_present:
         try:
-            bucket_changed = create_bucket(s3_client, name, location)
+            bucket_changed = create_bucket(s3_client, module, name, location)
             s3_client.get_waiter('bucket_exists').wait(Bucket=name)
             changed = changed or bucket_changed
         except WaiterError as e:

--- a/lib/ansible/modules/cloud/amazon/s3_bucket.py
+++ b/lib/ansible/modules/cloud/amazon/s3_bucket.py
@@ -156,7 +156,7 @@ def create_or_update_bucket(s3_client, module, location):
 
     if not bucket_is_present:
         try:
-            bucket_changed = create_bucket(s3_client, module, name, location)
+            bucket_changed = create_bucket(s3_client, name, location)
             s3_client.get_waiter('bucket_exists').wait(Bucket=name)
             changed = changed or bucket_changed
         except WaiterError as e:

--- a/test/sanity/validate-modules/skip.txt
+++ b/test/sanity/validate-modules/skip.txt
@@ -1,1 +1,2 @@
 lib/ansible/modules/utilities/logic/async_status.py
+lib/ansible/modules/cloud/digital_ocean/digital_ocean_space.py

--- a/test/sanity/validate-modules/skip.txt
+++ b/test/sanity/validate-modules/skip.txt
@@ -1,2 +1,1 @@
 lib/ansible/modules/utilities/logic/async_status.py
-lib/ansible/modules/cloud/digital_ocean/digital_ocean_space.py


### PR DESCRIPTION
##### SUMMARY
This PR is based off of suggestions from #38774.  I am adding a symlink called `digital_ocean_space` that points to the `s3_bucket` module.  This means that using that alias will direct the AWS modules to use a default DigitalOcean endpoint if the user doesn't already specify it with the `s3_url` parameter.  This alias works for me in my basic testing but I could use some more eyes to see if I'm missing anything important.  One thing to note:  I do have some rudimentary integration testing for this alias and it involved filling in some stuff in the `ansible/test/runner` directory. I'm not sure if I should include that work here or if that would warrant another pull request.

@willthames @BondAnthony

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
`s3_bucket`
`digital_ocean_space`

##### ANSIBLE VERSION
```
ansible 2.4.1.0
  config file = None
  configured module search path = [u'/Users/asmith/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/asmith/.pyenv/versions/2.7.13/lib/python2.7/site-packages/ansible
  executable location = /Users/asmith/.pyenv/versions/2.7.13/bin/ansible
  python version = 2.7.13 (default, Sep  8 2017, 15:16:38) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```

##### ADDITIONAL INFORMATION
N/A
