### PR TITLE
Fix eos_eapi integration test failure

### DIFF
--- a/test/integration/targets/eos_eapi/tests/cli/badtransport.yaml
+++ b/test/integration/targets/eos_eapi/tests/cli/badtransport.yaml
@@ -1,13 +1,14 @@
 - debug: msg="START CLI/BADTRANSPORT.YAML"
 
-- name: Expect transport other than cli to fail
-  eos_eapi:
-    provider: "{{ eapi }}"
-  register: eos_eapi_output
-  connection: local
-  ignore_errors: yes
+- block:
+  - name: Expect transport other than cli to fail
+    eos_eapi:
+      provider: "{{ eapi }}"
+    register: eos_eapi_output
+    ignore_errors: yes
 
-- assert:
-    that: eos_eapi_output.failed == true
+  - assert:
+      that: eos_eapi_output.failed == true
+  when: "ansible_connection == 'local'"
 
 - debug: msg="START CLI/BADTRANSPORT.YAML"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Run eos_eapi bad transport test case only when the connection is of type local 

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Test Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
eos_eapi/tests/cli/badtransport.yaml

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
