### PR TITLE
empty lines in csvfile means row has no items in list; check row len …

### DIFF
--- a/lib/ansible/plugins/lookup/csvfile.py
+++ b/lib/ansible/plugins/lookup/csvfile.py
@@ -106,7 +106,7 @@ class LookupModule(LookupBase):
             creader = CSVReader(f, delimiter=to_native(delimiter), encoding=encoding)
 
             for row in creader:
-                if row[0] == key:
+                if len(row) and row[0] == key:
                     return row[int(col)]
         except Exception as e:
             raise AnsibleError("csvfile: %s" % to_native(e))


### PR DESCRIPTION
…first.

##### SUMMARY
empty lines in csvfile means row has no items in list; check row len …

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lookup/csvfile.py

##### ANSIBLE VERSION
```
ansible 2.5.2
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/vigiroux/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /bin/ansible
  python version = 2.7.5 (default, Aug  4 2017, 00:39:18) [GCC 4.8.5 20150623 (Red Hat 4.8.5-16)]
```


##### ADDITIONAL INFORMATION
```
An empty/blank line in "mycsvfile.txt" causes an exception to be raise when trying to access row[0] when looking for the key (row[0] == key) since there is no 0'th element in row.

fatal: [myhost]: FAILED! => {"msg": "The conditional check 'lookup('csvfile', item+'  file=mycsvfile.txt col=0 delimiter=:')' failed. The error was: An unhandled exception occurred while running the lookup plugin 'csvfile'. Error was a <type 'exceptions.TypeError'>, original message: not all arguments converted during string formatting\n\nThe error appears to have been in '/ansible/playbooks/mypb.yml': line 116, column 7, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n    - name: lookup account name\n      ^ here\n"}

```
