### PR TITLE
Fixes #24241 Module always updates installed plugins

### DIFF
--- a/changelogs/fragments/40645-jenkins_plugin.yaml
+++ b/changelogs/fragments/40645-jenkins_plugin.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- jenkins_plugin: fix plugin always updated even if already uptodate (https://github.com/ansible/ansible/pull/40645)

--- a/lib/ansible/modules/web_infrastructure/jenkins_plugin.py
+++ b/lib/ansible/modules/web_infrastructure/jenkins_plugin.py
@@ -275,7 +275,7 @@ state:
     sample: "present"
 '''
 
-from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import AnsibleModule, to_bytes
 from ansible.module_utils.six.moves.urllib.parse import urlencode
 from ansible.module_utils.urls import fetch_url, url_argument_spec
 from ansible.module_utils._text import to_native
@@ -505,7 +505,7 @@ class JenkinsPlugin(object):
                 sha1sum_old = base64.b64encode(sha1_old.digest())
 
                 # If the latest version changed, download it
-                if sha1sum_old != plugin_data['sha1']:
+                if sha1sum_old != to_bytes(plugin_data['sha1']):
                     if not self.module.check_mode:
                         r = self._download_plugin(plugin_url)
                         self._write_file(plugin_file, r)


### PR DESCRIPTION
##### SUMMARY
Backport of #40591 for Ansible 2.5

When setting state=latest, plugin are always updated because old sha1 is bytes and and is compared to new sha1 which is str (so it always detecting a sha1 change)

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
`jenkins_plugin.py`

##### ANSIBLE VERSION
ansible 2.5.3

##### ADDITIONAL INFORMATION
Local python (running ansible): Python 2.7.12
ansible_python_interpreter: Python 3.5.2
#24241
