### PR TITLE
Update ios_system.py (#39623)

### DIFF
--- a/lib/ansible/modules/network/ios/ios_system.py
+++ b/lib/ansible/modules/network/ios/ios_system.py
@@ -86,7 +86,7 @@ EXAMPLES = """
   ios_system:
     hostname: ios01
     domain_name: test.example.com
-    domain-search:
+    domain_search:
       - ansible.com
       - redhat.com
       - cisco.com


### PR DESCRIPTION
<!--- Your description here -->
Typo in the example of `domain_search`, was `domain-search`should be `domain_search`
+label: docsite_pr
(cherry picked from commit 75304bd121e7791b40a111847dccba148e61a6a9)

##### SUMMARY
Corrects example in ios_system module documentation.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
ios_system.py

##### ANSIBLE VERSION
2.5

##### ADDITIONAL INFORMATION
Thanks to @smolz for contributing this fix.