### PR TITLE
Fix vxlan_vtep_vni tests

### DIFF
--- a/test/integration/targets/nxos_vxlan_vtep_vni/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_vxlan_vtep_vni/tests/common/sanity.yaml
@@ -123,11 +123,29 @@
   
     - assert: *true
 
-    - name: "Conf 6 Idempotence"
+    - name: check configure vxlan_vtep_vni ingress static idempotence check
       nxos_vxlan_vtep_vni: *conf6
       register: result
 
     - assert: *false
+
+    - name: Remove and reconfigure vxlan_vtep
+      nxos_vxlan_vtep: &remove_vtep
+        interface: nve1
+        state: absent
+        provider: "{{ connection }}"
+
+    - name: Configure vxlan_vtep with host reachability bgp
+      nxos_vxlan_vtep:
+        interface: nve1
+        host_reachability: True
+        provider: "{{ connection }}"
+
+    - name: configure vxlan_vtep_vni
+      nxos_vxlan_vtep_vni: &config_vni
+        interface: nve1
+        vni: 8000
+        provider: "{{ connection }}"
 
     - name: configure vxlan_vtep_vni ingress bgp
       nxos_vxlan_vtep_vni: &conf7
@@ -160,6 +178,18 @@
       register: result
 
     - assert: *false
+
+    - name: Remove and reconfigure vxlan_vtep
+      nxos_vxlan_vtep: *remove_vtep
+
+    - name: Configure vxlan_vtep with host reachability static
+      nxos_vxlan_vtep:
+        interface: nve1
+        host_reachability: False
+        provider: "{{ connection }}"
+
+    - name: configure vxlan_vtep_vni
+      nxos_vxlan_vtep_vni: *config_vni
 
     - name: configure vxlan_vtep_vni peer-list
       nxos_vxlan_vtep_vni: &conf9


### PR DESCRIPTION
##### SUMMARY
In later versions of Nexus, the `host_reachability` under the nve interface must be set property for the desired `ingress_replication` setting.

* To set ingress_replication to bgp, host_reachability must be set to `True`
* To set ingress_replication to static, host_reachability must be set to `False`

Older version of Nexus did not enforce this.  These change work with the latest and also older versions of Nexus that support vxlan.

Nexus will not allow you to simply toggle the `host_reachability` setting so in the tests we remove the vtep and reconfigure with the correct setting.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
nxos_vxlan_vtep_vni

##### ANSIBLE VERSION
```
ansible 2.6.0 (rel260/fix_vxlan_vtep_vni 168416cad0) last updated 2018/05/10 12:03:41 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/Users/mwiebe/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mwiebe/Projects/nxos_ansible/fix_ansible/lib/ansible
  executable location = /Users/mwiebe/Projects/nxos_ansible/fix_ansible/bin/ansible
  python version = 2.7.13 (default, Apr  4 2017, 08:47:57) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.38)]
```


##### ADDITIONAL INFORMATION
All tests pass.