### PR TITLE
Fix legacy Nexus 3k integration test and module issues.

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_facts.py
+++ b/lib/ansible/modules/network/nxos/nxos_facts.py
@@ -499,7 +499,13 @@ class Legacy(FactsBase):
         return objects
 
     def parse_fan_info(self, data):
-        data = data['fandetails']['TABLE_faninfo']['ROW_faninfo']
+        objects = list()
+        if data.get('fandetails'):
+            data = data['fandetails']['TABLE_faninfo']['ROW_faninfo']
+        elif data.get('fandetails_3k'):
+            data = data['fandetails_3k']['TABLE_faninfo']['ROW_faninfo']
+        else:
+            return objects
         objects = list(self.transform_iterable(data, self.FAN_MAP))
         return objects
 

--- a/test/integration/targets/nxos_config/tests/common/sublevel_block.yaml
+++ b/test/integration/targets/nxos_config/tests/common/sublevel_block.yaml
@@ -8,6 +8,7 @@
     lines: no ip access-list test
     provider: "{{ connection }}"
     match: none
+  ignore_errors: yes
 
 - name: configure sub level command using block replace
   nxos_config:

--- a/test/integration/targets/nxos_pim_rp_address/tests/common/configure.yaml
+++ b/test/integration/targets/nxos_pim_rp_address/tests/common/configure.yaml
@@ -5,7 +5,7 @@
 
 - set_fact: bidir="true"
 - set_fact: bidir="false"
-  when: platform is match("N3K")
+  when: platform is match("N3L")
 
 - block:
   - name: "Disable feature PIM"
@@ -49,18 +49,18 @@
       state: present
       provider: "{{ connection }}"
     register: result
-    when: platform is not match("N3K")
+    when: platform is not match("N3L")
 
   - assert: *true
-    when: platform is not match("N3K")
+    when: platform is not match("N3L")
 
   - name: Check idempotence rp_address + group_list remove bidir
     nxos_pim_rp_address: *configglnb
     register: result
-    when: platform is not match("N3K")
+    when: platform is not match("N3L")
 
   - assert: *false
-    when: platform is not match("N3K")
+    when: platform is not match("N3L")
 
   - name: Configure rp_address + bidir 
     nxos_pim_rp_address: &configbi
@@ -85,18 +85,18 @@
       state: present
       provider: "{{ connection }}"
     register: result
-    when: platform is not match("N3K")
+    when: platform is not match("N3L")
 
   - assert: *true
-    when: platform is not match("N3K")
+    when: platform is not match("N3L")
 
   - name: Check idempotence rp_address remove bidir
     nxos_pim_rp_address: *confignbi
     register: result
-    when: platform is not match("N3K")
+    when: platform is not match("N3L")
 
   - assert: *false
-    when: platform is not match("N3K")
+    when: platform is not match("N3L")
 
   - name: Remove rp_address + group_list 
     nxos_pim_rp_address: &configglr
@@ -154,18 +154,18 @@
       state: present
       provider: "{{ connection }}"
     register: result
-    when: platform is not match("N3K")
+    when: platform is not match("N3L")
 
   - assert: *true
-    when: platform is not match("N3K")
+    when: platform is not match("N3L")
 
   - name: Check idempotence rp_address + prefix_list
     nxos_pim_rp_address: *configplnbi
     register: result
-    when: platform is not match("N3K")
+    when: platform is not match("N3L")
 
   - assert: *false
-    when: platform is not match("N3K")
+    when: platform is not match("N3L")
 
   - name: Remove rp_address + prefix_list 
     nxos_pim_rp_address: &configplr
@@ -209,18 +209,18 @@
       state: present
       provider: "{{ connection }}"
     register: result
-    when: platform is not match("N3K")
+    when: platform is not match("N3L")
 
   - assert: *true
-    when: platform is not match("N3K")
+    when: platform is not match("N3L")
 
   - name: Check idempotence rp_address + route_map
     nxos_pim_rp_address: *configrmnbi
     register: result
-    when: platform is not match("N3K")
+    when: platform is not match("N3L")
 
   - assert: *false
-    when: platform is not match("N3K")
+    when: platform is not match("N3L")
 
   - name: Remove rp_address + route_map 
     nxos_pim_rp_address: &configrmr

--- a/test/integration/targets/nxos_pim_rp_address/tests/common/configure.yaml
+++ b/test/integration/targets/nxos_pim_rp_address/tests/common/configure.yaml
@@ -3,6 +3,10 @@
 - debug: msg="Using provider={{ connection.transport }}"
   when: ansible_connection == "local"
 
+- set_fact: bidir="true"
+- set_fact: bidir="false"
+  when: platform is match("N3K")
+
 - block:
   - name: "Disable feature PIM"
     nxos_feature: &disable_feature
@@ -20,7 +24,7 @@
     nxos_pim_rp_address: &configgl
       rp_address: "10.1.1.20"
       group_list: "224.0.0.0/8"
-      bidir: True
+      bidir: "{{ bidir }}"
       state: present
       provider: "{{ connection }}"
     register: result
@@ -45,19 +49,23 @@
       state: present
       provider: "{{ connection }}"
     register: result
+    when: platform is not match("N3K")
 
   - assert: *true
+    when: platform is not match("N3K")
 
   - name: Check idempotence rp_address + group_list remove bidir
     nxos_pim_rp_address: *configglnb
     register: result
+    when: platform is not match("N3K")
 
   - assert: *false
+    when: platform is not match("N3K")
 
   - name: Configure rp_address + bidir 
     nxos_pim_rp_address: &configbi
       rp_address: "10.1.1.20"
-      bidir: True
+      bidir: "{{ bidir }}"
       state: present
       provider: "{{ connection }}"
     register: result
@@ -77,14 +85,18 @@
       state: present
       provider: "{{ connection }}"
     register: result
+    when: platform is not match("N3K")
 
   - assert: *true
+    when: platform is not match("N3K")
 
   - name: Check idempotence rp_address remove bidir
     nxos_pim_rp_address: *confignbi
     register: result
+    when: platform is not match("N3K")
 
   - assert: *false
+    when: platform is not match("N3K")
 
   - name: Remove rp_address + group_list 
     nxos_pim_rp_address: &configglr
@@ -121,7 +133,7 @@
     nxos_pim_rp_address: &configpl
       rp_address: "10.1.1.20"
       prefix_list: "pim_prefix_list"
-      bidir: True
+      bidir: "{{ bidir }}"
       state: present
       provider: "{{ connection }}"
     register: result
@@ -142,14 +154,18 @@
       state: present
       provider: "{{ connection }}"
     register: result
+    when: platform is not match("N3K")
 
   - assert: *true
+    when: platform is not match("N3K")
 
   - name: Check idempotence rp_address + prefix_list
     nxos_pim_rp_address: *configplnbi
     register: result
+    when: platform is not match("N3K")
 
   - assert: *false
+    when: platform is not match("N3K")
 
   - name: Remove rp_address + prefix_list 
     nxos_pim_rp_address: &configplr
@@ -172,7 +188,7 @@
     nxos_pim_rp_address: &configrm
       rp_address: "10.1.1.20"
       route_map: "pim_routemap"
-      bidir: True
+      bidir: "{{ bidir }}"
       state: present
       provider: "{{ connection }}"
     register: result
@@ -193,14 +209,18 @@
       state: present
       provider: "{{ connection }}"
     register: result
+    when: platform is not match("N3K")
 
   - assert: *true
+    when: platform is not match("N3K")
 
   - name: Check idempotence rp_address + route_map
     nxos_pim_rp_address: *configrmnbi
     register: result
+    when: platform is not match("N3K")
 
   - assert: *false
+    when: platform is not match("N3K")
 
   - name: Remove rp_address + route_map 
     nxos_pim_rp_address: &configrmr

--- a/test/integration/targets/nxos_vrf/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_vrf/tests/common/sanity.yaml
@@ -13,10 +13,10 @@
   when: (platform is not match("N35|N7K")) and ((imagetag != 'I2'))
 
 - set_fact: vnind="5000"
-  when: platform is not match("N35|N7K")
+  when: platform is not match("N35|N7K|N3K")
 
 - set_fact: vnid="default"
-  when: platform is not match("N35|N7K")
+  when: platform is not match("N35|N7K|N3K")
 
 - name: "Enable feature BGP"
   nxos_feature:

--- a/test/integration/targets/nxos_vrf/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_vrf/tests/common/sanity.yaml
@@ -13,10 +13,10 @@
   when: (platform is not match("N35|N7K")) and ((imagetag != 'I2'))
 
 - set_fact: vnind="5000"
-  when: platform is not match("N35|N7K|N3K")
+  when: platform is not match("N35|N7K|N3L")
 
 - set_fact: vnid="default"
-  when: platform is not match("N35|N7K|N3K")
+  when: platform is not match("N35|N7K|N3L")
 
 - name: "Enable feature BGP"
   nxos_feature:

--- a/test/integration/targets/nxos_vrf_af/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_vrf_af/tests/common/sanity.yaml
@@ -130,7 +130,7 @@
 
   - assert: *false
 
-  when: not platform is search("N35")
+  when: not platform is search("N35|N3K")
 
   always:
   - name: Remove vrf

--- a/test/integration/targets/nxos_vrf_af/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_vrf_af/tests/common/sanity.yaml
@@ -130,7 +130,7 @@
 
   - assert: *false
 
-  when: not platform is search("N35|N3K")
+  when: not platform is search("N35|N3L")
 
   always:
   - name: Remove vrf

--- a/test/integration/targets/prepare_nxos_tests/tasks/main.yml
+++ b/test/integration/targets/prepare_nxos_tests/tasks/main.yml
@@ -80,6 +80,10 @@
 - set_fact: platform="N35NG"
   when: ( chassis_type is search("C35")) and image_version is search("7.0\(3\)I7")
 
+# Set platform to N3L(N3K Legacy) for C3048 platform.
+- set_fact: platform="N3L"
+  when: ( chassis_type is search("C3048"))
+
 # Create matrix of simple keys based on platform
 # and image version for use within test playbooks.
 - set_fact: imagetag=""


### PR DESCRIPTION
##### SUMMARY
This PR fixes several bugs in `devel` for Legacy N3Ks
* Fixes a defect in `nxos_facts` for parsing fan data.
* Adds new platform tag `N3L` to represent legacy N3K's in `prepare_nxos_tests`.
* Skips integration test steps that are not applicable to `N3L` platform type.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
Various nxos_* modules

##### ANSIBLE VERSION
```
ansible 2.6.0 (rel260/nxos_fixes 556f6e6e46) last updated 2018/05/17 09:19:23 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/Users/mwiebe/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mwiebe/Projects/nxos_ansible/fix_ansible/lib/ansible
  executable location = /Users/mwiebe/Projects/nxos_ansible/fix_ansible/bin/ansible
  python version = 2.7.13 (default, Apr  4 2017, 08:47:57) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.38)]
```

