### PR TITLE
rhsm_repository: use C locale for out/err scraping

### DIFF
--- a/lib/ansible/modules/packaging/os/rhsm_repository.py
+++ b/lib/ansible/modules/packaging/os/rhsm_repository.py
@@ -88,7 +88,8 @@ def run_subscription_manager(module, arguments):
     if not rhsm_bin:
         module.fail_json(msg='The executable file subscription-manager was not found in PATH')
 
-    rc, out, err = module.run_command("%s %s" % (rhsm_bin, " ".join(arguments)))
+    lang_env = dict(LANG='C', LC_ALL='C', LC_MESSAGES='C')
+    rc, out, err = module.run_command("%s %s" % (rhsm_bin, " ".join(arguments)), environ_update=lang_env)
 
     if rc == 1 and (err == 'The password you typed is invalid.\nPlease try again.\n' or os.getuid() != 0):
         module.fail_json(msg='The executable file subscription-manager must be run using root privileges')


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes https://github.com/ansible/ansible/issues/40332
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
rhsm_repository

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION