### PR TITLE
New module - meraki_admin

### DIFF
--- a/lib/ansible/modules/network/meraki/meraki_admin.py
+++ b/lib/ansible/modules/network/meraki/meraki_admin.py
@@ -1,0 +1,329 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2018, Kevin Breit (@kbreit) <kevin.breit@kevinbreit.net>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: meraki_admin
+short_description: Manage administrators in the Meraki cloud
+version_added: "2.6"
+description:
+- Allows for creation, management, and visibility into administrators within Meraki
+notes:
+- More information about the Meraki API can be found at U(https://dashboard.meraki.com/api_docs).
+- Some of the options are likely only used for developers within Meraki
+options:
+    name:
+        description:
+        - Name of the dashboard administrator.
+        - Required when creating a new administrator.
+    email:
+        description:
+        - Email address for the dashboard administrator.
+        - Email cannot be updated.
+        - Required when creating or editing an administrator.
+    orgAccess:
+        description:
+        - Privileges assigned to the administrator in the organization.
+        choices: ['full','read-only','none']
+    tags:
+        description:
+        - Tags the administrator has privileges on.
+        - When creating a new administrator, C(org_name), C(network), or C(tags) must be specified.
+        - If C(none) is specified, C(network) or C(tags) must be specified.
+    networks:
+        description:
+        - List of networks the administrator has privileges on.
+        - When creating a new administrator, C(org_name), C(network), or C(tags) must be specified.
+    state:
+        description:
+        - Create or modify an organization
+        choices: ['present', 'absent', 'query']
+        required: true
+    org_name:
+        description:
+        - Name of organization.
+        - Used when C(name) should refer to another object.
+        - When creating a new administrator, C(org_name), C(network), or C(tags) must be specified.
+        aliases: ['organization']
+    org_id:
+        description:
+        - ID of organization
+author:
+    - Kevin Breit (@kbreit)
+extends_documentation_fragment: meraki
+'''
+
+EXAMPLES = '''
+- name: Query information about all administrators associated to the organization
+  meraki_admin:
+    auth_key: abc12345
+    state: query
+  delegate_to: localhost
+- name: Query information about a single administrator by name
+  meraki_admin:
+    auth_key: abc12345
+    state: query
+    name: Jane Doe
+- name: Query information about a single administrator by email
+  meraki_admin:
+    auth_key: abc12345
+    state: query
+    email: jane@doe.com
+- name: Create a new administrator with organization access
+  meraki_admin:
+    auth_key: abc12345
+    state: present
+    name: Jane Doe
+    orgAccess: read-only
+    email: jane@doe.com
+- name: Create a new administrator with organization access
+  meraki_admin:
+    auth_key: abc12345
+    state: present
+    name: Jane Doe
+    orgAccess: read-only
+    email: jane@doe.com
+- name: Revoke access to an organization for an administrator
+  meraki_admin:
+    auth_key: abc12345
+    state: absent
+    email: jane@doe.com
+'''
+
+RETURN = '''
+response:
+    description: Data returned from Meraki dashboard.
+    type: dict
+    returned: info
+'''
+
+import os
+from ansible.module_utils.basic import AnsibleModule, json, env_fallback
+from ansible.module_utils.urls import fetch_url
+from ansible.module_utils._text import to_native
+from ansible.module_utils.network.meraki.meraki import MerakiModule, meraki_argument_spec
+
+
+def get_admins(meraki, org_id):
+    admins = meraki.request(
+        meraki.construct_path(
+            'query',
+            function='admin',
+            org_id=org_id
+        ),
+        method='GET'
+    )
+    return json.loads(admins)
+
+
+def get_admin_id(meraki, org_name, data, name=None, email=None):
+    admin_id = None
+    for a in data:
+        if meraki.params['name'] is not None:
+            if meraki.params['name'] == a['name']:
+                # meraki.fail_json(msg='HERE')
+                if admin_id is not None:
+                    meraki.fail_json(msg='There are multiple administrators with the same name')
+                else:
+                    admin_id = a['id']
+        elif meraki.params['email']:
+            if meraki.params['email'] == a['email']:
+                    return a['id']
+    if admin_id is None:
+        meraki.fail_json(msg='No admin_id found')
+    return admin_id
+
+
+def get_admin(meraki, data, id):
+    for a in data:
+        if a['id'] == id:
+            return a
+    meraki.fail_json(msg='No admin found by specified name or email')
+
+
+def find_admin(meraki, data, email):
+    # meraki.fail_json(msg='find_admin', data=data)
+    for a in data:
+        if a['email'] == email:
+            return a
+    return None
+
+
+def delete_admin(meraki, org_id, admin_id):
+    path = meraki.construct_path('revoke', 'admin', org_id=org_id) + admin_id
+    # meraki.fail_json(msg=path)
+    r = meraki.request(path,
+                       method='DELETE'
+                       )
+
+
+def create_admin(meraki, org_id, name, email, orgAccess=None, tags=[], networks=[]):
+    payload = dict()
+    payload['name'] = name
+    payload['email'] = email
+    payload['orgAccess'] = orgAccess
+    payload['tags'] = tags
+    payload['networks'] = networks
+
+    is_admin_existing = find_admin(meraki, get_admins(meraki, org_id), email)
+
+    if orgAccess is not None:
+        payload['orgAccess'] = orgAccess
+    elif tags is not None:
+        payload['tags'] = tags
+    elif networks is not None:
+        payload['networks'] = networks
+
+    if is_admin_existing is None:  # Create new admin
+        path = meraki.construct_path('create', function='admin', org_id=org_id)
+        r = meraki.request(path,
+                           method='POST',
+                           payload=json.dumps(payload)
+                           )
+        return json.loads(r)
+    elif is_admin_existing is not None:  # Update existing admin
+        if meraki.is_update_required(is_admin_existing, payload) is True:
+            # meraki.fail_json(msg='Update is required!!!', original=is_admin_existing, proposed=payload)
+            path = meraki.construct_path('update', function='admin', org_id=org_id) + is_admin_existing['id']
+            r = meraki.request(path,
+                               method='PUT',
+                               payload=json.dumps(payload)
+                               )
+            return json.loads(r)
+        else:
+            # meraki.fail_json(msg='No update is required!!!')
+            return -1
+
+
+def main():
+    # define the available arguments/parameters that a user can pass to
+    # the module
+    argument_spec = meraki_argument_spec()
+    argument_spec.update(state=dict(type='str', choices=['present', 'query', 'absent'], required=True),
+                         name=dict(type='str'),
+                         email=dict(type='str'),
+                         orgAccess=dict(type='str', choices=['full', 'read-only', 'none']),
+                         tags=dict(type='json'),
+                         networks=dict(type='json'),
+                         org_name=dict(type='str', aliases=['organization']),
+                         org_id=dict(type='int'),
+                         )
+
+    # seed the result dict in the object
+    # we primarily care about changed and state
+    # change is if this module effectively modified the target
+    # state will include any data that you want your module to pass back
+    # for consumption, for example, in a subsequent task
+    result = dict(
+        changed=False,
+    )
+
+    # the AnsibleModule object will be our abstraction working with Ansible
+    # this includes instantiation, a couple of common attr would be the
+    # args/params passed to the execution, as well as if the module
+    # supports check mode
+    module = AnsibleModule(argument_spec=argument_spec,
+                           supports_check_mode=False,
+                           )
+    meraki = MerakiModule(module, function='admin')
+
+    meraki.function = 'admin'
+    meraki.params['follow_redirects'] = 'all'
+
+    query_urls = {'admin': '/organizations/{org_id}/admins',
+                  }
+    create_urls = {'admin': '/organizations/{org_id}/admins',
+                   }
+    update_urls = {'admin': '/organizations/{org_id}/admins/',
+                   }
+    revoke_urls = {'admin': '/organizations/{org_id}/admins/{net_id}',
+                   }
+
+    meraki.url_catalog['query'] = query_urls
+    meraki.url_catalog['create'] = create_urls
+    meraki.url_catalog['update'] = update_urls
+    meraki.url_catalog['revoke'] = revoke_urls
+
+    try:
+        meraki.params['auth_key'] = os.environ['MERAKI_KEY']
+    except KeyError:
+        pass
+
+    if meraki.params['auth_key'] is None:
+        module.fail_json(msg='Meraki Dashboard API key not set')
+
+    payload = None
+
+    # if the user is working with this module in only check mode we do not
+    # want to make any changes to the environment, just return the current
+    # state with no modifications
+    if module.check_mode:
+        return result
+
+    # execute checks for argument completeness
+    if meraki.params['state'] == 'query':
+        meraki.mututally_exclusive = ['name', 'email']
+        if not meraki.params['org_name'] and not meraki.params['org_id']:
+            meraki.fail_json(msg='org_name or org_id required')
+    meraki.required_if = [(['state'], ['absent'], ['email']),
+                          ]
+
+    # manipulate or modify the state as needed (this is going to be the
+    # part where your module will do what it needs to do)
+    org_id = meraki.get_org_id(meraki.params['org_name'])
+    if meraki.params['state'] == 'query':
+        admins = get_admins(meraki, org_id)
+        if not meraki.params['name'] and not meraki.params['email']:  # Return all admins for org
+            meraki.result['data'] = admins
+        if meraki.params['name'] is not None:  # Return a single admin for org
+            admin_id = get_admin_id(meraki, meraki.params['org_name'], admins, name=meraki.params['name'])
+            meraki.result['data'] = admin_id
+            admin = get_admin(meraki, admins, admin_id)
+            meraki.result['data'] = admin
+        elif meraki.params['email'] is not None:
+            admin_id = get_admin_id(meraki, meraki.params['org_name'], admins, email=meraki.params['email'])
+            meraki.result['data'] = admin_id
+            admin = get_admin(meraki, admins, admin_id)
+            meraki.result['data'] = admin
+    elif meraki.params['state'] == 'present':
+        if meraki.params['orgAccess'] is not None:
+            r = create_admin(meraki,
+                             org_id,
+                             meraki.params['name'],
+                             meraki.params['email'],
+                             orgAccess=meraki.params['orgAccess']
+                             )
+            if r != -1:
+                meraki.result['data'] = r
+                meraki.result['changed'] = True
+    elif meraki.params['state'] == 'absent':
+        admin_id = get_admin_id(meraki,
+                                meraki.params['org_name'],
+                                get_admins(meraki, org_id),
+                                email=meraki.params['email']
+                                )
+        r = delete_admin(meraki, org_id, admin_id)
+
+        if r != -1:
+            meraki.result['data'] = r
+            meraki.result['changed'] = True
+
+    # in the event of a successful module execution, you will want to
+    # simple AnsibleModule.exit_json(), passing the key/value results
+    meraki.exit_json(**meraki.result)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/network/meraki/meraki_admin.py
+++ b/lib/ansible/modules/network/meraki/meraki_admin.py
@@ -13,7 +13,7 @@ ANSIBLE_METADATA = {
     'supported_by': 'community'
 }
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: meraki_admin
 short_description: Manage administrators in the Meraki cloud
@@ -65,7 +65,7 @@ author:
 extends_documentation_fragment: meraki
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 - name: Query information about all administrators associated to the organization
   meraki_admin:
     auth_key: abc12345
@@ -102,11 +102,49 @@ EXAMPLES = '''
     email: jane@doe.com
 '''
 
-RETURN = '''
-response:
-    description: Data returned from Meraki dashboard.
-    type: dict
+RETURN = r'''
+data:
+    description: Information about the created or manipulated object.
     returned: info
+    type: list
+    sample:
+        [
+            {
+                "email": "john@doe.com",
+                "id": "12345677890",
+                "name": "John Doe",
+                "networks": [],
+                "orgAccess": "full",
+                "tags": []
+            }
+        ]
+changed:
+    description: Whether object changed as a result of the request.
+    returned: info
+    type: string
+    sample:
+        "changed": false
+
+status:
+    description: HTTP response code
+    returned: info
+    type: int
+    sample:
+        "status": 200
+
+response:
+    description: HTTP response description and bytes
+    returned: info
+    type: string
+    sample:
+        "response": "OK (unknown bytes)"
+
+failed:
+    description: Boolean value whether the task failed
+    returned: info
+    type: bool
+    sample:
+        "failed": false 
 '''
 
 import os

--- a/lib/ansible/modules/network/meraki/meraki_admin.py
+++ b/lib/ansible/modules/network/meraki/meraki_admin.py
@@ -167,6 +167,7 @@ def delete_admin(meraki, org_id, admin_id):
                        method='DELETE'
                        )
 
+
 def network_factory(meraki, networks, nets):
     networks = json.loads(networks)
     networks_new = []
@@ -174,8 +175,8 @@ def network_factory(meraki, networks, nets):
         networks_new.append({'id': meraki.get_net_id(org_name=meraki.params['org_name'],
                                                      net_name=n['network'],
                                                      data=nets),
-                            'access': n['access']
-                            })
+                             'access': n['access']
+                             })
     return networks_new
 
 

--- a/lib/ansible/modules/network/meraki/meraki_admin.py
+++ b/lib/ansible/modules/network/meraki/meraki_admin.py
@@ -264,7 +264,7 @@ def main():
                    }
     update_urls = {'admin': '/organizations/{org_id}/admins/',
                    }
-    revoke_urls = {'admin': '/organizations/{org_id}/admins/{net_id}',
+    revoke_urls = {'admin': '/organizations/{org_id}/admins/',
                    }
 
     meraki.url_catalog['query'] = query_urls

--- a/lib/ansible/modules/network/meraki/meraki_admin.py
+++ b/lib/ansible/modules/network/meraki/meraki_admin.py
@@ -144,7 +144,7 @@ failed:
     returned: info
     type: bool
     sample:
-        "failed": false 
+        "failed": false
 '''
 
 import os

--- a/lib/ansible/modules/network/meraki/meraki_admin.py
+++ b/lib/ansible/modules/network/meraki/meraki_admin.py
@@ -17,12 +17,12 @@ DOCUMENTATION = r'''
 ---
 module: meraki_admin
 short_description: Manage administrators in the Meraki cloud
-version_added: "2.6"
+version_added: '2.6'
 description:
-- Allows for creation, management, and visibility into administrators within Meraki
+- Allows for creation, management, and visibility into administrators within Meraki.
 notes:
 - More information about the Meraki API can be found at U(https://dashboard.meraki.com/api_docs).
-- Some of the options are likely only used for developers within Meraki
+- Some of the options are likely only used for developers within Meraki.
 options:
     name:
         description:
@@ -36,7 +36,7 @@ options:
     orgAccess:
         description:
         - Privileges assigned to the administrator in the organization.
-        choices: ['full','read-only','none']
+        choices: [ full, none, read-only ]
     tags:
         description:
         - Tags the administrator has privileges on.
@@ -49,7 +49,7 @@ options:
     state:
         description:
         - Create or modify an organization
-        choices: ['present', 'absent', 'query']
+        choices: [ absent, present, query ]
         required: true
     org_name:
         description:
@@ -59,7 +59,7 @@ options:
         aliases: ['organization']
     org_id:
         description:
-        - ID of organization
+        - ID of organization.
 author:
     - Kevin Breit (@kbreit)
 extends_documentation_fragment: meraki
@@ -71,16 +71,19 @@ EXAMPLES = r'''
     auth_key: abc12345
     state: query
   delegate_to: localhost
+
 - name: Query information about a single administrator by name
   meraki_admin:
     auth_key: abc12345
     state: query
     name: Jane Doe
+
 - name: Query information about a single administrator by email
   meraki_admin:
     auth_key: abc12345
     state: query
     email: jane@doe.com
+
 - name: Create a new administrator with organization access
   meraki_admin:
     auth_key: abc12345
@@ -88,6 +91,7 @@ EXAMPLES = r'''
     name: Jane Doe
     orgAccess: read-only
     email: jane@doe.com
+
 - name: Create a new administrator with organization access
   meraki_admin:
     auth_key: abc12345
@@ -95,6 +99,7 @@ EXAMPLES = r'''
     name: Jane Doe
     orgAccess: read-only
     email: jane@doe.com
+
 - name: Revoke access to an organization for an administrator
   meraki_admin:
     auth_key: abc12345

--- a/test/integration/targets/meraki_admin/tasks/main.yml
+++ b/test/integration/targets/meraki_admin/tasks/main.yml
@@ -55,9 +55,9 @@
   register: create_tags_invalid
   ignore_errors: yes
 
-- assert:
-    that:
-      - '"Invalid permission type" in create_tags_invalid.msg'
+# - assert:
+#     that:
+#       - '"Invalid permission type" in create_tags_invalid.msg'
 
 - name: Create administrator with networks
   meraki_admin:
@@ -93,15 +93,14 @@
   register: create_network_invalid
   ignore_errors: yes
 
-- assert:
-    that:
-      - '"No network found with the name" in create_network_invalid.msg'
+# - assert:
+#     that:
+#       - '"No network found with the name" in create_network_invalid.msg'
 
 - name: Query all administrators
   meraki_admin:
     auth_key: '{{auth_key}}'
     state: query
-    # org_name: kbreit@insight.com
     org_name: '{{test_org_name}}'
   delegate_to: localhost
   register: query_all
@@ -133,4 +132,28 @@
     that:
       - query_name.data.name == "Jane Doe"
       - query_email.data.email == "meraki+janedoe@kevinbreit.net"
-#       - query_all.changed == False
+
+- name: Delete administrators
+  meraki_admin:
+    auth_key: '{{auth_key}}'
+    state: absent
+    org_name: '{{test_org_name}}'
+    email: '{{item}}'
+  delegate_to: localhost
+  register: delete_all
+  loop:
+      - meraki+janedoe@kevinbreit.net
+      - meraki+johndoe@kevinbreit.net
+      - meraki+jimdoe@kevinbreit.net
+
+- name: Query all administrators
+  meraki_admin:
+    auth_key: '{{auth_key}}'
+    state: query
+    org_name: '{{test_org_name}}'
+  delegate_to: localhost
+  register: query_all_deleted
+
+- assert:
+    that:
+      - query_all_deleted.data | length == 1

--- a/test/integration/targets/meraki_admin/tasks/main.yml
+++ b/test/integration/targets/meraki_admin/tasks/main.yml
@@ -3,145 +3,134 @@
 
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
-# - name: Create new administrator
-#   meraki_admin:
-#     auth_key: '{{auth_key}}'
-#     state: present
-#     org_name: '{{test_org_name}}'
-#     name: Jane Doe
-#     email: meraki+janedoe@kevinbreit.net
-#     orgAccess: read-only
-#   delegate_to: localhost
-#   register: create_orgaccess
+- name: Create new administrator
+  meraki_admin:
+    auth_key: '{{auth_key}}'
+    state: present
+    org_name: '{{test_org_name}}'
+    name: Jane Doe
+    email: meraki+janedoe@kevinbreit.net
+    orgAccess: read-only
+  delegate_to: localhost
+  register: create_orgaccess
 
-# - debug:
-#     msg: '{{create_orgaccess}}'
+- name: Create new admin assertion
+  assert:
+    that:
+      - create_orgaccess.changed == true
+      - 'create_orgaccess.data.name == "Jane Doe"'
 
-# - name: Create new admin assertion
-#   assert:
-#     that:
-#       - create_orgaccess.changed is True
-#       - 'create_orgaccess.data.name == "Jane Doe"'
+- name: Create administrator with tags
+  meraki_admin:
+    auth_key: '{{auth_key}}'
+    state: present
+    org_name: '{{test_org_name}}'
+    name: John Doe
+    email: meraki+johndoe@kevinbreit.net
+    orgAccess: none
+    tags:
+      - { "tag": "production", "access": "read-only" }
+      - { "tag": "beta", "access": "full" }
+  delegate_to: localhost
+  register: create_tags
 
-# - name: Create administrator with tags
-#   meraki_admin:
-#     auth_key: '{{auth_key}}'
-#     state: present
-#     org_name: '{{test_org_name}}'
-#     name: John Doe
-#     email: meraki+johndoe@kevinbreit.net
-#     orgAccess: none
-#     tags:
-#       - { "tag": "production", "access": "read-only" }
-#       - { "tag": "beta", "access": "full" }
-#   delegate_to: localhost
-#   register: create_tags
+- assert:
+    that:
+      - create_tags.changed == true
+      - create_tags.data.name == "John Doe"
+      - create_tags.data.tags | length == 2
 
-# - assert:
-#     that:
-#       - create_tags.changed is True
-#       - create_tags.data.name == "John Doe"
-#       - create_tags.data.tags | length == 3
+- name: Create administrator with invalid tags
+  meraki_admin:
+    auth_key: '{{auth_key}}'
+    state: present
+    org_name: '{{test_org_name}}'
+    name: Jake Doe
+    email: meraki+jakedoe@kevinbreit.net
+    orgAccess: none
+    tags:
+      - { "tag": "production", "access": "read-only" }
+      - { "tag": "beta", "access": "invalid" }
+  delegate_to: localhost
+  register: create_tags_invalid
+  ignore_errors: yes
 
-# - name: Create administrator with invalid tags
-#   meraki_admin:
-#     auth_key: '{{auth_key}}'
-#     state: present
-#     org_name: '{{test_org_name}}'
-#     name: John Doe
-#     email: meraki+John@kevinbreit.net
-#     orgAccess: none
-#     tags:
-#       - { "tag": "production", "access": "read-only" }
-#       - { "tag": "beta", "access": "invalid" }
-#   delegate_to: localhost
-#   register: create_tags_invalid
+- assert:
+    that:
+      - '"Invalid permission type" in create_tags_invalid.msg'
 
-# - assert:
-#     that:
-#       - '"Admin has invalid access level of" in create_tags_invalid.msg'
+- name: Create administrator with networks
+  meraki_admin:
+    auth_key: '{{auth_key}}'
+    state: present
+    org_name: '{{test_org_name}}'
+    name: Jim Doe
+    email: meraki+jimdoe@kevinbreit.net
+    orgAccess: none
+    networks:
+      - { "network": "TestNet", "access": "read-only" }
+      - { "network": "TestNet2", "access": "full" }
+  delegate_to: localhost
+  register: create_network
 
-# - name: Create administrator with networks
-#   meraki_admin:
-#     auth_key: '{{auth_key}}'
-#     state: present
-#     org_name: '{{test_org_name}}'
-#     name: John Doe
-#     email: meraki+John@kevinbreit.net
-#     orgAccess: none
-#     networks:
-#       - { "network": "readnet", "access": "read-only" }
-#       - { "network": "nonenet", "access": "none" }
-#       - { "network": "fullnet", "access": "full" }
-#   delegate_to: localhost
-#   register: create_network
+- assert:
+    that:
+      - create_network.changed == true
+      - create_network.data.name == "Jim Doe"
+      - create_network.data.networks | length == 2
 
-# - assert:
-#     that:
-#       - create_tags.changed is True
-#       - create_tags.data.name == "John Doe"
-#       - create_tags.data.tags | length == 3
+- name: Create administrator with invalid network
+  meraki_admin:
+    auth_key: '{{auth_key}}'
+    state: present
+    org_name: '{{test_org_name}}'
+    name: John Doe
+    email: meraki+John@kevinbreit.net
+    orgAccess: none
+    networks:
+      - { "network": "readnet", "access": "read-only" }
+  delegate_to: localhost
+  register: create_network_invalid
+  ignore_errors: yes
 
-# - name: Create administrator with invalid network
-#   meraki_admin:
-#     auth_key: '{{auth_key}}'
-#     state: present
-#     org_name: '{{test_org_name}}'
-#     name: John Doe
-#     email: meraki+John@kevinbreit.net
-#     orgAccess: none
-#     networks:
-#       - { "network": "readnet", "access": "read-only" }
-#   delegate_to: localhost
-#   register: create_network_invalid
+- assert:
+    that:
+      - '"No network found with the name" in create_network_invalid.msg'
 
-# - assert:
-#     that:
-#       - '"Error finding network" in create_tags.body'
+- name: Query all administrators
+  meraki_admin:
+    auth_key: '{{auth_key}}'
+    state: query
+    # org_name: kbreit@insight.com
+    org_name: '{{test_org_name}}'
+  delegate_to: localhost
+  register: query_all
 
-# - name: Query all administrators
-#   meraki_admin:
-#     auth_key: '{{auth_key}}'
-#     state: query
-#     # org_name: kbreit@insight.com
-#     org_name: '{{test_org_name}}'
-#   delegate_to: localhost
-#   register: query_all
+- assert:
+    that:
+      - query_all.data | length == 4
+      - query_all.changed == False
 
-# - debug:
-#     msg: '{{query_all}}'
+- name: Query admin by name
+  meraki_admin:
+    auth_key: '{{auth_key}}'
+    state: query
+    org_name: '{{test_org_name}}'
+    name: Jane Doe
+  delegate_to: localhost
+  register: query_name
 
-# - assert:
-#     that:
-#       - query_all.data | length == 2
-#       - query_all.changed == False
+- name: Query admin by email
+  meraki_admin:
+    auth_key: '{{auth_key}}'
+    state: query
+    org_name: '{{test_org_name}}'
+    email: meraki+janedoe@kevinbreit.net
+  delegate_to: localhost
+  register: query_email
 
-# - name: Query admin by name
-#   meraki_admin:
-#     auth_key: '{{auth_key}}'
-#     state: query
-#     org_name: '{{test_org_name}}'
-#     name: Jane Doe
-#   delegate_to: localhost
-#   register: query_name
-
-# - debug:
-#     msg: '{{query_name}}'
-
-# - name: Query admin by email
-#   meraki_admin:
-#     auth_key: '{{auth_key}}'
-#     state: query
-#     org_name: '{{test_org_name}}'
-#     email: jane@doe.com
-#   delegate_to: localhost
-#   register: query_email
-
-# - debug:
-#     msg: '{{query_email}}'
-
-# - assert:
-#     that:
-#       - query_name.data.name == "Jane Doe"
-#       - query_email.data.email == "jane@doe.com"
+- assert:
+    that:
+      - query_name.data.name == "Jane Doe"
+      - query_email.data.email == "meraki+janedoe@kevinbreit.net"
 #       - query_all.changed == False

--- a/test/integration/targets/meraki_admin/tasks/main.yml
+++ b/test/integration/targets/meraki_admin/tasks/main.yml
@@ -1,0 +1,147 @@
+# Test code for the Meraki Organization module
+# Copyright: (c) 2018, Kevin Breit (@kbreit)
+
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+---
+# - name: Create new administrator
+#   meraki_admin:
+#     auth_key: '{{auth_key}}'
+#     state: present
+#     org_name: '{{test_org_name}}'
+#     name: Jane Doe
+#     email: meraki+janedoe@kevinbreit.net
+#     orgAccess: read-only
+#   delegate_to: localhost
+#   register: create_orgaccess
+
+# - debug:
+#     msg: '{{create_orgaccess}}'
+
+# - name: Create new admin assertion
+#   assert:
+#     that:
+#       - create_orgaccess.changed is True
+#       - 'create_orgaccess.data.name == "Jane Doe"'
+
+# - name: Create administrator with tags
+#   meraki_admin:
+#     auth_key: '{{auth_key}}'
+#     state: present
+#     org_name: '{{test_org_name}}'
+#     name: John Doe
+#     email: meraki+johndoe@kevinbreit.net
+#     orgAccess: none
+#     tags:
+#       - { "tag": "production", "access": "read-only" }
+#       - { "tag": "beta", "access": "full" }
+#   delegate_to: localhost
+#   register: create_tags
+
+# - assert:
+#     that:
+#       - create_tags.changed is True
+#       - create_tags.data.name == "John Doe"
+#       - create_tags.data.tags | length == 3
+
+# - name: Create administrator with invalid tags
+#   meraki_admin:
+#     auth_key: '{{auth_key}}'
+#     state: present
+#     org_name: '{{test_org_name}}'
+#     name: John Doe
+#     email: meraki+John@kevinbreit.net
+#     orgAccess: none
+#     tags:
+#       - { "tag": "production", "access": "read-only" }
+#       - { "tag": "beta", "access": "invalid" }
+#   delegate_to: localhost
+#   register: create_tags_invalid
+
+# - assert:
+#     that:
+#       - '"Admin has invalid access level of" in create_tags_invalid.msg'
+
+# - name: Create administrator with networks
+#   meraki_admin:
+#     auth_key: '{{auth_key}}'
+#     state: present
+#     org_name: '{{test_org_name}}'
+#     name: John Doe
+#     email: meraki+John@kevinbreit.net
+#     orgAccess: none
+#     networks:
+#       - { "network": "readnet", "access": "read-only" }
+#       - { "network": "nonenet", "access": "none" }
+#       - { "network": "fullnet", "access": "full" }
+#   delegate_to: localhost
+#   register: create_network
+
+# - assert:
+#     that:
+#       - create_tags.changed is True
+#       - create_tags.data.name == "John Doe"
+#       - create_tags.data.tags | length == 3
+
+# - name: Create administrator with invalid network
+#   meraki_admin:
+#     auth_key: '{{auth_key}}'
+#     state: present
+#     org_name: '{{test_org_name}}'
+#     name: John Doe
+#     email: meraki+John@kevinbreit.net
+#     orgAccess: none
+#     networks:
+#       - { "network": "readnet", "access": "read-only" }
+#   delegate_to: localhost
+#   register: create_network_invalid
+
+# - assert:
+#     that:
+#       - '"Error finding network" in create_tags.body'
+
+# - name: Query all administrators
+#   meraki_admin:
+#     auth_key: '{{auth_key}}'
+#     state: query
+#     # org_name: kbreit@insight.com
+#     org_name: '{{test_org_name}}'
+#   delegate_to: localhost
+#   register: query_all
+
+# - debug:
+#     msg: '{{query_all}}'
+
+# - assert:
+#     that:
+#       - query_all.data | length == 2
+#       - query_all.changed == False
+
+# - name: Query admin by name
+#   meraki_admin:
+#     auth_key: '{{auth_key}}'
+#     state: query
+#     org_name: '{{test_org_name}}'
+#     name: Jane Doe
+#   delegate_to: localhost
+#   register: query_name
+
+# - debug:
+#     msg: '{{query_name}}'
+
+# - name: Query admin by email
+#   meraki_admin:
+#     auth_key: '{{auth_key}}'
+#     state: query
+#     org_name: '{{test_org_name}}'
+#     email: jane@doe.com
+#   delegate_to: localhost
+#   register: query_email
+
+# - debug:
+#     msg: '{{query_email}}'
+
+# - assert:
+#     that:
+#       - query_name.data.name == "Jane Doe"
+#       - query_email.data.email == "jane@doe.com"
+#       - query_all.changed == False

--- a/test/integration/targets/meraki_admin/tasks/main.yml
+++ b/test/integration/targets/meraki_admin/tasks/main.yml
@@ -55,9 +55,9 @@
   register: create_tags_invalid
   ignore_errors: yes
 
-# - assert:
-#     that:
-#       - '"Invalid permission type" in create_tags_invalid.msg'
+- assert:
+    that:
+      - '"Invalid permission type" in create_tags_invalid.msg'
 
 - name: Create administrator with networks
   meraki_admin:
@@ -78,6 +78,42 @@
       - create_network.changed == true
       - create_network.data.name == "Jim Doe"
       - create_network.data.networks | length == 2
+
+- name: Update administrator
+  meraki_admin:
+    auth_key: '{{auth_key}}'
+    state: present
+    org_name: '{{test_org_name}}'
+    name: Jim Doe
+    email: meraki+jimdoe@kevinbreit.net
+    orgAccess: none
+    networks:
+      - { "network": "TestNet", "access": "full" }
+  delegate_to: localhost
+  register: update_network
+
+- assert:
+    that:
+      - update_network.changed == true
+      - update_network.data.networks.0.access == "full"
+      - update_network.data.networks | length == 1
+
+- name: Update administrator for idempotency check
+  meraki_admin:
+    auth_key: '{{auth_key}}'
+    state: present
+    org_name: '{{test_org_name}}'
+    name: Jim Doe
+    email: meraki+jimdoe@kevinbreit.net
+    orgAccess: none
+    networks:
+      - { "network": "TestNet", "access": "full" }
+  delegate_to: localhost
+  register: update_network_idempotent
+
+- assert:
+    that:
+      - update_network_idempotent.changed == false
 
 - name: Create administrator with invalid network
   meraki_admin:

--- a/test/integration/targets/meraki_admin/tasks/main.yml
+++ b/test/integration/targets/meraki_admin/tasks/main.yml
@@ -9,7 +9,7 @@
     state: present
     org_name: '{{test_org_name}}'
     name: Jane Doe
-    email: meraki+janedoe@kevinbreit.net
+    email: '{{email_prefix}}+janedoe@{{email_domain}}'
     orgAccess: read-only
   delegate_to: localhost
   register: create_orgaccess
@@ -26,7 +26,7 @@
     state: present
     org_name: '{{test_org_name}}'
     name: John Doe
-    email: meraki+johndoe@kevinbreit.net
+    email: '{{email_prefix}}+johndoe@{{email_domain}}'
     orgAccess: none
     tags:
       - { "tag": "production", "access": "read-only" }
@@ -46,18 +46,39 @@
     state: present
     org_name: '{{test_org_name}}'
     name: Jake Doe
-    email: meraki+jakedoe@kevinbreit.net
+    email: '{{email_prefix}}+jakedoe@{{email_domain}}'
     orgAccess: none
     tags:
       - { "tag": "production", "access": "read-only" }
-      - { "tag": "beta", "access": "invalid" }
+      - { "tag": "alpha", "access": "invalid" }
   delegate_to: localhost
   register: create_tags_invalid
   ignore_errors: yes
 
 - assert:
     that:
-      - '"Invalid permission type" in create_tags_invalid.msg'
+      - '"400" in create_tags_invalid.msg'
+      # - '"must contain only valid tags" in create_tags_invalid.msg'
+
+- name: Create administrator with invalid tag permission
+  meraki_admin:
+    auth_key: '{{auth_key}}'
+    state: present
+    org_name: '{{test_org_name}}'
+    name: Jake Doe
+    email: '{{email_prefix}}+jakedoe@{{email_domain}}'
+    orgAccess: none
+    tags:
+      - { "tag": "production", "access": "read-only" }
+      - { "tag": "beta", "access": "invalid" }
+  delegate_to: localhost
+  register: create_tags_invalid_permission
+  ignore_errors: yes
+
+- assert:
+    that:
+      - '"400" in create_tags_invalid_permission.msg'
+      # - '"Invalid permission type" in create_tags_invalid_permission.msg'
 
 - name: Create administrator with networks
   meraki_admin:
@@ -65,7 +86,7 @@
     state: present
     org_name: '{{test_org_name}}'
     name: Jim Doe
-    email: meraki+jimdoe@kevinbreit.net
+    email: '{{email_prefix}}+jimdoe@{{email_domain}}'
     orgAccess: none
     networks:
       - { "network": "TestNet", "access": "read-only" }
@@ -85,7 +106,7 @@
     state: present
     org_name: '{{test_org_name}}'
     name: Jim Doe
-    email: meraki+jimdoe@kevinbreit.net
+    email: '{{email_prefix}}+jimdoe@{{email_domain}}'
     orgAccess: none
     networks:
       - { "network": "TestNet", "access": "full" }
@@ -104,7 +125,7 @@
     state: present
     org_name: '{{test_org_name}}'
     name: Jim Doe
-    email: meraki+jimdoe@kevinbreit.net
+    email: '{{email_prefix}}+jimdoe@{{email_domain}}'
     orgAccess: none
     networks:
       - { "network": "TestNet", "access": "full" }
@@ -121,7 +142,7 @@
     state: present
     org_name: '{{test_org_name}}'
     name: John Doe
-    email: meraki+John@kevinbreit.net
+    email: '{{email_prefix}}+John@{{email_domain}}'
     orgAccess: none
     networks:
       - { "network": "readnet", "access": "read-only" }
@@ -129,9 +150,10 @@
   register: create_network_invalid
   ignore_errors: yes
 
-# - assert:
-#     that:
-#       - '"No network found with the name" in create_network_invalid.msg'
+- assert:
+    that:
+      - '"No network found with the name" in create_network_invalid.msg'
+      # - '"400" in create_network_invalid.msg'
 
 - name: Query all administrators
   meraki_admin:
@@ -160,14 +182,14 @@
     auth_key: '{{auth_key}}'
     state: query
     org_name: '{{test_org_name}}'
-    email: meraki+janedoe@kevinbreit.net
+    email: '{{email_prefix}}+janedoe@{{email_domain}}'
   delegate_to: localhost
   register: query_email
 
 - assert:
     that:
       - query_name.data.name == "Jane Doe"
-      - query_email.data.email == "meraki+janedoe@kevinbreit.net"
+      - 'query_email.data.email == "{{email_prefix}}+janedoe@{{email_domain}}"'
 
 - name: Delete administrators
   meraki_admin:
@@ -178,9 +200,9 @@
   delegate_to: localhost
   register: delete_all
   loop:
-      - meraki+janedoe@kevinbreit.net
-      - meraki+johndoe@kevinbreit.net
-      - meraki+jimdoe@kevinbreit.net
+      - '{{email_prefix}}+janedoe@{{email_domain}}'
+      - '{{email_prefix}}+johndoe@{{email_domain}}'
+      - '{{email_prefix}}+jimdoe@{{email_domain}}'
 
 - name: Query all administrators
   meraki_admin:


### PR DESCRIPTION
##### SUMMARY
meraki_admin allows for CRUD functionality related to administrators in a Meraki organization. Permissions can be assigned by organization, tag, or network

##### ISSUE TYPE
 - New Module Pull Request

##### COMPONENT NAME
meraki/meraki_admin

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0 (meraki/meraki_admin dba1921903) last updated 2018/05/07 20:51:55 (GMT -500)
  config file = None
  configured module search path = ['/Users/kbreit/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/kbreit/Documents/Programming/ansible/lib/ansible
  executable location = /Users/kbreit/Documents/Programming/ansible/bin/ansible
  python version = 3.5.4 (default, Feb 25 2018, 14:56:02) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```

##### ADDITIONAL INFORMATION
Open items before merge:

- Enable body error output in meraki module utility (PR 39838)
- Improve module documentation