### PR TITLE
Fixes #38787: azure_rm_resourcegroup idempotency broke when specifying location

### DIFF
--- a/lib/ansible/module_utils/azure_rm_common.py
+++ b/lib/ansible/module_utils/azure_rm_common.py
@@ -176,6 +176,11 @@ def format_resource_id(val, subscription_id, namespace, types, resource_group):
                        type=types,
                        subscription=subscription_id) if not is_valid_resource_id(val) else val
 
+
+def normalize_location_name(name):
+    return name.replace(' ', '').lower()
+
+
 # FUTURE: either get this from the requirements file (if we can be sure it's always available at runtime)
 # or generate the requirements files from this so we only have one source of truth to maintain...
 AZURE_PKG_VERSIONS = {

--- a/lib/ansible/modules/cloud/azure/azure_rm_resourcegroup.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_resourcegroup.py
@@ -96,7 +96,7 @@ try:
 except ImportError:
     pass
 
-from ansible.module_utils.azure_rm_common import AzureRMModuleBase
+from ansible.module_utils.azure_rm_common import AzureRMModuleBase, normalize_location_name
 
 
 def resource_group_to_dict(rg):
@@ -162,7 +162,7 @@ class AzureRMResourceGroup(AzureRMModuleBase):
                 if update_tags:
                     changed = True
 
-                if self.location and self.location != results['location']:
+                if self.location and normalize_location_name(self.location) != results['location']:
                     self.fail("Resource group '{0}' already exists in location '{1}' and cannot be "
                               "moved.".format(self.name, results['location']))
         except CloudError:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
User can set location as the display name, but it will break the idempotent,

Fixes #38787

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
azure_rm-resourcegroup.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5.2
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
