### PR TITLE
Option to control if entire play should be aborted if batch of hosts failed

### DIFF
--- a/docs/docsite/keyword_desc.yml
+++ b/docs/docsite/keyword_desc.yml
@@ -11,6 +11,11 @@ become_flags: A string of flag(s) to pass to the privilege escalation program wh
 become_method: Which method of privilege escalation to use (such as sudo or su).
 become_user: "User that you 'become' after using privilege escalation. The remote/login user must have permissions to become this user."
 block: List of tasks in a block.
+break_play_on_batch_failed: |
+    Boolean that controls if entire play is to be broken when a batch of hosts became failed
+
+    .. seealso:: :ref:`playbooks_strategies`
+
 changed_when: "Conditional expression that overrides the task's normal 'changed' status."
 check_mode: |
     A boolean that controls if a task is executed in 'check' mode
@@ -65,7 +70,7 @@ serial: |
 
     .. seealso:: :ref:`rolling_update_batch_size`
 
-strategy: Allows you to choose the connection plugin to use for the play.
+strategy: Allows you to choose the execution strategy plugin to use for the play.
 tags: Tags applied to the task or included tasks, this allows selecting subsets of tasks from the command line.
 tasks: Main list of tasks to execute in the play, they run after :term:`roles` and before :term:`post_tasks`.
 until: "This keyword implies a ':term:`retries` loop' that will go on until the condition supplied here is met or we hit the :term:`retries` limit."

--- a/lib/ansible/executor/playbook_executor.py
+++ b/lib/ansible/executor/playbook_executor.py
@@ -180,7 +180,7 @@ class PlaybookExecutor:
                             failed_hosts_count = len(self._tqm._failed_hosts) + len(self._tqm._unreachable_hosts) - \
                                 (previously_failed + previously_unreachable)
 
-                            if len(batch) == failed_hosts_count:
+                            if len(batch) == failed_hosts_count and play.break_play_on_batch_failed:
                                 break_play = True
                                 break
 

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -78,6 +78,7 @@ class Play(Base, Taggable, CollectionSearch):
     _force_handlers = FieldAttribute(isa='bool', default=context.cliargs_deferred_get('force_handlers'), always_post_validate=True)
     _max_fail_percentage = FieldAttribute(isa='percent', always_post_validate=True)
     _serial = FieldAttribute(isa='list', default=list, always_post_validate=True)
+    _break_play_on_batch_failed = FieldAttribute(isa='bool', default=True, always_post_validate=True)
     _strategy = FieldAttribute(isa='string', default=C.DEFAULT_STRATEGY, always_post_validate=True)
     _order = FieldAttribute(isa='string', always_post_validate=True)
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
When using serial strategy, if entire batch of hosts failed (due to they are unreachable or due to some processing error) then Ansible interrupts all remaining plays.

While it makes sense for some cases, there're also situations when such behaviour is absolutely unexpectable. 

I'm not going to diving into details of possible cases, just one example. 
Imagine you manage a system distributed within several hosts (usual case for all of us). Main playbook includes some other playbooks, which explicitly sets 'serial: 1' in order to process hosts one by one before going further. And it's absolutely vital to complete main play despite of the fact that some hosts were marked as failed.

We successfully introduced an option which allows to control whether it's acceptable to continue plays if current batch of hosts failed.
Using of such option is responsibility of playbook designer, i.e. you should understand what you do and that in concrete case such behaviour is acceptable.

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
Playbook executor

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible-playbook 2.5.2
  config file = /home/andrey/.ansible.cfg
  configured module search path = [u'/home/andrey/projects/devops/ansible/lib']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = bin/ansible-playbook
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->
I demonstrate a case when in main playbook another playbook is included which is for communicating with several hosts using serial strategy with batch size equal to 1. If one of target hosts is unreachable than our main playbook wouldn't be completed.
The code is below.
1. Main play:
`- import_playbook: test_unavailable_node_different_strategy.yml`
`- hosts: 127.0.0.1`
`connection: local`
`tasks:`
`  - debug: msg="Playbook finished"`

2. Included play which targets several hosts using serial=1:
`- name: Serial processing of hosts`
`   hosts: all`
`   serial: 1`
`   tasks:`
`    - name: Create temporary file`
`      tempfile:`
`        state: file`
`      register: tmp_path`
`   - name: Remove the file created on previous step`
`      file:`
`        path: "{{tmp_path.path}}"`
`        state: absent`

We will not reach execution of tasks in the main playbook - entire play would be interrupted.

Adding the option **break_play_on_batch_failed: false** which dictates to not interrupt entire play will fix this situation.

So having two hosts one of which is up and one is down, launch the main play:

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
andrey@aagenosov:~/projects/devops/ansible_notes$ ansible-playbook -i '10.16.42.59,10.16.43.57' ./main.yml --ask-pass -u user
SSH password: 

PLAY [Serial processing of hosts] ************************************************************************************************************************************************

TASK [Create temporary file] *****************************************************************************************************************************************************
changed: [10.16.42.59]

TASK [Remove the file created on previous step] **********************************************************************************************************************************
changed: [10.16.42.59]

PLAY [Serial processing of hosts] ************************************************************************************************************************************************

TASK [Create temporary file] *****************************************************************************************************************************************************
fatal: [10.16.43.57]: UNREACHABLE! => {"changed": false, "msg": "Failed to connect to the host via ssh: ssh: connect to host 10.16.43.57 port 22: No route to host\r\n", "unreachable": true}

PLAY RECAP ***********************************************************************************************************************************************************************
10.16.42.59                : ok=4    changed=2    unreachable=0    failed=0   
10.16.43.57                : ok=0    changed=0    unreachable=1    failed=0

```
