### PR TITLE
Move summary to top for issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -5,6 +5,9 @@ Also test if the latest release, and devel branch are affected too.
 ALWAYS add information AFTER (OUTSIDE) these html comments.
 Otherwise it may end up being automatically closed by our bot. -->
 
+##### SUMMARY
+<!--- Explain the problem briefly -->
+
 ##### ISSUE TYPE
 <!--- Pick one below and delete the rest -->
  - Bug Report
@@ -31,9 +34,6 @@ Otherwise, mention any settings you have changed/added/removed in ansible.cfg
 managing, or say "N/A" for anything that is not platform-specific.
 Also mention the specific version of what you are trying to control,
 e.g. if this is a network bug the version of firmware on the network device.-->
-
-##### SUMMARY
-<!--- Explain the problem briefly -->
 
 ##### STEPS TO REPRODUCE
 <!--- For bugs, show exactly how to reproduce the problem, using a minimal test-case.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -11,6 +11,9 @@ Also test if the latest release, and devel branch are affected too.
 ALWAYS add information AFTER (OUTSIDE) these html comments.
 Otherwise it may end up being automatically closed by our bot. -->
 
+##### SUMMARY
+<!--- Explain the problem briefly -->
+
 ##### ISSUE TYPE
  - Bug Report
 
@@ -34,9 +37,6 @@ Otherwise, mention any settings you have changed/added/removed in ansible.cfg
 managing, or say "N/A" for anything that is not platform-specific.
 Also mention the specific version of what you are trying to control,
 e.g. if this is a network bug the version of firmware on the network device.-->
-
-##### SUMMARY
-<!--- Explain the problem briefly -->
 
 ##### STEPS TO REPRODUCE
 <!--- For bugs, show exactly how to reproduce the problem, using a minimal test-case.

--- a/.github/ISSUE_TEMPLATE/documentation_report.md
+++ b/.github/ISSUE_TEMPLATE/documentation_report.md
@@ -11,6 +11,9 @@ Also test if the latest release, and devel branch are affected too.
 ALWAYS add information AFTER (OUTSIDE) these html comments.
 Otherwise it may end up being automatically closed by our bot. -->
 
+##### SUMMARY
+<!--- Explain the problem briefly -->
+
 ##### ISSUE TYPE
  - Documentation Report
 
@@ -34,9 +37,6 @@ Otherwise, mention any settings you have changed/added/removed in ansible.cfg
 managing, or say "N/A" for anything that is not platform-specific.
 Also mention the specific version of what you are trying to control,
 e.g. if this is a network bug the version of firmware on the network device.-->
-
-##### SUMMARY
-<!--- Explain the problem briefly -->
 
 ##### STEPS TO REPRODUCE
 <!--- For bugs, show exactly how to reproduce the problem, using a minimal test-case.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -11,6 +11,9 @@ Also test if the latest release, and devel branch are affected too.
 ALWAYS add information AFTER (OUTSIDE) these html comments.
 Otherwise it may end up being automatically closed by our bot. -->
 
+##### SUMMARY
+<!--- Explain the problem briefly -->
+
 ##### ISSUE TYPE
  - Feature Idea
 
@@ -34,9 +37,6 @@ Otherwise, mention any settings you have changed/added/removed in ansible.cfg
 managing, or say "N/A" for anything that is not platform-specific.
 Also mention the specific version of what you are trying to control,
 e.g. if this is a network bug the version of firmware on the network device.-->
-
-##### SUMMARY
-<!--- Explain the problem briefly -->
 
 ##### STEPS TO REPRODUCE
 <!--- For bugs, show exactly how to reproduce the problem, using a minimal test-case.


### PR DESCRIPTION
##### SUMMARY

Move summary template for issue templates to the top to be consistent with PR templates and also because it's nice to have the summary at the top.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Docs Pull Request

##### COMPONENT NAME
`.github/ISSUE_TEMPLATE/bug_report.md`
`.github/ISSUE_TEMPLATE/documentation_report.md`
`.github/ISSUE_TEMPLATE/feature_request.md`
`.github/ISSUE_TEMPLATE.md`


##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6
```