### PR TITLE
allow non-integer values in /etc/default/passwd 

### DIFF
--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -1442,11 +1442,23 @@ class SunOS(User):
                         fields[1] = self.password
                         fields[2] = str(int(time.time() // 86400))
                         if minweeks:
-                            fields[3] = str(int(minweeks) * 7)
+                            try:
+                                fields[3] = str(int(minweeks) * 7)
+                            except ValueError:
+                                # mirror solaris, which allows for any value in this field, and ignores anything that is not an int.
+                                pass
                         if maxweeks:
-                            fields[4] = str(int(maxweeks) * 7)
+                            try:
+                                fields[4] = str(int(maxweeks) * 7)
+                            except ValueError:
+                                # mirror solaris, which allows for any value in this field, and ignores anything that is not an int.
+                                pass
                         if warnweeks:
-                            fields[5] = str(int(warnweeks) * 7)
+                            try:
+                                fields[5] = str(int(warnweeks) * 7)
+                            except ValueError:
+                                # mirror solaris, which allows for any value in this field, and ignores anything that is not an int.
+                                pass
                         line = ':'.join(fields)
                         lines.append('%s\n' % line)
                     open(self.SHADOWFILE, 'w+').writelines(lines)


### PR DESCRIPTION


##### SUMMARY
fixes #38040
Ignore non-integer values in `/etc/default/passwd` on Solaris to match OS behavior

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
user

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
(ansible-devel) ben@munin:~/test$ ansible --version
ansible 2.6.0 (solaris-user-defaults 5a826e205c) last updated 2018/05/17 08:57:57 (GMT -700)
  config file = /home/ben/test/ansible.cfg
  configured module search path = [u'/home/ben/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/ben/dev/github/ansible/ansible/lib/ansible
  executable location = /home/ben/venvs/ansible-devel/bin/ansible
  python version = 2.7.14 (default, Sep 23 2017, 22:06:14) [GCC 7.2.0]
```


##### ADDITIONAL INFORMATION
