### PR TITLE
Fixes eos_logging idempotence issue #31862

### DIFF
--- a/lib/ansible/modules/network/eos/eos_logging.py
+++ b/lib/ansible/modules/network/eos/eos_logging.py
@@ -113,7 +113,6 @@ commands:
 """
 
 import re
-import q
 from copy import deepcopy
 
 from ansible.module_utils.basic import AnsibleModule
@@ -221,6 +220,7 @@ def parse_facility(line):
     match = re.search(r'logging facility (\S+)', line, re.M)
     if match:
         facility = match.group(1)
+
     return facility
 
 
@@ -240,6 +240,7 @@ def parse_size(line, dest):
                     size = str(match.group(1))
                 else:
                     size = str(10)
+
     return size
 
 
@@ -363,7 +364,7 @@ def map_params_to_obj(module, required_if=None):
             module.params['size'] = None
 
         parse_obj(obj, module)
-        
+
     return obj
 
 

--- a/lib/ansible/modules/network/eos/eos_logging.py
+++ b/lib/ansible/modules/network/eos/eos_logging.py
@@ -113,7 +113,8 @@ commands:
 """
 
 import re
-import q
+
+
 from copy import deepcopy
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.network.common.utils import remove_default_spec
@@ -213,8 +214,6 @@ def map_obj_to_commands(updates, module):
 
                 commands.append(dest_cmd)
 
-    cmds = [item for item in commands]
-    q(cmds)
     return commands
 
 

--- a/lib/ansible/modules/network/eos/eos_logging.py
+++ b/lib/ansible/modules/network/eos/eos_logging.py
@@ -113,8 +113,8 @@ commands:
 """
 
 import re
-from copy import deepcopy
 
+from copy import deepcopy
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.network.common.utils import remove_default_spec
 from ansible.module_utils.network.eos.eos import get_config, load_config
@@ -147,7 +147,6 @@ def map_obj_to_commands(updates, module):
         level = w['level']
         state = w['state']
         del w['state']
-
 
         if state == 'absent' and w in have:
             if dest == 'host':
@@ -190,8 +189,9 @@ def map_obj_to_commands(updates, module):
                 # Case 1:       logging buffered <size> <level>
                 #               logging buffered <same-size>
                 #
-                # Case 2:       Same buffered logging configuration already exists(i.e., both size & level
-                #               are same)
+                # Case 2:       Same buffered logging configuration
+                #               already exists (i.e., both size &
+                #               level are same)
 
                 for entry in have:
                     if entry['dest'] == 'buffered' and entry['size'] == size:
@@ -290,7 +290,6 @@ def map_config_to_obj(module):
 
             else:
                 dest = None
-                pass
 
             obj.append({'dest': dest,
                         'name': parse_name(line, dest),
@@ -408,7 +407,6 @@ def main():
     have = map_config_to_obj(module)
     want = map_params_to_obj(module, required_if=required_if)
 
-
     commands = map_obj_to_commands((want, have), module)
     result['commands'] = commands
 
@@ -421,6 +419,7 @@ def main():
         result['changed'] = True
 
     module.exit_json(**result)
+
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/network/eos/eos_logging.py
+++ b/lib/ansible/modules/network/eos/eos_logging.py
@@ -113,7 +113,7 @@ commands:
 """
 
 import re
-
+import q
 from copy import deepcopy
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.network.common.utils import remove_default_spec
@@ -149,14 +149,15 @@ def map_obj_to_commands(updates, module):
         del w['state']
 
         if state == 'absent' and w in have:
-            if dest == 'host':
-                commands.append('no logging host {}'.format(name))
+            if dest:
+                if dest == 'host':
+                    commands.append('no logging host {}'.format(name))
 
-            elif dest in DEST_GROUP:
-                commands.append('no logging {}'.format(dest))
+                elif dest in DEST_GROUP:
+                    commands.append('no logging {}'.format(dest))
 
-            else:
-                module.fail_json(msg='dest must be among console, monitor, buffered, host, on')
+                else:
+                    module.fail_json(msg='dest must be among console, monitor, buffered, host, on')
 
             if facility:
                 commands.append('no logging facility {}'.format(facility))
@@ -212,6 +213,8 @@ def map_obj_to_commands(updates, module):
 
                 commands.append(dest_cmd)
 
+    cmds = [item for item in commands]
+    q(cmds)
     return commands
 
 

--- a/test/integration/targets/eos_logging/tests/cli/basic.yaml
+++ b/test/integration/targets/eos_logging/tests/cli/basic.yaml
@@ -64,6 +64,7 @@
       - 'result.changed == true'
       - '"logging console warnings" in result.commands'
 
+
 - name: Configure buffer size
   eos_logging:
     dest: buffered
@@ -76,11 +77,43 @@
       - 'result.changed == true'
       - '"logging buffered 480000" in result.commands'
 
+- name: Set up logging destination and facility at the same time
+  eos_logging:
+    dest: buffered
+    size: 4096
+    facility: local7
+    level: informational
+    state: present
+  become: yes
+  register: result
+
+- assert:
+    that:
+      - 'result.changed == true'
+      - '"logging buffered 4096 informational" in result.commands'
+      - '"logging facility local7" in result.commands'
+
+- name: Set up logging destination and facility at the same time again (idempotent)
+  eos_logging:
+    dest: buffered
+    size: 4096
+    facility: local7
+    level: informational
+    state: present
+  become: yes
+  register: result
+
+- assert:
+    that:
+      - 'result.changed == false'
+
+
 - name: remove logging as collection tearDown
   eos_logging:
     aggregate:
       - { dest: console, level: warnings, state: absent }
-      - { dest: buffered, size: 480000, state: absent }
+      - { dest: buffered, level: informational, size: 4096, state: absent }
+      - { facility: local7, state: absent }
   become: yes
   register: result
 
@@ -89,3 +122,4 @@
       - 'result.changed == true'
       - '"no logging console" in result.commands'
       - '"no logging buffered" in result.commands'
+      - '"no logging facility local7" in result.commands'

--- a/test/integration/targets/eos_logging/tests/cli/basic.yaml
+++ b/test/integration/targets/eos_logging/tests/cli/basic.yaml
@@ -107,7 +107,6 @@
     that:
       - 'result.changed == false'
 
-
 - name: remove logging as collection tearDown
   eos_logging:
     aggregate:


### PR DESCRIPTION
##### SUMMARY

Fixes eos_logging idempotence issue while setting logging destination as buffered & facility.

The change iterates over all the entries in the 'have' list to decide whether a new command needs to appended/executed or not.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
eos_logging.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
Issue reported at https://github.com/ansible/ansible/issues/31862

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

Before change:
Playbook:
tasks:
    - name: Set Buffered Logging & Facility 
      eos_logging:
        dest: buffered
        size: 300
        facility: local7
        level: informational
        state: present

The above playbook would result in 'Changed: True' for every run.
After fixing it, this idempotence issue does not occur.
```
