### PR TITLE
Document capability of giving regex search flags

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters.rst
@@ -829,6 +829,9 @@ To search a string with a regex, use the "regex_search" filter::
 
     # will return empty if it cannot find a match
     {{ 'ansible' | regex_search('(foobar)') }}
+    
+    # case insensitive search in multiline mode
+    {{ 'foo\nBAR' | regex_search("^bar", multiline=True, ignorecase=True) }}
 
 
 To search for all occurrences of regex matches, use the "regex_findall" filter::


### PR DESCRIPTION
##### SUMMARY
Add a note about regex_search keyword arguments which allows case insensitive and multiline searches

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
docs

##### ANSIBLE VERSION
```
ansible 2.5.2
python version = 2.7.15 (default, May  1 2018, 16:44:37) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
