### PR TITLE
Fix example in ipa_dnszone module

### DIFF
--- a/lib/ansible/modules/identity/ipa/ipa_dnszone.py
+++ b/lib/ansible/modules/identity/ipa/ipa_dnszone.py
@@ -35,7 +35,7 @@ version_added: "2.5"
 
 EXAMPLES = '''
 # Ensure dns zone is present
-- ipa_dnsrecord:
+- ipa_dnszone:
     ipa_host: spider.example.com
     ipa_pass: Passw0rd!
     state: present


### PR DESCRIPTION
The ipa_dnszone module had a typo in the examples where "ipa_dnsrecord" was being used instead of "ipa_dnszone".