### PR TITLE
Make Cloudstack paging work for listVirtualMachines

### DIFF
--- a/contrib/inventory/cloudstack.py
+++ b/contrib/inventory/cloudstack.py
@@ -147,11 +147,11 @@ class CloudStackInventory(object):
         sys.exit(1)
 
     def get_host(self, name, project_id=None, domain_id=None, **kwargs):
-        hosts = self.cs.listVirtualMachines(projectid=project_id, domainid=domain_id, **kwargs)
+        hosts = self.cs.listVirtualMachines(projectid=project_id, domainid=domain_id, fetch_list=True, **kwargs)
         data = {}
         if not hosts:
             return data
-        for host in hosts['virtualmachine']:
+        for host in hosts:
             host_name = host['displayname']
             if name == host_name:
                 data['zone'] = host['zonename']
@@ -202,10 +202,10 @@ class CloudStackInventory(object):
                         'hosts': []
                     }
 
-        hosts = self.cs.listVirtualMachines(projectid=project_id, domainid=domain_id, **kwargs)
+        hosts = self.cs.listVirtualMachines(projectid=project_id, domainid=domain_id, fetch_list=True, **kwargs)
         if not hosts:
             return data
-        for host in hosts['virtualmachine']:
+        for host in hosts:
             host_name = host['displayname']
             data['all']['hosts'].append(host_name)
             data['_meta']['hostvars'][host_name] = {}


### PR DESCRIPTION
Cloudstack paging wasn't supported, so once a cs domain has over 500 (default page size) VMs, Ansible can no longer find newly created VM.

##### SUMMARY
Cloudstack paging wasn't supported, so once a cs domain has over 500 (default page size) VMs, Ansible can no longer find newly created VM.

Paging is supported in the cs module, the cs module abstracts away the pages, and returns a list of the VMs. The normal cloudstack response contains a "count" variable (the count of virtualmachines in the domain), and a list of the virtualmachines, when paging, the cs module just returns a list of virtualmachines, so some small changes needed to be made to remove the reference to the "virtualmachine" key.

##### ISSUE TYPE
 - Bugfix Pull Request


##### COMPONENT NAME
cloudstack

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
[root@173d518834c1 playbook]# ansible --version
ansible 2.6.0
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Apr 11 2018, 07:36:10) [GCC 4.8.5 20150623 (Red Hat 4.8.5-28)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before this change, once 500 VMs exists in the domain, the following error is seen.
```
fatal: [server38]: FAILED! => {"api_http_method": "get", "api_key": "******", "api_region": "cloudstack", "api_timeout": "30", "api_url": "http://172.17.0.2:8080/client/api", "changed": false, "msg": "Virtual machine 'server38' not found", "zone": "Sandbox-simulator"}
```
