### PR TITLE
fixed link to Docker scenario guide

### DIFF
--- a/lib/ansible/modules/cloud/docker/_docker.py
+++ b/lib/ansible/modules/cloud/docker/_docker.py
@@ -25,7 +25,7 @@ deprecated:
 description:
   - This is the original Ansible module for managing the Docker container life cycle.
   - NOTE - Additional and newer modules are available. For the latest on orchestrating containers with Ansible
-    visit our Getting Started with Docker Guide at U(https://github.com/ansible/ansible/blob/devel/docs/docsite/rst/guide_docker.rst).
+    visit our Getting Started with Docker Guide at U(http://docs.ansible.com/ansible/latest/scenario_guides/guide_docker.html).
 options:
   count:
     description:

--- a/lib/ansible/modules/cloud/docker/_docker.py
+++ b/lib/ansible/modules/cloud/docker/_docker.py
@@ -25,7 +25,7 @@ deprecated:
 description:
   - This is the original Ansible module for managing the Docker container life cycle.
   - NOTE - Additional and newer modules are available. For the latest on orchestrating containers with Ansible
-    visit our Getting Started with Docker Guide at U(http://docs.ansible.com/ansible/latest/scenario_guides/guide_docker.html).
+    visit our Getting Started with Docker Guide at U(https://docs.ansible.com/ansible/latest/scenario_guides/guide_docker.html).
 options:
   count:
     description:


### PR DESCRIPTION
##### SUMMARY

The link to the docker scenario guide was wrong, and to Github instead of the docs.
This commit fixes that.

##### ISSUE TYPE

 - Docs Pull Request

##### COMPONENT NAME

docker

##### ANSIBLE VERSION

not relevant


##### ADDITIONAL INFORMATION

not relevant
