### PR TITLE
authorized_key 29891 use os.path.realpath to follow keyfile symlinks

### DIFF
--- a/changelogs/fragments/authorized_key_symlinks.yaml
+++ b/changelogs/fragments/authorized_key_symlinks.yaml
@@ -1,0 +1,3 @@
+---
+- bugfixes: authorized_key now follows symlinks by default instead of overwriting them
+  this behaviour can be changed by setting follow_symlinks True/False

--- a/changelogs/fragments/authorized_key_symlinks.yaml
+++ b/changelogs/fragments/authorized_key_symlinks.yaml
@@ -1,4 +1,4 @@
 ---
 bugfixes:
-- authorized_key now follows symlinks by default instead of overwriting them
-  this behaviour can be changed by setting follow_symlinks True/False
+- authorized_key now have an option for following symlinks,
+  default behaviour (False) can be changed by setting follow True/False

--- a/changelogs/fragments/authorized_key_symlinks.yaml
+++ b/changelogs/fragments/authorized_key_symlinks.yaml
@@ -1,3 +1,4 @@
 ---
-- bugfixes: authorized_key now follows symlinks by default instead of overwriting them
+bugfixes:
+- authorized_key now follows symlinks by default instead of overwriting them
   this behaviour can be changed by setting follow_symlinks True/False

--- a/lib/ansible/modules/system/authorized_key.py
+++ b/lib/ansible/modules/system/authorized_key.py
@@ -297,7 +297,7 @@ def keyfile(module, user, write=False, path=None, manage_dir=True):
     """
 
     if module.check_mode and path is not None:
-        keysfile = path
+        keysfile = os.path.realpath(path)
         return keysfile
 
     try:
@@ -313,6 +313,8 @@ def keyfile(module, user, write=False, path=None, manage_dir=True):
     else:
         sshdir = os.path.dirname(path)
         keysfile = path
+
+    keysfile = os.path.realpath(keysfile)
 
     if not write:
         return keysfile

--- a/lib/ansible/modules/system/authorized_key.py
+++ b/lib/ansible/modules/system/authorized_key.py
@@ -284,7 +284,7 @@ class keydict(dict):
         return [item[1] for item in self.items()]
 
 
-def keyfile(module, user, write=False, path=None, manage_dir=True, follow_symlink=True):
+def keyfile(module, user, write=False, path=None, manage_dir=True, follow=False):
     """
     Calculate name of authorized keys file, optionally creating the
     directories and file, properly setting permissions.
@@ -293,14 +293,14 @@ def keyfile(module, user, write=False, path=None, manage_dir=True, follow_symlin
     :param bool write: if True, write changes to authorized_keys file (creating directories if needed)
     :param str path: if not None, use provided path rather than default of '~user/.ssh/authorized_keys'
     :param bool manage_dir: if True, create and set ownership of the parent dir of the authorized_keys file
-    :param bool follow_symlink: if False symlinks will be overwritten
+    :param bool follow: if True symlinks will be followed and not replaced
     :return: full path string to authorized_keys for user
     """
 
     if module.check_mode and path is not None:
         keysfile = path
 
-        if follow_symlink:
+        if follow:
             return os.path.realpath(keysfile)
 
         return keysfile
@@ -319,7 +319,7 @@ def keyfile(module, user, write=False, path=None, manage_dir=True, follow_symlin
         sshdir = os.path.dirname(path)
         keysfile = path
 
-    if follow_symlink:
+    if follow:
         keysfile = os.path.realpath(keysfile)
 
     if not write:
@@ -526,7 +526,7 @@ def enforce_state(module, params):
     key_options = params.get("key_options", None)
     exclusive = params.get("exclusive", False)
     comment = params.get("comment", None)
-    follow_symlink = params.get('follow_symlink', True)
+    follow = params.get('follow', False)
     error_msg = "Error getting key from: %s"
 
     # if the key is a url, request it and use it as key source
@@ -622,7 +622,7 @@ def enforce_state(module, params):
             do_write = True
 
     if do_write:
-        filename = keyfile(module, user, do_write, path, manage_dir, follow_symlink)
+        filename = keyfile(module, user, do_write, path, manage_dir, follow)
         new_content = serialize(existing_keys)
 
         diff = None
@@ -659,7 +659,7 @@ def main():
             exclusive=dict(default=False, type='bool'),
             comment=dict(required=False, default=None, type='str'),
             validate_certs=dict(default=True, type='bool'),
-            follow_symlink=dict(default=True, type='bool')
+            follow=dict(default=True, type='bool')
         ),
         supports_check_mode=True
     )

--- a/lib/ansible/modules/system/authorized_key.py
+++ b/lib/ansible/modules/system/authorized_key.py
@@ -78,6 +78,12 @@ options:
         cases such as fetching it from GitHub or GitLab.
       - If no comment is specified, the existing comment will be kept.
     version_added: "2.4"
+  follow:
+    description:
+      - Follow path symlink instead of replacing it
+    type: bool
+    default: 'no'
+    version_added: "2.7"
 author: "Ansible Core Team"
 '''
 
@@ -659,7 +665,7 @@ def main():
             exclusive=dict(default=False, type='bool'),
             comment=dict(required=False, default=None, type='str'),
             validate_certs=dict(default=True, type='bool'),
-            follow=dict(default=True, type='bool')
+            follow=dict(default=False, type='bool')
         ),
         supports_check_mode=True
     )


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
Fixes #29891, gets the real path of given path or default to prevent symlinks being replaced
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request
##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
authorized_key
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.2
  config file = /home/acalm/.ansible.cfg
  configured module search path = ['/home/acalm/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib64/python3.6/site-packages/ansible
  executable location = /usr/lib/python-exec/python3.6/ansible
  python version = 3.6.5 (default, Apr 24 2018, 21:20:09) [GCC 6.4.0]

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
