### PR TITLE
Fix docker_image archive features to work with Python 3

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_image.py
+++ b/lib/ansible/modules/cloud/docker/docker_image.py
@@ -396,7 +396,7 @@ class ImageManager(DockerBaseClass):
                 self.fail("Error getting image %s - %s" % (image_name, str(exc)))
 
             try:
-                with open(self.archive_path, 'w') as fd:
+                with open(self.archive_path, 'wb') as fd:
                     if HAS_DOCKER_PY_3:
                         for chunk in image:
                             fd.write(chunk)
@@ -547,7 +547,7 @@ class ImageManager(DockerBaseClass):
         '''
         try:
             self.log("Opening image %s" % self.load_path)
-            image_tar = open(self.load_path, 'r')
+            image_tar = open(self.load_path, 'rb')
         except Exception as exc:
             self.fail("Error opening image %s - %s" % (self.load_path, str(exc)))
 


### PR DESCRIPTION
Without binary mode, ansible shows a "write() argument must be str, not bytes" error when using Python 3.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Similar fixes were already applied to various places in ansible, looks like this has been missed.

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
docker_image

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.3
  config file = None
  configured module search path = ['~/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python3.6/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 3.6.5 (default, Mar 31 2018, 19:45:04) [GCC]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
failed: [A.B.C.D -> localhost] (item=someimage) => {"changed": false, "item": "someimage", "msg": "Error writing image archive ./someimage.tar - write() argument must be str, not bytes"}
```
