### PR TITLE
Clarify wording on 2.6 roadmap schedule.

### DIFF
--- a/docs/docsite/rst/roadmap/ROADMAP_2_6.rst
+++ b/docs/docsite/rst/roadmap/ROADMAP_2_6.rst
@@ -7,13 +7,13 @@ Ansible 2.6
 Release Schedule
 ----------------
 
-Proposed
+Expected
 ========
 
-- 2018-05-17 Core Freeze (Core Engine and Non-Community Modules)
+- 2018-05-17 Core Freeze (Core Engine and Core Modules/Plugins)
 - 2018-05-17 Alpha Release 1
 - 2018-05-24 Alpha Release 2
-- 2018-05-25 Community Freeze (Community Modules)
+- 2018-05-25 Community Freeze (Non-Core Modules/Plugins)
 - 2018-05-31 Branch stable-2.6
 - 2018-05-31 Release Candidate 1
 - 2018-06-07 Release Candidate 2

--- a/docs/docsite/rst/roadmap/ROADMAP_2_6.rst
+++ b/docs/docsite/rst/roadmap/ROADMAP_2_6.rst
@@ -10,7 +10,7 @@ Release Schedule
 Expected
 ========
 
-- 2018-05-17 Core Freeze (Core Engine and Core Modules/Plugins)
+- 2018-05-17 Core Freeze (Engine and Core Modules/Plugins)
 - 2018-05-17 Alpha Release 1
 - 2018-05-24 Alpha Release 2
 - 2018-05-25 Community Freeze (Non-Core Modules/Plugins)


### PR DESCRIPTION
##### SUMMARY

Clarify wording on 2.6 roadmap schedule.

##### ISSUE TYPE

Docs Pull Request

##### COMPONENT NAME

roadmap

##### ANSIBLE VERSION

```
ansible 2.6.0 (roadmap-fix 2714dcd2b6) last updated 2018/05/18 09:14:28 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
