### PR TITLE
Add "runtime" to support `docker run --runtime`

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -316,6 +316,7 @@ options:
   runtime:
     description:
       - Runtime to use for the container.
+    version_added: "2.6"
   shm_size:
     description:
       - Size of `/dev/shm`. The format is `<number><unit>`. `number` must be greater than `0`.

--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -911,8 +911,8 @@ class TaskParameters(DockerBaseClass):
             devices='devices',
             pid_mode='pid_mode',
             tmpfs='tmpfs',
-            init='init'
-            runtime='runtime',
+            init='init',
+            runtime='runtime'
         )
 
         if HAS_DOCKER_PY_2 or HAS_DOCKER_PY_3:

--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -313,6 +313,9 @@ options:
     description:
        - Use with restart policy to control maximum number of restart attempts.
     default: 0
+  runtime:
+    description:
+      - Runtime to use for the container.
   shm_size:
     description:
       - Size of `/dev/shm`. The format is `<number><unit>`. `number` must be greater than `0`.
@@ -691,6 +694,7 @@ class TaskParameters(DockerBaseClass):
         self.restart = None
         self.restart_retries = None
         self.restart_policy = None
+        self.runtime = None
         self.shm_size = None
         self.security_opts = None
         self.state = None
@@ -908,6 +912,7 @@ class TaskParameters(DockerBaseClass):
             pid_mode='pid_mode',
             tmpfs='tmpfs',
             init='init'
+            runtime='runtime',
         )
 
         if HAS_DOCKER_PY_2 or HAS_DOCKER_PY_3:
@@ -1262,6 +1267,7 @@ class Container(DockerBaseClass):
             read_only=host_config.get('ReadonlyRootfs'),
             restart_policy=restart_policy.get('Name'),
             restart_retries=restart_policy.get('MaximumRetryCount'),
+            runtime=host_config.get('Runtime'),
             # Cannot test shm_size, as shm_size is not included in container inspection results.
             # shm_size=host_config.get('ShmSize'),
             security_opts=host_config.get("SecurityOpt"),
@@ -2042,6 +2048,7 @@ def main():
         restart=dict(type='bool', default=False),
         restart_policy=dict(type='str', choices=['no', 'on-failure', 'always', 'unless-stopped']),
         restart_retries=dict(type='int', default=None),
+        runtime=dict(type='str'),
         shm_size=dict(type='str'),
         security_opts=dict(type='list'),
         state=dict(type='str', choices=['absent', 'present', 'started', 'stopped'], default='started'),


### PR DESCRIPTION
* Add support for `--runtime` option to `docker_container` module

Fixes #40694

+label: docsite_pr

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
The `--runtime` option is missing from the docker_container module. With this option, it is possible to sandbox Docker containers with [Google's gVisor](https://github.com/google/gvisor).

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
docker_container

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.2
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/teresaejunior/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.15rc1 (default, Apr 15 2018, 21:51:34) [GCC 7.3.0]
```