### PR TITLE
reverting changes from #39726 a0b4462a to avoid casting strings to ints

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -1010,10 +1010,11 @@ class PyVmomiHelper(PyVmomi):
                 dvps = self.cache.get_all_objs(self.content, [vim.dvs.DistributedVirtualPortgroup])
                 for dvp in dvps:
                     if hasattr(dvp.config.defaultPortConfig, 'vlan') and \
-                            dvp.config.defaultPortConfig.vlan.vlanId == int(network['vlan']):
+                            isinstance(dvp.config.defaultPortConfig.vlan.vlanId, int) and \
+                            str(dvp.config.defaultPortConfig.vlan.vlanId) == network['vlan']:
                         network['name'] = dvp.config.name
                         break
-                    if dvp.config.name == str(network['vlan']):
+                    if dvp.config.name == network['vlan']:
                         network['name'] = dvp.config.name
                         break
                 else:


### PR DESCRIPTION
##### SUMMARY
Fixes changes from #39726 a0b4462a as it was possible to end up with a ``ValueError: invalid literal for int() with base 10: 'non_existing_vlan'`` situation if you passed in a string that was not a number, ie: ``vlan_name`` vs ``3``.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
cloud/vmware/vmware_guest.py

##### ANSIBLE VERSION
```
ansible 2.6.0 (revert_39726 de3aa03865) last updated 2018/05/15 00:04:24 (GMT -400)
  config file = /Users/deric/.ansible.cfg
  configured module search path = [u'/Users/deric/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/deric/ansible/lib/ansible
  executable location = /Users/deric/ansible/bain/ansible
  python version = 2.7.14 (default, Sep 25 2017, 09:54:19) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.37)]
```


##### ADDITIONAL INFORMATION
I believe #39726 had backports as well.
