### PR TITLE
reset_connection is not run_once

### DIFF
--- a/lib/ansible/plugins/strategy/linear.py
+++ b/lib/ansible/plugins/strategy/linear.py
@@ -263,7 +263,7 @@ class StrategyModule(StrategyBase):
                         # for the linear strategy, we run meta tasks just once and for
                         # all hosts currently being iterated over rather than one host
                         results.extend(self._execute_meta(task, play_context, iterator, host))
-                        if task.args.get('_raw_params', None) not in ('noop', 'reset_connection')):
+                        if task.args.get('_raw_params', None) not in ('noop', 'reset_connection'):
                             run_once = True
                     else:
                         # handle step if needed, skip meta actions as they are used internally

--- a/lib/ansible/plugins/strategy/linear.py
+++ b/lib/ansible/plugins/strategy/linear.py
@@ -263,7 +263,7 @@ class StrategyModule(StrategyBase):
                         # for the linear strategy, we run meta tasks just once and for
                         # all hosts currently being iterated over rather than one host
                         results.extend(self._execute_meta(task, play_context, iterator, host))
-                        if task.args.get('_raw_params', None) != 'noop':
+                        if task.args.get('_raw_params', None) not in ('noop', 'reset_connection')):
                             run_once = True
                     else:
                         # handle step if needed, skip meta actions as they are used internally


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
in linear only first host was being reset
fixes #39364
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
modules/meta:
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
>=2.5
```

