### PR TITLE
SSH key path option added to netconf_config.py

### DIFF
--- a/lib/ansible/modules/network/netconf/netconf_config.py
+++ b/lib/ansible/modules/network/netconf/netconf_config.py
@@ -222,7 +222,7 @@ def main():
             port=dict(type='int', default=830),
 
             username=dict(type='str', no_log=True),
-            password=dict(type='str', no_log=True),
+            password=dict(type='str', required=False, no_log=True),
 
             hostkey_verify=dict(type='bool', default=True),
             look_for_keys=dict(type='bool', default=True),
@@ -230,7 +230,7 @@ def main():
             allow_agent=dict(type='bool', default=True),
             key_filename=dict(type='path', required=False),
         ),
-        mutually_exclusive=[('xml', 'src')]
+        mutually_exclusive=[('xml', 'src'), ('password', 'key_filename')]
     )
 
     if not module._socket_path and not HAS_NCCLIENT:

--- a/lib/ansible/modules/network/netconf/netconf_config.py
+++ b/lib/ansible/modules/network/netconf/netconf_config.py
@@ -85,7 +85,7 @@ options:
   password:
     description:
      - password of the user to authenticate with
-    required: true
+    required: false
   xml:
     description:
      - the XML content to send to the device
@@ -222,7 +222,7 @@ def main():
             port=dict(type='int', default=830),
 
             username=dict(type='str', no_log=True),
-            password=dict(type='str', required=False, no_log=True),
+            password=dict(type='str', no_log=True),
 
             hostkey_verify=dict(type='bool', default=True),
             look_for_keys=dict(type='bool', default=True),

--- a/lib/ansible/modules/network/netconf/netconf_config.py
+++ b/lib/ansible/modules/network/netconf/netconf_config.py
@@ -58,6 +58,12 @@ options:
     default: true
     required: false
     version_added: "2.4"
+  key_filename:
+    description:
+     - if true, sets the path to ssh key to be used to connect to host
+     - if false, use default usual ssh keys (e.g. ~/.ssh/id_*)
+    default: false
+    required: false
   datastore:
     description:
      - auto, uses candidate and fallback to running
@@ -223,6 +229,7 @@ def main():
             look_for_keys=dict(type='bool', default=True),
 
             allow_agent=dict(type='bool', default=True),
+            key_filename=dict(type='path', required=False),
         ),
         mutually_exclusive=[('xml', 'src')]
     )
@@ -254,6 +261,7 @@ def main():
             look_for_keys=module.params['look_for_keys'],
             username=module.params['username'],
             password=module.params['password'],
+            key_filename=module.params['key_filename'],
         )
 
         try:

--- a/lib/ansible/modules/network/netconf/netconf_config.py
+++ b/lib/ansible/modules/network/netconf/netconf_config.py
@@ -60,10 +60,9 @@ options:
     version_added: "2.4"
   key_filename:
     description:
-     - if true, sets the path to ssh key to be used to connect to host
-     - if false, use default usual ssh keys (e.g. ~/.ssh/id_*)
-    default: false
+     - Specifies the path to ssh key to be used to connect to host
     required: false
+    version_added: "2.6"
   datastore:
     description:
      - auto, uses candidate and fallback to running

--- a/lib/ansible/modules/network/netconf/netconf_config.py
+++ b/lib/ansible/modules/network/netconf/netconf_config.py
@@ -149,6 +149,13 @@ EXAMPLES = '''
             </system>
         </config>
 
+- name: Send XML Template Payload
+  netconf_config:
+    host: 10.0.0.1
+    username: admin
+    key_filename: /home/admin/.ssh/privatekeyfile
+    src: my_xml_template.j2
+
 '''
 
 RETURN = '''

--- a/lib/ansible/modules/network/netconf/netconf_config.py
+++ b/lib/ansible/modules/network/netconf/netconf_config.py
@@ -62,7 +62,7 @@ options:
     description:
      - Specifies the path to ssh key to be used to connect to host
     required: false
-    version_added: "2.6"
+    version_added: "2.7"
   datastore:
     description:
      - auto, uses candidate and fallback to running


### PR DESCRIPTION
##### SUMMARY
SSH key path option added to netconf_config module in order to specify a specific SSH key to be used per host.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
module netconf_config.py

##### ANSIBLE VERSION
2.5.2

##### ADDITIONAL INFORMATION
key_filename option currently already exists for NCCLIENT but is not supported by netconf_config.
