### PR TITLE
jenkins_job_facts: Add validate_certs argument

### DIFF
--- a/lib/ansible/modules/web_infrastructure/jenkins_job_facts.py
+++ b/lib/ansible/modules/web_infrastructure/jenkins_job_facts.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 #
 # Copyright: (c) Ansible Project
+#
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import (absolute_import, division, print_function)
@@ -18,40 +19,41 @@ module: jenkins_job_facts
 short_description: Get facts about Jenkins jobs
 version_added: "2.5"
 description:
-  - "Query facts about which Jenkins jobs exist"
+  - This module can be used to query the facts about which Jenkins jobs which already exists.
 requirements:
   - "python-jenkins >= 0.4.12"
 options:
   name:
     description:
       - Exact name of the Jenkins job to fetch facts about.
-    required: false
   glob:
     description:
       - A shell glob of Jenkins job names to fetch facts about.
-    required: false
   color:
     description:
       - Only fetch jobs with the given status color.
-    required: false
   password:
     description:
       - Password to authenticate with the Jenkins server.
-    required: false
+      - This is a required parameter, if C(token) is not provided.
   token:
     description:
-      - API token used to authenticate alternatively to C(password).
-    required: false
+      - API token used to authenticate with the Jenkins server.
+      - This is a required parameter, if C(password) is not provided.
   url:
     description:
-      - Url where the Jenkins server is accessible.
-    required: false
+      - URL where the Jenkins server is accessible.
     default: http://localhost:8080
   user:
     description:
        - User to authenticate with the Jenkins server.
-    required: false
-
+  validate_certs:
+    description:
+       - If set to C(False), the SSL certificates will not be validated.
+       - This should only set to C(False) used on personally controlled sites using self-signed certificates.
+    default: true
+    type: bool
+    version_added: "2.6"
 author:
   - "Chris St. Pierre (@stpierre)"
 '''
@@ -104,6 +106,14 @@ EXAMPLES = '''
     user: admin
     password: hunter2
   register: my_jenkins_job_facts
+
+- name: Get the facts from custom URL with token and validate_certs=False
+  jenkins_job_facts:
+    user: admin
+    token: 126df5c60d66c66e3b75b11104a16a8a
+    url: https://jenkins.example.com
+    validate_certs: False
+  register: my_jenkins_job_facts
 '''
 
 RETURN = '''
@@ -112,17 +122,26 @@ jobs:
   description: All jobs found matching the specified criteria
   returned: success
   type: list
-  sample: [{"name": "test-job", "fullname": "test-folder/test-job", "url": "http://localhost:8080/job/test-job/", "color": "blue"}, ...]
+  sample:
+    [
+        {
+            "name": "test-job",
+            "fullname": "test-folder/test-job",
+            "url": "http://localhost:8080/job/test-job/",
+            "color": "blue"
+        },
+    ]
 '''
 
+import ssl
 import fnmatch
 import traceback
 
 try:
     import jenkins
-    python_jenkins_installed = True
+    HAS_JENKINS = True
 except ImportError:
-    python_jenkins_installed = False
+    HAS_JENKINS = False
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
@@ -133,6 +152,14 @@ def get_jenkins_connection(module):
     username = module.params.get("user")
     password = module.params.get("password")
     token = module.params.get("token")
+
+    validate_certs = module.params.get('validate_certs')
+    if not validate_certs and hasattr(ssl, 'SSLContext'):
+        ssl._create_default_https_context = ssl._create_unverified_context
+    if validate_certs and not hasattr(ssl, 'SSLContext'):
+        module.fail_json(msg="Module does not support changing verification mode with python < 2.7.9."
+                             " Either update Python or use validate_certs=false.")
+
     if username and (password or token):
         return jenkins.Jenkins(url, username, password or token)
     elif username:
@@ -142,7 +169,7 @@ def get_jenkins_connection(module):
 
 
 def test_dependencies(module):
-    if not python_jenkins_installed:
+    if not HAS_JENKINS:
         module.fail_json(
             msg="python-jenkins required for this module. "
             "see http://python-jenkins.readthedocs.io/en/latest/install.html")
@@ -189,20 +216,27 @@ def get_jobs(module):
 def main():
     module = AnsibleModule(
         argument_spec=dict(
-            name=dict(type='str', required=False),
-            glob=dict(type='str', required=False),
-            color=dict(type='str', required=False),
-            password=dict(required=False, no_log=True),
-            token=dict(required=False, no_log=True),
-            url=dict(required=False, default="http://localhost:8080"),
-            user=dict(required=False)),
+            name=dict(),
+            glob=dict(),
+            color=dict(),
+            password=dict(no_log=True),
+            token=dict(no_log=True),
+            url=dict(default="http://localhost:8080"),
+            user=dict(),
+            validate_certs=dict(type='bool', default=True),
+        ),
         mutually_exclusive=[
             ['password', 'token'],
             ['name', 'glob'],
         ],
-        supports_check_mode=True)
+        required_one_of=[
+            ['password', 'token'],
+        ],
+        supports_check_mode=True,
+    )
 
     test_dependencies(module)
+    jobs = list()
 
     try:
         jobs = get_jobs(module)


### PR DESCRIPTION
##### SUMMARY
This fix adds validate_certs argument in jenkins_job_facts module.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Feature Pull Request
 - Docs Pull Request

##### COMPONENT NAME
lib/ansible/modules/web_infrastructure/jenkins_job_facts.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6devel
```