### PR TITLE
Compare storage_class when comparing s3 lifecycle rules

### DIFF
--- a/lib/ansible/modules/cloud/amazon/s3_lifecycle.py
+++ b/lib/ansible/modules/cloud/amazon/s3_lifecycle.py
@@ -280,10 +280,23 @@ def compare_rule(rule_a, rule_b):
         rule1_expiration = Expiration()
     if rule2_expiration is None:
         rule2_expiration = Expiration()
+    rule1_storage_class = None
+    rule2_storage_class = None
+    try:
+        rule1_storage_class = rule1_transition.storage_class
+    except AttributeError:
+        pass
+
+    try:
+        rule2_storage_class = rule2_transition.storage_class
+    except AttributeError:
+        pass
 
     if (rule1.__dict__ == rule2.__dict__ and
-            rule1_expiration.__dict__ == rule2_expiration.__dict__ and
-            rule1_transition.__dict__ == rule2_transition.__dict__):
+                rule1_expiration.__dict__ == rule2_expiration.__dict__ and
+                rule1_transition.__dict__ == rule2_transition.__dict__ and
+                rule1_storage_class == rule2_storage_class):
+
         return True
     else:
         return False

--- a/lib/ansible/modules/cloud/amazon/s3_lifecycle.py
+++ b/lib/ansible/modules/cloud/amazon/s3_lifecycle.py
@@ -144,6 +144,7 @@ try:
     from boto.s3.connection import OrdinaryCallingFormat, Location
     from boto.s3.lifecycle import Lifecycle, Rule, Expiration, Transition
     from boto.exception import BotoServerError, S3ResponseError
+
     HAS_BOTO = True
 except ImportError:
     HAS_BOTO = False
@@ -293,9 +294,9 @@ def compare_rule(rule_a, rule_b):
         pass
 
     if (rule1.__dict__ == rule2.__dict__ and
-                rule1_expiration.__dict__ == rule2_expiration.__dict__ and
-                rule1_transition.__dict__ == rule2_transition.__dict__ and
-                rule1_storage_class == rule2_storage_class):
+            rule1_expiration.__dict__ == rule2_expiration.__dict__ and
+            rule1_transition.__dict__ == rule2_transition.__dict__ and
+            rule1_storage_class == rule2_storage_class):
 
         return True
     else:

--- a/test/integration/targets/s3_lifecycle/aliases
+++ b/test/integration/targets/s3_lifecycle/aliases
@@ -1,0 +1,2 @@
+cloud/aws
+posix/ci/cloud/group4/aws

--- a/test/integration/targets/s3_lifecycle/tasks/main.yml
+++ b/test/integration/targets/s3_lifecycle/tasks/main.yml
@@ -1,0 +1,210 @@
+---
+
+- block:
+
+    # ============================================================
+    - name: set connection information for all tasks
+      set_fact:
+        aws_connection_info: &aws_connection_info
+          aws_access_key: "{{ aws_access_key }}"
+          aws_secret_key: "{{ aws_secret_key }}"
+          security_token: "{{ security_token }}"
+          region: "{{ aws_region }}"
+      no_log: true
+
+    # ============================================================
+    - name: Create simple s3_bucket
+      s3_bucket:
+        name: "{{ resource_prefix }}-testbucket-ansible"
+        state: present
+        <<: *aws_connection_info
+      register: output
+
+    - assert:
+        that:
+          - output.changed
+          - output.name == '{{ resource_prefix }}-testbucket-ansible'
+          - not output.requester_pays
+  # ============================================================
+    - name: Create a lifecycle policy
+      s3_lifecycle:
+        name: "{{ resource_prefix }}-testbucket-ansible"
+        expiration_days: 30
+        prefix: /pre
+      register: output
+
+    - assert:
+        that:
+          - output is changed
+  # ============================================================
+    - name: Create a lifecycle policy (idempotency)
+      s3_lifecycle:
+        name: "{{ resource_prefix }}-testbucket-ansible"
+        expiration_days: 30
+        prefix: /pre
+      register: output
+
+    - assert:
+        that:
+          - output is not changed
+  # ============================================================
+    - name: Create a second lifecycle policy
+      s3_lifecycle:
+        name: "{{ resource_prefix }}-testbucket-ansible"
+        transition_days: 300
+        prefix: /something
+      register: output
+
+    - assert:
+        that:
+          - output is changed
+  # ============================================================
+    - name: Create a second lifecycle policy (idempotency)
+      s3_lifecycle:
+        name: "{{ resource_prefix }}-testbucket-ansible"
+        transition_days: 300
+        prefix: /something
+      register: output
+
+    - assert:
+        that:
+          - output is not changed
+  # ============================================================
+    - name: Try to create a bad lifecycle policy
+      s3_lifecycle:
+        name: "{{ resource_prefix }}-testbucket-ansible"
+        transition_days: 300
+        prefix: /something/else
+      register: output
+      failed_when: false
+
+    - assert:
+        that:
+          - "'overlapping' in output.msg"
+  # ============================================================
+    - name: Disable the second lifecycle policy
+      s3_lifecycle:
+        name: "{{ resource_prefix }}-testbucket-ansible"
+        status: disabled
+        transition_days: 300
+        prefix: /something
+      register: output
+
+    - assert:
+        that:
+          - output is changed
+  # ============================================================
+    - name: Disable the second lifecycle policy (idempotency)
+      s3_lifecycle:
+        name: "{{ resource_prefix }}-testbucket-ansible"
+        status: disabled
+        transition_days: 300
+        prefix: /something
+      register: output
+
+    - assert:
+        that:
+          - output is not changed
+  # ============================================================
+    - name: Re-enable the second lifecycle policy
+      s3_lifecycle:
+        name: "{{ resource_prefix }}-testbucket-ansible"
+        status: enabled
+        transition_days: 300
+        prefix: /something
+      register: output
+
+    - assert:
+        that:
+          - output is changed
+  # ============================================================
+    - name: Re-enable the second lifecycle policy (idempotency)
+      s3_lifecycle:
+        name: "{{ resource_prefix }}-testbucket-ansible"
+        status: enabled
+        transition_days: 300
+        prefix: /something
+      register: output
+
+    - assert:
+        that:
+          - output is not changed
+  # ============================================================
+    - name: Delete the second lifecycle policy
+      s3_lifecycle:
+        name: "{{ resource_prefix }}-testbucket-ansible"
+        state: absent
+        prefix: /something
+      register: output
+
+    - assert:
+        that:
+          - output is changed
+  # ============================================================
+    - name: Delete the second lifecycle policy (idempotency)
+      s3_lifecycle:
+        name: "{{ resource_prefix }}-testbucket-ansible"
+        state: absent
+        prefix: /something
+      register: output
+
+    - assert:
+        that:
+          - output is not changed
+  # ============================================================
+    - name: Create a second lifecycle policy, with infrequent access
+      s3_lifecycle:
+        name: "{{ resource_prefix }}-testbucket-ansible"
+        transition_days: 300
+        storage_class: standard_ia
+        prefix: /something
+      register: output
+
+    - assert:
+        that:
+          - output is changed
+  # ============================================================
+    - name: Create a second lifecycle policy, with infrequent access (idempotency)
+      s3_lifecycle:
+        name: "{{ resource_prefix }}-testbucket-ansible"
+        storage_class: standard_ia
+        transition_days: 300
+        prefix: /something
+      register: output
+
+    - assert:
+        that:
+          - output is not changed
+  # ============================================================
+    - name: Create a second lifecycle policy, with glacier
+      s3_lifecycle:
+        name: "{{ resource_prefix }}-testbucket-ansible"
+        transition_days: 300
+        prefix: /something
+      register: output
+
+    - assert:
+        that:
+          - output is changed
+  # ============================================================
+    - name: Create a second lifecycle policy, with glacier (idempotency)
+      s3_lifecycle:
+        name: "{{ resource_prefix }}-testbucket-ansible"
+        transition_days: 300
+        prefix: /something
+      register: output
+
+    - assert:
+        that:
+          - output is not changed
+  # ============================================================
+  always:
+    - name: Ensure all buckets are deleted
+      s3_bucket:
+        name: "{{item}}"
+        state: absent
+        <<: *aws_connection_info
+      ignore_errors: yes
+      with_items:
+        - "{{ resource_prefix }}-testbucket-ansible"
+

--- a/test/integration/targets/s3_lifecycle/tasks/main.yml
+++ b/test/integration/targets/s3_lifecycle/tasks/main.yml
@@ -31,6 +31,7 @@
         name: "{{ resource_prefix }}-testbucket-ansible"
         expiration_days: 30
         prefix: /pre
+        <<: *aws_connection_info
       register: output
 
     - assert:
@@ -42,6 +43,7 @@
         name: "{{ resource_prefix }}-testbucket-ansible"
         expiration_days: 30
         prefix: /pre
+        <<: *aws_connection_info
       register: output
 
     - assert:
@@ -53,6 +55,7 @@
         name: "{{ resource_prefix }}-testbucket-ansible"
         transition_days: 300
         prefix: /something
+        <<: *aws_connection_info
       register: output
 
     - assert:
@@ -64,6 +67,7 @@
         name: "{{ resource_prefix }}-testbucket-ansible"
         transition_days: 300
         prefix: /something
+        <<: *aws_connection_info
       register: output
 
     - assert:
@@ -75,6 +79,7 @@
         name: "{{ resource_prefix }}-testbucket-ansible"
         transition_days: 300
         prefix: /something/else
+        <<: *aws_connection_info
       register: output
       failed_when: false
 
@@ -88,6 +93,7 @@
         status: disabled
         transition_days: 300
         prefix: /something
+        <<: *aws_connection_info
       register: output
 
     - assert:
@@ -100,6 +106,7 @@
         status: disabled
         transition_days: 300
         prefix: /something
+        <<: *aws_connection_info
       register: output
 
     - assert:
@@ -112,6 +119,7 @@
         status: enabled
         transition_days: 300
         prefix: /something
+        <<: *aws_connection_info
       register: output
 
     - assert:
@@ -124,6 +132,7 @@
         status: enabled
         transition_days: 300
         prefix: /something
+        <<: *aws_connection_info
       register: output
 
     - assert:
@@ -135,6 +144,7 @@
         name: "{{ resource_prefix }}-testbucket-ansible"
         state: absent
         prefix: /something
+        <<: *aws_connection_info
       register: output
 
     - assert:
@@ -146,6 +156,7 @@
         name: "{{ resource_prefix }}-testbucket-ansible"
         state: absent
         prefix: /something
+        <<: *aws_connection_info
       register: output
 
     - assert:
@@ -158,6 +169,7 @@
         transition_days: 300
         storage_class: standard_ia
         prefix: /something
+        <<: *aws_connection_info
       register: output
 
     - assert:
@@ -170,6 +182,7 @@
         storage_class: standard_ia
         transition_days: 300
         prefix: /something
+        <<: *aws_connection_info
       register: output
 
     - assert:
@@ -181,6 +194,7 @@
         name: "{{ resource_prefix }}-testbucket-ansible"
         transition_days: 300
         prefix: /something
+        <<: *aws_connection_info
       register: output
 
     - assert:
@@ -192,6 +206,7 @@
         name: "{{ resource_prefix }}-testbucket-ansible"
         transition_days: 300
         prefix: /something
+        <<: *aws_connection_info
       register: output
 
     - assert:

--- a/test/integration/targets/s3_lifecycle/tasks/main.yml
+++ b/test/integration/targets/s3_lifecycle/tasks/main.yml
@@ -207,4 +207,3 @@
       ignore_errors: yes
       with_items:
         - "{{ resource_prefix }}-testbucket-ansible"
-


### PR DESCRIPTION
##### SUMMARY
This PR fixes a bug where lifecycle rule comparison was not comparing the `storage_class`. 
This also adds several integration tests to the `s3_lifecycle` module

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
s3_lifecycle

##### ANSIBLE VERSION

```
$ ansible --version
ansible 2.6.0 (s3-lifecycle-tests e83f152266) last updated 2018/05/14 11:03:43 (GMT -700)
  config file = None
  configured module search path = [u'/home/ben/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/ben/dev/github/ansible/ansible/lib/ansible
  executable location = /home/ben/venvs/ansible-devel/bin/ansible
  python version = 2.7.14 (default, Sep 23 2017, 22:06:14) [GCC 7.2.0]
```


##### ADDITIONAL INFORMATION
Given the tasks:
```yaml
  # ============================================================
    - name: Create a second lifecycle policy, with infrequent access
      s3_lifecycle:
        name: "{{ resource_prefix }}-testbucket-ansible"
        transition_days: 300
        storage_class: standard_ia
        prefix: /something
      register: output

    - assert:
        that:
          - output is changed
  # ============================================================
    - name: Create a second lifecycle policy, with infrequent access (idempotency)
      s3_lifecycle:
        name: "{{ resource_prefix }}-testbucket-ansible"
        storage_class: standard_ia
        transition_days: 300
        prefix: /something
      register: output

    - assert:
        that:
          - output is not changed
  # ============================================================
    - name: Create a second lifecycle policy, with glacier
      s3_lifecycle:
        name: "{{ resource_prefix }}-testbucket-ansible"
        transition_days: 300
        storage_class: glacier
        prefix: /something
      register: output

    - assert:
        that:
          - output is changed
  # ============================================================
    - name: Create a second lifecycle policy, with glacier (idempotency)
      s3_lifecycle:
        name: "{{ resource_prefix }}-testbucket-ansible"
        transition_days: 300
        storage_class: glacier
        prefix: /something
      register: output

    - assert:
        that:
          - output is not changed
```
The existing code would fail like this:
```
TASK [s3_lifecycle : Create a second lifecycle policy, with infrequent access] ******************************************************************************************************************************
changed: [localhost]

TASK [s3_lifecycle : assert] ********************************************************************************************************************************************************************************
ok: [localhost] => {
    "changed": false, 
    "msg": "All assertions passed"
}

TASK [s3_lifecycle : Create a second lifecycle policy, with infrequent access (idempotency)] ****************************************************************************************************************
ok: [localhost]

TASK [s3_lifecycle : assert] ********************************************************************************************************************************************************************************
ok: [localhost] => {
    "changed": false, 
    "msg": "All assertions passed"
}

TASK [s3_lifecycle : Create a second lifecycle policy, with glacier] ****************************************************************************************************************************************
ok: [localhost]

TASK [s3_lifecycle : assert] ********************************************************************************************************************************************************************************
fatal: [localhost]: FAILED! => {
    "assertion": "output is changed", 
    "changed": false, 
    "evaluated_to": false
}
```
After this PR, the tasks all succeed:
```
TASK [s3_lifecycle : Create a second lifecycle policy, with infrequent access] ******************************************************************************************************************************
changed: [localhost]

TASK [s3_lifecycle : assert] ********************************************************************************************************************************************************************************
ok: [localhost] => {
    "changed": false, 
    "msg": "All assertions passed"
}

TASK [s3_lifecycle : Create a second lifecycle policy, with infrequent access (idempotency)] ****************************************************************************************************************
ok: [localhost]

TASK [s3_lifecycle : assert] ********************************************************************************************************************************************************************************
ok: [localhost] => {
    "changed": false, 
    "msg": "All assertions passed"
}

TASK [s3_lifecycle : Create a second lifecycle policy, with glacier] ****************************************************************************************************************************************
changed: [localhost]

TASK [s3_lifecycle : assert] ********************************************************************************************************************************************************************************
ok: [localhost] => {
    "changed": false, 
    "msg": "All assertions passed"
}
```
It's probably good to note that it's very possible that people are relying on this broken behavior, intentionally or unintentionally, since `storage_class` is optional