### PR TITLE
cloudstack: added fetch_list=True where appropriate

### DIFF
--- a/lib/ansible/modules/cloud/cloudstack/cs_account.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_account.py
@@ -192,11 +192,12 @@ class AnsibleCloudStackAccount(AnsibleCloudStack):
             args = {
                 'listall': True,
                 'domainid': self.get_domain(key='id'),
+                'fetch_list': True,
             }
             accounts = self.query_api('listAccounts', **args)
             if accounts:
                 account_name = self.module.params.get('name')
-                for a in accounts['account']:
+                for a in accounts:
                     if account_name == a['name']:
                         self.account = a
                         break

--- a/lib/ansible/modules/cloud/cloudstack/cs_configuration.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_configuration.py
@@ -216,10 +216,11 @@ class AnsibleCloudStackConfiguration(AnsibleCloudStack):
     def get_configuration(self):
         configuration = None
         args = self._get_common_configuration_args()
+        args['fetch_list'] = True
         configurations = self.query_api('listConfigurations', **args)
         if not configurations:
             self.module.fail_json(msg="Configuration %s not found." % args['name'])
-        for config in configurations['configuration']:
+        for config in configurations:
             if args['name'] == config['name']:
                 configuration = config
         return configuration

--- a/lib/ansible/modules/cloud/cloudstack/cs_domain.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_domain.py
@@ -141,12 +141,13 @@ class AnsibleCloudStackDomain(AnsibleCloudStack):
             path = "root/" + path
 
         args = {
-            'listall': True
+            'listall': True,
+            'fetch_list': True,
         }
 
         domains = self.query_api('listDomains', **args)
         if domains:
-            for d in domains['domain']:
+            for d in domains:
                 if path == d['path'].lower():
                     return d
         return None

--- a/lib/ansible/modules/cloud/cloudstack/cs_firewall.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_firewall.py
@@ -242,7 +242,8 @@ class AnsibleCloudStackFirewall(AnsibleCloudStack):
             args = {
                 'account': self.get_account('name'),
                 'domainid': self.get_domain('id'),
-                'projectid': self.get_project('id')
+                'projectid': self.get_project('id'),
+                'fetch_list': True,
             }
             if fw_type == 'egress':
                 args['networkid'] = self.get_network(key='id')
@@ -255,8 +256,8 @@ class AnsibleCloudStackFirewall(AnsibleCloudStack):
                     self.module.fail_json(msg="missing required argument for type ingress: ip_address")
                 firewall_rules = self.query_api('listFirewallRules', **args)
 
-            if firewall_rules and 'firewallrule' in firewall_rules:
-                for rule in firewall_rules['firewallrule']:
+            if firewall_rules:
+                for rule in firewall_rules:
                     type_match = self._type_cidrs_match(rule, cidrs)
 
                     protocol_match = (

--- a/lib/ansible/modules/cloud/cloudstack/cs_host.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_host.py
@@ -427,10 +427,11 @@ class AnsibleCloudStackHost(AnsibleCloudStack):
         name = self.module.params.get('name')
         args = {
             'zoneid': self.get_zone(key='id'),
+            'fetch_list': True,
         }
         res = self.query_api('listHosts', **args)
         if res:
-            for h in res['host']:
+            for h in res:
                 if name in [h['ipaddress'], h['name']]:
                     self.host = h
         return self.host

--- a/lib/ansible/modules/cloud/cloudstack/cs_instance.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_instance.py
@@ -411,6 +411,7 @@ class AnsibleCloudStackInstance(AnsibleCloudStack):
             'projectid': self.get_project(key='id'),
             'zoneid': self.get_zone(key='id'),
             'isrecursive': True,
+            'fetch_list': True,
         }
 
         if template:
@@ -419,9 +420,10 @@ class AnsibleCloudStackInstance(AnsibleCloudStack):
 
             rootdisksize = self.module.params.get('root_disk_size')
             args['templatefilter'] = self.module.params.get('template_filter')
+            args['fetch_list'] = True
             templates = self.query_api('listTemplates', **args)
             if templates:
-                for t in templates['template']:
+                for t in templates:
                     if template in [t['displaytext'], t['name'], t['id']]:
                         if rootdisksize and t['size'] > rootdisksize * 1024 ** 3:
                             continue
@@ -440,9 +442,10 @@ class AnsibleCloudStackInstance(AnsibleCloudStack):
                 return self._get_by_key(key, self.iso)
 
             args['isofilter'] = self.module.params.get('template_filter')
+            args['fetch_list'] = True
             isos = self.query_api('listIsos', **args)
             if isos:
-                for i in isos['iso']:
+                for i in isos:
                     if iso in [i['displaytext'], i['name'], i['id']]:
                         self.iso = i
                         return self._get_by_key(key, self.iso)
@@ -567,6 +570,7 @@ class AnsibleCloudStackInstance(AnsibleCloudStack):
             'domainid': self.get_domain(key='id'),
             'projectid': self.get_project(key='id'),
             'zoneid': self.get_zone(key='id'),
+            'fetch_list': True,
         }
         networks = self.query_api('listNetworks', **args)
         if not networks:
@@ -575,7 +579,7 @@ class AnsibleCloudStackInstance(AnsibleCloudStack):
         network_ids = []
         network_displaytexts = []
         for network_name in network_names:
-            for n in networks['network']:
+            for n in networks:
                 if network_name in [n['displaytext'], n['name'], n['id']]:
                     network_ids.append(n['id'])
                     network_displaytexts.append(n['name'])

--- a/lib/ansible/modules/cloud/cloudstack/cs_instance_facts.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_instance_facts.py
@@ -225,11 +225,12 @@ class AnsibleCloudStackInstanceFacts(AnsibleCloudStack):
                 'domainid': self.get_domain(key='id'),
                 'projectid': self.get_project(key='id'),
                 'virtualmachineid': instance['id'],
+                'fetch_list': True,
             }
 
             volumes = self.query_api('listVolumes', **args)
             if volumes:
-                for vol in volumes['volume']:
+                for vol in volumes:
                     volume_details.append({'size': vol['size'], 'type': vol['type'], 'name': vol['name']})
         return volume_details
 

--- a/lib/ansible/modules/cloud/cloudstack/cs_instancegroup.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_instancegroup.py
@@ -124,10 +124,11 @@ class AnsibleCloudStackInstanceGroup(AnsibleCloudStack):
             'account': self.get_account('name'),
             'domainid': self.get_domain('id'),
             'projectid': self.get_project('id'),
+            'fetch_list': True,
         }
         instance_groups = self.query_api('listInstanceGroups', **args)
         if instance_groups:
-            for g in instance_groups['instancegroup']:
+            for g in instance_groups:
                 if name in [g['name'], g['id']]:
                     self.instance_group = g
                     break

--- a/lib/ansible/modules/cloud/cloudstack/cs_network.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_network.py
@@ -386,12 +386,13 @@ class AnsibleCloudStackNetwork(AnsibleCloudStack):
             self.module.fail_json(msg="missing required arguments: network_offering")
 
         args = {
-            'zoneid': self.get_zone(key='id')
+            'zoneid': self.get_zone(key='id'),
+            'fetch_list': True,
         }
 
         network_offerings = self.query_api('listNetworkOfferings', **args)
         if network_offerings:
-            for no in network_offerings['networkoffering']:
+            for no in network_offerings:
                 if network_offering in [no['name'], no['displaytext'], no['id']]:
                     return self._get_by_key(key, no)
         self.module.fail_json(msg="Network offering '%s' not found" % network_offering)
@@ -414,10 +415,11 @@ class AnsibleCloudStackNetwork(AnsibleCloudStack):
                 'account': self.get_account(key='name'),
                 'domainid': self.get_domain(key='id'),
                 'vpcid': self.get_vpc(key='id'),
+                'fetch_list': True,
             }
             networks = self.query_api('listNetworks', **args)
             if networks:
-                for n in networks['network']:
+                for n in networks:
                     if network in [n['name'], n['displaytext'], n['id']]:
                         self.network = n
                         self.network['acl'] = self.get_network_acl(key='name', acl_id=n.get('aclid'))

--- a/lib/ansible/modules/cloud/cloudstack/cs_project.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_project.py
@@ -153,11 +153,12 @@ class AnsibleCloudStackProject(AnsibleCloudStack):
 
             args = {
                 'account': self.get_account(key='name'),
-                'domainid': self.get_domain(key='id')
+                'domainid': self.get_domain(key='id'),
+                'fetch_list': True,
             }
             projects = self.query_api('listProjects', **args)
             if projects:
-                for p in projects['project']:
+                for p in projects:
                     if project.lower() in [p['name'].lower(), p['id']]:
                         self.project = p
                         break

--- a/lib/ansible/modules/cloud/cloudstack/cs_router.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_router.py
@@ -211,7 +211,8 @@ class AnsibleCloudStackRouter(AnsibleCloudStack):
                 'projectid': self.get_project(key='id'),
                 'account': self.get_account(key='name'),
                 'domainid': self.get_domain(key='id'),
-                'listall': True
+                'listall': True,
+                'fetch_list': True,
             }
 
             if self.module.params.get('zone'):
@@ -219,7 +220,7 @@ class AnsibleCloudStackRouter(AnsibleCloudStack):
 
             routers = self.query_api('listRouters', **args)
             if routers:
-                for r in routers['router']:
+                for r in routers:
                     if router.lower() in [r['name'].lower(), r['id']]:
                         self.router = r
                         break

--- a/lib/ansible/modules/cloud/cloudstack/cs_template.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_template.py
@@ -422,11 +422,12 @@ class AnsibleCloudStackTemplate(AnsibleCloudStack):
             'account': self.get_account(key='name'),
             'domainid': self.get_domain(key='id'),
             'projectid': self.get_project(key='id'),
-            'volumeid': self.get_root_volume('id')
+            'volumeid': self.get_root_volume('id'),
+            'fetch_list': True,
         }
         snapshots = self.query_api('listSnapshots', **args)
         if snapshots:
-            for s in snapshots['snapshot']:
+            for s in snapshots:
                 if snapshot in [s['name'], s['id']]:
                     return self._get_by_key(key, s)
         self.module.fail_json(msg="Snapshot '%s' not found" % snapshot)

--- a/lib/ansible/modules/cloud/cloudstack/cs_user.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_user.py
@@ -218,13 +218,14 @@ class AnsibleCloudStackUser(AnsibleCloudStack):
         if not self.user:
             args = {
                 'domainid': self.get_domain('id'),
+                'fetch_list': True,
             }
 
             users = self.query_api('listUsers', **args)
 
             if users:
                 user_name = self.module.params.get('username')
-                for u in users['user']:
+                for u in users:
                     if user_name.lower() == u['username'].lower():
                         self.user = u
                         break

--- a/lib/ansible/modules/cloud/cloudstack/cs_volume.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_volume.py
@@ -245,11 +245,12 @@ class AnsibleCloudStackVolume(AnsibleCloudStack):
                 'zoneid': self.get_zone(key='id'),
                 'displayvolume': self.module.params.get('display_volume'),
                 'type': 'DATADISK',
+                'fetch_list': True,
             }
             volumes = self.query_api('listVolumes', **args)
             if volumes:
                 volume_name = self.module.params.get('name')
-                for v in volumes['volume']:
+                for v in volumes:
                     if volume_name.lower() == v['name'].lower():
                         self.volume = v
                         break

--- a/lib/ansible/modules/cloud/cloudstack/cs_vpc.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_vpc.py
@@ -222,11 +222,12 @@ class AnsibleCloudStackVpc(AnsibleCloudStack):
             'domainid': self.get_domain(key='id'),
             'projectid': self.get_project(key='id'),
             'zoneid': self.get_zone(key='id'),
+            'fetch_list': True,
         }
         vpcs = self.query_api('listVPCs', **args)
         if vpcs:
             vpc_name = self.module.params.get('name')
-            for v in vpcs['vpc']:
+            for v in vpcs:
                 if vpc_name in [v['name'], v['displaytext'], v['id']]:
                     # Fail if the identifyer matches more than one VPC
                     if self.vpc:

--- a/lib/ansible/modules/cloud/cloudstack/cs_vpn_connection.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_vpn_connection.py
@@ -206,13 +206,14 @@ class AnsibleCloudStackVpnConnection(AnsibleCloudStack):
         args = {
             'account': self.get_account(key='name'),
             'domainid': self.get_domain(key='id'),
-            'projectid': self.get_project(key='id')
+            'projectid': self.get_project(key='id'),
+            'fetch_list': True,
         }
 
         vpn_customer_gateway = identifier or self.module.params.get('vpn_customer_gateway')
         vcgws = self.query_api('listVpnCustomerGateways', **args)
         if vcgws:
-            for vcgw in vcgws['vpncustomergateway']:
+            for vcgw in vcgws:
                 if vpn_customer_gateway.lower() in [vcgw['id'], vcgw['name'].lower()]:
                     self.vpn_customer_gateway = vcgw
                     return self._get_by_key(key, self.vpn_customer_gateway)

--- a/lib/ansible/modules/cloud/cloudstack/cs_vpn_customer_gateway.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_vpn_customer_gateway.py
@@ -218,12 +218,13 @@ class AnsibleCloudStackVpnCustomerGateway(AnsibleCloudStack):
         args = {
             'account': self.get_account(key='name'),
             'domainid': self.get_domain(key='id'),
-            'projectid': self.get_project(key='id')
+            'projectid': self.get_project(key='id'),
+            'fetch_list': True,
         }
         vpn_customer_gateway = self.module.params.get('name')
         vpn_customer_gateways = self.query_api('listVpnCustomerGateways', **args)
         if vpn_customer_gateways:
-            for vgw in vpn_customer_gateways['vpncustomergateway']:
+            for vgw in vpn_customer_gateways:
                 if vpn_customer_gateway.lower() in [vgw['id'], vgw['name'].lower()]:
                     return vgw
 


### PR DESCRIPTION
##### SUMMARY
Further updates to the cloudstack module to enable automatic paging from the cs module. Previous work at #40018 

##### ISSUE TYPE
 - Feature Pull Request
##### COMPONENT NAME

cloudstack

##### ANSIBLE VERSION

ansible 2.6.0
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Apr 11 2018, 07:36:10) [GCC 4.8.5 20150623 (Red Hat 4.8.5-28)]

##### ADDITIONAL INFORMATION

Having reviewed the cloudstack module files I've only added the fetch_list argument where appropriate, for example, where a single object is requested from the API, or only the first object is used by only referencing the first entry in an array, fetch_list has not be added. Where a complete list is requested, and iterated, fetch_list has been added.

In some cases where there is potential for longer lists to be generated, but with specific arguments, I've also added fetch_list.





