### PR TITLE
Adds the virtual argument to bigip_policy_rule

### DIFF
--- a/lib/ansible/modules/network/f5/bigip_policy_rule.py
+++ b/lib/ansible/modules/network/f5/bigip_policy_rule.py
@@ -30,12 +30,12 @@ options:
         a C(type) be specified.
       - These conditions can be specified in any order. Despite them being a list, the
         BIG-IP does not treat their order as anything special.
-      - Available C(type) values are C(forward).
     suboptions:
       type:
         description:
           - The action type. This value controls what below options are required.
-          - When C(type) is C(forward), will associate a given C(pool) with this rule.
+          - When C(type) is C(forward), will associate a given C(pool), or C(virtual)
+            with this rule.
           - When C(type) is C(enable), will associate a given C(asm_policy) with
             this rule.
           - When C(type) is C(ignore), will remove all existing actions from this
@@ -45,6 +45,10 @@ options:
       pool:
         description:
           - Pool that you want to forward traffic to.
+          - This parameter is only valid with the C(forward) type.
+      virtual:
+        description:
+          - Virtual Server that you want to forward traffic to.
           - This parameter is only valid with the C(forward) type.
       asm_policy:
         description:
@@ -393,11 +397,14 @@ class ModuleParameters(Parameters):
         :return:
         """
         action['type'] = 'forward'
-        if 'pool' not in item:
+        if not any(x for x in ['pool', 'virtual'] if x in item):
             raise F5ModuleError(
-                "A 'pool' must be specified when the 'forward' type is used."
+                "A 'pool' or 'virtual' must be specified when the 'forward' type is used."
             )
-        action['pool'] = fq_name(self.partition, item['pool'])
+        if item.get('pool', None):
+            action['pool'] = fq_name(self.partition, item['pool'])
+        elif item.get('virtual', None):
+            action['virtual'] = fq_name(self.partition, item['virtual'])
 
     def _handle_enable_action(self, action, item):
         """Handle the nuances of the enable type
@@ -811,10 +818,11 @@ class ArgumentSpec(object):
                         required=True
                     ),
                     pool=dict(),
-                    asm_policy=dict()
+                    asm_policy=dict(),
+                    virtual=dict()
                 ),
                 mutually_exclusive=[
-                    ['pool', 'asm_policy']
+                    ['pool', 'asm_policy', 'virtual']
                 ]
             ),
             conditions=dict(


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
This patch allows the module ot manage forwarding actions to virtual
servers in addition to the existing pools argument

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
bigip_policy_rule

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0
  config file = None
  configured module search path = ['/root/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python3.6/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 3.6.5 (default, May  5 2018, 03:09:35) [GCC 4.9.2]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
