### PR TITLE
Fix unset ansible_virtualization_role

### DIFF
--- a/changelogs/fragments/39138-facts-fix_virtualization_facts_for_vmware_linux.yaml
+++ b/changelogs/fragments/39138-facts-fix_virtualization_facts_for_vmware_linux.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- Fix unset 'ansible_virtualization_role' fact while setting virtualization facts for real hardware.

--- a/lib/ansible/module_utils/facts/virtual/linux.py
+++ b/lib/ansible/module_utils/facts/virtual/linux.py
@@ -242,7 +242,7 @@ class LinuxVirtual(Virtual):
             if rc == 0:
                 # Strip out commented lines (specific dmidecode output)
                 vendor_name = ''.join([line.strip() for line in out.splitlines() if not line.startswith('#')])
-                if vendor_name.startwith('VMware'):
+                if vendor_name.startswith('VMware'):
                     virtual_facts['virtualization_type'] = 'VMware'
                     virtual_facts['virtualization_role'] = 'guest'
                     return virtual_facts


### PR DESCRIPTION
##### SUMMARY
Error was:
AttributeError("'str' object has no attribute 'startwith'",)

Closes #39138

(cherry picked from commit 2397ca1a7e15a1a6941b07a5a1e3a52837ee9d7c)

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/39138-facts-fix_virtualization_facts_for_vmware_linux.yaml
lib/ansible/module_utils/facts/virtual/linux.py

##### ANSIBLE VERSION
```
Stable-2.5
```