### PR TITLE
service: More DragonFly BSD support

### DIFF
--- a/lib/ansible/modules/system/service.py
+++ b/lib/ansible/modules/system/service.py
@@ -1086,6 +1086,21 @@ class DragonFlyBsdService(FreeBsdService):
     platform = 'DragonFly'
     distribution = None
 
+    def service_enable(self):
+        if self.enable:
+            self.rcconf_value = "YES"
+        else:
+            self.rcconf_value = "NO"
+
+        rcfiles = ['/etc/rc.conf']  # Overkill?
+        for rcfile in rcfiles:
+            if os.path.isfile(rcfile):
+                self.rcconf_file = rcfile
+
+        self.rcconf_key = "%s" % string.replace(self.name, "-", "_")
+
+        return self.service_enable_rcconf()
+
 
 class OpenBsdService(Service):
     """


### PR DESCRIPTION
##### SUMMARY

The initial 'service' support for DragonFly BSD used exactly the same approach as for FreeBSD but this won't work for enabling/disabling a service (see below).

Use NetBSD's way which set correctly the service var in /etc/rc.conf as specified in the manpage:

" The _enable postfix in the name of a variable for starting a service can be omitted (as in NetBSD)."

https://leaf.dragonflybsd.org/cgi/web-man?command=rc.conf&section=ANY

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

system/service

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0 (patch-1 44ca666f74) last updated 2018/05/20 15:57:24 (GMT +200)
  config file = None
  configured module search path = [u'/home/antonioh/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/antonioh/s/ansible/lib/ansible
  executable location = /home/antonioh/s/ansible/bin/ansible
  python version = 2.7.14 (default, Apr 13 2018, 21:27:59) [GCC 5.4.1 [DragonFly] Release/2016-08-27]

```


##### ADDITIONAL INFORMATION

```
# file: site.yml

- hosts: all
tasks:
- name: Enable vknetd if not already enabled
service:
name: vknetd
state: started
enabled: yes
become: yes


BEFORE
--------------------------

$ ansible-playbook -vv -i ~/temp/inventory ~/temp/site.yml
ansible-playbook 2.6.0 (devel 44d9dd2c77) last updated 2018/05/20 14:57:46 (GMT +200)
config file = None
configured module search path = [u'/home/antonioh/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
ansible python module location = /home/antonioh/s/ansible/lib/ansible
executable location = /home/antonioh/s/ansible/bin/ansible-playbook
python version = 2.7.14 (default, Apr 13 2018, 21:27:59) [GCC 5.4.1 [DragonFly] Release/2016-08-27]
No config file found; using defaults                                                                                                                                                                                                          

PLAYBOOK: site.yml ***************************************************************************************************
1 plays in /home/antonioh/temp/site.yml

PLAY [all] ***********************************************************************************************************

TASK [Gathering Facts] ***********************************************************************************************
task path: /home/antonioh/temp/site.yml:5
ok: [dfly99]
META: ran handlers

TASK [Enable vknetd if not already enabled] **************************************************************************
task path: /home/antonioh/temp/site.yml:7
changed: [dfly99] => {"changed": true, "enabled": true, "name": "vknetd", "state": "started"}
META: ran handlers
META: ran handlers

PLAY RECAP ***********************************************************************************************************
dfly99                     : ok=2    changed=1    unreachable=0    failed=0

$ grep vknet /etc/rc.conf
$vknetd="YES"

AFTER
--------------------------

$ grep vknet /etc/rc.conf
$ ansible-playbook -vv -i ~/temp/inventory ~/temp/site.yml
ansible-playbook 2.6.0 (patch-1 728324e7a6) last updated 2018/05/17 19:06:40 (GMT +200)
config file = None
configured module search path = [u'/home/antonioh/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
ansible python module location = /home/antonioh/s/ansible/lib/ansible
executable location = /home/antonioh/s/ansible/bin/ansible-playbook
python version = 2.7.14 (default, Apr 13 2018, 21:27:59) [GCC 5.4.1 [DragonFly] Release/2016-08-27]
No config file found; using defaults                                                                                                                                                                                                          

PLAYBOOK: site.yml ***************************************************************************************************
1 plays in /home/antonioh/temp/site.yml

PLAY [all] ***********************************************************************************************************

TASK [Gathering Facts] ***********************************************************************************************
task path: /home/antonioh/temp/site.yml:5
ok: [dfly99]
META: ran handlers

TASK [Enable vknetd if not already enabled] **************************************************************************
task path: /home/antonioh/temp/site.yml:7
changed: [dfly99] => {"changed": true, "enabled": true, "name": "vknetd", "state": "started"}
META: ran handlers
META: ran handlers

PLAY RECAP ***********************************************************************************************************
dfly99                     : ok=2    changed=1    unreachable=0    failed=0

$ grep vknet /etc/rc.conf
vknetd="YES"

```
