### PR TITLE
Backport # 40134 - Ensure Ctrl+C interrupt for pause module works in all cases

### DIFF
--- a/changelogs/fragments/pause-ctrl-c.yaml
+++ b/changelogs/fragments/pause-ctrl-c.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - pause - ensure ctrl+c interrupt works in all cases (https://github.com/ansible/ansible/issues/35372)

--- a/test/integration/targets/pause/aliases
+++ b/test/integration/targets/pause/aliases
@@ -1,0 +1,1 @@
+posix/ci/group2

--- a/test/integration/targets/pause/pause-1.yml
+++ b/test/integration/targets/pause/pause-1.yml
@@ -1,0 +1,11 @@
+- name: Test pause module in default state
+  hosts: testhost
+  become: no
+  gather_facts: no
+
+  tasks:
+    - name: EXPECTED FAILURE
+      pause:
+
+    - debug:
+        msg: Task after pause

--- a/test/integration/targets/pause/pause-2.yml
+++ b/test/integration/targets/pause/pause-2.yml
@@ -1,0 +1,12 @@
+- name: Test pause module with custom prompt
+  hosts: testhost
+  become: no
+  gather_facts: no
+
+  tasks:
+    - name: EXPECTED FAILURE
+      pause:
+        prompt: Custom prompt
+
+    - debug:
+        msg: Task after pause

--- a/test/integration/targets/pause/pause-3.yml
+++ b/test/integration/targets/pause/pause-3.yml
@@ -1,0 +1,12 @@
+- name: Test pause module with pause
+  hosts: testhost
+  become: no
+  gather_facts: no
+
+  tasks:
+    - name: EXPECTED FAILURE
+      pause:
+        seconds: 2
+
+    - debug:
+        msg: Task after pause

--- a/test/integration/targets/pause/pause-4.yml
+++ b/test/integration/targets/pause/pause-4.yml
@@ -1,0 +1,13 @@
+- name: Test pause module with pause and custom prompt
+  hosts: testhost
+  become: no
+  gather_facts: no
+
+  tasks:
+    - name: EXPECTED FAILURE
+      pause:
+        seconds: 2
+        prompt: Waiting for two seconds
+
+    - debug:
+        msg: Task after pause

--- a/test/integration/targets/pause/pause-5.yml
+++ b/test/integration/targets/pause/pause-5.yml
@@ -1,0 +1,35 @@
+- name: Test pause module echo output
+  hosts: testhost
+  become: no
+  gather_facts: no
+
+  tasks:
+    - pause:
+        echo: yes
+        prompt: Enter some text
+      register: results
+
+    - name: Ensure that input was captured
+      assert:
+        that:
+          - results.user_input == 'hello there'
+
+    - pause:
+        echo: yes
+        prompt: Enter some text to edit
+      register: result
+
+    - name: Ensure edited input was captured
+      assert:
+        that:
+          - result.user_input == 'hello tommy boy'
+
+    - pause:
+        echo: no
+        prompt: Enter some text
+      register: result
+
+    - name: Ensure secret input was caputered
+      assert:
+        that:
+          - result.user_input == 'supersecretpancakes'

--- a/test/integration/targets/pause/runme.sh
+++ b/test/integration/targets/pause/runme.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -eux
+
+# Test pause module when no tty and non-interactive. This is to prevent playbooks
+# from hanging in cron and Tower jobs.
+/usr/bin/env bash << EOF
+ansible-playbook test-pause-no-tty.yml -i ../../inventory 2>&1 | \
+    grep '\[WARNING\]: Not waiting for response to prompt as stdin is not interactive' && {
+        echo 'Successfully skipped pause in no TTY mode' >&2
+        exit 0
+    } || {
+        echo 'Failed to skip pause module' >&2
+        exit 1
+    }
+EOF
+
+# Test pause with seconds and minutes specified
+ansible-playbook test-pause.yml -i ../../inventory "$@"
+
+# Interactively test pause
+pip install pexpect
+python test-pause.py -i ../../inventory "$@"

--- a/test/integration/targets/pause/test-pause-no-tty.yml
+++ b/test/integration/targets/pause/test-pause-no-tty.yml
@@ -1,0 +1,7 @@
+- name: Test pause
+  hosts: testhost
+  gather_facts: no
+  become: no
+
+  tasks:
+    - pause:

--- a/test/integration/targets/pause/test-pause.py
+++ b/test/integration/targets/pause/test-pause.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python
+
+import os
+import pexpect
+import sys
+import termios
+
+from ansible.module_utils.six import PY2
+
+args = sys.argv[1:]
+
+env_vars = {
+    'ANSIBLE_ROLES_PATH': './roles',
+    'ANSIBLE_NOCOLOR': 'True',
+    'ANSIBLE_RETRY_FILES_ENABLED': 'False'
+}
+
+try:
+    backspace = termios.tcgetattr(sys.stdin.fileno())[6][termios.VERASE]
+except Exception:
+    backspace = b'\x7f'
+
+if PY2:
+    log_buffer = sys.stdout
+else:
+    log_buffer = sys.stdout.buffer
+
+os.environ.update(env_vars)
+
+# -- Plain pause -- #
+playbook = 'pause-1.yml'
+
+# Case 1 - Contiune with enter
+pause_test = pexpect.spawn(
+    'ansible-playbook',
+    args=[playbook] + args,
+    timeout=10,
+    env=os.environ
+)
+
+pause_test.logfile = log_buffer
+pause_test.expect(r'Press enter to continue, Ctrl\+C to interrupt:')
+pause_test.send('\r')
+pause_test.expect('Task after pause')
+pause_test.expect(pexpect.EOF)
+pause_test.close()
+
+
+# Case 2 - Continue with C
+pause_test = pexpect.spawn(
+    'ansible-playbook',
+    args=[playbook] + args,
+    timeout=10,
+    env=os.environ
+)
+
+pause_test.logfile = log_buffer
+pause_test.expect(r'Press enter to continue, Ctrl\+C to interrupt:')
+pause_test.send('\x03')
+pause_test.expect("Press 'C' to continue the play or 'A' to abort")
+pause_test.send('C')
+pause_test.expect('Task after pause')
+pause_test.expect(pexpect.EOF)
+pause_test.close()
+
+
+# Case 3 - Abort with A
+pause_test = pexpect.spawn(
+    'ansible-playbook',
+    args=[playbook] + args,
+    timeout=10,
+    env=os.environ
+)
+
+pause_test.logfile = log_buffer
+pause_test.expect(r'Press enter to continue, Ctrl\+C to interrupt:')
+pause_test.send('\x03')
+pause_test.expect("Press 'C' to continue the play or 'A' to abort")
+pause_test.send('A')
+pause_test.expect('user requested abort!')
+pause_test.expect(pexpect.EOF)
+pause_test.close()
+
+# -- Custom Prompt -- #
+playbook = 'pause-2.yml'
+
+# Case 1 - Contiune with enter
+pause_test = pexpect.spawn(
+    'ansible-playbook',
+    args=[playbook] + args,
+    timeout=10,
+    env=os.environ
+)
+
+pause_test.logfile = log_buffer
+pause_test.expect(r'Custom prompt:')
+pause_test.send('\r')
+pause_test.expect('Task after pause')
+pause_test.expect(pexpect.EOF)
+pause_test.close()
+
+
+# Case 2 - Contiune with C
+pause_test = pexpect.spawn(
+    'ansible-playbook',
+    args=[playbook] + args,
+    timeout=10,
+    env=os.environ
+)
+
+pause_test.logfile = log_buffer
+pause_test.expect(r'Custom prompt:')
+pause_test.send('\x03')
+pause_test.expect("Press 'C' to continue the play or 'A' to abort")
+pause_test.send('C')
+pause_test.expect('Task after pause')
+pause_test.expect(pexpect.EOF)
+pause_test.close()
+
+
+# Case 3 - Abort with A
+pause_test = pexpect.spawn(
+    'ansible-playbook',
+    args=[playbook] + args,
+    timeout=10,
+    env=os.environ
+)
+
+pause_test.logfile = log_buffer
+pause_test.expect(r'Custom prompt:')
+pause_test.send('\x03')
+pause_test.expect("Press 'C' to continue the play or 'A' to abort")
+pause_test.send('A')
+pause_test.expect('user requested abort!')
+pause_test.expect(pexpect.EOF)
+pause_test.close()
+
+# -- Pause for N seconds -- #
+
+playbook = 'pause-3.yml'
+
+# Case 1 - Wait for task to continue after timeout
+pause_test = pexpect.spawn(
+    'ansible-playbook',
+    args=[playbook] + args,
+    timeout=10,
+    env=os.environ
+)
+
+pause_test.logfile = log_buffer
+pause_test.expect(r'Pausing for \d+ seconds')
+pause_test.expect(r"\(ctrl\+C then 'C' = continue early, ctrl\+C then 'A' = abort\)")
+pause_test.expect('Task after pause')
+pause_test.expect(pexpect.EOF)
+pause_test.close()
+
+# Case 2 - Contiune with Ctrl + C, C
+pause_test = pexpect.spawn(
+    'ansible-playbook',
+    args=[playbook] + args,
+    timeout=10,
+    env=os.environ
+)
+
+pause_test.logfile = log_buffer
+pause_test.expect(r'Pausing for \d+ seconds')
+pause_test.expect(r"\(ctrl\+C then 'C' = continue early, ctrl\+C then 'A' = abort\)")
+pause_test.send('\x03')
+pause_test.send('C')
+pause_test.expect('Task after pause')
+pause_test.expect(pexpect.EOF)
+pause_test.close()
+
+
+# Case 3 - Abort with Ctrl + C, A
+pause_test = pexpect.spawn(
+    'ansible-playbook',
+    args=[playbook] + args,
+    timeout=10,
+    env=os.environ
+)
+
+pause_test.logfile = log_buffer
+pause_test.expect(r'Pausing for \d+ seconds')
+pause_test.expect(r"\(ctrl\+C then 'C' = continue early, ctrl\+C then 'A' = abort\)")
+pause_test.send('\x03')
+pause_test.send('A')
+pause_test.expect('user requested abort!')
+pause_test.expect(pexpect.EOF)
+pause_test.close()
+
+# -- Pause for N seconds with custom prompt -- #
+
+playbook = 'pause-4.yml'
+
+# Case 1 - Wait for task to continue after timeout
+pause_test = pexpect.spawn(
+    'ansible-playbook',
+    args=[playbook] + args,
+    timeout=10,
+    env=os.environ
+)
+
+pause_test.logfile = log_buffer
+pause_test.expect(r'Pausing for \d+ seconds')
+pause_test.expect(r"\(ctrl\+C then 'C' = continue early, ctrl\+C then 'A' = abort\)")
+pause_test.expect(r"Waiting for two seconds:")
+pause_test.expect('Task after pause')
+pause_test.expect(pexpect.EOF)
+pause_test.close()
+
+# Case 2 - Contiune with Ctrl + C, C
+pause_test = pexpect.spawn(
+    'ansible-playbook',
+    args=[playbook] + args,
+    timeout=10,
+    env=os.environ
+)
+
+pause_test.logfile = log_buffer
+pause_test.expect(r'Pausing for \d+ seconds')
+pause_test.expect(r"\(ctrl\+C then 'C' = continue early, ctrl\+C then 'A' = abort\)")
+pause_test.expect(r"Waiting for two seconds:")
+pause_test.send('\x03')
+pause_test.send('C')
+pause_test.expect('Task after pause')
+pause_test.expect(pexpect.EOF)
+pause_test.close()
+
+
+# Case 3 - Abort with Ctrl + C, A
+pause_test = pexpect.spawn(
+    'ansible-playbook',
+    args=[playbook] + args,
+    timeout=10,
+    env=os.environ
+)
+
+pause_test.logfile = log_buffer
+pause_test.expect(r'Pausing for \d+ seconds')
+pause_test.expect(r"\(ctrl\+C then 'C' = continue early, ctrl\+C then 'A' = abort\)")
+pause_test.expect(r"Waiting for two seconds:")
+pause_test.send('\x03')
+pause_test.send('A')
+pause_test.expect('user requested abort!')
+pause_test.expect(pexpect.EOF)
+pause_test.close()
+
+# -- Enter input and ensure it's caputered, echoed, and can be edited -- #
+
+playbook = 'pause-5.yml'
+
+pause_test = pexpect.spawn(
+    'ansible-playbook',
+    args=[playbook] + args,
+    timeout=10,
+    env=os.environ
+)
+
+pause_test.logfile = log_buffer
+pause_test.expect(r'Enter some text:')
+pause_test.sendline('hello there')
+pause_test.expect(r'Enter some text to edit:')
+pause_test.send('hello there')
+pause_test.send(backspace * 4)
+pause_test.send('ommy boy\r')
+pause_test.expect(r'Enter some text \(output is hidden\):')
+pause_test.sendline('supersecretpancakes')
+pause_test.expect(pexpect.EOF)
+pause_test.close()

--- a/test/integration/targets/pause/test-pause.yml
+++ b/test/integration/targets/pause/test-pause.yml
@@ -1,0 +1,21 @@
+- name: Test pause
+  hosts: testhost
+  gather_facts: no
+  become: no
+
+  tasks:
+    - pause:
+        seconds: 1
+      register: results
+
+    - assert:
+        that:
+          - results.stdout is search('Paused for \d+\.\d+ seconds')
+
+    - pause:
+        minutes: 1
+      register: results
+
+    - assert:
+        that:
+          - results.stdout is search('Paused for \d+\.\d+ minutes')


### PR DESCRIPTION
##### SUMMARY
Backport of #40134 for 2.5

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT NAME
`pause.py`

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```
