### PR TITLE
Remove duplicate include in user_guide

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_loops.rst
+++ b/docs/docsite/rst/user_guide/playbooks_loops.rst
@@ -262,7 +262,6 @@ Ansible by default sets the loop variable ``item`` for each loop, which causes t
 As of Ansible 2.1, the ``loop_control`` option can be used to specify the name of the variable to be used for the loop::
 
     # main.yml
-    - include: inner.yml
     - include_tasks: inner.yml
       loop:
         - 1


### PR DESCRIPTION
Looks like two commits merged close to each other and an '-include'
got left along with its replacement '-include_tasks'

##### SUMMARY
Documentation fix - an example in playbook_loops has 'include: inner.yml' and 'include_tasks: inner.yml' next to each other, probably as a result of a merge conflict.

##### ISSUE TYPE
Docs pull request

##### COMPONENT NAME
user_guide/playbooks_loops.rst

##### ANSIBLE VERSION
devel
```
$ ansible --version
ansible 2.6.0 (remove-duplicate-include 6626f30181) last updated 2018/05/10 11:51:22 (GMT -500)
  python version = 2.7.15 (default, May  1 2018, 16:44:37) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```

##### ADDITIONAL INFORMATION
