### PR TITLE
backport PR 40341 for issue 39472:

### DIFF
--- a/changelogs/fragments/py36-spwd.yaml
+++ b/changelogs/fragments/py36-spwd.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- spwd - With python 3.6 spwd.getspnam returns PermissionError instead of KeyError if user does not have privileges (https://github.com/ansible/ansible/issues/39472)

--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -218,6 +218,7 @@ EXAMPLES = '''
     expires: 1422403387
 '''
 
+import errno
 import grp
 import os
 import platform
@@ -616,6 +617,13 @@ class User(object):
                 return passwd, expires
             except KeyError:
                 return passwd, expires
+            except OSError as e:
+                # Python 3.6 raises PermissionError instead of KeyError
+                # Due to absence of PermissionError in python2.7 need to check
+                # errno
+                if e.errno in (errno.EACCES, errno.EPERM):
+                    return passwd, expires
+                raise
 
         if not self.user_exists():
             return passwd, expires


### PR DESCRIPTION

##### SUMMARY
With python 3.6 spwd.getspnam returns PermissionError instead of
KeyError if user does not have privileges

(cherry picked from commit 0023b1ee9eca1286493c56ce5e1aa1b2272c3e39)


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
system.user

##### ANSIBLE VERSION
```
ansible 2.5.2
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/gtema/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.15 (default, May  2 2018, 14:12:52) [GCC 8.0.1 20180324 (Red Hat 8.0.1-0.20)]

```


##### ADDITIONAL INFORMATION
The issue is blocking openstack modules tests with python3.6
