### PR TITLE
accept + and - modifiers for file attributes

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1355,10 +1355,16 @@ class AnsibleModule(object):
 
         existing = self.get_file_attributes(b_path)
 
-        if existing.get('attr_flags', '') != attributes:
+        if attributes.startswith(('-', '+')):
+            attr_mod = attributes[0]
+            attributes = attributes[1:]
+        else:
+            attr_mod = '='
+
+        if existing.get('attr_flags', '') != attributes or attr_mod == '-':
             attrcmd = self.get_bin_path('chattr')
             if attrcmd:
-                attrcmd = [attrcmd, '=%s' % attributes, b_path]
+                attrcmd = [attrcmd, '%s%s' % (attr_mod, attributes), b_path]
                 changed = True
 
                 if diff is not None:

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1355,10 +1355,11 @@ class AnsibleModule(object):
 
         existing = self.get_file_attributes(b_path)
 
-        attr_mod = '='
         if attributes.startswith(('-', '+')):
             attr_mod = attributes[0]
             attributes = attributes[1:]
+        else:
+            attr_mod = '='
 
         if existing.get('attr_flags', '') != attributes or attr_mod == '-':
             attrcmd = self.get_bin_path('chattr')

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1355,11 +1355,10 @@ class AnsibleModule(object):
 
         existing = self.get_file_attributes(b_path)
 
+        attr_mod = '='
         if attributes.startswith(('-', '+')):
             attr_mod = attributes[0]
             attributes = attributes[1:]
-        else:
-            attr_mod = '='
 
         if existing.get('attr_flags', '') != attributes or attr_mod == '-':
             attrcmd = self.get_bin_path('chattr')

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1372,7 +1372,7 @@ class AnsibleModule(object):
                     diff['before']['attributes'] = existing.get('attr_flags')
                     if 'after' not in diff:
                         diff['after'] = {}
-                    diff['after']['attributes'] = attributes
+                    diff['after']['attributes'] = '%s%s' % (attr_mod, attributes)
 
                 if not self.check_mode:
                     try:

--- a/test/integration/targets/file/tasks/main.yml
+++ b/test/integration/targets/file/tasks/main.yml
@@ -114,7 +114,6 @@
       - "file_attributes_result_4 is not changed"
   when: file_attributes_result_4 is changed
 
-
 - name: change ownership and group
   file: path={{output_dir}}/baz.txt owner=1234 group=1234
 

--- a/test/integration/targets/file/tasks/main.yml
+++ b/test/integration/targets/file/tasks/main.yml
@@ -82,13 +82,13 @@
       - "file4_result.changed == true"
       - "file4_result.mode == '0600'"
 
-- name: change file attribute "A"
+- name: explicitly set file attribute "A"
   file: path={{output_dir}}/baz.txt attributes=A
   register: file_attributes_result
   ignore_errors: True
 
-- name: reapply file attribute "A"
-  file: path={{output_dir}}/baz.txt attributes=A
+- name: add file attribute "A"
+  file: path={{output_dir}}/baz.txt attributes=+A
   register: file_attributes_result_2
   when: file_attributes_result is changed
 
@@ -97,6 +97,23 @@
     that:
       - "file_attributes_result_2 is not changed"
   when: file_attributes_result is changed
+
+- name: remove file attribute "A"
+  file: path={{output_dir}}/baz.txt attributes=-A
+  register: file_attributes_result_3
+  ignore_errors: True
+
+- name: explicitly remove file attributes
+  file: path={{output_dir}}/baz.txt attributes=""
+  register: file_attributes_result_4
+  when: file_attributes_result3 is changed
+
+- name: verify that the file was not marked as changed
+  assert:
+    that:
+      - "file_attributes_result_4 is not changed"
+  when: file_attributes_result_4 is changed
+
 
 - name: change ownership and group
   file: path={{output_dir}}/baz.txt owner=1234 group=1234

--- a/test/integration/targets/file/tasks/main.yml
+++ b/test/integration/targets/file/tasks/main.yml
@@ -106,7 +106,7 @@
 - name: explicitly remove file attributes
   file: path={{output_dir}}/baz.txt attributes=""
   register: file_attributes_result_4
-  when: file_attributes_result3 is changed
+  when: file_attributes_result_3 is changed
 
 - name: verify that the file was not marked as changed
   assert:

--- a/test/integration/targets/file/tasks/main.yml
+++ b/test/integration/targets/file/tasks/main.yml
@@ -106,7 +106,7 @@
 - name: explicitly remove file attributes
   file: path={{output_dir}}/baz.txt attributes=""
   register: file_attributes_result_4
-  when: file_attributes_result_3 is changed
+  when: file_attributes_result3 is changed
 
 - name: verify that the file was not marked as changed
   assert:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #33838, allow chattr modifiers (+ and -) for file attributes
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
basic.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.2
  config file = /home/acalm/.ansible.cfg
  configured module search path = ['/home/acalm/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib64/python3.6/site-packages/ansible
  executable location = /usr/lib/python-exec/python3.6/ansible
  python version = 3.6.5 (default, Apr 24 2018, 21:20:09) [GCC 6.4.0]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->
Currently setting attributes with the file module results in the exact specified attributes, this pr adds options to add or remove specific file attributes by prefixing attributes with either + or -, using none of these prefixes will replace any attributes with the specified attributes, just like before.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
