### PR TITLE
Add support for IOS vlan parsing filter.

### DIFF
--- a/lib/ansible/plugins/filter/network.py
+++ b/lib/ansible/plugins/filter/network.py
@@ -398,6 +398,7 @@ def comp_type5(unencrypted_password, encrypted_password, return_orginal=False):
             return True
     return False
 
+
 def vlan_parser(vlan_list):
 
     '''

--- a/lib/ansible/plugins/filter/network.py
+++ b/lib/ansible/plugins/filter/network.py
@@ -398,6 +398,77 @@ def comp_type5(unencrypted_password, encrypted_password, return_orginal=False):
             return True
     return False
 
+def vlan_parser(vlan_list):
+    '''
+        Input: Unsorted list of vlan integers
+        Output: Sorted list of integers according to Cisco IOS vlan list rules
+
+        1. Vlans are listed in ascending order
+        2. Runs of 3 or more consecutive vlans are listed with a dash
+        3. The first line of the list can be 48 characters long
+        4. Subsequent list lines can be 44 characters
+    '''
+
+    #Sort and remove duplicates
+    sorted_list = sorted(set(vlan_list))
+
+    if sorted_list[0] < 1 or sorted_list[-1] > 4094:
+        raise AnsibleFilterError('Valid VLAN range is 1-4094')
+
+    parse_list = []
+    idx = 0
+    while idx < len(sorted_list):
+        start = idx
+        end = start
+        while end < len(sorted_list) - 1:
+            if sorted_list[end + 1] - sorted_list[end] == 1:
+                end += 1
+            else:
+                break
+
+        if start == end:
+            # Single VLAN
+            parse_list.append(str(sorted_list[idx]))
+        elif start + 1 == end:
+            # Run of 2 VLANs
+            parse_list.append(str(sorted_list[start]))
+            parse_list.append(str(sorted_list[end]))
+        else:
+            # Run of 3 or more VLANs
+            parse_list.append(str(sorted_list[start]) + '-' + str(sorted_list[end]))
+        idx = end + 1
+
+    line_count = 0
+    result = ['']
+    for vlans in parse_list:
+        #First line (" switchport trunk allowed vlan ")
+        if line_count == 0:
+            if len(result[line_count] + vlans) > 48:
+                result.append('')
+                line_count += 1
+                result[line_count] += vlans + ','
+            else:
+                result[line_count] += vlans + ','
+
+        #Subsequent lines (" switchport trunk allowed vlan add ")
+        else:
+            if len(result[line_count] + vlans) > 44:
+                result.append('')
+                line_count += 1
+                result[line_count] += vlans + ','
+            else:
+                result[line_count] += vlans + ','
+
+    #Remove trailing orphan commas
+    for idx in range(0, len(result)):
+        result[idx] = result[idx].rstrip(',')
+
+    #Sometimes text wraps to next line, but there are no remaining VLANs
+    if '' in result:
+        result.remove('')
+
+    return result
+
 
 class FilterModule(object):
     """Filters for working with output from network devices"""
@@ -408,7 +479,8 @@ class FilterModule(object):
         'parse_xml': parse_xml,
         'type5_pw': type5_pw,
         'hash_salt': hash_salt,
-        'comp_type5': comp_type5
+        'comp_type5': comp_type5,
+        'vlan_parser': vlan_parser
     }
 
     def filters(self):

--- a/lib/ansible/plugins/filter/network.py
+++ b/lib/ansible/plugins/filter/network.py
@@ -399,6 +399,7 @@ def comp_type5(unencrypted_password, encrypted_password, return_orginal=False):
     return False
 
 def vlan_parser(vlan_list):
+
     '''
         Input: Unsorted list of vlan integers
         Output: Sorted list of integers according to Cisco IOS vlan list rules
@@ -409,7 +410,7 @@ def vlan_parser(vlan_list):
         4. Subsequent list lines can be 44 characters
     '''
 
-    #Sort and remove duplicates
+    # Sort and remove duplicates
     sorted_list = sorted(set(vlan_list))
 
     if sorted_list[0] < 1 or sorted_list[-1] > 4094:
@@ -441,7 +442,7 @@ def vlan_parser(vlan_list):
     line_count = 0
     result = ['']
     for vlans in parse_list:
-        #First line (" switchport trunk allowed vlan ")
+        # First line (" switchport trunk allowed vlan ")
         if line_count == 0:
             if len(result[line_count] + vlans) > 48:
                 result.append('')
@@ -450,7 +451,7 @@ def vlan_parser(vlan_list):
             else:
                 result[line_count] += vlans + ','
 
-        #Subsequent lines (" switchport trunk allowed vlan add ")
+        # Subsequent lines (" switchport trunk allowed vlan add ")
         else:
             if len(result[line_count] + vlans) > 44:
                 result.append('')
@@ -459,11 +460,11 @@ def vlan_parser(vlan_list):
             else:
                 result[line_count] += vlans + ','
 
-    #Remove trailing orphan commas
+    # Remove trailing orphan commas
     for idx in range(0, len(result)):
         result[idx] = result[idx].rstrip(',')
 
-    #Sometimes text wraps to next line, but there are no remaining VLANs
+    # Sometimes text wraps to next line, but there are no remaining VLANs
     if '' in result:
         result.remove('')
 

--- a/lib/ansible/plugins/filter/network.py
+++ b/lib/ansible/plugins/filter/network.py
@@ -399,16 +399,16 @@ def comp_type5(unencrypted_password, encrypted_password, return_orginal=False):
     return False
 
 
-def vlan_parser(vlan_list):
+def vlan_parser(vlan_list, first_line_len=48, other_line_len=44):
 
     '''
         Input: Unsorted list of vlan integers
-        Output: Sorted list of integers according to Cisco IOS vlan list rules
+        Output: Sorted string list of integers according to IOS-like vlan list rules
 
         1. Vlans are listed in ascending order
         2. Runs of 3 or more consecutive vlans are listed with a dash
-        3. The first line of the list can be 48 characters long
-        4. Subsequent list lines can be 44 characters
+        3. The first line of the list can be first_line_len characters long
+        4. Subsequent list lines can be other_line_len characters
     '''
 
     # Sort and remove duplicates
@@ -445,7 +445,7 @@ def vlan_parser(vlan_list):
     for vlans in parse_list:
         # First line (" switchport trunk allowed vlan ")
         if line_count == 0:
-            if len(result[line_count] + vlans) > 48:
+            if len(result[line_count] + vlans) > first_line_len:
                 result.append('')
                 line_count += 1
                 result[line_count] += vlans + ','
@@ -454,7 +454,7 @@ def vlan_parser(vlan_list):
 
         # Subsequent lines (" switchport trunk allowed vlan add ")
         else:
-            if len(result[line_count] + vlans) > 44:
+            if len(result[line_count] + vlans) > other_line_len:
                 result.append('')
                 line_count += 1
                 result[line_count] += vlans + ','

--- a/test/units/plugins/filter/test_network.py
+++ b/test/units/plugins/filter/test_network.py
@@ -23,7 +23,8 @@ import sys
 import pytest
 
 from units.compat import unittest
-from ansible.plugins.filter.network import parse_xml, type5_pw, hash_salt, comp_type5
+from ansible.plugins.filter.network import parse_xml, type5_pw, hash_salt, comp_type5, vlan_parser
+
 from ansible.errors import AnsibleFilterError
 
 fixture_path = os.path.join(os.path.dirname(__file__), 'fixtures', 'network')

--- a/test/units/plugins/filter/test_network.py
+++ b/test/units/plugins/filter/test_network.py
@@ -165,3 +165,20 @@ class TestCompareType5(unittest.TestCase):
         encrypted_password = '$1$nTc1$Z28sUTcWfXlvVe2x.3XAa.'
         parsed = comp_type5(unencrypted_password, encrypted_password)
         self.assertEqual(parsed, False)
+
+class TestVlanParser(unittest.TestCase):
+
+    def test_compression(self):
+        raw_list = [1, 2, 3]
+        parsed_list = ['1-3']
+        self.assertEqual(vlan_parser(raw_list), parsed_list)
+
+    def test_single_line(self):
+        raw_list = [100, 1688, 3002, 3003, 3004, 3005, 3102, 3103, 3104, 3105, 3802, 3900, 3998, 3999]
+        parsed_list = ['100,1688,3002-3005,3102-3105,3802,3900,3998,3999']
+        self.assertEqual(vlan_parser(raw_list), parsed_list)
+
+    def test_multi_line(self):
+        raw_list = [100, 1688, 3002, 3004, 3005, 3050, 3102, 3104, 3105, 3151, 3802, 3900, 3998, 3999]
+        parsed_list = ['100,1688,3002,3004,3005,3050,3102,3104,3105,3151', '3802,3900,3998,3999']
+        self.assertEqual(vlan_parser(raw_list), parsed_list)

--- a/test/units/plugins/filter/test_network.py
+++ b/test/units/plugins/filter/test_network.py
@@ -167,6 +167,7 @@ class TestCompareType5(unittest.TestCase):
         parsed = comp_type5(unencrypted_password, encrypted_password)
         self.assertEqual(parsed, False)
 
+
 class TestVlanParser(unittest.TestCase):
 
     def test_compression(self):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Add support for IOS vlan parsing filter.

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
filter_plugin

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.3
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/Users/sdodd/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.14 (default, Jan  6 2018, 12:16:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
Example Jinja template below:

{% set parsed_vlans = vlans | vlan_parser %}
switchport trunk allowed vlan {{ parsed_vlans[0] }}
{% for i in range (1, parsed_vlans | count) %}
switchport trunk allowed vlan add {{ parsed_vlans[i] }}

This allows for dynamic generation of vlan lists on a Cisco IOS tagged interface. You can store an exhaustive raw list of the exact vlans required for an interface and then compare that to the parsed IOS output that would actually be generated for the config. 
```
