### PR TITLE
ec2_vpc_net: fix hanging waiter when using host bits in a CIDR block

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_net.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_net.py
@@ -314,7 +314,6 @@ def wait_for_vpc_attribute(connection, module, vpc_id, attribute, expected_value
         module.fail_json(msg="Failed to wait for {0} to be updated".format(attribute))
 
 
-
 def get_cidr_network_bits(module, cidr_block):
     fixed_cidrs = []
     for cidr in cidr_block:

--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_net.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_net.py
@@ -170,6 +170,7 @@ from ansible.module_utils.ec2 import (AWSRetry, camel_dict_to_snake_dict, compar
                                       ansible_dict_to_boto3_tag_list, boto3_tag_list_to_ansible_dict)
 from ansible.module_utils.six import string_types
 from ansible.module_utils._text import to_native
+from ansible.module_utils.network.common.utils import to_subnet
 
 
 def vpc_exists(module, vpc, name, cidr_block, multi):
@@ -313,6 +314,25 @@ def wait_for_vpc_attribute(connection, module, vpc_id, attribute, expected_value
         module.fail_json(msg="Failed to wait for {0} to be updated".format(attribute))
 
 
+
+def get_cidr_network_bits(module, cidr_block):
+    fixed_cidrs = []
+    for cidr in cidr_block:
+        split_addr = cidr.split('/')
+        if len(split_addr) == 2:
+            # this_ip is a IPv4 CIDR that may or may not have host bits set
+            # Get the network bits.
+            valid_cidr = to_subnet(split_addr[0], split_addr[1])
+            if cidr != valid_cidr:
+                module.warn("One of your CIDR addresses ({0}) has host bits set. To get rid of this warning, "
+                            "check the network mask and make sure that only network bits are set: {1}.".format(cidr, valid_cidr))
+            fixed_cidrs.append(valid_cidr)
+        else:
+            # let AWS handle invalid CIDRs
+            fixed_cidrs.append(cidr)
+    return fixed_cidrs
+
+
 def main():
     argument_spec = dict(
         name=dict(required=True),
@@ -333,7 +353,7 @@ def main():
     )
 
     name = module.params.get('name')
-    cidr_block = module.params.get('cidr_block')
+    cidr_block = get_cidr_network_bits(module, module.params.get('cidr_block'))
     purge_cidrs = module.params.get('purge_cidrs')
     tenancy = module.params.get('tenancy')
     dns_support = module.params.get('dns_support')


### PR DESCRIPTION
##### SUMMARY
If you use a CIDR that has host bits set the module hangs indefinitely (since AWS corrects it under the hood; the waiter then is repeatedly comparing two different values). Fixed by stripping the host bits before calling AWS.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/ec2_vpc_net.py

##### ANSIBLE VERSION
```
2.6.0
```
