### PR TITLE
Only create monitor if monitor variable is true

### DIFF
--- a/lib/ansible/modules/net_tools/dnsmadeeasy.py
+++ b/lib/ansible/modules/net_tools/dnsmadeeasy.py
@@ -664,10 +664,10 @@ def main():
         # create record and monitor as the record does not exist
         if not current_record:
             record = DME.createRecord(DME.prepareRecord(new_record))
-            
-            if not monitor
+
+            if monitor is False
                 module.exit_json(changed=True, result=dict(record=record))
-              
+
             result = DME.updateMonitor(record['id'], DME.prepareMonitor(new_monitor))
             module.exit_json(changed=True, result=dict(record=record, monitor=result))
 

--- a/lib/ansible/modules/net_tools/dnsmadeeasy.py
+++ b/lib/ansible/modules/net_tools/dnsmadeeasy.py
@@ -665,7 +665,7 @@ def main():
         if not current_record:
             record = DME.createRecord(DME.prepareRecord(new_record))
 
-            if monitor is False
+            if monitor is False:
                 module.exit_json(changed=True, result=dict(record=record))
 
             result = DME.updateMonitor(record['id'], DME.prepareMonitor(new_monitor))

--- a/lib/ansible/modules/net_tools/dnsmadeeasy.py
+++ b/lib/ansible/modules/net_tools/dnsmadeeasy.py
@@ -580,6 +580,7 @@ def main():
     record_name = module.params["record_name"]
     record_type = module.params["record_type"]
     record_value = module.params["record_value"]
+    monitor = module.params["monitor"]
 
     # Follow Keyword Controlled Behavior
     if record_name is None:
@@ -663,8 +664,12 @@ def main():
         # create record and monitor as the record does not exist
         if not current_record:
             record = DME.createRecord(DME.prepareRecord(new_record))
-            monitor = DME.updateMonitor(record['id'], DME.prepareMonitor(new_monitor))
-            module.exit_json(changed=True, result=dict(record=record, monitor=monitor))
+            
+            if not monitor
+                module.exit_json(changed=True, result=dict(record=record))
+              
+            result = DME.updateMonitor(record['id'], DME.prepareMonitor(new_monitor))
+            module.exit_json(changed=True, result=dict(record=record, monitor=result))
 
         # update the record
         updated = False


### PR DESCRIPTION
##### SUMMARY

Currently DNSMadeEasy integration creates a monitor even if the `monitor` property is set to `no`.
This fixes that behavior.
Note that this issue only occurs if the given record is *not* created in dnsmadeeasy.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
dnsmadeeasy

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.3
  config file = None
  configured module search path = [u'/Users/sam/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/Cellar/ansible/2.5.3/libexec/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.15 (default, May  1 2018, 16:44:08) [GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.1)]
```


##### ADDITIONAL INFORMATION

1. Ensure no `NS` record exists for `sub.domain.com`
2. Run the following task
3. See an error in the console saying it could not create monitor

```
    - name: Create NS record
      dnsmadeeasy:
        state: present
        account_key: "key"
        account_secret: "secret"
        domain: "domain.com"
        record_name: "sub"
        record_type: NS
        record_value: "ns.domain.com."
        monitor: no
```
