### PR TITLE
Fix encoding issue when parsing plugin examples

### DIFF
--- a/changelogs/fragments/encoding-docs-plugin-parsing.yaml
+++ b/changelogs/fragments/encoding-docs-plugin-parsing.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- Fix an encoding issue when parsing the examples from a plugins' documentation

--- a/lib/ansible/parsing/plugin_docs.py
+++ b/lib/ansible/parsing/plugin_docs.py
@@ -8,6 +8,7 @@ __metaclass__ = type
 import ast
 import yaml
 
+from ansible.module_utils._text import to_text
 from ansible.parsing.metadata import extract_metadata
 from ansible.parsing.yaml.loader import AnsibleLoader
 
@@ -61,7 +62,7 @@ def read_docstring(filename, verbose=True, ignore_errors=True):
                                 data[varkey] = AnsibleLoader(child.value.s, file_name=filename).get_single_data()
                             else:
                                 # not yaml, should be a simple string
-                                data[varkey] = child.value.s
+                                data[varkey] = to_text(child.value.s)
                         display.debug('assigned :%s' % varkey)
 
         # Metadata is per-file and a dict rather than per-plugin/function and yaml


### PR DESCRIPTION
##### SUMMARY
There was a non-fatal docs build error when non-ascii characters were used in examples (for instance, the debug documentation).  This should fix that problem.

##### ISSUE TYPE
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
lib/ansible/parsing/plugin_docs.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
