### PR TITLE
cloudstack: cs_instance with details

### DIFF
--- a/lib/ansible/modules/cloud/cloudstack/cs_instance.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_instance.py
@@ -299,6 +299,7 @@ default_ip6:
   returned: success
   type: string
   sample: 2a04:c43:c00:a07:4b4:beff:fe00:74
+  version_added: '2.6'
 public_ip:
   description: Public IP address with instance via static NAT rule.
   returned: success

--- a/lib/ansible/modules/cloud/cloudstack/cs_instance.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_instance.py
@@ -149,6 +149,9 @@ options:
     description:
       - Poll async jobs until job has finished.
     default: true
+  details:
+    description:
+      - Map to specify custom parameters.
 extends_documentation_fragment: cloudstack
 '''
 
@@ -290,6 +293,11 @@ default_ip:
   returned: success
   type: string
   sample: 10.23.37.42
+default_ip6:
+  description: Default IPv6 address of the instance.
+  returned: success
+  type: string
+  sample: 2a04:c43:c00:a07:4b4:beff:fe00:74
 public_ip:
   description: Public IP address with instance via static NAT rule.
   returned: success
@@ -610,17 +618,18 @@ class AnsibleCloudStackInstance(AnsibleCloudStack):
         return user_data
 
     def get_details(self):
-        res = None
+        details = self.module.params.get('details')
         cpu = self.module.params.get('cpu')
         cpu_speed = self.module.params.get('cpu_speed')
         memory = self.module.params.get('memory')
         if all([cpu, cpu_speed, memory]):
-            res = [{
+            details.extends({
                 'cpuNumber': cpu,
                 'cpuSpeed': cpu_speed,
                 'memory': memory,
-            }]
-        return res
+            })
+
+        return details
 
     def deploy_instance(self, start_vm=True):
         self.result['changed'] = True
@@ -869,8 +878,11 @@ class AnsibleCloudStackInstance(AnsibleCloudStack):
                 self.result['affinity_groups'] = affinity_groups
             if 'nic' in instance:
                 for nic in instance['nic']:
-                    if nic['isdefault'] and 'ipaddress' in nic:
-                        self.result['default_ip'] = nic['ipaddress']
+                    if nic['isdefault']:
+                        if 'ipaddress' in nic:
+                            self.result['default_ip'] = nic['ipaddress']
+                        if 'ip6address' in nic:
+                            self.result['default_ip6'] = nic['ip6address']
         return self.result
 
 
@@ -911,6 +923,7 @@ def main():
         ssh_key=dict(),
         force=dict(type='bool', default=False),
         tags=dict(type='list', aliases=['tag']),
+        details=dict(type='dict'),
         poll_async=dict(type='bool', default=True),
     ))
 

--- a/lib/ansible/modules/cloud/cloudstack/cs_instance.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_instance.py
@@ -152,6 +152,7 @@ options:
   details:
     description:
       - Map to specify custom parameters.
+    version_added: '2.6'
 extends_documentation_fragment: cloudstack
 '''
 


### PR DESCRIPTION
##### SUMMARY

CloudStack's [deployVirtualMachine](http://cloudstack.apache.org/api/apidocs-4.10/apis/deployVirtualMachine.html) supports passing a map (dict) of key, values.

<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
cloud / cloudstack /cs_instance

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->

```
ansible 2.6.0 (cs-instance-ipv6 e71da2f4d1) last updated 2018/05/16 07:21:15 (GMT +200)
  config file = None
  configured module search path = ['/home/yoan/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/yoan/soft/ansible/lib/ansible
  executable location = venv/bin/ansible
  python version = 3.6.5 (default, May 11 2018, 04:00:52) [GCC 8.1.0]
```


##### ADDITIONAL INFORMATION

With this feature, you may deploy instances with IPv6 on [Exoscale](https://community.exoscale.com/api/compute/#deployvirtualmachine_GET)

<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```yml
---
- name: privision our VMs
  hosts: localhost
  connection: local
  tasks:
    - name: ensure VMs are created and running
      cs_instance:
        template: Linux Debian 9 64-bit
        name: test
        service_offering: Micro
        security_groups: default
        ssh_key: mykey
        state: present
        details:
          ip4: true
          ip6: true
      register: vm
    - name: show VM IP
      debug: msg="VM {{ vm.default_ip }} {{ vm.default_ip6 }}"
    - name: wait for SSH to come up
      wait_for: port=22 host={{ vm.default_ip }} delay=5
```

produces

```
PLAY [privision our VMs] ***************************************************************

TASK [Gathering Facts] *****************************************************************
ok: [localhost]

TASK [ensure VMs are created and running] **********************************************
changed: [localhost]

TASK [show VM IP] **********************************************************************
ok: [localhost] => {
    "msg": "VM 159.100.241.244 2a04:c43:c00:a07:445:60ff:fe00:8b"
}

TASK [wait for SSH to come up] *********************************************************
ok: [localhost]

PLAY RECAP *****************************************************************************
localhost                  : ok=4    changed=1    unreachable=0    failed=0
```