### PR TITLE
add win_wait_for_process

### DIFF
--- a/lib/ansible/modules/windows/win_wait_for_process.ps1
+++ b/lib/ansible/modules/windows/win_wait_for_process.ps1
@@ -102,7 +102,7 @@ Start-Sleep -Seconds $pre_wait_delay
 if ($state -eq "present" ) {
     #wait for a process to start
     $Processes = @()
-    $attempts = -1
+    $attempts = 0
     Do {
         if (((Get-Date) - $module_start).TotalSeconds -gt $timeout)
         {
@@ -112,7 +112,7 @@ if ($state -eq "present" ) {
         $Processes = Get-ProcessMatchesFilter -Owner $owner -ProcessNameExact $process_name_exact -ProcessNamePattern $process_name_pattern -ProcessId $process_id
         Start-Sleep -Seconds $sleep
         $attempts ++
-        $ProcessCount = $(if ($Processes -is [array]) { $Processess.count } else{ 1 })
+        $ProcessCount = $(if ($Processes -is [array]) { $Processes.count } else{ 1 })
     } While ($ProcessCount -lt $process_min_count)
 
     if ($attempts -gt 0)

--- a/lib/ansible/modules/windows/win_wait_for_process.ps1
+++ b/lib/ansible/modules/windows/win_wait_for_process.ps1
@@ -29,7 +29,12 @@ $result = @{
 # validate the input
 if ($state -eq "absent" -and $sleep -ne 1)
 {
-    Fail-json $result "sleep parameter is of no effect when waiting for a proces to stop."
+    Fail-json $result "sleep parameter is of no effect when waiting for a process to stop."
+}
+
+if ($state -eq "absent" -and $process_min_count -ne 1)
+{
+    Fail-json $result "process_min_count parameter is of no effect when waiting for a process to stop."
 }
 
 if (($process_name_exact -or $process_name_pattern) -and $process_id)

--- a/lib/ansible/modules/windows/win_wait_for_process.ps1
+++ b/lib/ansible/modules/windows/win_wait_for_process.ps1
@@ -117,7 +117,16 @@ if ($state -eq "present" ) {
         $Processes = Get-ProcessMatchesFilter -Owner $owner -ProcessNameExact $process_name_exact -ProcessNamePattern $process_name_pattern -ProcessId $process_id
         Start-Sleep -Seconds $sleep
         $attempts ++
-        $ProcessCount = $(if ($Processes -is [array]) { $Processes.count } else{ 1 })
+        $ProcessCount = $null
+        if ($Processes -is [array]) { 
+            $ProcessCount = $Processes.count 
+        } 
+        elseif ($null -ne $Processes) { 
+            $ProcessCount = 1 
+        }
+        else {
+            $ProcessCount = 0
+        }
     } While ($ProcessCount -lt $process_min_count)
 
     if ($attempts -gt 0)

--- a/lib/ansible/modules/windows/win_wait_for_process.ps1
+++ b/lib/ansible/modules/windows/win_wait_for_process.ps1
@@ -12,7 +12,11 @@ $ErrorActionPreference = "Stop"
 $params = Parse-Args -arguments $args -supports_check_mode $true
 
 $process_name = Get-AnsibleParam -obj $params -name "process_name" -type "str" 
+$process_id = Get-AnsibleParam -obj $params -name "process_id" -type "int" -default 0 #pid is a reserved variable in PowerShell.  use process_id instead.
+$owner = Get-AnsibleParam -obj $params -name "owner" -type "str"
 $sleep = Get-AnsibleParam -obj $params -name "sleep" -type "int" -default 1
+$pre_wait_delay = Get-AnsibleParam -obj $params -name "pre_wait_delay" -type "int" -default 0
+$post_wait_delay = Get-AnsibleParam -obj $params -name "post_wait_delay" -type "int" -default 0
 $process_min_count = Get-AnsibleParam -obj $params -name "process_min_count" -type "int" -default 1
 $state = Get-AnsibleParam -obj $params -name "state" -type "str" -default "present" -validateset "present","absent"
 $timeout = Get-AnsibleParam -obj $params -name "timeout" -type "int" -default 300
@@ -24,10 +28,65 @@ $result = @{
 # validate the input
 if ($state -eq "absent" -and $sleep -ne 1)
 {
-    Fail-json $result "sleep parameter is of no effet when waiting for a proces to stop."
+    Fail-json $result "sleep parameter is of no effect when waiting for a proces to stop."
+}
+
+if ($process_name -and $process_id)
+{
+    Fail-json $result "process_id and process_name may not be used at the same time."
+}
+if (-not ($process_name -or $process_id -or $user))
+{
+    Fail-json $result "at least one of: process_name, process_id, or user must be supplied"
 }
 
 $module_start = Get-Date
+
+#Get-Process doesn't actually return a UserName value, so get it from WMI.
+Function Test-ProcessMatchesFilter {
+    [cmdletbinding()]
+    Param(
+        [parameter(ValueFromPipeline)]
+        $WindowsProcess,
+        [String]
+        $Owner,
+        [String]
+        $ProcessName,
+        [int]
+        $ProcessId
+    )
+    Begin {
+        $owners = @{}
+        Get-WmiObject win32_process | ForEach-Object {$owners[$_.handle] = $_.getowner().user}
+    }
+    Process {
+        $include = $true
+
+        if ([String]::IsNullOrEmpty($WindowsProcess.Owner))
+        {
+            #always add the owner to proces info so that it's reported back
+            $WindowsProcess = $WindowsProcess | Select-Object -Property *,@{Name="Owner";Expression={$owners[$_.id.tostring()]}} 
+        }
+        if (-not [String]::IsNullOrEmpty($user) )
+        {
+            $include = $include -and ($WindowsProcess.Owner -eq $user)
+        }
+        if(-not [String]::IsNullOrEmpty($process_name))
+        {
+            $include = $include -and ($WindowsProcess.ProcessName -match $ProcessName)
+        }
+        if ($process_id -and $process_id -ne 0)
+        {
+            $include = $include -and ($WindowsProcess.Id -eq $ProcessId)
+        }
+       
+        if ($include)
+        {
+           $WindowsProcess
+        }
+    }
+}
+
 if ($state -eq "present" )
 {
     #wait for a process to start
@@ -36,34 +95,38 @@ if ($state -eq "present" )
     Do {
         if (((Get-Date) - $module_start).TotalSeconds -gt $timeout)
         {
-            Fail-Json $result "timeout while waiting for $process_name to start"
+            Fail-Json $result "timeout while waiting for $process_name to start.  waited $timeout seconds"
         }
-        $Processes = Get-Process | Where-Object {$_.ProcessName -match $process_name}
+       
+        $Processes = Get-Process | Test-ProcessMatchesFilter -Owner $owner -ProcessName $process_name -ProcessId $process_id | Select-Object -Property Id, ProcessName, Owner
         Start-Sleep -Seconds $sleep
         $attempts ++
-    } While ($Processes.count -lt $process_min_count)
+        $ProcessCount = $(if ($Processes -is [array]) { $Processess.count } else{ 1 })
+    } While ($ProcessCount -lt $process_min_count)
 
     if ($attempts -gt 0)
     {
         $result.changed = $true
     }
-    $result.matched_processess = ($Processes.count)
-    #$result.processess = $Processes
+    $result.matched_processess = $Processes
 }
 elseif ($state -eq "absent")
 {
     #wait for a process to stop
-    $Processes = Get-Process | Where-Object {$_.ProcessName -match $process_name} 
-    if ($Processes.count -gt 0 )
+    $Processes = Get-Process | Test-ProcessMatchesFilter -Owner $owner -ProcessName $process_name -ProcessId $process_id | Select-Object -Property ID, ProcessName, Owner
+    $result.matched_processess = $Processes
+    Fail-Json $result "faildebug"
+    $ProcessCount = $(if ($Processes -is [array]) { $Processess.count } else{ 1 })
+    if ($ProcessCount -gt 0 )
     {
         try { 
             Wait-Process -Id $($Processes | Select-Object -ExpandProperty ID) -Timeout $timeout -ErrorAction Stop
            
-            $result.matched_processess = ($Processes.count)
+            $result.matched_processess = $Processes
             $result.changed = $true
         }
         catch {
-            Fail-Json $result "timeout while waiting for $process_name to stop"
+            Fail-Json $result "$($_.Exception.Message). timeout while waiting for $process_name to stop.  waited $timeout seconds"
         }
     }
     else{

--- a/lib/ansible/modules/windows/win_wait_for_process.ps1
+++ b/lib/ansible/modules/windows/win_wait_for_process.ps1
@@ -1,0 +1,75 @@
+#!powershell
+# This file is part of Ansible
+
+# Copyright (c) 2017 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+#Requires -Module Ansible.ModuleUtils.Legacy
+#Requires -Module Ansible.ModuleUtils.FileUtil
+
+$ErrorActionPreference = "Stop"
+
+$params = Parse-Args -arguments $args -supports_check_mode $true
+
+$process_name = Get-AnsibleParam -obj $params -name "process_name" -type "str" 
+$sleep = Get-AnsibleParam -obj $params -name "sleep" -type "int" -default 1
+$process_min_count = Get-AnsibleParam -obj $params -name "process_min_count" -type "int" -default 1
+$state = Get-AnsibleParam -obj $params -name "state" -type "str" -default "present" -validateset "present","absent"
+$timeout = Get-AnsibleParam -obj $params -name "timeout" -type "int" -default 300
+
+$result = @{
+    changed = $false
+}
+
+# validate the input
+if ($state -eq "absent" -and $sleep -ne 1)
+{
+    Fail-json $result "sleep parameter is of no effet when waiting for a proces to stop."
+}
+
+$module_start = Get-Date
+if ($state -eq "present" )
+{
+    #wait for a process to start
+    $Processes = @()
+    $attempts = -1
+    Do {
+        if (((Get-Date) - $module_start).TotalSeconds -gt $timeout)
+        {
+            Fail-Json $result "timeout while waiting for $process_name to start"
+        }
+        $Processes = Get-Process | Where-Object {$_.ProcessName -match $process_name}
+        Start-Sleep -Seconds $sleep
+        $attempts ++
+    } While ($Processes.count -lt $process_min_count)
+
+    if ($attempts -gt 0)
+    {
+        $result.changed = $true
+    }
+    $result.matched_processess = ($Processes.count)
+    #$result.processess = $Processes
+}
+elseif ($state -eq "absent")
+{
+    #wait for a process to stop
+    $Processes = Get-Process | Where-Object {$_.ProcessName -match $process_name} 
+    if ($Processes.count -gt 0 )
+    {
+        try { 
+            Wait-Process -Id $($Processes | Select-Object -ExpandProperty ID) -Timeout $timeout -ErrorAction Stop
+           
+            $result.matched_processess = ($Processes.count)
+            $result.changed = $true
+        }
+        catch {
+            Fail-Json $result "timeout while waiting for $process_name to stop"
+        }
+    }
+    else{
+        $result.changed = $false
+
+    }
+}
+$result.elapsed = ((Get-Date) - $module_start).TotalSeconds
+Exit-Json $result

--- a/lib/ansible/modules/windows/win_wait_for_process.py
+++ b/lib/ansible/modules/windows/win_wait_for_process.py
@@ -21,11 +21,12 @@ description:
   behave poorly and do not enumerate external dependencies in thier
   manifset.
 options:
-  process_name:
+  process_name_exact:
     description:
-      - The name of the process for which to wait.
-      - Supports RegEx input. Be sure to escape RegEx reserved
-        characters if attempting plaintext match.
+      - The name of the process(es) for which to wait.
+  process_name_pattern:
+     description:
+      - RegEx pattern matching desired process(es)
   sleep:
     description:
     - Number of seconds to sleep between checks.

--- a/lib/ansible/modules/windows/win_wait_for_process.py
+++ b/lib/ansible/modules/windows/win_wait_for_process.py
@@ -18,8 +18,8 @@ version_added: '2.7'
 short_description: Waits for a process to exist or not exist before continuing.
 description:
 - Waiting for a process to start or stop is useful when Windows services
-  behave poorly and do not enumerate external dependencies in thier
-  manifset.
+  behave poorly and do not enumerate external dependencies in their
+  manifest.
 options:
   process_name_exact:
     description:

--- a/lib/ansible/modules/windows/win_wait_for_process.py
+++ b/lib/ansible/modules/windows/win_wait_for_process.py
@@ -7,14 +7,14 @@
 # this is a windows documentation stub, actual code lives in the .ps1
 # file of the same name
 
-ANSIBLE_METADATA = {'metadata_version': '1.0',
+ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],
                     'supported_by': 'community'}
 
 DOCUMENTATION = r'''
 ---
 module: win_wait_for_process
-version_added: '2.6'
+version_added: '2.7'
 short_description: Waits for a process to exist or not exist before continuing.
 description:
 - Waiting for a process to start or stop is useful when Windows services
@@ -24,6 +24,7 @@ options:
   process_name_exact:
     description:
       - The name of the process(es) for which to wait.
+      - Must inclue the file extension of the process binary (.exe)
   process_name_pattern:
      description:
       - RegEx pattern matching desired process(es)

--- a/lib/ansible/modules/windows/win_wait_for_process.py
+++ b/lib/ansible/modules/windows/win_wait_for_process.py
@@ -14,40 +14,40 @@ ANSIBLE_METADATA = {'metadata_version': '1.0',
 DOCUMENTATION = r'''
 ---
 module: win_wait_for_process
-version_added: '2.4'
-short_description: Waits for a process to exsist or not exist before continuing.
+version_added: '2.6'
+short_description: Waits for a process to exist or not exist before continuing.
 description:
-- Waiting for a process to start or stop is useful when Windows services 
-  behave poorly and do not enumerate external dependencies in thier 
+- Waiting for a process to start or stop is useful when Windows services
+  behave poorly and do not enumerate external dependencies in thier
   manifset.
 options:
   process_name:
     description:
       - The name of the process for which to wait.
       - Supports RegEx input. Be sure to escape RegEx reserved
-        characters if attempting plaintext match
+        characters if attempting plaintext match.
   sleep:
     description:
     - Number of seconds to sleep between checks.
-    - Only applies when waiting for a process to start.  Waiting for a process to start 
-      does not have a native non-polling mechanism. Waiting for a stop uses native PowerShell 
+    - Only applies when waiting for a process to start.  Waiting for a process to start
+      does not have a native non-polling mechanism. Waiting for a stop uses native PowerShell
       and does not require polling.
     default: 1
   process_min_count:
     description:
-      - Minimum number of process matching the supplied pattern to satisfy C(present) condition
+      - Minimum number of process matching the supplied pattern to satisfy C(present) condition.
       - Only applies to C(present).
     default: 1
   state:
     description:
     - When checking for a running process C(present) will block execution
-      until the process exists, or until the timeout has been reached. 
-      C(absent) will block execution untile the processs no longer exists, 
+      until the process exists, or until the timeout has been reached.
+      C(absent) will block execution untile the processs no longer exists,
       or until the timeout has been reached.
     - When waiting for C(present), the module will return changed only if
-      the process was not present on the initial check but became present on 
+      the process was not present on the initial check but became present on
       subsequent checks.
-    - If, while waiting for C(absent), new processes matching the supplied 
+    - If, while waiting for C(absent), new processes matching the supplied
       pattern are started, these new processes will not be included in the
       action.
     default: present
@@ -55,23 +55,23 @@ options:
   timeout:
     description:
     - The maximum number of seconds to wait for a for a process to start or stop
-      before erroring out
+      before erroring out.
     default: 300
 author:
 - Charles Crossan (@crossan007)
 '''
 
 EXAMPLES = r'''
-- name: wait 300 seconds for all Oracle VirtualBox processes to stop. (VBoxHeadless, VirtualBox, VBoxSVC)
+- name: Wait 300 seconds for all Oracle VirtualBox processes to stop. (VBoxHeadless, VirtualBox, VBoxSVC)
   win_wait_for_process:
     process_name: "v(irtual)?box(headless|svc)?"
     state: absent
     timeout: 500
 
 
-- name: wait 300 seconds for 3 instances of cmd to start, waiting 5 seconds between each check
+- name: Wait 300 seconds for 3 instances of cmd to start, waiting 5 seconds between each check
   win_wait_for_process:
-    process_name: "cmd\.exe"
+    process_name: "cmd\\.exe"
     state: present
     timeout: 500
     sleep: 5
@@ -89,9 +89,9 @@ elapsed:
 changed:
   description: True if a process was started or stopped during the module execution.
   returned: always
-  type: boolean
-matched_processes: 
+  type: bool
+matched_processes:
   description: Count of processes stopped or started.
   returned: always
-  type: integer
+  type: int
 '''

--- a/lib/ansible/modules/windows/win_wait_for_process.py
+++ b/lib/ansible/modules/windows/win_wait_for_process.py
@@ -1,0 +1,97 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2017, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# this is a windows documentation stub, actual code lives in the .ps1
+# file of the same name
+
+ANSIBLE_METADATA = {'metadata_version': '1.0',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = r'''
+---
+module: win_wait_for_process
+version_added: '2.4'
+short_description: Waits for a process to exsist or not exist before continuing.
+description:
+- Waiting for a process to start or stop is useful when Windows services 
+  behave poorly and do not enumerate external dependencies in thier 
+  manifset.
+options:
+  process_name:
+    description:
+      - The name of the process for which to wait.
+      - Supports RegEx input. Be sure to escape RegEx reserved
+        characters if attempting plaintext match
+  sleep:
+    description:
+    - Number of seconds to sleep between checks.
+    - Only applies when waiting for a process to start.  Waiting for a process to start 
+      does not have a native non-polling mechanism. Waiting for a stop uses native PowerShell 
+      and does not require polling.
+    default: 1
+  process_min_count:
+    description:
+      - Minimum number of process matching the supplied pattern to satisfy C(present) condition
+      - Only applies to C(present).
+    default: 1
+  state:
+    description:
+    - When checking for a running process C(present) will block execution
+      until the process exists, or until the timeout has been reached. 
+      C(absent) will block execution untile the processs no longer exists, 
+      or until the timeout has been reached.
+    - When waiting for C(present), the module will return changed only if
+      the process was not present on the initial check but became present on 
+      subsequent checks.
+    - If, while waiting for C(absent), new processes matching the supplied 
+      pattern are started, these new processes will not be included in the
+      action.
+    default: present
+    choices: [ absent,  present ]
+  timeout:
+    description:
+    - The maximum number of seconds to wait for a for a process to start or stop
+      before erroring out
+    default: 300
+author:
+- Charles Crossan (@crossan007)
+'''
+
+EXAMPLES = r'''
+- name: wait 300 seconds for all Oracle VirtualBox processes to stop. (VBoxHeadless, VirtualBox, VBoxSVC)
+  win_wait_for_process:
+    process_name: "v(irtual)?box(headless|svc)?"
+    state: absent
+    timeout: 500
+
+
+- name: wait 300 seconds for 3 instances of cmd to start, waiting 5 seconds between each check
+  win_wait_for_process:
+    process_name: "cmd\.exe"
+    state: present
+    timeout: 500
+    sleep: 5
+    process_min_count: 3
+
+'''
+
+RETURN = r'''
+elapsed:
+  description: The elapsed seconds between the start of poll and the end of the
+    module.
+  returned: always
+  type: float
+  sample: 3.14159265
+changed:
+  description: True if a process was started or stopped during the module execution.
+  returned: always
+  type: boolean
+matched_processes: 
+  description: Count of processes stopped or started.
+  returned: always
+  type: integer
+'''


### PR DESCRIPTION
##### SUMMARY
Add a module to wait for a windows *process* to be present or absent. 

##### ISSUE TYPE
 - New Module Pull Request

##### COMPONENT NAME
win_wait_for_process

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/vagrant/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Aug  4 2017, 00:39:18) [GCC 4.8.5 20150623 (Red Hat 4.8.5-16)]
```


##### ADDITIONAL INFORMATION
Sometimes it's necessary to wait for a Windows process to exist / not exist before continuing a playbook. 

Scenarios include:
 *  Processes that must be stopped to prevent holding locks on files which will be replaced / altered in the playbook
 *  Processes that must be running in order to make .NET API calls through win_shell 