### PR TITLE
ios_facts: Add check to skip lldp neighbors if lldp doesn't exist or isn't enabled.

### DIFF
--- a/lib/ansible/module_utils/network/ios/ios.py
+++ b/lib/ansible/module_utils/network/ios/ios.py
@@ -29,7 +29,7 @@ import json
 from ansible.module_utils._text import to_text
 from ansible.module_utils.basic import env_fallback, return_values
 from ansible.module_utils.network.common.utils import to_list, ComplexList
-from ansible.module_utils.connection import Connection
+from ansible.module_utils.connection import Connection, ConnectionError
 
 _DEVICE_CONFIGS = {}
 
@@ -144,7 +144,13 @@ def run_commands(module, commands, check_rc=True):
             prompt = None
             answer = None
 
-        out = connection.get(command, prompt, answer)
+        try:
+            out = connection.get(command, prompt, answer)
+        except ConnectionError as e:
+            if check_rc:
+                raise
+            else:
+                out = e
 
         try:
             out = to_text(out, errors='surrogate_or_strict')

--- a/lib/ansible/modules/network/ios/ios_facts.py
+++ b/lib/ansible/modules/network/ios/ios_facts.py
@@ -281,7 +281,9 @@ class Interfaces(FactsBase):
             self.populate_ipv6_interfaces(data)
 
         data = self.responses[3]
-        if data:
+        lldp_errs = ['Invalid input', 'LLDP is not enabled']
+
+        if data and not any(err in data for err in lldp_errs):
             neighbors = self.run(['show lldp neighbors detail'])
             if neighbors:
                 self.facts['neighbors'] = self.parse_neighbors(neighbors[0])


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes https://github.com/ansible/ansible/issues/37507

Older IOS devices that don't support LLDP fail when including `interfaces` as part of `ios_facts`. This commit adds a check for any IOS errors when running the command `show lldp` and skips the LLDP neighbor parsing if LLDP isn't available.

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
ios_facts
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0 (devel ddf7873d6e) last updated 2018/05/14 16:49:20 (GMT -400)
  config file = /Users/tyler8/projects/pycon18/projfiles/ansible.cfg
  configured module search path = ['/Users/tyler8/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/tyler8/projects/pycon18/ansible/lib/ansible
  executable location = /Users/tyler8/.local/share/virtualenvs/pycon18-CTYMJGfK/bin/ansible
  python version = 3.6.5 (default, Mar 30 2018, 06:41:53) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->
```---
- hosts: csr
  gather_facts: no
  connection: network_cli

  tasks:

  - name: IOS | Get the facts
    ios_facts:
      gather_subset: all
    register: thefacts

  - debug: msg="{{ thefacts }}"
```
<!--- Paste verbatim command output below, e.g. before and after your change -->
With LLDP enabled with no neighbors: 
```
            "ansible_net_model": "CSR1000V",
            "ansible_net_neighbors": {
                "null": [
                    {
                        "host": null,
                        "port": null
                    }
                ]
            },
            "ansible_net_serialnum": "1234QWERTY",
```
With no LLDP enabled (should be same for no LLDP support:
```
            "ansible_net_model": "CSR1000V",
            "ansible_net_serialnum": "1234QWERTY",
```

I don't have the ability to test on a device that doesn't support LLDP at all - however the check logic should be the same regardless if the error string is present.