### PR TITLE
Fix opennebula test stub

### DIFF
--- a/test/integration/targets/one_host/tasks/main.yml
+++ b/test/integration/targets/one_host/tasks/main.yml
@@ -27,10 +27,10 @@
     api_token: "{{ opennebula_password }}"
     validate_certs: false
   environment:
-    ONE_TEST_FIXTURE: "{{ opennebula_test_fixture }}"
-    ONE_TEST_FIXTURE_FILE: /tmp/opennebula-fixtures.json.gz
-    ONE_TEST_FIXTURE_REPLAY: "{{ opennebula_test_fixture_replay }}"
-    ONE_TEST_FIXTURE_UNIT: "test_{{test_number}}_{{ item }}"
+    PYONE_TEST_FIXTURE: "{{ opennebula_test_fixture }}"
+    PYONE_TEST_FIXTURE_FILE: /tmp/opennebula-fixtures.json.gz
+    PYONE_TEST_FIXTURE_REPLAY: "{{ opennebula_test_fixture_replay }}"
+    PYONE_TEST_FIXTURE_UNIT: "test_{{test_number}}_{{ item }}"
   with_items: "{{opennebula_test.hosts}}"
   register: result
 
@@ -47,10 +47,10 @@
     api_password: "{{ opennebula_password }}"
     validate_certs: false
   environment:
-    ONE_TEST_FIXTURE: "{{ opennebula_test_fixture }}"
-    ONE_TEST_FIXTURE_FILE: /tmp/opennebula-fixtures.json.gz
-    ONE_TEST_FIXTURE_REPLAY: "{{ opennebula_test_fixture_replay }}"
-    ONE_TEST_FIXTURE_UNIT: "test_{{test_number}}_{{item}}"
+    PYONE_TEST_FIXTURE: "{{ opennebula_test_fixture }}"
+    PYONE_TEST_FIXTURE_FILE: /tmp/opennebula-fixtures.json.gz
+    PYONE_TEST_FIXTURE_REPLAY: "{{ opennebula_test_fixture_replay }}"
+    PYONE_TEST_FIXTURE_UNIT: "test_{{test_number}}_{{item}}"
   ignore_errors: true
   register: result
   with_items:
@@ -77,10 +77,10 @@
     api_password: "{{ opennebula_password }}"
     validate_certs: false
   environment:
-    ONE_TEST_FIXTURE: "{{ opennebula_test_fixture }}"
-    ONE_TEST_FIXTURE_FILE: /tmp/opennebula-fixtures.json.gz
-    ONE_TEST_FIXTURE_REPLAY: "{{ opennebula_test_fixture_replay }}"
-    ONE_TEST_FIXTURE_UNIT: "test_{{test_number}}"
+    PYONE_TEST_FIXTURE: "{{ opennebula_test_fixture }}"
+    PYONE_TEST_FIXTURE_FILE: /tmp/opennebula-fixtures.json.gz
+    PYONE_TEST_FIXTURE_REPLAY: "{{ opennebula_test_fixture_replay }}"
+    PYONE_TEST_FIXTURE_UNIT: "test_{{test_number}}"
   register: result
 
 - name: "assert test_{{test_number}} worked"
@@ -102,10 +102,10 @@
     api_password: "{{ opennebula_password }}"
     validate_certs: false
   environment:
-    ONE_TEST_FIXTURE: "{{ opennebula_test_fixture }}"
-    ONE_TEST_FIXTURE_FILE: /tmp/opennebula-fixtures.json.gz
-    ONE_TEST_FIXTURE_REPLAY: "{{ opennebula_test_fixture_replay }}"
-    ONE_TEST_FIXTURE_UNIT: "test_{{test_number}}_{{ item }}"
+    PYONE_TEST_FIXTURE: "{{ opennebula_test_fixture }}"
+    PYONE_TEST_FIXTURE_FILE: /tmp/opennebula-fixtures.json.gz
+    PYONE_TEST_FIXTURE_REPLAY: "{{ opennebula_test_fixture_replay }}"
+    PYONE_TEST_FIXTURE_UNIT: "test_{{test_number}}_{{ item }}"
   with_items: "{{opennebula_test.hosts}}"
   register: result
 
@@ -132,10 +132,10 @@
         - custom
       TEST_VALUE: 2
   environment:
-    ONE_TEST_FIXTURE: "{{ opennebula_test_fixture }}"
-    ONE_TEST_FIXTURE_FILE: /tmp/opennebula-fixtures.json.gz
-    ONE_TEST_FIXTURE_REPLAY: "{{ opennebula_test_fixture_replay }}"
-    ONE_TEST_FIXTURE_UNIT: "test_{{test_number}}_{{ item }}"
+    PYONE_TEST_FIXTURE: "{{ opennebula_test_fixture }}"
+    PYONE_TEST_FIXTURE_FILE: /tmp/opennebula-fixtures.json.gz
+    PYONE_TEST_FIXTURE_REPLAY: "{{ opennebula_test_fixture_replay }}"
+    PYONE_TEST_FIXTURE_UNIT: "test_{{test_number}}_{{ item }}"
   with_items: "{{opennebula_test.hosts}}"
   register: result
 
@@ -162,10 +162,10 @@
     attributes:
       TEST_VALUE: "2"
   environment:
-    ONE_TEST_FIXTURE: "{{ opennebula_test_fixture }}"
-    ONE_TEST_FIXTURE_FILE: /tmp/opennebula-fixtures.json.gz
-    ONE_TEST_FIXTURE_REPLAY: "{{ opennebula_test_fixture_replay }}"
-    ONE_TEST_FIXTURE_UNIT: "test_{{test_number}}_{{ item }}"
+    PYONE_TEST_FIXTURE: "{{ opennebula_test_fixture }}"
+    PYONE_TEST_FIXTURE_FILE: /tmp/opennebula-fixtures.json.gz
+    PYONE_TEST_FIXTURE_REPLAY: "{{ opennebula_test_fixture_replay }}"
+    PYONE_TEST_FIXTURE_UNIT: "test_{{test_number}}_{{ item }}"
   with_items: "{{opennebula_test.hosts}}"
   register: result
 
@@ -187,10 +187,10 @@
     api_password: "{{ opennebula_password }}"
     validate_certs: false
   environment:
-    ONE_TEST_FIXTURE: "{{ opennebula_test_fixture }}"
-    ONE_TEST_FIXTURE_FILE: /tmp/opennebula-fixtures.json.gz
-    ONE_TEST_FIXTURE_REPLAY: "{{ opennebula_test_fixture_replay }}"
-    ONE_TEST_FIXTURE_UNIT: "test_{{test_number}}_{{ item }}"
+    PYONE_TEST_FIXTURE: "{{ opennebula_test_fixture }}"
+    PYONE_TEST_FIXTURE_FILE: /tmp/opennebula-fixtures.json.gz
+    PYONE_TEST_FIXTURE_REPLAY: "{{ opennebula_test_fixture_replay }}"
+    PYONE_TEST_FIXTURE_UNIT: "test_{{test_number}}_{{ item }}"
   with_items: "{{opennebula_test.hosts}}"
   register: result
 
@@ -212,10 +212,10 @@
     api_password: "{{ opennebula_password }}"
     validate_certs: false
   environment:
-    ONE_TEST_FIXTURE: "{{ opennebula_test_fixture }}"
-    ONE_TEST_FIXTURE_FILE: /tmp/opennebula-fixtures.json.gz
-    ONE_TEST_FIXTURE_REPLAY: "{{ opennebula_test_fixture_replay }}"
-    ONE_TEST_FIXTURE_UNIT: "test_{{test_number}}_{{ item }}"
+    PYONE_TEST_FIXTURE: "{{ opennebula_test_fixture }}"
+    PYONE_TEST_FIXTURE_FILE: /tmp/opennebula-fixtures.json.gz
+    PYONE_TEST_FIXTURE_REPLAY: "{{ opennebula_test_fixture_replay }}"
+    PYONE_TEST_FIXTURE_UNIT: "test_{{test_number}}_{{ item }}"
   with_items: "{{opennebula_test.hosts}}"
   register: result
 


### PR DESCRIPTION
##### SUMMARY
opennebula module utils include some test related code to activate fixture recording functionality provided by pyone, the OpenNebula python binding interface.

This code has now been moved out of opennebula module utils and placed mostly into the pyone library itself. 

pyone can now enable fixture recording depending exclusively on special environment variables, those environment variables have been moved to a separate namespacing prefix: PYONE_, making it more obvious that are unrelated to the ansible module and communicate directly with the bindings interface pyone.

This pull requests deletes the redundant test code in module utils.

Fixture recording can be used during integration tests with a live OpenNebula platform. The generated fixtures allow to re-run the same tests without the platform and tests run an order of magnitude faster, which is very convenient during development. Recorded fixtures are also used during continue delivery as there is no live OpenNebula platform to run the integration tests with.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
one_host 
opennebula module utils

##### ANSIBLE VERSION
```
ansible 2.6.0 (fix-opennebula-test-stub 80dc7b9785) last updated 2018/05/19 14:47:35 (GMT +200)
  config file = None
  configured module search path = [u'/home/rafael/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/rafael/Development/privaz.io/python/ansible/lib/ansible
  executable location = /home/rafael/Development/privaz.io/python/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 14 2018, 13:36:31) [GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]
```