### PR TITLE
Overhaul httptester support in ansible-test.

### DIFF
--- a/test/integration/targets/get_url/aliases
+++ b/test/integration/targets/get_url/aliases
@@ -1,2 +1,3 @@
 destructive
 posix/ci/group1
+needs/httptester

--- a/test/integration/targets/lookups/aliases
+++ b/test/integration/targets/lookups/aliases
@@ -1,1 +1,2 @@
 posix/ci/group2
+needs/httptester

--- a/test/integration/targets/prepare_http_tests/tasks/main.yml
+++ b/test/integration/targets/prepare_http_tests/tasks/main.yml
@@ -46,4 +46,26 @@
       command: update-ca-certificates
       when: ansible_os_family == 'Debian' or ansible_os_family == 'Suse'
 
+    - name: FreeBSD - Retrieve test cacert
+      get_url:
+        url: "http://ansible.http.tests/cacert.pem"
+        dest: "/tmp/ansible.pem"
+      when: ansible_os_family == 'FreeBSD'
+
+    - name: FreeBSD - Add cacert to root certificate store
+      blockinfile:
+        path: "/etc/ssl/cert.pem"
+        block: "{{ lookup('file', '/tmp/ansible.pem') }}"
+      when: ansible_os_family == 'FreeBSD'
+
+    - name: MacOS - Retrieve test cacert
+      get_url:
+        url: "http://ansible.http.tests/cacert.pem"
+        dest: "/usr/local/etc/openssl/certs/ansible.pem"
+      when: ansible_os_family == 'Darwin'
+
+    - name: MacOS - Update ca certificates
+      command: /usr/local/opt/openssl/bin/c_rehash
+      when: ansible_os_family == 'Darwin'
+
   when: has_httptester|bool

--- a/test/integration/targets/uri/aliases
+++ b/test/integration/targets/uri/aliases
@@ -1,2 +1,3 @@
 destructive
 posix/ci/group1
+needs/httptester

--- a/test/runner/lib/config.py
+++ b/test/runner/lib/config.py
@@ -43,7 +43,6 @@ class EnvironmentConfig(CommonConfig):
         self.remote = args.remote  # type: str
 
         self.docker_privileged = args.docker_privileged if 'docker_privileged' in args else False  # type: bool
-        self.docker_util = docker_qualify_image(args.docker_util if 'docker_util' in args else '')  # type: str
         self.docker_pull = args.docker_pull if 'docker_pull' in args else False  # type: bool
         self.docker_keep_git = args.docker_keep_git if 'docker_keep_git' in args else False  # type: bool
         self.docker_memory = args.docker_memory if 'docker_memory' in args else None
@@ -69,6 +68,9 @@ class EnvironmentConfig(CommonConfig):
 
         if self.delegate:
             self.requirements = True
+
+        self.inject_httptester = args.inject_httptester if 'inject_httptester' in args else False  # type: bool
+        self.httptester = docker_qualify_image(args.httptester if 'httptester' in args else '')  # type: str
 
     @property
     def python_executable(self):

--- a/test/runner/lib/docker_util.py
+++ b/test/runner/lib/docker_util.py
@@ -56,6 +56,17 @@ def get_docker_container_id():
     raise ApplicationError('Found multiple container_id candidates: %s\n%s' % (sorted(container_ids), contents))
 
 
+def get_docker_container_ip(args, container_id):
+    """
+    :type args: EnvironmentConfig
+    :type container_id: str
+    :rtype: str
+    """
+    results = docker_inspect(args, container_id)
+    ipaddress = results[0]['NetworkSettings']['IPAddress']
+    return ipaddress
+
+
 def docker_pull(args, image):
     """
     :type args: EnvironmentConfig

--- a/test/runner/lib/docker_util.py
+++ b/test/runner/lib/docker_util.py
@@ -15,6 +15,7 @@ from lib.util import (
     run_command,
     common_environment,
     display,
+    find_executable,
 )
 
 from lib.config import (
@@ -22,6 +23,13 @@ from lib.config import (
 )
 
 BUFFER_SIZE = 256 * 256
+
+
+def docker_available():
+    """
+    :rtype: bool
+    """
+    return find_executable('docker', required=False)
 
 
 def get_docker_container_id():

--- a/test/runner/lib/executor.py
+++ b/test/runner/lib/executor.py
@@ -100,6 +100,12 @@ SUPPORTED_PYTHON_VERSIONS = (
     '3.7',
 )
 
+HTTPTESTER_HOSTS = (
+    'ansible.http.tests',
+    'sni1.ansible.http.tests',
+    'fail.ansible.http.tests',
+)
+
 
 def check_startup():
     """Checks to perform at startup before running commands."""
@@ -276,6 +282,9 @@ def command_shell(args):
         raise Delegate()
 
     install_command_requirements(args)
+
+    if args.inject_httptester:
+        inject_httptester(args)
 
     cmd = create_shell_command(['bash', '-i'])
     run_command(args, cmd)
@@ -649,7 +658,7 @@ def command_integration_filter(args, targets, init_callback=None):
     cloud_init(args, internal_targets)
 
     if args.delegate:
-        raise Delegate(require=changes, exclude=exclude)
+        raise Delegate(require=changes, exclude=exclude, integration_targets=internal_targets)
 
     install_command_requirements(args)
 
@@ -696,6 +705,9 @@ def command_integration_filtered(args, targets, all_targets):
                 seconds = 3
                 display.warning('SSH service not responding. Waiting %d second(s) before checking again.' % seconds)
                 time.sleep(seconds)
+
+    if args.inject_httptester:
+        inject_httptester(args)
 
     start_at_task = args.start_at_task
 
@@ -815,6 +827,64 @@ def command_integration_filtered(args, targets, all_targets):
             len(failed), len(passed) + len(failed), '\n'.join(target.name for target in failed)))
 
 
+def inject_httptester(args):
+    """
+    :type args: CommonConfig
+    """
+    comment = ' # ansible-test httptester\n'
+    append_lines = ['127.0.0.1 %s%s' % (host, comment) for host in HTTPTESTER_HOSTS]
+
+    with open('/etc/hosts', 'r+') as hosts_fd:
+        original_lines = hosts_fd.readlines()
+
+        if not any(line.endswith(comment) for line in original_lines):
+            hosts_fd.writelines(append_lines)
+
+    # determine which forwarding mechanism to use
+    pfctl = find_executable('pfctl', required=False)
+    iptables = find_executable('iptables', required=False)
+
+    if pfctl:
+        kldload = find_executable('kldload', required=False)
+
+        if kldload:
+            try:
+                run_command(args, ['kldload', 'pf'], capture=True)
+            except SubprocessError:
+                pass  # already loaded
+
+        rules = '''
+rdr pass inet proto tcp from any to any port 80 -> 127.0.0.1 port 8080
+rdr pass inet proto tcp from any to any port 443 -> 127.0.0.1 port 8443
+'''
+        cmd = ['pfctl', '-ef', '-']
+
+        try:
+            run_command(args, cmd, capture=True, data=rules)
+        except SubprocessError:
+            pass  # non-zero exit status on success
+
+    elif iptables:
+        ports = [
+            (80, 8080),
+            (443, 8443),
+        ]
+
+        for src, dst in ports:
+            rule = ['-o', 'lo', '-p', 'tcp', '--dport', str(src), '-j', 'REDIRECT', '--to-port', str(dst)]
+
+            try:
+                # check for existing rule
+                cmd = ['iptables', '-t', 'nat', '-C', 'OUTPUT'] + rule
+                run_command(args, cmd, capture=True)
+            except SubprocessError:
+                # append rule when it does not exist
+                cmd = ['iptables', '-t', 'nat', '-A', 'OUTPUT'] + rule
+                run_command(args, cmd, capture=True)
+    else:
+        raise ApplicationError('No supported port forwarding mechanism detected.')
+
+
 def run_setup_targets(args, test_dir, target_names, targets_dict, targets_executed, always):
     """
     :type args: IntegrationConfig
@@ -851,6 +921,11 @@ def integration_environment(args, target, cmd):
     :rtype: dict[str, str]
     """
     env = ansible_environment(args)
+
+    if args.inject_httptester:
+        env.update(dict(
+            HTTPTESTER='1',
+        ))
 
     integration = dict(
         JUNIT_OUTPUT_DIR=os.path.abspath('test/results/junit'),
@@ -1464,15 +1539,17 @@ class NoTestsForChanges(ApplicationWarning):
 
 class Delegate(Exception):
     """Trigger command delegation."""
-    def __init__(self, exclude=None, require=None):
+    def __init__(self, exclude=None, require=None, integration_targets=None):
         """
         :type exclude: list[str] | None
         :type require: list[str] | None
+        :type integration_targets: tuple[IntegrationTarget] | None
         """
         super(Delegate, self).__init__()
 
         self.exclude = exclude or []
         self.require = require or []
+        self.integration_targets = integration_targets or tuple()
 
 
 class AllTargetsSkipped(ApplicationWarning):

--- a/test/runner/lib/util.py
+++ b/test/runner/lib/util.py
@@ -3,6 +3,7 @@
 from __future__ import absolute_import, print_function
 
 import atexit
+import contextlib
 import errno
 import filecmp
 import fcntl
@@ -14,6 +15,7 @@ import pkgutil
 import random
 import re
 import shutil
+import socket
 import stat
 import string
 import subprocess
@@ -718,6 +720,18 @@ def parse_to_dict(pattern, value):
         raise Exception('Pattern "%s" did not match value: %s' % (pattern, value))
 
     return match.groupdict()
+
+
+def get_available_port():
+    """
+    :rtype: int
+    """
+    # this relies on the kernel not reusing previously assigned ports immediately
+    socket_fd = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+
+    with contextlib.closing(socket_fd):
+        socket_fd.bind(('', 0))
+        return socket_fd.getsockname()[1]
 
 
 def get_subclasses(class_type):

--- a/test/runner/test.py
+++ b/test/runner/test.py
@@ -88,7 +88,7 @@ def main():
         try:
             args.func(config)
         except Delegate as ex:
-            delegate(config, ex.exclude, ex.require)
+            delegate(config, ex.exclude, ex.require, ex.integration_targets)
 
         display.review_warnings()
     except ApplicationWarning as ex:
@@ -278,6 +278,7 @@ def parse_args():
                                    config=PosixIntegrationConfig)
 
     add_extra_docker_options(posix_integration)
+    add_httptester_options(posix_integration, argparse)
 
     network_integration = subparsers.add_parser('network-integration',
                                                 parents=[integration],
@@ -380,6 +381,7 @@ def parse_args():
 
     add_environments(shell, tox_version=True)
     add_extra_docker_options(shell)
+    add_httptester_options(shell, argparse)
 
     coverage_common = argparse.ArgumentParser(add_help=False, parents=[common])
 
@@ -606,6 +608,29 @@ def add_extra_coverage_options(parser):
                         help='generate empty report of all python source files')
 
 
+def add_httptester_options(parser, argparse):
+    """
+    :type parser: argparse.ArgumentParser
+    :type argparse: argparse
+    """
+    group = parser.add_mutually_exclusive_group()
+
+    group.add_argument('--httptester',
+                       metavar='IMAGE',
+                       default='quay.io/ansible/http-test-container:1.0.0',
+                       help='docker image to use for the httptester container')
+
+    group.add_argument('--disable-httptester',
+                       dest='httptester',
+                       action='store_const',
+                       const='',
+                       help='do not use the httptester container')
+
+    parser.add_argument('--inject-httptester',
+                        action='store_true',
+                        help=argparse.SUPPRESS)  # internal use only
+
+
 def add_extra_docker_options(parser, integration=True):
     """
     :type parser: argparse.ArgumentParser
@@ -624,11 +649,6 @@ def add_extra_docker_options(parser, integration=True):
 
     if not integration:
         return
-
-    docker.add_argument('--docker-util',
-                        metavar='IMAGE',
-                        default='quay.io/ansible/http-test-container:1.0.0',
-                        help='docker utility image to provide test services')
 
     docker.add_argument('--docker-privileged',
                         action='store_true',


### PR DESCRIPTION
##### SUMMARY

Overhaul httptester support in ansible-test:

- Works with the `--remote` option.
- Can be disabled with the `--disable-httptester` option.
- Change image with the `--httptester` option.
- Only load and run httptester for targets that require it.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.6.0 (remote-httptester 2d6116b026) last updated 2018/05/09 00:37:59 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
