### PR TITLE
Fix junos_config confirm timeout issue (#40238)

### DIFF
--- a/changelogs/fragments/junos_config_confirm_issue.yaml
+++ b/changelogs/fragments/junos_config_confirm_issue.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- Fix junos_config confirm timeout issue (https://github.com/ansible/ansible/pull/40238)

--- a/lib/ansible/modules/network/junos/junos_config.py
+++ b/lib/ansible/modules/network/junos/junos_config.py
@@ -199,7 +199,7 @@ from ansible.module_utils.network.junos.junos import get_diff, load_config, get_
 from ansible.module_utils.network.junos.junos import commit_configuration, discard_changes, locked_config
 from ansible.module_utils.network.junos.junos import junos_argument_spec, load_configuration, get_connection, tostring
 from ansible.module_utils.six import string_types
-from ansible.module_utils._text import to_native
+from ansible.module_utils._text import to_native, to_text
 
 try:
     from lxml.etree import Element, fromstring
@@ -377,10 +377,11 @@ def main():
                             'comment': module.params['comment']
                         }
 
-                        if module.params['confirm'] > 0:
+                        confirm = module.params['confirm']
+                        if confirm > 0:
                             kwargs.update({
                                 'confirm': True,
-                                'confirm_timeout': module.params['confirm']
+                                'confirm_timeout': to_text(confirm, errors='surrogate_then_replace')
                             })
                         commit_configuration(module, **kwargs)
                     else:

--- a/test/units/modules/network/junos/test_junos_config.py
+++ b/test/units/modules/network/junos/test_junos_config.py
@@ -23,6 +23,7 @@ __metaclass__ = type
 from ansible.compat.tests.mock import patch
 from ansible.modules.network.junos import junos_config
 from units.modules.utils import set_module_args
+from ansible.module_utils._text import to_text
 from .junos_module import TestJunosModule, load_fixture
 
 
@@ -118,7 +119,7 @@ class TestJunosConfigModule(TestJunosModule):
         set_module_args(dict(src=src, confirm=40))
         self.execute_module(changed=True)
         args, kwargs = self.commit_configuration.call_args
-        self.assertEqual(kwargs['confirm_timeout'], 40)
+        self.assertEqual(kwargs['confirm_timeout'], to_text(40))
 
     def test_junos_config_rollback(self):
         rollback = 10


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #39922

* Fix junos_config confirm timeout issue

* Fix unit test

* Update changelog

(cherry picked from commit 865f2c5990554e51e412f8c3748ff0e6fc29f59c)
Merged to devel https://github.com/ansible/ansible/pull/40238

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
junos_config

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
