### PR TITLE
Add support for fargate launch_type in ecs_service module and ecs_taskdefinition module

### DIFF
--- a/hacking/aws_config/testing_policies/compute-policy.json
+++ b/hacking/aws_config/testing_policies/compute-policy.json
@@ -109,29 +109,6 @@
                 "arn:aws:ec2:{{aws_region}}:{{aws_account}}:*"
             ]
         },
-        {
-            "Sid": "UnspecifiedCodeRepositories",
-            "Effect": "Allow",
-            "Action": [
-                "ecr:DescribeRepositories",
-                "ecr:CreateRepository"
-            ],
-            "Resource": "*"
-        },
-        {
-            "Sid": "SpecifiedCodeRepositories",
-            "Effect": "Allow",
-            "Action": [
-                "ecr:GetRepositoryPolicy",
-                "ecr:SetRepositoryPolicy",
-                "ecr:DeleteRepository",
-                "ecr:DeleteRepositoryPolicy",
-                "ecr:DeleteRepositoryPolicy"
-            ],
-            "Resource": [
-                "arn:aws:ecr:{{aws_region}}:{{aws_account}}:repository/ansible-*"
-            ]
-        },
 {# According to http://docs.aws.amazon.com/elasticloadbalancing/latest/userguide/load-balancer-authentication-access-control.html #}
 {# Resource level access control is not possible for the new ELB API (providing Application Load Balancer functionality #}
 {# While it remains possible for the old API, there is no distinction of the Actions between old API and new API #}
@@ -237,29 +214,6 @@
                 "arn:aws:iam::{{aws_account}}:role/ecsInstanceRole",
                 "arn:aws:iam::{{aws_account}}:role/ecsServiceRole"
             ]
-        },
-        {
-          "Sid": "AllowECSManagement",
-          "Effect": "Allow",
-          "Action": [
-            "application-autoscaling:Describe*",
-            "application-autoscaling:PutScalingPolicy",
-            "application-autoscaling:RegisterScalableTarget",
-            "cloudwatch:DescribeAlarms",
-            "cloudwatch:PutMetricAlarm",
-            "ecs:CreateCluster",
-            "ecs:CreateService",
-            "ecs:DeleteCluster",
-            "ecs:DeleteService",
-            "ecs:Describe*",
-            "ecs:DeregisterTaskDefinition",
-            "ecs:List*",
-            "ecs:RegisterTaskDefinition",
-            "ecs:UpdateService"
-          ],
-          "Resource": [
-            "*"
-          ]
         },
         {
           "Sid": "AllowSESManagement",

--- a/lib/ansible/modules/cloud/amazon/ecs_service.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_service.py
@@ -103,6 +103,13 @@ options:
           - I(network_configuration) has two keys, I(subnets), a list of subnet IDs to which the task is attached and I(security_groups),
             a list of group names or group IDs for the task
         version_added: 2.6
+    launch_type:
+        description:
+          - The launch type on which to run your service
+        required: false
+        version_added: 2.5
+        choices: ["EC2", "FARGATE"]
+        default: "EC2"
 extends_documentation_fragment:
     - aws
     - ec2
@@ -357,7 +364,8 @@ class EcsServiceManager:
 
     def create_service(self, service_name, cluster_name, task_definition, load_balancers,
                        desired_count, client_token, role, deployment_configuration,
-                       placement_constraints, placement_strategy, network_configuration):
+                       placement_constraints, placement_strategy, network_configuration,
+                       launch_type):
         params = dict(
             cluster=cluster_name,
             serviceName=service_name,
@@ -368,7 +376,8 @@ class EcsServiceManager:
             role=role,
             deploymentConfiguration=deployment_configuration,
             placementConstraints=placement_constraints,
-            placementStrategy=placement_strategy)
+            placementStrategy=placement_strategy,
+            launchType=launch_type)
         if network_configuration:
             params['networkConfiguration'] = network_configuration
         response = self.ecs.create_service(**params)
@@ -431,7 +440,8 @@ def main():
         deployment_configuration=dict(required=False, default={}, type='dict'),
         placement_constraints=dict(required=False, default=[], type='list'),
         placement_strategy=dict(required=False, default=[], type='list'),
-        network_configuration=dict(required=False, type='dict')
+        network_configuration=dict(required=False, type='dict'),
+        launch_type=dict(required=False, choices=['EC2', 'FARGATE'], default='EC2')
     ))
 
     module = AnsibleAWSModule(argument_spec=argument_spec,
@@ -501,7 +511,8 @@ def main():
                                                           deploymentConfiguration,
                                                           module.params['placement_constraints'],
                                                           module.params['placement_strategy'],
-                                                          network_configuration)
+                                                          network_configuration,
+                                                          module.params['launch_type'])
 
                 results['service'] = response
 

--- a/lib/ansible/modules/cloud/amazon/ecs_service.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_service.py
@@ -523,7 +523,7 @@ def main():
                                                               network_configuration,
                                                               module.params['launch_type'])
                     except botocore.exceptions.ClientError as e:
-                        module.fail_json(msg=e.message)
+                        module.fail_json_aws(e, msg="Couldn't create service")
 
                 results['service'] = response
 
@@ -548,7 +548,7 @@ def main():
                             module.params['cluster']
                         )
                     except botocore.exceptions.ClientError as e:
-                        module.fail_json(msg=e.message)
+                        module.fail_json_aws(e, msg="Couldn't delete service")
                 results['changed'] = True
 
     elif module.params['state'] == 'deleting':

--- a/test/integration/targets/ecs_cluster/playbooks/network_fail.yml
+++ b/test/integration/targets/ecs_cluster/playbooks/network_fail.yml
@@ -1,5 +1,7 @@
 - hosts: localhost
   connection: local
+  vars:
+     resource_prefix: 'ansible-testing'
 
   tasks:
     - block:
@@ -61,7 +63,7 @@
           ecs_service:
             name: "{{ resource_prefix }}-vpc"
             cluster: "{{ resource_prefix }}"
-            task_definition: "{{ resource_prefix }}"
+            task_definition: "{{ resource_prefix }}-vpc"
             desired_count: 1
             network_configuration:
               subnets:
@@ -78,6 +80,47 @@
             that:
               - ecs_service_creation_vpc.failed
               - 'ecs_service_creation_vpc.msg == "botocore needs to be version 1.7.44 or higher to use network configuration"'
+
+        - name: create ecs_service using awsvpc network_configuration and launch_type
+          ecs_service:
+            name: "{{ resource_prefix }}-vpc"
+            cluster: "{{ resource_prefix }}"
+            task_definition: "{{ resource_prefix }}-vpc"
+            desired_count: 1
+            network_configuration:
+              subnets:
+                - subnet-abcd1234
+              groups:
+                - sg-abcd1234
+            launch_type: FARGATE
+            state: present
+            <<: *aws_connection_info
+          register: ecs_service_creation_vpc_launchtype
+          ignore_errors: yes
+
+        - name: check that graceful failure message is returned from ecs_service
+          assert:
+            that:
+              - ecs_service_creation_vpc_launchtype.failed
+              - 'ecs_service_creation_vpc_launchtype.msg == "botocore needs to be version 1.7.44 or higher to use network configuration"'
+
+        - name: create ecs_service with launchtype and missing network_configuration
+          ecs_service:
+            name: "{{ resource_prefix }}-vpc"
+            cluster: "{{ resource_prefix }}"
+            task_definition: "{{ resource_prefix }}-vpc"
+            desired_count: 1
+            launch_type: FARGATE
+            state: present
+            <<: *aws_connection_info
+          register: ecs_service_creation_vpc_launchtype_nonet
+          ignore_errors: yes
+
+        - name: check that graceful failure message is returned from ecs_service
+          assert:
+            that:
+              - ecs_service_creation_vpc_launchtype_nonet.failed
+              - 'ecs_service_creation_vpc_launchtype_nonet.msg == "launch_type is FARGATE but all of the following are missing: network_configuration"'
 
         - name: create ecs_task using awsvpc network_configuration
           ecs_task:
@@ -100,6 +143,7 @@
             that:
               - ecs_task_creation_vpc.failed
               - 'ecs_task_creation_vpc.msg == "botocore needs to be version 1.7.44 or higher to use network configuration"'
+
 
       always:
         - name: scale down ecs service
@@ -134,6 +178,18 @@
                 memory: 128
             family: "{{ resource_prefix }}"
             revision: "{{ ecs_taskdefinition_creation.taskdefinition.revision }}"
+            state: absent
+            <<: *aws_connection_info
+          ignore_errors: yes
+
+        - name: remove ecs task definition vpc
+          ecs_taskdefinition:
+            containers:
+              - name: my_container
+                image: ubuntu
+                memory: 128
+            family: "{{ resource_prefix }}-vpc"
+            revision: "{{ ecs_taskdefinition_creation_vpc.taskdefinition.revision }}"
             state: absent
             <<: *aws_connection_info
           ignore_errors: yes

--- a/test/integration/targets/ecs_cluster/playbooks/roles/ecs_cluster/defaults/main.yml
+++ b/test/integration/targets/ecs_cluster/playbooks/roles/ecs_cluster/defaults/main.yml
@@ -1,11 +1,3 @@
-# http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html
-# amzn-ami-2017.09.b-amazon-ecs-optimized
-ecs_agent_images:
-  us-east-1: ami-71ef560b
-  us-east-2: ami-1b8ca37e
-  us-west-2: ami-d2f489aa
-  us-west-1: ami-6b81980b
-
 ecs_cluster_name: "{{ resource_prefix }}"
 user_data: |
   #!/bin/bash

--- a/test/integration/targets/ecs_cluster/playbooks/roles/ecs_cluster/defaults/main.yml
+++ b/test/integration/targets/ecs_cluster/playbooks/roles/ecs_cluster/defaults/main.yml
@@ -3,6 +3,8 @@
 ecs_agent_images:
   us-east-1: ami-71ef560b
   us-east-2: ami-1b8ca37e
+  us-west-2: ami-d2f489aa
+  us-west-1: ami-6b81980b
 
 ecs_cluster_name: "{{ resource_prefix }}"
 user_data: |
@@ -33,3 +35,11 @@ ecs_service_placement_strategy:
 ecs_task_container_port: 8080
 ecs_target_group_name: "{{ resource_prefix[:28] }}-tg"
 ecs_load_balancer_name: "{{ resource_prefix[:29] }}-lb"
+ecs_fargate_task_containers:
+- name: "{{ ecs_task_name }}"
+  image: "{{ ecs_task_image_path }}"
+  essential: true
+  portMappings:
+  - containerPort: "{{ ecs_task_container_port }}"
+    hostPort: "{{ ecs_task_host_port|default(0) }}"
+  #mountPoints: "{{ ecs_task_mount_points|default([]) }}"

--- a/test/integration/targets/ecs_cluster/playbooks/roles/ecs_cluster/tasks/main.yml
+++ b/test/integration/targets/ecs_cluster/playbooks/roles/ecs_cluster/tasks/main.yml
@@ -123,12 +123,24 @@
         <<: *aws_connection_info
       register: setup_sg
 
+    - name: find a suitable AMI
+      ec2_ami_facts:
+        owner: amazon
+        filters:
+          description: "Amazon Linux AMI* ECS *"
+        <<: *aws_connection_info
+      register: ec2_ami_facts
+
+    - name: set image id fact
+      set_fact:
+        ecs_image_id: "{{ (ec2_ami_facts.images|first).image_id }}"
+
     - name: provision ec2 instance to create an image
       ec2:
         key_name: '{{ ec2_keypair|default(setup_key.key.name) }}'
         instance_type: t2.micro
         state: present
-        image: '{{ ecs_agent_images[aws_region] }}'
+        image: '{{ ecs_image_id }}'
         wait: yes
         user_data: "{{ user_data }}"
         instance_profile_name: ecsInstanceRole

--- a/test/integration/targets/ecs_cluster/playbooks/roles/ecs_cluster/tasks/main.yml
+++ b/test/integration/targets/ecs_cluster/playbooks/roles/ecs_cluster/tasks/main.yml
@@ -344,6 +344,11 @@
         that:
           - delete_ecs_service.changed
 
+    - name: assert that deleting ECS service worked
+      assert:
+        that:
+          - delete_ecs_service.changed
+
     - name: create VPC-networked task definition with host port set to 0 (expected to fail)
       ecs_taskdefinition:
         containers: "{{ ecs_task_containers }}"
@@ -382,6 +387,17 @@
         that:
           - "ecs_taskdefinition_facts.network_mode == 'awsvpc'"
 
+    - name: pause to allow service to scale down
+      pause:
+        seconds: 60
+
+    - name: delete ECS service definition
+      ecs_service:
+        state: absent
+        name: "{{ ecs_service_name }}4"
+        cluster: "{{ ecs_cluster_name }}"
+        <<: *aws_connection_info
+      register: delete_ecs_service
 
     - name: create ECS service definition with network configuration
       ecs_service:
@@ -448,7 +464,6 @@
           - "update_ecs_service_with_vpc.service.networkConfiguration.awsvpcConfiguration.subnets|length == 2"
           - "update_ecs_service_with_vpc.service.networkConfiguration.awsvpcConfiguration.securityGroups|length == 1"
 
-
     - name: obtain facts for all ECS services in the cluster
       ecs_service_facts:
         cluster: "{{ ecs_cluster_name }}"
@@ -511,6 +526,103 @@
         task_definition: "{{ ecs_task_name }}-vpc:{{ ecs_task_definition.taskdefinition.revision + 1}}"
         <<: *aws_connection_info
 
+    # ============================================================
+    # Begin tests for Fargate
+
+    - name: create Fargate VPC-networked task definition with host port set to 8080 and unsupported network mode (expected to fail)
+      ecs_taskdefinition:
+        containers: "{{ ecs_fargate_task_containers }}"
+        family: "{{ ecs_task_name }}-vpc"
+        network_mode: bridge
+        launch_type: FARGATE
+        cpu: 512
+        memory: 1024
+        state: present
+        <<: *aws_connection_info
+      vars:
+        ecs_task_host_port: 8080
+      ignore_errors: yes
+      register: ecs_fargate_task_definition_bridged_with_host_port
+
+    - name: check that fargate task definition with bridged networking fails gracefully
+      assert:
+        that:
+          - ecs_fargate_task_definition_bridged_with_host_port is failed
+          - 'ecs_fargate_task_definition_bridged_with_host_port.msg == "To use FARGATE launch type, network_mode must be awsvpc"' 
+
+    - name: create Fargate VPC-networked task definition without CPU or Memory (expected to Fail)
+      ecs_taskdefinition:
+        containers: "{{ ecs_fargate_task_containers }}"
+        family: "{{ ecs_task_name }}-vpc"
+        network_mode: awsvpc
+        launch_type: FARGATE
+        state: present
+        <<: *aws_connection_info
+      ignore_errors: yes
+      register: ecs_fargate_task_definition_vpc_no_mem
+
+    - name: check that fargate task definition without memory or cpu fails gracefully
+      assert:
+        that:
+          - ecs_fargate_task_definition_vpc_no_mem is failed
+          - 'ecs_fargate_task_definition_vpc_no_mem.msg == "launch_type is FARGATE but all of the following are missing: cpu, memory"' 
+
+    - name: create Fargate VPC-networked task definition with CPU or Memory 
+      ecs_taskdefinition:
+        containers: "{{ ecs_fargate_task_containers }}"
+        family: "{{ ecs_task_name }}-vpc"
+        network_mode: awsvpc
+        launch_type: FARGATE
+        cpu: 512
+        memory: 1024
+        state: present
+        <<: *aws_connection_info
+      vars:
+        ecs_task_host_port: 8080
+      register: ecs_fargate_task_definition
+
+    - name: obtain ECS task definition facts
+      ecs_taskdefinition_facts:
+        task_definition: "{{ ecs_task_name }}-vpc:{{ ecs_fargate_task_definition.taskdefinition.revision }}"
+        <<: *aws_connection_info
+
+    - name: create fargate ECS service without network config (expected to fail)
+      ecs_service:
+        state: present
+        name: "{{ ecs_service_name }}4"
+        cluster: "{{ ecs_cluster_name }}"
+        task_definition: "{{ ecs_task_name }}-vpc:{{ ecs_fargate_task_definition.taskdefinition.revision }}"
+        desired_count: 1
+        deployment_configuration: "{{ ecs_service_deployment_configuration }}"
+        launch_type: FARGATE
+        <<: *aws_connection_info
+      register: ecs_fargate_service_network_without_awsvpc
+      ignore_errors: yes
+     
+    - name: assert that using Fargate ECS service fails
+      assert:
+        that:
+          - ecs_fargate_service_network_without_awsvpc is failed
+
+    - name: create fargate ECS service with network config 
+      ecs_service:
+        state: present
+        name: "{{ ecs_service_name }}4"
+        cluster: "{{ ecs_cluster_name }}"
+        task_definition: "{{ ecs_task_name }}-vpc:{{ ecs_fargate_task_definition.taskdefinition.revision }}"
+        desired_count: 1
+        deployment_configuration: "{{ ecs_service_deployment_configuration }}"
+        launch_type: FARGATE
+        network_configuration:
+          subnets: "{{ setup_subnet.results | json_query('[].subnet.id') }}"
+          security_groups:
+            - '{{ setup_sg.group_id }}'
+        <<: *aws_connection_info
+      register: ecs_fargate_service_network_with_awsvpc
+
+    # ============================================================
+    # End tests for Fargate
+
   always:
     # TEAR DOWN: snapshot, ec2 instance, ec2 key pair, security group, vpc
     - name: Announce teardown start
@@ -568,6 +680,18 @@
       ignore_errors: yes
       register: ecs_service_scale_down
 
+    - name: scale down Fargate ECS service
+      ecs_service:
+        state: present
+        name: "{{ ecs_service_name }}4"
+        cluster: "{{ ecs_cluster_name }}"
+        task_definition: "{{ ecs_task_name }}-vpc:{{ ecs_fargate_task_definition.taskdefinition.revision }}"
+        desired_count: 0
+        deployment_configuration: "{{ ecs_service_deployment_configuration }}"
+        <<: *aws_connection_info
+      ignore_errors: yes
+      register: ecs_service_scale_down
+
     - name: pause to allow services to scale down
       pause:
         seconds: 60
@@ -589,11 +713,31 @@
         <<: *aws_connection_info
       ignore_errors: yes
 
+    - name: remove fargate ECS service 
+      ecs_service:
+        state: absent
+        name: "{{ ecs_service_name }}4"
+        cluster: "{{ ecs_cluster_name }}"
+        <<: *aws_connection_info
+      ignore_errors: yes
+      register: ecs_fargate_service_network_with_awsvpc
+ 
     - name: remove ecs task definition
       ecs_taskdefinition:
         containers: "{{ ecs_task_containers }}"
         family: "{{ ecs_task_name }}"
         revision: "{{ ecs_task_definition.taskdefinition.revision }}"
+        state: absent
+        <<: *aws_connection_info
+      vars:
+        ecs_task_host_port: 8080
+      ignore_errors: yes
+
+    - name: remove ecs task definition again
+      ecs_taskdefinition:
+        containers: "{{ ecs_task_containers }}"
+        family: "{{ ecs_task_name }}"
+        revision: "{{ ecs_task_definition_again.taskdefinition.revision }}"
         state: absent
         <<: *aws_connection_info
       vars:
@@ -609,6 +753,15 @@
         <<: *aws_connection_info
       vars:
         ecs_task_host_port: 8080
+      ignore_errors: yes
+
+    - name: remove fargate ecs task definition
+      ecs_taskdefinition:
+        containers: "{{ ecs_fargate_task_containers }}"
+        family: "{{ ecs_task_name }}-vpc"
+        revision: "{{ ecs_fargate_task_definition.taskdefinition.revision }}"
+        state: absent
+        <<: *aws_connection_info
       ignore_errors: yes
 
     - name: remove load balancer


### PR DESCRIPTION
##### SUMMARY
Add support for fargate launch_type in ecs_service module and ecs_taskdefinition module. This fixes #35607 . There are now two types of ECS clusters in AWS, EC2 and Fargate ,this adds support for Fargate.

Added some additional error checking to make sure when the playbook is executed it identifies required values such as memory, cpu, and network_type, and network_configuration before reaching out to the AWS API.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
ecs_service, ecs_taskdefinition

##### ANSIBLE VERSION
```
ansible 2.6.0dev0 (devel eb9fe31e51) last updated 2018/05/25 14:26:56 (GMT -700)
  config file = None
  configured module search path = [u'/home/mjmayer/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/mjmayer/ansible_mjmayer/lib/ansible
  executable location = /home/mjmayer/ansible_mjmayer/bin/ansible
  python version = 2.7.5 (default, Apr 11 2018, 17:41:36) [GCC 4.8.5 20150623 (Red Hat 4.8.5-28.0.1)]

```

