### PR TITLE
iosxr_command does not work with prompt and answer arguments

### DIFF
--- a/lib/ansible/module_utils/network/iosxr/iosxr.py
+++ b/lib/ansible/module_utils/network/iosxr/iosxr.py
@@ -34,7 +34,7 @@ from time import sleep
 from ansible.module_utils._text import to_text, to_bytes
 from ansible.module_utils.basic import env_fallback
 from ansible.module_utils.network.common.utils import to_list
-from ansible.module_utils.connection import Connection
+from ansible.module_utils.connection import Connection, ConnectionError
 from ansible.module_utils.network.common.netconf import NetconfConnection
 
 try:
@@ -454,7 +454,10 @@ def run_command(module, commands):
             sendonly = False
             newline = True
 
-        out = conn.get(command, prompt=prompt, answer=answer, sendonly=sendonly, newline=newline)
+        try:
+            out = conn.get(command=command, prompt=prompt, answer=answer, sendonly=sendonly, newline=newline)
+        except ConnectionError as e:
+            out = e
 
         try:
             responses.append(to_text(out, errors='surrogate_or_strict'))

--- a/lib/ansible/module_utils/network/iosxr/iosxr.py
+++ b/lib/ansible/module_utils/network/iosxr/iosxr.py
@@ -34,7 +34,7 @@ from time import sleep
 from ansible.module_utils._text import to_text, to_bytes
 from ansible.module_utils.basic import env_fallback
 from ansible.module_utils.network.common.utils import to_list
-from ansible.module_utils.connection import Connection, ConnectionError
+from ansible.module_utils.connection import Connection
 from ansible.module_utils.network.common.netconf import NetconfConnection
 
 try:

--- a/lib/ansible/module_utils/network/iosxr/iosxr.py
+++ b/lib/ansible/module_utils/network/iosxr/iosxr.py
@@ -454,10 +454,7 @@ def run_command(module, commands):
             sendonly = False
             newline = True
 
-        try:
-            out = conn.get(command=command, prompt=prompt, answer=answer, sendonly=sendonly, newline=newline)
-        except ConnectionError as e:
-            out = e
+        out = conn.get(command=command, prompt=prompt, answer=answer, sendonly=sendonly, newline=newline)
 
         try:
             responses.append(to_text(out, errors='surrogate_or_strict'))

--- a/test/integration/targets/iosxr_command/tests/cli/prompt.yaml
+++ b/test/integration/targets/iosxr_command/tests/cli/prompt.yaml
@@ -1,0 +1,25 @@
+---
+- debug: msg="START cli/prompt.yaml on connection={{ ansible_connection }}"
+
+- name: delete config file on disk to prevent failure of copy task for duplicate
+  iosxr_command:
+    commands:
+        - command : 'delete harddisk:ansible_tmp.txt'
+          prompt : 'Delete harddisk\:ansible_tmp\.txt\[confirm\]'
+          answer: "\r\n"
+  ignore_errors: yes
+
+- name: copy
+  iosxr_command:
+    commands:
+        - command : 'copy running-config harddisk:ansible_tmp.txt'
+          prompt : 'Destination file name \(control-c to abort\)\: \[\/ansible_tmp.txt\]\?'
+          answer : 'ansible_tmp.txt'
+  register: result
+
+- assert:
+    that:
+      - "result.stdout is defined"
+      - "'ansible_tmp' in result.stdout[0]"
+
+- debug: msg="END cli/prompt.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/iosxr_command/tests/cli/prompt.yaml
+++ b/test/integration/targets/iosxr_command/tests/cli/prompt.yaml
@@ -4,17 +4,17 @@
 - name: delete config file on disk to prevent failure of copy task for duplicate
   iosxr_command:
     commands:
-        - command : 'delete harddisk:ansible_tmp.txt'
-          prompt : 'Delete harddisk\:ansible_tmp\.txt\[confirm\]'
+        - command: 'delete harddisk:ansible_tmp.txt'
+          prompt: 'Delete harddisk\:ansible_tmp\.txt\[confirm\]'
           answer: "\r\n"
   ignore_errors: yes
 
 - name: copy
   iosxr_command:
     commands:
-        - command : 'copy running-config harddisk:ansible_tmp.txt'
-          prompt : 'Destination file name \(control-c to abort\)\: \[\/ansible_tmp.txt\]\?'
-          answer : 'ansible_tmp.txt'
+        - command: 'copy running-config harddisk:ansible_tmp.txt'
+          prompt: 'Destination file name \(control-c to abort\)\: \[\/ansible_tmp.txt\]\?'
+          answer: 'ansible_tmp.txt'
   register: result
 
 - assert:


### PR DESCRIPTION
##### SUMMARY
fixes #39856 
iosxr's Cliconf 'get()' method defines all arguments as optional arguments. We were calling "command" argument as positional argument which messed up prompt and answer.

##### ISSUE TYPE
 - Bugfix Pull Request
 
##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```