### PR TITLE
Remove the default empty dict parameter for tags. Add helpful failure…

### DIFF
--- a/lib/ansible/module_utils/aws/elbv2.py
+++ b/lib/ansible/module_utils/aws/elbv2.py
@@ -231,6 +231,9 @@ class ApplicationLoadBalancer(ElasticLoadBalancerV2):
         self.access_logs_s3_prefix = module.params.get("access_logs_s3_prefix")
         self.idle_timeout = module.params.get("idle_timeout")
 
+        if self.elb is not None and self.elb['Type'] != 'application':
+            self.module.fail_json(msg="The load balancer type you are trying to manage is not application. Try elb_network_lb module instead.")
+
     def create_elb(self):
         """
         Create a load balancer
@@ -339,6 +342,9 @@ class NetworkLoadBalancer(ElasticLoadBalancerV2):
 
         # Ansible module parameters specific to NLBs
         self.type = 'network'
+
+        if self.elb is not None and self.elb['Type'] != 'network':
+            self.module.fail_json(msg="The load balancer type you are trying to manage is not network. Try elb_application_lb module instead.")
 
     def create_elb(self):
         """

--- a/lib/ansible/modules/cloud/amazon/elb_application_lb.py
+++ b/lib/ansible/modules/cloud/amazon/elb_application_lb.py
@@ -509,7 +509,7 @@ def main():
             security_groups=dict(type='list'),
             scheme=dict(default='internet-facing', choices=['internet-facing', 'internal']),
             state=dict(choices=['present', 'absent'], type='str'),
-            tags=dict(default={}, type='dict'),
+            tags=dict(type='dict'),
             wait_timeout=dict(type='int'),
             wait=dict(default=False, type='bool')
         )


### PR DESCRIPTION
… message when using wrong lb module

##### SUMMARY
The tags parameter should not default to an empty dict otherwise it'll remove tags specified by the user even if no tags parameter is passed in the task.

Also added a helpful failure message if the user is trying to manage a network_lb with the application_lb module and vice versa.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
elb_application_lb

##### ANSIBLE VERSION
```
2.6
```


##### ADDITIONAL INFORMATION

