### PR TITLE
Tower modules: move HAS_TOWER_CLI check in module_utils and minor improvements

### DIFF
--- a/lib/ansible/module_utils/ansible_tower.py
+++ b/lib/ansible/module_utils/ansible_tower.py
@@ -95,6 +95,14 @@ class TowerModule(AnsibleModule):
         )
         args.update(argument_spec)
 
+        mutually_exclusive = kwargs.get('mutually_exclusive', [])
+        kwargs['mutually_exclusive'] = mutually_exclusive.extend((
+            ('tower_config_file', 'tower_host'),
+            ('tower_config_file', 'tower_username'),
+            ('tower_config_file', 'tower_password'),
+            ('tower_config_file', 'tower_verify_ssl'),
+        ))
+
         super(TowerModule, self).__init__(argument_spec=args, **kwargs)
 
         if not HAS_TOWER_CLI:

--- a/lib/ansible/module_utils/ansible_tower.py
+++ b/lib/ansible/module_utils/ansible_tower.py
@@ -37,6 +37,8 @@ try:
 except ImportError:
     HAS_TOWER_CLI = False
 
+from ansible.module_utils.basic import AnsibleModule
+
 
 def tower_auth_config(module):
     '''tower_auth_config attempts to load the tower-cli.cfg file
@@ -82,11 +84,18 @@ def tower_check_mode(module):
             module.fail_json(changed=False, msg='Failed check mode: {0}'.format(excinfo))
 
 
-def tower_argument_spec():
-    return dict(
-        tower_host=dict(),
-        tower_username=dict(),
-        tower_password=dict(no_log=True),
-        tower_verify_ssl=dict(type='bool', default=True),
-        tower_config_file=dict(type='path'),
-    )
+class TowerModule(AnsibleModule):
+    def __init__(self, argument_spec, **kwargs):
+        args = dict(
+            tower_host=dict(),
+            tower_username=dict(),
+            tower_password=dict(no_log=True),
+            tower_verify_ssl=dict(type='bool', default=True),
+            tower_config_file=dict(type='path'),
+        )
+        args.update(argument_spec)
+
+        super(TowerModule, self).__init__(argument_spec=args, **kwargs)
+
+        if not HAS_TOWER_CLI:
+            self.fail_json(msg='ansible-tower-cli required for this module')

--- a/lib/ansible/module_utils/ansible_tower.py
+++ b/lib/ansible/module_utils/ansible_tower.py
@@ -49,7 +49,6 @@ def tower_auth_config(module):
     '''
     config_file = module.params.pop('tower_config_file', None)
     if config_file:
-        config_file = os.path.expanduser(config_file)
         if not os.path.exists(config_file):
             module.fail_json(msg='file not found: %s' % config_file)
         if os.path.isdir(config_file):

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_credential.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_credential.py
@@ -128,7 +128,7 @@ EXAMPLES = '''
 import os
 
 from ansible.module_utils._text import to_text
-from ansible.module_utils.ansible_tower import tower_argument_spec, tower_auth_config, tower_check_mode, HAS_TOWER_CLI
+from ansible.module_utils.ansible_tower import TowerModule, tower_auth_config, tower_check_mode
 
 try:
     import tower_cli
@@ -178,8 +178,7 @@ def credential_type_for_v1_kind(params, module):
 
 def main():
 
-    argument_spec = tower_argument_spec()
-    argument_spec.update(dict(
+    argument_spec = dict(
         name=dict(required=True),
         user=dict(),
         team=dict(),
@@ -206,12 +205,9 @@ def main():
         organization=dict(required=True),
         project=dict(),
         state=dict(choices=['present', 'absent'], default='present'),
-    ))
+    )
 
-    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
-
-    if not HAS_TOWER_CLI:
-        module.fail_json(msg='ansible-tower-cli required for this module')
+    module = TowerModule(argument_spec=argument_spec, supports_check_mode=True)
 
     name = module.params.get('name')
     organization = module.params.get('organization')
@@ -291,6 +287,5 @@ def main():
     module.exit_json(**json_output)
 
 
-from ansible.module_utils.basic import AnsibleModule
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_group.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_group.py
@@ -93,7 +93,7 @@ EXAMPLES = '''
 
 import os
 
-from ansible.module_utils.ansible_tower import tower_argument_spec, tower_auth_config, tower_check_mode, HAS_TOWER_CLI
+from ansible.module_utils.ansible_tower import TowerModule, tower_auth_config, tower_check_mode
 
 try:
     import tower_cli
@@ -105,8 +105,7 @@ except ImportError:
 
 
 def main():
-    argument_spec = tower_argument_spec()
-    argument_spec.update(dict(
+    argument_spec = dict(
         name=dict(required=True),
         description=dict(),
         inventory=dict(required=True),
@@ -124,12 +123,9 @@ def main():
         overwrite_vars=dict(),
         update_on_launch=dict(type='bool', default=False),
         state=dict(choices=['present', 'absent'], default='present'),
-    ))
+    )
 
-    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
-
-    if not HAS_TOWER_CLI:
-        module.fail_json(msg='ansible-tower-cli required for this module')
+    module = TowerModule(argument_spec=argument_spec, supports_check_mode=True)
 
     name = module.params.get('name')
     inventory = module.params.get('inventory')
@@ -177,6 +173,5 @@ def main():
     module.exit_json(**json_output)
 
 
-from ansible.module_utils.basic import AnsibleModule
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_host.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_host.py
@@ -64,7 +64,7 @@ EXAMPLES = '''
 
 import os
 
-from ansible.module_utils.ansible_tower import tower_argument_spec, tower_auth_config, tower_check_mode, HAS_TOWER_CLI
+from ansible.module_utils.ansible_tower import TowerModule, tower_auth_config, tower_check_mode, HAS_TOWER_CLI
 
 try:
     import tower_cli
@@ -76,19 +76,15 @@ except ImportError:
 
 
 def main():
-    argument_spec = tower_argument_spec()
-    argument_spec.update(dict(
+    argument_spec = dict(
         name=dict(required=True),
         description=dict(),
         inventory=dict(required=True),
         enabled=dict(type='bool', default=True),
         variables=dict(),
         state=dict(choices=['present', 'absent'], default='present'),
-    ))
-    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
-
-    if not HAS_TOWER_CLI:
-        module.fail_json(msg='ansible-tower-cli required for this module')
+    )
+    module = TowerModule(argument_spec=argument_spec, supports_check_mode=True)
 
     name = module.params.get('name')
     description = module.params.get('description')
@@ -129,6 +125,5 @@ def main():
     module.exit_json(**json_output)
 
 
-from ansible.module_utils.basic import AnsibleModule
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_inventory.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_inventory.py
@@ -67,7 +67,7 @@ EXAMPLES = '''
 '''
 
 
-from ansible.module_utils.ansible_tower import tower_argument_spec, tower_auth_config, tower_check_mode, HAS_TOWER_CLI
+from ansible.module_utils.ansible_tower import TowerModule, tower_auth_config, tower_check_mode
 
 try:
     import tower_cli
@@ -79,8 +79,7 @@ except ImportError:
 
 
 def main():
-    argument_spec = tower_argument_spec()
-    argument_spec.update(dict(
+    argument_spec = dict(
         name=dict(required=True),
         description=dict(),
         organization=dict(required=True),
@@ -88,12 +87,9 @@ def main():
         kind=dict(choices=['', 'smart'], default=''),
         host_filter=dict(),
         state=dict(choices=['present', 'absent'], default='present'),
-    ))
+    )
 
-    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
-
-    if not HAS_TOWER_CLI:
-        module.fail_json(msg='ansible-tower-cli required for this module')
+    module = TowerModule(argument_spec=argument_spec, supports_check_mode=True)
 
     name = module.params.get('name')
     description = module.params.get('description')
@@ -130,6 +126,5 @@ def main():
     module.exit_json(**json_output)
 
 
-from ansible.module_utils.basic import AnsibleModule
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_inventory_source.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_inventory_source.py
@@ -183,13 +183,7 @@ EXAMPLES = '''
 RETURN = ''' # '''
 
 
-from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.ansible_tower import (
-    tower_argument_spec,
-    tower_auth_config,
-    tower_check_mode,
-    HAS_TOWER_CLI
-)
+from ansible.module_utils.ansible_tower import TowerModule, tower_auth_config, tower_check_mode
 
 try:
     import tower_cli
@@ -217,8 +211,7 @@ SOURCE_CHOICES = {
 
 
 def main():
-    argument_spec = tower_argument_spec()
-    argument_spec.update(dict(
+    argument_spec = dict(
         name=dict(required=True),
         description=dict(required=False),
         inventory=dict(required=True),
@@ -239,13 +232,9 @@ def main():
         update_on_launch=dict(type='bool', required=False),
         update_cache_timeout=dict(type='int', required=False),
         state=dict(choices=['present', 'absent'], default='present'),
-    ))
+    )
 
-    module = AnsibleModule(argument_spec=argument_spec,
-                           supports_check_mode=True)
-
-    if not HAS_TOWER_CLI:
-        module.fail_json(msg='ansible-tower-cli required for this module')
+    module = TowerModule(argument_spec=argument_spec, supports_check_mode=True)
 
     name = module.params.get('name')
     inventory = module.params.get('inventory')

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_cancel.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_cancel.py
@@ -54,9 +54,7 @@ status:
 '''
 
 
-from ansible.module_utils.basic import AnsibleModule
-
-from ansible.module_utils.ansible_tower import tower_auth_config, tower_check_mode, tower_argument_spec, HAS_TOWER_CLI
+from ansible.module_utils.ansible_tower import TowerModule, tower_auth_config, tower_check_mode
 
 try:
     import tower_cli
@@ -68,19 +66,15 @@ except ImportError:
 
 
 def main():
-    argument_spec = tower_argument_spec()
-    argument_spec.update(dict(
+    argument_spec = dict(
         job_id=dict(type='int', required=True),
         fail_if_not_running=dict(type='bool', default=False),
-    ))
+    )
 
-    module = AnsibleModule(
+    module = TowerModule(
         argument_spec=argument_spec,
         supports_check_mode=True,
     )
-
-    if not HAS_TOWER_CLI:
-        module.fail_json(msg='ansible-tower-cli required for this module')
 
     job_id = module.params.get('job_id')
     json_output = {}

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_launch.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_launch.py
@@ -82,9 +82,7 @@ status:
 '''
 
 
-from ansible.module_utils.basic import AnsibleModule
-
-from ansible.module_utils.ansible_tower import tower_auth_config, tower_check_mode, tower_argument_spec, HAS_TOWER_CLI
+from ansible.module_utils.ansible_tower import TowerModule, tower_auth_config, tower_check_mode
 
 try:
     import tower_cli
@@ -96,8 +94,7 @@ except ImportError:
 
 
 def main():
-    argument_spec = tower_argument_spec()
-    argument_spec.update(dict(
+    argument_spec = dict(
         job_template=dict(required=True),
         job_type=dict(choices=['run', 'check', 'scan']),
         inventory=dict(),
@@ -105,15 +102,12 @@ def main():
         limit=dict(),
         tags=dict(type='list'),
         extra_vars=dict(type='list'),
-    ))
+    )
 
-    module = AnsibleModule(
+    module = TowerModule(
         argument_spec,
         supports_check_mode=True
     )
-
-    if not HAS_TOWER_CLI:
-        module.fail_json(msg='ansible-tower-cli required for this module')
 
     json_output = {}
     tags = module.params.get('tags')

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_list.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_list.py
@@ -78,9 +78,7 @@ results:
 '''
 
 
-from ansible.module_utils.basic import AnsibleModule
-
-from ansible.module_utils.ansible_tower import tower_auth_config, tower_check_mode, tower_argument_spec, HAS_TOWER_CLI
+from ansible.module_utils.ansible_tower import TowerModule, tower_auth_config, tower_check_mode
 
 try:
     import tower_cli
@@ -92,21 +90,17 @@ except ImportError:
 
 
 def main():
-    argument_spec = tower_argument_spec()
-    argument_spec.update(dict(
+    argument_spec = dict(
         status=dict(choices=['pending', 'waiting', 'running', 'error', 'failed', 'canceled', 'successful']),
         page=dict(type='int'),
         all_pages=dict(type='bool', default=False),
         query=dict(type='dict'),
-    ))
+    )
 
-    module = AnsibleModule(
+    module = TowerModule(
         argument_spec=argument_spec,
         supports_check_mode=True
     )
-
-    if not HAS_TOWER_CLI:
-        module.fail_json(msg='ansible-tower-cli required for this module')
 
     json_output = {}
 

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_template.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_template.py
@@ -181,7 +181,7 @@ EXAMPLES = '''
     tower_config_file: "~/tower_cli.cfg"
 '''
 
-from ansible.module_utils.ansible_tower import tower_argument_spec, tower_auth_config, tower_check_mode, HAS_TOWER_CLI
+from ansible.module_utils.ansible_tower import TowerModule, tower_auth_config, tower_check_mode
 
 try:
     import tower_cli
@@ -250,8 +250,7 @@ def update_resources(module, p):
 
 
 def main():
-    argument_spec = tower_argument_spec()
-    argument_spec.update(dict(
+    argument_spec = dict(
         name=dict(required=True),
         description=dict(default=''),
         job_type=dict(choices=['run', 'check', 'scan'], required=True),
@@ -285,12 +284,9 @@ def main():
         diff_mode_enabled=dict(type='bool', default=False),
         concurrent_jobs_enabled=dict(type='bool', default=False),
         state=dict(choices=['present', 'absent'], default='present'),
-    ))
+    )
 
-    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
-
-    if not HAS_TOWER_CLI:
-        module.fail_json(msg='ansible-tower-cli required for this module')
+    module = TowerModule(argument_spec=argument_spec, supports_check_mode=True)
 
     name = module.params.get('name')
     state = module.params.pop('state')
@@ -318,6 +314,5 @@ def main():
     module.exit_json(**json_output)
 
 
-from ansible.module_utils.basic import AnsibleModule
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_wait.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_wait.py
@@ -81,8 +81,7 @@ status:
 '''
 
 
-from ansible.module_utils.ansible_tower import tower_auth_config, tower_check_mode, tower_argument_spec, HAS_TOWER_CLI
-from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.ansible_tower import TowerModule, tower_auth_config, tower_check_mode
 from ansible.module_utils.six.moves import cStringIO as StringIO
 
 
@@ -96,21 +95,17 @@ except ImportError:
 
 
 def main():
-    argument_spec = tower_argument_spec()
-    argument_spec.update(dict(
+    argument_spec = dict(
         job_id=dict(type='int', required=True),
         timeout=dict(type='int'),
         min_interval=dict(type='float', default=1),
         max_interval=dict(type='float', default=30),
-    ))
+    )
 
-    module = AnsibleModule(
+    module = TowerModule(
         argument_spec,
         supports_check_mode=True
     )
-
-    if not HAS_TOWER_CLI:
-        module.fail_json(msg='ansible-tower-cli required for this module')
 
     json_output = {}
     fail_json = None

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_label.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_label.py
@@ -49,7 +49,7 @@ EXAMPLES = '''
     tower_config_file: "~/tower_cli.cfg"
 '''
 
-from ansible.module_utils.ansible_tower import tower_argument_spec, tower_auth_config, tower_check_mode, HAS_TOWER_CLI
+from ansible.module_utils.ansible_tower import TowerModule, tower_auth_config, tower_check_mode
 
 try:
     import tower_cli
@@ -61,17 +61,13 @@ except ImportError:
 
 
 def main():
-    argument_spec = tower_argument_spec()
-    argument_spec.update(dict(
+    argument_spec = dict(
         name=dict(required=True),
         organization=dict(required=True),
         state=dict(choices=['present', 'absent'], default='present'),
-    ))
+    )
 
-    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
-
-    if not HAS_TOWER_CLI:
-        module.fail_json(msg='ansible-tower-cli required for this module')
+    module = TowerModule(argument_spec=argument_spec, supports_check_mode=True)
 
     name = module.params.get('name')
     organization = module.params.get('organization')
@@ -102,6 +98,5 @@ def main():
     module.exit_json(**json_output)
 
 
-from ansible.module_utils.basic import AnsibleModule
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_organization.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_organization.py
@@ -48,7 +48,7 @@ EXAMPLES = '''
     tower_config_file: "~/tower_cli.cfg"
 '''
 
-from ansible.module_utils.ansible_tower import tower_argument_spec, tower_auth_config, tower_check_mode, HAS_TOWER_CLI
+from ansible.module_utils.ansible_tower import TowerModule, tower_auth_config, tower_check_mode
 
 try:
     import tower_cli
@@ -60,17 +60,13 @@ except ImportError:
 
 
 def main():
-    argument_spec = tower_argument_spec()
-    argument_spec.update(dict(
+    argument_spec = dict(
         name=dict(required=True),
         description=dict(),
         state=dict(choices=['present', 'absent'], default='present'),
-    ))
+    )
 
-    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
-
-    if not HAS_TOWER_CLI:
-        module.fail_json(msg='ansible-tower-cli required for this module')
+    module = TowerModule(argument_spec=argument_spec, supports_check_mode=True)
 
     name = module.params.get('name')
     description = module.params.get('description')
@@ -95,6 +91,5 @@ def main():
     module.exit_json(**json_output)
 
 
-from ansible.module_utils.basic import AnsibleModule
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_project.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_project.py
@@ -84,7 +84,7 @@ EXAMPLES = '''
     tower_config_file: "~/tower_cli.cfg"
 '''
 
-from ansible.module_utils.ansible_tower import tower_argument_spec, tower_auth_config, tower_check_mode, HAS_TOWER_CLI
+from ansible.module_utils.ansible_tower import TowerModule, tower_auth_config, tower_check_mode
 
 try:
     import tower_cli
@@ -96,8 +96,7 @@ except ImportError:
 
 
 def main():
-    argument_spec = tower_argument_spec()
-    argument_spec.update(dict(
+    argument_spec = dict(
         name=dict(),
         description=dict(),
         organization=dict(),
@@ -111,12 +110,9 @@ def main():
         local_path=dict(),
 
         state=dict(choices=['present', 'absent'], default='present'),
-    ))
+    )
 
-    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
-
-    if not HAS_TOWER_CLI:
-        module.fail_json(msg='ansible-tower-cli required for this module')
+    module = TowerModule(argument_spec=argument_spec, supports_check_mode=True)
 
     name = module.params.get('name')
     description = module.params.get('description')
@@ -172,6 +168,5 @@ def main():
     module.exit_json(**json_output)
 
 
-from ansible.module_utils.basic import AnsibleModule
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_role.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_role.py
@@ -71,7 +71,7 @@ EXAMPLES = '''
     tower_config_file: "~/tower_cli.cfg"
 '''
 
-from ansible.module_utils.ansible_tower import tower_argument_spec, tower_auth_config, tower_check_mode, HAS_TOWER_CLI
+from ansible.module_utils.ansible_tower import TowerModule, tower_auth_config, tower_check_mode
 
 try:
     import tower_cli
@@ -110,8 +110,7 @@ def update_resources(module, p):
 
 def main():
 
-    argument_spec = tower_argument_spec()
-    argument_spec.update(dict(
+    argument_spec = dict(
         user=dict(),
         team=dict(),
         role=dict(choices=["admin", "read", "member", "execute", "adhoc", "update", "use", "auditor"]),
@@ -122,12 +121,9 @@ def main():
         organization=dict(),
         project=dict(),
         state=dict(choices=['present', 'absent'], default='present'),
-    ))
+    )
 
-    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
-
-    if not HAS_TOWER_CLI:
-        module.fail_json(msg='ansible-tower-cli required for this module')
+    module = TowerModule(argument_spec=argument_spec, supports_check_mode=True)
 
     role_type = module.params.pop('role')
     state = module.params.pop('state')
@@ -155,6 +151,5 @@ def main():
     module.exit_json(**json_output)
 
 
-from ansible.module_utils.basic import AnsibleModule
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_team.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_team.py
@@ -50,7 +50,7 @@ EXAMPLES = '''
     tower_config_file: "~/tower_cli.cfg"
 '''
 
-from ansible.module_utils.ansible_tower import tower_argument_spec, tower_auth_config, tower_check_mode, HAS_TOWER_CLI
+from ansible.module_utils.ansible_tower import TowerModule, tower_auth_config, tower_check_mode
 
 try:
     import tower_cli
@@ -63,18 +63,14 @@ except ImportError:
 
 def main():
 
-    argument_spec = tower_argument_spec()
-    argument_spec.update(dict(
+    argument_spec = dict(
         name=dict(required=True),
         description=dict(),
         organization=dict(required=True),
         state=dict(choices=['present', 'absent'], default='present'),
-    ))
+    )
 
-    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
-
-    if not HAS_TOWER_CLI:
-        module.fail_json(msg='ansible-tower-cli required for this module')
+    module = TowerModule(argument_spec=argument_spec, supports_check_mode=True)
 
     name = module.params.get('name')
     description = module.params.get('description')
@@ -107,6 +103,5 @@ def main():
     module.exit_json(**json_output)
 
 
-from ansible.module_utils.basic import AnsibleModule
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_user.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_user.py
@@ -71,7 +71,7 @@ EXAMPLES = '''
     tower_config_file: "~/tower_cli.cfg"
 '''
 
-from ansible.module_utils.ansible_tower import tower_argument_spec, tower_auth_config, tower_check_mode, HAS_TOWER_CLI
+from ansible.module_utils.ansible_tower import TowerModule, tower_auth_config, tower_check_mode
 
 try:
     import tower_cli
@@ -83,8 +83,7 @@ except ImportError:
 
 
 def main():
-    argument_spec = tower_argument_spec()
-    argument_spec.update(dict(
+    argument_spec = dict(
         username=dict(required=True),
         first_name=dict(),
         last_name=dict(),
@@ -93,12 +92,9 @@ def main():
         superuser=dict(type='bool', default=False),
         auditor=dict(type='bool', default=False),
         state=dict(choices=['present', 'absent'], default='present'),
-    ))
+    )
 
-    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
-
-    if not HAS_TOWER_CLI:
-        module.fail_json(msg='ansible-tower-cli required for this module')
+    module = TowerModule(argument_spec=argument_spec, supports_check_mode=True)
 
     username = module.params.get('username')
     first_name = module.params.get('first_name')
@@ -130,6 +126,5 @@ def main():
     module.exit_json(**json_output)
 
 
-from ansible.module_utils.basic import AnsibleModule
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
##### SUMMARY

Tower modules:
* move common code in `module_utils`
* flag `tower_auth_args` as mutually exclusive with `tower_host`, `tower_username`, `tower_username` and `tower_verify_ssl` (see https://github.com/ansible/ansible/issues/36988#issuecomment-370443318)
* remove useless call to `os.path.expanduser`

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
tower modules

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0 (devel 3b496db4d8) last updated 2018/05/05 02:10:49 (GMT +200)
```