### PR TITLE
Add OpenBSD password encryption

### DIFF
--- a/docs/docsite/rst/reference_appendices/faq.rst
+++ b/docs/docsite/rst/reference_appendices/faq.rst
@@ -364,6 +364,7 @@ The mkpasswd utility that is available on most Linux systems is a great option:
 .. code-block:: shell-session
 
     mkpasswd --method=sha-512
+    
 
 If this utility is not installed on your system (e.g. you are using OS X) then you can still easily
 generate these passwords using Python. First, ensure that the `Passlib <https://bitbucket.org/ecollins/passlib/wiki/Home>`_
@@ -381,6 +382,12 @@ Once the library is ready, SHA512 password values can then be generated as follo
 
 Use the integrated :ref:`hash_filters` to generate a hashed version of a password.
 You shouldn't put plaintext passwords in your playbook or host_vars; instead, use :doc:`../user_guide/playbooks_vault` to encrypt sensitive data.
+
+In OpenBSD, a similar option is available in the base system called encrypt(1):
+
+.. code-block:: shell-session
+
+    encrypt
 
 .. _commercial_support:
 


### PR DESCRIPTION
Add docs to password encryption section of FAQ for OpenBSD.

+label: docsite_pr

##### SUMMARY
OpenBSD comes with its own encryption utility, which must be run on the password text, `encrypt <password>`. following the code block above in the FAQ, i only included the base command in the code block. I wasn't quite sure where to add my change, so I put it at the bottom of the section since the rest all flows well together.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
FAQ section in the docs

##### ANSIBLE VERSION
N/A the command is in the host system, not a part of Ansible.

##### ADDITIONAL INFORMATION
It took me a while poking around to figure out that the ansible user module wasn't properly encrypting the password for OpenBSD. It appears to work fine for FreeBSD from my experience (2.2-2.4). I thought the few of us in BSD-land would appreciate this little tid-bit.