### PR TITLE
add normalize_interface in module_utils and fix nxos_l3_interface module

### DIFF
--- a/lib/ansible/module_utils/network/nxos/nxos.py
+++ b/lib/ansible/module_utils/network/nxos/nxos.py
@@ -439,3 +439,43 @@ def load_config(module, config, return_error=False, opts=None):
 def get_capabilities(module):
     conn = get_connection(module)
     return conn.get_capabilities()
+
+
+def normalize_interface(name):
+    """Return the normalized interface name
+    """
+    if not name:
+        return
+
+    def _get_number(name):
+        digits = ''
+        for char in name:
+            if char.isdigit() or char in '/.':
+                digits += char
+        return digits
+
+    if name.lower().startswith('et'):
+        if_type = 'Ethernet'
+    elif name.lower().startswith('vl'):
+        if_type = 'Vlan'
+    elif name.lower().startswith('lo'):
+        if_type = 'loopback'
+    elif name.lower().startswith('po'):
+        if_type = 'port-channel'
+    elif name.lower().startswith('nv'):
+        if_type = 'nve'
+    else:
+        if_type = None
+
+    number_list = name.split(' ')
+    if len(number_list) == 2:
+        number = number_list[-1].strip()
+    else:
+        number = _get_number(name)
+
+    if if_type:
+        proper_interface = if_type + number
+    else:
+        proper_interface = name
+
+    return proper_interface

--- a/lib/ansible/modules/network/nxos/nxos_interface.py
+++ b/lib/ansible/modules/network/nxos/nxos_interface.py
@@ -215,7 +215,7 @@ import time
 from copy import deepcopy
 
 from ansible.module_utils.network.nxos.nxos import load_config, run_commands
-from ansible.module_utils.network.nxos.nxos import nxos_argument_spec
+from ansible.module_utils.network.nxos.nxos import nxos_argument_spec, normalize_interface
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.network.common.utils import conditional, remove_default_spec
 
@@ -291,46 +291,6 @@ def get_interfaces_dict(module):
             interfaces[intf_type].append(intf)
 
     return interfaces
-
-
-def normalize_interface(name):
-    """Return the normalized interface name
-    """
-    if not name:
-        return None
-
-    def _get_number(name):
-        digits = ''
-        for char in name:
-            if char.isdigit() or char in '/.':
-                digits += char
-        return digits
-
-    if name.lower().startswith('et'):
-        if_type = 'Ethernet'
-    elif name.lower().startswith('vl'):
-        if_type = 'Vlan'
-    elif name.lower().startswith('lo'):
-        if_type = 'loopback'
-    elif name.lower().startswith('po'):
-        if_type = 'port-channel'
-    elif name.lower().startswith('nv'):
-        if_type = 'nve'
-    else:
-        if_type = None
-
-    number_list = name.split(' ')
-    if len(number_list) == 2:
-        number = number_list[-1].strip()
-    else:
-        number = _get_number(name)
-
-    if if_type:
-        proper_interface = if_type + number
-    else:
-        proper_interface = name
-
-    return proper_interface
 
 
 def get_vlan_interface_attributes(name, intf_type, module):

--- a/lib/ansible/modules/network/nxos/nxos_l3_interface.py
+++ b/lib/ansible/modules/network/nxos/nxos_l3_interface.py
@@ -90,7 +90,7 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.network.common.config import CustomNetworkConfig
 from ansible.module_utils.network.common.utils import remove_default_spec
 from ansible.module_utils.network.nxos.nxos import get_config, load_config
-from ansible.module_utils.network.nxos.nxos import nxos_argument_spec
+from ansible.module_utils.network.nxos.nxos import nxos_argument_spec, normalize_interface
 
 
 def search_obj_in_list(name, lst):
@@ -151,10 +151,14 @@ def map_params_to_obj(module):
                 if item.get(key) is None:
                     item[key] = module.params[key]
 
-            obj.append(item.copy())
+            d = item.copy()
+            name = d['name']
+            d['name'] = normalize_interface(name)
+            obj.append(d)
+
     else:
         obj.append({
-            'name': module.params['name'],
+            'name': normalize_interface(module.params['name']),
             'ipv4': module.params['ipv4'],
             'ipv6': module.params['ipv6'],
             'state': module.params['state']
@@ -175,7 +179,7 @@ def map_config_to_obj(want, module):
         if config:
             match_name = re.findall(r'interface (\S+)', config, re.M)
             if match_name:
-                obj['name'] = match_name[0]
+                obj['name'] = normalize_interface(match_name[0])
 
             match_ipv4 = re.findall(r'ip address (\S+)', config, re.M)
             if match_ipv4:

--- a/lib/ansible/modules/network/nxos/nxos_linkagg.py
+++ b/lib/ansible/modules/network/nxos/nxos_linkagg.py
@@ -128,48 +128,9 @@ from copy import deepcopy
 
 from ansible.module_utils.network.nxos.nxos import get_config, load_config, run_commands
 from ansible.module_utils.network.nxos.nxos import get_capabilities, nxos_argument_spec
+from ansible.module_utils.network.nxos.nxos import normalize_interface
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.network.common.utils import remove_default_spec
-
-
-def normalize_interface(name):
-    """Return the normalized interface name
-    """
-    if not name:
-        return
-
-    def _get_number(name):
-        digits = ''
-        for char in name:
-            if char.isdigit() or char in '/.':
-                digits += char
-        return digits
-
-    if name.lower().startswith('et'):
-        if_type = 'Ethernet'
-    elif name.lower().startswith('vl'):
-        if_type = 'Vlan'
-    elif name.lower().startswith('lo'):
-        if_type = 'loopback'
-    elif name.lower().startswith('po'):
-        if_type = 'port-channel'
-    elif name.lower().startswith('nv'):
-        if_type = 'nve'
-    else:
-        if_type = None
-
-    number_list = name.split(' ')
-    if len(number_list) == 2:
-        number = number_list[-1].strip()
-    else:
-        number = _get_number(name)
-
-    if if_type:
-        proper_interface = if_type + number
-    else:
-        proper_interface = name
-
-    return proper_interface
 
 
 def execute_show_command(command, module):


### PR DESCRIPTION
Signed-off-by: Trishna Guha <trishnaguha17@gmail.com>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes https://github.com/ansible/ansible/issues/40537
Move `normalize_interface` to common module_utils nxos
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
modules/network/nxos/nxos_l3_interface.py
modules/network/nxos/nxos_interface.py
modules/network/nxos/nxos_linkagg.py
module_utils/network/nxos/nxos.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```