### PR TITLE
Add random_mac string filter

### DIFF
--- a/changelogs/fragments/add_random_mac_filtter.yaml
+++ b/changelogs/fragments/add_random_mac_filtter.yaml
@@ -1,0 +1,6 @@
+---
+minor_changes:
+  - Added new filter to generate random MAC addresses from a given
+    string acting as a prefix. Refer to the appropriate entry
+    which has been added to user_guide playbook_filters.rst
+    document.

--- a/docs/docsite/rst/user_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters.rst
@@ -243,6 +243,22 @@ An example of using this filter with ``loop``::
         key: "{{ lookup('file', item.1) }}"
       loop: "{{ users|subelements('authorized') }}"
 
+.. _random_mac_filter:
+
+Random Mac Address Filter
+`````````````````````````
+
+.. versionadded:: 2.6
+
+This filter can be used to generate a random MAC address from a string prefix.
+
+To get a random MAC address from a string prefix starting with '52:54:00'::
+
+    "{{ '52:54:00'|random_mac }}"
+    # => '52:54:00:ef:1c:03'
+
+Note that if anything is wrong with the prefix string, the filter will issue an error.
+
 .. _random_filter:
 
 Random Number Filter

--- a/test/integration/targets/filters/tasks/main.yml
+++ b/test/integration/targets/filters/tasks/main.yml
@@ -193,3 +193,45 @@
     - "'QW5zaWJsZSAtIOOBj+OCieOBqOOBvwo=' | b64decode == 'Ansible - くらとみ\n'"
     - "'Ansible - くらとみ\n' | b64encode(encoding='utf-16-le') == 'QQBuAHMAaQBiAGwAZQAgAC0AIABPMIkwaDB/MAoA'"
     - "'QQBuAHMAaQBiAGwAZQAgAC0AIABPMIkwaDB/MAoA' | b64decode(encoding='utf-16-le') == 'Ansible - くらとみ\n'"
+
+- name: Test random_mac filter bad argument type
+  debug:
+    var: "0 | random_mac"
+  register: _bad_random_mac_filter
+  ignore_errors: yes
+
+- name: Verify random_mac filter showed a bad argument type error message
+  assert:
+    that:
+      - _bad_random_mac_filter is failed
+      - "_bad_random_mac_filter.msg is match('Invalid value type (.*int.*) for random_mac .*')"
+
+- name: Test random_mac filter bad argument value
+  debug:
+    var: "'dummy' | random_mac"
+  register: _bad_random_mac_filter
+  ignore_errors: yes
+
+- name: Verify random_mac filter showed a bad argument value error message
+  assert:
+    that:
+      - _bad_random_mac_filter is failed
+      - "_bad_random_mac_filter.msg is match('Invalid value (.*) for random_mac: .* not hexa byte')"
+
+- name: Test random_mac filter prefix too big
+  debug:
+    var: "'00:00:00:00:00:00' | random_mac"
+  register: _bad_random_mac_filter
+  ignore_errors: yes
+
+- name: Verify random_mac filter showed a prefix too big error message
+  assert:
+    that:
+      - _bad_random_mac_filter is failed
+      - "_bad_random_mac_filter.msg is match('Invalid value (.*) for random_mac: 5 colon.* separated items max')"
+
+- name:  Verify random_mac filter
+  assert:
+    that:
+            - "'00:00:00' | random_mac is match('^00:00:00:[a-f0-9][a-f0-9]:[a-f0-9][a-f0-9]:[a-f0-9][a-f0-9]$')"
+            - "'00:00:00' | random_mac != '00:00:00' | random_mac"


### PR DESCRIPTION
##### SUMMARY
Add random_mac string filter which can be used when creating KVM/libvirt VMs for instance:
00:00:00 | random_mac
will return a string value like
00:00:00:23:85:bc

##### ISSUE TYPE
 - New Filter Pull Request

##### COMPONENT NAME
core filters

##### ANSIBLE VERSION
```
ansible 2.5.1
  config file = None
  configured module search path = [u'/Users/olivierbourdon/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/olivierbourdon/.venvs/ansible-brew-py27/lib/python2.7/site-packages/ansible
  executable location = /Users/olivierbourdon/.venvs/ansible-brew-py27/bin/ansible
  python version = 2.7.14 (default, Sep 22 2017, 00:06:07) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```


##### ADDITIONAL INFORMATION
Tests added for all potential errors and standard case