### PR TITLE
Pass obj=data to AnsibleParserError for context in IncludeRole

### DIFF
--- a/lib/ansible/playbook/role_include.py
+++ b/lib/ansible/playbook/role_include.py
@@ -112,12 +112,12 @@ class IncludeRole(TaskInclude):
         # name is needed, or use role as alias
         ir._role_name = ir.args.get('name', ir.args.get('role'))
         if ir._role_name is None:
-            raise AnsibleParserError("'name' is a required field for %s." % ir.action)
+            raise AnsibleParserError("'name' is a required field for %s." % ir.action, obj=data)
 
         # validate bad args, otherwise we silently ignore
         bad_opts = my_arg_names.difference(IncludeRole.VALID_ARGS)
         if bad_opts:
-            raise AnsibleParserError('Invalid options for %s: %s' % (ir.action, ','.join(list(bad_opts))))
+            raise AnsibleParserError('Invalid options for %s: %s' % (ir.action, ','.join(list(bad_opts))), obj=data)
 
         # build options for role includes
         for key in my_arg_names.intersection(IncludeRole.FROM_ARGS):


### PR DESCRIPTION
##### SUMMARY
Pass obj=data to AnsibleParserError for context in IncludeRole. Fixes #31374

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/playbook/role_include.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.4
2.5
2.6
```


##### ADDITIONAL INFORMATION
before:
```
ERROR! 'name' is a required field for include_role.
```

after:
```
ERROR! 'name' is a required field for include_role.

The error appears to have been in '/Users/matt/projects/ansibledev/playbooks/31374/31374.yml': line 4, column 7, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

  tasks:
    - include_role: foo
      ^ here
```