### PR TITLE
Fixes #40661 fixed elasticache inventory node limit issue.

### DIFF
--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -799,7 +799,6 @@ class Ec2Inventory(object):
                         # CacheNodes. Because of that we can't make use of the get_list
                         # method in the AWSQueryConnection. Let's do the work manually
                         clusters = clusters + response['DescribeCacheClustersResponse']['DescribeCacheClustersResult']['CacheClusters']
-
                     except KeyError as e:
                         error = "ElastiCache query to AWS failed (unexpected format)."
                         self.fail_with_error(error, 'getting ElastiCache clusters')
@@ -815,7 +814,6 @@ class Ec2Inventory(object):
             elif not e.reason == "Forbidden":
                 error = "Looks like AWS ElastiCache is down:\n%s" % e.message
             self.fail_with_error(error, 'getting ElastiCache clusters')
-
 
         for cluster in clusters:
             self.add_elasticache_cluster(cluster, region)

--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -790,11 +790,11 @@ class Ec2Inventory(object):
                 # because we also want nodes' information
                 _marker = 1
                 while _marker:
-                   if _marker == 1:
-                       _marker = None
-                   response = conn.describe_cache_clusters(None, None, _marker, True)
-                   _marker = response['DescribeCacheClustersResponse']['DescribeCacheClustersResult']['Marker']
-                  
+                     if _marker == 1:
+                         _marker = None
+                     response = conn.describe_cache_clusters(None, None, _marker, True)
+                     _marker = response['DescribeCacheClustersResponse']['DescribeCacheClustersResult']['Marker']
+
         except boto.exception.BotoServerError as e:
             error = e.reason
 

--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -782,7 +782,7 @@ class Ec2Inventory(object):
         # ElastiCache boto module doesn't provide a get_all_instances method,
         # that's why we need to call describe directly (it would be called by
         # the shorthand method anyway...)
-        cluster = []
+        clusters = []
         try:
             conn = self.connect_to_aws(elasticache, region)
             if conn:
@@ -794,7 +794,15 @@ class Ec2Inventory(object):
                         _marker = None
                     response = conn.describe_cache_clusters(None, None, _marker, True)
                     _marker = response['DescribeCacheClustersResponse']['DescribeCacheClustersResult']['Marker']
+                    try:
+                        # Boto also doesn't provide wrapper classes to CacheClusters or
+                        # CacheNodes. Because of that we can't make use of the get_list
+                        # method in the AWSQueryConnection. Let's do the work manually
+                        clusters = clusters + response['DescribeCacheClustersResponse']['DescribeCacheClustersResult']['CacheClusters']
 
+                    except KeyError as e:
+                        error = "ElastiCache query to AWS failed (unexpected format)."
+                        self.fail_with_error(error, 'getting ElastiCache clusters')
         except boto.exception.BotoServerError as e:
             error = e.reason
 
@@ -808,15 +816,6 @@ class Ec2Inventory(object):
                 error = "Looks like AWS ElastiCache is down:\n%s" % e.message
             self.fail_with_error(error, 'getting ElastiCache clusters')
 
-        try:
-            # Boto also doesn't provide wrapper classes to CacheClusters or
-            # CacheNodes. Because of that we can't make use of the get_list
-            # method in the AWSQueryConnection. Let's do the work manually
-            clusters = cluster + response['DescribeCacheClustersResponse']['DescribeCacheClustersResult']['CacheClusters']
-
-        except KeyError as e:
-            error = "ElastiCache query to AWS failed (unexpected format)."
-            self.fail_with_error(error, 'getting ElastiCache clusters')
 
         for cluster in clusters:
             self.add_elasticache_cluster(cluster, region)

--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -782,13 +782,19 @@ class Ec2Inventory(object):
         # ElastiCache boto module doesn't provide a get_all_instances method,
         # that's why we need to call describe directly (it would be called by
         # the shorthand method anyway...)
+        cluster = []
         try:
             conn = self.connect_to_aws(elasticache, region)
             if conn:
                 # show_cache_node_info = True
                 # because we also want nodes' information
-                response = conn.describe_cache_clusters(None, None, None, True)
-
+                _marker = 1
+                while _marker:
+                   if _marker == 1:
+                       _marker = None
+                   response = conn.describe_cache_clusters(None, None, _marker, True)
+                   _marker = response['DescribeCacheClustersResponse']['DescribeCacheClustersResult']['Marker']
+                  
         except boto.exception.BotoServerError as e:
             error = e.reason
 
@@ -806,7 +812,7 @@ class Ec2Inventory(object):
             # Boto also doesn't provide wrapper classes to CacheClusters or
             # CacheNodes. Because of that we can't make use of the get_list
             # method in the AWSQueryConnection. Let's do the work manually
-            clusters = response['DescribeCacheClustersResponse']['DescribeCacheClustersResult']['CacheClusters']
+            clusters = cluster + response['DescribeCacheClustersResponse']['DescribeCacheClustersResult']['CacheClusters']
 
         except KeyError as e:
             error = "ElastiCache query to AWS failed (unexpected format)."

--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -790,10 +790,10 @@ class Ec2Inventory(object):
                 # because we also want nodes' information
                 _marker = 1
                 while _marker:
-                     if _marker == 1:
-                         _marker = None
-                     response = conn.describe_cache_clusters(None, None, _marker, True)
-                     _marker = response['DescribeCacheClustersResponse']['DescribeCacheClustersResult']['Marker']
+                    if _marker == 1:
+                        _marker = None
+                    response = conn.describe_cache_clusters(None, None, _marker, True)
+                    _marker = response['DescribeCacheClustersResponse']['DescribeCacheClustersResult']['Marker']
 
         except boto.exception.BotoServerError as e:
             error = e.reason


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
Fixes #40661 
The Results get truncated at 100 nodes as pagination not get processed properly. Used the marker to get the output appended from the next pages untill it get end. Now we getting all nodes and respective replication groups.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->

Inventory

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
