### PR TITLE
Fix file operation to work with ESXi directly

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest_file_operation.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_file_operation.py
@@ -277,6 +277,7 @@ class VmwareGuestFileManager(PyVmomi):
         result = dict(changed=True, uuid=self.vm.summary.config.uuid)
         vm_username = self.module.params['vm_username']
         vm_password = self.module.params['vm_password']
+        hostname = self.module.params['hostname']
         dest = self.module.params["fetch"]['dest']
         src = self.module.params['fetch']['src']
         creds = vim.vm.guest.NamePasswordAuthentication(username=vm_username, password=vm_password)
@@ -286,6 +287,7 @@ class VmwareGuestFileManager(PyVmomi):
             fileTransferInfo = file_manager.InitiateFileTransferFromGuest(vm=self.vm, auth=creds,
                                                                           guestFilePath=src)
             url = fileTransferInfo.url
+            url = url.replace("*", hostname)
             resp, info = urls.fetch_url(self.module, url, method="GET")
             try:
                 with open(dest, "wb") as local_file:
@@ -316,6 +318,7 @@ class VmwareGuestFileManager(PyVmomi):
         result = dict(changed=True, uuid=self.vm.summary.config.uuid)
         vm_username = self.module.params['vm_username']
         vm_password = self.module.params['vm_password']
+        hostname = self.module.params['hostname']
         overwrite = self.module.params["copy"]["overwrite"]
         dest = self.module.params["copy"]['dest']
         src = self.module.params['copy']['src']
@@ -340,6 +343,7 @@ class VmwareGuestFileManager(PyVmomi):
             url = file_manager.InitiateFileTransferToGuest(vm=self.vm, auth=creds, guestFilePath=dest,
                                                            fileAttributes=file_attributes, overwrite=overwrite,
                                                            fileSize=file_size)
+            url = url.replace("*", hostname)
             resp, info = urls.fetch_url(self.module, url, data=data, method="PUT")
 
             status_code = info["status"]


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #40058 
Fixes File operations to work with ESXi  directly. 
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request
 

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
vmware_guest_file_operation

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0
  config file = None
  configured module search path = [u'/home/stravassac/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/stravassac/virtualenvs/ansible_dev/local/lib/python2.7/site-packages/ansible
  executable location = /home/stravassac/virtualenvs/ansible_dev/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
