### PR TITLE
Network requirements to be installed by ansible-test (#40042)

### DIFF
--- a/test/runner/requirements/network-integration.txt
+++ b/test/runner/requirements/network-integration.txt
@@ -3,3 +3,6 @@ jinja2
 junit-xml
 paramiko
 pyyaml
+pexpect # for _user test
+ncclient # for Junos
+jxmlease # for Junos


### PR DESCRIPTION
##### SUMMARY

Previously the test framework (DCI, Zuul) were installing the various
dependencies, this meant the list of what was required was duplicated.

Having everything defined in ansible-test makes it easier for people to
run tests locally.

Also this allows the test to work correctly on Python 2 & Python 3
(cherry picked from commit 27942d937f8a4ff6f2e05fe8d989949d8eb50d72)

##### ISSUE TYPE
 - Bugfix Pull Request

