### PR TITLE
Explicit availability of 'null' timeout in expect module

### DIFF
--- a/lib/ansible/modules/commands/expect.py
+++ b/lib/ansible/modules/commands/expect.py
@@ -45,7 +45,8 @@ options:
     required: true
   timeout:
     description:
-      - Amount of time in seconds to wait for the expected strings.
+      - Amount of time in seconds to wait for the expected strings. Use
+        C(null) to disable timeout.
     default: 30
   echo:
     description:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This PR explicits the availability of the option to disable the timeout of the expect module by passing `null` to the `timeout` option.

The behavior is documented [here](https://github.com/pexpect/pexpect/blob/master/pexpect/pty_spawn.py#L91) in the pexpect python module.
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
expect

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.3
  config file = /home/sweenu/.ansible.cfg
  configured module search path = ['/home/sweenu/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python3.6/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 3.6.5 (default, May 11 2018, 04:00:52) [GCC 8.1.0]

```
