### PR TITLE
Honor ignore_errors when invoking the debugger, add config to disable this behavior

### DIFF
--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -993,6 +993,18 @@ ENABLE_TASK_DEBUGGER:
   ini:
     - {key: enable_task_debugger, section: defaults}
   version_added: "2.5"
+TASK_DEBUGGER_IGNORE_ERRORS:
+  name: Whether a failed task with ignore_errors=True will still invoke the debugger
+  default: True
+  description:
+    - This option defines whether the task debugger will be invoked on a failed task when ignore_errors=True
+      is specified.
+    - True specifies that the debugger wil honor ignore_errors, False will not honor ignore_errors.
+  type: boolean
+  env: [{name: ANSIBLE_TASK_DEBUGGER_IGNORE_ERRORS}]
+  ini:
+    - {key: task_debugger_ignore_errors, section: defaults}
+  version_added: "2.7"
 DEFAULT_STRATEGY:
   name: Implied strategy
   default: 'linear'

--- a/lib/ansible/executor/task_result.py
+++ b/lib/ansible/executor/task_result.py
@@ -7,6 +7,7 @@ __metaclass__ = type
 
 from copy import deepcopy
 
+from ansible import constants as C
 from ansible.parsing.dataloader import DataLoader
 from ansible.vars.clean import strip_internal_keys
 
@@ -66,18 +67,19 @@ class TaskResult:
 
     def needs_debugger(self, globally_enabled=False):
         _debugger = self._task_fields.get('debugger')
+        _ignore_errors = C.TASK_DEBUGGER_IGNORE_ERRORS and self._task_fields.get('ignore_errors')
 
         ret = False
-        if globally_enabled and (self.is_failed() or self.is_unreachable()):
+        if globally_enabled and not _ignore_errors and (self.is_failed() or self.is_unreachable()):
             ret = True
 
         if _debugger in ('always',):
             ret = True
         elif _debugger in ('never',):
             ret = False
-        elif _debugger in ('on_failed',) and self.is_failed():
+        elif _debugger in ('on_failed',) and self.is_failed() and not _ignore_errors:
             ret = True
-        elif _debugger in ('on_unreachable',) and self.is_unreachable():
+        elif _debugger in ('on_unreachable',) and self.is_unreachable() and not _ignore_errors:
             ret = True
         elif _debugger in('on_skipped',) and self.is_skipped():
             ret = True

--- a/lib/ansible/executor/task_result.py
+++ b/lib/ansible/executor/task_result.py
@@ -70,7 +70,7 @@ class TaskResult:
         _ignore_errors = C.TASK_DEBUGGER_IGNORE_ERRORS and self._task_fields.get('ignore_errors')
 
         ret = False
-        if globally_enabled and not _ignore_errors and (self.is_failed() or self.is_unreachable()):
+        if globally_enabled and ((self.is_failed() and not _ignore_errors) or self.is_unreachable()):
             ret = True
 
         if _debugger in ('always',):
@@ -79,7 +79,7 @@ class TaskResult:
             ret = False
         elif _debugger in ('on_failed',) and self.is_failed() and not _ignore_errors:
             ret = True
-        elif _debugger in ('on_unreachable',) and self.is_unreachable() and not _ignore_errors:
+        elif _debugger in ('on_unreachable',) and self.is_unreachable():
             ret = True
         elif _debugger in('on_skipped',) and self.is_skipped():
             ret = True


### PR DESCRIPTION
##### SUMMARY
Honor ignore_errors when invoking the debugger, add config to disable this behavior. Fixes #39863

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
lib/ansible/config/base.yml
lib/ansible/executor/task_result.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```