### PR TITLE
win_environment: Added explicit check for null, empty string with state=present (#40468)

### DIFF
--- a/changelogs/fragments/win_environment-do-not-delete-on-null.yaml
+++ b/changelogs/fragments/win_environment-do-not-delete-on-null.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_environment - Fix for issue where the environment value was deleted when a null value or empty string was set - https://github.com/ansible/ansible/issues/40450

--- a/lib/ansible/modules/windows/win_environment.ps1
+++ b/lib/ansible/modules/windows/win_environment.ps1
@@ -28,6 +28,8 @@ $result = @{
 if ($state -eq "absent" -and $value) {
     Add-Warning -obj $result -message "When removing environment variable '$name' it should not have a value '$value' set"
     $value = $null
+} elseif ($state -eq "present" -and (-not $value)) {
+    Fail-Json -obj $result -message "When state=present, value must be defined and not an empty string, if you wish to remove the envvar, set state=absent"
 }
 
 if ($state -eq "present" -and $before_value -ne $value) {

--- a/lib/ansible/modules/windows/win_environment.py
+++ b/lib/ansible/modules/windows/win_environment.py
@@ -30,6 +30,7 @@ options:
   value:
     description:
     - The value to store in the environment variable.
+    - Must be set when C(state=present) and cannot be an empty string.
     - Can be omitted for C(state=absent).
   level:
     description:

--- a/test/integration/targets/win_environment/tasks/main.yml
+++ b/test/integration/targets/win_environment/tasks/main.yml
@@ -9,6 +9,23 @@
   - process
   - user
 
+- name: fail to create environment value with null value
+  win_environment:
+    name: "{{test_environment_name}}"
+    state: present
+    level: machine
+  register: create_fail_null
+  failed_when: create_fail_null.msg != "When state=present, value must be defined and not an empty string, if you wish to remove the envvar, set state=absent"
+
+- name: fail to create environment value with empty value
+  win_environment:
+    name: "{{test_environment_name}}"
+    value: ''
+    state: present
+    level: machine
+  register: create_fail_empty_string
+  failed_when: create_fail_null.msg != "When state=present, value must be defined and not an empty string, if you wish to remove the envvar, set state=absent"
+
 - name: create test environment value for machine check
   win_environment:
     name: "{{test_environment_name}}"


### PR DESCRIPTION
(cherry picked from commit db195831fda8f644f8e4b3085d19102e7d3586ea)

##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/40468

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
win_environment

##### ANSIBLE VERSION
```
2.5
```