### PR TITLE
Correct pip chdir without virtualenv 2

### DIFF
--- a/lib/ansible/modules/packaging/language/pip.py
+++ b/lib/ansible/modules/packaging/language/pip.py
@@ -427,10 +427,14 @@ def main():
     chdir = module.params['chdir']
     umask = module.params['umask']
     env = module.params['virtualenv']
+    executable = module.params['executable']
 
     venv_created = False
     if chdir:
-        env = os.path.join(chdir, env)
+        if env:
+            env = os.path.join(chdir, env)
+        elif executable:
+            executable = os.path.join(chdir, executable)
 
     if umask and not isinstance(umask, int):
         try:
@@ -458,7 +462,7 @@ def main():
                 venv_created = True
                 out, err = setup_virtualenv(module, env, chdir, out, err)
 
-        pip = _get_pip(module, env, module.params['executable'])
+        pip = _get_pip(module, env, executable)
 
         cmd = '%s %s' % (pip, state_map[state])
 

--- a/test/integration/targets/pip/tasks/pip.yml
+++ b/test/integration/targets/pip/tasks/pip.yml
@@ -275,9 +275,9 @@
     executable: "{{ output_dir }}/pipenv/bin/pip"
     state: latest
     name: pip
-  register: venv_chdir_wo_virtualenv
+  register: pip_chdir_wo_virtualenv
 
 - name: test for previos task not fail
   assert:
     that:
-      - "venv_chdir_wo_virtualenv.state == 'latest'"
+      - "pip_chdir_wo_virtualenv.state == 'latest'"

--- a/test/integration/targets/pip/tasks/pip.yml
+++ b/test/integration/targets/pip/tasks/pip.yml
@@ -256,3 +256,28 @@
   assert:
     that:
       - not pip_install_empty.changed
+
+# https://github.com/ansible/ansible/issues/37912
+- name: install pip throught pip into fresh virtualenv for test pip without virtualenv
+  pip:
+    name: pip
+    virtualenv: "{{ output_dir }}/pipenv"
+  register: pip_install_venv4test
+
+- name: test for previos task not fail
+  assert:
+    that:
+      - "pip_install_venv4test.state == 'present'"
+
+- name: pip chdir without virtualenv
+  pip:
+    chdir: "{{ output_dir }}/"
+    executable: "{{ output_dir }}/pipenv/bin/pip"
+    state: latest
+    name: pip
+  register: venv_chdir_wo_virtualenv
+
+- name: test for previos task not fail
+  assert:
+    that:
+      - "venv_chdir_wo_virtualenv.state == 'latest'"


### PR DESCRIPTION
see #37912, #37973 

##### SUMMARY
pip modile broken when set option chdir without virtualenv

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/packaging/language/pip.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0
  config file = /home/user/projects/remains/deploy/ansible.cfg
  configured module search path = [u'/home/user/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```
