### PR TITLE
fixed passing non-default base_url from explicitly set cloud_environment

### DIFF
--- a/lib/ansible/module_utils/azure_rm_common.py
+++ b/lib/ansible/module_utils/azure_rm_common.py
@@ -870,16 +870,16 @@ class AzureRMModuleBase(object):
 
         client_argspec = inspect.getargspec(client_type.__init__)
 
+        if not base_url:
+            # most things are resource_manager, don't make everyone specify
+            base_url = self._cloud_environment.endpoints.resource_manager
+
         client_kwargs = dict(credentials=self.azure_credentials, subscription_id=self.subscription_id, base_url=base_url)
 
         api_profile_dict = {}
 
         if self.api_profile:
             api_profile_dict = self.get_api_profile(client_type.__name__, self.api_profile)
-
-        if not base_url:
-            # most things are resource_manager, don't make everyone specify
-            client_kwargs['base_url'] = self._cloud_environment.endpoints.resource_manager
 
         # unversioned clients won't accept profile; only send it if necessary
         # clients without a version specified in the profile will use the default

--- a/lib/ansible/module_utils/azure_rm_common.py
+++ b/lib/ansible/module_utils/azure_rm_common.py
@@ -879,7 +879,7 @@ class AzureRMModuleBase(object):
 
         if not base_url:
             # most things are resource_manager, don't make everyone specify
-            base_url = self._cloud_environment.endpoints.resource_manager
+            client_kwargs['base_url'] = self._cloud_environment.endpoints.resource_manager
 
         # unversioned clients won't accept profile; only send it if necessary
         # clients without a version specified in the profile will use the default


### PR DESCRIPTION
##### SUMMARY
Fixes an issue with non-default cloud_environments (e.g. cloud_environment=AzureGermanCloud) trying to use default http://management.azure.com endpoint and failing with 'subscription not found' for some of the resources.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
Azure generic module

##### ANSIBLE VERSION
```
ansible 2.6.0 (devel 4faa94a2e9) last updated 2018/05/16 10:40:41 (GMT +200)
  config file = /Users/timur/work/dhl/dhl-parcel-platform/ansible.cfg
  configured module search path = [u'/Users/timur/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/timur/work/dhl/ansible/lib/ansible
  executable location = /Users/timur/work/dhl/ansible/bin/ansible
  python version = 2.7.15 (default, May  1 2018, 16:44:08) [GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.1)]

```

##### ADDITIONAL INFORMATION
when ~/.azure/credentials specified like that

```
[default]
subscription_id=.....
ad_user=....
tenant=....
password=...
cloud_environment=AzureGermanCloud
```

correct base_url from AzureGermanCloud was not passed to the created modules, and http://management.azure.com was used instead
default http://management.azure.com knows nothing about German subscriptions, producing SubscriptionNotFound errors when creating e.g. security groups
it is unclear why some resources it  works (e.g. with virtual machines) but I'd leave this to Azure developers