### PR TITLE
always_run: removed deprecated always_run task option

### DIFF
--- a/changelogs/fragments/always_run_removal.yaml
+++ b/changelogs/fragments/always_run_removal.yaml
@@ -1,0 +1,2 @@
+removed_features:
+- removed the deprecated always_run task option, please use `check_mode: no` instead

--- a/docs/docsite/keyword_desc.yml
+++ b/docs/docsite/keyword_desc.yml
@@ -4,7 +4,6 @@ accelerate_port: "*DEPRECATED*, set to override default port use for accelerate 
 action: "The 'action' to execute for a task, it normally translates into a C(module) or action plugin."
 args: "*DEPRECATED*, A secondary way to add arguments into a task. Takes a dictionary in which keys map to options and values."
 always: List of tasks, in a block, that execute no matter if there is an error in the block or not.
-always_run: "*DEPRECATED*, forces a task to run even in check mode. Use :term:`check_mode` directive instead."
 any_errors_fatal: Force any un-handled task errors on any host to propagate to all hosts and end the play.
 async: Run a task asynchronously if the C(action) supports this; value is maximum runtime in seconds.
 become: Boolean that controls if privilege escalation is used or not on :term:`Task` execution.

--- a/docs/docsite/rst/porting_guides/porting_guide_2.6.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.6.rst
@@ -17,7 +17,7 @@ This document is part of a collection on porting. The complete list of porting g
 Playbook
 ========
 
-No notable changes.
+* The deprecated task option ``always_run`` has been removed, please use ``check_mode: no`` instead.
 
 Deprecated
 ==========

--- a/lib/ansible/playbook/base.py
+++ b/lib/ansible/playbook/base.py
@@ -578,7 +578,6 @@ class Base(FieldAttributeBase):
     # flags and misc. settings
     _environment = FieldAttribute(isa='list', extend=True, prepend=True)
     _no_log = FieldAttribute(isa='bool')
-    _always_run = FieldAttribute(isa='bool')
     _run_once = FieldAttribute(isa='bool')
     _ignore_errors = FieldAttribute(isa='bool')
     _check_mode = FieldAttribute(isa='bool')

--- a/lib/ansible/playbook/play_context.py
+++ b/lib/ansible/playbook/play_context.py
@@ -436,11 +436,6 @@ class PlayContext(Base):
         if new_info.no_log is None:
             new_info.no_log = C.DEFAULT_NO_LOG
 
-        if task.always_run:
-            display.deprecated("always_run is deprecated. Use check_mode = no instead.", version="2.4", removed=False)
-            new_info.check_mode = False
-
-        # check_mode replaces always_run, overwrite always_run if both are given
         if task.check_mode is not None:
             new_info.check_mode = task.check_mode
 

--- a/test/integration/targets/check_mode/roles/test_always_run/meta/main.yml
+++ b/test/integration/targets/check_mode/roles/test_always_run/meta/main.yml
@@ -1,4 +1,4 @@
-# test code for the always_run option
+# test code for the check_mode: no option
 # (c) 2014, James Cammarata <jcammarata@ansible.com>
 
 # This file is part of Ansible

--- a/test/integration/targets/check_mode/roles/test_always_run/tasks/main.yml
+++ b/test/integration/targets/check_mode/roles/test_always_run/tasks/main.yml
@@ -1,4 +1,4 @@
-# test code for the always_run option
+# test code for the check_mode: no option
 # (c) 2014, James Cammarata <jcammarata@ansible.com>
 
 # This file is part of Ansible

--- a/test/legacy/roles/prepare_tests/tasks/main.yml
+++ b/test/legacy/roles/prepare_tests/tasks/main.yml
@@ -19,13 +19,12 @@
 
 #- name: clean out the test directory
 #  file: name={{output_dir|mandatory}} state=absent
-#  always_run: True
 #  tags:
 #    - prepare
 #  when: clean_working_dir|default("yes")|bool
 #
 #- name: create the test directory
 #  file: name={{output_dir}} state=directory
-#  always_run: True
+#  check_mode: no
 #  tags:
 #    - prepare

--- a/test/units/playbook/test_base.py
+++ b/test/units/playbook/test_base.py
@@ -114,8 +114,6 @@ class TestBase(unittest.TestCase):
         data = {'no_log': False,
                 'remote_user': None,
                 'vars': self.assorted_vars,
-                # 'check_mode': False,
-                'always_run': False,
                 'environment': [],
                 'run_once': False,
                 'connection': None,


### PR DESCRIPTION
##### SUMMARY
We didn't deprecate the `always_run` feature like we said we would in 2.4. This PR removes it from the codebase.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
playbook/base
always_run

##### ANSIBLE VERSION
```
devel
```