### PR TITLE
ios_facts: Add check to skip lldp neighbors if lldp doesn't exist or …

### DIFF
--- a/lib/ansible/module_utils/network/ios/ios.py
+++ b/lib/ansible/module_utils/network/ios/ios.py
@@ -29,7 +29,7 @@ import json
 from ansible.module_utils._text import to_text
 from ansible.module_utils.basic import env_fallback, return_values
 from ansible.module_utils.network.common.utils import to_list, ComplexList
-from ansible.module_utils.connection import Connection
+from ansible.module_utils.connection import Connection, ConnectionError
 
 _DEVICE_CONFIGS = {}
 
@@ -144,7 +144,13 @@ def run_commands(module, commands, check_rc=True):
             prompt = None
             answer = None
 
-        out = connection.get(command, prompt, answer)
+        try:
+            out = connection.get(command, prompt, answer)
+        except ConnectionError as e:
+            if check_rc:
+                raise
+            else:
+                out = e
 
         try:
             out = to_text(out, errors='surrogate_or_strict')

--- a/lib/ansible/modules/network/ios/ios_facts.py
+++ b/lib/ansible/modules/network/ios/ios_facts.py
@@ -281,7 +281,9 @@ class Interfaces(FactsBase):
             self.populate_ipv6_interfaces(data)
 
         data = self.responses[3]
-        if data:
+        lldp_errs = ['Invalid input', 'LLDP is not enabled']
+
+        if data and not any(err in data for err in lldp_errs):
             neighbors = self.run(['show lldp neighbors detail'])
             if neighbors:
                 self.facts['neighbors'] = self.parse_neighbors(neighbors[0])


### PR DESCRIPTION
…isn't enabled. (#40109)

* Add check to skip lldp neighbors if lldp doesn't exist or isn't enabled.

* Re-enable check_rc on ios' run_commands

(cherry picked from commit 39bed45bafb3032ab9f482f87634e69b8259a17f)

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
ios_facts

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```
