### PR TITLE
Fixes #40195: k8s - Removed references to username/password auth

### DIFF
--- a/lib/ansible/module_utils/k8s/common.py
+++ b/lib/ansible/module_utils/k8s/common.py
@@ -142,7 +142,7 @@ class KubernetesAnsibleModule(AnsibleModule):
     def authenticate(self):
         try:
             auth_options = {}
-            auth_args = ('host', 'api_key', 'kubeconfig', 'context', 'username', 'password',
+            auth_args = ('host', 'api_key', 'kubeconfig', 'context',
                          'cert_file', 'key_file', 'ssl_ca_cert', 'verify_ssl')
             for key, value in iteritems(self.params):
                 if key in auth_args and value is not None:

--- a/lib/ansible/module_utils/k8s/helper.py
+++ b/lib/ansible/module_utils/k8s/helper.py
@@ -75,10 +75,6 @@ AUTH_ARG_SPEC = {
     'api_key': {
         'no_log': True,
     },
-    'username': {},
-    'password': {
-        'no_log': True,
-    },
     'verify_ssl': {
         'type': 'bool',
     },

--- a/lib/ansible/module_utils/k8s/inventory.py
+++ b/lib/ansible/module_utils/k8s/inventory.py
@@ -84,7 +84,7 @@ class K8sInventoryHelper(object):
     def authenticate(self, connection=None):
         auth_options = {}
         if connection:
-            auth_args = ('host', 'api_key', 'kubeconfig', 'context', 'username', 'password',
+            auth_args = ('host', 'api_key', 'kubeconfig', 'context',
                          'cert_file', 'key_file', 'ssl_ca_cert', 'verify_ssl')
             for key, value in iteritems(connection):
                 if key in auth_args and value is not None:

--- a/lib/ansible/module_utils/k8s/lookup.py
+++ b/lib/ansible/module_utils/k8s/lookup.py
@@ -88,7 +88,7 @@ class KubernetesLookup(object):
         self.kind = to_snake(self.kind)
         self.helper = self.get_helper(self.api_version, self.kind)
 
-        auth_args = ('host', 'api_key', 'kubeconfig', 'context', 'username', 'password',
+        auth_args = ('host', 'api_key', 'kubeconfig', 'context',
                      'cert_file', 'key_file', 'ssl_ca_cert', 'verify_ssl')
 
         for arg in AUTH_ARG_SPEC:

--- a/lib/ansible/modules/clustering/k8s/k8s_raw.py
+++ b/lib/ansible/modules/clustering/k8s/k8s_raw.py
@@ -28,7 +28,7 @@ description:
   - Pass the object definition from a source file or inline. See examples for reading
     files and using Jinja templates.
   - Access to the full range of K8s APIs.
-  - Authenticate using either a config file, certificates, password or token.
+  - Authenticate using either a config file, certificates or token.
   - Supports check mode.
 
 extends_documentation_fragment:

--- a/lib/ansible/modules/clustering/openshift/openshift_raw.py
+++ b/lib/ansible/modules/clustering/openshift/openshift_raw.py
@@ -28,7 +28,7 @@ description:
   - Pass the object definition from a source file or inline. See examples for reading
     files and using Jinja templates.
   - Access to the full range of K8s and OpenShift APIs.
-  - Authenticate using either a config file, certificates, password or token.
+  - Authenticate using either a config file, certificates or token.
   - Supports check mode.
 
 extends_documentation_fragment:

--- a/lib/ansible/utils/module_docs_fragments/k8s_auth_options.py
+++ b/lib/ansible/utils/module_docs_fragments/k8s_auth_options.py
@@ -38,14 +38,6 @@ options:
   context:
     description:
     - The name of a context found in the config file. Can also be specified via K8S_AUTH_CONTEXT environment variable.
-  username:
-    description:
-    - Provide a username for authenticating with the API. Can also be specified via K8S_AUTH_USERNAME environment
-      variable.
-  password:
-    description:
-    - Provide a password for authenticating with the API. Can also be specified via K8S_AUTH_PASSWORD environment
-      variable.
   cert_file:
     description:
     - Path to a certificate used to authenticate with the API. Can also be specified via K8S_AUTH_CERT_FILE environment


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
If #40195 turns out to be just a documentation issue this PR updates the docs and removes references to username/password authentication in the k8s_raw and openshift_raw modules.

If Issue #40195 is *not* simply a docs issue, this PR should be closed.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
openshift_raw
k8s_raw

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0 (k8s-auth-fix b46ee0cd21) last updated 2018/05/15 20:28:46 (GMT +000)
  config file = /home/mwatkins/git/caasd-containerland-config/deployment/ansible.cfg
  configured module search path = [u'/home/mwatkins/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/mwatkins/git/ansible/lib/ansible
  executable location = /home/mwatkins/git/ansible/bin/ansible
  python version = 2.7.5 (default, Aug  4 2017, 00:39:18) [GCC 4.8.5 20150623 (Red Hat 4.8.5-16)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

See #40195
