### PR TITLE
Allow Unicode chars to be dumped by yaml stdout callback

### DIFF
--- a/lib/ansible/plugins/callback/yaml.py
+++ b/lib/ansible/plugins/callback/yaml.py
@@ -113,7 +113,7 @@ class CallbackModule(Default):
 
         if abridged_result:
             dumped += '\n'
-            dumped += yaml.dump(abridged_result, width=1000, Dumper=AnsibleDumper, default_flow_style=False)
+            dumped += yaml.dump(abridged_result, allow_unicode=True, width=1000, Dumper=AnsibleDumper, default_flow_style=False).decode('utf-8')
 
         # indent by a couple of spaces
         dumped = '\n  '.join(dumped.split('\n')).rstrip()

--- a/lib/ansible/plugins/callback/yaml.py
+++ b/lib/ansible/plugins/callback/yaml.py
@@ -26,6 +26,8 @@ import string
 import sys
 from ansible.plugins.callback import CallbackBase, strip_internal_keys
 from ansible.plugins.callback.default import CallbackModule as Default
+from ansible.module_utils.six import string_types
+from ansible.module_utils._text import to_bytes, to_text
 from ansible.parsing.yaml.dumper import AnsibleDumper
 
 
@@ -113,7 +115,7 @@ class CallbackModule(Default):
 
         if abridged_result:
             dumped += '\n'
-            dumped += yaml.dump(abridged_result, allow_unicode=True, width=1000, Dumper=AnsibleDumper, default_flow_style=False).decode('utf-8')
+            dumped += to_text(yaml.dump(abridged_result, allow_unicode=True, width=1000, Dumper=AnsibleDumper, default_flow_style=False))
 
         # indent by a couple of spaces
         dumped = '\n  '.join(dumped.split('\n')).rstrip()


### PR DESCRIPTION
##### SUMMARY
Allow Unicode in yaml.dumper to support printing strings unescaped with `\uxxx` chars.

Cf. https://stackoverflow.com/a/29600111

Example desired output:
![image](https://user-images.githubusercontent.com/345210/40078659-87441246-5885-11e8-9ca6-581d2f0548b5.png)

Example current output:
![image](https://user-images.githubusercontent.com/345210/40078678-9684f1f8-5885-11e8-8cf1-5359bff305a6.png)


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
yaml.py
