### PR TITLE
updating win_chocolatey.py docs examples

### DIFF
--- a/lib/ansible/modules/windows/win_chocolatey.py
+++ b/lib/ansible/modules/windows/win_chocolatey.py
@@ -150,7 +150,7 @@ EXAMPLES = r'''
 
 - name: Install notepadplusplus version 6.6
   win_chocolatey:
-    name: notepadplusplus.install
+    name: notepadplusplus
     version: '6.6'
 
 - name: Install git from specified repository


### PR DESCRIPTION
<!--- Your description here -->
Edit to the notepadplusplus example. 

+label: docsite_pr

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Removed `.install` as per chocolatey documentation, the package is just notepadplusplus. 


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.2
  config file = None
  configured module search path = [u'/Users/jajackso/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.13 (default, Dec 18 2016, 07:03:39) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

chocolatey docs referenced found here: https://chocolatey.org/packages/notepadplusplus
