### PR TITLE
apt_repository: fix rendering default mode in docs

### DIFF
--- a/lib/ansible/modules/packaging/os/apt_repository.py
+++ b/lib/ansible/modules/packaging/os/apt_repository.py
@@ -36,7 +36,7 @@ options:
     mode:
         description:
             - The octal mode for newly created files in sources.list.d
-        default: 0644
+        default: '0644'
         version_added: "1.6"
     update_cache:
         description:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes https://github.com/ansible/ansible/issues/29549
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
apt_repository

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION