### PR TITLE
[2.5] Fix ios_vlan to correctly identify unmodified config when havin…

### DIFF
--- a/test/sanity/pylint/ignore.txt
+++ b/test/sanity/pylint/ignore.txt
@@ -47,7 +47,6 @@ lib/ansible/modules/network/eos/eos_linkagg.py ansible-format-automatic-specific
 lib/ansible/modules/network/eos/eos_logging.py ansible-format-automatic-specification
 lib/ansible/modules/network/eos/eos_static_route.py ansible-format-automatic-specification
 lib/ansible/modules/network/ios/ios_l3_interface.py ansible-format-automatic-specification
-lib/ansible/modules/network/ios/ios_vlan.py ansible-format-automatic-specification
 lib/ansible/modules/network/iosxr/iosxr_banner.py ansible-format-automatic-specification
 lib/ansible/modules/network/iosxr/iosxr_interface.py ansible-format-automatic-specification
 lib/ansible/modules/network/nxos/nxos_logging.py ansible-format-automatic-specification

--- a/test/units/modules/network/ios/fixtures/ios_vlan_config.cfg
+++ b/test/units/modules/network/ios/fixtures/ios_vlan_config.cfg
@@ -1,0 +1,8 @@
+VLAN Name                             Status    Ports
+---- -------------------------------- --------- -------------------------------
+1    default                          active    Gi1/0/4, Gi1/0/5
+                                                Gi1/0/52
+                                                Gi1/0/54
+2    vlan2                            active    Gi1/0/6, Gi1/0/7
+1002 fddi-default                     act/unsup 
+1003 fddo-default                     act/unsup

--- a/test/units/modules/network/ios/test_ios_vlan.py
+++ b/test/units/modules/network/ios/test_ios_vlan.py
@@ -1,0 +1,137 @@
+# (c) 2018 Red Hat Inc.
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import json
+
+from ansible.compat.tests.mock import patch
+from ansible.modules.network.ios import ios_vlan
+from ansible.modules.network.ios.ios_vlan import parse_vlan_brief
+from units.modules.utils import set_module_args
+from .ios_module import TestIosModule, load_fixture
+
+
+class TestIosVlanModule(TestIosModule):
+
+    module = ios_vlan
+
+    def setUp(self):
+        super(TestIosVlanModule, self).setUp()
+
+        self.mock_run_commands = patch('ansible.modules.network.ios.ios_vlan.run_commands')
+        self.run_commands = self.mock_run_commands.start()
+
+        self.mock_load_config = patch('ansible.modules.network.ios.ios_vlan.load_config')
+        self.load_config = self.mock_load_config.start()
+
+    def tearDown(self):
+        super(TestIosVlanModule, self).tearDown()
+        self.mock_run_commands.stop()
+        self.mock_load_config.stop()
+
+    def load_fixtures(self, commands=None, transport='cli'):
+        self.run_commands.return_value = [load_fixture('ios_vlan_config.cfg')]
+        self.load_config.return_value = {'diff': None, 'session': 'session'}
+
+    def test_ios_vlan_create(self):
+        set_module_args({'vlan_id': '3', 'name': 'test', 'state': 'present'})
+        result = self.execute_module(changed=True)
+        expected_commands = [
+            'vlan 3',
+            'name test',
+        ]
+        self.assertEqual(result['commands'], expected_commands)
+
+    def test_ios_vlan_rename(self):
+        set_module_args({'vlan_id': '2', 'name': 'test', 'state': 'present'})
+        result = self.execute_module(changed=True)
+        expected_commands = [
+            'vlan 2',
+            'name test',
+        ]
+        self.assertEqual(result['commands'], expected_commands)
+
+    def test_ios_vlan_with_interfaces(self):
+        set_module_args({'vlan_id': '2', 'name': 'vlan2', 'state': 'present', 'interfaces': ['GigabitEthernet1/0/8', 'GigabitEthernet1/0/7']})
+        result = self.execute_module(changed=True)
+        expected_commands = [
+            'vlan 2',
+            'interface GigabitEthernet1/0/8',
+            'switchport mode access',
+            'switchport access vlan 2',
+            'vlan 2',
+            'interface GigabitEthernet1/0/6',
+            'switchport mode access',
+            'no switchport access vlan 2',
+        ]
+        self.assertEqual(result['commands'], expected_commands)
+
+    def test_ios_vlan_with_interfaces_and_newvlan(self):
+        set_module_args({'vlan_id': '3', 'name': 'vlan3', 'state': 'present', 'interfaces': ['GigabitEthernet1/0/8', 'GigabitEthernet1/0/7']})
+        result = self.execute_module(changed=True)
+        expected_commands = [
+            'vlan 3',
+            'name vlan3',
+            'interface GigabitEthernet1/0/8',
+            'switchport mode access',
+            'switchport access vlan 3',
+            'interface GigabitEthernet1/0/7',
+            'switchport mode access',
+            'switchport access vlan 3',
+        ]
+        self.assertEqual(result['commands'], expected_commands)
+
+    def test_parse_vlan_brief(self):
+        result = parse_vlan_brief(load_fixture('ios_vlan_config.cfg'))
+        obj = [
+            {
+                'name': 'default',
+                'interfaces': [
+                    'GigabitEthernet1/0/4',
+                    'GigabitEthernet1/0/5',
+                    'GigabitEthernet1/0/52',
+                    'GigabitEthernet1/0/54',
+                ],
+                'state': 'active',
+                'vlan_id': '1',
+            },
+            {
+                'name': 'vlan2',
+                'interfaces': [
+                    'GigabitEthernet1/0/6',
+                    'GigabitEthernet1/0/7',
+                ],
+                'state': 'active',
+                'vlan_id': '2',
+            },
+            {
+                'name': 'fddi-default',
+                'interfaces': [],
+                'state': 'act/unsup',
+                'vlan_id': '1002',
+            },
+            {
+                'name': 'fddo-default',
+                'interfaces': [],
+                'state': 'act/unsup',
+                'vlan_id': '1003',
+            },
+        ]
+        self.assertEqual(result, obj)


### PR DESCRIPTION
…g long interface names (#40145)

Change the command to get the interface in a vlan "show vlan" => "show vlan brief"
Change the parsing of the return command of the switch.
The return of the ios command is fixed so i cut with fix number of carracter.
Adding looking for the next line to add the forgeted interfaces.
(cherry picked from commit 3903ca5)

Co-authored-by: pierremahot <pierre.mahot@orange.fr>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - New Module Pull Request
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
