### PR TITLE
dnstxt: Non-existent RR returns empty string

### DIFF
--- a/lib/ansible/plugins/lookup/dnstxt.py
+++ b/lib/ansible/plugins/lookup/dnstxt.py
@@ -84,6 +84,8 @@ class LookupModule(LookupBase):
                 string = 'NXDOMAIN'
             except dns.resolver.Timeout:
                 string = ''
+            except dns.resolver.NoAnswer:
+                string = ''
             except DNSException as e:
                 raise AnsibleError("dns.resolver unhandled exception %s" % to_native(e))
 


### PR DESCRIPTION
##### SUMMARY
Currently a lookup returns

> fatal: [localhost]: FAILED! => {"msg": "dns.resolver unhandled exception The DNS response does not contain an answer to the question: example.com. IN TXT"}

if the queried DNS server does not return the record in question. One probably wants an empty string instead of an unhandled exception in almost all cases.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
dnstxt plugin

##### ANSIBLE VERSION
```
ansible 2.5.3
```
