### PR TITLE
expand user before calling abspath

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -829,14 +829,14 @@ class TaskParameters(DockerBaseClass):
             if ':' in vol:
                 if len(vol.split(':')) == 3:
                     host, container, mode = vol.split(':')
-                    if re.match(r'[\.~]', host):
-                        host = os.path.abspath(host)
+                    if re.match(r'[.~]', host):
+                        host = os.path.abspath(os.path.expanduser(host))
                     new_vols.append("%s:%s:%s" % (host, container, mode))
                     continue
                 elif len(vol.split(':')) == 2:
                     parts = vol.split(':')
-                    if parts[1] not in VOLUME_PERMISSIONS and re.match(r'[\.~]', parts[0]):
-                        host = os.path.abspath(parts[0])
+                    if parts[1] not in VOLUME_PERMISSIONS and re.match(r'[.~]', parts[0]):
+                        host = os.path.abspath(os.path.expanduser(parts[0]))
                         new_vols.append("%s:%s:rw" % (host, parts[1]))
                         continue
             new_vols.append(vol)

--- a/test/sanity/code-smell/use-argspec-type-path.py
+++ b/test/sanity/code-smell/use-argspec-type-path.py
@@ -7,6 +7,7 @@ import sys
 def main():
     skip = set([
         # add legitimate uses of expanduser to the following list
+        'lib/ansible/modules/cloud/docker/docker_container.py',  # uses colon-separated paths, can't use type=path
         'lib/ansible/modules/cloud/lxc/lxc_container.py',
         'lib/ansible/modules/cloud/rackspace/rax_files_objects.py',
         'lib/ansible/modules/database/mongodb/mongodb_parameter.py',


### PR DESCRIPTION
##### SUMMARY
Previously, we called `os.path.abspath` on the host path on docker volume mounts. This turns `~/foo` to `/<current_working_directory>/~/foo`. This adds a call to `os.path.expanduser` to fix this.
fixes #22999

##### ISSUE TYPE
 - Bugfix Pull Request


##### COMPONENT NAME
`docker_container`

##### ANSIBLE VERSION

```
ansible 2.6.0 (docker-container-path 7c7615dc21) last updated 2018/05/15 13:21:50 (GMT -700)
  config file = None
  configured module search path = [u'/home/ben/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/ben/dev/github/ansible/ansible/lib/ansible
  executable location = /home/ben/venvs/ansible-devel/bin/ansible
  python version = 2.7.14 (default, Sep 23 2017, 22:06:14) [GCC 7.2.0]

```


##### ADDITIONAL INFORMATION
