### PR TITLE
Skip XPath function calls

### DIFF
--- a/lib/ansible/modules/files/xml.py
+++ b/lib/ansible/modules/files/xml.py
@@ -495,8 +495,10 @@ def check_or_make_target(module, tree, xpath, namespaces):
                         for subexpr in eoa_value:
                             # module.fail_json(msg="element=%s subexpr=%s node=%s now tree=%s" %
                             #                      (element, subexpr, etree.tostring(node, pretty_print=True), etree.tostring(tree, pretty_print=True))
-                            check_or_make_target(module, nk, "./" + subexpr, namespaces)
-                    changed = True
+                            if subexpr[-1] != ')':
+                                # skip XPath function calls
+                                check_or_make_target(module, nk, "./" + subexpr, namespaces)
+                                changed = True
 
                 # module.fail_json(msg="now tree=%s" % etree.tostring(tree, pretty_print=True))
             elif eoa == "":


### PR DESCRIPTION
##### SUMMARY
Skip XPath function calls when creating attributes in **xml** module.

When creating attributes, skip XPath function calls. They're used for matching, but do not represent actual attributes. Example:

```xpath
/foo[@bar=42 and not(@quux)]
```

This will match an element `foo`, and if it's missing, create one with attribute `bar` only.

##### ISSUE TYPE
Bugfix Pull Request

##### COMPONENT NAME
Module: xml

##### ANSIBLE VERSION
```
ansible 2.5.3
  config file = /home/styopa/.ansible.cfg
  configured module search path = [u'/home/styopa/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.15 (default, May  1 2018, 05:55:50) [GCC 7.3.0]
```


##### ADDITIONAL INFORMATION
Sample playbook:
```yaml
---
- hosts: localhost
  gather_facts: false
  tasks:
    - name: Illustrate bugfix
      xml:
        path: sample.xml
        backup: true
        pretty_print: true
        xpath: /root/foo[not(@bar)]
        attribute: quux
        value: quux
```

Sample XML file:
```xml
<?xml version='1.0' encoding='UTF-8'?>
<root>
  <foo bar="42"/>
</root>
```

Result without patch:
```bash
$ ansible-playbook playbook.yml

PLAY [localhost] ***

TASK [Illustrate bugfix] ***
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Can't process Xpath ./not(@bar) in order to spawn nodes! tree is <foo/>\n"}

PLAY RECAP ***
localhost                  : ok=0    changed=0    unreachable=0    failed=1
```
Result with patch:
```
$ ansible-playbook playbook.yml

PLAY [localhost] ***

TASK [Illustrate bugfix] ***
changed: [localhost]

PLAY RECAP ***
localhost                  : ok=1    changed=1    unreachable=0    failed=0
```

Resulting XML file:
```xml
<?xml version='1.0' encoding='UTF-8'?>
<root>
  <foo bar="42"/>
  <foo quux="quux"/>
</root>
```