### PR TITLE
Feature: Add include option to unarchive

### DIFF
--- a/changelogs/fragments/40522-unarchive-add-include.yml
+++ b/changelogs/fragments/40522-unarchive-add-include.yml
@@ -1,0 +1,4 @@
+minor_changes:
+  - >
+    unarchive - add ``include`` parameter to allow extracting specific files
+    from an archive (https://github.com/ansible/ansible/pull/40522)

--- a/lib/ansible/modules/unarchive.py
+++ b/lib/ansible/modules/unarchive.py
@@ -61,6 +61,10 @@ options:
     type: list
     elements: str
     version_added: "2.1"
+  include:
+    description:
+      - List of file entries that you would like to extract from the archive.
+    version_added: "2.7"
   keep_newer:
     description:
       - Do not replace existing files that are newer than files from the archive.
@@ -264,6 +268,7 @@ class ZipArchive(object):
         self.module = module
         self.excludes = module.params['exclude']
         self.includes = []
+        self.include_files = self.module.params['include']
         self.cmd_path = self.module.get_bin_path('unzip')
         self.zipinfocmd_path = self.module.get_bin_path('zipinfo')
         self._files_in_archive = []
@@ -337,14 +342,18 @@ class ZipArchive(object):
         else:
             try:
                 for member in archive.namelist():
-                    exclude_flag = False
-                    if self.excludes:
-                        for exclude in self.excludes:
-                            if fnmatch.fnmatch(member, exclude):
-                                exclude_flag = True
+                    if self.include_files:
+                        if member in self.include_files:
+                            self._files_in_archive.append(to_native(member))
+                    else:
+                        exclude_flag = False
+                        if self.excludes:
+                            for exclude in self.excludes:
+                                if not fnmatch.fnmatch(member, exclude):
+                                    self._files_in_archive.append(to_native(member))
                                 break
-                    if not exclude_flag:
-                        self._files_in_archive.append(to_native(member))
+                        if not exclude_flag:
+                            self._files_in_archive.append(to_native(member))
             except Exception:
                 archive.close()
                 raise UnarchiveError('Unable to list files in the archive')
@@ -357,6 +366,8 @@ class ZipArchive(object):
         cmd = [self.zipinfocmd_path, '-T', '-s', self.src]
         if self.excludes:
             cmd.extend(['-x', ] + self.excludes)
+        if self.include_files:
+            cmd.extend(self.include_files)
         rc, out, err = self.module.run_command(cmd)
 
         old_out = out
@@ -665,6 +676,8 @@ class ZipArchive(object):
         # cmd.extend(map(shell_escape, self.includes))
         if self.excludes:
             cmd.extend(['-x'] + self.excludes)
+        if self.include_files:
+            cmd.extend(self.include_files)
         cmd.extend(['-d', self.b_dest])
         rc, out, err = self.module.run_command(cmd)
         return dict(cmd=cmd, rc=rc, out=out, err=err)
@@ -690,6 +703,7 @@ class TgzArchive(object):
         if self.module.check_mode:
             self.module.exit_json(skipped=True, msg="remote module (%s) does not support check mode when using gtar" % self.module._name)
         self.excludes = [path.rstrip('/') for path in self.module.params['exclude']]
+        self.include_files = self.module.params['include']
         # Prefer gtar (GNU tar) as it supports the compression options -z, -j and -J
         self.cmd_path = self.module.get_bin_path('gtar', None)
         if not self.cmd_path:
@@ -697,7 +711,6 @@ class TgzArchive(object):
             self.cmd_path = self.module.get_bin_path('tar')
         self.zipflag = '-z'
         self._files_in_archive = []
-
         if self.cmd_path:
             self.tar_type = self._get_tar_type()
         else:
@@ -726,8 +739,10 @@ class TgzArchive(object):
         if self.excludes:
             cmd.extend(['--exclude=' + f for f in self.excludes])
         cmd.extend(['-f', self.src])
-        rc, out, err = self.module.run_command(cmd, cwd=self.b_dest, environ_update=dict(LANG='C', LC_ALL='C', LC_MESSAGES='C'))
+        if self.include_files:
+            cmd.extend(self.include_files)
 
+        rc, out, err = self.module.run_command(cmd, cwd=self.dest, environ_update=dict(LANG='C', LC_ALL='C', LC_MESSAGES='C'))
         if rc != 0:
             raise UnarchiveError('Unable to list files in the archive')
 
@@ -769,6 +784,8 @@ class TgzArchive(object):
         if self.excludes:
             cmd.extend(['--exclude=' + f for f in self.excludes])
         cmd.extend(['-f', self.src])
+        if self.include_files:
+            cmd.extend(self.include_files)
         rc, out, err = self.module.run_command(cmd, cwd=self.b_dest, environ_update=dict(LANG='C', LC_ALL='C', LC_MESSAGES='C'))
 
         # Check whether the differences are in something that we're
@@ -820,6 +837,8 @@ class TgzArchive(object):
         if self.excludes:
             cmd.extend(['--exclude=' + f for f in self.excludes])
         cmd.extend(['-f', self.src])
+        if self.include_files:
+            cmd.extend(self.include_files)
         rc, out, err = self.module.run_command(cmd, cwd=self.b_dest, environ_update=dict(LANG='C', LC_ALL='C', LC_MESSAGES='C'))
         return dict(cmd=cmd, rc=rc, out=out, err=err)
 
@@ -887,6 +906,7 @@ def main():
             list_files=dict(type='bool', default=False),
             keep_newer=dict(type='bool', default=False),
             exclude=dict(type='list', elements='str', default=[]),
+            include=dict(type='list', default=[]),
             extra_opts=dict(type='list', elements='str', default=[]),
             validate_certs=dict(type='bool', default=True),
         ),

--- a/lib/ansible/modules/unarchive.py
+++ b/lib/ansible/modules/unarchive.py
@@ -58,13 +58,18 @@ options:
   exclude:
     description:
       - List the directory and file entries that you would like to exclude from the unarchive action.
+      - Mutually exclusive with C(include).
     type: list
+    default: []
     elements: str
     version_added: "2.1"
   include:
     description:
-      - List of file entries that you would like to extract from the archive.
+      - List of directory and file entries that you would like to extract from the archive. Only
+        files listed here will be extracted.
+      - Mutually exclusive with C(exclude).
     type: list
+    default: []
     elements: str
     version_added: "2.11"
   keep_newer:

--- a/lib/ansible/modules/unarchive.py
+++ b/lib/ansible/modules/unarchive.py
@@ -358,8 +358,8 @@ class ZipArchive(object):
                         if self.excludes:
                             for exclude in self.excludes:
                                 if not fnmatch.fnmatch(member, exclude):
-                                    self._files_in_archive.append(to_native(member))
-                                break
+                                    exclude_flag = True
+                                    break
                         if not exclude_flag:
                             self._files_in_archive.append(to_native(member))
             except Exception:

--- a/lib/ansible/modules/unarchive.py
+++ b/lib/ansible/modules/unarchive.py
@@ -64,6 +64,8 @@ options:
   include:
     description:
       - List of file entries that you would like to extract from the archive.
+    type: list
+    elements: str
     version_added: "2.11"
   keep_newer:
     description:
@@ -711,6 +713,7 @@ class TgzArchive(object):
             self.cmd_path = self.module.get_bin_path('tar')
         self.zipflag = '-z'
         self._files_in_archive = []
+
         if self.cmd_path:
             self.tar_type = self._get_tar_type()
         else:
@@ -906,7 +909,7 @@ def main():
             list_files=dict(type='bool', default=False),
             keep_newer=dict(type='bool', default=False),
             exclude=dict(type='list', elements='str', default=[]),
-            include=dict(type='list', default=[]),
+            include=dict(type='list', elements='str', default=[]),
             extra_opts=dict(type='list', elements='str', default=[]),
             validate_certs=dict(type='bool', default=True),
         ),

--- a/lib/ansible/modules/unarchive.py
+++ b/lib/ansible/modules/unarchive.py
@@ -913,6 +913,7 @@ def main():
         add_file_common_args=True,
         # check-mode only works for zip files, we cover that later
         supports_check_mode=True,
+        mutually_exclusive=[('include', 'exclude')],
     )
 
     src = module.params['src']

--- a/lib/ansible/modules/unarchive.py
+++ b/lib/ansible/modules/unarchive.py
@@ -350,8 +350,9 @@ class ZipArchive(object):
             try:
                 for member in archive.namelist():
                     if self.include_files:
-                        if member in self.include_files:
-                            self._files_in_archive.append(to_native(member))
+                        for include in self.include_files:
+                            if fnmatch.fnmatch(member, include):
+                                self._files_in_archive.append(to_native(member))
                     else:
                         exclude_flag = False
                         if self.excludes:

--- a/lib/ansible/modules/unarchive.py
+++ b/lib/ansible/modules/unarchive.py
@@ -64,7 +64,7 @@ options:
   include:
     description:
       - List of file entries that you would like to extract from the archive.
-    version_added: "2.7"
+    version_added: "2.11"
   keep_newer:
     description:
       - Do not replace existing files that are newer than files from the archive.
@@ -742,7 +742,7 @@ class TgzArchive(object):
         if self.include_files:
             cmd.extend(self.include_files)
 
-        rc, out, err = self.module.run_command(cmd, cwd=self.dest, environ_update=dict(LANG='C', LC_ALL='C', LC_MESSAGES='C'))
+        rc, out, err = self.module.run_command(cmd, cwd=self.b_dest, environ_update=dict(LANG='C', LC_ALL='C', LC_MESSAGES='C'))
         if rc != 0:
             raise UnarchiveError('Unable to list files in the archive')
 

--- a/test/integration/targets/unarchive/tasks/main.yml
+++ b/test/integration/targets/unarchive/tasks/main.yml
@@ -6,6 +6,7 @@
 - import_tasks: test_tar_gz_keep_newer.yml
 - import_tasks: test_zip.yml
 - import_tasks: test_exclude.yml
+- import_tasks: test_include.yml
 - import_tasks: test_parent_not_writeable.yml
 - import_tasks: test_mode.yml
 - import_tasks: test_quotable_characters.yml
@@ -14,4 +15,3 @@
 - import_tasks: test_symlink.yml
 - import_tasks: test_download.yml
 - import_tasks: test_unprivileged_user.yml
-- import_tasks: test_include.yml

--- a/test/integration/targets/unarchive/tasks/main.yml
+++ b/test/integration/targets/unarchive/tasks/main.yml
@@ -14,3 +14,4 @@
 - import_tasks: test_symlink.yml
 - import_tasks: test_download.yml
 - import_tasks: test_unprivileged_user.yml
+- import_tasks: test_include.yml

--- a/test/integration/targets/unarchive/tasks/prepare_tests.yml
+++ b/test/integration/targets/unarchive/tasks/prepare_tests.yml
@@ -89,4 +89,4 @@
     mode: preserve
 
 - name: prep a tar.gz file with directory
-  shell: tar czvf test-unarchive-dir.tar.gz unarchive-dir  chdir={{remote_tmp_dir}}
+  shell: tar czvf test-unarchive-dir.tar.gz unarchive-dir chdir={{remote_tmp_dir}}

--- a/test/integration/targets/unarchive/tasks/test_exclude.yml
+++ b/test/integration/targets/unarchive/tasks/test_exclude.yml
@@ -37,12 +37,3 @@
   file:
     path: '{{remote_tmp_dir}}/test-unarchive-zip'
     state: absent
-
-- name: remove our test files for the archive
-  file:
-    path: '{{remote_tmp_dir}}/{{item}}'
-    state: absent
-  with_items:
-    - foo-unarchive.txt
-    - foo-unarchive-777.txt
-    - FOO-UNAR.TXT

--- a/test/integration/targets/unarchive/tasks/test_include.yml
+++ b/test/integration/targets/unarchive/tasks/test_include.yml
@@ -1,0 +1,64 @@
+- name: Create a tar file with multiple files
+  shell: tar cvf test-unarchive-multi.tar foo-unarchive-777.txt foo-unarchive.txt
+  args:
+    chdir: "{{ remote_tmp_dir }}"
+
+- name: Create include test directories
+  file:
+    state: directory
+    path: "{{ remote_tmp_dir }}/{{ item }}"
+  loop:
+    - include-zip
+    - include-tar
+
+- name: Unpack zip file include one file
+  unarchive:
+    src: "{{ remote_tmp_dir }}/test-unarchive.zip"
+    dest: "{{ remote_tmp_dir }}/include-zip"
+    include:
+      - FOO-UNAR.TXT
+
+- name: Verify that single file was unarchived
+  find:
+    paths: "{{ remote_tmp_dir }}/include-zip"
+  register: unarchive_dir02
+
+- name: Verify that zip extraction included only one file
+  assert:
+    that:
+      - file_names == ['FOO-UNAR.TXT']
+  vars:
+    file_names: "{{ unarchive_dir02.files | map(attribute='path') | map('basename') }}"
+
+- name: Unpack tar file include one file
+  unarchive:
+    src: "{{ remote_tmp_dir }}/test-unarchive-multi.tar"
+    dest: "{{ remote_tmp_dir }}/include-tar"
+    include:
+      - foo-unarchive-777.txt
+
+- name: verify that single file was unarchived from tar
+  find:
+    paths: "{{ remote_tmp_dir }}/include-tar"
+  register: unarchive_dir03
+
+- name: Verify that tar extraction included only one file
+  assert:
+    that:
+      - file_names == ['foo-unarchive-777.txt']
+  vars:
+    file_names: "{{ unarchive_dir03.files | map(attribute='path') | map('basename') }}"
+
+- name: Check mutually exclusive parameters
+  assert:
+    that:
+      - unarchive_mutually_exclusive_check is failed
+      - "'mutually exclusive' in unarchive_mutually_exclusive_check.msg"
+
+- name: "Remove include feature tests directory"
+  file:
+    state: absent
+    path: "{{ remote_tmp_dir }}/{{ item }}"
+  loop:
+    - 'include-zip'
+    - 'include-tar'

--- a/test/integration/targets/unarchive/tasks/test_include.yml
+++ b/test/integration/targets/unarchive/tasks/test_include.yml
@@ -50,6 +50,17 @@
     file_names: "{{ unarchive_dir03.files | map(attribute='path') | map('basename') }}"
 
 - name: Check mutually exclusive parameters
+  unarchive:
+    src: "{{ remote_tmp_dir }}/test-unarchive-multi.tar"
+    dest: "{{ remote_tmp_dir }}/include-tar"
+    include:
+      - foo-unarchive-777.txt
+    exclude:
+      - foo
+  ignore_errors: yes
+  register: unarchive_mutually_exclusive_check
+
+- name: Check mutually exclusive parameters
   assert:
     that:
       - unarchive_mutually_exclusive_check is failed

--- a/test/integration/targets/unarchive/tasks/test_include.yml
+++ b/test/integration/targets/unarchive/tasks/test_include.yml
@@ -23,12 +23,17 @@
     paths: "{{ remote_tmp_dir }}/include-zip"
   register: unarchive_dir02
 
+# The map filter was added in Jinja2 2.7, which is newer than the version on RHEL/CentOS 6,
+# so we skip this validation on those hosts
 - name: Verify that zip extraction included only one file
   assert:
     that:
       - file_names == ['FOO-UNAR.TXT']
   vars:
     file_names: "{{ unarchive_dir02.files | map(attribute='path') | map('basename') }}"
+  when:
+    - "ansible_facts.os_family == 'RedHat'"
+    - ansible_facts.distribution_major_version is version('7', '>=')
 
 - name: Unpack tar file include one file
   unarchive:
@@ -48,6 +53,9 @@
       - file_names == ['foo-unarchive-777.txt']
   vars:
     file_names: "{{ unarchive_dir03.files | map(attribute='path') | map('basename') }}"
+  when:
+    - "ansible_facts.os_family == 'RedHat'"
+    - ansible_facts.distribution_major_version is version('7', '>=')
 
 - name: Check mutually exclusive parameters
   unarchive:


### PR DESCRIPTION
##### SUMMARY

This should allow users to extract specific files from an archive as desired.

Fixes #16130, #27081.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
unarchive

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0a1 (feature/unarchive/add_include_option 70f23af274) last updated 2018/05/22 01:18:14 (GMT -500)
  config file = /home/saviles/data/git/github/ansible/ansible.cfg
  configured module search path = ['/home/saviles/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/saviles/data/git/github/ansible/lib/ansible
  executable location = /home/saviles/data/git/github/ansible/bin/ansible
  python version = 3.6.5 (default, Mar 29 2018, 18:20:46) [GCC 8.0.1 20180317 (Red Hat 8.0.1-0.19)]

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

**Playbook**
```
- hosts: localhost
  vars:
    issue: 16130
    src_dir: "files/{{ issue }}"
    dst_dir: "/tmp/{{ issue }}"
  tasks:
    - name: Create directory
      file:
        state: directory
        path: "{{item}}"
      with_items:
        - "{{src_dir}}"
        - "{{dst_dir}}"
        - "{{dst_dir}}-tar"
    - name: Create files
      shell: "touch {{src_dir}}/{include,exclude}-{0..9}.txt"

    - name: Create archive file
      archive:
        format: "zip"
        path: "{{src_dir}}/*"
        dest: "{{src_dir}}.zip"
    - name: Unpack zip file
      unarchive:
        src: "{{src_dir}}.zip"
        dest: "{{dst_dir}}"
        remote_src: yes
        include:
          - 'include-2.txt'
      register: unzipped

    - name: Create archive file
      archive:
        format: "tar"
        path: "{{src_dir}}/*"
        dest: "{{src_dir}}.tar"
    - name: Unpack zip file
      unarchive:
        src: "{{src_dir}}.tar"
        dest: "{{dst_dir}}-tar"
        # remote_src: yes
        include:
          - 'include-4.txt'
```

<!--- Paste verbatim command output below, e.g. before and after your change -->
**Output**
```
$ tree /tmp/16130*
/tmp/16130
└── include-2.txt
/tmp/16130-tar
└── include-4.txt

0 directories, 2 files
```
