### PR TITLE
 Fix to output string of items rather than unicode of items. 

### DIFF
--- a/lib/ansible/plugins/callback/__init__.py
+++ b/lib/ansible/plugins/callback/__init__.py
@@ -227,7 +227,8 @@ class CallbackBase(AnsiblePlugin):
             item = result.get('_ansible_item_label')
         else:
             item = result.get('item', None)
-
+        ## Fix to output string of items rather than unicode of items. 
+        item = [str(x) for x in item]
         return item
 
     def _process_items(self, result):

--- a/lib/ansible/plugins/callback/__init__.py
+++ b/lib/ansible/plugins/callback/__init__.py
@@ -227,7 +227,7 @@ class CallbackBase(AnsiblePlugin):
             item = result.get('_ansible_item_label')
         else:
             item = result.get('item', None)
-        ## Fix to output string of items rather than unicode of items. 
+        #Fix to output string of items rather than unicode of items.
         item = [str(x) for x in item]
         return item
 


### PR DESCRIPTION
##### SUMMARY
 Fix to output string of items rather than unicode of items. 

While looking into callback modules and seeing outputs, I came accross this anomoly. Ansible normally outputs in strings, and not unicode, however when using with_items it outputs the list in a unicode format. 

After searching, I found that converting the list within the get_items method of __initi__.py fixed this. 


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
__initi__.py

##### ANSIBLE VERSION
```
ansible 2.5.2
  config file = /home/excalibrax/Dropbox/LinuxDocs/projects/ansible_testing/callback_plugins_git/testing_role/ansible.cfg
  configured module search path = [u'/home/excalibrax/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.14 (default, Mar 14 2018, 13:36:31) [GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]

```


##### ADDITIONAL INFORMATION
This effects output to the screen via the callback modules, and should not effect any existing roles or aspects of ansible. 
Code to reproduce:
```
  - name: add packages
    yum:
      name: "{{ item }}"
      state: present
    with_items:
       - httpd
       - perl
```
Output changes:
```
Original output:
ok: [172.16.0.2] => (item=[u'httpd', u'perl'])
changed: [172.16.0.3] => (item=[u'httpd', u'perl'])
New output:
ok: [172.16.0.2] => (item=['httpd', 'perl'])
changed: [172.16.0.3] => (item=['httpd', 'perl'])
```
