### PR TITLE
Docs: update `ec2` module to use wait_for_connection instead of wait_for

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2.py
+++ b/lib/ansible/modules/cloud/amazon/ec2.py
@@ -91,7 +91,7 @@ options:
       - ramdisk I(eri) to use for the instance
   wait:
     description:
-      - wait for the instance to reach its desired state before returning.  Does not wait for SSH, see 'wait_for' example for details.
+      - wait for the instance to reach its desired state before returning.  Does not wait for SSH, see 'wait_for_connection' example for details.
     type: bool
     default: 'no'
   wait_timeout:
@@ -384,12 +384,10 @@ EXAMPLES = '''
       with_items: "{{ ec2.instances }}"
 
     - name: Wait for SSH to come up
-      wait_for:
-        host: "{{ item.public_dns_name }}"
-        port: 22
+      delegate_to: "{{ item.public_dns_name }}"
+      wait_for_connection:
         delay: 60
         timeout: 320
-        state: started
       with_items: "{{ ec2.instances }}"
 
 - name: Configure instance(s)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

Update AWS EC2 module to use `wait_for_connection` instead of `wait_for` in docs examples

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
ec2

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
