### PR TITLE
Corrects use of environment variable in cron module example

### DIFF
--- a/lib/ansible/modules/system/cron.py
+++ b/lib/ansible/modules/system/cron.py
@@ -173,7 +173,7 @@ EXAMPLES = '''
     minute: 0
     hour: 12
     user: root
-    job: "YUMINTERACTIVE: 0 /usr/sbin/yum-autoupdate"
+    job: "YUMINTERACTIVE=0 /usr/sbin/yum-autoupdate"
     cron_file: ansible_yum-autoupdate
 
 - name: Removes a cron file from under /etc/cron.d


### PR DESCRIPTION
##### SUMMARY
The syntax of the `# Creates a cron file under /etc/cron.d` job example is not valid (or at least I couldn't find any mention of cron sytax that uses a colon to set an env var).

I strongly suspect that this a bug created by an automatic conversion script, converting from `arg=value` to `arg: value`:
https://github.com/ansible/ansible/commit/b56a9852ee30c338d5f153f51cedfbad74161917#diff-d62002ec9c674dc53b0782ca1794023eL191

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
cron

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.2.0
  config file = None
  configured module search path = ['/home/cn13/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python3.6/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 3.6.2 (default, Sep 13 2017, 14:26:54) [GCC 4.9.2]
```


##### ADDITIONAL INFORMATION
None