### PR TITLE
winrm: add better exception handling for krb5 auth with pexpect (#39930)

### DIFF
--- a/changelogs/fragments/winrm_kinit_error-fix.yaml
+++ b/changelogs/fragments/winrm_kinit_error-fix.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- winrm - Add better error handling when the kinit process fails


### PR DESCRIPTION
(cherry picked from commit 5e28e282a5d7846b97cae923518f58767dcb80ec)

##### SUMMARY
Backport https://github.com/ansible/ansible/pull/39930

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
winrm

##### ANSIBLE VERSION
```
2.5
```