### PR TITLE
Move lookups test to group1.

### DIFF
--- a/test/integration/targets/lookups/aliases
+++ b/test/integration/targets/lookups/aliases
@@ -1,2 +1,2 @@
-posix/ci/group2
+posix/ci/group1
 needs/httptester


### PR DESCRIPTION
##### SUMMARY

Move lookups test to group1.

This will improve CI performance as all tests with `needs/httptester` will be in `posix/ci/group1`.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

lookups integration test

##### ANSIBLE VERSION

```
ansible 2.6.0 (lookups 565c7e5a66) last updated 2018/05/09 09:27:39 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
