### PR TITLE
Add pluck filter

### DIFF
--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -472,6 +472,7 @@ def flatten(mylist, levels=None):
 
     return ret
 
+
 def pluck(data, keypath):
     ''' takes a dictionary or list and collects the values of the
         properties defined in the 'keypath', ignoring null values '''
@@ -491,6 +492,7 @@ def pluck(data, keypath):
         else:
             # when we reach the last key, exit the recursion
             yield data
+
 
 def dict_to_list_of_dict_key_value_elements(mydict):
     ''' takes a dictionary and transforms it into a list of dictionaries,

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -472,6 +472,25 @@ def flatten(mylist, levels=None):
 
     return ret
 
+def pluck(data, keypath):
+    ''' takes a dictionary or list and collects the values of the
+        properties defined in the 'keypath', ignoring null values '''
+
+    if isinstance(data, list):
+        # when one of the items is a list, simply pluck the items in it
+        for item in data:
+            for result in pluck(item, keypath):
+                yield result
+    elif data:
+        # take the first key of the keypath and pass the rest down the recursion
+        keys = keypath if isinstance(keypath, list) else keypath.split('.')
+        if len(keys) > 0:
+            subdata = data.get(keys[0]) if isinstance(data, dict) else getattr(data, keys[0])
+            for result in pluck(subdata, keys[1:]):
+                yield result
+        else:
+            # when we reach the last key, exit the recursion
+            yield data
 
 def dict_to_list_of_dict_key_value_elements(mydict):
     ''' takes a dictionary and transforms it into a list of dictionaries,
@@ -573,5 +592,6 @@ class FilterModule(object):
             'combine': combine,
             'extract': extract,
             'flatten': flatten,
+            'pluck': pluck,
             'dict2items': dict_to_list_of_dict_key_value_elements,
         }


### PR DESCRIPTION
##### SUMMARY
Add pluck filter to simplify extracting information from a JSON structure. This filter is a bit easier to use and more concise than the `map` filter. It also replaces a few situations where you would have to use the `json_query` filter (that requires the `jmespath` python library).

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
filter_plugin

##### ANSIBLE VERSION
```
ansible 2.5.1
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/devops/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```

##### ADDITIONAL INFORMATION
Example YAML structure:
```
sites:
  - name: default
    template: default

  - name: development
    template: dev
    upstream: 10.0.0.100
    domains:
      - { host: dev.mydomain.com }

  - name: production
    template: prod
    upstream: 10.0.1.100
    domains:
      - { host: prod.mydomain1.com, cert: mydomain1.com }
      - { host: prod.mydomain2.com, cert: mydomain2.com }
      - { host: prod.mydomain3.com, cert: mydomain3.com }

```

Let's say we've loaded the YAML above into a variable called `config` and we want to extract some information:
```
- set_fact:
     templates: "{{config|pluck('sites.template')|list}}"
     certs: "{{config|pluck('sites.domains.cert')|list}}"
     hosts: "{{config|pluck('sites.domains.host')|list}}"

# Results:
# templates = ["default", "dev", "prod"]
# certs = ["mydomain1.com", "mydomain2.com", "mydomain3.com"]
# hosts = ["dev.mydomain.com", "prod.mydomain1.com", "prod.mydomain2.com", "prod.mydomain3.com"]
```

With the `map` filter this would be a lot more complicated, because it would break when one of the entries doesn't have a `domains` property.

You can use the pluck filter in many scenarios. For example, extracting the file paths of the `find` module:
```
- find:
     paths: files/config
     file_type: directory
     register: result

- debug: msg={{result|pluck('files.path')|list}}
```

You can also provide an array for the `keypath` argument:

```
- debug: msg={{result|pluck(['files','path'])|list}}
```