### PR TITLE
Skip N35 and N3L platforms for nxos_evpn_global test

### DIFF
--- a/test/integration/targets/nxos_evpn_global/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_evpn_global/tests/common/sanity.yaml
@@ -57,7 +57,7 @@
 
   - assert: *false
 
-  when: not ( platform is search('N3K'))
+  when: not ( platform is search('N3K|N35|N3L'))
 
   rescue:
   - debug: msg="connection={{ ansible_connection }} nxos_evpn_global sanity test - FALURE ENCOUNTERED"


### PR DESCRIPTION
##### SUMMARY
This PR Skip N35 and N3L platforms for nxos_evpn_global test

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
Various nxos_evpn_global module

##### ANSIBLE VERSION
```
ansible 2.6.0 (rel260/nxos_fixes 556f6e6e46) last updated 2018/05/17 09:19:23 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/Users/mwiebe/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mwiebe/Projects/nxos_ansible/fix_ansible/lib/ansible
  executable location = /Users/mwiebe/Projects/nxos_ansible/fix_ansible/bin/ansible
  python version = 2.7.13 (default, Apr  4 2017, 08:47:57) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.38)]
```