### PR TITLE
Make docs-build sanity test disabled by default.

### DIFF
--- a/test/runner/lib/config.py
+++ b/test/runner/lib/config.py
@@ -139,6 +139,7 @@ class SanityConfig(TestConfig):
         self.test = args.test  # type: list [str]
         self.skip_test = args.skip_test  # type: list [str]
         self.list_tests = args.list_tests  # type: bool
+        self.allow_disabled = args.allow_disabled  # type: bool
 
         if args.base_branch:
             self.base_branch = args.base_branch  # str

--- a/test/runner/test.py
+++ b/test/runner/test.py
@@ -357,6 +357,10 @@ def parse_args():
                         choices=[test.name for test in sanity_get_tests()],
                         help='tests to skip').completer = complete_sanity_test
 
+    sanity.add_argument('--allow-disabled',
+                        action='store_true',
+                        help='allow tests to run which are disabled by default')
+
     sanity.add_argument('--list-tests',
                         action='store_true',
                         help='list available tests')

--- a/test/sanity/code-smell/docs-build.json
+++ b/test/sanity/code-smell/docs-build.json
@@ -1,4 +1,5 @@
 {
+    "disabled": true,
     "always": true,
     "output": "path-line-column-message"
 }

--- a/test/utils/shippable/sanity.sh
+++ b/test/utils/shippable/sanity.sh
@@ -23,4 +23,4 @@ esac
 # shellcheck disable=SC2086
 ansible-test sanity --color -v --junit ${COVERAGE:+"$COVERAGE"} ${CHANGED:+"$CHANGED"} \
     --docker --docker-keep-git --base-branch "${base_branch}" \
-    "${options[@]}"
+    "${options[@]}" --allow-disabled


### PR DESCRIPTION
##### SUMMARY

Make docs-build sanity test disabled by default.

Always run it during CI.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.6.0 (sanity-disabled e1b272c17c) last updated 2018/05/09 16:51:45 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
