### PR TITLE
Add 2 new autoloader options for Composer module

### DIFF
--- a/lib/ansible/modules/packaging/language/composer.py
+++ b/lib/ansible/modules/packaging/language/composer.py
@@ -101,6 +101,13 @@ options:
         default: false
         type: bool
         aliases: [ classmap-authoritative ]
+    apcu_autoloader:
+        version_added: "2.7"
+        description:
+            - Uses APCu to cache found/not-found classes
+        default: false
+        type: bool
+        aliases: [ apcu-autoloader ]
     ignore_platform_reqs:
         version_added: "2.0"
         description:
@@ -191,6 +198,7 @@ def main():
             no_dev=dict(default=True, type="bool", aliases=["no-dev"]),
             no_scripts=dict(default=False, type="bool", aliases=["no-scripts"]),
             no_plugins=dict(default=False, type="bool", aliases=["no-plugins"]),
+            apcu_autoloader=dict(default=False, type="bool", aliases=["apcu-autoloader"]),
             optimize_autoloader=dict(default=True, type="bool", aliases=["optimize-autoloader"]),
             classmap_authoritative=dict(default=False, type="bool", aliases=["classmap-authoritative"]),
             ignore_platform_reqs=dict(default=False, type="bool", aliases=["ignore-platform-reqs"]),
@@ -231,6 +239,7 @@ def main():
         'no_dev': 'no-dev',
         'no_scripts': 'no-scripts',
         'no_plugins': 'no_plugins',
+        'apcu_autoloader': 'acpu-autoloader',
         'optimize_autoloader': 'optimize-autoloader',
         'classmap_authoritative': 'classmap-authoritative',
         'ignore_platform_reqs': 'ignore-platform-reqs',

--- a/lib/ansible/modules/packaging/language/composer.py
+++ b/lib/ansible/modules/packaging/language/composer.py
@@ -92,6 +92,15 @@ options:
         default: true
         type: bool
         aliases: [ optimize-autoloader ]
+    classmap_authoritative:
+        version_added: "2.7"
+        description:
+            - Autoload classes from classmap only.
+            - Implicitely enable optimize_autoloader.
+            - Recommended especially for production, but can take a bit of time to run.
+        default: false
+        type: bool
+        aliases: [ classmap-authoritative ]
     ignore_platform_reqs:
         version_added: "2.0"
         description:
@@ -183,6 +192,7 @@ def main():
             no_scripts=dict(default=False, type="bool", aliases=["no-scripts"]),
             no_plugins=dict(default=False, type="bool", aliases=["no-plugins"]),
             optimize_autoloader=dict(default=True, type="bool", aliases=["optimize-autoloader"]),
+            classmap_authoritative=dict(default=False, type="bool", aliases=["classmap-authoritative"]),
             ignore_platform_reqs=dict(default=False, type="bool", aliases=["ignore-platform-reqs"]),
         ),
         required_if=[('global_command', False, ['working_dir'])],
@@ -222,6 +232,7 @@ def main():
         'no_scripts': 'no-scripts',
         'no_plugins': 'no_plugins',
         'optimize_autoloader': 'optimize-autoloader',
+        'classmap_authoritative': 'classmap-authoritative',
         'ignore_platform_reqs': 'ignore-platform-reqs',
     }
 

--- a/lib/ansible/modules/packaging/language/composer.py
+++ b/lib/ansible/modules/packaging/language/composer.py
@@ -238,7 +238,7 @@ def main():
         'prefer_dist': 'prefer-dist',
         'no_dev': 'no-dev',
         'no_scripts': 'no-scripts',
-        'no_plugins': 'no_plugins',
+        'no_plugins': 'no-plugins',
         'apcu_autoloader': 'acpu-autoloader',
         'optimize_autoloader': 'optimize-autoloader',
         'classmap_authoritative': 'classmap-authoritative',


### PR DESCRIPTION
##### SUMMARY
Add support for two options in the composer module, which are now used pretty often for prod envs :
- classmap-authoritative
- apcu-autoloader

##### ISSUE TYPE
Feature Pull Request

##### COMPONENT NAME
composer

##### ANSIBLE VERSION
```
ansible 2.5.3
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/talus/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/talus/.local/lib/python3.6/site-packages/ansible
  executable location = /home/talus/.local/bin/ansible
  python version = 3.6.5 (default, Apr  1 2018, 05:46:30) [GCC 7.3.0]
```

With this change, the following options are now supported :

```yaml
composer:
    classmap-authoritative: true
    apcu-autoloader: true
```

Resulting in

```shell
composer install --classmap-authoritative --apcu-autoloader
```

And the same for commands supporting this (such as `global` commands, `update`, `dump-autoload`, ...). Before, we had to do something like this :

```yaml
composer:
        arguments: --classmap-authoritative --apcu-autoloader
```