### PR TITLE
EdgeOS - Intelligently insert set commands if a delete command is specified

### DIFF
--- a/lib/ansible/modules/network/edgeos/edgeos_config.py
+++ b/lib/ansible/modules/network/edgeos/edgeos_config.py
@@ -163,6 +163,7 @@ def diff_config(commands, config):
 
     updates = list()
     visited = set()
+    delete_commands = [line for line in commands if line.startswith('delete')]
 
     for line in commands:
         item = str(line).replace("'", '')
@@ -170,8 +171,18 @@ def diff_config(commands, config):
         if not item.startswith('set') and not item.startswith('delete'):
             raise ValueError('line must start with either `set` or `delete`')
 
-        elif item.startswith('set') and item not in config:
-            updates.append(line)
+        elif item.startswith('set'):
+
+            if item not in config:
+                updates.append(line)
+
+            # If there is a corresponding delete command in the desired config, make sure to append
+            # the set command even though it already exists in the running config
+            else:
+                ditem = re.sub('set', 'delete', item)
+                for line in delete_commands:
+                    if ditem.startswith(line):
+                        updates.append(item)
 
         elif item.startswith('delete'):
             if not config:


### PR DESCRIPTION
##### SUMMARY

If a `delete` command was issued before a series of `set` commands in `edgeos_config` and the `set` commands already exist in the running config of the target device, only the `delete` command would be entered. This resulted in a device that would be improperly configured since the `set` commands were never issued.

This PR adds checking for `delete` commands when a `set` command is specified and it already exists in the running config, and will insert the `set` commands appropriately.

Fixes #40437 

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT NAME
`edgeos_config.py`

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```

##### ADDITIONAL INFORMATION

This may also affect VyOS modules.