### PR TITLE
asa_acl: Push entire ACL when differences are detected

### DIFF
--- a/lib/ansible/modules/network/asa/asa_acl.py
+++ b/lib/ansible/modules/network/asa/asa_acl.py
@@ -194,7 +194,7 @@ def main():
     if not module.params['force']:
         contents = get_acl_config(module, acl_name)
         config = NetworkConfig(indent=1, contents=contents)
-        if candidate.difference(config)
+        if candidate.difference(config):
             commands = candidate.items
         else:
             commands = candidate.difference(config)

--- a/lib/ansible/modules/network/asa/asa_acl.py
+++ b/lib/ansible/modules/network/asa/asa_acl.py
@@ -194,8 +194,10 @@ def main():
     if not module.params['force']:
         contents = get_acl_config(module, acl_name)
         config = NetworkConfig(indent=1, contents=contents)
-
-        commands = candidate.difference(config)
+        if candidate.difference(config)
+            commands = candidate.items
+        else:
+            commands = candidate.difference(config)
         commands = dumps(commands, 'commands').split('\n')
         commands = [str(c) for c in commands if c]
     else:


### PR DESCRIPTION
When a difference is detected between the currently configured ACL and the playbook commands only the missing lines are pushed to the device. Following the example in the asa_acl module documentation, where the current ACL is deleted before pushing commands, results in an incomplete ACL.

For example:

Playbook:
```
---
- asa_acl:
    lines:
      - access-list ACL-ANSIBLE extended permit tcp any any eq 82
      - access-list ACL-ANSIBLE extended permit tcp any any eq www
      - access-list ACL-ANSIBLE extended permit tcp any any eq 97
      - access-list ACL-ANSIBLE extended permit tcp any any eq 98
      - access-list ACL-ANSIBLE extended permit tcp any any eq 99
    before: clear configure access-list ACL-ANSIBLE
    match: strict
    replace: block
    provider: "{{ cli }}"
```
Running config:
```
access-list ACL-ANSIBLE extended permit tcp any any eq 82
access-list ACL-ANSIBLE extended permit tcp any any eq www
access-list ACL-ANSIBLE extended permit tcp any any eq 97
access-list ACL-ANSIBLE extended permit tcp any any eq 98
```
Running config after running playbook:
```
access-list ACL-ANSIBLE extended permit tcp any any eq 99
```
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
asa_acl.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
