### PR TITLE
Add vm scale sets to azure dynamic inventory

### DIFF
--- a/contrib/inventory/azure_rm.ini
+++ b/contrib/inventory/azure_rm.ini
@@ -15,6 +15,9 @@
 # Include powerstate. If you don't need powerstate information, turning it off improves runtime performance.
 include_powerstate=yes
 
+# Include VM Scale sets VMs. Will filter Scale Sets based on tags, location or resource group.
+include_vm_scale_sets=no
+
 # Control grouping with the following boolean flags. Valid values: yes, no, true, false, True, False, 0, 1.
 group_by_resource_group=yes
 group_by_location=yes

--- a/contrib/inventory/azure_rm.py
+++ b/contrib/inventory/azure_rm.py
@@ -262,7 +262,8 @@ AZURE_CONFIG_SETTINGS = dict(
     group_by_security_group='AZURE_GROUP_BY_SECURITY_GROUP',
     group_by_tag='AZURE_GROUP_BY_TAG',
     group_by_os_family='AZURE_GROUP_BY_OS_FAMILY',
-    use_private_ip='AZURE_USE_PRIVATE_IP'
+    use_private_ip='AZURE_USE_PRIVATE_IP',
+    include_vm_scale_sets='AZURE_INCLUDE_VM_SCALE_SETS'
 )
 
 AZURE_MIN_VERSION = "2.0.0"
@@ -518,6 +519,7 @@ class AzureRM(object):
                              self.subscription_id,
                              base_url=base_url,
                              api_version=api_version)
+
         client.config.add_user_agent(ANSIBLE_USER_AGENT)
         return client
 
@@ -527,7 +529,7 @@ class AzureRM(object):
         if not self._network_client:
             self._network_client = self.get_mgmt_svc_client(NetworkManagementClient,
                                                             self._cloud_environment.endpoints.resource_manager,
-                                                            '2017-06-01')
+                                                            '2018-02-01')
             self._register('Microsoft.Network')
         return self._network_client
 
@@ -537,7 +539,7 @@ class AzureRM(object):
         if not self._resource_client:
             self._resource_client = self.get_mgmt_svc_client(ResourceManagementClient,
                                                              self._cloud_environment.endpoints.resource_manager,
-                                                             '2017-05-10')
+                                                             '2018-02-01')
         return self._resource_client
 
     @property
@@ -546,7 +548,7 @@ class AzureRM(object):
         if not self._compute_client:
             self._compute_client = self.get_mgmt_svc_client(ComputeManagementClient,
                                                             self._cloud_environment.endpoints.resource_manager,
-                                                            '2017-03-30')
+                                                            '2017-12-01')
             self._register('Microsoft.Compute')
         return self._compute_client
 
@@ -578,6 +580,7 @@ class AzureInventory(object):
         self.group_by_tag = True
         self.include_powerstate = True
         self.use_private_ip = False
+        self.include_vm_scale_sets = False
 
         self._inventory = dict(
             _meta=dict(
@@ -650,6 +653,8 @@ class AzureInventory(object):
             for resource_group in self.resource_groups:
                 try:
                     virtual_machines = self._compute_client.virtual_machines.list(resource_group.lower())
+                    if self.include_vm_scale_sets:
+                        virtual_machines = list(virtual_machines) + self.get_vmss_vm_inventory()
                 except Exception as exc:
                     sys.exit("Error: fetching virtual machines for resource group {0} - {1}".format(resource_group, str(exc)))
                 if self._args.host or self.tags:
@@ -661,6 +666,8 @@ class AzureInventory(object):
             # get all VMs within the subscription
             try:
                 virtual_machines = self._compute_client.virtual_machines.list_all()
+                if self.include_vm_scale_sets:
+                    virtual_machines = list(virtual_machines) + self.get_vmss_vm_inventory() 
             except Exception as exc:
                 sys.exit("Error: fetching virtual machines - {0}".format(str(exc)))
 
@@ -670,9 +677,43 @@ class AzureInventory(object):
             else:
                 self._load_machines(virtual_machines)
 
+    def get_vmss_vm_inventory(self):
+        virtual_machine_scale_sets = self._compute_client.virtual_machine_scale_sets.list_all()
+        selected_scale_sets = self._selected_machines(virtual_machine_scale_sets)
+        vmss_vms = []
+        for scale_set in selected_scale_sets:
+            vmss_vms += self.get_vm_instances_in_vmss(scale_set)
+        return vmss_vms 
+
+    def get_vm_instances_in_vmss(self, vmss):
+        id_dict = azure_id_to_dict(vmss.id)
+        resource_group = id_dict['resourceGroups']
+        vms = []
+        nic_configs = self.get_vm_nics_for_vmss(resource_group, vmss.name)
+        for vm in self._compute_client.virtual_machine_scale_set_vms.list(resource_group, vmss.name):
+            for nic_config in nic_configs:
+                vm_id = azure_id_to_dict(vm.id)
+                nic_id = azure_id_to_dict(nic_config["id"])
+                if vm_id["virtualMachineScaleSets"] == nic_id["virtualMachineScaleSets"] and \
+                   vm_id["virtualMachines"] == nic_id["virtualMachines"] and \
+                   vm_id["resourceGroups"].lower() == nic_id["resourceGroups"].lower():
+                    vm.private_ip_address = nic_config["private_ip_address"]
+                    vm.hardware_profile = type('obj', (object,), {'vm_size' : vmss.sku.name})
+                    vm.vmss_vm = True
+                    #print(vm.__dict__)
+                    vms.append(vm)
+        return vms
+
+    def get_vm_nics_for_vmss(self, resource_group, name):
+        vmss_nics = self._network_client.network_interfaces.list_virtual_machine_scale_set_network_interfaces(resource_group, name)
+        vm_ids = [{"id": vm.id, "private_ip_address": vm.ip_configurations[0].private_ip_address} for vm in vmss_nics ]
+        return vm_ids
+
     def _load_machines(self, machines):
         for machine in machines:
             id_dict = azure_id_to_dict(machine.id)
+
+            vmss_vm = getattr(machine, 'vmss_vm', False)
 
             # TODO - The API is returning an ID value containing resource group name in ALL CAPS. If/when it gets
             #       fixed, we should remove the .lower(). Opened Issue
@@ -737,39 +778,43 @@ class AzureInventory(object):
                             host_vars['windows_rm']['listeners'].append(dict(protocol=listener.protocol.name,
                                                                              certificate_url=listener.certificate_url))
 
-            for interface in machine.network_profile.network_interfaces:
-                interface_reference = self._parse_ref_id(interface.id)
-                network_interface = self._network_client.network_interfaces.get(
-                    interface_reference['resourceGroups'],
-                    interface_reference['networkInterfaces'])
-                if network_interface.primary:
-                    if self.group_by_security_group and \
-                       self._security_groups[resource_group].get(network_interface.id, None):
-                        host_vars['security_group'] = \
-                            self._security_groups[resource_group][network_interface.id]['name']
-                        host_vars['security_group_id'] = \
-                            self._security_groups[resource_group][network_interface.id]['id']
-                    host_vars['network_interface'] = network_interface.name
-                    host_vars['network_interface_id'] = network_interface.id
-                    host_vars['mac_address'] = network_interface.mac_address
-                    for ip_config in network_interface.ip_configurations:
-                        host_vars['private_ip'] = ip_config.private_ip_address
-                        host_vars['private_ip_alloc_method'] = ip_config.private_ip_allocation_method
-                        if self.use_private_ip:
-                            host_vars['ansible_host'] = ip_config.private_ip_address
-                        if ip_config.public_ip_address:
-                            public_ip_reference = self._parse_ref_id(ip_config.public_ip_address.id)
-                            public_ip_address = self._network_client.public_ip_addresses.get(
-                                public_ip_reference['resourceGroups'],
-                                public_ip_reference['publicIPAddresses'])
-                            if not self.use_private_ip:
-                                host_vars['ansible_host'] = public_ip_address.ip_address
-                            host_vars['public_ip'] = public_ip_address.ip_address
-                            host_vars['public_ip_name'] = public_ip_address.name
-                            host_vars['public_ip_alloc_method'] = public_ip_address.public_ip_allocation_method
-                            host_vars['public_ip_id'] = public_ip_address.id
-                            if public_ip_address.dns_settings:
-                                host_vars['fqdn'] = public_ip_address.dns_settings.fqdn
+            # here we are assuming all vmss vms have private ip addresses
+            if vmss_vm:
+                host_vars['ansible_host'] = machine.private_ip_address
+            else:
+                for interface in machine.network_profile.network_interfaces:
+                    interface_reference = self._parse_ref_id(interface.id)
+                    network_interface = self._network_client.network_interfaces.get(
+                        interface_reference['resourceGroups'],
+                        interface_reference['networkInterfaces'])
+                    if network_interface.primary:
+                        if self.group_by_security_group and \
+                           self._security_groups[resource_group].get(network_interface.id, None):
+                            host_vars['security_group'] = \
+                                self._security_groups[resource_group][network_interface.id]['name']
+                            host_vars['security_group_id'] = \
+                                self._security_groups[resource_group][network_interface.id]['id']
+                        host_vars['network_interface'] = network_interface.name
+                        host_vars['network_interface_id'] = network_interface.id
+                        host_vars['mac_address'] = network_interface.mac_address
+                        for ip_config in network_interface.ip_configurations:
+                            host_vars['private_ip'] = ip_config.private_ip_address
+                            host_vars['private_ip_alloc_method'] = ip_config.private_ip_allocation_method
+                            if self.use_private_ip:
+                                host_vars['ansible_host'] = ip_config.private_ip_address
+                            if ip_config.public_ip_address:
+                                public_ip_reference = self._parse_ref_id(ip_config.public_ip_address.id)
+                                public_ip_address = self._network_client.public_ip_addresses.get(
+                                    public_ip_reference['resourceGroups'],
+                                    public_ip_reference['publicIPAddresses'])
+                                if not self.use_private_ip:
+                                    host_vars['ansible_host'] = public_ip_address.ip_address
+                                host_vars['public_ip'] = public_ip_address.ip_address
+                                host_vars['public_ip_name'] = public_ip_address.name
+                                host_vars['public_ip_alloc_method'] = public_ip_address.public_ip_allocation_method
+                                host_vars['public_ip_id'] = public_ip_address.id
+                                if public_ip_address.dns_settings:
+                                    host_vars['fqdn'] = public_ip_address.dns_settings.fqdn
 
             self._add_host(host_vars)
 

--- a/contrib/inventory/azure_rm.py
+++ b/contrib/inventory/azure_rm.py
@@ -109,9 +109,9 @@ required. For a specific host, this script returns the following variables:
   "virtual_machine_size": "Standard_DS4"
 }
 
-Run for Specific Virtual machine scale set
+Run for Specific Virtual Machine Scale Set
 -----------------------
-When run for a specific Virtual machine scale set using the --vmss option, a resource group is required.
+When run for a specific Virtual Machine Scale Set using the --vmss option, a resource group is required.
 
 Groups
 ------
@@ -668,7 +668,7 @@ class AzureInventory(object):
 
                 except Exception as exc:
                     sys.exit("Error: fetching virtual machines for resource group {0} - {1}".format(resource_group, str(exc)))
-                if self._args.host or self.tags:
+                if self._args.host or self.tags or self._args.vmss:
                     selected_machines = self._selected_machines(virtual_machines)
                     self._load_machines(selected_machines)
                 else:
@@ -723,8 +723,14 @@ class AzureInventory(object):
                     vm.private_ip_address = nic_config.get("private_ip_address", None)
                     vm.public_ip_address = nic_config.get("public_ip_address", None)
                     vm.hardware_profile = type('obj', (object,), {'vm_size': vmss.sku.name})
+
+                    # custom properties
                     vm.vmss_vm = True
                     vm.vmss_name = vm_id["virtualMachineScaleSets"]
+                    vm.nic_id = nic_config["id"]
+                    vm.nic_name = nic_id["networkInterfaces"]
+
+
                     vm_instances.append(vm)
         return vm_instances
 
@@ -787,7 +793,7 @@ class AzureInventory(object):
                 operating_system_type=machine.storage_profile.os_disk.os_type.value.lower()
             )
 
-            if self.include_powerstate:
+            if self.include_powerstate and not self.include_vm_scale_sets:
                 host_vars['powerstate'] = self._get_powerstate(resource_group, machine.name)
 
             if machine.storage_profile.image_reference:
@@ -802,7 +808,7 @@ class AzureInventory(object):
             if machine.os_profile is not None and machine.os_profile.windows_configuration is not None:
                 host_vars['ansible_connection'] = 'winrm'
                 host_vars['windows_auto_updates_enabled'] = \
-                    machine.os_profile.windows_configuration.enable_automatic_updates
+                    machine.os_profile.windows_configuration.enable_automatic_updates                
                 host_vars['windows_timezone'] = machine.os_profile.windows_configuration.time_zone
                 host_vars['windows_rm'] = None
                 if machine.os_profile.windows_configuration.win_rm is not None:
@@ -816,6 +822,13 @@ class AzureInventory(object):
             if vmss_vm:
                 host_vars['ansible_host'] = machine.private_ip_address
                 host_vars['public_ip'] = machine.public_ip_address
+                host_vars['private_id'] = machine.private_ip_address
+                host_vars['network_interface_id'] = getattr(machine, 'nic_id', None)
+                host_vars['network_interface'] = getattr(machine, 'nic_name', None)
+
+                if self.group_by_security_group and self._security_groups[resource_group].get(machine.nic_id, None):
+                    host_vars['security_group'] = self._security_groups[resource_group][network_interface.id]['name']
+                    host_vars['security_group_id'] = self._security_groups[resource_group][network_interface.id]['id']
             else:
                 for interface in machine.network_profile.network_interfaces:
                     interface_reference = self._parse_ref_id(interface.id)

--- a/contrib/inventory/azure_rm.py
+++ b/contrib/inventory/azure_rm.py
@@ -718,7 +718,7 @@ class AzureInventory(object):
                     vm_nic_info.update({"public_ip_address": vm.public_ip_address})
 
             vm_nics.append(vm_nic_info)
-        return vm_ids
+        return vm_nics
 
     def _load_machines(self, machines):
         for machine in machines:

--- a/contrib/inventory/azure_rm.py
+++ b/contrib/inventory/azure_rm.py
@@ -111,8 +111,7 @@ required. For a specific host, this script returns the following variables:
 
 Run for Specific Virtual machine scale set
 -----------------------
-When run for a specific Virtual machine scale set using the --vmss option, a resource group is
-required. 
+When run for a specific Virtual machine scale set using the --vmss option, a resource group is required.
 
 Groups
 ------
@@ -150,7 +149,7 @@ AZURE_TAGS=key1:value1,key2:value2
 If you don't need the powerstate, you can improve performance by turning off powerstate fetching:
 AZURE_INCLUDE_POWERSTATE=no
 
-Select hosts in Virtual machine scale set by setting below environment variable, 
+Select hosts in Virtual machine scale set by setting below environment variable,
 or set include_vm_scale_sets in azure_rm.ini:
 AZURE_INCLUDE_VM_SCALE_SETS=yes
 

--- a/contrib/inventory/azure_rm.py
+++ b/contrib/inventory/azure_rm.py
@@ -882,15 +882,12 @@ class AzureInventory(object):
         return selected_machines
 
     def _selected_vmss(self, vmsses):
-        selected_vmsses = []
 
         if self._args.vmss:
             for vmss in vmsses:
                 if self._args.vmss == vmss.name:
-                    selected_vmsses.append(vmss)
-        else:
-            selected_vmsses = vmsses
-        return selected_vmsses
+                    return [vmss]
+        return vmsses
 
     def _get_security_groups(self, resource_group):
         ''' For a given resource_group build a mapping of network_interface.id to security_group name '''

--- a/contrib/inventory/azure_rm.py
+++ b/contrib/inventory/azure_rm.py
@@ -700,7 +700,6 @@ class AzureInventory(object):
                     vm.private_ip_address = nic_config["private_ip_address"]
                     vm.hardware_profile = type('obj', (object,), {'vm_size' : vmss.sku.name})
                     vm.vmss_vm = True
-                    #print(vm.__dict__)
                     vms.append(vm)
         return vms
 

--- a/contrib/inventory/azure_rm.py
+++ b/contrib/inventory/azure_rm.py
@@ -583,7 +583,7 @@ class AzureInventory(object):
         self.replace_dash_in_groups = False
         self.group_by_resource_group = True
         self.group_by_location = True
-        self.group_by_os_family = True
+        self.group_by_os_family = False
         self.group_by_security_group = True
         self.group_by_tag = True
         self.include_powerstate = True
@@ -812,7 +812,7 @@ class AzureInventory(object):
             )
 
             if self.include_powerstate:
-                if self.include_vm_scale_sets: 
+                if self.include_vm_scale_sets:
                     host_vars['powerstate'] = getattr(machine, 'power_state', None)
                 else:
                     host_vars['powerstate'] = self._get_powerstate(resource_group, machine.name)

--- a/contrib/inventory/azure_rm.py
+++ b/contrib/inventory/azure_rm.py
@@ -667,7 +667,7 @@ class AzureInventory(object):
             try:
                 virtual_machines = self._compute_client.virtual_machines.list_all()
                 if self.include_vm_scale_sets:
-                    virtual_machines = list(virtual_machines) + self.get_vmss_vm_inventory() 
+                    virtual_machines = list(virtual_machines) + self.get_vmss_vm_inventory()
             except Exception as exc:
                 sys.exit("Error: fetching virtual machines - {0}".format(str(exc)))
 
@@ -683,7 +683,7 @@ class AzureInventory(object):
         vmss_vms = []
         for scale_set in selected_scale_sets:
             vmss_vms += self.get_vm_instances_in_vmss(scale_set)
-        return vmss_vms 
+        return vmss_vms
 
     def get_vm_instances_in_vmss(self, vmss):
         id_dict = azure_id_to_dict(vmss.id)
@@ -698,14 +698,14 @@ class AzureInventory(object):
                    vm_id["virtualMachines"] == nic_id["virtualMachines"] and \
                    vm_id["resourceGroups"].lower() == nic_id["resourceGroups"].lower():
                     vm.private_ip_address = nic_config["private_ip_address"]
-                    vm.hardware_profile = type('obj', (object,), {'vm_size' : vmss.sku.name})
+                    vm.hardware_profile = type('obj', (object,), {'vm_size': vmss.sku.name})
                     vm.vmss_vm = True
                     vms.append(vm)
         return vms
 
     def get_vm_nics_for_vmss(self, resource_group, name):
         vmss_nics = self._network_client.network_interfaces.list_virtual_machine_scale_set_network_interfaces(resource_group, name)
-        vm_ids = [{"id": vm.id, "private_ip_address": vm.ip_configurations[0].private_ip_address} for vm in vmss_nics ]
+        vm_ids = [{"id": vm.id, "private_ip_address": vm.ip_configurations[0].private_ip_address} for vm in vmss_nics]
         return vm_ids
 
     def _load_machines(self, machines):

--- a/contrib/inventory/azure_rm.py
+++ b/contrib/inventory/azure_rm.py
@@ -111,7 +111,7 @@ required. For a specific host, this script returns the following variables:
 
 Run for Specific Virtual Machine Scale Set
 -----------------------
-When run for a specific Virtual Machine Scale Set using the --vmss option, a resource group is required.
+Run for a specific Virtual Machine Scale Set using the --vmss option.
 
 Groups
 ------
@@ -730,8 +730,8 @@ class AzureInventory(object):
                     vm.nic_id = nic_config["id"]
                     vm.nic_name = nic_id["networkInterfaces"]
 
-
                     vm_instances.append(vm)
+
         return vm_instances
 
     def get_vm_nics_for_vmss(self, resource_group, name):
@@ -808,7 +808,7 @@ class AzureInventory(object):
             if machine.os_profile is not None and machine.os_profile.windows_configuration is not None:
                 host_vars['ansible_connection'] = 'winrm'
                 host_vars['windows_auto_updates_enabled'] = \
-                    machine.os_profile.windows_configuration.enable_automatic_updates                
+                    machine.os_profile.windows_configuration.enable_automatic_update
                 host_vars['windows_timezone'] = machine.os_profile.windows_configuration.time_zone
                 host_vars['windows_rm'] = None
                 if machine.os_profile.windows_configuration.win_rm is not None:


### PR DESCRIPTION
##### SUMMARY
Adds support for running playbooks on VM Scale Sets VMs. Filter the scale sets with tags, resource groups and location.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
`contrib`

##### ANSIBLE VERSION
```
2.5.2
```