### PR TITLE
[Trivial refactor] Remove special-case Display construction everywhere.

### DIFF
--- a/bin/ansible
+++ b/bin/ansible
@@ -65,7 +65,7 @@ if __name__ == '__main__':
 
     try:  # bad ANSIBLE_CONFIG or config options can force ugly stacktrace
         import ansible.constants as C
-        from ansible.utils.display import Display
+        from ansible.utils.display import display
     except AnsibleOptionsError as e:
         display.error(to_text(e), wrap_text=False)
         sys.exit(5)
@@ -74,7 +74,6 @@ if __name__ == '__main__':
     me = os.path.basename(sys.argv[0])
 
     try:
-        display = Display()
         display.debug("starting run")
 
         sub = None

--- a/bin/ansible-connection
+++ b/bin/ansible-connection
@@ -31,7 +31,7 @@ from ansible.module_utils.service import fork_process
 from ansible.playbook.play_context import PlayContext
 from ansible.plugins.loader import connection_loader
 from ansible.utils.path import unfrackpath, makedirs_safe
-from ansible.utils.display import Display
+from ansible.utils.display import display
 from ansible.utils.jsonrpc import JsonRpcServer
 
 
@@ -305,5 +305,4 @@ def main():
 
 
 if __name__ == '__main__':
-    display = Display()
     main()

--- a/docs/bin/plugin_formatter.py
+++ b/docs/bin/plugin_formatter.py
@@ -51,7 +51,7 @@ from ansible.errors import AnsibleError
 from ansible.module_utils._text import to_bytes, to_text
 from ansible.plugins.loader import fragment_loader
 from ansible.utils import plugin_docs
-from ansible.utils.display import Display
+from ansible.utils.display import display
 
 
 #####################################################################################
@@ -82,7 +82,6 @@ _RULER = re.compile(r"HORIZONTALLINE")
 DEPRECATED = b" (D)"
 
 pp = PrettyPrinter()
-display = Display()
 
 
 def rst_ify(text):

--- a/docs/docsite/rst/dev_guide/developing_plugins.rst
+++ b/docs/docsite/rst/dev_guide/developing_plugins.rst
@@ -226,12 +226,7 @@ Here's a simple lookup plugin implementation --- this lookup returns the content
   """
   from ansible.errors import AnsibleError, AnsibleParserError
   from ansible.plugins.lookup import LookupBase
-
-  try:
-      from __main__ import display
-  except ImportError:
-      from ansible.utils.display import Display
-      display = Display()
+  from ansible.utils.display import display
 
 
   class LookupModule(LookupBase):

--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -40,16 +40,11 @@ from ansible.module_utils.six import with_metaclass, string_types
 from ansible.module_utils._text import to_bytes, to_text
 from ansible.parsing.dataloader import DataLoader
 from ansible.release import __version__
+from ansible.utils.display import display
 from ansible.utils.path import unfrackpath
 from ansible.utils.vars import load_extra_vars, load_options_vars
 from ansible.vars.manager import VariableManager
 from ansible.parsing.vault import PromptVaultSecret, get_file_vault_secret
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
 
 
 class SortedOptParser(optparse.OptionParser):

--- a/lib/ansible/cli/adhoc.py
+++ b/lib/ansible/cli/adhoc.py
@@ -31,12 +31,7 @@ from ansible.parsing.splitter import parse_kv
 from ansible.playbook import Playbook
 from ansible.playbook.play import Play
 from ansible.plugins.loader import get_all_plugin_loaders
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
+from ansible.utils.display import display
 
 
 ########################################################

--- a/lib/ansible/cli/config.py
+++ b/lib/ansible/cli/config.py
@@ -16,14 +16,8 @@ from ansible.errors import AnsibleError, AnsibleOptionsError
 from ansible.module_utils._text import to_native, to_text, to_bytes
 from ansible.parsing.yaml.dumper import AnsibleDumper
 from ansible.utils.color import stringc
+from ansible.utils.display import display
 from ansible.utils.path import unfrackpath
-
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
 
 
 class ConfigCLI(CLI):

--- a/lib/ansible/cli/console.py
+++ b/lib/ansible/cli/console.py
@@ -47,12 +47,7 @@ from ansible.playbook.play import Play
 from ansible.plugins.loader import module_loader, fragment_loader
 from ansible.utils import plugin_docs
 from ansible.utils.color import stringc
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
+from ansible.utils.display import display
 
 
 class ConsoleCLI(CLI, cmd.Cmd):

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -30,13 +30,8 @@ from ansible.module_utils.six import string_types
 from ansible.parsing.yaml.dumper import AnsibleDumper
 from ansible.plugins.loader import module_loader, action_loader, lookup_loader, callback_loader, cache_loader, \
     vars_loader, connection_loader, strategy_loader, inventory_loader, shell_loader, fragment_loader
+from ansible.utils.display import display
 from ansible.utils.plugin_docs import BLACKLIST, get_docstring
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
 
 
 class DocCLI(CLI):

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -41,12 +41,7 @@ from ansible.galaxy.role import GalaxyRole
 from ansible.galaxy.token import GalaxyToken
 from ansible.module_utils._text import to_text
 from ansible.playbook.role.requirement import RoleRequirement
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
+from ansible.utils.display import display
 
 
 class GalaxyCLI(CLI):

--- a/lib/ansible/cli/inventory.py
+++ b/lib/ansible/cli/inventory.py
@@ -26,13 +26,9 @@ from ansible.errors import AnsibleError, AnsibleOptionsError
 from ansible.inventory.host import Host
 from ansible.plugins.loader import vars_loader
 from ansible.parsing.dataloader import DataLoader
+from ansible.utils.display import display
 from ansible.utils.vars import combine_vars
 
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
 
 INTERNAL_VARS = frozenset(['ansible_diff_mode',
                            'ansible_facts',

--- a/lib/ansible/cli/playbook.py
+++ b/lib/ansible/cli/playbook.py
@@ -28,12 +28,7 @@ from ansible.errors import AnsibleError, AnsibleOptionsError
 from ansible.executor.playbook_executor import PlaybookExecutor
 from ansible.playbook.block import Block
 from ansible.playbook.play_context import PlayContext
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
+from ansible.utils.display import display
 
 
 class PlaybookCLI(CLI):

--- a/lib/ansible/cli/pull.py
+++ b/lib/ansible/cli/pull.py
@@ -33,12 +33,7 @@ from ansible.errors import AnsibleOptionsError
 from ansible.module_utils._text import to_native, to_text
 from ansible.plugins.loader import module_loader
 from ansible.utils.cmd_functions import run_cmd
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
+from ansible.utils.display import display
 
 
 ########################################################

--- a/lib/ansible/cli/vault.py
+++ b/lib/ansible/cli/vault.py
@@ -28,12 +28,7 @@ from ansible.errors import AnsibleOptionsError
 from ansible.module_utils._text import to_text, to_bytes
 from ansible.parsing.dataloader import DataLoader
 from ansible.parsing.vault import VaultEditor, VaultLib, match_encrypt_secret
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
+from ansible.utils.display import display
 
 
 class VaultCLI(CLI):

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -20,7 +20,7 @@ from ansible.config.manager import ConfigManager, ensure_type, get_ini_config_va
 def _deprecated(msg, version='2.8'):
     ''' display is not guaranteed here, nor it being the full class, but try anyways, fallback to sys.stderr.write '''
     try:
-        from __main__ import display
+        from ansible.utils.display import display
         display.deprecated(msg, version=version)
     except:
         import sys

--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -38,16 +38,11 @@ from ansible.errors import AnsibleError
 from ansible.module_utils._text import to_bytes, to_text, to_native
 from ansible.plugins.loader import module_utils_loader, ps_module_utils_loader
 from ansible.plugins.shell.powershell import async_watchdog, async_wrapper, become_wrapper, leaf_exec, exec_wrapper
+from ansible.utils.display import display
 # Must import strategy and use write_locks from there
 # If we import write_locks directly then we end up binding a
 # variable to the object and then it never gets updated.
 from ansible.executor import action_write_locks
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
 
 
 REPLACER = b"#<<INCLUDE_ANSIBLE_MODULE_COMMON>>"

--- a/lib/ansible/executor/play_iterator.py
+++ b/lib/ansible/executor/play_iterator.py
@@ -26,13 +26,7 @@ from ansible.module_utils.six import iteritems
 from ansible.module_utils.parsing.convert_bool import boolean
 from ansible.playbook.block import Block
 from ansible.playbook.task import Task
-
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
+from ansible.utils.display import display
 
 
 __all__ = ['PlayIterator']

--- a/lib/ansible/executor/playbook_executor.py
+++ b/lib/ansible/executor/playbook_executor.py
@@ -28,14 +28,9 @@ from ansible.playbook import Playbook
 from ansible.template import Templar
 from ansible.utils.helpers import pct_to_int
 from ansible.module_utils.parsing.convert_bool import boolean
+from ansible.utils.display import display
 from ansible.utils.path import makedirs_safe
 from ansible.utils.ssh_functions import check_for_controlpersist
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
 
 
 class PlaybookExecutor:

--- a/lib/ansible/executor/process/worker.py
+++ b/lib/ansible/executor/process/worker.py
@@ -40,12 +40,9 @@ from ansible.errors import AnsibleConnectionFailure
 from ansible.executor.task_executor import TaskExecutor
 from ansible.executor.task_result import TaskResult
 from ansible.module_utils._text import to_text
+from ansible.utils.display import display
+from ansible.utils.profiling import run_with_profiler
 
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
 
 __all__ = ['WorkerProcess']
 

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -21,16 +21,11 @@ from ansible.module_utils._text import to_text, to_native
 from ansible.playbook.conditional import Conditional
 from ansible.playbook.task import Task
 from ansible.template import Templar
+from ansible.utils.display import display
 from ansible.utils.listify import listify_lookup_plugin_terms
 from ansible.utils.unsafe_proxy import UnsafeProxy, wrap_var
 from ansible.vars.clean import namespace_facts, clean_facts
 from ansible.utils.vars import combine_vars
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
 
 
 __all__ = ['TaskExecutor']

--- a/lib/ansible/executor/task_queue_manager.py
+++ b/lib/ansible/executor/task_queue_manager.py
@@ -35,15 +35,10 @@ from ansible.playbook.play_context import PlayContext
 from ansible.plugins.loader import callback_loader, strategy_loader, module_loader
 from ansible.plugins.callback import CallbackBase
 from ansible.template import Templar
+from ansible.utils.display import display
 from ansible.utils.helpers import pct_to_int
 from ansible.vars.hostvars import HostVars
 from ansible.vars.reserved import warn_if_reserved
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
 
 
 __all__ = ['TaskQueueManager']

--- a/lib/ansible/galaxy/api.py
+++ b/lib/ansible/galaxy/api.py
@@ -32,12 +32,7 @@ from ansible.module_utils.six.moves.urllib.error import HTTPError
 from ansible.module_utils.six.moves.urllib.parse import quote as urlquote, urlencode
 from ansible.module_utils._text import to_native, to_text
 from ansible.module_utils.urls import open_url
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
+from ansible.utils.display import display
 
 
 def g_connect(method):

--- a/lib/ansible/galaxy/login.py
+++ b/lib/ansible/galaxy/login.py
@@ -31,12 +31,7 @@ from ansible.module_utils.six.moves.urllib.parse import quote as urlquote, urlpa
 from ansible.module_utils.six.moves.urllib.error import HTTPError
 from ansible.module_utils.urls import open_url
 from ansible.utils.color import stringc
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
+from ansible.utils.display import display
 
 
 class GalaxyLogin(object):

--- a/lib/ansible/galaxy/role.py
+++ b/lib/ansible/galaxy/role.py
@@ -35,12 +35,7 @@ from ansible.errors import AnsibleError
 from ansible.module_utils.urls import open_url
 from ansible.playbook.role.requirement import RoleRequirement
 from ansible.galaxy.api import GalaxyAPI
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
+from ansible.utils.display import display
 
 
 class GalaxyRole(object):

--- a/lib/ansible/galaxy/token.py
+++ b/lib/ansible/galaxy/token.py
@@ -26,11 +26,7 @@ from stat import S_IRUSR, S_IWUSR
 
 import yaml
 
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
+from ansible.utils.display import display
 
 
 class GalaxyToken(object):

--- a/lib/ansible/inventory/data.py
+++ b/lib/ansible/inventory/data.py
@@ -26,14 +26,9 @@ from ansible.errors import AnsibleError
 from ansible.inventory.group import Group
 from ansible.inventory.host import Host
 from ansible.module_utils.six import iteritems
-from ansible.utils.vars import combine_vars
+from ansible.utils.display import display
 from ansible.utils.path import basedir
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
+from ansible.utils.vars import combine_vars
 
 
 class InventoryData(object):

--- a/lib/ansible/inventory/manager.py
+++ b/lib/ansible/inventory/manager.py
@@ -31,13 +31,9 @@ from ansible.module_utils.six import string_types
 from ansible.module_utils._text import to_bytes, to_text
 from ansible.parsing.utils.addresses import parse_address
 from ansible.plugins.loader import inventory_loader
+from ansible.utils.display import display
 from ansible.utils.path import unfrackpath
 
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
 
 IGNORED_ALWAYS = [br"^\.", b"^host_vars$", b"^group_vars$", b"^vars_plugins$"]
 IGNORED_PATTERNS = [to_bytes(x) for x in C.INVENTORY_IGNORE_PATTERNS]

--- a/lib/ansible/parsing/dataloader.py
+++ b/lib/ansible/parsing/dataloader.py
@@ -20,13 +20,8 @@ from ansible.module_utils._text import to_bytes, to_native, to_text
 from ansible.parsing.quoting import unquote
 from ansible.parsing.utils.yaml import from_yaml
 from ansible.parsing.vault import VaultLib, b_HEADER, is_encrypted, is_encrypted_file, parse_vaulttext_envelope
+from ansible.utils.display import display
 from ansible.utils.path import unfrackpath
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
 
 
 # Tries to determine if a path is inside a role, last dir must be 'tasks'

--- a/lib/ansible/parsing/plugin_docs.py
+++ b/lib/ansible/parsing/plugin_docs.py
@@ -11,12 +11,7 @@ import yaml
 from ansible.module_utils._text import to_text
 from ansible.parsing.metadata import extract_metadata
 from ansible.parsing.yaml.loader import AnsibleLoader
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
+from ansible.utils.display import display
 
 
 def read_docstring(filename, verbose=True, ignore_errors=True):

--- a/lib/ansible/parsing/vault/__init__.py
+++ b/lib/ansible/parsing/vault/__init__.py
@@ -78,13 +78,8 @@ from ansible.module_utils.six import PY3, binary_type
 # Note: on py2, this zip is izip not the list based zip() builtin
 from ansible.module_utils.six.moves import zip
 from ansible.module_utils._text import to_bytes, to_text, to_native
+from ansible.utils.display import display
 from ansible.utils.path import makedirs_safe
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
 
 
 b_HEADER = b'$ANSIBLE_VAULT'

--- a/lib/ansible/parsing/yaml/constructor.py
+++ b/lib/ansible/parsing/yaml/constructor.py
@@ -25,14 +25,9 @@ from yaml.nodes import MappingNode
 from ansible.module_utils._text import to_bytes
 from ansible.parsing.yaml.objects import AnsibleMapping, AnsibleSequence, AnsibleUnicode
 from ansible.parsing.yaml.objects import AnsibleVaultEncryptedUnicode
+from ansible.utils.display import display
 from ansible.utils.unsafe_proxy import wrap_var
 from ansible.parsing.vault import VaultLib
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
 
 
 class AnsibleConstructor(SafeConstructor):

--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -27,12 +27,7 @@ from ansible.module_utils._text import to_text, to_native
 from ansible.playbook.play import Play
 from ansible.playbook.playbook_include import PlaybookInclude
 from ansible.plugins.loader import get_all_plugin_loaders
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
+from ansible.utils.display import display
 
 
 __all__ = ['Playbook']

--- a/lib/ansible/playbook/base.py
+++ b/lib/ansible/playbook/base.py
@@ -20,13 +20,8 @@ from ansible.errors import AnsibleParserError, AnsibleUndefinedVariable, Ansible
 from ansible.module_utils._text import to_text, to_native
 from ansible.playbook.attribute import Attribute, FieldAttribute
 from ansible.parsing.dataloader import DataLoader
+from ansible.utils.display import display
 from ansible.utils.vars import combine_vars, isidentifier, get_unique_id
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
 
 
 def _generic_g(prop_name, self):

--- a/lib/ansible/playbook/become.py
+++ b/lib/ansible/playbook/become.py
@@ -22,12 +22,7 @@ __metaclass__ = type
 from ansible import constants as C
 from ansible.errors import AnsibleParserError
 from ansible.playbook.attribute import FieldAttribute
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
+from ansible.utils.display import display
 
 
 class Become:

--- a/lib/ansible/playbook/conditional.py
+++ b/lib/ansible/playbook/conditional.py
@@ -29,12 +29,7 @@ from ansible.errors import AnsibleError, AnsibleUndefinedVariable
 from ansible.module_utils.six import text_type
 from ansible.module_utils._text import to_native
 from ansible.playbook.attribute import FieldAttribute
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
+from ansible.utils.display import display
 
 
 DEFINED_REGEX = re.compile(r'(hostvars\[.+\]|[\w_]+)\s+(not\s+is|is|is\s+not)\s+(defined|undefined)')

--- a/lib/ansible/playbook/helpers.py
+++ b/lib/ansible/playbook/helpers.py
@@ -25,12 +25,7 @@ from ansible.errors import AnsibleParserError, AnsibleUndefinedVariable, Ansible
 from ansible.module_utils._text import to_native
 from ansible.module_utils.six import string_types
 from ansible.parsing.mod_args import ModuleArgsParser
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
+from ansible.utils.display import display
 
 
 def load_list_of_blocks(ds, play, parent_block=None, role=None, task_include=None, use_handlers=False, variable_manager=None, loader=None):

--- a/lib/ansible/playbook/included_file.py
+++ b/lib/ansible/playbook/included_file.py
@@ -24,12 +24,7 @@ import os
 from ansible.playbook.task_include import TaskInclude
 from ansible.playbook.role_include import IncludeRole
 from ansible.template import Templar
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
+from ansible.utils.display import display
 
 
 class IncludedFile:

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -29,13 +29,8 @@ from ansible.playbook.block import Block
 from ansible.playbook.helpers import load_list_of_blocks, load_list_of_roles
 from ansible.playbook.role import Role
 from ansible.playbook.taggable import Taggable
+from ansible.utils.display import display
 from ansible.vars.manager import preprocess_vars
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
 
 
 __all__ = ['Play']

--- a/lib/ansible/playbook/play_context.py
+++ b/lib/ansible/playbook/play_context.py
@@ -37,14 +37,8 @@ from ansible.module_utils.parsing.convert_bool import boolean
 from ansible.playbook.attribute import FieldAttribute
 from ansible.playbook.base import Base
 from ansible.plugins import get_plugin_class
+from ansible.utils.display import display
 from ansible.utils.ssh_functions import check_for_controlpersist
-
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
 
 
 __all__ = ['PlayContext']

--- a/lib/ansible/playbook/role/definition.py
+++ b/lib/ansible/playbook/role/definition.py
@@ -31,13 +31,8 @@ from ansible.playbook.become import Become
 from ansible.playbook.conditional import Conditional
 from ansible.playbook.taggable import Taggable
 from ansible.template import Templar
+from ansible.utils.display import display
 from ansible.utils.path import unfrackpath
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
 
 
 __all__ = ['RoleDefinition']

--- a/lib/ansible/playbook/role/requirement.py
+++ b/lib/ansible/playbook/role/requirement.py
@@ -30,10 +30,10 @@ from ansible.errors import AnsibleError
 from ansible.module_utils._text import to_native
 from ansible.module_utils.six import string_types
 from ansible.playbook.role.definition import RoleDefinition
+from ansible.utils.display import display
 
 
 __all__ = ['RoleRequirement']
-
 
 VALID_SPEC_KEYS = [
     'name',
@@ -42,12 +42,6 @@ VALID_SPEC_KEYS = [
     'src',
     'version',
 ]
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
 
 
 class RoleRequirement(RoleDefinition):

--- a/lib/ansible/playbook/role_include.py
+++ b/lib/ansible/playbook/role_include.py
@@ -26,12 +26,8 @@ from ansible.playbook.attribute import FieldAttribute
 from ansible.playbook.task_include import TaskInclude
 from ansible.playbook.role import Role
 from ansible.playbook.role.include import RoleInclude
+from ansible.utils.display import display
 
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
 
 __all__ = ['IncludeRole']
 

--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -36,13 +36,8 @@ from ansible.playbook.conditional import Conditional
 from ansible.playbook.loop_control import LoopControl
 from ansible.playbook.role import Role
 from ansible.playbook.taggable import Taggable
+from ansible.utils.display import display
 
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
 
 __all__ = ['Task']
 

--- a/lib/ansible/playbook/task_include.py
+++ b/lib/ansible/playbook/task_include.py
@@ -21,12 +21,8 @@ __metaclass__ = type
 
 from ansible.playbook.attribute import FieldAttribute
 from ansible.playbook.task import Task
+from ansible.utils.display import display
 
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
 
 __all__ = ['TaskInclude']
 

--- a/lib/ansible/plugins/__init__.py
+++ b/lib/ansible/plugins/__init__.py
@@ -25,12 +25,8 @@ from abc import ABCMeta
 
 from ansible import constants as C
 from ansible.module_utils.six import with_metaclass, string_types
+from ansible.utils.display import display
 
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
 
 # Global so that all instances of a PluginLoader will share the caches
 MODULE_CACHE = {}

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -25,15 +25,9 @@ from ansible.module_utils.six.moves import shlex_quote
 from ansible.module_utils._text import to_bytes, to_native, to_text
 from ansible.parsing.utils.jsonify import jsonify
 from ansible.release import __version__
+from ansible.utils.display import display
 from ansible.utils.unsafe_proxy import wrap_var
 from ansible.vars.clean import remove_internal_keys
-
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
 
 
 class ActionBase(with_metaclass(ABCMeta, object)):

--- a/lib/ansible/plugins/action/add_host.py
+++ b/lib/ansible/plugins/action/add_host.py
@@ -24,12 +24,7 @@ from ansible.errors import AnsibleError
 from ansible.module_utils.six import string_types
 from ansible.plugins.action import ActionBase
 from ansible.parsing.utils.addresses import parse_address
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
+from ansible.utils.display import display
 
 
 class ActionModule(ActionBase):

--- a/lib/ansible/plugins/action/aireos.py
+++ b/lib/ansible/plugins/action/aireos.py
@@ -28,13 +28,7 @@ from ansible.module_utils.connection import Connection
 from ansible.plugins.action.normal import ActionModule as _ActionModule
 from ansible.module_utils.network.aireos.aireos import aireos_provider_spec
 from ansible.module_utils.network.common.utils import load_provider
-
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
+from ansible.utils.display import display
 
 
 class ActionModule(_ActionModule):

--- a/lib/ansible/plugins/action/aruba.py
+++ b/lib/ansible/plugins/action/aruba.py
@@ -28,12 +28,7 @@ from ansible.module_utils.connection import Connection
 from ansible.plugins.action.normal import ActionModule as _ActionModule
 from ansible.module_utils.network.aruba.aruba import aruba_provider_spec
 from ansible.module_utils.network.common.utils import load_provider
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
+from ansible.utils.display import display
 
 
 class ActionModule(_ActionModule):

--- a/lib/ansible/plugins/action/asa.py
+++ b/lib/ansible/plugins/action/asa.py
@@ -28,13 +28,7 @@ from ansible.plugins.action.normal import ActionModule as _ActionModule
 from ansible.module_utils.network.asa.asa import asa_provider_spec
 from ansible.module_utils.network.common.utils import load_provider
 from ansible.module_utils.connection import request_builder
-
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
+from ansible.utils.display import display
 
 
 class ActionModule(_ActionModule):

--- a/lib/ansible/plugins/action/bigip.py
+++ b/lib/ansible/plugins/action/bigip.py
@@ -28,17 +28,12 @@ from ansible.module_utils._text import to_text
 from ansible.module_utils.connection import Connection
 from ansible.module_utils.network.common.utils import load_provider
 from ansible.plugins.action.normal import ActionModule as _ActionModule
+from ansible.utils.display import display
 
 try:
     from library.module_utils.network.f5.common import f5_provider_spec
 except:
     from ansible.module_utils.network.f5.common import f5_provider_spec
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
 
 
 class ActionModule(_ActionModule):

--- a/lib/ansible/plugins/action/bigiq.py
+++ b/lib/ansible/plugins/action/bigiq.py
@@ -28,17 +28,12 @@ from ansible.module_utils._text import to_text
 from ansible.module_utils.connection import Connection
 from ansible.module_utils.network.common.utils import load_provider
 from ansible.plugins.action.normal import ActionModule as _ActionModule
+from ansible.utils.display import display
 
 try:
     from library.module_utils.network.f5.common import f5_provider_spec
 except:
     from ansible.module_utils.network.f5.common import f5_provider_spec
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
 
 
 class ActionModule(_ActionModule):

--- a/lib/ansible/plugins/action/ce.py
+++ b/lib/ansible/plugins/action/ce.py
@@ -28,13 +28,7 @@ from ansible.module_utils.connection import Connection
 from ansible.plugins.action.normal import ActionModule as _ActionModule
 from ansible.module_utils.network.cloudengine.ce import ce_provider_spec
 from ansible.module_utils.network.common.utils import load_provider
-
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
+from ansible.utils.display import display
 
 
 class ActionModule(_ActionModule):

--- a/lib/ansible/plugins/action/cnos.py
+++ b/lib/ansible/plugins/action/cnos.py
@@ -26,13 +26,7 @@ from ansible.module_utils.network.cnos.cnos import cnos_provider_spec
 from ansible.module_utils.network.common.utils import load_provider
 from ansible.module_utils.connection import Connection
 from ansible.module_utils._text import to_text
-
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
+from ansible.utils.display import display
 
 
 class ActionModule(_ActionModule):

--- a/lib/ansible/plugins/action/dellos10.py
+++ b/lib/ansible/plugins/action/dellos10.py
@@ -30,12 +30,7 @@ from ansible.module_utils.connection import Connection
 from ansible.plugins.action.normal import ActionModule as _ActionModule
 from ansible.module_utils.network.common.utils import load_provider
 from ansible.module_utils.network.dellos10.dellos10 import dellos10_provider_spec
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
+from ansible.utils.display import display
 
 
 class ActionModule(_ActionModule):

--- a/lib/ansible/plugins/action/dellos6.py
+++ b/lib/ansible/plugins/action/dellos6.py
@@ -30,12 +30,7 @@ from ansible.module_utils.connection import Connection
 from ansible.plugins.action.normal import ActionModule as _ActionModule
 from ansible.module_utils.network.dellos6.dellos6 import dellos6_provider_spec
 from ansible.module_utils.network.common.utils import load_provider
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
+from ansible.utils.display import display
 
 
 class ActionModule(_ActionModule):

--- a/lib/ansible/plugins/action/dellos9.py
+++ b/lib/ansible/plugins/action/dellos9.py
@@ -30,12 +30,7 @@ from ansible.module_utils.connection import Connection
 from ansible.plugins.action.normal import ActionModule as _ActionModule
 from ansible.module_utils.network.common.utils import load_provider
 from ansible.module_utils.network.dellos9.dellos9 import dellos9_provider_spec
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
+from ansible.utils.display import display
 
 
 class ActionModule(_ActionModule):

--- a/lib/ansible/plugins/action/enos.py
+++ b/lib/ansible/plugins/action/enos.py
@@ -26,13 +26,7 @@ from ansible.module_utils.network.enos.enos import enos_provider_spec
 from ansible.module_utils.network.common.utils import load_provider
 from ansible.module_utils.connection import Connection
 from ansible.module_utils._text import to_text
-
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
+from ansible.utils.display import display
 
 
 class ActionModule(_ActionModule):

--- a/lib/ansible/plugins/action/eos.py
+++ b/lib/ansible/plugins/action/eos.py
@@ -28,12 +28,7 @@ from ansible.module_utils.connection import Connection
 from ansible.module_utils.network.eos.eos import eos_provider_spec
 from ansible.plugins.action.normal import ActionModule as _ActionModule
 from ansible.module_utils.network.common.utils import load_provider
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
+from ansible.utils.display import display
 
 
 class ActionModule(_ActionModule):

--- a/lib/ansible/plugins/action/fetch.py
+++ b/lib/ansible/plugins/action/fetch.py
@@ -25,14 +25,9 @@ from ansible.module_utils._text import to_bytes
 from ansible.module_utils.six import string_types
 from ansible.module_utils.parsing.convert_bool import boolean
 from ansible.plugins.action import ActionBase
+from ansible.utils.display import display
 from ansible.utils.hashing import checksum, checksum_s, md5, secure_hash
 from ansible.utils.path import makedirs_safe
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
 
 
 class ActionModule(ActionBase):

--- a/lib/ansible/plugins/action/ios.py
+++ b/lib/ansible/plugins/action/ios.py
@@ -28,12 +28,7 @@ from ansible.module_utils.connection import Connection
 from ansible.plugins.action.normal import ActionModule as _ActionModule
 from ansible.module_utils.network.common.utils import load_provider
 from ansible.module_utils.network.ios.ios import ios_provider_spec
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
+from ansible.utils.display import display
 
 
 class ActionModule(_ActionModule):

--- a/lib/ansible/plugins/action/iosxr.py
+++ b/lib/ansible/plugins/action/iosxr.py
@@ -28,12 +28,7 @@ from ansible.module_utils.connection import Connection
 from ansible.module_utils.network.iosxr.iosxr import iosxr_provider_spec
 from ansible.plugins.action.normal import ActionModule as _ActionModule
 from ansible.module_utils.network.common.utils import load_provider
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
+from ansible.utils.display import display
 
 
 class ActionModule(_ActionModule):

--- a/lib/ansible/plugins/action/ironware.py
+++ b/lib/ansible/plugins/action/ironware.py
@@ -29,12 +29,7 @@ from ansible.module_utils.connection import Connection
 from ansible.plugins.action.normal import ActionModule as _ActionModule
 from ansible.module_utils.network.common.utils import load_provider
 from ansible.module_utils.network.ironware.ironware import ironware_provider_spec
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
+from ansible.utils.display import display
 
 
 class ActionModule(_ActionModule):

--- a/lib/ansible/plugins/action/junos.py
+++ b/lib/ansible/plugins/action/junos.py
@@ -29,13 +29,8 @@ from ansible.module_utils.network.common.utils import load_provider
 from ansible.module_utils.network.junos.junos import junos_provider_spec
 from ansible.plugins.loader import connection_loader, module_loader
 from ansible.plugins.action.normal import ActionModule as _ActionModule
+from ansible.utils.display import display
 
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
 
 CLI_SUPPORTED_MODULES = ['junos_netconf', 'junos_command']
 

--- a/lib/ansible/plugins/action/net_base.py
+++ b/lib/ansible/plugins/action/net_base.py
@@ -28,14 +28,10 @@ from ansible.plugins.action import ActionBase
 from ansible.plugins.action.nxos import ActionModule as _NxosActionModule
 from ansible.plugins.action.eos import ActionModule as _EosActionModule
 from ansible.module_utils.network.common.utils import load_provider
+from ansible.utils.display import display
 
 from imp import find_module, load_module
 
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
 
 _CLI_ONLY_MODULES = frozenset(['junos_netconf', 'iosxr_netconf', 'iosxr_config', 'iosxr_command'])
 _NETCONF_SUPPORTED_PLATFORMS = frozenset(['junos', 'iosxr'])

--- a/lib/ansible/plugins/action/net_get.py
+++ b/lib/ansible/plugins/action/net_get.py
@@ -27,12 +27,7 @@ from ansible.module_utils.connection import Connection
 from ansible.errors import AnsibleError
 from ansible.plugins.action import ActionBase
 from ansible.module_utils.six.moves.urllib.parse import urlsplit
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
+from ansible.utils.display import display
 
 
 class ActionModule(ActionBase):

--- a/lib/ansible/plugins/action/net_put.py
+++ b/lib/ansible/plugins/action/net_put.py
@@ -27,12 +27,7 @@ from ansible.module_utils.connection import Connection
 from ansible.errors import AnsibleError
 from ansible.plugins.action import ActionBase
 from ansible.module_utils.six.moves.urllib.parse import urlsplit
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
+from ansible.utils.display import display
 
 
 class ActionModule(ActionBase):

--- a/lib/ansible/plugins/action/nxos.py
+++ b/lib/ansible/plugins/action/nxos.py
@@ -28,12 +28,7 @@ from ansible.module_utils.connection import Connection
 from ansible.plugins.action.normal import ActionModule as _ActionModule
 from ansible.module_utils.network.common.utils import load_provider
 from ansible.module_utils.network.nxos.nxos import nxos_provider_spec
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
+from ansible.utils.display import display
 
 
 class ActionModule(_ActionModule):

--- a/lib/ansible/plugins/action/package.py
+++ b/lib/ansible/plugins/action/package.py
@@ -19,12 +19,7 @@ __metaclass__ = type
 
 from ansible.errors import AnsibleAction, AnsibleActionFail
 from ansible.plugins.action import ActionBase
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
+from ansible.utils.display import display
 
 
 class ActionModule(ActionBase):

--- a/lib/ansible/plugins/action/pause.py
+++ b/lib/ansible/plugins/action/pause.py
@@ -30,12 +30,7 @@ from ansible.module_utils._text import to_text, to_native
 from ansible.module_utils.parsing.convert_bool import boolean
 from ansible.module_utils.six import PY3
 from ansible.plugins.action import ActionBase
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
+from ansible.utils.display import display
 
 try:
     import curses

--- a/lib/ansible/plugins/action/sros.py
+++ b/lib/ansible/plugins/action/sros.py
@@ -26,12 +26,7 @@ from ansible import constants as C
 from ansible.plugins.action.normal import ActionModule as _ActionModule
 from ansible.module_utils.network.sros.sros import sros_provider_spec
 from ansible.module_utils.network.common.utils import load_provider
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
+from ansible.utils.display import display
 
 
 class ActionModule(_ActionModule):

--- a/lib/ansible/plugins/action/vyos.py
+++ b/lib/ansible/plugins/action/vyos.py
@@ -28,12 +28,7 @@ from ansible.module_utils._text import to_text
 from ansible.module_utils.connection import Connection
 from ansible.module_utils.network.common.utils import load_provider
 from ansible.module_utils.network.vyos.vyos import vyos_provider_spec
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
+from ansible.utils.display import display
 
 
 class ActionModule(_ActionModule):

--- a/lib/ansible/plugins/action/wait_for_connection.py
+++ b/lib/ansible/plugins/action/wait_for_connection.py
@@ -23,12 +23,7 @@ import time
 from datetime import datetime, timedelta
 
 from ansible.plugins.action import ActionBase
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
+from ansible.utils.display import display
 
 
 class TimedOutException(Exception):

--- a/lib/ansible/plugins/action/win_reboot.py
+++ b/lib/ansible/plugins/action/win_reboot.py
@@ -11,12 +11,7 @@ from datetime import datetime, timedelta
 from ansible.errors import AnsibleError
 from ansible.plugins.action import ActionBase
 from ansible.module_utils._text import to_native
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
+from ansible.utils.display import display
 
 
 class TimedOutException(Exception):

--- a/lib/ansible/plugins/action/win_updates.py
+++ b/lib/ansible/plugins/action/win_updates.py
@@ -8,12 +8,7 @@ from ansible.module_utils._text import to_text
 from ansible.module_utils.parsing.convert_bool import boolean
 from ansible.parsing.yaml.objects import AnsibleUnicode
 from ansible.plugins.action import ActionBase
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
+from ansible.utils.display import display
 
 
 class ActionModule(ActionBase):

--- a/lib/ansible/plugins/cache/__init__.py
+++ b/lib/ansible/plugins/cache/__init__.py
@@ -28,12 +28,7 @@ from ansible.errors import AnsibleError
 from ansible.module_utils.six import with_metaclass
 from ansible.module_utils._text import to_bytes
 from ansible.plugins.loader import cache_loader
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
+from ansible.utils.display import display
 
 
 class BaseCacheModule(with_metaclass(ABCMeta, object)):

--- a/lib/ansible/plugins/callback/__init__.py
+++ b/lib/ansible/plugins/callback/__init__.py
@@ -31,12 +31,8 @@ from ansible.plugins import AnsiblePlugin, get_plugin_class
 from ansible.module_utils._text import to_text
 from ansible.utils.color import stringc
 from ansible.vars.clean import strip_internal_keys
+from ansible.utils.display import display as global_display
 
-try:
-    from __main__ import display as global_display
-except ImportError:
-    from ansible.utils.display import Display
-    global_display = Display()
 
 try:
     from __main__ import cli

--- a/lib/ansible/plugins/callback/dense.py
+++ b/lib/ansible/plugins/callback/dense.py
@@ -32,12 +32,7 @@ except ImportError:
 from ansible.module_utils.six import binary_type, text_type
 from ansible.plugins.callback.default import CallbackModule as CallbackModule_default
 from ansible.utils.color import colorize, hostcolor
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
+from ansible.utils.display import display
 
 import sys
 

--- a/lib/ansible/plugins/cliconf/__init__.py
+++ b/lib/ansible/plugins/cliconf/__init__.py
@@ -27,18 +27,13 @@ from functools import wraps
 from ansible.errors import AnsibleError, AnsibleConnectionFailure
 from ansible.module_utils._text import to_bytes, to_text
 from ansible.module_utils.six import with_metaclass
+from ansible.utils.display import display
 
 try:
     from scp import SCPClient
     HAS_SCP = True
 except ImportError:
     HAS_SCP = False
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
 
 
 def enable_mode(func):

--- a/lib/ansible/plugins/connection/__init__.py
+++ b/lib/ansible/plugins/connection/__init__.py
@@ -18,12 +18,7 @@ from ansible.module_utils.six import string_types
 from ansible.module_utils._text import to_bytes, to_text
 from ansible.plugins import AnsiblePlugin
 from ansible.plugins.loader import shell_loader
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
+from ansible.utils.display import display
 
 
 __all__ = ['ConnectionBase', 'ensure_connect']

--- a/lib/ansible/plugins/connection/buildah.py
+++ b/lib/ansible/plugins/connection/buildah.py
@@ -49,13 +49,7 @@ import subprocess
 import ansible.constants as C
 from ansible.module_utils._text import to_bytes, to_native
 from ansible.plugins.connection import ConnectionBase, ensure_connect
-
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
+from ansible.utils.display import display
 
 
 # this _has to be_ named Connection

--- a/lib/ansible/plugins/connection/chroot.py
+++ b/lib/ansible/plugins/connection/chroot.py
@@ -46,13 +46,7 @@ from ansible.module_utils.basic import is_executable
 from ansible.module_utils.six.moves import shlex_quote
 from ansible.module_utils._text import to_bytes
 from ansible.plugins.connection import ConnectionBase, BUFSIZE
-
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
+from ansible.utils.display import display
 
 
 class Connection(ConnectionBase):

--- a/lib/ansible/plugins/connection/docker.py
+++ b/lib/ansible/plugins/connection/docker.py
@@ -52,13 +52,7 @@ from ansible.errors import AnsibleError, AnsibleFileNotFound
 from ansible.module_utils.six.moves import shlex_quote
 from ansible.module_utils._text import to_bytes, to_native, to_text
 from ansible.plugins.connection import ConnectionBase, BUFSIZE
-
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
+from ansible.utils.display import display
 
 
 class Connection(ConnectionBase):

--- a/lib/ansible/plugins/connection/funcd.py
+++ b/lib/ansible/plugins/connection/funcd.py
@@ -38,12 +38,7 @@ import tempfile
 import shutil
 
 from ansible.errors import AnsibleError
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
+from ansible.utils.display import display
 
 
 class Connection(object):

--- a/lib/ansible/plugins/connection/iocage.py
+++ b/lib/ansible/plugins/connection/iocage.py
@@ -35,12 +35,7 @@ import subprocess
 from ansible.plugins.connection.jail import Connection as Jail
 
 from ansible.errors import AnsibleError
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
+from ansible.utils.display import display
 
 
 class Connection(Jail):

--- a/lib/ansible/plugins/connection/jail.py
+++ b/lib/ansible/plugins/connection/jail.py
@@ -42,12 +42,7 @@ from ansible.errors import AnsibleError
 from ansible.module_utils.six.moves import shlex_quote
 from ansible.module_utils._text import to_bytes, to_native, to_text
 from ansible.plugins.connection import ConnectionBase, BUFSIZE
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
+from ansible.utils.display import display
 
 
 class Connection(ConnectionBase):

--- a/lib/ansible/plugins/connection/kubectl.py
+++ b/lib/ansible/plugins/connection/kubectl.py
@@ -167,13 +167,7 @@ from ansible.errors import AnsibleError, AnsibleFileNotFound
 from ansible.module_utils.six.moves import shlex_quote
 from ansible.module_utils._text import to_bytes
 from ansible.plugins.connection import ConnectionBase, BUFSIZE
-
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
+from ansible.utils.display import display
 
 
 CONNECTION_TRANSPORT = 'kubectl'

--- a/lib/ansible/plugins/connection/libvirt_lxc.py
+++ b/lib/ansible/plugins/connection/libvirt_lxc.py
@@ -36,13 +36,7 @@ from ansible.errors import AnsibleError
 from ansible.module_utils.six.moves import shlex_quote
 from ansible.module_utils._text import to_bytes
 from ansible.plugins.connection import ConnectionBase, BUFSIZE
-
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
+from ansible.utils.display import display
 
 
 class Connection(ConnectionBase):

--- a/lib/ansible/plugins/connection/local.py
+++ b/lib/ansible/plugins/connection/local.py
@@ -41,13 +41,7 @@ from ansible.errors import AnsibleError, AnsibleFileNotFound
 from ansible.module_utils.six import text_type, binary_type
 from ansible.module_utils._text import to_bytes, to_native, to_text
 from ansible.plugins.connection import ConnectionBase
-
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
+from ansible.utils.display import display
 
 
 class Connection(ConnectionBase):

--- a/lib/ansible/plugins/connection/netconf.py
+++ b/lib/ansible/plugins/connection/netconf.py
@@ -140,6 +140,7 @@ from ansible.module_utils.parsing.convert_bool import BOOLEANS_TRUE
 from ansible.plugins.loader import netconf_loader
 from ansible.plugins.connection import ConnectionBase, ensure_connect
 from ansible.plugins.connection.local import Connection as LocalConnection
+from ansible.utils.display import display
 
 try:
     from ncclient import manager
@@ -149,11 +150,6 @@ try:
 except ImportError:
     raise AnsibleError("ncclient is not installed")
 
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
 
 logging.getLogger('ncclient').setLevel(logging.INFO)
 

--- a/lib/ansible/plugins/connection/network_cli.py
+++ b/lib/ansible/plugins/connection/network_cli.py
@@ -174,12 +174,7 @@ from ansible.playbook.play_context import PlayContext
 from ansible.plugins.loader import cliconf_loader, terminal_loader, connection_loader
 from ansible.plugins.connection import ConnectionBase
 from ansible.utils.path import unfrackpath
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
+from ansible.utils.display import display
 
 
 class Connection(ConnectionBase):

--- a/lib/ansible/plugins/connection/paramiko_ssh.py
+++ b/lib/ansible/plugins/connection/paramiko_ssh.py
@@ -146,12 +146,7 @@ from ansible.module_utils.six.moves import input
 from ansible.plugins.connection import ConnectionBase
 from ansible.utils.path import makedirs_safe
 from ansible.module_utils._text import to_bytes, to_native
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
+from ansible.utils.display import display
 
 
 AUTHENTICITY_MSG = """

--- a/lib/ansible/plugins/connection/persistent.py
+++ b/lib/ansible/plugins/connection/persistent.py
@@ -39,12 +39,7 @@ from ansible.module_utils._text import to_text
 from ansible.module_utils.six.moves import cPickle
 from ansible.module_utils.connection import Connection as SocketConnection
 from ansible.errors import AnsibleError
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
+from ansible.utils.display import display
 
 
 class Connection(ConnectionBase):

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -228,13 +228,8 @@ from ansible.module_utils.six.moves import shlex_quote
 from ansible.module_utils._text import to_bytes, to_native, to_text
 from ansible.module_utils.parsing.convert_bool import BOOLEANS, boolean
 from ansible.plugins.connection import ConnectionBase, BUFSIZE
+from ansible.utils.display import display
 from ansible.utils.path import unfrackpath, makedirs_safe
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
 
 
 SSHPASS_AVAILABLE = None

--- a/lib/ansible/plugins/connection/winrm.py
+++ b/lib/ansible/plugins/connection/winrm.py
@@ -121,6 +121,7 @@ from ansible.module_utils._text import to_bytes, to_native, to_text
 from ansible.module_utils.six import binary_type
 from ansible.plugins.connection import ConnectionBase
 from ansible.plugins.shell.powershell import leaf_exec
+from ansible.utils.display import display
 from ansible.utils.hashing import secure_hash
 from ansible.utils.path import makedirs_safe
 
@@ -152,12 +153,6 @@ try:
     HAS_IPADDRESS = True
 except ImportError:
     HAS_IPADDRESS = False
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
 
 
 class Connection(ConnectionBase):

--- a/lib/ansible/plugins/connection/zone.py
+++ b/lib/ansible/plugins/connection/zone.py
@@ -37,13 +37,7 @@ from ansible.errors import AnsibleError
 from ansible.module_utils.six.moves import shlex_quote
 from ansible.module_utils._text import to_bytes
 from ansible.plugins.connection import ConnectionBase, BUFSIZE
-
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
+from ansible.utils.display import display
 
 
 class Connection(ConnectionBase):

--- a/lib/ansible/plugins/filter/network.py
+++ b/lib/ansible/plugins/filter/network.py
@@ -30,6 +30,7 @@ from xml.etree.ElementTree import fromstring
 from ansible.module_utils.network.common.utils import Template
 from ansible.module_utils.six import iteritems, string_types
 from ansible.errors import AnsibleError
+from ansible.utils.display import display
 
 try:
     import yaml
@@ -42,13 +43,6 @@ try:
     HAS_TEXTFSM = True
 except ImportError:
     HAS_TEXTFSM = False
-
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
 
 
 def re_matchall(regex, value):

--- a/lib/ansible/plugins/inventory/__init__.py
+++ b/lib/ansible/plugins/inventory/__init__.py
@@ -33,12 +33,8 @@ from ansible.module_utils._text import to_bytes, to_native
 from ansible.module_utils.parsing.convert_bool import boolean
 from ansible.module_utils.six import string_types
 from ansible.template import Templar
+from ansible.utils.display import display
 
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
 
 _SAFE_GROUP = re.compile("[^A-Za-z0-9_]")
 

--- a/lib/ansible/plugins/loader.py
+++ b/lib/ansible/plugins/loader.py
@@ -21,13 +21,8 @@ from ansible.errors import AnsibleError
 from ansible.module_utils._text import to_text
 from ansible.parsing.utils.yaml import from_yaml
 from ansible.plugins import get_plugin_class, MODULE_CACHE, PATH_CACHE, PLUGIN_PATH_CACHE
+from ansible.utils.display import display
 from ansible.utils.plugin_docs import get_docstring
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
 
 
 def get_all_plugin_loaders():

--- a/lib/ansible/plugins/lookup/__init__.py
+++ b/lib/ansible/plugins/lookup/__init__.py
@@ -23,12 +23,8 @@ from abc import abstractmethod
 
 from ansible.errors import AnsibleFileNotFound
 from ansible.plugins import AnsiblePlugin
+from ansible.utils.display import display
 
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
 
 __all__ = ['LookupBase']
 

--- a/lib/ansible/plugins/lookup/aws_ssm.py
+++ b/lib/ansible/plugins/lookup/aws_ssm.py
@@ -103,12 +103,8 @@ from ansible.module_utils._text import to_native
 from ansible.module_utils.ec2 import HAS_BOTO3, boto3_tag_list_to_ansible_dict
 from ansible.errors import AnsibleError
 from ansible.plugins.lookup import LookupBase
+from ansible.utils.display import display
 
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
 
 try:
     from botocore.exceptions import ClientError

--- a/lib/ansible/plugins/lookup/conjur_variable.py
+++ b/lib/ansible/plugins/lookup/conjur_variable.py
@@ -60,17 +60,11 @@ from base64 import b64encode
 from netrc import netrc
 from os import environ
 from time import time
-from ansible.module_utils.six.moves.urllib.parse import quote_plus
 import yaml
 
+from ansible.module_utils.six.moves.urllib.parse import quote_plus
 from ansible.module_utils.urls import open_url
-
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
+from ansible.utils.display import display
 
 
 # Load configuration and return as dictionary if file is present on file system

--- a/lib/ansible/plugins/lookup/cyberarkpassword.py
+++ b/lib/ansible/plugins/lookup/cyberarkpassword.py
@@ -72,12 +72,8 @@ from ansible.errors import AnsibleError
 from ansible.plugins.lookup import LookupBase
 from ansible.parsing.splitter import parse_kv
 from ansible.module_utils._text import to_text
+from ansible.utils.display import display
 
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
 
 CLIPASSWORDSDK_CMD = os.getenv('AIM_CLIPASSWORDSDK_CMD', '/opt/CARKaim/sdk/clipasswordsdk')
 

--- a/lib/ansible/plugins/lookup/file.py
+++ b/lib/ansible/plugins/lookup/file.py
@@ -50,12 +50,7 @@ RETURN = """
 from ansible.errors import AnsibleError, AnsibleParserError
 from ansible.plugins.lookup import LookupBase
 from ansible.module_utils._text import to_text
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
+from ansible.utils.display import display
 
 
 class LookupModule(LookupBase):

--- a/lib/ansible/plugins/lookup/filetree.py
+++ b/lib/ansible/plugins/lookup/filetree.py
@@ -99,12 +99,7 @@ except ImportError:
 
 from ansible.plugins.lookup import LookupBase
 from ansible.module_utils._text import to_native, to_text
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
+from ansible.utils.display import display
 
 
 # If selinux fails to find a default, return an array of None

--- a/lib/ansible/plugins/lookup/keyring.py
+++ b/lib/ansible/plugins/lookup/keyring.py
@@ -36,20 +36,13 @@ RETURN = """
 HAS_KEYRING = True
 
 from ansible.errors import AnsibleError
+from ansible.utils.display import display
+from ansible.plugins.lookup import LookupBase
 
 try:
     import keyring
 except ImportError:
     HAS_KEYRING = False
-
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
-
-from ansible.plugins.lookup import LookupBase
 
 
 class LookupModule(LookupBase):

--- a/lib/ansible/plugins/lookup/template.py
+++ b/lib/ansible/plugins/lookup/template.py
@@ -35,12 +35,7 @@ from ansible.errors import AnsibleError
 from ansible.plugins.lookup import LookupBase
 from ansible.module_utils._text import to_bytes, to_text
 from ansible.template import generate_ansible_template_vars
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
+from ansible.utils.display import display
 
 
 class LookupModule(LookupBase):

--- a/lib/ansible/plugins/lookup/url.py
+++ b/lib/ansible/plugins/lookup/url.py
@@ -47,12 +47,7 @@ from ansible.module_utils.six.moves.urllib.error import HTTPError, URLError
 from ansible.module_utils._text import to_text
 from ansible.module_utils.urls import open_url, ConnectionError, SSLValidationError
 from ansible.plugins.lookup import LookupBase
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
+from ansible.utils.display import display
 
 
 class LookupModule(LookupBase):

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -47,15 +47,10 @@ from ansible.playbook.task_include import TaskInclude
 from ansible.playbook.role_include import IncludeRole
 from ansible.plugins.loader import action_loader, connection_loader, filter_loader, lookup_loader, module_loader, test_loader
 from ansible.template import Templar
+from ansible.utils.display import display
 from ansible.utils.vars import combine_vars
 from ansible.vars.clean import strip_internal_keys
 
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
 
 __all__ = ['StrategyBase']
 

--- a/lib/ansible/plugins/strategy/free.py
+++ b/lib/ansible/plugins/strategy/free.py
@@ -38,13 +38,7 @@ from ansible.plugins.loader import action_loader
 from ansible.plugins.strategy import StrategyBase
 from ansible.template import Templar
 from ansible.module_utils._text import to_text
-
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
+from ansible.utils.display import display
 
 
 class StrategyModule(StrategyBase):

--- a/lib/ansible/plugins/strategy/linear.py
+++ b/lib/ansible/plugins/strategy/linear.py
@@ -41,13 +41,7 @@ from ansible.playbook.task import Task
 from ansible.plugins.loader import action_loader
 from ansible.plugins.strategy import StrategyBase
 from ansible.template import Templar
-
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
+from ansible.utils.display import display
 
 
 class StrategyModule(StrategyBase):

--- a/lib/ansible/plugins/terminal/junos.py
+++ b/lib/ansible/plugins/terminal/junos.py
@@ -24,13 +24,7 @@ import re
 
 from ansible.plugins.terminal import TerminalBase
 from ansible.errors import AnsibleConnectionFailure
-
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
+from ansible.utils.display import display
 
 
 class TerminalModule(TerminalBase):

--- a/lib/ansible/plugins/vars/__init__.py
+++ b/lib/ansible/plugins/vars/__init__.py
@@ -18,13 +18,8 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+from ansible.utils.display import display
 from ansible.utils.path import basedir
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
 
 
 class BaseVarsPlugin(object):

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -51,13 +51,8 @@ from ansible.plugins.loader import filter_loader, lookup_loader, test_loader
 from ansible.template.safe_eval import safe_eval
 from ansible.template.template import AnsibleJ2Template
 from ansible.template.vars import AnsibleJ2Vars
+from ansible.utils.display import display
 from ansible.utils.unsafe_proxy import UnsafeProxy, wrap_var
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
 
 
 __all__ = ['Templar', 'generate_ansible_template_vars']

--- a/lib/ansible/utils/display.py
+++ b/lib/ansible/utils/display.py
@@ -359,3 +359,8 @@ class Display:
         else:
             tty_size = 0
         self.columns = max(79, tty_size - 1)
+
+
+#: One Display instance exists. Its :attr:`verbosity` may be changed by
+#: ansible.cli modules during startup.
+display = Display()

--- a/lib/ansible/utils/encrypt.py
+++ b/lib/ansible/utils/encrypt.py
@@ -11,6 +11,7 @@ from ansible import constants as C
 from ansible.errors import AnsibleError, AnsibleAssertionError
 from ansible.module_utils.six import text_type
 from ansible.module_utils._text import to_text, to_bytes
+from ansible.utils.display import display
 
 
 PASSLIB_AVAILABLE = False
@@ -19,12 +20,6 @@ try:
     PASSLIB_AVAILABLE = True
 except:
     pass
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
 
 __all__ = ['do_encrypt']
 

--- a/lib/ansible/utils/jsonrpc.py
+++ b/lib/ansible/utils/jsonrpc.py
@@ -9,13 +9,7 @@ import traceback
 
 from ansible.module_utils._text import to_text
 from ansible.module_utils.six import binary_type
-
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
+from ansible.utils.display import display
 
 
 class JsonRpcServer(object):

--- a/lib/ansible/utils/plugin_docs.py
+++ b/lib/ansible/utils/plugin_docs.py
@@ -27,12 +27,7 @@ from ansible.module_utils.six import string_types
 from ansible.module_utils._text import to_native
 from ansible.parsing.plugin_docs import read_docstring
 from ansible.parsing.yaml.loader import AnsibleLoader
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
+from ansible.utils.display import display
 
 
 # modules that are ok that they do not have documentation strings

--- a/lib/ansible/vars/clean.py
+++ b/lib/ansible/vars/clean.py
@@ -14,12 +14,7 @@ from ansible import constants as C
 from ansible.module_utils._text import to_text
 from ansible.module_utils.six import string_types
 from ansible.plugins.loader import connection_loader
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
+from ansible.utils.display import display
 
 
 def strip_internal_keys(dirty, exceptions=None):

--- a/lib/ansible/vars/manager.py
+++ b/lib/ansible/vars/manager.py
@@ -44,12 +44,7 @@ from ansible.utils.listify import listify_lookup_plugin_terms
 from ansible.utils.vars import combine_vars
 from ansible.utils.unsafe_proxy import wrap_var
 from ansible.vars.clean import namespace_facts
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
+from ansible.utils.display import display
 
 
 def preprocess_vars(a):

--- a/lib/ansible/vars/reserved.py
+++ b/lib/ansible/vars/reserved.py
@@ -23,12 +23,7 @@ from ansible.playbook import Play
 from ansible.playbook.block import Block
 from ansible.playbook.role import Role
 from ansible.playbook.task import Task
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
+from ansible.utils.display import display
 
 
 def get_reserved_names(include_private=True):

--- a/lib/ansible/vars/unsafe_proxy.py
+++ b/lib/ansible/vars/unsafe_proxy.py
@@ -21,11 +21,7 @@ __metaclass__ = type
 
 # This is backwards compat.  unsafe_proxy was moved to avoid circular imports.
 from ansible.utils.unsafe_proxy import *  # pylint: disable=wildcard-import,unused-wildcard-import
+from ansible.utils.display import display
 
-try:
-    from __main__ import display
-except:
-    from ansible.utils.display import Display
-    display = Display()
 
 display.deprecated('ansible.vars.unsafe_proxy is deprecated.  Use ansible.utils.unsafe_proxy instead.', version='2.8')


### PR DESCRIPTION

##### SUMMARY

````
Construct one Display instance in a single location and import it
everywhere as a regular Python import, rather than cutpasted gunk that
serves no purpose.

Existing third-party code using the __main__/import dance will still
function, presumably in every case they'll still get exactly the same
Display instance as before, i.e. the one from __main__, but now
imported from a.u.display.
````

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

All

##### ANSIBLE VERSION

origin/devel


##### ADDITIONAL INFORMATION

