### PR TITLE
Add cnos to network target prefixes.

### DIFF
--- a/test/integration/target-prefixes.network
+++ b/test/integration/target-prefixes.network
@@ -6,6 +6,7 @@ asa
 bigip
 ce
 cl
+cnos
 dellos10
 dellos6
 dellos9


### PR DESCRIPTION
##### SUMMARY

Add cnos to network target prefixes.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

test/integration/target-prefixes.network

##### ANSIBLE VERSION

```
ansible 2.6.0 (cnos-prefix 8e301a1fdc) last updated 2018/05/17 07:13:12 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
