### PR TITLE
firewalld: amend docs for python3 only hosts

### DIFF
--- a/lib/ansible/modules/system/firewalld.py
+++ b/lib/ansible/modules/system/firewalld.py
@@ -74,7 +74,9 @@ options:
     version_added: "2.1"
 notes:
   - Not tested on any Debian based system.
-  - Requires the python2 bindings of firewalld, which may not be installed by default if the distribution switched to python 3
+  - Requires the python2 bindings of firewalld, which may not be installed by default.
+  - For distributions where the python2 firewalld bindings are unavailable (e.g Fedora 28 and later) you will have to set the
+    ansible_python_interpreter for these hosts to the python3 interpreter path and install the python3 bindings.
   - Zone transactions (creating, deleting) can be performed by using only the zone and state parameters "present" or "absent".
     Note that zone transactions must explicitly be permanent. This is a limitation in firewalld.
     This also means that you will have to reload firewalld after adding a zone that you wish to perform immediate actions on.


### PR DESCRIPTION
Signed-off-by: Felix Kaechele <felix@kaechele.ca>

##### SUMMARY
Amend the docs for the firewalld module, as Fedora 28 removed the python2 bindings for firewalld.

See https://bugzilla.redhat.com/show_bug.cgi?id=1575428

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
firewalld

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.2
  config file = /home/felix/.ansible.cfg
  configured module search path = [u'/home/felix/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.15 (default, May  2 2018, 14:12:52) [GCC 8.0.1 20180324 (Red Hat 8.0.1-0.20)]

```
