### PR TITLE
Reduce noise in warnings from ansible

### DIFF
--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -665,7 +665,8 @@ def _find_module_utils(module_name, b_module_data, module_path, module_args, tas
         # Optimization -- don't lock if the module has already been cached
         if os.path.exists(cached_module_filename):
             display.debug('ANSIBALLZ: using cached module: %s' % cached_module_filename)
-            zipdata = open(cached_module_filename, 'rb').read()
+            with open(cached_module_filename, 'rb') as module_data:
+                zipdata = module_data.read()
         else:
             if module_name in action_write_locks.action_write_locks:
                 display.debug('ANSIBALLZ: Using lock for %s' % module_name)

--- a/lib/ansible/parsing/plugin_docs.py
+++ b/lib/ansible/parsing/plugin_docs.py
@@ -39,8 +39,8 @@ def read_docstring(filename, verbose=True, ignore_errors=True):
     }
 
     try:
-        b_module_data = open(filename, 'rb').read()
-        M = ast.parse(b_module_data)
+        with open(filename, 'rb') as b_module_data:
+            M = ast.parse(b_module_data.read())
 
         for child in M.body:
             if isinstance(child, ast.Assign):


### PR DESCRIPTION
##### SUMMARY
When python is compiled in debug mode, or certain command line flags are
passed, python issues helpful warnings to let users know of files opened
by not closed.

This can be fairly spammy on an ansible run.  This change reduces the
number of such warnings by a factor of 10.

##### ISSUE TYPE
 - Bugfix Pull Request
