### PR TITLE
Module basic.py to create parent dirs of tmpdir if needed

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -938,6 +938,9 @@ class AnsibleModule(object):
         # clean it up once finished.
         if self._tmpdir is None:
             basedir = os.path.expanduser(os.path.expandvars(self._remote_tmp))
+            if not os.path.exists(basedir):
+                os.makedirs(basedir, mode=0o700)
+
             basefile = "ansible-moduletmp-%s-" % time.time()
             tmpdir = tempfile.mkdtemp(prefix=basefile, dir=basedir)
             if not self._keep_remote_files:

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -939,6 +939,11 @@ class AnsibleModule(object):
         if self._tmpdir is None:
             basedir = os.path.expanduser(os.path.expandvars(self._remote_tmp))
             if not os.path.exists(basedir):
+                self.warn("Module remote_tmp %s did not exist and was created "
+                          "with a mode of 0700, this may cause issues when "
+                          "running as another user. To avoid this, create the "
+                          "remote_tmp dir with the correct permissions "
+                          "manually" % basedir)
                 os.makedirs(basedir, mode=0o700)
 
             basefile = "ansible-moduletmp-%s-" % time.time()

--- a/test/units/module_utils/basic/test_tmpdir.py
+++ b/test/units/module_utils/basic/test_tmpdir.py
@@ -24,6 +24,7 @@ class TestAnsibleModuleTmpDir:
                 "_ansible_remote_tmp": "/path/tmpdir",
                 "_ansible_keep_remote_files": False,
             },
+            True,
             "/path/to/dir"
         ),
         (
@@ -32,6 +33,16 @@ class TestAnsibleModuleTmpDir:
                 "_ansible_remote_tmp": "/path/tmpdir",
                 "_ansible_keep_remote_files": False
             },
+            False,
+            "/path/tmpdir/ansible-moduletmp-42-"
+        ),
+        (
+            {
+                "_ansible_tmpdir": None,
+                "_ansible_remote_tmp": "/path/tmpdir",
+                "_ansible_keep_remote_files": False
+            },
+            True,
             "/path/tmpdir/ansible-moduletmp-42-"
         ),
         (
@@ -40,26 +51,30 @@ class TestAnsibleModuleTmpDir:
                 "_ansible_remote_tmp": "$HOME/.test",
                 "_ansible_keep_remote_files": False
             },
+            False,
             os.path.join(os.environ['HOME'], ".test/ansible-moduletmp-42-")
         ),
     )
 
     # pylint bug: https://github.com/PyCQA/pylint/issues/511
     # pylint: disable=undefined-variable
-    @pytest.mark.parametrize('stdin, expected', ((s, e) for s, e in DATA),
+    @pytest.mark.parametrize('stdin, expected, stat_exists', ((s, e, t) for s, t, e in DATA),
                              indirect=['stdin'])
-    def test_tmpdir_property(self, am, monkeypatch, expected):
+    def test_tmpdir_property(self, am, monkeypatch, expected, stat_exists):
+        makedirs = {'called': False}
+
         def mock_mkdtemp(prefix, dir):
             return os.path.join(dir, prefix)
 
         def mock_makedirs(path, mode):
+            makedirs['called'] = True
             expected = os.path.expanduser(os.path.expandvars(am._remote_tmp))
             assert path == expected
             assert mode == 0o700
             return
 
         monkeypatch.setattr(tempfile, 'mkdtemp', mock_mkdtemp)
-        monkeypatch.setattr(os.path, 'exists', lambda x: False)
+        monkeypatch.setattr(os.path, 'exists', lambda x: stat_exists)
         monkeypatch.setattr(os, 'makedirs', mock_makedirs)
         monkeypatch.setattr(shutil, 'rmtree', lambda x: None)
 
@@ -69,3 +84,6 @@ class TestAnsibleModuleTmpDir:
 
         # verify subsequent calls always produces the same tmpdir
         assert am.tmpdir == actual_tmpdir
+
+        if not stat_exists:
+            assert makedirs['called']

--- a/test/units/module_utils/basic/test_tmpdir.py
+++ b/test/units/module_utils/basic/test_tmpdir.py
@@ -51,7 +51,16 @@ class TestAnsibleModuleTmpDir:
     def test_tmpdir_property(self, am, monkeypatch, expected):
         def mock_mkdtemp(prefix, dir):
             return os.path.join(dir, prefix)
+
+        def mock_makedirs(path, mode):
+            expected = os.path.expanduser(os.path.expandvars(am._remote_tmp))
+            assert path == expected
+            assert mode == 0o700
+            return
+
         monkeypatch.setattr(tempfile, 'mkdtemp', mock_mkdtemp)
+        monkeypatch.setattr(os.path, 'exists', lambda x: False)
+        monkeypatch.setattr(os, 'makedirs', mock_makedirs)
         monkeypatch.setattr(shutil, 'rmtree', lambda x: None)
 
         with patch('time.time', return_value=42):


### PR DESCRIPTION
##### SUMMARY
When pipelining is enabled and the path at `remote_tmp` does not already exists, `module.tmpdir` will fail to create the tmp directory. This change will ensure the parent dirs exists before creating that module tmp directory.

Fixes https://github.com/ansible/ansible/issues/40168

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
module_utils/basic.py

##### ANSIBLE VERSION
```
devel
```