### PR TITLE
uses .txt for shared content

### DIFF
--- a/docs/docsite/rst/network/user_guide/platform_eos.rst
+++ b/docs/docsite/rst/network/user_guide/platform_eos.rst
@@ -166,4 +166,4 @@ In this example two variables defined in ``group_vars`` get passed to the module
 - the ``eapi`` variable gets passed to the ``provider`` option of the module
 - the ``proxy_env`` variable gets passed to the ``environment`` option of the module
 
-.. include:: shared_snippets/SSH_warning.rst
+.. include:: shared_snippets/SSH_warning.txt

--- a/docs/docsite/rst/network/user_guide/platform_ios.rst
+++ b/docs/docsite/rst/network/user_guide/platform_ios.rst
@@ -67,4 +67,4 @@ Example CLI Task
      register: backup_ios_location
      when: ansible_network_os == 'ios'
 
-.. include:: shared_snippets/SSH_warning.rst
+.. include:: shared_snippets/SSH_warning.txt

--- a/docs/docsite/rst/network/user_guide/platform_junos.rst
+++ b/docs/docsite/rst/network/user_guide/platform_junos.rst
@@ -112,4 +112,4 @@ Example NETCONF Task
      when: ansible_network_os == 'junos'
 
 
-.. include:: shared_snippets/SSH_warning.rst
+.. include:: shared_snippets/SSH_warning.txt

--- a/docs/docsite/rst/network/user_guide/platform_nxos.rst
+++ b/docs/docsite/rst/network/user_guide/platform_nxos.rst
@@ -117,4 +117,4 @@ Example NX-API Task
 
 In this example the ``proxy_env`` variable defined in ``group_vars`` gets passed to the ``environment`` option of the module used in the task.
 
-.. include:: shared_snippets/SSH_warning.rst
+.. include:: shared_snippets/SSH_warning.txt

--- a/docs/docsite/rst/network/user_guide/shared_snippets/SSH_warning.txt
+++ b/docs/docsite/rst/network/user_guide/shared_snippets/SSH_warning.txt
@@ -1,4 +1,2 @@
-:orphan:
-
 .. warning:: 
    Never store passwords in plain text. We recommend using SSH keys to authenticate SSH connections. Ansible supports ssh-agent to manage your SSH keys. If you must use passwords to authenticate SSH connections, we recommend encrypting them with :ref:`Ansible Vault <playbooks_vault>`.


### PR DESCRIPTION
##### SUMMARY
Uses `.txt` extension for documentation snippets that are not included in any TOC but are included in other pages.

Closes #40415 

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
docs.ansible.com

##### ANSIBLE VERSION
2.5
