### PR TITLE
Add exos and slxos to network prefixes list.

### DIFF
--- a/test/integration/target-prefixes.network
+++ b/test/integration/target-prefixes.network
@@ -12,6 +12,7 @@ dellos9
 edgeos
 enos
 eos
+exos
 ios
 iosxr
 ironware
@@ -24,5 +25,6 @@ onyx
 openvswitch
 ops
 pn
+slxos
 sros
 vyos


### PR DESCRIPTION
##### SUMMARY

Add exos and slxos to network prefixes list.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

target-prefixes.network

##### ANSIBLE VERSION

```
ansible 2.6.0 (network-prefixes 84574acac7) last updated 2018/05/16 09:41:57 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
