### PR TITLE
Add ability to define Resource Group for Security Group for Azure NIC creation

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_networkinterface.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_networkinterface.py
@@ -443,7 +443,7 @@ class AzureRMNetworkInterface(AzureRMModuleBase):
         security_group_dict = parse_resource_id(self.security_group_name)
         security_group_name = security_group_dict.get('name')
         security_group_resource_group = security_group_dict.get('resource_group', self.security_group_resource_group)
-        
+
         if security_group_resource_group is None:
             security_group_resource_group = self.resource_group
 
@@ -480,7 +480,6 @@ class AzureRMNetworkInterface(AzureRMModuleBase):
                 update_tags, results['tags'] = self.update_tags(results['tags'])
                 if update_tags:
                     changed = True
-
 
                 nsg = self.get_security_group(security_group_resource_group, self.security_group_name)
                 if nsg and results.get('network_security_group') and results['network_security_group'].get('id') != nsg.id:

--- a/test/integration/targets/azure_rm_networkinterface/tasks/main.yml
+++ b/test/integration/targets/azure_rm_networkinterface/tasks/main.yml
@@ -76,21 +76,21 @@
   azure_rm_networkinterface:
       resource_group: "{{ resource_group }}"
       name: testnic001sgrg
-      virtual_network: testnic001
+      virtual_network: "{{ vn.state.id }}"      
       subnet: testnic001
-      public_ip_name: testnic001
+      public_ip_name: testnic001sgrg
       public_ip_allocation_method: Static
       security_group: testnic001sgrg
       security_group_resource_group: "{{ resource_group_secondary }}"
   register: output
 
-- name: Create NIC using virtual_network_resource_group parameter (idempotent)
+- name: Create NIC using security_group_resource_group parameter (idempotent)
   azure_rm_networkinterface:
       resource_group: "{{ resource_group }}"
       name: testnic001sgrg
-      virtual_network: testnic001
+      virtual_network: "{{ vn.state.id }}"
       subnet: testnic001
-      public_ip_name: testnic001
+      public_ip_name: testnic001sgrg
       public_ip_allocation_method: Static
       security_group: testnic001
       security_group_resource_group: "{{ resource_group_secondary }}"      

--- a/test/integration/targets/azure_rm_networkinterface/tasks/main.yml
+++ b/test/integration/targets/azure_rm_networkinterface/tasks/main.yml
@@ -66,7 +66,46 @@
       resource_group: "{{ resource_group }}"
       name: testnic001rg
       state: absent
-  
+
+- name: Create Security Group in secondary Resource Group
+  azure_rm_securitygroup:
+    name: testnic001sgrg
+    resource_group: "{{ resource_group_secondary }}"
+
+- name: Create NIC using security_group_resource_group parameter
+  azure_rm_networkinterface:
+      resource_group: "{{ resource_group }}"
+      name: testnic001sgrg
+      virtual_network: testnic001
+      subnet: testnic001
+      public_ip_name: testnic001
+      public_ip_allocation_method: Static
+      security_group: testnic001sgrg
+      security_group_resource_group: "{{ resource_group_secondary }}"
+  register: output
+
+- name: Create NIC using virtual_network_resource_group parameter (idempotent)
+  azure_rm_networkinterface:
+      resource_group: "{{ resource_group }}"
+      name: testnic001sgrg
+      virtual_network: testnic001
+      subnet: testnic001
+      public_ip_name: testnic001
+      public_ip_allocation_method: Static
+      security_group: testnic001
+      security_group_resource_group: "{{ resource_group_secondary }}"      
+  register: output
+
+- assert:
+    that:
+      - not output.changed
+
+- name: Delete NIC
+  azure_rm_networkinterface:
+      resource_group: "{{ resource_group }}"
+      name: testnic001sgrg      
+      state: absent
+
 - name: Create NIC
   azure_rm_networkinterface:
       resource_group: "{{ resource_group }}"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Allows for the creation of Network Interfaces in Azure with references to Network Security Groups in a different Resource Group

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
`azure_rm_networkinterface`

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
