### PR TITLE
Fix eos_eapi integration test failure (#40132)

### DIFF
--- a/test/integration/targets/eos_eapi/tests/cli/badtransport.yaml
+++ b/test/integration/targets/eos_eapi/tests/cli/badtransport.yaml
@@ -1,13 +1,14 @@
 - debug: msg="START CLI/BADTRANSPORT.YAML"
 
-- name: Expect transport other than cli to fail
-  eos_eapi:
-    provider: "{{ eapi }}"
-  register: eos_eapi_output
-  connection: local
-  ignore_errors: yes
+- block:
+  - name: Expect transport other than cli to fail
+    eos_eapi:
+      provider: "{{ eapi }}"
+    register: eos_eapi_output
+    ignore_errors: yes
 
-- assert:
-    that: eos_eapi_output.failed == true
+  - assert:
+      that: eos_eapi_output.failed == true
+  when: "ansible_connection == 'local'"
 
 - debug: msg="START CLI/BADTRANSPORT.YAML"


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Merged to devel https://github.com/ansible/ansible/pull/40132
(cherry picked from commit dda351ca6c77b4dbdceac8d132213b1f6cd528da)

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Test Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
