### PR TITLE
Changed int to str in junos_config module. Fixes #39920

### DIFF
--- a/lib/ansible/modules/network/junos/junos_config.py
+++ b/lib/ansible/modules/network/junos/junos_config.py
@@ -295,7 +295,7 @@ def main():
         # deprecated replace in Ansible 2.3
         replace=dict(type='bool'),
 
-        confirm=dict(default=0, type='int'),
+        confirm=dict(default=0, type='str'),
         comment=dict(default=DEFAULT_COMMENT),
         confirm_commit=dict(type='bool', default=False),
 

--- a/test/units/modules/network/junos/test_junos_config.py
+++ b/test/units/modules/network/junos/test_junos_config.py
@@ -118,7 +118,7 @@ class TestJunosConfigModule(TestJunosModule):
         set_module_args(dict(src=src, confirm=40))
         self.execute_module(changed=True)
         args, kwargs = self.commit_configuration.call_args
-        self.assertEqual(kwargs['confirm_timeout'], 40)
+        self.assertEqual(kwargs['confirm_timeout'], '40')
 
     def test_junos_config_rollback(self):
         rollback = 10


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Changing 'int' to 'str' in `junos_config` module
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
This corrects 'type' error that occurs
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
junos_config
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0 (junos-config 9ca54ae852) last updated 2018/05/09 12:53:01 (GMT -400)
  config file = None
  configured module search path = [u'/home/dirtyonekanobi/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /media/storage/projects/ansible_junos_fix/ansible/lib/ansible
  executable location = /media/storage/projects/ansible_junos_fix/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 14 2018, 13:36:31) [GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->
There may be more elegant solutions to this issue, or it may be a symptom of a larger problem.  However this seemed to be the simplest resolution with the smallest scope.
<!--- Paste verbatim command output below, e.g. before and after your change -->
BEFORE:
```
The full traceback is:
Traceback (most recent call last):
  File "/tmp/ansible_FTq_V2/ansible_module_junos_config.py", line 404, in <module>
    main()
  File "/tmp/ansible_FTq_V2/ansible_module_junos_config.py", line 385, in main
    commit_configuration(module, **kwargs)
  File "/tmp/ansible_FTq_V2/ansible_modlib.zip/ansible/module_utils/network/junos/junos.py", line 152, in commit_configuration
  File "/tmp/ansible_FTq_V2/ansible_modlib.zip/ansible/module_utils/network/common/netconf.py", line 70, in __rpc__
  File "/tmp/ansible_FTq_V2/ansible_modlib.zip/ansible/module_utils/network/common/netconf.py", line 102, in parse_rpc_error
ansible.module_utils.connection.ConnectionError: Argument must be bytes or unicode, got 'int'

fatal: [qfx1]: FAILED! => {
    "changed": false, 
    "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_FTq_V2/ansible_module_junos_config.py\", line 404, in <module>\n    main()\n  File \"/tmp/ansible_FTq_V2/ansible_module_junos_config.py\", line 385, in main\n    commit_configuration(module, **kwargs)\n  File \"/tmp/ansible_FTq_V2/ansible_modlib.zip/ansible/module_utils/network/junos/junos.py\", line 152, in commit_configuration\n  File \"/tmp/ansible_FTq_V2/ansible_modlib.zip/ansible/module_utils/network/common/netconf.py\", line 70, in __rpc__\n  File \"/tmp/ansible_FTq_V2/ansible_modlib.zip/ansible/module_utils/network/common/netconf.py\", line 102, in parse_rpc_error\nansible.module_utils.connection.ConnectionError: Argument must be bytes or unicode, got 'int'\n", 
    "module_stdout": "", 
    "msg": "MODULE FAILURE", 
    "rc": 1
}
```
AFTER:
```
changed: [qfx1] => {
    "backup_path": "/media/storage/projects/ansible_junos_fix/backup/qfx1_config.2018-05-09@12:08:57", 
    "changed": true, 
    "invocation": {
        "module_args": {
            "backup": true, 
            "comment": "configured by junos_config", 
            "confirm": "5", 
            "confirm_commit": false, 
            "host": null, 
            "lines": [
                "set system host-name testing1234"
            ], 
            "password": null, 
            "port": null, 
            "provider": null, 
            "replace": null, 
            "rollback": null, 
            "src": null, 
            "src_format": null, 
            "ssh_keyfile": null, 
            "timeout": null, 
            "transport": null, 
            "update": "merge", 
            "username": null, 
            "zeroize": false
        }
    }
}
```
