### PR TITLE
Handling of configurations blocks with end-* at the end of the block

### DIFF
--- a/changelogs/fragments/iosxr_config_crash.yaml
+++ b/changelogs/fragments/iosxr_config_crash.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- iosxr_config - handle configuration block with mis-indented sublevel command

--- a/lib/ansible/modules/network/iosxr/iosxr_config.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_config.py
@@ -193,12 +193,18 @@ backup_path:
   type: string
   sample: /playbooks/ansible/backup/iosxr01.2016-07-16@22:28:34
 """
+import re
+
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.network.iosxr.iosxr import load_config, get_config
 from ansible.module_utils.network.iosxr.iosxr import iosxr_argument_spec, copy_file
 from ansible.module_utils.network.common.config import NetworkConfig, dumps
 
 DEFAULT_COMMIT_COMMENT = 'configured by iosxr_config'
+
+CONFIG_MISPLACED_CHILDREN = [
+    re.compile(r'end-\s*(.+)$')
+]
 
 
 def copy_file_to_node(module):
@@ -242,6 +248,29 @@ def get_candidate(module):
     return candidate
 
 
+def sanitize_candidate_config(config):
+    last_parents = None
+    for regex in CONFIG_MISPLACED_CHILDREN:
+        for index, line in enumerate(config):
+            if line._parents:
+                last_parents = line._parents
+            m = regex.search(line.text)
+            if m and m.group(0):
+                config[index]._parents = last_parents
+
+
+def sanitize_running_config(config):
+    last_parents = None
+    for regex in CONFIG_MISPLACED_CHILDREN:
+        for index, line in enumerate(config):
+            if line._parents:
+                last_parents = line._parents
+            m = regex.search(line.text)
+            if m and m.group(0):
+                config[index].text = ' ' + m.group(0)
+                config[index]._parents = last_parents
+
+
 def run(module, result):
     match = module.params['match']
     replace = module.params['replace']
@@ -253,6 +282,9 @@ def run(module, result):
 
     candidate_config = get_candidate(module)
     running_config = get_running_config(module)
+
+    sanitize_candidate_config(candidate_config.items)
+    sanitize_running_config(running_config.items)
 
     commands = None
     if match != 'none' and replace != 'config':

--- a/test/integration/targets/iosxr_config/templates/basic/change_prefix_set.j2
+++ b/test/integration/targets/iosxr_config/templates/basic/change_prefix_set.j2
@@ -1,0 +1,7 @@
+prefix-set ebpg_filter
+  192.168.0.0/16 ge 15 le 30
+end-set
+
+interface Loopback999
+ description this is a test interface for prefix-set
+

--- a/test/integration/targets/iosxr_config/templates/basic/init_prefix_set.j2
+++ b/test/integration/targets/iosxr_config/templates/basic/init_prefix_set.j2
@@ -1,0 +1,3 @@
+prefix-set ebpg_filter
+  192.168.0.0/16 ge 17 le 30
+end-set

--- a/test/integration/targets/iosxr_config/tests/cli/misplaced_sublevel.yaml
+++ b/test/integration/targets/iosxr_config/tests/cli/misplaced_sublevel.yaml
@@ -1,0 +1,27 @@
+---
+- debug: msg="START cli/misplaced_sublevel.yaml on connection={{ ansible_connection }}"
+
+- name: setup
+  iosxr_config:
+    src: basic/init_prefix_set.j2
+  ignore_errors: yes
+
+- name: Change prefix-set and new command after prefix-set
+  iosxr_config:
+    src: basic/change_prefix_set.j2
+  register: result
+
+- assert:
+    that:
+      - "result.changed == true"
+
+- name: Play same config again to verify no diff in prefix-set also works
+  iosxr_config:
+    src: basic/change_prefix_set.j2
+  register: result
+
+- assert:
+    that:
+      - "result.changed == true"
+
+- debug: msg="END cli/misplaced_sublevel.yaml on connection={{ ansible_connection }}"


### PR DESCRIPTION
…(#39673)

* handle end-policy issue

* revert changes in iosxr cliconf

* fix trailing parents not included in difference

* Moving fix to platform specific fix

* pep 8 issues

(cherry picked from commit ef577b71cc1c917a601883cb2d56f1f640673cb9)

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
