### PR TITLE
Add minimal size for logical volume (lvol)

### DIFF
--- a/lib/ansible/modules/system/lvol.py
+++ b/lib/ansible/modules/system/lvol.py
@@ -563,15 +563,15 @@ def main():
                 cmd = "%s %s -%s %s%s %s/%s %s" % (tool, test_opt, size_opt, size, size_unit, vg, this_lv['name'], pvs)
                 rc, out, err = module.run_command(cmd)
                 if "Reached maximum COW size" in out:
-                   module.fail_json(msg="Unable to resize %s to %s%s" % (lv, size, size_unit), rc=rc, err=err, out=out)
+                    module.fail_json(msg="Unable to resize %s to %s%s" % (lv, size, size_unit), rc=rc, err=err, out=out)
                 elif rc == 0:
-                   changed = True
+                    changed = True
                 elif "matches existing size" in err:
-                   module.exit_json(changed=False, vg=vg, lv=this_lv['name'], size=this_lv['size'])
+                    module.exit_json(changed=False, vg=vg, lv=this_lv['name'], size=this_lv['size'])
                 elif "not larger than existing size" in err:
-                   module.exit_json(changed=False, vg=vg, lv=this_lv['name'], size=this_lv['size'], msg="Original size is larger than requested size", err=err)
+                    module.exit_json(changed=False, vg=vg, lv=this_lv['name'], size=this_lv['size'], msg="Original size is larger than requested size", err=err)
                 else:
-                   module.fail_json(msg="Unable to resize %s to %s%s" % (lv, size, size_unit), rc=rc, err=err)
+                    module.fail_json(msg="Unable to resize %s to %s%s" % (lv, size, size_unit), rc=rc, err=err)
 
     if this_lv is not None:
         if active:

--- a/lib/ansible/modules/system/lvol.py
+++ b/lib/ansible/modules/system/lvol.py
@@ -16,6 +16,7 @@ DOCUMENTATION = '''
 author:
     - Jeroen Hoekx (@jhoekx)
     - Alexander Bulimov (@abulimov)
+    - Marco Rodrigues (@gothicx)
 module: lvol
 short_description: Configure LVM logical volumes
 description:
@@ -28,6 +29,13 @@ options:
   lv:
     description:
     - The name of the logical volume.
+  min_size:
+    description:
+    - The minimum size to extend the logical volume up to. The size must be specified
+      in megabytes (mM) or gigabytes (gG); Float values must begin with a digit.
+      In the case the actual lv size is greater than the minimum size it does
+      nothing.
+      version_added: "2.6"
   size:
     description:
     - The size of the logical volume, according to lvcreate(8) --size, by
@@ -152,6 +160,13 @@ EXAMPLES = '''
     size: 80%VG
     force: yes
 
+- name: Extend the logical volume up to a minimal size
+  lvol:
+    vg: firefly
+    lv: test
+    min_size: 3g
+    resizefs: true
+
 - name: Reduce the logical volume to 512m
   lvol:
     vg: firefly
@@ -261,6 +276,7 @@ def main():
         argument_spec=dict(
             vg=dict(type='str', required=True),
             lv=dict(type='str'),
+            min_size=dict(type='str'),
             size=dict(type='str'),
             opts=dict(type='str'),
             state=dict(type='str', default='present', choices=['absent', 'present']),
@@ -290,6 +306,7 @@ def main():
 
     vg = module.params['vg']
     lv = module.params['lv']
+    min_size = module.params['min_size']
     size = module.params['size']
     opts = module.params['opts']
     state = module.params['state']
@@ -316,6 +333,18 @@ def main():
         test_opt = ' --test'
     else:
         test_opt = ''
+
+    if min_size:
+         if min_size[-1].lower() in 'mg':
+             min_size_unit = min_size[-1].lower()
+             min_size = min_size[0:-1]
+
+         try:
+             float(min_size)
+             if not min_size[0].isdigit():
+                 raise ValueError()
+         except ValueError:
+             module.fail_json(msg="Bad min_size specification of '%s'" % min_size)
 
     if size:
         # LVCREATE(8) -l --extents option with percentage
@@ -457,9 +486,6 @@ def main():
             else:
                 module.fail_json(msg="Failed to remove logical volume %s" % (lv), rc=rc, err=err)
 
-        elif not size:
-            pass
-
         elif size_opt == 'l':
             # Resize LV based on % value
             tool = None
@@ -507,9 +533,17 @@ def main():
         else:
             # resize LV based on absolute values
             tool = None
-            if int(size) > this_lv['size']:
-                tool = module.get_bin_path("lvextend", required=True)
-            elif shrink and int(size) < this_lv['size']:
+	    if size is not None:
+    	       if int(size) > this_lv['size']:
+                  tool = module.get_bin_path("lvextend", required=True)
+	    elif min_size is not None:
+		if min_size_unit.lower() in 'm':
+        	    if int(min_size) > this_lv['size']:
+                     tool = module.get_bin_path("lvextend", required=True)
+                elif min_size_unit.lower() in 'g':
+        	    if int(min_size) > (this_lv['size'] / 1024):
+                       tool = module.get_bin_path("lvextend", required=True)
+            elif not min_size and shrink and int(size) < this_lv['size']:
                 if int(size) == 0:
                     module.fail_json(msg="Sorry, no shrinking of %s to 0 permitted." % (this_lv['name']))
                 if not force:
@@ -521,18 +555,23 @@ def main():
             if tool:
                 if resizefs:
                     tool = '%s %s' % (tool, '--resizefs')
+		
+		if min_size:
+		   size = min_size
+		   size_unit = min_size_unit
+
                 cmd = "%s %s -%s %s%s %s/%s %s" % (tool, test_opt, size_opt, size, size_unit, vg, this_lv['name'], pvs)
                 rc, out, err = module.run_command(cmd)
                 if "Reached maximum COW size" in out:
-                    module.fail_json(msg="Unable to resize %s to %s%s" % (lv, size, size_unit), rc=rc, err=err, out=out)
+                   module.fail_json(msg="Unable to resize %s to %s%s" % (lv, size, size_unit), rc=rc, err=err, out=out)
                 elif rc == 0:
-                    changed = True
+                   changed = True
                 elif "matches existing size" in err:
-                    module.exit_json(changed=False, vg=vg, lv=this_lv['name'], size=this_lv['size'])
+                   module.exit_json(changed=False, vg=vg, lv=this_lv['name'], size=this_lv['size'])
                 elif "not larger than existing size" in err:
-                    module.exit_json(changed=False, vg=vg, lv=this_lv['name'], size=this_lv['size'], msg="Original size is larger than requested size", err=err)
+                   module.exit_json(changed=False, vg=vg, lv=this_lv['name'], size=this_lv['size'], msg="Original size is larger than requested size", err=err)
                 else:
-                    module.fail_json(msg="Unable to resize %s to %s%s" % (lv, size, size_unit), rc=rc, err=err)
+                   module.fail_json(msg="Unable to resize %s to %s%s" % (lv, size, size_unit), rc=rc, err=err)
 
     if this_lv is not None:
         if active:

--- a/lib/ansible/modules/system/lvol.py
+++ b/lib/ansible/modules/system/lvol.py
@@ -34,7 +34,7 @@ options:
     - The minimum size to extend the logical volume up to. The size must be in
       megabytes (mM) or gigabytes (gG); Float values must begin with a digit.
       If the actual lv size is greater than the minimum size it does nothing.
-      version_added: "2.6"
+    version_added: "2.6"
   size:
     description:
     - The size of the logical volume, according to lvcreate(8) --size, by
@@ -87,7 +87,7 @@ options:
     description:
     - Resize the underlying filesystem together with the logical volume.
     type: bool
-    default: 'yes'
+    default: 'false'
     version_added: "2.5"
 notes:
   - You must specify lv (when managing the state of logical volumes) or thinpool (when managing a thin provisioned volume).

--- a/lib/ansible/modules/system/lvol.py
+++ b/lib/ansible/modules/system/lvol.py
@@ -31,10 +31,9 @@ options:
     - The name of the logical volume.
   min_size:
     description:
-    - The minimum size to extend the logical volume up to. The size must be specified
-      in megabytes (mM) or gigabytes (gG); Float values must begin with a digit.
-      In the case the actual lv size is greater than the minimum size it does
-      nothing.
+    - The minimum size to extend the logical volume up to. The size must be in
+      megabytes (mM) or gigabytes (gG); Float values must begin with a digit.
+      If the actual lv size is greater than the minimum size it does nothing.
       version_added: "2.6"
   size:
     description:
@@ -335,16 +334,16 @@ def main():
         test_opt = ''
 
     if min_size:
-         if min_size[-1].lower() in 'mg':
-             min_size_unit = min_size[-1].lower()
-             min_size = min_size[0:-1]
+        if min_size[-1].lower() in 'mg':
+            min_size_unit = min_size[-1].lower()
+            min_size = min_size[0:-1]
 
-         try:
-             float(min_size)
-             if not min_size[0].isdigit():
-                 raise ValueError()
-         except ValueError:
-             module.fail_json(msg="Bad min_size specification of '%s'" % min_size)
+        try:
+            float(min_size)
+            if not min_size[0].isdigit():
+                raise ValueError()
+        except ValueError:
+            module.fail_json(msg="Bad min_size specification of '%s'" % min_size)
 
     if size:
         # LVCREATE(8) -l --extents option with percentage
@@ -533,16 +532,16 @@ def main():
         else:
             # resize LV based on absolute values
             tool = None
-	    if size is not None:
-    	       if int(size) > this_lv['size']:
-                  tool = module.get_bin_path("lvextend", required=True)
-	    elif min_size is not None:
-		if min_size_unit.lower() in 'm':
-        	    if int(min_size) > this_lv['size']:
-                     tool = module.get_bin_path("lvextend", required=True)
+            if size is not None:
+                if int(size) > this_lv['size']:
+                    tool = module.get_bin_path("lvextend", required=True)
+            elif min_size is not None:
+                if min_size_unit.lower() in 'm':
+                    if int(min_size) > this_lv['size']:
+                        tool = module.get_bin_path("lvextend", required=True)
                 elif min_size_unit.lower() in 'g':
-        	    if int(min_size) > (this_lv['size'] / 1024):
-                       tool = module.get_bin_path("lvextend", required=True)
+                    if int(min_size) > (this_lv['size'] / 1024):
+                        tool = module.get_bin_path("lvextend", required=True)
             elif not min_size and shrink and int(size) < this_lv['size']:
                 if int(size) == 0:
                     module.fail_json(msg="Sorry, no shrinking of %s to 0 permitted." % (this_lv['name']))
@@ -555,10 +554,10 @@ def main():
             if tool:
                 if resizefs:
                     tool = '%s %s' % (tool, '--resizefs')
-		
-		if min_size:
-		   size = min_size
-		   size_unit = min_size_unit
+
+                if min_size:
+                    size = min_size
+                    size_unit = min_size_unit
 
                 cmd = "%s %s -%s %s%s %s/%s %s" % (tool, test_opt, size_opt, size, size_unit, vg, this_lv['name'], pvs)
                 rc, out, err = module.run_command(cmd)

--- a/test/sanity/validate-modules/ignore.txt
+++ b/test/sanity/validate-modules/ignore.txt
@@ -1277,7 +1277,6 @@ lib/ansible/modules/system/iptables.py E326
 lib/ansible/modules/system/java_cert.py E324
 lib/ansible/modules/system/java_cert.py E325
 lib/ansible/modules/system/known_hosts.py E324
-lib/ansible/modules/system/lvol.py E324
 lib/ansible/modules/system/make.py E317
 lib/ansible/modules/system/mount.py E324
 lib/ansible/modules/system/open_iscsi.py E322


### PR DESCRIPTION
##### SUMMARY
The minimum size to extend the logical volume up to. The size must be in megabytes (mM) or gigabytes (gG); Float values must begin with a digit.
If the actual lv size is greater than the minimum size it does nothing.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
- lvol

##### ANSIBLE VERSION
```
ansible 2.6.0
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible-2.6.0-py2.7.egg/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Aug  4 2017, 00:39:18) [GCC 4.8.5 20150623 (Red Hat 4.8.5-16)]
```


##### ADDITIONAL INFORMATION
The use case for this was the need to extend any LV partition up to a particular size and don't force all machines with different partitions sizes to all have the same. For the partitions that were already above for some particular reason, the change is not performed.

```
task path: /root/playbooks/site.yml:5
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: root
<127.0.0.1> EXEC /bin/sh -c 'echo ~root && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /root/.ansible/tmp/ansible-tmp-1526853697.9-70196715448096 `" && echo ansible-tmp-1526853697.9-70196715448096="` echo /root/.ansible/tmp/ansible-tmp-1526853697.9-70196715448096 `" ) && sleep 0'
Using module file /usr/lib/python2.7/site-packages/ansible-2.6.0-py2.7.egg/ansible/modules/system/lvol.py
<127.0.0.1> PUT /root/.ansible/tmp/ansible-local-305850ck92F/tmpCrPhh3 TO /root/.ansible/tmp/ansible-tmp-1526853697.9-70196715448096/lvol.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /root/.ansible/tmp/ansible-tmp-1526853697.9-70196715448096/ /root/.ansible/tmp/ansible-tmp-1526853697.9-70196715448096/lvol.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/usr/bin/python /root/.ansible/tmp/ansible-tmp-1526853697.9-70196715448096/lvol.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /root/.ansible/tmp/ansible-tmp-1526853697.9-70196715448096/ > /dev/null 2>&1 && sleep 0'
changed: [localhost] => {
    "changed": true,
    "invocation": {
        "module_args": {
            "active": true,
            "force": false,
            "lv": "test",
            "min_size": "3g",
            "opts": null,
            "pvs": null,
            "resizefs": true,
            "shrink": true,
            "size": null,
            "snapshot": null,
            "state": "present",
            "thinpool": null,
            "vg": "firefly"
        }
    },
    "lv": "test",
    "size": 1024,
    "vg": "firefly"
}
META: ran handlers
META: ran handlers

PLAY RECAP ************************************************************************************************************************************************************************************************************************************************************************************
localhost                  : ok=2    changed=1    unreachable=0    failed=0
```
