### PR TITLE
fix: Ensure zip excluded files are not checked

### DIFF
--- a/lib/ansible/modules/files/unarchive.py
+++ b/lib/ansible/modules/files/unarchive.py
@@ -131,6 +131,7 @@ EXAMPLES = r'''
 import binascii
 import codecs
 import datetime
+import fnmatch
 import grp
 import os
 import platform
@@ -262,7 +263,11 @@ class ZipArchive(object):
         else:
             try:
                 for member in archive.namelist():
-                    if member not in self.excludes:
+                    if self.excludes:
+                        for exclude in self.excludes:
+                            if not fnmatch.fnmatch(member, exclude):
+                                self._files_in_archive.append(to_native(member))
+                    else:
                         self._files_in_archive.append(to_native(member))
             except:
                 archive.close()

--- a/test/integration/targets/unarchive/tasks/main.yml
+++ b/test/integration/targets/unarchive/tasks/main.yml
@@ -17,7 +17,7 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 # Make sure we start fresh
 
-# Need unzup for unarchive module, and zip for archive creation.
+# Need unzip for unarchive module, and zip for archive creation.
 - name: Ensure zip and unzip is present to create test archive (yum)
   yum: name=zip,unzip state=latest
   when: ansible_pkg_mgr  ==  'yum'
@@ -26,11 +26,11 @@
   #  dnf: name=zip state=latest
   #  when: ansible_pkg_mgr  ==  'dnf'
 
-- name: Ensure zip & unzup is present to create test archive (apt)
+- name: Ensure zip & unzip is present to create test archive (apt)
   apt: name=zip,unzip state=latest
   when: ansible_pkg_mgr  ==  'apt'
 
-- name: Ensure zip & unzup is present to create test archive (pkg)
+- name: Ensure zip & unzip is present to create test archive (pkg)
   pkgng: name=zip,unzip state=present
   when: ansible_pkg_mgr  ==  'pkgng'
 
@@ -51,18 +51,18 @@
 
 # This gets around an unzip timestamp bug in some distributions
 # Recent unzip on Ubuntu and BSD will randomly round some timestamps up.
-# But that doesn't seem to happen when the timestamp has an even second. 
+# But that doesn't seem to happen when the timestamp has an even second.
 - name: Bug work around
   command: touch -t "201705111530.00" {{output_dir}}/foo-unarchive.txt {{output_dir}}/foo-unarchive-777.txt {{output_dir}}/FOO-UNAR.TXT
 # See Ubuntu bug 1691636: https://bugs.launchpad.net/ubuntu/+source/unzip/+bug/1691636
-# When these are fixed, this code should be removed.  
+# When these are fixed, this code should be removed.
 
 - name: prep a zip file
   shell: zip test-unarchive.zip foo-unarchive.txt foo-unarchive-777.txt chdir={{output_dir}}
 
 - name: add a file with Windows permissions to zip file
   shell: zip -k test-unarchive.zip FOO-UNAR.TXT chdir={{output_dir}}
-  
+
 - name: prep a subdirectory
   file: path={{output_dir}}/unarchive-dir state=directory
 
@@ -178,7 +178,7 @@
 - name: repeat the last request to verify no changes
   unarchive: src={{output_dir}}/test-unarchive.zip dest={{output_dir | expanduser}}/test-unarchive-zip remote_src=yes list_files=True
   register: unarchive03b
-  
+
 - name: verify that the task was not marked as changed
   assert:
     that:
@@ -224,7 +224,7 @@
   when: unarchive04.stat.exists
 
 - name: try unarchiving to /tmp
-  unarchive: src={{output_dir}}/test-unarchive.tar.gz dest=/tmp remote_src=yes 
+  unarchive: src={{output_dir}}/test-unarchive.tar.gz dest=/tmp remote_src=yes
   register: unarchive05
 
 - name: verify that the file was marked as changed
@@ -271,7 +271,6 @@
 - name: create our unarchive destination
   file: path={{output_dir}}/test-unarchive-tar-gz state=directory
 
-
 - name: unarchive over existing extraction and set mode to 0644
   unarchive:
     src: "{{ output_dir }}/test-unarchive.tar.gz"
@@ -312,7 +311,6 @@
 
 - name: remove our tar.gz unarchive destination
   file: path={{ output_dir }}/test-unarchive-tar-gz state=absent
-
 
 - name: create our unarchive destination
   file: path={{output_dir}}/test-unarchive-zip state=directory
@@ -378,10 +376,8 @@
 - name: remove our zip unarchive destination
   file: path={{ output_dir }}/test-unarchive-zip state=absent
 
-
 - name: create our unarchive destination
   file: path={{output_dir}}/test-unarchive-tar-gz state=directory
-
 
 - name: create a directory with quotable chars
   file: path="{{ output_dir }}/test-quotes~root" state=directory
@@ -522,7 +518,6 @@
 
 - name: remove our tar.gz unarchive destination
   file: path={{ output_dir }}/test-unarchive-tar-gz state=absent
-
 
 - name: Create a file
   file:

--- a/test/integration/targets/unarchive/tasks/main.yml
+++ b/test/integration/targets/unarchive/tasks/main.yml
@@ -184,6 +184,26 @@
     that:
       - "unarchive03b.changed == false"
 
+- name: "Create {{ output_dir }}/exclude directory"
+  file:
+    state: directory
+    path: "{{ output_dir }}/exclude"
+
+- name: Unpack zip file excluding one file.
+  unarchive:
+    src: "{{ output_dir }}/test-unarchive.zip"
+    dest: "{{ output_dir }}/exclude"
+    exclude: "foo-unarchive-*.txt"
+
+- name: verify that the file was unarchived
+  shell: find {{ output_dir }}/exclude chdir={{ output_dir }}
+  register: unarchive_dir01
+
+- name: verify that zip extraction excluded file
+  assert:
+    that:
+      - "'foo-unarchive-777.txt' not in unarchive_dir01.stdout"
+
 - name: remove our zip unarchive destination
   file: path={{output_dir}}/test-unarchive-zip state=absent
 


### PR DESCRIPTION
##### SUMMARY
This ensures that excluded entries for `unarchive` are no checked after its unzipped.

Fixes #26279

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
unarchive

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0 (fix/unarchive_excludes 939fd86723) last updated 2018/05/14 17:56:20 (GMT -500)
  config file = None
  configured module search path = [u'/home/saviles/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/saviles/data/git/github/ansible/lib/ansible
  executable location = /home/saviles/data/git/github/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 14 2018, 16:45:33) [GCC 8.0.1 20180222 (Red Hat 8.0.1-0.16)]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

Creating the sample zip file:
```
mkdir -p tester/top_level/{bar,foo}/static
touch tester/top_level/bar/baz.txt
touch tester/top_level/foo/static
touch tester/top_level/foo/static/0.png
touch tester/top_level/foo/static/1.png
touch tester/top_level/foo/static/2.png
touch tester/top_level/foo/static/3.png

zip -r test-26279.zip tester/
```
I'm using the following playbook:
```
---
- hosts: local
  tasks:
    - name: Create directory
      file:
        state: directory
        path: /tmp/test-26279
    - name: Unpack zip file excluding one folder.
      unarchive:
        src: files/test-26279.zip
        dest: /tmp/test-26279
        copy: no
        mode: 0755
        exclude: "tester/top_level/foo/static/*"

```


<!--- Paste verbatim command output below, e.g. before and after your change -->
Before:

```
$ ansible-playbook -i hosts issue-26279.yml

PLAY [local] *********************************************************************************************************************************************************************************

TASK [Gathering Facts] ***********************************************************************************************************************************************************************
ok: [ansible_host=127.0.0.1]

TASK [Create directory] **********************************************************************************************************************************************************************
changed: [ansible_host=127.0.0.1]

TASK [Unpack zip file excluding one folder.] *************************************************************************************************************************************************
fatal: [ansible_host=127.0.0.1]: FAILED! => {
    "changed": true, 
    "dest": "/tmp/test-26279", 
    "extract_results": {
        "cmd": [
            "/usr/bin/unzip", 
            "-o", 
            "files/test-26279.zip", 
            "-x", 
            "tester/top_level/foo/static/*", 
            "-d", 
            "/tmp/test-26279"
        ], 
        "err": "", 
        "out": "Archive:  files/test-26279.zip\n   creating: /tmp/test-26279/tester/\n   creating: /tmp/test-26279/tester/top_level/\n   creating: /tmp/test-26279/tester/top_level/foo/\n   creating: /tmp/test-26279/tester/top_level/bar/\n extracting: /tmp/test-26279/tester/top_level/bar/baz.txt  \n   creating: /tmp/test-26279/tester/top_level/bar/static/\n", 
        "rc": 0
    }, 
    "gid": 1000, 
    "group": "saviles", 
    "handler": "ZipArchive", 
    "mode": "0775", 
    "owner": "saviles", 
    "size": 60, 
    "src": "files/test-26279.zip", 
    "state": "directory", 
    "uid": 1000
}

MSG:

Unexpected error when accessing exploded file: [Errno 2] No such file or directory: '/tmp/test-26279/tester/top_level/foo/static/'

	to retry, use: --limit @/home/saviles/data/git/github/ansible/validations/issue-26279.retry

PLAY RECAP ***********************************************************************************************************************************************************************************
ansible_host=127.0.0.1     : ok=2    changed=1    unreachable=0    failed=1   
```

After:
```
$ ansible-playbook -i hosts issue-26279.yml

PLAY [local] *********************************************************************************************************************************************************************************

TASK [Gathering Facts] ***********************************************************************************************************************************************************************
ok: [ansible_host=127.0.0.1]

TASK [Create directory] **********************************************************************************************************************************************************************
changed: [ansible_host=127.0.0.1]

TASK [Unpack zip file excluding one folder.] *************************************************************************************************************************************************
changed: [ansible_host=127.0.0.1]

PLAY RECAP ***********************************************************************************************************************************************************************************
ansible_host=127.0.0.1     : ok=3    changed=2    unreachable=0    failed=0   

```
