### PR TITLE
Use colspan on td instead of divs for hierarchical tables

### DIFF
--- a/docs/docsite/_themes/sphinx_rtd_theme/static/css/theme.css
+++ b/docs/docsite/_themes/sphinx_rtd_theme/static/css/theme.css
@@ -421,51 +421,17 @@ table {
        max-width: 100%;
 }
 
-
-.outer-elbow-container {
-    display: flex;
-    height: 100%;
-    flex-direction: row;
-}
-
-.elbow-placeholder {
+.documentation-table td.elbow-placeholder {
     border-left: 1px solid #000;
-    height: 100%;
+    border-top: 0px;
     width: 30px;
+    min-width: 30px;
 }
 
-.elbow-key {
-    height: 100%;
-    padding: 4px;
-    border-top: 1px solid #000;
-    flex-grow: 1;
-    border-left: 1px solid #000;
-}
-
-.elbow-blocker {
-    height: 0;
-    overflow: hidden;
-}
-
-.return-value-column {
-    height: 1px
-}
-
-.return-value-column td {
-    height: inherit
-}
-
-@-moz-document url-prefix() {
-    .return-value-column td {
-        height: 100%
-    }
-}
-
-.cell-border {
+.documentation-table th, .documentation-table td {
     padding: 4px;
     border-left: 1px solid #000;
     border-top: 1px solid #000;
-    height: 100%;
 }
 
 .documentation-table {

--- a/docs/docsite/_themes/srtd/static/css/theme.css
+++ b/docs/docsite/_themes/srtd/static/css/theme.css
@@ -4867,50 +4867,17 @@ table {
     }
 }
 
-.outer-elbow-container {
-    display: flex;
-    height: 100%;
-    flex-direction: row;
-}
-
-.elbow-placeholder {
+.documentation-table td.elbow-placeholder {
     border-left: 1px solid #000;
-    height: 100%;
+    border-top: 0px;
     width: 30px;
+    min-width: 30px;
 }
 
-.elbow-key {
-    height: 100%;
-    padding: 4px;
-    border-top: 1px solid #000;
-    flex-grow: 1;
-    border-left: 1px solid #000;
-}
-
-.elbow-blocker {
-    height: 0;
-    overflow: hidden;
-}
-
-.return-value-column {
-    height: 1px
-}
-
-.return-value-column td {
-    height: inherit
-}
-
-@-moz-document url-prefix() {
-    .return-value-column td {
-        height: 100%
-    }
-}
-
-.cell-border {
+.documentation-table th, .documentation-table td {
     padding: 4px;
     border-left: 1px solid #000;
     border-top: 1px solid #000;
-    height: 100%;
 }
 
 .documentation-table {

--- a/docs/templates/plugin.rst.j2
+++ b/docs/templates/plugin.rst.j2
@@ -88,104 +88,107 @@ Parameters
 .. raw:: html
 
     <table  border=0 cellpadding=0 class="documentation-table">
+        {# Pre-compute the nesting depth to allocate columns #}
+        {% set ns = namespace(maxdepth=1) %}
+        {% for key, value in options|dictsort recursive %}
+            {% set ns.maxdepth = [loop.depth, ns.maxdepth] | max %}
+            {% if value.suboptions %}
+                {% if value.suboptions.items %}
+                    @{ loop(value.suboptions.items()) }@
+                {% elif value.suboptions[0].items %}
+                    @{ loop(value.suboptions[0].items()) }@
+                {% endif %}
+            {% endif %}
+        {% endfor %}
         {# Header of the documentation #}
         <tr>
-            <th class="head"><div class="cell-border">Parameter</div></th>
-            <th class="head"><div class="cell-border">Choices/<font color="blue">Defaults</font></div></th>
+            <th colspan="@{ ns.maxdepth }@">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
             {% if plugin_type != 'module' %}
-                <th class="head"><div class="cell-border">Configuration</div></th>
+                <th>Configuration</th>
             {% endif %}
-            <th class="head" width="100%"><div class="cell-border">Comments</div></th>
+            <th width="100%">Comments</th>
         </tr>
         {% for key, value in options|dictsort recursive %}
-            <tr class="return-value-column">
+            <tr>
+                {# indentation based on nesting level #}
+                {% for i in range(1, loop.depth) %}
+                    <td class="elbow-placeholder"></td>
+                {% endfor %}
                 {# parameter name with required and/or introduced label #}
-                <td>
-                    <div class="outer-elbow-container">
-                        {% for i in range(1, loop.depth) %}
-                            <div class="elbow-placeholder">&nbsp;</div>
-                        {% endfor %}
-                        <div class="elbow-key">
-                            <b>@{ key }@</b>
-                            {% if value.get('required', False) %}<br/><div style="font-size: small; color: red">required</div>{% endif %}
-                            {% if value.version_added %}<br/><div style="font-size: small; color: darkgreen">(added in @{value.version_added}@)</div>{% endif %}
-                        </div>
-                    </div>
+                <td colspan="@{ ns.maxdepth - loop.depth0 }@">
+                    <b>@{ key }@</b>
+                    {% if value.get('required', False) %}<br/><div style="font-size: small; color: red">required</div>{% endif %}
+                    {% if value.version_added %}<br/><div style="font-size: small; color: darkgreen">(added in @{value.version_added}@)</div>{% endif %}
                 </td>
                 {# default / choices #}
                 <td>
-                    <div class="cell-border">
-                        {# Turn boolean values in 'yes' and 'no' values #}
-                        {% if value.default is sameas true %}
-                            {% set _x = value.update({'default': 'yes'}) %}
-                        {% elif value.default is sameas false %}
-                            {% set _x = value.update({'default': 'no'}) %}
-                        {% endif %}
-                        {% if value.type == 'bool' %}
-                            {% set _x = value.update({'choices': ['no', 'yes']}) %}
-                        {% endif %}
-                        {# Show possible choices and highlight details #}
-                        {% if value.choices %}
-                            <ul><b>Choices:</b>
-                                {% for choice in value.choices %}
-                                    {# Turn boolean values in 'yes' and 'no' values #}
-                                    {% if choice is sameas true %}
-                                        {% set choice = 'yes' %}
-                                    {% elif choice is sameas false %}
-                                        {% set choice = 'no' %}
-                                    {% endif %}
-                                    {% if (value.default is string and value.default == choice) or (value.default is iterable and value.default is not string and choice in value.default) %}
-                                        <li><div style="color: blue"><b>@{ choice | escape }@</b>&nbsp;&larr;</div></li>
-                                    {% else %}
-                                        <li>@{ choice | escape }@</li>
-                                    {% endif %}
-                                {% endfor %}
-                            </ul>
-                        {% endif %}
-                        {# Show default value, when multiple choice or no choices #}
-                        {% if value.default is defined and value.default not in value.choices %}
-                            <b>Default:</b><br/><div style="color: blue">@{ value.default | escape }@</div>
-                        {% endif %}
-                    </div>
+                    {# Turn boolean values in 'yes' and 'no' values #}
+                    {% if value.default is sameas true %}
+                        {% set _x = value.update({'default': 'yes'}) %}
+                    {% elif value.default is sameas false %}
+                        {% set _x = value.update({'default': 'no'}) %}
+                    {% endif %}
+                    {% if value.type == 'bool' %}
+                        {% set _x = value.update({'choices': ['no', 'yes']}) %}
+                    {% endif %}
+                    {# Show possible choices and highlight details #}
+                    {% if value.choices %}
+                        <ul><b>Choices:</b>
+                            {% for choice in value.choices %}
+                                {# Turn boolean values in 'yes' and 'no' values #}
+                                {% if choice is sameas true %}
+                                    {% set choice = 'yes' %}
+                                {% elif choice is sameas false %}
+                                    {% set choice = 'no' %}
+                                {% endif %}
+                                {% if (value.default is string and value.default == choice) or (value.default is iterable and value.default is not string and choice in value.default) %}
+                                    <li><div style="color: blue"><b>@{ choice | escape }@</b>&nbsp;&larr;</div></li>
+                                {% else %}
+                                    <li>@{ choice | escape }@</li>
+                                {% endif %}
+                            {% endfor %}
+                        </ul>
+                    {% endif %}
+                    {# Show default value, when multiple choice or no choices #}
+                    {% if value.default is defined and value.default not in value.choices %}
+                        <b>Default:</b><br/><div style="color: blue">@{ value.default | escape }@</div>
+                    {% endif %}
                 </td>
                 {# configuration #}
                 {% if plugin_type != 'module' %}
                     <td>
-                        <div class="cell-border">
-                            {% if 'ini' in value %}
-                                <div> ini entries:
-                                    {% for ini in value.ini %}
-                                        <p>[@{ ini.section }@ ]<br>@{ ini.key }@ = @{ value.default | default('VALUE') }@</p>
-                                    {% endfor %}
-                                </div>
-                            {% endif %}
-                            {% if 'env' in value %}
-                                {% for env in value.env %}
-                                    <div>env:@{ env.name }@</div>
+                        {% if 'ini' in value %}
+                            <div> ini entries:
+                                {% for ini in value.ini %}
+                                    <p>[@{ ini.section }@ ]<br>@{ ini.key }@ = @{ value.default | default('VALUE') }@</p>
                                 {% endfor %}
-                            {% endif %}
-                            {% if 'vars' in value %}
-                                {% for myvar in value.vars %}
-                                    <div>var: @{ myvar.name }@</div>
-                                {% endfor %}
-                            {% endif %}
-                        </div>
+                            </div>
+                        {% endif %}
+                        {% if 'env' in value %}
+                            {% for env in value.env %}
+                                <div>env:@{ env.name }@</div>
+                            {% endfor %}
+                        {% endif %}
+                        {% if 'vars' in value %}
+                            {% for myvar in value.vars %}
+                                <div>var: @{ myvar.name }@</div>
+                            {% endfor %}
+                        {% endif %}
                     </td>
                 {% endif %}
                 {# description #}
                 <td>
-                    <div class="cell-border">
-                        {% if value.description is string %}
-                            <div>@{ value.description | replace('\n', '\n    ') | html_ify }@</div>
-                        {% else %}
-                            {% for desc in value.description %}
-                                <div>@{ desc | replace('\n', '\n    ') | html_ify }@</div>
-                            {% endfor %}
-                        {% endif %}
-                        {% if 'aliases' in value and value.aliases %}
-                            <div style="font-size: small; color: darkgreen"><br/>aliases: @{ value.aliases|join(', ') }@</div>
-                        {% endif %}
-                    </div>
+                    {% if value.description is string %}
+                        <div>@{ value.description | replace('\n', '\n    ') | html_ify }@</div>
+                    {% else %}
+                        {% for desc in value.description %}
+                            <div>@{ desc | replace('\n', '\n    ') | html_ify }@</div>
+                        {% endfor %}
+                    {% endif %}
+                    {% if 'aliases' in value and value.aliases %}
+                        <div style="font-size: small; color: darkgreen"><br/>aliases: @{ value.aliases|join(', ') }@</div>
+                    {% endif %}
                 </td>
             </tr>
             {% if value.suboptions %}
@@ -242,43 +245,49 @@ Facts returned by this module are added/updated in the ``hostvars`` host facts a
 .. raw:: html
 
     <table border=0 cellpadding=0 class="documentation-table">
+        {# Pre-compute the nesting depth to allocate columns #}
+        {% set ns = namespace(maxdepth=1) %}
+        {% for key, value in returnfacts|dictsort recursive %}
+            {% set ns.maxdepth = [loop.depth, ns.maxdepth] | max %}
+            {% if value.contains %}
+                {% if value.contains.items %}
+                    @{ loop(value.contains.items()) }@
+                {% elif value.contains[0].items %}
+                    @{ loop(value.contains[0].items()) }@
+                {% endif %}
+            {% endif %}
+        {% endfor %}
         <tr>
-            <th class="head"><div class="cell-border">Fact</div></th>
-            <th class="head"><div class="cell-border">Returned</div></th>
-            <th class="head" width="100%"><div class="cell-border">Description</div></th>
+            <th colspan="@{ ns.maxdepth }@">Fact</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
         </tr>
         {% for key, value in returnfacts|dictsort recursive %}
-            <tr class="return-value-column">
-                <td>
-                    <div class="outer-elbow-container">
-                        {% for i in range(1, loop.depth) %}
-                            <div class="elbow-placeholder">&nbsp;</div>
-                        {% endfor %}
-                        <div class="elbow-key">
-                            <b>@{ key }@</b>
-                            <br/><div style="font-size: small; color: red">@{ value.type }@</div>
-                        </div>
-                    </div>
+            <tr>
+                {% for i in range(1, loop.depth) %}
+                    <td class="elbow-placeholder"></td>
+                {% endfor %}
+                <td colspan="@{ ns.maxdepth - loop.depth0 }@" colspan="@{ ns.maxdepth - loop.depth0 }@">
+                    <b>@{ key }@</b>
+                    <br/><div style="font-size: small; color: red">@{ value.type }@</div>
                 </td>
-                <td><div class="cell-border">@{ value.returned | html_ify }@</div></td>
+                <td>@{ value.returned | html_ify }@</td>
                 <td>
-                    <div class="cell-border">
-                        {% if value.description is string %}
-                            <div>@{ value.description | html_ify }@
+                    {% if value.description is string %}
+                        <div>@{ value.description | html_ify }@
+                        </div>
+                    {% else %}
+                        {% for desc in value.description %}
+                            <div>@{ desc | html_ify }@
                             </div>
-                        {% else %}
-                            {% for desc in value.description %}
-                                <div>@{ desc | html_ify }@
-                                </div>
-                            {% endfor %}
-                        {% endif %}
-                        <br/>
-                        {% if value.sample is defined and value.sample %}
-                            <div style="font-size: smaller"><b>Sample:</b></div>
-                            {# TODO: The sample should be escaped, using | escape or | htmlify, but both mess things up beyond repair with dicts #}
-                            <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">@{ value.sample | replace('\n', '\n    ') | html_ify }@</div>
-                        {% endif %}
-                    </div>
+                        {% endfor %}
+                    {% endif %}
+                    <br/>
+                    {% if value.sample is defined and value.sample %}
+                        <div style="font-size: smaller"><b>Sample:</b></div>
+                        {# TODO: The sample should be escaped, using | escape or | htmlify, but both mess things up beyond repair with dicts #}
+                        <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">@{ value.sample | replace('\n', '\n    ') | html_ify }@</div>
+                    {% endif %}
                 </td>
             </tr>
             {# ---------------------------------------------------------
@@ -308,41 +317,46 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
 .. raw:: html
 
     <table border=0 cellpadding=0 class="documentation-table">
+        {% set ns = namespace(maxdepth=1) %}
+        {% for key, value in returndocs|dictsort recursive %}
+            {% set ns.maxdepth = [loop.depth, ns.maxdepth] | max %}
+            {% if value.contains %}
+                {% if value.contains.items %}
+                    @{ loop(value.contains.items()) }@
+                {% elif value.contains[0].items %}
+                    @{ loop(value.contains[0].items()) }@
+                {% endif %}
+            {% endif %}
+        {% endfor %}
         <tr>
-            <th class="head"><div class="cell-border">Key</div></th>
-            <th class="head"><div class="cell-border">Returned</div></th>
-            <th class="head" width="100%"><div class="cell-border">Description</div></th>
+            <th colspan="@{ ns.maxdepth }@">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
         </tr>
         {% for key, value in returndocs|dictsort recursive %}
-            <tr class="return-value-column">
-                <td>
-                    <div class="outer-elbow-container">
-                        {% for i in range(1, loop.depth) %}
-                            <div class="elbow-placeholder">&nbsp;</div>
-                        {% endfor %}
-                        <div class="elbow-key">
-                            <b>@{ key }@</b>
-                            <br/><div style="font-size: small; color: red">@{ value.type }@</div>
-                        </div>
-                    </div>
+            <tr>
+                {% for i in range(1, loop.depth) %}
+                    <td class="elbow-placeholder">&nbsp;</td>
+                {% endfor %}
+                <td colspan="@{ ns.maxdepth - loop.depth0 }@">
+                    <b>@{ key }@</b>
+                    <br/><div style="font-size: small; color: red">@{ value.type }@</div>
                 </td>
-                <td><div class="cell-border">@{ value.returned | html_ify }@</div></td>
+                <td>@{ value.returned | html_ify }@</td>
                 <td>
-                    <div class="cell-border">
-                        {% if value.description is string %}
-                            <div>@{ value.description | html_ify |indent(4)}@</div>
-                        {% else %}
-                            {% for desc in value.description %}
-                                <div>@{ desc | html_ify |indent(4)}@</div>
-                            {% endfor %}
-                        {% endif %}
-                        <br/>
-                        {% if value.sample is defined and value.sample %}
-                            <div style="font-size: smaller"><b>Sample:</b></div>
-                            {# TODO: The sample should be escaped, using |escape or |htmlify, but both mess things up beyond repair with dicts #}
-                            <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">@{ value.sample | replace('\n', '\n    ') | html_ify }@</div>
-                        {% endif %}
-                    </div>
+                    {% if value.description is string %}
+                        <div>@{ value.description | html_ify |indent(4)}@</div>
+                    {% else %}
+                        {% for desc in value.description %}
+                            <div>@{ desc | html_ify |indent(4)}@</div>
+                        {% endfor %}
+                    {% endif %}
+                    <br/>
+                    {% if value.sample is defined and value.sample %}
+                        <div style="font-size: smaller"><b>Sample:</b></div>
+                        {# TODO: The sample should be escaped, using |escape or |htmlify, but both mess things up beyond repair with dicts #}
+                        <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">@{ value.sample | replace('\n', '\n    ') | html_ify }@</div>
+                    {% endif %}
                 </td>
             </tr>
             {# ---------------------------------------------------------


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #40007
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

In 496ce388ab4dc464b9b3f821e05b98ebfc7fb17f support was added for tables with
hierarchical keys to better describe module and plugin options, return
values, and retured facts.  However, it used divs within a single table cell
to achieve this effect, which meant applying borders to those divs instead of
to the table cells, which required some hacks to get the divs to the full
height of the table row.  One of the hacks used, to distinguish Firefox from
other browsers, is deprecated and disabled by default in Firefox Developer
Edition.  #38087 documents this issue.

Refactor to use colspan to provide table cells which can vary in width and
indentation; the outermost has the greatest colspan, and each nested key has a
colspan of one less than the parent, with padding cells providing indentation.
All of the styling is applied to table cells, avoiding the need for hacks to
get the height to work out, and avoiding the need for browser-specific
styling.  This also simplifies the markup and CSS substantially, as a lot of
extra divs can be removed.

This does require that we do two passes over the options, return values, and
return facts in the Jinja2 template; one to determine the maximum nestig
depth so that we can compute the maximum colspan needed, and then one to
actually lay out the rows.  We could avoid this by just picking a colspan that
is likely to be greater than would ever be needed, like 10, but it's easy
enough to compute exactly.

I spent some time trying to factor out the common code into Jinja2 macros, but
the three tables are just different enough, with different columns, different
names for the sub-elements to recurse on, and so on that any attempt to
abstract it seemed to be more confusing than just having the slightly
duplicated code.


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
$ ansible --version
ansible 2.6.0 (issue-38087-use-colspan-for-hierarchical-tables 4ef7beff66) last updated 2018/05/10 04:06:02 (GMT -400)
  config file = None
  configured module search path = [u'/Users/lambda/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/lambda/src/ansible/lib/ansible
  executable location = /Users/lambda/src/ansible/bin/ansible
  python version = 2.7.14 (v2.7.14:84471935ed, Sep 16 2017, 12:01:12) [GCC 4.2.1 (Apple Inc. build 5666) (dot 3)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

The issue is documented in #38087. For more details on the Firefox changes that triggered a regression, see https://bugzilla.mozilla.org/show_bug.cgi?id=1035091 for the original removal of `@-moz-document`, https://bugzilla.mozilla.org/show_bug.cgi?id=1446470 for adding in a special case for the `@-moz-document url-prefix()` hack to conditionally include Mozilla-specific rules, and https://bugzilla.mozilla.org/show_bug.cgi?id=1449753 for the plans to eventually remove even that support once enough sites have moved away from using that hack.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
