### PR TITLE
Display.vvvv expects a string

### DIFF
--- a/lib/ansible/plugins/lookup/cyberarkpassword.py
+++ b/lib/ansible/plugins/lookup/cyberarkpassword.py
@@ -167,7 +167,7 @@ class LookupModule(LookupBase):
 
     def run(self, terms, variables=None, **kwargs):
 
-        display.vvvv(terms)
+        display.vvvv("%s" % terms)
         if isinstance(terms, list):
             return_values = []
             for term in terms:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
'terms' is a list and display.vvvv is especting a string.

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
Fixes #36517

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
cyberarkpassword.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.2
  config file = /home/adrian/Documentos/opensolutions/carrefour/envmgmt/ansible.cfg
  configured module search path = [u'/home/adrian/Documentos/opensolutions/carrefour/envmgmt/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.15 (default, May  1 2018, 20:16:04) [GCC 7.3.1 20180406]

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->
This fix was provided by @cyberark-bizdev in PR 36532, but that issue was closed waiting for a rebase.

I think that the code of the ``run`` func could be simplified because ``terms`` is always a [list or iterator](https://github.com/ansible/ansible/blob/51b595992b75c867bae098a76400196d372018a3/lib/ansible/utils/listify.py#L38). And I have seen others lookup plugins only using terms[0], but I'm not sure if there is any case when several terms could be passed to this plugin.
