### PR TITLE
Corrects docs for ltm external monitor

### DIFF
--- a/lib/ansible/modules/network/f5/bigip_monitor_external.py
+++ b/lib/ansible/modules/network/f5/bigip_monitor_external.py
@@ -87,9 +87,36 @@ author:
 '''
 
 EXAMPLES = r'''
-- name: Create a ...
+- name: Create an external monitor
   bigip_monitor_external:
     name: foo
+    password: secret
+    server: lb.mydomain.com
+    state: present
+    user: admin
+  delegate_to: localhost
+
+- name: Create an external monitor with variables
+  bigip_monitor_external:
+    name: foo
+    timeout: 10
+    variables:
+      var1: foo
+      var2: bar
+    password: secret
+    server: lb.mydomain.com
+    state: present
+    user: admin
+  delegate_to: localhost
+
+- name: Add a variable to an existing set
+  bigip_monitor_external:
+    name: foo
+    timeout: 10
+    variables:
+      var1: foo
+      var2: bar
+      cat: dog
     password: secret
     server: lb.mydomain.com
     state: present


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
Examples were incorrect. This fixes them

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
bigip_monitor_external

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0
  config file = None
  configured module search path = ['/root/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python3.6/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 3.6.5 (default, May  5 2018, 03:09:35) [GCC 4.9.2]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
