### PR TITLE
Fix for NameError (#39665)

### DIFF
--- a/lib/ansible/module_utils/network/cnos/cnos.py
+++ b/lib/ansible/module_utils/network/cnos/cnos.py
@@ -35,8 +35,8 @@ import time
 import socket
 import re
 try:
-    import cnos_errorcodes
-    import cnos_devicerules
+    from ansible.module_utils.network.cnos import cnos_errorcodes
+    from ansible.module_utils.network.cnos import cnos_devicerules
     HAS_LIB = True
 except:
     HAS_LIB = False


### PR DESCRIPTION
Issue : NameError: global name ‘cnos_devicerules’ is not defined. while running cnos modules.
Device Rule file validates the range and type of data going into each CLI based on device type it is executed against.
This has to be backported to 2.5
(cherry picked from commit 3c32b483bc934e2f470e86dff4657bcd43dc62b1)

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - New Module Pull Request
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
