### PR TITLE
ACME: fix Jinja2 templating in examples

### DIFF
--- a/lib/ansible/modules/web_infrastructure/acme_certificate.py
+++ b/lib/ansible/modules/web_infrastructure/acme_certificate.py
@@ -190,7 +190,7 @@ options:
     version_added: 2.6
 '''
 
-EXAMPLES = '''
+EXAMPLES = R'''
 ### Example with HTTP challenge ###
 
 - name: Create a challenge for sample.com using a account key from a variable.


### PR DESCRIPTION
##### SUMMARY
While working on #40365, I noticed that one Jinja2 template is destroyed in the module -> .rst conversion process (`'\'\\1\''` is converted to `''\1''`). This PR prevents this conversion by making the `EXAMPLES` string a raw string.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
acme_certificate

##### ANSIBLE VERSION
```
2.6, 2.5
```
