### PR TITLE
Updates to fileglob Documentation

### DIFF
--- a/lib/ansible/plugins/lookup/fileglob.py
+++ b/lib/ansible/plugins/lookup/fileglob.py
@@ -17,7 +17,8 @@ DOCUMENTATION = """
         description: path(s) of files to read
         required: True
     notes:
-      - Patterns ore only supported on files, not directory/paths.
+      - Patterns are only supported on files, not directory/paths.
+      - Matching is against local system files.
 """
 
 EXAMPLES = """


### PR DESCRIPTION
##### SUMMARY

Fixed typo and expanded Notes.

I am not aware of this issue being tracked.

##### ISSUE TYPE

 - Docs Pull Request

##### COMPONENT NAME

`fileglob` lookup plugin.

##### ANSIBLE VERSION

```
ansible 2.5.3
  config file = None
  configured module search path = [u'/home/daryl/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /mnt/data/src/ansible/.env/lib/python2.7/site-packages/ansible
  executable location = /mnt/data/src/ansible/.env/bin/ansible
  python version = 2.7.15 (default, May  1 2018, 20:16:04) [GCC 7.3.1 20180406]


```


##### ADDITIONAL INFORMATION

```
$ ansible-doc -t lookup fileglob
```
###### Before
```
> FILEGLOB    (/mnt/data/src/ansible/.env/lib/python2.7/site-packages/ansible/plugins/lookup/fileglob.py)

        Matches all files in a single directory, non-recursively, that match a pattern. It calls Python's "glob" library.

OPTIONS (= is mandatory):

= _terms
        path(s) of files to read



NOTES:
      * Patterns ore only supported on files, not directory/paths.

AUTHOR: Michael DeHaan <michael.dehaan@gmail.com>

EXAMPLES:
- name: display content of all .txt files in dir
  debug: msg={{lookup('fileglob', '/my/path/*.txt')}}

- name: Copy each file over that matches the given pattern
  copy:
    src: "{{ item }}"
    dest: "/etc/fooapp/"
    owner: "root"
    mode: 0600
  with_fileglob:
    - "/playbooks/files/fooapp/*"

RETURN VALUES:


  _raw:
    description:
      - content of file(s)
```


###### After

```
> FILEGLOB    (/mnt/data/src/ansible/.env/lib/python2.7/site-packages/ansible/plugins/lookup/fileglob.py)

        Matches all files in a single directory, non-recursively, that match a pattern. It calls Python's "glob" library.

OPTIONS (= is mandatory):

= _terms
        path(s) of files to read



NOTES:
      * Patterns are only supported on files, not directory/paths.
      * Matching is against local system files.

AUTHOR: Michael DeHaan <michael.dehaan@gmail.com>

EXAMPLES:
- name: display content of all .txt files in dir
  debug: msg={{lookup('fileglob', '/my/path/*.txt')}}

- name: Copy each file over that matches the given pattern
  copy:
    src: "{{ item }}"
    dest: "/etc/fooapp/"
    owner: "root"
    mode: 0600
  with_fileglob:
    - "/playbooks/files/fooapp/*"

RETURN VALUES:


  _raw:
    description:
      - content of file(s)
```
