### PR TITLE
Add an error message if a pkg cannot be removed, fixes #35672

### DIFF
--- a/lib/ansible/modules/packaging/os/yum.py
+++ b/lib/ansible/modules/packaging/os/yum.py
@@ -1073,6 +1073,10 @@ class YumModule(YumDnf):
                     installed = self.is_installed(repoq, pkg)
 
                 if installed:
+                    # Return a mesage so it's obvious to the user why yum failed
+                    # and which package couldn't be removed. More details:
+                    # https://github.com/ansible/ansible/issues/35672
+                    res['msg'] = "Package '%s' couldn't be removed!" % pkg
                     self.module.fail_json(**res)
 
             res['changed'] = True
@@ -1306,7 +1310,6 @@ class YumModule(YumDnf):
         return res
 
     def ensure(self, repoq):
-
         pkgs = self.names
 
         # autoremove was provided without `name`


### PR DESCRIPTION
##### SUMMARY
When yum cannot remove a package it fails, but the message why the module failed isn't obvious. This adds an `error` return field which prints exactly which package couldn't be removed.
This PR is a fix for https://github.com/ansible/ansible/issues/35672.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
yum

##### ANSIBLE VERSION
```
ansible 2.6.0dev0
```