### PR TITLE
Add scope parameter to systemd

### DIFF
--- a/lib/ansible/modules/system/systemd.py
+++ b/lib/ansible/modules/system/systemd.py
@@ -50,16 +50,10 @@ options:
         aliases: [ daemon-reload ]
     scope:
         description:
-            - run systemctl within a given service manager scope, either as the default system scope (None),
+            - run systemctl within a given service manager scope, either as the default system scope (system),
               the current user's scope (user), or the scope of all users (global).
         choices: [ system, user, global ]
         default: 'system'
-    user:
-        description:
-            - run systemctl talking to the service manager of the calling user, rather than the service manager
-              of the system.
-        type: bool
-        default: 'no'
     no_block:
         description:
             - Do not synchronously wait for the requested operation to finish.

--- a/lib/ansible/modules/system/systemd.py
+++ b/lib/ansible/modules/system/systemd.py
@@ -54,6 +54,7 @@ options:
               the current user's scope (user), or the scope of all users (global).
         choices: [ system, user, global ]
         default: 'system'
+        version_added: "2.6"
     no_block:
         description:
             - Do not synchronously wait for the requested operation to finish.

--- a/lib/ansible/modules/system/systemd.py
+++ b/lib/ansible/modules/system/systemd.py
@@ -48,6 +48,12 @@ options:
         type: bool
         default: 'no'
         aliases: [ daemon-reload ]
+    scope:
+        description:
+            - run systemctl within a given service manager scope, either as the default system scope (None),
+              the current user's scope (user), or the scope of all users (global).
+        choices: [ system, user, global ]
+        default: 'system'
     user:
         description:
             - run systemctl talking to the service manager of the calling user, rather than the service manager
@@ -298,7 +304,7 @@ def main():
             force=dict(type='bool'),
             masked=dict(type='bool'),
             daemon_reload=dict(type='bool', default=False, aliases=['daemon-reload']),
-            user=dict(type='bool', default=False),
+            scope=dict(type='str', default='system', choices=['system', 'user', 'global']),
             no_block=dict(type='bool', default=False),
         ),
         supports_check_mode=True,
@@ -306,8 +312,10 @@ def main():
     )
 
     systemctl = module.get_bin_path('systemctl', True)
-    if module.params['user']:
+    if module.params['scope'] == 'user':
         systemctl = systemctl + " --user"
+    if module.params['scope'] == 'global':
+        systemctl = systemctl + " --global"
     if module.params['no_block']:
         systemctl = systemctl + " --no-block"
     if module.params['force']:
@@ -401,8 +409,8 @@ def main():
             if rc == 0:
                 enabled = True
             elif rc == 1:
-                # if not a user service and both init script and unit file exist stdout should have enabled/disabled, otherwise use rc entries
-                if not module.params['user'] and \
+                # if not a user or global user service and both init script and unit file exist stdout should have enabled/disabled, otherwise use rc entries
+                if module.params['scope'] == 'system' and \
                         is_initd and \
                         (not out.strip().endswith('disabled') or sysv_is_enabled(unit)):
                     enabled = True

--- a/lib/ansible/modules/system/systemd.py
+++ b/lib/ansible/modules/system/systemd.py
@@ -60,7 +60,7 @@ options:
               the current user's scope (user), or the scope of all users (global).
         choices: [ system, user, global ]
         default: 'system'
-        version_added: "2.6"
+        version_added: "2.7"
     no_block:
         description:
             - Do not synchronously wait for the requested operation to finish.


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This change changes the user: paramater into a state: paramater with the following choices:
- system
- user
- global

with system being the default. The system scope is the default scope. The user scope matches with the old user: paramater. The global scope applies to all users.

An example use case would be masking a unit. In the system scope it would create the mask via symlink from /etc/systemd/system/. In the user scope it would mask via symlink from ~/.config/systemd/user/. In the global scope it would mask via symlink from /etc/systemd/user/.

Previously a global: paramater was tested but since global is a keyword in python, it caused errors during testing. Since this patch removes the old user: paramater, it is a backwards incompatible change.

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
Fixes #38828
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
systemd
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0
  config file = /home/hi117/.ansible.cfg
  configured module search path = [u'/home/hi117/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.15 (default, May  1 2018, 20:16:04) [GCC 7.3.1 20180406]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Output of make tests-nonet, snipped to only the relavent tests.
```
test/units/modules/system/test_systemd.py::ParseSystemctlShowTestCase::test_multiline_exec PASSED
test/units/modules/system/test_systemd.py::ParseSystemctlShowTestCase::test_simple PASSED
test/units/modules/system/test_systemd.py::ParseSystemctlShowTestCase::test_single_line_with_brace PASSED 
```
