### PR TITLE
Fix uri test on Python 2.6.

### DIFF
--- a/test/integration/targets/uri/files/constraints.txt
+++ b/test/integration/targets/uri/files/constraints.txt
@@ -1,1 +1,2 @@
 cryptography < 2.2 ; python_version < "2.7" # cryptography 2.2+ requires python 2.7+
+pyopenssl < 18.0 ; python_version < "2.7" # pyopenssl 18.0+ requires python 2.7+


### PR DESCRIPTION
##### SUMMARY

Fix uri test on Python 2.6.

(cherry picked from commit 5c124876faf25486904c797ed4e00e423c871192)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

uri integration test

##### ANSIBLE VERSION

```
ansible 2.4.4.0 (uri-fix-2.4 5eb3993823) last updated 2018/05/16 15:04:02 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
