### PR TITLE
Adding changed option to save_when for aireos

### DIFF
--- a/lib/ansible/modules/network/aireos/aireos_config.py
+++ b/lib/ansible/modules/network/aireos/aireos_config.py
@@ -88,6 +88,7 @@ options:
         no changes are made, the configuration is still saved to the
         startup config.  This option will always cause the module to
         return changed. This argument is mutually exclusive with I(save_when).
+      - This option is deprecated as of Ansible 2.6, use C(save_when)
     type: bool
     default: 'no'
   save_when:
@@ -223,7 +224,8 @@ def main():
 
         backup=dict(type='bool', default=False),
 
-        save=dict(type='bool', default=False),
+        # save is deprecated as of 2.6, use save_when instead
+        save=dict(type='bool', default=False, removed_in_version='2.10'),
         save_when=dict(choices=['always', 'never', 'changed'], default='never'),
 
         diff_against=dict(choices=['running', 'intended']),
@@ -232,7 +234,8 @@ def main():
 
     argument_spec.update(aireos_argument_spec)
 
-    mutually_exclusive = [('lines', 'src')]
+    mutually_exclusive = [('lines', 'src'),
+                          ('save', 'save_when')]
 
     required_if = [('diff_against', 'intended', ['intended_config'])]
 

--- a/lib/ansible/modules/network/aireos/aireos_config.py
+++ b/lib/ansible/modules/network/aireos/aireos_config.py
@@ -82,11 +82,28 @@ options:
     aliases: ['config']
   save:
     description:
-      - The C(save) argument instructs the module to save the running-
-        config to the startup-config at the conclusion of the module
-        running.  If check mode is specified, this argument is ignored.
+      - The C(save) argument instructs the module to save the
+        running-config to startup-config.  This operation is performed
+        after any changes are made to the current running config.  If
+        no changes are made, the configuration is still saved to the
+        startup config.  This option will always cause the module to
+        return changed. This argument is mutually exclusive with I(save_when).
     type: bool
     default: 'no'
+  save_when:
+    description:
+      - When changes are made to the device running-configuration, the
+        changes are not copied to non-volatile storage by default.  Using
+        this argument will change that.  If the argument is set to
+        I(always), then the running-config will always be copied to the
+        startup-config and the module will always return as changed.
+        If the argument is set to I(never), the running-config will never
+        be copied to the startup-config.  If the argument is set to I(changed),
+        then the running-config will only be copied to the startup-config if
+        the task has made a change.
+    default: never
+    choices: ['always', 'never', 'changed']
+    version_added: "2.6"
   diff_against:
     description:
       - When using the C(ansible-playbook --diff) command line argument
@@ -178,6 +195,16 @@ def get_candidate(module):
     return candidate
 
 
+def save_config(module, result):
+    result['changed'] = True
+    if not module.check_mode:
+        command = {"command": "save config", "prompt": "Are you sure you want to save", "answer": "y"}
+        run_commands(module, command)
+    else:
+        module.warn('Skipping command `save config` due to check_mode.  Configuration not copied to '
+                    'non-volatile storage')
+
+
 def main():
     """ main entry point for module execution
     """
@@ -197,6 +224,7 @@ def main():
         backup=dict(type='bool', default=False),
 
         save=dict(type='bool', default=False),
+        save_when=dict(choices=['always', 'never', 'changed'], default='never'),
 
         diff_against=dict(choices=['running', 'intended']),
         diff_ignore_lines=dict(type='list')
@@ -255,13 +283,10 @@ def main():
 
     diff_ignore_lines = module.params['diff_ignore_lines']
 
-    if module.params['save']:
-        result['changed'] = True
-        if not module.check_mode:
-            command = {"command": "save config", "prompt": "Are you sure you want to save", "answer": "y"}
-            run_commands(module, command)
-        else:
-            module.warn('Skipping command `save config` due to check_mode.  Configuration not copied to non-volatile storage')
+    if module.params['save_when'] == 'always' or module.params['save']:
+        save_config(module, result)
+    elif module.params['save_when'] == 'changed' and result['changed']:
+        save_config(module, result)
 
     if module._diff:
         output = run_commands(module, 'show run-config commands')

--- a/lib/ansible/modules/network/aireos/aireos_config.py
+++ b/lib/ansible/modules/network/aireos/aireos_config.py
@@ -88,7 +88,7 @@ options:
         no changes are made, the configuration is still saved to the
         startup config.  This option will always cause the module to
         return changed. This argument is mutually exclusive with I(save_when).
-      - This option is deprecated as of Ansible 2.6, use C(save_when)
+      - This option is deprecated as of Ansible 2.7, use C(save_when)
     type: bool
     default: 'no'
   save_when:
@@ -104,7 +104,7 @@ options:
         the task has made a change.
     default: never
     choices: ['always', 'never', 'changed']
-    version_added: "2.6"
+    version_added: "2.7"
   diff_against:
     description:
       - When using the C(ansible-playbook --diff) command line argument
@@ -224,8 +224,8 @@ def main():
 
         backup=dict(type='bool', default=False),
 
-        # save is deprecated as of 2.6, use save_when instead
-        save=dict(type='bool', default=False, removed_in_version='2.10'),
+        # save is deprecated as of 2.7, use save_when instead
+        save=dict(type='bool', default=False, removed_in_version='2.11'),
         save_when=dict(choices=['always', 'never', 'changed'], default='never'),
 
         diff_against=dict(choices=['running', 'intended']),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Adding a new module parameter `save_when` with options `always`, `changed`, and `never`.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
aireos_config

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0dev0 (aireos_save_when_changed 1d7059e5db) last updated 2018/05/24 10:56:38 (GMT -700)
  config file = None
  configured module search path = [u'/Users/james/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/james/Documents/git/ansible/lib/ansible
  executable location = /Users/james/Documents/git/ansible/bin/ansible
  python version = 2.7.15 (default, May  1 2018, 16:44:08) [GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.1)]
```


