### PR TITLE
apt_key: clarify the keyring option in docs

### DIFF
--- a/lib/ansible/modules/packaging/os/apt_key.py
+++ b/lib/ansible/modules/packaging/os/apt_key.py
@@ -41,7 +41,7 @@ options:
             - The path to a keyfile on the remote server to add to the keyring.
     keyring:
         description:
-            - The path to specific keyring file in /etc/apt/trusted.gpg.d/
+            - The full path to specific keyring file in /etc/apt/trusted.gpg.d/
         version_added: "1.3"
     url:
         description:


### PR DESCRIPTION
##### SUMMARY
Fixes https://github.com/ansible/ansible/issues/39851

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
apt_key

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION