### PR TITLE
update k8s module arguments to allow resource_definition to be a string

### DIFF
--- a/lib/ansible/module_utils/k8s/common.py
+++ b/lib/ansible/module_utils/k8s/common.py
@@ -62,7 +62,6 @@ COMMON_ARG_SPEC = {
         'default': False,
     },
     'resource_definition': {
-        'type': 'dict',
         'aliases': ['definition', 'inline']
     },
     'src': {

--- a/lib/ansible/modules/clustering/k8s/k8s.py
+++ b/lib/ansible/modules/clustering/k8s/k8s.py
@@ -80,21 +80,6 @@ EXAMPLES = '''
     state: present
     src: /testing/service.yml
 
-- name: Get an existing Service object
-  k8s_raw:
-    api_version: v1
-    kind: Service
-    name: web
-    namespace: testing
-  register: web_service
-
-- name: Get a list of all service objects
-  k8s_raw:
-    api_version: v1
-    kind: ServiceList
-    namespace: testing
-  register: service_list
-
 - name: Remove an existing Service object
   k8s_raw:
     state: absent
@@ -113,12 +98,12 @@ EXAMPLES = '''
 - name: Read definition file from the Ansible controller file system
   k8s_raw:
     state: present
-    definition: "{{ lookup('file', '/testing/deployment.yml') | from_yaml }}"
+    definition: "{{ lookup('file', '/testing/deployment.yml') }}"
 
 - name: Read definition file from the Ansible controller file system after Jinja templating
   k8s_raw:
     state: present
-    definition: "{{ lookup('template', '/testing/deployment.yml') | from_yaml }}"
+    definition: "{{ lookup('template', '/testing/deployment.yml') }}"
 '''
 
 RETURN = '''
@@ -149,8 +134,8 @@ result:
        returned: success
        type: complex
      items:
-       description: Returned only when the I(kind) is a List type resource. Contains a set of objects.
-       returned: when resource is a List
+       description: Returned only when multiple yaml documents are passed to src or resource_definition
+       returned: when resource_definition or src contains list of objects
        type: list
 '''
 

--- a/lib/ansible/utils/module_docs_fragments/k8s_resource_options.py
+++ b/lib/ansible/utils/module_docs_fragments/k8s_resource_options.py
@@ -25,14 +25,14 @@ class ModuleDocFragment(object):
 options:
   resource_definition:
     description:
-    - "Provide a valid YAML definition for an object when creating or updating. NOTE: I(kind), I(api_version), I(name),
+    - "Provide a valid YAML definition (either as a string or a dict) for an object when creating or updating. NOTE: I(kind), I(api_version), I(name),
       and I(namespace) will be overwritten by corresponding values found in the provided I(resource_definition)."
     aliases:
     - definition
     - inline
   src:
     description:
-    - "Provide a path to a file containing a valid YAML definition of an object to be created or updated. Mutually
+    - "Provide a path to a file containing a valid YAML definition of an object or objects to be created or updated. Mutually
       exclusive with I(resource_definition). NOTE: I(kind), I(api_version), I(name), and I(namespace) will be
       overwritten by corresponding values found in the configuration read in from the I(src) file."
     - Reads from the local file system. To read from the Ansible controller's file system, use the file lookup


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Allows resource_definition to be a string, if it is, attempts to yaml load it (as it would do with src). This allows the user to template multi-document yaml files and defer the loading to `k8s`, preventing the normal error that `from_yaml` would give you with multidocument yaml strings.

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
Fixes #40684 

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
k8s