### PR TITLE
Backport: apt: don't markmanual if apt-mark is not installed

### DIFF
--- a/changelogs/fragments/40600-apt-mark-availability.yml
+++ b/changelogs/fragments/40600-apt-mark-availability.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- skip marking packages as manually installed when apt-mark is not available (https://github.com/ansible/ansible/pull/40600)

--- a/lib/ansible/modules/packaging/os/apt.py
+++ b/lib/ansible/modules/packaging/os/apt.py
@@ -473,7 +473,13 @@ def mark_installed_manually(m, packages):
     if not packages:
         return
 
-    apt_mark_cmd_path = m.get_bin_path("apt-mark", required=True)
+    apt_mark_cmd_path = m.get_bin_path("apt-mark")
+
+    # https://github.com/ansible/ansible/issues/40531
+    if apt_mark_cmd_path is None:
+        m.warn("Could not find apt-mark binary, not marking package(s) as manually installed.")
+        return
+
     cmd = "%s manual %s" % (apt_mark_cmd_path, ' '.join(packages))
     rc, out, err = m.run_command(cmd)
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Backport of https://github.com/ansible/ansible/pull/40600
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
apt

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```


##### ADDITIONAL INFORMATION
