### PR TITLE
Correct the OpenStack plugin example config

### DIFF
--- a/lib/ansible/plugins/inventory/openstack.py
+++ b/lib/ansible/plugins/inventory/openstack.py
@@ -93,11 +93,9 @@ DOCUMENTATION = '''
 EXAMPLES = '''
 # file must be named openstack.yaml or openstack.yml
 # Make the plugin behave like the default behavior of the old script
-simple_config_file:
-    plugin: openstack
-    inventory_hostname: 'name'
-    expand_hostvars: true
-    fail_on_errors: true
+plugin: openstack
+expand_hostvars: yes
+fail_on_errors: yes
 '''
 
 import collections


### PR DESCRIPTION
##### SUMMARY
The current example configuration is not
quite right, so this patch implements a
fix which corrects it.

The 'inventory_hostname' argument is removed
as it's the same value as the default.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
openstack inventory plugin

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0 (devel 553cf4cdfc) last updated 2018/05/20 14:11:41 (GMT +100)
  config file = ~/.ansible.cfg
  configured module search path = [u'~/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = ~/code/ansible/lib/ansible
  executable location = ~/venvs/ansible-devel/bin/ansible
  python version = 2.7.10 (default, Oct  6 2017, 22:29:07) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.31)]
```


##### ADDITIONAL INFORMATION

* https://github.com/AlanCoding/Ansible-inventory-file-examples/tree/master/plugins#using-openstack
* http://odyssey4me.github.io/ansible/openstack/2018/05/20/ansible-2.5-openstack.html
