### PR TITLE
nxos_interface: Disable switchport for loopback/svi

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_interface.py
+++ b/lib/ansible/modules/network/nxos/nxos_interface.py
@@ -474,7 +474,7 @@ def map_obj_to_commands(updates, module):
             else:
                 commands.append(interface)
                 # Don't run switchport command for loopback and svi interfaces
-                if interface_type in ('ethernet', 'portchannel'):
+                if get_interface_type(name) in ('ethernet', 'portchannel'):
                     if mode == 'layer2':
                         commands.append('switchport')
                     elif mode == 'layer3':

--- a/lib/ansible/modules/network/nxos/nxos_interface.py
+++ b/lib/ansible/modules/network/nxos/nxos_interface.py
@@ -1,20 +1,7 @@
 #!/usr/bin/python
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
-#
+# -*- coding: utf-8 -*-
+
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],
@@ -444,10 +431,12 @@ def map_obj_to_commands(updates, module):
 
         elif state == 'present':
             if obj_in_have:
-                if mode == 'layer2' and mode != obj_in_have.get('mode'):
-                    add_command_to_interface(interface, 'switchport', commands)
-                elif mode == 'layer3' and mode != obj_in_have.get('mode'):
-                    add_command_to_interface(interface, 'no switchport', commands)
+                # Don't run switchport command for loopback and svi interfaces
+                if get_interface_type(name) in ('ethernet', 'portchannel'):
+                    if mode == 'layer2' and mode != obj_in_have.get('mode'):
+                        add_command_to_interface(interface, 'switchport', commands)
+                    elif mode == 'layer3' and mode != obj_in_have.get('mode'):
+                        add_command_to_interface(interface, 'no switchport', commands)
 
                 if admin_state == 'up' and admin_state != obj_in_have.get('admin_state'):
                     add_command_to_interface(interface, 'no shutdown', commands)
@@ -484,10 +473,12 @@ def map_obj_to_commands(updates, module):
 
             else:
                 commands.append(interface)
-                if mode == 'layer2':
-                    commands.append('switchport')
-                elif mode == 'layer3':
-                    commands.append('no switchport')
+                # Don't run switchport command for loopback and svi interfaces
+                if interface_type in ('ethernet', 'portchannel'):
+                    if mode == 'layer2':
+                        commands.append('switchport')
+                    elif mode == 'layer3':
+                        commands.append('no switchport')
 
                 if admin_state == 'up':
                     commands.append('no shutdown')


### PR DESCRIPTION
##### SUMMARY
Fixes #38559

This PR fixes a regression introduced in v2.5 that if you have an interface type of "loopback" or "svi", and have "mode" set, causes the module to thrown an exception because a switchport command is issued to an interface that does not support it.

We probably want to fix this by testing if the "mode" parameter is allowed for these interface types, but that's a breaking change and probably requires a deprecation process and warnings before making that switch.

At least we want to fix this regression first.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
nxos_interface

##### ANSIBLE VERSION
v2.5 and older