### PR TITLE
apt: better error msg when update_cache fails (#37410)

### DIFF
--- a/lib/ansible/modules/packaging/os/apt.py
+++ b/lib/ansible/modules/packaging/os/apt.py
@@ -955,14 +955,15 @@ def main():
             tdelta = datetime.timedelta(seconds=p['cache_valid_time'])
             if not mtimestamp + tdelta >= now:
                 # Retry to update the cache up to 3 times
+                err = ''
                 for retry in range(3):
                     try:
                         cache.update()
                         break
-                    except apt.cache.FetchFailedException:
-                        pass
+                    except apt.cache.FetchFailedException as e:
+                        err = to_native(e)
                 else:
-                    module.fail_json(msg='Failed to update apt cache.')
+                    module.fail_json(msg='Failed to update apt cache: %s' % err)
                 cache.open(progress=None)
                 updated_cache = True
                 mtimestamp, updated_cache_time = get_updated_cache_time()

--- a/test/integration/targets/apt/tasks/apt.yml
+++ b/test/integration/targets/apt/tasks/apt.yml
@@ -162,6 +162,29 @@
         - "not apt_result.changed"
         - "apt_result.failed"
 
+# https://github.com/ansible/ansible/issues/23155
+- name: create a repo file
+  copy:
+    dest: /etc/apt/sources.list.d/non-existing.list
+    content: deb http://ppa.launchpad.net/non-existing trusty main
+
+- name: test for sane error message
+  apt:
+    update_cache: yes
+  register: apt_result
+  ignore_errors: yes
+
+- name: verify sane error message
+  assert:
+    that:
+      - "'E:Failed to fetch' in apt_result['msg']"
+      - "'403' in apt_result['msg']"
+
+- name: Clean up
+  file:
+    name: /etc/apt/sources.list.d/non-existing.list
+    state: absent
+
 - name: autoclean during install
   apt: pkg=hello state=present autoclean=yes
 


### PR DESCRIPTION
##### SUMMARY
Fixes https://github.com/ansible/ansible/issues/23155
Backports https://github.com/ansible/ansible/pull/37410

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

apt

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
stable-2.4
```


##### ADDITIONAL INFORMATION
```

```

(cherry picked from commit a6d31b6fb13af1f3697c4517b088592bb850787a)