### PR TITLE
Defer task_vars creation to WorkerProcess when possible.

### DIFF
--- a/lib/ansible/executor/process/worker.py
+++ b/lib/ansible/executor/process/worker.py
@@ -57,12 +57,12 @@ class WorkerProcess(multiprocessing.Process):
     for reading later.
     '''
 
-    def __init__(self, rslt_q, task_vars, host, task, play_context, loader, variable_manager, shared_loader_obj):
+    def __init__(self, rslt_q, vars_factory, host, task, play_context, loader, variable_manager, shared_loader_obj):
 
         super(WorkerProcess, self).__init__()
         # takes a task queue manager as the sole param:
         self._rslt_q = rslt_q
-        self._task_vars = task_vars
+        self._vars_factory = vars_factory
         self._host = host
         self._task = task
         self._play_context = play_context
@@ -110,7 +110,7 @@ class WorkerProcess(multiprocessing.Process):
             executor_result = TaskExecutor(
                 self._host,
                 self._task,
-                self._task_vars,
+                self._vars_factory(),
                 self._play_context,
                 self._new_stdin,
                 self._loader,

--- a/test/units/plugins/strategy/test_strategy_base.py
+++ b/test/units/plugins/strategy/test_strategy_base.py
@@ -213,13 +213,13 @@ class TestStrategyBase(unittest.TestCase):
 
         try:
             strategy_base = StrategyBase(tqm=tqm)
-            strategy_base._queue_task(host=mock_host, task=mock_task, task_vars=dict(), play_context=MagicMock())
+            strategy_base._queue_task(host=mock_host, task=mock_task, vars_factory=(lambda: {}), play_context=MagicMock())
             self.assertEqual(strategy_base._cur_worker, 1)
             self.assertEqual(strategy_base._pending_results, 1)
-            strategy_base._queue_task(host=mock_host, task=mock_task, task_vars=dict(), play_context=MagicMock())
+            strategy_base._queue_task(host=mock_host, task=mock_task, vars_factory=(lambda: {}), play_context=MagicMock())
             self.assertEqual(strategy_base._cur_worker, 2)
             self.assertEqual(strategy_base._pending_results, 2)
-            strategy_base._queue_task(host=mock_host, task=mock_task, task_vars=dict(), play_context=MagicMock())
+            strategy_base._queue_task(host=mock_host, task=mock_task, vars_factory=(lambda: {}), play_context=MagicMock())
             self.assertEqual(strategy_base._cur_worker, 0)
             self.assertEqual(strategy_base._pending_results, 3)
         finally:
@@ -344,7 +344,7 @@ class TestStrategyBase(unittest.TestCase):
             (mock_host.name, mock_task._uuid): {
                 'task': mock_task,
                 'host': mock_host,
-                'task_vars': {},
+                'vars_factory': (lambda: {}),
                 'play_context': {},
             }
         }
@@ -564,7 +564,7 @@ class TestStrategyBase(unittest.TestCase):
             strategy_base._queued_task_cache[(mock_host.name, mock_handler_task._uuid)] = {
                 'task': mock_handler_task,
                 'host': mock_host,
-                'task_vars': {},
+                'vars_factory': (lambda: {}),
                 'play_context': mock_play_context
             }
             tqm._final_q.put(task_result)


### PR DESCRIPTION
##### SUMMARY

````
Ansible calls VariableManager.get_vars() prior to forking each task in
order to template the task's title for the "v2_playbook_on_task_start"
plugin callback, and to template the "run_once" playbook setting if it
exists.

This wraps get_vars() in a caching factory, taking care to avoid calling
it when neither the task title nor run_once contain a template, avoiding
a major bottleneck in the top-level process when possible.

The factory produces the same dict instance on each call, so the dict's
lifetime and any changes made to it propagate identically to how things
worked previously.

For DebOps common.yml, 90% of tasks can avoid calling get_vars() in the
top-level process, delaying it until TaskExecutor starts in the worker,
effectively parallelizing get_vars() for most tasks.

The net effect is that in a 10 target run against Ansible HEAD on an 8
vCPU controller, common.yml runtime drops from 4m22s to 2m40s (-38.9%).

This will be even more pronounced with larger runs -- the top-level
process spends about one third of its time asleep, which leaves plenty
of room to be kept busy with more targets.

process/worker.py:
    Receive a factory function rather than a concrete dict. Invoke the
    factory during run(), i.e. post-fork.

strategy/__init__.py:
    * Add get_vars_factory() to produce the factory.
    * add_tqm_variables() is needlessly inflexible requiring a dict as
      input, change it to get_tqm_variables()
    * _queue_task() receives the factory rather than a dict.

strategy/free.py:
strategy/linear.py:
    * Use factory rather than task_vars dict.
    * Restructure "run_once" and callback logic to only invoke the
      factory if necessary.

template/__init__.py:
    * Rename _clean_regex to better reflect what it matches.
    * Add is_template_uncached() to avoid invoking Jinja2 compiler in
      the majority of cases. This can't become default since some code
      relies on is_template() to ensure a compiled template is cached
      pre-fork in the top-level process.
````

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

Strategy plug-in/executor.

##### ANSIBLE VERSION

devel