### PR TITLE
vmware_guest: cast vlan to int or str when relevant

### DIFF
--- a/changelogs/fragments/38398-vmware_guest_typecast_vlan.yaml
+++ b/changelogs/fragments/38398-vmware_guest_typecast_vlan.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- Typecast VLAN ID to match various conditions. Explicitly converting to integer/string will make the module works as expected with or without the NativeType support.

--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -915,10 +915,10 @@ class PyVmomiHelper(PyVmomi):
                 dvps = self.cache.get_all_objs(self.content, [vim.dvs.DistributedVirtualPortgroup])
                 for dvp in dvps:
                     if hasattr(dvp.config.defaultPortConfig, 'vlan') and \
-                            dvp.config.defaultPortConfig.vlan.vlanId == network['vlan']:
+                            dvp.config.defaultPortConfig.vlan.vlanId == int(network['vlan']):
                         network['name'] = dvp.config.name
                         break
-                    if dvp.config.name == network['vlan']:
+                    if dvp.config.name == str(network['vlan']):
                         network['name'] = dvp.config.name
                         break
                 else:


### PR DESCRIPTION
##### SUMMARY
`network['vlan']` should be a VLAN ID
Integers passed around using jinja variable references are
converted to strings (see # 9362)
The # 32738 PR should allow using 'NativeType' in ansible
Explicitly converting to integer will make the module works
as expected with or without the NativeType support

`network['vlan']` can also be a VLAN NAME (fallback)
Explicitly converting to string will make the module works
as expected with or without the NativeType support

Signed-off-by: Matthieu Fronton <m@tthieu.fr>
Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

(cherry picked from commit a0b4462aea1a3294d69dc487b02c22cddf08d9cd)

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/38398-vmware_guest_typecast_vlan.yaml
lib/ansible/modules/cloud/vmware/vmware_guest.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
Stable-2.5
```