### PR TITLE
More file refactoring

### DIFF
--- a/changelogs/fragments/file-disallow-src.yaml
+++ b/changelogs/fragments/file-disallow-src.yaml
@@ -1,0 +1,8 @@
+---
+bugfixes:
+- file module - The file module allowed the user to specify src as a parameter
+  when state was not link or hard.  This is documented as only applying to
+  state=link or state=hard but in previous Ansible, this could have an effect
+  in rare cornercases.  For instance, "ansible -m file -a 'state=directory
+  path=/tmp src=/var/lib'" would create /tmp/lib.  This has been disabled and
+  a warning emitted (will change to an error in Ansible-2.10).

--- a/docs/docsite/rst/porting_guides/porting_guide_2.6.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.6.rst
@@ -51,6 +51,18 @@ Noteworthy module changes
 * The ``win_iis_webapppool`` module no longer accepts a string for the ``atributes`` module option; use the free form dictionary value instead
 * The ``name`` module option for ``win_package`` has been removed; this is not used anywhere and should just be removed from your playbooks
 * The ``win_regedit`` module no longer automatically corrects the hive path ``HCCC`` to ``HKCC``; use ``HKCC`` because this is the correct hive path
+* The :ref:`file_module` now emits a deprecation warning when ``src`` is specified with a state
+  other than ``hard`` or ``link`` as it is only supposed to be useful with those.  This could have
+  an effect on people who were depending on a buggy interaction between src and other state's to
+  place files into a subdirectory.  For instance::
+
+    $ ansible localhost -m file -a 'path=/var/lib src=/tmp/ state=directory'
+
+  Would create a directory named ``/tmp/lib``.  Instead of the above, simply spell out the entire
+  destination path like this::
+
+    $ ansible localhost -m file -a 'path=/tmp/lib state=directory'
+
 
 Plugins
 =======

--- a/lib/ansible/modules/files/file.py
+++ b/lib/ansible/modules/files/file.py
@@ -159,9 +159,6 @@ def _ansible_excepthook(exc_type, exc_value, tb):
 
 def additional_parameter_handling(params):
     """Additional parameter validation and reformatting"""
-
-    params['b_src'] = to_bytes(params['src'], errors='surrogate_or_strict', nonstring='passthru')
-
     # state should default to file, but since that creates many conflicts,
     # default state to 'current' when it exists.
     prev_state = get_state(to_bytes(params['path'], errors='surrogate_or_strict'))
@@ -426,8 +423,9 @@ def ensure_directory(path, follow, recurse):
     return {'path': path, 'changed': changed, 'diff': diff}
 
 
-def ensure_symlink(path, src, b_src, follow, force):
+def ensure_symlink(path, src, follow, force):
     b_path = to_bytes(path, errors='surrogate_or_strict')
+    b_src = to_bytes(src, errors='surrogate_or_strict')
     prev_state = get_state(b_path)
     file_args = module.load_file_common_arguments(module.params)
 
@@ -437,7 +435,7 @@ def ensure_symlink(path, src, b_src, follow, force):
         if follow:
             # use the current target of the link as the source
             src = to_native(os.path.realpath(b_path), errors='strict')
-            b_src = to_bytes(os.path.realpath(b_path), errors='strict')
+            b_src = to_bytes(src, errors='surrogate_or_strict')
 
     if not os.path.islink(b_path) and os.path.isdir(b_path):
         relpath = path
@@ -537,8 +535,9 @@ def ensure_symlink(path, src, b_src, follow, force):
     return {'dest': path, 'src': src, 'changed': changed, 'diff': diff}
 
 
-def ensure_hardlink(path, src, b_src, follow, force):
+def ensure_hardlink(path, src, follow, force):
     b_path = to_bytes(path, errors='surrogate_or_strict')
+    b_src = to_bytes(src, errors='surrogate_or_strict')
     prev_state = get_state(b_path)
     file_args = module.load_file_common_arguments(module.params)
 
@@ -665,7 +664,6 @@ def main():
     follow = params['follow']
     path = params['path']
     src = params['src']
-    b_src = params['b_src']
 
     # short-circuit for diff_peek
     if params['_diff_peek'] is not None:
@@ -677,8 +675,8 @@ def main():
         basename = None
         if params['original_basename']:
             basename = params['original_basename']
-        elif b_src is not None:
-            basename = os.path.basename(b_src)
+        elif src is not None:
+            basename = os.path.basename(src)
         if basename:
             params['path'] = path = os.path.join(path, basename)
 
@@ -687,9 +685,9 @@ def main():
     elif state == 'directory':
         result = ensure_directory(path, follow, recurse)
     elif state == 'link':
-        result = ensure_symlink(path, src, b_src, follow, force)
+        result = ensure_symlink(path, src, follow, force)
     elif state == 'hard':
-        result = ensure_hardlink(path, src, b_src, follow, force)
+        result = ensure_hardlink(path, src, follow, force)
     elif state == 'touch':
         result = execute_touch(path, follow)
     elif state == 'absent':

--- a/lib/ansible/modules/files/file.py
+++ b/lib/ansible/modules/files/file.py
@@ -176,6 +176,16 @@ def additional_parameter_handling(params):
         raise ParameterError(results={"msg": "recurse option requires state to be 'directory'",
                                       "path": params["path"]})
 
+    # Make sure that src makes sense with the state
+    if params['src'] and params['state'] not in ('link', 'hard'):
+        params['src'] = None
+        module.warn("The src option requires state to be 'link' or 'hard'.  This will become an"
+                    " error in Ansible 2.10")
+
+        # In 2.10, switch to this
+        # raise ParameterError(results={"msg": "src option requires state to be 'link' or 'hard'",
+        #                               "path": params["path"]})
+
     # When path is a directory, rewrite the pathname to be the file inside of the directory
     # TODO: Why do we exclude link?  Why don't we exclude directory?  Should we exclude touch?
     if (params['state'] not in ("link", "absent") and os.path.isdir(to_bytes(params['path'], errors='surrogate_or_strict'))):

--- a/test/integration/targets/file/tasks/main.yml
+++ b/test/integration/targets/file/tasks/main.yml
@@ -134,7 +134,9 @@
       - "file6_result.changed == true"
 
 - name: touch a hard link
-  file: src={{output_file}} dest={{output_dir}}/hard.txt state=touch
+  file:
+    dest: '{{ output_dir }}/hard.txt'
+    state: 'touch'
   register: file6_touch_result
 
 - name: verify that the hard link was touched


### PR DESCRIPTION
##### SUMMARY
* Move creation of b_src and b_path from the src and path parameters into the state functions.  It means repeated code but it is better to only pass a single value into the function instead of two that have the same meaning, just different formats.
* Move rewriting of path when it is a directory into additional_parameter_handling because it's a parameter validation and conversion.
* Only allow the src parameter to work with state=link and state=hard as documented.  Emit a warning if src is set with any other state.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/files/file.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```