### PR TITLE
ansible-vault: prevent discarding the vault file ownership (#11544)

### DIFF
--- a/lib/ansible/cli/vault.py
+++ b/lib/ansible/cli/vault.py
@@ -112,6 +112,12 @@ class VaultCLI(CLI):
                                    action='store', type='string',
                                    help='the vault id used to encrypt (required if more than vault-id is provided)')
 
+        if self.action in ["create", "decrypt", "edit", "encrypt", "rekey", "view"]:
+            self.parser.add_option('--exclusive', default=False, dest='exclusive',
+                                   action='store_true',
+                                   help='ensure correct vault modification with exclusive locking (for multi-user scenarios)')
+        self.parser.set_defaults(exclusive=False)
+
     def parse(self):
 
         self.parser = CLI.base_parser(
@@ -250,7 +256,7 @@ class VaultCLI(CLI):
 
         # FIXME: do we need to create VaultEditor here? its not reused
         vault = VaultLib(vault_secrets)
-        self.editor = VaultEditor(vault)
+        self.editor = VaultEditor(vault, self.options.exclusive)
 
         self.execute()
 

--- a/lib/ansible/parsing/vault/__init__.py
+++ b/lib/ansible/parsing/vault/__init__.py
@@ -1130,10 +1130,9 @@ class VaultEditorLock:
             if self.is_locked:
                 return self
             time.sleep(random.uniform(1.0, 2.0))
-        else:
-            raise AnsibleVaultError('Cannot access the vault file {0} '
-                                    'that is being concurrently modified. '
-                                    'Please try again.'.format(self.path))
+        raise AnsibleVaultError('Cannot access the vault file {0} '
+                                'that is being concurrently modified. '
+                                'Please try again.'.format(self.path))
 
 # Ansible requires at least Python 2.6, which has been released in October
 # 2008. At the same time the Linux 2.6.27 has been released. NFS supports
@@ -1141,7 +1140,7 @@ class VaultEditorLock:
 
     def acquire(self):
         try:
-            self.fd = open(self.path, 'rb' if self.readonly else 'r+b')
+            self.fd = open(self.path, 'r' if self.readonly else 'a+')
         except Exception as exc:
             raise AnsibleError(str(exc))
         # two readers can share a lock; a first writer makes an exclusive lock


### PR DESCRIPTION
##### SUMMARY

`ansible-vault` operations (encrypt/decrypt/edit) replace processed vault file with its new version. Running `ansible-vault` by another user changes file ownership and can make vault inaccessible for the original owner.

This PR replaces file shuffling with write to the original file.

Fixes #11544

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ansible-vault

##### ANSIBLE VERSION
```
ansible 2.6.0 (bugfix-11544-vault-owner 1c546a6d76) last updated 2018/05/15 18:25:56 (GMT +200)
  config file = None
  configured module search path = [u'/home/<user>/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/<user>/dev/ansible/lib/ansible
  executable location = /home/<user>/dev/ansible/bin/ansible
  python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]
```

##### ADDITIONAL INFORMATION

Problem description and bugfix rationale are captured in #11544.