### PR TITLE
azure_rm_loadbalancer_facts requires rg

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_loadbalancer_facts.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_loadbalancer_facts.py
@@ -44,6 +44,7 @@ options:
     resource_group:
         description:
             - The resource group to search for the desired load balancer
+        required: true
     tags:
         description:
             - Limit results by providing a list of tags. Format tags as 'key' or 'key:value'.
@@ -153,7 +154,7 @@ class AzureRMLoadBalancerFacts(AzureRMModuleBase):
         self.log('List all load balancers')
 
         try:
-            response = self.network_client.load_balancers.list()
+            response = self.network_client.load_balancers.list(self.resource_group)
         except AzureHttpError as exc:
             self.fail('Failed to list all items - {}'.format(str(exc)))
 


### PR DESCRIPTION
Getting facts of all loadbalancers via azure_rm_loadbalancer_facts requires a resource group.
This fix adds the rg as parameter to the list() call.

##### SUMMARY
Fixes #39974 
Getting list of all facts from an azure loadbalancer results in an error message.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
azure_rm_loadbalancer_facts

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible
```


##### ADDITIONAL INFORMATION
The call elf.network_client.load_balancers.list() expects at least one parameter, the resource group.
