### PR TITLE
New option to clean untracked and ignored files

### DIFF
--- a/test/integration/targets/git/tasks/clean.yml
+++ b/test/integration/targets/git/tasks/clean.yml
@@ -1,0 +1,102 @@
+---
+- name: CLEAN | clear checkout_dir
+  file: state=absent path={{ checkout_dir }}
+
+- name: CLEAN | Clone example git repo that we are going to modify
+  git:
+    repo: '{{ repo_format1 }}'
+    dest: '{{ checkout_dir }}/repo'
+
+- name: CLEAN | add untracked and ignored file
+  file: path='{{ checkout_dir }}/repo/{{ item }}' state=touch
+  with_items:
+    - untracked_file1
+    - ignoreme
+
+- name: CLEAN | update README.md file
+  copy: content='BLAH' dest='{{ checkout_dir }}/repo/README.md'
+
+- name: CLEAN | add gitignore file
+  copy: content='ignoreme' dest='{{ checkout_dir }}/repo/.gitignore'
+
+- name: CLEAN | try git clone now with local changes
+  git:
+    repo: '{{ repo_format1 }}'
+    dest: '{{ checkout_dir }}/repo'
+  ignore_errors: yes
+  register: git_clone
+
+- name: CLEAN | git clone should fail when local changes exist
+  assert:
+    that:
+      - git_clone.failed
+
+- name: CLEAN | clean only ignored files
+  git:
+    repo: '{{ repo_format1 }}'
+    dest: '{{ checkout_dir }}/repo'
+    clean: ignored
+  register: git_clean_ignored
+
+- name: CLEAN | ignored files should be cleaned
+  assert:
+    that:
+      - git_clean_ignored is changed
+
+- name: CLEAN | clean only untracked files
+  git:
+    repo: '{{ repo_format1 }}'
+    dest: '{{ checkout_dir }}/repo'
+    clean: untracked
+  register: git_clean_untracked
+
+- name: CLEAN | untracked files should be cleaned
+  assert:
+    that:
+      - git_clean_untracked is changed
+
+- name: CLEAN | Try cleaning ignored files again
+  git:
+    repo: '{{ repo_format1 }}'
+    dest: '{{ checkout_dir }}/repo'
+    clean: ignored
+  register: git_clean_ignored_2
+
+- name: CLEAN | No more ignored files
+  assert:
+    that:
+      - not git_clean_ignored_2 is changed
+
+- name: CLEAN | Try cleaning untracked files again
+  git:
+    repo: '{{ repo_format1 }}'
+    dest: '{{ checkout_dir }}/repo'
+    clean: untracked
+  register: git_clean_untracked_2
+
+- name: CLEAN | No more untracked files
+  assert:
+    that:
+      - not git_clean_untracked_2 is changed
+
+- name: CLEAN | add untracked and ignored file
+  file: path='{{ checkout_dir }}/repo/{{ item }}' state=touch
+  with_items:
+    - untracked_file1
+    - ignoreme
+
+- name: CLEAN | add gitignore file
+  copy: content='ignoreme' dest='{{ checkout_dir }}/repo/.gitignore'
+
+- name: CLEAN | now clone using clean
+  git:
+    repo: '{{ repo_format1 }}'
+    dest: '{{ checkout_dir }}/repo'
+    clean: all
+  ignore_errors: yes
+  register: git_clone
+
+- name: CLEAN | clone works after cleaning all files
+  assert:
+    that:
+      - git_clone is changed

--- a/test/integration/targets/git/tasks/main.yml
+++ b/test/integration/targets/git/tasks/main.yml
@@ -34,6 +34,7 @@
     - gpg_version.stdout
     - not (ansible_os_family == 'RedHat' and ansible_distribution_major_version is version('7', '<'))
 - import_tasks: localmods.yml
+- import_tasks: clean.yml
 - import_tasks: reset-origin.yml
 - import_tasks: ambiguous-ref.yml
 - import_tasks: archive.yml


### PR DESCRIPTION
##### SUMMARY

This is a rebase of the PR: https://github.com/ansible/ansible/issues/20554

Git module should have an option to run git clean -f to remove untracked files. This is useful to say build a project from a pristine repository. Currently, all untracked files remain in the directory.

The clean_ignored and clean_untracked options will clean ignored and untracked file respectively.

Fixes #14357

**EDIT**: Rebased with latest 2.11 devel release. Hopefull gets merged.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
git

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.11.0.dev0 (rags/git-clean 5c17411231) last updated 2020/10/25 15:49:38 (GMT +550)
  config file = None
  configured module search path = ['/Users/raghu/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/raghu/repos/ansible/lib/ansible
  ansible collection location = /Users/raghu/.ansible/collections:/usr/share/ansible/collections
  executable location = /Users/raghu/repos/ansible/bin/ansible
  python version = 3.8.5 (default, Jul 21 2020, 10:48:26) [Clang 11.0.3 (clang-1103.0.32.62)]
  libyaml = True
```