### PR TITLE
yum will fail on 'No space left on device', fixes #32791

### DIFF
--- a/lib/ansible/modules/packaging/os/yum.py
+++ b/lib/ansible/modules/packaging/os/yum.py
@@ -830,6 +830,16 @@ def exec_install(module, items, action, pkgs, res, yum_basecmd):
         res['changed'] = False
         module.fail_json(**res)
 
+    # Fail if yum prints 'No space left on device' because that means some
+    # packages failed executing their post install scripts because of lack of
+    # free space (e.g. kernel package couldn't generate initramfs). Note that
+    # yum can still exit with rc=0 even if some post scripts didn't execute
+    # correctly.
+    if 'No space left on device' in (out or err):
+        res['changed'] = False
+        res['msg'] = 'No space left on device'
+        module.fail_json(**res)
+
     # FIXME - if we did an install - go and check the rpmdb to see if it actually installed
     # look for each pkg in rpmdb
     # look for each pkg via obsoletes


### PR DESCRIPTION
##### SUMMARY
During the installing of packages if yum runs out of free disk space, some post install scripts could fail (like e.g. when the kernel package generates initramfs), but yum would still exit with a status 0.  This is bad, especially for the kernel package, because it makes it not boot. Because the yum module is usually used with for automation, which means the users cannot read every message yum prints, it's better that the yum module fails if it detects that there is no free space on the disk.

This PR is a fix for https://github.com/ansible/ansible/issues/32791

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
yum

##### ANSIBLE VERSION
```
ansible 2.6.0dev0
```