### PR TITLE
ACI_L3_OUT: Update default for dscp to not allow APIC to handle it

### DIFF
--- a/lib/ansible/modules/network/aci/aci_l3out.py
+++ b/lib/ansible/modules/network/aci/aci_l3out.py
@@ -48,8 +48,8 @@ options:
   dscp:
     description:
     - The target Differentiated Service (DSCP) value.
+    - The APIC defaults to C(unspecified) when unset during creation.
     choices: [ AF11, AF12, AF13, AF21, AF22, AF23, AF31, AF32, AF33, AF41, AF42, AF43, CS0, CS1, CS2, CS3, CS4, CS5, CS6, CS7, EF, VA, unspecified ]
-    default: unspecified
     aliases: [ target ]
   route_control:
     description:
@@ -63,7 +63,6 @@ options:
   description:
     description:
     - Description for the L3Out.
-    default:
     aliases: [ descr ]
   state:
     description:
@@ -219,21 +218,17 @@ def main():
     argument_spec = aci_argument_spec()
     argument_spec.update(
         l3out=dict(type='str', aliases=['l3out_name', 'name']),
-        domain=dict(type='str', aliases=[
-                    'ext_routed_domain_name', 'routed_domain']),
+        domain=dict(type='str', aliases=['ext_routed_domain_name', 'routed_domain']),
         vrf=dict(type='str', aliases=['vrf_name']),
         tenant=dict(type='str', aliases=['tenant_name']),
         description=dict(type='str', aliases=['descr']),
-        route_control=dict(type='list', choices=[
-                           'export', 'import'], aliases=['route_control_enforcement']),
-        dscp=dict(type='str', default='unspecified',
-                  choices=['AF11', 'AF12', 'AF13', 'AF21', 'AF22', 'AF23', 'AF31', 'AF32', 'AF33', 'AF41', 'AF42', 'AF43',
-                           'CS0', 'CS1', 'CS2', 'CS3', 'CS4', 'CS5', 'CS6', 'CS7', 'EF', 'VA', 'unspecified'],
+        route_control=dict(type='list', choices=['export', 'import'], aliases=['route_control_enforcement']),
+        dscp=dict(type='str',
+                  choices=['AF11', 'AF12', 'AF13', 'AF21', 'AF22', 'AF23', 'AF31', 'AF32', 'AF33', 'AF41', 'AF42',
+                           'AF43', 'CS0', 'CS1', 'CS2', 'CS3', 'CS4', 'CS5', 'CS6', 'CS7', 'EF', 'VA', 'unspecified'],
                   aliases=['target']),
-        l3protocol=dict(type='list',
-                        choices=['static', 'bgp', 'ospf', 'pim']),
-        state=dict(type='str', default='present',
-                   choices=['absent', 'present', 'query'])
+        l3protocol=dict(type='list', choices=['static', 'bgp', 'ospf', 'pim']),
+        state=dict(type='str', default='present', choices=['absent', 'present', 'query'])
     )
 
     module = AnsibleModule(
@@ -266,8 +261,7 @@ def main():
             enforce_ctrl = 'export'
         else:
             enforce_ctrl = 'export,import'
-    child_classes = ['l3extRsL3DomAtt', 'l3extRsEctx',
-                     'bgpExtP', 'ospfExtP', 'eigrpExtP', 'pimExtP']
+    child_classes = ['l3extRsL3DomAtt', 'l3extRsEctx', 'bgpExtP', 'ospfExtP', 'eigrpExtP', 'pimExtP']
 
     aci.construct_url(
         root_class=dict(


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
The config parameters should allow the APIC to handle default values in order to prevent existing objects from having their attributes changed unintentionally.

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
No bugs, fixing new module for 2.6

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
aci_l3out

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5.2
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
