### PR TITLE
File refactor2

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -217,7 +217,8 @@ _ANSIBLE_ARGS = None
 
 FILE_COMMON_ARGUMENTS = dict(
     # These are things we want. About setting metadata (mode, ownership, permissions in general) on
-    # created files
+    # created files (these are used by set_fs_attributes_if_different and included in
+    # load_file_common_arguments)
     mode=dict(type='raw'),
     owner=dict(),
     group=dict(),
@@ -234,7 +235,7 @@ FILE_COMMON_ARGUMENTS = dict(
 
     # not taken by the file module, but other action plugins call the file module so this ignores
     # them for now. In the future, the caller should take care of removing these from the module
-    # arugments before calling the file module.
+    # arguments before calling the file module.
     content=dict(no_log=True),  # used by copy
     backup=dict(),  # Used by a few modules to create a remote backup before updating the file
     remote_src=dict(),  # used by assemble

--- a/lib/ansible/modules/files/file.py
+++ b/lib/ansible/modules/files/file.py
@@ -370,7 +370,7 @@ def ensure_directory(path, b_path, prev_state, follow, recurse):
 
     if prev_state == 'absent':
         if module.check_mode:
-            module.exit_json(changed=True, diff=diff)
+            return {'changed': True, 'diff': diff}
         curpath = ''
 
         try:
@@ -411,7 +411,7 @@ def ensure_directory(path, b_path, prev_state, follow, recurse):
     if recurse:
         changed |= recursive_set_attributes(to_bytes(file_args['path'], errors='surrogate_or_strict'), follow, file_args)
 
-    module.exit_json(path=path, changed=changed, diff=diff)
+    return {'path': path, 'changed': changed, 'diff': diff}
 
 
 def ensure_symlink(path, b_path, src, b_src, prev_state, follow, force):
@@ -508,7 +508,7 @@ def ensure_symlink(path, b_path, src, b_src, prev_state, follow, force):
                                                   'path': path})
 
     if module.check_mode and not os.path.exists(b_path):
-        module.exit_json(dest=path, src=src, changed=changed, diff=diff)
+        return {'dest': path, 'src': src, 'changed': changed, 'diff': diff}
 
     # Whenever we create a link to a nonexistent target we know that the nonexistent target
     # cannot have any permissions set on it.  Skip setting those and emit a warning (the user
@@ -519,7 +519,7 @@ def ensure_symlink(path, b_path, src, b_src, prev_state, follow, force):
     else:
         changed = module.set_fs_attributes_if_different(file_args, changed, diff, expand=False)
 
-    module.exit_json(dest=path, src=src, changed=changed, diff=diff)
+    return {'dest': path, 'src': src, 'changed': changed, 'diff': diff}
 
 
 def ensure_hardlink(path, b_path, src, b_src, prev_state, follow, force):
@@ -572,7 +572,7 @@ def ensure_hardlink(path, b_path, src, b_src, prev_state, follow, force):
         changed = True
         if os.path.exists(b_path):
             if os.stat(b_path).st_ino == os.stat(b_src).st_ino:
-                module.exit_json(path=path, changed=False)
+                return {'path': path, 'changed': False}
             elif not force:
                 raise AnsibleModuleError(results={'msg': 'Cannot link: different hard link exists at destination',
                                                   'dest': path, 'src': src})
@@ -610,11 +610,11 @@ def ensure_hardlink(path, b_path, src, b_src, prev_state, follow, force):
                                                   'path': path})
 
     if module.check_mode and not os.path.exists(b_path):
-        module.exit_json(dest=path, src=src, changed=changed, diff=diff)
+        return {'dest': path, 'src': src, 'changed': changed, 'diff': diff}
 
     changed = module.set_fs_attributes_if_different(file_args, changed, diff, expand=False)
 
-    module.exit_json(dest=path, src=src, changed=changed, diff=diff)
+    return {'dest': path, 'src': src, 'changed': changed, 'diff': diff}
 
 
 def main():
@@ -681,7 +681,6 @@ def main():
         result = execute_touch(path, b_path, prev_state, follow)
     elif state == 'absent':
         result = ensure_absent(path, b_path, prev_state)
-        module.exit_json(**result)
 
     module.exit_json(**result)
 


### PR DESCRIPTION
##### SUMMARY

This PR builds on https://github.com/ansible/ansible/pull/39345 finishing up the standardization of return calues from functions.

*   Port away from fail_json()
    Use an exception to return failures rather than fail_json().  This way
    we can easily catch the failures if the calling code decides it can deal
    with it.  This has the side effect of making it easier to unittest this
    code as we can catch the expected exceptions instead of having to catch
    the interpreter exiting and then parse stdout for the expected data.
* Port away from exit_json()
  Consolidate successful exits from the program into the main() function by having all other functions return results to the main function instead of calling exit_json() directly.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
lib/ansible/modules/files/file.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
Ansible 2.6
```
