### PR TITLE
Backport/2.5/37847Fix interfaces_file to accept allow-* (#37847

### DIFF
--- a/changelogs/fragments/interfaces_file-allow.yaml
+++ b/changelogs/fragments/interfaces_file-allow.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- Fix interfaces_file to support `allow-` https://github.com/ansible/ansible/pull/37847

--- a/lib/ansible/modules/system/interfaces_file.py
+++ b/lib/ansible/modules/system/interfaces_file.py
@@ -225,7 +225,7 @@ def read_interfaces_lines(module, line_strings):
         elif words[0] == "auto":
             lines.append(lineDict(line))
             currently_processing = "NONE"
-        elif words[0] == "allow-":
+        elif words[0].startswith("allow-"):
             lines.append(lineDict(line))
             currently_processing = "NONE"
         elif words[0] == "no-auto-down":


### PR DESCRIPTION
##### SUMMARY
Fix interfaces_file to accept allow-* (#37847)  …
(cherry picked from commit 5ac41ee)


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
interfaces_file

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
