### PR TITLE
sychronize: handle non-string task_vars

### DIFF
--- a/lib/ansible/plugins/action/synchronize.py
+++ b/lib/ansible/plugins/action/synchronize.py
@@ -117,8 +117,9 @@ class ActionModule(ActionBase):
         if 'ansible_syslog_facility' in task_vars:
             del task_vars['ansible_syslog_facility']
         for key in list(task_vars.keys()):
-            if key.startswith("ansible_") and key.endswith("_interpreter"):
-                del task_vars[key]
+            if isinstance(key, string_types):
+                if key.startswith("ansible_") and key.endswith("_interpreter"):
+                    del task_vars[key]
 
         # Add the definitions from localhost
         for host in C.LOCALHOST:

--- a/test/units/plugins/action/test_synchronize.py
+++ b/test/units/plugins/action/test_synchronize.py
@@ -151,6 +151,9 @@ class SynchronizeTester(object):
             fdata = f.read()
         fdata = fdata.decode("utf-8")
         in_task_vars = json.loads(fdata)
+        # Note json key values must be strings, but YAML variables may
+        # put non-string keys.  Add to ensure this is ignored.
+        in_task_vars[None] = None
 
         # load expected final task vars
         outvarspath = os.path.join(fixturepath, test_meta.get('fixtures', {}).get('taskvars_out', 'taskvars_out.json'))


### PR DESCRIPTION
##### SUMMARY

We found a situation where synchronize didn't handle a vars.yaml file with

```yaml
 null: null
```

as it assumes everything in ``task_vars`` has a ``<starts|ends>with()``.  Thus put a string check before examining the ``task_vars`` keys.

Since JSON enforces all dict keys are strings, I don't believe we can represent this in the exisiting fixture's variables.  Thus it is added separately to the unit test to cover this path.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
sychronize

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0 (none-taskvar ca2de22005) last updated 2018/05/18 11:38:48 (GMT +1100)
  config file = None
  configured module search path = [u'/home/iwienand/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/iwienand/programs/ansible/lib/ansible
  executable location = /home/iwienand/programs/ansible/bin/ansible
  python version = 2.7.15 (default, May  2 2018, 14:12:52) [GCC 8.0.1 20180324 (Red Hat 8.0.1-0.20)]
```


##### ADDITIONAL INFORMATION
This was first discussed in https://github.com/ansible/ansible/pull/40370

