### PR TITLE
[AWS] Add Ansible Version to botocore user agent string

### DIFF
--- a/lib/ansible/module_utils/ansible_release.py
+++ b/lib/ansible/module_utils/ansible_release.py
@@ -1,0 +1,1 @@
+../release.py

--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -129,7 +129,7 @@ def _boto3_conn(conn_type=None, resource=None, region=None, endpoint=None, **par
 
 
     config = botocore.config.Config(
-        user_agent_extra='Ansible {0}'.format(__version__),
+        user_agent_extra='Ansible/{0}'.format(__version__),
     )
     session = boto3.session.Session(
         profile_name=profile,

--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -29,6 +29,7 @@
 import os
 import re
 
+from ansible.module_utils.ansible_release import __version__
 from ansible.module_utils._text import to_native, to_text
 from ansible.module_utils.cloud import CloudRetry
 from ansible.module_utils.six import string_types, binary_type, text_type
@@ -126,15 +127,21 @@ def _boto3_conn(conn_type=None, resource=None, region=None, endpoint=None, **par
                          'the conn_type parameter in the boto3_conn function '
                          'call')
 
+
+    config = botocore.config.Config(
+        user_agent_extra='Ansible {0}'.format(__version__),
+    )
+    session = boto3.session.Session(
+        profile_name=profile,
+    )
+
     if conn_type == 'resource':
-        resource = boto3.session.Session(profile_name=profile).resource(resource, region_name=region, endpoint_url=endpoint, **params)
-        return resource
+        return session.resource(resource, config=config, region_name=region, endpoint_url=endpoint, **params)
     elif conn_type == 'client':
-        client = boto3.session.Session(profile_name=profile).client(resource, region_name=region, endpoint_url=endpoint, **params)
-        return client
+        return session.client(resource, config=config, region_name=region, endpoint_url=endpoint, **params)
     else:
-        client = boto3.session.Session(profile_name=profile).client(resource, region_name=region, endpoint_url=endpoint, **params)
-        resource = boto3.session.Session(profile_name=profile).resource(resource, region_name=region, endpoint_url=endpoint, **params)
+        client = session.client(resource, region_name=region, endpoint_url=endpoint, **params)
+        resource = session.resource(resource, region_name=region, endpoint_url=endpoint, **params)
         return client, resource
 
 

--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -129,7 +129,7 @@ def _boto3_conn(conn_type=None, resource=None, region=None, endpoint=None, **par
 
     if params.get('config'):
         config = params.pop('config')
-        config.user_agent_extra='Ansible/{0}'.format(__version__),
+        config.user_agent_extra = 'Ansible/{0}'.format(__version__)
     else:
         config = botocore.config.Config(
             user_agent_extra='Ansible/{0}'.format(__version__),

--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -127,10 +127,13 @@ def _boto3_conn(conn_type=None, resource=None, region=None, endpoint=None, **par
                          'the conn_type parameter in the boto3_conn function '
                          'call')
 
-
-    config = botocore.config.Config(
-        user_agent_extra='Ansible/{0}'.format(__version__),
-    )
+    if params.get('config'):
+        config = params.pop('config')
+        config.user_agent_extra='Ansible/{0}'.format(__version__),
+    else:
+        config = botocore.config.Config(
+            user_agent_extra='Ansible/{0}'.format(__version__),
+        )
     session = boto3.session.Session(
         profile_name=profile,
     )

--- a/test/runner/lib/target.py
+++ b/test/runner/lib/target.py
@@ -319,7 +319,9 @@ def walk_test_targets(path=None, module_path=None, extensions=None, prefix=None,
             file_path = os.path.join(root, file_name)
 
             if os.path.islink(file_path):
-                continue
+                # special case to allow a symlink of ansible_release.py -> ../release.py
+                if file_path != 'lib/ansible/module_utils/ansible_release.py':
+                    continue
 
             yield TestTarget(file_path, module_path, prefix, path)
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Most AWS tools (AWS CLI, botocore, etc) usually add version information to user-agent strings to distinguish their calls and include attribution in audit systems like CloudTrail. This PR adds `Ansible/2.6.0`* as an additional value in the user agent string. 

This change also creates a symlink between the existing `lib/ansible/release.py` and `lib/ansible/module_utils/release.py` to allow modules to discover the ansible version when ansible isn't installed on the target host. An alternative to doing this would be to add the Ansible version to the module args dictionary in `lib/executor` but that seemed much more invasive. 

* the `__version__` from lib/ansible/release.py is the source of the version number. 

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0 (boto3-user-agent-magic d51edbf84a) last updated 2018/05/09 16:19:49 (GMT -700)
  config file = /home/ryansb/code/summit-2018-demo/ansible.cfg
  configured module search path = [u'/home/ryansb/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/ryansb/code/ansible/lib/ansible
  executable location = /home/ryansb/.pyenv/versions/summit-ansible/bin/ansible
  python version = 2.7.14 (default, Mar  8 2018, 16:16:54) [GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

In addition to the boto3, botocore, Python, and OS versions, Ansible is now included as well. 
```
  "userAgent": "Boto3/1.7.14 Python/2.7.14 Linux/4.16.6-202.fc27.x86_64 Botocore/1.10.14 Ansible/2.6.0",     
```

Full cloudtrail log with this change:
```
$ aws cloudtrail lookup-events --max-items 10 --query 'Events[].CloudTrailEvent' | grep -i ansible
{                                      
  "eventVersion": "1.05",              
  "eventID": "fef827b5-7f55-4250-9fd3-623f225c095e", 
  "eventTime": "2018-05-11T04:06:41Z",                                         
  "requestParameters": {                                                       
    "instancesSet": {                  
      "items": [                                                               
        {                              
          "instanceId": "i-078cd829ed62da0a2"
        }                              
      ]                                                                        
    }                                                                                                                                                         
  },                                   
  "eventType": "AwsApiCall",           
  "responseElements": {                
    "instancesSet": {                  
      "items": [
        {
          "instanceId": "i-078cd829ed62da0a2", 
          "currentState": {
            "code": 32, 
            "name": "shutting-down"
          }
        }
      ]
    }
  }, 
  "awsRegion": "us-east-2",            
  "eventName": "TerminateInstances",   
  "userIdentity": {                    
    "userName": "ryansb",              
    "principalId": "AIDAIYSN33VO5EOC4REPC",                                    
    "accessKeyId": "REDACTED",                                     
    "type": "IAMUser",                 
    "arn": "arn:aws:iam::01234:user/ryansb",                            
    "accountId": "01234"        
  },                                   
  "eventSource": "ec2.amazonaws.com",  
  "requestID": "5766df62-78db-4a69-a5ba-ee49787c6c98",                         
  "userAgent": "Boto3/1.7.14 Python/2.7.14 Linux/4.16.6-202.fc27.x86_64 Botocore/1.10.14 Ansible/2.6.0",                                                      
  "sourceIPAddress": "172.58.91.218",  
  "recipientAccountId": "01234" 
}
```
