### PR TITLE
Deprecate private for include_role

### DIFF
--- a/lib/ansible/modules/utilities/logic/include_role.py
+++ b/lib/ansible/modules/utilities/logic/include_role.py
@@ -49,8 +49,8 @@ options:
     default: 'yes'
   private:
     description:
-      - If C(yes) the variables from C(defaults/) and C(vars/) in a role will not be made available to the rest of the
-        play.
+      - This option is a no op, and the functionality described in previous versions was not implemented. This
+        option will be removed in Ansible v2.8.
     type: bool
     default: 'no'
 notes:

--- a/lib/ansible/playbook/role_include.py
+++ b/lib/ansible/playbook/role_include.py
@@ -114,6 +114,12 @@ class IncludeRole(TaskInclude):
         if ir._role_name is None:
             raise AnsibleParserError("'name' is a required field for %s." % ir.action)
 
+        if ir.private is not None:
+            display.deprecated(
+                msg='Supplying "private" for "include_role" is a no op, and is deprecated',
+                version='2.8'
+            )
+
         # validate bad args, otherwise we silently ignore
         bad_opts = my_arg_names.difference(IncludeRole.VALID_ARGS)
         if bad_opts:


### PR DESCRIPTION
##### SUMMARY
Deprecate private for include_role

`private` was documented, but never implemented, although accepted and ignored by `include_role`.

We discussed just removing it, since this module is `preview` status, but agreed to a shorter deprecation cycle instead.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/utilities/logic/include_role.py
lib/ansible/playbook/role_include.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```