### PR TITLE
Add is_item_sequence util function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,5 @@ htmlcov/
 # ansible-test coverage results
 test/units/.coverage.*
 /test/integration/cloud-config-azure.yml
+
+/SYMLINK_CACHE.json

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -197,13 +197,6 @@ except NameError:
     unicode = text_type
 
 try:
-    # Python 2.6+
-    bytes
-except NameError:
-    # Python 2.4
-    bytes = binary_type
-
-try:
     # Python 2
     basestring
 except NameError:

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -2,6 +2,8 @@
 # Copyright (c), Toshio Kuratomi <tkuratomi@ansible.com> 2016
 # Simplified BSD License (see licenses/simplified_bsd.txt or https://opensource.org/licenses/BSD-2-Clause)
 
+from __future__ import absolute_import, division, print_function
+
 SIZE_RANGES = {
     'Y': 1 << 80,
     'Z': 1 << 70,
@@ -621,7 +623,7 @@ def bytes_to_human(size, isbits=False, unit=None):
     else:
         suffix = base
 
-    return '%.2f %s' % (float(size) / limit, suffix)
+    return '%.2f %s' % (size / limit, suffix)
 
 
 def human_to_bytes(number, default_unit=None, isbits=False):

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -81,8 +81,6 @@ import pwd
 import platform
 import errno
 import datetime
-from collections import deque
-from collections import Mapping, MutableMapping, Sequence, MutableSequence, Set, MutableSet
 from itertools import chain, repeat
 
 try:
@@ -106,14 +104,6 @@ except ImportError:
 
 # Python2 & 3 way to get NoneType
 NoneType = type(None)
-
-# Note: When getting Sequence from collections, it matches with strings.  If
-# this matters, make sure to check for strings before checking for sequencetype
-try:
-    from collections.abc import KeysView
-    SEQUENCETYPE = (Sequence, frozenset, KeysView)
-except ImportError:
-    SEQUENCETYPE = (Sequence, frozenset)
 
 try:
     import json
@@ -162,6 +152,13 @@ except ImportError:
     except ImportError:
         pass
 
+from ansible.module_utils.common._collections_compat import (
+    deque,
+    KeysView,
+    Mapping, MutableMapping,
+    Sequence, MutableSequence,
+    Set, MutableSet,
+)
 from ansible.module_utils.pycompat24 import get_exception, literal_eval
 from ansible.module_utils.six import (
     PY2,
@@ -177,6 +174,10 @@ from ansible.module_utils.six.moves import map, reduce, shlex_quote
 from ansible.module_utils._text import to_native, to_bytes, to_text
 from ansible.module_utils.parsing.convert_bool import BOOLEANS_FALSE, BOOLEANS_TRUE, boolean
 
+
+# Note: When getting Sequence from collections, it matches with strings.  If
+# this matters, make sure to check for strings before checking for sequencetype
+SEQUENCETYPE = frozenset, KeysView, Sequence
 
 PASSWORD_MATCH = re.compile(r'^(?:.+[-_\s])?pass(?:[-_\s]?(?:word|phrase|wrd|wd)?)(?:[-_\s].+)?$', re.I)
 

--- a/lib/ansible/module_utils/common/_collections_compat.py
+++ b/lib/ansible/module_utils/common/_collections_compat.py
@@ -1,0 +1,29 @@
+# Copyright (c), Sviatoslav Sydorenko <ssydoren@redhat.com> 2018
+# Simplified BSD License (see licenses/simplified_bsd.txt or https://opensource.org/licenses/BSD-2-Clause)
+"""Collections ABC import shim.
+
+This module is intended only for internal use.
+It will go away once the bundled copy of six includes equivalent functionality.
+Third parties should not use this.
+"""
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+try:
+    """Python 3.3+ branch."""
+    from collections.abc import (
+        deque, KeysView,
+        Mapping, MutableMapping,
+        Sequence, MutableSequence,
+        Set, MutableSet,
+    )
+except ImportError:
+    """Use old lib location under 2.6-3.2."""
+    from collections import (
+        deque, KeysView,
+        Mapping, MutableMapping,
+        Sequence, MutableSequence,
+        Set, MutableSet,
+    )

--- a/lib/ansible/module_utils/common/collections.py
+++ b/lib/ansible/module_utils/common/collections.py
@@ -6,8 +6,8 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-from ..six import binary_type, text_type
-from ._collections_compat import Sequence
+from ansible.module_utils.six import binary_type, text_type
+from ansible.module_utils.common._collections_compat import Sequence
 
 
 def is_string(seq):

--- a/lib/ansible/module_utils/common/collections.py
+++ b/lib/ansible/module_utils/common/collections.py
@@ -1,0 +1,29 @@
+# Copyright (c), Sviatoslav Sydorenko <ssydoren@redhat.com> 2018
+# Simplified BSD License (see licenses/simplified_bsd.txt or https://opensource.org/licenses/BSD-2-Clause)
+"""Collection of low-level utility functions."""
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+from ..six import binary_type, text_type
+from ._collections_compat import Sequence
+
+
+def is_string(seq):
+    """Identify whether the input has a string-like type (inclding bytes)."""
+    return isinstance(seq, (text_type, binary_type))
+
+
+def is_sequence(seq, include_strings=False):
+    """Identify whether the input is a sequence.
+
+    Strings and bytes are not sequences here,
+    unless ``include_string`` is ``True``.
+
+    Non-indexable things are never of a sequence type.
+    """
+    if not include_strings and is_string(seq):
+        return False
+
+    return isinstance(seq, Sequence)

--- a/lib/ansible/module_utils/common/collections.py
+++ b/lib/ansible/module_utils/common/collections.py
@@ -15,6 +15,18 @@ def is_string(seq):
     return isinstance(seq, (text_type, binary_type))
 
 
+def is_iterable(seq, include_strings=False):
+    """Identify whether the input is an iterable."""
+    if not include_strings and is_string(seq):
+        return False
+
+    try:
+        iter(seq)
+        return True
+    except TypeError:
+        return False
+
+
 def is_sequence(seq, include_strings=False):
     """Identify whether the input is a sequence.
 

--- a/test/units/module_utils/common/collections.py
+++ b/test/units/module_utils/common/collections.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+# Copyright (c), Sviatoslav Sydorenko <ssydoren@redhat.com> 2018
+# Simplified BSD License (see licenses/simplified_bsd.txt or https://opensource.org/licenses/BSD-2-Clause)
+"""Test low-level utility functions from ``module_utils.common.collections``."""
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+
+from ansible.module_utils.common._collections_compat import Sequence
+from ansible.module_utils.common.collections import is_sequence
+
+
+class SeqStub:
+    """Stub emulating a sequence type.
+
+    >>> from collections.abc import Sequence
+    >>> assert issubclass(SeqStub, Sequence)
+    >>> assert isinstance(SeqStub(), Sequence)
+    """
+
+
+Sequence.register(SeqStub)
+
+
+TEST_STRINGS = u'he', u'Україна', u'Česká republika'
+TEST_STRINGS = TEST_STRINGS + tuple(s.encode('utf-8') for s in TEST_STRINGS)
+
+TEST_ITEMS_NON_SEQUENCES = (
+    {}, object(), frozenset(),
+    4, 0.,
+) + TEST_STRINGS
+
+TEST_ITEMS_SEQUENCES = (
+    [], (),
+    SeqStub(),
+)
+TEST_ITEMS_SEQUENCES = TEST_ITEMS_SEQUENCES + (
+    # Iterable effectively containing nested random data:
+    TEST_ITEMS_NON_SEQUENCES,
+)
+
+
+@pytest.mark.parametrize('sequence_input', TEST_ITEMS_SEQUENCES)
+def test_sequence_positive(sequence_input):
+    """Test that non-string item sequences are identified correctly."""
+    assert is_sequence(sequence_input)
+    assert is_sequence(sequence_input, include_strings=False)
+
+
+@pytest.mark.parametrize('non_sequence_input', TEST_ITEMS_NON_SEQUENCES)
+def test_sequence_negative(non_sequence_input):
+    """Test that non-sequences are identified correctly."""
+    assert not is_sequence(non_sequence_input)
+
+
+@pytest.mark.parametrize('string_input', TEST_STRINGS)
+def test_sequence_string_types_with_strings(string_input):
+    """Test that ``is_sequence`` can separate string and non-string."""
+    assert is_sequence(string_input, include_strings=True)
+
+
+@pytest.mark.parametrize('string_input', TEST_STRINGS)
+def test_sequence_string_types_without_strings(string_input):
+    """Test that ``is_sequence`` can separate string and non-string."""
+    assert not is_sequence(string_input, include_strings=False)


### PR DESCRIPTION
##### SUMMARY
This is a helper for identifying whether the var is a sequence,
but is not of string-like type.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
‒

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
devel

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->
‒