### PR TITLE
save_snapshot_locally nxos_snapshot

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_snapshot.py
+++ b/lib/ansible/modules/network/nxos/nxos_snapshot.py
@@ -372,7 +372,7 @@ def main():
                 result['commands'] = action_results
                 result['changed'] = True
 
-            if action == 'create' and module.params['path']:
+            if action == 'create' and module.params['path'] and module.params['save_snapshot_locally']:
                 command = 'show snapshot | include {}'.format(module.params['snapshot_name'])
                 content = execute_show_command(command, module)[0]
                 if content:

--- a/test/integration/targets/nxos_snapshot/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_snapshot/tests/common/sanity.yaml
@@ -13,6 +13,7 @@
       action: create
       snapshot_name: test_snapshot1
       description: Ansible
+      save_snapshot_locally: true
       provider: "{{ connection }}"
 
   - name: create another snapshot
@@ -24,6 +25,7 @@
       show_command: show ip interface brief
       row_id: ROW_intf
       element_key1: intf-name
+      save_snapshot_locally: true
       provider: "{{ connection }}"
 
   - name: compare snapshots


### PR DESCRIPTION
Signed-off-by: Trishna Guha <trishnaguha17@gmail.com>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
fixes https://github.com/ansible/ansible/issues/40113
As per doc, `save_snapshot_locally` should be true in order to locally save snapshot created.

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
modules/network/nxos/nxos_snapshot.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```