### PR TITLE
Bump python support version for openstack modules

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_auth.py
+++ b/lib/ansible/modules/cloud/openstack/os_auth.py
@@ -21,7 +21,7 @@ author: "Monty Taylor (@emonty)"
 description:
     - Retrieve an auth token from an OpenStack Cloud
 requirements:
-    - "python >= 2.6"
+    - "python >= 2.7"
     - "openstacksdk"
 options:
   availability_zone:

--- a/lib/ansible/modules/cloud/openstack/os_flavor_facts.py
+++ b/lib/ansible/modules/cloud/openstack/os_flavor_facts.py
@@ -29,7 +29,7 @@ notes:
     - This module creates a new top-level C(openstack_flavors) fact, which
       contains a list of unsorted flavors.
 requirements:
-    - "python >= 2.6"
+    - "python >= 2.7"
     - "openstacksdk"
 options:
    name:

--- a/lib/ansible/modules/cloud/openstack/os_group.py
+++ b/lib/ansible/modules/cloud/openstack/os_group.py
@@ -42,7 +42,7 @@ options:
      description:
        - Ignored. Present for backwards compatibility
 requirements:
-    - "python >= 2.6"
+    - "python >= 2.7"
     - "openstacksdk"
 '''
 

--- a/lib/ansible/modules/cloud/openstack/os_image_facts.py
+++ b/lib/ansible/modules/cloud/openstack/os_image_facts.py
@@ -22,7 +22,7 @@ description:
 notes:
     - Facts are placed in the C(openstack) variable.
 requirements:
-    - "python >= 2.6"
+    - "python >= 2.7"
     - "openstacksdk"
 options:
    image:

--- a/lib/ansible/modules/cloud/openstack/os_keystone_domain.py
+++ b/lib/ansible/modules/cloud/openstack/os_keystone_domain.py
@@ -46,7 +46,7 @@ options:
      description:
        - Ignored. Present for backwards compatibility
 requirements:
-    - "python >= 2.6"
+    - "python >= 2.7"
     - "openstacksdk"
 '''
 

--- a/lib/ansible/modules/cloud/openstack/os_keystone_domain_facts.py
+++ b/lib/ansible/modules/cloud/openstack/os_keystone_domain_facts.py
@@ -21,7 +21,7 @@ author: "Ricardo Carrillo Cruz (@rcarrillocruz)"
 description:
     - Retrieve facts about a one or more OpenStack domains
 requirements:
-    - "python >= 2.6"
+    - "python >= 2.7"
     - "sdk"
 options:
    name:

--- a/lib/ansible/modules/cloud/openstack/os_keystone_role.py
+++ b/lib/ansible/modules/cloud/openstack/os_keystone_role.py
@@ -35,7 +35,7 @@ options:
        - Ignored. Present for backwards compatibility
      required: false
 requirements:
-    - "python >= 2.6"
+    - "python >= 2.7"
     - "openstacksdk"
 '''
 

--- a/lib/ansible/modules/cloud/openstack/os_keystone_service.py
+++ b/lib/ansible/modules/cloud/openstack/os_keystone_service.py
@@ -48,7 +48,7 @@ options:
      description:
        - Ignored. Present for backwards compatibility
 requirements:
-    - "python >= 2.6"
+    - "python >= 2.7"
     - "openstacksdk"
 '''
 

--- a/lib/ansible/modules/cloud/openstack/os_networks_facts.py
+++ b/lib/ansible/modules/cloud/openstack/os_networks_facts.py
@@ -21,7 +21,7 @@ author: "Davide Agnello (@dagnello)"
 description:
     - Retrieve facts about one or more networks from OpenStack.
 requirements:
-    - "python >= 2.6"
+    - "python >= 2.7"
     - "sdk"
 options:
    name:

--- a/lib/ansible/modules/cloud/openstack/os_nova_host_aggregate.py
+++ b/lib/ansible/modules/cloud/openstack/os_nova_host_aggregate.py
@@ -37,7 +37,7 @@ options:
     choices: [present, absent]
     default: present
 requirements:
-    - "python >= 2.6"
+    - "python >= 2.7"
     - "openstacksdk"
 '''
 

--- a/lib/ansible/modules/cloud/openstack/os_port_facts.py
+++ b/lib/ansible/modules/cloud/openstack/os_port_facts.py
@@ -22,7 +22,7 @@ description:
 notes:
     - Facts are placed in the C(openstack_ports) variable.
 requirements:
-    - "python >= 2.6"
+    - "python >= 2.7"
     - "openstacksdk"
 options:
     port:

--- a/lib/ansible/modules/cloud/openstack/os_project.py
+++ b/lib/ansible/modules/cloud/openstack/os_project.py
@@ -50,7 +50,7 @@ options:
      description:
        - Ignored. Present for backwards compatibility
 requirements:
-    - "python >= 2.6"
+    - "python >= 2.7"
     - "openstacksdk"
 '''
 

--- a/lib/ansible/modules/cloud/openstack/os_project_facts.py
+++ b/lib/ansible/modules/cloud/openstack/os_project_facts.py
@@ -21,7 +21,7 @@ author: "Ricardo Carrillo Cruz (@rcarrillocruz)"
 description:
     - Retrieve facts about a one or more OpenStack projects
 requirements:
-    - "python >= 2.6"
+    - "python >= 2.7"
     - "openstacksdk"
 options:
    name:

--- a/lib/ansible/modules/cloud/openstack/os_quota.py
+++ b/lib/ansible/modules/cloud/openstack/os_quota.py
@@ -105,7 +105,7 @@ options:
 
 
 requirements:
-    - "python >= 2.6"
+    - "python >= 2.7"
     - "openstacksdk >= 0.13.0"
 '''
 

--- a/lib/ansible/modules/cloud/openstack/os_recordset.py
+++ b/lib/ansible/modules/cloud/openstack/os_recordset.py
@@ -54,7 +54,7 @@ options:
      description:
        - Ignored. Present for backwards compatibility
 requirements:
-    - "python >= 2.6"
+    - "python >= 2.7"
     - "openstacksdk"
 '''
 

--- a/lib/ansible/modules/cloud/openstack/os_server.py
+++ b/lib/ansible/modules/cloud/openstack/os_server.py
@@ -166,7 +166,7 @@ options:
      description:
        - Availability zone in which to create the server.
 requirements:
-    - "python >= 2.6"
+    - "python >= 2.7"
     - "openstacksdk"
 '''
 

--- a/lib/ansible/modules/cloud/openstack/os_server_action.py
+++ b/lib/ansible/modules/cloud/openstack/os_server_action.py
@@ -54,7 +54,7 @@ options:
      description:
        - Ignored. Present for backwards compatibility
 requirements:
-    - "python >= 2.6"
+    - "python >= 2.7"
     - "openstacksdk"
 '''
 

--- a/lib/ansible/modules/cloud/openstack/os_server_facts.py
+++ b/lib/ansible/modules/cloud/openstack/os_server_facts.py
@@ -24,7 +24,7 @@ notes:
     - This module creates a new top-level C(openstack_servers) fact, which
       contains a list of servers.
 requirements:
-    - "python >= 2.6"
+    - "python >= 2.7"
     - "openstacksdk"
 options:
    server:

--- a/lib/ansible/modules/cloud/openstack/os_server_group.py
+++ b/lib/ansible/modules/cloud/openstack/os_server_group.py
@@ -45,7 +45,7 @@ options:
        - Ignored. Present for backwards compatibility
      required: false
 requirements:
-    - "python >= 2.6"
+    - "python >= 2.7"
     - "openstacksdk"
 '''
 

--- a/lib/ansible/modules/cloud/openstack/os_server_volume.py
+++ b/lib/ansible/modules/cloud/openstack/os_server_volume.py
@@ -44,7 +44,7 @@ options:
      description:
        - Ignored. Present for backwards compatibility
 requirements:
-    - "python >= 2.6"
+    - "python >= 2.7"
     - "openstacksdk"
 '''
 

--- a/lib/ansible/modules/cloud/openstack/os_stack.py
+++ b/lib/ansible/modules/cloud/openstack/os_stack.py
@@ -59,7 +59,7 @@ options:
       description:
         - Ignored. Present for backwards compatibility
 requirements:
-    - "python >= 2.6"
+    - "python >= 2.7"
     - "openstacksdk"
 '''
 EXAMPLES = '''

--- a/lib/ansible/modules/cloud/openstack/os_subnet.py
+++ b/lib/ansible/modules/cloud/openstack/os_subnet.py
@@ -96,7 +96,7 @@ options:
      description:
        - Ignored. Present for backwards compatibility
 requirements:
-    - "python >= 2.6"
+    - "python >= 2.7"
     - "openstacksdk"
 '''
 

--- a/lib/ansible/modules/cloud/openstack/os_subnets_facts.py
+++ b/lib/ansible/modules/cloud/openstack/os_subnets_facts.py
@@ -21,7 +21,7 @@ author: "Davide Agnello (@dagnello)"
 description:
     - Retrieve facts about one or more subnets from OpenStack.
 requirements:
-    - "python >= 2.6"
+    - "python >= 2.7"
     - "openstacksdk"
 options:
    subnet:

--- a/lib/ansible/modules/cloud/openstack/os_user.py
+++ b/lib/ansible/modules/cloud/openstack/os_user.py
@@ -66,7 +66,7 @@ options:
      description:
        - Ignored. Present for backwards compatibility
 requirements:
-    - "python >= 2.6"
+    - "python >= 2.7"
     - "openstacksdk"
 '''
 

--- a/lib/ansible/modules/cloud/openstack/os_user_facts.py
+++ b/lib/ansible/modules/cloud/openstack/os_user_facts.py
@@ -21,7 +21,7 @@ author: "Ricardo Carrillo Cruz (@rcarrillocruz)"
 description:
     - Retrieve facts about a one or more OpenStack users
 requirements:
-    - "python >= 2.6"
+    - "python >= 2.7"
     - "openstacksdk"
 options:
    name:

--- a/lib/ansible/modules/cloud/openstack/os_user_group.py
+++ b/lib/ansible/modules/cloud/openstack/os_user_group.py
@@ -39,7 +39,7 @@ options:
        - Ignored. Present for backwards compatibility
      required: false
 requirements:
-    - "python >= 2.6"
+    - "python >= 2.7"
     - "openstacksdk"
 '''
 

--- a/lib/ansible/modules/cloud/openstack/os_user_role.py
+++ b/lib/ansible/modules/cloud/openstack/os_user_role.py
@@ -52,7 +52,7 @@ options:
      description:
        - Ignored. Present for backwards compatibility
 requirements:
-    - "python >= 2.6"
+    - "python >= 2.7"
     - "openstacksdk"
 '''
 

--- a/lib/ansible/modules/cloud/openstack/os_volume.py
+++ b/lib/ansible/modules/cloud/openstack/os_volume.py
@@ -59,7 +59,7 @@ options:
        - Scheduler hints passed to volume API in form of dict
      version_added: "2.4"
 requirements:
-     - "python >= 2.6"
+     - "python >= 2.7"
      - "openstacksdk"
 '''
 

--- a/lib/ansible/modules/cloud/openstack/os_zone.py
+++ b/lib/ansible/modules/cloud/openstack/os_zone.py
@@ -52,7 +52,7 @@ options:
      description:
        - Ignored. Present for backwards compatibility
 requirements:
-    - "python >= 2.6"
+    - "python >= 2.7"
     - "openstacksdk"
 '''
 


### PR DESCRIPTION
##### SUMMARY
The openstack modules do not support python 2.6 as the underlying
library dependency (openstacksdk) does not support python 2.6. Update
the docs to make this clear.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
modules/cloud/openstack/os_*