### PR TITLE
Fix for Azure loadbalancer tags.

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_loadbalancer.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_loadbalancer.py
@@ -621,7 +621,7 @@ class AzureRMLoadBalancer(AzureRMModuleBase):
 
     def exec_module(self, **kwargs):
         """Main module execution method"""
-        for key in self.module_args.keys() + ['tags']:
+        for key in list(self.module_args.keys()) + ['tags']:
             setattr(self, key, kwargs[key])
 
         changed = False

--- a/lib/ansible/modules/cloud/azure/azure_rm_loadbalancer.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_loadbalancer.py
@@ -610,6 +610,7 @@ class AzureRMLoadBalancer(AzureRMModuleBase):
         self.natpool_frontend_port_end = None
         self.natpool_backend_port = None
         self.natpool_protocol = None
+        self.tags = None
 
         self.results = dict(changed=False, state=dict())
 
@@ -620,7 +621,7 @@ class AzureRMLoadBalancer(AzureRMModuleBase):
 
     def exec_module(self, **kwargs):
         """Main module execution method"""
-        for key in self.module_args.keys():
+        for key in self.module_args.keys() + ['tags']:
             setattr(self, key, kwargs[key])
 
         changed = False
@@ -685,6 +686,13 @@ class AzureRMLoadBalancer(AzureRMModuleBase):
             changed = True
 
         self.results['state'] = load_balancer_to_dict(load_balancer)
+        if 'tags' in self.results['state']:
+            update_tags, self.results['state']['tags'] = self.update_tags(self.results['state']['tags'])
+            if update_tags:
+                changed = True
+        else:
+            if self.tags:
+                changed = True
         self.results['changed'] = changed
 
         if self.state == 'present' and changed:
@@ -761,6 +769,7 @@ class AzureRMLoadBalancer(AzureRMModuleBase):
             param = self.network_models.LoadBalancer(
                 sku=self.network_models.LoadBalancerSku(self.sku) if self.sku else None,
                 location=self.location,
+                tags=self.tags,
                 frontend_ip_configurations=frontend_ip_configurations_param,
                 backend_address_pools=backend_address_pools_param,
                 probes=probes_param,

--- a/lib/ansible/modules/cloud/azure/azure_rm_loadbalancer_facts.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_loadbalancer_facts.py
@@ -44,6 +44,7 @@ options:
     resource_group:
         description:
             - The resource group to search for the desired load balancer
+        required: true
     tags:
         description:
             - Limit results by providing a list of tags. Format tags as 'key' or 'key:value'.
@@ -153,7 +154,7 @@ class AzureRMLoadBalancerFacts(AzureRMModuleBase):
         self.log('List all load balancers')
 
         try:
-            response = self.network_client.load_balancers.list()
+            response = self.network_client.load_balancers.list(self.resource_group)
         except AzureHttpError as exc:
             self.fail('Failed to list all items - {}'.format(str(exc)))
 

--- a/lib/ansible/modules/cloud/azure/azure_rm_loadbalancer_facts.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_loadbalancer_facts.py
@@ -44,7 +44,6 @@ options:
     resource_group:
         description:
             - The resource group to search for the desired load balancer
-        required: true
     tags:
         description:
             - Limit results by providing a list of tags. Format tags as 'key' or 'key:value'.
@@ -154,7 +153,7 @@ class AzureRMLoadBalancerFacts(AzureRMModuleBase):
         self.log('List all load balancers')
 
         try:
-            response = self.network_client.load_balancers.list(self.resource_group)
+            response = self.network_client.load_balancers.list()
         except AzureHttpError as exc:
             self.fail('Failed to list all items - {}'.format(str(exc)))
 


### PR DESCRIPTION
It was possible to add tags to an Azure loadbalancer, but the tags were never set in Azure.
This patch fixes that.

##### SUMMARY
It was possible to add tags to an Azure loadbalancer in a playbook, but the tags were never set in Azure. This patch fixes that.

fixes #39896 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
azure_rm_loadbalancer

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible
```


##### ADDITIONAL INFORMATION
