### PR TITLE
Fix the help of the jsonfile cache plugin

### DIFF
--- a/lib/ansible/plugins/cache/jsonfile.py
+++ b/lib/ansible/plugins/cache/jsonfile.py
@@ -30,7 +30,7 @@ DOCUMENTATION = '''
           - name: ANSIBLE_CACHE_PLUGIN_PREFIX
         ini:
           - key: fact_caching_prefix
-          - section: defaults
+            section: defaults
       _timeout:
         default: 86400
         description: Expiration timeout for the cache plugin data


### PR DESCRIPTION
In https://docs.ansible.com/ansible/2.5/plugins/cache/jsonfile.html,
the help for the _prefix parameter shows:
```
ini entries:

[ ]
fact_caching_prefix = VALUE

[defaults ]
= VALUE

env:ANSIBLE_CACHE_PLUGIN_PREFIX
```

whereas I suppose that what was expected is:
```
ini entries:

[defaults ]
fact_caching_prefix = VALUE

env:ANSIBLE_CACHE_PLUGIN_PREFIX
```