### PR TITLE
Fix tower_* modules **params kwargs

### DIFF
--- a/lib/ansible/module_utils/ansible_tower.py
+++ b/lib/ansible/module_utils/ansible_tower.py
@@ -45,7 +45,7 @@ def tower_auth_config(module):
     it will attempt to fetch values from the module pararms and
     only pass those values that have been set.
     '''
-    config_file = module.params.get('tower_config_file')
+    config_file = module.params.pop('tower_config_file', None)
     if config_file:
         config_file = os.path.expanduser(config_file)
         if not os.path.exists(config_file):
@@ -57,16 +57,16 @@ def tower_auth_config(module):
             return parser.string_to_dict(f.read())
     else:
         auth_config = {}
-        host = module.params.get('tower_host')
+        host = module.params.pop('tower_host', None)
         if host:
             auth_config['host'] = host
-        username = module.params.get('tower_username')
+        username = module.params.pop('tower_username', None)
         if username:
             auth_config['username'] = username
-        password = module.params.get('tower_password')
+        password = module.params.pop('tower_password', None)
         if password:
             auth_config['password'] = password
-        verify_ssl = module.params.get('tower_verify_ssl')
+        verify_ssl = module.params.pop('tower_verify_ssl', None)
         if verify_ssl is not None:
             auth_config['verify_ssl'] = verify_ssl
         return auth_config

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_group.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_group.py
@@ -134,7 +134,7 @@ def main():
     name = module.params.get('name')
     inventory = module.params.get('inventory')
     credential = module.params.get('credential')
-    state = module.params.get('state')
+    state = module.params.pop('state')
 
     variables = module.params.get('variables')
     if variables:

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_template.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_template.py
@@ -222,7 +222,7 @@ def main():
         module.fail_json(msg='ansible-tower-cli required for this module')
 
     name = module.params.get('name')
-    state = module.params.get('state')
+    state = module.params.pop('state')
     json_output = {'job_template': name, 'state': state}
 
     tower_auth = tower_auth_config(module)

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_role.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_role.py
@@ -134,7 +134,7 @@ def main():
         module.fail_json(msg='ansible-tower-cli required for this module')
 
     role_type = module.params.pop('role')
-    state = module.params.get('state')
+    state = module.params.pop('state')
 
     json_output = {'role': role_type, 'state': state}
 

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_role.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_role.py
@@ -87,10 +87,6 @@ def update_resources(module, p):
     by name using their unique field (identity)
     '''
     params = p.copy()
-    for key in p:
-        if key.startswith('tower_'):
-            params.pop(key)
-    params.pop('state', None)
     identity_map = {
         'user': 'username',
         'team': 'name',


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #39745

There are some ansible_tower modules which do pass an entire `**params` dict to the tower-cli API calls.
It is convenient and it might be a desired behaviour but there are some parameters coming from the module (defined by the user in a playbook) which will be passed to Ansible Tower. It will result in a an error because Ansible Tower won't be able to find those resources.
This PR offers a reliable way to use the ansible_tower modules by cleaning the `**params` dict of the unwanted parameters before making the API call to Ansible Tower.

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
ansible_tower modules

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
$ ansible --version
ansible 2.6.0 (devel-piroux_fix-tower-params-kwargs 170d81580b) last updated 2018/05/15 10:03:17 (GMT +000)
  config file = None
  configured module search path = [u'/home/piroux/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/piroux/***/ansible-devel/lib/ansible
  executable location = /home/piroux/***/ansible-devel/bin/ansible
  python version = 2.7.6 (default, Nov 23 2017, 15:49:48) [GCC 4.8.4]
```
