### PR TITLE
Add RETURN docs for the pip module

### DIFF
--- a/lib/ansible/modules/packaging/language/pip.py
+++ b/lib/ansible/modules/packaging/language/pip.py
@@ -190,6 +190,34 @@ EXAMPLES = '''
   become: True
 '''
 
+RETURN = '''
+cmd:
+  description: pip command used by the module
+  returned: success
+  type: string
+  sample: pip2 install ansible six
+name:
+  description: list of python modules targetted by pip
+  returned: success
+  type: list
+  sample: ['ansible', 'six']
+requirements:
+  description: Path to the requirements file
+  returned: success, if a requirements file was provided
+  type: string
+  sample: "/srv/git/project/requirements.txt"
+version:
+  description: Version of the package specified in 'name'
+  returned: success, if a name and version were provided
+  type: string
+  sample: "2.5.1"
+virtualenv:
+  description: Path to the virtualenv
+  returned: success, if a virtualenv path was provided
+  type: string
+  sample: "/tmp/virtualenv"
+'''
+
 import os
 import re
 import sys


### PR DESCRIPTION
The pip module returns some things. Let's document them.

##### SUMMARY
This is no-op, it only adds return documentation for the pip module.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
pip

##### ANSIBLE VERSION
```
ansible 2.5.2
  config file = None
  configured module search path = [u'/home/dmsimard/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /tmp/foo/lib/python2.7/site-packages/ansible
  executable location = /tmp/foo/bin/ansible
  python version = 2.7.14 (default, Mar 14 2018, 16:45:33) [GCC 8.0.1 20180222 (Red Hat 8.0.1-0.16)]
```
