### PR TITLE
[WIP] Start of subelements filter

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters.rst
@@ -184,6 +184,65 @@ into::
     - key: Environment
       value: dev
 
+subelements Filter
+``````````````````
+
+.. versionadded:: 2.7
+
+Produces a product of an object, and subelement values of that object, similar to the ``subelements`` lookup::
+
+    {{ users|subelements('groups', skip_missing=True) }}
+
+Which turns::
+
+    users:
+      - name: alice
+        authorized:
+          - /tmp/alice/onekey.pub
+          - /tmp/alice/twokey.pub
+        groups:
+          - wheel
+          - docker
+      - name: bob
+        authorized:
+          - /tmp/bob/id_rsa.pub
+        groups:
+          - docker
+
+Into::
+
+    -
+      - name: alice
+        groups:
+          - wheel
+          - docker
+        authorized:
+          - /tmp/alice/onekey.pub
+      - wheel
+    -
+      - name: alice
+        groups:
+          - wheel
+          - docker
+        authorized:
+          - /tmp/alice/onekey.pub
+      - docker
+    -
+      - name: bob
+        authorized:
+          - /tmp/bob/id_rsa.pub
+        groups:
+          - docker
+      - docker
+
+An example of using this filter with ``loop``::
+
+    - name: Set authorized ssh key, extracting just that data from 'users'
+      authorized_key:
+        user: "{{ item.0.name }}"
+        key: "{{ lookup('file', item.1) }}"
+      loop: "{{ users|subelements('authorized') }}"
+
 .. _random_filter:
 
 Random Number Filter

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -488,6 +488,40 @@ def flatten(mylist, levels=None):
     return ret
 
 
+def subelements(obj, subelements, skip_missing=False):
+    if isinstance(obj, dict):
+        element_list = list(obj.values())
+    elif isinstance(obj, list):
+        element_list = obj[:]
+    else:
+        raise AnsibleFilterError('obj must be a list of dicts or a nested dict')
+
+    if isinstance(subelements, list):
+        subelement_list = subelements[:]
+    elif isinstance(subelements, string_types):
+        subelement_list = subelements.split('.')
+    else:
+        raise AnsibleFilterError('subelements must be a list or a string')
+
+    for element in element_list:
+        values = element
+        for subelement in subelement_list:
+            try:
+                values = values[subelement]
+            except KeyError:
+                if skip_missing:
+                    values = []
+                    break
+                raise AnsibleFilterError("could not find %r key in iterated item %r" % (subelement, values))
+            except TypeError:
+                raise AnsibleFilterError("the key %s should point to a dictionary, got '%s'" % (subelement, values))
+        if not isinstance(values, list):
+            raise AnsibleFilterError("the key %r should point to a list, got %r" % (subelement, values))
+
+        for value in values:
+            yield element, value
+
+
 def dict_to_list_of_dict_key_value_elements(mydict):
     ''' takes a dictionary and transforms it into a list of dictionaries,
         with each having a 'key' and 'value' keys that correspond to the keys and values of the original '''
@@ -589,4 +623,5 @@ class FilterModule(object):
             'extract': extract,
             'flatten': flatten,
             'dict2items': dict_to_list_of_dict_key_value_elements,
+            'subelements': subelements,
         }

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -489,6 +489,14 @@ def flatten(mylist, levels=None):
 
 
 def subelements(obj, subelements, skip_missing=False):
+    '''Accepts a dict or list of dicts, and a dotted accessor and produces a product
+    of the element and the results of the dotted accessor
+
+    >>> obj = [{"name": "alice", "groups": ["wheel"], "authorized": ["/tmp/alice/onekey.pub"]}]
+    >>> subelements(obj, 'groups')
+    [({'name': 'alice', 'groups': ['wheel'], 'authorized': ['/tmp/alice/onekey.pub']}, 'wheel')]
+
+    '''
     if isinstance(obj, dict):
         element_list = list(obj.values())
     elif isinstance(obj, list):
@@ -502,6 +510,8 @@ def subelements(obj, subelements, skip_missing=False):
         subelement_list = subelements.split('.')
     else:
         raise AnsibleFilterError('subelements must be a list or a string')
+
+    results = []
 
     for element in element_list:
         values = element
@@ -519,7 +529,9 @@ def subelements(obj, subelements, skip_missing=False):
             raise AnsibleFilterError("the key %r should point to a list, got %r" % (subelement, values))
 
         for value in values:
-            yield element, value
+            results.append((element, value))
+
+    return results
 
 
 def dict_to_list_of_dict_key_value_elements(mydict):


### PR DESCRIPTION
##### SUMMARY

Adds a filter that acts similarly to the subelements lookup.  This lookup is not a 1:1 re-implementation of the lookup.

For starters, this filter pays no attention to skipped keys.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
lib/ansible/plugins/filter/core.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```