### PR TITLE
Ensure timezone tests reset system timezone to original value (#39326)

### DIFF
--- a/test/integration/targets/timezone/tasks/main.yml
+++ b/test/integration/targets/timezone/tasks/main.yml
@@ -1,15 +1,21 @@
-- name: set timezone to Etc/UTC
+- name: Set timezone to Etc/UTC
   timezone:
     name: Etc/UTC
+  register: original_timezone
 
-- name: set timezone to Australia/Brisbane
-  timezone:
-    name: Australia/Brisbane
-  register: timezone_set
+- block:
+    - name: Set timezone to Australia/Brisbane
+      timezone:
+        name: Australia/Brisbane
+      register: timezone_set
 
-- name: ensure timezone changed
-  assert:
-    that:
-      - timezone_set.changed
-      - timezone_set.diff.after.name == 'Australia/Brisbane'
-      - timezone_set.diff.before.name == 'Etc/UTC'
+    - name: Ensure timezone changed
+      assert:
+        that:
+          - timezone_set is changed
+          - timezone_set.diff.after.name == 'Australia/Brisbane'
+          - timezone_set.diff.before.name == 'Etc/UTC'
+  always:
+    - name: Restore original system timezone - {{ original_timezone.diff.before.name }}
+      timezone:
+        name: "{{ original_timezone.diff.before.name }}"


### PR DESCRIPTION
##### SUMMARY

Ensure timezone tests reset system timezone to original value (#39326)

(cherry picked from commit fda67bae50c3384f8656b5c013bfed5cb360997d)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

timezone integration test

##### ANSIBLE VERSION

```
ansible 2.5.2 (timezone-2.5 70e62a5c16) last updated 2018/05/09 15:51:34 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
