### PR TITLE
ACI: Add from_card and to_card parameters

### DIFF
--- a/lib/ansible/modules/network/aci/aci_access_port_to_interface_policy_leaf_profile.py
+++ b/lib/ansible/modules/network/aci/aci_access_port_to_interface_policy_leaf_profile.py
@@ -59,20 +59,22 @@ options:
     description:
     - The beggining (from range) of the card range block for the leaf access port block.
     aliases: [ from_card_range ]
+    version_added: '2.6'
   to_card:
     description:
     - The end (to range) of the card range block for the leaf access port block.
     aliases: [ to_card_range ]
+    version_added: '2.6'
   policy_group:
     description:
     - The name of the fabric access policy group to be associated with the leaf interface profile interface selector.
     aliases: [ policy_group_name ]
   interface_type:
-    version_added: '2.6'
     description:
     - The type of interface for the static EPG deployement.
     choices: [ fex, port_channel, switch_port, vpc ]
     default: switch_port
+    version_added: '2.6'
   state:
     description:
     - Use C(present) or C(absent) for adding or removing.

--- a/lib/ansible/modules/network/aci/aci_access_port_to_interface_policy_leaf_profile.py
+++ b/lib/ansible/modules/network/aci/aci_access_port_to_interface_policy_leaf_profile.py
@@ -45,17 +45,24 @@ options:
   leaf_port_blk_description:
     description:
     - The description to assign to the C(leaf_port_blk)
-    required: no
-  from:
+  from_port:
     description:
     - The beggining (from range) of the port range block for the leaf access port block.
+    aliases: [ from, fromPort, from_port_range ]
     required: yes
-    aliases: [ fromPort, from_port_range ]
-  to:
+  to_port:
     description:
     - The end (to range) of the port range block for the leaf access port block.
+    aliases: [ to, toPort, to_port_range ]
     required: yes
-    aliases: [ toPort, to_port_range ]
+  from_card:
+    description:
+    - The beggining (from range) of the card range block for the leaf access port block.
+    aliases: [ from_card_range ]
+  to_card:
+    description:
+    - The end (to range) of the card range block for the leaf access port block.
+    aliases: [ to_card_range ]
   policy_group:
     description:
     - The name of the fabric access policy group to be associated with the leaf interface profile interface selector.
@@ -84,8 +91,8 @@ EXAMPLES = r'''
     leaf_interface_profile: leafintprfname
     access_port_selector: accessportselectorname
     leaf_port_blk: leafportblkname
-    from: 13
-    to: 16
+    from_port: 13
+    toi_port: 16
     policy_group: policygroupname
     state: present
 
@@ -97,8 +104,8 @@ EXAMPLES = r'''
     leaf_interface_profile: leafintprfname
     access_port_selector: accessportselectorname
     leaf_port_blk: leafportblkname
-    from: 13
-    to: 16
+    from_port: 13
+    to_port: 16
     state: present
 
 - name: Remove an interface access port selector associated with an Interface Policy Leaf Profile
@@ -231,19 +238,20 @@ from ansible.module_utils.basic import AnsibleModule
 
 def main():
     argument_spec = aci_argument_spec()
-    argument_spec.update({
-        'leaf_interface_profile': dict(type='str', aliases=['leaf_interface_profile_name']),  # Not required for querying all objects
-        'access_port_selector': dict(type='str', aliases=['name', 'access_port_selector_name']),  # Not required for querying all objects
-        'description': dict(typ='str'),
-        'leaf_port_blk': dict(type='str', aliases=['leaf_port_blk_name']),
-        'leaf_port_blk_description': dict(type='str'),
-        # NOTE: Keyword 'from' is a reserved word in python, so we need it as a string
-        'from': dict(type='str', aliases=['fromPort', 'from_port_range']),
-        'to': dict(type='str', aliases=['toPort', 'to_port_range']),
-        'policy_group': dict(type='str', aliases=['policy_group_name']),
-        'interface_type': dict(type='str', default='switch_port', choices=['fex', 'port_channel', 'switch_port', 'vpc']),
-        'state': dict(type='str', default='present', choices=['absent', 'present', 'query']),
-    })
+    argument_spec.update(
+        leaf_interface_profile=dict(type='str', aliases=['leaf_interface_profile_name']),  # Not required for querying all objects
+        access_port_selector=dict(type='str', aliases=['name', 'access_port_selector_name']),  # Not required for querying all objects
+        description=dict(typ='str'),
+        leaf_port_blk=dict(type='str', aliases=['leaf_port_blk_name']),
+        leaf_port_blk_description=dict(type='str'),
+        from_port=dict(type='str', aliases=['from', 'fromPort', 'from_port_range']),
+        to_port=dict(type='str', aliases=['to', 'toPort', 'to_port_range']),
+        from_card=dict(type='str', aliases=['from_card_range']),
+        to_card=dict(type='str', aliases=['to_card_range']),
+        policy_group=dict(type='str', aliases=['policy_group_name']),
+        interface_type=dict(type='str', default='switch_port', choices=['fex', 'port_channel', 'switch_port', 'vpc']),
+        state=dict(type='str', default='present', choices=['absent', 'present', 'query']),
+    )
 
     module = AnsibleModule(
         argument_spec=argument_spec,
@@ -259,8 +267,10 @@ def main():
     description = module.params['description']
     leaf_port_blk = module.params['leaf_port_blk']
     leaf_port_blk_description = module.params['leaf_port_blk_description']
-    from_ = module.params['from']
-    to_ = module.params['to']
+    from_port = module.params['from_port']
+    to_port = module.params['to_port']
+    from_card = module.params['from_card']
+    to_card = module.params['to_card']
     policy_group = module.params['policy_group']
     interface_type = module.params['interface_type']
     state = module.params['state']
@@ -271,7 +281,7 @@ def main():
             aci_class='infraAccPortP',
             aci_rn='infra/accportprof-{0}'.format(leaf_interface_profile),
             filter_target='eq(infraAccPortP.name, "{0}")'.format(leaf_interface_profile),
-            module_object=leaf_interface_profile
+            module_object=leaf_interface_profile,
         ),
         subclass_1=dict(
             aci_class='infraHPortS',
@@ -280,7 +290,7 @@ def main():
             filter_target='eq(infraHPortS.name, "{0}")'.format(access_port_selector),
             module_object=access_port_selector,
         ),
-        child_classes=['infraPortBlk', 'infraRsAccBaseGrp']
+        child_classes=['infraPortBlk', 'infraRsAccBaseGrp'],
     )
 
     INTERFACE_TYPE_MAPPING = dict(
@@ -298,6 +308,7 @@ def main():
             class_config=dict(
                 descr=description,
                 name=access_port_selector,
+                #  type='range',
             ),
             child_configs=[
                 dict(
@@ -305,8 +316,10 @@ def main():
                         attributes=dict(
                             descr=leaf_port_blk_description,
                             name=leaf_port_blk,
-                            fromPort=from_,
-                            toPort=to_,
+                            fromPort=from_port,
+                            toPort=to_port,
+                            fromCard=from_card,
+                            toCard=to_card,
                         ),
                     ),
                 ),


### PR DESCRIPTION
##### SUMMARY
Add missing **from_card** and **to_card** parameters.

Also rename **from** and **to** parameters to **from_port** and **to_port**.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
aci_access_port_to_interface_policy_leaf_profile

##### ANSIBLE VERSION
v2.5