### PR TITLE
Add a 'machinectl shell' become_method

### DIFF
--- a/docs/docsite/rst/user_guide/become.rst
+++ b/docs/docsite/rst/user_guide/become.rst
@@ -11,7 +11,7 @@ Ansible can use existing privilege escalation systems to allow a user to execute
 Become
 ======
 
-Ansible allows you to 'become' another user, different from the user that logged into the machine (remote user). This is done using existing privilege escalation tools such as `sudo`, `su`, `pfexec`, `doas`, `pbrun`, `dzdo`, `ksu`, `runas` and others.
+Ansible allows you to 'become' another user, different from the user that logged into the machine (remote user). This is done using existing privilege escalation tools such as `sudo`, `su`, `pfexec`, `doas`, `pbrun`, `dzdo`, `ksu`, `runas`, `machinectl` and others.
 
 
 .. note:: Prior to version 1.9, Ansible mostly allowed the use of `sudo` and a limited use of `su` to allow a login/remote user to become a different user and execute tasks and create resources with the second user's permissions. As of Ansible version 1.9,  `become` supersedes the old sudo/su, while still being backwards compatible. This new implementation also makes it easier to add other privilege escalation tools, including `pbrun` (Powerbroker), `pfexec`, `dzdo` (Centrify), and others.
@@ -31,7 +31,7 @@ become_user
     set to user with desired privileges — the user you `become`, NOT the user you login as. Does NOT imply ``become: yes``, to allow it to be set at host level.
 
 become_method
-    (at play or task level) overrides the default method set in ansible.cfg, set to `sudo`/`su`/`pbrun`/`pfexec`/`doas`/`dzdo`/`ksu`/`runas`
+    (at play or task level) overrides the default method set in ansible.cfg, set to `sudo`/`su`/`pbrun`/`pfexec`/`doas`/`dzdo`/`ksu`/`runas`/`machinectl`
 
 become_flags
     (at play or task level) permit the use of specific flags for the tasks or role. One common use is to change the user to nobody when the shell is set to no login. Added in Ansible 2.2.
@@ -91,7 +91,7 @@ Command line options
 
 --become-method=BECOME_METHOD
     privilege escalation method to use (default=sudo),
-    valid choices: [ sudo | su | pbrun | pfexec | doas | dzdo | ksu | runas ]
+    valid choices: [ sudo | su | pbrun | pfexec | doas | dzdo | ksu | runas | machinectl ]
 
 --become-user=BECOME_USER
     run operations as this user (default=root), does not imply --become/-b
@@ -207,6 +207,32 @@ a temporary file name which changes every time.  If you have '/sbin/service'
 or '/bin/chmod' as the allowed commands this will fail with ansible as those
 paths won't match with the temporary file that ansible creates to run the
 module.
+
+Environment variables populated by pam_systemd
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The default methods used by ``become`` use the default PAM login modules, but
+in most distributions they do not open a new "session", in the sense of
+systemd. Because the ``pam_systemd`` module is never called, you might have
+surprises compared to a normal session opened through ssh: some environment
+variables set by ``pam_systemd``, most notably ``XDG_RUNTIME_DIR``, are not
+populated for the new user and instead inherited or just emptied.
+
+This might cause trouble when trying to invoke systemd commands that depend on
+``XDG_RUNTIME_DIR`` to access the bus:
+
+.. code-block:: console
+
+   $ echo $XDG_RUNTIME_DIR
+
+   $ systemctl --user status
+   Failed to connect to bus: Permission denied
+
+To force ``become`` to open a new systemd session that goes through
+``pam_systemd``, you can use ``become_method: machinectl``.
+
+For more information, see `this systemd issue
+<https://github.com/systemd/systemd/issues/825#issuecomment-127917622>`_.
 
 .. _become-network:
 

--- a/docs/docsite/rst/user_guide/become.rst
+++ b/docs/docsite/rst/user_guide/become.rst
@@ -211,12 +211,13 @@ module.
 Environment variables populated by pam_systemd
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The default methods used by ``become`` use the default PAM login modules, but
-in most distributions they do not open a new "session", in the sense of
-systemd. Because the ``pam_systemd`` module is never called, you might have
-surprises compared to a normal session opened through ssh: some environment
-variables set by ``pam_systemd``, most notably ``XDG_RUNTIME_DIR``, are not
-populated for the new user and instead inherited or just emptied.
+For most Linux distributions using ``systemd`` as their init, the default
+methods used by ``become`` do not open a new "session", in the sense of
+systemd.  Because the ``pam_systemd`` module will not fully initialize a new
+session, you might have surprises compared to a normal session opened through
+ssh: some environment variables set by ``pam_systemd``, most notably
+``XDG_RUNTIME_DIR``, are not populated for the new user and instead inherited
+or just emptied.
 
 This might cause trouble when trying to invoke systemd commands that depend on
 ``XDG_RUNTIME_DIR`` to access the bus:

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -59,7 +59,7 @@ def set_constant(name, value, export=vars()):
 
 
 # CONSTANTS ### yes, actual ones
-BECOME_METHODS = ['sudo', 'su', 'pbrun', 'pfexec', 'doas', 'dzdo', 'ksu', 'runas', 'pmrun', 'enable']
+BECOME_METHODS = ['sudo', 'su', 'pbrun', 'pfexec', 'doas', 'dzdo', 'ksu', 'runas', 'pmrun', 'enable', 'machinectl']
 BECOME_ERROR_STRINGS = {
     'sudo': 'Sorry, try again.',
     'su': 'Authentication failure',
@@ -70,6 +70,7 @@ BECOME_ERROR_STRINGS = {
     'ksu': 'Password incorrect',
     'pmrun': 'You are not permitted to run this command',
     'enable': '',
+    'machinectl': '',
 }  # FIXME: deal with i18n
 BECOME_MISSING_STRINGS = {
     'sudo': 'sorry, a password is required to run sudo',
@@ -81,6 +82,7 @@ BECOME_MISSING_STRINGS = {
     'ksu': 'No password given',
     'pmrun': '',
     'enable': '',
+    'machinectl': '',
 }  # FIXME: deal with i18n
 BLACKLIST_EXTS = ('.pyc', '.pyo', '.swp', '.bak', '~', '.rpm', '.md', '.txt')
 BOOL_TRUE = BOOLEANS_TRUE

--- a/lib/ansible/modules/commands/command.py
+++ b/lib/ansible/modules/commands/command.py
@@ -142,7 +142,7 @@ def check_command(module, commandline):
                 'mount': 'mount', 'rpm': 'yum, dnf or zypper', 'yum': 'yum', 'apt-get': 'apt',
                 'tar': 'unarchive', 'unzip': 'unarchive', 'sed': 'replace, lineinfile or template',
                 'dnf': 'dnf', 'zypper': 'zypper'}
-    become = ['sudo', 'su', 'pbrun', 'pfexec', 'runas', 'pmrun']
+    become = ['sudo', 'su', 'pbrun', 'pfexec', 'runas', 'pmrun', 'machinectl']
     if isinstance(commandline, list):
         command = commandline[0]
     else:

--- a/lib/ansible/playbook/play_context.py
+++ b/lib/ansible/playbook/play_context.py
@@ -557,6 +557,11 @@ class PlayContext(Base):
                 prompt = 'Enter UPM user password:'
                 becomecmd = '%s %s %s' % (exe, flags, shlex_quote(command))
 
+            elif self.become_method == 'machinectl':
+
+                exe = self.become_exe or 'machinectl'
+                becomecmd = '%s shell -q %s %s@ %s' % (exe, flags, self.become_user, command)
+
             else:
                 raise AnsibleError("Privilege escalation method not found: %s" % self.become_method)
 


### PR DESCRIPTION
##### SUMMARY

This commit adds a new become_method that uses 'machinectl shell' to open the unprivileged user session.

Some commands, for instance `systemd --user`, require environment variables that get populated during the PAM login of the user, like XDG_RUNTIME_DIR. Traditional commands like "su" don't open a new session, so the PAM environment variables aren't properly populated before running the commands. This has led to horrible hacks like this https://github.com/ansible/ansible/issues/27631#issuecomment-356730416 or this https://uggedal.com/journal/ansible-systemd-user/ to populate the XDG_RUNTIME_DIR variable with its supposed location, instead of letting the PAM module set it.

Lennart Poettering's position on that issue was that "su" wasn't a good way to open unprivileged sessions, as he explained here: https://github.com/systemd/systemd/issues/825#issuecomment-127917622 . systemd therefore added a "machinectl shell" command that allows people to switch to a different user by opening a new session, and therefore using PAM which populates the environment variables.

##### ISSUE TYPE

 - Feature Pull Request

##### COMPONENT NAME

play_context.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0 (devel bbdd1d7297) last updated 2018/05/07 22:55:11 (GMT +200)
  configured module search path = ['/home/antoine/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/antoine/contrib/ansible/lib/ansible
  executable location = /home/antoine/contrib/ansible/bin/ansible
  python version = 3.6.4 (default, Jan  5 2018, 02:35:40) [GCC 7.2.1 20171224]
```


##### ADDITIONAL INFORMATION

Before :

```
fatal: [myhost]: FAILED! => {"changed": false, "msg": "failure 1 during daemon-reload: Failed to connect to bus: No such file or directory\n"}
```

After : 
```
changed: [myhost]
```

Diff :

```diff
 name: Restart the website
 systemd:
   name: app.service
   daemon_reload: True
   enabled: True
   user: True
   state: restarted
 become: true
 become_user: antoine
+become_method: machinectl
```
