### PR TITLE
Improve error message if policy_document does not exist

### DIFF
--- a/lib/ansible/modules/cloud/amazon/iam_policy.py
+++ b/lib/ansible/modules/cloud/amazon/iam_policy.py
@@ -293,13 +293,21 @@ def main():
     policy_name = module.params.get('policy_name')
     skip = module.params.get('skip_duplicates')
 
-    if module.params.get('policy_document') is not None and module.params.get('policy_json') is not None:
+    policy_document = module.params.get('policy_document')
+    if policy_document is not None and module.params.get('policy_json') is not None:
         module.fail_json(msg='Only one of "policy_document" or "policy_json" may be set')
 
-    if module.params.get('policy_document') is not None:
-        with open(module.params.get('policy_document'), 'r') as json_data:
-            pdoc = json.dumps(json.load(json_data))
-            json_data.close()
+    if policy_document is not None:
+        try:
+            with open(policy_document, 'r') as json_data:
+                pdoc = json.dumps(json.load(json_data))
+                json_data.close()
+        except IOError:
+            if e.errno == 2:
+                module.fail_json(
+                    msg='policy_document {0:!r} does not exist'.format(policy_document))
+            else:
+                raise
     elif module.params.get('policy_json') is not None:
         pdoc = module.params.get('policy_json')
         # if its a string, assume it is already JSON


### PR DESCRIPTION
##### SUMMARY
Improve error message if policy_document does not exist

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
iam_policy

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
$ ansible --version
ansible 2.5.2
  config file = $HOME/src/ansible/ansible.cfg
  configured module search path = ['$HOME/gerrit/sre/ansible/library', '/usr/share/ansible']
  ansible python module location = $HOME/virtualenvs/ansible2/lib/python3.6/site-packages/ansible
  executable location = $HOME/virtualenvs/ansible2/bin/ansible
  python version = 3.6.3 (default, Oct  6 2017, 12:05:24) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]
```