### PR TITLE
fix vmware_guest wait_for_ip_address on existing VMs

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -2179,6 +2179,8 @@ def main():
             tmp_result = set_vm_power_state(pyv.content, vm, module.params['state'], module.params['force'], module.params['state_change_timeout'])
             if tmp_result['changed']:
                 result["changed"] = True
+                if module.params['wait_for_ip_address']:
+                    pyv.wait_for_vm_ip(vm)
             if not tmp_result["failed"]:
                 result["failed"] = False
             result['instance'] = tmp_result['instance']


### PR DESCRIPTION
The wait_for_ip_address functionality of vmware_guest was previously only coded to work for new VMs (clone, and from scratch). For an existing VM which was powered on it did nothing.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
vmware_guest

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0
  config file = None
  configured module search path = [u'/Users/phemmer/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/phemmer/ansible-2.5/lib/python2.7/site-packages/ansible
  executable location = /Users/phemmer/ansible-2.5/bin/ansible
  python version = 2.7.10 (default, Feb  7 2017, 00:08:15) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.34)]
```