### PR TITLE
mysql_user: Match both single quotes and backticks when checking curr…

### DIFF
--- a/changelogs/fragments/40092-mysql_user-match-backticks.yml
+++ b/changelogs/fragments/40092-mysql_user-match-backticks.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "mysql_user: match backticks, single and double quotes when checking user privileges."

--- a/lib/ansible/modules/database/mysql/mysql_user.py
+++ b/lib/ansible/modules/database/mysql/mysql_user.py
@@ -434,14 +434,14 @@ def privileges_get(cursor, user, host):
             return x
 
     for grant in grants:
-        res = re.match("GRANT (.+) ON (.+) TO '.*'@'.*'( IDENTIFIED BY PASSWORD '.+')? ?(.*)", grant[0])
+        res = re.match("""GRANT (.+) ON (.+) TO (['`"]).*\\3@(['`"]).*\\4( IDENTIFIED BY PASSWORD (['`"]).+\5)? ?(.*)""", grant[0])
         if res is None:
             raise InvalidPrivsError('unable to parse the MySQL grant string: %s' % grant[0])
         privileges = res.group(1).split(", ")
         privileges = [pick(x) for x in privileges]
-        if "WITH GRANT OPTION" in res.group(4):
+        if "WITH GRANT OPTION" in res.group(7):
             privileges.append('GRANT')
-        if "REQUIRE SSL" in res.group(4):
+        if "REQUIRE SSL" in res.group(7):
             privileges.append('REQUIRESSL')
         db = res.group(2)
         output[db] = privileges


### PR DESCRIPTION
…ent privileges

##### SUMMARY
Match both backticks and single quotes when checking current privileges in the mysql_user module, allowing the module to parse correctly the output generated by a MySQL 8.0.11 server.

Fixes #40091 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
mysql_user

##### ANSIBLE VERSION
```
ansible 2.5.1
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```