### PR TITLE
Add IncludeRole.get_name to provide better name for include_role

### DIFF
--- a/lib/ansible/playbook/role_include.py
+++ b/lib/ansible/playbook/role_include.py
@@ -64,6 +64,10 @@ class IncludeRole(TaskInclude):
         self._role_name = None
         self._role_path = None
 
+    def get_name(self):
+        ''' return the name of the task '''
+        return "%s : %s" % (self.action, self._role_name)
+
     def get_block_list(self, play=None, variable_manager=None, loader=None):
 
         # only need play passed in when dynamic


### PR DESCRIPTION
##### SUMMARY
Add IncludeRole.get_name to provide better name for include_role. Fixes #36343

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/playbook/role_include.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.4
2.5
2.6
```


##### ADDITIONAL INFORMATION
before:
```
TASK [include_role] **************************************************************************************************
```

after:
```
TASK [include_role : foo] ********************************************************************************************
```