### PR TITLE
Add integration tests for iam_policy

### DIFF
--- a/test/integration/targets/iam_policy/aliases
+++ b/test/integration/targets/iam_policy/aliases
@@ -1,0 +1,2 @@
+cloud/aws
+posix/ci/cloud/group4/aws

--- a/test/integration/targets/iam_policy/aliases
+++ b/test/integration/targets/iam_policy/aliases
@@ -1,2 +1,2 @@
 cloud/aws
-posix/ci/cloud/group4/aws
+unsupported

--- a/test/integration/targets/iam_policy/defaults/main.yml
+++ b/test/integration/targets/iam_policy/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+iam_user_name: '{{resource_prefix}}'
+iam_role_name: '{{resource_prefix}}'
+iam_group_name: '{{resource_prefix}}'
+iam_policy_name: '{{resource_prefix}}'

--- a/test/integration/targets/iam_policy/files/no_access.json
+++ b/test/integration/targets/iam_policy/files/no_access.json
@@ -1,0 +1,10 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Deny",
+            "Action": "*",
+            "Resource": "*"
+        }
+    ]
+}

--- a/test/integration/targets/iam_policy/files/no_access_with_id.json
+++ b/test/integration/targets/iam_policy/files/no_access_with_id.json
@@ -1,0 +1,11 @@
+{
+    "Id": "MyId",
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Deny",
+            "Action": "*",
+            "Resource": "*"
+        }
+    ]
+}

--- a/test/integration/targets/iam_policy/files/no_trust.json
+++ b/test/integration/targets/iam_policy/files/no_trust.json
@@ -1,0 +1,10 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Deny",
+      "Principal": {"AWS": "*"},
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}

--- a/test/integration/targets/iam_policy/tasks/main.yml
+++ b/test/integration/targets/iam_policy/tasks/main.yml
@@ -1,0 +1,275 @@
+---
+- block:
+    # ============================================================
+    - name: set up aws connection info
+      set_fact:
+        aws_connection_info: &aws_connection_info
+           aws_access_key: "{{ aws_access_key }}"
+           aws_secret_key: "{{ aws_secret_key }}"
+           security_token: "{{ security_token }}"
+           region: "{{ aws_region }}"
+      no_log: yes
+    # ============================================================
+    - name: Copy over policy
+      copy:
+        src: no_access.json
+        dest: "/var/tmp/"
+    # ============================================================
+    - name: Copy over other policy
+      copy:
+        src: no_access_with_id.json
+        dest: "/var/tmp/"
+    # ============================================================
+    - name: Create user for tests
+      iam_user:
+        name: "{{ iam_user_name }}"
+        state: present
+        <<: *aws_connection_info
+    # ============================================================
+    - name: Create role for tests
+      iam_role:
+        name: "{{ iam_role_name }}"
+        assume_role_policy_document: "{{ lookup('file','no_trust.json') }}"
+        state: present
+        <<: *aws_connection_info
+    # ============================================================
+    - name: Create group for tests
+      iam_group:
+        name: "{{ iam_group_name }}"
+        state: present
+        <<: *aws_connection_info
+    # ============================================================
+    - name: Create policy for user
+      iam_policy:
+        iam_type: user
+        iam_name: "{{ iam_user_name }}"
+        policy_name: "{{ iam_policy_name }}"
+        state: present
+        policy_document: "/var/tmp/no_access.json"
+        <<: *aws_connection_info
+      register: result 
+    # ============================================================
+    - name: Assert policy was added for user
+      assert:
+        that:
+          - result.changed == True
+          - result.policies == ["{{ iam_policy_name }}"]
+          - result.user_name == "{{ iam_user_name }}" 
+    # ============================================================
+    - name: Update policy for user
+      iam_policy:
+        iam_type: user
+        iam_name: "{{ iam_user_name }}"
+        policy_name: "{{ iam_policy_name }}"
+        state: present
+        policy_document: "/var/tmp/no_access_with_id.json"
+        <<: *aws_connection_info
+      register: result 
+    # ============================================================
+    - name: Assert policy was updated for user
+      assert:
+        that:
+          - result.changed == True
+    # ============================================================
+    - name: Update policy for user with same policy
+      iam_policy:
+        iam_type: user
+        iam_name: "{{ iam_user_name }}"
+        policy_name: "{{ iam_policy_name }}"
+        state: present
+        policy_document: "/var/tmp/no_access_with_id.json"
+        <<: *aws_connection_info
+      register: result 
+    # ============================================================
+    - name: Assert policy did not change for user
+      assert:
+        that:
+          - result.changed == False
+    # ============================================================
+    - name: Create policy for user using policy_json
+      iam_policy:
+        iam_type: user
+        iam_name: "{{ iam_user_name }}"
+        policy_name: "{{ iam_policy_name }}"
+        state: present
+        policy_json: "{{ lookup('file', '/var/tmp/no_access.json') }}"
+        <<: *aws_connection_info
+      register: result 
+    # ============================================================
+    - name: Assert policy was added for user
+      assert:
+        that:
+          - result.changed == True
+          - result.policies == ["{{ iam_policy_name }}"]
+          - result.user_name == "{{ iam_user_name }}" 
+    # ============================================================
+    - name: Create policy for role
+      iam_policy:
+        iam_type: role
+        iam_name: "{{ iam_role_name }}"
+        policy_name: "{{ iam_policy_name }}"
+        state: present
+        policy_document: "/var/tmp/no_access.json"
+        <<: *aws_connection_info
+      register: result 
+    # ============================================================
+    - name: Assert policy was added for role
+      assert:
+        that:
+          - result.changed == True
+          - result.policies == ["{{ iam_policy_name }}"]
+          - result.role_name == "{{ iam_role_name }}" 
+    # ============================================================
+    - name: Update policy for role
+      iam_policy:
+        iam_type: role
+        iam_name: "{{ iam_role_name }}"
+        policy_name: "{{ iam_policy_name }}"
+        state: present
+        policy_document: "/var/tmp/no_access_with_id.json"
+        <<: *aws_connection_info
+      register: result 
+    # ============================================================
+    - name: Assert policy was updated for role
+      assert:
+        that:
+          - result.changed == True
+    # ============================================================
+    - name: Update policy for role with same policy
+      iam_policy:
+        iam_type: role
+        iam_name: "{{ iam_role_name }}"
+        policy_name: "{{ iam_policy_name }}"
+        state: present
+        policy_document: "/var/tmp/no_access_with_id.json"
+        <<: *aws_connection_info
+      register: result 
+    # ============================================================
+    - name: Assert policy did not change for role
+      assert:
+        that:
+          - result.changed == False
+    # ============================================================
+    - name: Create policy for role using policy_json
+      iam_policy:
+        iam_type: role
+        iam_name: "{{ iam_role_name }}"
+        policy_name: "{{ iam_policy_name }}"
+        state: present
+        policy_json: "{{ lookup('file', '/var/tmp/no_access.json') }}"
+        <<: *aws_connection_info
+      register: result 
+    # ============================================================
+    - name: Assert policy was added for role
+      assert:
+        that:
+          - result.changed == True
+          - result.policies == ["{{ iam_policy_name }}"]
+          - result.role_name == "{{ iam_role_name }}" 
+    # ============================================================
+    - name: Create policy for group
+      iam_policy:
+        iam_type: group
+        iam_name: "{{ iam_group_name }}"
+        policy_name: "{{ iam_policy_name }}"
+        state: present
+        policy_document: "/var/tmp/no_access.json"
+        <<: *aws_connection_info
+      register: result 
+    # ============================================================
+    - name: Assert policy was added for group
+      assert:
+        that:
+          - result.changed == True
+          - result.policies == ["{{ iam_policy_name }}"]
+          - result.group_name == "{{ iam_group_name }}" 
+    # ============================================================
+    - name: Update policy for group
+      iam_policy:
+        iam_type: group
+        iam_name: "{{ iam_group_name }}"
+        policy_name: "{{ iam_policy_name }}"
+        state: present
+        policy_document: "/var/tmp/no_access_with_id.json"
+        <<: *aws_connection_info
+      register: result 
+    # ============================================================
+    - name: Assert policy was updated for group
+      assert:
+        that:
+          - result.changed == True
+    # ============================================================
+    - name: Update policy for group with same policy
+      iam_policy:
+        iam_type: group
+        iam_name: "{{ iam_group_name }}"
+        policy_name: "{{ iam_policy_name }}"
+        state: present
+        policy_document: "/var/tmp/no_access_with_id.json"
+        <<: *aws_connection_info
+      register: result 
+    # ============================================================
+    - name: Assert policy did not change for group
+      assert:
+        that:
+          - result.changed == False
+    # ============================================================
+    - name: Create policy for group using policy_json
+      iam_policy:
+        iam_type: group
+        iam_name: "{{ iam_group_name }}"
+        policy_name: "{{ iam_policy_name }}"
+        state: present
+        policy_json: "{{ lookup('file', '/var/tmp/no_access.json') }}"
+        <<: *aws_connection_info
+      register: result 
+    # ============================================================
+    - name: Assert policy was added for group
+      assert:
+        that:
+          - result.changed == True
+          - result.policies == ["{{ iam_policy_name }}"]
+          - result.group_name == "{{ iam_group_name }}" 
+  always:
+    # ============================================================
+    - name: Delete policy for user
+      iam_policy:
+        iam_type: user
+        iam_name: "{{ iam_user_name }}"
+        policy_name: "{{ iam_policy_name }}"
+        state: absent
+        <<: *aws_connection_info
+    # ============================================================
+    - name: Delete user for tests
+      iam_user:
+       name: "{{ iam_user_name }}"
+       state: absent
+       <<: *aws_connection_info
+    # ============================================================
+    - name: Delete policy for role
+      iam_policy:
+        iam_type: role
+        iam_name: "{{ iam_role_name }}"
+        policy_name: "{{ iam_policy_name }}"
+        state: absent
+        <<: *aws_connection_info
+    # ============================================================
+    - name: Delete role for tests
+      iam_role:
+       name: "{{ iam_role_name }}"
+       state: absent
+       <<: *aws_connection_info
+    # ============================================================
+    - name: Delete policy for group
+      iam_policy:
+        iam_type: group
+        iam_name: "{{ iam_group_name }}"
+        policy_name: "{{ iam_policy_name }}"
+        state: absent
+        <<: *aws_connection_info
+    # ============================================================
+    - name: Delete group for tests
+      iam_group:
+       name: "{{ iam_group_name }}"
+       state: absent
+       <<: *aws_connection_info

--- a/test/integration/targets/iam_policy/tasks/main.yml
+++ b/test/integration/targets/iam_policy/tasks/main.yml
@@ -10,15 +10,20 @@
            region: "{{ aws_region }}"
       no_log: yes
     # ============================================================
+    - name: Create a temporary folder for the policies
+      tempfile:
+        state: directory
+      register: tmpdir
+    # ============================================================
     - name: Copy over policy
       copy:
         src: no_access.json
-        dest: "/var/tmp/"
+        dest: "{{ tmpdir.path }}"
     # ============================================================
     - name: Copy over other policy
       copy:
         src: no_access_with_id.json
-        dest: "/var/tmp/"
+        dest: "{{ tmpdir.path }}"
     # ============================================================
     - name: Create user for tests
       iam_user:
@@ -45,7 +50,7 @@
         iam_name: "{{ iam_user_name }}"
         policy_name: "{{ iam_policy_name }}"
         state: present
-        policy_document: "/var/tmp/no_access.json"
+        policy_document: "{{ tmpdir.path }}/no_access.json"
         <<: *aws_connection_info
       register: result 
     # ============================================================
@@ -62,7 +67,7 @@
         iam_name: "{{ iam_user_name }}"
         policy_name: "{{ iam_policy_name }}"
         state: present
-        policy_document: "/var/tmp/no_access_with_id.json"
+        policy_document: "{{ tmpdir.path }}/no_access_with_id.json"
         <<: *aws_connection_info
       register: result 
     # ============================================================
@@ -77,7 +82,7 @@
         iam_name: "{{ iam_user_name }}"
         policy_name: "{{ iam_policy_name }}"
         state: present
-        policy_document: "/var/tmp/no_access_with_id.json"
+        policy_document: "{{ tmpdir.path }}/no_access_with_id.json"
         <<: *aws_connection_info
       register: result 
     # ============================================================
@@ -92,7 +97,7 @@
         iam_name: "{{ iam_user_name }}"
         policy_name: "{{ iam_policy_name }}"
         state: present
-        policy_json: "{{ lookup('file', '/var/tmp/no_access.json') }}"
+        policy_json: "{{ lookup('file', '{{ tmpdir.path }}/no_access.json') }}"
         <<: *aws_connection_info
       register: result 
     # ============================================================
@@ -109,7 +114,7 @@
         iam_name: "{{ iam_role_name }}"
         policy_name: "{{ iam_policy_name }}"
         state: present
-        policy_document: "/var/tmp/no_access.json"
+        policy_document: "{{ tmpdir.path }}/no_access.json"
         <<: *aws_connection_info
       register: result 
     # ============================================================
@@ -126,7 +131,7 @@
         iam_name: "{{ iam_role_name }}"
         policy_name: "{{ iam_policy_name }}"
         state: present
-        policy_document: "/var/tmp/no_access_with_id.json"
+        policy_document: "{{ tmpdir.path }}/no_access_with_id.json"
         <<: *aws_connection_info
       register: result 
     # ============================================================
@@ -141,7 +146,7 @@
         iam_name: "{{ iam_role_name }}"
         policy_name: "{{ iam_policy_name }}"
         state: present
-        policy_document: "/var/tmp/no_access_with_id.json"
+        policy_document: "{{ tmpdir.path }}/no_access_with_id.json"
         <<: *aws_connection_info
       register: result 
     # ============================================================
@@ -156,7 +161,7 @@
         iam_name: "{{ iam_role_name }}"
         policy_name: "{{ iam_policy_name }}"
         state: present
-        policy_json: "{{ lookup('file', '/var/tmp/no_access.json') }}"
+        policy_json: "{{ lookup('file', '{{ tmpdir.path }}/no_access.json') }}"
         <<: *aws_connection_info
       register: result 
     # ============================================================
@@ -173,7 +178,7 @@
         iam_name: "{{ iam_group_name }}"
         policy_name: "{{ iam_policy_name }}"
         state: present
-        policy_document: "/var/tmp/no_access.json"
+        policy_document: "{{ tmpdir.path }}/no_access.json"
         <<: *aws_connection_info
       register: result 
     # ============================================================
@@ -190,7 +195,7 @@
         iam_name: "{{ iam_group_name }}"
         policy_name: "{{ iam_policy_name }}"
         state: present
-        policy_document: "/var/tmp/no_access_with_id.json"
+        policy_document: "{{ tmpdir.path }}/no_access_with_id.json"
         <<: *aws_connection_info
       register: result 
     # ============================================================
@@ -205,7 +210,7 @@
         iam_name: "{{ iam_group_name }}"
         policy_name: "{{ iam_policy_name }}"
         state: present
-        policy_document: "/var/tmp/no_access_with_id.json"
+        policy_document: "{{ tmpdir.path }}/no_access_with_id.json"
         <<: *aws_connection_info
       register: result 
     # ============================================================
@@ -220,7 +225,7 @@
         iam_name: "{{ iam_group_name }}"
         policy_name: "{{ iam_policy_name }}"
         state: present
-        policy_json: "{{ lookup('file', '/var/tmp/no_access.json') }}"
+        policy_json: "{{ lookup('file', '{{ tmpdir.path }}/no_access.json') }}"
         <<: *aws_connection_info
       register: result 
     # ============================================================
@@ -229,7 +234,41 @@
         that:
           - result.changed == True
           - result.policies == ["{{ iam_policy_name }}"]
-          - result.group_name == "{{ iam_group_name }}" 
+          - result.group_name == "{{ iam_group_name }}"
+    # ============================================================
+    - name: Delete policy for user
+      iam_policy:
+        iam_type: user
+        iam_name: "{{ iam_user_name }}"
+        policy_name: "{{ iam_policy_name }}"
+        state: absent
+        <<: *aws_connection_info
+    - assert:
+        that:
+          - result.changed == True
+    # ============================================================
+    - name: Delete policy for role
+      iam_policy:
+        iam_type: role
+        iam_name: "{{ iam_role_name }}"
+        policy_name: "{{ iam_policy_name }}"
+        state: absent
+        <<: *aws_connection_info
+    - assert:
+        that:
+          - result.changed == True
+    # ============================================================
+    - name: Delete policy for group
+      iam_policy:
+        iam_type: group
+        iam_name: "{{ iam_group_name }}"
+        policy_name: "{{ iam_policy_name }}"
+        state: absent
+        <<: *aws_connection_info
+    - assert:
+        that:
+          - result.changed == True
+    # ============================================================
   always:
     # ============================================================
     - name: Delete policy for user
@@ -279,3 +318,8 @@
         state: absent
         <<: *aws_connection_info
       ignore_errors: yes
+    # ============================================================
+    - name: Delete temporary folder containing the policies
+      file:
+        state: absent
+        path: "{{ tmpdir.path }}/"

--- a/test/integration/targets/iam_policy/tasks/main.yml
+++ b/test/integration/targets/iam_policy/tasks/main.yml
@@ -239,12 +239,14 @@
         policy_name: "{{ iam_policy_name }}"
         state: absent
         <<: *aws_connection_info
+      ignore_errors: yes
     # ============================================================
     - name: Delete user for tests
       iam_user:
-       name: "{{ iam_user_name }}"
-       state: absent
-       <<: *aws_connection_info
+        name: "{{ iam_user_name }}"
+        state: absent
+        <<: *aws_connection_info
+      ignore_errors: yes
     # ============================================================
     - name: Delete policy for role
       iam_policy:
@@ -253,12 +255,14 @@
         policy_name: "{{ iam_policy_name }}"
         state: absent
         <<: *aws_connection_info
+      ignore_errors: yes
     # ============================================================
     - name: Delete role for tests
       iam_role:
-       name: "{{ iam_role_name }}"
-       state: absent
-       <<: *aws_connection_info
+        name: "{{ iam_role_name }}"
+        state: absent
+        <<: *aws_connection_info
+      ignore_errors: yes
     # ============================================================
     - name: Delete policy for group
       iam_policy:
@@ -267,9 +271,11 @@
         policy_name: "{{ iam_policy_name }}"
         state: absent
         <<: *aws_connection_info
+      ignore_errors: yes
     # ============================================================
     - name: Delete group for tests
       iam_group:
-       name: "{{ iam_group_name }}"
-       state: absent
-       <<: *aws_connection_info
+        name: "{{ iam_group_name }}"
+        state: absent
+        <<: *aws_connection_info
+      ignore_errors: yes


### PR DESCRIPTION
This adds integration tests for the `iam_policy` policy. I was looking to port this over to `boto3`. However, it did not have integration tests in the first place so I figured to send up some tests before doing anything. Let me know if there is anything else needed in the tests.