### PR TITLE
Fix two "ansilbe" typos to "ansible".

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1279,7 +1279,7 @@ While neither is technically a new plugin, these connections may now be used dir
   * Fix pip module when using python3's pyvenv and python3 -m venv to create virtualenvs
 * Fix for the AnsiBallZ wrapper so that it gives a better error message when
   there's not enough disk space to create its tempdir.
-* Fix so ansilbe-galaxy install --force with unversioned roles will once again
+* Fix so ansible-galaxy install --force with unversioned roles will once again
   overwrite old versions.
 * Fix for RabbitMQ 3.6.7 endpoint return code changing.
 * Fix for Foreman organization creation

--- a/lib/ansible/modules/network/cloudengine/ce_vlan.py
+++ b/lib/ansible/modules/network/cloudengine/ce_vlan.py
@@ -285,7 +285,7 @@ class Vlan(object):
 
     def init_module(self):
         """
-        init ansilbe NetworkModule.
+        init ansible NetworkModule.
         """
 
         required_one_of = [["vlan_id", "vlan_range"]]


### PR DESCRIPTION
##### SUMMARY
Fix two "ansilbe" typos to read "ansible".

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
- CHANGELOG.md
- cloudengine

##### ANSIBLE VERSION
git devel branch


##### ADDITIONAL INFORMATION

Before:
```
$ git grep -i ansilbe
CHANGELOG.md:* Fix so ansilbe-galaxy install --force with unversioned roles will once again
lib/ansible/modules/network/cloudengine/ce_vlan.py:        init ansilbe NetworkModule.
$
```

After:
```
$ git grep -i ansilbe
$
```
