### PR TITLE
Adds wait parameters to bigiq applications

### DIFF
--- a/lib/ansible/modules/network/f5/bigiq_application_fasthttp.py
+++ b/lib/ansible/modules/network/f5/bigiq_application_fasthttp.py
@@ -91,6 +91,11 @@ options:
     choices:
       - absent
       - present
+  wait:
+    description:
+      - If the module should wait for the application to be created, deleted or updated.
+    type: bool
+    default: yes
 extends_documentation_fragment: f5
 notes:
   - This module does not support updating of your application (whether deployed or not).
@@ -572,9 +577,10 @@ class ModuleManager(object):
         if self.module.check_mode:
             return True
         self_link = self.remove_from_device()
-        self.wait_for_apply_template_task(self_link)
-        if self.exists():
-            raise F5ModuleError("Failed to delete the resource.")
+        if self.want.wait:
+            self.wait_for_apply_template_task(self_link)
+            if self.exists():
+                raise F5ModuleError("Failed to delete the resource.")
         return True
 
     def has_no_service_environment(self):
@@ -605,11 +611,12 @@ class ModuleManager(object):
         if self.module.check_mode:
             return True
         self_link = self.create_on_device()
-        self.wait_for_apply_template_task(self_link)
-        if not self.exists():
-            raise F5ModuleError(
-                "Failed to deploy application."
-            )
+        if self.want.wait:
+            self.wait_for_apply_template_task(self_link)
+            if not self.exists():
+                raise F5ModuleError(
+                    "Failed to deploy application."
+                )
         return True
 
     def create_on_device(self):
@@ -710,6 +717,7 @@ class ArgumentSpec(object):
                 default='present',
                 choices=['present', 'absent']
             ),
+            wait=dict(type='bool', default='yes')
         )
         self.argument_spec = {}
         self.argument_spec.update(f5_argument_spec)

--- a/lib/ansible/modules/network/f5/bigiq_application_fastl4_tcp.py
+++ b/lib/ansible/modules/network/f5/bigiq_application_fastl4_tcp.py
@@ -91,6 +91,11 @@ options:
     choices:
       - absent
       - present
+  wait:
+    description:
+      - If the module should wait for the application to be created, deleted or updated.
+    type: bool
+    default: yes
 extends_documentation_fragment: f5
 notes:
   - This module does not support updating of your application (whether deployed or not).
@@ -530,9 +535,10 @@ class ModuleManager(object):
         if self.module.check_mode:
             return True
         self_link = self.remove_from_device()
-        self.wait_for_apply_template_task(self_link)
-        if self.exists():
-            raise F5ModuleError("Failed to delete the resource.")
+        if self.want.wait:
+            self.wait_for_apply_template_task(self_link)
+            if self.exists():
+                raise F5ModuleError("Failed to delete the resource.")
         return True
 
     def create(self):
@@ -552,11 +558,12 @@ class ModuleManager(object):
         if self.module.check_mode:
             return True
         self_link = self.create_on_device()
-        self.wait_for_apply_template_task(self_link)
-        if not self.exists():
-            raise F5ModuleError(
-                "Failed to deploy application."
-            )
+        if self.want.wait:
+            self.wait_for_apply_template_task(self_link)
+            if not self.exists():
+                raise F5ModuleError(
+                    "Failed to deploy application."
+                )
         return True
 
     def create_on_device(self):
@@ -657,6 +664,7 @@ class ArgumentSpec(object):
                 default='present',
                 choices=['present', 'absent']
             ),
+            wait=dict(type='bool', default='yes')
         )
         self.argument_spec = {}
         self.argument_spec.update(f5_argument_spec)

--- a/lib/ansible/modules/network/f5/bigiq_application_fastl4_udp.py
+++ b/lib/ansible/modules/network/f5/bigiq_application_fastl4_udp.py
@@ -91,6 +91,11 @@ options:
     choices:
       - absent
       - present
+  wait:
+    description:
+      - If the module should wait for the application to be created, deleted or updated.
+    type: bool
+    default: yes
 extends_documentation_fragment: f5
 notes:
   - This module does not support updating of your application (whether deployed or not).
@@ -530,9 +535,10 @@ class ModuleManager(object):
         if self.module.check_mode:
             return True
         self_link = self.remove_from_device()
-        self.wait_for_apply_template_task(self_link)
-        if self.exists():
-            raise F5ModuleError("Failed to delete the resource.")
+        if self.want.wait:
+            self.wait_for_apply_template_task(self_link)
+            if self.exists():
+                raise F5ModuleError("Failed to delete the resource.")
         return True
 
     def create(self):
@@ -552,11 +558,12 @@ class ModuleManager(object):
         if self.module.check_mode:
             return True
         self_link = self.create_on_device()
-        self.wait_for_apply_template_task(self_link)
-        if not self.exists():
-            raise F5ModuleError(
-                "Failed to deploy application."
-            )
+        if self.want.wait:
+            self.wait_for_apply_template_task(self_link)
+            if not self.exists():
+                raise F5ModuleError(
+                    "Failed to deploy application."
+                )
         return True
 
     def create_on_device(self):
@@ -657,6 +664,7 @@ class ArgumentSpec(object):
                 default='present',
                 choices=['present', 'absent']
             ),
+            wait=dict(type='bool', default='yes')
         )
         self.argument_spec = {}
         self.argument_spec.update(f5_argument_spec)

--- a/lib/ansible/modules/network/f5/bigiq_application_http.py
+++ b/lib/ansible/modules/network/f5/bigiq_application_http.py
@@ -91,6 +91,11 @@ options:
     choices:
       - absent
       - present
+  wait:
+    description:
+      - If the module should wait for the application to be created, deleted or updated.
+    type: bool
+    default: yes
 extends_documentation_fragment: f5
 notes:
   - This module does not support updating of your application (whether deployed or not).
@@ -572,9 +577,10 @@ class ModuleManager(object):
         if self.module.check_mode:
             return True
         self_link = self.remove_from_device()
-        self.wait_for_apply_template_task(self_link)
-        if self.exists():
-            raise F5ModuleError("Failed to delete the resource.")
+        if self.want.wait:
+            self.wait_for_apply_template_task(self_link)
+            if self.exists():
+                raise F5ModuleError("Failed to delete the resource.")
         return True
 
     def has_no_service_environment(self):
@@ -605,11 +611,12 @@ class ModuleManager(object):
         if self.module.check_mode:
             return True
         self_link = self.create_on_device()
-        self.wait_for_apply_template_task(self_link)
-        if not self.exists():
-            raise F5ModuleError(
-                "Failed to deploy application."
-            )
+        if self.want.wait:
+            self.wait_for_apply_template_task(self_link)
+            if not self.exists():
+                raise F5ModuleError(
+                    "Failed to deploy application."
+                )
         return True
 
     def create_on_device(self):
@@ -710,6 +717,7 @@ class ArgumentSpec(object):
                 default='present',
                 choices=['present', 'absent']
             ),
+            wait=dict(type='bool', default='yes')
         )
         self.argument_spec = {}
         self.argument_spec.update(f5_argument_spec)

--- a/lib/ansible/modules/network/f5/bigiq_application_https_waf.py
+++ b/lib/ansible/modules/network/f5/bigiq_application_https_waf.py
@@ -155,6 +155,11 @@ options:
     choices:
       - absent
       - present
+  wait:
+    description:
+      - If the module should wait for the application to be created, deleted or updated.
+    type: bool
+    default: yes
 extends_documentation_fragment: f5
 author:
   - Tim Rupp (@caphrim007)
@@ -811,9 +816,10 @@ class ModuleManager(object):
         if self.module.check_mode:
             return True
         self_link = self.remove_from_device()
-        self.wait_for_apply_template_task(self_link)
-        if self.exists():
-            raise F5ModuleError("Failed to delete the resource.")
+        if self.want.wait:
+            self.wait_for_apply_template_task(self_link)
+            if self.exists():
+                raise F5ModuleError("Failed to delete the resource.")
         return True
 
     def has_no_service_environment(self):
@@ -848,11 +854,12 @@ class ModuleManager(object):
         if self.module.check_mode:
             return True
         self_link = self.create_on_device()
-        self.wait_for_apply_template_task(self_link)
-        if not self.exists():
-            raise F5ModuleError(
-                "Failed to deploy application."
-            )
+        if self.want.wait:
+            self.wait_for_apply_template_task(self_link)
+            if not self.exists():
+                raise F5ModuleError(
+                    "Failed to deploy application."
+                )
         return True
 
     def create_on_device(self):
@@ -974,7 +981,8 @@ class ArgumentSpec(object):
                 )
             ),
             add_analytics=dict(type='bool', default='no'),
-            domain_names=dict(type='list')
+            domain_names=dict(type='list'),
+            wait=dict(type='bool', default='yes')
         )
         self.argument_spec = {}
         self.argument_spec.update(f5_argument_spec)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
The wait parameter allows the module to wait or not wait when
an application is created. By default the modules will wait.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
bigiq modules

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0
  config file = None
  configured module search path = ['/root/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python3.6/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 3.6.5 (default, May  5 2018, 03:09:35) [GCC 4.9.2]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
