### PR TITLE
Add SVI Example for CISCO NX-OS platform

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_l3_interface.py
+++ b/lib/ansible/modules/network/nxos/nxos_l3_interface.py
@@ -55,6 +55,11 @@ EXAMPLES = """
     name: Ethernet2/3
     state: absent
 
+- name: Set interface Vlan1 (SVI) IPv4 address
+  nxos_l3_interface:
+    name: Vlan1
+    ipv4: 192.168.0.5/24
+
 - name: Set IP addresses on aggregate
   nxos_l3_interface:
     aggregate:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Add SVI Example for CISCO NX-OS platform

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

Refers #40323 and https://github.com/ansible/community/issues/311

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
nxos_l3_interface

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0
  config file = None
  configured module search path = ['/Users/jacksonisaac/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /anaconda3/lib/python3.6/site-packages/ansible-2.6.0-py3.6.egg/ansible
  executable location = /anaconda3/bin/ansible
  python version = 3.6.4 |Anaconda, Inc.| (default, Jan 16 2018, 12:04:33) [GCC 4.2.1 Compatible Clang 4.0.1 (tags/RELEASE_401/final)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

N/A. Just replicating https://github.com/ansible/ansible/pull/40021

<!--- Paste verbatim command output below, e.g. before and after your change -->

