### PR TITLE
"route" has to be the first option in ufw command (#31756)

### DIFF
--- a/changelogs/fragments/ufw-route-first-option.yaml
+++ b/changelogs/fragments/ufw-route-first-option.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- Fix ufw module, "route" has to be the first option in ufw command https://github.com/ansible/ansible/pull/31756

--- a/lib/ansible/modules/system/ufw.py
+++ b/lib/ansible/modules/system/ufw.py
@@ -314,11 +314,11 @@ def main():
         elif command == 'rule':
             # Rules are constructed according to the long format
             #
-            # ufw [--dry-run] [delete] [insert NUM] [route] allow|deny|reject|limit [in|out on INTERFACE] [log|log-all] \
+            # ufw [--dry-run] [route] [delete] [insert NUM] allow|deny|reject|limit [in|out on INTERFACE] [log|log-all] \
             #     [from ADDRESS [port PORT]] [to ADDRESS [port PORT]] \
             #     [proto protocol] [app application] [comment COMMENT]
-            cmd.append([module.boolean(params['delete']), 'delete'])
             cmd.append([module.boolean(params['route']), 'route'])
+            cmd.append([module.boolean(params['delete']), 'delete'])
             cmd.append([params['insert'], "insert %s" % params['insert']])
             cmd.append([value])
             cmd.append([params['direction'], "%s" % params['direction']])


### PR DESCRIPTION
##### SUMMARY
For supporting deletion of ufw routes, route option has to be placed before delete option
(cherry picked from commit 21004d86f9486684005672a19e90a3bd13b8ad5a)

<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - New Module Pull Request
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
