### PR TITLE
Remove tab check from validate-modules.

### DIFF
--- a/docs/docsite/rst/dev_guide/testing_validate-modules.rst
+++ b/docs/docsite/rst/dev_guide/testing_validate-modules.rst
@@ -121,7 +121,6 @@ Errors
 ---------   -------------------
   **4xx**   **Syntax**
   401       Python ``SyntaxError`` while parsing module
-  402       Indentation contains tabs
   403       Type comparison using ``type()`` found. Use ``isinstance()`` instead
   ..
 ---------   -------------------

--- a/test/sanity/validate-modules/main.py
+++ b/test/sanity/validate-modules/main.py
@@ -396,19 +396,6 @@ class ModuleValidator(Validator):
                         'https://docs.ansible.com/ansible/devel/dev_guide/developing_modules_documenting.html#copyright'
                 )
 
-    def _check_for_tabs(self):
-        for line_no, line in enumerate(self.text.splitlines()):
-            indent = INDENT_REGEX.search(line)
-            if indent and '\t' in line:
-                index = line.index('\t')
-                self.reporter.error(
-                    path=self.object_path,
-                    code=402,
-                    msg='indentation contains tabs',
-                    line=line_no + 1,
-                    column=index
-                )
-
     def _find_blacklist_imports(self):
         for child in self.ast.body:
             names = []
@@ -1358,7 +1345,6 @@ class ModuleValidator(Validator):
             main = self._find_main_call()
             self._find_module_utils(main)
             self._find_has_import()
-            self._check_for_tabs()
             first_callable = self._get_first_callable()
             self._ensure_imports_below_docs(doc_info, first_callable)
 


### PR DESCRIPTION
##### SUMMARY

Remove tab check from validate-modules.

It is redundant with the pycodestyle W191 "indentation contains tabs" check.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

module validator

##### ANSIBLE VERSION

```
ansible 2.6.0 (no-tab-check 31e7820451) last updated 2018/05/21 13:54:52 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
