### PR TITLE
New Module: gitlab_hooks module and related tests

### DIFF
--- a/lib/ansible/module_utils/gitlab.py
+++ b/lib/ansible/module_utils/gitlab.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 # -*- coding: utf-8 -*-
 
 # (c) 2018, Marcus Watkins <marwatk@marcuswatkins.net>

--- a/lib/ansible/module_utils/gitlab.py
+++ b/lib/ansible/module_utils/gitlab.py
@@ -1,0 +1,38 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2018, Marcus Watkins <marwatk@marcuswatkins.net>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+import json
+
+from ansible.module_utils.urls import fetch_url
+
+try:
+    from urllib import quote_plus  # Python 2.X
+except ImportError:
+    from urllib.parse import quote_plus  # Python 3+
+
+
+def request(module, api_url, project, path, access_token, private_token, rawdata='', method='GET'):
+    url = "%s/v4/projects/%s%s" % (api_url, quote_plus(project), path)
+    headers = {}
+    if access_token:
+        headers['Authorization'] = "Bearer %s" % access_token
+    else:
+        headers['Private-Token'] = private_token
+
+    headers['Accept'] = "application/json"
+    headers['Content-Type'] = "application/json"
+
+    response, info = fetch_url(module=module, url=url, headers=headers, data=rawdata, method=method)
+    status = info['status']
+    content = ""
+    if response:
+        content = response.read()
+    if status == 204:
+        return True, content
+    elif status == 200 or status == 201:
+        return True, json.loads(content)
+    else:
+        return False, str(status) + ": " + content

--- a/lib/ansible/modules/source_control/gitlab_hooks.py
+++ b/lib/ansible/modules/source_control/gitlab_hooks.py
@@ -1,0 +1,294 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2018, Marcus Watkins <marwatk@marcuswatkins.net>
+# Based on code:
+# (c) 2013, Phillip Gentry <phillip@cx.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = '''
+---
+module: gitlab_hooks
+short_description: Manages GitLab project hooks.
+description:
+     - Adds, updates and removes project hooks
+version_added: "2.6"
+options:
+  api_url:
+    description:
+      - GitLab API url, example: https://gitlab.example.com/api
+    required: true
+  access_token:
+    description:
+      - The oauth key provided by GitLab. One of access_token or private_token is required. See https://docs.gitlab.com/ee/api/oauth2.html
+    required: false
+  private_token:
+    description:
+      - Personal access token to use. One of private_token or access_token is required. See https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html
+    required: false
+  project:
+    description:
+      - Numeric project id or name of project in the form of group/name
+    required: true
+  hook_url:
+    description:
+      - The url that you want GitLab to post to, this is used as the primary key for updates and deletion.
+    required: true
+  state:
+    description:
+      - When C(present) the hook will be updated to match the input or created if it doesn't exist. When C(absent) it will be deleted if it exists.
+    required: true
+    default: present
+    choices: [ "present", "absent" ]
+  push_events:
+    description:
+      - Trigger hook on push events
+    type: bool
+    default: 'no'
+  issues_events:
+    description:
+      - Trigger hook on issues events
+    type: bool
+    default: 'no'
+  merge_requests_events:
+    description:
+      - Trigger hook on merge requests events
+    type: bool
+    default: 'no'
+  tag_push_events:
+    description:
+      - Trigger hook on tag push events
+    type: bool
+    default: 'no'
+  note_events:
+    description:
+      - Trigger hook on note events
+    type: bool
+    default: 'no'
+  job_events:
+    description:
+      - Trigger hook on job events
+    type: bool
+    default: 'no'
+  pipeline_events:
+    description:
+      - Trigger hook on pipeline events
+    type: bool
+    default: 'no'
+  wiki_page_events:
+    description:
+      - Trigger hook on wiki events
+    type: bool
+    default: 'no'
+  enable_ssl_verification:
+    description:
+      - Whether GitLab will do SSL verification when triggering the hook
+    type: bool
+    default: 'no'
+  token:
+    description:
+      - Secret token to validate hook messages at the receiver.
+      - If this is present it will always result in a change as it cannot be retrieved from GitLab.
+      - Will show up in the X-Gitlab-Token HTTP request header
+    required: false
+author: "Marcus Watkins (@marwatk)"
+'''
+
+EXAMPLES = '''
+# Example creating a new project hook
+- gitlab_hooks:
+    api_url: https://gitlab.example.com/api
+    access_token: "{{ access_token }}"
+    project: "my_group/my_project"
+    hook_url: "https://my-ci-server.example.com/gitlab-hook"
+    state: present
+    push_events: yes
+    enable_ssl_verification: no
+    token: "my-super-secret-token-that-my-ci-server-will-check"
+
+# Update the above hook to add tag pushes
+- gitlab_hooks:
+    api_url: https://gitlab.example.com/api
+    access_token: "{{ access_token }}"
+    project: "my_group/my_project"
+    hook_url: "https://my-ci-server.example.com/gitlab-hook"
+    state: present
+    push_events: yes
+    tag_push_events: yes
+    enable_ssl_verification: no
+    token: "my-super-secret-token-that-my-ci-server-will-check"
+
+# Delete the previous hook
+- gitlab_hooks:
+    api_url: https://gitlab.example.com/api
+    access_token: "{{ access_token }}"
+    project: "my_group/my_project"
+    hook_url: "https://my-ci-server.example.com/gitlab-hook"
+    state: absent
+
+# Delete a hook by numeric project id
+- gitlab_hooks:
+    api_url: https://gitlab.example.com/api
+    access_token: "{{ access_token }}"
+    project: 10
+    hook_url: "https://my-ci-server.example.com/gitlab-hook"
+    state: absent
+'''
+
+import json
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.urls import fetch_url
+from copy import deepcopy
+
+try:
+    from urllib import quote_plus  # Python 2.X
+except ImportError:
+    from urllib.parse import quote_plus  # Python 3+
+
+
+def request(module, api_url, project, path, access_token, private_token, rawdata='', method='GET'):
+    url = "%s/v4/projects/%s%s" % (api_url, quote_plus(project), path)
+    headers = {}
+    if access_token:
+        headers['Authorization'] = "Bearer %s" % access_token
+    else:
+        headers['Private-Token'] = private_token
+
+    headers['Accept'] = "application/json"
+    headers['Content-Type'] = "application/json"
+
+    response, info = fetch_url(module=module, url=url, headers=headers, data=rawdata, method=method)
+    status = info['status']
+    content = ""
+    if response:
+        content = response.read()
+    if status == 204:
+        return True, content
+    elif status == 200 or status == 201:
+        return True, json.loads(content)
+    else:
+        return False, str(status) + ": " + content
+
+
+def _list(module, api_url, project, access_token, private_token):
+    path = "/hooks"
+    return request(module, api_url, project, path, access_token, private_token)
+
+
+def _find(module, api_url, project, hook_url, access_token, private_token):
+    success, data = _list(module, api_url, project, access_token, private_token)
+    if success:
+        for i in data:
+            if i["url"] == hook_url:
+                return success, i
+        return success, None
+    return success, data
+
+
+def _publish(module, api_url, project, data, access_token, private_token):
+    path = "/hooks"
+    method = "POST"
+    if 'id' in data:
+        path += "/%s" % str(data["id"])
+        method = "PUT"
+    data = deepcopy(data)
+    data.pop('id', None)
+    return request(module, api_url, project, path, access_token, private_token, json.dumps(data, sort_keys=True), method)
+
+
+def _delete(module, api_url, project, hook_id, access_token, private_token):
+    path = "/hooks/%s" % str(hook_id)
+    return request(module, api_url, project, path, access_token, private_token, method='DELETE')
+
+
+def _are_equivalent(input, existing):
+    for key in [
+            'url', 'push_events', 'issues_events', 'merge_requests_events',
+            'tag_push_events', 'note_events', 'job_events', 'pipeline_events', 'wiki_page_events',
+            'enable_ssl_verification']:
+        if key in input and key not in existing:
+            return False
+        if key not in input and key in existing:
+            return False
+        if not input[key] == existing[key]:
+            return False
+    return True
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            api_url=dict(required=True),
+            access_token=dict(required=False, no_log=True),
+            private_token=dict(required=False, no_log=True),
+            project=dict(required=True),
+            hook_url=dict(required=True),
+            state=dict(default='present', choices=['present', 'absent']),
+            push_events=dict(default='yes', type='bool'),
+            issues_events=dict(default='no', type='bool'),
+            merge_requests_events=dict(default='no', type='bool'),
+            tag_push_events=dict(default='no', type='bool'),
+            note_events=dict(default='no', type='bool'),
+            job_events=dict(default='no', type='bool'),
+            pipeline_events=dict(default='no', type='bool'),
+            wiki_page_events=dict(default='no', type='bool'),
+            enable_ssl_verification=dict(default='no', type='bool'),
+            token=dict(required=False, no_log=True),
+        )
+    )
+
+    api_url = module.params['api_url']
+    access_token = module.params['access_token']
+    private_token = module.params['private_token']
+    project = module.params['project']
+    state = module.params['state']
+
+    if not access_token and not private_token:
+        module.fail_json(msg="need either access_token or private_token")
+
+    input = {'url': module.params['hook_url']}
+
+    for key in [
+            'push_events', 'issues_events', 'merge_requests_events',
+            'tag_push_events', 'note_events', 'job_events', 'pipeline_events', 'wiki_page_events',
+            'enable_ssl_verification', 'token']:
+        input[key] = module.params[key]
+
+    success, existing = _find(module, api_url, project, input['url'], access_token, private_token)
+
+    if not success:
+        module.fail_json(msg="failed to list hooks", result=existing)
+
+    if existing:
+        input['id'] = existing['id']
+
+    changed = False
+    success = True
+    response = None
+
+    if state == 'present':
+        if not existing or input['token'] or not _are_equivalent(existing, input):
+            success, response = _publish(module, api_url, project, input, access_token, private_token)
+            changed = True
+    else:
+        if existing:
+            success, response = _delete(module, api_url, project, existing['id'], access_token, private_token)
+            changed = True
+
+    if success:
+        module.exit_json(changed=changed, msg='Success', result=response, previous_version=existing)
+    else:
+        module.fail_json(msg='Failure', result=response)
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/source_control/gitlab_hooks.py
+++ b/lib/ansible/modules/source_control/gitlab_hooks.py
@@ -172,37 +172,9 @@ previous_version:
 import json
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.urls import fetch_url
 from copy import deepcopy
 
-try:
-    from urllib import quote_plus  # Python 2.X
-except ImportError:
-    from urllib.parse import quote_plus  # Python 3+
-
-
-def request(module, api_url, project, path, access_token, private_token, rawdata='', method='GET'):
-    url = "%s/v4/projects/%s%s" % (api_url, quote_plus(project), path)
-    headers = {}
-    if access_token:
-        headers['Authorization'] = "Bearer %s" % access_token
-    else:
-        headers['Private-Token'] = private_token
-
-    headers['Accept'] = "application/json"
-    headers['Content-Type'] = "application/json"
-
-    response, info = fetch_url(module=module, url=url, headers=headers, data=rawdata, method=method)
-    status = info['status']
-    content = ""
-    if response:
-        content = response.read()
-    if status == 204:
-        return True, content
-    elif status == 200 or status == 201:
-        return True, json.loads(content)
-    else:
-        return False, str(status) + ": " + content
+from ansible.module_utils.gitlab import request
 
 
 def _list(module, api_url, project, access_token, private_token):
@@ -269,7 +241,14 @@ def main():
             wiki_page_events=dict(default='no', type='bool'),
             enable_ssl_verification=dict(default='no', type='bool'),
             token=dict(required=False, no_log=True),
-        )
+        ),
+        mutually_exclusive=[
+            ['access_token', 'private_token']
+        ],
+        required_one_of=[
+            ['access_token', 'private_token']
+        ],
+        supports_check_mode=True,
     )
 
     api_url = module.params['api_url']
@@ -303,11 +282,13 @@ def main():
 
     if state == 'present':
         if not existing or input['token'] or not _are_equivalent(existing, input):
-            success, response = _publish(module, api_url, project, input, access_token, private_token)
+            if not module.check_mode:
+                success, response = _publish(module, api_url, project, input, access_token, private_token)
             changed = True
     else:
         if existing:
-            success, response = _delete(module, api_url, project, existing['id'], access_token, private_token)
+            if not module.check_mode:
+                success, response = _delete(module, api_url, project, existing['id'], access_token, private_token)
             changed = True
 
     if success:

--- a/lib/ansible/modules/source_control/gitlab_hooks.py
+++ b/lib/ansible/modules/source_control/gitlab_hooks.py
@@ -25,7 +25,7 @@ version_added: "2.6"
 options:
   api_url:
     description:
-      - GitLab API url, example: https://gitlab.example.com/api
+      - GitLab API url, e.g. https://gitlab.example.com/api
     required: true
   access_token:
     description:
@@ -53,7 +53,7 @@ options:
     description:
       - Trigger hook on push events
     type: bool
-    default: 'no'
+    default: 'yes'
   issues_events:
     description:
       - Trigger hook on issues events
@@ -143,6 +143,31 @@ EXAMPLES = '''
     hook_url: "https://my-ci-server.example.com/gitlab-hook"
     state: absent
 '''
+
+RETURN = '''
+msg:
+    description: Success or failure message
+    returned: always
+    type: string
+    sample: "Success"
+
+result:
+    description: json parsed response from the server
+    returned: always
+    type: dict
+
+error:
+    description: the error message returned by the Gitlab API
+    returned: failed
+    type: string
+    sample: "400: key is already in use"
+
+previous_version:
+    description: object describing the state prior to this task
+    returned: changed
+    type: dict
+'''
+
 
 import json
 
@@ -288,7 +313,7 @@ def main():
     if success:
         module.exit_json(changed=changed, msg='Success', result=response, previous_version=existing)
     else:
-        module.fail_json(msg='Failure', result=response)
+        module.fail_json(msg='Failure', error=response)
 
 if __name__ == '__main__':
     main()

--- a/test/units/modules/source_control/test_gitlab_hooks.py
+++ b/test/units/modules/source_control/test_gitlab_hooks.py
@@ -68,7 +68,7 @@ def fail_json(*args, **kwargs):
 
 @pytest.fixture
 def fetch_url_mock(mocker):
-    return mocker.patch('ansible.modules.source_control.gitlab_hooks.fetch_url')
+    return mocker.patch('ansible.module_utils.gitlab.fetch_url')
 
 
 @pytest.fixture

--- a/test/units/modules/source_control/test_gitlab_hooks.py
+++ b/test/units/modules/source_control/test_gitlab_hooks.py
@@ -1,0 +1,288 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2018 Marcus Watkins <marwatk@marcuswatkins.net>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from ansible.compat.tests.mock import patch
+from ansible.modules.source_control import gitlab_hooks
+from ansible.module_utils._text import to_bytes
+from ansible.module_utils import basic
+
+import pytest
+import json
+
+fake_server_state = [
+    {
+        "id": 1,
+        "url": "https://notification-server.example.com/gitlab-hook",
+        "project_id": 10,
+        "push_events": True,
+        "issues_events": True,
+        "merge_requests_events": True,
+        "tag_push_events": True,
+        "note_events": True,
+        "job_events": True,
+        "pipeline_events": True,
+        "wiki_page_events": True,
+        "enable_ssl_verification": True,
+        "created_at": "2012-10-12T17:04:47Z"
+    },
+]
+
+
+def set_module_args(args):
+    """prepare arguments so that they will be picked up during module creation"""
+    args = json.dumps({'ANSIBLE_MODULE_ARGS': args})
+    basic._ANSIBLE_ARGS = to_bytes(args)
+
+
+class FakeReader:
+    def __init__(self, object):
+        self.content = json.dumps(object, sort_keys=True)
+
+    def read(self):
+        return self.content
+
+
+class AnsibleExitJson(Exception):
+    """Exception class to be raised by module.exit_json and caught by the test case"""
+    pass
+
+
+class AnsibleFailJson(Exception):
+    """Exception class to be raised by module.fail_json and caught by the test case"""
+    pass
+
+
+def exit_json(*args, **kwargs):
+    """function to patch over exit_json; package return data into an exception"""
+    if 'changed' not in kwargs:
+        kwargs['changed'] = False
+    raise AnsibleExitJson(kwargs)
+
+
+def fail_json(*args, **kwargs):
+    """function to patch over fail_json; package return data into an exception"""
+    kwargs['failed'] = True
+    raise AnsibleFailJson(kwargs)
+
+
+@pytest.fixture
+def fetch_url_mock(mocker):
+    return mocker.patch('ansible.modules.source_control.gitlab_hooks.fetch_url')
+
+
+@pytest.fixture
+def module_mock(mocker):
+    return mocker.patch.multiple(basic.AnsibleModule,
+                                 exit_json=exit_json,
+                                 fail_json=fail_json)
+
+
+def test_access_token_output(capfd, fetch_url_mock, module_mock):
+    fetch_url_mock.return_value = [FakeReader(fake_server_state), {'status': 200}]
+    set_module_args({
+        'api_url': 'https://gitlab.example.com/api',
+        'access_token': 'test-access-token',
+        'project': '10',
+        'hook_url': 'https://my-ci-server.example.com/gitlab-hook',
+        'state': 'absent'
+    })
+    with pytest.raises(AnsibleExitJson) as result:
+        gitlab_hooks.main()
+
+    first_call = fetch_url_mock.call_args_list[0][1]
+    assert first_call['url'] == 'https://gitlab.example.com/api/v4/projects/10/hooks'
+    assert first_call['headers']['Authorization'] == 'Bearer test-access-token'
+    assert 'Private-Token' not in first_call['headers']
+    assert first_call['method'] == 'GET'
+
+
+def test_private_token_output(capfd, fetch_url_mock, module_mock):
+    fetch_url_mock.return_value = [FakeReader(fake_server_state), {'status': 200}]
+    set_module_args({
+        'api_url': 'https://gitlab.example.com/api',
+        'private_token': 'test-private-token',
+        'project': 'foo/bar',
+        'hook_url': 'https://my-ci-server.example.com/gitlab-hook',
+        'state': 'absent'
+    })
+    with pytest.raises(AnsibleExitJson) as result:
+        gitlab_hooks.main()
+
+    first_call = fetch_url_mock.call_args_list[0][1]
+    assert first_call['url'] == 'https://gitlab.example.com/api/v4/projects/foo%2Fbar/hooks'
+    assert first_call['headers']['Private-Token'] == 'test-private-token'
+    assert 'Authorization' not in first_call['headers']
+    assert first_call['method'] == 'GET'
+
+
+def test_bad_http_first_response(capfd, fetch_url_mock, module_mock):
+    fetch_url_mock.side_effect = [[FakeReader("Permission denied"), {'status': 403}], [FakeReader("Permission denied"), {'status': 403}]]
+    set_module_args({
+        'api_url': 'https://gitlab.example.com/api',
+        'access_token': 'test-access-token',
+        'project': '10',
+        'hook_url': 'https://my-ci-server.example.com/gitlab-hook',
+        'state': 'absent'
+    })
+    with pytest.raises(AnsibleFailJson):
+        gitlab_hooks.main()
+
+
+def test_bad_http_second_response(capfd, fetch_url_mock, module_mock):
+    fetch_url_mock.side_effect = [[FakeReader(fake_server_state), {'status': 200}], [FakeReader("Permission denied"), {'status': 403}]]
+    set_module_args({
+        'api_url': 'https://gitlab.example.com/api',
+        'access_token': 'test-access-token',
+        'project': '10',
+        'hook_url': 'https://my-ci-server.example.com/gitlab-hook',
+        'state': 'present'
+    })
+    with pytest.raises(AnsibleFailJson):
+        gitlab_hooks.main()
+
+
+def test_delete_non_existing(capfd, fetch_url_mock, module_mock):
+    fetch_url_mock.return_value = [FakeReader(fake_server_state), {'status': 200}]
+    set_module_args({
+        'api_url': 'https://gitlab.example.com/api',
+        'access_token': 'test-access-token',
+        'project': '10',
+        'hook_url': 'https://my-ci-server.example.com/gitlab-hook',
+        'state': 'absent'
+    })
+    with pytest.raises(AnsibleExitJson) as result:
+        gitlab_hooks.main()
+
+    assert result.value.args[0]['changed'] is False
+
+
+def test_delete_existing(capfd, fetch_url_mock, module_mock):
+    fetch_url_mock.return_value = [FakeReader(fake_server_state), {'status': 200}]
+    set_module_args({
+        'api_url': 'https://gitlab.example.com/api',
+        'access_token': 'test-access-token',
+        'project': '10',
+        'hook_url': 'https://notification-server.example.com/gitlab-hook',
+        'state': 'absent'
+    })
+    with pytest.raises(AnsibleExitJson) as result:
+        gitlab_hooks.main()
+
+    second_call = fetch_url_mock.call_args_list[1][1]
+
+    assert second_call['url'] == 'https://gitlab.example.com/api/v4/projects/10/hooks/1'
+    assert second_call['method'] == 'DELETE'
+
+    assert result.value.args[0]['changed'] is True
+
+
+def test_add_new(capfd, fetch_url_mock, module_mock):
+    fetch_url_mock.return_value = [FakeReader(fake_server_state), {'status': 200}]
+    set_module_args({
+        'api_url': 'https://gitlab.example.com/api',
+        'access_token': 'test-access-token',
+        'project': '10',
+        'hook_url': 'https://my-ci-server.example.com/gitlab-hook',
+        'state': 'present'
+    })
+    with pytest.raises(AnsibleExitJson) as result:
+        gitlab_hooks.main()
+
+    second_call = fetch_url_mock.call_args_list[1][1]
+
+    assert second_call['url'] == 'https://gitlab.example.com/api/v4/projects/10/hooks'
+    assert second_call['method'] == 'POST'
+    assert second_call['data'] == ('{"enable_ssl_verification": false, "issues_events": false, "job_events": false, '
+                                   '"merge_requests_events": false, "note_events": false, "pipeline_events": false, "push_events": true, "tag_push_events": '
+                                   'false, "token": null, "url": "https://my-ci-server.example.com/gitlab-hook", "wiki_page_events": false}')
+    assert result.value.args[0]['changed'] is True
+
+
+def test_update_existing(capfd, fetch_url_mock, module_mock):
+    fetch_url_mock.return_value = [FakeReader(fake_server_state), {'status': 200}]
+    set_module_args({
+        'api_url': 'https://gitlab.example.com/api',
+        'access_token': 'test-access-token',
+        'project': '10',
+        'hook_url': 'https://notification-server.example.com/gitlab-hook',
+        'push_events': 'yes',
+        'issues_events': 'yes',
+        'merge_requests_events': 'yes',
+        'tag_push_events': 'yes',
+        'note_events': 'yes',
+        'job_events': 'yes',
+        'pipeline_events': 'yes',
+        'wiki_page_events': 'no',
+        'enable_ssl_verification': 'yes',
+        'state': 'present'
+    })
+    with pytest.raises(AnsibleExitJson) as result:
+        gitlab_hooks.main()
+
+    second_call = fetch_url_mock.call_args_list[1][1]
+
+    assert second_call['url'] == 'https://gitlab.example.com/api/v4/projects/10/hooks/1'
+    assert second_call['method'] == 'PUT'
+    assert second_call['data'] == ('{"enable_ssl_verification": true, "issues_events": true, "job_events": true, '
+                                   '"merge_requests_events": true, "note_events": true, "pipeline_events": true, "push_events": true, "tag_push_events": '
+                                   'true, "token": null, "url": "https://notification-server.example.com/gitlab-hook", "wiki_page_events": false}')
+    assert result.value.args[0]['changed'] is True
+
+
+def test_unchanged_existing(capfd, fetch_url_mock, module_mock):
+    fetch_url_mock.return_value = [FakeReader(fake_server_state), {'status': 200}]
+    set_module_args({
+        'api_url': 'https://gitlab.example.com/api',
+        'access_token': 'test-access-token',
+        'project': '10',
+        'hook_url': 'https://notification-server.example.com/gitlab-hook',
+        'push_events': 'yes',
+        'issues_events': 'yes',
+        'merge_requests_events': 'yes',
+        'tag_push_events': 'yes',
+        'note_events': 'yes',
+        'job_events': 'yes',
+        'pipeline_events': 'yes',
+        'wiki_page_events': 'yes',
+        'enable_ssl_verification': 'yes',
+        'state': 'present'
+    })
+    with pytest.raises(AnsibleExitJson) as result:
+        gitlab_hooks.main()
+
+    assert result.value.args[0]['changed'] is False
+    assert fetch_url_mock.call_count == 1
+
+
+def test_unchanged_existing_with_token(capfd, fetch_url_mock, module_mock):
+    fetch_url_mock.return_value = [FakeReader(fake_server_state), {'status': 200}]
+    set_module_args({
+        'api_url': 'https://gitlab.example.com/api',
+        'access_token': 'test-access-token',
+        'project': '10',
+        'hook_url': 'https://notification-server.example.com/gitlab-hook',
+        'push_events': 'yes',
+        'issues_events': 'yes',
+        'merge_requests_events': 'yes',
+        'tag_push_events': 'yes',
+        'note_events': 'yes',
+        'job_events': 'yes',
+        'pipeline_events': 'yes',
+        'wiki_page_events': 'yes',
+        'enable_ssl_verification': 'yes',
+        'state': 'present',
+        'token': 'secret-token',
+    })
+    with pytest.raises(AnsibleExitJson) as result:
+        gitlab_hooks.main()
+
+    second_call = fetch_url_mock.call_args_list[1][1]
+
+    assert second_call['url'] == 'https://gitlab.example.com/api/v4/projects/10/hooks/1'
+    assert second_call['method'] == 'PUT'
+    assert second_call['data'] == ('{"enable_ssl_verification": true, "issues_events": true, "job_events": true, '
+                                   '"merge_requests_events": true, "note_events": true, "pipeline_events": true, "push_events": true, '
+                                   '"tag_push_events": true, "token": "secret-token", "url": "https://notification-server.example.com/gitlab-hook", '
+                                   '"wiki_page_events": true}')
+    assert result.value.args[0]['changed'] is True


### PR DESCRIPTION
##### SUMMARY

Adds a module for manipulating Gitlab project hooks

##### ISSUE TYPE
 - New Module Pull Request

##### COMPONENT NAME
gitlab_hooks

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0 (gitlab-hooks dfe25c642c) last updated 2018/05/14 18:15:19 (GMT +000)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/mwatkins/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/mwatkins/git/ansible/lib/ansible
  executable location = /home/mwatkins/git/ansible/bin/ansible
  python version = 2.7.5 (default, Aug  4 2017, 00:39:18) [GCC 4.8.5 20150623 (Red Hat 4.8.5-16)]
```


##### ADDITIONAL INFORMATION
This module uses the Gitlab v4 web API directly with no external dependencies
There are unit tests for each possible action

I started work on this on Thursday morning, and it looks like between the time I started and went to submit this PR another user [started work](https://github.com/ansible/ansible/pull/39991) on the exact same functionality (though his uses a Gitlab python library instead of the web API directly). Because my version was already complete I figured I'd submit anyway and see if the community prefers this approach. I'm happy to devote resources to improving the other, though, if that increases the likelihood of acceptance.

I have also [another PR](https://github.com/ansible/ansible/pull/40097) for dealing with Gitlab Deploy Keys that is very similar to this module.

