### PR TITLE
Fix uri test on Python 2.6.

### DIFF
--- a/test/integration/targets/uri/files/constraints.txt
+++ b/test/integration/targets/uri/files/constraints.txt
@@ -1,1 +1,2 @@
 cryptography < 2.2 ; python_version < "2.7" # cryptography 2.2+ requires python 2.7+
+pyopenssl < 18.0 ; python_version < "2.7" # pyopenssl 18.0+ requires python 2.7+


### PR DESCRIPTION
##### SUMMARY

Fix uri test on Python 2.6.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

uri integration test

##### ANSIBLE VERSION

```
ansible 2.6.0 (uri-fix 86c9dba03c) last updated 2018/05/16 14:14:08 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
