### PR TITLE
Implement test case prefix to filter test cases

### DIFF
--- a/changelogs/fragments/40174-junit-test-case-prefix-filter.yaml
+++ b/changelogs/fragments/40174-junit-test-case-prefix-filter.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+- junit callback plug-in - introduce a new option to consider a task only as test case if it has this value as prefix.

--- a/lib/ansible/plugins/callback/junit.py
+++ b/lib/ansible/plugins/callback/junit.py
@@ -128,7 +128,9 @@ class CallbackModule(CallbackBase):
                                      Default: True
         JUNIT_HIDE_TASK_ARGUMENTS (optional): Hide the arguments for a task
                                      Default: False
-        JUNIT_TEST_CASE_PREFIX (optional): Consider a task only as test case if it has this value as prefix. Additionaly failing tasks are recorded as failed test cases.
+        JUNIT_TEST_CASE_PREFIX (optional): Consider a task only as test case if it has this value as prefix. Additionaly failing tasks are recorded as failed
+				     test cases.
+				     Default: <empty>
 
     Requires:
         junit_xml

--- a/lib/ansible/plugins/callback/junit.py
+++ b/lib/ansible/plugins/callback/junit.py
@@ -129,8 +129,8 @@ class CallbackModule(CallbackBase):
         JUNIT_HIDE_TASK_ARGUMENTS (optional): Hide the arguments for a task
                                      Default: False
         JUNIT_TEST_CASE_PREFIX (optional): Consider a task only as test case if it has this value as prefix. Additionaly failing tasks are recorded as failed
-				     test cases.
-				     Default: <empty>
+                                     test cases.
+                                     Default: <empty>
 
     Requires:
         junit_xml

--- a/lib/ansible/plugins/callback/junit.py
+++ b/lib/ansible/plugins/callback/junit.py
@@ -69,6 +69,7 @@ DOCUMENTATION = '''
         name: Prefix to find actual test cases
         default: <empty>
         description: Consider a task only as test case if it has this value as prefix. Additionaly failing tasks are recorded as failed test cases.
+        version_added: "2.8"
         env:
           - name: JUNIT_TEST_CASE_PREFIX
     requirements:

--- a/lib/ansible/plugins/callback/junit.py
+++ b/lib/ansible/plugins/callback/junit.py
@@ -65,6 +65,12 @@ DOCUMENTATION = '''
         version_added: "2.8"
         env:
           - name: JUNIT_HIDE_TASK_ARGUMENTS
+      test_case_prefix:
+        name: Prefix to find actual test cases
+        default: <empty>
+        description: Consider a task only as test case if it has this value as prefix. Additionaly failing tasks are recorded as failed test cases.
+        env:
+          - name: JUNIT_TEST_CASE_PREFIX
     requirements:
       - whitelist in configuration
       - junit_xml (python lib)
@@ -122,6 +128,7 @@ class CallbackModule(CallbackBase):
                                      Default: True
         JUNIT_HIDE_TASK_ARGUMENTS (optional): Hide the arguments for a task
                                      Default: False
+        JUNIT_TEST_CASE_PREFIX (optional): Consider a task only as test case if it has this value as prefix. Additionaly failing tasks are recorded as failed test cases.
 
     Requires:
         junit_xml
@@ -143,6 +150,7 @@ class CallbackModule(CallbackBase):
         self._fail_on_ignore = os.getenv('JUNIT_FAIL_ON_IGNORE', 'False').lower()
         self._include_setup_tasks_in_report = os.getenv('JUNIT_INCLUDE_SETUP_TASKS_IN_REPORT', 'True').lower()
         self._hide_task_arguments = os.getenv('JUNIT_HIDE_TASK_ARGUMENTS', 'False').lower()
+        self._test_case_prefix = os.getenv('JUNIT_TEST_CASE_PREFIX', '')
         self._playbook_path = None
         self._playbook_name = None
         self._play_name = None
@@ -211,7 +219,8 @@ class CallbackModule(CallbackBase):
             elif status == 'ok':
                 status = 'failed'
 
-        task_data.add_host(HostData(host_uuid, host_name, status, result))
+        if task_data.name.startswith(self._test_case_prefix) or status == 'failed':
+            task_data.add_host(HostData(host_uuid, host_name, status, result))
 
     def _build_test_case(self, task_data, host_data):
         """ build a TestCase from the given TaskData and HostData """


### PR DESCRIPTION
##### SUMMARY
Implement a prefix that is checked for the task name to filter test cases

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
callback_plugin junit.py

##### ANSIBLE VERSION
```
ansible 2.4.1.0
  config file = /somepath/ansible.cfg
  configured module search path = [u'/home/myuser/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.14 (default, Nov  3 2017, 10:55:25) [GCC 7.2.1 20170915 (Red Hat 7.2.1-2)]
```


##### ADDITIONAL INFORMATION
The feature is intended to reduce the number of test cases in the output xml.

The idea behind that, is that you usually have several types of tasks in a playbook that executes tests:
- Prepare a request
- Execute a request
- Do assertions

In order to have a good overview of the test cases, the assertions are the most important tasks. Furthermore tasks that failed will also be reported in any case.

To keep it backward compatible this feature is disabled by default. (self._test_case_prefix defaults to an empty string - thus the comparison should always be true)