### PR TITLE
Backport #39818 to stable-2.5

### DIFF
--- a/changelogs/fragments/39818-loop_control_task_vars.yaml
+++ b/changelogs/fragments/39818-loop_control_task_vars.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - loop_control - update template vars for loop_control fields on each loop iteration (https://github.com/ansible/ansible/pull/39818).

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -302,6 +302,9 @@ class TaskExecutor:
             if index_var:
                 task_vars[index_var] = item_index
 
+            # Update template vars to reflect current loop iteration
+            templar.set_available_variables(task_vars)
+
             # pause between loop iterations
             if loop_pause and ran_once:
                 try:


### PR DESCRIPTION
##### SUMMARY
Backport of #39818 to `stable-2.5`

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
loop_control

##### ANSIBLE VERSION
```
ansible 2.5.2 (backport/2.5/39818 2bde70f818) last updated 2018/05/07 16:02:59 (GMT -500)
```

##### ADDITIONAL INFORMATION
N/A