### PR TITLE
winrm: add better exception handling for krb5 auth with pexpect

### DIFF
--- a/changelogs/fragments/winrm_kinit_error-fix.yaml
+++ b/changelogs/fragments/winrm_kinit_error-fix.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- winrm - Add better error handling when the kinit process fails

--- a/lib/ansible/plugins/connection/winrm.py
+++ b/lib/ansible/plugins/connection/winrm.py
@@ -285,19 +285,31 @@ class Connection(ConnectionBase):
         # doing so. Unfortunately it is not available on the built in Python
         # so we can only use it if someone has installed it
         if HAS_PEXPECT:
-            kinit_cmdline = " ".join(kinit_cmdline)
+            proc_mechanism = "pexpect"
+            command = kinit_cmdline.pop(0)
             password = to_text(password, encoding='utf-8',
                                errors='surrogate_or_strict')
 
             display.vvvv("calling kinit with pexpect for principal %s"
                          % principal)
-            events = {
-                ".*:": password + "\n"
-            }
-            # technically this is the stdout but to match subprocess we will
-            # call it stderr
-            stderr, rc = pexpect.run(kinit_cmdline, withexitstatus=True, events=events, env=krb5env, timeout=60)
+            child = pexpect.spawn(command, kinit_cmdline, timeout=60,
+                                  env=krb5env)
+            try:
+                child.expect(".*:")
+                child.sendline(password)
+            except OSError as err:
+                # child exited before the pass was sent, Ansible will raise
+                # error based on the rc below, just display the error here
+                display.vvvv("kinit with pexpect raised OSError: %s"
+                             % to_native(err))
+
+            # technically this is the stdout + stderr but to match the
+            # subprocess error checking behaviour, we will call it stderr
+            stderr = child.read()
+            child.wait()
+            rc = child.exitstatus
         else:
+            proc_mechanism = "subprocess"
             password = to_bytes(password, encoding='utf-8',
                                 errors='surrogate_or_strict')
 
@@ -311,7 +323,9 @@ class Connection(ConnectionBase):
             rc = p.returncode != 0
 
         if rc != 0:
-            raise AnsibleConnectionFailure("Kerberos auth failure: %s" % to_native(stderr.strip()))
+            err_msg = "Kerberos auth failure for principal %s with %s: %s" \
+                      % (principal, proc_mechanism, to_native(stderr.strip()))
+            raise AnsibleConnectionFailure(err_msg)
 
         display.vvvvv("kinit succeeded for principal %s" % principal)
 

--- a/lib/ansible/plugins/connection/winrm.py
+++ b/lib/ansible/plugins/connection/winrm.py
@@ -323,11 +323,11 @@ class Connection(ConnectionBase):
                          % principal)
             try:
                 p = subprocess.Popen(kinit_cmdline, stdin=subprocess.PIPE,
-                                    stdout=subprocess.PIPE,
-                                    stderr=subprocess.PIPE,
-                                    env=krb5env)
+                                     stdout=subprocess.PIPE,
+                                     stderr=subprocess.PIPE,
+                                     env=krb5env)
 
-            except FileNotFoundError as err:
+            except OSError as err:
                 err_msg = "Kerberos auth failure when calling kinit cmd " \
                           "'%s': %s" % (self._kinit_cmd, to_native(err))
                 raise AnsibleConnectionFailure(err_msg)

--- a/test/units/plugins/connection/test_winrm.py
+++ b/test/units/plugins/connection/test_winrm.py
@@ -13,6 +13,8 @@ import pytest
 from io import StringIO
 
 from ansible.compat.tests.mock import patch, MagicMock
+from ansible.errors import AnsibleConnectionFailure
+from ansible.module_utils._text import to_bytes
 from ansible.playbook.play_context import PlayContext
 from ansible.plugins.loader import connection_loader
 
@@ -219,3 +221,148 @@ class TestConnectionWinRM(object):
                 % (attr, actual, expected)
 
         module_patcher.stop()
+
+
+class TestWinRMKerbAuth(object):
+
+    DATA = (
+        # default
+        ({"_extras": {}}, (["kinit", "user@domain"],), False),
+        ({"_extras": {}}, ("kinit", ["user@domain"],), True),
+
+        # override kinit path from options
+        ({"_extras": {}, 'ansible_winrm_kinit_cmd': 'kinit2'},
+         (["kinit2", "user@domain"],), False),
+        ({"_extras": {}, 'ansible_winrm_kinit_cmd': 'kinit2'},
+         ("kinit2", ["user@domain"],), True),
+
+        # we expect the -f flag when delegation is set
+        ({"_extras": {'ansible_winrm_kerberos_delegation': True}},
+         (["kinit", "-f", "user@domain"],), False),
+        ({"_extras": {'ansible_winrm_kerberos_delegation': True}},
+         ("kinit", ["-f", "user@domain"],), True),
+    )
+
+    # pylint bug: https://github.com/PyCQA/pylint/issues/511
+    # pylint: disable=undefined-variable
+    @pytest.mark.parametrize('options, expected, pexpect',
+                             ((o, e, p) for o, e, p in DATA))
+    def test_kinit_success(self, options, expected, pexpect):
+        def mock_popen_communicate(input=None, timeout=None):
+            return b"", b""
+
+        mock_pexpect = None
+        if pexpect:
+            mock_pexpect = MagicMock()
+            mock_pexpect.spawn.return_value.exitstatus = 0
+
+        mock_subprocess = MagicMock()
+        mock_subprocess.Popen.return_value.communicate = mock_popen_communicate
+        mock_subprocess.Popen.return_value.returncode = 0
+
+        modules = {
+            'pexpect': mock_pexpect,
+            'subprocess': mock_subprocess,
+        }
+
+        with patch.dict(sys.modules, modules):
+            pc = PlayContext()
+            new_stdin = StringIO()
+
+            connection_loader._module_cache = {}
+            conn = connection_loader.get('winrm', pc, new_stdin)
+            conn.set_options(var_options=options)
+
+            conn._kerb_auth("user@domain", "pass")
+            if pexpect:
+                assert len(mock_pexpect.method_calls) == 1
+                assert mock_pexpect.method_calls[0][1] == expected
+                actual_env = mock_pexpect.method_calls[0][2]['env']
+            else:
+                assert len(mock_subprocess.method_calls) == 1
+                assert mock_subprocess.method_calls[0][1] == expected
+                actual_env = mock_subprocess.method_calls[0][2]['env']
+
+            assert list(actual_env.keys()) == ['KRB5CCNAME']
+            assert actual_env['KRB5CCNAME'].startswith("FILE:/")
+
+    # pylint bug: https://github.com/PyCQA/pylint/issues/511
+    # pylint: disable=undefined-variable
+    @pytest.mark.parametrize('use_pexpect', (False, True),)
+    def test_kinit_with_missing_executable(self, use_pexpect):
+        expected_err = "[Errno 2] No such file or directory: " \
+                       "'/fake/kinit': '/fake/kinit'"
+        mock_subprocess = MagicMock()
+        mock_subprocess.Popen = MagicMock(side_effect=FileNotFoundError(expected_err))
+
+        mock_pexpect = None
+        if use_pexpect:
+            expected_err = "The command was not found or was not " \
+                           "executable: /fake/kinit"
+
+            mock_pexpect = MagicMock()
+            mock_pexpect.ExceptionPexpect = Exception
+            mock_pexpect.spawn = MagicMock(side_effect=Exception(expected_err))
+
+        modules = {
+            'pexpect': mock_pexpect,
+            'subprocess': mock_subprocess,
+        }
+
+        with patch.dict(sys.modules, modules):
+            pc = PlayContext()
+            new_stdin = StringIO()
+
+            connection_loader._module_cache = {}
+            conn = connection_loader.get('winrm', pc, new_stdin)
+            options = {"_extras": {}, "ansible_winrm_kinit_cmd": "/fake/kinit"}
+            conn.set_options(var_options=options)
+
+            with pytest.raises(AnsibleConnectionFailure) as err:
+                conn._kerb_auth("user@domain", "pass")
+            assert str(err.value) == "Kerberos auth failure when calling " \
+                                     "kinit cmd '/fake/kinit': %s" % expected_err
+
+    # pylint bug: https://github.com/PyCQA/pylint/issues/511
+    # pylint: disable=undefined-variable
+    @pytest.mark.parametrize('use_pexpect', (False, True),)
+    def test_kinit_error(self, use_pexpect):
+        mechanism = "subprocess"
+        expected_err = "kinit: krb5_parse_name: " \
+                       "Configuration file does not specify default realm"
+
+        def mock_popen_communicate(input=None, timeout=None):
+            return b"", to_bytes(expected_err)
+
+        mock_subprocess = MagicMock()
+        mock_subprocess.Popen.return_value.communicate = mock_popen_communicate
+        mock_subprocess.Popen.return_value.returncode = 1
+
+        mock_pexpect = None
+        if use_pexpect:
+            mechanism = "pexpect"
+            expected_err = "Configuration file does not specify default realm"
+
+            mock_pexpect = MagicMock()
+            mock_pexpect.spawn.return_value.expect = MagicMock(side_effect=OSError)
+            mock_pexpect.spawn.return_value.read.return_value = to_bytes(expected_err)
+            mock_pexpect.spawn.return_value.exitstatus = 1
+
+        modules = {
+            'pexpect': mock_pexpect,
+            'subprocess': mock_subprocess,
+        }
+
+        with patch.dict(sys.modules, modules):
+            pc = PlayContext()
+            new_stdin = StringIO()
+
+            connection_loader._module_cache = {}
+            conn = connection_loader.get('winrm', pc, new_stdin)
+            conn.set_options(var_options={"_extras": {}})
+
+            with pytest.raises(AnsibleConnectionFailure) as err:
+                conn._kerb_auth("invaliduser", "pass")
+
+            assert str(err.value) == "Kerberos auth failure for principal " \
+                                     "invaliduser with %s: %s" % (mechanism, expected_err)

--- a/test/units/plugins/connection/test_winrm.py
+++ b/test/units/plugins/connection/test_winrm.py
@@ -293,7 +293,7 @@ class TestWinRMKerbAuth(object):
         expected_err = "[Errno 2] No such file or directory: " \
                        "'/fake/kinit': '/fake/kinit'"
         mock_subprocess = MagicMock()
-        mock_subprocess.Popen = MagicMock(side_effect=FileNotFoundError(expected_err))
+        mock_subprocess.Popen = MagicMock(side_effect=OSError(expected_err))
 
         mock_pexpect = None
         if use_pexpect:


### PR DESCRIPTION
##### SUMMARY
When using pexpect to get the kerberos ticket in Ansible, if it fails before the password prompt an ugly stacktrace will be shown like below

```
TASK [win_ping] *****************************************************************************************************************************
task path: /Users/jborean/dev/module-tester/adhoc.yml:5
Using module file /Users/jborean/dev/ansible/lib/ansible/modules/windows/win_ping.ps1
<SERVER2016.domain.local> ESTABLISH WINRM CONNECTION FOR USER: vagrant on PORT 5986 TO SERVER2016.domain.local
The full traceback is:
Traceback (most recent call last):
  File "/Users/jborean/dev/ansible/lib/ansible/executor/task_executor.py", line 138, in run
    res = self._execute()
  File "/Users/jborean/dev/ansible/lib/ansible/executor/task_executor.py", line 571, in _execute
    result = self._handler.run(task_vars=variables)
  File "/Users/jborean/dev/ansible/lib/ansible/plugins/action/normal.py", line 46, in run
    result = merge_hash(result, self._execute_module(task_vars=task_vars, wrap_async=wrap_async))
  File "/Users/jborean/dev/ansible/lib/ansible/plugins/action/__init__.py", line 799, in _execute_module
    res = self._low_level_execute_command(cmd, sudoable=sudoable, in_data=in_data)
  File "/Users/jborean/dev/ansible/lib/ansible/plugins/action/__init__.py", line 906, in _low_level_execute_command
    rc, stdout, stderr = self._connection.exec_command(cmd, in_data=in_data, sudoable=sudoable)
  File "/Users/jborean/dev/ansible/lib/ansible/plugins/connection/winrm.py", line 482, in exec_command
    super(Connection, self).exec_command(cmd, in_data=in_data, sudoable=sudoable)
  File "/Users/jborean/dev/ansible/lib/ansible/plugins/connection/__init__.py", line 38, in wrapped
    self._connect()
  File "/Users/jborean/dev/ansible/lib/ansible/plugins/connection/winrm.py", line 451, in _connect
    self.protocol = self._winrm_connect()
  File "/Users/jborean/dev/ansible/lib/ansible/plugins/connection/winrm.py", line 345, in _winrm_connect
    self._kerb_auth(self._winrm_user, self._winrm_pass)
  File "/Users/jborean/dev/ansible/lib/ansible/plugins/connection/winrm.py", line 300, in _kerb_auth
    stderr, rc = pexpect.run(kinit_cmdline, withexitstatus=True, events=events, env=krb5env, timeout=60)
  File "/Users/jborean/venvs/ansible-py36/lib/python3.6/site-packages/pexpect/run.py", line 123, in run
    child.send(responses[index])
  File "/Users/jborean/venvs/ansible-py36/lib/python3.6/site-packages/pexpect/pty_spawn.py", line 529, in send
    return os.write(self.child_fd, b)
OSError: [Errno 5] Input/output error

fatal: [SERVER2016.domain.local]: FAILED! => {
    "msg": "Unexpected failure during module execution.",
    "stdout": ""
}
```

What this change does is to catch the OSError and get the actual stderr from the proc and report that instead. Now the error is shown as

```
TASK [win_ping] *****************************************************************************************************************************
task path: /Users/jborean/dev/module-tester/adhoc.yml:5
Using module file /Users/jborean/dev/ansible/lib/ansible/modules/windows/win_ping.ps1
<SERVER2016.domain.local> ESTABLISH WINRM CONNECTION FOR USER: vagrant on PORT 5986 TO SERVER2016.domain.local
fatal: [SERVER2016.domain.local]: UNREACHABLE! => {
    "changed": false,
    "msg": "Kerberos auth failure for principal vagrant with pexpect: Configuration file does not specify default realm",
    "unreachable": true
}
```

Also changes the error in a minor way to alwasy show the process mechanism and principal that was used in the kninit process.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
winrm

##### ANSIBLE VERSION
```
devel
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
