### PR TITLE
add SVI example for Cisco IOS/IOS-XE platform (#40021)

### DIFF
--- a/lib/ansible/modules/network/ios/ios_l3_interface.py
+++ b/lib/ansible/modules/network/ios/ios_l3_interface.py
@@ -72,6 +72,11 @@ EXAMPLES = """
     ipv4: dhcp
     ipv6: dhcp
 
+- name: Set interface Vlan1 (SVI) IPv4 address
+  ios_l3_interface:
+    name: Vlan1
+    ipv4: 192.168.0.5/24
+
 - name: Set IP addresses on aggregate
   ios_l3_interface:
     aggregate:


### PR DESCRIPTION
on networktocode slack there was a user that wanted an example of how to add a switch vlan interface.  This will work and was tested on a 3850 cisco ios switch
(cherry picked from commit 0dc73e782278bf507a3e40898bda96e6c47c9b20)

##### SUMMARY
Adds another example to the network module docs.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
docs.ansible.com

##### ANSIBLE VERSION
2.5
