### PR TITLE
Refactor systemd module

### DIFF
--- a/lib/ansible/modules/system/systemd.py
+++ b/lib/ansible/modules/system/systemd.py
@@ -28,9 +28,9 @@ options:
         description:
             - C(started)/C(stopped) are idempotent actions that will not run commands unless necessary.
               C(restarted) will always bounce the service. C(reloaded) will always reload.
-              C(tried-restarting) - restart unit if active.
-              C(reloaded-or-restarted) - reload unit if possible, otherwise start or restart.
-              C(tried-reloading-or-restarting) - if active, reload unit, if supported, otherwise restart.
+              C(tried-restarting) - restart unit if active (added in 2.8).
+              C(reloaded-or-restarted) - reload unit if possible, otherwise start or restart (added in 2.8).
+              C(tried-reloading-or-restarting) - if active, reload unit, if supported, otherwise restart (added in 2.8).
         choices: [ tried-restarting, reloaded-or-restarted, tried-reloading-or-restarting, reloaded, restarted, started, stopped ]
     enabled:
         description:

--- a/lib/ansible/modules/system/systemd.py
+++ b/lib/ansible/modules/system/systemd.py
@@ -254,7 +254,7 @@ status:
             "WatchdogTimestampMonotonic": "0",
             "WatchdogUSec": "0",
         }
-'''  # NOQA
+'''  # noqa: E501
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.service import sysv_exists, sysv_is_enabled, fail_if_missing

--- a/lib/ansible/modules/system/systemd.py
+++ b/lib/ansible/modules/system/systemd.py
@@ -401,10 +401,10 @@ def detect_systemd_features(ansible_module, systemctl_executable):
         for l in commands_block.splitlines()
     )
     commands_list = set(filter(bool, transformed_commands))  # drop empty lines
-    return SystemdFeatures(**{  # FIXME: change syntax to Python 2.6-compatible
-        f: (f.replace('_', '-') in commands_list)
+    return SystemdFeatures(**dict(
+        (f, f.replace('_', '-') in commands_list)
         for f in SystemdFeatures._fields
-    })
+    ))
 
 
 def convert_action_to_actor(action, systemd_features):

--- a/lib/ansible/modules/system/systemd.py
+++ b/lib/ansible/modules/system/systemd.py
@@ -489,6 +489,16 @@ def main():
 
                 if action:
                     result['changed'] = True
+                    if action == 'reloaded':
+                        rc, out, err = module.run_command(
+                            r"%s %s '%s' | grep ^ExecReload="
+                            % (systemctl, 'cat', unit)
+                        )
+                        if rc != 0:
+                            module.warn(
+                                'The service (%s) does not support `reload` action and it is likely to fail.'
+                                % unit
+                            )
                     if not module.check_mode:
                         (rc, out, err) = module.run_command("%s %s '%s'" % (systemctl, action, unit))
                         if rc != 0:


### PR DESCRIPTION
##### SUMMARY
This adds a declarative "state machine" dict to the resulting action lookup.
Also it enables a few new `state` argument values:
* `tried-restarting` - restart unit if active.
* `reloaded-or-restarted` - reload unit if possible, otherwise start or restart.
* `tried-reloading-or-restarting` - if active, reload unit, if supported, otherwise restart.
(all mapped to corresponding `systemctl` arguments)
Besides that this patch adds warning if user tries to use `reload` on units, which don't support such action (and effectively cause task fail)

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - Bugfix Pull Request

##### COMPONENT NAME
systemd

##### ANSIBLE VERSION
devel

##### ADDITIONAL INFORMATION
‒