### PR TITLE
add SVI example for Cisco IOS/IOS-XE platform

### DIFF
--- a/lib/ansible/modules/network/ios/ios_l3_interface.py
+++ b/lib/ansible/modules/network/ios/ios_l3_interface.py
@@ -72,6 +72,11 @@ EXAMPLES = """
     ipv4: dhcp
     ipv6: dhcp
 
+- name: Set interface Vlan1 (SVI) IPv4 address
+  ios_l3_interface:
+    name: Vlan1
+    ipv4: 192.168.0.5/24
+
 - name: Set IP addresses on aggregate
   ios_l3_interface:
     aggregate:


### PR DESCRIPTION
##### SUMMARY
on networktocode slack there was a user that wanted an example of how to add a switch vlan interface.  This will work and was tested on a 3850 cisco ios switch.  Read more about [SVI here](https://en.wikipedia.org/wiki/Switch_virtual_interface)

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
ios_l3_interface

##### ANSIBLE VERSION
```
ansible 2.6.0
  config file = /Users/sean/.ansible.cfg
  configured module search path = [u'/Users/sean/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Library/Python/2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.10 (default, Oct  6 2017, 22:29:07) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.31)]
```


##### ADDITIONAL INFORMATION
N/A, just simple example for doc page
