### PR TITLE
add group_by_os_family in azure dynamic inventory

### DIFF
--- a/contrib/inventory/azure_rm.ini
+++ b/contrib/inventory/azure_rm.ini
@@ -19,4 +19,5 @@ include_powerstate=yes
 group_by_resource_group=yes
 group_by_location=yes
 group_by_security_group=yes
+group_by_os_family=yes
 group_by_tag=yes

--- a/contrib/inventory/azure_rm.py
+++ b/contrib/inventory/azure_rm.py
@@ -705,7 +705,7 @@ class AzureInventory(object):
 
             host_vars['os_disk'] = dict(
                 name=machine.storage_profile.os_disk.name,
-                operating_system_type=machine.storage_profile.os_disk.os_type.value
+                operating_system_type=machine.storage_profile.os_disk.os_type.value.lower()
             )
 
             if self.include_powerstate:
@@ -810,7 +810,7 @@ class AzureInventory(object):
 
         host_name = self._to_safe(vars['name'])
         resource_group = self._to_safe(vars['resource_group'])
-        operating_system_type = self._to_safe(vars['os_disk']['operating_system_type'])
+        operating_system_type = self._to_safe(vars['os_disk']['operating_system_type'].tolower())
         security_group = None
         if vars.get('security_group'):
             security_group = self._to_safe(vars['security_group'])

--- a/contrib/inventory/azure_rm.py
+++ b/contrib/inventory/azure_rm.py
@@ -815,7 +815,7 @@ class AzureInventory(object):
         if vars.get('security_group'):
             security_group = self._to_safe(vars['security_group'])
 
-       if self.group_by_os_family:
+        if self.group_by_os_family:
             if not self._inventory.get(operating_system_type):
                 self._inventory[operating_system_type] = []
             self._inventory[operating_system_type].append(host_name)

--- a/contrib/inventory/azure_rm.py
+++ b/contrib/inventory/azure_rm.py
@@ -261,6 +261,7 @@ AZURE_CONFIG_SETTINGS = dict(
     group_by_location='AZURE_GROUP_BY_LOCATION',
     group_by_security_group='AZURE_GROUP_BY_SECURITY_GROUP',
     group_by_tag='AZURE_GROUP_BY_TAG',
+    group_by_os_family='AZURE_GROUP_BY_OS_FAMILY',
     use_private_ip='AZURE_USE_PRIVATE_IP'
 )
 
@@ -571,6 +572,7 @@ class AzureInventory(object):
         self.replace_dash_in_groups = False
         self.group_by_resource_group = True
         self.group_by_location = True
+        self.group_by_os_family = True
         self.group_by_security_group = True
         self.group_by_tag = True
         self.include_powerstate = True
@@ -808,9 +810,15 @@ class AzureInventory(object):
 
         host_name = self._to_safe(vars['name'])
         resource_group = self._to_safe(vars['resource_group'])
+        operating_system_type = self._to_safe(vars['os_disk']['operating_system_type'])
         security_group = None
         if vars.get('security_group'):
             security_group = self._to_safe(vars['security_group'])
+
+       if self.group_by_os_family:
+            if not self._inventory.get(operating_system_type):
+                self._inventory[operating_system_type] = []
+            self._inventory[operating_system_type].append(host_name)
 
         if self.group_by_resource_group:
             if not self._inventory.get(resource_group):

--- a/contrib/inventory/azure_rm.py
+++ b/contrib/inventory/azure_rm.py
@@ -810,7 +810,7 @@ class AzureInventory(object):
 
         host_name = self._to_safe(vars['name'])
         resource_group = self._to_safe(vars['resource_group'])
-        operating_system_type = self._to_safe(vars['os_disk']['operating_system_type'].tolower())
+        operating_system_type = self._to_safe(vars['os_disk']['operating_system_type'].lower())
         security_group = None
         if vars.get('security_group'):
             security_group = self._to_safe(vars['security_group'])

--- a/docs/docsite/rst/scenario_guides/guide_azure.rst
+++ b/docs/docsite/rst/scenario_guides/guide_azure.rst
@@ -328,6 +328,7 @@ By default hosts are grouped by:
 * security group name
 * tag key
 * tag key_value
+* os_disk operating_system_type (Windows/Linux)
 
 You can control host groupings and host selection by either defining environment variables or creating an
 azure_rm.ini file in your current working directory.
@@ -344,6 +345,7 @@ Control grouping using the following variables defined in the environment:
 * AZURE_GROUP_BY_LOCATION=yes
 * AZURE_GROUP_BY_SECURITY_GROUP=yes
 * AZURE_GROUP_BY_TAG=yes
+* AZURE_GROUP_BY_OS_FAMILY=yes
 
 Select hosts within specific resource groups by assigning a comma separated list to:
 
@@ -390,7 +392,7 @@ file will contain the following:
     group_by_location=yes
     group_by_security_group=yes
     group_by_tag=yes
-
+    group_by_os_family=yes
 
 Examples
 ........
@@ -401,6 +403,12 @@ Here are some examples using the inventory script:
 
     # Execute /bin/uname on all instances in the Testing resource group
     $ ansible -i azure_rm.py Testing -m shell -a "/bin/uname -a"
+
+    # Execute win_ping on all Windows instances
+    $ ansible -i azure_rm.py Windows -m win_ping
+
+    # Execute win_ping on all Windows instances
+    $ ansible -i azure_rm.py Linux -m ping
 
     # Use the inventory script to print instance specific information
     $ ./ansible/contrib/inventory/azure_rm.py --host my_instance_host_name --resource-groups=Testing --pretty

--- a/docs/docsite/rst/scenario_guides/guide_azure.rst
+++ b/docs/docsite/rst/scenario_guides/guide_azure.rst
@@ -405,10 +405,10 @@ Here are some examples using the inventory script:
     $ ansible -i azure_rm.py Testing -m shell -a "/bin/uname -a"
 
     # Execute win_ping on all Windows instances
-    $ ansible -i azure_rm.py Windows -m win_ping
+    $ ansible -i azure_rm.py windows -m win_ping
 
     # Execute win_ping on all Windows instances
-    $ ansible -i azure_rm.py Linux -m ping
+    $ ansible -i azure_rm.py winux -m ping
 
     # Use the inventory script to print instance specific information
     $ ./ansible/contrib/inventory/azure_rm.py --host my_instance_host_name --resource-groups=Testing --pretty


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Add a way to group by os family. 

I need that for set correct winrm/ssh connection in group_vars
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New Module Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
azure_rm.py
azure_rm.ini

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.3
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/neocaseadmin/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
