### PR TITLE
JM: allowing us to pass abitrary extra flags to chocolatey

### DIFF
--- a/lib/ansible/modules/windows/win_chocolatey.ps1
+++ b/lib/ansible/modules/windows/win_chocolatey.ps1
@@ -33,6 +33,7 @@ $skipscripts = Get-AnsibleParam -obj $params -name "skip_scripts" -type "bool" -
 $proxy_url = Get-AnsibleParam -obj $params -name "proxy_url" -type "str"
 $proxy_username = Get-AnsibleParam -obj $params -name "proxy_username" -type "str"
 $proxy_password = Get-AnsibleParam -obj $params -name "proxy_password" -type "str" -failifempty ($proxy_username -ne $null)
+$extra_flags = Get-AnsibleParam -obj $params -name "extra_flags" -type "str"
 
 $result = @{
     changed = $false 
@@ -182,7 +183,8 @@ Function Choco-Upgrade
         [bool] $allowprerelease,
         [string] $proxy_url,
         [string] $proxy_username,
-        [string] $proxy_password
+        [string] $proxy_password,
+        [string] $extra_flags
     )
 
     if (-not (Choco-IsInstalled $package))
@@ -191,6 +193,11 @@ Function Choco-Upgrade
     }
 
     $options = @( "-y", $package, "--timeout", "$timeout", "--failonunfound" )
+
+    if ($extra_flags)
+    {
+        $options += "$extra_flags"
+    }
 
     if ($check_mode)
     {
@@ -317,7 +324,8 @@ Function Choco-Install
         [bool] $allowprerelease,
         [string] $proxy_url,
         [string] $proxy_username,
-        [string] $proxy_password
+        [string] $proxy_password,
+        [string] $extra_flags
     )
 
     if (Choco-IsInstalled $package)
@@ -330,7 +338,7 @@ Function Choco-Install
                 -ignorechecksums $ignorechecksums -ignoredependencies $ignoredependencies `
                 -allowdowngrade $allowdowngrade -proxy_url $proxy_url `
                 -proxy_username $proxy_username -proxy_password $proxy_password `
-                -allowprerelease $allowprerelease
+                -allowprerelease $allowprerelease -extra_flags $extra_flags
             return
         }
         elseif (-not $force)
@@ -340,6 +348,11 @@ Function Choco-Install
     }
 
     $options = @( "-y", $package, "--timeout", "$timeout", "--failonunfound" )
+
+    if ($extra_flags)
+    {
+        $options += "$extra_flags"
+    }
 
     if ($check_mode)
     {
@@ -519,7 +532,7 @@ if ($state -in ("downgrade", "latest", "present", "reinstalled")) {
         -ignorechecksums $ignorechecksums -ignoredependencies $ignoredependencies `
         -allowdowngrade ($state -eq "downgrade") -proxy_url $proxy_url `
         -proxy_username $proxy_username -proxy_password $proxy_password `
-        -allowprerelease $allowprerelease
+        -allowprerelease $allowprerelease -extra_flags $extra_flags
 }
 
 Exit-Json -obj $result

--- a/lib/ansible/modules/windows/win_chocolatey.py
+++ b/lib/ansible/modules/windows/win_chocolatey.py
@@ -54,7 +54,7 @@ options:
   extra_flags:
     description:
       - Flags to pass directly to chocolatey, for example '--x86'
-    type: string
+    version_added: '2.6'
   install_args:
     description:
       - Arguments to pass to the native installer.

--- a/lib/ansible/modules/windows/win_chocolatey.py
+++ b/lib/ansible/modules/windows/win_chocolatey.py
@@ -51,6 +51,10 @@ options:
   source:
     description:
       - Specify source rather than using default chocolatey repository.
+  extra_flags:
+    description:
+      - Flags to pass directly to chocolatey, for example '--x86'
+    type: string
   install_args:
     description:
       - Arguments to pass to the native installer.
@@ -152,6 +156,11 @@ EXAMPLES = r'''
   win_chocolatey:
     name: notepadplusplus
     version: '6.6'
+
+- name: Install notepadplusplus 32 bit version
+  win_chocolatey:
+    name: notepadplusplus
+    extra_flags: '--x86'
 
 - name: Install git from specified repository
   win_chocolatey:


### PR DESCRIPTION
##### SUMMARY
There are a number of extra flags that chocolatey can use which are not currently supported by the win_chocolatey module. For example:
  * --x86 - to install the 32 bit version of a package
  * --allowunofficial - to install unofficial packages

This mod allows an arbitrary string to be defined and passed to chocolatey for such cases. My particular use case is to install a 32bit version so I did think about having a '32bit' boolean value, but since chocolatey is still also in active development, I thought allowing extra flags arbitrarily would allow admins to react to changes and potentially breakages more easily.

##### ISSUE TYPE

 - Feature Pull Request

##### COMPONENT NAME

win_chocolatey module

##### ANSIBLE VERSION

```
ansible 2.6.0dev0 (devel ffe4017168) last updated 2018/05/25 10:02:10 (GMT +100)
  config file = /home/share/sandbox/ansible/ansible.cfg
  configured module search path = ['/home/jezm/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/share/sandbox/ansible-source/lib/ansible
  executable location = /home/share/sandbox/ansible-source/bin/ansible
  python version = 3.6.5 (default, Apr 14 2018, 13:17:30) [GCC 7.3.1 20180406]

```
