### PR TITLE
cs_vpc: fix state=present started vpc

### DIFF
--- a/lib/ansible/modules/cloud/cloudstack/cs_vpc.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_vpc.py
@@ -51,12 +51,13 @@ options:
   state:
     description:
       - "State of the VPC."
-      - "The state C(started) is only considered while creating the VPC, added in version 2.6."
+      - "The state C(present) creates a started VPC."
+      - "The state C(stopped) is only considered while creating the VPC, added in version 2.6."
     default: present
     choices:
       - present
       - absent
-      - started
+      - stopped
       - restarted
   domain:
     description:
@@ -92,6 +93,7 @@ EXAMPLES = '''
     name: my_vpc
     display_text: My example VPC
     cidr: 10.10.0.0/16
+    state: stopped
 
 - name: Ensure a VPC is present and started after creating
   local_action:
@@ -99,7 +101,6 @@ EXAMPLES = '''
     name: my_vpc
     display_text: My example VPC
     cidr: 10.10.0.0/16
-    state: started
 
 - name: Ensure a VPC is absent
   local_action:
@@ -289,7 +290,7 @@ class AnsibleCloudStackVpc(AnsibleCloudStack):
             'domainid': self.get_domain(key='id'),
             'projectid': self.get_project(key='id'),
             'zoneid': self.get_zone(key='id'),
-            'start': self.module.params.get('state') == 'started'
+            'start': self.module.params.get('state') != 'stopped'
         }
         self.result['diff']['after'] = args
         if not self.module.check_mode:
@@ -338,7 +339,7 @@ def main():
         vpc_offering=dict(),
         network_domain=dict(),
         clean_up=dict(type='bool'),
-        state=dict(choices=['present', 'absent', 'started', 'restarted'], default='present'),
+        state=dict(choices=['present', 'absent', 'stopped', 'restarted'], default='present'),
         domain=dict(),
         account=dict(),
         project=dict(),

--- a/test/integration/targets/cs_vpc/tasks/main.yml
+++ b/test/integration/targets/cs_vpc/tasks/main.yml
@@ -55,7 +55,7 @@
     vpc_offering: Redundant VPC offering
     network_domain: test.example.com
     zone: "{{ cs_common_zone_adv }}"
-    state: started
+    state: stopped
   register: vpc
   check_mode: true
 - name: verify test create vpc with custom offering in check mode
@@ -72,7 +72,7 @@
     vpc_offering: Redundant VPC offering
     network_domain: test.example.com
     zone: "{{ cs_common_zone_adv }}"
-    state: started
+    state: stopped
   register: vpc
 - name: verify test create vpc with custom offering
   assert:
@@ -92,7 +92,7 @@
     vpc_offering: Redundant VPC offering
     network_domain: test.example.com
     zone: "{{ cs_common_zone_adv }}"
-    state: started
+    state: stopped
   register: vpc
 - name: verify test create vpc with custom offering idempotence
   assert:

--- a/test/integration/targets/cs_vpn_connection/aliases
+++ b/test/integration/targets/cs_vpn_connection/aliases
@@ -1,3 +1,2 @@
 cloud/cs
 posix/ci/cloud/group1/cs
-disabled

--- a/test/integration/targets/cs_vpn_gateway/aliases
+++ b/test/integration/targets/cs_vpn_gateway/aliases
@@ -1,3 +1,2 @@
 cloud/cs
 posix/ci/cloud/group1/cs
-disabled


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
Fix regression introduced in 2.6 in which state=present does not create a started vpc. Reverted the logic, by replacing the state=started with state=stopped.

this fixes #40569 and fixes #40570 


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
cs_vpc

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
