### PR TITLE
deprecate network filter

### DIFF
--- a/lib/ansible/plugins/filter/ipaddr.py
+++ b/lib/ansible/plugins/filter/ipaddr.py
@@ -501,7 +501,7 @@ def ipaddr(value, query='', version=False, alias='ipaddr'):
         'net': _net_query,
         'next_usable': _next_usable_query,
         'netmask': _netmask_query,
-        'network': _network_query,
+        'network': _network_query,  # deprecate
         'network_id': _network_id_query,
         'network/prefix': _subnet_query,
         'network_netmask': _network_netmask_query,


### PR DESCRIPTION
I neglected to add the tag to deprecate network filter, once the option to deprecate filters became available in the PR: https://github.com/ansible/ansible/pull/26566 , this since come up in https://github.com/ansible/ansible/pull/35400 where I realize my issue.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - New Module Pull Request
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
