### PR TITLE
docs: Suggest get_url or uri for file checksum validation

### DIFF
--- a/lib/ansible/modules/files/unarchive.py
+++ b/lib/ansible/modules/files/unarchive.py
@@ -26,6 +26,7 @@ description:
      - By default, it will copy the source file from the local system to the target before unpacking.
      - Set C(remote_src=yes) to unpack an archive which already exists on the target.
      - For Windows targets, use the M(win_unzip) module instead.
+     - If checksum validation is desired, use M(get_url) or M(uri) instead to fetch the file and set C(remote_src=yes).
 options:
   src:
     description:


### PR DESCRIPTION
##### SUMMARY
Updating `unarchive` documentation suggestion using `get_url` or `uri` if checksum validation is required. 

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
unarchive

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0 (docs/unarchive_module 6ace8d2cf5) last updated 2018/05/14 10:53:05 (GMT -500)
  config file = None
  configured module search path = ['/home/saviles/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/saviles/data/git/github/ansible/lib/ansible
  executable location = /home/saviles/data/git/github/ansible/bin/ansible
  python version = 3.6.5 (default, Mar 29 2018, 18:20:46) [GCC 8.0.1 20180317 (Red Hat 8.0.1-0.19)]

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->
The maintainer of `unarchive` suggested the documentation fix but not no one has done it.
