### PR TITLE
Fixing issues with httpapi

### DIFF
--- a/bin/ansible-connection
+++ b/bin/ansible-connection
@@ -69,7 +69,7 @@ class ConnectionProcess(object):
         self.connection = None
         self._ansible_playbook_pid = ansible_playbook_pid
 
-    def start(self):
+    def start(self, variables):
         try:
             messages = list()
             result = {}
@@ -83,7 +83,7 @@ class ConnectionProcess(object):
                 self.play_context.private_key_file = os.path.join(self.original_path, self.play_context.private_key_file)
             self.connection = connection_loader.get(self.play_context.connection, self.play_context, '/dev/null',
                                                     ansible_playbook_pid=self._ansible_playbook_pid)
-            self.connection.set_options()
+            self.connection.set_options(var_options=variables)
             self.connection._connect()
             self.connection._socket_path = self.socket_path
             self.srv.register(self.connection)
@@ -201,10 +201,21 @@ def main():
             init_data += cur_line
             cur_line = stdin.readline()
 
+        cur_line = stdin.readline()
+        vars_data = b''
+
+        while cur_line.strip() != b'#END_VARS#':
+            if cur_line == b'':
+                raise Exception("EOF found before vars data was complete")
+            vars_data += cur_line
+            cur_line = stdin.readline()
+
         if PY3:
             pc_data = cPickle.loads(init_data, encoding='bytes')
+            variables = cPickle.loads(vars_data, encoding='bytes')
         else:
             pc_data = cPickle.loads(init_data)
+            variables = cPickle.loads(vars_data)
 
         play_context = PlayContext()
         play_context.deserialize(pc_data)
@@ -242,7 +253,7 @@ def main():
                         os.close(r)
                         wfd = os.fdopen(w, 'w')
                         process = ConnectionProcess(wfd, play_context, socket_path, original_path, ansible_playbook_pid)
-                        process.start()
+                        process.start(variables)
                     except Exception:
                         messages.append(traceback.format_exc())
                         rc = 1

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -813,7 +813,7 @@ class TaskExecutor:
             self._play_context.timeout = connection.get_option('persistent_command_timeout')
             display.vvvv('attempting to start connection', host=self._play_context.remote_addr)
             display.vvvv('using connection plugin %s' % connection.transport, host=self._play_context.remote_addr)
-            socket_path = self._start_connection()
+            socket_path = self._start_connection(variables)
             display.vvvv('local domain socket path is %s' % socket_path, host=self._play_context.remote_addr)
             setattr(connection, '_socket_path', socket_path)
 
@@ -886,7 +886,7 @@ class TaskExecutor:
 
         return handler
 
-    def _start_connection(self):
+    def _start_connection(self, variables):
         '''
         Starts the persistent connection
         '''
@@ -918,8 +918,12 @@ class TaskExecutor:
         # that means only protocol=0 will work.
         src = cPickle.dumps(self._play_context.serialize(), protocol=0)
         stdin.write(src)
-
         stdin.write(b'\n#END_INIT#\n')
+
+        src = cPickle.dumps(variables, protocol=0)
+        stdin.write(src)
+        stdin.write(b'\n#END_VARS#\n')
+
         stdin.flush()
 
         (stdout, stderr) = p.communicate()

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -813,7 +813,9 @@ class TaskExecutor:
             self._play_context.timeout = connection.get_option('persistent_command_timeout')
             display.vvvv('attempting to start connection', host=self._play_context.remote_addr)
             display.vvvv('using connection plugin %s' % connection.transport, host=self._play_context.remote_addr)
-            socket_path = self._start_connection(variables)
+            # We don't need to send the entire contents of variables to ansible-connection
+            filtered_vars = dict((key, value) for key, value in variables.items() if key.startswith('ansible'))
+            socket_path = self._start_connection(filtered_vars)
             display.vvvv('local domain socket path is %s' % socket_path, host=self._play_context.remote_addr)
             setattr(connection, '_socket_path', socket_path)
 

--- a/lib/ansible/plugins/connection/httpapi.py
+++ b/lib/ansible/plugins/connection/httpapi.py
@@ -295,7 +295,10 @@ class Connection(ConnectionBase):
         '''
         Sends the command to the device over api
         '''
-        url_kwargs = dict(url_username=self._play_context.remote_user, url_password=self._play_context.password)
+        url_kwargs = dict(
+            url_username=self.get_option('remote_user'), url_password=self.get_option('password'),
+            timeout=self.get_option('persistent_command_timeout'),
+        )
         url_kwargs.update(kwargs)
         response = open_url(self._url + path, data=data, **url_kwargs)
         self._auth = response.info().get('Set-Cookie')

--- a/lib/ansible/plugins/connection/httpapi.py
+++ b/lib/ansible/plugins/connection/httpapi.py
@@ -16,7 +16,7 @@ version_added: "2.6"
 options:
   host:
     description:
-      - Specifies the remote device FQDN or IP address to establish the SSH
+      - Specifies the remote device FQDN or IP address to establish the HTTP(S)
         connection to.
     default: inventory_hostname
     vars:
@@ -34,6 +34,7 @@ options:
       - name: ANSIBLE_REMOTE_PORT
     vars:
       - name: ansible_port
+      - name: ansible_httpapi_port
   network_os:
     description:
       - Configures the device platform network operating system.  This value is

--- a/lib/ansible/plugins/connection/persistent.py
+++ b/lib/ansible/plugins/connection/persistent.py
@@ -117,8 +117,12 @@ class Connection(ConnectionBase):
         # that means only protocol=0 will work.
         src = cPickle.dumps(self._play_context.serialize(), protocol=0)
         stdin.write(src)
-
         stdin.write(b'\n#END_INIT#\n')
+
+        src = cPickle.dumps({}, protocol=0)
+        stdin.write(src)
+        stdin.write(b'\n#END_VARS#\n')
+
         stdin.flush()
 
         (stdout, stderr) = p.communicate()

--- a/test/integration/targets/nxos_ntp/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_ntp/tests/common/sanity.yaml
@@ -11,7 +11,6 @@
     vrf_name: management
     source_addr: 5.5.5.5
     state: absent
-    provider: "{{ connection }}"
   ignore_errors: yes
 
 - block:
@@ -24,7 +23,6 @@
       vrf_name: management
       source_addr: 5.5.5.5
       state: present
-      provider: "{{ connection }}"
     register: result
 
   - assert: &true
@@ -47,7 +45,6 @@
       vrf_name: default
       source_addr: default
       state: present
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -76,7 +73,6 @@
       peer: 1.2.3.4
       prefer: enabled
       state: present
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -91,7 +87,6 @@
     nxos_ntp: &config3
       source_int: default
       state: present
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true

--- a/test/integration/targets/nxos_ntp_auth/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_ntp_auth/tests/common/sanity.yaml
@@ -8,7 +8,6 @@
     key_id: 32
     md5string: hello
     state: absent
-    provider: "{{ connection }}"
   ignore_errors: yes
 
 - block:
@@ -19,7 +18,6 @@
       md5string: hello
       authentication: off
       state: present
-      provider: "{{ connection }}"      
     register: result
 
   - assert: &true
@@ -32,7 +30,6 @@
       md5string: hello
       authentication: off
       state: absent
-      provider: "{{ connection }}"      
     register: result
 
   - assert: *true
@@ -43,7 +40,6 @@
       md5string: hello
       auth_type: encrypt
       state: present
-      provider: "{{ connection }}"      
     register: result
 
   - assert: *true
@@ -60,7 +56,6 @@
     nxos_ntp_auth: &authon
       authentication: on
       state: present
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -75,7 +70,6 @@
     nxos_ntp_auth: &authoff
       authentication: off
       state: present
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -91,7 +85,6 @@
       key_id: 32
       trusted_key: true
       state: present
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -107,7 +100,6 @@
       key_id: 32
       trusted_key: false
       state: present
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -125,7 +117,6 @@
       auth_type: encrypt
       authentication: on
       state: absent
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true

--- a/test/integration/targets/nxos_ntp_options/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_ntp_options/tests/common/sanity.yaml
@@ -6,7 +6,6 @@
 - name: "Apply default ntp config" 
   nxos_ntp_options: &default
     state: absent
-    provider: "{{ connection }}"
   ignore_errors: yes
 
 - block:
@@ -16,7 +15,6 @@
       master: true
       logging: true
       state: present
-      provider: "{{ connection }}"      
     register: result
 
   - assert: &true
@@ -36,7 +34,6 @@
       master: true
       stratum: 10
       state: present
-      provider: "{{ connection }}"      
     register: result
 
   - assert: *true
@@ -53,7 +50,6 @@
       stratum: 10
       logging: false
       state: present
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -69,7 +65,6 @@
       master: false
       logging: true
       state: present
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true

--- a/test/integration/targets/nxos_nxapi/tests/cli/configure.yaml
+++ b/test/integration/targets/nxos_nxapi/tests/cli/configure.yaml
@@ -7,7 +7,6 @@
 - name: Setup - put NXAPI in stopped state
   nxos_nxapi:
     state: absent
-    provider: "{{ cli }}"
 
 - name: Configure NXAPI
   nxos_nxapi:
@@ -15,13 +14,11 @@
     enable_sandbox: "{{nxapi_sandbox_option|default(omit)}}"
     enable_https: yes
     https_port: 9443
-    provider: "{{ cli }}"
   register: result
 
 - nxos_command:
     commands:
       - show nxapi | json
-    provider: "{{ cli }}"
   register: result
 
 - include: targets/nxos_nxapi/tasks/platform/n7k/assert_changes.yaml
@@ -39,7 +36,6 @@
     enable_sandbox: "{{nxapi_sandbox_option|default(omit)}}"
     enable_https: yes
     https_port: 9443
-    provider: "{{ cli }}"
   register: result
 
 - name: Assert configuration is idempotent

--- a/test/integration/targets/nxos_nxapi/tests/cli/disable.yaml
+++ b/test/integration/targets/nxos_nxapi/tests/cli/disable.yaml
@@ -4,14 +4,12 @@
 - name: Disable NXAPI
   nxos_nxapi:
     state: absent
-    provider: "{{ cli }}"
   register: result
 
 - name: Check NXAPI state
   nxos_command:
     commands:
       - show feature | grep nxapi
-    provider: "{{ cli }}"
   register: result
 
 - name: Assert NXAPI is disabled
@@ -23,7 +21,6 @@
   nxos_nxapi:
     state:
       absent
-    provider: "{{ cli }}"
   register: result
 
 - name: Assert idempotence

--- a/test/integration/targets/nxos_nxapi/tests/cli/enable.yaml
+++ b/test/integration/targets/nxos_nxapi/tests/cli/enable.yaml
@@ -4,20 +4,17 @@
 - name: Setup - put NXAPI in stopped state
   nxos_nxapi:
       state: absent
-      provider: "{{ cli }}"
   register: result
 
 - name: Enable NXAPI
   nxos_nxapi:
       state: present
-      provider: "{{ cli }}"
   register: result
 
 - name: Check NXAPI state
   nxos_command:
       commands:
           - show feature | grep nxapi
-      provider: "{{ cli }}"
   register: result
 
 - name: Assert NXAPI is enabled
@@ -26,7 +23,6 @@
 
 - name: Enable NXAPI again
   nxos_nxapi:
-      provider: "{{ cli }}"
   register: result
 
 - name: Assert idempotence

--- a/test/integration/targets/nxos_ospf/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_ospf/tests/common/sanity.yaml
@@ -7,7 +7,6 @@
   nxos_feature:
     feature: ospf
     state: enabled
-    provider: "{{ connection }}"
   ignore_errors: yes
 
 - block:
@@ -15,7 +14,6 @@
     nxos_ospf: &config
       ospf: 1
       state: present
-      provider: "{{ connection }}"
     register: result
 
   - assert: &true
@@ -35,7 +33,6 @@
     nxos_feature:
       feature: ospf
       state: disabled
-      provider: "{{ connection }}"
     ignore_errors: yes
 
   always:
@@ -43,7 +40,6 @@
     nxos_ospf: &unconfig
       ospf: 1
       state: absent
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true

--- a/test/integration/targets/nxos_ospf_vrf/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_ospf_vrf/tests/common/sanity.yaml
@@ -7,7 +7,6 @@
   nxos_feature:
     feature: ospf
     state: enabled
-    provider: "{{ connection }}"
   ignore_errors: yes
 
 - block:
@@ -24,7 +23,6 @@
       vrf: test
       passive_interface: true
       state: present
-      provider: "{{ connection }}"
     register: result
 
   - assert: &true
@@ -50,7 +48,6 @@
       vrf: default
       passive_interface: true
       state: present
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -71,7 +68,6 @@
       passive_interface: false
       vrf: default
       state: present
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -87,7 +83,6 @@
       ospf: 2
       vrf: default
       state: absent
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -103,7 +98,6 @@
       ospf: 1
       vrf: test
       state: absent
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -119,7 +113,6 @@
     nxos_feature:
       feature: ospf
       state: disabled
-      provider: "{{ connection }}"
     ignore_errors: yes
 
 - debug: msg="END connection={{ ansible_connection }} nxos_ospf_vrf sanity test"

--- a/test/integration/targets/nxos_overlay_global/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_overlay_global/tests/common/sanity.yaml
@@ -16,7 +16,6 @@
   - name: "Enable nv overlay evpn"
     nxos_evpn_global: &enable_evpn
       nv_overlay_evpn: true
-      provider: "{{ connection }}"
 
   - name: "Apply N7K specific setup config"
     include: targets/nxos_overlay_global/tasks/platform/n7k/setup.yaml
@@ -28,13 +27,11 @@
         - feature-set fabric
         - feature fabric forwarding
       match: none
-      provider: "{{ connection }}"
     when: platform is match('N7K')
 
   - name: "Remove possibly existing mac"
     nxos_overlay_global:
       anycast_gateway_mac: "default"
-      provider: "{{ connection }}"
     ignore_errors: yes
 
   when: overlay_global_supported
@@ -45,7 +42,6 @@
   - name: Configure overlay global
     nxos_overlay_global: &configure
       anycast_gateway_mac: "b.b.b"
-      provider: "{{ connection }}"
     register: result
 
   - assert: &true
@@ -63,7 +59,6 @@
   - name: Update anycast gateway mac
     nxos_overlay_global: &update
       anycast_gateway_mac: "a.a.a"
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -78,7 +73,6 @@
   - name: Remove anycast gateway mac
     nxos_overlay_global: &remove
       anycast_gateway_mac: "default"
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -99,7 +93,6 @@
   - name: "Disable nv overlay evpn"
     nxos_evpn_global: &disable_evpn
       nv_overlay_evpn: false
-      provider: "{{ connection }}"
     ignore_errors: yes
     when: overlay_global_supported
 

--- a/test/integration/targets/nxos_pim/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_pim/tests/common/sanity.yaml
@@ -7,18 +7,15 @@
   nxos_feature: &disable_feature
     feature: pim
     state: disabled
-    provider: "{{ connection }}"
 
 - name: "Setup: Enable feature PIM"
   nxos_feature:
     feature: pim
     state: enabled
-    provider: "{{ connection }}"
 
 - name: "Setup: Configure ssm_range none"
   nxos_pim: &none
     ssm_range: "none"
-    provider: "{{ connection }}"
 
 - block:
   - name: Configure ssm_range
@@ -26,7 +23,6 @@
       ssm_range: 
         - "239.128.1.0/24"
         - "224.0.0.0/8"
-      provider: "{{ connection }}"
     register: result
 
   - assert: &true
@@ -44,7 +40,6 @@
   - name: Configure ssm_range default
     nxos_pim: &conf_default
       ssm_range: "default"
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true

--- a/test/integration/targets/nxos_pim_interface/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_pim_interface/tests/common/sanity.yaml
@@ -7,13 +7,11 @@
   nxos_feature: &disable_feature
     feature: pim
     state: disabled
-    provider: "{{ connection }}"
 
 - name: "Enable feature PIM"
   nxos_feature:
     feature: pim
     state: enabled
-    provider: "{{ connection }}"
 
 - set_fact: testint="{{ nxos_int1 }}"
 
@@ -21,7 +19,6 @@
   nxos_config:
     lines:
       - "default interface {{ testint }}"
-    provider: "{{ connection }}"
   ignore_errors: yes
 
 - name: "Ensure {{testint}} is layer3"
@@ -31,14 +28,12 @@
     description: 'Configured by Ansible - Layer3'
     admin_state: 'up'
     state: present
-    provider: "{{ connection }}"
 
 - block:
   - name: Configure nxos_pim_interface state absent
     nxos_pim_interface: &pimabsent
       interface: "{{ testint }}"
       state: absent
-      provider: "{{ connection }}"
 
   - name: configure jp policy and type
     nxos_pim_interface: &configjp
@@ -49,7 +44,6 @@
       jp_type_out: routemap
       sparse: True
       border: True
-      provider: "{{ connection }}"
     register: result
 
   - assert: &true
@@ -69,7 +63,6 @@
       interface: "{{ testint }}"
       neighbor_policy: NPR
       neighbor_type: routemap
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -88,7 +81,6 @@
       interface: "{{ testint }}"
       neighbor_policy: NPPF
       neighbor_type: prefix
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -103,7 +95,6 @@
     nxos_pim_interface: &confighak1
       interface: "{{ testint }}"
       hello_auth_key: password1
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -116,7 +107,6 @@
       sparse: True
       border: True
       state: present
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -133,7 +123,6 @@
       sparse: False
       border: False
       state: present
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -151,7 +140,6 @@
     nxos_pim_interface: &configdefault
       interface: "{{ testint }}"
       state: default
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -167,7 +155,6 @@
       interface: "{{ testint }}"
       border: True
       state: present
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true

--- a/test/integration/targets/nxos_pim_rp_address/tests/common/configure.yaml
+++ b/test/integration/targets/nxos_pim_rp_address/tests/common/configure.yaml
@@ -12,13 +12,11 @@
     nxos_feature: &disable_feature
       feature: pim
       state: disabled
-      provider: "{{ connection }}"
 
   - name: "Enable feature PIM"
     nxos_feature: &enable_feature
       feature: pim
       state: enabled
-      provider: "{{ connection }}"
 
   - name: Configure rp_address + group_list 
     nxos_pim_rp_address: &configgl
@@ -26,7 +24,6 @@
       group_list: "224.0.0.0/8"
       bidir: "{{ bidir }}"
       state: present
-      provider: "{{ connection }}"
     register: result
 
   - assert: &true
@@ -47,7 +44,6 @@
       group_list: "224.0.0.0/8"
       bidir: False
       state: present
-      provider: "{{ connection }}"
     register: result
     when: platform is not match("N3L")
 
@@ -67,7 +63,6 @@
       rp_address: "10.1.1.20"
       bidir: "{{ bidir }}"
       state: present
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -83,7 +78,6 @@
       rp_address: "10.1.1.20"
       bidir: False
       state: present
-      provider: "{{ connection }}"
     register: result
     when: platform is not match("N3L")
 
@@ -103,7 +97,6 @@
       rp_address: "10.1.1.20"
       group_list: "224.0.0.0/8"
       state: absent
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -118,7 +111,6 @@
     nxos_pim_rp_address: &configbir
       rp_address: "10.1.1.20"
       state: absent
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -135,7 +127,6 @@
       prefix_list: "pim_prefix_list"
       bidir: "{{ bidir }}"
       state: present
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -152,7 +143,6 @@
       prefix_list: "pim_prefix_list"
       bidir: False
       state: present
-      provider: "{{ connection }}"
     register: result
     when: platform is not match("N3L")
 
@@ -173,7 +163,6 @@
       prefix_list: "pim_prefix_list"
       bidir: False
       state: absent
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -190,7 +179,6 @@
       route_map: "pim_routemap"
       bidir: "{{ bidir }}"
       state: present
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -207,7 +195,6 @@
       route_map: "pim_routemap"
       bidir: False
       state: present
-      provider: "{{ connection }}"
     register: result
     when: platform is not match("N3L")
 
@@ -228,7 +215,6 @@
       route_map: "pim_routemap"
       bidir: False
       state: absent
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true

--- a/test/integration/targets/nxos_portchannel/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_portchannel/tests/common/sanity.yaml
@@ -10,21 +10,18 @@
   nxos_feature:
     feature: lacp
     state: enabled
-    provider: "{{ connection }}"
   ignore_errors: yes
 
 - name: "Put interface {{testint1}} into default state"
   nxos_config: &intdefault1
     lines:
       - "default interface {{ testint1 }}"
-    provider: "{{ connection }}"
   ignore_errors: yes
 
 - name: "Put interface {{testint2}} into default state"
   nxos_config: &intdefault2
     lines:
       - "default interface {{ testint2 }}"
-    provider: "{{ connection }}"
   ignore_errors: yes
 
 - name: Remove possibly configured port-channel 99
@@ -34,7 +31,6 @@
     force: 'true'
     state: absent
     timeout: 60
-    provider: "{{ connection }}"
 
 - block:
   - name: Configure port-channel mode active
@@ -45,7 +41,6 @@
       force: 'true'
       state: present
       timeout: 60
-      provider: "{{ connection }}"
     register: result
 
   - assert: &true
@@ -68,7 +63,6 @@
       force: 'true'
       state: present
       timeout: 60
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -91,7 +85,6 @@
       feature: lacp
       state: disabled
       timeout: 60
-      provider: "{{ connection }}"
 
   always:
   - name: Delete port-channel

--- a/test/integration/targets/nxos_rollback/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_rollback/tests/common/sanity.yaml
@@ -9,20 +9,17 @@
       - terminal dont-ask
       - delete backup.cfg
     match: none
-    provider: "{{ connection }}"
   ignore_errors: yes
 
 - name: Create checkpoint file
   nxos_rollback:
     checkpoint_file: backup.cfg
     timeout: 300
-    provider: "{{ connection }}"
 
 - name: rollback to the previously created checkpoint file
   nxos_rollback:
     rollback_to: backup.cfg
     timeout: 300
-    provider: "{{ connection }}"
 
 - name: cleanup checkpoint file
   nxos_config: *delete

--- a/test/integration/targets/nxos_snapshot/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_snapshot/tests/common/sanity.yaml
@@ -14,7 +14,6 @@
       snapshot_name: test_snapshot1
       description: Ansible
       save_snapshot_locally: true
-      provider: "{{ connection }}"
 
   - name: create another snapshot
     nxos_snapshot:
@@ -26,7 +25,6 @@
       row_id: ROW_intf
       element_key1: intf-name
       save_snapshot_locally: true
-      provider: "{{ connection }}"
 
   - name: compare snapshots
     nxos_snapshot:
@@ -36,7 +34,6 @@
       comparison_results_file: compare_snapshots.txt
       compare_option: summary
       path: '.'
-      provider: "{{ connection }}"
 
   - name: FAIL compare snapshots
     nxos_snapshot:
@@ -45,7 +42,6 @@
       snapshot2: test_snapshot2
       compare_option: summary
       path: '.'
-      provider: "{{ connection }}"
     register: result
     ignore_errors: yes
 
@@ -60,7 +56,6 @@
   - name: delete snapshot
     nxos_snapshot:
       action: delete_all
-      provider: "{{ connection }}"
     ignore_errors: yes
 
 - debug: msg="END connection={{ ansible_connection }} nxos_snapshot sanity test"

--- a/test/integration/targets/nxos_snmp_community/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_snmp_community/tests/common/sanity.yaml
@@ -8,7 +8,6 @@
     community: TESTING7
     group: network-operator
     state: absent 
-    provider: "{{ connection }}"
   ignore_errors: yes
 
 - block:
@@ -18,7 +17,6 @@
       community: TESTING7
       group: network-operator
       state: present
-      provider: "{{ connection }}"
     register: result
 
   - assert: &true
@@ -38,7 +36,6 @@
       community: TESTING7
       group: network-admin
       state: present
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -66,7 +63,6 @@
       community: TESTING7
       access: ro
       state: present
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -95,7 +91,6 @@
       access: rw
       acl: ansible_acl
       state: present
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -112,7 +107,6 @@
       access: rw
       acl: new_acl
       state: present
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -129,7 +123,6 @@
       access: rw
       acl: default
       state: present
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true

--- a/test/integration/targets/nxos_snmp_contact/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_snmp_contact/tests/common/sanity.yaml
@@ -7,7 +7,6 @@
   nxos_snmp_contact: &remove
     contact: Test
     state: absent 
-    provider: "{{ connection }}"
 
 - block:
 
@@ -15,7 +14,6 @@
     nxos_snmp_contact: &config
       contact: Testing
       state: present
-      provider: "{{ connection }}"
     register: result
 
   - assert: &true
@@ -34,7 +32,6 @@
     nxos_snmp_contact: &config1
       contact: Test
       state: present
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true

--- a/test/integration/targets/nxos_snmp_host/tests/common/sanity_snmp_v1_trap.yaml
+++ b/test/integration/targets/nxos_snmp_host/tests/common/sanity_snmp_v1_trap.yaml
@@ -21,7 +21,6 @@
     src_intf: "{{ intname|default(omit) }}"
     udp: 222
     state: absent 
-    provider: "{{ connection }}"
   ignore_errors: yes
 
 - block:
@@ -37,7 +36,6 @@
       src_intf: "{{ intname|default(omit) }}"
       udp: 222
       state: present 
-      provider: "{{ connection }}"
     register: result
 
   - assert: &true
@@ -59,7 +57,6 @@
         vrf_filter: default
         udp: 222
         state: present 
-        provider: "{{ connection }}"
       register: result
 
     - assert: *true
@@ -79,7 +76,6 @@
       vrf: management
       vrf_filter: management
       state: absent
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -97,7 +93,6 @@
         udp: 222
         vrf_filter: default
         state: absent
-        provider: "{{ connection }}"
       register: result
 
     - assert: *true

--- a/test/integration/targets/nxos_snmp_host/tests/common/sanity_snmp_v2_inform.yaml
+++ b/test/integration/targets/nxos_snmp_host/tests/common/sanity_snmp_v2_inform.yaml
@@ -21,7 +21,6 @@
     src_intf: "{{ intname|default(omit) }}"
     udp: 222
     state: absent 
-    provider: "{{ connection }}"
   ignore_errors: yes
 
 - block:
@@ -37,7 +36,6 @@
       src_intf: "{{ intname|default(omit) }}"
       udp: 222
       state: present 
-      provider: "{{ connection }}"
     register: result
 
   - assert: &true
@@ -59,7 +57,6 @@
         vrf_filter: default
         udp: 222
         state: present 
-        provider: "{{ connection }}"
       register: result
 
     - assert: *true
@@ -79,7 +76,6 @@
       vrf: management
       vrf_filter: management
       state: absent
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -97,7 +93,6 @@
         udp: 222
         vrf_filter: default
         state: absent
-        provider: "{{ connection }}"
       register: result
 
     - assert: *true

--- a/test/integration/targets/nxos_snmp_host/tests/common/sanity_snmp_v3_inform.yaml
+++ b/test/integration/targets/nxos_snmp_host/tests/common/sanity_snmp_v3_inform.yaml
@@ -26,7 +26,6 @@
     vrf_filter: management
     src_intf: "{{ intname|default(omit) }}"
     state: absent 
-    provider: "{{ connection }}"
   ignore_errors: yes
 
 - block:
@@ -42,7 +41,6 @@
       vrf_filter: management
       src_intf: "{{ intname|default(omit) }}"
       state: present 
-      provider: "{{ connection }}"
     register: result
 
   - assert: &true
@@ -63,7 +61,6 @@
         snmp_host: 3.3.3.3
         vrf_filter: default
         state: present 
-        provider: "{{ connection }}"
       register: result
 
     - assert: *true
@@ -82,7 +79,6 @@
       vrf: management
       vrf_filter: management
       state: absent
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -99,7 +95,6 @@
         snmp_host: 3.3.3.3
         vrf_filter: default
         state: absent
-        provider: "{{ connection }}"
       register: result
 
     - assert: *true

--- a/test/integration/targets/nxos_snmp_host/tests/common/sanity_snmp_v3_trap.yaml
+++ b/test/integration/targets/nxos_snmp_host/tests/common/sanity_snmp_v3_trap.yaml
@@ -23,7 +23,6 @@
     vrf_filter: management
     src_intf: "{{ intname|default(omit) }}"
     state: absent 
-    provider: "{{ connection }}"
   ignore_errors: yes
 
 - block:
@@ -40,7 +39,6 @@
       vrf_filter: management
       src_intf: "{{ intname|default(omit) }}"
       state: present 
-      provider: "{{ connection }}"
     register: result
 
   - assert: &true
@@ -62,7 +60,6 @@
         udp: 222
         vrf_filter: default
         state: present 
-        provider: "{{ connection }}"
       register: result
 
     - assert: *true
@@ -82,7 +79,6 @@
       vrf: management
       vrf_filter: management
       state: absent
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -100,7 +96,6 @@
         udp: 222
         vrf_filter: default
         state: absent
-        provider: "{{ connection }}"
       register: result
 
     - assert: *true

--- a/test/integration/targets/nxos_snmp_location/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_snmp_location/tests/common/sanity.yaml
@@ -7,14 +7,12 @@
   nxos_snmp_location: &remove
     location: Test 
     state: absent
-    provider: "{{ connection }}"
 
 - block:
   - name: Configure snmp location 
     nxos_snmp_location: &config
       location: Testing
       state: present
-      provider: "{{ connection }}"
     register: result
 
   - assert: &true
@@ -33,7 +31,6 @@
     nxos_snmp_location: &config1
       location: Test
       state: present
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true

--- a/test/integration/targets/nxos_snmp_traps/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_snmp_traps/tests/common/sanity.yaml
@@ -7,14 +7,12 @@
   nxos_snmp_traps: &remove
     group: all 
     state: disabled
-    provider: "{{ connection }}"
 
 - block:
   - name: Configure one snmp trap group 
     nxos_snmp_traps: &config
       group: bridge 
       state: enabled
-      provider: "{{ connection }}"
     register: result
 
   - assert: &true
@@ -33,7 +31,6 @@
     nxos_snmp_traps: &rem1
       group: bridge
       state: disabled
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -48,7 +45,6 @@
     nxos_snmp_traps: &config1
       group: all
       state: enabled
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true

--- a/test/integration/targets/nxos_snmp_user/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_snmp_user/tests/common/sanity.yaml
@@ -7,7 +7,6 @@
   nxos_snmp_user: &remove
     user: ntc
     state: absent
-    provider: "{{ connection }}"
 
 - pause:
     seconds: 5
@@ -21,7 +20,6 @@
       pwd: N$tOpe%1
       privacy: HelloU$er1
       encrypt: true
-      provider: "{{ connection }}"
     register: result
 
   - assert: &true
@@ -32,7 +30,6 @@
     nxos_snmp_user: &chg
       user: ntc
       group: network-admin
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -50,7 +47,6 @@
       user: ntc
       group: network-admin
       state: absent
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -69,7 +65,6 @@
       user: ntc
       group: network-operator
       state: absent
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true

--- a/test/integration/targets/nxos_static_route/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_static_route/tests/common/sanity.yaml
@@ -12,7 +12,6 @@
       pref: 100
       tag: 5500
       vrf: "{{ item }}"
-      provider: "{{ connection }}"
     with_items: "{{ vrfs }}"
     register: result
 
@@ -37,7 +36,6 @@
       pref: 10
       tag: default
       vrf: "{{ item }}"
-      provider: "{{ connection }}"
     with_items: "{{ vrfs }}"
     register: result
 
@@ -58,7 +56,6 @@
       pref: 100
       vrf: "{{ item }}"
       state: absent
-      provider: "{{ connection }}"
     with_items: "{{ vrfs }}"
     register: result
 
@@ -76,7 +73,6 @@
       aggregate:
         - { prefix: "192.168.22.64/24", next_hop: "3.3.3.3" }
         - { prefix: "192.168.24.64/24", next_hop: "3.3.3.3" }
-      provider: "{{ connection }}"
     register: result
 
   - assert:
@@ -97,7 +93,6 @@
         - { prefix: "192.168.22.64/24", next_hop: "3.3.3.3" }
         - { prefix: "192.168.24.64/24", next_hop: "3.3.3.3" }
       state: absent
-      provider: "{{ connection }}"
     register: result
 
   - assert:
@@ -122,7 +117,6 @@
       tag: 5500
       vrf: "{{ item }}"
       state: absent
-      provider: "{{ connection }}"
     with_items: "{{ vrfs }}"
     ignore_errors: yes
 
@@ -132,7 +126,6 @@
         - { prefix: "192.168.22.64/24", next_hop: "3.3.3.3" }
         - { prefix: "192.168.24.64/24", next_hop: "3.3.3.3" }
       state: absent
-      provider: "{{ connection }}"
     ignore_errors: yes
 
 - debug: msg="END connection={{ ansible_connection }} nxos_static_route sanity test"

--- a/test/integration/targets/nxos_switchport/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_switchport/tests/common/sanity.yaml
@@ -13,33 +13,28 @@
   nxos_config: &default
     lines:
       - "default interface {{ intname }}"
-    provider: "{{ connection }}"
   ignore_errors: yes
 
 - name: "Setup vlans"
   nxos_vlan:
     vlan_range: "5-10,20"
-    provider: "{{ connection }}"
 
 - block:
   - name: Ensure interface is in L2 state
     nxos_interface:
       interface: "{{ intname }}"
       mode: 'layer2'
-      provider: "{{ connection }}"
 
   - name: Ensure interface is in its default switchport state
     nxos_switchport: &def_swi
       interface: "{{ intname }}"
       state: unconfigured
-      provider: "{{ connection }}"
 
   - name: Ensure interface is configured for access vlan 20
     nxos_switchport: &acc_vl
       interface: "{{ intname }}"
       mode: access
       access_vlan: 20
-      provider: "{{ connection }}"
     register: result
 
   - assert: &true
@@ -60,7 +55,6 @@
       mode: trunk
       native_vlan: 10
       trunk_allowed_vlans: 5-10
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -77,7 +71,6 @@
       mode: trunk
       native_vlan: 10
       trunk_vlans: 2-50
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -94,7 +87,6 @@
       mode: trunk
       trunk_vlans: 2-50
       state: absent
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -123,7 +115,6 @@
       mode: trunk
       trunk_vlans: 30-4094
       state: absent
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -151,7 +142,6 @@
     nxos_vlan:
       vlan_range: "5-10,20"
       state: absent
-      provider: "{{ connection }}"
     ignore_errors: yes
 
   - name: "default interface"

--- a/test/integration/targets/nxos_system/tests/cli/net_system.yaml
+++ b/test/integration/targets/nxos_system/tests/cli/net_system.yaml
@@ -10,14 +10,12 @@
       - no ip domain-list ansible.com
       - no ip domain-list redhat.com
     match: none
-    provider: "{{ cli }}"
 
 - name: configure domain_list using platform agnostic module
   net_system:
     domain_search:
       - ansible.com
       - redhat.com
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -32,6 +30,5 @@
       - no ip domain-list ansible.com
       - no ip domain-list redhat.com
     match: none
-    provider: "{{ cli }}"
 
 - debug: msg="END nxos cli/net_system.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/nxos_system/tests/cli/set_domain_list.yaml
+++ b/test/integration/targets/nxos_system/tests/cli/set_domain_list.yaml
@@ -7,14 +7,12 @@
       - no ip domain-list ansible.com
       - no ip domain-list redhat.com
     match: none
-    provider: "{{ cli }}"
 
 - name: configure domain_list
   nxos_system:
     domain_search:
       - ansible.com
       - redhat.com
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -28,7 +26,6 @@
     domain_search:
       - ansible.com
       - redhat.com
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -39,7 +36,6 @@
   nxos_system:
     domain_search:
       - ansible.com
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -51,7 +47,6 @@
   nxos_system:
     domain_search:
       - ansible.com
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -63,7 +58,6 @@
     domain_search:
       - ansible.com
       - redhat.com
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -76,7 +70,6 @@
     domain_search:
       - ansible.com
       - redhat.com
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -88,7 +81,6 @@
     domain_search:
       - ansible.com
       - eng.ansible.com
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -103,7 +95,6 @@
     domain_search:
       - ansible.com
       - eng.ansible.com
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -117,6 +108,5 @@
       - no ip domain-list redhat.com
       - no ip domain-list eng.ansible.com
     match: none
-    provider: "{{ cli }}"
 
 - debug: msg="END cli/set_domain_search.yaml"

--- a/test/integration/targets/nxos_system/tests/cli/set_domain_name.yaml
+++ b/test/integration/targets/nxos_system/tests/cli/set_domain_name.yaml
@@ -5,12 +5,10 @@
   nxos_config:
     lines: no ip domain-name eng.ansible.com
     match: none
-    provider: "{{ cli }}"
 
 - name: configure domain_name
   nxos_system:
     domain_name: eng.ansible.com
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -20,7 +18,6 @@
 - name: verify domain_name
   nxos_system:
     domain_name: eng.ansible.com
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -31,6 +28,5 @@
   nxos_config:
     lines: no ip domain-name eng.ansible.com
     match: none
-    provider: "{{ cli }}"
 
 - debug: msg="END cli/set_domain_name.yaml"

--- a/test/integration/targets/nxos_system/tests/cli/set_name_servers.yaml
+++ b/test/integration/targets/nxos_system/tests/cli/set_name_servers.yaml
@@ -8,7 +8,6 @@
       - no ip name-server 2.2.2.2
       - no ip name-server 3.3.3.3
     match: none
-    provider: "{{ cli }}"
 
 - name: configure name_servers
   nxos_system:
@@ -16,7 +15,6 @@
       - 1.1.1.1
       - 2.2.2.2
       - 3.3.3.3
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -32,7 +30,6 @@
       - 1.1.1.1
       - 2.2.2.2
       - 3.3.3.3
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -45,7 +42,6 @@
 #      - 1.1.1.1
 #      - { server: 2.2.2.2, vrf: ansible }
 #      - 3.3.3.3
-#    provider: "{{ cli }}"
 #  register: result
 
 #- assert:
@@ -61,7 +57,6 @@
 #      - 1.1.1.1
 #      - { server: 2.2.2.2, vrf: ansible }
 #      - 3.3.3.3
-#    provider: "{{ cli }}"
 #  register: result
 #
 #- assert:
@@ -73,7 +68,6 @@
     name_servers:
       - 1.1.1.1
       - 2.2.2.2
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -87,7 +81,6 @@
     lines:
       - no ip lookup source-interface
     match: none
-    provider: "{{ cli }}"
   ignore_errors: yes
   # FIXME Copied from iosxr, not sure what we need here
 

--- a/test/integration/targets/nxos_system/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_system/tests/common/sanity.yaml
@@ -8,26 +8,22 @@
     nxos_system: &hostname
       hostname: switch
       domain_name: test.example.com
-      provider: "{{ connection }}"
 
   - name: remove configuration
     nxos_system:
       state: absent
-      provider: "{{ connection }}"
 
   - name: configure name servers
     nxos_system:
       name_servers:
         - 8.8.8.8
         - 8.8.4.4
-      provider: "{{ connection }}"
 
   - name: configure name servers with VRF support
     nxos_system:
       name_servers:
         - { server: 8.8.8.8, vrf: management }
         - { server: 8.8.4.4, vrf: management }
-      provider: "{{ connection }}"
 
   always:
   - name: Re-configure hostname

--- a/test/integration/targets/nxos_system/tests/common/set_hostname.yaml
+++ b/test/integration/targets/nxos_system/tests/common/set_hostname.yaml
@@ -8,12 +8,10 @@
     nxos_config:
       lines: hostname switch
       match: none
-      provider: "{{ connection }}"
 
   - name: configure hostname
     nxos_system:
       hostname: foo
-      provider: "{{ connection }}"
     register: result
 
   - assert:
@@ -23,7 +21,6 @@
   - name: verify hostname
     nxos_system:
       hostname: foo
-      provider: "{{ connection }}"
     register: result
 
   - assert:
@@ -35,7 +32,6 @@
     nxos_config:
       lines: hostname switch
       match: none
-      provider: "{{ connection }}"
 
 
   - debug: msg="END connection={{ ansible_connection }}/set_hostname.yaml"

--- a/test/integration/targets/nxos_system/tests/nxapi/net_system.yaml
+++ b/test/integration/targets/nxos_system/tests/nxapi/net_system.yaml
@@ -11,7 +11,6 @@
       - no ip domain-list ansible.com
       - no ip domain-list redhat.com
     match: none
-    provider: "{{ nxapi }}"
   ignore_errors: yes
 
 - name: configure domain_list using platform agnostic module
@@ -19,7 +18,6 @@
     domain_search:
       - ansible.com
       - redhat.com
-    provider: "{{ nxapi }}"
   register: result
 
 - assert:
@@ -34,6 +32,5 @@
       - no ip domain-list ansible.com
       - no ip domain-list redhat.com
     match: none
-    provider: "{{ nxapi }}"
 
 - debug: msg="END nxos nxapi/net_system.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/nxos_system/tests/nxapi/set_domain_list.yaml
+++ b/test/integration/targets/nxos_system/tests/nxapi/set_domain_list.yaml
@@ -9,7 +9,6 @@
     lines:
       - no ip domain-list {{ item }}
     match: none
-    provider: "{{ nxapi }}"
   ignore_errors: yes
   with_items:
       - ansible.com
@@ -20,7 +19,6 @@
     domain_search:
       - ansible.com
       - redhat.com
-    provider: "{{ nxapi }}"
   register: result
 
 - assert:
@@ -34,7 +32,6 @@
     domain_search:
       - ansible.com
       - redhat.com
-    provider: "{{ nxapi }}"
   register: result
 
 - assert:
@@ -45,7 +42,6 @@
   nxos_system:
     domain_search:
       - ansible.com
-    provider: "{{ nxapi }}"
   register: result
 
 - assert:
@@ -57,7 +53,6 @@
   nxos_system:
     domain_search:
       - ansible.com
-    provider: "{{ nxapi }}"
   register: result
 
 - assert:
@@ -69,7 +64,6 @@
     domain_search:
       - ansible.com
       - redhat.com
-    provider: "{{ nxapi }}"
   register: result
 
 - assert:
@@ -82,7 +76,6 @@
     domain_search:
       - ansible.com
       - redhat.com
-    provider: "{{ nxapi }}"
   register: result
 
 - assert:
@@ -94,7 +87,6 @@
     domain_search:
       - ansible.com
       - eng.ansible.com
-    provider: "{{ nxapi }}"
   register: result
 
 - assert:
@@ -109,7 +101,6 @@
     domain_search:
       - ansible.com
       - eng.ansible.com
-    provider: "{{ nxapi }}"
   register: result
 
 - assert:
@@ -121,7 +112,6 @@
     lines:
       - no ip domain-list {{ item }}
     match: none
-    provider: "{{ nxapi }}"
   ignore_errors: yes
   with_items:
       - ansible.com

--- a/test/integration/targets/nxos_system/tests/nxapi/set_domain_name.yaml
+++ b/test/integration/targets/nxos_system/tests/nxapi/set_domain_name.yaml
@@ -5,14 +5,12 @@
   nxos_config:
     lines: no ip domain-name eng.ansible.com
     match: none
-    provider: "{{ nxapi }}"
 # NXAPI errors if you try to remove something that doesn't exist
   ignore_errors: yes
 
 - name: configure domain_name
   nxos_system:
     domain_name: eng.ansible.com
-    provider: "{{ nxapi }}"
   register: result
 
 - assert:
@@ -22,7 +20,6 @@
 - name: verify domain_name
   nxos_system:
     domain_name: eng.ansible.com
-    provider: "{{ nxapi }}"
   register: result
 
 - assert:
@@ -33,6 +30,5 @@
   nxos_config:
     lines: no ip domain-name eng.ansible.com
     match: none
-    provider: "{{ nxapi }}"
 
 - debug: msg="END nxapi/set_domain_name.yaml"

--- a/test/integration/targets/nxos_system/tests/nxapi/set_name_servers.yaml
+++ b/test/integration/targets/nxos_system/tests/nxapi/set_name_servers.yaml
@@ -9,7 +9,6 @@
     lines:
       - no ip name-server {{ item }}
     match: none
-    provider: "{{ nxapi }}"
   ignore_errors: yes
   with_items:
       - 1.1.1.1
@@ -22,7 +21,6 @@
       - 1.1.1.1
       - 2.2.2.2
       - 3.3.3.3
-    provider: "{{ nxapi }}"
   register: result
 
 - assert:
@@ -38,7 +36,6 @@
       - 1.1.1.1
       - 2.2.2.2
       - 3.3.3.3
-    provider: "{{ nxapi }}"
   register: result
 
 - assert:
@@ -51,7 +48,6 @@
 #      - 1.1.1.1
 #      - { server: 2.2.2.2, vrf: ansible }
 #      - 3.3.3.3
-#    provider: "{{ nxapi }}"
 #  register: result
 
 #- assert:
@@ -67,7 +63,6 @@
 #      - 1.1.1.1
 #      - { server: 2.2.2.2, vrf: ansible }
 #      - 3.3.3.3
-#    provider: "{{ nxapi }}"
 #  register: result
 #
 #- assert:
@@ -79,7 +74,6 @@
     name_servers:
       - 1.1.1.1
       - 2.2.2.2
-    provider: "{{ nxapi }}"
   register: result
 
 - assert:
@@ -93,7 +87,6 @@
     lines:
       - no ip lookup source-interface
     match: none
-    provider: "{{ nxapi }}"
   ignore_errors: yes
   # FIXME Copied from iosxr, not sure what we need here
 

--- a/test/integration/targets/nxos_udld/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_udld/tests/common/sanity.yaml
@@ -14,13 +14,11 @@
     nxos_feature: 
       feature: udld
       state: enabled
-      provider: "{{ connection }}"
 
   - name: Configure udld
     nxos_udld: &conf1
       aggressive: enabled
       msg_time: 20
-      provider: "{{ connection }}"
     register: result
 
   - assert: &true
@@ -38,12 +36,10 @@
   - name: Reset udld
     nxos_udld:
       reset: True
-      provider: "{{ connection }}"
 
   - name: Configure udld2
     nxos_udld: &conf2
       aggressive: disabled
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -57,7 +53,6 @@
   - name: Configure udld3
     nxos_udld: &conf3
       msg_time: default
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -77,7 +72,6 @@
   - name: Remove udld config
     nxos_udld: &conf4
       state: absent
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -95,7 +89,6 @@
     nxos_feature: 
       feature: udld
       state: disabled
-      provider: "{{ connection }}"
     ignore_errors: yes
 
 - debug: msg="END connection={{ ansible_connection }} nxos_udld sanity test"

--- a/test/integration/targets/nxos_udld_interface/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_udld_interface/tests/common/sanity.yaml
@@ -20,13 +20,11 @@
     nxos_feature: 
       feature: udld
       state: enabled
-      provider: "{{ connection }}"
 
   - name: "put the interface into default state"
     nxos_config: 
       commands:
         - "default interface {{intname}}"
-      provider: "{{ connection }}"
       match: none
 
   - name: ensure interface is configured to be in aggressive mode
@@ -34,7 +32,6 @@
       interface: "{{ intname }}"
       mode: aggressive
       state: present
-      provider: "{{ connection }}"
     register: result
 
   - assert: &true
@@ -56,7 +53,6 @@
         interface: "{{ intname }}"
         mode: enabled
         state: present
-        provider: "{{ connection }}"
       register: result
 
     - assert: *true
@@ -84,7 +80,6 @@
         interface: "{{ intname }}"
         mode: disabled
         state: present
-        provider: "{{ connection }}"
       register: result
 
     - assert: *true
@@ -102,7 +97,6 @@
       interface: "{{ intname }}"
       mode: enabled
       state: absent
-      provider: "{{ connection }}"
 
   when: udld_run
 
@@ -111,7 +105,6 @@
     nxos_feature: 
       feature: udld
       state: disabled
-      provider: "{{ connection }}"
     ignore_errors: yes
 
 - debug: msg="END connection={{ ansible_connection }} nxos_udld_interface sanity test"

--- a/test/integration/targets/nxos_user/tests/common/auth.yaml
+++ b/test/integration/targets/nxos_user/tests/common/auth.yaml
@@ -5,7 +5,6 @@
       name: auth_user
       role: network-operator
       state: present
-      provider: "{{ connection }}"
       configured_password: pass123
 
   - name: test login
@@ -32,5 +31,4 @@
     nxos_user:
       name: auth_user
       state: absent
-      provider: "{{ connection }}"
     register: result

--- a/test/integration/targets/nxos_user/tests/common/basic.yaml
+++ b/test/integration/targets/nxos_user/tests/common/basic.yaml
@@ -10,7 +10,6 @@
       - { name: ansibletest2 }
       - { name: ansibletest3 }
     state: absent
-    provider: "{{ connection }}"
 
 # Start tests
 - name: Create user
@@ -18,7 +17,6 @@
     name: ansibletest1
     roles: network-operator
     state: present
-    provider: "{{ connection }}"
   register: result
 
 - assert:
@@ -34,7 +32,6 @@
       - { name: ansibletest3 }
     state: present
     roles: network-admin
-    provider: "{{ connection }}"
   register: result
 
 - assert:
@@ -48,7 +45,6 @@
       - { name: ansibletest2 }
       - { name: ansibletest3 }
     state: absent
-    provider: "{{ connection }}"
   register: result
 
 - assert:

--- a/test/integration/targets/nxos_user/tests/common/net_user.yaml
+++ b/test/integration/targets/nxos_user/tests/common/net_user.yaml
@@ -10,7 +10,6 @@
   net_user:
     name: ansibletest1
     state: absent
-    provider: "{{ connection }}"
 
 # Start tests
 - name: Create user with platform agnostic module
@@ -18,7 +17,6 @@
     name: ansibletest1
     roles: network-operator
     state: present
-    provider: "{{ connection }}"
   register: result
 
 - assert:
@@ -31,6 +29,5 @@
   net_user:
     name: ansibletest1
     state: absent
-    provider: "{{ connection }}"
 
 - debug: msg="END connection={{ ansible_connection }} nxos common/net_user.yaml"

--- a/test/integration/targets/nxos_user/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_user/tests/common/sanity.yaml
@@ -15,7 +15,6 @@
       update_password: on_create
       roles: network-operator
       state: present
-      provider: "{{ connection }}"
     register: result
 
   - assert: &true
@@ -36,7 +35,6 @@
     nxos_user: &remove
       name: netend
       state: absent
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -54,7 +52,6 @@
 #      name: ansible
 #      sshkey: "{{ lookup('file', '~/.ssh/id_rsa.pub') }}"
 #      state: present
-#      provider: "{{ connection }}"
 #    register: result
 #
 #  - assert: *true
@@ -79,7 +76,6 @@
       roles: 
         - network-admin
         - network-operator
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -97,7 +93,6 @@
     nxos_user: &tear
       name: ansible
       purge: yes
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true

--- a/test/integration/targets/nxos_vlan/tests/common/agg.yaml
+++ b/test/integration/targets/nxos_vlan/tests/common/agg.yaml
@@ -8,7 +8,6 @@
     lines:
       - no vlan 102
       - no vlan 103
-    provider: "{{ connection }}"
   ignore_errors: yes
 
 
@@ -19,7 +18,6 @@
       - { name: app03, vlan_id: 103 }
     vlan_state: active
     admin_state: up
-    provider: "{{ connection }}"
   register: result
 
 - assert:
@@ -45,7 +43,6 @@
       - { name: app03, vlan_id: 103 }
     vlan_state: active
     admin_state: down
-    provider: "{{ connection }}"
   register: result
 
 - assert:
@@ -67,7 +64,6 @@
   nxos_vlan: &purge
     vlan_id: 1
     purge: yes
-    provider: "{{ connection }}"
   register: result
 
 - assert:

--- a/test/integration/targets/nxos_vlan/tests/common/interface.yaml
+++ b/test/integration/targets/nxos_vlan/tests/common/interface.yaml
@@ -6,7 +6,6 @@
   nxos_config:
     lines:
       - no vlan 100
-    provider: "{{ connection }}"
   ignore_errors: yes
 
 - name: setup - remove vlan from interfaces used in test(part1)
@@ -15,7 +14,6 @@
       - no switchport access vlan 100
     parents: switchport
     before: "interface {{ testint1 }}"
-    provider: "{{ connection }}"
 
 - name: setup - remove vlan from interfaces used in test(part2)
   nxos_config:
@@ -23,12 +21,10 @@
       - no switchport access vlan 100
     parents: switchport
     before: "interface {{ testint2 }}"
-    provider: "{{ connection }}"
 
 - name: create vlan
   nxos_vlan:
     vlan_id: 100
-    provider: "{{ connection }}"
 
 - name: Add interfaces to vlan and check intent (config + intent)
   nxos_vlan: &interfaces
@@ -39,7 +35,6 @@
     associated_interfaces:
       - "{{ testint1 }}"
       - "{{ testint2 }}"
-    provider: "{{ connection }}"
   register: result
 
 - assert:
@@ -68,7 +63,6 @@
     associated_interfaces:
       - "{{ testint1 }}"
       - "{{ testint2 }}"
-    provider: "{{ connection }}"
   register: result
 
 - assert:
@@ -80,7 +74,6 @@
     vlan_id: 100
     associated_interfaces:
       - test
-    provider: "{{ connection }}"
   register: result
   ignore_errors: yes
 
@@ -93,7 +86,6 @@
     vlan_id: 100
     interfaces:
       - "{{ testint2 }}"
-    provider: "{{ connection }}"
   register: result
 
 - assert:
@@ -116,7 +108,6 @@
   nxos_config:
     lines:
       - no vlan 100
-    provider: "{{ connection }}"
 
 - name: teardown - remove vlan from interfaces used in test(part1)
   nxos_config:
@@ -124,7 +115,6 @@
       - no switchport access vlan 100
     parents: switchport
     before: "interface {{ testint1 }}"
-    provider: "{{ connection }}"
 
 - name: teardown - remove vlan from interfaces used in test(part2)
   nxos_config:
@@ -132,4 +122,3 @@
       - no switchport access vlan 100
     parents: switchport
     before: "interface {{ testint2 }}"
-    provider: "{{ connection }}"

--- a/test/integration/targets/nxos_vlan/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_vlan/tests/common/sanity.yaml
@@ -11,14 +11,12 @@
     nxos_config: 
       commands:
         - feature vn-segment-vlan-based
-      provider: "{{ connection }}"
       match: none
     when: platform is search('N9K')
 
   - name: Ensure a range of VLANs are present on the switch
     nxos_vlan: &conf_vlan
       vlan_range: "2-10,20,50,55-60,100-150"
-      provider: "{{ connection }}"
     register: result
 
   - assert: &true
@@ -40,7 +38,6 @@
       admin_state: down
       name: WEB
       mapped_vni: 5555
-      provider: "{{ connection }}"
     register: result
     when: platform is search('N9K')
 
@@ -62,7 +59,6 @@
       admin_state: up
       name: default
       mapped_vni: default
-      provider: "{{ connection }}"
     register: result
     when: platform is search('N9K')
 
@@ -83,7 +79,6 @@
       vlan_state: suspend
       admin_state: down
       name: WEB
-      provider: "{{ connection }}"
     register: result
     when: platform is search('N3K|N7K')
 
@@ -104,7 +99,6 @@
       vlan_state: active
       admin_state: up
       name: default
-      provider: "{{ connection }}"
     register: result
     when: platform is search('N3K|N7K')
 
@@ -124,7 +118,6 @@
 #    nxos_vlan: &mode1
 #      vlan_id: 50
 #      mode: fabricpath
-#      provider: "{{ connection }}"
 #    register: result
 #    when: platform is search('N5k|N7K')
 #
@@ -143,7 +136,6 @@
 #    nxos_vlan: &mode2
 #      vlan_id: 50
 #      mode: ce
-#      provider: "{{ connection }}"
 #    register: result
 #    when: platform is search('N5k|N7K')
 #
@@ -162,7 +154,6 @@
     nxos_vlan: &no_vlan
       vlan_id: 50
       state: absent
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -180,7 +171,6 @@
       interfaces:
         - "{{ testint1 }}"
         - "{{ testint2 }}"
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -195,7 +185,6 @@
     nxos_vlan: &remint
       vlan_id: 101
       interfaces: default
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -215,14 +204,12 @@
       nxos_vlan:
         vlan_range: "2-10,20,50,55-60,100-150"
         state: absent
-        provider: "{{ connection }}"
       ignore_errors: yes
 
     - name: "Disable feature vn segement"
       nxos_feature: 
         feature: vn-segment-vlan-based
         state: disabled
-        provider: "{{ connection }}"
       ignore_errors: yes
       when: platform is search('N9K')
 

--- a/test/integration/targets/nxos_vpc/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_vpc/tests/common/sanity.yaml
@@ -8,12 +8,10 @@
     nxos_feature:
       feature: vpc
       state: enabled
-      provider: "{{ connection }}"
 
   - name: Ensure ntc VRF exists on switch
     nxos_vrf:
       vrf: ntc
-      provider: "{{ connection }}"
 
   - name: Configure vpc
     nxos_vpc: &conf_vpc
@@ -22,7 +20,6 @@
       pkl_dest: 192.168.100.4
       pkl_src: 10.1.100.20
       pkl_vrf: ntc
-      provider: "{{ connection }}"
     register: result
 
   - assert: &true
@@ -45,7 +42,6 @@
       system_priority: 2000
       peer_gw: True
       delay_restore: 5
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -62,7 +58,6 @@
         state: present
         domain: 100
         auto_recovery: False
-        provider: "{{ connection }}"
       register: result
 
     - assert: *true
@@ -78,7 +73,6 @@
         state: present
         domain: 100
         auto_recovery: True
-        provider: "{{ connection }}"
       register: result
 
     - assert: *true
@@ -97,7 +91,6 @@
         state: present
         domain: 100
         auto_recovery: True
-        provider: "{{ connection }}"
       register: result
 
     - assert: *true
@@ -113,7 +106,6 @@
         state: present
         domain: 100
         auto_recovery: False
-        provider: "{{ connection }}"
       register: result
 
     - assert: *true
@@ -134,7 +126,6 @@
       system_priority: default
       peer_gw: True
       delay_restore: default
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -150,7 +141,6 @@
       state: present
       domain: 100
       peer_gw: False
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -165,7 +155,6 @@
     nxos_vpc: &rem_vpc
       state: absent
       domain: 100
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -181,14 +170,12 @@
     nxos_vrf:
       vrf: ntc
       state: absent
-      provider: "{{ connection }}"
     ignore_errors: yes
 
   - name: disable feature vpc
     nxos_feature:
       feature: vpc
       state: disabled
-      provider: "{{ connection }}"
     ignore_errors: yes
 
 - debug: msg="END connection={{ ansible_connection }} nxos_vpc sanity test"

--- a/test/integration/targets/nxos_vpc_interface/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_vpc_interface/tests/common/sanity.yaml
@@ -8,7 +8,6 @@
     nxos_feature:
       feature: vpc
       state: enabled
-      provider: "{{ connection }}"
 
   - name: create port-channel10
     nxos_config:
@@ -16,7 +15,6 @@
         - interface port-channel10
         - switchport
       match: none
-      provider: "{{ connection }}"
 
   - name: create port-channel11
     nxos_config:
@@ -24,7 +22,6 @@
         - interface port-channel11
         - switchport
       match: none
-      provider: "{{ connection }}"
 
   - name: configure vpc
     nxos_vpc:
@@ -36,13 +33,11 @@
       pkl_src: 10.1.100.20
       peer_gw: true
       auto_recovery: false
-      provider: "{{ connection }}"
 
   - name: Configure vpc port channel
     nxos_vpc_interface: &conf
       portchannel: 10
       vpc: 10
-      provider: "{{ connection }}"
     register: result
 
   - assert: &true
@@ -61,7 +56,6 @@
     nxos_vpc_interface: &conf1
       portchannel: 11
       peer_link: True
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -76,7 +70,6 @@
     nxos_vpc_interface: &conf2
       portchannel: 11
       peer_link: False
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -92,7 +85,6 @@
       portchannel: 10
       vpc: 10
       state: absent
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -114,7 +106,6 @@
       pkl_src: 10.1.100.20
       peer_gw: true
       auto_recovery: false
-      provider: "{{ connection }}"
     ignore_errors: yes
 
   - name: remove vpc port channel
@@ -122,7 +113,6 @@
       portchannel: 10
       vpc: 10
       state: absent
-      provider: "{{ connection }}"
     ignore_errors: yes
 
   - name: remove port channel
@@ -131,13 +121,11 @@
         - no interface port-channel10
         - no interface port-channel11
       match: none
-      provider: "{{ connection }}"
     ignore_errors: yes
 
   - name: disable feature vpc
     nxos_feature:
       feature: vpc
       state: disabled
-      provider: "{{ connection }}"
 
 - debug: msg="END connection={{ ansible_connection }} nxos_vpc_interface sanity test"

--- a/test/integration/targets/nxos_vrf/tests/common/intent.yaml
+++ b/test/integration/targets/nxos_vrf/tests/common/intent.yaml
@@ -12,7 +12,6 @@
       - no vrf member test1
     parents: no switchport
     before: "interface {{ testint1 }}"
-    provider: "{{ connection }}"
   ignore_errors: yes
 
 - name: setup - remove vrf from interfaces used in test(part2)
@@ -21,21 +20,18 @@
       - no vrf member test1
     parents: no switchport
     before: "interface {{ testint2 }}"
-    provider: "{{ connection }}"
   ignore_errors: yes
 
 - name: setup - delete VRF test1 used in test
   nxos_config:
     lines:
       - no vrf context test1
-    provider: "{{ connection }}"
   ignore_errors: yes
 
 - name: setup - remove VRF test2 used in test
   nxos_config:
     lines:
       - no vrf context test2
-    provider: "{{ connection }}"
   ignore_errors: yes
 
 - name: aggregate definitions of VRFs
@@ -43,7 +39,6 @@
     aggregate:
       - { name: test1, description: Configured by Ansible }
       - { name: test2, description: Testing, admin_state: down }
-    provider: "{{ connection }}"
   register: result
 
 - assert:
@@ -73,7 +68,6 @@
     associated_interfaces:
       - "{{ testint1 }}"
       - "{{ testint2 }}"
-    provider: "{{ connection }}"
   register: result
 
 - assert:
@@ -99,7 +93,6 @@
     associated_interfaces:
       - "{{ testint1 }}"
       - "{{ testint2 }}"
-    provider: "{{ connection }}"
   register: result
 
 - assert:
@@ -111,7 +104,6 @@
     name: test1
     associated_interfaces:
       - test
-    provider: "{{ connection }}"
   register: result
   ignore_errors: yes
 
@@ -124,7 +116,6 @@
     name: test1
     interfaces:
       - "{{ testint2 }}"
-    provider: "{{ connection }}"
   register: result
 
 - assert:
@@ -147,7 +138,6 @@
       - { name: test1, description: Configured by Ansible }
       - { name: test2, description: Testing, admin_state: down }
     state: absent
-    provider: "{{ connection }}"
   register: result
 
 - assert:
@@ -170,7 +160,6 @@
       - no vrf member test1
     parents: no switchport
     before: "interface {{ testint1 }}"
-    provider: "{{ connection }}"
   ignore_errors: yes
 
 - name: setup - remove vrf from interfaces used in test(part2)
@@ -179,21 +168,18 @@
       - no vrf member test1
     parents: no switchport
     before: "interface {{ testint2 }}"
-    provider: "{{ connection }}"
   ignore_errors: yes
 
 - name: setup - delete VRF test1 used in test
   nxos_config:
     lines:
       - no vrf context test1
-    provider: "{{ connection }}"
   ignore_errors: yes
 
 - name: setup - remove VRF test2 used in test
   nxos_config:
     lines:
       - no vrf context test2
-    provider: "{{ connection }}"
   ignore_errors: yes
 
 - debug: msg="END connection={{ ansible_connection }} nxos_vrf intent & aggregate test"

--- a/test/integration/targets/nxos_vrf/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_vrf/tests/common/sanity.yaml
@@ -22,7 +22,6 @@
   nxos_feature:
     feature: bgp
     state: enabled
-    provider: "{{ connection }}"
   ignore_errors: yes
 
 - block:
@@ -36,7 +35,6 @@
       interfaces:
         - "{{ intname1 }}"
         - "{{ intname2 }}"
-      provider: "{{ connection }}"
     register: result
 
   - assert: &true
@@ -61,7 +59,6 @@
       vni: "{{vnid|default(omit)}}"
       rd: "{{rdd|default(omit)}}"
       interfaces: default
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -76,7 +73,6 @@
     nxos_vrf: &remove
       vrf: ntc
       state: absent
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -95,7 +91,6 @@
     nxos_feature:
       feature: bgp
       state: disabled
-      provider: "{{ connection }}"
     ignore_errors: yes
 
   - debug: msg="END connection={{ ansible_connection }} nxos_vrf sanity test"

--- a/test/integration/targets/nxos_vrf_af/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_vrf_af/tests/common/sanity.yaml
@@ -7,18 +7,15 @@
   nxos_feature:
     feature: bgp
     state: enabled
-    provider: "{{ connection }}"
 
 - name: Configure feature nv overlay
   nxos_config:
     commands: "feature nv overlay"
-    provider: "{{ connection }}"
   ignore_errors: yes
 
 - name: Configure nv overlay evpn
   nxos_config:
     commands: "nv overlay evpn"
-    provider: "{{ connection }}"
   ignore_errors: yes
 
 - block:
@@ -27,7 +24,6 @@
       vrf: ansible
       afi: ipv4
       route_target_both_auto_evpn: True
-      provider: "{{ connection }}"
     register: result
 
   - assert: &true
@@ -47,7 +43,6 @@
       vrf: ansible
       afi: ipv6
       route_target_both_auto_evpn: True
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -63,7 +58,6 @@
       vrf: ansible
       afi: ipv4
       route_target_both_auto_evpn: False
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -79,7 +73,6 @@
       vrf: ansible
       afi: ipv6
       route_target_both_auto_evpn: False
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -96,7 +89,6 @@
       afi: ipv6
       route_target_both_auto_evpn: True
       state: absent
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -116,7 +108,6 @@
       afi: ipv4
       route_target_both_auto_evpn: True
       state: absent
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -136,26 +127,22 @@
   - name: Remove vrf
     nxos_config:
       commands: "no vrf context ansible"
-      provider: "{{ connection }}"
     ignore_errors: yes
 
   - name: Remove nv overlay evpn
     nxos_config:
       commands: "no nv overlay evpn"
-      provider: "{{ connection }}"
     ignore_errors: yes
 
   - name: Remove feature nv overlay
     nxos_config:
       commands: "no feature nv overlay"
-      provider: "{{ connection }}"
     ignore_errors: yes
 
   - name: Remove feature bgp
     nxos_feature:
       feature: bgp
       state: disabled
-      provider: "{{ connection }}"
     ignore_errors: yes
 
 - debug: msg="END connection={{ ansible_connection }} nxos_vrf_af sanity test"

--- a/test/integration/targets/nxos_vrf_interface/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_vrf_interface/tests/common/sanity.yaml
@@ -14,14 +14,12 @@
       parents:
         - "interface {{ intname }}"
       match: none
-      provider: "{{ connection }}"
 
   - name: Ensure vrf ntc exists on interface
     nxos_vrf_interface: &configure
       vrf: ntc
       interface: "{{ intname }}"
       state: present
-      provider: "{{ connection }}"
     register: result
 
   - assert: &true
@@ -41,7 +39,6 @@
       vrf: ntc
       interface: "{{ intname }}"
       state: absent
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -56,7 +53,6 @@
   - name: put interface in default mode
     nxos_config:
       lines: "default interface {{ intname }}"
-      provider: "{{ connection }}"
       match: none
     ignore_errors: yes
 

--- a/test/integration/targets/nxos_vrrp/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_vrrp/tests/common/sanity.yaml
@@ -8,18 +8,15 @@
     nxos_feature: 
       feature: interface-vlan
       state: enabled
-      provider: "{{ connection }}"
 
   - name: "Enable vrrp"
     nxos_feature: 
       feature: vrrp
       state: enabled
-      provider: "{{ connection }}"
 
   - name: "create int vlan 10"
     nxos_config: 
       commands: "int vlan 10"
-      provider: "{{ connection }}"
 
   - name: Ensure vrrp group 100 and vip 10.1.100.1 is on vlan10
     nxos_vrrp: &configure
@@ -27,7 +24,6 @@
       group: 100
       vip: 10.1.100.1
       admin_state: 'no shutdown'
-      provider: "{{ connection }}"
     register: result
 
   - assert: &true
@@ -48,7 +44,6 @@
       group: 100
       vip: default
       admin_state: default
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -64,7 +59,6 @@
       interface: vlan10
       group: 100
       state: absent
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -90,7 +84,6 @@
       interval: 10
       priority: 130
       authentication: AUTHKEY
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -110,7 +103,6 @@
       interval: default
       priority: default
       authentication: default
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -130,7 +122,6 @@
       nxos_config: 
         commands:
           - no feature interface-vlan
-        provider: "{{ connection }}"
         match: none
       ignore_errors: yes
 
@@ -138,7 +129,6 @@
       nxos_feature: 
         feature: vrrp
         state: disabled
-        provider: "{{ connection }}"
       ignore_errors: yes
 
 - debug: msg="END connection={{ ansible_connection }} nxos_vrrp sanity test"

--- a/test/integration/targets/nxos_vtp_domain/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_vtp_domain/tests/common/sanity.yaml
@@ -8,12 +8,10 @@
     nxos_feature:
       feature: vtp
       state: enabled
-      provider: "{{ connection }}"
 
   - name: configure vtp domain
     nxos_vtp_domain: &configure
       domain: ntc
-      provider: "{{ connection }}"
     register: result
 
   - assert: &true
@@ -33,6 +31,5 @@
     nxos_feature:
       feature: vtp
       state: disabled
-      provider: "{{ connection }}"
 
 - debug: msg="END connection={{ ansible_connection }} nxos_vtp_domain sanity test"

--- a/test/integration/targets/nxos_vtp_password/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_vtp_password/tests/common/sanity.yaml
@@ -8,18 +8,15 @@
     nxos_feature:
       feature: vtp
       state: enabled
-      provider: "{{ connection }}"
 
   - name: configure vtp domain
     nxos_vtp_domain:
       domain: testing
-      provider: "{{ connection }}"
 
   - name: configure vtp password
     nxos_vtp_password: &configure
       vtp_password: ntc
       state: present
-      provider: "{{ connection }}"
     register: result
 
   - assert: &true
@@ -38,7 +35,6 @@
     nxos_vtp_password: &remove
       vtp_password: ntc
       state: absent
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -54,6 +50,5 @@
     nxos_feature:
       feature: vtp
       state: disabled
-      provider: "{{ connection }}"
 
 - debug: msg="END connection={{ ansible_connection }} nxos_vtp_password sanity test"

--- a/test/integration/targets/nxos_vtp_version/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_vtp_version/tests/common/sanity.yaml
@@ -8,12 +8,10 @@
     nxos_feature:
       feature: vtp
       state: enabled
-      provider: "{{ connection }}"
 
   - name: configure vtp version
     nxos_vtp_version: &configure
       version: 2
-      provider: "{{ connection }}"
     register: result
 
   - assert: &true
@@ -33,6 +31,5 @@
     nxos_feature:
       feature: vtp
       state: disabled
-      provider: "{{ connection }}"
 
 - debug: msg="END connection={{ ansible_connection }} nxos_vtp_version sanity test"

--- a/test/integration/targets/nxos_vxlan_vtep/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_vxlan_vtep/tests/common/sanity.yaml
@@ -12,7 +12,6 @@
     nxos_config: 
       commands:
         - feature nv overlay
-      provider: "{{ connection }}"
       match: none
 
   - block:
@@ -24,7 +23,6 @@
         source_interface: Loopback0
         source_interface_hold_down_time: 30
         shutdown: false
-        provider: "{{ connection }}"
       register: result
   
     - assert: &true
@@ -47,7 +45,6 @@
         source_interface_hold_down_time: default
         source_interface: default
         shutdown: true
-        provider: "{{ connection }}"
       register: result
   
     - assert: *true
@@ -68,7 +65,6 @@
         host_reachability: true
         source_interface: Loopback0
         shutdown: false
-        provider: "{{ connection }}"
       register: result
   
     - assert:
@@ -90,7 +86,6 @@
         host_reachability: false
         source_interface: default
         shutdown: true
-        provider: "{{ connection }}"
       register: result
   
     - assert: *true
@@ -112,7 +107,6 @@
       source_interface_hold_down_time: 30
       shutdown: true
       state: absent
-      provider: "{{ connection }}"
     register: result
 
   - assert:
@@ -138,7 +132,6 @@
     nxos_feature: 
       feature: nve
       state: disabled
-      provider: "{{ connection }}"
     ignore_errors: yes
 
 - debug: msg="END connection={{ ansible_connection }} nxos_vxlan_vtep sanity test"

--- a/test/integration/targets/nxos_vxlan_vtep_vni/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_vxlan_vtep_vni/tests/common/sanity.yaml
@@ -12,21 +12,18 @@
     nxos_config: 
       commands:
         - feature nv overlay
-      provider: "{{ connection }}"
       match: none
 
   - name: configure vxlan_vtep
     nxos_vxlan_vtep:
       interface: nve1
       host_reachability: True
-      provider: "{{ connection }}"
 
   - name: configure vxlan_vtep_vni assoc-vrf
     nxos_vxlan_vtep_vni: &conf1
       interface: nve1
       vni: 6000
       assoc_vrf: True
-      provider: "{{ connection }}"
     register: result
 
   - assert: &true
@@ -47,13 +44,11 @@
       vni: 6000
       assoc_vrf: True
       state: absent
-      provider: "{{ connection }}"
 
   - name: configure vxlan_vtep_vni
     nxos_vxlan_vtep_vni: &conf2
       interface: nve1
       vni: 8000
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -63,7 +58,6 @@
       interface: nve1
       vni: 8000
       multicast_group: 224.1.1.1
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -79,7 +73,6 @@
       interface: nve1
       vni: 8000
       multicast_group: default
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -95,20 +88,17 @@
       interface: nve1
       vni: 8000
       state: absent
-      provider: "{{ connection }}"
 
   - name: configure vxlan_vtep
     nxos_vxlan_vtep:
       interface: nve1
       host_reachability: False
-      provider: "{{ connection }}"
 
   - block:
     - name: configure vxlan_vtep_vni
       nxos_vxlan_vtep_vni: &conf5
         interface: nve1
         vni: 8000
-        provider: "{{ connection }}"
       register: result
   
     - assert: *true
@@ -118,7 +108,6 @@
         interface: nve1
         vni: 8000
         ingress_replication: static
-        provider: "{{ connection }}"
       register: result
   
     - assert: *true
@@ -133,26 +122,22 @@
       nxos_vxlan_vtep: &remove_vtep
         interface: nve1
         state: absent
-        provider: "{{ connection }}"
 
     - name: Configure vxlan_vtep with host reachability bgp
       nxos_vxlan_vtep:
         interface: nve1
         host_reachability: True
-        provider: "{{ connection }}"
 
     - name: configure vxlan_vtep_vni
       nxos_vxlan_vtep_vni: &config_vni
         interface: nve1
         vni: 8000
-        provider: "{{ connection }}"
 
     - name: configure vxlan_vtep_vni ingress bgp
       nxos_vxlan_vtep_vni: &conf7
         interface: nve1
         vni: 8000
         ingress_replication: bgp
-        provider: "{{ connection }}"
       register: result
   
     - assert: *true
@@ -168,7 +153,6 @@
         interface: nve1
         vni: 8000
         ingress_replication: default
-        provider: "{{ connection }}"
       register: result
   
     - assert: *true
@@ -186,7 +170,6 @@
       nxos_vxlan_vtep:
         interface: nve1
         host_reachability: False
-        provider: "{{ connection }}"
 
     - name: configure vxlan_vtep_vni
       nxos_vxlan_vtep_vni: *config_vni
@@ -201,7 +184,6 @@
           - 3.3.3.3
           - 4.4.4.4
         ingress_replication: static
-        provider: "{{ connection }}"
       register: result
   
     - assert: *true
@@ -218,7 +200,6 @@
         vni: 8000
         peer_list: default
         ingress_replication: static
-        provider: "{{ connection }}"
       register: result
   
     - assert: *true
@@ -261,14 +242,12 @@
       interface: nve1
       shutdown: true
       state: absent
-      provider: "{{ connection }}"
     ignore_errors: yes
 
   - name: "Disable feature nv overlay"
     nxos_feature: 
       feature: nve
       state: disabled
-      provider: "{{ connection }}"
     ignore_errors: yes
 
 - debug: msg="END connection={{ ansible_connection }} nxos_vxlan_vtep_vni sanity test"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
`connection` is no longer supplied to (most) nxos tests, so we need to also remove the `provider: {{ connection }}` line from the tests themselves.

Also push variables to ansible-connection so plugins can set options not found in play_context 

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
nxos

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6
```

