### PR TITLE
parted module not idempotent for esp flag and name

### DIFF
--- a/lib/ansible/modules/system/parted.py
+++ b/lib/ansible/modules/system/parted.py
@@ -658,10 +658,18 @@ def main():
 
             # Assign name to the partition
             if name is not None and partition.get('name', None) != name:
-                script += "name %s %s " % (number, name)
+                # Wrap double quotes in single quotes so the shell doesn't strip
+                # the double quotes as those need to be included in the arg
+                # passed to parted
+                script += 'name %s \'"%s"\' ' % (number, name)
 
             # Manage flags
             if flags:
+                # Parted infers boot with esp, if you assign esp, boot is set
+                # and if boot is unset, esp is also unset.
+                if 'esp' in flags and 'boot' not in flags:
+                    flags.append('boot')
+
                 # Compute only the changes in flags status
                 flags_off = list(set(partition['flags']) - set(flags))
                 flags_on = list(set(flags) - set(partition['flags']))

--- a/test/units/modules/system/test_parted.py
+++ b/test/units/modules/system/test_parted.py
@@ -237,4 +237,4 @@ class TestParted(ModuleTestCase):
             '_ansible_check_mode': True,
         })
         with patch('ansible.modules.system.parted.get_device_info', return_value=parted_dict2):
-            self.execute_module(changed=True, script='unit KiB mklabel gpt mkpart primary 0% 100% unit KiB name 1 lvmpartition set 1 lvm on')
+            self.execute_module(changed=True, script='unit KiB mklabel gpt mkpart primary 0% 100% unit KiB name 1 \'"lvmpartition"\' set 1 lvm on')


### PR DESCRIPTION
Signed-off-by: Adam Miller <admiller@redhat.com>

##### SUMMARY
Fixes #40452 

Currently the parted module doesn't take into account names with
spaces in them which leads to non-idempotent transactions on the
state of the system because the name comparison will never succeed.

Also, when the esp flag is set, parted infers the boot flag and the
parted module did not previously account for this. This lead to
non-idempotent transactions as well.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
parted

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0dev0 (issue/40452/parted-idempotent-name 0e5cabf2c7) last updated 2018/05/22 11:27:53 (GMT -500)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/admiller/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/admiller/src/dev/ansible/lib/ansible
  executable location = /home/admiller/src/dev/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 14 2018, 13:36:31) [GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]
```


