### PR TITLE
Fix eos_config integration test failure (#39662)

### DIFF
--- a/test/integration/targets/eos_config/tests/cli/check_mode.yaml
+++ b/test/integration/targets/eos_config/tests/cli/check_mode.yaml
@@ -6,6 +6,8 @@
      lines:
          - ip address 119.31.1.1 255.255.255.256
      parents: interface Loopback911
+     provider: "{{ cli }}"
+  become: yes
   check_mode: 1
   environment:
     ANSIBLE_EOS_USE_SESSIONS: 1
@@ -23,6 +25,8 @@
     before:
       - "no ip access-list test"
     src: basic/cmds.j2
+    provider: "{{ cli }}"
+  become: yes
   check_mode: yes
   register: config
 
@@ -31,6 +35,7 @@
     commands:
       - show configuration sessions | json
     provider: "{{ cli }}"
+  become: yes
   register: result
 
 - assert:
@@ -42,6 +47,8 @@
      lines:
          - ip address 119.31.1.1 255.255.255.256
      parents: interface Loopback911
+     provider: "{{ cli }}"
+  become: yes
   check_mode: 1
   environment:
     ANSIBLE_EOS_USE_SESSIONS: 0
@@ -57,6 +64,8 @@
      lines:
          - ip address 119.31.1.1 255.255.255.255
      parents: interface Loopback911
+     provider: "{{ cli }}"
+  become: yes
   check_mode: yes
   register: result
   environment:


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Enable become for eos_config check_mode test cases
(cherry picked from commit b20b964c4aa6f0d62b8d133319346b3ff8a656af)

Merged to devel https://github.com/ansible/ansible/pull/39662

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Test Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
eos_config/tests/cli/check_mode.yaml
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
