### PR TITLE
Enable check_mode in command module

### DIFF
--- a/changelogs/fragments/command_shell_check_mode.yaml
+++ b/changelogs/fragments/command_shell_check_mode.yaml
@@ -1,0 +1,6 @@
+---
+minor_changes:
+  - command module - Add support for check mode when passing creates or removes arguments.
+    (https://github.com/ansible/ansible/pull/40428)
+  - shell module - Add support for check mode when passing creates or removes arguments.
+    (https://github.com/ansible/ansible/pull/40428)

--- a/docs/docsite/rst/porting_guides/porting_guide_2.7.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.7.rst
@@ -100,7 +100,9 @@ The following modules will be removed in Ansible 2.10. Please update your playbo
 Noteworthy module changes
 -------------------------
 
-No notable changes.
+Check mode is now supported in the ``command`` and ``shell`` modules. However, only when ``creates`` or ``removes`` is
+specified. If either of these are specified, the module will check for existence of the file and report the correct
+changed status, if they are not included the module will skip like it had done previously.
 
 Plugins
 =======

--- a/lib/ansible/modules/commands/command.py
+++ b/lib/ansible/modules/commands/command.py
@@ -185,7 +185,8 @@ def main():
             # The default for this really comes from the action plugin
             warn=dict(type='bool', default=True),
             stdin=dict(required=False),
-        )
+        ),
+        supports_check_mode=True,
     )
     shell = module.params['_uses_shell']
     chdir = module.params['chdir']
@@ -245,7 +246,13 @@ def main():
 
     startd = datetime.datetime.now()
 
-    rc, out, err = module.run_command(args, executable=executable, use_unsafe_shell=shell, encoding=None, data=stdin)
+    if not module.check_mode:
+        rc, out, err = module.run_command(args, executable=executable, use_unsafe_shell=shell, encoding=None, data=stdin)
+    elif creates or removes:
+        rc = 0
+        out = err = b'Command would have run if not in check mode'
+    else:
+        module.exit_json(msg="skipped, running in check mode", skipped=True)
 
     endd = datetime.datetime.now()
     delta = endd - startd

--- a/lib/ansible/modules/commands/command.py
+++ b/lib/ansible/modules/commands/command.py
@@ -64,6 +64,8 @@ notes:
        use the C(command) module when possible.
     -  " C(creates), C(removes), and C(chdir) can be specified after the command.
        For instance, if you only want to run a command if a certain file does not exist, use this."
+    -  Check mode is supported when passing C(creates) or C(removes). If running in check mode and either of these are specified, the module will
+       check for the existence of the file and report the correct changed status. If these are not supplied, the task will be skipped.
     -  The C(executable) parameter is removed since version 2.4. If you have a need for this parameter, use the M(shell) module instead.
     -  For Windows targets, use the M(win_command) module instead.
 author:

--- a/lib/ansible/modules/commands/shell.py
+++ b/lib/ansible/modules/commands/shell.py
@@ -61,6 +61,10 @@ notes:
      playbooks will follow the trend of using M(command) unless the C(shell)
      module is explicitly required. When running ad-hoc commands, use your best
      judgement.
+  -  Check mode is supported when passing C(creates) or C(removes). If running
+     in check mode and either of these are specified, the module will check for
+     the existence of the file and report the correct changed status. If these
+     are not supplied, the task will be skipped.
   -  To sanitize any variables passed to the shell module, you should use
      "{{ var | quote }}" instead of just "{{ var }}" to make sure they don't include evil things like semicolons.
   - For Windows targets, use the M(win_shell) module instead.


### PR DESCRIPTION
##### SUMMARY
As per #15828. This adds support for check_mode where possible and leaves behaviour as is where not. This only works if supplying creates or removes since it needs something to base the heuristic off. If none are supplied it will just skip as usual.

Fixes #15828.


##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
lib/ansible/modules/commands/command.py

##### ANSIBLE VERSION
```
ansible 2.5.2
  config file = None
  configured module search path = [u'/Users/jradtilbrook/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/Cellar/ansible/2.5.2/libexec/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.15 (default, May  1 2018, 16:44:08) [GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.1)]
```


##### ADDITIONAL INFORMATION
I wasn't too sure about the messages to use. Let me know if you want them changed to something better.
