### PR TITLE
Make it clear that recurse only applies to state=directory

### DIFF
--- a/lib/ansible/modules/files/file.py
+++ b/lib/ansible/modules/files/file.py
@@ -58,7 +58,7 @@ options:
         created (C(path)) which is how the UNIX command C(ln -s SRC DEST) treats relative paths.
   recurse:
     description:
-      - recursively set the specified file attributes (applies only to directories)
+      - recursively set the specified file attributes (applies only to C(state=directory))
     type: bool
     default: 'no'
     version_added: "1.1"


### PR DESCRIPTION
+label: docsite_pr

##### SUMMARY
This would otherwise cause confusion as it could be interpreted as only changing attributes for directories (and not files inside).

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
file

##### ANSIBLE VERSION
```
ansible 2.5.2
  config file = /home/user/tmp/ansible.cfg
  configured module search path = [u'/home/user/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.14 (default, Apr 16 2018, 20:08:15) [GCC 7.3.1 20180406]
```