### PR TITLE
Added Proxmox Cloud-Init Support

### DIFF
--- a/lib/ansible/modules/cloud/misc/proxmox_kvm.py
+++ b/lib/ansible/modules/cloud/misc/proxmox_kvm.py
@@ -707,7 +707,7 @@ def create_vm(module, proxmox, vmid, newid, node, name, memory, cpu, cores, sock
     only_v4 = ['force', 'protection', 'skiplock']
 
     # valide clone parameters
-    valid_clone_params = ['format', 'full', 'pool', 'snapname', 'storage', 'target' ]
+    valid_clone_params = ['format', 'full', 'pool', 'snapname', 'storage', 'target']
     clone_params = {}
     # Default args for vm. Note: -args option is for experts only. It allows you to pass arbitrary arguments to kvm.
     vm_args = "-serial unix:/var/run/qemu-server/{}.serial,server,nowait".format(vmid)
@@ -834,7 +834,7 @@ def main():
             bootdisk=dict(type='str'),
             ciuser=dict(type='str', default='root'),
             cipassword=dict(type='str'),
-            citype=dict(type='str', default='nocloud', choices=['nocloud','configdrive2']),
+            citype=dict(type='str', default='nocloud', choices=['nocloud', 'configdrive2']),
             clone=dict(type='str', default=None),
             cores=dict(type='int', default=1),
             cpu=dict(type='str', default='kvm64'),

--- a/lib/ansible/modules/cloud/misc/proxmox_kvm.py
+++ b/lib/ansible/modules/cloud/misc/proxmox_kvm.py
@@ -82,6 +82,7 @@ options:
     version_added: 2.6
     description:
       - Specifies the cloud-init configuration format.
+    choices: ['nocloud', 'configdrive2']
   clone:
     description:
       - Name of VM to be cloned. If C(vmid) is setted, C(clone) can take arbitrary value but required for intiating the clone.

--- a/lib/ansible/modules/cloud/misc/proxmox_kvm.py
+++ b/lib/ansible/modules/cloud/misc/proxmox_kvm.py
@@ -721,8 +721,14 @@ def create_vm(module, proxmox, vmid, newid, node, name, memory, cpu, cores, sock
 
     # Verify Cloud-Init support
     if PVE_FULL_VERSION < 5.2:
-      if 'ciuser' in kwargs or 'cipassword' in kwargs or 'citype' or 'ipconfig' in kwargs or 'nameserver' in kwargs or 'searchdomain' in kwargs or 'sshkeys' in kwargs:
-        module.fail_json(msg='Cloud-Init is not supported on Proxmox Versions older than 5.2, your version: %s' % PVE_FULL_VERSION)
+        if ('ciuser' in kwargs or
+            'cipassword' in kwargs or
+            'citype' in kwargs or
+            'ipconfig' in kwargs or
+            ' nameserver' in kwargs or
+            'searchdomain' in kwargs or
+            'sshkeys' in kwargs):
+            module.fail_json(msg='Cloud-Init is not supported on Proxmox Versions older than 5.2, your version: %s' % PVE_FULL_VERSION)
 
     # The features work only on PVE 4
     if PVE_MAJOR_VERSION < 4:

--- a/lib/ansible/modules/cloud/misc/proxmox_kvm.py
+++ b/lib/ansible/modules/cloud/misc/proxmox_kvm.py
@@ -20,7 +20,7 @@ short_description: Management of Qemu(KVM) Virtual Machines in Proxmox VE cluste
 description:
   - Allows you to create/delete/stop Qemu(KVM) Virtual Machines in Proxmox VE cluster.
 version_added: "2.3"
-author: "Abdoul Bah (@helldorado) <bahabdoul at gmail.com>"
+author: "Abdoul Bah (@helldorado) <bahabdoul at gmail.com>, Thijs Cramer <thijs.cramer at gmail.com>"
 options:
   acpi:
     description:
@@ -71,11 +71,15 @@ options:
     description:
       - Enable booting from specified disk. C((ide|sata|scsi|virtio)\d+)
   ciuser:
+    version_added: 2.6
     description:
       - Set username used in Cloud-Init Config.
   cipassword:
+    version_added: 2.6
+    description:
       - Set password used in Cloud-Init Config (NOT RECOMMENDED, use sshkeys instead).
   citype:
+    version_added: 2.6
     description:
       - Specifies the cloud-init configuration format.
   clone:
@@ -159,10 +163,11 @@ options:
       - C(size) is the size of the disk in GB.
       - C(format) is the drive's backing file's data format. C(qcow2|raw|subvol).
   ipconfig:
+    version_added: 2.6
     description:
       - A hash/dictionary of ip's used in the Cloud-Init Configuration.
       - Keys allowed are - C(ipconfig[n]).
-      - Values allowed are - C("gw=IP/CIDR,gw6=IP6/CIDR,ip=IP/CIDR,ip6=IP/CIDR").
+      - 'Values allowed are - C("gw=IP/CIDR,gw6=IP6/CIDR,ip=IP/CIDR,ip6=IP/CIDR").'
       - C(gw) is the IPv4 Default Gateway.
       - C(gw6) is the IPv6 Default Gateway.
       - C(ip) is the IPv4 IP Address.
@@ -204,6 +209,7 @@ options:
       - Specifies the VM name. Only used on the configuration web interface.
       - Required only for C(state=present).
   nameserver:
+    version_added: 2.6
     description:
       - Specifies the DNS Nameserver used by Cloud-Init Config.
   net:
@@ -285,6 +291,7 @@ options:
       - Specifies the SCSI controller model.
     choices: ['lsi', 'lsi53c810', 'virtio-scsi-pci', 'virtio-scsi-single', 'megasas', 'pvscsi']
   searchdomain:
+    version_added: 2.6
     description:
       - The DNS Search Domain used by Cloud-Init Config.
   serial:
@@ -314,6 +321,7 @@ options:
       - Sets the number of CPU sockets. (1 - N).
     default: 1
   sshkeys:
+    version_added: 2.6
     description:
       - The SSH Keys used by Cloud-Init Config (OpenSSH Format).
   startdate:

--- a/lib/ansible/modules/cloud/misc/proxmox_kvm.py
+++ b/lib/ansible/modules/cloud/misc/proxmox_kvm.py
@@ -721,13 +721,15 @@ def create_vm(module, proxmox, vmid, newid, node, name, memory, cpu, cores, sock
 
     # Verify Cloud-Init support
     if PVE_FULL_VERSION < 5.2:
-        if ('ciuser' in kwargs or
-            'cipassword' in kwargs or
+        if (
+            'ciuser' in kwargs or
+                'cipassword' in kwargs or
             'citype' in kwargs or
             'ipconfig' in kwargs or
-            ' nameserver' in kwargs or
+            'nameserver' in kwargs or
             'searchdomain' in kwargs or
-            'sshkeys' in kwargs):
+            'sshkeys' in kwargs
+        ):
             module.fail_json(msg='Cloud-Init is not supported on Proxmox Versions older than 5.2, your version: %s' % PVE_FULL_VERSION)
 
     # The features work only on PVE 4


### PR DESCRIPTION
##### SUMMARY
Proxmox 5.2 has recently updated their product to support Cloud-Init, this pull requests adds the required fields to the proxmox_kvm module.

##### ISSUE TYPE
 - Feature Pull Request
 - Docs Pull Request

##### COMPONENT NAME
cloud/misc/proxmox_kvm.py

##### ANSIBLE VERSION
Tested on develop branch (Ansible 2.6-dev0)

##### ADDITIONAL INFORMATION
Tested with the following playbook:
```
---
- name: Create VM on Proxmox
  hosts: localhost
  gather_facts: false

  vars:
    proxmox_host: localhost
    proxmox_username: prov@pam
    proxmox_password: password
    machine_name: test-cloud-init

  tasks:
    - proxmox_kvm:
        api_host: "{{ proxmox_host }}"
        api_user: "{{ proxmox_username }}"
        api_password: "{{ proxmox_password }}"
        name: "{{ machine_name }}"
        node: nas
        clone: cloud-init-template
        full: 1

    - proxmox_kvm:
        update: yes
        api_host: "{{ proxmox_host }}"
        api_user: "{{ proxmox_username }}"
        api_password: "{{ proxmox_password }}"
        name: "{{ machine_name }}"
        node: nas
        ciuser: thijs
        cipassword: password
        citype: nocloud
        ipconfig: '{"ipconfig0":"ip=192.168.1.200/24,gw=192.168.1.1"}'
        ide: '{"ide2":"vm:cloudinit"}'
```
Template has been created according to this guide: https://pve.proxmox.com/wiki/Cloud-Init_Support

I don't know whether this has any impact on ansible-cloud or anything *should* be done for ansible-cloud. If that's required, I can implement that in the same branch.