### PR TITLE
ovirt: Support passing `hostname` along with `url`

### DIFF
--- a/lib/ansible/module_utils/ovirt.py
+++ b/lib/ansible/module_utils/ovirt.py
@@ -135,8 +135,12 @@ def create_connection(auth):
     :return: Python SDK connection
     """
 
+    url = auth.get('url')
+    if url is None and auth.get('hostname') is not None:
+        url = 'https://{0}/ovirt-engine/api'.format(auth.get('hostname'))
+
     return sdk.Connection(
-        url=auth.get('url'),
+        url=url,
         username=auth.get('username'),
         password=auth.get('password'),
         ca_file=auth.get('ca_file', None),
@@ -338,6 +342,7 @@ def wait(
 
 def __get_auth_dict():
     OVIRT_URL = os.environ.get('OVIRT_URL')
+    OVIRT_HOSTNAME  = os.environ.get('OVIRT_HOSTNAME')
     OVIRT_USERNAME = os.environ.get('OVIRT_USERNAME')
     OVIRT_PASSWORD = os.environ.get('OVIRT_PASSWORD')
     OVIRT_TOKEN = os.environ.get('OVIRT_TOKEN')
@@ -345,6 +350,8 @@ def __get_auth_dict():
     OVIRT_INSECURE = OVIRT_CAFILE is None
 
     env_vars = None
+    if OVIRT_URL is None and OVIRT_HOSTNAME is not None:
+        OVIRT_URL = 'https://{0}/ovirt-engine/api'.format(OVIRT_HOSTNAME)
     if OVIRT_URL and ((OVIRT_USERNAME and OVIRT_PASSWORD) or OVIRT_TOKEN):
         env_vars = {
             'url': OVIRT_URL,

--- a/lib/ansible/modules/cloud/ovirt/ovirt_auth.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_auth.py
@@ -59,9 +59,18 @@ options:
     url:
         required: False
         description:
-            - "A string containing the base URL of the server.
+            - "A string containing the API URL of the server.
                For example: I(https://server.example.com/ovirt-engine/api).
                Default value is set by I(OVIRT_URL) environment variable."
+            - "Either C(url) or C(hostname) is required."
+    hostname:
+        required: False
+        description:
+            - "A string containing the hostname of the server.
+               For example: I(server.example.com).
+               Default value is set by I(OVIRT_HOSTNAME) environment variable."
+            - "Either C(url) or C(hostname) is required."
+        version_added: "2.6"
     insecure:
         required: False
         description:
@@ -217,6 +226,7 @@ def main():
     module = AnsibleModule(
         argument_spec=dict(
             url=dict(default=None),
+            hostname=dict(default=None),
             username=dict(default=None),
             password=dict(default=None, no_log=True),
             ca_file=dict(default=None, type='path'),
@@ -249,7 +259,14 @@ def main():
 
         return var
 
-    url = get_required_parameter('url', 'OVIRT_URL', required=True)
+    url = get_required_parameter('url', 'OVIRT_URL', required=False)
+    hostname = get_required_parameter('hostname', 'OVIRT_HOSTNAME', required=False)
+    if url is None and hostname is None:
+        module.fail_json(msg="You must specify either 'url' or 'hostname'.")
+
+    if url is None and hostname is not None:
+        url = 'https://{0}/ovirt-engine/api'.format(hostname)
+
     username = get_required_parameter('username', 'OVIRT_USERNAME', required=True)
     password = get_required_parameter('password', 'OVIRT_PASSWORD', required=True)
     token = get_required_parameter('token', 'OVIRT_TOKEN')

--- a/lib/ansible/utils/module_docs_fragments/ovirt.py
+++ b/lib/ansible/utils/module_docs_fragments/ovirt.py
@@ -45,8 +45,12 @@ options:
             - C(username)[I(required)] - The name of the user, something like I(admin@internal).
               Default value is set by I(OVIRT_USERNAME) environment variable.
             - "C(password)[I(required)] - The password of the user. Default value is set by I(OVIRT_PASSWORD) environment variable."
-            - "C(url)[I(required)] - A string containing the base URL of the server, usually
-            something like `I(https://server.example.com/ovirt-engine/api)`. Default value is set by I(OVIRT_URL) environment variable."
+            - "C(url) - A string containing the API URL of the server, usually
+            something like `I(https://server.example.com/ovirt-engine/api)`. Default value is set by I(OVIRT_URL) environment variable.
+            Either C(url) or C(hostname) is required."
+            - "C(hostname) - A string containing the hostname of the server, usually
+            something like `I(server.example.com)`. Default value is set by I(OVIRT_HOSTNAME) environment variable.
+            Either C(url) or C(hostname) is required."
             - "C(token) - Token to be used instead of login with username/password. Default value is set by I(OVIRT_TOKEN) environment variable."
             - "C(insecure) - A boolean flag that indicates if the server TLS
             certificate and host name should be checked."

--- a/lib/ansible/utils/module_docs_fragments/ovirt_facts.py
+++ b/lib/ansible/utils/module_docs_fragments/ovirt_facts.py
@@ -42,8 +42,12 @@ options:
             - C(username)[I(required)] - The name of the user, something like I(admin@internal).
               Default value is set by I(OVIRT_USERNAME) environment variable.
             - "C(password)[I(required)] - The password of the user. Default value is set by I(OVIRT_PASSWORD) environment variable."
-            - "C(url)[I(required)] - A string containing the base URL of the server, usually
-            something like `I(https://server.example.com/ovirt-engine/api)`. Default value is set by I(OVIRT_URL) environment variable."
+            - "C(url)- A string containing the API URL of the server, usually
+            something like `I(https://server.example.com/ovirt-engine/api)`. Default value is set by I(OVIRT_URL) environment variable.
+            Either C(url) or C(hostname) is required."
+            - "C(hostname) - A string containing the hostname of the server, usually
+            something like `I(server.example.com)`. Default value is set by I(OVIRT_HOSTNAME) environment variable.
+            Either C(url) or C(hostname) is required."
             - "C(token) - Token to be used instead of login with username/password. Default value is set by I(OVIRT_TOKEN) environment variable."
             - "C(insecure) - A boolean flag that indicates if the server TLS
             certificate and host name should be checked."


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This PR add support to pass `hostname`. Previously we supported only `url` to be passed, but it shown to be more user friendly to specify just hostname of the engine.

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
ovirt

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5.3
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
