### PR TITLE
win_updates: fix typo with download failure and whitelist on multiple updates

### DIFF
--- a/changelogs/fragments/win_updates_typo_whitelist_fix.yaml
+++ b/changelogs/fragments/win_updates_typo_whitelist_fix.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+- win_updates - Fix typo that hid the download error when a download failed
+- win_updates - Fix logic when using a whitelist for multiple updates


### PR DESCRIPTION
##### SUMMARY
Fix a typo on the error if an update failed to download.
Fixed the logic for whitelist when multiple entries are used.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
win_updates

##### ANSIBLE VERSION
```
devel
```