### PR TITLE
Omit token should also be removed recursively for lists in tasks args

### DIFF
--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -41,17 +41,11 @@ def remove_omit(task_args, omit_token):
     Remove args with a value equal to the ``omit_token`` recursively
     to align with now having suboptions in the argument_spec
     '''
-    new_args = {}
-
-    for i in iteritems(task_args):
-        if i[1] == omit_token:
-            continue
-        elif isinstance(i[1], dict):
-            new_args[i[0]] = remove_omit(i[1], omit_token)
-        else:
-            new_args[i[0]] = i[1]
-
-    return new_args
+    if isinstance(task_args, list):
+        return [ remove_omit(elem, omit_token) for elem in task_args if elem != omit_token ]
+    if isinstance(task_args, dict):
+        return { key : remove_omit(val, omit_token) for key, val in task_args.items() if val != omit_token }
+    return task_args
 
 
 class TaskExecutor:


### PR DESCRIPTION
Remove args with a value equal to the ``omit_token`` recursively - for dicts and lists.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Many modules requires args to be passed as a list: ie. ec2 volumes. There is no way to omit, element of dictionary if it is inside list. 
This also will be really usable for `uri` module and json body args.
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
```
- ec2:
    state: present
    vpc_subnet_id: "{{ vpc_subnet_id }}"
    volumes:
      - device_name: "{{ device_name }}"
        volume_size: "{{ volume_size }}"
        volume_type: "{{ volume_type | default('gp2') }}"
        iops: "{{ iops | default(omit)  }}"
```
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.2
```
