### PR TITLE
Filesystem: add support for F2FS

### DIFF
--- a/test/integration/targets/filesystem/defaults/main.yml
+++ b/test/integration/targets/filesystem/defaults/main.yml
@@ -5,6 +5,11 @@ tested_filesystems:
   # Other minimal sizes:
   # - XFS: 20Mo
   # - Btrfs: 100Mo (50Mo when "--metadata single" is used)
+  # - f2fs:
+  #     - 1.2.0 requires at leat 116Mo
+  #     - 1.7.0 requires at least 30Mo
+  #     - 1.10.0 requires at least 38Mo
+  #     - resizefs asserts when initial fs is smaller than 60Mo and seems to require 1.10.0
   ext4: {fssize: 10, grow: True}
   ext4dev: {fssize: 10, grow: True}
   ext3: {fssize: 10, grow: True}
@@ -13,4 +18,5 @@ tested_filesystems:
   btrfs: {fssize: 100, grow: False}  # grow not implemented
   vfat: {fssize: 20, grow: True}
   ocfs2: {fssize: '{{ ocfs2_fssize }}', grow: False}  # grow not implemented
+  f2fs: {fssize: '{{ f2fs_fssize|default(60) }}', grow: 'f2fs_version is version("1.10.0", ">=")'}
   # untested: lvm, requires a block device

--- a/test/integration/targets/filesystem/tasks/main.yml
+++ b/test/integration/targets/filesystem/tasks/main.yml
@@ -22,8 +22,14 @@
   when:
     - 'not (item.key == "btrfs" and ansible_system == "FreeBSD")'
     - 'not (item.key == "ocfs2" and ansible_os_family != "Debian")'
-    # On Ubuntu trusty, blkid is unable to identify filesystem smaller than 256Mo, see:
+    # On Ubuntu trusty, blkid (2.20.1) is unable to identify filesystem smaller than 256Mo, see:
     # https://www.kernel.org/pub/linux/utils/util-linux/v2.21/v2.21-ChangeLog
     # https://anonscm.debian.org/cgit/collab-maint/pkg-util-linux.git/commit/?id=04f7020eadf31efc731558df92daa0a1c336c46c
     - 'not (item.key == "btrfs" and (ansible_distribution == "Ubuntu" and ansible_distribution_release == "trusty"))'
+    - 'not (item.key == "f2fs" and ansible_system == "FreeBSD")'
+    # f2fs-tools package not available with RHEL/CentOS
+    - 'not (item.key == "f2fs" and ansible_distribution in ["CentOS", "RedHat"])'
+    # On Ubuntu trusty, blkid (2.20.1) is unable to identify F2FS filesystem. blkid handles F2FS since v2.23, see:
+    # https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/v2.23/v2.23-ReleaseNotes
+    - 'not (item.key == "f2fs" and ansible_distribution == "Ubuntu" and ansible_distribution_version is version("14.04", "<="))'
   loop: "{{ lookup('dict', tested_filesystems) }}"

--- a/test/integration/targets/filesystem/tasks/setup.yml
+++ b/test/integration/targets/filesystem/tasks/setup.yml
@@ -35,6 +35,24 @@
       name: ocfs2-tools
       state: present
     when: ansible_os_family == 'Debian'
+
+  - when:
+      - ansible_os_family != 'RedHat' or ansible_distribution == 'Fedora'
+      - ansible_distribution != 'Ubuntu' or ansible_distribution_version is version('16.04', '>=')
+    block:
+      - name: install f2fs
+        package:
+          name: f2fs-tools
+          state: present
+
+      - name: fetch f2fs version
+        command: mkfs.f2fs /dev/null
+        ignore_errors: yes
+        register: mkfs_f2fs
+
+      - set_fact:
+          f2fs_version: '{{ mkfs_f2fs.stdout | regex_search("F2FS-tools: mkfs.f2fs Ver:.*") | regex_replace("F2FS-tools: mkfs.f2fs Ver: ([0-9.]+) .*", "\1") }}'
+
   when: ansible_system == 'Linux'
 
 - block:

--- a/test/integration/targets/filesystem/vars/Ubuntu-14.04.yml
+++ b/test/integration/targets/filesystem/vars/Ubuntu-14.04.yml
@@ -1,2 +1,3 @@
 ---
 ocfs2_fssize: 108
+f2fs_fssize: 116


### PR DESCRIPTION
##### SUMMARY
Filesystem: add support for F2FS

Integration tests provided (Ubuntu 16.04, Fedora (all versions), OpenSuse)

Fixes #40418

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
filesystem

##### ANSIBLE VERSION
```
ansible 2.6.0 (devel 44d9dd2c77) last updated 2018/05/20 14:41:59 (GMT +200)
```

##### ADDITIONAL INFORMATION

grow/resize operation requires quite a recent version of f2fs-tools.