### PR TITLE
Fix ios test pt. 2

### DIFF
--- a/lib/ansible/modules/network/ios/ios_l3_interface.py
+++ b/lib/ansible/modules/network/ios/ios_l3_interface.py
@@ -107,11 +107,10 @@ from copy import deepcopy
 
 from ansible.module_utils._text import to_text
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.six import iteritems
 from ansible.module_utils.network.ios.ios import get_config, load_config
 from ansible.module_utils.network.ios.ios import ios_argument_spec
 from ansible.module_utils.network.common.config import NetworkConfig
-from ansible.module_utils.network.common.utils import conditional, remove_default_spec
+from ansible.module_utils.network.common.utils import remove_default_spec
 from ansible.module_utils.network.common.utils import is_netmask, is_masklen, to_netmask, to_masklen
 
 
@@ -197,6 +196,8 @@ def map_obj_to_commands(updates, module):
                     commands.append('no ipv6 address {}'.format(ipv6))
                 else:
                     commands.append('no ipv6 address')
+                    if 'dhcp' in obj_in_have['ipv6']:
+                        commands.append('no ipv6 address dhcp')
 
         elif state == 'present':
             if ipv4:

--- a/test/integration/targets/ios_l3_interface/tests/cli/basic.yaml
+++ b/test/integration/targets/ios_l3_interface/tests/cli/basic.yaml
@@ -168,6 +168,8 @@
     provider: "{{ cli }}"
   register: result
 
+- assert: *unchanged
+
 - name: Delete second interface ipv4 and ipv6 address (setup)
   ios_l3_interface:
     name: "{{ test_interface2 }}"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
`dhcp` needs to be removed seperately when clearing all ipv6 addresses on certain ios devices

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
ios_l3_interface

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6
```