### PR TITLE
Fixes 40711: return `delta`, `start`, `end` on skipped change as documented

### DIFF
--- a/lib/ansible/modules/commands/command.py
+++ b/lib/ansible/modules/commands/command.py
@@ -221,11 +221,15 @@ def main():
         # and the filename already exists.  This allows idempotence
         # of command executions.
         if glob.glob(creates):
+            startd = datetime.datetime.now()
             module.exit_json(
                 cmd=args,
                 stdout="skipped, since %s exists" % creates,
                 changed=False,
-                rc=0
+                rc=0,
+                start=str(startd),
+                end=str(startd),
+                delta=str(0)
             )
 
     if removes:
@@ -233,11 +237,15 @@ def main():
         # and the filename does not exist.  This allows idempotence
         # of command executions.
         if not glob.glob(removes):
+            startd = datetime.datetime.now()
             module.exit_json(
                 cmd=args,
                 stdout="skipped, since %s does not exist" % removes,
                 changed=False,
-                rc=0
+                rc=0,
+                start=str(startd),
+                end=str(startd),
+                delta=str(0)
             )
 
     if warn:


### PR DESCRIPTION
Documentation declares `delta`, `start`, `end` to be returned always. If
due to the internal logic command was not executed be consistent with
the interface and return those.

##### SUMMARY
it was discussed in the ansible-devel IRC, that changing i/f would not be the best solution, since it might create confusion. Instead attributes will be filled with "stub" values.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
command

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.2
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /bin/ansible
  python version = 2.7.15 (default, May 16 2018, 17:50:09) [GCC 8.1.1 20180502 (Red Hat 8.1.1-1)]
```


##### ADDITIONAL INFORMATION
