### PR TITLE
Fix Windows FQDN lookup in WinRM setup

### DIFF
--- a/examples/scripts/ConfigureRemotingForAnsible.ps1
+++ b/examples/scripts/ConfigureRemotingForAnsible.ps1
@@ -93,7 +93,7 @@ Function New-LegacySelfSignedCert
     )
 
     $hostnonFQDN = $env:computerName 
-    $hostFQDN = [System.Net.Dns]::GetHostByName(($env:computerName)).Hostname
+    $hostFQDN = (Get-WmiObject win32_computersystem).DNSHostName+"."+(Get-WmiObject win32_computersystem).Domain.ToLower()
     $SignatureAlgorithm = "SHA256"
 
     $name = New-Object -COM "X509Enrollment.CX500DistinguishedName.1"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

The WinRM setup Powershell script looks for the FQDN, but after executing this point I got the following error message:

```
Exception calling "GetHostByName" with "1" argument(s): "No such host is known"
At line:1 char:1
+ [System.Net.Dns]::GetHostByName(($env:computerName)).HostName
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [], MethodInvocationException
    + FullyQualifiedErrorId : SocketException

```
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
ConfigureRemotingForAnsible.ps1
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.2
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/foobar/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.13 (default, Nov 24 2017, 17:33:09) [GCC 6.3.0 20170516]

```
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

OS: Microsoft Windows Server 2012 R2

If you want to reproduce the error, execute the following command:

`[System.Net.Dns]::GetHostByName(($env:computerName)).Hostname`

