### PR TITLE
apt: don't markmanual if apt-mark is not installed

### DIFF
--- a/lib/ansible/modules/packaging/os/apt.py
+++ b/lib/ansible/modules/packaging/os/apt.py
@@ -496,6 +496,7 @@ def mark_installed_manually(m, packages):
 
     # https://github.com/ansible/ansible/issues/40531
     if apt_mark_cmd_path is None:
+        m.warn("Could not find apt-mark binary, not marking package(s) as manually installed.")
         return
 
     cmd = "%s manual %s" % (apt_mark_cmd_path, ' '.join(packages))

--- a/lib/ansible/modules/packaging/os/apt.py
+++ b/lib/ansible/modules/packaging/os/apt.py
@@ -492,7 +492,12 @@ def mark_installed_manually(m, packages):
     if not packages:
         return
 
-    apt_mark_cmd_path = m.get_bin_path("apt-mark", required=True)
+    apt_mark_cmd_path = m.get_bin_path("apt-mark")
+
+    # https://github.com/ansible/ansible/issues/40531
+    if apt_mark_cmd_path is None:
+        return
+
     cmd = "%s manual %s" % (apt_mark_cmd_path, ' '.join(packages))
     rc, out, err = m.run_command(cmd)
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes https://github.com/ansible/ansible/issues/40531
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
apt

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5.3
devel
```


##### ADDITIONAL INFORMATION