### PR TITLE
fix nxos_system test

### DIFF
--- a/test/integration/targets/nxos_system/tests/common/set_hostname.yaml
+++ b/test/integration/targets/nxos_system/tests/common/set_hostname.yaml
@@ -6,7 +6,7 @@
 - block:
   - name: setup
     nxos_config:
-      lines: "hostname {{ inventory_hostname_short }}"
+      lines: "hostname switch"
       match: none
 
   - name: configure hostname
@@ -30,7 +30,7 @@
   always:
   - name: teardown
     nxos_config:
-      lines: "hostname {{ inventory_hostname_short }}"
+      lines: "hostname switch"
       match: none
 
 

--- a/test/integration/targets/nxos_system/tests/nxapi/net_system.yaml
+++ b/test/integration/targets/nxos_system/tests/nxapi/net_system.yaml
@@ -1,6 +1,5 @@
 ---
 - debug: msg="START nxos nxapi/net_system.yaml on connection={{ ansible_connection }}"
-- debug: msg="Using provider={{ connection.transport }}"
 
 # Add minimal testcase to check args are passed correctly to
 # implementation module and module run is successful.


### PR DESCRIPTION
Signed-off-by: Trishna Guha <trishnaguha17@gmail.com>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
change {{ inventory_hostname }} to switch as this causes failure on dci even after changing it to {{ inventory_hostname_short }}
```
hostname 5cccdde5-d30d-4cad-babb-9744992f6239\r\r\n                                                         ^\r\n% String exceeded max length of (32) at '^' marker.\r\n\rswitch(config)
```
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
test/integration/targets/nxos_system
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```