### PR TITLE
Backport #38707: ec2_vpc_route_table: Update matching_count parsing on find_subnets fu…

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_route_table.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_route_table.py
@@ -254,7 +254,7 @@ def find_subnets(connection, module, vpc_id, identified_subnets):
     'Name' tag, or a CIDR such as 10.0.0.0/8.
 
     Note that this function is duplicated in other ec2 modules, and should
-    potentially be moved into potentially be moved into a shared module_utils
+    potentially be moved into a shared module_utils
     """
     subnet_ids = []
     subnet_names = []
@@ -292,7 +292,7 @@ def find_subnets(connection, module, vpc_id, identified_subnets):
             module.fail_json_aws(e, msg="Couldn't find subnet with names %s" % subnet_names)
 
         for name in subnet_names:
-            matching_count = len([1 for s in subnets_by_name if s.tags.get('Name') == name])
+            matching_count = len([1 for s in subnets_by_name for t in s.get('Tags', []) if t['Key'] == 'Name' and t['Value'] == name])
             if matching_count == 0:
                 module.fail_json(msg='Subnet named "{0}" does not exist'.format(name))
             elif matching_count > 1:

--- a/test/integration/targets/ec2_vpc_route_table/tasks/main.yml
+++ b/test/integration/targets/ec2_vpc_route_table/tasks/main.yml
@@ -25,7 +25,7 @@
       state: present
       tags:
         Public: "{{ item.public|string }}"
-        Name: "{{ item.public|ternary('public', 'private') }}-{{ item.az }}"
+        Name: "{{ (item.public|bool)|ternary('public', 'private') }}-{{ item.az }}"
       <<: *aws_connection_info
     with_items:
       - cidr: 10.228.228.0/24
@@ -336,6 +336,78 @@
     assert:
       that:
         - check_mode_results.changed
+
+  - name: add subnets by cidr to public route table
+    ec2_vpc_route_table:
+      vpc_id: "{{ vpc.vpc.id }}"
+      routes:
+      - dest: 0.0.0.0/0
+        gateway_id: igw
+      subnets: "{{ vpc_subnets|json_query('subnets[?tags.Public == `True`].cidr_block') }}"
+      lookup: id
+      route_table_id: "{{ create_public_table.route_table.id }}"
+      <<: *aws_connection_info
+    register: add_subnets_cidr
+
+  - name: assert route table contains subnets added by cidr
+    assert:
+      that:
+        - add_subnets_cidr.changed
+        - add_subnets_cidr.route_table.associations|length == 2
+
+  - name: purge subnets added by cidr
+    ec2_vpc_route_table:
+      vpc_id: "{{ vpc.vpc.id }}"
+      routes:
+      - dest: 0.0.0.0/0
+        gateway_id: igw
+      subnets: []
+      lookup: id
+      route_table_id: "{{ create_public_table.route_table.id }}"
+      <<: *aws_connection_info
+    register: purge_subnets_cidr
+
+  - name: assert purge subnets added by cidr worked
+    assert:
+      that:
+        - purge_subnets_cidr.changed
+        - purge_subnets_cidr.route_table.associations|length == 0
+
+  - name: add subnets by name to public route table
+    ec2_vpc_route_table:
+      vpc_id: "{{ vpc.vpc.id }}"
+      routes:
+      - dest: 0.0.0.0/0
+        gateway_id: igw
+      subnets: "{{ vpc_subnets|json_query('subnets[?tags.Public == `True`].tags.Name') }}"
+      lookup: id
+      route_table_id: "{{ create_public_table.route_table.id }}"
+      <<: *aws_connection_info
+    register: add_subnets_name
+
+  - name: assert route table contains subnets added by name
+    assert:
+      that:
+        - add_subnets_name.changed
+        - add_subnets_name.route_table.associations|length == 2
+
+  - name: purge subnets added by name
+    ec2_vpc_route_table:
+      vpc_id: "{{ vpc.vpc.id }}"
+      routes:
+      - dest: 0.0.0.0/0
+        gateway_id: igw
+      subnets: []
+      lookup: id
+      route_table_id: "{{ create_public_table.route_table.id }}"
+      <<: *aws_connection_info
+    register: purge_subnets_name
+
+  - name: assert purge subnets added by name worked
+    assert:
+      that:
+        - purge_subnets_name.changed
+        - purge_subnets_name.route_table.associations|length == 0
 
   - name: purge routes
     ec2_vpc_route_table:


### PR DESCRIPTION
##### SUMMARY
- Backport of #38707 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
```
lib/ansible/modules/cloud/amazon/ec2_vpc_route_table.py
test/integration/targets/ec2_vpc_route_table/tasks/main.yml
```

##### ANSIBLE VERSION
```
2.5
```

##### ADDITIONAL INFORMATION
see [the original PR](https://github.com/ansible/ansible/pull/38707 "PR #38570")
