### PR TITLE
uses .txt for shared content (#40416)

### DIFF
--- a/docs/docsite/rst/network/user_guide/platform_eos.rst
+++ b/docs/docsite/rst/network/user_guide/platform_eos.rst
@@ -130,4 +130,4 @@ In this example two variables defined in ``group_vars`` get passed to the module
 - the ``proxy_env`` variable gets passed to the ``environment`` option of the module
 
 
-.. include:: shared_snippets/SSH_warning.rst
+.. include:: shared_snippets/SSH_warning.txt

--- a/docs/docsite/rst/network/user_guide/platform_ios.rst
+++ b/docs/docsite/rst/network/user_guide/platform_ios.rst
@@ -67,4 +67,4 @@ Example CLI Task
      register: backup_ios_location
      when: ansible_network_os == 'ios'
 
-.. include:: shared_snippets/SSH_warning.rst
+.. include:: shared_snippets/SSH_warning.txt

--- a/docs/docsite/rst/network/user_guide/platform_junos.rst
+++ b/docs/docsite/rst/network/user_guide/platform_junos.rst
@@ -112,4 +112,4 @@ Example NETCONF Task
      when: ansible_network_os == 'junos'
 
 
-.. include:: shared_snippets/SSH_warning.rst
+.. include:: shared_snippets/SSH_warning.txt

--- a/docs/docsite/rst/network/user_guide/platform_nxos.rst
+++ b/docs/docsite/rst/network/user_guide/platform_nxos.rst
@@ -126,4 +126,4 @@ In this example two variables defined in ``group_vars`` get passed to the module
 - the ``proxy_env`` variable gets passed to the ``environment`` option of the module
 
 
-.. include:: shared_snippets/SSH_warning.rst
+.. include:: shared_snippets/SSH_warning.txt

--- a/docs/docsite/rst/network/user_guide/shared_snippets/SSH_warning.txt
+++ b/docs/docsite/rst/network/user_guide/shared_snippets/SSH_warning.txt
@@ -1,4 +1,2 @@
-:orphan:
-
 .. warning:: 
    Never store passwords in plain text. We recommend using SSH keys to authenticate SSH connections. Ansible supports ssh-agent to manage your SSH keys. If you must use passwords to authenticate SSH connections, we recommend encrypting them with :ref:`Ansible Vault <playbooks_vault>`.


### PR DESCRIPTION
(cherry picked from commit 69eef14e3ba43deb93677a5f601e6b0451f6b6c1)

##### SUMMARY
Backports fix for #40415 
Uses .txt extension for included docs snippets. This avoids "not-in-toctree" errors without using the `.. _orphan` tag, which does not play well with included docs.

See also #39108 for background.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
docs.ansible.com

##### ANSIBLE VERSION
2.5
