### PR TITLE
Install git in pip tests (#39460)

### DIFF
--- a/test/integration/targets/pip/tasks/pip.yml
+++ b/test/integration/targets/pip/tasks/pip.yml
@@ -18,6 +18,12 @@
 
 # FIXME: replace the python test package
 
+- name: install git, needed for repo installs
+  package:
+    name: git
+    state: present
+  when: ansible_distribution != "MacOSX"
+
 # first some tests installed system-wide
 # verify things were not installed to start with
 


### PR DESCRIPTION
##### SUMMARY

Install git in pip tests (#39460)

* Install git in pip tests
* Ignore MacOSX

(cherry picked from commit 90354d282db5c49cfcd7da3eabbefd54cd7957d5)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

pip integration tests

##### ANSIBLE VERSION

```
ansible 2.5.2 (git-2.5 6c4d3f7eb5) last updated 2018/05/09 10:52:50 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
