### PR TITLE
Fixes #37752 Delete all versions and deletemarkers in S3_Bucket when force paramet…

### DIFF
--- a/lib/ansible/modules/cloud/amazon/s3_bucket.py
+++ b/lib/ansible/modules/cloud/amazon/s3_bucket.py
@@ -416,11 +416,13 @@ def paginated_list(s3_client, **pagination_params):
     for page in pg.paginate(**pagination_params):
         yield [data['Key'] for data in page.get('Contents', [])]
 
+
 def paginated_versions_list(s3_client, **pagination_params):
     pg = s3_client.get_paginator('list_object_versions')
     for page in pg.paginate(**pagination_params):
         # We have to merge the Versions and DeleteMarker lists here, as DeleteMarkers can still prevent a bucket deletion
         yield [(data['Key'], data['VersionId']) for data in (page.get('Versions', []) + page.get('DeleteMarkers', []))]
+
 
 def destroy_bucket(s3_client, module):
 

--- a/lib/ansible/modules/cloud/amazon/s3_bucket.py
+++ b/lib/ansible/modules/cloud/amazon/s3_bucket.py
@@ -30,7 +30,7 @@ author: "Rob White (@wimnat)"
 options:
   force:
     description:
-      - When trying to delete a bucket, delete all keys in the bucket first (an s3 bucket must be empty for a successful deletion)
+      - When trying to delete a bucket, delete all keys (including versions) in the bucket first (an s3 bucket must be empty for a successful deletion)
     type: bool
     default: 'no'
   name:
@@ -416,6 +416,11 @@ def paginated_list(s3_client, **pagination_params):
     for page in pg.paginate(**pagination_params):
         yield [data['Key'] for data in page.get('Contents', [])]
 
+def paginated_versions_list(s3_client, **pagination_params):
+    pg = s3_client.get_paginator('list_object_versions')
+    for page in pg.paginate(**pagination_params):
+        # We have to merge the Versions and DeleteMarker lists here, as DeleteMarkers can still prevent a bucket deletion
+        yield [(data['Key'], data['VersionId']) for data in (page.get('Versions', []) + page.get('DeleteMarkers', []))]
 
 def destroy_bucket(s3_client, module):
 
@@ -432,10 +437,10 @@ def destroy_bucket(s3_client, module):
         module.exit_json(changed=False)
 
     if force:
-        # if there are contents then we need to delete them before we can delete the bucket
+        # if there are contents then we need to delete them (including versions) before we can delete the bucket
         try:
-            for keys in paginated_list(s3_client, Bucket=name):
-                formatted_keys = [{'Key': key} for key in keys]
+            for key_version_pairs in paginated_versions_list(s3_client, Bucket=name):
+                formatted_keys = [{'Key': key, 'VersionId': version} for key, version in key_version_pairs]
                 if formatted_keys:
                     s3_client.delete_objects(Bucket=name, Delete={'Objects': formatted_keys})
         except (BotoCoreError, ClientError) as e:

--- a/lib/ansible/modules/cloud/amazon/s3_bucket.py
+++ b/lib/ansible/modules/cloud/amazon/s3_bucket.py
@@ -30,7 +30,8 @@ author: "Rob White (@wimnat)"
 options:
   force:
     description:
-      - When trying to delete a bucket, delete all keys (including versions) in the bucket first (an s3 bucket must be empty for a successful deletion)
+      - When trying to delete a bucket, delete all keys (including versions and delete markers)
+        in the bucket first (an s3 bucket must be empty for a successful deletion)
     type: bool
     default: 'no'
   name:


### PR DESCRIPTION
…er is passed

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Creates a new method `paginated_versions_list` in the s3_bucket module to return a more complex list of tuples of object `Key` and `VersionId`s including those of `DeleteMarker`s for all items in the bucket. Then uses this to generate the list of objects to be deleted to allow the `force: true` parameter to handle buckets with versioning turned on successfully.
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
Fixes #37752 by deleting all object versions and `DeleteMarker`s before attempting bucket deletion
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
s3_bucket
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
