### PR TITLE
Adds bigip_monitor_external module

### DIFF
--- a/lib/ansible/modules/network/f5/bigip_monitor_external.py
+++ b/lib/ansible/modules/network/f5/bigip_monitor_external.py
@@ -1,0 +1,628 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Copyright: (c) 2018, F5 Networks Inc.
+# GNU General Public License v3.0 (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = r'''
+---
+module: bigip_monitor_external
+short_description: Manages external LTM monitors on a BIG-IP
+description:
+  - Manages external LTM monitors on a BIG-IP.
+version_added: 2.6
+options:
+  name:
+    description:
+      - Specifies the name of the monitor.
+    required: True
+  parent:
+    description:
+      - The parent template of this monitor template. Once this value has
+        been set, it cannot be changed. By default, this value is the C(http)
+        parent on the C(Common) partition.
+    default: "/Common/external"
+  arguments:
+    description:
+      - Specifies any command-line arguments that the script requires.
+  ip:
+    description:
+      - IP address part of the IP/port definition. If this parameter is not
+        provided when creating a new monitor, then the default value will be
+        '*'.
+  port:
+    description:
+      - Port address part of the IP/port definition. If this parameter is not
+        provided when creating a new monitor, then the default value will be
+        '*'. Note that if specifying an IP address, a value between 1 and 65535
+        must be specified.
+  external_program:
+    description:
+      - Specifies the name of the file for the monitor to use. In order to reference
+        a file, you must first import it using options on the System > File Management > External
+        Monitor Program File List > Import screen. The BIG-IP system automatically
+        places the file in the proper location on the file system.
+  interval:
+    description:
+      - The interval specifying how frequently the monitor instance of this
+        template will run. If this parameter is not provided when creating
+        a new monitor, then the default value will be 5. This value B(must)
+        be less than the C(timeout) value.
+  timeout:
+    description:
+      - The number of seconds in which the node or service must respond to
+        the monitor request. If the target responds within the set time
+        period, it is considered up. If the target does not respond within
+        the set time period, it is considered down. You can change this
+        number to any number you want, however, it should be 3 times the
+        interval number of seconds plus 1 second. If this parameter is not
+        provided when creating a new monitor, then the default value will be 16.
+  variables:
+    description:
+      - Specifies any variables that the script requires.
+      - Note that double quotes in values will be suppressed.
+  partition:
+    description:
+      - Device partition to manage resources on.
+    default: Common
+  state:
+    description:
+      - When C(present), ensures that the monitor exists.
+      - When C(absent), ensures the monitor is removed.
+    default: present
+    choices:
+      - present
+      - absent
+extends_documentation_fragment: f5
+author:
+  - Tim Rupp (@caphrim007)
+'''
+
+EXAMPLES = r'''
+- name: Create a ...
+  bigip_monitor_external:
+    name: foo
+    password: secret
+    server: lb.mydomain.com
+    state: present
+    user: admin
+  delegate_to: localhost
+'''
+
+RETURN = r'''
+parent:
+  description: New parent template of the monitor.
+  returned: changed
+  type: string
+  sample: external
+ip:
+  description: The new IP of IP/port definition.
+  returned: changed
+  type: string
+  sample: 10.12.13.14
+interval:
+  description: The new interval in which to run the monitor check.
+  returned: changed
+  type: int
+  sample: 2
+timeout:
+  description: The new timeout in which the remote system must respond to the monitor.
+  returned: changed
+  type: int
+  sample: 10
+'''
+
+import os
+import re
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import env_fallback
+from ansible.module_utils.six import iteritems
+
+try:
+    from library.module_utils.network.f5.bigip import HAS_F5SDK
+    from library.module_utils.network.f5.bigip import F5Client
+    from library.module_utils.network.f5.common import F5ModuleError
+    from library.module_utils.network.f5.common import AnsibleF5Parameters
+    from library.module_utils.network.f5.common import cleanup_tokens
+    from library.module_utils.network.f5.common import fq_name
+    from library.module_utils.network.f5.common import f5_argument_spec
+    from library.module_utils.network.f5.common import compare_dictionary
+    try:
+        from library.module_utils.network.f5.common import iControlUnexpectedHTTPError
+    except ImportError:
+        HAS_F5SDK = False
+except ImportError:
+    from ansible.module_utils.network.f5.bigip import HAS_F5SDK
+    from ansible.module_utils.network.f5.bigip import F5Client
+    from ansible.module_utils.network.f5.common import F5ModuleError
+    from ansible.module_utils.network.f5.common import AnsibleF5Parameters
+    from ansible.module_utils.network.f5.common import cleanup_tokens
+    from ansible.module_utils.network.f5.common import fq_name
+    from ansible.module_utils.network.f5.common import f5_argument_spec
+    from ansible.module_utils.network.f5.common import compare_dictionary
+    try:
+        from ansible.module_utils.network.f5.common import iControlUnexpectedHTTPError
+    except ImportError:
+        HAS_F5SDK = False
+
+try:
+    import netaddr
+    HAS_NETADDR = True
+except ImportError:
+    HAS_NETADDR = False
+
+
+class Parameters(AnsibleF5Parameters):
+    api_map = {
+        'defaultsFrom': 'parent',
+        'apiRawValues': 'variables',
+        'run': 'external_program',
+        'args': 'arguments'
+    }
+
+    api_attributes = [
+        'defaultsFrom', 'interval', 'timeout', 'destination', 'run', 'args'
+    ]
+
+    returnables = [
+        'parent', 'ip', 'port', 'interval', 'timeout', 'variables', 'external_program',
+        'arguments'
+    ]
+
+    updatables = [
+        'destination', 'interval', 'timeout', 'variables', 'external_program',
+        'arguments'
+    ]
+
+    def to_return(self):
+        result = {}
+        try:
+            for returnable in self.returnables:
+                result[returnable] = getattr(self, returnable)
+            result = self._filter_params(result)
+        except Exception:
+            pass
+        return result
+
+    @property
+    def destination(self):
+        if self.ip is None and self.port is None:
+            return None
+        destination = '{0}:{1}'.format(self.ip, self.port)
+        return destination
+
+    @destination.setter
+    def destination(self, value):
+        ip, port = value.split(':')
+        self._values['ip'] = ip
+        self._values['port'] = port
+
+    @property
+    def interval(self):
+        if self._values['interval'] is None:
+            return None
+
+        # Per BZ617284, the BIG-IP UI does not raise a warning about this.
+        # So I do
+        if 1 > int(self._values['interval']) > 86400:
+            raise F5ModuleError(
+                "Interval value must be between 1 and 86400"
+            )
+        return int(self._values['interval'])
+
+    @property
+    def timeout(self):
+        if self._values['timeout'] is None:
+            return None
+        return int(self._values['timeout'])
+
+    @property
+    def ip(self):
+        if self._values['ip'] is None:
+            return None
+        try:
+            if self._values['ip'] in ['*', '0.0.0.0']:
+                return '*'
+            result = str(netaddr.IPAddress(self._values['ip']))
+            return result
+        except netaddr.core.AddrFormatError:
+            raise F5ModuleError(
+                "The provided 'ip' parameter is not an IP address."
+            )
+
+    @property
+    def port(self):
+        if self._values['port'] is None:
+            return None
+        elif self._values['port'] == '*':
+            return '*'
+        return int(self._values['port'])
+
+    @property
+    def parent(self):
+        if self._values['parent'] is None:
+            return None
+        if self._values['parent'].startswith('/'):
+            parent = os.path.basename(self._values['parent'])
+            result = '/{0}/{1}'.format(self.partition, parent)
+        else:
+            result = '/{0}/{1}'.format(self.partition, self._values['parent'])
+        return result
+
+    @property
+    def type(self):
+        return 'external'
+
+
+class ApiParameters(Parameters):
+    @property
+    def variables(self):
+        if self._values['variables'] is None:
+            return None
+        pattern = r'^userDefined\s(?P<key>.*)'
+        result = {}
+        for k, v in iteritems(self._values['variables']):
+            matches = re.match(pattern, k)
+            if not matches:
+                raise F5ModuleError(
+                    "Unable to find the variable 'key' in the API payload."
+                )
+            key = matches.group('key')
+            result[key] = v
+        return result
+
+
+class ModuleParameters(Parameters):
+    @property
+    def variables(self):
+        if self._values['variables'] is None:
+            return None
+        result = {}
+        for k, v in iteritems(self._values['variables']):
+            result[k] = str(v).replace('"', '')
+        return result
+
+    @property
+    def external_program(self):
+        if self._values['external_program'] is None:
+            return None
+        return fq_name(self.partition, self._values['external_program'])
+
+
+class Changes(Parameters):
+    def to_return(self):
+        result = {}
+        try:
+            for returnable in self.returnables:
+                result[returnable] = getattr(self, returnable)
+            result = self._filter_params(result)
+        except Exception:
+            pass
+        return result
+
+
+class UsableChanges(Changes):
+    pass
+
+
+class ReportableChanges(Changes):
+    pass
+
+
+class Difference(object):
+    def __init__(self, want, have=None):
+        self.want = want
+        self.have = have
+
+    def compare(self, param):
+        try:
+            result = getattr(self, param)
+            return result
+        except AttributeError:
+            return self.__default(param)
+
+    def __default(self, param):
+        attr1 = getattr(self.want, param)
+        try:
+            attr2 = getattr(self.have, param)
+            if attr1 != attr2:
+                return attr1
+        except AttributeError:
+            return attr1
+
+    @property
+    def parent(self):
+        if self.want.parent != self.have.parent:
+            raise F5ModuleError(
+                "The parent monitor cannot be changed"
+            )
+
+    @property
+    def destination(self):
+        if self.want.ip is None and self.want.port is None:
+            return None
+        if self.want.port is None:
+            self.want.update({'port': self.have.port})
+        if self.want.ip is None:
+            self.want.update({'ip': self.have.ip})
+
+        if self.want.port in [None, '*'] and self.want.ip != '*':
+            raise F5ModuleError(
+                "Specifying an IP address requires that a port number be specified"
+            )
+
+        if self.want.destination != self.have.destination:
+            return self.want.destination
+
+    @property
+    def interval(self):
+        if self.want.timeout is not None and self.want.interval is not None:
+            if self.want.interval >= self.want.timeout:
+                raise F5ModuleError(
+                    "Parameter 'interval' must be less than 'timeout'."
+                )
+        elif self.want.timeout is not None:
+            if self.have.interval >= self.want.timeout:
+                raise F5ModuleError(
+                    "Parameter 'interval' must be less than 'timeout'."
+                )
+        elif self.want.interval is not None:
+            if self.want.interval >= self.have.timeout:
+                raise F5ModuleError(
+                    "Parameter 'interval' must be less than 'timeout'."
+                )
+        if self.want.interval != self.have.interval:
+            return self.want.interval
+
+    @property
+    def variables(self):
+        if self.want.variables is None:
+            return None
+        if self.have.variables is None:
+            return dict(
+                variables=self.want.variables
+            )
+        result = dict()
+
+        different = compare_dictionary([self.want.variables], [self.have.variables])
+        if not different:
+            return None
+
+        for k, v in iteritems(self.want.variables):
+            if k in self.have.variables and v != self.have.variables[k]:
+                result[k] = v
+            elif k not in self.have.variables:
+                result[k] = v
+        for k, v in iteritems(self.have.variables):
+            if k not in self.want.variables:
+                result[k] = "none"
+        if result:
+            result = dict(
+                variables=result
+            )
+            return result
+
+
+class ModuleManager(object):
+    def __init__(self, *args, **kwargs):
+        self.module = kwargs.get('module', None)
+        self.client = kwargs.get('client', None)
+        self.want = ModuleParameters(params=self.module.params)
+        self.have = ApiParameters()
+        self.changes = UsableChanges()
+
+    def _set_changed_options(self):
+        changed = {}
+        for key in Parameters.returnables:
+            if getattr(self.want, key) is not None:
+                changed[key] = getattr(self.want, key)
+        if changed:
+            self.changes = UsableChanges(params=changed)
+
+    def _update_changed_options(self):
+        diff = Difference(self.want, self.have)
+        updatables = Parameters.updatables
+        changed = dict()
+        for k in updatables:
+            change = diff.compare(k)
+            if change is None:
+                continue
+            else:
+                if isinstance(change, dict):
+                    changed.update(change)
+                else:
+                    changed[k] = change
+        if changed:
+            self.changes = UsableChanges(params=changed)
+            return True
+        return False
+
+    def should_update(self):
+        result = self._update_changed_options()
+        if result:
+            return True
+        return False
+
+    def exec_module(self):
+        changed = False
+        result = dict()
+        state = self.want.state
+
+        try:
+            if state == "present":
+                changed = self.present()
+            elif state == "absent":
+                changed = self.absent()
+        except iControlUnexpectedHTTPError as e:
+            raise F5ModuleError(str(e))
+
+        reportable = ReportableChanges(params=self.changes.to_return())
+        changes = reportable.to_return()
+        result.update(**changes)
+        result.update(dict(changed=changed))
+        self._announce_deprecations(result)
+        return result
+
+    def _announce_deprecations(self, result):
+        warnings = result.pop('__warnings', [])
+        for warning in warnings:
+            self.client.module.deprecate(
+                msg=warning['msg'],
+                version=warning['version']
+            )
+
+    def present(self):
+        if self.exists():
+            return self.update()
+        else:
+            return self.create()
+
+    def create(self):
+        self._set_changed_options()
+        if self.want.timeout is None:
+            self.want.update({'timeout': 16})
+        if self.want.interval is None:
+            self.want.update({'interval': 5})
+        if self.want.ip is None:
+            self.want.update({'ip': '*'})
+        if self.want.port is None:
+            self.want.update({'port': '*'})
+        if self.module.check_mode:
+            return True
+        self.create_on_device()
+        return True
+
+    def update(self):
+        self.have = self.read_current_from_device()
+        if not self.should_update():
+            return False
+        if self.module.check_mode:
+            return True
+        self.update_on_device()
+        return True
+
+    def absent(self):
+        if self.exists():
+            return self.remove()
+        return False
+
+    def remove(self):
+        if self.module.check_mode:
+            return True
+        self.remove_from_device()
+        if self.exists():
+            raise F5ModuleError("Failed to delete the monitor.")
+        return True
+
+    def read_current_from_device(self):
+        resource = self.client.api.tm.ltm.monitor.externals.external.load(
+            name=self.want.name,
+            partition=self.want.partition
+        )
+        result = resource.attrs
+        return ApiParameters(params=result)
+
+    def exists(self):
+        result = self.client.api.tm.ltm.monitor.externals.external.exists(
+            name=self.want.name,
+            partition=self.want.partition
+        )
+        return result
+
+    def update_on_device(self):
+        params = self.changes.api_params()
+        result = self.client.api.tm.ltm.monitor.externals.external.load(
+            name=self.want.name,
+            partition=self.want.partition
+        )
+        if params:
+            result.modify(**params)
+        if self.changes.variables:
+            self.set_variable_on_device(self.changes.variables)
+
+    def set_variable_on_device(self, commands):
+        command = ' '.join(['user-defined {0} \\\"{1}\\\"'.format(k, v) for k, v in iteritems(commands)])
+        command = 'tmsh modify ltm monitor external {0} {1}'.format(self.want.name, command)
+        self.client.api.tm.util.bash.exec_cmd(
+            'run',
+            utilCmdArgs='-c "{0}"'.format(command)
+        )
+
+    def create_on_device(self):
+        params = self.want.api_params()
+        self.client.api.tm.ltm.monitor.externals.external.create(
+            name=self.want.name,
+            partition=self.want.partition,
+            **params
+        )
+        if self.want.variables:
+            self.set_variable_on_device(self.want.variables)
+
+    def remove_from_device(self):
+        result = self.client.api.tm.ltm.monitor.externals.external.load(
+            name=self.want.name,
+            partition=self.want.partition
+        )
+        if result:
+            result.delete()
+
+
+class ArgumentSpec(object):
+    def __init__(self):
+        self.supports_check_mode = True
+        argument_spec = dict(
+            name=dict(required=True),
+            parent=dict(default='/Common/external'),
+            arguments=dict(),
+            ip=dict(),
+            port=dict(type='int'),
+            external_program=dict(),
+            interval=dict(type='int'),
+            timeout=dict(type='int'),
+            state=dict(
+                default='present',
+                choices=['present', 'absent']
+            ),
+            variables=dict(type='dict'),
+            partition=dict(
+                default='Common',
+                fallback=(env_fallback, ['F5_PARTITION'])
+            )
+        )
+        self.argument_spec = {}
+        self.argument_spec.update(f5_argument_spec)
+        self.argument_spec.update(argument_spec)
+
+
+def main():
+    spec = ArgumentSpec()
+
+    module = AnsibleModule(
+        argument_spec=spec.argument_spec,
+        supports_check_mode=spec.supports_check_mode
+    )
+    if not HAS_F5SDK:
+        module.fail_json(msg="The python f5-sdk module is required")
+
+    try:
+        client = F5Client(**module.params)
+        mm = ModuleManager(module=module, client=client)
+        results = mm.exec_module()
+        cleanup_tokens(client)
+        module.exit_json(**results)
+    except F5ModuleError as ex:
+        cleanup_tokens(client)
+        module.fail_json(msg=str(ex))
+
+
+if __name__ == '__main__':
+    main()

--- a/test/units/modules/network/f5/test_bigip_monitor_external.py
+++ b/test/units/modules/network/f5/test_bigip_monitor_external.py
@@ -1,0 +1,122 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright: (c) 2017, F5 Networks Inc.
+# GNU General Public License v3.0 (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import os
+import json
+import pytest
+import sys
+
+from nose.plugins.skip import SkipTest
+if sys.version_info < (2, 7):
+    raise SkipTest("F5 Ansible modules require Python >= 2.7")
+
+from ansible.compat.tests import unittest
+from ansible.compat.tests.mock import Mock
+from ansible.compat.tests.mock import patch
+from ansible.module_utils.basic import AnsibleModule
+
+try:
+    from library.modules.bigip_monitor_external import ApiParameters
+    from library.modules.bigip_monitor_external import ModuleParameters
+    from library.modules.bigip_monitor_external import ModuleManager
+    from library.modules.bigip_monitor_external import ArgumentSpec
+    from library.module_utils.network.f5.common import F5ModuleError
+    from library.module_utils.network.f5.common import iControlUnexpectedHTTPError
+    from test.unit.modules.utils import set_module_args
+except ImportError:
+    try:
+        from ansible.modules.network.f5.bigip_monitor_external import ApiParameters
+        from ansible.modules.network.f5.bigip_monitor_external import ModuleParameters
+        from ansible.modules.network.f5.bigip_monitor_external import ModuleManager
+        from ansible.modules.network.f5.bigip_monitor_external import ArgumentSpec
+        from ansible.module_utils.network.f5.common import F5ModuleError
+        from ansible.module_utils.network.f5.common import iControlUnexpectedHTTPError
+        from units.modules.utils import set_module_args
+    except ImportError:
+        raise SkipTest("F5 Ansible modules require the f5-sdk Python library")
+
+fixture_path = os.path.join(os.path.dirname(__file__), 'fixtures')
+fixture_data = {}
+
+
+def load_fixture(name):
+    path = os.path.join(fixture_path, name)
+
+    if path in fixture_data:
+        return fixture_data[path]
+
+    with open(path) as f:
+        data = f.read()
+
+    try:
+        data = json.loads(data)
+    except Exception:
+        pass
+
+    fixture_data[path] = data
+    return data
+
+
+class TestParameters(unittest.TestCase):
+    def test_module_parameters(self):
+        args = dict(
+            name='foo',
+            parent='parent',
+            ip='10.10.10.10',
+            port=80,
+            interval=20,
+            timeout=30,
+            partition='Common'
+        )
+
+        p = ModuleParameters(params=args)
+        assert p.name == 'foo'
+        assert p.parent == '/Common/parent'
+        assert p.ip == '10.10.10.10'
+        assert p.type == 'external'
+        assert p.port == 80
+        assert p.destination == '10.10.10.10:80'
+        assert p.interval == 20
+        assert p.timeout == 30
+
+
+@patch('ansible.module_utils.f5_utils.AnsibleF5Client._get_mgmt_root',
+       return_value=True)
+class TestManager(unittest.TestCase):
+
+    def setUp(self):
+        self.spec = ArgumentSpec()
+
+    def test_create_monitor(self, *args):
+        set_module_args(dict(
+            name='foo',
+            parent='parent',
+            ip='10.10.10.10',
+            port=80,
+            interval=20,
+            timeout=30,
+            partition='Common',
+            server='localhost',
+            password='password',
+            user='admin'
+        ))
+
+        module = AnsibleModule(
+            argument_spec=self.spec.argument_spec,
+            supports_check_mode=self.spec.supports_check_mode
+        )
+
+        # Override methods in the specific type of manager
+        mm = ModuleManager(module=module)
+        mm.exists = Mock(side_effect=[False, True])
+        mm.create_on_device = Mock(return_value=True)
+
+        results = mm.exec_module()
+
+        assert results['changed'] is True
+        assert results['parent'] == '/Common/parent'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
This module can be used to manage external LTM monitors on a bigip

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New Module Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
bigip_monitor_external

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0
  config file = /here/test/integration/ansible.cfg
  configured module search path = ['/here/library/modules']
  ansible python module location = /usr/local/lib/python3.6/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 3.6.5 (default, May  5 2018, 03:09:35) [GCC 4.9.2]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
