### PR TITLE
ios cliconf plugin fix regex for version

### DIFF
--- a/lib/ansible/plugins/cliconf/ios.py
+++ b/lib/ansible/plugins/cliconf/ios.py
@@ -38,9 +38,9 @@ class Cliconf(CliconfBase):
         reply = self.get('show version')
         data = to_text(reply, errors='surrogate_or_strict').strip()
 
-        match = re.search(r'Version (\S+),', data)
+        match = re.search(r'Version (\S+)', data)
         if match:
-            device_info['network_os_version'] = match.group(1)
+            device_info['network_os_version'] = match.group(1).strip(',')
 
         match = re.search(r'^Cisco (.+) \(revision', data, re.M)
         if match:


### PR DESCRIPTION
Signed-off-by: Trishna Guha <trishnaguha17@gmail.com>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
fixes https://github.com/ansible/ansible/issues/39616
fixes https://github.com/ansible/ansible/pull/39621#issuecomment-388119942

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
plugins/cliconf/ios.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel, 2.5
```