### PR TITLE
Add check mode support to nclu module

### DIFF
--- a/lib/ansible/modules/network/cumulus/nclu.py
+++ b/lib/ansible/modules/network/cumulus/nclu.py
@@ -152,7 +152,9 @@ def run_nclu(module, command_list, command_string, commit, atomic, abort, descri
         _changed = True
 
     # Do the commit.
-    if do_commit:
+    if module.check_mode:
+        command_helper(module, "abort")
+    elif do_commit:
         result = command_helper(module, "commit description '%s'" % description)
         if "commit ignored" in result:
             _changed = False
@@ -175,6 +177,7 @@ def main(testing=False):
                             ('commit', 'atomic'),
                             ('abort', 'atomic')]
     )
+    supports_check_mode=True
     command_list = module.params.get('commands', None)
     command_string = module.params.get('template', None)
     commit = module.params.get('commit')

--- a/lib/ansible/modules/network/cumulus/nclu.py
+++ b/lib/ansible/modules/network/cumulus/nclu.py
@@ -152,7 +152,7 @@ def run_nclu(module, command_list, command_string, commit, atomic, abort, descri
         _changed = True
 
     # Do the commit.
-    if module.check_mode:
+    if check_mode:
         command_helper(module, "abort")
     elif do_commit:
         result = command_helper(module, "commit description '%s'" % description)

--- a/lib/ansible/modules/network/cumulus/nclu.py
+++ b/lib/ansible/modules/network/cumulus/nclu.py
@@ -152,8 +152,9 @@ def run_nclu(module, command_list, command_string, commit, atomic, abort, descri
         _changed = True
 
     # Do the commit.
-    if check_mode:
+    if module.check_mode:
         command_helper(module, "abort")
+        _changed = False
     elif do_commit:
         result = command_helper(module, "commit description '%s'" % description)
         if "commit ignored" in result:

--- a/lib/ansible/modules/network/cumulus/nclu.py
+++ b/lib/ansible/modules/network/cumulus/nclu.py
@@ -177,7 +177,7 @@ def main(testing=False):
                             ('commit', 'atomic'),
                             ('abort', 'atomic')]
     )
-    supports_check_mode=True
+    supports_check_mode = True
     command_list = module.params.get('commands', None)
     command_string = module.params.get('template', None)
     commit = module.params.get('commit')

--- a/test/units/modules/network/cumulus/test_nclu.py
+++ b/test/units/modules/network/cumulus/test_nclu.py
@@ -220,3 +220,14 @@ class TestNclu(unittest.TestCase):
         self.assertEqual(len(module.pending), 0)
         self.assertEqual(module.fail_code, {})
         self.assertEqual(changed, False)
+
+    def test_check_mode(self):
+        module = FakeModule()
+        module.check_mode = True
+        changed, output = nclu.run_nclu(module,
+                                        ['add int swp1', 'add int swp2'],
+                                        None, False, True, False, "atomically")
+
+        self.assertEqual(len(module.pending), 0)
+        self.assertEqual(module.fail_code, {})
+        self.assertEqual(changed, False)

--- a/test/units/modules/network/cumulus/test_nclu.py
+++ b/test/units/modules/network/cumulus/test_nclu.py
@@ -234,7 +234,6 @@ class TestNclu(unittest.TestCase):
 
     def test_check_mode(self):
         module = FakeModule()
-        module.check_mode = False
         module.check_mode = True
         changed, output = nclu.run_nclu(module,
                                         ['add int swp1', 'add int swp2'],

--- a/test/units/modules/network/cumulus/test_nclu.py
+++ b/test/units/modules/network/cumulus/test_nclu.py
@@ -103,6 +103,7 @@ class TestNclu(unittest.TestCase):
 
     def test_command_helper(self):
         module = FakeModule()
+        module.check_mode = False
         module.mock_output("/usr/bin/net add int swp1", 0, "", "")
 
         result = nclu.command_helper(module, 'add int swp1', 'error out')
@@ -111,6 +112,7 @@ class TestNclu(unittest.TestCase):
 
     def test_command_helper_error_code(self):
         module = FakeModule()
+        module.check_mode = False
         module.mock_output("/usr/bin/net fake fail command", 1, "", "")
 
         result = nclu.command_helper(module, 'fake fail command', 'error out')
@@ -118,6 +120,7 @@ class TestNclu(unittest.TestCase):
 
     def test_command_helper_error_msg(self):
         module = FakeModule()
+        module.check_mode = False
         module.mock_output("/usr/bin/net fake fail command", 0,
                            "ERROR: Command not found", "")
 
@@ -126,6 +129,7 @@ class TestNclu(unittest.TestCase):
 
     def test_command_helper_no_error_msg(self):
         module = FakeModule()
+        module.check_mode = False
         module.mock_output("/usr/bin/net fake fail command", 0,
                            "ERROR: Command not found", "")
 
@@ -134,6 +138,7 @@ class TestNclu(unittest.TestCase):
 
     def test_empty_run(self):
         module = FakeModule()
+        module.check_mode = False
         changed, output = nclu.run_nclu(module, None, None, False, False, False, "")
         self.assertEqual(module.command_history, ['/usr/bin/net pending',
                                                   '/usr/bin/net pending'])
@@ -142,6 +147,7 @@ class TestNclu(unittest.TestCase):
 
     def test_command_list(self):
         module = FakeModule()
+        module.check_mode = False
         changed, output = nclu.run_nclu(module, ['add int swp1', 'add int swp2'],
                                         None, False, False, False, "")
 
@@ -155,6 +161,7 @@ class TestNclu(unittest.TestCase):
 
     def test_command_list_commit(self):
         module = FakeModule()
+        module.check_mode = False
         changed, output = nclu.run_nclu(module,
                                         ['add int swp1', 'add int swp2'],
                                         None, True, False, False, "committed")
@@ -171,6 +178,7 @@ class TestNclu(unittest.TestCase):
 
     def test_command_atomic(self):
         module = FakeModule()
+        module.check_mode = False
         changed, output = nclu.run_nclu(module,
                                         ['add int swp1', 'add int swp2'],
                                         None, False, True, False, "atomically")
@@ -188,6 +196,7 @@ class TestNclu(unittest.TestCase):
 
     def test_command_abort_first(self):
         module = FakeModule()
+        module.check_mode = False
         module.pending = "dirty"
         nclu.run_nclu(module, None, None, False, False, True, "")
 
@@ -195,6 +204,7 @@ class TestNclu(unittest.TestCase):
 
     def test_command_template_commit(self):
         module = FakeModule()
+        module.check_mode = False
         changed, output = nclu.run_nclu(module, None,
                                         "    add int swp1\n    add int swp2",
                                         True, False, False, "committed")
@@ -211,6 +221,7 @@ class TestNclu(unittest.TestCase):
 
     def test_commit_ignored(self):
         module = FakeModule()
+        module.check_mode = False
         changed, output = nclu.run_nclu(module, None, None, True, False, False, "ignore me")
 
         self.assertEqual(module.command_history, ['/usr/bin/net pending',
@@ -223,6 +234,7 @@ class TestNclu(unittest.TestCase):
 
     def test_check_mode(self):
         module = FakeModule()
+        module.check_mode = False
         module.check_mode = True
         changed, output = nclu.run_nclu(module,
                                         ['add int swp1', 'add int swp2'],


### PR DESCRIPTION
Fixes #37713

##### SUMMARY
Add support for check mode to nclu module

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
nclu

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.1.0
  config file = None
  configured module search path = [u'/home/cumulus/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.9 (default, Jun 29 2016, 13:08:31) [GCC 4.9.2]
```


##### ADDITIONAL INFORMATION
Issue ansible/ansible#37713
```

```
