### PR TITLE
Change Brocade references to Extreme

### DIFF
--- a/lib/ansible/modules/network/ironware/ironware_command.py
+++ b/lib/ansible/modules/network/ironware/ironware_command.py
@@ -17,9 +17,9 @@ DOCUMENTATION = """
 module: ironware_command
 version_added: "2.5"
 author: "Paul Baker (@paulquack)"
-short_description: Run arbitrary commands on Brocade IronWare devices
+short_description: Run arbitrary commands on Extreme IronWare devices
 description:
-  - Sends arbitrary commands to a Brocade Ironware node and returns the
+  - Sends arbitrary commands to a Extreme Ironware node and returns the
     results read from the device. This module includes a I(wait_for)
     argument that will cause the module to wait for a specific condition
     before returning or timing out if the condition is not met.

--- a/lib/ansible/modules/network/ironware/ironware_config.py
+++ b/lib/ansible/modules/network/ironware/ironware_config.py
@@ -17,9 +17,9 @@ DOCUMENTATION = """
 module: ironware_config
 version_added: "2.5"
 author: "Paul Baker (@paulquack)"
-short_description: Manage configuration sections on Brocade Ironware devices
+short_description: Manage configuration sections on Extreme Ironware devices
 description:
-  - Brocade Ironware configurations use a simple block indent file syntax
+  - Extreme Ironware configurations use a simple block indent file syntax
     for segmenting configuration into sections.  This module provides
     an implementation for working with Ironware configuration sections in
     a deterministic way.

--- a/lib/ansible/modules/network/ironware/ironware_facts.py
+++ b/lib/ansible/modules/network/ironware/ironware_facts.py
@@ -17,7 +17,7 @@ DOCUMENTATION = """
 module: ironware_facts
 version_added: "2.5"
 author: "Paul Baker (@paulquack)"
-short_description: Collect facts from devices running Brocade Ironware
+short_description: Collect facts from devices running Extreme Ironware
 description:
   - Collects a base set of device facts from a remote device that
     is running Ironware.  This module prepends all of the


### PR DESCRIPTION
##### SUMMARY

Replace "Brocade" references in Ironware docs with "Extreme"

##### ISSUE TYPE

 - Docs Pull Request

##### COMPONENT NAME

* ironware_command
* ironware_config
* ironware_facts

##### ANSIBLE VERSION
```
ansible 2.6.0dev0 (devel 0a701ff746) last updated 2018/05/22 16:57:54 (GMT -700)
  config file = None
  configured module search path = [u'/Users/lhill/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/lhill/github/ansible/lib/ansible
  executable location = /Users/lhill/github/ansible/bin/ansible
  python version = 2.7.10 (default, Oct  6 2017, 22:29:07) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.31)]
```


##### ADDITIONAL INFORMATION

Extreme Networks acquired the Data Center assets from Brocade in late 2017. This includes the Ironware (MLXe) product line. The "Brocade" name is now owned by Broadcom, and should in future only refer to to Brocade SAN equipment.

Before:
```
lindsaysmacbook:ansible lhill$ ansible-doc ironware_command|grep -e Brocade -e Extreme
        Sends arbitrary commands to a Brocade Ironware node and returns the results read from the device. This
lindsaysmacbook:ansible lhill$
```
After:
```
lindsaysmacbook:ansible lhill$ ansible-doc ironware_command|grep -e Brocade -e Extreme
        Sends arbitrary commands to a Extreme Ironware node and returns the results read from the device. This
lindsaysmacbook:ansible lhill$
```