### PR TITLE
aws_ec2: tag values as hostnames - backport #35880

### DIFF
--- a/changelogs/fragments/aws_ec2_inventory_support_tag_value_hostnames.yaml
+++ b/changelogs/fragments/aws_ec2_inventory_support_tag_value_hostnames.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Support tag values as hostnames in aws_ec2 inventory plugin


### PR DESCRIPTION
##### SUMMARY
Backport #35880
Fix using tag values as hostnames

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/inventory/aws_ec2.py

##### ANSIBLE VERSION
```
2.5.2
```
