### PR TITLE
Update cron.py

### DIFF
--- a/lib/ansible/modules/system/cron.py
+++ b/lib/ansible/modules/system/cron.py
@@ -388,8 +388,12 @@ class CronTab(object):
 
         # failing that, attempt to find job by exact match
         if job:
+            blank_trimmed_job = " ".join(job.split())  #  by Loreton:  create a line with single BLANK word separator just for comparing
             for i, l in enumerate(self.lines):
-                if l == job:
+                l = l.strip()
+                if len(l) and l[0] == '#': continue
+                blank_trimmed_line = " ".join(l.split())
+                if blank_trimmed_line == blank_trimmed_job:
                     # if no leading ansible header, insert one
                     if not re.match(r'%s' % self.ansible, self.lines[i - 1]):
                         self.lines.insert(i, self.do_comment(name))
@@ -684,9 +688,13 @@ def main():
             if len(old_job) == 0:
                 crontab.add_job(name, job)
                 changed = True
-            if len(old_job) > 0 and old_job[1] != job:
-                crontab.update_job(name, job)
-                changed = True
+            # if len(old_job) > 0 and old_job[1] != job:
+            if len(old_job) > 0:
+                trimmed_new_job = ' '.join(job.split())        # var created just for understanding
+                trimmed_old_job = ' '.join(old_job[1].split()) # var created just for understanding
+                if trimmed_old_job != trimmed_new_job: 
+                    crontab.update_job(name, job)
+                    changed = True
             if len(old_job) > 2:
                 crontab.update_job(name, job)
                 changed = True


### PR DESCRIPTION
Try to find out if a line already exists even if it contains words separated by a different BLANK character number. I tried it with a classical entry and with a special_time "@reboot". If it exists just the job_name will be inserted.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
If we wish to insert a line and that line is already present but the fields are separated by differents number of BLANKs, the new line will be insereted resulting in duplicated line. 
This change try to find out if a line already exists even if it contains words separated by a different BLANK character number. 
I tested it with a classical entry and with a special_time (@reboot) entry. If it exists just the job_name will be inserted.

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - New Module Pull Request
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
