### PR TITLE
Change default output of NXAPI to text to match CLI

### DIFF
--- a/lib/ansible/plugins/cliconf/eos.py
+++ b/lib/ansible/plugins/cliconf/eos.py
@@ -25,6 +25,7 @@ import time
 from itertools import chain
 
 from ansible.module_utils._text import to_bytes
+from ansible.module_utils.connection import ConnectionError
 from ansible.module_utils.network.common.utils import to_list
 from ansible.plugins.cliconf import CliconfBase, enable_mode
 from ansible.plugins.connection.network_cli import Connection as NetworkCli

--- a/lib/ansible/plugins/cliconf/nxos.py
+++ b/lib/ansible/plugins/cliconf/nxos.py
@@ -24,6 +24,7 @@ import json
 from itertools import chain
 
 from ansible.module_utils._text import to_bytes, to_text
+from ansible.module_utils.connection import ConnectionError
 from ansible.module_utils.network.common.utils import to_list
 from ansible.plugins.cliconf import CliconfBase
 from ansible.plugins.connection.network_cli import Connection as NetworkCli

--- a/lib/ansible/plugins/httpapi/nxos.py
+++ b/lib/ansible/plugins/httpapi/nxos.py
@@ -35,7 +35,7 @@ class HttpApi:
         responses = list()
 
         for item in to_list(data):
-            cmd_output = message_kwargs.get('output', 'json')
+            cmd_output = message_kwargs.get('output', 'text')
             if isinstance(item, dict):
                 command = item['command']
                 if command.endswith('| json'):
@@ -50,7 +50,7 @@ class HttpApi:
                 responses.extend(self._run_queue(queue, output))
                 queue = list()
 
-            output = cmd_output or 'json'
+            output = cmd_output
             queue.append(command)
 
         if queue:

--- a/lib/ansible/plugins/httpapi/nxos.py
+++ b/lib/ansible/plugins/httpapi/nxos.py
@@ -38,13 +38,15 @@ class HttpApi:
             cmd_output = message_kwargs.get('output', 'text')
             if isinstance(item, dict):
                 command = item['command']
-                if command.endswith('| json'):
-                    command = command.rsplit('|', 1)[0]
-                    cmd_output = 'json'
-                elif 'output' in item:
+                if 'output' in item:
                     cmd_output = item['output']
             else:
                 command = item
+
+            # Emulate '| json' from CLI
+            if command.endswith('| json'):
+                command = command.rsplit('|', 1)[0]
+                cmd_output = 'json'
 
             if output and output != cmd_output:
                 responses.extend(self._run_queue(queue, output))


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
Also add missing import for `ConnectionError` to cliconf plugins

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
nxos

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6
```