### PR TITLE
tower_job_template: Add support for extra_vars as a key=value format

### DIFF
--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_template.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_template.py
@@ -74,6 +74,10 @@ options:
     host_config_key:
       description:
         - Allow provisioning callbacks using this host config key.
+    extra_vars:
+      description:
+        - Extra variables used by Ansible in YAML or key=value format.
+      version_added: "2.6"
     extra_vars_path:
       description:
         - Path to the C(extra_vars) YAML file.
@@ -159,9 +163,13 @@ def update_fields(p):
         v = params.pop(old_k)
         params_update[new_k] = v
 
-    extra_vars = params.get('extra_vars_path')
+    extra_vars = params.get('extra_vars')
     if extra_vars is not None:
-        params_update['extra_vars'] = ['@' + extra_vars]
+        params_update['extra_vars'] = [str(extra_vars)]
+
+    extra_vars_path = params.get('extra_vars_path')
+    if extra_vars_path is not None:
+        params_update['extra_vars'] = ['@' + extra_vars_path]
 
     params.update(params_update)
     return params
@@ -205,6 +213,7 @@ def main():
         job_tags=dict(),
         skip_tags=dict(),
         host_config_key=dict(),
+        extra_vars=dict(type='dict', required=False),
         extra_vars_path=dict(type='path', required=False),
         ask_extra_vars=dict(type='bool', default=False),
         ask_limit=dict(type='bool', default=False),

--- a/test/integration/targets/tower_job_template/tasks/main.yml
+++ b/test/integration/targets/tower_job_template/tasks/main.yml
@@ -52,3 +52,19 @@
 - assert:
     that:
       - "result is changed"
+
+- name: Create a Job Template with extra_vars
+  tower_job_template:
+    name: hello-world
+    project: Job Template Test Project
+    inventory: Demo Inventory
+    playbook: hello_world.yml
+    machine_credential: Demo Credential
+    job_type: run
+    extra_vars: test=value
+    state: present
+  register: result
+
+- assert:
+    that:
+      - "result is changed"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Add option to supply extra_vars when creating a job template.  
We use this to set a pip package version we want to install without having to push a vars file.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
tower_job_template

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible --version
ansible 2.4.2.0
python version = 2.7.14 (default, Mar 22 2018, 14:43:05) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
It was quite difficult to pass extra vars to a tower_job_template. First you need to create a vars file, push it to the repository and then link to it via the tower_job_template module.

I have added a option to add 'extra_vars' directly without breaking backwards compatibility.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
Old method:
Set 'extra_vars':
- Push file containing the extra variables to the repository
- Set the path via the extra_vars_path

New method:
- Set the extra var(s) via 'extra_vars'
```
