### PR TITLE
Documentation: show non-string non-iterable defaults for choices

### DIFF
--- a/docs/bin/plugin_formatter.py
+++ b/docs/bin/plugin_formatter.py
@@ -31,9 +31,8 @@ import sys
 import warnings
 from collections import defaultdict
 from distutils.version import LooseVersion
-from pprint import PrettyPrinter
 from functools import partial
-from ansible.module_utils.common.collections import is_sequence
+from pprint import PrettyPrinter
 
 try:
     from html import escape as html_escape
@@ -51,6 +50,7 @@ from six import iteritems, string_types
 
 from ansible.errors import AnsibleError
 from ansible.module_utils._text import to_bytes, to_text
+from ansible.module_utils.common.collections import is_sequence
 from ansible.plugins.loader import fragment_loader
 from ansible.utils import plugin_docs
 from ansible.utils.display import Display

--- a/docs/bin/plugin_formatter.py
+++ b/docs/bin/plugin_formatter.py
@@ -29,9 +29,11 @@ import os
 import re
 import sys
 import warnings
-from collections import defaultdict, Sequence
+from collections import defaultdict
 from distutils.version import LooseVersion
 from pprint import PrettyPrinter
+from functools import partial
+from ansible.module_utils.common.collections import is_sequence
 
 try:
     from html import escape as html_escape
@@ -132,10 +134,7 @@ def rst_xline(width, char="="):
     return char * width
 
 
-def test_list(value):
-    ''' Return true if the object is a list or tuple '''
-
-    return isinstance(value, Sequence) and not isinstance(value, string_types)
+test_list = partial(is_sequence, include_strings=False)
 
 
 def write_data(text, output_dir, outputname, module=None):

--- a/docs/bin/plugin_formatter.py
+++ b/docs/bin/plugin_formatter.py
@@ -29,7 +29,7 @@ import os
 import re
 import sys
 import warnings
-from collections import defaultdict
+from collections import defaultdict, Sequence
 from distutils.version import LooseVersion
 from pprint import PrettyPrinter
 
@@ -130,6 +130,12 @@ def rst_xline(width, char="="):
     ''' return a restructured text line of a given length '''
 
     return char * width
+
+
+def test_list(value):
+    ''' Return true if the object is a list or tuple '''
+
+    return isinstance(value, Sequence) and not isinstance(value, string_types)
 
 
 def write_data(text, output_dir, outputname, module=None):
@@ -304,6 +310,7 @@ def jinja2_environment(template_dir, typ, plugin_type):
         env.filters['html_ify'] = html_ify
         env.filters['fmt'] = rst_fmt
         env.filters['xline'] = rst_xline
+        env.tests['list'] = test_list
         templates['plugin'] = env.get_template('plugin.rst.j2')
 
         if plugin_type == 'module':

--- a/docs/templates/plugin.rst.j2
+++ b/docs/templates/plugin.rst.j2
@@ -142,7 +142,7 @@ Parameters
                                 {% elif choice is sameas false %}
                                     {% set choice = 'no' %}
                                 {% endif %}
-                                {% if ((value.default is string or value.default is not iterable) and value.default == choice) or (value.default is iterable and value.default is not string and choice in value.default) %}
+                                {% if (value.default is not list and value.default == choice) or (value.default is list and choice in value.default) %}
                                     <li><div style="color: blue"><b>@{ choice | escape }@</b>&nbsp;&larr;</div></li>
                                 {% else %}
                                     <li>@{ choice | escape }@</li>

--- a/docs/templates/plugin.rst.j2
+++ b/docs/templates/plugin.rst.j2
@@ -142,7 +142,7 @@ Parameters
                                 {% elif choice is sameas false %}
                                     {% set choice = 'no' %}
                                 {% endif %}
-                                {% if (value.default is string and value.default == choice) or (value.default is iterable and value.default is not string and choice in value.default) %}
+                                {% if ((value.default is string or value.default is not iterable) and value.default == choice) or (value.default is iterable and value.default is not string and choice in value.default) %}
                                     <li><div style="color: blue"><b>@{ choice | escape }@</b>&nbsp;&larr;</div></li>
                                 {% else %}
                                     <li>@{ choice | escape }@</li>


### PR DESCRIPTION
##### SUMMARY
If there is a list of choices for an option whose type is not string, the default is currently not marked.

Example: https://docs.ansible.com/ansible/devel/modules/acme_certificate_module.html, search for `acme_version`; the default value is `1` (integer), but it is not marked.

##### ISSUE TYPE
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
docs/templates/plugin.rst.j2

##### ANSIBLE VERSION
```
2.6.0
2.5.4
```

##### ADDITIONAL INFORMATION
Kind of follow-up to #40050, which fixed the display of the choices in this case. Pinging @webknjaz @dagwieers because of this.
