### PR TITLE
Fix get_fs_size for LVM filesystem

### DIFF
--- a/lib/ansible/modules/system/filesystem.py
+++ b/lib/ansible/modules/system/filesystem.py
@@ -307,8 +307,8 @@ class LVM(Filesystem):
 
     def get_fs_size(self, dev):
         cmd = self.module.get_bin_path('pvs', required=True)
-        _, size, _ = self.module.run_command([cmd, '--noheadings', '-o', 'pv_size', '--units', 'b', str(dev)], check_rc=True)
-        block_count = int(size[:-1])  # block size is 1
+        _, size, _ = self.module.run_command([cmd, '--noheadings', '-o', 'pv_size', '--units', 'b', '--nosuffix', str(dev)], check_rc=True)
+        block_count = int(size)
         return block_count
 
 

--- a/test/integration/targets/filesystem/defaults/main.yml
+++ b/test/integration/targets/filesystem/defaults/main.yml
@@ -19,4 +19,4 @@ tested_filesystems:
   vfat: {fssize: 20, grow: True}
   ocfs2: {fssize: '{{ ocfs2_fssize }}', grow: False}  # grow not implemented
   f2fs: {fssize: '{{ f2fs_fssize|default(60) }}', grow: 'f2fs_version is version("1.10.0", ">=")'}
-  # untested: lvm, requires a block device
+  lvm: {fssize: 20, grow: True}

--- a/test/integration/targets/filesystem/tasks/create_device.yml
+++ b/test/integration/targets/filesystem/tasks/create_device.yml
@@ -22,6 +22,11 @@
         removes: '{{ dev }}'
       when: fstype == 'lvm'
 
+    - name: 'Clean correct device for LVM'
+      set_fact:
+        dev: '{{ image_file }}'
+      when: fstype == 'lvm'
+
     - file:
         name: '{{ image_file }}'
         state: absent

--- a/test/integration/targets/filesystem/tasks/create_device.yml
+++ b/test/integration/targets/filesystem/tasks/create_device.yml
@@ -1,0 +1,27 @@
+- name: 'Create a "disk" file'
+  command: 'dd if=/dev/zero of={{ image_file }} bs=1M count={{ fssize }}'
+
+- vars:
+    dev: '{{ image_file }}'
+  block:
+    - when: fstype == 'lvm'
+      block:
+        - name: 'Create a loop device for LVM'
+          command: 'losetup --show -f {{ dev }}'
+          register: loop_device_cmd
+
+        - set_fact:
+            dev: "{{ loop_device_cmd.stdout }}"
+
+    - include_tasks: '{{ action }}.yml'
+
+  always:
+    - name: 'Detach loop device used for LVM'
+      command: 'losetup -d {{ dev }}'
+      args:
+        removes: '{{ dev }}'
+      when: fstype == 'lvm'
+
+    - file:
+        name: '{{ image_file }}'
+        state: absent

--- a/test/integration/targets/filesystem/tasks/create_fs.yml
+++ b/test/integration/targets/filesystem/tasks/create_fs.yml
@@ -44,7 +44,12 @@
       - 'uuid.stdout != uuid3.stdout'
 
 - name: increase fake device
-  shell: 'dd if=/dev/zero bs=1M count=20 >> {{ image_file }}'
+  shell: 'dd if=/dev/zero bs=1M count=1 >> {{ image_file }}'
+
+- when: fstype == 'lvm'
+  block:
+    - name: Resize loop device for LVM
+      command: losetup -c {{ dev }}
 
 - when: 'grow|bool and (fstype != "vfat" or resize_vfat)'
   block:

--- a/test/integration/targets/filesystem/tasks/create_fs.yml
+++ b/test/integration/targets/filesystem/tasks/create_fs.yml
@@ -1,89 +1,77 @@
-- block:
-  - name: 'Create a "disk" file'
-    command: 'dd if=/dev/zero of={{ dev }} bs=1M count={{ fssize }}'
+- name: filesystem creation
+  filesystem:
+    dev: '{{ dev }}'
+    fstype: '{{ fstype }}'
+  register: fs_result
 
-  - name: filesystem creation
+- assert:
+    that:
+      - 'fs_result is changed'
+      - 'fs_result is success'
+
+- command: 'blkid -c /dev/null -o value -s UUID {{ dev }}'
+  register: uuid
+
+- name: "Check that filesystem isn't created if force isn't used"
+  filesystem:
+    dev: '{{ dev }}'
+    fstype: '{{ fstype }}'
+  register: fs2_result
+
+- command: 'blkid -c /dev/null -o value -s UUID {{ dev }}'
+  register: uuid2
+
+- assert:
+    that:
+      - 'not (fs2_result is changed)'
+      - 'fs2_result is success'
+      - 'uuid.stdout == uuid2.stdout'
+
+- name: Check that filesystem is recreated if force is used
+  filesystem:
+    dev: '{{ dev }}'
+    fstype: '{{ fstype }}'
+    force: yes
+  register: fs3_result
+
+- command: 'blkid -c /dev/null -o value -s UUID {{ dev }}'
+  register: uuid3
+
+- assert:
+    that:
+      - 'fs3_result is changed'
+      - 'fs3_result is success'
+      - 'uuid.stdout != uuid3.stdout'
+
+- name: increase fake device
+  shell: 'dd if=/dev/zero bs=1M count=20 >> {{ image_file }}'
+
+- when: 'grow|bool and (fstype != "vfat" or resize_vfat)'
+  block:
+  - name: Expand filesystem
     filesystem:
       dev: '{{ dev }}'
       fstype: '{{ fstype }}'
-    register: fs_result
+      resizefs: yes
+    register: fs4_result
+
+  - command: 'blkid -c /dev/null -o value -s UUID {{ dev }}'
+    register: uuid4
 
   - assert:
       that:
-        - 'fs_result is changed'
-        - 'fs_result is success'
+        - 'fs4_result is changed'
+        - 'fs4_result is success'
+        - 'uuid3.stdout == uuid4.stdout' # unchanged
 
-  - command: 'blkid -c /dev/null -o value -s UUID {{ dev }}'
-    register: uuid
-
-  - name: "Check that filesystem isn't created if force isn't used"
+  - name: Try to expand filesystem again
     filesystem:
       dev: '{{ dev }}'
       fstype: '{{ fstype }}'
-    register: fs2_result
-
-  - command: 'blkid -c /dev/null -o value -s UUID {{ dev }}'
-    register: uuid2
+      resizefs: yes
+    register: fs5_result
 
   - assert:
       that:
-        - 'not (fs2_result is changed)'
-        - 'fs2_result is success'
-        - 'uuid.stdout == uuid2.stdout'
-
-  - name: Check that filesystem is recreated if force is used
-    filesystem:
-      dev: '{{ dev }}'
-      fstype: '{{ fstype }}'
-      force: yes
-    register: fs3_result
-
-  - command: 'blkid -c /dev/null -o value -s UUID {{ dev }}'
-    register: uuid3
-
-  - assert:
-      that:
-        - 'fs3_result is changed'
-        - 'fs3_result is success'
-        - 'uuid.stdout != uuid3.stdout'
-
-  - name: increase fake device
-    shell: 'dd if=/dev/zero bs=1M count=20 >> {{ dev }}'
-
-  - when: 'grow|bool and (fstype != "vfat" or resize_vfat)'
-    block:
-    - name: Expand filesystem
-      filesystem:
-        dev: '{{ dev }}'
-        fstype: '{{ fstype }}'
-        resizefs: yes
-      register: fs4_result
-
-    - command: 'blkid -c /dev/null -o value -s UUID {{ dev }}'
-      register: uuid4
-
-    - assert:
-        that:
-          - 'fs4_result is changed'
-          - 'fs4_result is success'
-          - 'uuid3.stdout == uuid4.stdout' # unchanged
-
-    - name: Try to expand filesystem again
-      filesystem:
-        dev: '{{ dev }}'
-        fstype: '{{ fstype }}'
-        resizefs: yes
-      register: fs5_result
-
-    - assert:
-        that:
-          - 'not (fs5_result is changed)'
-          - 'fs5_result is successful'
-
-  - import_tasks: overwrite_another_fs.yml
-    when: ansible_system != 'FreeBSD'
-
-  always:
-    - file:
-        name: '{{ dev }}'
-        state: absent
+        - 'not (fs5_result is changed)'
+        - 'fs5_result is successful'

--- a/test/integration/targets/filesystem/tasks/main.yml
+++ b/test/integration/targets/filesystem/tasks/main.yml
@@ -13,23 +13,27 @@
       paths:
         - '../vars/'
 
-- include_tasks: create_fs.yml
+- include_tasks: create_device.yml
   vars:
-    dev: '{{ ansible_user_dir }}/ansible_testing/img'
-    fstype: '{{ item.key }}'
-    fssize: '{{ item.value.fssize }}'
-    grow: '{{ item.value.grow }}'
+    image_file: '{{ ansible_user_dir }}/ansible_testing/img'
+    fstype: '{{ item.0.key }}'
+    fssize: '{{ item.0.value.fssize }}'
+    grow: '{{ item.0.value.grow }}'
+    action: '{{ item.1 }}'
   when:
-    - 'not (item.key == "btrfs" and ansible_system == "FreeBSD")'
-    - 'not (item.key == "ocfs2" and ansible_os_family != "Debian")'
-    # On Ubuntu trusty, blkid (2.20.1) is unable to identify filesystem smaller than 256Mo, see:
+    - 'not (item.0.key == "btrfs" and ansible_system == "FreeBSD")' # btrfs not available on FreeBSD
+    # On Ubuntu trusty, blkid is unable to identify filesystem smaller than 256Mo, see
     # https://www.kernel.org/pub/linux/utils/util-linux/v2.21/v2.21-ChangeLog
     # https://anonscm.debian.org/cgit/collab-maint/pkg-util-linux.git/commit/?id=04f7020eadf31efc731558df92daa0a1c336c46c
-    - 'not (item.key == "btrfs" and (ansible_distribution == "Ubuntu" and ansible_distribution_release == "trusty"))'
-    - 'not (item.key == "f2fs" and ansible_system == "FreeBSD")'
+    - 'not (item.0.key == "btrfs" and (ansible_distribution == "Ubuntu" and ansible_distribution_release == "trusty"))'
+    - 'not (item.0.key == "lvm" and ansible_system == "FreeBSD")' # LVM not available on FreeBSD
+    - 'not (item.0.key == "lvm" and ansible_virtualization_type == "docker")' # Tests use losetup which can not be used inside unprivileged container
+    - 'not (item.0.key == "ocfs2" and ansible_os_family != "Debian")' # ocfs2 only available on Debian based distributions
+    - 'not (item.0.key == "f2fs" and ansible_system == "FreeBSD")'
     # f2fs-tools package not available with RHEL/CentOS
-    - 'not (item.key == "f2fs" and ansible_distribution in ["CentOS", "RedHat"])'
+    - 'not (item.0.key == "f2fs" and ansible_distribution in ["CentOS", "RedHat"])'
     # On Ubuntu trusty, blkid (2.20.1) is unable to identify F2FS filesystem. blkid handles F2FS since v2.23, see:
     # https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/v2.23/v2.23-ReleaseNotes
-    - 'not (item.key == "f2fs" and ansible_distribution == "Ubuntu" and ansible_distribution_version is version("14.04", "<="))'
-  loop: "{{ lookup('dict', tested_filesystems) }}"
+    - 'not (item.0.key == "f2fs" and ansible_distribution == "Ubuntu" and ansible_distribution_version is version("14.04", "<="))'
+    - 'not (item.1 == "overwrite_another_fs" and ansible_system == "FreeBSD")'
+  loop: "{{ query('dict', tested_filesystems)|product(['create_fs', 'overwrite_another_fs'])|list }}"

--- a/test/integration/targets/filesystem/tasks/overwrite_another_fs.yml
+++ b/test/integration/targets/filesystem/tasks/overwrite_another_fs.yml
@@ -1,5 +1,5 @@
 - name: 'Recreate "disk" file'
-  command: 'dd if=/dev/zero of={{ dev }} bs=1M count={{ fssize }}'
+  command: 'dd if=/dev/zero of={{ image_file }} bs=1M count={{ fssize }}'
 
 - name: 'Create a swap filesystem'
   command: 'mkswap {{ dev }}'

--- a/test/integration/targets/filesystem/tasks/setup.yml
+++ b/test/integration/targets/filesystem/tasks/setup.yml
@@ -2,18 +2,19 @@
   package:
     name: '{{ item }}'
     state: present
-  when: ansible_system == 'Linux' or item != 'dosfstools'
   with_items:
     - e2fsprogs
     - xfsprogs
-    - dosfstools
 
 - block:
   - name: install btrfs progs
     package:
       name: btrfs-progs
       state: present
-    when: ansible_os_family != 'Suse' and not (ansible_distribution == 'Ubuntu' and ansible_distribution_version is version('16.04', '<='))
+    when:
+      - ansible_os_family != 'Suse'
+      - not (ansible_distribution == 'Ubuntu' and ansible_distribution_version is version('16.04', '<='))
+      - ansible_system != "FreeBSD"
 
   - name: install btrfs progs (Ubuntu <= 16.04)
     package:
@@ -39,6 +40,7 @@
   - when:
       - ansible_os_family != 'RedHat' or ansible_distribution == 'Fedora'
       - ansible_distribution != 'Ubuntu' or ansible_distribution_version is version('16.04', '>=')
+      - ansible_system != "FreeBSD"
     block:
       - name: install f2fs
         package:
@@ -53,7 +55,13 @@
       - set_fact:
           f2fs_version: '{{ mkfs_f2fs.stdout | regex_search("F2FS-tools: mkfs.f2fs Ver:.*") | regex_replace("F2FS-tools: mkfs.f2fs Ver: ([0-9.]+) .*", "\1") }}'
 
-  when: ansible_system == 'Linux'
+  - name: install dosfstools and lvm2 (Linux)
+    package:
+      name: '{{ item }}'
+    with_items:
+      - dosfstools
+      - lvm2
+    when: ansible_system == 'Linux'
 
 - block:
   - name: install fatresize


### PR DESCRIPTION
##### SUMMARY
Fix get_fs_size method for LVM in filesystem module 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
filesystem module
_lib/ansible/modules/system/filesystem.py_

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5.2
```


##### ADDITIONAL INFORMATION

When i resize an lvm filesystem 
``` yml
- name: debian_lvm | resize
  filesystem:
    dev: /dev/sdb
    resizefs: True
    fstype: lvm
```

```
TASK [latnok : debian_lvm | resize] **********************************************************************************************************************************************************
fatal: [XXX.XXX.XXX.XXX]: FAILED! => {"changed": false, "module_stderr": "Shared connection to XXX.XXX.XXX.XXX closed.\r\n", "module_stdout": "\r\nTraceback (most recent call last):\r\n  File \"/tmp/ansible_mnw1n1dh/ansible_module_filesystem.py\", line 347, in <module>\r\n    main()\r\n  File \"/tmp/ansible_mnw1n1dh/ansible_module_filesystem.py\", line 331, in main\r\n    out = filesystem.grow(dev)\r\n  File \"/tmp/ansible_mnw1n1dh/ansible_module_filesystem.py\", line 142, in grow\r\n    fssize_in_bytes = self.get_fs_size(dev)\r\n  File \"/tmp/ansible_mnw1n1dh/ansible_module_filesystem.py\", line 259, in get_fs_size\r\n    block_count = int(size[:-1])  # block size is 1\r\nValueError: invalid literal for int() with base 10: '  42945478656B'\r\n", "msg": "MODULE FAILURE", "rc": 1}
```

Ansible execute the follow command
```
sudo pvs --noheadings -o pv_size --units b /dev/sdb
```
The command's result the volume size with the unit measure : 42945478656**B**. And cast to int failed.

To output the volume size without the unit measure the option ``--nosuffix`` is necessary.

I test my fix on debian9.