### PR TITLE
Docs: improving example syntax highlighting a little

### DIFF
--- a/docs/templates/plugin.rst.j2
+++ b/docs/templates/plugin.rst.j2
@@ -218,7 +218,7 @@ Notes
 Examples
 --------
 
-.. code-block:: yaml
+.. code-block:: yaml+jinja
 
 {%   for example in examples %}
 {%     if example['description'] %}@{ example['description'] | indent(4, True) }@{% endif %}


### PR DESCRIPTION
##### SUMMARY
Tries to improve syntax highlighting for module examples a bit. See https://github.com/ansible/ansible/pull/40050#issuecomment-389748352 (discussion with @dagwieers).

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
docs/templates/plugin.rst.j2

##### ANSIBLE VERSION
```
2.6.0
```
