### PR TITLE
[WIP] cloudstack: add pagination support

### DIFF
--- a/lib/ansible/module_utils/cloudstack.py
+++ b/lib/ansible/module_utils/cloudstack.py
@@ -218,7 +218,10 @@ class AnsibleCloudStack:
 
     def query_api(self, command, **args):
         try:
-            res = getattr(self.cs, command)(**args)
+            if command.startswith('list') and 'fetch_list' not in args:
+                res = getattr(self.cs, command)(**args, fetch_list=True)
+            else:
+                res = getattr(self.cs, command)(**args)
 
             if 'errortext' in res:
                 self.fail_json(msg="Failed: '%s'" % res['errortext'])


### PR DESCRIPTION
##### SUMMARY
currently we do not support use pagination and as a consequence we only support 500 items returned from the api. This implements pagination for list commands.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
cloudstack

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
