### PR TITLE
py2/py3 compat fix (Issue 40514)

### DIFF
--- a/lib/ansible/plugins/action/asa_config.py
+++ b/lib/ansible/plugins/action/asa_config.py
@@ -55,7 +55,7 @@ class ActionModule(_ActionModule):
 
         # strip out any keys that have two leading and two trailing
         # underscore characters
-        for key in result.keys():
+        for key in list(result):
             if PRIVATE_KEYS_RE.match(key):
                 del result[key]
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
One liner fix to plugins/action/asa_config.py to address py2/py3 compatibility issue. Fixes #40514 

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
plugins/action/asa_config.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.2
  config file = /home/ignw/my_network_as_code/ansible.cfg
  configured module search path = ['/usr/local/lib/python3.6/dist-packages/napalm_ansible/modules']
  ansible python module location = /usr/local/lib/python3.6/dist-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 3.6.3 (default, Oct  3 2017, 21:45:48) [GCC 7.2.0]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
<10.0.0.8> <10.0.0.8> ssh connection has completed successfully
<10.0.0.8> connection to remote device started successfully
<10.0.0.8> local domain socket listeners started successfully
<10.0.0.8>
<10.0.0.8> local domain socket path is /home/ignw/.ansible/pc/8617761c70
<10.0.0.8> socket_path: /home/ignw/.ansible/pc/8617761c70
Using module file /usr/local/lib/python3.6/dist-packages/ansible/modules/network/asa/asa_config.py
<10.0.0.8> ESTABLISH LOCAL CONNECTION FOR USER: ignw
<10.0.0.8> EXEC /bin/sh -c 'echo ~ && sleep 0'
<10.0.0.8> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/ignw/.ansible/tmp/ansible-tmp-1526941893.6014657-134187020317411 `" && echo ansible-tmp-1526941893.6014657-134187020317411="` echo /home/ignw/.ansible/tmp/ansible-tmp-1526941893.6014657-134187020317411 `" ) && sleep 0'
<10.0.0.8> PUT /home/ignw/.ansible/tmp/ansible-local-24856l3y7x_n7/tmpq9jw7ue_ TO /home/ignw/.ansible/tmp/ansible-tmp-1526941893.6014657-134187020317411/asa_config.py
<10.0.0.8> EXEC /bin/sh -c 'chmod u+x /home/ignw/.ansible/tmp/ansible-tmp-1526941893.6014657-134187020317411/ /home/ignw/.ansible/tmp/ansible-tmp-1526941893.6014657-134187020317411/asa_config.py && sleep 0'
<10.0.0.8> EXEC /bin/sh -c '/usr/bin/python3 /home/ignw/.ansible/tmp/ansible-tmp-1526941893.6014657-134187020317411/asa_config.py && sleep 0'
<10.0.0.8> EXEC /bin/sh -c 'rm -f -r /home/ignw/.ansible/tmp/ansible-tmp-1526941893.6014657-134187020317411/ > /dev/null 2>&1 && sleep 0'
The full traceback is:
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/dist-packages/ansible/executor/task_executor.py", line 138, in run
    res = self._execute()
  File "/usr/local/lib/python3.6/dist-packages/ansible/executor/task_executor.py", line 558, in _execute
    result = self._handler.run(task_vars=variables)
  File "/usr/local/lib/python3.6/dist-packages/ansible/plugins/action/asa_config.py", line 58, in run
    for key in result.keys().copy():
AttributeError: 'dict_keys' object has no attribute 'copy'

fatal: [acme-sea-asa1]: FAILED! => {
    "msg": "Unexpected failure during module execution.",
    "stdout": ""
}

PLAY RECAP *************************************************************************************************************************
acme-sea-asa1              : ok=0    changed=0    unreachable=0    failed=1

After Play runs as expected:
PLAY [Backup Cisco ASA Configurations] ************************************************************************************
META: ran handlers

TASK [asa_config] *********************************************************************************************************
task path: /home/ignw/my_network_as_code/backup_configurations.yaml:15
<10.0.0.8> using connection plugin network_cli (was local)
<10.0.0.8> starting connection from persistent connection plugin
<10.0.0.8> local domain socket does not exist, starting it
<10.0.0.8> control socket path is /home/ignw/.ansible/pc/56d0c348d4
<10.0.0.8> <10.0.0.8> ESTABLISH CONNECTION FOR USER: ignw on PORT 22 TO 10.0.0.8
<10.0.0.8> <10.0.0.8> ssh connection done, setting terminal
<10.0.0.8> <10.0.0.8> loaded terminal plugin for network_os asa
<10.0.0.8> <10.0.0.8> loaded cliconf plugin for network_os asa
<10.0.0.8> <10.0.0.8> firing event: on_open_shell()
<10.0.0.8> <10.0.0.8> firing event: on_become
<10.0.0.8> <10.0.0.8> ssh connection has completed successfully
<10.0.0.8> connection to remote device started successfully
<10.0.0.8> local domain socket listeners started successfully
<10.0.0.8>
<10.0.0.8> local domain socket path is /home/ignw/.ansible/pc/56d0c348d4
<10.0.0.8> socket_path: /home/ignw/.ansible/pc/56d0c348d4
Using module file /usr/local/lib/python3.6/dist-packages/ansible/modules/network/asa/asa_config.py
<10.0.0.8> ESTABLISH LOCAL CONNECTION FOR USER: ignw
<10.0.0.8> EXEC /bin/sh -c 'echo ~ && sleep 0'
<10.0.0.8> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/ignw/.ansible/tmp/ansible-tmp-1527085836.785725-223346732295176 `" && echo ansible-tmp-1527085836.785725-223346732295176="` echo /home/ignw/.ansible/tmp/ansible-tmp-1527085836.785725-223346732295176 `" ) && sleep 0'
<10.0.0.8> PUT /home/ignw/.ansible/tmp/ansible-local-9530t4998lhs/tmp0ew0rssf TO /home/ignw/.ansible/tmp/ansible-tmp-1527085836.785725-223346732295176/asa_config.py
<10.0.0.8> EXEC /bin/sh -c 'chmod u+x /home/ignw/.ansible/tmp/ansible-tmp-1527085836.785725-223346732295176/ /home/ignw/.ansible/tmp/ansible-tmp-1527085836.785725-223346732295176/asa_config.py && sleep 0'
<10.0.0.8> EXEC /bin/sh -c '/usr/bin/python3 /home/ignw/.ansible/tmp/ansible-tmp-1527085836.785725-223346732295176/asa_config.py && sleep 0'
<10.0.0.8> EXEC /bin/sh -c 'rm -f -r /home/ignw/.ansible/tmp/ansible-tmp-1527085836.785725-223346732295176/ > /dev/null 2>&1 && sleep 0'
ok: [acme-sea-asa1] => {
    "backup_path": "/home/ignw/my_network_as_code/backup/acme-sea-asa1_config.2018-05-23@14:30:37",
    "changed": false,
    "invocation": {
        "module_args": {
            "after": null,
            "auth_pass": null,
            "authorize": null,
            "backup": true,
            "before": null,
            "config": null,
            "context": null,
            "defaults": false,
            "host": null,
            "lines": null,
            "match": "line",
            "parents": null,
            "password": null,
            "passwords": null,
            "port": null,
            "provider": {
                "auth_pass": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
                "authorize": true,
                "context": null,
                "host": "10.0.0.8",
                "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
                "passwords": null,
                "port": null,
                "ssh_keyfile": null,
                "timeout": null,
                "username": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER"
            },
            "replace": "line",
            "save": false,
            "src": null,
            "ssh_keyfile": null,
            "timeout": null,
            "username": null
        }
    }
}

```