### PR TITLE
Group logic detecting user, ensure rsync_opts is a list if omitted

### DIFF
--- a/lib/ansible/modules/files/synchronize.py
+++ b/lib/ansible/modules/files/synchronize.py
@@ -366,7 +366,7 @@ def main():
             group=dict(type='bool'),
             set_remote_user=dict(type='bool', default=True),
             rsync_timeout=dict(type='int', default=0),
-            rsync_opts=dict(type='list'),
+            rsync_opts=dict(type='list', default=[]),
             ssh_args=dict(type='str'),
             partial=dict(type='bool', default=False),
             verify_host=dict(type='bool', default=False),

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -583,7 +583,7 @@ class ActionBase(with_metaclass(ABCMeta, object)):
                 expand_path = '~%s' % self._play_context.become_user
             else:
                 # use remote user instead, if none set default to current user
-                expand_path = '~%s' % self._play_context.remote_user or self._connection.default_user or ''
+                expand_path = '~%s' % (self._play_context.remote_user or self._connection.default_user or '')
 
         # use shell to construct appropriate command and execute
         cmd = self._connection._shell.expand_user(expand_path)


### PR DESCRIPTION
##### SUMMARY
Group logic detecting user, ensure rsync_opts is a list if omitted. Fixes #40483

This fixes 2 issues:

1. `rsync_opts` not provided, defaults to `None`

    ```
        for rsync_opt in rsync_opts:
        TypeError: 'NoneType' object is not iterable
    ```
1. `or` logic not grouped, causing invalid `expand_path`

    ```
    "msg": "failed to transfer file to ~None/.ansible/tmp/...
    ```

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/files/synchronize.py
lib/ansible/plugins/action/__init__.py


##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
2.6
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```