### PR TITLE
Detect invalid task_args in ActionBase

### DIFF
--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -93,6 +93,9 @@ class ActionBase(with_metaclass(ABCMeta, object)):
         elif self._task.async_val and self._play_context.check_mode:
             raise AnsibleActionFail('check mode and async cannot be used on same task.')
 
+        if task_vars and (None in list(task_vars.keys())):
+            raise AnsibleActionFail('An invalid "None" key was found in task_vars.')
+
         if self._connection._shell.tmpdir is None and self._early_needs_tmp_path():
             self._make_tmp_path()
 

--- a/test/units/plugins/action/test_action.py
+++ b/test/units/plugins/action/test_action.py
@@ -27,7 +27,7 @@ from ansible import constants as C
 from ansible.compat.tests import unittest
 from ansible.compat.tests.mock import patch, MagicMock, mock_open
 
-from ansible.errors import AnsibleError
+from ansible.errors import AnsibleError, AnsibleActionFail
 from ansible.module_utils.six import text_type
 from ansible.module_utils.six.moves import shlex_quote, builtins
 from ansible.module_utils._text import to_bytes
@@ -85,6 +85,23 @@ class TestActionBase(unittest.TestCase):
         action_base = DerivedActionBase(mock_task, mock_connection, play_context, None, None, None)
         results = action_base.run()
         self.assertEqual(results, {})
+
+    def test_action_base_run_invalid_task_args(self):
+        mock_task = MagicMock()
+        mock_task.action = "foo"
+        mock_task.args = dict(a=1, b=2, c=3)
+
+        mock_connection = MagicMock()
+
+        play_context = PlayContext()
+
+        mock_task.async_val = None
+        action_base = DerivedActionBase(mock_task, mock_connection, play_context, None, None, None)
+        task_vars = {
+            None: None
+        }
+        self.assertRaises(AnsibleActionFail, action_base.run,
+                          task_vars=task_vars)
 
     def test_action_base__configure_module(self):
         fake_loader = DictDataLoader({


### PR DESCRIPTION
##### SUMMARY

We found a situation where we had a ```vars.yaml``` with

```yaml
null: null
```

This ends up with a failure in https://github.com/ansible/ansible/blob/9eb2a6b41b80d07cca36fe607e0bfe331d8b08ba/lib/ansible/plugins/action/synchronize.py#L119

where it assumes the key is a value (in particular, a string I guess).
Rather than an internal exception, it would be better to give a
standard failure for this.  This checks for a ``None`` key in the
``task_vars in ActionBase.run()`` and raises a sensible error.  A unit
test is added.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
plugins/ActionBase

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0 (none-taskvar ca2de22005) last updated 2018/05/18 11:38:48 (GMT +1100)
  config file = None
  configured module search path = [u'/home/iwienand/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/iwienand/programs/ansible/lib/ansible
  executable location = /home/iwienand/programs/ansible/bin/ansible
  python version = 2.7.15 (default, May  2 2018, 14:12:52) [GCC 8.0.1 20180324 (Red Hat 8.0.1-0.20)]

```


