### PR TITLE
Fixes incorrect variable name

### DIFF
--- a/hacking/test-module
+++ b/hacking/test-module
@@ -126,7 +126,7 @@ def boilerplate_module(modfile, args, interpreters, check, destfile):
     # default selinux fs list is pass in as _ansible_selinux_special_fs arg
     complex_args['_ansible_selinux_special_fs'] = C.DEFAULT_SELINUX_SPECIAL_FS
     complex_args['_ansible_tmp'] = C.DEFAULT_LOCAL_TMP
-    comlpex_args['_ansible_keep_remote_files'] = C.DEFAULT_KEEP_REMOTE_FILES
+    complex_args['_ansible_keep_remote_files'] = C.DEFAULT_KEEP_REMOTE_FILES
 
     if args.startswith("@"):
         # Argument is a YAML file (JSON is a subset of YAML)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
Incorrect variable name was causing a NameError

  NameError: name 'comlpex_args' is not defined

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
hacking/test-module

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0 (bugfix.fix-incorrect-variable-name eeac67606d) last updated 2018/05/16 18:03:58 (GMT +000)
  config file = None
  configured module search path = ['/root/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /here/local/ansible/lib/ansible
  executable location = /here/local/ansible/bin/ansible
  python version = 3.6.5 (default, May  5 2018, 03:09:35) [GCC 4.9.2]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
