### PR TITLE
Adding module to manage replication subnet groups for AWS Database Migration Service

### DIFF
--- a/lib/ansible/modules/cloud/amazon/dms_subnet_group.py
+++ b/lib/ansible/modules/cloud/amazon/dms_subnet_group.py
@@ -28,8 +28,8 @@ options:
   state:
     description:
      - Whether the replication subnet group should be exist or not.
-    required: true
     choices: ['present', 'absent']
+    default: 'present'
   description:
     description:
     - The description for the subnet group.
@@ -167,7 +167,7 @@ def main():
     module = AnsibleAWSModule(
         argument_spec={
             'name': dict(type='str', required=True),
-            'state': dict(type='str', choices=['present', 'absent'], required=True),
+            'state': dict(type='str', choices=['present', 'absent'], default='present'),
             'description': dict(type='str', required=True),
             'subnet_ids': dict(type='list', required=True),
         },

--- a/lib/ansible/modules/cloud/amazon/dms_subnet_group.py
+++ b/lib/ansible/modules/cloud/amazon/dms_subnet_group.py
@@ -1,0 +1,206 @@
+#!/usr/bin/python
+
+# Copyright: (c) 2018, Aaron Smith <ajsmith10381@gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = r'''
+---
+module: dms_subnet_group
+short_description: Manage subnet groups for AWS Database Migration Service.
+description:
+    - Create, update, and destroy AWS Database Migration Service subnet groups.
+author: "Aaron Smith (@slapula)"
+version_added: "2.6"
+requirements: [ 'botocore', 'boto3' ]
+options:
+  name:
+    description:
+    - The name for the replication subnet group. This value is stored as a lowercase string.
+    required: true
+  state:
+    description:
+     - Whether the replication subnet group should be exist or not.
+    required: true
+    choices: ['present', 'absent']
+  description:
+    description:
+    - The description for the subnet group.
+    required: true
+  subnet_ids:
+    description:
+    - The EC2 subnet IDs for the subnet group.
+    required: true
+extends_documentation_fragment:
+    - ec2
+    - aws
+'''
+
+
+EXAMPLES = r'''
+- name: Create replication subnet group for DMS instances
+  dms_subnet_group:
+    name: 'my_dms_subnet_group'
+    state: present
+    subnet_ids:
+      - 'subnet-1a2b3c4d'
+      - 'subnet-4d3c2b1a'
+
+- name: Remove replication subnet group
+  dms_subnet_group:
+    name: 'my_dms_subnet_group'
+    state: absent
+    subnet_ids:
+      - 'subnet-1a2b3c4d'
+      - 'subnet-4d3c2b1a'
+'''
+
+
+RETURN = r'''#'''
+
+import os
+import time
+
+from ansible.module_utils.aws.core import AnsibleAWSModule
+from ansible.module_utils.ec2 import boto3_conn, get_aws_connection_info, AWSRetry
+from ansible.module_utils.ec2 import camel_dict_to_snake_dict, boto3_tag_list_to_ansible_dict
+
+try:
+    from botocore.exceptions import BotoCoreError, ClientError
+except ImportError:
+    pass  # handled by AnsibleAWSModule
+
+
+def group_exists(client, module, result):
+    try:
+        response = client.describe_replication_subnet_groups()
+        for i in response['ReplicationSubnetGroups']:
+            if i['ReplicationSubnetGroupIdentifier'] == module.params.get('name'):
+                result['current_config'] = i
+                return True
+    except (ClientError, IndexError):
+        return False
+
+    return False
+
+
+def group_waiter(client, module):
+    try:
+        group_ready = False
+        while group_ready is False:
+            time.sleep(5)
+            status_check = client.describe_replication_subnet_groups()
+            for i in status_check['ReplicationSubnetGroups']:
+                if i['ReplicationSubnetGroupIdentifier'] == module.params.get('name'):
+                    if i['SubnetGroupStatus'] == 'Complete':
+                        group_ready = True
+    except (BotoCoreError, ClientError) as e:
+        module.fail_json_aws(e, msg="Failed while waiting on replication subnet group status")
+
+
+def create_group(client, module, params, result):
+    if module.check_mode:
+        module.exit_json(changed=True)
+    try:
+        response = client.create_replication_subnet_group(**params)
+        group_waiter(client, module)
+        result['changed'] = True
+        return result
+    except (BotoCoreError, ClientError) as e:
+        module.fail_json_aws(e, msg="Failed to create replication subnet group")
+
+    return result
+
+
+def update_group(client, module, params, result):
+    if module.check_mode:
+        module.exit_json(changed=True)
+    try:
+        updated_params = {}
+        param_changed = []
+        updated_params['ReplicationSubnetGroupIdentifier'] = params['ReplicationSubnetGroupIdentifier']
+        if params['ReplicationSubnetGroupDescription'] != result['current_config']['ReplicationSubnetGroupDescription']:
+            updated_params['ReplicationSubnetGroupDescription'] = params['ReplicationSubnetGroupDescription']
+            param_changed.append(True)
+        else:
+            param_changed.append(False)
+        updated_params['SubnetIds'] = params['SubnetIds']
+        current_subnets = [n['SubnetIdentifier'] for n in result['current_config']['Subnets']]
+        if sorted(updated_params['SubnetIds']) != sorted(current_subnets):
+            param_changed.append(True)
+        else:
+            param_changed.append(False)
+        if any(param_changed):
+            response = client.modify_replication_subnet_group(**updated_params)
+            group_waiter(client, module)
+            result['changed'] = True
+            return result
+    except (BotoCoreError, ClientError) as e:
+        module.fail_json_aws(e, msg="Failed to update replication subnet group")
+
+    return result
+
+
+def delete_group(client, module, result):
+    if module.check_mode:
+        module.exit_json(changed=True)
+    try:
+        response = client.delete_replication_subnet_group(
+            ReplicationSubnetGroupIdentifier=module.params.get('name')
+        )
+        result['changed'] = True
+        return result
+    except (BotoCoreError, ClientError) as e:
+        module.fail_json_aws(e, msg="Failed to delete replication subnet group")
+
+    return result
+
+
+def main():
+    module = AnsibleAWSModule(
+        argument_spec={
+            'name': dict(type='str', required=True),
+            'state': dict(type='str', choices=['present', 'absent'], required=True),
+            'description': dict(type='str', required=True),
+            'subnet_ids': dict(type='list', required=True),
+        },
+        supports_check_mode=True,
+    )
+
+    result = {
+        'changed': False
+    }
+
+    params = {}
+    params['ReplicationSubnetGroupIdentifier'] = module.params.get('name')
+    params['ReplicationSubnetGroupDescription'] = module.params.get('description')
+    params['SubnetIds'] = module.params.get('subnet_ids')
+
+    client = module.client('dms')
+
+    group_status = group_exists(client, module, result)
+
+    desired_state = module.params.get('state')
+
+    if desired_state == 'present':
+        if not group_status:
+            create_group(client, module, params, result)
+        if group_status:
+            update_group(client, module, params, result)
+
+    if desired_state == 'absent':
+        if group_status:
+            delete_group(client, module, result)
+
+    module.exit_json(changed=result['changed'], output=result)
+
+
+if __name__ == '__main__':
+    main()

--- a/test/integration/targets/dms_subnet_group/aliases
+++ b/test/integration/targets/dms_subnet_group/aliases
@@ -1,0 +1,2 @@
+cloud/aws
+posix/ci/cloud/group4/aws

--- a/test/integration/targets/dms_subnet_group/aliases
+++ b/test/integration/targets/dms_subnet_group/aliases
@@ -1,2 +1,3 @@
 cloud/aws
 posix/ci/cloud/group4/aws
+unstable

--- a/test/integration/targets/dms_subnet_group/aliases
+++ b/test/integration/targets/dms_subnet_group/aliases
@@ -1,3 +1,2 @@
 cloud/aws
-unsupported
-unstable
+posix/ci/cloud/group4/aws

--- a/test/integration/targets/dms_subnet_group/aliases
+++ b/test/integration/targets/dms_subnet_group/aliases
@@ -1,3 +1,3 @@
 cloud/aws
-posix/ci/cloud/group4/aws
+unsupported
 unstable

--- a/test/integration/targets/dms_subnet_group/defaults/main.yml
+++ b/test/integration/targets/dms_subnet_group/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+# defaults file for ec2_vpc_subnet
+ec2_vpc_subnet_name: '{{resource_prefix}}'
+ec2_vpc_subnet_description: 'Created by ansible integration tests'

--- a/test/integration/targets/dms_subnet_group/meta/main.yml
+++ b/test/integration/targets/dms_subnet_group/meta/main.yml
@@ -1,0 +1,3 @@
+dependencies:
+  - prepare_tests
+  - setup_ec2

--- a/test/integration/targets/dms_subnet_group/tasks/main.yml
+++ b/test/integration/targets/dms_subnet_group/tasks/main.yml
@@ -1,24 +1,14 @@
 ---
-# A Note about ec2 environment variable name preference:
-#  - EC2_URL -> AWS_URL
-#  - EC2_ACCESS_KEY -> AWS_ACCESS_KEY_ID -> AWS_ACCESS_KEY
-#  - EC2_SECRET_KEY -> AWS_SECRET_ACCESS_KEY -> AWX_SECRET_KEY
-#  - EC2_REGION -> AWS_REGION
-#
-
-# - include: ../../setup_ec2/tasks/common.yml module_name: ec2_vpc_subnet
+- name: set up aws connection info
+  set_fact:
+    aws_connection_info: &aws_connection_info
+      aws_access_key: "{{ aws_access_key }}"
+      aws_secret_key: "{{ aws_secret_key }}"
+      security_token: "{{ security_token }}"
+      region: "{{ aws_region }}"
+  no_log: yes
 
 - block:
-
-    - name: set up aws connection info
-      set_fact:
-        aws_connection_info: &aws_connection_info
-          aws_access_key: "{{ aws_access_key }}"
-          aws_secret_key: "{{ aws_secret_key }}"
-          #security_token: "{{ security_token }}"
-          region: "{{ aws_region }}"
-      no_log: yes
-
     ################################################
     # TESTING PREREQUIREMENTS
     ################################################
@@ -74,6 +64,42 @@
     # PARAMETER TESTING
     ################################################
 
+    - name: test with no parameters
+      dms_subnet_group:
+      register: result
+      ignore_errors: true
+
+    - name: assert failure when called with no parameters
+      assert:
+        that:
+           - result.failed
+           - 'result.msg.startswith("missing required arguments:")'
+
+    - name: test with missing parameters
+      dms_subnet_group:
+        name: 'my-dms-subnet-group'
+      register: result
+      ignore_errors: true
+
+    - name: assert failure when called with missing parameters
+      assert:
+        that:
+           - result.failed
+           - 'result.msg.startswith("missing required arguments:")'
+
+    - name: test with missing parameters
+      dms_subnet_group:
+        name: 'my-dms-subnet-group'
+        description: 'test string'
+      register: result
+      ignore_errors: true
+      check_mode: true
+
+    - name: assert failure when called with missing parameters
+      assert:
+        that:
+           - result.failed
+           - 'result.msg.startswith("missing required arguments:")'
 
     ################################################
     # MODULE TESTING

--- a/test/integration/targets/dms_subnet_group/tasks/main.yml
+++ b/test/integration/targets/dms_subnet_group/tasks/main.yml
@@ -1,0 +1,179 @@
+---
+# A Note about ec2 environment variable name preference:
+#  - EC2_URL -> AWS_URL
+#  - EC2_ACCESS_KEY -> AWS_ACCESS_KEY_ID -> AWS_ACCESS_KEY
+#  - EC2_SECRET_KEY -> AWS_SECRET_ACCESS_KEY -> AWX_SECRET_KEY
+#  - EC2_REGION -> AWS_REGION
+#
+
+# - include: ../../setup_ec2/tasks/common.yml module_name: ec2_vpc_subnet
+
+- block:
+
+    - name: set up aws connection info
+      set_fact:
+        aws_connection_info: &aws_connection_info
+          aws_access_key: "{{ aws_access_key }}"
+          aws_secret_key: "{{ aws_secret_key }}"
+          #security_token: "{{ security_token }}"
+          region: "{{ aws_region }}"
+      no_log: yes
+
+    ################################################
+    # TESTING PREREQUIREMENTS
+    ################################################
+
+    - name: create a VPC
+      ec2_vpc_net:
+        name: "{{ resource_prefix }}-vpc"
+        state: present
+        cidr_block: "10.10.0.0/16"
+        <<: *aws_connection_info
+        tags:
+          Name: "{{ resource_prefix }}-vpc"
+          Description: "Created by ansible-test"
+      register: vpc_result
+
+    - name: create subnet a
+      ec2_vpc_subnet:
+        cidr: "10.10.11.0/24"
+        az: "{{ aws_region }}a"
+        vpc_id: "{{ vpc_result.vpc.id }}"
+        tags:
+          Name: '{{ec2_vpc_subnet_name}}'
+          Description: '{{ec2_vpc_subnet_description}}'
+        <<: *aws_connection_info
+        state: present
+      register: vpc_subnet_a
+
+    - name: create subnet b
+      ec2_vpc_subnet:
+        cidr: "10.10.22.0/24"
+        az: "{{ aws_region }}b"
+        vpc_id: "{{ vpc_result.vpc.id }}"
+        tags:
+          Name: '{{ec2_vpc_subnet_name}}'
+          Description: '{{ec2_vpc_subnet_description}}'
+        <<: *aws_connection_info
+        state: present
+      register: vpc_subnet_b
+
+    - name: create subnet c
+      ec2_vpc_subnet:
+        cidr: "10.10.33.0/24"
+        az: "{{ aws_region }}b"
+        vpc_id: "{{ vpc_result.vpc.id }}"
+        tags:
+          Name: '{{ec2_vpc_subnet_name}}'
+          Description: '{{ec2_vpc_subnet_description}}'
+        <<: *aws_connection_info
+        state: present
+      register: vpc_subnet_c
+
+    ################################################
+    # PARAMETER TESTING
+    ################################################
+
+
+    ################################################
+    # MODULE TESTING
+    ################################################
+
+    - name: Create replication subnet group for DMS instances
+      dms_subnet_group:
+        <<: *aws_connection_info
+        name: 'my_dms_subnet_group'
+        state: present
+        description: 'my testing replication group'
+        subnet_ids:
+          - "{{ vpc_subnet_a.subnet.id }}"
+          - "{{ vpc_subnet_b.subnet.id }}"
+      register: result
+
+    - name: assert correct keys are returned
+      assert:
+        that:
+          - result.changed
+
+    - name: no changes made to replication subnet group
+      dms_subnet_group:
+        <<: *aws_connection_info
+        name: 'my_dms_subnet_group'
+        state: present
+        description: 'my testing replication group'
+        subnet_ids:
+          - "{{ vpc_subnet_a.subnet.id }}"
+          - "{{ vpc_subnet_b.subnet.id }}"
+      register: result
+
+    - name: assert correct keys are returned
+      assert:
+        that:
+          - not result.changed
+
+    - name: Make a change to replication subnet group
+      dms_subnet_group:
+        <<: *aws_connection_info
+        name: 'my_dms_subnet_group'
+        state: present
+        description: 'generating a change to this subnet group'
+        subnet_ids:
+          - "{{ vpc_subnet_a.subnet.id }}"
+          - "{{ vpc_subnet_b.subnet.id }}"
+          - "{{ vpc_subnet_c.subnet.id }}"
+      register: result
+
+    - name: assert correct keys are returned
+      assert:
+        that:
+          - result.changed
+
+  always:
+
+    ################################################
+    # TEARDOWN TESTING RESOURCES
+    ################################################
+
+    - name: Delete replication subnet group
+      dms_subnet_group:
+        <<: *aws_connection_info
+        name: 'my_dms_subnet_group'
+        state: absent
+        description: 'generating a change to this subnet group'
+        subnet_ids:
+          - "{{ vpc_subnet_a.subnet.id }}"
+          - "{{ vpc_subnet_b.subnet.id }}"
+          - "{{ vpc_subnet_c.subnet.id }}"
+      ignore_errors: yes
+
+    - name: tear down subnet a
+      ec2_vpc_subnet:
+        cidr: "10.10.11.0/24"
+        vpc_id: "{{ vpc_result.vpc.id }}"
+        state: absent
+        <<: *aws_connection_info
+      ignore_errors: yes
+
+    - name: tear down subnet b
+      ec2_vpc_subnet:
+        cidr: "10.10.22.0/24"
+        vpc_id: "{{ vpc_result.vpc.id }}"
+        state: absent
+        <<: *aws_connection_info
+      ignore_errors: yes
+
+    - name: tear down subnet c
+      ec2_vpc_subnet:
+        cidr: "10.10.33.0/24"
+        vpc_id: "{{ vpc_result.vpc.id }}"
+        state: absent
+        <<: *aws_connection_info
+      ignore_errors: yes
+
+    - name: tidy up VPC
+      ec2_vpc_net:
+        name: "{{ resource_prefix }}-vpc"
+        state: absent
+        cidr_block: "10.10.0.0/16"
+        <<: *aws_connection_info
+      ignore_errors: yes


### PR DESCRIPTION
##### SUMMARY
This is my first pull request of several to add support for AWS Database Migration Service.  This module manages the replication subnet groups in the spirit of `rds_subnet_group` and `redshift_subnet_group`.  It's a pretty simple module in terms of functionality.  One omission however.  I did not include support for adding and removing tags since AWS' documentation around replication subnet group ARNs is lacking (and I haven't been able to figure out how to properly form them myself) and you need the ARN to use the API calls.

##### ISSUE TYPE
 - New Module Pull Request

##### COMPONENT NAME
`dms_subnet_group`

##### ANSIBLE VERSION
```
ansible 2.4.1.0
  config file = None
  configured module search path = [u'/Users/asmith/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/asmith/.pyenv/versions/2.7.13/lib/python2.7/site-packages/ansible
  executable location = /Users/asmith/.pyenv/versions/2.7.13/bin/ansible
  python version = 2.7.13 (default, Sep  8 2017, 15:16:38) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```
