### PR TITLE
Update influxdb_database.py: InfluxDB >= 1.2.4 not supported

### DIFF
--- a/lib/ansible/modules/database/influxdb/influxdb_database.py
+++ b/lib/ansible/modules/database/influxdb/influxdb_database.py
@@ -22,7 +22,7 @@ version_added: 2.1
 author: "Kamil Szczygiel (@kamsz)"
 requirements:
     - "python >= 2.6"
-    - "influxdb >= 0.9"
+    - "influxdb >= 0.9 & <= 1.2.4"
     - requests
 options:
     database_name:


### PR DESCRIPTION

+label: docsite_pr

##### SUMMARY
The `influxdb_database` module does not support InfluxDB >= 1.2.4
Took me some effort to figure that out, therefore it would be nice to mention it in the docs.

Source of truth:
https://github.com/influxdata/influxdb-python#influxdb-pre-v110-users

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
module: influxdb_database

##### ANSIBLE VERSION
n/a


##### ADDITIONAL INFORMATION
```

```
