### PR TITLE
git: clarify the archive option in docs

### DIFF
--- a/lib/ansible/modules/source_control/git.py
+++ b/lib/ansible/modules/source_control/git.py
@@ -157,6 +157,8 @@ options:
               archive file of the specified format containing the tree structure
               for the source tree.
               Allowed archive formats ["zip", "tar.gz", "tar", "tgz"]
+            - This will clone and perform git archive from local directory as not
+              all git servers support git archive.
         version_added: "2.4"
 
 requirements:


### PR DESCRIPTION
##### SUMMARY
Fixes https://github.com/ansible/ansible/issues/38963

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
git

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION