### PR TITLE
changed accportgrp to accbundle

### DIFF
--- a/lib/ansible/modules/network/aci/aci_access_port_to_interface_policy_leaf_profile.py
+++ b/lib/ansible/modules/network/aci/aci_access_port_to_interface_policy_leaf_profile.py
@@ -61,6 +61,7 @@ options:
     - The name of the fabric access policy group to be associated with the leaf interface profile interface selector.
     aliases: [ policy_group_name ]
   policy_group_type:
+    version_added: '2.6'
     description:
     - The type of interface for the static EPG deployement.
     choices: [ port_channel, switch_port, vpc ]
@@ -240,7 +241,7 @@ def main():
         'from': dict(type='str', aliases=['fromPort', 'from_port_range']),
         'to': dict(type='str', aliases=['toPort', 'to_port_range']),
         'policy_group': dict(type='str', aliases=['policy_group_name']),
-        'policy_group_type': dict(type='str'),        
+        'policy_group_type': dict(type='str', default='switch_port', choices=['port_channel', 'switch_port', 'vpc']),
         'state': dict(type='str', default='present', choices=['absent', 'present', 'query']),
     })
 

--- a/lib/ansible/modules/network/aci/aci_access_port_to_interface_policy_leaf_profile.py
+++ b/lib/ansible/modules/network/aci/aci_access_port_to_interface_policy_leaf_profile.py
@@ -60,6 +60,11 @@ options:
     description:
     - The name of the fabric access policy group to be associated with the leaf interface profile interface selector.
     aliases: [ policy_group_name ]
+  policy_group_type:
+    description:
+    - The type of interface for the static EPG deployement.
+    choices: [ port_channel, switch_port, vpc ]
+    default: switch_port
   state:
     description:
     - Use C(present) or C(absent) for adding or removing.
@@ -235,6 +240,7 @@ def main():
         'from': dict(type='str', aliases=['fromPort', 'from_port_range']),
         'to': dict(type='str', aliases=['toPort', 'to_port_range']),
         'policy_group': dict(type='str', aliases=['policy_group_name']),
+        'policy_group_type': dict(type='str'),        
         'state': dict(type='str', default='present', choices=['absent', 'present', 'query']),
     })
 
@@ -255,6 +261,7 @@ def main():
     from_ = module.params['from']
     to_ = module.params['to']
     policy_group = module.params['policy_group']
+    policy_group_type = module.params['policy_group_type']
     state = module.params['state']
 
     aci = ACIModule(module)
@@ -274,6 +281,13 @@ def main():
         ),
         child_classes=['infraPortBlk', 'infraRsAccBaseGrp']
     )
+
+    POLICY_GROUP_TYPE_MAPPING = dict(
+        port_channel='uni/infra/funcprof/accbundle-{0}'.format(policy_group),
+        switch_port='uni/infra/funcprof/accportgrp-{0}'.format(policy_group),
+        vpc='uni/infra/funcprof/accbundle-{0}'.format(policy_group),
+    )
+
     aci.get_existing()
 
     if state == 'present':
@@ -297,7 +311,7 @@ def main():
                 dict(
                     infraRsAccBaseGrp=dict(
                         attributes=dict(
-                            tDn='uni/infra/funcprof/accportgrp-{0}'.format(policy_group),
+                            tDn=POLICY_GROUP_TYPE_MAPPING[policy_group_type],
                         ),
                     ),
                 ),

--- a/lib/ansible/modules/network/aci/aci_access_port_to_interface_policy_leaf_profile.py
+++ b/lib/ansible/modules/network/aci/aci_access_port_to_interface_policy_leaf_profile.py
@@ -60,11 +60,11 @@ options:
     description:
     - The name of the fabric access policy group to be associated with the leaf interface profile interface selector.
     aliases: [ policy_group_name ]
-  policy_group_type:
+  interface_type:
     version_added: '2.6'
     description:
     - The type of interface for the static EPG deployement.
-    choices: [ port_channel, switch_port, vpc ]
+    choices: [ fex, port_channel, switch_port, vpc ]
     default: switch_port
   state:
     description:
@@ -241,7 +241,7 @@ def main():
         'from': dict(type='str', aliases=['fromPort', 'from_port_range']),
         'to': dict(type='str', aliases=['toPort', 'to_port_range']),
         'policy_group': dict(type='str', aliases=['policy_group_name']),
-        'policy_group_type': dict(type='str', default='switch_port', choices=['port_channel', 'switch_port', 'vpc']),
+        'interface_type': dict(type='str', default='switch_port', choices=['fex', 'port_channel', 'switch_port', 'vpc']),
         'state': dict(type='str', default='present', choices=['absent', 'present', 'query']),
     })
 
@@ -262,7 +262,7 @@ def main():
     from_ = module.params['from']
     to_ = module.params['to']
     policy_group = module.params['policy_group']
-    policy_group_type = module.params['policy_group_type']
+    interface_type = module.params['interface_type']
     state = module.params['state']
 
     aci = ACIModule(module)
@@ -283,7 +283,8 @@ def main():
         child_classes=['infraPortBlk', 'infraRsAccBaseGrp']
     )
 
-    POLICY_GROUP_TYPE_MAPPING = dict(
+    INTERFACE_TYPE_MAPPING = dict(
+        fex='uni/infra/funcprof/accportgrp-{0}'.format(policy_group),
         port_channel='uni/infra/funcprof/accbundle-{0}'.format(policy_group),
         switch_port='uni/infra/funcprof/accportgrp-{0}'.format(policy_group),
         vpc='uni/infra/funcprof/accbundle-{0}'.format(policy_group),
@@ -312,7 +313,7 @@ def main():
                 dict(
                     infraRsAccBaseGrp=dict(
                         attributes=dict(
-                            tDn=POLICY_GROUP_TYPE_MAPPING[policy_group_type],
+                            tDn=INTERFACE_TYPE_MAPPING[interface_type],
                         ),
                     ),
                 ),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #38549 

++ added new parameter "interface_type" (default is "switch_port")
++ if interface_type == "vpc" or "port_channel", then change accportgrp to accbundle

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
lib/ansible/modules/network/aci/aci_access_port_to_interface_policy_leaf_profile.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0 (accbundle f607370aa6) last updated 2018/05/14 15:34:37 (GMT -400)
  config file = None
  configured module search path = ['/root/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /mnt/c/winbash/ansible/ansible/lib/ansible
  executable location = /mnt/c/winbash/ansible/ansible/bin/ansible
  python version = 3.5.2 (default, Nov 23 2017, 16:37:01) [GCC 5.4.0 20160609]
```