### PR TITLE
ec2_instance - fix instance creation with IPv6

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_instance.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_instance.py
@@ -784,7 +784,6 @@ def build_network_spec(params, ec2=None):
 
         if interface_params.get('ipv6_addresses'):
             spec['Ipv6Addresses'] = [{'Ipv6Address': a} for a in interface_params.get('ipv6_addresses', [])]
-            spec['Ipv6AddressCount'] = len(spec['Ipv6Addresses'])
 
         if interface_params.get('private_ip_address'):
             spec['PrivateIpAddress'] = interface_params.get('private_ip_address')


### PR DESCRIPTION
##### SUMMARY
When creating an AWS EC2 instance via ec2_instance_module with an IPv6 address, the mutually exclusive parameters are passed - `Ipv6Addresses` and `Ipv6AddressCount`. 
https://docs.aws.amazon.com/cli/latest/reference/ec2/assign-ipv6-addresses.html#options

`Ipv6AddressCount` was deleted.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ec2_instance_module

##### ANSIBLE VERSION
```
ansible 2.5.2
  config file = /home/d/repos/ansible/ansible.cfg
  configured module search path = [u'/home/d/repos/ansible/library']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.12 (default, Nov 20 2017, 18:23:56) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION
```
      - ec2_instance:
          instance_type: t2.small
          key_name: '{{ key_name }}'
          image_id: ami-43a15f3e
          vpc_subnet_id: "{{ vpc_subnetwork_id }}" 
          network:
            interfaces:
                - ipv6_addresses:
                    - '{{ ipv6_addr }}'
```  
```
  error:
    code: InvalidParameterCombination
    message: IPv6 addresses and IPv6 address count may not be specified on the same request
  msg: 'Failed to create new EC2 instance: An error occurred (InvalidParameterCombination) when calling the RunInstances operation: IPv6 addresses and IPv6 address count may not be specified on the same request'
  response_metadata:
    http_headers:
      connection: close
      date: Thu, 17 May 2018 13:51:04 GMT
      server: AmazonEC2
      transfer-encoding: chunked
    http_status_code: 400
    request_id: 12345678-1111-1111-1111-123456789012
    retry_attempts: 0
```
