### PR TITLE
ios_command: Correct answer example and consolidate docs on command param.

### DIFF
--- a/lib/ansible/modules/network/ios/ios_command.py
+++ b/lib/ansible/modules/network/ios/ios_command.py
@@ -47,7 +47,7 @@ options:
         the number of retries has expired. If a command sent to the
         device requires answering a prompt, it is possible to pass
         a dict containing I(command), I(answer) and I(prompt).
-        Common answers: 'y' or "\\r" (carriage return, must be
+        Common answers are 'y' or "\\r" (carriage return, must be
         double quotes). See examples.
     required: true
   wait_for:

--- a/lib/ansible/modules/network/ios/ios_command.py
+++ b/lib/ansible/modules/network/ios/ios_command.py
@@ -47,7 +47,8 @@ options:
         the number of retries has expired. If a command sent to the
         device requires answering a prompt, it is possible to pass
         a dict containing I(command), I(answer) and I(prompt).
-        See examples.
+        Common answers: 'y' or "\\r" (carriage return, must be
+        double quotes). See examples.
     required: true
   wait_for:
     description:
@@ -110,12 +111,15 @@ tasks:
       wait_for:
         - result[0] contains IOS
         - result[1] contains Loopback0
-  - name: run command that requires answering a prompt
+  - name: run commands that require answering a prompt
     ios_command:
       commands:
-        - command: 'clear counters GigabitEthernet0/2'
+        - command: 'clear counters GigabitEthernet0/1'
           prompt: 'Clear "show interface" counters on this interface \[confirm\]'
           answer: 'y'
+        - command: 'clear counters GigabitEthernet0/2'
+          prompt: '[confirm]'
+          answer: "\r"
 """
 
 RETURN = """

--- a/lib/ansible/modules/network/ios/ios_command.py
+++ b/lib/ansible/modules/network/ios/ios_command.py
@@ -37,8 +37,6 @@ description:
 extends_documentation_fragment: ios
 notes:
   - Tested against IOS 15.6
-  - If a command sent to the device requires answering a prompt, it is possible
-    to pass a dict containing I(command), I(answer) and I(prompt). See examples.
 options:
   commands:
     description:
@@ -46,7 +44,10 @@ options:
         configured provider. The resulting output from the command
         is returned. If the I(wait_for) argument is provided, the
         module is not returned until the condition is satisfied or
-        the number of retries has expired.
+        the number of retries has expired. If a command sent to the
+        device requires answering a prompt, it is possible to pass
+        a dict containing I(command), I(answer) and I(prompt).
+        Common answers are "y" and "\\r". See examples.
     required: true
   wait_for:
     description:
@@ -114,7 +115,7 @@ tasks:
       commands:
         - command: 'clear counters GigabitEthernet0/2'
           prompt: 'Clear "show interface" counters on this interface [confirm]'
-          answer: c
+          answer: y
 """
 
 RETURN = """

--- a/lib/ansible/modules/network/ios/ios_command.py
+++ b/lib/ansible/modules/network/ios/ios_command.py
@@ -47,7 +47,7 @@ options:
         the number of retries has expired. If a command sent to the
         device requires answering a prompt, it is possible to pass
         a dict containing I(command), I(answer) and I(prompt).
-        Common answers are "y" and "\\r". See examples.
+        See examples.
     required: true
   wait_for:
     description:
@@ -85,7 +85,7 @@ options:
     default: 1
 """
 
-EXAMPLES = """
+EXAMPLES = r"""
 tasks:
   - name: run show version on remote devices
     ios_command:
@@ -114,8 +114,8 @@ tasks:
     ios_command:
       commands:
         - command: 'clear counters GigabitEthernet0/2'
-          prompt: 'Clear "show interface" counters on this interface [confirm]'
-          answer: y
+          prompt: 'Clear "show interface" counters on this interface \[confirm\]'
+          answer: 'y'
 """
 
 RETURN = """


### PR DESCRIPTION
…te to be in line with command docs.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
Fixes: https://github.com/ansible/ansible/issues/40016

`c` does not actually confirm a Cisco prompt. `'y'` does. I verified this on legacy IOS 15.4.1 and IOS-XE 16.06.03.

I think the "Note" on the command parameter could go overlooked as it displays at the bottom of the parameters list when rendered with Sphinx. This puts it inline and clearly attached to what it is describing.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
ios_commands
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0 (iosdocs 13498066c3) last updated 2018/05/15 11:09:22 (GMT -400)
  config file = None
  configured module search path = ['/Users/tyler8/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/tyler8/projects/pycon18/ansible/lib/ansible
  executable location = /Users/tyler8/.local/share/virtualenvs/pycon18-CTYMJGfK/bin/ansible
  python version = 3.6.5 (default, Mar 30 2018, 06:41:53) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
N/A
```
