### PR TITLE
networking roadmap cli modules

### DIFF
--- a/docs/docsite/rst/roadmap/ROADMAP_2_6.rst
+++ b/docs/docsite/rst/roadmap/ROADMAP_2_6.rst
@@ -55,8 +55,8 @@ Connection work
 Modules
 =======
 
-* New ``cli_config`` - platform agnostic module for sending text based config over network_cli
-* New ``cli_command`` - platform agnostic command module
+* New ``network_config`` - platform agnostic module for sending text based config over network_cli
+* New ``network_command`` - platform agnostic command module
 * New ``network_get`` - platform agnostic module for pulling configuration via SCP/SFTP over network_cli
 * New ``network_put`` - platform agnostic module for pushing configuration via SCP/SFTP over network_cli
 


### PR DESCRIPTION
Signed-off-by: Trishna Guha <trishnaguha17@gmail.com>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
networking roadmap cli modules
rename cli_config and cli_command modules to network_config, network_command modules respectively.
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
docs/docsite/rst/roadmap/ROADMAP_2_6.rst
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```