### PR TITLE
Adding a new filter plugin that can encrypt and decrypt values using AWS KMS service.

### DIFF
--- a/lib/ansible/plugins/filter/aws_kms.py
+++ b/lib/ansible/plugins/filter/aws_kms.py
@@ -1,0 +1,92 @@
+"""
+(c) 2018, Archie Gunasekara <contact@achinthagunasekara.com>.
+Module to handle encrypting and decrypting of items with AWS KMS.
+"""
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+import base64
+from ansible.errors import AnsibleError, AnsibleFilterError
+
+
+try:
+    import botocore
+    import aws_encryption_sdk
+    HAS_DEPENDENCIES = True
+except ImportError:
+    HAS_DEPENDENCIES = False
+
+
+def dependency_check():
+    """
+    Throw an AnsibleError if dependencies are missing.
+    Args:
+    Returns:
+        None
+    """
+    if not HAS_DEPENDENCIES:
+        raise AnsibleError('You need to install "botocore" and "aws_encryption_sdk"'
+                           'before using aws_kms filter')
+
+
+def aws_kms_encrypt(plaintext, key_arn):
+    """
+    Encrypt with AWS KMS.
+    Args:
+        plaintext (str): Plain text string to encrypt.
+        key_arn (str): ARN to the AWS KMS key to use for encryption.
+    Returns:
+        str: Encrypted string for the plain text input.
+    """
+    dependency_check()
+    try:
+        session = botocore.session.get_session()
+        kms_kwargs = {
+            'key_ids': [key_arn],
+            'botocore_session': session
+        }
+        master_key_provider = aws_encryption_sdk.KMSMasterKeyProvider(**kms_kwargs)
+        ciphertext, encryptor_header = aws_encryption_sdk.encrypt(  # pylint: disable=unused-variable
+            source=plaintext,
+            key_provider=master_key_provider
+        )
+        return base64.b64encode(ciphertext)
+    except aws_encryption_sdk.exceptions.NotSupportedError:
+        raise AnsibleFilterError('Unable to encrypt value using KMS')
+
+
+def aws_kms_decrypt(ciphertext, key_arn):
+    """
+    Decrypt with AWS KMS.
+    Args:
+        ciphertext (str): Encrypted string to decrypt.
+        key_arn (str): ARN to the AWS KMS key to use for decryption.
+    Returns:
+        str: Plain text decrypted string.
+    """
+    dependency_check()
+    try:
+        session = botocore.session.get_session()
+        kms_kwargs = {
+            'key_ids': [key_arn],
+            'botocore_session': session
+        }
+        master_key_provider = aws_encryption_sdk.KMSMasterKeyProvider(**kms_kwargs)
+        cycled_plaintext, decrypted_header = aws_encryption_sdk.decrypt(  # pylint: disable=unused-variable
+            source=base64.b64decode(ciphertext),
+            key_provider=master_key_provider
+        )
+        return cycled_plaintext.rstrip()
+    except aws_encryption_sdk.exceptions.NotSupportedError:
+        raise AnsibleFilterError('Unable to decrypt value using KMS')
+
+
+class FilterModule(object):  # pylint: disable=too-few-public-methods
+    """ Filter module to provide functions """
+    def filters(self):  # pylint: disable=no-self-use
+        """ Filter module to provide functions """
+        return {
+            'aws_kms_encrypt': aws_kms_encrypt,
+            'aws_kms_decrypt': aws_kms_decrypt
+        }

--- a/lib/ansible/plugins/filter/aws_kms.py
+++ b/lib/ansible/plugins/filter/aws_kms.py
@@ -3,7 +3,7 @@
 Module to handle encrypting and decrypting of items with AWS KMS.
 """
 from __future__ import (absolute_import, division, print_function)
-__metaclass__ = type
+__metaclass__ = type  # pylint: disable=invalid-name
 
 
 import base64
@@ -52,8 +52,8 @@ def aws_kms_encrypt(plaintext, key_arn):
             key_provider=master_key_provider
         )
         return base64.b64encode(ciphertext)
-    except aws_encryption_sdk.exceptions.NotSupportedError:
-        raise AnsibleFilterError('Unable to encrypt value using KMS')
+    except aws_encryption_sdk.exceptions.AWSEncryptionSDKClientError as kms_ex:
+        raise AnsibleFilterError("Unable to encrypt value using KMS - %s" % kms_ex)
 
 
 def aws_kms_decrypt(ciphertext, key_arn):
@@ -78,8 +78,8 @@ def aws_kms_decrypt(ciphertext, key_arn):
             key_provider=master_key_provider
         )
         return cycled_plaintext.rstrip()
-    except aws_encryption_sdk.exceptions.NotSupportedError:
-        raise AnsibleFilterError('Unable to decrypt value using KMS')
+    except aws_encryption_sdk.exceptions.AWSEncryptionSDKClientError as kms_ex:
+        raise AnsibleFilterError("Unable to encrypt value using KMS - %s" % kms_ex)
 
 
 class FilterModule(object):  # pylint: disable=too-few-public-methods

--- a/lib/ansible/plugins/filter/aws_kms.py
+++ b/lib/ansible/plugins/filter/aws_kms.py
@@ -3,7 +3,7 @@
 Module to handle encrypting and decrypting of items with AWS KMS.
 """
 from __future__ import (absolute_import, division, print_function)
-__metaclass__ = type  # pylint: disable=invalid-name
+__metaclass__ = type
 
 
 import base64


### PR DESCRIPTION
##### SUMMARY

Adding a new filter plugin that can encrypt and decrypt values using AWS KMS service.
This filter plugin can be used to encrypt values using the AWS KMS service and store them within your repository, then decrypt then when you want to use them.

E.G.

In `my_role\defaults\main.yml`
```
encrypted_value: >-
  {{ abcd123abcd13 abcd123abcd13abcd12abcd13
  abcd123abcd13abcd123abcd13abcd123ab1d1312
  abcd123abcd13abcd123abcd13abcd123ssdsas12
  sadsdsasd | aws_kms_decrypt(KEY_ARN) }}
```

In `my_role\tasks\main.yml`

```
- debug:
    msg: "Decrypted value is {{ encrypted_value }}"
```

Same can be done for encrypting values.

E.G

In `my_role\tasks\main.yml`

```
- debug:
    msg: "Encrypted value is {{ 'abc123abc123abc123' | aws_kms_encrypt(KEY_ARN) }}"
```

##### ADDITIONAL INFORMATION

* https://aws.amazon.com/documentation/kms/
* https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/introduction.html