### PR TITLE
gluster_volume: Fix `volume set' and `quota' features (#40438)

### DIFF
--- a/lib/ansible/modules/system/gluster_volume.py
+++ b/lib/ansible/modules/system/gluster_volume.py
@@ -111,6 +111,16 @@ EXAMPLES = """
     options:
       performance.cache-size: 256MB
 
+- name: Set multiple options on GlusterFS volume
+  gluster_volume:
+    state: present
+    name: test1
+    options:
+      { performance.cache-size: 128MB,
+        write-behind: 'off',
+        quick-read: 'on'
+      }
+
 - name: start gluster volume
   gluster_volume:
     state: started
@@ -409,8 +419,8 @@ def main():
     if cluster is not None and len(cluster) > 1 and cluster[-1] == '':
         cluster = cluster[0:-1]
 
-    if cluster is None or cluster[0] == '':
-        cluster = [myhostname]
+    if cluster is None:
+        cluster = []
 
     if brick_paths is not None and "," in brick_paths:
         brick_paths = brick_paths.split(",")


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

The code was failing to parse host:brick pattern since the cluster variable was always set.
Which was causing the volume set and volume quota operations. 

* Add documentation for setting multiple options.
* Do not set `cluster' to myhostname, if cluster is not set. This will cause
  parse error, since module will try to parse the brick and hosts.
* Also fixes issue #40410

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
gluster_volume

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible --version 
ansible 2.5.3
  config file = /tmp/ansible.cfg
  configured module search path = [u'/home/sac/work/ansible/lib/ansible/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.15 (default, May 16 2018, 17:50:09) [GCC 8.1.1 20180502 (Red Hat 8.1.1-1)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

Tested the module for:
* Volume creation
* Add brick to a volume
* Set a single option
* Set multiple options
* Set quota on a volume
* Delete a volume

To ensure no regressions. 

<!--- Paste verbatim command output below, e.g. before and after your change -->
*Before the change*:
```
ansible-playbook vol_set_1.yml 

PLAY [servers] ***************************************************************************************************************************************

TASK [Set gluster option] ************************************************************************************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: None
failed: [10.70.42.25] (item={u'name': u'rabbitmq-main', u'options': {u'performance.cache-size': u'128MB'}}) => {"changed": false, "item": {"name": "rabbitmq-main", "options": {"performance.cache-size": "128MB"}}, "msg": "error running gluster (/usr/sbin/gluster --mode=script volume add-brick rabbitmq-main dhcp42-25.lab.eng.blr.redhat.com:None) command (rc=1): Wrong brick type: dhcp42-25.lab.eng.blr.redhat.com:None, use <HOSTNAME>:<export-dir-abs-path>\nUsage: volume add-brick <VOLNAME> [<stripe|replica> <COUNT> [arbiter <COUNT>]] <NEW-BRICK> ... [force]\n"}

NO MORE HOSTS LEFT ***********************************************************************************************************************************
        to retry, use: --limit @/tmp/vol_set_1.retry

PLAY RECAP *******************************************************************************************************************************************
10.70.42.25                : ok=0    changed=0    unreachable=0    failed=1   


```

*After the change*:
```
ansible-playbook vol_set_1.yml                                                                                                   
                                                                                                                                                      
PLAY [servers] ***************************************************************************************************************************************
                                                                                                                                                      
TASK [Set gluster option] ************************************************************************************************************************
changed: [10.70.42.25] => (item={u'name': u'rabbitmq-main', u'options': {u'performance.cache-size': u'128MB'}})                                       
                                                                                                                                                      
PLAY RECAP *******************************************************************************************************************************************
10.70.42.25                : ok=1    changed=1    unreachable=0    failed=0                                                                           
                                                                                          
```