### PR TITLE
Don't display host pattern warning for empty groups (fixes #35255)

### DIFF
--- a/lib/ansible/inventory/manager.py
+++ b/lib/ansible/inventory/manager.py
@@ -544,8 +544,10 @@ class InventoryManager(object):
             if implicit:
                 results.append(implicit)
 
-        if not results and pattern != 'all':
+        # Display warning if specified host pattern did not match any groups or hosts
+        if not results and not matching_groups and pattern != 'all':
             display.warning("Could not match supplied host pattern, ignoring: %s" % pattern)
+
         return results
 
     def list_hosts(self, pattern="all"):


### PR DESCRIPTION
##### SUMMARY
The warning about a host pattern being ignored would previously trigger on an existing (but empty) group, which probably wasn't the intent of the code. This commit prevents the warning from showing when a group matches but is empty. This fixes #35255

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
inventory manager

##### ANSIBLE VERSION
```
ansible 2.6.0 (fix_empty_groups_warning 7ce948848c) last updated 2018/05/09 13:05:41 (GMT -500)
```

##### ADDITIONAL INFORMATION
N/A