### PR TITLE
Adding module to manage AWS Storage gateways

### DIFF
--- a/lib/ansible/modules/cloud/amazon/storage_gateway.py
+++ b/lib/ansible/modules/cloud/amazon/storage_gateway.py
@@ -15,11 +15,10 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = r'''
 ---
 module: storage_gateway
-short_description: Manage AWS Storage Gateway resources
+short_description: Manage AWS Storage Gateway instances
 description:
-    - Module manages AWS Config resources
-    - Supported resource types include gateway.
-version_added: "2.6"
+    - Activate or deactivate AWS Storage Gateway instances.
+version_added: "2.7"
 requirements: [ 'botocore', 'boto3' ]
 author:
     - "Aaron Smith (@slapula)"

--- a/lib/ansible/modules/cloud/amazon/storage_gateway.py
+++ b/lib/ansible/modules/cloud/amazon/storage_gateway.py
@@ -139,7 +139,7 @@ def create_gateway(client, module, params, result):
                     GatewayARN=gw_response['GatewayARN'],
                     DiskIds=[disks_response['Disks'][0]['DiskId']]
                 )
-        result['GatewayARN'] = gw_response['GatewayARN']
+        result['gateway_arn'] = gw_response['GatewayARN']
         result['Disks'] = disks_response['Disks']
         result['changed'] = True
         return result
@@ -164,7 +164,7 @@ def update_gateway(client, module, params, result):
             disks_response = client.list_local_disks(
                 GatewayARN=result['GatewayARN']
             )
-            result['GatewayARN'] = response['GatewayARN']
+            result['gateway_arn'] = response['GatewayARN']
             result['Disks'] = disks_response['Disks']
             result['changed'] = True
             return result
@@ -203,7 +203,8 @@ def main():
     )
 
     result = {
-        'changed': False
+        'changed': False,
+        'gateway_arn': ''
     }
 
     desired_state = module.params.get('state')
@@ -233,7 +234,7 @@ def main():
         if gateway_status:
             delete_gateway(client, module, result)
 
-    module.exit_json(changed=result['changed'], output=result)
+    module.exit_json(changed=result['changed'], gateway_arn=result['gateway_arn'])
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/cloud/amazon/storage_gateway.py
+++ b/lib/ansible/modules/cloud/amazon/storage_gateway.py
@@ -1,0 +1,241 @@
+#!/usr/bin/python
+
+# Copyright: (c) 2018, Aaron Smith <ajsmith10381@gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = r'''
+---
+module: storage_gateway
+short_description: Manage AWS Storage Gateway resources
+description:
+    - Module manages AWS Config resources
+    - Supported resource types include gateway.
+version_added: "2.6"
+requirements: [ 'botocore', 'boto3' ]
+author:
+    - "Aaron Smith (@slapula)"
+options:
+  name:
+    description:
+    - The name you configured for your gateway.
+    required: true
+  state:
+    description:
+    - Whether the resource should be present or absent.
+    default: present
+    choices: ['present', 'absent']
+  activation_key:
+    description:
+    - Your gateway activation key. See AWS documentation on how to acquire this key.
+    required: true
+  timezone:
+    description:
+    - A value that indicates the time zone you want to set for the gateway.
+    required: true
+  gateway_region:
+    description:
+    - A value that indicates the region where you want to store your data.
+    required: true
+  gateway_type:
+    description:
+    - A value that defines the type of gateway to activate.
+    - The type specified is critical to all later functions of the gateway and cannot be changed after activation.
+    default: 'STORED'
+    choices: ['STORED', 'CACHED', 'VTL', 'FILE_S3']
+  tape_drive_type:
+    description:
+    - The value that indicates the type of tape drive to use for tape gateway.
+    choices: ['IBM-ULT3580-TD5']
+  medium_changer_type:
+    description:
+    - The value that indicates the type of medium changer to use for tape gateway.
+    choices: ['STK-L700', 'AWS-Gateway-VTL']
+extends_documentation_fragment:
+  - aws
+  - ec2
+'''
+
+EXAMPLES = r'''
+  - name: Activate file gateway
+    storage_gateway:
+      name: "example-file-gateway"
+      state: present
+      activation_key: "{{ activation_code.stdout }}"
+      timezone: 'GMT-6:00'
+      gateway_region: "{{ aws_region }}"
+      gateway_type: 'FILE_S3'
+'''
+
+RETURN = r'''
+gateway_arn:
+    description: The ARN of the gateway you just created or updated.
+    returned: always
+    type: string
+'''
+
+import time
+import ast
+
+try:
+    import botocore
+    from botocore.exceptions import BotoCoreError, ClientError
+except ImportError:
+    pass  # handled by AnsibleAWSModule
+
+from ansible.module_utils.aws.core import AnsibleAWSModule
+from ansible.module_utils.ec2 import boto3_conn, get_aws_connection_info, AWSRetry
+from ansible.module_utils.ec2 import camel_dict_to_snake_dict, boto3_tag_list_to_ansible_dict
+
+
+def gateway_exists(client, module, params, result):
+    try:
+        gateway_list = client.list_gateways()
+        for i in gateway_list['Gateways']:
+            if i['GatewayName'] == params['GatewayName']:
+                disks_response = client.list_local_disks(
+                    GatewayARN=i['GatewayARN']
+                )
+                result['GatewayARN'] = i['GatewayARN']
+                result['Disks'] = disks_response['Disks']
+                return True
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError):
+        return False
+
+    return False
+
+
+def create_gateway(client, module, params, result):
+    try:
+        gw_response = client.activate_gateway(**params)
+        time.sleep(15)  # Need a waiter here but it doesn't exist yet in the StorageGateway API
+        disks_response = client.list_local_disks(
+            GatewayARN=gw_response['GatewayARN']
+        )
+        if disks_response['Disks']:
+            if params['GatewayType'] == 'FILE_S3':
+                vol_response = client.add_cache(
+                    GatewayARN=gw_response['GatewayARN'],
+                    DiskIds=[disks_response['Disks'][0]['DiskId']]
+                )
+            if params['GatewayType'] == 'CACHED' or params['GatewayType'] == 'VTL':
+                vol_response = client.add_cache(
+                    GatewayARN=gw_response['GatewayARN'],
+                    DiskIds=[disks_response['Disks'][0]['DiskId']]
+                )
+                vol_response = client.add_upload_buffer(
+                    GatewayARN=gw_response['GatewayARN'],
+                    DiskIds=[disks_response['Disks'][1]['DiskId']]
+                )
+            if params['GatewayType'] == 'STORED':
+                vol_response = client.add_upload_buffer(
+                    GatewayARN=gw_response['GatewayARN'],
+                    DiskIds=[disks_response['Disks'][0]['DiskId']]
+                )
+        result['GatewayARN'] = gw_response['GatewayARN']
+        result['Disks'] = disks_response['Disks']
+        result['changed'] = True
+        return result
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+        module.fail_json_aws(e, msg="Couldn't activate storage gateway instance")
+
+    return result
+
+
+def update_gateway(client, module, params, result):
+    current_params = client.describe_gateway_information(
+        GatewayARN=result['GatewayARN']
+    )
+
+    if params['GatewayName'] != current_params['GatewayName'] or params['GatewayTimezone'] != current_params['GatewayTimezone']:
+        try:
+            response = client.update_gateway_information(
+                GatewayARN=result['GatewayARN'],
+                GatewayName=params['GatewayName'],
+                GatewayTimezone=params['GatewayTimezone']
+            )
+            disks_response = client.list_local_disks(
+                GatewayARN=result['GatewayARN']
+            )
+            result['GatewayARN'] = response['GatewayARN']
+            result['Disks'] = disks_response['Disks']
+            result['changed'] = True
+            return result
+        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+            module.fail_json_aws(e, msg="Couldn't update storage gateway")
+
+    return result
+
+
+def delete_gateway(client, module, result):
+    try:
+        response = client.delete_gateway(
+            GatewayARN=result['GatewayARN']
+        )
+        result['changed'] = True
+        return result
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+        module.fail_json_aws(e, msg="Couldn't delete storage gateway")
+
+    return result
+
+
+def main():
+    module = AnsibleAWSModule(
+        argument_spec={
+            'name': dict(type='str', required=True),
+            'state': dict(type='str', choices=['present', 'absent'], default='present'),
+            'activation_key': dict(type='str', required=True),
+            'timezone': dict(type='str', required=True),
+            'gateway_region': dict(type='str', required=True),
+            'gateway_type': dict(type='str', default='STORED', choices=['STORED', 'CACHED', 'VTL', 'FILE_S3']),
+            'tape_drive_type': dict(type='str', choices=['IBM-ULT3580-TD5']),
+            'medium_changer_type': dict(type='str', choices=['STK-L700', 'AWS-Gateway-VTL']),
+        },
+        supports_check_mode=False,
+    )
+
+    result = {
+        'changed': False
+    }
+
+    desired_state = module.params.get('state')
+
+    params = {}
+    params['GatewayName'] = module.params.get('name')
+    params['ActivationKey'] = module.params.get('activation_key')
+    params['GatewayTimezone'] = module.params.get('timezone')
+    params['GatewayRegion'] = module.params.get('gateway_region')
+    params['GatewayType'] = module.params.get('gateway_type')
+    if module.params.get('tape_drive_type'):
+        params['TapeDriveType'] = module.params.get('tape_drive_type')
+    if module.params.get('medium_changer_type'):
+        params['MediumChangerType'] = module.params.get('medium_changer_type')
+
+    client = module.client('storagegateway')
+
+    gateway_status = gateway_exists(client, module, params, result)
+
+    if desired_state == 'present':
+        if not gateway_status:
+            create_gateway(client, module, params, result)
+        if gateway_status:
+            update_gateway(client, module, params, result)
+
+    if desired_state == 'absent':
+        if gateway_status:
+            delete_gateway(client, module, result)
+
+    module.exit_json(changed=result['changed'], output=result)
+
+
+if __name__ == '__main__':
+    main()

--- a/test/integration/targets/storage_gateway/aliases
+++ b/test/integration/targets/storage_gateway/aliases
@@ -1,2 +1,2 @@
 cloud/aws
-posix/ci/cloud/group4/aws
+unsupported

--- a/test/integration/targets/storage_gateway/aliases
+++ b/test/integration/targets/storage_gateway/aliases
@@ -1,0 +1,3 @@
+cloud/aws
+posix/ci/cloud/group4/aws
+#unsupported

--- a/test/integration/targets/storage_gateway/aliases
+++ b/test/integration/targets/storage_gateway/aliases
@@ -1,3 +1,2 @@
 cloud/aws
 posix/ci/cloud/group4/aws
-#unsupported

--- a/test/integration/targets/storage_gateway/aliases
+++ b/test/integration/targets/storage_gateway/aliases
@@ -1,2 +1,2 @@
 cloud/aws
-unsupported
+posix/ci/cloud/group4/aws

--- a/test/integration/targets/storage_gateway/defaults/main.yaml
+++ b/test/integration/targets/storage_gateway/defaults/main.yaml
@@ -1,0 +1,39 @@
+---
+# defaults file for ec2_instance
+ec2_instance_name: '{{resource_prefix}}-node'
+ec2_instance_owner: 'integration-run-{{resource_prefix}}'
+ec2_file_ami_image:
+  # amazon/aws-storage-gateway-file-2018-03-21
+  ap-northeast-1: ami-798cdc1f
+  ap-northeast-2: ami-d10ca0bf
+  ap-south-1: ami-e238638d
+  ap-southeast-1: ami-48114d34
+  ap-southeast-2: ami-47d41925
+  ca-central-1: ami-edd95f89
+  eu-central-1: ami-9aa9f971
+  eu-west-1: ami-10f1a569
+  eu-west-2: ami-4c34d22b
+  eu-west-3: ami-38388e45
+  sa-east-1: ami-0f481c63
+  us-east-1: ami-6e14c313
+  us-east-2: ami-7845741d
+  us-west-1: ami-ba9483da
+  us-west-2: ami-be21bdc6
+ec2_vol_vtl_ami_image:
+  # amazon/aws-storage-gateway-2.0.9.2
+  ap-northeast-1: ami-0a8bcd6c
+  ap-northeast-2: ami-6667ca08
+  ap-south-1: ami-c04718af
+  ap-southeast-1: ami-37175c4b
+  ap-southeast-2: ami-95d91ff7
+  ca-central-1: ami-7e880f1a
+  eu-central-1: ami-71ec811e
+  eu-west-1: ami-dc82c7a5
+  eu-west-2: ami-4d64802a
+  eu-west-3: ami-2b66d056
+  sa-east-1: ami-ec165d80
+  us-east-1: ami-571ff42a
+  us-east-2: ami-a7facdc2
+  us-west-1: ami-68e7ec08
+  us-west-2: ami-989119e0
+  us-gov-west-1: ami-9ce277fd

--- a/test/integration/targets/storage_gateway/meta/main.yaml
+++ b/test/integration/targets/storage_gateway/meta/main.yaml
@@ -1,0 +1,3 @@
+dependencies:
+  - prepare_tests
+  - setup_ec2

--- a/test/integration/targets/storage_gateway/tasks/main.yaml
+++ b/test/integration/targets/storage_gateway/tasks/main.yaml
@@ -1,0 +1,327 @@
+---
+- name: set connection information for all tasks
+  set_fact:
+    aws_connection_info: &aws_connection_info
+      aws_access_key: "{{ aws_access_key }}"
+      aws_secret_key: "{{ aws_secret_key }}"
+      region: "{{ aws_region }}"
+  no_log: true
+
+- block:
+
+  # ============================================================
+  # Prerequisites
+  # ============================================================
+
+  - name: Create VPC for use in testing
+    ec2_vpc_net:
+      name: "{{ resource_prefix }}-vpc"
+      cidr_block: 10.22.32.0/23
+      tags:
+        Name: Ansible ec2_instance Testing VPC
+      tenancy: default
+      <<: *aws_connection_info
+    register: testing_vpc
+
+  - name: Create internet gateway for use in testing
+    ec2_vpc_igw:
+      vpc_id: "{{ testing_vpc.vpc.id }}"
+      state: present
+      <<: *aws_connection_info
+    register: igw
+
+  - name: Create testing subnet
+    ec2_vpc_subnet:
+      state: present
+      vpc_id: "{{ testing_vpc.vpc.id }}"
+      cidr: 10.22.32.0/24
+      az: "{{ aws_region }}a"
+      resource_tags:
+        Name: "{{ resource_prefix }}-subnet"
+      <<: *aws_connection_info
+    register: testing_subnet
+
+  - name: create routing rules
+    ec2_vpc_route_table:
+      vpc_id: "{{ testing_vpc.vpc.id }}"
+      tags:
+        created: "{{ resource_prefix }}-route"
+      routes:
+        - dest: 0.0.0.0/0
+          gateway_id: "{{ igw.gateway_id }}"
+      subnets:
+        - "{{ testing_subnet.subnet.id }}"
+      <<: *aws_connection_info
+
+  - name: create a security group with the vpc
+    ec2_group:
+      name: "{{ resource_prefix }}-sg"
+      description: a security group for ansible tests
+      vpc_id: "{{ testing_vpc.vpc.id }}"
+      rules:
+        - proto: tcp
+          from_port: 22
+          to_port: 22
+          cidr_ip: 0.0.0.0/0
+        - proto: tcp
+          from_port: 80
+          to_port: 80
+          cidr_ip: 0.0.0.0/0
+      <<: *aws_connection_info
+    register: sg
+
+  - name: Create storage gateway instance
+    ec2_instance:
+      name: "{{ resource_prefix }}-test-file-gateway"
+      image_id: "{{ ec2_file_ami_image[aws_region] }}"
+      tags:
+        TestId: "{{ resource_prefix }}"
+      security_groups: "{{ sg.group_id }}"
+      vpc_subnet_id: "{{ testing_subnet.subnet.id }}"
+      network:
+        assign_public_ip: true
+      instance_type: m4.xlarge
+      volumes:
+        - device_name: /dev/sdb
+          ebs:
+            volume_size: 150
+            delete_on_termination: true
+            volume_type: standard
+      <<: *aws_connection_info
+    register: gateway_instance
+
+  - name: Send storage gateway activation code request
+    uri:
+      url: "http://{{ gateway_instance.instances[0].public_ip_address }}/?activationRegion={{ aws_region }}"
+    retries: 10
+    register: code_request
+
+  - name: Extract activation code from request
+    shell: echo "{{ code_request.url }}" | awk -F'[=&]' '{print $2}'
+    register: activation_code
+
+  # ============================================================
+  # Parameter Tests
+  # ============================================================
+
+  - name: test with no parameters
+    storage_gateway:
+    register: result
+    ignore_errors: true
+
+  - name: assert failure when called with no parameters
+    assert:
+      that:
+         - 'result.failed'
+         - 'result.msg.startswith("missing required arguments:")'
+
+  - name: test for missing parameters
+    storage_gateway:
+      name: 'test-gateway'
+    register: result
+    ignore_errors: true
+
+  - name: assert failure when called with no parameters
+    assert:
+      that:
+         - 'result.failed'
+         - 'result.msg.startswith("missing required arguments:")'
+
+  - name: test for missing parameters
+    storage_gateway:
+      name: 'test-gateway'
+      activation_key: '1234567890'
+    register: result
+    ignore_errors: true
+
+  - name: assert failure when called with missing parameters
+    assert:
+      that:
+         - 'result.failed'
+         - 'result.msg.startswith("missing required arguments:")'
+
+  - name: test for wrong gateway type
+    storage_gateway:
+      name: "{{ resource_prefix }}-test-file-gateway"
+      state: present
+      activation_key: "{{ activation_code.stdout }}"
+      timezone: 'GMT-6:00'
+      gateway_region: "{{ aws_region }}"
+      gateway_type: 'WRONG_TYPE'
+      <<: *aws_connection_info
+
+  - name: assert failure when called with missing parameters
+    assert:
+      that:
+         - 'result.failed'
+         - 'result.msg.startswith("value of gateway_type must be one of:")'
+
+  # ============================================================
+  # Resource Tests
+  # ============================================================
+
+  - name: Activate file gateway for testing
+    storage_gateway:
+      name: "{{ resource_prefix }}-test-file-gateway"
+      state: present
+      activation_key: "{{ activation_code.stdout }}"
+      timezone: 'GMT-6:00'
+      gateway_region: "{{ aws_region }}"
+      gateway_type: 'FILE_S3'
+      <<: *aws_connection_info
+    register: result
+
+  - name: assert changed is True
+    assert:
+      that:
+          - result.changed
+          - result.endpoint_arn is not none
+
+  - name: No changes to file gateway
+    storage_gateway:
+      name: "{{ resource_prefix }}-test-file-gateway"
+      state: present
+      activation_key: "{{ activation_code.stdout }}"
+      timezone: 'GMT-6:00'
+      gateway_region: "{{ aws_region }}"
+      gateway_type: 'FILE_S3'
+      <<: *aws_connection_info
+    register: result
+
+  - name: assert changed is True
+    assert:
+      that:
+          - not result.changed
+          - result.endpoint_arn is not none
+
+  - name: Update file gateway
+    storage_gateway:
+      name: "{{ resource_prefix }}-test-file-gateway"
+      state: present
+      activation_key: "{{ activation_code.stdout }}"
+      timezone: 'GMT-7:00'
+      gateway_region: "{{ aws_region }}"
+      gateway_type: 'FILE_S3'
+      <<: *aws_connection_info
+    register: result
+
+  - name: assert changed is True
+    assert:
+      that:
+          - result.changed
+          - result.endpoint_arn is not none
+
+  - name: Deactivate file gateway
+    storage_gateway:
+      name: "{{ resource_prefix }}-test-file-gateway"
+      state: absent
+      activation_key: "{{ activation_code.stdout }}"
+      timezone: 'GMT-6:00'
+      gateway_region: "{{ aws_region }}"
+      gateway_type: 'FILE_S3'
+      <<: *aws_connection_info
+    register: result
+    ignore_errors: yes
+
+  - name: assert changed is True
+    assert:
+      that:
+          - result.changed
+
+  always:
+
+  # ============================================================
+  # Teardown testing resources
+  # ============================================================
+
+  - name: remove any instances in the test VPC
+    ec2_instance:
+      filters:
+        vpc_id: "{{ testing_vpc.vpc.id }}"
+      state: absent
+      <<: *aws_connection_info
+    register: removed
+    until: removed is not failed
+    ignore_errors: yes
+    retries: 10
+
+  - name: remove ENIs
+    ec2_eni_facts:
+      filters:
+        vpc-id: "{{ testing_vpc.vpc.id }}"
+      <<: *aws_connection_info
+    register: enis
+
+  - name: delete all ENIs
+    ec2_eni:
+      eni_id: "{{ item.id }}"
+      state: absent
+      <<: *aws_connection_info
+    until: removed is not failed
+    with_items: "{{ enis.network_interfaces }}"
+    ignore_errors: yes
+    retries: 10
+
+  - name: remove the security group
+    ec2_group:
+      name: "{{ resource_prefix }}-sg"
+      description: a security group for ansible tests
+      vpc_id: "{{ testing_vpc.vpc.id }}"
+      state: absent
+      <<: *aws_connection_info
+    register: removed
+    until: removed is not failed
+    ignore_errors: yes
+    retries: 10
+
+  - name: remove routing rules
+    ec2_vpc_route_table:
+      state: absent
+      vpc_id: "{{ testing_vpc.vpc.id }}"
+      tags:
+        created: "{{ resource_prefix }}-route"
+      routes:
+        - dest: 0.0.0.0/0
+          gateway_id: "{{ igw.gateway_id }}"
+      subnets:
+        - "{{ testing_subnet.subnet.id }}"
+      <<: *aws_connection_info
+    register: removed
+    until: removed is not failed
+    ignore_errors: yes
+    retries: 10
+
+  - name: remove internet gateway
+    ec2_vpc_igw:
+      vpc_id: "{{ testing_vpc.vpc.id }}"
+      state: absent
+      <<: *aws_connection_info
+    register: removed
+    until: removed is not failed
+    ignore_errors: yes
+    retries: 10
+
+  - name: remove testing subnet
+    ec2_vpc_subnet:
+      state: absent
+      vpc_id: "{{ testing_vpc.vpc.id }}"
+      cidr: 10.22.32.0/24
+      <<: *aws_connection_info
+    register: removed
+    until: removed is not failed
+    ignore_errors: yes
+    retries: 10
+
+  - name: remove the VPC
+    ec2_vpc_net:
+      name: "{{ resource_prefix }}-vpc"
+      cidr_block: 10.22.32.0/23
+      state: absent
+      tags:
+        Name: Ansible Testing VPC
+      tenancy: default
+      <<: *aws_connection_info
+    register: removed
+    until: removed is not failed
+    ignore_errors: yes
+    retries: 10

--- a/test/integration/targets/storage_gateway/tasks/main.yaml
+++ b/test/integration/targets/storage_gateway/tasks/main.yaml
@@ -4,7 +4,7 @@
     aws_connection_info: &aws_connection_info
       aws_access_key: "{{ aws_access_key }}"
       aws_secret_key: "{{ aws_secret_key }}"
-      security_token: "{{ security_token }}"
+      #security_token: "{{ security_token }}"
       region: "{{ aws_region }}"
   no_log: true
 
@@ -141,27 +141,11 @@
          - 'result.failed'
          - 'result.msg.startswith("missing required arguments:")'
 
-  - name: test for wrong gateway type
-    storage_gateway:
-      name: "{{ resource_prefix }}-test-file-gateway"
-      state: present
-      activation_key: "{{ activation_code.stdout }}"
-      timezone: 'GMT-6:00'
-      gateway_region: "{{ aws_region }}"
-      gateway_type: 'WRONG_TYPE'
-      <<: *aws_connection_info
-
-  - name: assert failure when called with missing parameters
-    assert:
-      that:
-         - 'result.failed'
-         - 'result.msg.startswith("value of gateway_type must be one of:")'
-
   # ============================================================
   # Resource Tests
   # ============================================================
 
-  - name: Activate file gateway for testing
+  - name: Activate storage gateway for testing
     storage_gateway:
       name: "{{ resource_prefix }}-test-file-gateway"
       state: present
@@ -176,9 +160,9 @@
     assert:
       that:
           - result.changed
-          - result.endpoint_arn is not none
+          - result.gateway_arn is not none
 
-  - name: No changes to file gateway
+  - name: No changes to storage gateway
     storage_gateway:
       name: "{{ resource_prefix }}-test-file-gateway"
       state: present
@@ -193,9 +177,9 @@
     assert:
       that:
           - not result.changed
-          - result.endpoint_arn is not none
+          - result.gateway_arn is not none
 
-  - name: Update file gateway
+  - name: Update storage gateway
     storage_gateway:
       name: "{{ resource_prefix }}-test-file-gateway"
       state: present
@@ -210,9 +194,9 @@
     assert:
       that:
           - result.changed
-          - result.endpoint_arn is not none
+          - result.gateway_arn is not none
 
-  - name: Deactivate file gateway
+  - name: Deactivate storage gateway
     storage_gateway:
       name: "{{ resource_prefix }}-test-file-gateway"
       state: absent

--- a/test/integration/targets/storage_gateway/tasks/main.yaml
+++ b/test/integration/targets/storage_gateway/tasks/main.yaml
@@ -4,6 +4,7 @@
     aws_connection_info: &aws_connection_info
       aws_access_key: "{{ aws_access_key }}"
       aws_secret_key: "{{ aws_secret_key }}"
+      security_token: "{{ security_token }}"
       region: "{{ aws_region }}"
   no_log: true
 


### PR DESCRIPTION
##### SUMMARY
This is the first pull request of several that will add support for AWS Storage Gateway resources. This one manages the activation/deactivation of storage gateway instances. Right now, the module makes a big assumption that instance is fresh and that detected disks can be used for cache or buffer storage depending on the type of the gateway that's being defined.  I'm open to alternative ways to handle this.  This way just seemed to be the easiest without getting bogged down in local disk micromanagement.

##### ISSUE TYPE
 - New Module Pull Request

##### COMPONENT NAME
`storage_gateway`

##### ANSIBLE VERSION
```
ansible 2.4.1.0
  config file = None
  configured module search path = [u'/Users/asmith/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/asmith/.pyenv/versions/2.7.13/lib/python2.7/site-packages/ansible
  executable location = /Users/asmith/.pyenv/versions/2.7.13/bin/ansible
  python version = 2.7.13 (default, Sep  8 2017, 15:16:38) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```
