### PR TITLE
Fix flatten filter documentation

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters.rst
@@ -127,7 +127,7 @@ Flatten a list (same thing the `flatten` lookup does)::
 
 Flatten only the first level of a list (akin to the `items` lookup)::
 
-    {{ [3, [4, [2]] ]|flatten(level=1) }}
+    {{ [3, [4, [2]] ]|flatten(levels=1) }}
 
 
 .. _set_theory_filters:


### PR DESCRIPTION
##### SUMMARY
Fix a documentation issue for *flatten" filter. Missing **s** for levels keyword.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
playbooks_filters

##### ANSIBLE VERSION
```
ansible 2.6.0
```
##### ADDITIONAL INFORMATION
