### PR TITLE
Added botmeta for _letsencrypt symlink

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -680,6 +680,7 @@ files:
   $modules/utilities/logic/pause.py: tbielawa
   $modules/utilities/logic/set_stats.py: bcoca
   $modules/utilities/logic/wait_for.py: AnderEnder gregswift jarv jhoekx
+  $modules/web_infrastructure/_letsencrypt.py: mgruener resmo felixfontein
   $modules/web_infrastructure/acme_certificate.py: mgruener resmo felixfontein
   $modules/web_infrastructure/ansible_tower/: $team_tower
   $modules/web_infrastructure/apache2_mod_proxy.py: oboukili


### PR DESCRIPTION
##### SUMMARY
See discussion in #39997. Without this, the active maintainers aren't informed about new tickets.

##### ISSUE TYPE
Bugfix Pull Request

##### COMPONENT NAME
botmeta

##### ANSIBLE VERSION
```
2.5.0
```

##### ADDITIONAL INFORMATION
@mkrizek I've added the new entry directly below the `acme_certificate.py` entry to emphasize that they belong together; if you prefer alphabetical order I can change that.