### PR TITLE
removed_in: 2.6 is valid

### DIFF
--- a/test/sanity/validate-modules/schema.py
+++ b/test/sanity/validate-modules/schema.py
@@ -92,7 +92,7 @@ def deprecation_schema():
         # Deprecation cycle changed at 2.4 (though not retroactively)
         # 2.3 -> removed_in: "2.5" + n for docs stub
         # 2.4 -> removed_in: "2.8" + n for docs stub
-        Required('removed_in'): Any("2.2", "2.3", "2.4", "2.5", "2.8", "2.9", "2.10"),
+        Required('removed_in'): Any("2.2", "2.3", "2.4", "2.5", "2.6", "2.8", "2.9", "2.10"),
         Required('why'): Any(*string_types),
         Required('alternative'): Any(*string_types),
         'removed': Any(True),


### PR DESCRIPTION
##### SUMMARY
It's OK that modules may have `removed_in: 2.6`

##### ISSUE TYPE
 - Bugfix Pull Request
