### PR TITLE
Fix flag in debug message about vault password client script

### DIFF
--- a/lib/ansible/parsing/vault/__init__.py
+++ b/lib/ansible/parsing/vault/__init__.py
@@ -496,7 +496,7 @@ class ClientScriptVaultSecret(ScriptVaultSecret):
                                                       encoding=encoding,
                                                       loader=loader)
         self._vault_id = vault_id
-        display.vvvv('Executing vault password client script: %s --vault-id=%s' % (filename, vault_id))
+        display.vvvv('Executing vault password client script: %s --vault-id %s' % (filename, vault_id))
 
     def _run(self, command):
         try:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

This changes the contents of a debug message that is printed when using a vault password _client_ script. The message states the invocation of the script, but erroneously stated that it was invoked as `example --vault-id=example`, while it's [actually](https://github.com/alikins/ansible/blob/stable-2.5/lib/ansible/parsing/vault/__init__.py#L527) `example --vault-id example`.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
Ansible
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.2
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/tom/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.15rc1 (default, Apr 15 2018, 21:51:34) [GCC 7.3.0]
```

##### ADDITIONAL INFORMATION
When using a vault password _client_ script to decrypt a Vault-encrypted file, a feature added in 2.5, there is a debug message printed with the invocation of the script when you add `-vvvv` to the Ansible command, such as in the example below. 

Before:
```
tom@tom:~/development/ansible$ ansible-playbook --inventory hosts --vault-id "dev@./scripts/get-vault-pass-client.sh" main.yml -vvvv
(...)
The vault password file ./scripts/get-vault-pass-client.sh is a client script.
Executing vault password client script: /home/tom/development/ansible/scripts/get-vault-pass-client.sh --vault-id=dev
(...)
```
After:
```
tom@tom:~/development/ansible$ ansible-playbook --inventory hosts --vault-id "dev@./scripts/get-vault-pass-client.sh" main.yml -vvvv
(...)
The vault password file ./scripts/get-vault-pass-client.sh is a client script.
Executing vault password client script: /home/tom/development/ansible/scripts/get-vault-pass-client.sh --vault-id dev
(...)
```