### PR TITLE
Lenovo cli expansion - Modify command acronyms to full commands

### DIFF
--- a/lib/ansible/modules/network/cnos/cnos_backup.py
+++ b/lib/ansible/modules/network/cnos/cnos_backup.py
@@ -32,7 +32,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = '''
 ---
 module: cnos_backup
-author: "Dave Kasberg (@dkasberg)"
+author: "Anil Kumar Muraleedharan (@amuraleedhar)"
 short_description: Backup the current running or startup configuration to a remote server on devices running Lenovo CNOS
 description:
     - This module allows you to work with switch configurations. It provides a
@@ -103,8 +103,8 @@ Tasks : The following are examples of using the module cnos_backup. These are wr
 - name: Test Running Config Backup
   cnos_backup:
       host: "{{ inventory_hostname }}"
-      username: "{{ hostvars[inventory_hostname]['username'] }}"
-      password: "{{ hostvars[inventory_hostname]['password'] }}"
+      username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+      password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
       deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
       enablePassword: "{{ hostvars[inventory_hostname]['enablePassword'] }}"
       outputfile: "./results/test_backup_{{ inventory_hostname }}_output.txt"
@@ -118,8 +118,8 @@ Tasks : The following are examples of using the module cnos_backup. These are wr
 - name: Test Startup Config Backup
   cnos_backup:
       host: "{{ inventory_hostname }}"
-      username: "{{ hostvars[inventory_hostname]['username'] }}"
-      password: "{{ hostvars[inventory_hostname]['password'] }}"
+      username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+      password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
       deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
       enablePassword: "{{ hostvars[inventory_hostname]['enablePassword'] }}"
       outputfile: "./results/test_backup_{{ inventory_hostname }}_output.txt"
@@ -133,8 +133,8 @@ Tasks : The following are examples of using the module cnos_backup. These are wr
 - name: Test Running Config Backup -TFTP
   cnos_backup:
       host: "{{ inventory_hostname }}"
-      username: "{{ hostvars[inventory_hostname]['username'] }}"
-      password: "{{ hostvars[inventory_hostname]['password'] }}"
+      username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+      password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
       deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
       enablePassword: "{{ hostvars[inventory_hostname]['enablePassword'] }}"
       outputfile: "./results/test_backup_{{ inventory_hostname }}_output.txt"
@@ -148,8 +148,8 @@ Tasks : The following are examples of using the module cnos_backup. These are wr
 - name: Test Startup Config Backup - TFTP
   cnos_backup:
       host: "{{ inventory_hostname }}"
-      username: "{{ hostvars[inventory_hostname]['username'] }}"
-      password: "{{ hostvars[inventory_hostname]['password'] }}"
+      username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+      password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
       deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
       enablePassword: "{{ hostvars[inventory_hostname]['enablePassword'] }}"
       outputfile: "./results/test_backup_{{ inventory_hostname }}_output.txt"
@@ -243,7 +243,7 @@ def main():
     time.sleep(2)
 
     #
-    # Enable and enter configure terminal then send command
+    # Enable and then send command
     output = output + cnos.waitForDeviceResponse("\n", ">", 2, remote_conn)
 
     output = output + \

--- a/lib/ansible/modules/network/cnos/cnos_bgp.py
+++ b/lib/ansible/modules/network/cnos/cnos_bgp.py
@@ -31,7 +31,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = '''
 ---
 module: cnos_bgp
-author: "Dave Kasberg (@dkasberg)"
+author: "Anil Kumar Muraleedharan (@amuraleedhar)"
 short_description: Manage BGP resources and attributes on devices running Lenovo CNOS
 description:
     - This module allows you to work with Border Gateway Protocol (BGP) related configurations.
@@ -117,8 +117,8 @@ Tasks: The following are examples of using the module cnos_bgp. These are writte
 - name: Test BGP  - neighbor
   cnos_bgp:
       host: "{{ inventory_hostname }}"
-      username: "{{ hostvars[inventory_hostname]['username'] }}"
-      password: "{{ hostvars[inventory_hostname]['password'] }}"
+      username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+      password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
       deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
       enablePassword: "{{ hostvars[inventory_hostname]['enablePassword'] }}"
       outputfile: "./results/test_bgp_{{ inventory_hostname }}_output.txt"
@@ -133,8 +133,8 @@ Tasks: The following are examples of using the module cnos_bgp. These are writte
 - name: Test BGP  - BFD
   cnos_bgp:
       host: "{{ inventory_hostname }}"
-      username: "{{ hostvars[inventory_hostname]['username'] }}"
-      password: "{{ hostvars[inventory_hostname]['password'] }}"
+      username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+      password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
       deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
       enablePassword: "{{ hostvars[inventory_hostname]['enablePassword'] }}"
       outputfile: "./results/test_bgp_{{ inventory_hostname }}_output.txt"
@@ -147,8 +147,8 @@ Tasks: The following are examples of using the module cnos_bgp. These are writte
 - name: Test BGP  - address-family - dampening
   cnos_bgp:
       host: "{{ inventory_hostname }}"
-      username: "{{ hostvars[inventory_hostname]['username'] }}"
-      password: "{{ hostvars[inventory_hostname]['password'] }}"
+      username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+      password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
       deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
       enablePassword: "{{ hostvars[inventory_hostname]['enablePassword'] }}"
       outputfile: "./results/test_bgp_{{ inventory_hostname }}_output.txt"
@@ -165,8 +165,8 @@ Tasks: The following are examples of using the module cnos_bgp. These are writte
 - name: Test BGP  - address-family - network
   cnos_bgp:
       host: "{{ inventory_hostname }}"
-      username: "{{ hostvars[inventory_hostname]['username'] }}"
-      password: "{{ hostvars[inventory_hostname]['password'] }}"
+      username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+      password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
       deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
       enablePassword: "{{ hostvars[inventory_hostname]['enablePassword'] }}"
       outputfile: "./results/test_bgp_{{ inventory_hostname }}_output.txt"
@@ -180,8 +180,8 @@ Tasks: The following are examples of using the module cnos_bgp. These are writte
 - name: Test BGP - bestpath - always-compare-med
   cnos_bgp:
       host: "{{ inventory_hostname }}"
-      username: "{{ hostvars[inventory_hostname]['username'] }}"
-      password: "{{ hostvars[inventory_hostname]['password'] }}"
+      username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+      password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
       deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
       enablePassword: "{{ hostvars[inventory_hostname]['enablePassword'] }}"
       outputfile: "./results/test_bgp_{{ inventory_hostname }}_output.txt"
@@ -192,8 +192,8 @@ Tasks: The following are examples of using the module cnos_bgp. These are writte
 - name: Test BGP - bestpath-compare-confed-aspat
   cnos_bgp:
       host: "{{ inventory_hostname }}"
-      username: "{{ hostvars[inventory_hostname]['username'] }}"
-      password: "{{ hostvars[inventory_hostname]['password'] }}"
+      username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+      password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
       deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
       enablePassword: "{{ hostvars[inventory_hostname]['enablePassword'] }}"
       outputfile: "./results/test_bgp_{{ inventory_hostname }}_output.txt"
@@ -204,8 +204,8 @@ Tasks: The following are examples of using the module cnos_bgp. These are writte
 - name: Test BGP - bgp
   cnos_bgp:
       host: "{{ inventory_hostname }}"
-      username: "{{ hostvars[inventory_hostname]['username'] }}"
-      password: "{{ hostvars[inventory_hostname]['password'] }}"
+      username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+      password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
       deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
       enablePassword: "{{ hostvars[inventory_hostname]['enablePassword'] }}"
       outputfile: "./results/test_bgp_{{ inventory_hostname }}_output.txt"
@@ -216,8 +216,8 @@ Tasks: The following are examples of using the module cnos_bgp. These are writte
 - name: Test BGP  - cluster-id
   cnos_bgp:
       host: "{{ inventory_hostname }}"
-      username: "{{ hostvars[inventory_hostname]['username'] }}"
-      password: "{{ hostvars[inventory_hostname]['password'] }}"
+      username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+      password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
       deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
       enablePassword: "{{ hostvars[inventory_hostname]['enablePassword'] }}"
       outputfile: "./results/test_bgp_{{ inventory_hostname }}_output.txt"
@@ -228,8 +228,8 @@ Tasks: The following are examples of using the module cnos_bgp. These are writte
 - name: Test BGP - confederation-identifier
   cnos_bgp:
       host: "{{ inventory_hostname }}"
-      username: "{{ hostvars[inventory_hostname]['username'] }}"
-      password: "{{ hostvars[inventory_hostname]['password'] }}"
+      username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+      password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
       deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
       enablePassword: "{{ hostvars[inventory_hostname]['enablePassword'] }}"
       outputfile: "./results/test_bgp_{{ inventory_hostname }}_output.txt"
@@ -241,8 +241,8 @@ Tasks: The following are examples of using the module cnos_bgp. These are writte
 - name: Test BGP - enforce-first-as
   cnos_bgp:
       host: "{{ inventory_hostname }}"
-      username: "{{ hostvars[inventory_hostname]['username'] }}"
-      password: "{{ hostvars[inventory_hostname]['password'] }}"
+      username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+      password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
       deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
       enablePassword: "{{ hostvars[inventory_hostname]['enablePassword'] }}"
       outputfile: "./results/test_bgp_{{ inventory_hostname }}_output.txt"
@@ -252,8 +252,8 @@ Tasks: The following are examples of using the module cnos_bgp. These are writte
 - name: Test BGP - fast-external-failover
   cnos_bgp:
       host: "{{ inventory_hostname }}"
-      username: "{{ hostvars[inventory_hostname]['username'] }}"
-      password: "{{ hostvars[inventory_hostname]['password'] }}"
+      username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+      password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
       deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
       enablePassword: "{{ hostvars[inventory_hostname]['enablePassword'] }}"
       outputfile: "./results/test_bgp_{{ inventory_hostname }}_output.txt"
@@ -263,8 +263,8 @@ Tasks: The following are examples of using the module cnos_bgp. These are writte
 - name: Test BGP  - graceful-restart
   cnos_bgp:
       host: "{{ inventory_hostname }}"
-      username: "{{ hostvars[inventory_hostname]['username'] }}"
-      password: "{{ hostvars[inventory_hostname]['password'] }}"
+      username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+      password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
       deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
       enablePassword: "{{ hostvars[inventory_hostname]['enablePassword'] }}"
       outputfile: "./results/test_bgp_{{ inventory_hostname }}_output.txt"
@@ -275,8 +275,8 @@ Tasks: The following are examples of using the module cnos_bgp. These are writte
 - name: Test BGP - graceful-restart-helper
   cnos_bgp:
       host: "{{ inventory_hostname }}"
-      username: "{{ hostvars[inventory_hostname]['username'] }}"
-      password: "{{ hostvars[inventory_hostname]['password'] }}"
+      username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+      password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
       deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
       enablePassword: "{{ hostvars[inventory_hostname]['enablePassword'] }}"
       outputfile: "./results/test_bgp_{{ inventory_hostname }}_output.txt"
@@ -286,8 +286,8 @@ Tasks: The following are examples of using the module cnos_bgp. These are writte
 - name: Test BGP - maxas-limit
   cnos_bgp:
       host: "{{ inventory_hostname }}"
-      username: "{{ hostvars[inventory_hostname]['username'] }}"
-      password: "{{ hostvars[inventory_hostname]['password'] }}"
+      username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+      password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
       deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
       enablePassword: "{{ hostvars[inventory_hostname]['enablePassword'] }}"
       outputfile: "./results/test_bgp_{{ inventory_hostname }}_output.txt"
@@ -298,8 +298,8 @@ Tasks: The following are examples of using the module cnos_bgp. These are writte
 - name: Test BGP  - neighbor
   cnos_bgp:
       host: "{{ inventory_hostname }}"
-      username: "{{ hostvars[inventory_hostname]['username'] }}"
-      password: "{{ hostvars[inventory_hostname]['password'] }}"
+      username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+      password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
       deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
       enablePassword: "{{ hostvars[inventory_hostname]['enablePassword'] }}"
       outputfile: "./results/test_bgp_{{ inventory_hostname }}_output.txt"
@@ -314,8 +314,8 @@ Tasks: The following are examples of using the module cnos_bgp. These are writte
 - name: Test BGP - router-id
   cnos_bgp:
       host: "{{ inventory_hostname }}"
-      username: "{{ hostvars[inventory_hostname]['username'] }}"
-      password: "{{ hostvars[inventory_hostname]['password'] }}"
+      username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+      password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
       deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
       enablePassword: "{{ hostvars[inventory_hostname]['enablePassword'] }}"
       outputfile: "./results/test_bgp_{{ inventory_hostname }}_output.txt"
@@ -326,8 +326,8 @@ Tasks: The following are examples of using the module cnos_bgp. These are writte
 - name: Test BGP - synchronization
   cnos_bgp:
       host: "{{ inventory_hostname }}"
-      username: "{{ hostvars[inventory_hostname]['username'] }}"
-      password: "{{ hostvars[inventory_hostname]['password'] }}"
+      username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+      password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
       deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
       enablePassword: "{{ hostvars[inventory_hostname]['enablePassword'] }}"
       outputfile: "./results/test_bgp_{{ inventory_hostname }}_output.txt"
@@ -337,8 +337,8 @@ Tasks: The following are examples of using the module cnos_bgp. These are writte
 - name: Test BGP - timers
   cnos_bgp:
       host: "{{ inventory_hostname }}"
-      username: "{{ hostvars[inventory_hostname]['username'] }}"
-      password: "{{ hostvars[inventory_hostname]['password'] }}"
+      username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+      password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
       deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
       enablePassword: "{{ hostvars[inventory_hostname]['enablePassword'] }}"
       outputfile: "./results/test_bgp_{{ inventory_hostname }}_output.txt"
@@ -350,8 +350,8 @@ Tasks: The following are examples of using the module cnos_bgp. These are writte
 - name: Test BGP - vrf
   cnos_bgp:
       host: "{{ inventory_hostname }}"
-      username: "{{ hostvars[inventory_hostname]['username'] }}"
-      password: "{{ hostvars[inventory_hostname]['password'] }}"
+      username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+      password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
       deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
       enablePassword: "{{ hostvars[inventory_hostname]['enablePassword'] }}"
       outputfile: "./results/test_bgp_{{ inventory_hostname }}_output.txt"
@@ -449,7 +449,7 @@ def main():
     output = output + cnos.waitForDeviceResponse("terminal length 0\n", "#", 2, remote_conn)
 
     # Go to config mode
-    output = output + cnos.waitForDeviceResponse("configure d\n", "(config)#", 2, remote_conn)
+    output = output + cnos.waitForDeviceResponse("configure device\n", "(config)#", 2, remote_conn)
 
     # Send the CLi command
     output = output + cnos.routerConfig(remote_conn, deviceType, "(config)#", 2, "bgp", asNum,

--- a/lib/ansible/modules/network/cnos/cnos_conditional_command.py
+++ b/lib/ansible/modules/network/cnos/cnos_conditional_command.py
@@ -32,7 +32,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = '''
 ---
 module: cnos_conditional_command
-author: "Dave Kasberg (@dkasberg)"
+author: "Anil Kumar Muraleedharan (@amuraleedhar)"
 short_description: Execute a single command based on condition on devices running Lenovo CNOS
 description:
    - This module allows you to modify the running configuration of a switch. It provides a way to
@@ -79,8 +79,8 @@ Tasks : The following are examples of using the module cnos_conditional_command.
 - name: Applying CLI template on VLAG Tier1 Leaf Switch1
   cnos_conditional_command:
       host: "{{ inventory_hostname }}"
-      username: "{{ hostvars[inventory_hostname]['username'] }}"
-      password: "{{ hostvars[inventory_hostname]['password'] }}"
+      username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+      password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
       deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
       enablePassword: "{{ hostvars[inventory_hostname]['enablePassword'] }}"
       outputfile: "./results/test_conditional_command_{{ inventory_hostname }}_output.txt"
@@ -171,7 +171,7 @@ def main():
     output = output + cnos.waitForDeviceResponse("terminal length 0\n", "#", 2, remote_conn)
 
     # Go to config mode
-    output = output + cnos.waitForDeviceResponse("configure d\n", "(config)#", 2, remote_conn)
+    output = output + cnos.waitForDeviceResponse("configure device\n", "(config)#", 2, remote_conn)
 
     # Send the CLi command
     output = output + cnos.waitForDeviceResponse(cliCommand + "\n", "(config)#", 2, remote_conn)

--- a/lib/ansible/modules/network/cnos/cnos_conditional_template.py
+++ b/lib/ansible/modules/network/cnos/cnos_conditional_template.py
@@ -32,7 +32,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = '''
 ---
 module: cnos_conditional_template
-author: "Dave Kasberg (@dkasberg)"
+author: "Anil Kumar Muraleedharan (@amuraleedhar)"
 short_description: Manage switch configuration using templates based on condition on devices running Lenovo CNOS
 description:
     - This module allows you to work with the running configuration of a switch. It provides a way to
@@ -82,8 +82,8 @@ Tasks : The following are examples of using the module cnos_conditional_template
 - name: Applying CLI template on VLAG Tier1 Leaf Switch1
   cnos_conditional_template:
       host: "{{ inventory_hostname }}"
-      username: "{{ hostvars[inventory_hostname]['username'] }}"
-      password: "{{ hostvars[inventory_hostname]['password'] }}"
+      username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+      password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
       deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
       outputfile: "./results/vlag_1tier_leaf_switch1_{{ inventory_hostname }}_output.txt"
       condition: "{{ hostvars[inventory_hostname]['condition']}}"
@@ -182,7 +182,7 @@ def main():
     output = output + cnos.waitForDeviceResponse("terminal length 0\n", "#", 2, remote_conn)
 
     # Go to config mode
-    output = output + cnos.waitForDeviceResponse("configure d\n", "(config)#", 2, remote_conn)
+    output = output + cnos.waitForDeviceResponse("configure device\n", "(config)#", 2, remote_conn)
     # Send commands one by one
     # with open(commandfile, "r") as f:
     f = open(commandfile, "r")

--- a/lib/ansible/modules/network/cnos/cnos_factory.py
+++ b/lib/ansible/modules/network/cnos/cnos_factory.py
@@ -32,7 +32,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = '''
 ---
 module: cnos_factory
-author: "Dave Kasberg (@dkasberg)"
+author: "Anil Kumar Muraleedharan (@amuraleedhar)"
 short_description: Reset the switch's startup configuration to default (factory) on devices running Lenovo CNOS
 description:
     - This module allows you to reset a switch's startup configuration. The method provides a way to reset the
@@ -53,8 +53,8 @@ Tasks : The following are examples of using the module cnos_reload. These are wr
 - name: Test Reset to factory
   cnos_factory:
       host: "{{ inventory_hostname }}"
-      username: "{{ hostvars[inventory_hostname]['username'] }}"
-      password: "{{ hostvars[inventory_hostname]['password'] }}"
+      username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+      password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
       deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
       outputfile: "./results/test_factory_{{ inventory_hostname }}_output.txt"
 

--- a/lib/ansible/modules/network/cnos/cnos_image.py
+++ b/lib/ansible/modules/network/cnos/cnos_image.py
@@ -32,7 +32,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = '''
 ---
 module: cnos_image
-author: "Dave Kasberg (@dkasberg)"
+author: "Anil Kumar Muraleedharan (@amuraleedhar)"
 short_description: Perform firmware upgrade/download from a remote server on devices running Lenovo CNOS
 description:
     - This module allows you to work with switch firmware images. It provides a way to download a firmware image
@@ -84,8 +84,8 @@ Tasks : The following are examples of using the module cnos_image. These are wri
 - name: Test Image transfer
   cnos_image:
       host: "{{ inventory_hostname }}"
-      username: "{{ hostvars[inventory_hostname]['username'] }}"
-      password: "{{ hostvars[inventory_hostname]['password'] }}"
+      username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+      password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
       deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
       enablePassword: "{{ hostvars[inventory_hostname]['enablePassword'] }}"
       outputfile: "./results/test_image_{{ inventory_hostname }}_output.txt"
@@ -99,8 +99,8 @@ Tasks : The following are examples of using the module cnos_image. These are wri
 - name: Test Image tftp
   cnos_image:
       host: "{{ inventory_hostname }}"
-      username: "{{ hostvars[inventory_hostname]['username'] }}"
-      password: "{{ hostvars[inventory_hostname]['password'] }}"
+      username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+      password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
       deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
       enablePassword: "{{ hostvars[inventory_hostname]['enablePassword'] }}"
       outputfile: "./results/test_image_{{ inventory_hostname }}_output.txt"
@@ -189,7 +189,7 @@ def main():
     remote_conn = remote_conn_pre.invoke_shell()
     time.sleep(2)
 
-    # Enable and enter configure terminal then send command
+    # Enable and then send command
     output = output + cnos.waitForDeviceResponse("\n", ">", 2, remote_conn)
 
     output = output + cnos.enterEnableModeForDevice(enablePassword, 3, remote_conn)

--- a/lib/ansible/modules/network/cnos/cnos_interface.py
+++ b/lib/ansible/modules/network/cnos/cnos_interface.py
@@ -31,7 +31,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = '''
 ---
 module: cnos_interface
-author: "Dave Kasberg (@dkasberg)"
+author: "Anil Kumar Muraleedharan (@amuraleedhar)"
 short_description: Manage interface configuration on devices running Lenovo CNOS
 description:
     - This module allows you to work with interface related configurations. The operators used are
@@ -135,8 +135,8 @@ Tasks : The following are examples of using the module cnos_interface. These are
 - name: Test Interface Ethernet - aggregation-group
   cnos_interface:
       host: "{{ inventory_hostname }}"
-      username: "{{ hostvars[inventory_hostname]['username'] }}"
-      password: "{{ hostvars[inventory_hostname]['password'] }}"
+      username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+      password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
       deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
       enablePassword: "{{ hostvars[inventory_hostname]['enablePassword'] }}"
       outputfile: "./results/test_interface_{{ inventory_hostname }}_output.txt"
@@ -149,8 +149,8 @@ Tasks : The following are examples of using the module cnos_interface. These are
 - name: Test Interface Ethernet - bridge-port
   cnos_interface:
       host: "{{ inventory_hostname }}"
-      username: "{{ hostvars[inventory_hostname]['username'] }}"
-      password: "{{ hostvars[inventory_hostname]['password'] }}"
+      username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+      password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
       deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
       enablePassword: "{{ hostvars[inventory_hostname]['enablePassword'] }}"
       outputfile: "./results/test_interface_{{ inventory_hostname }}_output.txt"
@@ -163,8 +163,8 @@ Tasks : The following are examples of using the module cnos_interface. These are
 - name: Test Interface Ethernet - bridgeport mode
   cnos_interface:
       host: "{{ inventory_hostname }}"
-      username: "{{ hostvars[inventory_hostname]['username'] }}"
-      password: "{{ hostvars[inventory_hostname]['password'] }}"
+      username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+      password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
       deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
       enablePassword: "{{ hostvars[inventory_hostname]['enablePassword'] }}"
       outputfile: "./results/test_interface_{{ inventory_hostname }}_output.txt"
@@ -177,8 +177,8 @@ Tasks : The following are examples of using the module cnos_interface. These are
 - name: Test Interface Ethernet  - Description
   cnos_interface:
       host: "{{ inventory_hostname }}"
-      username: "{{ hostvars[inventory_hostname]['username'] }}"
-      password: "{{ hostvars[inventory_hostname]['password'] }}"
+      username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+      password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
       deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
       enablePassword: "{{ hostvars[inventory_hostname]['enablePassword'] }}"
       outputfile: "./results/test_interface_{{ inventory_hostname }}_output.txt"
@@ -190,8 +190,8 @@ Tasks : The following are examples of using the module cnos_interface. These are
 - name: Test Interface Ethernet - Duplex
   cnos_interface:
       host: "{{ inventory_hostname }}"
-      username: "{{ hostvars[inventory_hostname]['username'] }}"
-      password: "{{ hostvars[inventory_hostname]['password'] }}"
+      username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+      password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
       deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
       enablePassword: "{{ hostvars[inventory_hostname]['enablePassword'] }}"
       outputfile: "./results/test_interface_{{ inventory_hostname }}_output.txt"
@@ -203,8 +203,8 @@ Tasks : The following are examples of using the module cnos_interface. These are
 - name: Test Interface Ethernet - flowcontrol
   cnos_interface:
       host: "{{ inventory_hostname }}"
-      username: "{{ hostvars[inventory_hostname]['username'] }}"
-      password: "{{ hostvars[inventory_hostname]['password'] }}"
+      username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+      password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
       deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
       enablePassword: "{{ hostvars[inventory_hostname]['enablePassword'] }}"
       outputfile: "./results/test_interface_{{ inventory_hostname }}_output.txt"
@@ -217,8 +217,8 @@ Tasks : The following are examples of using the module cnos_interface. These are
 - name: Test Interface Ethernet - lacp
   cnos_interface:
       host: "{{ inventory_hostname }}"
-      username: "{{ hostvars[inventory_hostname]['username'] }}"
-      password: "{{ hostvars[inventory_hostname]['password'] }}"
+      username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+      password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
       deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
       enablePassword: "{{ hostvars[inventory_hostname]['enablePassword'] }}"
       outputfile: "./results/test_interface_{{ inventory_hostname }}_output.txt"
@@ -231,8 +231,8 @@ Tasks : The following are examples of using the module cnos_interface. These are
 - name: Test Interface Ethernet  - lldp
   cnos_interface:
       host: "{{ inventory_hostname }}"
-      username: "{{ hostvars[inventory_hostname]['username'] }}"
-      password: "{{ hostvars[inventory_hostname]['password'] }}"
+      username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+      password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
       deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
       enablePassword: "{{ hostvars[inventory_hostname]['enablePassword'] }}"
       outputfile: "./results/test_interface_{{ inventory_hostname }}_output.txt"
@@ -245,8 +245,8 @@ Tasks : The following are examples of using the module cnos_interface. These are
 - name: Test Interface Ethernet - load-interval
   cnos_interface:
       host: "{{ inventory_hostname }}"
-      username: "{{ hostvars[inventory_hostname]['username'] }}"
-      password: "{{ hostvars[inventory_hostname]['password'] }}"
+      username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+      password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
       deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
       enablePassword: "{{ hostvars[inventory_hostname]['enablePassword'] }}"
       outputfile: "./results/test_interface_{{ inventory_hostname }}_output.txt"
@@ -260,8 +260,8 @@ Tasks : The following are examples of using the module cnos_interface. These are
 - name: Test Interface Ethernet - mac
   cnos_interface:
       host: "{{ inventory_hostname }}"
-      username: "{{ hostvars[inventory_hostname]['username'] }}"
-      password: "{{ hostvars[inventory_hostname]['password'] }}"
+      username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+      password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
       deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
       enablePassword: "{{ hostvars[inventory_hostname]['enablePassword'] }}"
       outputfile: "./results/test_interface_{{ inventory_hostname }}_output.txt"
@@ -273,8 +273,8 @@ Tasks : The following are examples of using the module cnos_interface. These are
 - name: Test Interface Ethernet - microburst-detection
   cnos_interface:
       host: "{{ inventory_hostname }}"
-      username: "{{ hostvars[inventory_hostname]['username'] }}"
-      password: "{{ hostvars[inventory_hostname]['password'] }}"
+      username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+      password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
       deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
       enablePassword: "{{ hostvars[inventory_hostname]['enablePassword'] }}"
       outputfile: "./results/test_interface_{{ inventory_hostname }}_output.txt"
@@ -286,8 +286,8 @@ Tasks : The following are examples of using the module cnos_interface. These are
 - name: Test Interface Ethernet  - mtu
   cnos_interface:
       host: "{{ inventory_hostname }}"
-      username: "{{ hostvars[inventory_hostname]['username'] }}"
-      password: "{{ hostvars[inventory_hostname]['password'] }}"
+      username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+      password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
       deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
       enablePassword: "{{ hostvars[inventory_hostname]['enablePassword'] }}"
       outputfile: "./results/test_interface_{{ inventory_hostname }}_output.txt"
@@ -299,8 +299,8 @@ Tasks : The following are examples of using the module cnos_interface. These are
 - name: Test Interface Ethernet - service-policy
   cnos_interface:
       host: "{{ inventory_hostname }}"
-      username: "{{ hostvars[inventory_hostname]['username'] }}"
-      password: "{{ hostvars[inventory_hostname]['password'] }}"
+      username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+      password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
       deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
       enablePassword: "{{ hostvars[inventory_hostname]['enablePassword'] }}"
       outputfile: "./results/test_interface_{{ inventory_hostname }}_output.txt"
@@ -313,8 +313,8 @@ Tasks : The following are examples of using the module cnos_interface. These are
 - name: Test Interface Ethernet - speed
   cnos_interface:
       host: "{{ inventory_hostname }}"
-      username: "{{ hostvars[inventory_hostname]['username'] }}"
-      password: "{{ hostvars[inventory_hostname]['password'] }}"
+      username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+      password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
       deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
       enablePassword: "{{ hostvars[inventory_hostname]['enablePassword'] }}"
       outputfile: "./results/test_interface_{{ inventory_hostname }}_output.txt"
@@ -326,8 +326,8 @@ Tasks : The following are examples of using the module cnos_interface. These are
 - name: Test Interface Ethernet - storm
   cnos_interface:
       host: "{{ inventory_hostname }}"
-      username: "{{ hostvars[inventory_hostname]['username'] }}"
-      password: "{{ hostvars[inventory_hostname]['password'] }}"
+      username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+      password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
       deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
       enablePassword: "{{ hostvars[inventory_hostname]['enablePassword'] }}"
       outputfile: "./results/test_interface_{{ inventory_hostname }}_output.txt"
@@ -340,8 +340,8 @@ Tasks : The following are examples of using the module cnos_interface. These are
 - name: Test Interface Ethernet - vlan
   cnos_interface:
       host: "{{ inventory_hostname }}"
-      username: "{{ hostvars[inventory_hostname]['username'] }}"
-      password: "{{ hostvars[inventory_hostname]['password'] }}"
+      username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+      password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
       deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
       enablePassword: "{{ hostvars[inventory_hostname]['enablePassword'] }}"
       outputfile: "./results/test_interface_{{ inventory_hostname }}_output.txt"
@@ -353,8 +353,8 @@ Tasks : The following are examples of using the module cnos_interface. These are
 - name: Test Interface Ethernet - vrrp
   cnos_interface:
       host: "{{ inventory_hostname }}"
-      username: "{{ hostvars[inventory_hostname]['username'] }}"
-      password: "{{ hostvars[inventory_hostname]['password'] }}"
+      username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+      password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
       deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
       enablePassword: "{{ hostvars[inventory_hostname]['enablePassword'] }}"
       outputfile: "./results/test_interface_{{ inventory_hostname }}_output.txt"
@@ -366,8 +366,8 @@ Tasks : The following are examples of using the module cnos_interface. These are
 - name: Test Interface Ethernet - spanning tree1
   cnos_interface:
       host: "{{ inventory_hostname }}"
-      username: "{{ hostvars[inventory_hostname]['username'] }}"
-      password: "{{ hostvars[inventory_hostname]['password'] }}"
+      username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+      password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
       deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
       enablePassword: "{{ hostvars[inventory_hostname]['enablePassword'] }}"
       outputfile: "./results/test_interface_{{ inventory_hostname }}_output.txt"
@@ -380,8 +380,8 @@ Tasks : The following are examples of using the module cnos_interface. These are
 - name: Test Interface Ethernet - spanning tree 2
   cnos_interface:
       host: "{{ inventory_hostname }}"
-      username: "{{ hostvars[inventory_hostname]['username'] }}"
-      password: "{{ hostvars[inventory_hostname]['password'] }}"
+      username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+      password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
       deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
       enablePassword: "{{ hostvars[inventory_hostname]['enablePassword'] }}"
       outputfile: "./results/test_interface_{{ inventory_hostname }}_output.txt"
@@ -396,8 +396,8 @@ Tasks : The following are examples of using the module cnos_interface. These are
 - name: Test Interface Ethernet - ip1
   cnos_interface:
       host: "{{ inventory_hostname }}"
-      username: "{{ hostvars[inventory_hostname]['username'] }}"
-      password: "{{ hostvars[inventory_hostname]['password'] }}"
+      username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+      password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
       deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
       enablePassword: "{{ hostvars[inventory_hostname]['enablePassword'] }}"
       outputfile: "./results/test_interface_{{ inventory_hostname }}_output.txt"
@@ -411,8 +411,8 @@ Tasks : The following are examples of using the module cnos_interface. These are
 - name: Test Interface Ethernet - ip2
   cnos_interface:
       host: "{{ inventory_hostname }}"
-      username: "{{ hostvars[inventory_hostname]['username'] }}"
-      password: "{{ hostvars[inventory_hostname]['password'] }}"
+      username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+      password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
       deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
       enablePassword: "{{ hostvars[inventory_hostname]['enablePassword'] }}"
       outputfile: "./results/test_interface_{{ inventory_hostname }}_output.txt"
@@ -425,8 +425,8 @@ Tasks : The following are examples of using the module cnos_interface. These are
 - name: Test Interface Ethernet - bfd
   cnos_interface:
       host: "{{ inventory_hostname }}"
-      username: "{{ hostvars[inventory_hostname]['username'] }}"
-      password: "{{ hostvars[inventory_hostname]['password'] }}"
+      username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+      password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
       deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
       enablePassword: "{{ hostvars[inventory_hostname]['enablePassword'] }}"
       outputfile: "./results/test_interface_{{ inventory_hostname }}_output.txt"
@@ -441,8 +441,8 @@ Tasks : The following are examples of using the module cnos_interface. These are
 - name: Test Interface Ethernet - bfd
   cnos_interface:
       host: "{{ inventory_hostname }}"
-      username: "{{ hostvars[inventory_hostname]['username'] }}"
-      password: "{{ hostvars[inventory_hostname]['password'] }}"
+      username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+      password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
       deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
       enablePassword: "{{ hostvars[inventory_hostname]['enablePassword'] }}"
       outputfile: "./results/test_interface_{{ inventory_hostname }}_output.txt"
@@ -548,7 +548,7 @@ def main():
     output = output + cnos.waitForDeviceResponse("terminal length 0\n", "#", 2, remote_conn)
 
     # Go to config mode
-    output = output + cnos.waitForDeviceResponse("configure d\n", "(config)#", 2, remote_conn)
+    output = output + cnos.waitForDeviceResponse("configure device\n", "(config)#", 2, remote_conn)
 
     # Send the CLi command
     if(interfaceOption is None or interfaceOption == ""):

--- a/lib/ansible/modules/network/cnos/cnos_portchannel.py
+++ b/lib/ansible/modules/network/cnos/cnos_portchannel.py
@@ -31,7 +31,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = '''
 ---
 module: cnos_portchannel
-author: "Dave Kasberg (@dkasberg)"
+author: "Anil Kumar Muraleedharan (@amuraleedhar)"
 short_description: Manage portchannel (port aggregation) configuration on devices running Lenovo CNOS
 description:
     - This module allows you to work with port aggregation related configurations. The operators
@@ -121,8 +121,8 @@ Tasks : The following are examples of using the module cnos_portchannel. These a
 - name: Test Port Channel - aggregation-group
   cnos_portchannel:
     host: "{{ inventory_hostname }}"
-    username: "{{ hostvars[inventory_hostname]['username'] }}"
-    password: "{{ hostvars[inventory_hostname]['password'] }}"
+    username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+    password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
     deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
     outputfile: "./results/test_portchannel_{{ inventory_hostname }}_output.txt"
     interfaceRange: 33
@@ -133,8 +133,8 @@ Tasks : The following are examples of using the module cnos_portchannel. These a
 - name: Test Port Channel - aggregation-group - Interface Range
   cnos_portchannel:
   host: "{{ inventory_hostname }}"
-  username: "{{ hostvars[inventory_hostname]['username'] }}"
-  password: "{{ hostvars[inventory_hostname]['password'] }}"
+  username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+  password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
   deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
   outputfile: "./results/test_portchannel_{{ inventory_hostname }}_output.txt"
   interfaceRange: "1/1-2"
@@ -145,8 +145,8 @@ Tasks : The following are examples of using the module cnos_portchannel. These a
 - name: Test Port Channel - bridge-port
   cnos_portchannel:
   host: "{{ inventory_hostname }}"
-  username: "{{ hostvars[inventory_hostname]['username'] }}"
-  password: "{{ hostvars[inventory_hostname]['password'] }}"
+  username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+  password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
   deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
   outputfile: "./results/test_portchannel_{{ inventory_hostname }}_output.txt"
   interfaceRange: 33
@@ -157,8 +157,8 @@ Tasks : The following are examples of using the module cnos_portchannel. These a
 - name: Test Port Channel - bridgeport mode
   cnos_portchannel:
   host: "{{ inventory_hostname }}"
-  username: "{{ hostvars[inventory_hostname]['username'] }}"
-  password: "{{ hostvars[inventory_hostname]['password'] }}"
+  username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+  password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
   deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
   outputfile: "./results/test_portchannel_{{ inventory_hostname }}_output.txt"
   interfaceRange: 33
@@ -169,8 +169,8 @@ Tasks : The following are examples of using the module cnos_portchannel. These a
 - name: Test Port Channel  - Description
   cnos_portchannel:
   host: "{{ inventory_hostname }}"
-  username: "{{ hostvars[inventory_hostname]['username'] }}"
-  password: "{{ hostvars[inventory_hostname]['password'] }}"
+  username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+  password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
   deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
   outputfile: "./results/test_portchannel_{{ inventory_hostname }}_output.txt"
   interfaceRange: 33
@@ -180,8 +180,8 @@ Tasks : The following are examples of using the module cnos_portchannel. These a
 - name: Test Port Channel - Duplex
   cnos_portchannel:
   host: "{{ inventory_hostname }}"
-  username: "{{ hostvars[inventory_hostname]['username'] }}"
-  password: "{{ hostvars[inventory_hostname]['password'] }}"
+  username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+  password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
   deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
   outputfile: "./results/test_portchannel_{{ inventory_hostname }}_output.txt"
   interfaceRange: 33
@@ -191,8 +191,8 @@ Tasks : The following are examples of using the module cnos_portchannel. These a
 - name: Test Port Channel - flowcontrol
   cnos_portchannel:
   host: "{{ inventory_hostname }}"
-  username: "{{ hostvars[inventory_hostname]['username'] }}"
-  password: "{{ hostvars[inventory_hostname]['password'] }}"
+  username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+  password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
   deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
   outputfile: "./results/test_portchannel_{{ inventory_hostname }}_output.txt"
   interfaceRange: 33
@@ -203,8 +203,8 @@ Tasks : The following are examples of using the module cnos_portchannel. These a
 - name: Test Port Channel - lacp
   cnos_portchannel:
   host: "{{ inventory_hostname }}"
-  username: "{{ hostvars[inventory_hostname]['username'] }}"
-  password: "{{ hostvars[inventory_hostname]['password'] }}"
+  username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+  password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
   deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
   outputfile: "./results/test_portchannel_{{ inventory_hostname }}_output.txt"
   interfaceRange: 33
@@ -215,8 +215,8 @@ Tasks : The following are examples of using the module cnos_portchannel. These a
 - name: Test Port Channel  - lldp
   cnos_portchannel:
   host: "{{ inventory_hostname }}"
-  username: "{{ hostvars[inventory_hostname]['username'] }}"
-  password: "{{ hostvars[inventory_hostname]['password'] }}"
+  username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+  password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
   deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
   outputfile: "./results/test_portchannel_{{ inventory_hostname }}_output.txt"
   interfaceRange: 33
@@ -227,8 +227,8 @@ Tasks : The following are examples of using the module cnos_portchannel. These a
 - name: Test Port Channel - load-interval
   cnos_portchannel:
   host: "{{ inventory_hostname }}"
-  username: "{{ hostvars[inventory_hostname]['username'] }}"
-  password: "{{ hostvars[inventory_hostname]['password'] }}"
+  username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+  password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
   deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
   outputfile: "./results/test_portchannel_{{ inventory_hostname }}_output.txt"
   interfaceRange: 33
@@ -240,8 +240,8 @@ Tasks : The following are examples of using the module cnos_portchannel. These a
 #- name: Test Port Channel - mac
 #  cnos_portchannel:
 #  host: "{{ inventory_hostname }}"
-#  username: "{{ hostvars[inventory_hostname]['username'] }}"
-#  password: "{{ hostvars[inventory_hostname]['password'] }}"
+#  username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+#  password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
 #  deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
 #  outputfile: "./results/test_portchannel_{{ inventory_hostname }}_output.txt"
 #  interfaceRange: 33,
@@ -251,8 +251,8 @@ Tasks : The following are examples of using the module cnos_portchannel. These a
 - name: Test Port Channel - microburst-detection
   cnos_portchannel:
   host: "{{ inventory_hostname }}"
-  username: "{{ hostvars[inventory_hostname]['username'] }}"
-  password: "{{ hostvars[inventory_hostname]['password'] }}"
+  username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+  password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
   deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
   outputfile: "./results/test_portchannel_{{ inventory_hostname }}_output.txt"
   interfaceRange: 33
@@ -262,8 +262,8 @@ Tasks : The following are examples of using the module cnos_portchannel. These a
 - name: Test Port Channel  - mtu
   cnos_portchannel:
   host: "{{ inventory_hostname }}"
-  username: "{{ hostvars[inventory_hostname]['username'] }}"
-  password: "{{ hostvars[inventory_hostname]['password'] }}"
+  username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+  password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
   deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
   outputfile: "./results/test_portchannel_{{ inventory_hostname }}_output.txt"
   interfaceRange: 33
@@ -273,8 +273,8 @@ Tasks : The following are examples of using the module cnos_portchannel. These a
 - name: Test Port Channel - service-policy
   cnos_portchannel:
   host: "{{ inventory_hostname }}"
-  username: "{{ hostvars[inventory_hostname]['username'] }}"
-  password: "{{ hostvars[inventory_hostname]['password'] }}"
+  username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+  password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
   deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
   outputfile: "./results/test_portchannel_{{ inventory_hostname }}_output.txt"
   interfaceRange: 33
@@ -285,8 +285,8 @@ Tasks : The following are examples of using the module cnos_portchannel. These a
 - name: Test Port Channel - speed
   cnos_portchannel:
   host: "{{ inventory_hostname }}"
-  username: "{{ hostvars[inventory_hostname]['username'] }}"
-  password: "{{ hostvars[inventory_hostname]['password'] }}"
+  username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+  password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
   deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
   outputfile: "./results/test_portchannel_{{ inventory_hostname }}_output.txt"
   interfaceRange: 33
@@ -296,8 +296,8 @@ Tasks : The following are examples of using the module cnos_portchannel. These a
 - name: Test Port Channel - storm
   cnos_portchannel:
   host: "{{ inventory_hostname }}"
-  username: "{{ hostvars[inventory_hostname]['username'] }}"
-  password: "{{ hostvars[inventory_hostname]['password'] }}"
+  username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+  password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
   deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
   outputfile: "./results/test_portchannel_{{ inventory_hostname }}_output.txt"
   interfaceRange: 33
@@ -308,8 +308,8 @@ Tasks : The following are examples of using the module cnos_portchannel. These a
 #- name: Test Port Channel - vlan
 #  cnos_portchannel:
 #  host: "{{ inventory_hostname }}"
-#  username: "{{ hostvars[inventory_hostname]['username'] }}"
-#  password: "{{ hostvars[inventory_hostname]['password'] }}"
+#  username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+#  password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
 #  deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
 #  outputfile: "./results/test_portchannel_{{ inventory_hostname }}_output.txt"
 #  interfaceRange: 33
@@ -319,8 +319,8 @@ Tasks : The following are examples of using the module cnos_portchannel. These a
 - name: Test Port Channel - vrrp
   cnos_portchannel:
   host: "{{ inventory_hostname }}"
-  username: "{{ hostvars[inventory_hostname]['username'] }}"
-  password: "{{ hostvars[inventory_hostname]['password'] }}"
+  username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+  password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
   deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
   outputfile: "./results/test_portchannel_{{ inventory_hostname }}_output.txt"
   interfaceRange: 33
@@ -330,8 +330,8 @@ Tasks : The following are examples of using the module cnos_portchannel. These a
 - name: Test Port Channel - spanning tree1
   cnos_portchannel:
   host: "{{ inventory_hostname }}"
-  username: "{{ hostvars[inventory_hostname]['username'] }}"
-  password: "{{ hostvars[inventory_hostname]['password'] }}"
+  username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+  password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
   deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
   outputfile: "./results/test_portchannel_{{ inventory_hostname }}_output.txt"
   interfaceRange: 33
@@ -342,8 +342,8 @@ Tasks : The following are examples of using the module cnos_portchannel. These a
 - name: Test Port Channel - spanning tree 2
   cnos_portchannel:
   host: "{{ inventory_hostname }}"
-  username: "{{ hostvars[inventory_hostname]['username'] }}"
-  password: "{{ hostvars[inventory_hostname]['password'] }}"
+  username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+  password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
   deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
   outputfile: "./results/test_portchannel_{{ inventory_hostname }}_output.txt"
   interfaceRange: 33
@@ -356,8 +356,8 @@ Tasks : The following are examples of using the module cnos_portchannel. These a
 - name: Test Port Channel - ip1
   cnos_portchannel:
   host: "{{ inventory_hostname }}"
-  username: "{{ hostvars[inventory_hostname]['username'] }}"
-  password: "{{ hostvars[inventory_hostname]['password'] }}"
+  username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+  password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
   deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
   outputfile: "./results/test_portchannel_{{ inventory_hostname }}_output.txt"
   interfaceRange: 33
@@ -369,8 +369,8 @@ Tasks : The following are examples of using the module cnos_portchannel. These a
 - name: Test Port Channel - ip2
   cnos_portchannel:
   host: "{{ inventory_hostname }}"
-  username: "{{ hostvars[inventory_hostname]['username'] }}"
-  password: "{{ hostvars[inventory_hostname]['password'] }}"
+  username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+  password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
   deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
   outputfile: "./results/test_portchannel_{{ inventory_hostname }}_output.txt"
   interfaceRange: 33
@@ -381,8 +381,8 @@ Tasks : The following are examples of using the module cnos_portchannel. These a
 - name: Test Port Channel - bfd
   cnos_portchannel:
   host: "{{ inventory_hostname }}"
-  username: "{{ hostvars[inventory_hostname]['username'] }}"
-  password: "{{ hostvars[inventory_hostname]['password'] }}"
+  username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+  password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
   deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
   outputfile: "./results/test_portchannel_{{ inventory_hostname }}_output.txt"
   interfaceRange: 33
@@ -395,8 +395,8 @@ Tasks : The following are examples of using the module cnos_portchannel. These a
 - name: Test Port Channel - bfd
   cnos_portchannel:
   host: "{{ inventory_hostname }}"
-  username: "{{ hostvars[inventory_hostname]['username'] }}"
-  password: "{{ hostvars[inventory_hostname]['password'] }}"
+  username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+  password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
   deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
   outputfile: "./results/test_portchannel_{{ inventory_hostname }}_output.txt"
   interfaceRange: 33
@@ -498,7 +498,7 @@ def main():
     output = output + cnos.waitForDeviceResponse("terminal length 0\n", "#", 2, remote_conn)
 
     # Go to config mode
-    output = output + cnos.waitForDeviceResponse("configure d\n", "(config)#", 2, remote_conn)
+    output = output + cnos.waitForDeviceResponse("configure device\n", "(config)#", 2, remote_conn)
 
     # Send the CLi command
     if(interfaceArg1 == "port-aggregation"):

--- a/lib/ansible/modules/network/cnos/cnos_reload.py
+++ b/lib/ansible/modules/network/cnos/cnos_reload.py
@@ -32,7 +32,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = '''
 ---
 module: cnos_reload
-author: "Dave Kasberg (@dkasberg)"
+author: "Anil Kumar Muraleedharan (@amuraleedhar)"
 short_description: Perform switch restart on devices running Lenovo CNOS
 description:
     - This module allows you to restart the switch using the current startup configuration.
@@ -52,8 +52,8 @@ Tasks : The following are examples of using the module cnos_reload. These are wr
 - name: Test Reload
   cnos_reload:
       host: "{{ inventory_hostname }}"
-      username: "{{ hostvars[inventory_hostname]['username'] }}"
-      password: "{{ hostvars[inventory_hostname]['password'] }}"
+      username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+      password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
       deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
       enablePassword: "{{ hostvars[inventory_hostname]['enablePassword'] }}"
       outputfile: "./results/test_reload_{{ inventory_hostname }}_output.txt"
@@ -123,7 +123,7 @@ def main():
     remote_conn = remote_conn_pre.invoke_shell()
     time.sleep(2)
 
-    # Enable and enter configure terminal then send command
+    # Enable and then send command
     output = output + cnos.waitForDeviceResponse("\n", ">", 2, remote_conn)
 
     output = output + cnos.enterEnableModeForDevice(enablePassword, 3, remote_conn)

--- a/lib/ansible/modules/network/cnos/cnos_rollback.py
+++ b/lib/ansible/modules/network/cnos/cnos_rollback.py
@@ -33,7 +33,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = '''
 ---
 module: cnos_rollback
-author: "Dave Kasberg (@dkasberg)"
+author: "Anil Kumar Muraleedharan (@amuraleedhar)"
 short_description: Roll back the running or startup configuration from a remote server on devices running Lenovo CNOS
 description:
     - This module allows you to work with switch configurations. It provides a way to roll back configurations
@@ -96,8 +96,8 @@ Tasks : The following are examples of using the module cnos_rollback. These are 
 - name: Test Rollback of config - Running config
   cnos_rolback:
       host: "{{ inventory_hostname }}"
-      username: "{{ hostvars[inventory_hostname]['username'] }}"
-      password: "{{ hostvars[inventory_hostname]['password'] }}"
+      username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+      password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
       deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
       enablePassword: "{{ hostvars[inventory_hostname]['enablePassword'] }}"
       outputfile: "./results/test_rollback_{{ inventory_hostname }}_output.txt"
@@ -111,8 +111,8 @@ Tasks : The following are examples of using the module cnos_rollback. These are 
 - name: Test Rollback of config - Startup config
   cnos_rolback:
       host: "{{ inventory_hostname }}"
-      username: "{{ hostvars[inventory_hostname]['username'] }}"
-      password: "{{ hostvars[inventory_hostname]['password'] }}"
+      username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+      password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
       deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
       enablePassword: "{{ hostvars[inventory_hostname]['enablePassword'] }}"
       outputfile: "./results/test_rollback_{{ inventory_hostname }}_output.txt"
@@ -126,8 +126,8 @@ Tasks : The following are examples of using the module cnos_rollback. These are 
 - name: Test Rollback of config - Running config - TFTP
   cnos_rolback:
       host: "{{ inventory_hostname }}"
-      username: "{{ hostvars[inventory_hostname]['username'] }}"
-      password: "{{ hostvars[inventory_hostname]['password'] }}"
+      username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+      password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
       deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
       enablePassword: "{{ hostvars[inventory_hostname]['enablePassword'] }}"
       outputfile: "./results/test_rollback_{{ inventory_hostname }}_output.txt"
@@ -141,8 +141,8 @@ Tasks : The following are examples of using the module cnos_rollback. These are 
 - name: Test Rollback of config - Startup config - TFTP
   cnos_rolback:
       host: "{{ inventory_hostname }}"
-      username: "{{ hostvars[inventory_hostname]['username'] }}"
-      password: "{{ hostvars[inventory_hostname]['password'] }}"
+      username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+      password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
       deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
       enablePassword: "{{ hostvars[inventory_hostname]['enablePassword'] }}"
       outputfile: "./results/test_rollback_{{ inventory_hostname }}_output.txt"
@@ -232,7 +232,7 @@ def main():
     remote_conn = remote_conn_pre.invoke_shell()
     time.sleep(2)
 
-    # Enable and enter configure terminal then send command
+    # Enable and then send command
     output = output + cnos.waitForDeviceResponse("\n", ">", 2, remote_conn)
 
     output = output + cnos.enterEnableModeForDevice(enablePassword, 3, remote_conn)

--- a/lib/ansible/modules/network/cnos/cnos_save.py
+++ b/lib/ansible/modules/network/cnos/cnos_save.py
@@ -32,7 +32,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = '''
 ---
 module: cnos_save
-author: "Dave Kasberg (@dkasberg)"
+author: "Anil Kumar Muraleedharan (@amuraleedhar)"
 short_description: Save the running configuration as the startup configuration on devices running Lenovo CNOS
 description:
     - This module allows you to copy the running configuration of a switch over its startup configuration.
@@ -53,8 +53,8 @@ Tasks : The following are examples of using the module cnos_save. These are writ
 - name: Test Save
   cnos_save:
       host: "{{ inventory_hostname }}"
-      username: "{{ hostvars[inventory_hostname]['username'] }}"
-      password: "{{ hostvars[inventory_hostname]['password'] }}"
+      username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+      password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
       deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
       enablePassword: "{{ hostvars[inventory_hostname]['enablePassword'] }}"
       outputfile: "./results/test_save_{{ inventory_hostname }}_output.txt"
@@ -124,7 +124,7 @@ def main():
     remote_conn = remote_conn_pre.invoke_shell()
     time.sleep(2)
 
-    # Enable and enter configure terminal then send command
+    # Enable and then send command
     output = output + cnos.waitForDeviceResponse("\n", ">", 2, remote_conn)
 
     output = output + cnos.enterEnableModeForDevice(enablePassword, 3, remote_conn)

--- a/lib/ansible/modules/network/cnos/cnos_showrun.py
+++ b/lib/ansible/modules/network/cnos/cnos_showrun.py
@@ -32,7 +32,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = '''
 ---
 module: cnos_showrun
-author: "Dave Kasberg (@dkasberg)"
+author: "Anil Kumar Muraleedharan (@amuraleedhar)"
 short_description: Collect the current running configuration on devices running Lenovo CNOS
 description:
     - This module allows you to view the switch running configuration. It executes the display running-config CLI
@@ -53,8 +53,8 @@ Tasks : The following are examples of using the module cnos_showrun. These are w
 - name: Run show running-config
   cnos_showrun:
       host: "{{ inventory_hostname }}"
-      username: "{{ hostvars[inventory_hostname]['username'] }}"
-      password: "{{ hostvars[inventory_hostname]['password'] }}"
+      username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+      password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
       deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
       enablePassword: "{{ hostvars[inventory_hostname]['enablePassword'] }}"
       outputfile: "./results/test_showrun_{{ inventory_hostname }}_output.txt"
@@ -123,7 +123,7 @@ def main():
     remote_conn = remote_conn_pre.invoke_shell()
     time.sleep(2)
 
-    # Enable and enter configure terminal then send command
+    # Enable and then send command
     output = output + cnos.waitForDeviceResponse("\n", ">", 2, remote_conn)
 
     output = output + cnos.enterEnableModeForDevice(enablePassword, 3, remote_conn)

--- a/lib/ansible/modules/network/cnos/cnos_template.py
+++ b/lib/ansible/modules/network/cnos/cnos_template.py
@@ -32,7 +32,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = '''
 ---
 module: cnos_template
-author: "Dave Kasberg (@dkasberg)"
+author: "Anil Kumar Muraleedharan (@amuraleedhar)"
 short_description: Manage switch configuration using templates on devices running Lenovo CNOS
 description:
     - This module allows you to work with the running configuration of a switch. It provides a way
@@ -74,8 +74,8 @@ Tasks : The following are examples of using the module cnos_template. These are 
 - name: Applying CLI commands on Switches
   cnos_template:
       host: "{{ inventory_hostname }}"
-      username: "{{ hostvars[inventory_hostname]['username'] }}"
-      password: "{{ hostvars[inventory_hostname]['password'] }}"
+      username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+      password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
       deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
       enablePassword: "{{ hostvars[inventory_hostname]['enablePassword'] }}"
       commandfile: "./commands/demo_template_{{ inventory_hostname }}_commands.txt"
@@ -156,10 +156,9 @@ def main():
     output = output + cnos.waitForDeviceResponse("terminal length 0\n", "#", 2, remote_conn)
 
     # Go to config mode
-    output = output + cnos.waitForDeviceResponse("configure d\n", "(config)#", 2, remote_conn)
+    output = output + cnos.waitForDeviceResponse("configure device\n", "(config)#", 2, remote_conn)
 
     # Send commands one by one to the device
-    # with open(commandfile, "r") as f:
     f = open(commandfile, "r")
     for line in f:
         # Omit the comment lines in template file

--- a/lib/ansible/modules/network/cnos/cnos_vlag.py
+++ b/lib/ansible/modules/network/cnos/cnos_vlag.py
@@ -32,7 +32,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = '''
 ---
 module: cnos_vlag
-author: "Dave Kasberg (@dkasberg)"
+author: "Anil Kumar Muraleedharan (@amuraleedhar)"
 short_description: Manage VLAG resources and attributes on devices running Lenovo CNOS
 description:
     - This module allows you to work with virtual Link Aggregation Groups
@@ -84,8 +84,8 @@ Tasks : The following are examples of using the module cnos_vlag. These are writ
 - name: Test Vlag  - enable
   cnos_vlag:
       host: "{{ inventory_hostname }}"
-      username: "{{ hostvars[inventory_hostname]['username']}}"
-      password: "{{ hostvars[inventory_hostname]['password']}}"
+      username: "{{ hostvars[inventory_hostname]['ansible_ssh_user']}}"
+      password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass']}}"
       deviceType: "{{ hostvars[inventory_hostname]['deviceType']}}"
       outputfile: "./results/cnos_vlag_{{ inventory_hostname }}_output.txt"
       vlagArg1: "enable"
@@ -93,8 +93,8 @@ Tasks : The following are examples of using the module cnos_vlag. These are writ
 - name: Test Vlag - autorecovery
   cnos_vlag:
       host: "{{ inventory_hostname }}"
-      username: "{{ hostvars[inventory_hostname]['username']}}"
-      password: "{{ hostvars[inventory_hostname]['password']}}"
+      username: "{{ hostvars[inventory_hostname]['ansible_ssh_user']}}"
+      password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass']}}"
       deviceType: "{{ hostvars[inventory_hostname]['deviceType']}}"
       outputfile: "./results/cnos_vlag_{{ inventory_hostname }}_output.txt"
       vlagArg1: "auto-recovery"
@@ -103,8 +103,8 @@ Tasks : The following are examples of using the module cnos_vlag. These are writ
 - name: Test Vlag - config-consistency
   cnos_vlag:
       host: "{{ inventory_hostname }}"
-      username: "{{ hostvars[inventory_hostname]['username']}}"
-      password: "{{ hostvars[inventory_hostname]['password']}}"
+      username: "{{ hostvars[inventory_hostname]['ansible_ssh_user']}}"
+      password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass']}}"
       deviceType: "{{ hostvars[inventory_hostname]['deviceType']}}"
       outputfile: "./results/cnos_vlag_{{ inventory_hostname }}_output.txt"
       vlagArg1: "config-consistency"
@@ -113,8 +113,8 @@ Tasks : The following are examples of using the module cnos_vlag. These are writ
 - name: Test Vlag - isl
   cnos_vlag:
       host: "{{ inventory_hostname }}"
-      username: "{{ hostvars[inventory_hostname]['username']}}"
-      password: "{{ hostvars[inventory_hostname]['password']}}"
+      username: "{{ hostvars[inventory_hostname]['ansible_ssh_user']}}"
+      password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass']}}"
       deviceType: "{{ hostvars[inventory_hostname]['deviceType']}}"
       outputfile: "./results/cnos_vlag_{{ inventory_hostname }}_output.txt"
       vlagArg1: "isl"
@@ -123,8 +123,8 @@ Tasks : The following are examples of using the module cnos_vlag. These are writ
 - name: Test Vlag  - mac-address-table
   cnos_vlag:
       host: "{{ inventory_hostname }}"
-      username: "{{ hostvars[inventory_hostname]['username']}}"
-      password: "{{ hostvars[inventory_hostname]['password']}}"
+      username: "{{ hostvars[inventory_hostname]['ansible_ssh_user']}}"
+      password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass']}}"
       deviceType: "{{ hostvars[inventory_hostname]['deviceType']}}"
       outputfile: "./results/cnos_vlag_{{ inventory_hostname }}_output.txt"
       vlagArg1: "mac-address-table"
@@ -132,8 +132,8 @@ Tasks : The following are examples of using the module cnos_vlag. These are writ
 - name: Test Vlag - peer-gateway
   cnos_vlag:
       host: "{{ inventory_hostname }}"
-      username: "{{ hostvars[inventory_hostname]['username']}}"
-      password: "{{ hostvars[inventory_hostname]['password']}}"
+      username: "{{ hostvars[inventory_hostname]['ansible_ssh_user']}}"
+      password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass']}}"
       deviceType: "{{ hostvars[inventory_hostname]['deviceType']}}"
       outputfile: "./results/cnos_vlag_{{ inventory_hostname }}_output.txt"
       vlagArg1: "peer-gateway"
@@ -141,8 +141,8 @@ Tasks : The following are examples of using the module cnos_vlag. These are writ
 - name: Test Vlag - priority
   cnos_vlag:
       host: "{{ inventory_hostname }}"
-      username: "{{ hostvars[inventory_hostname]['username']}}"
-      password: "{{ hostvars[inventory_hostname]['password']}}"
+      username: "{{ hostvars[inventory_hostname]['ansible_ssh_user']}}"
+      password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass']}}"
       deviceType: "{{ hostvars[inventory_hostname]['deviceType']}}"
       outputfile: "./results/cnos_vlag_{{ inventory_hostname }}_output.txt"
       vlagArg1: "priority"
@@ -151,8 +151,8 @@ Tasks : The following are examples of using the module cnos_vlag. These are writ
 - name: Test Vlag - startup-delay
   cnos_vlag:
       host: "{{ inventory_hostname }}"
-      username: "{{ hostvars[inventory_hostname]['username']}}"
-      password: "{{ hostvars[inventory_hostname]['password']}}"
+      username: "{{ hostvars[inventory_hostname]['ansible_ssh_user']}}"
+      password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass']}}"
       deviceType: "{{ hostvars[inventory_hostname]['deviceType']}}"
       outputfile: "./results/cnos_vlag_{{ inventory_hostname }}_output.txt"
       vlagArg1: "startup-delay"
@@ -161,8 +161,8 @@ Tasks : The following are examples of using the module cnos_vlag. These are writ
 - name: Test Vlag  - tier-id
   cnos_vlag:
       host: "{{ inventory_hostname }}"
-      username: "{{ hostvars[inventory_hostname]['username']}}"
-      password: "{{ hostvars[inventory_hostname]['password']}}"
+      username: "{{ hostvars[inventory_hostname]['ansible_ssh_user']}}"
+      password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass']}}"
       deviceType: "{{ hostvars[inventory_hostname]['deviceType']}}"
       outputfile: "./results/cnos_vlag_{{ inventory_hostname }}_output.txt"
       vlagArg1: "tier-id"
@@ -171,8 +171,8 @@ Tasks : The following are examples of using the module cnos_vlag. These are writ
 - name: Test Vlag - vrrp
   cnos_vlag:
       host: "{{ inventory_hostname }}"
-      username: "{{ hostvars[inventory_hostname]['username']}}"
-      password: "{{ hostvars[inventory_hostname]['password']}}"
+      username: "{{ hostvars[inventory_hostname]['ansible_ssh_user']}}"
+      password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass']}}"
       deviceType: "{{ hostvars[inventory_hostname]['deviceType']}}"
       outputfile: "./results/cnos_vlag_{{ inventory_hostname }}_output.txt"
       vlagArg1: "vrrp"
@@ -180,8 +180,8 @@ Tasks : The following are examples of using the module cnos_vlag. These are writ
 - name: Test Vlag - instance
   cnos_vlag:
       host: "{{ inventory_hostname }}"
-      username: "{{ hostvars[inventory_hostname]['username']}}"
-      password: "{{ hostvars[inventory_hostname]['password']}}"
+      username: "{{ hostvars[inventory_hostname]['ansible_ssh_user']}}"
+      password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass']}}"
       deviceType: "{{ hostvars[inventory_hostname]['deviceType']}}"
       outputfile: "./results/cnos_vlag_{{ inventory_hostname }}_output.txt"
       vlagArg1: "instance"
@@ -191,8 +191,8 @@ Tasks : The following are examples of using the module cnos_vlag. These are writ
 - name: Test Vlag - instance2
   cnos_vlag:
       host: "{{ inventory_hostname }}"
-      username: "{{ hostvars[inventory_hostname]['username']}}"
-      password: "{{ hostvars[inventory_hostname]['password']}}"
+      username: "{{ hostvars[inventory_hostname]['ansible_ssh_user']}}"
+      password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass']}}"
       deviceType: "{{ hostvars[inventory_hostname]['deviceType']}}"
       outputfile: "./results/cnos_vlag_{{ inventory_hostname }}_output.txt"
       vlagArg1: "instance"
@@ -201,8 +201,8 @@ Tasks : The following are examples of using the module cnos_vlag. These are writ
 - name: Test Vlag  - keepalive-attempts
   cnos_vlag:
       host: "{{ inventory_hostname }}"
-      username: "{{ hostvars[inventory_hostname]['username']}}"
-      password: "{{ hostvars[inventory_hostname]['password']}}"
+      username: "{{ hostvars[inventory_hostname]['ansible_ssh_user']}}"
+      password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass']}}"
       deviceType: "{{ hostvars[inventory_hostname]['deviceType']}}"
       outputfile: "./results/cnos_vlag_{{ inventory_hostname }}_output.txt"
       vlagArg1: "hlthchk"
@@ -212,8 +212,8 @@ Tasks : The following are examples of using the module cnos_vlag. These are writ
 - name: Test Vlag - keepalive-interval
   cnos_vlag:
       host: "{{ inventory_hostname }}"
-      username: "{{ hostvars[inventory_hostname]['username']}}"
-      password: "{{ hostvars[inventory_hostname]['password']}}"
+      username: "{{ hostvars[inventory_hostname]['ansible_ssh_user']}}"
+      password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass']}}"
       deviceType: "{{ hostvars[inventory_hostname]['deviceType']}}"
       outputfile: "./results/cnos_vlag_{{ inventory_hostname }}_output.txt"
       vlagArg1: "hlthchk"
@@ -223,8 +223,8 @@ Tasks : The following are examples of using the module cnos_vlag. These are writ
 - name: Test Vlag - retry-interval
   cnos_vlag:
       host: "{{ inventory_hostname }}"
-      username: "{{ hostvars[inventory_hostname]['username']}}"
-      password: "{{ hostvars[inventory_hostname]['password']}}"
+      username: "{{ hostvars[inventory_hostname]['ansible_ssh_user']}}"
+      password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass']}}"
       deviceType: "{{ hostvars[inventory_hostname]['deviceType']}}"
       outputfile: "./results/cnos_vlag_{{ inventory_hostname }}_output.txt"
       vlagArg1: "hlthchk"
@@ -234,8 +234,8 @@ Tasks : The following are examples of using the module cnos_vlag. These are writ
 - name: Test Vlag - peer ip
   cnos_vlag:
       host: "{{ inventory_hostname }}"
-      username: "{{ hostvars[inventory_hostname]['username']}}"
-      password: "{{ hostvars[inventory_hostname]['password']}}"
+      username: "{{ hostvars[inventory_hostname]['ansible_ssh_user']}}"
+      password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass']}}"
       deviceType: "{{ hostvars[inventory_hostname]['deviceType']}}"
       outputfile: "./results/cnos_vlag_{{ inventory_hostname }}_output.txt"
       vlagArg1: "hlthchk"
@@ -333,7 +333,7 @@ def main():
     # Go to config mode
     output = output + \
         cnos.waitForDeviceResponse(
-            "configure d\n", "(config)#", 2, remote_conn)
+            "configure device\n", "(config)#", 2, remote_conn)
 
     # Send the CLi command
     output = output + cnos.vlagConfig(

--- a/lib/ansible/modules/network/cnos/cnos_vlan.py
+++ b/lib/ansible/modules/network/cnos/cnos_vlan.py
@@ -33,7 +33,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = '''
 ---
 module: cnos_vlan
-author: "Dave Kasberg (@dkasberg)"
+author: "Anil Kumar Muraleedharan (@amuraleedhar)"
 short_description: Manage VLAN resources and attributes on devices running Lenovo CNOS
 description:
     - This module allows you to work with VLAN related configurations. The
@@ -87,8 +87,8 @@ Tasks: The following are examples of using the module cnos_vlan. These are writt
 - name: Test Vlan - Create a vlan, name it
   cnos_vlan:
       host: "{{ inventory_hostname }}"
-      username: "{{ hostvars[inventory_hostname]['username'] }}"
-      password: "{{ hostvars[inventory_hostname]['password'] }}"
+      username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+      password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
       deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
       enablePassword: "{{ hostvars[inventory_hostname]['enablePassword'] }}"
       outputfile: "./results/test_vlan_{{ inventory_hostname }}_output.txt"
@@ -99,8 +99,8 @@ Tasks: The following are examples of using the module cnos_vlan. These are writt
 - name: Test Vlan - Create a vlan, Flood configuration
   cnos_vlan:
       host: "{{ inventory_hostname }}"
-      username: "{{ hostvars[inventory_hostname]['username'] }}"
-      password: "{{ hostvars[inventory_hostname]['password'] }}"
+      username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+      password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
       deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
       enablePassword: "{{ hostvars[inventory_hostname]['enablePassword'] }}"
       outputfile: "./results/test_vlan_{{ inventory_hostname }}_output.txt"
@@ -111,8 +111,8 @@ Tasks: The following are examples of using the module cnos_vlan. These are writt
 - name: Test Vlan - Create a vlan, State configuration
   cnos_vlan:
       host: "{{ inventory_hostname }}"
-      username: "{{ hostvars[inventory_hostname]['username'] }}"
-      password: "{{ hostvars[inventory_hostname]['password'] }}"
+      username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+      password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
       deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
       enablePassword: "{{ hostvars[inventory_hostname]['enablePassword'] }}"
       outputfile: "./results/test_vlan_{{ inventory_hostname }}_output.txt"
@@ -123,8 +123,8 @@ Tasks: The following are examples of using the module cnos_vlan. These are writt
 - name: Test Vlan - VLAN Access map1
   cnos_vlan:
       host: "{{ inventory_hostname }}"
-      username: "{{ hostvars[inventory_hostname]['username'] }}"
-      password: "{{ hostvars[inventory_hostname]['password'] }}"
+      username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+      password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
       deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
       enablePassword: "{{ hostvars[inventory_hostname]['enablePassword'] }}"
       outputfile: "./results/test_vlan_{{ inventory_hostname }}_output.txt"
@@ -135,8 +135,8 @@ Tasks: The following are examples of using the module cnos_vlan. These are writt
 - name: Test Vlan - VLAN Accep Map2
   cnos_vlan:
       host: "{{ inventory_hostname }}"
-      username: "{{ hostvars[inventory_hostname]['username'] }}"
-      password: "{{ hostvars[inventory_hostname]['password'] }}"
+      username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+      password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
       deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
       enablePassword: "{{ hostvars[inventory_hostname]['enablePassword'] }}"
       outputfile: "./results/test_vlan_{{ inventory_hostname }}_output.txt"
@@ -148,8 +148,8 @@ Tasks: The following are examples of using the module cnos_vlan. These are writt
 - name: Test Vlan - ip igmp snooping query interval
   cnos_vlan:
       host: "{{ inventory_hostname }}"
-      username: "{{ hostvars[inventory_hostname]['username'] }}"
-      password: "{{ hostvars[inventory_hostname]['password'] }}"
+      username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+      password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
       deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
       enablePassword: "{{ hostvars[inventory_hostname]['enablePassword'] }}"
       outputfile: "./results/test_vlan_{{ inventory_hostname }}_output.txt"
@@ -161,8 +161,8 @@ Tasks: The following are examples of using the module cnos_vlan. These are writt
 - name: Test Vlan - ip igmp snooping mrouter interface port-aggregation 23
   cnos_vlan:
       host: "{{ inventory_hostname }}"
-      username: "{{ hostvars[inventory_hostname]['username'] }}"
-      password: "{{ hostvars[inventory_hostname]['password'] }}"
+      username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+      password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
       deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
       enablePassword: "{{ hostvars[inventory_hostname]['enablePassword'] }}"
       outputfile: "./results/test_vlan_{{ inventory_hostname }}_output.txt"
@@ -266,7 +266,7 @@ def main():
 
     # Go to config mode
     output = output + \
-        cnos.waitForDeviceResponse("conf d\n", "(config)#", 2, remote_conn)
+        cnos.waitForDeviceResponse("configure device\n", "(config)#", 2, remote_conn)
 
     # Send the CLi command
     output = output + \

--- a/lib/ansible/plugins/action/enos_config.py
+++ b/lib/ansible/plugins/action/enos_config.py
@@ -2,6 +2,8 @@
 # Copyright (C) 2017 Lenovo.
 #
 # GNU General Public License v3.0+
+# Copyright (C) 2017 Lenovo.
+# All rights reserved.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/lib/ansible/plugins/terminal/enos.py
+++ b/lib/ansible/plugins/terminal/enos.py
@@ -2,6 +2,8 @@
 # Copyright (C) 2017 Lenovo.
 #
 # GNU General Public License v3.0+
+# Copyright (C) 2017 Lenovo.
+# All rights reserved.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of


### PR DESCRIPTION
##### SUMMARY
Starting with our recent CNOS release version 10.7, we have moved certain CLI keywords to match with Industry Standard CLI (ISCLI) keywords.  For backward compatibility,  old CLI keywords will continue to work for next one or two CNOS releases with a condition that “command acronyms” of old CLI keywords, cannot be used. For eg: Use “display version” instead of “disp ver”. This PR is to expand the acronymns if they are present in the python code

This has to be backported to 2.5 as well.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib\ansible\modules\network\cnos\cnos_backup.py
lib\ansible\modules\network\cnos\cnos_bgp.py
lib\ansible\modules\network\cnos\cnos_conditional_command.py
lib\ansible\modules\network\cnos\cnos_conditional_template.py
lib\ansible\modules\network\cnos\cnos_factory.py
lib\ansible\modules\network\cnos\cnos_image.py
lib\ansible\modules\network\cnos\cnos_interface.py
lib\ansible\modules\network\cnos\cnos_portchannel.py
lib\ansible\modules\network\cnos\cnos_reload.py
lib\ansible\modules\network\cnos\cnos_rollback.py
lib\ansible\modules\network\cnos\cnos_save.py
lib\ansible\modules\network\cnos\cnos_showrun.py
lib\ansible\modules\network\cnos\cnos_template.py
lib\ansible\modules\network\cnos\cnos_vlag.py
lib\ansible\modules\network\cnos\cnos_vlan.py

##### ANSIBLE VERSION
ansible 2.6.0
config file = /etc/ansible/ansible.cfg
configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/sha re/ansible/plugins/modules']
ansible python module location = /usr/local/lib/python2.7/dist-packages/ansibl e-2.6.0-py2.7.egg/ansible
executable location = /usr/local/bin/ansible
python version = 2.7.6 (default, Nov 23 2017, 15:49:48) [GCC 4.8.4]

##### ADDITIONAL INFORMATION
Tried to change the documentation where the user has to use anisble_ssh_user and ansible_user_pass instead of username and password.