### PR TITLE
Migrate from MySQLdb to PyMySQL

### DIFF
--- a/changelogs/fragments/mysql-migrate_to_pymysql.yaml
+++ b/changelogs/fragments/mysql-migrate_to_pymysql.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- mysql_*, proxysql_* - PyMySQL (a pure-Python MySQL driver) is now a preferred dependency also supporting Python 3.X.

--- a/lib/ansible/module_utils/mysql.py
+++ b/lib/ansible/module_utils/mysql.py
@@ -37,6 +37,8 @@ except ImportError:
     except ImportError:
         mysql_driver = None
 
+mysql_driver_fail_msg = 'The PyMySQL (Python 2.7 and Python 3.X) or MySQL-python (Python 2.X) module is required.'
+
 
 def mysql_connect(module, login_user=None, login_password=None, config_file='', ssl_cert=None, ssl_key=None, ssl_ca=None, db=None, cursor_class=None,
                   connect_timeout=30):

--- a/lib/ansible/module_utils/mysql.py
+++ b/lib/ansible/module_utils/mysql.py
@@ -30,10 +30,12 @@
 import os
 
 try:
-    import MySQLdb
-    mysqldb_found = True
+    import pymysql as mysql_driver
 except ImportError:
-    mysqldb_found = False
+    try:
+        import MySQLdb as mysql_driver
+    except ImportError:
+        mysql_driver = None
 
 
 def mysql_connect(module, login_user=None, login_password=None, config_file='', ssl_cert=None, ssl_key=None, ssl_ca=None, db=None, cursor_class=None,
@@ -69,8 +71,8 @@ def mysql_connect(module, login_user=None, login_password=None, config_file='', 
     if connect_timeout is not None:
         config['connect_timeout'] = connect_timeout
 
-    db_connection = MySQLdb.connect(**config)
+    db_connection = mysql_driver.connect(**config)
     if cursor_class is not None:
-        return db_connection.cursor(cursorclass=MySQLdb.cursors.DictCursor)
+        return db_connection.cursor(cursorclass=mysql_driver.cursors.DictCursor)
     else:
         return db_connection.cursor()

--- a/lib/ansible/modules/database/mysql/mysql_db.py
+++ b/lib/ansible/modules/database/mysql/mysql_db.py
@@ -67,7 +67,7 @@ requirements:
    - mysql (command line binary)
    - mysqldump (command line binary)
 notes:
-   - Requires the python-mysqldb package on the remote host, as well as mysql and mysqldump binaries.
+   - Requires the PyMySQL package on the remote host, as well as mysql and mysqldump binaries.
    - This module is B(not idempotent) when I(state) is C(import), and will import the dump file each time if run more than once.
 extends_documentation_fragment: mysql
 '''
@@ -108,15 +108,16 @@ import subprocess
 import traceback
 
 try:
-    import MySQLdb
+    import pymysql as mysql_driver
 except ImportError:
-    mysqldb_found = False
-else:
-    mysqldb_found = True
+    try:
+        import MySQLdb as mysql_driver
+    except ImportError:
+        mysql_driver = None
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.database import mysql_quote_identifier
-from ansible.module_utils.mysql import mysql_connect, mysqldb_found
+from ansible.module_utils.mysql import mysql_connect
 from ansible.module_utils._text import to_native
 
 
@@ -279,8 +280,8 @@ def main():
         supports_check_mode=True
     )
 
-    if not mysqldb_found:
-        module.fail_json(msg="The MySQL-python module is required.")
+    if mysql_driver is None:
+        module.fail_json(msg="The PyMySQL or MySQL-python module is required.")
 
     db = module.params["name"]
     encoding = module.params["encoding"]

--- a/lib/ansible/modules/database/mysql/mysql_db.py
+++ b/lib/ansible/modules/database/mysql/mysql_db.py
@@ -67,7 +67,8 @@ requirements:
    - mysql (command line binary)
    - mysqldump (command line binary)
 notes:
-   - Requires the PyMySQL package on the remote host, as well as mysql and mysqldump binaries.
+   - Requires the PyMySQL (Python 2.7 and Python 3.X) or MySQL-python (Python 2.X) package on the remote host,
+     as well as mysql and mysqldump binaries.
    - This module is B(not idempotent) when I(state) is C(import), and will import the dump file each time if run more than once.
 extends_documentation_fragment: mysql
 '''
@@ -107,17 +108,9 @@ import pipes
 import subprocess
 import traceback
 
-try:
-    import pymysql as mysql_driver
-except ImportError:
-    try:
-        import MySQLdb as mysql_driver
-    except ImportError:
-        mysql_driver = None
-
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.database import mysql_quote_identifier
-from ansible.module_utils.mysql import mysql_connect
+from ansible.module_utils.mysql import mysql_connect, mysql_driver, mysql_driver_fail_msg
 from ansible.module_utils._text import to_native
 
 
@@ -281,7 +274,7 @@ def main():
     )
 
     if mysql_driver is None:
-        module.fail_json(msg="The PyMySQL or MySQL-python module is required.")
+        module.fail_json(msg=mysql_driver_fail_msg)
 
     db = module.params["name"]
     encoding = module.params["encoding"]

--- a/lib/ansible/modules/database/mysql/mysql_replication.py
+++ b/lib/ansible/modules/database/mysql/mysql_replication.py
@@ -118,16 +118,8 @@ EXAMPLES = '''
 import os
 import warnings
 
-try:
-    import pymysql as mysql_driver
-except ImportError:
-    try:
-        import MySQLdb as mysql_driver
-    except ImportError:
-        mysql_driver = None
-
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.mysql import mysql_connect
+from ansible.module_utils.mysql import mysql_connect, mysql_driver, mysql_driver_fail_msg
 from ansible.module_utils._text import to_native
 
 
@@ -241,7 +233,7 @@ def main():
     config_file = module.params['config_file']
 
     if mysql_driver is None:
-        module.fail_json(msg="The PyMySQL or MySQL-python module is required.")
+        module.fail_json(msg=mysql_driver_fail_msg)
     else:
         warnings.filterwarnings('error', category=mysql_driver.Warning)
 

--- a/lib/ansible/modules/database/mysql/mysql_replication.py
+++ b/lib/ansible/modules/database/mysql/mysql_replication.py
@@ -119,11 +119,12 @@ import os
 import warnings
 
 try:
-    import MySQLdb
+    import pymysql as mysql_driver
 except ImportError:
-    mysqldb_found = False
-else:
-    mysqldb_found = True
+    try:
+        import MySQLdb as mysql_driver
+    except ImportError:
+        mysql_driver = None
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.mysql import mysql_connect
@@ -239,16 +240,16 @@ def main():
     connect_timeout = module.params['connect_timeout']
     config_file = module.params['config_file']
 
-    if not mysqldb_found:
-        module.fail_json(msg="The MySQL-python module is required.")
+    if mysql_driver is None:
+        module.fail_json(msg="The PyMySQL or MySQL-python module is required.")
     else:
-        warnings.filterwarnings('error', category=MySQLdb.Warning)
+        warnings.filterwarnings('error', category=mysql_driver.Warning)
 
     login_password = module.params["login_password"]
     login_user = module.params["login_user"]
 
     try:
-        cursor = mysql_connect(module, login_user, login_password, config_file, ssl_cert, ssl_key, ssl_ca, None, 'MySQLdb.cursors.DictCursor',
+        cursor = mysql_connect(module, login_user, login_password, config_file, ssl_cert, ssl_key, ssl_ca, None, 'mysql_driver.cursors.DictCursor',
                                connect_timeout=connect_timeout)
     except Exception as e:
         if os.path.exists(config_file):
@@ -325,7 +326,7 @@ def main():
             chm.append("MASTER_AUTO_POSITION = 1")
         try:
             changemaster(cursor, chm, chm_params)
-        except MySQLdb.Warning as e:
+        except mysql_driver.Warning as e:
             result['warning'] = to_native(e)
         except Exception as e:
             module.fail_json(msg='%s. Query == CHANGE MASTER TO %s' % (to_native(e), chm))

--- a/lib/ansible/modules/database/mysql/mysql_user.py
+++ b/lib/ansible/modules/database/mysql/mysql_user.py
@@ -196,17 +196,9 @@ import re
 import string
 import traceback
 
-try:
-    import pymysql as mysql_driver
-except ImportError:
-    try:
-        import MySQLdb as mysql_driver
-    except ImportError:
-        mysql_driver = None
-
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.database import SQLParseError
-from ansible.module_utils.mysql import mysql_connect
+from ansible.module_utils.mysql import mysql_connect, mysql_driver, mysql_driver_fail_msg
 from ansible.module_utils.six import iteritems
 from ansible.module_utils._text import to_native
 
@@ -580,7 +572,7 @@ def main():
     sql_log_bin = module.params["sql_log_bin"]
 
     if mysql_driver is None:
-        module.fail_json(msg="The PyMySQL or MySQL-python module is required.")
+        module.fail_json(msg=mysql_driver_fail_msg)
 
     cursor = None
     try:

--- a/lib/ansible/modules/database/mysql/mysql_user.py
+++ b/lib/ansible/modules/database/mysql/mysql_user.py
@@ -197,15 +197,16 @@ import string
 import traceback
 
 try:
-    import MySQLdb
+    import pymysql as mysql_driver
 except ImportError:
-    mysqldb_found = False
-else:
-    mysqldb_found = True
+    try:
+        import MySQLdb as mysql_driver
+    except ImportError:
+        mysql_driver = None
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.database import SQLParseError
-from ansible.module_utils.mysql import mysql_connect, mysqldb_found
+from ansible.module_utils.mysql import mysql_connect
 from ansible.module_utils.six import iteritems
 from ansible.module_utils._text import to_native
 
@@ -578,8 +579,8 @@ def main():
     db = 'mysql'
     sql_log_bin = module.params["sql_log_bin"]
 
-    if not mysqldb_found:
-        module.fail_json(msg="The MySQL-python module is required.")
+    if mysql_driver is None:
+        module.fail_json(msg="The PyMySQL or MySQL-python module is required.")
 
     cursor = None
     try:
@@ -618,14 +619,14 @@ def main():
                 else:
                     changed = user_mod(cursor, user, host, host_all, None, encrypted, priv, append_privs, module)
 
-            except (SQLParseError, InvalidPrivsError, MySQLdb.Error) as e:
+            except (SQLParseError, InvalidPrivsError, mysql_driver.Error) as e:
                 module.fail_json(msg=to_native(e), exception=traceback.format_exc())
         else:
             if host_all:
                 module.fail_json(msg="host_all parameter cannot be used when adding a user")
             try:
                 changed = user_add(cursor, user, host, host_all, password, encrypted, priv, module.check_mode)
-            except (SQLParseError, InvalidPrivsError, MySQLdb.Error) as e:
+            except (SQLParseError, InvalidPrivsError, mysql_driver.Error) as e:
                 module.fail_json(msg=to_native(e), exception=traceback.format_exc())
     elif state == "absent":
         if user_exists(cursor, user, host, host_all):

--- a/lib/ansible/modules/database/mysql/mysql_variables.py
+++ b/lib/ansible/modules/database/mysql/mysql_variables.py
@@ -50,17 +50,9 @@ import os
 import warnings
 from re import match
 
-try:
-    import pymysql as mysql_driver
-except ImportError:
-    try:
-        import MySQLdb as mysql_driver
-    except ImportError:
-        mysql_driver = None
-
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.database import SQLParseError, mysql_quote_identifier
-from ansible.module_utils.mysql import mysql_connect
+from ansible.module_utils.mysql import mysql_connect, mysql_driver, mysql_driver_fail_msg
 from ansible.module_utils._text import to_native
 
 
@@ -150,7 +142,7 @@ def main():
     if match('^[0-9a-z_]+$', mysqlvar) is None:
         module.fail_json(msg="invalid variable name \"%s\"" % mysqlvar)
     if mysql_driver is None:
-        module.fail_json(msg="The PyMySQL or MySQL-python module is required.")
+        module.fail_json(msg=mysql_driver_fail_msg)
     else:
         warnings.filterwarnings('error', category=mysql_driver.Warning)
 

--- a/lib/ansible/modules/database/mysql/mysql_variables.py
+++ b/lib/ansible/modules/database/mysql/mysql_variables.py
@@ -51,15 +51,16 @@ import warnings
 from re import match
 
 try:
-    import MySQLdb
+    import pymysql as mysql_driver
 except ImportError:
-    mysqldb_found = False
-else:
-    mysqldb_found = True
+    try:
+        import MySQLdb as mysql_driver
+    except ImportError:
+        mysql_driver = None
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.database import SQLParseError, mysql_quote_identifier
-from ansible.module_utils.mysql import mysql_connect, mysqldb_found
+from ansible.module_utils.mysql import mysql_connect
 from ansible.module_utils._text import to_native
 
 
@@ -148,10 +149,10 @@ def main():
         module.fail_json(msg="Cannot run without variable to operate with")
     if match('^[0-9a-z_]+$', mysqlvar) is None:
         module.fail_json(msg="invalid variable name \"%s\"" % mysqlvar)
-    if not mysqldb_found:
-        module.fail_json(msg="The MySQL-python module is required.")
+    if mysql_driver is None:
+        module.fail_json(msg="The PyMySQL or MySQL-python module is required.")
     else:
-        warnings.filterwarnings('error', category=MySQLdb.Warning)
+        warnings.filterwarnings('error', category=mysql_driver.Warning)
 
     try:
         cursor = mysql_connect(module, user, password, config_file, ssl_cert, ssl_key, ssl_ca, db,

--- a/lib/ansible/modules/database/proxysql/proxysql_backend_servers.py
+++ b/lib/ansible/modules/database/proxysql/proxysql_backend_servers.py
@@ -148,17 +148,9 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.mysql import mysql_connect
+from ansible.module_utils.mysql import mysql_connect, mysql_driver, mysql_driver_fail_msg
 from ansible.module_utils.six import iteritems
 from ansible.module_utils._text import to_native
-
-try:
-    import pymysql as mysql_driver
-except ImportError:
-    try:
-        import MySQLdb as mysql_driver
-    except ImportError:
-        mysql_driver = None
 
 # ===========================================
 # proxysql module specific support methods.
@@ -193,7 +185,7 @@ def perform_checks(module):
             )
 
     if mysql_driver is None:
-        module.fail_json(msg="The PyMySQL or MySQL-python module is required.")
+        module.fail_json(msg=mysql_driver_fail_msg)
 
 
 def save_config_to_disk(cursor):

--- a/lib/ansible/modules/database/proxysql/proxysql_global_variables.py
+++ b/lib/ansible/modules/database/proxysql/proxysql_global_variables.py
@@ -73,16 +73,8 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.mysql import mysql_connect
+from ansible.module_utils.mysql import mysql_connect, mysql_driver, mysql_driver_fail_msg
 from ansible.module_utils._text import to_native
-
-try:
-    import pymysql as mysql_driver
-except ImportError:
-    try:
-        import MySQLdb as mysql_driver
-    except ImportError:
-        mysql_driver = None
 
 # ===========================================
 # proxysql module specific support methods.
@@ -97,7 +89,7 @@ def perform_checks(module):
         )
 
     if mysql_driver is None:
-        module.fail_json(msg="The PyMySQL or MySQL-python module is required.")
+        module.fail_json(msg=mysql_driver_fail_msg)
 
 
 def save_config_to_disk(variable, cursor):

--- a/lib/ansible/modules/database/proxysql/proxysql_global_variables.py
+++ b/lib/ansible/modules/database/proxysql/proxysql_global_variables.py
@@ -77,12 +77,12 @@ from ansible.module_utils.mysql import mysql_connect
 from ansible.module_utils._text import to_native
 
 try:
-    import MySQLdb
-    import MySQLdb.cursors
+    import pymysql as mysql_driver
 except ImportError:
-    MYSQLDB_FOUND = False
-else:
-    MYSQLDB_FOUND = True
+    try:
+        import MySQLdb as mysql_driver
+    except ImportError:
+        mysql_driver = None
 
 # ===========================================
 # proxysql module specific support methods.
@@ -96,10 +96,8 @@ def perform_checks(module):
             msg="login_port must be a valid unix port number (0-65535)"
         )
 
-    if not MYSQLDB_FOUND:
-        module.fail_json(
-            msg="the python mysqldb module is required"
-        )
+    if mysql_driver is None:
+        module.fail_json(msg="The PyMySQL or MySQL-python module is required.")
 
 
 def save_config_to_disk(variable, cursor):
@@ -211,8 +209,8 @@ def main():
                                login_user,
                                login_password,
                                config_file,
-                               cursor_class=MySQLdb.cursors.DictCursor)
-    except MySQLdb.Error as e:
+                               cursor_class=mysql_driver.cursors.DictCursor)
+    except mysql_driver.Error as e:
         module.fail_json(
             msg="unable to connect to ProxySQL Admin Module.. %s" % to_native(e)
         )
@@ -231,7 +229,7 @@ def main():
                     msg="The variable \"%s\" was not found" % variable
                 )
 
-        except MySQLdb.Error as e:
+        except mysql_driver.Error as e:
             module.fail_json(
                 msg="unable to get config.. %s" % to_native(e)
             )
@@ -264,7 +262,7 @@ def main():
                     msg="The variable \"%s\" was not found" % variable
                 )
 
-        except MySQLdb.Error as e:
+        except mysql_driver.Error as e:
             module.fail_json(
                 msg="unable to set config.. %s" % to_native(e)
             )

--- a/lib/ansible/modules/database/proxysql/proxysql_manage_config.py
+++ b/lib/ansible/modules/database/proxysql/proxysql_manage_config.py
@@ -100,11 +100,12 @@ from ansible.module_utils.mysql import mysql_connect
 from ansible.module_utils._text import to_native
 
 try:
-    import MySQLdb
+    import pymysql as mysql_driver
 except ImportError:
-    MYSQLDB_FOUND = False
-else:
-    MYSQLDB_FOUND = True
+    try:
+        import MySQLdb as mysql_driver
+    except ImportError:
+        mysql_driver = None
 
 # ===========================================
 # proxysql module specific support methods.
@@ -140,10 +141,8 @@ def perform_checks(module):
                           " with the CONFIG config_layer")
             module.fail_json(msg=msg_string % module.params["direction"])
 
-    if not MYSQLDB_FOUND:
-        module.fail_json(
-            msg="the python mysqldb module is required"
-        )
+    if mysql_driver is None:
+        module.fail_json(msg="The PyMySQL or MySQL-python module is required.")
 
 
 def manage_config(manage_config_settings, cursor):
@@ -201,7 +200,7 @@ def main():
                                login_user,
                                login_password,
                                config_file)
-    except MySQLdb.Error as e:
+    except mysql_driver.Error as e:
         module.fail_json(
             msg="unable to connect to ProxySQL Admin Module.. %s" % to_native(e)
         )
@@ -214,7 +213,7 @@ def main():
     try:
         result['changed'] = manage_config(manage_config_settings,
                                           cursor)
-    except MySQLdb.Error as e:
+    except mysql_driver.Error as e:
         module.fail_json(
             msg="unable to manage config.. %s" % to_native(e)
         )

--- a/lib/ansible/modules/database/proxysql/proxysql_manage_config.py
+++ b/lib/ansible/modules/database/proxysql/proxysql_manage_config.py
@@ -96,16 +96,8 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.mysql import mysql_connect
+from ansible.module_utils.mysql import mysql_connect, mysql_driver, mysql_driver_fail_msg
 from ansible.module_utils._text import to_native
-
-try:
-    import pymysql as mysql_driver
-except ImportError:
-    try:
-        import MySQLdb as mysql_driver
-    except ImportError:
-        mysql_driver = None
 
 # ===========================================
 # proxysql module specific support methods.
@@ -142,7 +134,7 @@ def perform_checks(module):
             module.fail_json(msg=msg_string % module.params["direction"])
 
     if mysql_driver is None:
-        module.fail_json(msg="The PyMySQL or MySQL-python module is required.")
+        module.fail_json(msg=mysql_driver_fail_msg)
 
 
 def manage_config(manage_config_settings, cursor):

--- a/lib/ansible/modules/database/proxysql/proxysql_mysql_users.py
+++ b/lib/ansible/modules/database/proxysql/proxysql_mysql_users.py
@@ -137,17 +137,9 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.mysql import mysql_connect
+from ansible.module_utils.mysql import mysql_connect, mysql_driver, mysql_driver_fail_msg
 from ansible.module_utils.six import iteritems
 from ansible.module_utils._text import to_native
-
-try:
-    import pymysql as mysql_driver
-except ImportError:
-    try:
-        import MySQLdb as mysql_driver
-    except ImportError:
-        mysql_driver = None
 
 # ===========================================
 # proxysql module specific support methods.
@@ -162,7 +154,7 @@ def perform_checks(module):
         )
 
     if mysql_driver is None:
-        module.fail_json(msg="The PyMySQL or MySQL-python module is required.")
+        module.fail_json(msg=mysql_driver_fail_msg)
 
 
 def save_config_to_disk(cursor):

--- a/lib/ansible/modules/database/proxysql/proxysql_mysql_users.py
+++ b/lib/ansible/modules/database/proxysql/proxysql_mysql_users.py
@@ -142,12 +142,12 @@ from ansible.module_utils.six import iteritems
 from ansible.module_utils._text import to_native
 
 try:
-    import MySQLdb
-    import MySQLdb.cursors
+    import pymysql as mysql_driver
 except ImportError:
-    MYSQLDB_FOUND = False
-else:
-    MYSQLDB_FOUND = True
+    try:
+        import MySQLdb as mysql_driver
+    except ImportError:
+        mysql_driver = None
 
 # ===========================================
 # proxysql module specific support methods.
@@ -161,10 +161,8 @@ def perform_checks(module):
             msg="login_port must be a valid unix port number (0-65535)"
         )
 
-    if not MYSQLDB_FOUND:
-        module.fail_json(
-            msg="the python mysqldb module is required"
-        )
+    if mysql_driver is None:
+        module.fail_json(msg="The PyMySQL or MySQL-python module is required.")
 
 
 def save_config_to_disk(cursor):
@@ -424,8 +422,8 @@ def main():
                                login_user,
                                login_password,
                                config_file,
-                               cursor_class=MySQLdb.cursors.DictCursor)
-    except MySQLdb.Error as e:
+                               cursor_class=mysql_driver.cursors.DictCursor)
+    except mysql_driver.Error as e:
         module.fail_json(
             msg="unable to connect to ProxySQL Admin Module.. %s" % to_native(e)
         )
@@ -454,7 +452,7 @@ def main():
                                  " and doesn't need to be updated.")
                 result['user'] = \
                     proxysql_user.get_user_config(cursor)
-        except MySQLdb.Error as e:
+        except mysql_driver.Error as e:
             module.fail_json(
                 msg="unable to modify user.. %s" % to_native(e)
             )
@@ -469,7 +467,7 @@ def main():
                 result['changed'] = False
                 result['msg'] = ("The user is already absent from the" +
                                  " mysql_users memory configuration")
-        except MySQLdb.Error as e:
+        except mysql_driver.Error as e:
             module.fail_json(
                 msg="unable to remove user.. %s" % to_native(e)
             )

--- a/lib/ansible/modules/database/proxysql/proxysql_query_rules.py
+++ b/lib/ansible/modules/database/proxysql/proxysql_query_rules.py
@@ -221,17 +221,9 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.mysql import mysql_connect
+from ansible.module_utils.mysql import mysql_connect, mysql_driver, mysql_driver_fail_msg
 from ansible.module_utils.six import iteritems
 from ansible.module_utils._text import to_native
-
-try:
-    import pymysql as mysql_driver
-except ImportError:
-    try:
-        import MySQLdb as mysql_driver
-    except ImportError:
-        mysql_driver = None
 
 # ===========================================
 # proxysql module specific support methods.
@@ -246,7 +238,7 @@ def perform_checks(module):
         )
 
     if mysql_driver is None:
-        module.fail_json(msg="The PyMySQL or MySQL-python module is required.")
+        module.fail_json(msg=mysql_driver_fail_msg)
 
 
 def save_config_to_disk(cursor):

--- a/lib/ansible/modules/database/proxysql/proxysql_replication_hostgroups.py
+++ b/lib/ansible/modules/database/proxysql/proxysql_replication_hostgroups.py
@@ -95,16 +95,8 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.mysql import mysql_connect
+from ansible.module_utils.mysql import mysql_connect, mysql_driver, mysql_driver_fail_msg
 from ansible.module_utils._text import to_native
-
-try:
-    import pymysql as mysql_driver
-except ImportError:
-    try:
-        import MySQLdb as mysql_driver
-    except ImportError:
-        mysql_driver = None
 
 # ===========================================
 # proxysql module specific support methods.
@@ -136,7 +128,7 @@ def perform_checks(module):
         )
 
     if mysql_driver is None:
-        module.fail_json(msg="The PyMySQL or MySQLdb module is required.")
+        module.fail_json(msg=mysql_driver_fail_msg)
 
 
 def save_config_to_disk(cursor):

--- a/lib/ansible/modules/database/proxysql/proxysql_replication_hostgroups.py
+++ b/lib/ansible/modules/database/proxysql/proxysql_replication_hostgroups.py
@@ -99,12 +99,12 @@ from ansible.module_utils.mysql import mysql_connect
 from ansible.module_utils._text import to_native
 
 try:
-    import MySQLdb
-    import MySQLdb.cursors
+    import pymysql as mysql_driver
 except ImportError:
-    MYSQLDB_FOUND = False
-else:
-    MYSQLDB_FOUND = True
+    try:
+        import MySQLdb as mysql_driver
+    except ImportError:
+        mysql_driver = None
 
 # ===========================================
 # proxysql module specific support methods.
@@ -135,10 +135,8 @@ def perform_checks(module):
             msg="reader_hostgroup cannot equal writer_hostgroup"
         )
 
-    if not MYSQLDB_FOUND:
-        module.fail_json(
-            msg="the python mysqldb module is required"
-        )
+    if mysql_driver is None:
+        module.fail_json(msg="The PyMySQL or MySQLdb module is required.")
 
 
 def save_config_to_disk(cursor):
@@ -328,8 +326,8 @@ def main():
                                login_user,
                                login_password,
                                config_file,
-                               cursor_class=MySQLdb.cursors.DictCursor)
-    except MySQLdb.Error as e:
+                               cursor_class=mysql_driver.cursors.DictCursor)
+    except mysql_driver.Error as e:
         module.fail_json(
             msg="unable to connect to ProxySQL Admin Module.. %s" % to_native(e)
         )
@@ -360,7 +358,7 @@ def main():
                     result['repl_group'] = \
                         proxysql_repl_group.get_repl_group_config(cursor)
 
-        except MySQLdb.Error as e:
+        except mysql_driver.Error as e:
             module.fail_json(
                 msg="unable to modify replication hostgroup.. %s" % to_native(e)
             )
@@ -378,7 +376,7 @@ def main():
                                  " mysql_replication_hostgroups memory" +
                                  " configuration")
 
-        except MySQLdb.Error as e:
+        except mysql_driver.Error as e:
             module.fail_json(
                 msg="unable to delete replication hostgroup.. %s" % to_native(e)
             )

--- a/lib/ansible/modules/database/proxysql/proxysql_scheduler.py
+++ b/lib/ansible/modules/database/proxysql/proxysql_scheduler.py
@@ -125,17 +125,9 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.mysql import mysql_connect
+from ansible.module_utils.mysql import mysql_connect, mysql_driver, mysql_driver_fail_msg
 from ansible.module_utils.six import iteritems
 from ansible.module_utils._text import to_native
-
-try:
-    import pymysql as mysql_driver
-except ImportError:
-    try:
-        import MySQLdb as mysql_driver
-    except ImportError:
-        mysql_driver = None
 
 # ===========================================
 # proxysql module specific support methods.
@@ -156,7 +148,7 @@ def perform_checks(module):
         )
 
     if mysql_driver is None:
-        module.fail_json(msg="The PyMySQL or MySQLdb module is required.")
+        module.fail_json(msg=mysql_driver_fail_msg)
 
 
 def save_config_to_disk(cursor):

--- a/lib/ansible/utils/module_docs_fragments/mysql.py
+++ b/lib/ansible/utils/module_docs_fragments/mysql.py
@@ -52,7 +52,8 @@ options:
   ssl_ca:
     version_added: "2.0"
     description:
-      - The path to a Certificate Authority (CA) certificate. This option, if used, must specify the same certificate as used by the server.
+      - The path to a Certificate Authority (CA) certificate. This option, if used, must specify the same certificate
+        as used by the server.
   ssl_cert:
     version_added: "2.0"
     description:
@@ -64,8 +65,8 @@ options:
 requirements:
    - PyMySQL
 notes:
-   - Requires the PyMySQL Python package on the remote host. For Ubuntu, this
-     is as easy as apt-get install python-pymysql. (See M(apt).) For CentOS/Fedora, this
+   - Requires the PyMySQL (Python 2.7 and Python 3.X) or MySQL-python (Python 2.X) Python package on the remote host.
+     For Ubuntu, this is as easy as apt-get install python-pymysql. (See M(apt).) For CentOS/Fedora, this
      is as easy as yum install python2-PyMySQL. (See M(yum).)
    - Both C(login_password) and C(login_user) are required when you are
      passing credentials. If none are present, the module will attempt to read

--- a/lib/ansible/utils/module_docs_fragments/mysql.py
+++ b/lib/ansible/utils/module_docs_fragments/mysql.py
@@ -62,11 +62,11 @@ options:
     description:
       - The path to the client private key.
 requirements:
-   - MySQLdb
+   - PyMySQL
 notes:
-   - Requires the MySQLdb Python package on the remote host. For Ubuntu, this
-     is as easy as apt-get install python-mysqldb. (See M(apt).) For CentOS/Fedora, this
-     is as easy as yum install MySQL-python. (See M(yum).)
+   - Requires the PyMySQL Python package on the remote host. For Ubuntu, this
+     is as easy as apt-get install python-pymysql. (See M(apt).) For CentOS/Fedora, this
+     is as easy as yum install python2-PyMySQL. (See M(yum).)
    - Both C(login_password) and C(login_user) are required when you are
      passing credentials. If none are present, the module will attempt to read
      the credentials from C(~/.my.cnf), and finally fall back to using the MySQL

--- a/lib/ansible/utils/module_docs_fragments/mysql.py
+++ b/lib/ansible/utils/module_docs_fragments/mysql.py
@@ -63,7 +63,8 @@ options:
     description:
       - The path to the client private key.
 requirements:
-   - PyMySQL
+   - PyMySQL (Python 2.7 and Python 3.X), or
+   - MySQLdb (Python 2.x)
 notes:
    - Requires the PyMySQL (Python 2.7 and Python 3.X) or MySQL-python (Python 2.X) Python package on the remote host.
      For Ubuntu, this is as easy as apt-get install python-pymysql. (See M(apt).) For CentOS/Fedora, this

--- a/lib/ansible/utils/module_docs_fragments/proxysql.py
+++ b/lib/ansible/utils/module_docs_fragments/proxysql.py
@@ -27,7 +27,7 @@ options:
         are to be read.
     default: ''
 requirements:
-   - MySQLdb
+   - PyMySQL
 '''
 
     # Documentation fragment for managing ProxySQL configuration

--- a/lib/ansible/utils/module_docs_fragments/proxysql.py
+++ b/lib/ansible/utils/module_docs_fragments/proxysql.py
@@ -27,7 +27,8 @@ options:
         are to be read.
     default: ''
 requirements:
-   - PyMySQL
+   - PyMySQL (Python 2.7 and Python 3.X), or
+   - MySQLdb (Python 2.x)
 '''
 
     # Documentation fragment for managing ProxySQL configuration

--- a/test/integration/targets/setup_mysql_db/vars/Fedora-py3.yml
+++ b/test/integration/targets/setup_mysql_db/vars/Fedora-py3.yml
@@ -2,5 +2,5 @@ mysql_service: 'mariadb'
 
 mysql_packages:
     - mariadb-server
-    - python3-mysql
+    - python3-PyMySQL
     - bzip2

--- a/test/integration/targets/setup_mysql_db/vars/Fedora.yml
+++ b/test/integration/targets/setup_mysql_db/vars/Fedora.yml
@@ -2,5 +2,5 @@ mysql_service: 'mariadb'
 
 mysql_packages:
     - mariadb-server
-    - MySQL-python
+    - python-PyMySQL
     - bzip2

--- a/test/integration/targets/setup_mysql_db/vars/FreeBSD.yml
+++ b/test/integration/targets/setup_mysql_db/vars/FreeBSD.yml
@@ -2,4 +2,4 @@ mysql_service: 'mysql-server'
 
 mysql_packages:
     - mariadb101-server
-    - py27-mysql-connector-python2
+    - py-pymysql

--- a/test/integration/targets/setup_mysql_db/vars/Suse.yml
+++ b/test/integration/targets/setup_mysql_db/vars/Suse.yml
@@ -2,5 +2,5 @@ mysql_service: 'mysql'
 
 mysql_packages:
     - mariadb
-    - python-MySQL-python
+    - python-PyMySQL
     - bzip2

--- a/test/integration/targets/setup_mysql_db/vars/Ubuntu-16-py3.yml
+++ b/test/integration/targets/setup_mysql_db/vars/Ubuntu-16-py3.yml
@@ -2,5 +2,5 @@ mysql_service: 'mysql'
 
 mysql_packages:
     - mysql-server
-    - python3-mysqldb
+    - python3-pymysql
     - bzip2


### PR DESCRIPTION
##### SUMMARY
Fixes #29887 

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
mysql,  proxysql

##### ANSIBLE VERSION
devel


##### ADDITIONAL INFORMATION
PyMySQL is a pure Python implementation of MySQL connector. It is widely available for Python 2.7 and 3. This eliminates the need to install MySQL client libs that MySQLdb was using just to use these modules.
