### PR TITLE
nxos enable mode fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,6 +151,8 @@ Ansible Changes By Release
   https://github.com/ansible/ansible/pull/37329
 * Fix Python 3 error in the openssl_certificate module:
   https://github.com/ansible/ansible/pull/35143
+* Fix nxos enable mode
+  https://github.com/ansible/ansible/pull/39898
 
 
 <a id="2.4.3"></a>

--- a/lib/ansible/module_utils/nxos.py
+++ b/lib/ansible/module_utils/nxos.py
@@ -47,6 +47,9 @@ nxos_provider_spec = {
     'password': dict(fallback=(env_fallback, ['ANSIBLE_NET_PASSWORD']), no_log=True),
     'ssh_keyfile': dict(fallback=(env_fallback, ['ANSIBLE_NET_SSH_KEYFILE'])),
 
+    'authorize': dict(fallback=(env_fallback, ['ANSIBLE_NET_AUTHORIZE']), type='bool'),
+    'auth_pass': dict(no_log=True, fallback=(env_fallback, ['ANSIBLE_NET_AUTH_PASS'])),
+
     'use_ssl': dict(type='bool'),
     'validate_certs': dict(type='bool'),
     'timeout': dict(type='int'),
@@ -71,10 +74,10 @@ def get_argspec():
 def check_args(module, warnings):
     for key in nxos_argument_spec:
         if module._name == 'nxos_user':
-            if key not in ['password', 'provider', 'transport'] and module.params[key]:
+            if key not in ['password', 'provider', 'transport', 'authorize'] and module.params[key]:
                 warnings.append('argument %s has been deprecated and will be in a future version' % key)
         else:
-            if key not in ['provider', 'transport'] and module.params[key]:
+            if key not in ['provider', 'transport', 'authorize'] and module.params[key]:
                 warnings.append('argument %s has been deprecated and will be removed in a future version' % key)
 
     # set argument's default value if not provided in input

--- a/lib/ansible/plugins/action/nxos.py
+++ b/lib/ansible/plugins/action/nxos.py
@@ -60,6 +60,9 @@ class ActionModule(_ActionModule):
             pc.password = provider['password'] or self._play_context.password
             pc.private_key_file = provider['ssh_keyfile'] or self._play_context.private_key_file
             pc.timeout = int(provider['timeout'] or C.PERSISTENT_COMMAND_TIMEOUT)
+            pc.become = provider['authorize'] or False
+            pc.become_pass = provider['auth_pass']
+
             display.vvv('using connection plugin %s' % pc.connection, pc.remote_addr)
             connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin)
 

--- a/lib/ansible/plugins/terminal/nxos.py
+++ b/lib/ansible/plugins/terminal/nxos.py
@@ -19,10 +19,12 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+import json
 import re
 
 from ansible.plugins.terminal import TerminalBase
 from ansible.errors import AnsibleConnectionFailure
+from ansible.module_utils._text import to_bytes, to_text
 
 
 class TerminalModule(TerminalBase):
@@ -45,6 +47,43 @@ class TerminalModule(TerminalBase):
         re.compile(br"unknown command"),
         re.compile(br"user not present")
     ]
+
+    def on_authorize(self, passwd=None):
+        if self._get_prompt().endswith(b'enable#'):
+            return
+
+        out = self._exec_cli_command(b'show privilege')
+        out = to_text(out, errors='surrogate_then_replace').strip()
+
+        if 'Disabled' in out:
+            raise AnsibleConnectionFailure('Feature privilege is not enabled')
+
+        # if already at privilege level 15 return
+        if '15' in out:
+            return
+
+        cmd = {u'command': u'enable'}
+        if passwd:
+            cmd[u'prompt'] = to_text(r"(?i)[\r\n]?Password: $", errors='surrogate_or_strict')
+            cmd[u'answer'] = passwd
+
+        try:
+            self._exec_cli_command(to_bytes(json.dumps(cmd), errors='surrogate_or_strict'))
+        except AnsibleConnectionFailure:
+            raise AnsibleConnectionFailure('unable to elevate privilege to enable mode')
+
+    def on_deauthorize(self):
+        prompt = self._get_prompt()
+        if prompt is None:
+            # if prompt is None most likely the terminal is hung up at a prompt
+            return
+
+        if b'(config' in prompt:
+            self._exec_cli_command(b'end')
+            self._exec_cli_command(b'exit')
+
+        elif prompt.endswith(b'enable#'):
+            self._exec_cli_command('exit')
 
     def on_open_shell(self):
         try:

--- a/lib/ansible/utils/module_docs_fragments/nxos.py
+++ b/lib/ansible/utils/module_docs_fragments/nxos.py
@@ -52,6 +52,24 @@ options:
         value of environment variable C(ANSIBLE_NET_PASSWORD) will be used instead.
     required: false
     default: null
+  authorize:
+    description:
+      - Instructs the module to enter privileged mode on the remote device
+        before sending any commands.  If not specified, the device will
+        attempt to execute all commands in non-privileged mode. If the value
+        is not specified in the task, the value of environment variable
+        C(ANSIBLE_NET_AUTHORIZE) will be used instead.
+    default: no
+    choices: ['yes', 'no']
+    version_added: 2.4.4
+  auth_pass:
+    description:
+      - Specifies the password to use if required to enter privileged mode
+        on the remote device.  If I(authorize) is false, then this argument
+        does nothing. If the value is not specified in the task, the value of
+        environment variable C(ANSIBLE_NET_AUTH_PASS) will be used instead.
+    default: none
+    version_added: 2.4.4
   timeout:
     description:
       - Specifies the timeout in seconds for communicating with the network device

--- a/lib/ansible/utils/module_docs_fragments/nxos.py
+++ b/lib/ansible/utils/module_docs_fragments/nxos.py
@@ -59,6 +59,7 @@ options:
         attempt to execute all commands in non-privileged mode. If the value
         is not specified in the task, the value of environment variable
         C(ANSIBLE_NET_AUTHORIZE) will be used instead.
+    type: bool
     default: no
     choices: ['yes', 'no']
     version_added: 2.4.4


### PR DESCRIPTION
Signed-off-by: Trishna Guha <trishnaguha17@gmail.com>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
fixes #39229
fixes #37526 

nxos enable mode
works with transport cli connection local
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
plugins/terminal/nxos.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.4
```
