### PR TITLE
If set mysql configuration in playbook do not override default value …

### DIFF
--- a/lib/ansible/module_utils/mysql.py
+++ b/lib/ansible/module_utils/mysql.py
@@ -74,7 +74,7 @@ def mysql_connect(module, login_user=None, login_password=None, config_file='', 
         config['ssl'] = {}
 
     cp = _parse_from_mysql_config_file(config_file)
-    if cp:
+    if cp and cp.has_section('client'):
         module.params['login_unix_socket'] = cp.get('client', 'socket', fallback=module.params['login_unix_socket'])
         module.params['login_host'] = cp.get('client', 'host', fallback=module.params['login_host'])
         module.params['login_port'] = cp.getint('client', 'port', fallback=module.params['login_port'])

--- a/lib/ansible/module_utils/mysql.py
+++ b/lib/ansible/module_utils/mysql.py
@@ -28,9 +28,7 @@
 # USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import os
-from ansible.module_utils.six import (
-    PY2
-)
+from ansible.module_utils.six.moves import configparser
 
 try:
     import pymysql as mysql_driver
@@ -46,14 +44,6 @@ except ImportError:
 from ansible.module_utils._text import to_native
 
 mysql_driver_fail_msg = 'The PyMySQL (Python 2.7 and Python 3.X) or MySQL-python (Python 2.X) module is required.'
-
-if PY2:
-    try:
-        import configparser
-    except ImportError:
-        import ConfigParser as configparser
-else:
-    import configparser
 
 
 def _parse_from_mysql_config_file(cnf):

--- a/lib/ansible/module_utils/mysql.py
+++ b/lib/ansible/module_utils/mysql.py
@@ -53,7 +53,7 @@ def _parse_from_mysql_config_file(cnf):
     return cp
 
 
-def mysql_connect(module, login_user=None, login_password=None, config_file='', ssl_cert=None, ssl_key=None, ssl_ca=None, db=None, cursor_class=None,
+def mysql_connect(module, login_user=None, login_password=None, config_file=None, ssl_cert=None, ssl_key=None, ssl_ca=None, db=None, cursor_class=None,
                   connect_timeout=30):
     config = {}
 
@@ -64,10 +64,8 @@ def mysql_connect(module, login_user=None, login_password=None, config_file='', 
         config['read_default_file'] = config_file
         cp = _parse_from_mysql_config_file(config_file)
         if cp and cp.has_section('client'):
-            if module.params['login_unix_socket'] is None:
-                module.params['login_unix_socket'] = cp.get('client', 'socket', fallback=module.params['login_unix_socket'])
-            if module.params['login_host'] is None:
-                module.params['login_host'] = cp.get('client', 'host', fallback='localhost')
+            module.params['login_unix_socket'] = cp.get('client', 'socket', fallback=module.params['login_unix_socket'])
+            module.params['login_host'] = cp.get('client', 'host', fallback=module.params['login_host'])
             module.params['login_port'] = cp.getint('client', 'port', fallback=module.params['login_port'])
 
     if module.params['login_unix_socket']:

--- a/lib/ansible/module_utils/mysql.py
+++ b/lib/ansible/module_utils/mysql.py
@@ -65,8 +65,10 @@ def mysql_connect(module, login_user=None, login_password=None, config_file='', 
 
     cp = _parse_from_mysql_config_file(config_file)
     if cp and cp.has_section('client'):
-        module.params['login_unix_socket'] = cp.get('client', 'socket', fallback=module.params['login_unix_socket'])
-        module.params['login_host'] = cp.get('client', 'host', fallback=module.params['login_host'])
+        if module.params['login_unix_socket'] is None:
+            module.params['login_unix_socket'] = cp.get('client', 'socket', fallback=module.params['login_unix_socket'])
+        if module.params['login_host'] is None:
+            module.params['login_host'] = cp.get('client', 'host', fallback='localhost')
         module.params['login_port'] = cp.getint('client', 'port', fallback=module.params['login_port'])
 
     if module.params['login_unix_socket']:

--- a/lib/ansible/module_utils/mysql.py
+++ b/lib/ansible/module_utils/mysql.py
@@ -47,9 +47,6 @@ mysql_driver_fail_msg = 'The PyMySQL (Python 2.7 and Python 3.X) or MySQL-python
 
 
 def _parse_from_mysql_config_file(cnf):
-    if not cnf:
-        return None
-
     cp = configparser.ConfigParser()
     cp.read(cnf)
 
@@ -63,22 +60,21 @@ def mysql_connect(module, login_user=None, login_password=None, config_file='', 
     if ssl_ca is not None or ssl_key is not None or ssl_cert is not None:
         config['ssl'] = {}
 
-    cp = _parse_from_mysql_config_file(config_file)
-    if cp and cp.has_section('client'):
-        if module.params['login_unix_socket'] is None:
-            module.params['login_unix_socket'] = cp.get('client', 'socket', fallback=module.params['login_unix_socket'])
-        if module.params['login_host'] is None:
-            module.params['login_host'] = cp.get('client', 'host', fallback='localhost')
-        module.params['login_port'] = cp.getint('client', 'port', fallback=module.params['login_port'])
+    if config_file:
+        config['read_default_file'] = config_file
+        cp = _parse_from_mysql_config_file(config_file)
+        if cp and cp.has_section('client'):
+            if module.params['login_unix_socket'] is None:
+                module.params['login_unix_socket'] = cp.get('client', 'socket', fallback=module.params['login_unix_socket'])
+            if module.params['login_host'] is None:
+                module.params['login_host'] = cp.get('client', 'host', fallback='localhost')
+            module.params['login_port'] = cp.getint('client', 'port', fallback=module.params['login_port'])
 
     if module.params['login_unix_socket']:
         config['unix_socket'] = module.params['login_unix_socket']
     else:
         config['host'] = module.params['login_host']
         config['port'] = module.params['login_port']
-
-    if os.path.exists(config_file):
-        config['read_default_file'] = config_file
 
     # If login_user or login_password are given, they should override the
     # config file

--- a/lib/ansible/modules/database/mysql/mysql_db.py
+++ b/lib/ansible/modules/database/mysql/mysql_db.py
@@ -309,7 +309,7 @@ def main():
         argument_spec=dict(
             login_user=dict(type='str'),
             login_password=dict(type='str', no_log=True),
-            login_host=dict(type='str', default='localhost'),
+            login_host=dict(type='str', default=None),
             login_port=dict(type='int', default=3306),
             login_unix_socket=dict(type='str'),
             name=dict(type='list', required=True, aliases=['db']),

--- a/lib/ansible/modules/database/mysql/mysql_db.py
+++ b/lib/ansible/modules/database/mysql/mysql_db.py
@@ -388,51 +388,6 @@ def main():
             module.fail_json(msg="unable to find %s. Exception message: %s" % (config_file, to_native(e)))
 
     changed = False
-    if not os.path.exists(config_file):
-        config_file = None
-
-    if db_exists(cursor, db):
-        if state == "absent":
-            if module.check_mode:
-                module.exit_json(changed=True, db=db)
-            else:
-                try:
-                    changed = db_delete(cursor, db)
-                except Exception as e:
-                    module.fail_json(msg="error deleting database: %s" % to_native(e))
-                module.exit_json(changed=changed, db=db)
-
-        elif state == "dump":
-            if module.check_mode:
-                module.exit_json(changed=True, db=db)
-            else:
-                rc, stdout, stderr = db_dump(module, login_host, login_user,
-                                             login_password, db, target, all_databases,
-                                             login_port, config_file, socket, ssl_cert, ssl_key,
-                                             ssl_ca, single_transaction, quick)
-                if rc != 0:
-                    module.fail_json(msg="%s" % stderr)
-                else:
-                    module.exit_json(changed=True, db=db, msg=stdout)
-
-        elif state == "import":
-            if module.check_mode:
-                module.exit_json(changed=True, db=db)
-            else:
-                rc, stdout, stderr = db_import(module, login_host, login_user,
-                                               login_password, db, target,
-                                               all_databases,
-                                               login_port, config_file,
-                                               socket, ssl_cert, ssl_key, ssl_ca)
-                if rc != 0:
-                    module.fail_json(msg="%s" % stderr)
-                else:
-                    module.exit_json(changed=True, db=db, msg=stdout)
-
-        elif state == "present":
-            if module.check_mode:
-                module.exit_json(changed=False, db=db)
-            module.exit_json(changed=False, db=db)
 
     existence_list = []
     non_existence_list = []

--- a/lib/ansible/modules/database/mysql/mysql_db.py
+++ b/lib/ansible/modules/database/mysql/mysql_db.py
@@ -309,7 +309,7 @@ def main():
         argument_spec=dict(
             login_user=dict(type='str'),
             login_password=dict(type='str', no_log=True),
-            login_host=dict(type='str', default=None),
+            login_host=dict(type='str', default='localhost'),
             login_port=dict(type='int', default=3306),
             login_unix_socket=dict(type='str'),
             name=dict(type='list', required=True, aliases=['db']),

--- a/lib/ansible/plugins/doc_fragments/mysql.py
+++ b/lib/ansible/plugins/doc_fragments/mysql.py
@@ -21,7 +21,6 @@ options:
     description:
       - Host running the database.
     type: str
-    default: localhost
   login_port:
     description:
       - Port of the MySQL server. Requires I(login_host) be defined as other than localhost if login_port is used.

--- a/lib/ansible/plugins/doc_fragments/mysql.py
+++ b/lib/ansible/plugins/doc_fragments/mysql.py
@@ -21,6 +21,7 @@ options:
     description:
       - Host running the database.
     type: str
+    default: "localhost"
   login_port:
     description:
       - Port of the MySQL server. Requires I(login_host) be defined as other than localhost if login_port is used.


### PR DESCRIPTION
…only for host, port, socket (#26919)

##### SUMMARY
Fixed #26919

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
mysql_db

##### ANSIBLE VERSION
```
ansible 2.6.0 (prevent-override-login-host-when-already-set-mycnf a3c2e26f66) last updated 2018/05/15 13:44:21 (GMT -400)
  config file = None
  configured module search path = ['/Users/kucuny/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/kucuny/works/osp/ansible/lib/ansible
  executable location = /Users/kucuny/works/osp/ansible/bin/ansible
  python version = 3.6.1 (default, Mar 23 2017, 16:49:06) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
# Test playbook yaml
---
- name: Mysql
  hosts: localhost
  gather_facts: no
  tasks:
    - name: dump from mysql
      mysql_db:
        name: <DATABASE_NAME>
        state: dump
        login_user: root
        login_password: root
        config_file: ~/my.cnf
        target: /tmp/testdump.sql.gz
```

```
# Test my.cnf
[client]
port        = 3306
host        = 127.0.0.1
```

```
ansible-playbook -v test.yml -i hosts
No config file found; using defaults

PLAY [Mysql] *********************************************************************************************************

TASK [dump from mysql] ***********************************************************************************************
changed: [localhost] => {"changed": true, "db": "<DATABASE_NAME>", "msg": ""}

PLAY RECAP ***********************************************************************************************************
localhost                  : ok=1    changed=1    unreachable=0    failed=0
```
```
 ll /tmp/testdump.sql.gz
-rw-r--r--  1 kucuny  wheel  20 May 15 13:41 [1]  /tmp/testdump.sql.gz
```