### PR TITLE
Update call method for parse_cli_textfsm (#38437)

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters.rst
@@ -447,7 +447,7 @@ The network filters also support parsing the output of a CLI command using the
 TextFSM library.  To parse the CLI output with TextFSM use the following
 filter::
 
-  {{ output | parse_cli_textfsm('path/to/fsm') }}
+  {{ output.stdout[0] | parse_cli_textfsm('path/to/fsm') }}
 
 Use of the TextFSM filter requires the TextFSM library to be installed.
 


### PR DESCRIPTION
+label: docsite_pr
(cherry picked from commit 7f5820274f60375cd217a78733467da569330df8)

##### SUMMARY
In the network section of the playbooks_filters page, call parse_cli_textfsm with the stdout[0] subset of "output" so existing TextFSM templates work without further modification.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
docs.ansible.com
##### ANSIBLE VERSION
2.5
