### PR TITLE
Correct doc for cache plugin

### DIFF
--- a/lib/ansible/plugins/cache/jsonfile.py
+++ b/lib/ansible/plugins/cache/jsonfile.py
@@ -12,7 +12,7 @@ DOCUMENTATION = '''
     description:
         - This cache uses JSON formatted, per host, files saved to the filesystem.
     version_added: "1.9"
-    author: Ansible Core
+    author: Ansible Core (@ansible-core)
     options:
       _uri:
         required: True
@@ -30,7 +30,7 @@ DOCUMENTATION = '''
           - name: ANSIBLE_CACHE_PLUGIN_PREFIX
         ini:
           - key: fact_caching_prefix
-          - section: defaults
+            section: defaults
       _timeout:
         default: 86400
         description: Expiration timeout for the cache plugin data

--- a/lib/ansible/plugins/cache/memcached.py
+++ b/lib/ansible/plugins/cache/memcached.py
@@ -30,7 +30,7 @@ DOCUMENTATION = '''
           - name: ANSIBLE_CACHE_PLUGIN_PREFIX
         ini:
           - key: fact_caching_prefix
-          - section: defaults
+            section: defaults
       _timeout:
         default: 86400
         description: Expiration timeout for the cache plugin data

--- a/lib/ansible/plugins/cache/mongodb.py
+++ b/lib/ansible/plugins/cache/mongodb.py
@@ -31,7 +31,7 @@ DOCUMENTATION = '''
           - name: ANSIBLE_CACHE_PLUGIN_PREFIX
         ini:
           - key: fact_caching_prefix
-          - section: defaults
+            section: defaults
       _timeout:
         default: 86400
         description: Expiration timeout in seconds for the cache plugin data

--- a/lib/ansible/plugins/cache/pickle.py
+++ b/lib/ansible/plugins/cache/pickle.py
@@ -30,7 +30,7 @@ DOCUMENTATION = '''
           - name: ANSIBLE_CACHE_PLUGIN_PREFIX
         ini:
           - key: fact_caching_prefix
-          - section: defaults
+            section: defaults
       _timeout:
         default: 86400
         description: Expiration timeout for the cache plugin data

--- a/lib/ansible/plugins/cache/redis.py
+++ b/lib/ansible/plugins/cache/redis.py
@@ -28,7 +28,7 @@ DOCUMENTATION = '''
           - name: ANSIBLE_CACHE_PLUGIN_PREFIX
         ini:
           - key: fact_caching_prefix
-          - section: defaults
+            section: defaults
       _timeout:
         default: 86400
         description: Expiration timeout for the cache plugin data

--- a/lib/ansible/plugins/cache/yaml.py
+++ b/lib/ansible/plugins/cache/yaml.py
@@ -30,7 +30,7 @@ DOCUMENTATION = '''
           - name: ANSIBLE_CACHE_PLUGIN_PREFIX
         ini:
           - key: fact_caching_prefix
-          - section: defaults
+            section: defaults
       _timeout:
         default: 86400
         description: Expiration timeout for the cache plugin data


### PR DESCRIPTION

##### SUMMARY
Section is a part of ini, so removing it as separate key.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
lib/ansible/plugins/cache/jsonfile.py
lib/ansible/plugins/cache/memcached.py
lib/ansible/plugins/cache/mongodb.py
lib/ansible/plugins/cache/pickle.py
lib/ansible/plugins/cache/redis.py
lib/ansible/plugins/cache/yaml.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6devel
```