### PR TITLE
reduce notifications on network/f5

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -465,8 +465,9 @@ files:
   $modules/network/eos/: privateip trishnaguha
   $modules/network/exos/: rdvencioneck
   $modules/network/f5/:
-    ignored: Etienne-Carriere mhite mryanlam perzizzle srvg wojtek0806 JoeReifel
+    ignored: Etienne-Carriere mhite mryanlam perzizzle srvg wojtek0806 JoeReifel $team_networking
     maintainers: caphrim007
+  $modules/network/files/: $team_networking
   $modules/network/fortios/: bjolivot
   $modules/network/illumos/: xen0l
   $modules/network/interface/: $team_networking


### PR DESCRIPTION
##### SUMMARY
As @caphrim007 has merge powers the networking team don't need to be notified on F5 issues or PRs

##### ISSUE TYPE
 - Bugfix Pull Request

