### PR TITLE
Restore nuage_vspk integration tests.

### DIFF
--- a/test/integration/targets/nuage_vspk/aliases
+++ b/test/integration/targets/nuage_vspk/aliases
@@ -1,3 +1,2 @@
 posix/ci/group1
 skip/python3
-disabled

--- a/test/integration/targets/nuage_vspk/tasks/main.yml
+++ b/test/integration/targets/nuage_vspk/tasks/main.yml
@@ -1,18 +1,19 @@
 ---
 
-- name: collect all test cases
-  find:
-    paths: "{{ role_path }}/tests"
-    patterns: "{{ testcase }}.yaml"
-  delegate_to: localhost
-  register: test_cases
+- block:
+    - name: collect all test cases
+      find:
+        paths: "{{ role_path }}/tests"
+        patterns: "{{ testcase }}.yaml"
+      delegate_to: localhost
+      register: test_cases
 
-- name: set test_items
-  set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
+    - name: set test_items
+      set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test case
-  include: "{{ test_case_to_run }}"
-  with_items: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run
+    - name: run test case
+      include: "{{ test_case_to_run }}"
+      with_items: "{{ test_items }}"
+      loop_control:
+        loop_var: test_case_to_run
   when: "ansible_python_version is version('2.7', '>=')"

--- a/test/integration/targets/prepare_nuage_tests/tasks/main.yml
+++ b/test/integration/targets/prepare_nuage_tests/tasks/main.yml
@@ -1,9 +1,11 @@
 ---
-- name: Install Nuage VSD API Simulator
-  pip:
-    name: nuage-vsd-sim
+- block:
+    - name: Install Nuage VSD API Simulator
+      pip:
+        name: nuage-vsd-sim
 
-- name: Start Nuage VSD API Simulator
-  shell: "(cd /; nuage-vsd-sim >/dev/null 2>&1 &)"
-  async: 10
-  poll: 0
+    - name: Start Nuage VSD API Simulator
+      shell: "(cd /; nuage-vsd-sim >/dev/null 2>&1 &)"
+      async: 10
+      poll: 0
+  when: "ansible_python_version is version('2.7', '>=')"


### PR DESCRIPTION
##### SUMMARY

Restore nuage_vspk integration tests.

(cherry picked from commit 1c7417c)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

nuage integration tests

##### ANSIBLE VERSION

```
ansible 2.5.2 (nuage-fix-2.5 593988f21e) last updated 2018/05/07 11:17:05 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
