### PR TITLE
Ensure remote_tmp basedir exists

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -938,6 +938,8 @@ class AnsibleModule(object):
         # clean it up once finished.
         if self._tmpdir is None:
             basedir = os.path.expanduser(os.path.expandvars(self._remote_tmp))
+            if not os.path.exists(basedir):
+                os.makedirs(basedir)
             basefile = "ansible-moduletmp-%s-" % time.time()
             tmpdir = tempfile.mkdtemp(prefix=basefile, dir=basedir)
             if not self._keep_remote_files:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This is a simple fix for the bug described in #40276 - it ensures that the parents of the `remote_tmp` option exist before creating the temp directories. Note, that as I am not an expert on the codebase this may not be the best approach - it is intended as a demonstration on how to resolve the issue described.

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

Fixes #40276

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
lib/ansible/module_utils/basic.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0 (40276-fix-remote-tmp a6bb3f9466) last updated 2018/05/16 14:50:21 (GMT -400)
  config file = /home/ecoutu/dev/deploy/ansible/ansible.cfg
  configured module search path = [u'/home/ecoutu/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/ecoutu/dev/ansible/lib/ansible
  executable location = /home/ecoutu/.virtualenvs/g/bin/ansible
  python version = 2.7.15rc1 (default, Apr 15 2018, 21:51:34) [GCC 7.3.0]

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
