### PR TITLE
Clean up vmware/vcenter integration tests.

### DIFF
--- a/test/integration/targets/vcenter_folder/aliases
+++ b/test/integration/targets/vcenter_folder/aliases
@@ -1,3 +1,2 @@
 posix/ci/cloud/group4/vcenter
 cloud/vcenter
-destructive

--- a/test/integration/targets/vcenter_license/aliases
+++ b/test/integration/targets/vcenter_license/aliases
@@ -1,3 +1,2 @@
 posix/ci/cloud/group4/vcenter
 cloud/vcenter
-destructive

--- a/test/integration/targets/vmware_cluster/aliases
+++ b/test/integration/targets/vmware_cluster/aliases
@@ -1,3 +1,2 @@
 posix/ci/cloud/group4/vcenter
 cloud/vcenter
-destructive

--- a/test/integration/targets/vmware_datacenter/aliases
+++ b/test/integration/targets/vmware_datacenter/aliases
@@ -1,3 +1,2 @@
 posix/ci/cloud/group4/vcenter
 cloud/vcenter
-destructive

--- a/test/integration/targets/vmware_datastore_cluster/aliases
+++ b/test/integration/targets/vmware_datastore_cluster/aliases
@@ -1,3 +1,2 @@
 posix/ci/cloud/group4/vcenter
 cloud/vcenter
-destructive

--- a/test/integration/targets/vmware_datastore_facts/aliases
+++ b/test/integration/targets/vmware_datastore_facts/aliases
@@ -1,3 +1,2 @@
 posix/ci/cloud/group1/vcenter
 cloud/vcenter
-destructive

--- a/test/integration/targets/vmware_datastore_maintenancemode/aliases
+++ b/test/integration/targets/vmware_datastore_maintenancemode/aliases
@@ -1,3 +1,2 @@
 cloud/vcenter
-posix/ci/cloud/group4/vcenter
 unsupported

--- a/test/integration/targets/vmware_datastore_maintenancemode/aliases
+++ b/test/integration/targets/vmware_datastore_maintenancemode/aliases
@@ -1,4 +1,4 @@
 cloud/vcenter
 destructive
 posix/ci/cloud/group4/vcenter
-disabled
+unsupported

--- a/test/integration/targets/vmware_datastore_maintenancemode/aliases
+++ b/test/integration/targets/vmware_datastore_maintenancemode/aliases
@@ -1,4 +1,3 @@
 cloud/vcenter
-destructive
 posix/ci/cloud/group4/vcenter
 unsupported

--- a/test/integration/targets/vmware_datastore_maintenancemode/tasks/main.yml
+++ b/test/integration/targets/vmware_datastore_maintenancemode/tasks/main.yml
@@ -4,106 +4,106 @@
 
 # TODO: vcsim does not support datastore maintenance mode properties
 
-#- name: store the vcenter container ip
-#  set_fact:
-#    vcsim: "{{ lookup('env', 'vcenter_host') }}"
+- name: store the vcenter container ip
+  set_fact:
+    vcsim: "{{ lookup('env', 'vcenter_host') }}"
 
-#- debug: var=vcsim
+- debug: var=vcsim
 
-#- name: Wait for Flask controller to come up online
-#  wait_for:
-#    host: "{{ vcsim }}"
-#    port: 5000
-#    state: started
+- name: Wait for Flask controller to come up online
+  wait_for:
+    host: "{{ vcsim }}"
+    port: 5000
+    state: started
 
-#- name: kill vcsim
-#  uri:
-#    url: http://{{ vcsim }}:5000/killall
+- name: kill vcsim
+  uri:
+    url: http://{{ vcsim }}:5000/killall
 
-#- name: start vcsim
-#  uri:
-#    url: http://{{ vcsim }}:5000/spawn?datacenter=1&cluster=1&folder=0
-#  register: vcsim_instance
+- name: start vcsim
+  uri:
+    url: http://{{ vcsim }}:5000/spawn?datacenter=1&cluster=1&folder=0
+  register: vcsim_instance
 
-#- name: Wait for vcsim server to come up online
-#  wait_for:
-#    host: "{{ vcsim }}"
-#    port: 443
-#    state: started
+- name: Wait for vcsim server to come up online
+  wait_for:
+    host: "{{ vcsim }}"
+    port: 443
+    state: started
 
-#- name: Get a list of datastores from vcsim
-#  uri:
-#    url: http://{{ vcsim }}:5000/govc_find?filter=D
-#  register: datastores
+- name: Get a list of datastores from vcsim
+  uri:
+    url: http://{{ vcsim }}:5000/govc_find?filter=D
+  register: datastores
 
-#- name: Enter datastore in maintenance mode
-#  vmware_datastore_maintenancemode:
-#    hostname: "{{ vcsim }}"
-#    username: "{{ vcsim_instance.json.username }}"
-#    password: "{{ vcsim_instance.json.password }}"
-#    state: present
-#    datastore: "{{ item | basename }}"
-#    validate_certs: False
-#  with_items: "{{ datastores['json'] }}"
-#  register: test_result_0001
+- name: Enter datastore in maintenance mode
+  vmware_datastore_maintenancemode:
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance.json.username }}"
+    password: "{{ vcsim_instance.json.password }}"
+    state: present
+    datastore: "{{ item | basename }}"
+    validate_certs: False
+  with_items: "{{ datastores['json'] }}"
+  register: test_result_0001
 
-#- debug: var=test_result_0001
+- debug: var=test_result_0001
 
-#- name: assert that changes were made
-#  assert:
-#    that:
-#      - "test_result_0001.results|map(attribute='changed')|unique|list == [true]"
+- name: assert that changes were made
+  assert:
+    that:
+      - "test_result_0001.results|map(attribute='changed')|unique|list == [true]"
 
-#- name: Enter datastore in maintenance mode again
-#  vmware_datastore_maintenancemode:
-#    hostname: "{{ vcsim }}"
-#    username: "{{ vcsim_instance.json.username }}"
-#    password: "{{ vcsim_instance.json.password }}"
-#    state: present
-#    datastore: "{{ item | basename }}"
-#    validate_certs: no
-#  with_items: "{{ datastores['json'] }}"
-#  register: test_result_0002
+- name: Enter datastore in maintenance mode again
+  vmware_datastore_maintenancemode:
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance.json.username }}"
+    password: "{{ vcsim_instance.json.password }}"
+    state: present
+    datastore: "{{ item | basename }}"
+    validate_certs: no
+  with_items: "{{ datastores['json'] }}"
+  register: test_result_0002
 
-#- debug: var=test_result_0002
+- debug: var=test_result_0002
 
-#- name: assert that no changes were made
-#  assert:
-#    that:
-#      - "test_result_0002.results|map(attribute='changed')|unique|list == [false]"
+- name: assert that no changes were made
+  assert:
+    that:
+      - "test_result_0002.results|map(attribute='changed')|unique|list == [false]"
 
-#- name: Exit datastores from maintenance mode
-#  vmware_datastore_maintenancemode:
-#    hostname: "{{ vcsim }}"
-#    username: "{{ vcsim_instance.json.username }}"
-#    password: "{{ vcsim_instance.json.password }}"
-#    state: absent
-#    esxi_hostname: "{{ item | basename }}"
-#    validate_certs: no
-#  with_items: "{{ datastores['json'] }}"
-#  register: test_result_0003
+- name: Exit datastores from maintenance mode
+  vmware_datastore_maintenancemode:
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance.json.username }}"
+    password: "{{ vcsim_instance.json.password }}"
+    state: absent
+    esxi_hostname: "{{ item | basename }}"
+    validate_certs: no
+  with_items: "{{ datastores['json'] }}"
+  register: test_result_0003
 
-#- debug: var=test_result_0003
+- debug: var=test_result_0003
 
-#- name: assert that changes were made
-#  assert:
-#    that:
-#      - "test_result_0003.results|map(attribute='changed')|unique|list == [true]"
+- name: assert that changes were made
+  assert:
+    that:
+      - "test_result_0003.results|map(attribute='changed')|unique|list == [true]"
 
-#- name: Exit datastores from maintenance mode again
-#  vmware_datastore_maintenancemode:
-#    hostname: "{{ vcsim }}"
-#    username: "{{ vcsim_instance.json.username }}"
-#    password: "{{ vcsim_instance.json.password }}"
-#    state: absent
-#    esxi_hostname: "{{ item | basename }}"
-#    validate_certs: no
-#  with_items: "{{ datastores['json'] }}"
-#  register: test_result_0004
+- name: Exit datastores from maintenance mode again
+  vmware_datastore_maintenancemode:
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance.json.username }}"
+    password: "{{ vcsim_instance.json.password }}"
+    state: absent
+    esxi_hostname: "{{ item | basename }}"
+    validate_certs: no
+  with_items: "{{ datastores['json'] }}"
+  register: test_result_0004
 
-#- debug: var=test_result_0004
+- debug: var=test_result_0004
 
-#- name: assert that no changes were made
-#  assert:
-#    that:
-#      - "test_result_0004.results|map(attribute='changed')|unique|list == [false]"
+- name: assert that no changes were made
+  assert:
+    that:
+      - "test_result_0004.results|map(attribute='changed')|unique|list == [false]"

--- a/test/integration/targets/vmware_drs_rule_facts/aliases
+++ b/test/integration/targets/vmware_drs_rule_facts/aliases
@@ -1,3 +1,2 @@
 posix/ci/cloud/group1/vcenter
 cloud/vcenter
-destructive

--- a/test/integration/targets/vmware_dvs_portgroup/aliases
+++ b/test/integration/targets/vmware_dvs_portgroup/aliases
@@ -1,3 +1,2 @@
 posix/ci/cloud/group4/vcenter
 cloud/vcenter
-destructive

--- a/test/integration/targets/vmware_dvswitch/aliases
+++ b/test/integration/targets/vmware_dvswitch/aliases
@@ -1,3 +1,2 @@
 posix/ci/cloud/group4/vcenter
 cloud/vcenter
-destructive

--- a/test/integration/targets/vmware_guest/aliases
+++ b/test/integration/targets/vmware_guest/aliases
@@ -1,3 +1,2 @@
 posix/ci/cloud/group4/vcenter
 cloud/vcenter
-destructive

--- a/test/integration/targets/vmware_guest_disk_facts/aliases
+++ b/test/integration/targets/vmware_guest_disk_facts/aliases
@@ -1,3 +1,3 @@
 posix/ci/cloud/group4/vcenter
 cloud/vcenter
-
+unsupported

--- a/test/integration/targets/vmware_guest_disk_facts/aliases
+++ b/test/integration/targets/vmware_guest_disk_facts/aliases
@@ -1,3 +1,2 @@
-posix/ci/cloud/group4/vcenter
 cloud/vcenter
 unsupported

--- a/test/integration/targets/vmware_guest_disk_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_guest_disk_facts/tasks/main.yml
@@ -3,52 +3,52 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 # TODO: vcsim does not support disk information
-#- name: Wait for Flask controller to come up online
-#  wait_for:
-#    host: "{{ vcsim }}"
-#    port: 5000
-#    state: started
-#
-#- name: kill vcsim
-#  uri:
-#    url: http://{{ vcsim }}:5000/killall
-#- name: start vcsim with no folders
-#  uri:
-#    url: http://{{ vcsim }}:5000/spawn?datacenter=1&cluster=1&folder=0
-#  register: vcsim_instance
-#
-#- name: Wait for Flask controller to come up online
-#  wait_for:
-#    host: "{{ vcsim }}"
-#    port: 443
-#    state: started
-#
-#- name: get a list of VMS from vcsim
-#  uri:
-#    url: http://{{ vcsim }}:5000/govc_find?filter=VM
-#  register: vmlist
-#
-#- debug: var=vcsim_instance
-#
-#- debug: var=vmlist
-#
-#- set_fact:
-#   vm1: "{{ vmlist['json'][0] }}"
-#
-#- debug: var=vm1
-#
-#- name: create new VMs with non-existent network
-#  vmware_guest_disk_facts:
-#    validate_certs: False
-#    hostname: "{{ vcsim }}"
-#    username: "{{ vcsim_instance['json']['username'] }}"
-#    password: "{{ vcsim_instance['json']['password'] }}"
-#    name: "{{ vm1 }}"
-#    datacenter: "{{ (vm1 | basename).split('_')[0] }}"
-#  register: disk_facts
-#- debug: var=disk_facts
-#
-#- name: assert that no changes were made
-#  assert:
-#    that:
-#        - "not disk_facts.changed"
+- name: Wait for Flask controller to come up online
+  wait_for:
+    host: "{{ vcsim }}"
+    port: 5000
+    state: started
+
+- name: kill vcsim
+  uri:
+    url: http://{{ vcsim }}:5000/killall
+- name: start vcsim with no folders
+  uri:
+    url: http://{{ vcsim }}:5000/spawn?datacenter=1&cluster=1&folder=0
+  register: vcsim_instance
+
+- name: Wait for Flask controller to come up online
+  wait_for:
+    host: "{{ vcsim }}"
+    port: 443
+    state: started
+
+- name: get a list of VMS from vcsim
+  uri:
+    url: http://{{ vcsim }}:5000/govc_find?filter=VM
+  register: vmlist
+
+- debug: var=vcsim_instance
+
+- debug: var=vmlist
+
+- set_fact:
+   vm1: "{{ vmlist['json'][0] }}"
+
+- debug: var=vm1
+
+- name: create new VMs with non-existent network
+  vmware_guest_disk_facts:
+    validate_certs: False
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    name: "{{ vm1 }}"
+    datacenter: "{{ (vm1 | basename).split('_')[0] }}"
+  register: disk_facts
+- debug: var=disk_facts
+
+- name: assert that no changes were made
+  assert:
+    that:
+        - "not disk_facts.changed"

--- a/test/integration/targets/vmware_guest_facts/aliases
+++ b/test/integration/targets/vmware_guest_facts/aliases
@@ -1,3 +1,2 @@
 posix/ci/cloud/group4/vcenter
 cloud/vcenter
-destructive

--- a/test/integration/targets/vmware_guest_find/aliases
+++ b/test/integration/targets/vmware_guest_find/aliases
@@ -1,3 +1,2 @@
 posix/ci/cloud/group4/vcenter
 cloud/vcenter
-destructive

--- a/test/integration/targets/vmware_guest_powerstate/aliases
+++ b/test/integration/targets/vmware_guest_powerstate/aliases
@@ -1,3 +1,2 @@
 posix/ci/cloud/group4/vcenter
 cloud/vcenter
-destructive

--- a/test/integration/targets/vmware_guest_snapshot/aliases
+++ b/test/integration/targets/vmware_guest_snapshot/aliases
@@ -1,3 +1,4 @@
 posix/ci/cloud/group4/vcenter
 cloud/vcenter
 destructive
+unsupported

--- a/test/integration/targets/vmware_guest_snapshot/aliases
+++ b/test/integration/targets/vmware_guest_snapshot/aliases
@@ -1,3 +1,2 @@
-posix/ci/cloud/group4/vcenter
 cloud/vcenter
 unsupported

--- a/test/integration/targets/vmware_guest_snapshot/aliases
+++ b/test/integration/targets/vmware_guest_snapshot/aliases
@@ -1,4 +1,3 @@
 posix/ci/cloud/group4/vcenter
 cloud/vcenter
-destructive
 unsupported

--- a/test/integration/targets/vmware_guest_snapshot/tasks/main.yml
+++ b/test/integration/targets/vmware_guest_snapshot/tasks/main.yml
@@ -1,230 +1,230 @@
-# - name: store the vcenter container ip
-#   set_fact:
-#     vcsim: "{{ lookup('env', 'vcenter_host') }}"
-# - debug: var=vcsim
-# 
-# - name: Wait for Flask controller to come up online
-#   wait_for:
-#     host: "{{ vcsim }}"
-#     port: 5000
-#     state: started
-# 
-# - name: kill vcsim
-#   uri:
-#     url: "{{ 'http://' + vcsim + ':5000/killall' }}"
-# - name: start vcsim with no folders
-#   uri:
-#     url: "{{ 'http://' + vcsim + ':5000/spawn?datacenter=1&cluster=1&folder=1' }}"
-#   register: vcsim_instance
-# 
-# - name: Wait for Flask controller to come up online
-#   wait_for:
-#     host: "{{ vcsim }}"
-#     port: 443
-#     state: started
-# 
-# - name: get a list of VMS from vcsim   
-#   uri:
-#     url: "{{ 'http://' + vcsim + ':5000/govc_find?filter=VM' }}"
-#   register: vmlist
-# 
-# - set_fact:
-#     vm1: "{{ vmlist['json'][0] }}"
-# 
-# - name: get a list of datacenters from vcsim
-#   uri:
-#     url: "{{ 'http://' + vcsim + ':5000/govc_find?filter=DC' }}"
-#   register: datacenters
-# 
-# - set_fact:
-#     dc1: "{{ datacenters['json'][0] }}"
-# 
-# - debug: var=vcsim_instance
-# - debug: var=vmlist
-# - debug: var=vm1
-# - debug: var=dc1
-# 
-# # Test0001: Try to delete the non-existent snapshot
-# - name: 0001 - Delete non-existent snapshot
-#   vmware_guest_snapshot:
-#     validate_certs: False
-#     hostname: "{{ vcsim }}"
-#     username: "{{ vcsim_instance['json']['username'] }}"
-#     password: "{{ vcsim_instance['json']['password'] }}"
-#     datacenter: "{{ dc1 | basename }}"
-#     folder: "{{ vm1 | dirname }}"
-#     name: "{{ vm1 | basename }}"
-#     state: absent
-#     snapshot_name: snap_a
-# 
-# # Test0002: Create two snapshots
-# - name: 0002 - Create snapshot
-#   vmware_guest_snapshot:
-#     validate_certs: False
-#     hostname: "{{ vcsim }}"
-#     username: "{{ vcsim_instance['json']['username'] }}"
-#     password: "{{ vcsim_instance['json']['password'] }}"
-#     datacenter: "{{ dc1 | basename }}"
-#     folder: "{{ vm1 | dirname }}"
-#     name: "{{ vm1 | basename }}"
-#     state: present
-#     snapshot_name: "snap_{{item}}"
-#     description: "snap named {{item}}"
-#   with_items:
-#     - a
-#     - b
-# 
-# # Test0003: Reanme a to c
-# - name: 0003 - Rename snapshot
-#   vmware_guest_snapshot:
-#     validate_certs: False
-#     hostname: "{{ vcsim }}"
-#     username: "{{ vcsim_instance['json']['username'] }}"
-#     password: "{{ vcsim_instance['json']['password'] }}"
-#     datacenter: "{{ dc1 | basename }}"
-#     folder: "{{ vm1 | dirname }}"
-#     name: "{{ vm1 | basename }}"
-#     state: present
-#     snapshot_name: snap_a
-#     new_snapshot_name: snap_c
-# 
-# # Test0004: Create snap_a again
-# - name: 0004 - Re-create snapshot a
-#   vmware_guest_snapshot:
-#     validate_certs: False
-#     hostname: "{{ vcsim }}"
-#     username: "{{ vcsim_instance['json']['username'] }}"
-#     password: "{{ vcsim_instance['json']['password'] }}"
-#     datacenter: "{{ dc1 | basename }}"
-#     folder: "{{ vm1 | dirname }}"
-#     name: "{{ vm1 | basename }}"
-#     state: present
-#     snapshot_name: snap_a
-#     description: "snap named a"
-# 
-# # Test0005: Change description of snap_c
-# - name: 0005 - Change description of snap_c
-#   vmware_guest_snapshot:
-#     validate_certs: False
-#     hostname: "{{ vcsim }}"
-#     username: "{{ vcsim_instance['json']['username'] }}"
-#     password: "{{ vcsim_instance['json']['password'] }}"
-#     datacenter: "{{ dc1 | basename }}"
-#     folder: "{{ vm1 | dirname }}"
-#     name: "{{ vm1 | basename }}"
-#     state: present
-#     snapshot_name: snap_c
-#     new_description: "renamed to snap_c from snap_a"
-# 
-# # Test0006: Delete snap_b with child remove
-# - name: 0006 - Delete snap_b with child remove
-#   vmware_guest_snapshot:
-#     validate_certs: False
-#     hostname: "{{ vcsim }}"
-#     username: "{{ vcsim_instance['json']['username'] }}"
-#     password: "{{ vcsim_instance['json']['password'] }}"
-#     datacenter: "{{ dc1 | basename }}"
-#     folder: "{{ vm1 | dirname }}"
-#     name: "{{ vm1 | basename }}"
-#     state: absent
-#     snapshot_name: snap_b
-#     remove_children: True
-# 
-# # Test0007: Delete all snapshots
-# - name: 0007 - Delete all snapshots
-#   vmware_guest_snapshot:
-#     validate_certs: False
-#     hostname: "{{ vcsim }}"
-#     username: "{{ vcsim_instance['json']['username'] }}"
-#     password: "{{ vcsim_instance['json']['password'] }}"
-#     datacenter: "{{ dc1 | basename }}"
-#     folder: "{{ vm1 | dirname }}"
-#     name: "{{ vm1 | basename }}"
-#     state: remove_all
-# 
-# # Test0008: Create snap_a again and revert to it
-# - name: 0008 - Re-create snapshot a
-#   vmware_guest_snapshot:
-#     validate_certs: False
-#     hostname: "{{ vcsim }}"
-#     username: "{{ vcsim_instance['json']['username'] }}"
-#     password: "{{ vcsim_instance['json']['password'] }}"
-#     datacenter: "{{ dc1 | basename }}"
-#     folder: "{{ vm1 | dirname }}"
-#     name: "{{ vm1 | basename }}"
-#     state: present
-#     snapshot_name: snap_a
-#     description: "snap named a"
-# 
-# - name: 0008 - Revert to snap_a
-#   vmware_guest_snapshot:
-#     validate_certs: False
-#     hostname: "{{ vcsim }}"
-#     username: "{{ vcsim_instance['json']['username'] }}"
-#     password: "{{ vcsim_instance['json']['password'] }}"
-#     datacenter: "{{ dc1 | basename }}"
-#     folder: "{{ vm1 | dirname }}"
-#     name: "{{ vm1 | basename }}"
-#     state: revert
-#     snapshot_name: snap_a
-# 
-# # Test0009: Create snap_a and check in result
-# - name: 0009 - create snapshot a
-#   vmware_guest_snapshot:
-#     validate_certs: False
-#     hostname: "{{ vcsim }}"
-#     username: "{{ vcsim_instance['json']['username'] }}"
-#     password: "{{ vcsim_instance['json']['password'] }}"
-#     datacenter: "{{ dc1 | basename }}"
-#     folder: "{{ vm1 | dirname }}"
-#     name: "{{ vm1 | basename }}"
-#     state: present
-#     snapshot_name: snap_a
-#     description: "snap named a"
-#   register: snapshot_details
-# 
-# - name: Check if snapshot details available or not
-#   assert:
-#     that:
-#         - "snapshot_details.results['current_snapshot']['name'] == 'snap_a'"
-# 
-# # Test0010: Failure sceanrios
-# - name: 0010 - Folder is missing
-#   vmware_guest_snapshot:
-#     validate_certs: False
-#     hostname: "{{ vcsim }}"
-#     username: "{{ vcsim_instance['json']['username'] }}"
-#     password: "{{ vcsim_instance['json']['password'] }}"
-#     datacenter: "{{ dc1 | basename }}"
-#     name: "{{ vm1 | basename }}"
-#     state: present
-#     snapshot_name: snap_a
-#     description: "snap named a"
-#   register: snapshot_failure_details
-#   ignore_errors: yes
-# 
-# - name: Check if error is shown
-#   assert:
-#     that:
-#         - "'parameters are required together: name, folder' in snapshot_failure_details['msg']"
-#         - "snapshot_failure_details.changed == false"
-# 
-# # Test0011: Failure sceanrios - when name and UUID is not specified
-# - name: 0011 - name and UUID is missing
-#   vmware_guest_snapshot:
-#     validate_certs: False
-#     hostname: "{{ vcsim }}"
-#     username: "{{ vcsim_instance['json']['username'] }}"
-#     password: "{{ vcsim_instance['json']['password'] }}"
-#     datacenter: "{{ dc1 | basename }}"
-#     state: present
-#     snapshot_name: snap_a
-#     description: "snap named a"
-#   register: snapshot_failure_details
-#   ignore_errors: yes
-# 
-# - name: Check if error is shown
-#   assert:
-#     that:
-#         - "'one of the following is required: name, uuid' in snapshot_failure_details['msg']"
-#         - "snapshot_failure_details.changed == false"
+ - name: store the vcenter container ip
+   set_fact:
+     vcsim: "{{ lookup('env', 'vcenter_host') }}"
+ - debug: var=vcsim
+
+ - name: Wait for Flask controller to come up online
+   wait_for:
+     host: "{{ vcsim }}"
+     port: 5000
+     state: started
+
+ - name: kill vcsim
+   uri:
+     url: "{{ 'http://' + vcsim + ':5000/killall' }}"
+ - name: start vcsim with no folders
+   uri:
+     url: "{{ 'http://' + vcsim + ':5000/spawn?datacenter=1&cluster=1&folder=1' }}"
+   register: vcsim_instance
+
+ - name: Wait for Flask controller to come up online
+   wait_for:
+     host: "{{ vcsim }}"
+     port: 443
+     state: started
+
+ - name: get a list of VMS from vcsim
+   uri:
+     url: "{{ 'http://' + vcsim + ':5000/govc_find?filter=VM' }}"
+   register: vmlist
+
+ - set_fact:
+     vm1: "{{ vmlist['json'][0] }}"
+
+ - name: get a list of datacenters from vcsim
+   uri:
+     url: "{{ 'http://' + vcsim + ':5000/govc_find?filter=DC' }}"
+   register: datacenters
+
+ - set_fact:
+     dc1: "{{ datacenters['json'][0] }}"
+
+ - debug: var=vcsim_instance
+ - debug: var=vmlist
+ - debug: var=vm1
+ - debug: var=dc1
+
+ # Test0001: Try to delete the non-existent snapshot
+ - name: 0001 - Delete non-existent snapshot
+   vmware_guest_snapshot:
+     validate_certs: False
+     hostname: "{{ vcsim }}"
+     username: "{{ vcsim_instance['json']['username'] }}"
+     password: "{{ vcsim_instance['json']['password'] }}"
+     datacenter: "{{ dc1 | basename }}"
+     folder: "{{ vm1 | dirname }}"
+     name: "{{ vm1 | basename }}"
+     state: absent
+     snapshot_name: snap_a
+
+ # Test0002: Create two snapshots
+ - name: 0002 - Create snapshot
+   vmware_guest_snapshot:
+     validate_certs: False
+     hostname: "{{ vcsim }}"
+     username: "{{ vcsim_instance['json']['username'] }}"
+     password: "{{ vcsim_instance['json']['password'] }}"
+     datacenter: "{{ dc1 | basename }}"
+     folder: "{{ vm1 | dirname }}"
+     name: "{{ vm1 | basename }}"
+     state: present
+     snapshot_name: "snap_{{item}}"
+     description: "snap named {{item}}"
+   with_items:
+     - a
+     - b
+
+ # Test0003: Reanme a to c
+ - name: 0003 - Rename snapshot
+   vmware_guest_snapshot:
+     validate_certs: False
+     hostname: "{{ vcsim }}"
+     username: "{{ vcsim_instance['json']['username'] }}"
+     password: "{{ vcsim_instance['json']['password'] }}"
+     datacenter: "{{ dc1 | basename }}"
+     folder: "{{ vm1 | dirname }}"
+     name: "{{ vm1 | basename }}"
+     state: present
+     snapshot_name: snap_a
+     new_snapshot_name: snap_c
+
+ # Test0004: Create snap_a again
+ - name: 0004 - Re-create snapshot a
+   vmware_guest_snapshot:
+     validate_certs: False
+     hostname: "{{ vcsim }}"
+     username: "{{ vcsim_instance['json']['username'] }}"
+     password: "{{ vcsim_instance['json']['password'] }}"
+     datacenter: "{{ dc1 | basename }}"
+     folder: "{{ vm1 | dirname }}"
+     name: "{{ vm1 | basename }}"
+     state: present
+     snapshot_name: snap_a
+     description: "snap named a"
+
+ # Test0005: Change description of snap_c
+ - name: 0005 - Change description of snap_c
+   vmware_guest_snapshot:
+     validate_certs: False
+     hostname: "{{ vcsim }}"
+     username: "{{ vcsim_instance['json']['username'] }}"
+     password: "{{ vcsim_instance['json']['password'] }}"
+     datacenter: "{{ dc1 | basename }}"
+     folder: "{{ vm1 | dirname }}"
+     name: "{{ vm1 | basename }}"
+     state: present
+     snapshot_name: snap_c
+     new_description: "renamed to snap_c from snap_a"
+
+ # Test0006: Delete snap_b with child remove
+ - name: 0006 - Delete snap_b with child remove
+   vmware_guest_snapshot:
+     validate_certs: False
+     hostname: "{{ vcsim }}"
+     username: "{{ vcsim_instance['json']['username'] }}"
+     password: "{{ vcsim_instance['json']['password'] }}"
+     datacenter: "{{ dc1 | basename }}"
+     folder: "{{ vm1 | dirname }}"
+     name: "{{ vm1 | basename }}"
+     state: absent
+     snapshot_name: snap_b
+     remove_children: True
+
+ # Test0007: Delete all snapshots
+ - name: 0007 - Delete all snapshots
+   vmware_guest_snapshot:
+     validate_certs: False
+     hostname: "{{ vcsim }}"
+     username: "{{ vcsim_instance['json']['username'] }}"
+     password: "{{ vcsim_instance['json']['password'] }}"
+     datacenter: "{{ dc1 | basename }}"
+     folder: "{{ vm1 | dirname }}"
+     name: "{{ vm1 | basename }}"
+     state: remove_all
+
+ # Test0008: Create snap_a again and revert to it
+ - name: 0008 - Re-create snapshot a
+   vmware_guest_snapshot:
+     validate_certs: False
+     hostname: "{{ vcsim }}"
+     username: "{{ vcsim_instance['json']['username'] }}"
+     password: "{{ vcsim_instance['json']['password'] }}"
+     datacenter: "{{ dc1 | basename }}"
+     folder: "{{ vm1 | dirname }}"
+     name: "{{ vm1 | basename }}"
+     state: present
+     snapshot_name: snap_a
+     description: "snap named a"
+
+ - name: 0008 - Revert to snap_a
+   vmware_guest_snapshot:
+     validate_certs: False
+     hostname: "{{ vcsim }}"
+     username: "{{ vcsim_instance['json']['username'] }}"
+     password: "{{ vcsim_instance['json']['password'] }}"
+     datacenter: "{{ dc1 | basename }}"
+     folder: "{{ vm1 | dirname }}"
+     name: "{{ vm1 | basename }}"
+     state: revert
+     snapshot_name: snap_a
+
+ # Test0009: Create snap_a and check in result
+ - name: 0009 - create snapshot a
+   vmware_guest_snapshot:
+     validate_certs: False
+     hostname: "{{ vcsim }}"
+     username: "{{ vcsim_instance['json']['username'] }}"
+     password: "{{ vcsim_instance['json']['password'] }}"
+     datacenter: "{{ dc1 | basename }}"
+     folder: "{{ vm1 | dirname }}"
+     name: "{{ vm1 | basename }}"
+     state: present
+     snapshot_name: snap_a
+     description: "snap named a"
+   register: snapshot_details
+
+ - name: Check if snapshot details available or not
+   assert:
+     that:
+         - "snapshot_details.results['current_snapshot']['name'] == 'snap_a'"
+
+ # Test0010: Failure sceanrios
+ - name: 0010 - Folder is missing
+   vmware_guest_snapshot:
+     validate_certs: False
+     hostname: "{{ vcsim }}"
+     username: "{{ vcsim_instance['json']['username'] }}"
+     password: "{{ vcsim_instance['json']['password'] }}"
+     datacenter: "{{ dc1 | basename }}"
+     name: "{{ vm1 | basename }}"
+     state: present
+     snapshot_name: snap_a
+     description: "snap named a"
+   register: snapshot_failure_details
+   ignore_errors: yes
+
+ - name: Check if error is shown
+   assert:
+     that:
+         - "'parameters are required together: name, folder' in snapshot_failure_details['msg']"
+         - "snapshot_failure_details.changed == false"
+
+ # Test0011: Failure sceanrios - when name and UUID is not specified
+ - name: 0011 - name and UUID is missing
+   vmware_guest_snapshot:
+     validate_certs: False
+     hostname: "{{ vcsim }}"
+     username: "{{ vcsim_instance['json']['username'] }}"
+     password: "{{ vcsim_instance['json']['password'] }}"
+     datacenter: "{{ dc1 | basename }}"
+     state: present
+     snapshot_name: snap_a
+     description: "snap named a"
+   register: snapshot_failure_details
+   ignore_errors: yes
+
+ - name: Check if error is shown
+   assert:
+     that:
+         - "'one of the following is required: name, uuid' in snapshot_failure_details['msg']"
+         - "snapshot_failure_details.changed == false"

--- a/test/integration/targets/vmware_guest_snapshot_facts/aliases
+++ b/test/integration/targets/vmware_guest_snapshot_facts/aliases
@@ -1,3 +1,4 @@
 posix/ci/cloud/group4/vcenter
 cloud/vcenter
 destructive
+unsupported

--- a/test/integration/targets/vmware_guest_snapshot_facts/aliases
+++ b/test/integration/targets/vmware_guest_snapshot_facts/aliases
@@ -1,3 +1,2 @@
-posix/ci/cloud/group4/vcenter
 cloud/vcenter
 unsupported

--- a/test/integration/targets/vmware_guest_snapshot_facts/aliases
+++ b/test/integration/targets/vmware_guest_snapshot_facts/aliases
@@ -1,4 +1,3 @@
 posix/ci/cloud/group4/vcenter
 cloud/vcenter
-destructive
 unsupported

--- a/test/integration/targets/vmware_guest_snapshot_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_guest_snapshot_facts/tasks/main.yml
@@ -4,64 +4,64 @@
 
 # TODO: vcsim does not support snapshot related functionalities
 
-# - name: store the vcenter container ip
-#   set_fact:
-#     vcsim: "{{ lookup('env', 'vcenter_host') }}"
-# - debug: var=vcsim
-# 
-# - name: Wait for Flask controller to come up online
-#   wait_for:
-#     host: "{{ vcsim }}"
-#     port: 5000
-#     state: started
-# 
-# - name: kill vcsim
-#   uri:
-#     url: "{{ 'http://' + vcsim + ':5000/killall' }}"
-# - name: start vcsim with no folders
-#   uri:
-#     url: "{{ 'http://' + vcsim + ':5000/spawn?datacenter=1&cluster=1&folder=1' }}"
-#   register: vcsim_instance
-# 
-# - name: Wait for Flask controller to come up online
-#   wait_for:
-#     host: "{{ vcsim }}"
-#     port: 443
-#     state: started
-# 
-# - name: get a list of VMS from vcsim   
-#   uri:
-#     url: "{{ 'http://' + vcsim + ':5000/govc_find?filter=VM' }}"
-#   register: vmlist
-# 
-# - set_fact:
-#     vm1: "{{ vmlist['json'][0] }}"
-# 
-# - name: get a list of datacenters from vcsim
-#   uri:
-#     url: "{{ 'http://' + vcsim + ':5000/govc_find?filter=DC' }}"
-#   register: datacenters
-# 
-# - set_fact:
-#     dc1: "{{ datacenters['json'][0] }}"
-# 
-# - debug: var=vcsim_instance
-# - debug: var=vmlist
-# - debug: var=vm1
-# - debug: var=dc1
-#
-# - name: Gather snapshot facts about given virtual machine
-#   vmware_guest_snapshot_facts:
-#     validate_certs: False
-#     hostname: "{{ vcsim }}"
-#     username: "{{ vcsim_instance['json']['username'] }}"
-#     password: "{{ vcsim_instance['json']['password'] }}"
-#     datacenter: "{{ dc1 | basename }}"
-#     folder: "{{ vm1 | dirname }}"
-#   register: vm_snapshot_facts
+ - name: store the vcenter container ip
+   set_fact:
+     vcsim: "{{ lookup('env', 'vcenter_host') }}"
+ - debug: var=vcsim
 
-# - debug: vm_snapshot_facts
+ - name: Wait for Flask controller to come up online
+   wait_for:
+     host: "{{ vcsim }}"
+     port: 5000
+     state: started
 
-# - assert:
-#     that:
-#       - "not vm_snapshot_facts.changed"
+ - name: kill vcsim
+   uri:
+     url: "{{ 'http://' + vcsim + ':5000/killall' }}"
+ - name: start vcsim with no folders
+   uri:
+     url: "{{ 'http://' + vcsim + ':5000/spawn?datacenter=1&cluster=1&folder=1' }}"
+   register: vcsim_instance
+
+ - name: Wait for Flask controller to come up online
+   wait_for:
+     host: "{{ vcsim }}"
+     port: 443
+     state: started
+
+ - name: get a list of VMS from vcsim
+   uri:
+     url: "{{ 'http://' + vcsim + ':5000/govc_find?filter=VM' }}"
+   register: vmlist
+
+ - set_fact:
+     vm1: "{{ vmlist['json'][0] }}"
+
+ - name: get a list of datacenters from vcsim
+   uri:
+     url: "{{ 'http://' + vcsim + ':5000/govc_find?filter=DC' }}"
+   register: datacenters
+
+ - set_fact:
+     dc1: "{{ datacenters['json'][0] }}"
+
+ - debug: var=vcsim_instance
+ - debug: var=vmlist
+ - debug: var=vm1
+ - debug: var=dc1
+
+ - name: Gather snapshot facts about given virtual machine
+   vmware_guest_snapshot_facts:
+     validate_certs: False
+     hostname: "{{ vcsim }}"
+     username: "{{ vcsim_instance['json']['username'] }}"
+     password: "{{ vcsim_instance['json']['password'] }}"
+     datacenter: "{{ dc1 | basename }}"
+     folder: "{{ vm1 | dirname }}"
+   register: vm_snapshot_facts
+
+ - debug: vm_snapshot_facts
+
+ - assert:
+     that:
+       - "not vm_snapshot_facts.changed"

--- a/test/integration/targets/vmware_guest_tools_wait/aliases
+++ b/test/integration/targets/vmware_guest_tools_wait/aliases
@@ -1,3 +1,2 @@
 posix/ci/cloud/group4/vcenter
 cloud/vcenter
-destructive

--- a/test/integration/targets/vmware_host/aliases
+++ b/test/integration/targets/vmware_host/aliases
@@ -1,3 +1,2 @@
 posix/ci/cloud/group4/vcenter
 cloud/vcenter
-destructive

--- a/test/integration/targets/vmware_host_acceptance/aliases
+++ b/test/integration/targets/vmware_host_acceptance/aliases
@@ -1,3 +1,3 @@
 posix/ci/cloud/group4/vcenter
 cloud/vcenter
-
+unsupported

--- a/test/integration/targets/vmware_host_acceptance/aliases
+++ b/test/integration/targets/vmware_host_acceptance/aliases
@@ -1,3 +1,2 @@
-posix/ci/cloud/group4/vcenter
 cloud/vcenter
 unsupported

--- a/test/integration/targets/vmware_host_acceptance/tasks/main.yml
+++ b/test/integration/targets/vmware_host_acceptance/tasks/main.yml
@@ -4,60 +4,60 @@
 
 # TODO: vcsim does not support Acceptance Level related to operations
 
-#- name: store the vcenter container ip
-#  set_fact:
-#    vcsim: "{{ lookup('env', 'vcenter_host') }}"
+- name: store the vcenter container ip
+  set_fact:
+    vcsim: "{{ lookup('env', 'vcenter_host') }}"
 
-#- debug: var=vcsim
+- debug: var=vcsim
 
-#- name: Wait for Flask controller to come up online
-#  wait_for:
-#    host: "{{ vcsim }}"
-#    port: 5000
-#    state: started
+- name: Wait for Flask controller to come up online
+  wait_for:
+    host: "{{ vcsim }}"
+    port: 5000
+    state: started
 
-#- name: kill vcsim
-#  uri:
-#    url: http://{{ vcsim }}:5000/killall
+- name: kill vcsim
+  uri:
+    url: http://{{ vcsim }}:5000/killall
 
-#- name: start vcsim
-#  uri:
-#    url: http://{{ vcsim }}:5000/spawn?cluster=2
-#  register: vcsim_instance
+- name: start vcsim
+  uri:
+    url: http://{{ vcsim }}:5000/spawn?cluster=2
+  register: vcsim_instance
 
-#- debug:
-#    var: vcsim_instance
+- debug:
+    var: vcsim_instance
 
-#- name: Wait for vcsim server to come up online
-#  wait_for:
-#    host: "{{ vcsim }}"
-#    port: 443
-#    state: started
+- name: Wait for vcsim server to come up online
+  wait_for:
+    host: "{{ vcsim }}"
+    port: 443
+    state: started
 
-#- name: get a list of hosts from vcsim
-#  uri:
-#    url: http://{{ vcsim }}:5000/govc_find?filter=H
-#  register: hosts
+- name: get a list of hosts from vcsim
+  uri:
+    url: http://{{ vcsim }}:5000/govc_find?filter=H
+  register: hosts
 
-#- name: get a host
-#  set_fact:
-#    host1: "{{ hosts.json[0] | basename }}"
+- name: get a host
+  set_fact:
+    host1: "{{ hosts.json[0] | basename }}"
 
-#- debug: var=host1
+- debug: var=host1
 
-#- name: Change acceptance level of given hosts
-#  vmware_host_acceptance:
-#    hostname: "{{ vcsim }}"
-#    username: "{{ user }}"
-#    password: "{{ passwd }}"
-#    esxi_hostname: "{{ host1 }}"
-#    validate_certs: no
-#    acceptance_level: vmware_certified
-#    state: present
-#  register: host_acceptance_facts
+- name: Change acceptance level of given hosts
+  vmware_host_acceptance:
+    hostname: "{{ vcsim }}"
+    username: "{{ user }}"
+    password: "{{ passwd }}"
+    esxi_hostname: "{{ host1 }}"
+    validate_certs: no
+    acceptance_level: vmware_certified
+    state: present
+  register: host_acceptance_facts
 
-#- debug: var=host_acceptance_facts
+- debug: var=host_acceptance_facts
 
-#- assert:
-#    that:
-#      - host_acceptance_facts.facts is defined
+- assert:
+    that:
+      - host_acceptance_facts.facts is defined

--- a/test/integration/targets/vmware_host_capability_facts/aliases
+++ b/test/integration/targets/vmware_host_capability_facts/aliases
@@ -1,3 +1,3 @@
 posix/ci/cloud/group4/vcenter
 cloud/vcenter
-
+unsupported

--- a/test/integration/targets/vmware_host_capability_facts/aliases
+++ b/test/integration/targets/vmware_host_capability_facts/aliases
@@ -1,3 +1,2 @@
-posix/ci/cloud/group4/vcenter
 cloud/vcenter
 unsupported

--- a/test/integration/targets/vmware_host_capability_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_host_capability_facts/tasks/main.yml
@@ -4,81 +4,81 @@
 
 # TODO: vcsim does not support host system capabilities
 
-#- name: store the vcenter container ip
-#  set_fact:
-#    vcsim: "{{ lookup('env', 'vcenter_host') }}"
+- name: store the vcenter container ip
+  set_fact:
+    vcsim: "{{ lookup('env', 'vcenter_host') }}"
 
-#- debug: var=vcsim
+- debug: var=vcsim
 
-#- name: Wait for Flask controller to come up online
-#  wait_for:
-#    host: "{{ vcsim }}"
-#    port: 5000
-#    state: started
+- name: Wait for Flask controller to come up online
+  wait_for:
+    host: "{{ vcsim }}"
+    port: 5000
+    state: started
 
-#- name: kill vcsim
-#  uri:
-#    url: http://{{ vcsim }}:5000/killall
+- name: kill vcsim
+  uri:
+    url: http://{{ vcsim }}:5000/killall
 
-#- name: start vcsim
-#  uri:
-#    url: http://{{ vcsim }}:5000/spawn?cluster=2
-#  register: vcsim_instance
+- name: start vcsim
+  uri:
+    url: http://{{ vcsim }}:5000/spawn?cluster=2
+  register: vcsim_instance
 
-#- debug:
-#    var: vcsim_instance
+- debug:
+    var: vcsim_instance
 
-#- name: Wait for vcsim server to come up online
-#  wait_for:
-#    host: "{{ vcsim }}"
-#    port: 443
-#    state: started
+- name: Wait for vcsim server to come up online
+  wait_for:
+    host: "{{ vcsim }}"
+    port: 443
+    state: started
 
-#- name: get a list of Cluster from vcsim
-#  uri:
-#    url: http://{{ vcsim }}:5000/govc_find?filter=CCR
-#  register: clusters
+- name: get a list of Cluster from vcsim
+  uri:
+    url: http://{{ vcsim }}:5000/govc_find?filter=CCR
+  register: clusters
 
-#- name: get a cluster
-#  set_fact:
-#    ccr1: "{{ clusters.json[0] | basename }}"
+- name: get a cluster
+  set_fact:
+    ccr1: "{{ clusters.json[0] | basename }}"
 
-#- name: get a list of hosts from vcsim
-#  uri:
-#    url: http://{{ vcsim }}:5000/govc_find?filter=H
-#  register: hosts
+- name: get a list of hosts from vcsim
+  uri:
+    url: http://{{ vcsim }}:5000/govc_find?filter=H
+  register: hosts
 
-#- name: get a host
-#  set_fact:
-#    host1: "{{ hosts.json[0] | basename }}"
+- name: get a host
+  set_fact:
+    host1: "{{ hosts.json[0] | basename }}"
 
-#- debug: var=ccr1
-#- debug: var=host1
+- debug: var=ccr1
+- debug: var=host1
 
-#- name: Gather capability facts for all ESXi host from given cluster
-#  vmware_host_capability_facts:
-#    hostname: "{{ vcsim }}"
-#    username: "{{ vcsim_instance.json.username }}"
-#    password: "{{ vcsim_instance.json.password }}"
-#    validate_certs: False
-#    cluster_name: "{{ ccr1 }}"
-#  register: capability_0001_results
+- name: Gather capability facts for all ESXi host from given cluster
+  vmware_host_capability_facts:
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance.json.username }}"
+    password: "{{ vcsim_instance.json.password }}"
+    validate_certs: False
+    cluster_name: "{{ ccr1 }}"
+  register: capability_0001_results
 
-#- assert:
-#    that:
-#      - "not capability_0001_results.changed"
-#      - "capability_0001_results.hosts_capability_facts is defined"
+- assert:
+    that:
+      - "not capability_0001_results.changed"
+      - "capability_0001_results.hosts_capability_facts is defined"
 
-#- name: Gather capability facts for ESXi host
-#  vmware_host_capability_facts:
-#    hostname: "{{ vcsim }}"
-#    username: "{{ vcsim_instance.json.username }}"
-#    password: "{{ vcsim_instance.json.password }}"
-#    validate_certs: False
-#    esxi_hostname: "{{ host1 }}"
-#  register: capability_0002_results
+- name: Gather capability facts for ESXi host
+  vmware_host_capability_facts:
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance.json.username }}"
+    password: "{{ vcsim_instance.json.password }}"
+    validate_certs: False
+    esxi_hostname: "{{ host1 }}"
+  register: capability_0002_results
 
-#- assert:
-#    that:
-#      - "not capability_0002_results.changed"
-#      - "capability_0002_results.hosts_capability_facts is defined"
+- assert:
+    that:
+      - "not capability_0002_results.changed"
+      - "capability_0002_results.hosts_capability_facts is defined"

--- a/test/integration/targets/vmware_host_config_facts/aliases
+++ b/test/integration/targets/vmware_host_config_facts/aliases
@@ -1,3 +1,2 @@
 posix/ci/cloud/group4/vcenter
 cloud/vcenter
-destructive

--- a/test/integration/targets/vmware_host_config_manager/aliases
+++ b/test/integration/targets/vmware_host_config_manager/aliases
@@ -1,3 +1,3 @@
 posix/ci/cloud/group4/vcenter
 cloud/vcenter
-
+unsupported

--- a/test/integration/targets/vmware_host_config_manager/aliases
+++ b/test/integration/targets/vmware_host_config_manager/aliases
@@ -1,3 +1,2 @@
-posix/ci/cloud/group4/vcenter
 cloud/vcenter
 unsupported

--- a/test/integration/targets/vmware_host_config_manager/tasks/main.yml
+++ b/test/integration/targets/vmware_host_config_manager/tasks/main.yml
@@ -4,85 +4,85 @@
 
 # TODO: vcsim does not support update host configuartion
 
-#- name: store the vcenter container ip
-#  set_fact:
-#    vcsim: "{{ lookup('env', 'vcenter_host') }}"
+- name: store the vcenter container ip
+  set_fact:
+    vcsim: "{{ lookup('env', 'vcenter_host') }}"
 
-#- debug: var=vcsim
+- debug: var=vcsim
 
-#- name: Wait for Flask controller to come up online
-#  wait_for:
-#    host: "{{ vcsim }}"
-#    port: 5000
-#    state: started
+- name: Wait for Flask controller to come up online
+  wait_for:
+    host: "{{ vcsim }}"
+    port: 5000
+    state: started
 
-#- name: kill vcsim
-#  uri:
-#    url: http://{{ vcsim }}:5000/killall
+- name: kill vcsim
+  uri:
+    url: http://{{ vcsim }}:5000/killall
 
-#- name: start vcsim
-#  uri:
-#    url: http://{{ vcsim }}:5000/spawn?cluster=2
-#  register: vcsim_instance
+- name: start vcsim
+  uri:
+    url: http://{{ vcsim }}:5000/spawn?cluster=2
+  register: vcsim_instance
 
-#- debug:
-#    var: vcsim_instance
+- debug:
+    var: vcsim_instance
 
-#- name: Wait for vcsim server to come up online
-#  wait_for:
-#    host: "{{ vcsim }}"
-#    port: 443
-#    state: started
+- name: Wait for vcsim server to come up online
+  wait_for:
+    host: "{{ vcsim }}"
+    port: 443
+    state: started
 
-#- name: get a list of Cluster from vcsim
-#  uri:
-#    url: http://{{ vcsim }}:5000/govc_find?filter=CCR
-#  register: clusters
+- name: get a list of Cluster from vcsim
+  uri:
+    url: http://{{ vcsim }}:5000/govc_find?filter=CCR
+  register: clusters
 
-#- name: get a cluster
-#  set_fact:
-#    ccr1: "{{ clusters.json[0] | basename }}"
+- name: get a cluster
+  set_fact:
+    ccr1: "{{ clusters.json[0] | basename }}"
 
-#- name: get a list of hosts from vcsim
-#  uri:
-#    url: http://{{ vcsim }}:5000/govc_find?filter=H
-#  register: hosts
+- name: get a list of hosts from vcsim
+  uri:
+    url: http://{{ vcsim }}:5000/govc_find?filter=H
+  register: hosts
 
-#- name: get a host
-#  set_fact:
-#    host1: "{{ hosts.json[0] | basename }}"
+- name: get a host
+  set_fact:
+    host1: "{{ hosts.json[0] | basename }}"
 
-#- debug: var=ccr1
-#- debug: var=host1
+- debug: var=ccr1
+- debug: var=host1
 
-#- name: Change facts about all hosts in given cluster
-#  vmware_host_config_manager:
-#    hostname: "{{ vcsim }}"
-#    username: "{{ vcsim_instance.json.username }}"
-#    password: "{{ vcsim_instance.json.password }}"
-#    cluster_name: "{{ ccr1 }}"
-#    options:
-#      'Config.HostAgent.log.level': 'verbose'
-#    validate_certs: no
-#  register: all_hosts_result
+- name: Change facts about all hosts in given cluster
+  vmware_host_config_manager:
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance.json.username }}"
+    password: "{{ vcsim_instance.json.password }}"
+    cluster_name: "{{ ccr1 }}"
+    options:
+      'Config.HostAgent.log.level': 'verbose'
+    validate_certs: no
+  register: all_hosts_result
 
-#- name: ensure changes are done to all hosts
-#  assert:
-#    that:
-#        - all_hosts_result.changed
+- name: ensure changes are done to all hosts
+  assert:
+    that:
+        - all_hosts_result.changed
 
-#- name: Change facts about a given host
-#  vmware_host_config_manager:
-#    hostname: "{{ vcsim }}"
-#    username: "{{ vcsim_instance.json.username }}"
-#    password: "{{ vcsim_instance.json.password }}"
-#    esxi_hostname: "{{ host1 }}"
-#    options:
-#      'Config.HostAgent.log.level': 'info'
-#    validate_certs: no
-#  register: host_result
+- name: Change facts about a given host
+  vmware_host_config_manager:
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance.json.username }}"
+    password: "{{ vcsim_instance.json.password }}"
+    esxi_hostname: "{{ host1 }}"
+    options:
+      'Config.HostAgent.log.level': 'info'
+    validate_certs: no
+  register: host_result
 
-#- name: ensure changes are done to given hosts
-#  assert:
-#    that:
-#        - all_hosts_result.changed
+- name: ensure changes are done to given hosts
+  assert:
+    that:
+        - all_hosts_result.changed

--- a/test/integration/targets/vmware_host_firewall_manager/aliases
+++ b/test/integration/targets/vmware_host_firewall_manager/aliases
@@ -1,3 +1,2 @@
 posix/ci/cloud/group4/vcenter
 cloud/vcenter
-destructive

--- a/test/integration/targets/vmware_host_ntp/aliases
+++ b/test/integration/targets/vmware_host_ntp/aliases
@@ -1,3 +1,3 @@
 posix/ci/cloud/group4/vcenter
 cloud/vcenter
-
+unsupported

--- a/test/integration/targets/vmware_host_ntp/aliases
+++ b/test/integration/targets/vmware_host_ntp/aliases
@@ -1,3 +1,2 @@
-posix/ci/cloud/group4/vcenter
 cloud/vcenter
 unsupported

--- a/test/integration/targets/vmware_host_ntp/tasks/main.yml
+++ b/test/integration/targets/vmware_host_ntp/tasks/main.yml
@@ -4,144 +4,144 @@
 
 # TODO: vcsim does not support update host NTP configuration
 
-#- name: store the vcenter container ip
-#  set_fact:
-#    vcsim: "{{ lookup('env', 'vcenter_host') }}"
+- name: store the vcenter container ip
+  set_fact:
+    vcsim: "{{ lookup('env', 'vcenter_host') }}"
 
-#- debug: var=vcsim
+- debug: var=vcsim
 
-#- name: Wait for Flask controller to come up online
-#  wait_for:
-#    host: "{{ vcsim }}"
-#    port: 5000
-#    state: started
+- name: Wait for Flask controller to come up online
+  wait_for:
+    host: "{{ vcsim }}"
+    port: 5000
+    state: started
 
-#- name: kill vcsim
-#  uri:
-#    url: http://{{ vcsim }}:5000/killall
+- name: kill vcsim
+  uri:
+    url: http://{{ vcsim }}:5000/killall
 
-#- name: start vcsim
-#  uri:
-#    url: http://{{ vcsim }}:5000/spawn?cluster=2
-#  register: vcsim_instance
+- name: start vcsim
+  uri:
+    url: http://{{ vcsim }}:5000/spawn?cluster=2
+  register: vcsim_instance
 
-#- debug:
-#    var: vcsim_instance
+- debug:
+    var: vcsim_instance
 
-#- name: Wait for vcsim server to come up online
-#  wait_for:
-#    host: "{{ vcsim }}"
-#    port: 443
-#    state: started
+- name: Wait for vcsim server to come up online
+  wait_for:
+    host: "{{ vcsim }}"
+    port: 443
+    state: started
 
-#- name: get a list of Cluster from vcsim
-#  uri:
-#    url: http://{{ vcsim }}:5000/govc_find?filter=CCR
-#  register: clusters
+- name: get a list of Cluster from vcsim
+  uri:
+    url: http://{{ vcsim }}:5000/govc_find?filter=CCR
+  register: clusters
 
-#- name: get a cluster
-#  set_fact:
-#    ccr1: "{{ clusters.json[0] | basename }}"
+- name: get a cluster
+  set_fact:
+    ccr1: "{{ clusters.json[0] | basename }}"
 
-#- name: get a list of hosts from vcsim
-#  uri:
-#    url: http://{{ vcsim }}:5000/govc_find?filter=H
-#  register: hosts
+- name: get a list of hosts from vcsim
+  uri:
+    url: http://{{ vcsim }}:5000/govc_find?filter=H
+  register: hosts
 
-#- name: get a host
-#  set_fact:
-#    host1: "{{ hosts.json[0] | basename }}"
+- name: get a host
+  set_fact:
+    host1: "{{ hosts.json[0] | basename }}"
 
-#- debug: var=ccr1
-#- debug: var=host1
+- debug: var=ccr1
+- debug: var=host1
 
-#- name: Change facts about all hosts in given cluster
-#  vmware_host_ntp:
-#    hostname: "{{ vcsim }}"
-#    username: "{{ vcsim_instance['json']['username'] }}"
-#    password: "{{ vcsim_instance['json']['password'] }}"
-#    esxi_hostname: "{{ host1 }}"
-#    state: present
-#    ntp_server:
-#      - 0.pool.ntp.org
-#    validate_certs: no
-#  register: present
+- name: Change facts about all hosts in given cluster
+  vmware_host_ntp:
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    esxi_hostname: "{{ host1 }}"
+    state: present
+    ntp_server:
+      - 0.pool.ntp.org
+    validate_certs: no
+  register: present
 
-#- debug: var=present
+- debug: var=present
 
-#- name: Change facts about all hosts in given cluster
-#  vmware_host_ntp:
-#    hostname: "{{ vcsim }}"
-#    username: "{{ vcsim_instance['json']['username'] }}"
-#    password: "{{ vcsim_instance['json']['password'] }}"
-#    esxi_hostname: "{{ host1 }}"
-#    state: present
-#    ntp_server:
-#      - 1.pool.ntp.org
-#    validate_certs: no
-#  register: present
+- name: Change facts about all hosts in given cluster
+  vmware_host_ntp:
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    esxi_hostname: "{{ host1 }}"
+    state: present
+    ntp_server:
+      - 1.pool.ntp.org
+    validate_certs: no
+  register: present
 
-#- debug: var=present
+- debug: var=present
 
-#- name: Change facts about all hosts in given cluster
-#  vmware_host_ntp:
-#    hostname: "{{ vcsim }}"
-#    username: "{{ vcsim_instance['json']['username'] }}"
-#    password: "{{ vcsim_instance['json']['password'] }}"
-#    esxi_hostname: "{{ host1 }}"
-#    state: absent
-#    ntp_server:
-#      - 1.pool.ntp.org
-#    validate_certs: no
-#  register: present
+- name: Change facts about all hosts in given cluster
+  vmware_host_ntp:
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    esxi_hostname: "{{ host1 }}"
+    state: absent
+    ntp_server:
+      - 1.pool.ntp.org
+    validate_certs: no
+  register: present
 
-#- debug: var=present
+- debug: var=present
 
-#- name: Change facts about all hosts in given cluster
-#  vmware_host_ntp:
-#    hostname: "{{ vcsim }}"
-#    username: "{{ vcsim_instance['json']['username'] }}"
-#    password: "{{ vcsim_instance['json']['password'] }}"
-#    esxi_hostname: "{{ host1 }}"
-#    state: present
-#    ntp_server:
-#      - 1.pool.ntp.org
-#    validate_certs: no
-#  register: present
+- name: Change facts about all hosts in given cluster
+  vmware_host_ntp:
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    esxi_hostname: "{{ host1 }}"
+    state: present
+    ntp_server:
+      - 1.pool.ntp.org
+    validate_certs: no
+  register: present
 
-#- debug: var=present
+- debug: var=present
 
-#- name: Change facts about all hosts in given cluster
-#  vmware_host_ntp:
-#    hostname: "{{ vcsim }}"
-#    username: "{{ vcsim_instance['json']['username'] }}"
-#    password: "{{ vcsim_instance['json']['password'] }}"
-#    esxi_hostname: "{{ host1 }}"
-#    state: present
-#    ntp_server:
-#      - 2.pool.ntp.org
-#      - 3.pool.ntp.org
-#      - 4.pool.ntp.org
-#    validate_certs: no
-#  register: present
+- name: Change facts about all hosts in given cluster
+  vmware_host_ntp:
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    esxi_hostname: "{{ host1 }}"
+    state: present
+    ntp_server:
+      - 2.pool.ntp.org
+      - 3.pool.ntp.org
+      - 4.pool.ntp.org
+    validate_certs: no
+  register: present
 
-#- debug: var=present
+- debug: var=present
 
-#- name: Change facts about all hosts in given cluster
-#  vmware_host_ntp:
-#    hostname: "{{ vcsim }}"
-#    username: "{{ vcsim_instance['json']['username'] }}"
-#    password: "{{ vcsim_instance['json']['password'] }}"
-#    esxi_hostname: "{{ host1 }}"
-#    state: absent
-#    ntp_server:
-#      - 0.pool.ntp.org
-#      - 1.pool.ntp.org
-#      - 2.pool.ntp.org
-#      - 3.pool.ntp.org
-#      - 4.pool.ntp.org
-#      - 6.pool.ntp.org
-#    validate_certs: no
-#  register: present
+- name: Change facts about all hosts in given cluster
+  vmware_host_ntp:
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    esxi_hostname: "{{ host1 }}"
+    state: absent
+    ntp_server:
+      - 0.pool.ntp.org
+      - 1.pool.ntp.org
+      - 2.pool.ntp.org
+      - 3.pool.ntp.org
+      - 4.pool.ntp.org
+      - 6.pool.ntp.org
+    validate_certs: no
+  register: present
 
-#- debug: var=present
+- debug: var=present

--- a/test/integration/targets/vmware_host_package_facts/aliases
+++ b/test/integration/targets/vmware_host_package_facts/aliases
@@ -1,3 +1,3 @@
 posix/ci/cloud/group4/vcenter
 cloud/vcenter
-
+unsupported

--- a/test/integration/targets/vmware_host_package_facts/aliases
+++ b/test/integration/targets/vmware_host_package_facts/aliases
@@ -1,3 +1,2 @@
-posix/ci/cloud/group4/vcenter
 cloud/vcenter
 unsupported

--- a/test/integration/targets/vmware_host_package_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_host_package_facts/tasks/main.yml
@@ -4,58 +4,58 @@
 
 # TODO: vcsim does not support Package Manager related to operations
 
-#- name: store the vcenter container ip
-#  set_fact:
-#    vcsim: "{{ lookup('env', 'vcenter_host') }}"
+- name: store the vcenter container ip
+  set_fact:
+    vcsim: "{{ lookup('env', 'vcenter_host') }}"
 
-#- debug: var=vcsim
+- debug: var=vcsim
 
-#- name: Wait for Flask controller to come up online
-#  wait_for:
-#    host: "{{ vcsim }}"
-#    port: 5000
-#    state: started
+- name: Wait for Flask controller to come up online
+  wait_for:
+    host: "{{ vcsim }}"
+    port: 5000
+    state: started
 
-#- name: kill vcsim
-#  uri:
-#    url: http://{{ vcsim }}:5000/killall
+- name: kill vcsim
+  uri:
+    url: http://{{ vcsim }}:5000/killall
 
-#- name: start vcsim
-#  uri:
-#    url: http://{{ vcsim }}:5000/spawn?cluster=2
-#  register: vcsim_instance
+- name: start vcsim
+  uri:
+    url: http://{{ vcsim }}:5000/spawn?cluster=2
+  register: vcsim_instance
 
-#- debug:
-#    var: vcsim_instance
+- debug:
+    var: vcsim_instance
 
-#- name: Wait for vcsim server to come up online
-#  wait_for:
-#    host: "{{ vcsim }}"
-#    port: 443
-#    state: started
+- name: Wait for vcsim server to come up online
+  wait_for:
+    host: "{{ vcsim }}"
+    port: 443
+    state: started
 
-#- name: get a list of hosts from vcsim
-#  uri:
-#    url: http://{{ vcsim }}:5000/govc_find?filter=H
-#  register: hosts
+- name: get a list of hosts from vcsim
+  uri:
+    url: http://{{ vcsim }}:5000/govc_find?filter=H
+  register: hosts
 
-#- name: get a host
-#  set_fact:
-#    host1: "{{ hosts.json[0] | basename }}"
+- name: get a host
+  set_fact:
+    host1: "{{ hosts.json[0] | basename }}"
 
-#- debug: var=host1
+- debug: var=host1
 
-#- name: Gather facts about all hosts in given cluster
-#  vmware_host_package_facts:
-#    hostname: "{{ vcsim }}"
-#    username: "{{ user }}"
-#    password: "{{ passwd }}"
-#    esxi_hostname: "{{ host1 }}"
-#    validate_certs: no
-#  register: host_packages
+- name: Gather facts about all hosts in given cluster
+  vmware_host_package_facts:
+    hostname: "{{ vcsim }}"
+    username: "{{ user }}"
+    password: "{{ passwd }}"
+    esxi_hostname: "{{ host1 }}"
+    validate_certs: no
+  register: host_packages
 
-#- debug: var=host_packages
+- debug: var=host_packages
 
-#- assert:
-#    that:
-#      - host_packages.hosts_package_facts is defined
+- assert:
+    that:
+      - host_packages.hosts_package_facts is defined

--- a/test/integration/targets/vmware_host_service_facts/aliases
+++ b/test/integration/targets/vmware_host_service_facts/aliases
@@ -1,3 +1,3 @@
 posix/ci/cloud/group4/vcenter
 cloud/vcenter
-
+unsupported

--- a/test/integration/targets/vmware_host_service_facts/aliases
+++ b/test/integration/targets/vmware_host_service_facts/aliases
@@ -1,3 +1,2 @@
-posix/ci/cloud/group4/vcenter
 cloud/vcenter
 unsupported

--- a/test/integration/targets/vmware_host_service_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_host_service_facts/tasks/main.yml
@@ -4,58 +4,58 @@
 
 # TODO: vcsim does not support service related to operations
 
-#- name: store the vcenter container ip
-#  set_fact:
-#    vcsim: "{{ lookup('env', 'vcenter_host') }}"
+- name: store the vcenter container ip
+  set_fact:
+    vcsim: "{{ lookup('env', 'vcenter_host') }}"
 
-#- debug: var=vcsim
+- debug: var=vcsim
 
-#- name: Wait for Flask controller to come up online
-#  wait_for:
-#    host: "{{ vcsim }}"
-#    port: 5000
-#    state: started
+- name: Wait for Flask controller to come up online
+  wait_for:
+    host: "{{ vcsim }}"
+    port: 5000
+    state: started
 
-#- name: kill vcsim
-#  uri:
-#    url: http://{{ vcsim }}:5000/killall
+- name: kill vcsim
+  uri:
+    url: http://{{ vcsim }}:5000/killall
 
-#- name: start vcsim
-#  uri:
-#    url: http://{{ vcsim }}:5000/spawn?cluster=2
-#  register: vcsim_instance
+- name: start vcsim
+  uri:
+    url: http://{{ vcsim }}:5000/spawn?cluster=2
+  register: vcsim_instance
 
-#- debug:
-#    var: vcsim_instance
+- debug:
+    var: vcsim_instance
 
-#- name: Wait for vcsim server to come up online
-#  wait_for:
-#    host: "{{ vcsim }}"
-#    port: 443
-#    state: started
+- name: Wait for vcsim server to come up online
+  wait_for:
+    host: "{{ vcsim }}"
+    port: 443
+    state: started
 
-#- name: get a list of hosts from vcsim
-#  uri:
-#    url: http://{{ vcsim }}:5000/govc_find?filter=H
-#  register: hosts
+- name: get a list of hosts from vcsim
+  uri:
+    url: http://{{ vcsim }}:5000/govc_find?filter=H
+  register: hosts
 
-#- name: get a host
-#  set_fact:
-#    host1: "{{ hosts.json[0] | basename }}"
+- name: get a host
+  set_fact:
+    host1: "{{ hosts.json[0] | basename }}"
 
-#- debug: var=host1
+- debug: var=host1
 
-#- name: Change facts about all hosts in given cluster
-#  vmware_host_service_facts:
-#    hostname: "{{ vcsim }}"
-#    username: "{{ user }}"
-#    password: "{{ passwd }}"
-#    esxi_hostname: "{{ host1 }}"
-#    validate_certs: no
-#  register: host_services
+- name: Change facts about all hosts in given cluster
+  vmware_host_service_facts:
+    hostname: "{{ vcsim }}"
+    username: "{{ user }}"
+    password: "{{ passwd }}"
+    esxi_hostname: "{{ host1 }}"
+    validate_certs: no
+  register: host_services
 
-#- debug: var=host_services
+- debug: var=host_services
 
-#- assert:
-#    that:
-#      - host_services.host_service_facts is defined
+- assert:
+    that:
+      - host_services.host_service_facts is defined

--- a/test/integration/targets/vmware_host_service_manager/aliases
+++ b/test/integration/targets/vmware_host_service_manager/aliases
@@ -1,3 +1,4 @@
 posix/ci/cloud/group4/vcenter
 cloud/vcenter
 destructive
+unsupported

--- a/test/integration/targets/vmware_host_service_manager/aliases
+++ b/test/integration/targets/vmware_host_service_manager/aliases
@@ -1,3 +1,2 @@
-posix/ci/cloud/group4/vcenter
 cloud/vcenter
 unsupported

--- a/test/integration/targets/vmware_host_service_manager/aliases
+++ b/test/integration/targets/vmware_host_service_manager/aliases
@@ -1,4 +1,3 @@
 posix/ci/cloud/group4/vcenter
 cloud/vcenter
-destructive
 unsupported

--- a/test/integration/targets/vmware_host_service_manager/tasks/main.yml
+++ b/test/integration/targets/vmware_host_service_manager/tasks/main.yml
@@ -5,85 +5,85 @@
 # TODO: vcsim does not support service management
 #       commenting this testcase till the time.
 
-#- name: store the vcenter container ip
-#  set_fact:
-#    vcsim: "{{ lookup('env', 'vcenter_host') }}"
+- name: store the vcenter container ip
+  set_fact:
+    vcsim: "{{ lookup('env', 'vcenter_host') }}"
 
-#- debug: var=vcsim
+- debug: var=vcsim
 
-#- name: Wait for Flask controller to come up online
-#  wait_for:
-#    host: "{{ vcsim }}"
-#    port: 5000
-#    state: started
+- name: Wait for Flask controller to come up online
+  wait_for:
+    host: "{{ vcsim }}"
+    port: 5000
+    state: started
 
-#- name: kill vcsim
-#  uri:
-#    url: http://{{ vcsim }}:5000/killall
+- name: kill vcsim
+  uri:
+    url: http://{{ vcsim }}:5000/killall
 
-#- name: start vcsim
-#  uri:
-#    url: http://{{ vcsim }}:5000/spawn?cluster=2
-#  register: vcsim_instance
+- name: start vcsim
+  uri:
+    url: http://{{ vcsim }}:5000/spawn?cluster=2
+  register: vcsim_instance
 
-#- debug:
-#    var: vcsim_instance
+- debug:
+    var: vcsim_instance
 
-#- name: Wait for vcsim server to come up online
-#  wait_for:
-#    host: "{{ vcsim }}"
-#    port: 443
-#    state: started
+- name: Wait for vcsim server to come up online
+  wait_for:
+    host: "{{ vcsim }}"
+    port: 443
+    state: started
 
-#- name: get a list of Cluster from vcsim
-#  uri:
-#    url: http://{{ vcsim }}:5000/govc_find?filter=CCR
-#  register: clusters
+- name: get a list of Cluster from vcsim
+  uri:
+    url: http://{{ vcsim }}:5000/govc_find?filter=CCR
+  register: clusters
 
-#- name: get a cluster
-#  set_fact:
-#    ccr1: "{{ clusters.json[0] | basename }}"
+- name: get a cluster
+  set_fact:
+    ccr1: "{{ clusters.json[0] | basename }}"
 
-#- name: get a list of hosts from vcsim
-#  uri:
-#    url: http://{{ vcsim }}:5000/govc_find?filter=H
-#  register: hosts
+- name: get a list of hosts from vcsim
+  uri:
+    url: http://{{ vcsim }}:5000/govc_find?filter=H
+  register: hosts
 
-#- name: get a cluster
-#  set_fact:
-#    host1: "{{ hosts.json[0] | basename }}"
+- name: get a cluster
+  set_fact:
+    host1: "{{ hosts.json[0] | basename }}"
 
-#- debug: var=ccr1
-#- debug: var=host1
+- debug: var=ccr1
+- debug: var=host1
 
-#- name: Start ntpd service on all hosts in given cluster
-#  vmware_host_service_manager:
-#    hostname: "{{ vcsim }}"
-#    username: "{{ vcsim_instance.json.username }}"
-#    password: "{{ vcsim_instance.json.password }}"
-#    validate_certs: no
-#    cluster_name: "{{ ccr1 }}"
-#    service_name: ntpd
-#    state: present
-#  register: all_hosts_result
+- name: Start ntpd service on all hosts in given cluster
+  vmware_host_service_manager:
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance.json.username }}"
+    password: "{{ vcsim_instance.json.password }}"
+    validate_certs: no
+    cluster_name: "{{ ccr1 }}"
+    service_name: ntpd
+    state: present
+  register: all_hosts_result
 
-#- name: ensure facts are gathered for all hosts
-#  assert:
-#    that:
-#        - all_hosts_result.changed
+- name: ensure facts are gathered for all hosts
+  assert:
+    that:
+        - all_hosts_result.changed
 
-#- name: Stop ntpd service on a given host
-#  vmware_host_service_manager:
-#    hostname: "{{ vcsim }}"
-#    username: "{{ vcsim_instance.json.username }}"
-#    password: "{{ vcsim_instance.json.password }}"
-#    validate_certs: no
-#    esxi_hostname: "{{ host1 }}"
-#    service_name: ntpd
-#    state: absent
-#  register: single_hosts_result
+- name: Stop ntpd service on a given host
+  vmware_host_service_manager:
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance.json.username }}"
+    password: "{{ vcsim_instance.json.password }}"
+    validate_certs: no
+    esxi_hostname: "{{ host1 }}"
+    service_name: ntpd
+    state: absent
+  register: single_hosts_result
 
-#- name: ensure facts are gathered for all hosts
-#  assert:
-#    that:
-#        - single_hosts_result.changed == False
+- name: ensure facts are gathered for all hosts
+  assert:
+    that:
+        - single_hosts_result.changed == False

--- a/test/integration/targets/vmware_host_vmnic_facts/aliases
+++ b/test/integration/targets/vmware_host_vmnic_facts/aliases
@@ -1,3 +1,3 @@
 posix/ci/cloud/group4/vcenter
 cloud/vcenter
-
+unsupported

--- a/test/integration/targets/vmware_host_vmnic_facts/aliases
+++ b/test/integration/targets/vmware_host_vmnic_facts/aliases
@@ -1,3 +1,2 @@
-posix/ci/cloud/group4/vcenter
 cloud/vcenter
 unsupported

--- a/test/integration/targets/vmware_host_vmnic_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_host_vmnic_facts/tasks/main.yml
@@ -4,58 +4,58 @@
 
 # TODO: vcsim does not support networkConfig related to operations
 
-#- name: store the vcenter container ip
-#  set_fact:
-#    vcsim: "{{ lookup('env', 'vcenter_host') }}"
+- name: store the vcenter container ip
+  set_fact:
+    vcsim: "{{ lookup('env', 'vcenter_host') }}"
 
-#- debug: var=vcsim
+- debug: var=vcsim
 
-#- name: Wait for Flask controller to come up online
-#  wait_for:
-#    host: "{{ vcsim }}"
-#    port: 5000
-#    state: started
+- name: Wait for Flask controller to come up online
+  wait_for:
+    host: "{{ vcsim }}"
+    port: 5000
+    state: started
 
-#- name: kill vcsim
-#  uri:
-#    url: http://{{ vcsim }}:5000/killall
+- name: kill vcsim
+  uri:
+    url: http://{{ vcsim }}:5000/killall
 
-#- name: start vcsim
-#  uri:
-#    url: http://{{ vcsim }}:5000/spawn?cluster=2
-#  register: vcsim_instance
+- name: start vcsim
+  uri:
+    url: http://{{ vcsim }}:5000/spawn?cluster=2
+  register: vcsim_instance
 
-#- debug:
-#    var: vcsim_instance
+- debug:
+    var: vcsim_instance
 
-#- name: Wait for vcsim server to come up online
-#  wait_for:
-#    host: "{{ vcsim }}"
-#    port: 443
-#    state: started
+- name: Wait for vcsim server to come up online
+  wait_for:
+    host: "{{ vcsim }}"
+    port: 443
+    state: started
 
-#- name: get a list of hosts from vcsim
-#  uri:
-#    url: http://{{ vcsim }}:5000/govc_find?filter=H
-#  register: hosts
+- name: get a list of hosts from vcsim
+  uri:
+    url: http://{{ vcsim }}:5000/govc_find?filter=H
+  register: hosts
 
-#- name: get a host
-#  set_fact:
-#    host1: "{{ hosts.json[0] | basename }}"
+- name: get a host
+  set_fact:
+    host1: "{{ hosts.json[0] | basename }}"
 
-#- debug: var=host1
+- debug: var=host1
 
-#- name: Gather facts about all hosts in given cluster
-#  vmware_host_vmnics_facts:
-#    hostname: "{{ vcsim }}"
-#    username: "{{ user }}"
-#    password: "{{ passwd }}"
-#    esxi_hostname: "{{ host1 }}"
-#    validate_certs: no
-#  register: host_vmnics
+- name: Gather facts about all hosts in given cluster
+  vmware_host_vmnics_facts:
+    hostname: "{{ vcsim }}"
+    username: "{{ user }}"
+    password: "{{ passwd }}"
+    esxi_hostname: "{{ host1 }}"
+    validate_certs: no
+  register: host_vmnics
 
-#- debug: var=host_vmnics
+- debug: var=host_vmnics
 
-#- assert:
-#    that:
-#      - host_vmnics.host_service_facts is defined
+- assert:
+    that:
+      - host_vmnics.host_service_facts is defined

--- a/test/integration/targets/vmware_local_role_manager/aliases
+++ b/test/integration/targets/vmware_local_role_manager/aliases
@@ -1,3 +1,2 @@
 posix/ci/cloud/group1/vcenter
 cloud/vcenter
-destructive

--- a/test/integration/targets/vmware_local_user_facts/aliases
+++ b/test/integration/targets/vmware_local_user_facts/aliases
@@ -1,3 +1,4 @@
 posix/ci/cloud/group1/vcenter
 cloud/vcenter
 destructive
+unsupported

--- a/test/integration/targets/vmware_local_user_facts/aliases
+++ b/test/integration/targets/vmware_local_user_facts/aliases
@@ -1,4 +1,3 @@
 posix/ci/cloud/group1/vcenter
 cloud/vcenter
-destructive
 unsupported

--- a/test/integration/targets/vmware_local_user_facts/aliases
+++ b/test/integration/targets/vmware_local_user_facts/aliases
@@ -1,3 +1,2 @@
-posix/ci/cloud/group1/vcenter
 cloud/vcenter
 unsupported

--- a/test/integration/targets/vmware_local_user_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_local_user_facts/tasks/main.yml
@@ -5,47 +5,47 @@
 # Commenting local user testcases as older vcsim docker image
 # does not support this.
 
-#- name: store the vcenter container ip
-#  set_fact:
-#    vcsim: "{{ lookup('env', 'vcenter_host') }}"
+- name: store the vcenter container ip
+  set_fact:
+    vcsim: "{{ lookup('env', 'vcenter_host') }}"
 
-#- debug: var=vcsim
+- debug: var=vcsim
 
-#- name: Wait for Flask controller to come up online
-#  wait_for:
-#    host: "{{ vcsim }}"
-#    port: 5000
-#    state: started
+- name: Wait for Flask controller to come up online
+  wait_for:
+    host: "{{ vcsim }}"
+    port: 5000
+    state: started
 
-#- name: kill vcsim
-#  uri:
-#    url: http://{{ vcsim }}:5000/killall
+- name: kill vcsim
+  uri:
+    url: http://{{ vcsim }}:5000/killall
 
 # Local user manager works only with standalone ESXi server
-#- name: start vcsim
-#  uri:
-#    url: http://{{ vcsim }}:5000/spawn?esx=1
-#  register: vcsim_instance
+- name: start vcsim
+  uri:
+    url: http://{{ vcsim }}:5000/spawn?esx=1
+  register: vcsim_instance
 
-#- debug:
-#    var: vcsim_instance
+- debug:
+    var: vcsim_instance
 
-#- name: Wait for vcsim server to come up online
-#  wait_for:
-#    host: "{{ vcsim }}"
-#    port: 443
-#    state: started
+- name: Wait for vcsim server to come up online
+  wait_for:
+    host: "{{ vcsim }}"
+    port: 443
+    state: started
 
-#- name: Gather facts about users
-#  vmware_local_user_facts:
-#    hostname: "{{ vcsim }}"
-#    username: "{{ vcsim_instance.json.username }}"
-#    password: "{{ vcsim_instance.json.password }}"
-#    validate_certs: False
-#  register: all_user_facts
+- name: Gather facts about users
+  vmware_local_user_facts:
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance.json.username }}"
+    password: "{{ vcsim_instance.json.password }}"
+    validate_certs: False
+  register: all_user_facts
 
-#- name: ensure user facts are gathered
-#  assert:
-#    that:
-#        - not all_user_facts.changed
-#        - all_user_facts.local_user_facts is defined
+- name: ensure user facts are gathered
+  assert:
+    that:
+        - not all_user_facts.changed
+        - all_user_facts.local_user_facts is defined

--- a/test/integration/targets/vmware_local_user_manager/aliases
+++ b/test/integration/targets/vmware_local_user_manager/aliases
@@ -1,3 +1,4 @@
 posix/ci/cloud/group1/vcenter
 cloud/vcenter
 destructive
+unsupported

--- a/test/integration/targets/vmware_local_user_manager/aliases
+++ b/test/integration/targets/vmware_local_user_manager/aliases
@@ -1,4 +1,3 @@
 posix/ci/cloud/group1/vcenter
 cloud/vcenter
-destructive
 unsupported

--- a/test/integration/targets/vmware_local_user_manager/aliases
+++ b/test/integration/targets/vmware_local_user_manager/aliases
@@ -1,3 +1,2 @@
-posix/ci/cloud/group1/vcenter
 cloud/vcenter
 unsupported

--- a/test/integration/targets/vmware_local_user_manager/tasks/main.yml
+++ b/test/integration/targets/vmware_local_user_manager/tasks/main.yml
@@ -5,123 +5,123 @@
 # Commenting local user testcases as older vcsim docker image
 # does not support this.
 
-#- name: store the vcenter container ip
-#  set_fact:
-#    vcsim: "{{ lookup('env', 'vcenter_host') }}"
+- name: store the vcenter container ip
+  set_fact:
+    vcsim: "{{ lookup('env', 'vcenter_host') }}"
 
-#- debug: var=vcsim
+- debug: var=vcsim
 
-#- name: Wait for Flask controller to come up online
-#  wait_for:
-#    host: "{{ vcsim }}"
-#    port: 5000
-#    state: started
+- name: Wait for Flask controller to come up online
+  wait_for:
+    host: "{{ vcsim }}"
+    port: 5000
+    state: started
 
-#- name: kill vcsim
-#  uri:
-#    url: http://{{ vcsim }}:5000/killall
+- name: kill vcsim
+  uri:
+    url: http://{{ vcsim }}:5000/killall
 
 # Local user manager works only with standalone ESXi server
-#- name: start vcsim
-#  uri:
-#    url: http://{{ vcsim }}:5000/spawn?esx=1
-#  register: vcsim_instance
+- name: start vcsim
+  uri:
+    url: http://{{ vcsim }}:5000/spawn?esx=1
+  register: vcsim_instance
 
-#- debug:
-#    var: vcsim_instance
+- debug:
+    var: vcsim_instance
 
-#- name: Wait for vcsim server to come up online
-#  wait_for:
-#    host: "{{ vcsim }}"
-#    port: 443
-#    state: started
+- name: Wait for vcsim server to come up online
+  wait_for:
+    host: "{{ vcsim }}"
+    port: 443
+    state: started
 
 # Testcase 0001: Add Local user in ESXi server
-#- name: add local user
-#  vmware_local_user_manager:
-#    hostname: "{{ vcsim }}"
-#    username: "{{ vcsim_instance.json.username }}"
-#    password: "{{ vcsim_instance.json.password }}"
-#    validate_certs: no
-#    local_user_name: testuser_0001
-#    local_user_password: "SamplePassword!"
-#    state: present
-#  register: user_add_0001
+- name: add local user
+  vmware_local_user_manager:
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance.json.username }}"
+    password: "{{ vcsim_instance.json.password }}"
+    validate_certs: no
+    local_user_name: testuser_0001
+    local_user_password: "SamplePassword!"
+    state: present
+  register: user_add_0001
 
-#- name: ensure user is created
-#  assert:
-#    that:
-#        - user_add_0001.changed == true
+- name: ensure user is created
+  assert:
+    that:
+        - user_add_0001.changed == true
 
 # Testcase 0002: Delete Local user in ESXi server
-#- name: Delete local user
-#  vmware_local_user_manager:
-#    hostname: "{{ vcsim }}"
-#    username: "{{ vcsim_instance.json.username }}"
-#    password: "{{ vcsim_instance.json.password }}"
-#    validate_certs: no
-#    local_user_name: testuser_0001
-#    state: absent
-#  register: user_delete_0002
+- name: Delete local user
+  vmware_local_user_manager:
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance.json.username }}"
+    password: "{{ vcsim_instance.json.password }}"
+    validate_certs: no
+    local_user_name: testuser_0001
+    state: absent
+  register: user_delete_0002
 
-#- name: ensure user is deleted
-#  assert:
-#    that:
-#        - user_delete_0002.changed == true
+- name: ensure user is deleted
+  assert:
+    that:
+        - user_delete_0002.changed == true
 
-#- name: kill vcsim
-#  uri:
-#    url: http://{{ vcsim }}:5000/killall
+- name: kill vcsim
+  uri:
+    url: http://{{ vcsim }}:5000/killall
 
 # Local user manager works only with standalone ESXi server not with vCenter
 # So testcase should check failures
-#- name: start vcsim
-#  uri:
-#    url: http://{{ vcsim }}:5000/spawn?cluster=2
-#  register: vcsim_instance
+- name: start vcsim
+  uri:
+    url: http://{{ vcsim }}:5000/spawn?cluster=2
+  register: vcsim_instance
 
-#- debug:
-#    var: vcsim_instance
+- debug:
+    var: vcsim_instance
 
-#- name: Wait for vcsim server to come up online
-#  wait_for:
-#    host: "{{ vcsim }}"
-#    port: 443
-#    state: started
+- name: Wait for vcsim server to come up online
+  wait_for:
+    host: "{{ vcsim }}"
+    port: 443
+    state: started
 
 # Testcase 0003: Add Local user in vCenter server
-#- name: add local user
-#  vmware_local_user_manager:
-#    hostname: "{{ vcsim }}"
-#    username: "{{ vcsim_instance.json.username }}"
-#    password: "{{ vcsim_instance.json.password }}"
-#    validate_certs: no
-#    local_user_name: testuser_0003
-#    local_user_password: "SamplePassword!"
-#    state: present
-#  register: user_add_0003
-#  ignore_errors: yes
+- name: add local user
+  vmware_local_user_manager:
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance.json.username }}"
+    password: "{{ vcsim_instance.json.password }}"
+    validate_certs: no
+    local_user_name: testuser_0003
+    local_user_password: "SamplePassword!"
+    state: present
+  register: user_add_0003
+  ignore_errors: yes
 
-#- name: ensure user is created
-#  assert:
-#    that:
-#        - user_add_0003.changed == false
-#        - "{{ 'Failed to get local account manager settings' in user_add_0003.msg }}"
+- name: ensure user is created
+  assert:
+    that:
+        - user_add_0003.changed == false
+        - "{{ 'Failed to get local account manager settings' in user_add_0003.msg }}"
 
-## Testcase 0003: Delete Local user in vCenter server
-#- name: Delete local user
-#  vmware_local_user_manager:
-#    hostname: "{{ vcsim }}"
-#    username: "{{ vcsim_instance.json.username }}"
-#    password: "{{ vcsim_instance.json.password }}"
-#    validate_certs: no
-#    local_user_name: testuser_0003
-#    state: absent
-#  register: user_delete_0004
-#  ignore_errors: yes
+# Testcase 0003: Delete Local user in vCenter server
+- name: Delete local user
+  vmware_local_user_manager:
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance.json.username }}"
+    password: "{{ vcsim_instance.json.password }}"
+    validate_certs: no
+    local_user_name: testuser_0003
+    state: absent
+  register: user_delete_0004
+  ignore_errors: yes
 
-#- name: ensure user is deleted
-#  assert:
-#    that:
-#        - user_delete_0004.changed == false
-#        - "{{ 'Failed to get local account manager settings' in user_delete_0004.msg }}"
+- name: ensure user is deleted
+  assert:
+    that:
+        - user_delete_0004.changed == false
+        - "{{ 'Failed to get local account manager settings' in user_delete_0004.msg }}"

--- a/test/integration/targets/vmware_maintenancemode/aliases
+++ b/test/integration/targets/vmware_maintenancemode/aliases
@@ -1,3 +1,2 @@
 posix/ci/cloud/group1/vcenter
 cloud/vcenter
-destructive

--- a/test/integration/targets/vmware_resource_pool/aliases
+++ b/test/integration/targets/vmware_resource_pool/aliases
@@ -1,3 +1,2 @@
 posix/ci/cloud/group4/vcenter
 cloud/vcenter
-destructive

--- a/test/integration/targets/vmware_resource_pool_facts/aliases
+++ b/test/integration/targets/vmware_resource_pool_facts/aliases
@@ -1,3 +1,2 @@
 posix/ci/cloud/group4/vcenter
 cloud/vcenter
-destructive

--- a/test/integration/targets/vmware_target_canonical_facts/aliases
+++ b/test/integration/targets/vmware_target_canonical_facts/aliases
@@ -1,3 +1,3 @@
 posix/ci/cloud/group4/vcenter
 cloud/vcenter
-
+unsupported

--- a/test/integration/targets/vmware_target_canonical_facts/aliases
+++ b/test/integration/targets/vmware_target_canonical_facts/aliases
@@ -1,3 +1,2 @@
-posix/ci/cloud/group4/vcenter
 cloud/vcenter
 unsupported

--- a/test/integration/targets/vmware_target_canonical_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_target_canonical_facts/tasks/main.yml
@@ -4,81 +4,81 @@
 
 # TODO: vcsim does not support SCSI target releated operations
 
-#- name: store the vcenter container ip
-#  set_fact:
-#    vcsim: "{{ lookup('env', 'vcenter_host') }}"
+- name: store the vcenter container ip
+  set_fact:
+    vcsim: "{{ lookup('env', 'vcenter_host') }}"
 
-#- debug: var=vcsim
+- debug: var=vcsim
 
-#- name: Wait for Flask controller to come up online
-#  wait_for:
-#    host: "{{ vcsim }}"
-#    port: 5000
-#    state: started
+- name: Wait for Flask controller to come up online
+  wait_for:
+    host: "{{ vcsim }}"
+    port: 5000
+    state: started
 
-#- name: kill vcsim
-#  uri:
-#    url: http://{{ vcsim }}:5000/killall
+- name: kill vcsim
+  uri:
+    url: http://{{ vcsim }}:5000/killall
 
-#- name: start vcsim
-#  uri:
-#    url: http://{{ vcsim }}:5000/spawn?cluster=2
-#  register: vcsim_instance
+- name: start vcsim
+  uri:
+    url: http://{{ vcsim }}:5000/spawn?cluster=2
+  register: vcsim_instance
 
-#- debug:
-#    var: vcsim_instance
+- debug:
+    var: vcsim_instance
 
-#- name: Wait for vcsim server to come up online
-#  wait_for:
-#    host: "{{ vcsim }}"
-#    port: 443
-#    state: started
+- name: Wait for vcsim server to come up online
+  wait_for:
+    host: "{{ vcsim }}"
+    port: 443
+    state: started
 
-#- name: get a list of Cluster from vcsim
-#  uri:
-#    url: http://{{ vcsim }}:5000/govc_find?filter=CCR
-#  register: clusters
+- name: get a list of Cluster from vcsim
+  uri:
+    url: http://{{ vcsim }}:5000/govc_find?filter=CCR
+  register: clusters
 
-#- name: get a cluster
-#  set_fact:
-#    ccr1: "{{ clusters.json[0] | basename }}"
+- name: get a cluster
+  set_fact:
+    ccr1: "{{ clusters.json[0] | basename }}"
 
-#- name: get a list of hosts from vcsim
-#  uri:
-#    url: http://{{ vcsim }}:5000/govc_find?filter=H
-#  register: hosts
+- name: get a list of hosts from vcsim
+  uri:
+    url: http://{{ vcsim }}:5000/govc_find?filter=H
+  register: hosts
 
-#- name: get a host
-#  set_fact:
-#    host1: "{{ hosts.json[0] | basename }}"
+- name: get a host
+  set_fact:
+    host1: "{{ hosts.json[0] | basename }}"
 
-#- debug: var=ccr1
-#- debug: var=host1
+- debug: var=ccr1
+- debug: var=host1
 
-#- name: Gather target facts for all ESXi host from given cluster
-#  vmware_target_canonical_facts:
-#    hostname: "{{ vcsim }}"
-#    username: "{{ vcsim_instance.json.username }}"
-#    password: "{{ vcsim_instance.json.password }}"
-#    validate_certs: False
-#    cluster_name: "{{ ccr1 }}"
-#  register: target_0001_results
+- name: Gather target facts for all ESXi host from given cluster
+  vmware_target_canonical_facts:
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance.json.username }}"
+    password: "{{ vcsim_instance.json.password }}"
+    validate_certs: False
+    cluster_name: "{{ ccr1 }}"
+  register: target_0001_results
 
-#- assert:
-#    that:
-#      - "not target_0001_results.changed"
-#      - "target_0001_results.scsi_tgt_facts is defined"
+- assert:
+    that:
+      - "not target_0001_results.changed"
+      - "target_0001_results.scsi_tgt_facts is defined"
 
-#- name: Gather target facts for ESXi host
-#  vmware_target_canonical_facts:
-#    hostname: "{{ vcsim }}"
-#    username: "{{ vcsim_instance.json.username }}"
-#    password: "{{ vcsim_instance.json.password }}"
-#    validate_certs: False
-#    esxi_hostname: "{{ host1 }}"
-#  register: target_0002_results
+- name: Gather target facts for ESXi host
+  vmware_target_canonical_facts:
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance.json.username }}"
+    password: "{{ vcsim_instance.json.password }}"
+    validate_certs: False
+    esxi_hostname: "{{ host1 }}"
+  register: target_0002_results
 
-#- assert:
-#    that:
-#      - "not target_0002_results.changed"
-#      - "target_0002_results.scsi_tgt_facts is defined"
+- assert:
+    that:
+      - "not target_0002_results.changed"
+      - "target_0002_results.scsi_tgt_facts is defined"

--- a/test/integration/targets/vmware_vm_facts/aliases
+++ b/test/integration/targets/vmware_vm_facts/aliases
@@ -1,4 +1,3 @@
 posix/ci/cloud/group1/vcenter
 posix/ci/cloud/group1/smoketest
 cloud/vcenter
-destructive

--- a/test/integration/targets/vmware_vm_vm_drs_rule/aliases
+++ b/test/integration/targets/vmware_vm_vm_drs_rule/aliases
@@ -1,3 +1,4 @@
 posix/ci/cloud/group4/vcenter
 cloud/vcenter
 destructive
+unsupported

--- a/test/integration/targets/vmware_vm_vm_drs_rule/aliases
+++ b/test/integration/targets/vmware_vm_vm_drs_rule/aliases
@@ -1,3 +1,2 @@
-posix/ci/cloud/group4/vcenter
 cloud/vcenter
 unsupported

--- a/test/integration/targets/vmware_vm_vm_drs_rule/aliases
+++ b/test/integration/targets/vmware_vm_vm_drs_rule/aliases
@@ -1,4 +1,3 @@
 posix/ci/cloud/group4/vcenter
 cloud/vcenter
-destructive
 unsupported

--- a/test/integration/targets/vmware_vm_vm_drs_rule/tasks/main.yml
+++ b/test/integration/targets/vmware_vm_vm_drs_rule/tasks/main.yml
@@ -4,74 +4,74 @@
 
 # TODO: vcsim does not support manage DRS rule
 
-#- name: store the vcenter container ip
-#  set_fact:
-#    vcsim: "{{ lookup('env', 'vcenter_host') }}"
-#- debug: var=vcsim
+- name: store the vcenter container ip
+  set_fact:
+    vcsim: "{{ lookup('env', 'vcenter_host') }}"
+- debug: var=vcsim
 
-#- name: wait for flask server
-#  wait_for:
-#    host: "{{ vcsim }}"
-#    port: 5000
-#    state: started
+- name: wait for flask server
+  wait_for:
+    host: "{{ vcsim }}"
+    port: 5000
+    state: started
 
-#- name: kill vcsim
-#  uri:
-#    url: http://{{ vcsim }}:5000/killall
+- name: kill vcsim
+  uri:
+    url: http://{{ vcsim }}:5000/killall
 
-#- name: start vcsim
-#  uri:
-#    url: http://{{ vcsim }}:5000/spawn?datacenter=2&cluster=1&folder=0&ds=2&pool=2
-#  register: vcsim_instance
+- name: start vcsim
+  uri:
+    url: http://{{ vcsim }}:5000/spawn?datacenter=2&cluster=1&folder=0&ds=2&pool=2
+  register: vcsim_instance
 
-#- name: wait for vcsim server
-#  wait_for:
-#    host: "{{ vcsim }}"
-#    port: 443
-#    state: started
+- name: wait for vcsim server
+  wait_for:
+    host: "{{ vcsim }}"
+    port: 443
+    state: started
 
-#- debug: var=vcsim_instance
+- debug: var=vcsim_instance
 
-#- name: Create a DRS Affinity rule for vms
-#  vmware_vm_vm_drs_rule:
-#    validate_certs: False
-#    hostname: "{{ vcsim }}"
-#    username: "{{ vcsim_instance['json']['username'] }}"
-#    password: "{{ vcsim_instance['json']['password'] }}"
-#    drs_rule_name: drs_rule_0001
-#    cluster_name: DC0_C0
-#    vms:
-#      - DC0_C0_RP0_VM0
-#      - DC0_C0_RP0_VM1
-#    enabled: True
-#    affinity_rule: True
-#    mandatory: True
-#  register: drs_rule_0001_results
+- name: Create a DRS Affinity rule for vms
+  vmware_vm_vm_drs_rule:
+    validate_certs: False
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    drs_rule_name: drs_rule_0001
+    cluster_name: DC0_C0
+    vms:
+      - DC0_C0_RP0_VM0
+      - DC0_C0_RP0_VM1
+    enabled: True
+    affinity_rule: True
+    mandatory: True
+  register: drs_rule_0001_results
 
-#- debug: var=drs_rule_0001_results
+- debug: var=drs_rule_0001_results
 
-#- assert:
-#    that:
-#        - "{{ drs_rule_0001_results.changed }}"
+- assert:
+    that:
+        - "{{ drs_rule_0001_results.changed }}"
 
-#- name: Create a DRS Anti-Affinity rule for vms
-#  vmware_vm_vm_drs_rule:
-#    validate_certs: False
-#    hostname: "{{ vcsim }}"
-#    username: "{{ vcsim_instance['json']['username'] }}"
-#    password: "{{ vcsim_instance['json']['password'] }}"
-#    drs_rule_name: drs_rule_0001
-#    cluster_name: DC0_C0
-#    vms:
-#      - DC0_C0_RP0_VM0
-#      - DC0_C0_RP0_VM1
-#    enabled: False
-#    affinity_rule: False
-#    mandatory: False
-#  register: drs_rule_0002_results
+- name: Create a DRS Anti-Affinity rule for vms
+  vmware_vm_vm_drs_rule:
+    validate_certs: False
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    drs_rule_name: drs_rule_0001
+    cluster_name: DC0_C0
+    vms:
+      - DC0_C0_RP0_VM0
+      - DC0_C0_RP0_VM1
+    enabled: False
+    affinity_rule: False
+    mandatory: False
+  register: drs_rule_0002_results
 
-#- debug: var=drs_rule_0002_results
+- debug: var=drs_rule_0002_results
 
-#- assert:
-#    that:
-#        - "{{ drs_rule_0002_results.changed }}"
+- assert:
+    that:
+        - "{{ drs_rule_0002_results.changed }}"

--- a/test/integration/targets/vmware_vmkernel_facts/aliases
+++ b/test/integration/targets/vmware_vmkernel_facts/aliases
@@ -1,3 +1,3 @@
 posix/ci/cloud/group4/vcenter
 cloud/vcenter
-
+unsupported

--- a/test/integration/targets/vmware_vmkernel_facts/aliases
+++ b/test/integration/targets/vmware_vmkernel_facts/aliases
@@ -1,3 +1,2 @@
-posix/ci/cloud/group4/vcenter
 cloud/vcenter
 unsupported

--- a/test/integration/targets/vmware_vmkernel_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_vmkernel_facts/tasks/main.yml
@@ -4,58 +4,58 @@
 
 # TODO: vcsim does not support HostVirtualNicManager related to operations
 
-#- name: store the vcenter container ip
-#  set_fact:
-#    vcsim: "{{ lookup('env', 'vcenter_host') }}"
+- name: store the vcenter container ip
+  set_fact:
+    vcsim: "{{ lookup('env', 'vcenter_host') }}"
 
-#- debug: var=vcsim
+- debug: var=vcsim
 
-#- name: Wait for Flask controller to come up online
-#  wait_for:
-#    host: "{{ vcsim }}"
-#    port: 5000
-#    state: started
+- name: Wait for Flask controller to come up online
+  wait_for:
+    host: "{{ vcsim }}"
+    port: 5000
+    state: started
 
-#- name: kill vcsim
-#  uri:
-#    url: http://{{ vcsim }}:5000/killall
+- name: kill vcsim
+  uri:
+    url: http://{{ vcsim }}:5000/killall
 
-#- name: start vcsim
-#  uri:
-#    url: http://{{ vcsim }}:5000/spawn?cluster=2
-#  register: vcsim_instance
+- name: start vcsim
+  uri:
+    url: http://{{ vcsim }}:5000/spawn?cluster=2
+  register: vcsim_instance
 
-#- debug:
-#    var: vcsim_instance
+- debug:
+    var: vcsim_instance
 
-#- name: Wait for vcsim server to come up online
-#  wait_for:
-#    host: "{{ vcsim }}"
-#    port: 443
-#    state: started
+- name: Wait for vcsim server to come up online
+  wait_for:
+    host: "{{ vcsim }}"
+    port: 443
+    state: started
 
-#- name: get a list of hosts from vcsim
-#  uri:
-#    url: http://{{ vcsim }}:5000/govc_find?filter=H
-#  register: hosts
+- name: get a list of hosts from vcsim
+  uri:
+    url: http://{{ vcsim }}:5000/govc_find?filter=H
+  register: hosts
 
-#- name: get a host
-#  set_fact:
-#    host1: "{{ hosts.json[0] | basename }}"
+- name: get a host
+  set_fact:
+    host1: "{{ hosts.json[0] | basename }}"
 
-#- debug: var=host1
+- debug: var=host1
 
-#- name: Gather VNICs facts about all hosts in given cluster
-#  vmware_vmkernel_facts:
-#    hostname: "{{ vcsim }}"
-#    username: "{{ user }}"
-#    password: "{{ passwd }}"
-#    esxi_hostname: "{{ host1 }}"
-#    validate_certs: no
-#  register: host_vmkernel
+- name: Gather VNICs facts about all hosts in given cluster
+  vmware_vmkernel_facts:
+    hostname: "{{ vcsim }}"
+    username: "{{ user }}"
+    password: "{{ passwd }}"
+    esxi_hostname: "{{ host1 }}"
+    validate_certs: no
+  register: host_vmkernel
 
-#- debug: var=host_vmkernel
+- debug: var=host_vmkernel
 
-#- assert:
-#    that:
-#      - host_vmkernel.host_vmk_facts is defined
+- assert:
+    that:
+      - host_vmkernel.host_vmk_facts is defined

--- a/test/integration/targets/vmware_vswitch/aliases
+++ b/test/integration/targets/vmware_vswitch/aliases
@@ -1,3 +1,4 @@
 posix/ci/cloud/group4/vcenter
 cloud/vcenter
 destructive
+unsupported

--- a/test/integration/targets/vmware_vswitch/aliases
+++ b/test/integration/targets/vmware_vswitch/aliases
@@ -1,3 +1,2 @@
-posix/ci/cloud/group4/vcenter
 cloud/vcenter
 unsupported

--- a/test/integration/targets/vmware_vswitch/aliases
+++ b/test/integration/targets/vmware_vswitch/aliases
@@ -1,4 +1,3 @@
 posix/ci/cloud/group4/vcenter
 cloud/vcenter
-destructive
 unsupported

--- a/test/integration/targets/vmware_vswitch/tasks/main.yml
+++ b/test/integration/targets/vmware_vswitch/tasks/main.yml
@@ -4,148 +4,148 @@
 
 # TODO: akasurde: VCSIM does not suport network manager system
 
-#- name: store the vcenter container ip
-#  set_fact:
-#    vcsim: '{{ lookup("env", "vcenter_host") }}'
+- name: store the vcenter container ip
+  set_fact:
+    vcsim: '{{ lookup("env", "vcenter_host") }}'
 
-#- debug:
-#    var: vcsim
+- debug:
+    var: vcsim
 
-#- name: Wait for Flask controller to come up online
-#  wait_for:
-#    host: '{{ vcsim }}'
-#    port: 5000
-#    state: started
+- name: Wait for Flask controller to come up online
+  wait_for:
+    host: '{{ vcsim }}'
+    port: 5000
+    state: started
 
-#- name: Kill vcsim
-#  uri:
-#    url: http://{{ vcsim }}:5000/killall
+- name: Kill vcsim
+  uri:
+    url: http://{{ vcsim }}:5000/killall
 
-#- name: Start vcsim
-#  uri:
-#    url: http://{{ vcsim }}:5000/spawn?cluster=2
-#  register: vcsim_instance
+- name: Start vcsim
+  uri:
+    url: http://{{ vcsim }}:5000/spawn?cluster=2
+  register: vcsim_instance
 
-#- name: Wait for Flask controller to come up online
-#  wait_for:
-#    host: '{{ vcsim }}'
-#    port: 443
-#    state: started
+- name: Wait for Flask controller to come up online
+  wait_for:
+    host: '{{ vcsim }}'
+    port: 443
+    state: started
 
-#- debug:
-#    var: vcsim_instance
+- debug:
+    var: vcsim_instance
 
 # FIXME: Implement check-mode support
-#- name: Add a nic to a switch (check-mode)
-#  vmware_vswitch: &add_nic
-#    hostname: '{{ vcsim }}'
-#    username: '{{ vcsim_instance.json.username }}'
-#    password: '{{ vcsim_instance.json.password }}'
-#    validate_certs: no
-#    switch: vmswitch_0001
-#    nics: vnic_1
-#    state: present
-#  check_mode: yes
-#  register: add_nic_check
+- name: Add a nic to a switch (check-mode)
+  vmware_vswitch: &add_nic
+    hostname: '{{ vcsim }}'
+    username: '{{ vcsim_instance.json.username }}'
+    password: '{{ vcsim_instance.json.password }}'
+    validate_certs: no
+    switch: vmswitch_0001
+    nics: vnic_1
+    state: present
+  check_mode: yes
+  register: add_nic_check
 
-#- assert:
-#    that:
-#    - add_nic_check.changed == true
-#    - add_nic_check.skipped == true
+- assert:
+    that:
+    - add_nic_check.changed == true
+    - add_nic_check.skipped == true
 
-#- name: Add a nic to a switch
-#  vmware_vswitch: *add_nic
-#  register: add_nic_run
+- name: Add a nic to a switch
+  vmware_vswitch: *add_nic
+  register: add_nic_run
 
-#- assert:
-#    that:
-#    - add_nic_run.changed == true
+- assert:
+    that:
+    - add_nic_run.changed == true
 
-## FIXME: Implement check-mode support
-#- name: Add a nic to a switch again (check-mode)
-#  vmware_vswitch: *add_nic
-#  check_mode: yes
-#  register: add_nic_again_check
-#
-#- assert:
-#    that:
-#    - add_nic_again_check.changed == false
-#
-#- name: Add a nic to a switch again
-#  vmware_vswitch: *add_nic
-#  register: add_nic_again_run
-#
-#- assert:
-#    that:
-#    - add_nic_again_run.changed == false
-#
-#- name: Remove a switch (check-mode)
-#  vmware_vswitch: &remove_nic
-#    hostname: '{{ vcsim }}'
-#    username: '{{ vcsim_instance.json.username }}'
-#    password: '{{ vcsim_instance.json.password }}'
-#    validate_certs: no
-#    switch: vmswitch_0001
-#    state: absent
-#  check_mode: yes
-#  register: remove_nic_check
-#
-## FIXME: Implement check-mode support
-#- assert:
-#    that:
-#    - remove_nic_check.changed == true
+# FIXME: Implement check-mode support
+- name: Add a nic to a switch again (check-mode)
+  vmware_vswitch: *add_nic
+  check_mode: yes
+  register: add_nic_again_check
 
-## FIXME: Removing a switch fails
-#- name: Remove a switch
-#  vmware_vswitch: *remove_nic
-#  register: remove_nic_run
-#
-#- assert:
-#    that:
-#    - remove_nic_run.changed == true
-#
-#- name: Remove a switch again (check-mode)
-#  vmware_vswitch: *remove_nic
-#  check_mode: yes
-#  register: remove_nic_again_check
-#
-## FIXME: Implement check-mode support
-#- assert:
-#    that:
-#    - remove_nic_again_check_mode.changed == false
-#
-## FIXME: Removing a switch fails
-#- name: Remove a switch again
-#  vmware_vswitch: *remove_nic
-#  register: remove_nic_again_run
-#
-#- assert:
-#    that:
-#    - remove_nic_again_run.changed == false
+- assert:
+    that:
+    - add_nic_again_check.changed == false
 
-#- name: get a list of Host Systems from vcsim
-#  uri:
-#    url: "{{ 'http://' + vcsim + ':5000/govc_find?filter=H' }}"
-#  register: host_systems
+- name: Add a nic to a switch again
+  vmware_vswitch: *add_nic
+  register: add_nic_again_run
 
-#- name: get a host system
-#  set_fact: hs1="{{ host_systems['json'][0] | basename }}"
+- assert:
+    that:
+    - add_nic_again_run.changed == false
 
-#- debug: var=hs1
+- name: Remove a switch (check-mode)
+  vmware_vswitch: &remove_nic
+    hostname: '{{ vcsim }}'
+    username: '{{ vcsim_instance.json.username }}'
+    password: '{{ vcsim_instance.json.password }}'
+    validate_certs: no
+    switch: vmswitch_0001
+    state: absent
+  check_mode: yes
+  register: remove_nic_check
 
-#- name: Add vswitch to a specific host system
-#  vmware_vswitch:
-#    validate_certs: False
-#    hostname: "{{ vcsim }}"
-#    username: "{{ vcsim_instance['json']['username'] }}"
-#    password: "{{ vcsim_instance['json']['password'] }}"
-#    switch: vmswitch_0002
-#    nics: vnic_1
-#    esxi_hostname: hs1
-#  register: add_vswitch_with_host_system
+# FIXME: Implement check-mode support
+- assert:
+    that:
+    - remove_nic_check.changed == true
 
-#- debug: var=add_vswitch_with_host_system
+# FIXME: Removing a switch fails
+- name: Remove a switch
+  vmware_vswitch: *remove_nic
+  register: remove_nic_run
 
-#- assert:
-#    that:
-#    - add_vswitch_with_host_system.changed == true
+- assert:
+    that:
+    - remove_nic_run.changed == true
+
+- name: Remove a switch again (check-mode)
+  vmware_vswitch: *remove_nic
+  check_mode: yes
+  register: remove_nic_again_check
+
+# FIXME: Implement check-mode support
+- assert:
+    that:
+    - remove_nic_again_check_mode.changed == false
+
+# FIXME: Removing a switch fails
+- name: Remove a switch again
+  vmware_vswitch: *remove_nic
+  register: remove_nic_again_run
+
+- assert:
+    that:
+    - remove_nic_again_run.changed == false
+
+- name: get a list of Host Systems from vcsim
+  uri:
+    url: "{{ 'http://' + vcsim + ':5000/govc_find?filter=H' }}"
+  register: host_systems
+
+- name: get a host system
+  set_fact: hs1="{{ host_systems['json'][0] | basename }}"
+
+- debug: var=hs1
+
+- name: Add vswitch to a specific host system
+  vmware_vswitch:
+    validate_certs: False
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    switch: vmswitch_0002
+    nics: vnic_1
+    esxi_hostname: hs1
+  register: add_vswitch_with_host_system
+
+- debug: var=add_vswitch_with_host_system
+
+- assert:
+    that:
+    - add_vswitch_with_host_system.changed == true

--- a/test/integration/targets/vmware_vswitch_facts/aliases
+++ b/test/integration/targets/vmware_vswitch_facts/aliases
@@ -1,3 +1,3 @@
 posix/ci/cloud/group4/vcenter
 cloud/vcenter
-
+unsupported

--- a/test/integration/targets/vmware_vswitch_facts/aliases
+++ b/test/integration/targets/vmware_vswitch_facts/aliases
@@ -1,3 +1,2 @@
-posix/ci/cloud/group4/vcenter
 cloud/vcenter
 unsupported

--- a/test/integration/targets/vmware_vswitch_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_vswitch_facts/tasks/main.yml
@@ -4,58 +4,58 @@
 
 # TODO: vcsim does not support networkConfig related to operations
 
-#- name: store the vcenter container ip
-#  set_fact:
-#    vcsim: "{{ lookup('env', 'vcenter_host') }}"
+- name: store the vcenter container ip
+  set_fact:
+    vcsim: "{{ lookup('env', 'vcenter_host') }}"
 
-#- debug: var=vcsim
+- debug: var=vcsim
 
-#- name: Wait for Flask controller to come up online
-#  wait_for:
-#    host: "{{ vcsim }}"
-#    port: 5000
-#    state: started
+- name: Wait for Flask controller to come up online
+  wait_for:
+    host: "{{ vcsim }}"
+    port: 5000
+    state: started
 
-#- name: kill vcsim
-#  uri:
-#    url: http://{{ vcsim }}:5000/killall
+- name: kill vcsim
+  uri:
+    url: http://{{ vcsim }}:5000/killall
 
-#- name: start vcsim
-#  uri:
-#    url: http://{{ vcsim }}:5000/spawn?cluster=2
-#  register: vcsim_instance
+- name: start vcsim
+  uri:
+    url: http://{{ vcsim }}:5000/spawn?cluster=2
+  register: vcsim_instance
 
-#- debug:
-#    var: vcsim_instance
+- debug:
+    var: vcsim_instance
 
-#- name: Wait for vcsim server to come up online
-#  wait_for:
-#    host: "{{ vcsim }}"
-#    port: 443
-#    state: started
+- name: Wait for vcsim server to come up online
+  wait_for:
+    host: "{{ vcsim }}"
+    port: 443
+    state: started
 
-#- name: get a list of hosts from vcsim
-#  uri:
-#    url: http://{{ vcsim }}:5000/govc_find?filter=H
-#  register: hosts
+- name: get a list of hosts from vcsim
+  uri:
+    url: http://{{ vcsim }}:5000/govc_find?filter=H
+  register: hosts
 
-#- name: get a host
-#  set_fact:
-#    host1: "{{ hosts.json[0] | basename }}"
+- name: get a host
+  set_fact:
+    host1: "{{ hosts.json[0] | basename }}"
 
-#- debug: var=host1
+- debug: var=host1
 
-#- name: Gather vswitch facts about all hosts in given cluster
-#  vmware_vswitch_facts:
-#    hostname: "{{ vcsim }}"
-#    username: "{{ user }}"
-#    password: "{{ passwd }}"
-#    esxi_hostname: "{{ host1 }}"
-#    validate_certs: no
-#  register: switch_facts
+- name: Gather vswitch facts about all hosts in given cluster
+  vmware_vswitch_facts:
+    hostname: "{{ vcsim }}"
+    username: "{{ user }}"
+    password: "{{ passwd }}"
+    esxi_hostname: "{{ host1 }}"
+    validate_certs: no
+  register: switch_facts
 
-#- debug: var=switch_facts
+- debug: var=switch_facts
 
-#- assert:
-#    that:
-#      - switch_facts.hosts_vswitch_facts is defined
+- assert:
+    that:
+      - switch_facts.hosts_vswitch_facts is defined


### PR DESCRIPTION
##### SUMMARY

Clean up vmware/vcenter integration tests:

- Mark unsupported vmware tests instead of commenting out all the tasks in the tests.
- Remove unnecessary destructive aliases.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

vwmware and vcenter integration tests

##### ANSIBLE VERSION

```
ansible 2.6.0 (vmware-unsupported dfadfe25d5) last updated 2018/05/08 11:14:17 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
