### PR TITLE
AzureStack Changes - API version and base_url

### DIFF
--- a/lib/ansible/module_utils/azure_rm_common.py
+++ b/lib/ansible/module_utils/azure_rm_common.py
@@ -913,7 +913,6 @@ class AzureRMModuleBase(object):
             client.config.session_configuration_callback = self._validation_ignore_callback
 
         return client
-
     # In the AZURE_API_PROFILES structure for ComputeManagementClient
     # one of the API versions returns a dictionary (i.e. 'latest')
     # Therefore this causes further functions to fail later - therefore
@@ -926,9 +925,7 @@ class AzureRMModuleBase(object):
             returnVal = AZURE_API_PROFILES[api_ver]['ComputeManagementClient']['virtual_machine_run_commands']
         else:
             returnVal = None
-
         return returnVal
-
     @property
     def storage_client(self):
         self.log('Getting storage client...')

--- a/lib/ansible/module_utils/azure_rm_common.py
+++ b/lib/ansible/module_utils/azure_rm_common.py
@@ -913,11 +913,13 @@ class AzureRMModuleBase(object):
             client.config.session_configuration_callback = self._validation_ignore_callback
 
         return client
+
     # In the AZURE_API_PROFILES structure for ComputeManagementClient
     # one of the API versions returns a dictionary (i.e. 'latest')
     # Therefore this causes further functions to fail later - therefore
     # we now check if the value is a str or a dictionary and always
     # return a string
+
     def get_compute_management_api(self, api_ver):
         if type(AZURE_API_PROFILES[api_ver]['ComputeManagementClient']) is str:
             returnVal = AZURE_API_PROFILES[api_ver]['ComputeManagementClient']
@@ -925,7 +927,9 @@ class AzureRMModuleBase(object):
             returnVal = AZURE_API_PROFILES[api_ver]['ComputeManagementClient']['virtual_machine_run_commands']
         else:
             returnVal = None
+
         return returnVal
+
     @property
     def storage_client(self):
         self.log('Getting storage client...')

--- a/lib/ansible/module_utils/azure_rm_common.py
+++ b/lib/ansible/module_utils/azure_rm_common.py
@@ -874,6 +874,7 @@ class AzureRMModuleBase(object):
         if not base_url:
             # most things are resource_manager, don't make everyone specify
             base_url = self._cloud_environment.endpoints.resource_manager
+            client_kwargs['base_url'] = base_url
 
         # unversioned clients won't accept profile; only send it if necessary
         # clients without a version specified in the profile will use the default
@@ -919,7 +920,7 @@ class AzureRMModuleBase(object):
         if not self._storage_client:
             self._storage_client = self.get_mgmt_svc_client(StorageManagementClient,
                                                             base_url=self._cloud_environment.endpoints.resource_manager,
-                                                            api_version='2017-10-01')
+                                                            api_version=AZURE_API_PROFILES[self.api_profile]['StorageManagementClient'])
         return self._storage_client
 
     @property
@@ -933,7 +934,7 @@ class AzureRMModuleBase(object):
         if not self._network_client:
             self._network_client = self.get_mgmt_svc_client(NetworkManagementClient,
                                                             base_url=self._cloud_environment.endpoints.resource_manager,
-                                                            api_version='2017-11-01')
+                                                            api_version=AZURE_API_PROFILES[self.api_profile]['NetworkManagementClient']) 
         return self._network_client
 
     @property
@@ -947,7 +948,7 @@ class AzureRMModuleBase(object):
         if not self._resource_client:
             self._resource_client = self.get_mgmt_svc_client(ResourceManagementClient,
                                                              base_url=self._cloud_environment.endpoints.resource_manager,
-                                                             api_version='2017-05-10')
+                                                             api_version=AZURE_API_PROFILES[self.api_profile]['ResourceManagementClient']) 
         return self._resource_client
 
     @property
@@ -961,7 +962,7 @@ class AzureRMModuleBase(object):
         if not self._compute_client:
             self._compute_client = self.get_mgmt_svc_client(ComputeManagementClient,
                                                             base_url=self._cloud_environment.endpoints.resource_manager,
-                                                            api_version='2017-03-30')
+                                                            api_version=AZURE_API_PROFILES[self.api_profile]['ComputeManagementClient']) 
         return self._compute_client
 
     @property

--- a/lib/ansible/module_utils/azure_rm_common.py
+++ b/lib/ansible/module_utils/azure_rm_common.py
@@ -934,7 +934,7 @@ class AzureRMModuleBase(object):
         if not self._network_client:
             self._network_client = self.get_mgmt_svc_client(NetworkManagementClient,
                                                             base_url=self._cloud_environment.endpoints.resource_manager,
-                                                            api_version=AZURE_API_PROFILES[self.api_profile]['NetworkManagementClient']) 
+                                                            api_version=AZURE_API_PROFILES[self.api_profile]['NetworkManagementClient'])
         return self._network_client
 
     @property
@@ -948,7 +948,7 @@ class AzureRMModuleBase(object):
         if not self._resource_client:
             self._resource_client = self.get_mgmt_svc_client(ResourceManagementClient,
                                                              base_url=self._cloud_environment.endpoints.resource_manager,
-                                                             api_version=AZURE_API_PROFILES[self.api_profile]['ResourceManagementClient']) 
+                                                             api_version=AZURE_API_PROFILES[self.api_profile]['ResourceManagementClient'])
         return self._resource_client
 
     @property
@@ -962,7 +962,7 @@ class AzureRMModuleBase(object):
         if not self._compute_client:
             self._compute_client = self.get_mgmt_svc_client(ComputeManagementClient,
                                                             base_url=self._cloud_environment.endpoints.resource_manager,
-                                                            api_version=AZURE_API_PROFILES[self.api_profile]['ComputeManagementClient']) 
+                                                            api_version=AZURE_API_PROFILES[self.api_profile]['ComputeManagementClient'])
         return self._compute_client
 
     @property

--- a/lib/ansible/module_utils/azure_rm_common.py
+++ b/lib/ansible/module_utils/azure_rm_common.py
@@ -913,22 +913,22 @@ class AzureRMModuleBase(object):
             client.config.session_configuration_callback = self._validation_ignore_callback
 
         return client
-    
+
     # In the AZURE_API_PROFILES structure for ComputeManagementClient
     # one of the API versions returns a dictionary (i.e. 'latest')
     # Therefore this causes further functions to fail later - therefore
     # we now check if the value is a str or a dictionary and always
     # return a string
-    def get_compute_management_api(api_ver):
+    def get_compute_management_api(self, api_ver):
         if type(AZURE_API_PROFILES[api_ver]['ComputeManagementClient']) is str:
             returnVal = AZURE_API_PROFILES[api_ver]['ComputeManagementClient']
         elif type(AZURE_API_PROFILES[api_ver]['ComputeManagementClient']) is dict:
             returnVal = AZURE_API_PROFILES[api_ver]['ComputeManagementClient']['virtual_machine_run_commands']
         else:
             returnVal = None
-        
+
         return returnVal
-    
+
     @property
     def storage_client(self):
         self.log('Getting storage client...')

--- a/lib/ansible/module_utils/azure_rm_common.py
+++ b/lib/ansible/module_utils/azure_rm_common.py
@@ -913,7 +913,22 @@ class AzureRMModuleBase(object):
             client.config.session_configuration_callback = self._validation_ignore_callback
 
         return client
-
+    
+    # In the AZURE_API_PROFILES structure for ComputeManagementClient
+    # one of the API versions returns a dictionary (i.e. 'latest')
+    # Therefore this causes further functions to fail later - therefore
+    # we now check if the value is a str or a dictionary and always
+    # return a string
+    def get_compute_management_api(api_ver):
+        if type(AZURE_API_PROFILES[api_ver]['ComputeManagementClient']) is str:
+            returnVal = AZURE_API_PROFILES[api_ver]['ComputeManagementClient']
+        elif type(AZURE_API_PROFILES[api_ver]['ComputeManagementClient']) is dict:
+            returnVal = AZURE_API_PROFILES[api_ver]['ComputeManagementClient']['virtual_machine_run_commands']
+        else:
+            returnVal = None
+        
+        return returnVal
+    
     @property
     def storage_client(self):
         self.log('Getting storage client...')
@@ -962,7 +977,7 @@ class AzureRMModuleBase(object):
         if not self._compute_client:
             self._compute_client = self.get_mgmt_svc_client(ComputeManagementClient,
                                                             base_url=self._cloud_environment.endpoints.resource_manager,
-                                                            api_version=AZURE_API_PROFILES[self.api_profile]['ComputeManagementClient'])
+                                                            api_version=self.get_compute_management_api(self.api_profile)
         return self._compute_client
 
     @property

--- a/lib/ansible/module_utils/azure_rm_common.py
+++ b/lib/ansible/module_utils/azure_rm_common.py
@@ -977,7 +977,7 @@ class AzureRMModuleBase(object):
         if not self._compute_client:
             self._compute_client = self.get_mgmt_svc_client(ComputeManagementClient,
                                                             base_url=self._cloud_environment.endpoints.resource_manager,
-                                                            api_version=self.get_compute_management_api(self.api_profile)
+                                                            api_version=self.get_compute_management_api(self.api_profile))
         return self._compute_client
 
     @property


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
When creating a Network Security Group in AzureStack using Ansible
when looking at the code the base-url was shown as "none" - this caused the code to use
the standard public azure base-url of "management.azure.com" - this caused ansible
not to work with AzureStack as the URL for AzureStack is not the public one. This address was
set in the credentials file and caused other resources (public ip address, resource grouyp etc...) to
be created OK but did not work for network security groups. After degugging I found that the
local variable is set to the credientials fiule value in this case but the value is not passed to
subsequent functions. This fixes this.

API versions were hardcoded for Azure/AzureStack in Ansible even though the ability
was present to pass the api-version in the playboook. Even though the possibility was there to pass
this it was still hardcoded in Ansible - this fix allows the api version to be passed down and used

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request
 

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.2
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Aug  4 2017, 00:39:18) [GCC 4.8.5 20150623 (Red Hat 4.8.5-16)]
  
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
