### PR TITLE
Move pyvmomi install into cloud test plugin.

### DIFF
--- a/test/integration/targets/vcenter_folder/tasks/main.yml
+++ b/test/integration/targets/vcenter_folder/tasks/main.yml
@@ -2,12 +2,6 @@
 # Copyright: (c) 2018, Abhijeet Kasurde <akasurde@redhat.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: make sure pyvmomi is installed
-  pip:
-    name: pyvmomi
-    state: latest
-  when: "{{ ansible_user_id == 'root' }}"
-
 - name: store the vcenter container ip
   set_fact:
     vcsim: "{{ lookup('env', 'vcenter_host') }}"

--- a/test/integration/targets/vcenter_license/tasks/main.yml
+++ b/test/integration/targets/vcenter_license/tasks/main.yml
@@ -2,11 +2,6 @@
 # Copyright: (c) 2017, Dag Wieers <dag@wieers.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: Make sure pyvmomi is installed
-  pip:
-    name: pyvmomi
-    state: latest
-
 - name: Store the vCenter container IP
   set_fact:
     vcenter_host: "{{ lookup('env', 'vcenter_host') }}"

--- a/test/integration/targets/vmware_cluster/tasks/main.yml
+++ b/test/integration/targets/vmware_cluster/tasks/main.yml
@@ -2,12 +2,6 @@
 # Copyright: (c) 2017, Abhijeet Kasurde <akasurde@redhat.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: Make sure pyvmomi is installed
-  pip:
-    name: pyvmomi
-    state: latest
-  when: "{{ ansible_user_id == 'root' }}"
-
 - name: store the vcenter container ip
   set_fact:
     vcsim: "{{ lookup('env', 'vcenter_host') }}"

--- a/test/integration/targets/vmware_datacenter/tasks/main.yml
+++ b/test/integration/targets/vmware_datacenter/tasks/main.yml
@@ -2,12 +2,6 @@
 # Copyright: (c) 2017, Abhijeet Kasurde <akasurde@redhat.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: Make sure pyvmomi is installed
-  pip:
-    name: pyvmomi
-    state: latest
-  when: "{{ ansible_user_id == 'root' }}"
-
 - name: store the vcenter container ip
   set_fact:
     vcsim: "{{ lookup('env', 'vcenter_host') }}"

--- a/test/integration/targets/vmware_datastore_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_datastore_facts/tasks/main.yml
@@ -16,10 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
-- name: make sure pyvmomi is installed
-  pip:
-    name: pyvmomi
-    state: latest
 
 - name: store the vcenter container ip
   set_fact:

--- a/test/integration/targets/vmware_drs_rule_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_drs_rule_facts/tasks/main.yml
@@ -2,12 +2,6 @@
 # Copyright: (c) 2018, Abhijeet Kasurde <akasurde@redhat.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: make sure pyvmomi is installed
-  pip:
-    name: pyvmomi
-    state: latest
-  when: "{{ ansible_user_id == 'root' }}"
-
 - name: store the vcenter container ip
   set_fact:
     vcsim: "{{ lookup('env', 'vcenter_host') }}"

--- a/test/integration/targets/vmware_dvs_portgroup/tasks/main.yml
+++ b/test/integration/targets/vmware_dvs_portgroup/tasks/main.yml
@@ -16,11 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
-- name: make sure pyvmomi is installed
-  pip:
-    name: pyvmomi
-    state: latest
-  when: "{{ ansible_user_id == 'root' }}"
 
 - name: store the vcenter container ip
   set_fact:

--- a/test/integration/targets/vmware_dvswitch/tasks/main.yml
+++ b/test/integration/targets/vmware_dvswitch/tasks/main.yml
@@ -2,12 +2,6 @@
 # Copyright: (c) 2017, Abhijeet Kasurde <akasurde@redhat.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: Make sure pyvmomi is installed
-  pip:
-    name: pyvmomi
-    state: latest
-  when: "{{ ansible_user_id == 'root' }}"
-
 - name: store the vcenter container ip
   set_fact:
     vcsim: "{{ lookup('env', 'vcenter_host') }}"

--- a/test/integration/targets/vmware_guest/tasks/main.yml
+++ b/test/integration/targets/vmware_guest/tasks/main.yml
@@ -2,12 +2,6 @@
 # Copyright: (c) 2017, James Tanner <tanner.jc@gmail.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: make sure pyvmomi is installed
-  pip:
-    name: pyvmomi
-    state: latest
-  when: "{{ ansible_user_id == 'root' }}"
-
 - name: store the vcenter container ip
   set_fact:
     vcsim: "{{ lookup('env', 'vcenter_host') }}"

--- a/test/integration/targets/vmware_guest_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_guest_facts/tasks/main.yml
@@ -2,12 +2,6 @@
 # Copyright: (c) 2017, Abhijeet Kasurde <akasurde@redhat.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: make sure pyvmomi is installed
-  pip:
-    name: pyvmomi
-    state: latest
-  when: "{{ ansible_user_id == 'root' }}"
-
 - name: store the vcenter container ip
   set_fact:
     vcsim: "{{ lookup('env', 'vcenter_host') }}"

--- a/test/integration/targets/vmware_guest_find/tasks/main.yml
+++ b/test/integration/targets/vmware_guest_find/tasks/main.yml
@@ -2,12 +2,6 @@
 # Copyright: (c) 2017, James Tanner <tanner.jc@gmail.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: make sure pyvmomi is installed
-  pip:
-    name: pyvmomi
-    state: latest
-  when: "{{ ansible_user_id == 'root' }}"
-
 - name: store the vcenter container ip
   set_fact:
     vcsim: "{{ lookup('env', 'vcenter_host') }}"

--- a/test/integration/targets/vmware_guest_powerstate/tasks/main.yml
+++ b/test/integration/targets/vmware_guest_powerstate/tasks/main.yml
@@ -2,12 +2,6 @@
 # Copyright: (c) 2017, Abhijeet Kasurde <akasurde@redhat.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: make sure pyvmomi is installed
-  pip:
-    name: pyvmomi
-    state: latest
-  when: "{{ ansible_user_id == 'root' }}"
-
 - name: store the vcenter container ip
   set_fact:
     vcsim: "{{ lookup('env', 'vcenter_host') }}"

--- a/test/integration/targets/vmware_guest_snapshot/tasks/main.yml
+++ b/test/integration/targets/vmware_guest_snapshot/tasks/main.yml
@@ -1,9 +1,3 @@
-# - name: make sure pyvmomi is installed
-#   pip:
-#     name: pyvmomi
-#     state: latest
-#   when: ansible_user_id == 'root'
-# 
 # - name: store the vcenter container ip
 #   set_fact:
 #     vcsim: "{{ lookup('env', 'vcenter_host') }}"

--- a/test/integration/targets/vmware_guest_tools_wait/tasks/main.yml
+++ b/test/integration/targets/vmware_guest_tools_wait/tasks/main.yml
@@ -2,12 +2,6 @@
 # Copyright: (c) 2017 Philippe Dellaert <philippe@dellaert.org>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: make sure pyvmomi is installed
-  pip:
-    name: pyvmomi
-    state: latest
-  when: "{{ ansible_user_id == 'root' }}"
-
 - name: store the vcenter container ip
   set_fact:
     vcsim: "{{ lookup('env', 'vcenter_host') }}"

--- a/test/integration/targets/vmware_host/tasks/main.yml
+++ b/test/integration/targets/vmware_host/tasks/main.yml
@@ -2,12 +2,6 @@
 # Copyright: (c) 2017, Abhijeet Kasurde <akasurde@redhat.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: make sure pyvmomi is installed
-  pip:
-    name: pyvmomi
-    state: latest
-  when: "{{ ansible_user_id == 'root' }}"
-
 - name: store the vcenter container ip
   set_fact:
     vcsim: "{{ lookup('env', 'vcenter_host') }}"

--- a/test/integration/targets/vmware_host_acceptance/tasks/main.yml
+++ b/test/integration/targets/vmware_host_acceptance/tasks/main.yml
@@ -3,11 +3,6 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 # TODO: vcsim does not support Acceptance Level related to operations
-#- name: make sure pyvmomi is installed
-#  pip:
-#    name: pyvmomi
-#    state: latest
-#  when: "{{ ansible_user_id == 'root' }}"
 
 #- name: store the vcenter container ip
 #  set_fact:

--- a/test/integration/targets/vmware_host_config_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_host_config_facts/tasks/main.yml
@@ -2,12 +2,6 @@
 # Copyright: (c) 2018, Abhijeet Kasurde <akasurde@redhat.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: make sure pyvmomi is installed
-  pip:
-    name: pyvmomi
-    state: latest
-  when: "{{ ansible_user_id == 'root' }}"
-
 - name: store the vcenter container ip
   set_fact:
     vcsim: "{{ lookup('env', 'vcenter_host') }}"

--- a/test/integration/targets/vmware_host_config_manager/tasks/main.yml
+++ b/test/integration/targets/vmware_host_config_manager/tasks/main.yml
@@ -3,11 +3,6 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 # TODO: vcsim does not support update host configuartion
-#- name: make sure pyvmomi is installed
-#  pip:
-#    name: pyvmomi
-#    state: latest
-#  when: "{{ ansible_user_id == 'root' }}"
 
 #- name: store the vcenter container ip
 #  set_fact:

--- a/test/integration/targets/vmware_host_dns_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_host_dns_facts/tasks/main.yml
@@ -2,12 +2,6 @@
 # Copyright: (c) 2018, Abhijeet Kasurde <akasurde@redhat.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: make sure pyvmomi is installed
-  pip:
-    name: pyvmomi
-    state: latest
-  when: "{{ ansible_user_id == 'root' }}"
-
 - name: store the vcenter container ip
   set_fact:
     vcsim: "{{ lookup('env', 'vcenter_host') }}"

--- a/test/integration/targets/vmware_host_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_host_facts/tasks/main.yml
@@ -1,8 +1,3 @@
-- name: make sure pyvmomi is installed
-  pip:
-    name: pyvmomi
-    state: latest
-
 - name: store the vcenter container ip
   set_fact:
     vcsim: "{{ lookup('env', 'vcenter_host') }}"

--- a/test/integration/targets/vmware_host_firewall_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_host_firewall_facts/tasks/main.yml
@@ -2,12 +2,6 @@
 # Copyright: (c) 2018, Abhijeet Kasurde <akasurde@redhat.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: make sure pyvmomi is installed
-  pip:
-    name: pyvmomi
-    state: latest
-  when: "{{ ansible_user_id == 'root' }}"
-
 - name: store the vcenter container ip
   set_fact:
     vcsim: "{{ lookup('env', 'vcenter_host') }}"

--- a/test/integration/targets/vmware_host_firewall_manager/tasks/main.yml
+++ b/test/integration/targets/vmware_host_firewall_manager/tasks/main.yml
@@ -2,12 +2,6 @@
 # Copyright: (c) 2018, Abhijeet Kasurde <akasurde@redhat.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: make sure pyvmomi is installed
-  pip:
-    name: pyvmomi
-    state: latest
-  when: "{{ ansible_user_id == 'root' }}"
-
 - name: store the vcenter container ip
   set_fact:
     vcsim: "{{ lookup('env', 'vcenter_host') }}"

--- a/test/integration/targets/vmware_host_ntp/tasks/main.yml
+++ b/test/integration/targets/vmware_host_ntp/tasks/main.yml
@@ -3,11 +3,6 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 # TODO: vcsim does not support update host NTP configuration
-#- name: make sure pyvmomi is installed
-#  pip:
-#    name: pyvmomi
-#    state: latest
-#  when: "{{ ansible_user_id == 'user' }}"
 
 #- name: store the vcenter container ip
 #  set_fact:

--- a/test/integration/targets/vmware_host_package_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_host_package_facts/tasks/main.yml
@@ -3,11 +3,6 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 # TODO: vcsim does not support Package Manager related to operations
-#- name: make sure pyvmomi is installed
-#  pip:
-#    name: pyvmomi
-#    state: latest
-#  when: "{{ ansible_user_id == 'root' }}"
 
 #- name: store the vcenter container ip
 #  set_fact:

--- a/test/integration/targets/vmware_host_service_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_host_service_facts/tasks/main.yml
@@ -3,11 +3,6 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 # TODO: vcsim does not support service related to operations
-#- name: make sure pyvmomi is installed
-#  pip:
-#    name: pyvmomi
-#    state: latest
-#  when: "{{ ansible_user_id == 'root' }}"
 
 #- name: store the vcenter container ip
 #  set_fact:

--- a/test/integration/targets/vmware_host_service_manager/tasks/main.yml
+++ b/test/integration/targets/vmware_host_service_manager/tasks/main.yml
@@ -4,11 +4,6 @@
 
 # TODO: vcsim does not support service management
 #       commenting this testcase till the time.
-#- name: make sure pyvmomi is installed
-#  pip:
-#    name: pyvmomi
-#    state: latest
-#  when: "{{ ansible_user_id == 'root' }}"
 
 #- name: store the vcenter container ip
 #  set_fact:

--- a/test/integration/targets/vmware_host_vmnic_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_host_vmnic_facts/tasks/main.yml
@@ -3,11 +3,6 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 # TODO: vcsim does not support networkConfig related to operations
-#- name: make sure pyvmomi is installed
-#  pip:
-#    name: pyvmomi
-#    state: latest
-#  when: "{{ ansible_user_id == 'root' }}"
 
 #- name: store the vcenter container ip
 #  set_fact:

--- a/test/integration/targets/vmware_local_role_manager/tasks/main.yml
+++ b/test/integration/targets/vmware_local_role_manager/tasks/main.yml
@@ -2,12 +2,6 @@
 # Copyright: (c) 2017, Abhijeet Kasurde <akasurde@redhat.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: make sure pyvmomi is installed
-  pip:
-    name: pyvmomi
-    state: latest
-  when: "{{ ansible_user_id == 'root' }}"
-
 - name: store the vcenter container ip
   set_fact:
     vcsim: "{{ lookup('env', 'vcenter_host') }}"

--- a/test/integration/targets/vmware_local_user_manager/tasks/main.yml
+++ b/test/integration/targets/vmware_local_user_manager/tasks/main.yml
@@ -5,12 +5,6 @@
 # Commenting local user testcases as older vcsim docker image
 # does not support this.
 
-#- name: make sure pyvmomi is installed
-#  pip:
-#    name: pyvmomi
-#    state: latest
-#  when: "{{ ansible_user_id == 'root' }}"
-
 #- name: store the vcenter container ip
 #  set_fact:
 #    vcsim: "{{ lookup('env', 'vcenter_host') }}"

--- a/test/integration/targets/vmware_maintenancemode/tasks/main.yml
+++ b/test/integration/targets/vmware_maintenancemode/tasks/main.yml
@@ -2,12 +2,6 @@
 # Copyright: (c) 2017, Abhijeet Kasurde <akasurde@redhat.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: make sure pyvmomi is installed
-  pip:
-    name: pyvmomi
-    state: latest
-  when: "{{ ansible_user_id == 'root' }}"
-
 - name: store the vcenter container ip
   set_fact:
     vcsim: "{{ lookup('env', 'vcenter_host') }}"

--- a/test/integration/targets/vmware_resource_pool/tasks/main.yml
+++ b/test/integration/targets/vmware_resource_pool/tasks/main.yml
@@ -2,12 +2,6 @@
 # Copyright: (c) 2017, Abhijeet Kasurde <akasurde@redhat.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: make sure pyvmomi is installed
-  pip:
-    name: pyvmomi
-    state: latest
-  when: "{{ ansible_user_id == 'root' }}"
-
 - name: store the vcenter container ip
   set_fact:
     vcsim: "{{ lookup('env', 'vcenter_host') }}"

--- a/test/integration/targets/vmware_vm_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_vm_facts/tasks/main.yml
@@ -2,12 +2,6 @@
 # Copyright: (c) 2017, Abhijeet Kasurde <akasurde@redhat.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: make sure pyvmomi is installed
-  pip:
-    name: pyvmomi
-    state: latest
-  when: "{{ ansible_user_id == 'root' }}"
-
 - name: store the vcenter container ip
   set_fact:
     vcsim: "{{ lookup('env', 'vcenter_host') }}"

--- a/test/integration/targets/vmware_vm_vm_drs_rule/tasks/main.yml
+++ b/test/integration/targets/vmware_vm_vm_drs_rule/tasks/main.yml
@@ -3,11 +3,6 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 # TODO: vcsim does not support manage DRS rule
-#- name: make sure pyvmomi is installed
-#  pip:
-#    name: pyvmomi
-#    state: latest
-#  when: "{{ ansible_user_id == 'root' }}"
 
 #- name: store the vcenter container ip
 #  set_fact:

--- a/test/integration/targets/vmware_vmkernel_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_vmkernel_facts/tasks/main.yml
@@ -3,11 +3,6 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 # TODO: vcsim does not support HostVirtualNicManager related to operations
-#- name: make sure pyvmomi is installed
-#  pip:
-#    name: pyvmomi
-#    state: latest
-#  when: "{{ ansible_user_id == 'root' }}"
 
 #- name: store the vcenter container ip
 #  set_fact:

--- a/test/integration/targets/vmware_vswitch/tasks/main.yml
+++ b/test/integration/targets/vmware_vswitch/tasks/main.yml
@@ -2,12 +2,6 @@
 # Copyright: (c) 2017, Abhijeet Kasurde <akasurde@redhat.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: Make sure pyvmomi is installed
-  pip:
-    name: pyvmomi
-    state: latest
-  when: "{{ ansible_user_id == 'root' }}"
-
 - name: store the vcenter container ip
   set_fact:
     vcsim: '{{ lookup("env", "vcenter_host") }}'

--- a/test/runner/requirements/integration.cloud.vcenter.txt
+++ b/test/runner/requirements/integration.cloud.vcenter.txt
@@ -1,0 +1,1 @@
+pyvmomi


### PR DESCRIPTION
##### SUMMARY

Move pyvmomi install into cloud test plugin.

(cherry picked from commit a5b808511395487f2c9679c11c27bdb1250c08d0)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

vmware and vcenter integration tests

##### ANSIBLE VERSION

```
ansible 2.5.2 (vmware-2.5 c97361b031) last updated 2018/05/08 12:07:02 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
