### PR TITLE
simplified `DistributedVirtualSwitch` namespacing

### DIFF
--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -143,12 +143,7 @@ def find_datastore_by_name(content, datastore_name):
 
 def find_dvs_by_name(content, switch_name):
 
-    # https://github.com/vmware/govmomi/issues/879
-    # https://github.com/ansible/ansible/pull/31798#issuecomment-336936222
-    try:
-        vmware_distributed_switches = get_all_objs(content, [vim.dvs.VmwareDistributedVirtualSwitch])
-    except IndexError:
-        vmware_distributed_switches = get_all_objs(content, [vim.DistributedVirtualSwitch])
+    vmware_distributed_switches = get_all_objs(content, [vim.DistributedVirtualSwitch])
 
     for dvs in vmware_distributed_switches:
         if dvs.name == switch_name:


### PR DESCRIPTION
##### SUMMARY
simplified `DistributedVirtualSwitch` namespacing in `module_utils/vmware.py`

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
module_utils/vmware.py

##### ANSIBLE VERSION
```
ansible 2.6.0 (DistributedVirtualSwitch 5b100bbd24) last updated 2018/05/15 15:09:11 (GMT -400)
  config file = /Users/deric/.ansible.cfg
  configured module search path = [u'/Users/deric/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/deric/ansible/lib/ansible
  executable location = /Users/deric/ansible/bin/ansible
  python version = 2.7.14 (default, Sep 25 2017, 09:54:19) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.37)]
```

##### ADDITIONAL INFORMATION
This simplified namespacing was discovered while preparing to upgrade the vcsim test container to the latest version of vcsim. The `try` & `except` no longer seems necessary.