### PR TITLE
Update panos_op.py (#39013)

### DIFF
--- a/lib/ansible/modules/network/panos/panos_op.py
+++ b/lib/ansible/modules/network/panos/panos_op.py
@@ -61,14 +61,14 @@ options:
 
 EXAMPLES = '''
 - name: show list of all interfaces
-  panos_object:
+  panos_op:
     ip_address: '{{ ip_address }}'
     username: '{{ username }}'
     password: '{{ password }}'
     cmd: 'show interfaces all'
 
 - name: show system info
-  panos_object:
+  panos_op:
     ip_address: '{{ ip_address }}'
     username: '{{ username }}'
     password: '{{ password }}'


### PR DESCRIPTION
<!--- Your description here -->
The examples were apparently pasted from panos_object and the module name wasn't updated.
+label: docsite_pr
(cherry picked from commit 5f0e6b2dc3417732f6e4acc3b8ef1deef6983750)

##### SUMMARY
Corrects examples in the panos_op module documentation, uses correct module name in tasks.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
panos_op.py

##### ANSIBLE VERSION
2.5

##### ADDITIONAL INFORMATION
Thanks to @awfki for contributing this fix.