### PR TITLE
facts: Detecting NVME partitions under Linux (#39730)

### DIFF
--- a/lib/ansible/module_utils/facts/hardware/linux.py
+++ b/lib/ansible/module_utils/facts/hardware/linux.py
@@ -585,7 +585,7 @@ class LinuxHardware(Hardware):
 
             d['partitions'] = {}
             for folder in os.listdir(sysdir):
-                m = re.search("(" + diskname + r"[p]*\d+)", folder)
+                m = re.search("(" + diskname + r"[p]?\d+)", folder)
                 if m:
                     part = {}
                     partname = m.group(1)

--- a/lib/ansible/module_utils/facts/hardware/linux.py
+++ b/lib/ansible/module_utils/facts/hardware/linux.py
@@ -585,7 +585,7 @@ class LinuxHardware(Hardware):
 
             d['partitions'] = {}
             for folder in os.listdir(sysdir):
-                m = re.search("(" + diskname + r"\d+)", folder)
+                m = re.search("(" + diskname + r"[p]*\d+)", folder)
                 if m:
                     part = {}
                     partname = m.group(1)


### PR DESCRIPTION
In the current state of the code, the nvme partitions are returned as empty as in :
        "ansible_devices": {
            "nvme0n1": {
                "model": "SAMSUNG MZVLW256HEHP-000L7",
                "partitions": {},

The parsing of the /sys/block/<diskname> try to find a disk named like :
    <diskname><x> as in sda1 for sda

But in the nvme context, the partition of nvme0n1 is named nvme0n1p1.
This add a possible 'p' between the diskname and the partname.

This patch simply add the option of having a 'p' between the diskname
and the partname.

The patch works on my host :
                "model": "INTEL SSDPEDMD400G4",
                "partitions": {
                    "nvme0n1p1": {
                         ...
                        "size": "93.13 GB",
                    }

Fixes #38742
Signed-off-by: Erwan Velu <erwan@redhat.com>
(cherry picked from commit 2214c747a22d594177f524d1f7e7e1f078c52491)

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - New Module Pull Request
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
