### PR TITLE
Make tags working in Azure loadbalancers

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_loadbalancer.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_loadbalancer.py
@@ -620,7 +620,7 @@ class AzureRMLoadBalancer(AzureRMModuleBase):
 
     def exec_module(self, **kwargs):
         """Main module execution method"""
-        for key in self.module_args.keys():
+        for key in self.module_args.keys() + ['tags']:
             setattr(self, key, kwargs[key])
 
         changed = False
@@ -685,6 +685,9 @@ class AzureRMLoadBalancer(AzureRMModuleBase):
             changed = True
 
         self.results['state'] = load_balancer_to_dict(load_balancer)
+        update_tags, self.results['state']['tags'] = self.update_tags(self.results['state']['tags'])
+        if update_tags:
+            changed = True
         self.results['changed'] = changed
 
         if self.state == 'present' and changed:
@@ -761,6 +764,7 @@ class AzureRMLoadBalancer(AzureRMModuleBase):
             param = self.network_models.LoadBalancer(
                 sku=self.network_models.LoadBalancerSku(self.sku) if self.sku else None,
                 location=self.location,
+                tags=self.tags,
                 frontend_ip_configurations=frontend_ip_configurations_param,
                 backend_address_pools=backend_address_pools_param,
                 probes=probes_param,


### PR DESCRIPTION
Tags could be defined in a loadbalancer, but were never set in Azure.
This patch fixes that.

##### SUMMARY
It was possible to set tags in an ansible playbook, but the tags were never set in Azure.
This patch fixes that.

See bug #39896 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
azure_rm_loadbalancer

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible
```


##### ADDITIONAL INFORMATION

