### PR TITLE
Update nxos_install_os module

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_install_os.py
+++ b/lib/ansible/modules/network/nxos/nxos_install_os.py
@@ -35,8 +35,8 @@ notes:
       - N9k 7.0(3)I4(6), 7.0(3)I5(3), 7.0(3)I6(1), 7.0(3)I7(1), 7.0(3)F2(2), 7.0(3)F3(2)
       - N3k 6.0(2)A8(6), 6.0(2)A8(8), 7.0(3)I6(1), 7.0(3)I7(1)
       - N7k 7.3(0)D1(1), 8.0(1), 8.2(1)
-    - This module requires both the ANSIBLE_PERSISTENT_CONNECT and
-      ANSIBLE_PERSISTENT_COMMAND timers to be set to 600 seconds or higher.
+    - This module requires both the ANSIBLE_PERSISTENT_CONNECT_TIMEOUT and
+      ANSIBLE_PERSISTENT_COMMAND_TIMEOUT timers to be set to 600 seconds or higher.
       The module will exit if the timers are not set properly.
     - Do not include full file paths, just the name of the file(s) stored on
       the top level flash directory.
@@ -250,6 +250,9 @@ def parse_show_install(data):
             ud['upgrade_succeeded'] = True
             break
         if re.search(r'Install has been successful', x):
+            ud['upgrade_succeeded'] = True
+            break
+        if re.search(r'Switching over onto standby', x):
             ud['upgrade_succeeded'] = True
             break
 

--- a/lib/ansible/modules/network/nxos/nxos_install_os.py
+++ b/lib/ansible/modules/network/nxos/nxos_install_os.py
@@ -124,6 +124,7 @@ install_state:
 
 import re
 from time import sleep
+from ansible import constants as C
 from ansible.module_utils.network.nxos.nxos import load_config, run_commands
 from ansible.module_utils.network.nxos.nxos import nxos_argument_spec, check_args
 from ansible.module_utils.basic import AnsibleModule
@@ -131,12 +132,12 @@ from ansible.module_utils.basic import AnsibleModule
 
 def check_ansible_timer(module):
     '''Check Ansible Timer Values'''
-    import os
-    command_timer = os.environ.get('ANSIBLE_PERSISTENT_COMMAND_TIMEOUT')
-    connect_timer = os.environ.get('ANSIBLE_PERSISTENT_CONNECT_TIMEOUT')
+    command_timer = C.PERSISTENT_COMMAND_TIMEOUT
+    connect_timer = C.PERSISTENT_CONNECT_TIMEOUT
     msg = "The 'ANSIBLE_PERSISTENT_COMMAND_TIMEOUT' and 'ANSIBLE_PERSISTENT_CONNECT_TIMEOUT'\n"
     msg = msg + "timers need to be set to 500 seconds or higher when using this module\n"
-    msg = msg + "\nPlease set the timers and re-run the playbook"
+    msg = msg + "in order to allow enough time for the upgrade to complete\n"
+    msg = msg + "\nPlease set the timers and re-run the playbook."
     timer_low = False
     if command_timer is None or connect_timer is None:
         timer_low = True

--- a/lib/ansible/modules/network/nxos/nxos_install_os.py
+++ b/lib/ansible/modules/network/nxos/nxos_install_os.py
@@ -131,18 +131,16 @@ from ansible.module_utils.basic import AnsibleModule
 
 def check_ansible_timer(module):
     '''Check Ansible Timer Values'''
-    msg = "The 'timeout' provider param value for this module to execute\n"
-    msg = msg + 'properly is too low.\n'
-    msg = msg + 'Upgrades can take a long time so the value needs to be set\n'
-    msg = msg + 'to the recommended value of 500 seconds or higher in the\n'
-    msg = msg + 'ansible playbook for the nxos_install_os module.\n'
-    msg = msg + '\n'
-    msg = msg + 'provider: "{{ connection | combine({\'timeout\': 500}) }}"'
-    data = module.params.get('provider')
+    import os
+    command_timer = os.environ.get('ANSIBLE_PERSISTENT_COMMAND_TIMEOUT')
+    connect_timer = os.environ.get('ANSIBLE_PERSISTENT_CONNECT_TIMEOUT')
+    msg = "The 'ANSIBLE_PERSISTENT_COMMAND_TIMEOUT' and 'ANSIBLE_PERSISTENT_CONNECT_TIMEOUT'\n"
+    msg = msg + "timers need to be set to 500 seconds or higher when using this module\n"
+    msg = msg + "\nPlease set the timers and re-run the playbook"
     timer_low = False
-    if data.get('timeout') is None:
+    if command_timer is None or connect_timer is None:
         timer_low = True
-    if data.get('timeout') is not None and data.get('timeout') < 500:
+    elif command_timer < 500 or connect_timer < 500:
         timer_low = True
     if timer_low:
         module.fail_json(msg=msg.split('\n'))

--- a/lib/ansible/plugins/action/nxos.py
+++ b/lib/ansible/plugins/action/nxos.py
@@ -55,6 +55,12 @@ class ActionModule(_ActionModule):
             elif self._play_context.connection == 'local':
                 self._task.args['username'] = self._play_context.connection_user
 
+        if self._task.action == 'nxos_install_os':
+            if C.PERSISTENT_COMMAND_TIMEOUT < 600 or C.PERSISTENT_CONNECT_TIMEOUT < 600:
+                msg = 'PERSISTENT_COMMAND_TIMEOUT and PERSISTENT_CONNECT_TIMEOUT'
+                msg += ' must be set to 600 seconds or higher when using nxos_install_os module'
+                return {'failed': True, 'msg': msg}
+
         if self._play_context.connection in ('network_cli', 'httpapi'):
             provider = self._task.args.get('provider', {})
             if any(provider.values()):

--- a/test/integration/targets/nxos_install_os/defaults/main.yaml
+++ b/test/integration/targets/nxos_install_os/defaults/main.yaml
@@ -1,0 +1,2 @@
+---
+testcase: "upgrade"

--- a/test/integration/targets/nxos_install_os/meta/main.yml
+++ b/test/integration/targets/nxos_install_os/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_nxos_tests

--- a/test/integration/targets/nxos_install_os/tasks/httpapi.yaml
+++ b/test/integration/targets/nxos_install_os/tasks/httpapi.yaml
@@ -9,8 +9,8 @@
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (ansible_connection=local transport=nxapi)
-  include: "{{ test_case_to_run }} ansible_connection=local connection={{ nxapi }}"
+- name: run test cases (ansible_connection=httpapi)
+  include: "{{ test_case_to_run }} ansible_connection=httpapi"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_install_os/tasks/main.yaml
+++ b/test/integration/targets/nxos_install_os/tasks/main.yaml
@@ -1,4 +1,5 @@
 ---
 - { include: network_cli.yaml, tags: ['cli'] }
 - { include: network_local.yaml, tags: ['local'] }
+- { include: httpapi.yaml, tags: ['httpapi'] }
 - { include: nxapi.yaml, tags: ['nxapi'] }

--- a/test/integration/targets/nxos_install_os/tasks/main.yaml
+++ b/test/integration/targets/nxos_install_os/tasks/main.yaml
@@ -1,0 +1,4 @@
+---
+- { include: network_cli.yaml, tags: ['cli'] }
+- { include: network_local.yaml, tags: ['local'] }
+- { include: nxapi.yaml, tags: ['nxapi'] }

--- a/test/integration/targets/nxos_install_os/tasks/network_cli.yaml
+++ b/test/integration/targets/nxos_install_os/tasks/network_cli.yaml
@@ -9,7 +9,7 @@
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=network_cli)
+- name: run test cases (ansible_connection=network_cli)
   include: "{{ test_case_to_run }} ansible_connection=network_cli"
   with_items: "{{ test_items }}"
   loop_control:

--- a/test/integration/targets/nxos_install_os/tasks/network_cli.yaml
+++ b/test/integration/targets/nxos_install_os/tasks/network_cli.yaml
@@ -1,0 +1,16 @@
+---
+- name: collect common test cases
+  find:
+    paths: "{{ role_path }}/tests/common"
+    patterns: "{{ testcase }}.yaml"
+  connection: local
+  register: test_cases
+
+- name: set test_items
+  set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
+
+- name: run test cases (connection=network_cli)
+  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={}"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run

--- a/test/integration/targets/nxos_install_os/tasks/network_cli.yaml
+++ b/test/integration/targets/nxos_install_os/tasks/network_cli.yaml
@@ -10,7 +10,7 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=network_cli)
-  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={}"
+  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={{ cli }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_install_os/tasks/network_cli.yaml
+++ b/test/integration/targets/nxos_install_os/tasks/network_cli.yaml
@@ -10,7 +10,7 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=network_cli)
-  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={{ cli }}"
+  include: "{{ test_case_to_run }} ansible_connection=network_cli"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_install_os/tasks/network_local.yaml
+++ b/test/integration/targets/nxos_install_os/tasks/network_local.yaml
@@ -1,0 +1,16 @@
+---
+- name: collect common test cases
+  find:
+    paths: "{{ role_path }}/tests/common"
+    patterns: "{{ testcase }}.yaml"
+  connection: local
+  register: test_cases
+
+- name: set test_items
+  set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
+
+- name: run test case (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local connection={{ cli }}"
+  with_first_found: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run

--- a/test/integration/targets/nxos_install_os/tasks/network_local.yaml
+++ b/test/integration/targets/nxos_install_os/tasks/network_local.yaml
@@ -10,7 +10,7 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local connection={{ cli }}"
+  include: "{{ test_case_to_run }} ansible_connection=local"
   with_first_found: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_install_os/tasks/network_local.yaml
+++ b/test/integration/targets/nxos_install_os/tasks/network_local.yaml
@@ -9,8 +9,8 @@
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local"
+- name: run test case (ansible_connection=local transport=ssh)
+  include: "{{ test_case_to_run }} ansible_connection=local connection={{ cli }}"
   with_first_found: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_install_os/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_install_os/tasks/nxapi.yaml
@@ -9,8 +9,8 @@
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=nxapi)
-  include: "{{ test_case_to_run }} ansible_connection=local connection={{ nxapi }}"
+- name: run test cases (connection=httpapi)
+  include: "{{ test_case_to_run }} ansible_connection=httpapi"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_install_os/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_install_os/tasks/nxapi.yaml
@@ -1,0 +1,16 @@
+---
+- name: collect common test cases
+  find:
+    paths: "{{ role_path }}/tests/common"
+    patterns: "{{ testcase }}.yaml"
+  connection: local
+  register: test_cases
+
+- name: set test_items
+  set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
+
+- name: run test cases (connection=nxapi)
+  include: "{{ test_case_to_run }} ansible_connection=local connection={{ nxapi }}"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run

--- a/test/integration/targets/nxos_install_os/tasks/upgrade/clear_persistent_sockets.yaml
+++ b/test/integration/targets/nxos_install_os/tasks/upgrade/clear_persistent_sockets.yaml
@@ -1,4 +1,8 @@
 ---
+# This playbook is only provided for reference as a brute force way to
+# clear persistent connections on an Ansible server.  This was a workaround
+# for a problem with meta: reset_connection but should not be used in
+# ansible release 2.6 or later.
 - name: Clean up sockets with file module
   file:
     state: absent

--- a/test/integration/targets/nxos_install_os/tasks/upgrade/clear_persistent_sockets.yaml
+++ b/test/integration/targets/nxos_install_os/tasks/upgrade/clear_persistent_sockets.yaml
@@ -1,6 +1,4 @@
 ---
-- set_fact: home="{{ lookup('env', 'HOME') }}"
-
 - name: Clean up sockets with file module
   file:
     state: absent

--- a/test/integration/targets/nxos_install_os/tasks/upgrade/clear_persistent_sockets.yaml
+++ b/test/integration/targets/nxos_install_os/tasks/upgrade/clear_persistent_sockets.yaml
@@ -1,0 +1,17 @@
+---
+- set_fact: home="{{ lookup('env', 'HOME') }}"
+
+- name: Clean up sockets with file module
+  file:
+    state: absent
+    path: "{{ home }}/.ansible/pc/"
+  delegate_to: 127.0.0.1
+
+- name: "Display socket info after delete"
+  shell: "/bin/ls {{ home }}/.ansible"
+  args:
+    executable: /bin/bash
+  delegate_to: 127.0.0.1
+  register: output
+
+- debug: msg="Local Socket Info {{ output['stdout_lines'] }}"

--- a/test/integration/targets/nxos_install_os/tasks/upgrade/copy_kick_system_images.yaml
+++ b/test/integration/targets/nxos_install_os/tasks/upgrade/copy_kick_system_images.yaml
@@ -3,13 +3,30 @@
   nxos_feature:
     feature: scp-server
     state: enabled
+    provider: "{{ connection }}"
+
+- name: "Setup - Turn on feature scp-server"
+  nxos_feature:
+    feature: scp-server
+    state: enabled
+  when: connection is defined
 
 - name: "Copy {{ si }} to bootflash"
   nxos_file_copy:
     local_file: "{{image_dir}}{{ si }}"
     file_system: "bootflash:"
-    host: "{{ inventory_hostname }}"
   register: result
+  ignore_errors: yes
+  when: ansible_connection == 'httpapi'
+
+
+- name: "Copy {{ si }} to bootflash"
+  nxos_file_copy:
+    local_file: "{{image_dir}}{{ si }}"
+    file_system: "bootflash:"
+  register: result
+  ignore_errors: yes
+  when: ansible_connection == 'httpapi'
 
 - debug:
     msg: "{{ item.key }} {{ item.value }}"
@@ -19,9 +36,10 @@
   nxos_file_copy:
     local_file: "{{image_dir}}/{{ ki }}"
     file_system: "bootflash:"
-    host: "{{ inventory_hostname }}"
   register: result
   when: ki is defined
+  ignore_errors: yes
+  when: ansible_connection == 'httpapi'
 
 - debug:
     msg: "{{ item.key }} {{ item.value }}"

--- a/test/integration/targets/nxos_install_os/tasks/upgrade/copy_kick_system_images.yaml
+++ b/test/integration/targets/nxos_install_os/tasks/upgrade/copy_kick_system_images.yaml
@@ -3,13 +3,11 @@
   nxos_feature:
     feature: scp-server
     state: enabled
-    provider: "{{ connection }}"
 
 - name: "Copy {{ si }} to bootflash"
   nxos_file_copy:
     local_file: "{{image_dir}}{{ si }}"
     file_system: "bootflash:"
-    provider: "{{ connection }}"
     host: "{{ inventory_hostname }}"
   register: result
 
@@ -21,7 +19,6 @@
   nxos_file_copy:
     local_file: "{{image_dir}}/{{ ki }}"
     file_system: "bootflash:"
-    provider: "{{ connection }}"
     host: "{{ inventory_hostname }}"
   register: result
   when: ki is defined

--- a/test/integration/targets/nxos_install_os/tasks/upgrade/copy_kick_system_images.yaml
+++ b/test/integration/targets/nxos_install_os/tasks/upgrade/copy_kick_system_images.yaml
@@ -1,14 +1,12 @@
 ---
-- name: "Setup - Turn on feature scp-server"
-  nxos_feature:
-    feature: scp-server
-    state: enabled
-    provider: "{{ connection }}"
+- set_fact: ignore_errors_httpapi='no'
+- set_fact: ignore_errors_httpapi='yes'
+  when: ansible_connection == 'httpapi'
 
-- name: "Setup - Turn on feature scp-server"
-  nxos_feature:
-    feature: scp-server
-    state: enabled
+- include: targets/nxos_install_os/tasks/upgrade/enable_scp_server.yaml
+  when: connection is not defined
+
+- include: targets/nxos_install_os/tasks/upgrade/enable_scp_server_provider.yaml
   when: connection is defined
 
 - name: "Copy {{ si }} to bootflash"
@@ -16,17 +14,14 @@
     local_file: "{{image_dir}}{{ si }}"
     file_system: "bootflash:"
   register: result
-  ignore_errors: yes
-  when: ansible_connection == 'httpapi'
-
+  ignore_errors: "{{ ignore_errors_httpapi }}"
 
 - name: "Copy {{ si }} to bootflash"
   nxos_file_copy:
     local_file: "{{image_dir}}{{ si }}"
     file_system: "bootflash:"
   register: result
-  ignore_errors: yes
-  when: ansible_connection == 'httpapi'
+  ignore_errors: "{{ ignore_errors_httpapi }}"
 
 - debug:
     msg: "{{ item.key }} {{ item.value }}"
@@ -38,8 +33,7 @@
     file_system: "bootflash:"
   register: result
   when: ki is defined
-  ignore_errors: yes
-  when: ansible_connection == 'httpapi'
+  ignore_errors: "{{ ignore_errors_httpapi }}"
 
 - debug:
     msg: "{{ item.key }} {{ item.value }}"

--- a/test/integration/targets/nxos_install_os/tasks/upgrade/copy_kick_system_images.yaml
+++ b/test/integration/targets/nxos_install_os/tasks/upgrade/copy_kick_system_images.yaml
@@ -1,0 +1,32 @@
+---
+- name: "Setup - Turn on feature scp-server"
+  nxos_feature:
+    feature: scp-server
+    state: enabled
+    provider: "{{ connection }}"
+
+- name: "Copy {{ si }} to bootflash"
+  nxos_file_copy:
+    local_file: "{{image_dir}}{{ si }}"
+    file_system: "bootflash:"
+    provider: "{{ connection }}"
+    host: "{{ inventory_hostname }}"
+  register: result
+
+- debug:
+    msg: "{{ item.key }} {{ item.value }}"
+  with_dict: "{{ result }}"
+
+- name: "Copy {{ ki }} to bootflash"
+  nxos_file_copy:
+    local_file: "{{image_dir}}/{{ ki }}"
+    file_system: "bootflash:"
+    provider: "{{ connection }}"
+    host: "{{ inventory_hostname }}"
+  register: result
+  when: ki is defined
+
+- debug:
+    msg: "{{ item.key }} {{ item.value }}"
+  with_dict: "{{ result }}"
+  when: ki is defined

--- a/test/integration/targets/nxos_install_os/tasks/upgrade/delete_files.yaml
+++ b/test/integration/targets/nxos_install_os/tasks/upgrade/delete_files.yaml
@@ -1,0 +1,11 @@
+---
+- name: "Delete Files To Make Room On Bootflash"
+  nxos_config: &remove_file
+    lines:
+      - terminal dont-ask
+      - allow delete boot-image
+      - "delete {{ item }}"
+    match: none
+    provider: "{{ connection }}"
+  ignore_errors: yes
+  with_items: "{{ delete_image_list }}"

--- a/test/integration/targets/nxos_install_os/tasks/upgrade/delete_files.yaml
+++ b/test/integration/targets/nxos_install_os/tasks/upgrade/delete_files.yaml
@@ -6,6 +6,5 @@
       - allow delete boot-image
       - "delete {{ item }}"
     match: none
-    provider: "{{ connection }}"
   ignore_errors: yes
   with_items: "{{ delete_image_list }}"

--- a/test/integration/targets/nxos_install_os/tasks/upgrade/delete_files.yaml
+++ b/test/integration/targets/nxos_install_os/tasks/upgrade/delete_files.yaml
@@ -8,3 +8,15 @@
     match: none
   ignore_errors: yes
   with_items: "{{ delete_image_list }}"
+
+- name: "Delete Files To Make Room On Bootflash"
+  nxos_config: &remove_file
+    lines:
+      - terminal dont-ask
+      - allow delete boot-image
+      - "delete {{ item }}"
+    match: none
+    provider: "{{ connection }}"
+  ignore_errors: yes
+  with_items: "{{ delete_image_list }}"
+  when: connection is defined

--- a/test/integration/targets/nxos_install_os/tasks/upgrade/delete_files.yaml
+++ b/test/integration/targets/nxos_install_os/tasks/upgrade/delete_files.yaml
@@ -8,15 +8,3 @@
     match: none
   ignore_errors: yes
   with_items: "{{ delete_image_list }}"
-
-- name: "Delete Files To Make Room On Bootflash"
-  nxos_config: &remove_file
-    lines:
-      - terminal dont-ask
-      - allow delete boot-image
-      - "delete {{ item }}"
-    match: none
-    provider: "{{ connection }}"
-  ignore_errors: yes
-  with_items: "{{ delete_image_list }}"
-  when: connection is defined

--- a/test/integration/targets/nxos_install_os/tasks/upgrade/delete_files_provider.yaml
+++ b/test/integration/targets/nxos_install_os/tasks/upgrade/delete_files_provider.yaml
@@ -1,0 +1,11 @@
+---
+ - name: "Delete Files To Make Room On Bootflash using provider"
+   nxos_config: &remove_file
+     lines:
+       - terminal dont-ask
+       - allow delete boot-image
+       - "delete {{ item }}"
+     match: none
+     provider: "{{ connection }}"
+   ignore_errors: yes
+   with_items: "{{ delete_image_list }}"

--- a/test/integration/targets/nxos_install_os/tasks/upgrade/enable_scp_server.yaml
+++ b/test/integration/targets/nxos_install_os/tasks/upgrade/enable_scp_server.yaml
@@ -1,0 +1,5 @@
+---
+- name: "Setup - Turn on feature scp-server"
+  nxos_feature:
+    feature: scp-server
+    state: enabled

--- a/test/integration/targets/nxos_install_os/tasks/upgrade/enable_scp_server_provider.yaml
+++ b/test/integration/targets/nxos_install_os/tasks/upgrade/enable_scp_server_provider.yaml
@@ -1,0 +1,6 @@
+---
+- name: "Setup - Turn on feature scp-server using provider"
+  nxos_feature:
+    feature: scp-server
+    state: enabled
+    provider: "{{ connection }}"

--- a/test/integration/targets/nxos_install_os/tasks/upgrade/install_os.yaml
+++ b/test/integration/targets/nxos_install_os/tasks/upgrade/install_os.yaml
@@ -1,0 +1,27 @@
+---
+- debug: msg="***WARNING*** Remove meta end_play to verify this module ***WARNING***"
+
+- meta: end_play
+
+- include: targets/nxos_install_os/tasks/upgrade/delete_files.yaml
+  when: delete_image_list is defined
+
+- include: targets/nxos_install_os/tasks/upgrade/copy_kick_system_images.yaml
+
+- include: targets/nxos_install_os/tasks/upgrade/install_with_kick.yaml
+  when: ki is defined and combined is undefined
+
+- include: targets/nxos_install_os/tasks/upgrade/install_system.yaml
+  when: combined is defined
+
+#- include: targets/nxos_install_os/tasks/upgrade/clear_persistent_sockets.yaml
+
+- meta: reset_connection
+
+- name: "Check installed OS for newly installed version {{ tv }}"
+  nxos_command:
+    commands: ['show version | json']
+    provider: "{{ connection }}"
+  register: output
+
+- debug: msg="Version detected {{ output['stdout_lines'][0]['kickstart_ver_str'] }}"

--- a/test/integration/targets/nxos_install_os/tasks/upgrade/install_os.yaml
+++ b/test/integration/targets/nxos_install_os/tasks/upgrade/install_os.yaml
@@ -1,10 +1,10 @@
 ---
-- debug: msg="***WARNING*** Remove meta end_play to verify this module ***WARNING***"
+#- debug: msg="***WARNING*** Remove meta end_play to verify this module ***WARNING***"
 
-- meta: end_play
+#- meta: end_play
 
-- include: targets/nxos_install_os/tasks/upgrade/delete_files.yaml
-  when: delete_image_list is defined
+#- include: targets/nxos_install_os/tasks/upgrade/delete_files.yaml
+#  when: delete_image_list is defined
 
 - include: targets/nxos_install_os/tasks/upgrade/copy_kick_system_images.yaml
 
@@ -21,7 +21,13 @@
 - name: "Check installed OS for newly installed version {{ tv }}"
   nxos_command:
     commands: ['show version | json']
+  register: output
+
+- name: "Check installed OS for newly installed version {{ tv }}"
+  nxos_command:
+    commands: ['show version | json']
     provider: "{{ connection }}"
   register: output
+  when: connection is defined
 
 - debug: msg="Version detected {{ output['stdout_lines'][0]['kickstart_ver_str'] }}"

--- a/test/integration/targets/nxos_install_os/tasks/upgrade/install_os_provider.yaml
+++ b/test/integration/targets/nxos_install_os/tasks/upgrade/install_os_provider.yaml
@@ -1,13 +1,13 @@
 ---
-- include: targets/nxos_install_os/tasks/upgrade/delete_files.yaml
+- include: targets/nxos_install_os/tasks/upgrade/delete_files_provider.yaml
   when: delete_image_list is defined
 
 - include: targets/nxos_install_os/tasks/upgrade/copy_kick_system_images.yaml
 
-- include: targets/nxos_install_os/tasks/upgrade/install_with_kick.yaml
+- include: targets/nxos_install_os/tasks/upgrade/install_with_kick_provider.yaml
   when: ki is defined and combined is undefined
 
-- include: targets/nxos_install_os/tasks/upgrade/install_system.yaml
+- include: targets/nxos_install_os/tasks/upgrade/install_system_provider.yaml
   when: combined is defined
 
 # Only needed when - meta: reset_connection does not work. Fixed in 2.6
@@ -18,6 +18,7 @@
 - name: "Check installed OS for newly installed version {{ tv }}"
   nxos_command:
     commands: ['show version | json']
+    provider: "{{ connection }}"
   register: output
 
 - debug: msg="Version detected {{ output['stdout_lines'][0]['kickstart_ver_str'] }}"

--- a/test/integration/targets/nxos_install_os/tasks/upgrade/install_system.yaml
+++ b/test/integration/targets/nxos_install_os/tasks/upgrade/install_system.yaml
@@ -4,7 +4,7 @@
   nxos_install_os:
     system_image_file: "{{ si }}"
     issu: "{{ issu }}"
-    provider: "{{ connection }}"
+    provider: "{{ connection | combine({'timeout': 500}) }}"
   register: result
 
 - debug: msg=" {{ result['install_state'] }}"

--- a/test/integration/targets/nxos_install_os/tasks/upgrade/install_system.yaml
+++ b/test/integration/targets/nxos_install_os/tasks/upgrade/install_system.yaml
@@ -6,6 +6,15 @@
     issu: "{{ issu }}"
   register: result
 
+- name: "Install OS image {{ si }}"
+  check_mode: "{{ checkmode }}"
+  nxos_install_os:
+    system_image_file: "{{ si }}"
+    issu: "{{ issu }}"
+    provider: "{{ connection }}"
+  register: result
+  when: connection is defined
+
 - debug: msg=" {{ result['install_state'] }}"
 
 - name: Wait for device to come back up with new image

--- a/test/integration/targets/nxos_install_os/tasks/upgrade/install_system.yaml
+++ b/test/integration/targets/nxos_install_os/tasks/upgrade/install_system.yaml
@@ -4,7 +4,6 @@
   nxos_install_os:
     system_image_file: "{{ si }}"
     issu: "{{ issu }}"
-    provider: "{{ connection | combine({'timeout': 500}) }}"
   register: result
 
 - debug: msg=" {{ result['install_state'] }}"

--- a/test/integration/targets/nxos_install_os/tasks/upgrade/install_system.yaml
+++ b/test/integration/targets/nxos_install_os/tasks/upgrade/install_system.yaml
@@ -1,0 +1,25 @@
+---
+- name: "Install OS image {{ si }}"
+  check_mode: "{{ checkmode }}"
+  nxos_install_os:
+    system_image_file: "{{ si }}"
+    issu: "{{ issu }}"
+    provider: "{{ connection }}"
+  register: result
+
+- debug: msg=" {{ result['install_state'] }}"
+
+- name: Wait for device to come back up with new image
+  wait_for:
+    port: 22
+    state: started
+    timeout: 500
+    delay: 60
+    host: "{{ inventory_hostname }}"
+  when: result.changed and not checkmode
+
+- debug: msg='Wait 5 mins to allow system to stabilize'
+  when: result.changed and not checkmode
+- pause:
+    seconds: 300
+  when: result.changed and not checkmode

--- a/test/integration/targets/nxos_install_os/tasks/upgrade/install_system.yaml
+++ b/test/integration/targets/nxos_install_os/tasks/upgrade/install_system.yaml
@@ -6,15 +6,6 @@
     issu: "{{ issu }}"
   register: result
 
-- name: "Install OS image {{ si }}"
-  check_mode: "{{ checkmode }}"
-  nxos_install_os:
-    system_image_file: "{{ si }}"
-    issu: "{{ issu }}"
-    provider: "{{ connection }}"
-  register: result
-  when: connection is defined
-
 - debug: msg=" {{ result['install_state'] }}"
 
 - name: Wait for device to come back up with new image

--- a/test/integration/targets/nxos_install_os/tasks/upgrade/install_system_provider.yaml
+++ b/test/integration/targets/nxos_install_os/tasks/upgrade/install_system_provider.yaml
@@ -1,10 +1,10 @@
 ---
-- name: "Install OS image {{ si }}"
+- name: "Install OS image {{ si }} using provider"
   check_mode: "{{ checkmode }}"
   nxos_install_os:
     system_image_file: "{{ si }}"
-    kickstart_image_file: "{{ ki }}"
     issu: "{{ issu }}"
+    provider: "{{ connection }}"
   register: result
 
 - debug: msg=" {{ result['install_state'] }}"

--- a/test/integration/targets/nxos_install_os/tasks/upgrade/install_with_kick.yaml
+++ b/test/integration/targets/nxos_install_os/tasks/upgrade/install_with_kick.yaml
@@ -7,6 +7,16 @@
     issu: "{{ issu }}"
   register: result
 
+- name: "Install OS image {{ si }}"
+  check_mode: "{{ checkmode }}"
+  nxos_install_os:
+    system_image_file: "{{ si }}"
+    kickstart_image_file: "{{ ki }}"
+    issu: "{{ issu }}"
+    provider: "{{ connection }}"
+  register: result
+  when: connection is defined
+
 - debug: msg=" {{ result['install_state'] }}"
 
 - name: Wait for device to come back up with new image

--- a/test/integration/targets/nxos_install_os/tasks/upgrade/install_with_kick.yaml
+++ b/test/integration/targets/nxos_install_os/tasks/upgrade/install_with_kick.yaml
@@ -5,7 +5,6 @@
     system_image_file: "{{ si }}"
     kickstart_image_file: "{{ ki }}"
     issu: "{{ issu }}"
-    provider: "{{ connection | combine({'timeout': 500}) }}"
   register: result
 
 - debug: msg=" {{ result['install_state'] }}"

--- a/test/integration/targets/nxos_install_os/tasks/upgrade/install_with_kick.yaml
+++ b/test/integration/targets/nxos_install_os/tasks/upgrade/install_with_kick.yaml
@@ -1,0 +1,26 @@
+---
+- name: "Install OS image {{ si }}"
+  check_mode: "{{ checkmode }}"
+  nxos_install_os:
+    system_image_file: "{{ si }}"
+    kickstart_image_file: "{{ ki }}"
+    issu: "{{ issu }}"
+    provider: "{{ connection | combine({'timeout': 500}) }}"
+  register: result
+
+- debug: msg=" {{ result['install_state'] }}"
+
+- name: Wait for device to come back up with new image
+  wait_for:
+    port: 22
+    state: started
+    timeout: 500
+    delay: 60
+    host: "{{ inventory_hostname }}"
+  when: result.changed and not checkmode
+
+- debug: msg='Wait 5 mins to allow system to stabilize'
+  when: result.changed and not checkmode
+- pause:
+    seconds: 300
+  when: result.changed and not checkmode

--- a/test/integration/targets/nxos_install_os/tasks/upgrade/install_with_kick_provider.yaml
+++ b/test/integration/targets/nxos_install_os/tasks/upgrade/install_with_kick_provider.yaml
@@ -1,10 +1,11 @@
 ---
-- name: "Install OS image {{ si }}"
+- name: "Install OS image {{ si }} using provider"
   check_mode: "{{ checkmode }}"
   nxos_install_os:
     system_image_file: "{{ si }}"
     kickstart_image_file: "{{ ki }}"
     issu: "{{ issu }}"
+    provider: "{{ connection }}"
   register: result
 
 - debug: msg=" {{ result['install_state'] }}"

--- a/test/integration/targets/nxos_install_os/tasks/upgrade/main_os_install.yaml
+++ b/test/integration/targets/nxos_install_os/tasks/upgrade/main_os_install.yaml
@@ -1,0 +1,10 @@
+---
+- debug: msg="***WARNING*** Remove meta end_play to verify this module ***WARNING***"
+
+- meta: end_play
+
+- include: targets/nxos_install_os/tasks/upgrade/install_os.yaml
+  when: connection is not defined
+
+- include: targets/nxos_install_os/tasks/upgrade/install_os_provider.yaml
+  when: connection is defined

--- a/test/integration/targets/nxos_install_os/tasks/upgrade/set_boot_pointer_and_reload.yaml
+++ b/test/integration/targets/nxos_install_os/tasks/upgrade/set_boot_pointer_and_reload.yaml
@@ -1,0 +1,34 @@
+---
+- name: "Reload to upgrade to OS image {{ si }}"
+  nxos_config:
+    lines:
+      - terminal dont-ask
+      - no boot nxos
+      - "boot nxos bootflash:{{ si }}"
+      - reload
+    match: none
+  ignore_errors: yes
+
+- name: "Reload to upgrade to OS image {{ si }}"
+  nxos_config:
+    lines:
+      - terminal dont-ask
+      - no boot nxos
+      - "boot nxos bootflash:{{ si }}"
+      - reload
+    match: none
+    provider: "{{ connection }}"
+  ignore_errors: yes
+  when: connection is defined
+
+- name: Wait for device to come back up with new image
+  wait_for:
+    port: 22
+    state: started
+    timeout: 500
+    delay: 60
+    host: "{{ inventory_hostname }}"
+
+- debug: msg='Wait 5 mins to allow system to stabilize'
+- pause:
+    seconds: 300

--- a/test/integration/targets/nxos_install_os/tasks/upgrade/set_boot_pointer_and_reload_provider.yaml
+++ b/test/integration/targets/nxos_install_os/tasks/upgrade/set_boot_pointer_and_reload_provider.yaml
@@ -1,5 +1,5 @@
 ---
-- name: "Reload to upgrade to OS image {{ si }}"
+- name: "Reload to upgrade to OS image {{ si }} using provider"
   nxos_config:
     lines:
       - terminal dont-ask
@@ -7,6 +7,7 @@
       - "boot nxos bootflash:{{ si }}"
       - reload
     match: none
+    provider: "{{ connection }}"
   ignore_errors: yes
 
 - name: Wait for device to come back up with new image

--- a/test/integration/targets/nxos_install_os/tests/common/upgrade.yaml
+++ b/test/integration/targets/nxos_install_os/tests/common/upgrade.yaml
@@ -1,7 +1,7 @@
 ---
 - debug: msg="START connection={{ ansible_connection }} nxos_os_install upgrade"
 - debug: msg="Using provider={{ connection.transport }}"
-  when: ansible_connection == "local"
+  when: connection is defined
 
 - set_fact: checkmode='no'
 - set_fact: issu='desired'

--- a/test/integration/targets/nxos_install_os/tests/common/upgrade.yaml
+++ b/test/integration/targets/nxos_install_os/tests/common/upgrade.yaml
@@ -6,7 +6,7 @@
 - set_fact: checkmode='no'
 - set_fact: issu='desired'
 
-- set_fact: image_dir='/root/agents_images/'
+- set_fact: image_dir='/Users/mwiebe/Projects/nxos_ansible/images/'
 
 - set_fact:
     delete_image_list:
@@ -21,7 +21,7 @@
 - set_fact: ki='n3000-uk9-kickstart.6.0.2.U6.1a.bin'
 
 - name: Upgrade to U6.1a
-  include: targets/nxos_install_os/tasks/upgrade/install_os.yaml
+  include: targets/nxos_install_os/tasks/upgrade/main_os_install.yaml
 
 #---------------------------------------------------------#
 # Upgrade to 6.0(2)U6(2a)                                 #
@@ -31,7 +31,7 @@
 - set_fact: ki='n3000-uk9-kickstart.6.0.2.U6.2a.bin'
 
 - name: Upgrade to U6.2a
-  include: targets/nxos_install_os/tasks/upgrade/install_os.yaml
+  include: targets/nxos_install_os/tasks/upgrade/main_os_install.yaml
 
 #---------------------------------------------------------#
 # Upgrade to 6.0(2)U6(3a)                                 #
@@ -41,16 +41,16 @@
 - set_fact: ki='n3000-uk9-kickstart.6.0.2.U6.3a.bin'
 
 - name: Upgrade to U6.3a
-  include: targets/nxos_install_os/tasks/upgrade/install_os.yaml
+  include: targets/nxos_install_os/tasks/upgrade/main_os_install.yaml
 
 #---------------------------------------------------------#
 # Upgrade to 7.0(3)I7(3)                                  #
 #---------------------------------------------------------#
 
-- set_fact: si='nxos.7.0.3.I7.3.bin'
+- set_fact: si='nxos.7.0.3.I7.2.bin'
 - set_fact: combined='true'
 
-- name: Upgrade to 7.0.3.I7.3
-  include: targets/nxos_install_os/tasks/upgrade/install_os.yaml
+- name: Upgrade to 7.0.3.I7.2
+  include: targets/nxos_install_os/tasks/upgrade/main_os_install.yaml
 
 - debug: msg="END connection={{ ansible_connection }} nxos_os_install upgrade"

--- a/test/integration/targets/nxos_install_os/tests/common/upgrade.yaml
+++ b/test/integration/targets/nxos_install_os/tests/common/upgrade.yaml
@@ -1,0 +1,56 @@
+---
+- debug: msg="START connection={{ ansible_connection }} nxos_os_install upgrade"
+- debug: msg="Using provider={{ connection.transport }}"
+  when: ansible_connection == "local"
+
+- set_fact: checkmode='no'
+- set_fact: issu='desired'
+
+- set_fact: image_dir='/root/agents_images/'
+
+- set_fact:
+    delete_image_list:
+      - nxos.7.0.3.I7.2.bin
+      - nxos.7.0.3.I7.3.bin
+
+#---------------------------------------------------------#
+# Upgrade to 6.0(2)U6(1a)                                 #
+#---------------------------------------------------------#
+
+- set_fact: si='n3000-uk9.6.0.2.U6.1a.bin'
+- set_fact: ki='n3000-uk9-kickstart.6.0.2.U6.1a.bin'
+
+- name: Upgrade to U6.1a
+  include: targets/nxos_install_os/tasks/upgrade/install_os.yaml
+
+#---------------------------------------------------------#
+# Upgrade to 6.0(2)U6(2a)                                 #
+#---------------------------------------------------------#
+
+- set_fact: si='n3000-uk9.6.0.2.U6.2a.bin'
+- set_fact: ki='n3000-uk9-kickstart.6.0.2.U6.2a.bin'
+
+- name: Upgrade to U6.2a
+  include: targets/nxos_install_os/tasks/upgrade/install_os.yaml
+
+#---------------------------------------------------------#
+# Upgrade to 6.0(2)U6(3a)                                 #
+#---------------------------------------------------------#
+
+- set_fact: si='n3000-uk9.6.0.2.U6.3a.bin'
+- set_fact: ki='n3000-uk9-kickstart.6.0.2.U6.3a.bin'
+
+- name: Upgrade to U6.3a
+  include: targets/nxos_install_os/tasks/upgrade/install_os.yaml
+
+#---------------------------------------------------------#
+# Upgrade to 7.0(3)I7(3)                                  #
+#---------------------------------------------------------#
+
+- set_fact: si='nxos.7.0.3.I7.3.bin'
+- set_fact: combined='true'
+
+- name: Upgrade to 7.0.3.I7.3
+  include: targets/nxos_install_os/tasks/upgrade/install_os.yaml
+
+- debug: msg="END connection={{ ansible_connection }} nxos_os_install upgrade"


### PR DESCRIPTION
##### SUMMARY
This update includes the following:
* Change to the `check_ansible_timer` method inside the module to make sure both `ANSIBLE_PERSISTENT_COMMAND_TIMEOUT` and `ANSIBLE_PERSISTENT_CONNECTION_TIMEOUT` are set properly when using this module.
  * I understand that there are multiple ways to set these timers, but we need a way to make sure they are set for connection `local`, `network_cli` and `nxapi`.  
  * Please advise if there is a way that we can check that these timers are set using all methods available (env vars, config file)
* Add integration test playbooks that can be used to upgrade Nexus devices.
  * By default they will not run since a `meta: end_play` has been added in the main `install_os.yaml` playbook.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
nxos_install_os

##### ANSIBLE VERSION
```
ansible 2.6.0 (rel260/nxos_install_os 1b5f7dc422) last updated 2018/05/14 14:50:05 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/Users/mwiebe/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mwiebe/Projects/nxos_ansible/fix_ansible/lib/ansible
  executable location = /Users/mwiebe/Projects/nxos_ansible/fix_ansible/bin/ansible
  python version = 2.7.13 (default, Apr  4 2017, 08:47:57) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.38)]
```
