### PR TITLE
Update documentation for wait_timeout option

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_asg.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_asg.py
@@ -114,7 +114,7 @@ options:
     version_added: "2.0"
   wait_timeout:
     description:
-      - How long before wait instances to become viable when replaced.  If you experience the error 'Waited too long for ELB instances to be healthy',
+      - How long before wait instances to become viable when replaced.  If you experience the error "Waited too long for ELB instances to be healthy",
         try increasing this value.
     default: 300
     version_added: "1.8"

--- a/lib/ansible/modules/cloud/amazon/ec2_asg.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_asg.py
@@ -114,7 +114,7 @@ options:
     version_added: "2.0"
   wait_timeout:
     description:
-      - How long before wait instances to become viable when replaced.  If you experience the error "Waited too long for ELB instances to be healthy",
+      - How long to wait for instances to become viable when replaced.  If you experience the error "Waited too long for ELB instances to be healthy",
         try increasing this value.
     default: 300
     version_added: "1.8"

--- a/lib/ansible/modules/cloud/amazon/ec2_asg.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_asg.py
@@ -114,7 +114,8 @@ options:
     version_added: "2.0"
   wait_timeout:
     description:
-      - how long before wait instances to become viable when replaced.  Used in conjunction with instance_ids option.
+      - How long before wait instances to become viable when replaced.  If you experience the error 'Waited too long for ELB instances to be healthy',
+        try increasing this value.
     default: 300
     version_added: "1.8"
   wait_for_instances:
@@ -618,7 +619,8 @@ def get_properties(autoscaling_group):
 def elb_dreg(asg_connection, group_name, instance_id):
     region, ec2_url, aws_connect_params = get_aws_connection_info(module, boto3=True)
     as_group = describe_autoscaling_groups(asg_connection, group_name)[0]
-    wait_timeout = module.params.get('wait_timeout')
+    
+    = module.params.get('wait_timeout')
     count = 1
     if as_group['LoadBalancerNames'] and as_group['HealthCheckType'] == 'ELB':
         elb_connection = boto3_conn(module,

--- a/lib/ansible/modules/cloud/amazon/ec2_asg.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_asg.py
@@ -620,7 +620,7 @@ def elb_dreg(asg_connection, group_name, instance_id):
     region, ec2_url, aws_connect_params = get_aws_connection_info(module, boto3=True)
     as_group = describe_autoscaling_groups(asg_connection, group_name)[0]
     
-    = module.params.get('wait_timeout')
+    wait_timeout = module.params.get('wait_timeout')
     count = 1
     if as_group['LoadBalancerNames'] and as_group['HealthCheckType'] == 'ELB':
         elb_connection = boto3_conn(module,

--- a/lib/ansible/modules/cloud/amazon/ec2_asg.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_asg.py
@@ -619,7 +619,6 @@ def get_properties(autoscaling_group):
 def elb_dreg(asg_connection, group_name, instance_id):
     region, ec2_url, aws_connect_params = get_aws_connection_info(module, boto3=True)
     as_group = describe_autoscaling_groups(asg_connection, group_name)[0]
-    
     wait_timeout = module.params.get('wait_timeout')
     count = 1
     if as_group['LoadBalancerNames'] and as_group['HealthCheckType'] == 'ELB':


### PR DESCRIPTION
Based on the documentation, 'wait_timeout' is 'Used in conjunction with instance_ids option'.  This lead me to believe that I could not use this parameter to try and solve the 'Waited too long for ELB instances to be healthy' error I was experiencing.

I ended up hacking on the 'ec2_asg' module and found that a change to 'wait_timeout' did fix my problem.

- Removed the misleading statement: Used in conjunction with instance_ids option
- Added statement: If you experience the error 'Waited too long for ELB instances to be healthy', try increasing this value.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - New Module Pull Request
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
