### PR TITLE
Search all assigned ipv6 addresses instead of just the first

### DIFF
--- a/lib/ansible/modules/network/ios/ios_l3_interface.py
+++ b/lib/ansible/modules/network/ios/ios_l3_interface.py
@@ -148,9 +148,18 @@ def validate_param_values(module, obj, param=None):
 def parse_config_argument(configobj, name, arg=None):
     cfg = configobj['interface %s' % name]
     cfg = '\n'.join(cfg.children)
-    match = re.search(r'%s (.+)$' % arg, cfg, re.M)
-    if match:
-        return match.group(1).strip()
+
+    values = []
+    matches = re.finditer(r'%s (.+)$' % arg, cfg, re.M)
+    for match in matches:
+        match_str = match.group(1).strip()
+        if arg == 'ipv6 address':
+            values.append(match_str)
+        else:
+            values = match_str
+            break
+
+    return values or None
 
 
 def search_obj_in_list(name, lst):
@@ -198,7 +207,7 @@ def map_obj_to_commands(updates, module):
                     commands.append('ip address {}'.format(ipv4))
 
             if ipv6:
-                if obj_in_have is None or obj_in_have.get('ipv6') is None or ipv6.lower() != obj_in_have['ipv6'].lower():
+                if obj_in_have is None or obj_in_have.get('ipv6') is None or ipv6.lower() not in [addr.lower() for addr in obj_in_have['ipv6']]:
                     commands.append('ipv6 address {}'.format(ipv6))
 
         if commands[-1] == interface:

--- a/test/integration/targets/ios_l3_interface/tests/cli/basic.yaml
+++ b/test/integration/targets/ios_l3_interface/tests/cli/basic.yaml
@@ -41,7 +41,7 @@
     provider: "{{ cli }}"
   register: result
 
-- assert:
+- assert: &unchanged
     that:
       - 'result.changed == false'
 
@@ -74,7 +74,7 @@
       - '"ip address dhcp" in result.commands'
 
 - name: Configure interface ipv6 address
-  ios_l3_interface:
+  ios_l3_interface: &ipv6-1
     name: "{{ test_interface }}"
     ipv6: fd5d:12c9:2201:1::1/64
     state: present
@@ -88,16 +88,36 @@
       - '"ipv6 address fd5d:12c9:2201:1::1/64" in result.commands'
 
 - name: Configure interface ipv6 address (idempotent)
-  ios_l3_interface:
+  ios_l3_interface: *ipv6-1
+  register: result
+
+- assert: *unchanged
+
+- name: Configure second ipv6 address on interface
+  ios_l3_interface: &ipv6-2
     name: "{{ test_interface }}"
-    ipv6: fd5d:12c9:2201:1::1/64
+    ipv6: fd5d:12c9:2291:1::1/64
     state: present
     provider: "{{ cli }}"
   register: result
 
 - assert:
     that:
-      - 'result.changed == false'
+      - 'result.changed == true'
+      - '"interface {{ test_interface }}" in result.commands'
+      - '"ipv6 address fd5d:12c9:2291:1::1/64" in result.commands'
+
+- name: Ensure first ipv6 address still associated with interface
+  ios_l3_interface: *ipv6-1
+  register: result
+
+- assert: *unchanged
+
+- name: Ensure second ipv6 address still associated with interface
+  ios_l3_interface: *ipv6-2
+  register: result
+
+- assert: *unchanged
 
 - name: Assign same ipv6 address to other interface (fail)
   ios_l3_interface:
@@ -181,9 +201,7 @@
     provider: "{{ cli }}"
   register: result
 
-- assert:
-    that:
-      - 'result.changed == false'
+- assert: *unchanged
 
 - name:  Change ipv4 and ipv6 address using aggregate
   ios_l3_interface:
@@ -232,8 +250,6 @@
     provider: "{{ cli }}"
   register: result
 
-- assert:
-    that:
-      - 'result.changed == false'
+- assert: *unchanged
 
 - debug: msg="END ios_l3_interface cli/basic.yaml on connection={{ ansible_connection }}"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
IOS can have multiple assigned IPv6 addresses, and will return the first one found. If trying to add an address which is already assigned, but not the first entry, the playbook would report a change even if no change actually happened

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
ios

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6
```