### PR TITLE
Update all pypi.python.org URLs to pypi.org (#38988)

### DIFF
--- a/contrib/inventory/scaleway.py
+++ b/contrib/inventory/scaleway.py
@@ -9,7 +9,7 @@ Shamelessly copied from an existing inventory script.
 
 This script generates an inventory that Ansible can understand by making API requests to Scaleway API
 
-Requires some python libraries, ensure to have them installed when using this script. (pip install requests https://pypi.python.org/pypi/requests)
+Requires some python libraries, ensure to have them installed when using this script. (pip install requests https://pypi.org/project/requests/)
 
 Before using this script you may want to modify scaleway.ini config file.
 

--- a/contrib/inventory/serf.py
+++ b/contrib/inventory/serf.py
@@ -21,7 +21,7 @@
 # (https://serfdom.io/).
 #
 # Requires the `serfclient` Python module from
-# https://pypi.python.org/pypi/serfclient
+# https://pypi.org/project/serfclient/
 #
 # Environment variables
 # ---------------------
@@ -35,7 +35,7 @@ import collections
 import os
 import sys
 
-# https://pypi.python.org/pypi/serfclient
+# https://pypi.org/project/serfclient/
 from serfclient import SerfClient, EnvironmentConfig
 
 try:

--- a/contrib/vault/vault-keyring-client.py
+++ b/contrib/vault/vault-keyring-client.py
@@ -25,7 +25,7 @@
 # This file *MUST* be saved with executable permissions. Otherwise, Ansible
 # will try to parse as a password file and display: "ERROR! Decryption failed"
 #
-# The `keyring` Python module is required: https://pypi.python.org/pypi/keyring
+# The `keyring` Python module is required: https://pypi.org/project/keyring/
 #
 # By default, this script will store the specified password in the keyring of
 # the user that invokes the script. To specify a user keyring, add a [vault]

--- a/contrib/vault/vault-keyring.py
+++ b/contrib/vault/vault-keyring.py
@@ -26,7 +26,7 @@
 # This file *MUST* be saved with executable permissions. Otherwise, Ansible
 # will try to parse as a password file and display: "ERROR! Decryption failed"
 #
-# The `keyring` Python module is required: https://pypi.python.org/pypi/keyring
+# The `keyring` Python module is required: https://pypi.org/project/keyring/
 #
 # By default, this script will store the specified password in the keyring of
 # the user that invokes the script. To specify a user keyring, add a [vault]

--- a/docs/docsite/rst/dev_guide/testing_pep8.rst
+++ b/docs/docsite/rst/dev_guide/testing_pep8.rst
@@ -48,7 +48,7 @@ The `PEP 8`_ check can be run locally with::
 
 
 .. _PEP 8: https://www.python.org/dev/peps/pep-0008/
-.. _pycodestyle: https://pypi.python.org/pypi/pycodestyle
+.. _pycodestyle: https://pypi.org/project/pycodestyle/
 .. _current ignore list: https://github.com/ansible/ansible/blob/devel/test/sanity/pep8/current-ignore.txt
 .. _legacy file list: https://github.com/ansible/ansible/blob/devel/test/sanity/pep8/legacy-files.txt
 .. _legacy ignore list: https://github.com/ansible/ansible/blob/devel/test/sanity/pep8/legacy-ignore.txt

--- a/docs/docsite/rst/user_guide/playbooks_filters_ipaddr.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters_ipaddr.rst
@@ -19,7 +19,7 @@ It can usually be installed either via your system package manager, or using
 
     pip install netaddr
 
-.. _netaddr: https://pypi.python.org/pypi/netaddr
+.. _netaddr: https://pypi.org/project/netaddr/
 
 .. contents:: Topics
    :local:

--- a/lib/ansible/modules/clustering/consul_acl.py
+++ b/lib/ansible/modules/clustering/consul_acl.py
@@ -610,10 +610,10 @@ def check_dependencies():
 
     if not pyhcl_installed:
         raise ImportError("pyhcl required for this module. "
-                          "See: https://pypi.python.org/pypi/pyhcl")
+                          "See: https://pypi.org/project/pyhcl/")
 
     if not has_requests:
-        raise ImportError("requests required for this module. See https://pypi.python.org/pypi/requests")
+        raise ImportError("requests required for this module. See https://pypi.org/project/requests/")
 
 
 def main():

--- a/lib/ansible/modules/network/panos/_panos_security_policy.py
+++ b/lib/ansible/modules/network/panos/_panos_security_policy.py
@@ -40,8 +40,8 @@ deprecated:
     removed_in: '2.9'
     why: This module depended on outdated and old SDK. In 2.4 use M(panos_security_rule) instead.
 requirements:
-    - pan-python can be obtained from PyPi U(https://pypi.python.org/pypi/pan-python)
-    - pandevice can be obtained from PyPi U(https://pypi.python.org/pypi/pandevice)
+    - pan-python can be obtained from PyPi U(https://pypi.org/project/pan-python/)
+    - pandevice can be obtained from PyPi U(https://pypi.org/project/pandevice/)
 notes:
     - Checkmode is not supported.
     - Panorama is supported

--- a/lib/ansible/modules/network/panos/panos_dag_tags.py
+++ b/lib/ansible/modules/network/panos/panos_dag_tags.py
@@ -33,8 +33,8 @@ description:
 author: "Vinay Venkataraghavan (@vinayvenkat)"
 version_added: "2.5"
 requirements:
-    - pan-python can be obtained from PyPi U(https://pypi.python.org/pypi/pan-python)
-    - pandevice can be obtained from PyPi U(https://pypi.python.org/pypi/pandevice)
+    - pan-python can be obtained from PyPi U(https://pypi.org/project/pan-python/)
+    - pandevice can be obtained from PyPi U(https://pypi.org/project/pandevice/)
 notes:
     - Checkmode is not supported.
     - Panorama is not supported.

--- a/lib/ansible/modules/network/panos/panos_interface.py
+++ b/lib/ansible/modules/network/panos/panos_interface.py
@@ -33,7 +33,7 @@ description:
 author: "Luigi Mori (@jtschichold), Ivan Bojer (@ivanbojer)"
 version_added: "2.3"
 requirements:
-    - pan-python can be obtained from PyPi U(https://pypi.python.org/pypi/pan-python)
+    - pan-python can be obtained from PyPi U(https://pypi.org/project/pan-python/)
 notes:
     - Checkmode is not supported.
 options:

--- a/lib/ansible/modules/network/panos/panos_match_rule.py
+++ b/lib/ansible/modules/network/panos/panos_match_rule.py
@@ -33,8 +33,8 @@ description:
 author: "Robert Hagen (@rnh556)"
 version_added: "2.5"
 requirements:
-    - pan-python can be obtained from PyPi U(https://pypi.python.org/pypi/pan-python)
-    - pandevice can be obtained from PyPi U(https://pypi.python.org/pypi/pandevice)
+    - pan-python can be obtained from PyPi U(https://pypi.org/project/pan-python/)
+    - pandevice can be obtained from PyPi U(https://pypi.org/project/pandevice/)
 notes:
     - Checkmode is not supported.
     - Panorama NOT is supported.

--- a/lib/ansible/modules/network/panos/panos_nat_rule.py
+++ b/lib/ansible/modules/network/panos/panos_nat_rule.py
@@ -17,8 +17,8 @@ description:
 author: "Luigi Mori (@jtschichold), Ivan Bojer (@ivanbojer), Robert Hagen (@rnh556)"
 version_added: "2.4"
 requirements:
-    - pan-python can be obtained from PyPi U(https://pypi.python.org/pypi/pan-python)
-    - pandevice can be obtained from PyPi U(https://pypi.python.org/pypi/pandevice)
+    - pan-python can be obtained from PyPi U(https://pypi.org/project/pan-python/)
+    - pandevice can be obtained from PyPi U(https://pypi.org/project/pandevice/)
 notes:
     - Checkmode is not supported.
     - Panorama is supported.

--- a/lib/ansible/modules/network/panos/panos_object.py
+++ b/lib/ansible/modules/network/panos/panos_object.py
@@ -34,8 +34,8 @@ description:
 author: "Bob Hagen (@rnh556)"
 version_added: "2.4"
 requirements:
-    - pan-python can be obtained from PyPi U(https://pypi.python.org/pypi/pan-python)
-    - pandevice can be obtained from PyPi U(https://pypi.python.org/pypi/pandevice)
+    - pan-python can be obtained from PyPi U(https://pypi.org/project/pan-python/)
+    - pandevice can be obtained from PyPi U(https://pypi.org/project/pandevice/)
 notes:
     - Checkmode is not supported.
     - Panorama is supported.

--- a/lib/ansible/modules/network/panos/panos_op.py
+++ b/lib/ansible/modules/network/panos/panos_op.py
@@ -31,8 +31,8 @@ description: This module will allow user to pass and execute any supported OP co
 author: "Ivan Bojer (@ivanbojer)"
 version_added: "2.5"
 requirements:
-    - pan-python can be obtained from PyPi U(https://pypi.python.org/pypi/pan-python)
-    - pandevice can be obtained from PyPi U(https://pypi.python.org/pypi/pandevice)
+    - pan-python can be obtained from PyPi U(https://pypi.org/project/pan-python/)
+    - pandevice can be obtained from PyPi U(https://pypi.org/project/pandevice/)
 notes:
     - Checkmode is NOT supported.
     - Panorama is NOT supported.

--- a/lib/ansible/modules/network/panos/panos_query_rules.py
+++ b/lib/ansible/modules/network/panos/panos_query_rules.py
@@ -35,9 +35,9 @@ description: >
 author: "Bob Hagen (@rnh556)"
 version_added: "2.5"
 requirements:
-    - pan-python can be obtained from PyPi U(https://pypi.python.org/pypi/pan-python)
-    - pandevice can be obtained from PyPi U(https://pypi.python.org/pypi/pandevice)
-    - xmltodict can be obtains from PyPi U(https://pypi.python.org/pypi/xmltodict)
+    - pan-python can be obtained from PyPi U(https://pypi.org/project/pan-python/)
+    - pandevice can be obtained from PyPi U(https://pypi.org/project/pandevice/)
+    - xmltodict can be obtains from PyPi U(https://pypi.org/project/xmltodict/)
 notes:
     - Checkmode is not supported.
     - Panorama is supported.

--- a/lib/ansible/modules/network/panos/panos_sag.py
+++ b/lib/ansible/modules/network/panos/panos_sag.py
@@ -28,9 +28,9 @@ description:
 author: "Vinay Venkataraghavan @vinayvenkat"
 version_added: "2.4"
 requirements:
-    - pan-python can be obtained from PyPi U(https://pypi.python.org/pypi/pan-python)
-    - pandevice can be obtained from PyPi U(https://pypi.python.org/pypi/pandevice)
-    - xmltodict can be obtained from PyPi U(https://pypi.python.org/pypi/xmltodict)
+    - pan-python can be obtained from PyPi U(https://pypi.org/project/pan-python/)
+    - pandevice can be obtained from PyPi U(https://pypi.org/project/pandevice/)
+    - xmltodict can be obtained from PyPi U(https://pypi.org/project/xmltodict/)
 options:
     ip_address:
         description:

--- a/lib/ansible/modules/network/panos/panos_security_rule.py
+++ b/lib/ansible/modules/network/panos/panos_security_rule.py
@@ -23,9 +23,9 @@ description:
 author: "Ivan Bojer (@ivanbojer), Robert Hagen (@rnh556)"
 version_added: "2.4"
 requirements:
-    - pan-python can be obtained from PyPi U(https://pypi.python.org/pypi/pan-python)
-    - pandevice can be obtained from PyPi U(https://pypi.python.org/pypi/pandevice)
-    - xmltodict can be obtained from PyPi U(https://pypi.python.org/pypi/xmltodict)
+    - pan-python can be obtained from PyPi U(https://pypi.org/project/pan-python/)
+    - pandevice can be obtained from PyPi U(https://pypi.org/project/pandevice/)
+    - xmltodict can be obtained from PyPi U(https://pypi.org/project/xmltodict/)
 notes:
     - Checkmode is not supported.
     - Panorama is supported.

--- a/lib/ansible/modules/notification/mqtt.py
+++ b/lib/ansible/modules/notification/mqtt.py
@@ -104,7 +104,7 @@ options:
 requirements: [ mosquitto ]
 notes:
  - This module requires a connection to an MQTT broker such as Mosquitto
-   U(http://mosquitto.org) and the I(Paho) C(mqtt) Python client (U(https://pypi.python.org/pypi/paho-mqtt)).
+   U(http://mosquitto.org) and the I(Paho) C(mqtt) Python client (U(https://pypi.org/project/paho-mqtt/)).
 author: "Jan-Piet Mens (@jpmens)"
 '''
 


### PR DESCRIPTION
For details on the new PyPI, see the blog post:

https://pythoninsider.blogspot.ca/2018/04/new-pypi-launched-legacy-pypi-shutting.html
(cherry picked from commit 1d640182c61af2d59cc1005f1ab5b217a56dcf15)

##### SUMMARY
Updates pypi.python.org URLs to pypi.org

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
docs.ansible.com

##### ANSIBLE VERSION
2.5
