### PR TITLE
Add release date for v2.5.0 to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ See [Porting Guide](https://docs.ansible.com/ansible/devel/porting_guides/portin
 
 <a id="2.5"></a>
 
-## 2.5 "Kashmir" - March 2018 (estimated)
+## 2.5 "Kashmir" - 2018-03-22
 
 [Porting Guide](https://docs.ansible.com/ansible/devel/porting_guides/porting_guide_2.5.html)
 


### PR DESCRIPTION
##### SUMMARY
Adds the release date of v2.5.0 to the changelog page. Date taken from https://github.com/ansible/ansible/blob/stable-2.5/changelogs/CHANGELOG-v2.5.rst#v250

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
none

##### ANSIBLE VERSION
```
ansible 2.5.0
```
