### PR TITLE
add --list-hosts-plain for list of hosts suitable for pipes / scripts

### DIFF
--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -418,11 +418,11 @@ class CLI(with_metaclass(ABCMeta, object)):
 
     @staticmethod
     def listhosts(option, opt, value, parser):
-        parser.values.listhosts = True;
+        parser.values.listhosts = True
         if opt == '--list-hosts-plain':
-            parser.values.listhostsplain = True;
+            parser.values.listhostsplain = True
         else:
-            parser.values.listhostsplain = False;
+            parser.values.listhostsplain = False
 
     @staticmethod
     def base_parser(usage="", output_opts=False, runas_opts=False, meta_opts=False, runtask_opts=False, vault_opts=False, module_opts=False,

--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -417,6 +417,14 @@ class CLI(with_metaclass(ABCMeta, object)):
             setattr(parser.values, option.dest, value)
 
     @staticmethod
+    def listhosts(option, opt, value, parser):
+        parser.values.listhosts = True;
+        if opt == '--list-hosts-plain':
+            parser.values.listhostsplain = True;
+        else:
+            parser.values.listhostsplain = False;
+
+    @staticmethod
     def base_parser(usage="", output_opts=False, runas_opts=False, meta_opts=False, runtask_opts=False, vault_opts=False, module_opts=False,
                     async_opts=False, connect_opts=False, subset_opts=False, check_opts=False, inventory_opts=False, epilog=None, fork_opts=False,
                     runas_prompt_opts=False, desc=None, basedir_opts=False, vault_rekey_opts=False):
@@ -430,8 +438,10 @@ class CLI(with_metaclass(ABCMeta, object)):
         if inventory_opts:
             parser.add_option('-i', '--inventory', '--inventory-file', dest='inventory', action="append",
                               help="specify inventory host path or comma separated host list. --inventory-file is deprecated")
-            parser.add_option('--list-hosts', dest='listhosts', action='store_true',
+            parser.add_option('--list-hosts', dest='listhosts', action='callback', callback=CLI.listhosts,
                               help='outputs a list of matching hosts; does not execute anything else')
+            parser.add_option('--list-hosts-plain', dest='listhosts', action='callback', callback=CLI.listhosts,
+                              help='outputs a plain list of matching hosts; does not execute anything else')
             parser.add_option('-l', '--limit', default=C.DEFAULT_SUBSET, dest='subset',
                               help='further limit selected hosts to an additional pattern')
 

--- a/lib/ansible/cli/adhoc.py
+++ b/lib/ansible/cli/adhoc.py
@@ -123,9 +123,12 @@ class AdHocCLI(CLI):
                 display.warning("No hosts matched, nothing to do")
 
         if self.options.listhosts:
-            display.display('  hosts (%d):' % len(hosts))
+            prefix = '';
+            if not self.options.listhostsplain:
+                display.display('  hosts (%d):' % len(hosts))
+                prefix = '    ';
             for host in hosts:
-                display.display('    %s' % host)
+                display.display('%s%s' % (prefix,host))
             return 0
 
         if self.options.module_name in C.MODULE_REQUIRE_ARGS and not self.options.module_args:

--- a/lib/ansible/cli/adhoc.py
+++ b/lib/ansible/cli/adhoc.py
@@ -123,12 +123,12 @@ class AdHocCLI(CLI):
                 display.warning("No hosts matched, nothing to do")
 
         if self.options.listhosts:
-            prefix = '';
+            prefix = ''
             if not self.options.listhostsplain:
                 display.display('  hosts (%d):' % len(hosts))
-                prefix = '    ';
+                prefix = '    '
             for host in hosts:
-                display.display('%s%s' % (prefix,host))
+                display.display('%s%s' % (prefix, host))
             return 0
 
         if self.options.module_name in C.MODULE_REQUIRE_ARGS and not self.options.module_args:


### PR DESCRIPTION
##### SUMMARY
Output from --list-hosts contains spurious information (number of hosts, extra white space) which makes it less easily consumed by scripts. The addition of a --list-hosts-plain option omits this extra text.

Fixes #39003 

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
cli

##### ANSIBLE VERSION
```
ansible 2.6.0dev0 (listhosts bed58a0fa9) last updated 2018/05/23 12:32:29 (GMT -400)
  config file = /home/utoddl/.ansible.cfg
  configured module search path = [u'/home/utoddl/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/utoddl/src/ansible/lib/ansible
  executable location = /home/utoddl/src/ansible/bin/ansible
  python version = 2.7.15 (default, May 16 2018, 17:50:09) [GCC 8.1.1 20180502 (Red Hat 8.1.1-1)]
```


##### ADDITIONAL INFORMATION
In the Ansible on RHEL prior to version 2, this extra "<spaces>Hosts (#):" line was not produced. Upgrading our Ansible broke many of our automation scripts which used "ansible --list-hosts" to get lists of hosts. 

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before:
```
$ ./bin/ansible www\* --list-hosts
  hosts (7):
    wwwdot1t.isis.unc.edu
    wwwdot2p.isis.unc.edu
    wwwdot0p.isis.unc.edu
    wwwdot3p.isis.unc.edu
    wwwdot1p.isis.unc.edu
    wwwdot0f.isis.unc.edu
    wwwdot0t.isis.unc.edu
```
After:
```
$ ./bin/ansible www\* --list-hosts-plain
wwwdot1t.isis.unc.edu
wwwdot2p.isis.unc.edu
wwwdot0p.isis.unc.edu
wwwdot3p.isis.unc.edu
wwwdot1p.isis.unc.edu
wwwdot0f.isis.unc.edu
wwwdot0t.isis.unc.edu
```
