### PR TITLE
added example when replace using a backreference containing numeric v…

### DIFF
--- a/lib/ansible/modules/files/replace.py
+++ b/lib/ansible/modules/files/replace.py
@@ -142,7 +142,7 @@ EXAMPLES = r"""
     dest: /etc/hosts
     regexp: '\b(localhost)(\d*)\b'
     replace: '\1\2.localdomain\2 \1\2'
-    
+
 # replace using a backreference containing numeric value
 # in this situation the replace backreference must be defined as `/g<number>`
   vars:

--- a/lib/ansible/modules/files/replace.py
+++ b/lib/ansible/modules/files/replace.py
@@ -142,6 +142,22 @@ EXAMPLES = r"""
     dest: /etc/hosts
     regexp: '\b(localhost)(\d*)\b'
     replace: '\1\2.localdomain\2 \1\2'
+    
+# replace using a backreference containing numeric value
+# in this situation the replace backreference must be defined as `/g<number>`
+  vars:
+    parameters:
+      - name: text_value
+        value: some-text
+      - name: int_value
+        value: "3306"
+
+  tasks:
+    - replace:
+        path: /var/tmp/test.txt
+        regexp: '(\s+{{ item.name }}\:\s)(.*)'
+        replace:  '\g<1>{{ item.value }}'
+      with_items: '{{ parameters }}'
 """
 
 import os


### PR DESCRIPTION
+label: docsite_pr

##### SUMMARY
added docs on how to do when using replace with a backreference containing numeric value

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
replace module

##### ANSIBLE VERSION
```
ansible 2.4.2.0
  config file = /Users/prune/Documents/dev/coyote/lab/ansible/ansible.cfg
  configured module search path = [u'/Users/prune/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/prune/Documents/dev/python/lib/python2.7/site-packages/ansible
  executable location = /Users/prune/Documents/dev/python/bin/ansible
  python version = 2.7.13 (default, Apr  4 2017, 08:47:57) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.38)]
```
