### PR TITLE
rewrite get_resource_pool method for correct resource_pool selection

### DIFF
--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -76,8 +76,8 @@ def wait_for_vm_ip(content, vm, timeout=300):
     return facts
 
 
-def find_obj(content, vimtype, name, first=True):
-    container = content.viewManager.CreateContainerView(container=content.rootFolder, recursive=True, type=vimtype)
+def find_obj(content, vimtype, name, first=True, folder=None):
+    container = content.viewManager.CreateContainerView(folder or content.rootFolder, recursive=True, type=vimtype)
     obj_list = container.view
     container.Destroy()
 
@@ -98,22 +98,6 @@ def find_obj(content, vimtype, name, first=True):
 
     # Return all matching objects if needed
     return [obj for obj in obj_list if obj.name == name]
-
-
-def find_objs(content, vimtypes, container=None, name=None):
-    """ Get all objects of certain type(s) and optionally match name """
-    items = []
-    cv = content.viewManager.CreateContainerView(container or content.rootFolder,
-                                                 vimtypes, recursive=True)
-    # make sure name does not contain a path
-    if name:
-        name = name.split('/')[-1]
-
-    for item in cv.view:
-        if not name or item.name == name:
-            items.append(item)
-    cv.Destroy()
-    return items
 
 
 def find_dvspg_by_name(dv_switch, portgroup_name):

--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -78,26 +78,18 @@ def wait_for_vm_ip(content, vm, timeout=300):
 
 def find_obj(content, vimtype, name, first=True, folder=None):
     container = content.viewManager.CreateContainerView(folder or content.rootFolder, recursive=True, type=vimtype)
-    obj_list = container.view
+    # Get all objects matching type (and name if given)
+    obj_list = [obj for obj in container.view if not name or to_text(obj.name) == to_text(name)]
     container.Destroy()
 
-    # Backward compatible with former get_obj() function
-    if name is None:
+    # Return first match or None
+    if first:
         if obj_list:
             return obj_list[0]
         return None
 
-    # Select the first match
-    if first is True:
-        for obj in obj_list:
-            if to_text(obj.name) == to_text(name):
-                return obj
-
-        # If no object found, return None
-        return None
-
-    # Return all matching objects if needed
-    return [obj for obj in obj_list if obj.name == name]
+    # Return all matching objects or empty list
+    return obj_list
 
 
 def find_dvspg_by_name(dv_switch, portgroup_name):

--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -105,6 +105,10 @@ def find_objs(content, vimtypes, container=None, name=None):
     items = []
     cv = content.viewManager.CreateContainerView(container or content.rootFolder,
                                                  vimtypes, recursive=True)
+    # make sure name does not contain a path
+    if name:
+        name = name.split('/')[-1]
+
     for item in cv.view:
         if not name or item.name == name:
             items.append(item)

--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -100,6 +100,18 @@ def find_obj(content, vimtype, name, first=True):
     return [obj for obj in obj_list if obj.name == name]
 
 
+def find_objs(content, vimtypes, container=None, name=None):
+    """ Get all objects of certain type(s) and optionally match name """
+    items = []
+    cv = content.viewManager.CreateContainerView(container or content.rootFolder,
+                                                 vimtypes, recursive=True)
+    for item in cv.view:
+        if not name or item.name == name:
+            items.append(item)
+    cv.Destroy()
+    return items
+
+
 def find_dvspg_by_name(dv_switch, portgroup_name):
 
     portgroups = dv_switch.portgroup

--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -1901,11 +1901,6 @@ class PyVmomiHelper(PyVmomi):
         host_name = host or self.params['esxi_hostname']
         resource_pool_name = resource_pool or self.params['resource_pool']
 
-        # if folder is given, only keep name
-        cluster_name = cluster_name.rsplit('/')[-1]
-        host_name = host_name.rsplit('/')[-1]
-        resource_pool_name = resource_pool_name.rsplit('/')[-1]
-
         # get the datacenter object
         datacenter_list = find_objs(self.content, [vim.Datacenter], None, self.params['datacenter'])
         if not datacenter_list:

--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -1901,6 +1901,11 @@ class PyVmomiHelper(PyVmomi):
         host_name = host or self.params['esxi_hostname']
         resource_pool_name = resource_pool or self.params['resource_pool']
 
+        # if folder is given, only keep name
+        cluster_name = cluster_name.rsplit('/')[-1]
+        host_name = host_name.rsplit('/')[-1]
+        resource_pool_name = resource_pool_name.rsplit('/')[-1]
+
         # get the datacenter object
         datacenter_list = find_objs(self.content, [vim.Datacenter], None, self.params['datacenter'])
         if not datacenter_list:

--- a/test/integration/targets/vmware_guest/tasks/cdrom_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/cdrom_d1_c1_f0.yml
@@ -35,7 +35,7 @@
     folder: "/{{ (clusterlist['json'][0]|basename).split('_')[0] }}/vm"
     name: CDROM-Test
     datacenter: "{{ (clusterlist['json'][0]|basename).split('_')[0] }}"
-    cluster: "{{ clusterlist['json'][0] }}"
+    cluster: "{{ clusterlist['json'][0]|basename }}"
     resource_pool: Resources
     guest_id: centos64Guest
     hardware:

--- a/test/integration/targets/vmware_guest/tasks/vapp_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/vapp_d1_c1_f0.yml
@@ -35,7 +35,7 @@
     folder: "/{{ (clusterlist['json'][0]|basename).split('_')[0] }}/vm"
     name: vApp-Test
     datacenter: "{{ (clusterlist['json'][0]|basename).split('_')[0] }}"
-    cluster: "{{ clusterlist['json'][0] }}"
+    cluster: "{{ clusterlist['json'][0]|basename }}"
     resource_pool: Resources
     guest_id: centos64Guest
     hardware:


### PR DESCRIPTION
##### SUMMARY
Fixes #33156 cluster option is ignored and #38043 random resource_pool selection when multiple resource_pools exist with the same name.

This change rewrites the get_resource_pool method to correctly select the resource pool based on all of the following parameters if given: datacenter, cluster, esxi_hostname and resource_pool.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
vmware_guest

##### ANSIBLE VERSION
```
2.5.2
```