### PR TITLE
Add dumpdata django command (#30045)

### DIFF
--- a/lib/ansible/modules/web_infrastructure/django_manage.py
+++ b/lib/ansible/modules/web_infrastructure/django_manage.py
@@ -6,8 +6,6 @@
 
 from __future__ import absolute_import, division, print_function
 
-import pipes
-
 __metaclass__ = type
 
 
@@ -26,7 +24,7 @@ description:
 version_added: "1.1"
 options:
   command:
-    choices: [ 'cleanup', 'collectstatic', 'flush', 'dumpdata, 'loaddata', 'migrate', 'runfcgi', 'syncdb', 'test', 'validate', ]
+    choices: [ 'cleanup', 'collectstatic', 'flush', 'dumpdata', 'loaddata', 'migrate', 'runfcgi', 'syncdb', 'test', 'validate']
     description:
       - The name of the Django management command to run. Built in commands are cleanup, collectstatic, flush, loaddata, migrate, runfcgi, syncdb,
         test, and validate.
@@ -115,7 +113,7 @@ EXAMPLES = """
     app_path: "{{ django_dir }}"
 
 # Create a dumped file from database or specific app.
-- django_manage
+- django_manage:
     command: dumpdata
     apps: main.Smoke
     indent: 4
@@ -148,6 +146,7 @@ EXAMPLES = """
 """
 
 import os
+import pipes
 import sys
 
 from ansible.module_utils.basic import AnsibleModule


### PR DESCRIPTION
##### SUMMARY
Added #30045

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
django_manage

##### ANSIBLE VERSION
```
ansible 2.6.0 (support-django-command-dumpdata c8896478e3) last updated 2018/05/14 14:29:27 (GMT -400)
  config file = /Users/kucuny/works/rgpkorea/sources/yogiyo-owner/misc/deploy/ansible.cfg
  configured module search path = ['/Users/kucuny/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/kucuny/works/osp/ansible/lib/ansible
  executable location = /Users/kucuny/works/osp/ansible/bin/ansible
  python version = 3.6.0 (default, Dec 24 2016, 08:01:42) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
Playbook
---
- hosts: localhost
  tasks:
    - django_manage:
        command: dumpdata
        settings: { settings }
        app_path: { app_path }
        apps: { app_name or app_name.ModelName }
        output: /tmp/output.dump  # Mandatory
        indent: 4  # Optional

Output
TASK [django_manage] ***************************************************************************************************************************************************************************************************************************
task path: test.yml:4
ok: [localhost] => {"app_path": "app_path", "changed": false, "cmd": "./manage.py dumpdata --settings=settings --indent=4 app_name.ModelName > /tmp/output.dump", "out": "", "pythonpath": null, "settings": "settings", "virtualenv": null}
META: ran handlers
META: ran handlers

PLAY RECAP *************************************************************************************************************************************************************************************************************************************
localhost                  : ok=2    changed=0    unreachable=0    failed=0
```
