### PR TITLE
Add 2 EBGP neighbors with template

### DIFF
--- a/lib/ansible/modules/network/cumulus/nclu.py
+++ b/lib/ansible/modules/network/cumulus/nclu.py
@@ -80,11 +80,12 @@ EXAMPLES = '''
     atomic: true
     description: "Ansible - add swp1"
 
-- name: Add two EBGP neighbors using BGP Unnumbered via Template
+- name: Configure BGP AS and add 2 EBGP neighbors using BGP Unnumbered via Template
   nclu:
     template: |
       {% for neighbor in range(51,53) %}
       add bgp neighbor swp{{neighbor}} interface remote-as external
+      add bgp autonomous-system 65000
       {% endfor %}
     atomic: true
 '''

--- a/lib/ansible/modules/network/cumulus/nclu.py
+++ b/lib/ansible/modules/network/cumulus/nclu.py
@@ -79,7 +79,7 @@ EXAMPLES = '''
         - add int swp1
     atomic: true
     description: "Ansible - add swp1"
-    
+
 - name: Add two EBGP neighbors using BGP Unnumbered via Template
   nclu:
     template: |

--- a/lib/ansible/modules/network/cumulus/nclu.py
+++ b/lib/ansible/modules/network/cumulus/nclu.py
@@ -79,6 +79,14 @@ EXAMPLES = '''
         - add int swp1
     atomic: true
     description: "Ansible - add swp1"
+    
+- name: Add two EBGP neighbors using BGP Unnumbered via Template
+  nclu:
+    template: |
+      {% for neighbor in range(51,53) %}
+      add bgp neighbor swp{{neighbor}} interface remote-as external
+      {% endfor %}
+    atomic: true
 '''
 
 RETURN = '''


### PR DESCRIPTION
Add 2 EBGP neighbors using BGP Unnumbered via Template
+label: docsite_pr
+label: issue #311

##### SUMMARY
Add 2 EBGP neighbors with template

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
nclu

##### ANSIBLE VERSION
ansible 2.5.2
  python version = 2.7.15 (default, May  1 2018, 16:44:08) [GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.1)]


##### ADDITIONAL INFORMATION
Issue #311
