### PR TITLE
Add src parameter to elasticsearch_plugin

### DIFF
--- a/lib/ansible/modules/database/misc/elasticsearch_plugin.py
+++ b/lib/ansible/modules/database/misc/elasticsearch_plugin.py
@@ -28,16 +28,31 @@ author:
 options:
     name:
         description:
-            - Name of the plugin to install. In Eleasticsearch >= 2.0, the name can be an URL or file location.
+            - Name of the plugin to install.
         required: True
     state:
         description:
             - Desired state of a plugin.
         choices: ["present", "absent"]
         default: present
+    src:
+        description:
+            - Optionally set the source location to retrieve the plugin from. This can be a file://
+              URL to install from a local file, or a remote URL. If this is not set, the plugin
+              location is just based on the name.
+            - The name parameter must match the descriptor in the plugin ZIP specified.
+            - Is only used if the state would change, which is solely checked based on the name
+              parameter. If, for example, the plugin is already installed, changing this has no
+              effect.
+            - For ES 1.x use url.
+        required: False
+        default: None
     url:
         description:
-            - Set exact URL to download the plugin from (Only works for ES 1.x)
+            - Set exact URL to download the plugin from (Only works for ES 1.x).
+            - For ES 2.x and higher, use src.
+        required: False
+        default: None
     timeout:
         description:
             - "Timeout setting: 30s, 1m, 1h..."
@@ -133,9 +148,8 @@ def parse_plugin_repo(string):
     return repo
 
 
-def is_plugin_present(plugin_dir, working_dir):
-    return os.path.isdir(os.path.join(working_dir, plugin_dir))
-
+def is_plugin_present(plugin_name, plugin_dir):
+    return os.path.isdir(os.path.join(plugin_dir, plugin_name))
 
 def parse_error(string):
     reason = "ERROR: "
@@ -145,11 +159,12 @@ def parse_error(string):
         return string
 
 
-def install_plugin(module, plugin_bin, plugin_name, version, url, proxy_host, proxy_port, timeout, force):
-    cmd_args = [plugin_bin, PACKAGE_STATE_MAP["present"], plugin_name]
+def install_plugin(module, plugin_bin, plugin_name, version, src, url, proxy_host, proxy_port, timeout, force):
+    cmd_args = [plugin_bin, PACKAGE_STATE_MAP["present"]]
+    is_old_command = (os.path.basename(plugin_bin) == 'plugin')
 
     # Timeout and version are only valid for plugin, not elasticsearch-plugin
-    if os.path.basename(plugin_bin) == 'plugin':
+    if is_old_command:
         if timeout:
             cmd_args.append("--timeout %s" % timeout)
 
@@ -160,11 +175,16 @@ def install_plugin(module, plugin_bin, plugin_name, version, url, proxy_host, pr
     if proxy_host and proxy_port:
         cmd_args.append("-DproxyHost=%s -DproxyPort=%s" % (proxy_host, proxy_port))
 
+    # Legacy ES 1.x
     if url:
         cmd_args.append("--url %s" % url)
 
     if force:
         cmd_args.append("--batch")
+    if src:
+        cmd_args.append(src)
+    else:
+        cmd_args.append(plugin_name)
 
     cmd = " ".join(cmd_args)
 
@@ -233,6 +253,7 @@ def main():
         argument_spec=dict(
             name=dict(required=True),
             state=dict(default="present", choices=PACKAGE_STATE_MAP.keys()),
+            src=dict(default=None),
             url=dict(default=None),
             timeout=dict(default="1m"),
             force=dict(default=False),
@@ -242,12 +263,14 @@ def main():
             proxy_port=dict(default=None),
             version=dict(default=None)
         ),
+        mutually_exclusive=[("src","url")],
         supports_check_mode=True
     )
 
     name = module.params["name"]
     state = module.params["state"]
     url = module.params["url"]
+    src = module.params["src"]
     timeout = module.params["timeout"]
     force = module.params["force"]
     plugin_bin = module.params["plugin_bin"]
@@ -259,14 +282,15 @@ def main():
     # Search provided path and system paths for valid binary
     plugin_bin = get_plugin_bin(module, plugin_bin)
 
-    present = is_plugin_present(parse_plugin_repo(name), plugin_dir)
+    repo = parse_plugin_repo(name)
+    present = is_plugin_present(repo, plugin_dir)
 
     # skip if the state is correct
     if (present and state == "present") or (state == "absent" and not present):
         module.exit_json(changed=False, name=name, state=state)
 
     if state == "present":
-        changed, cmd, out, err = install_plugin(module, plugin_bin, name, version, url, proxy_host, proxy_port, timeout, force)
+        changed, cmd, out, err = install_plugin(module, plugin_bin, name, version, src, url, proxy_host, proxy_port, timeout, force)
 
     elif state == "absent":
         changed, cmd, out, err = remove_plugin(module, plugin_bin, name)

--- a/lib/ansible/modules/database/misc/elasticsearch_plugin.py
+++ b/lib/ansible/modules/database/misc/elasticsearch_plugin.py
@@ -46,7 +46,7 @@ options:
               effect.
             - For ES 1.x use url.
         required: False
-        version_added: "2.6"
+        version_added: "2.7"
     url:
         description:
             - Set exact URL to download the plugin from (Only works for ES 1.x).

--- a/lib/ansible/modules/database/misc/elasticsearch_plugin.py
+++ b/lib/ansible/modules/database/misc/elasticsearch_plugin.py
@@ -46,6 +46,7 @@ options:
               effect.
             - For ES 1.x use url.
         required: False
+        version_added: "2.6"
     url:
         description:
             - Set exact URL to download the plugin from (Only works for ES 1.x).

--- a/lib/ansible/modules/database/misc/elasticsearch_plugin.py
+++ b/lib/ansible/modules/database/misc/elasticsearch_plugin.py
@@ -46,13 +46,11 @@ options:
               effect.
             - For ES 1.x use url.
         required: False
-        default: None
     url:
         description:
             - Set exact URL to download the plugin from (Only works for ES 1.x).
             - For ES 2.x and higher, use src.
         required: False
-        default: None
     timeout:
         description:
             - "Timeout setting: 30s, 1m, 1h..."
@@ -150,6 +148,7 @@ def parse_plugin_repo(string):
 
 def is_plugin_present(plugin_name, plugin_dir):
     return os.path.isdir(os.path.join(plugin_dir, plugin_name))
+
 
 def parse_error(string):
     reason = "ERROR: "
@@ -263,7 +262,7 @@ def main():
             proxy_port=dict(default=None),
             version=dict(default=None)
         ),
-        mutually_exclusive=[("src","url")],
+        mutually_exclusive=[("src", "url")],
         supports_check_mode=True
     )
 


### PR DESCRIPTION
##### SUMMARY

Previously specifying a URL or a file name (which is supported by the
Elasticsearch plugin tooling) would not work correctly with Ansible, because the
detection of the current installation state was based on the installed plugin name.

This commit adds a new "src" parameter for the module, which can be specified in
addition to the plugin name. It will be used to retrieve the plugin from
a custom location while keeping the final plugin name available to determine if
it is already present or not.

The url parameter remains for ES 1.x compatiblity.
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
- `elasticsearch_plugin` module

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0 (es-plugin-add-src-param 73645a6343) last updated 2018/05/09 17:12:01 (GMT +200)
  config file = /Users/ds/.ansible.cfg
  configured module search path = ['/Users/ds/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/ds/CenterDevice/repos/ansible/lib/ansible
  executable location = /Users/ds/CenterDevice/repos/ansible/bin/ansible
  python version = 3.6.4 (default, Mar  1 2018, 18:36:50) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```

##### ADDITIONAL INFORMATION

According to the docs, the `name` paramter of `elasticsearch_plugin`, "[...] in Eleasticsearch >= 2.0, the name can be an URL or file location.".

While this is true (the underlying (elasticsearch-)plugin tool which gets called to install/remove plugins supports this), the plugin's own logic was flawed. Before calling the external command, it would try to determine if the plugin was already installed by parsing the name and checking the existence of directories. However, the parsing logic made assumptions that would not work when actually specifying a URL for the module name.

Because the actual plugin name cannot be determined from just the file name alone (it is based on metadata inside the plugin ZIP file), there is no way to reliably solve this with just one parameter. The patch adds a new optional "src" parameter just for the location of the plugin, while keeping the name parameter for the actual plugin name.
