### PR TITLE
Fix postgresql_db issue on dump (#40424)

### DIFF
--- a/lib/ansible/modules/database/postgresql/postgresql_db.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_db.py
@@ -463,7 +463,7 @@ def main():
             method = state == "dump" and db_dump or db_restore
             try:
                 rc, stdout, stderr, cmd = method(module, target, target_opts, db, **kw)
-                if rc != 0:
+                if rc != 0 or not db_exists(cursor, db):
                     module.fail_json(msg=stderr, stdout=stdout, rc=rc, cmd=cmd)
                 else:
                     module.exit_json(changed=True, msg=stdout, stderr=stderr, rc=rc, cmd=cmd)


### PR DESCRIPTION
##### SUMMARY

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
postgresql_db

##### ANSIBLE VERSION
```
ansible 2.6.0
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible-2.6.0-py2.7.egg/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Apr 11 2018, 07:36:10) [GCC 4.8.5 20150623 (Red Hat 4.8.5-28)]
```


##### ADDITIONAL INFORMATION
```
BEFORE:
TASK [postgresql_db] *****************************************************************************************************************************************************************************************************************************************************************
changed: [localhost] => {"changed": true, "cmd": "/usr/bin/pg_dump examplecom --host=172.17.0.2 --port=5432 --username=postgres|/usr/bin/bzip2 > /tmp/test.sql.bz2", "msg": "", "rc": 0, "stderr": "pg_dump: [archiver (db)] connection to database \"examplecom\" failed: FATAL:  datxamplecom\" does not exist\n", "stderr_lines": ["pg_dump: [archiver (db)] connection to database \"examplecom\" failed: FATAL:  database \"examplecom\" does not exist"]}

AFTER:
TASK [postgresql_db] *****************************************************************************************************************************************************************************************************************************************************************
fatal: [localhost]: FAILED! => {"changed": false, "cmd": "/usr/bin/pg_dump examplecom --host=172.17.0.2 --port=5432 --username=postgres|/usr/bin/bzip2 > /tmp/test.sql.bz2", "msg": "pg_dump: [archiver (db)] connection to database \"examplecom\" failed: FATAL:  database \"examplecom\" does not exist\n", "rc": 0, "stdout": "", "stdout_lines": []}
```
