### PR TITLE
Use a more exact regex

### DIFF
--- a/lib/ansible/module_utils/facts/hardware/linux.py
+++ b/lib/ansible/module_utils/facts/hardware/linux.py
@@ -615,7 +615,7 @@ class LinuxHardware(Hardware):
 
             d['partitions'] = {}
             for folder in os.listdir(sysdir):
-                m = re.search("(" + diskname + r"[p]*\d+)", folder)
+                m = re.search("(" + diskname + r"[p]?\d+)", folder)
                 if m:
                     part = {}
                     partname = m.group(1)


### PR DESCRIPTION
The pattern we're matching can have zero or one p.  Be more careful to
match exactly that.

Slight revision of #39730

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME
facts

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```
Will join the backport to 2.5 in https://github.com/ansible/ansible/pull/39804