### PR TITLE
Grafana datasource module : Use url_argument_spec from urls

### DIFF
--- a/lib/ansible/modules/monitoring/grafana_datasource.py
+++ b/lib/ansible/modules/monitoring/grafana_datasource.py
@@ -409,6 +409,10 @@ def grafana_create_datasource(module, data):
     result = {}
     if datasource_exists is True:
         del ds['typeLogoUrl']
+        if ds.get('version'):
+            del ds['version']
+        if ds.get('readOnly'):
+            del ds['readOnly']
         if ds['basicAuth'] is False:
             del ds['basicAuthUser']
             del ds['basicAuthPassword']

--- a/lib/ansible/modules/monitoring/grafana_datasource.py
+++ b/lib/ansible/modules/monitoring/grafana_datasource.py
@@ -157,6 +157,16 @@ options:
       - Use trends or not for zabbix datasource type
     type: bool
     version_added: 2.6
+  client_cert:
+    required: false
+    description:
+      - TLS certificate path used by ansible to query grafana api
+    version_added: 2.6
+  client_key:
+    required: false
+    description:
+      - TLS private key path used by ansible to query grafana api
+    version_added: 2.6
   validate_certs:
     description:
       - Whether to validate the Grafana certificate.
@@ -503,6 +513,8 @@ def main():
             tsdb_resolution=dict(type='str', default='second', choices=['second', 'millisecond']),
             sslmode=dict(default='disable', choices=['disable', 'require', 'verify-ca', 'verify-full']),
             trends=dict(default=False, type='bool'),
+            client_cert=dict(type='path'),
+            client_key=dict(type='path'),
             validate_certs=dict(type='bool', default=True)
         ),
         supports_check_mode=False,

--- a/lib/ansible/modules/monitoring/grafana_datasource.py
+++ b/lib/ansible/modules/monitoring/grafana_datasource.py
@@ -281,7 +281,7 @@ import base64
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.urls import fetch_url, url_argument_spec
-from ansible.module_utils._text import to_bytes
+from ansible.module_utils._text import to_text
 
 __metaclass__ = type
 
@@ -313,7 +313,7 @@ def grafana_datasource_exists(module, grafana_url, name, headers):
     r, info = fetch_url(module, '%s/api/datasources/name/%s' % (grafana_url, name), headers=headers, method='GET')
     if info['status'] == 200:
         datasource_exists = True
-        ds = json.loads(r.read())
+        ds = json.loads(to_text(r.read(), errors='surrogate_or_strict'))
     elif info['status'] == 404:
         datasource_exists = False
     else:
@@ -432,7 +432,7 @@ def grafana_create_datasource(module, data):
             # update
             r, info = fetch_url(module, '%s/api/datasources/%d' % (data['grafana_url'], ds['id']), data=json.dumps(payload), headers=headers, method='PUT')
             if info['status'] == 200:
-                res = json.loads(r.read())
+                res = json.loads(to_text(r.read(), errors='surrogate_or_strict'))
                 result['name'] = data['name']
                 result['id'] = ds['id']
                 result['before'] = ds
@@ -445,7 +445,7 @@ def grafana_create_datasource(module, data):
         # create
         r, info = fetch_url(module, '%s/api/datasources' % data['grafana_url'], data=json.dumps(payload), headers=headers, method='POST')
         if info['status'] == 200:
-            res = json.loads(r.read())
+            res = json.loads(to_text(r.read(), errors='surrogate_or_strict'))
             result['msg'] = "Datasource %s created : %s" % (data['name'], res['message'])
             result['changed'] = True
             result['name'] = data['name']
@@ -468,7 +468,7 @@ def grafana_delete_datasource(module, data):
         # delete
         r, info = fetch_url(module, '%s/api/datasources/name/%s' % (data['grafana_url'], data['name']), headers=headers, method='DELETE')
         if info['status'] == 200:
-            res = json.loads(r.read())
+            res = json.loads(to_text(r.read(), errors='surrogate_or_strict'))
             result['msg'] = "Datasource %s deleted : %s" % (data['name'], res['message'])
             result['changed'] = True
             result['name'] = data['name']

--- a/lib/ansible/modules/monitoring/grafana_datasource.py
+++ b/lib/ansible/modules/monitoring/grafana_datasource.py
@@ -393,6 +393,8 @@ def grafana_create_datasource(module, data):
 
     if data['ds_type'] == 'postgres':
         json_data['sslmode'] = data['sslmode']
+        if data.get('password'):
+            payload['secureJsonData'] = {'password': data.get('password')}
 
     if data['ds_type'] == 'alexanderzobnin-zabbix-datasource':
         if data.get('trends'):


### PR DESCRIPTION
##### SUMMARY
Grafana datasource module : Added `client_cert` and `client_key` params.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
grafana_datasource

##### ANSIBLE VERSION
```
ansible 2.5.3
  config file = None
  configured module search path = [u'/home/seuf/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/seuf/python-virtualenv-ansible/lib/python2.7/site-packages/ansible
  executable location = /home/seuf/python-virtualenv-ansible/bin/ansible
  python version = 2.7.15 (default, May  2 2018, 14:12:52) [GCC 8.0.1 20180324 (Red Hat 8.0.1-0.20)]
```

##### ADDITIONAL INFORMATION
When grafana is configured behind a reverse proxy with TLS cert based authentification, this PR allow to give a tls `client_cert` and `client_key` used by ansible `fetch_url`.