### PR TITLE
action run: avoid misleading message about "core module not found"

### DIFF
--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -141,7 +141,7 @@ class ActionBase(with_metaclass(ABCMeta, object)):
                 ping_module = 'win_ping'
             else:
                 ping_module = 'ping'
-            module_path2 = self._shared_loader_obj.module_loader.find_plugin(ping_module, self._connection.module_implementation_preferences)
+            module_path2 = self._shared_loader_obj.module_loader.find_plugin(ping_module, self._connection.module_implementation_preferences[0])
             if module_path2 is not None:
                 raise AnsibleError("The module %s was not found in configured module paths" % (module_name))
             else:


### PR DESCRIPTION
##### SUMMARY
action run: avoid misleading message about "core module not found"

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
core

##### ANSIBLE VERSION
```
ansible 2.5.2
```


##### ADDITIONAL INFORMATION
When a module is blacklisted (eg, using plugin_filters.yml), the ping
module is looked for.
A call to find_plugin("ping", connection.module_implementation_preferences)
is run to in order to check whether ping.py is available.
This will bring the message:
> FAILED! => {"msg": "The module XXX was not found in configured module paths. Additionally, core modules are missing. If this is a checkout, run 'git pull --rebase' to correct this problem."}

The reason is that it will look for it in a dict() whose keys are known file extensions.
This dict() has a cache (_plugin_path_cache inside plugins/loader.py).
It's used to check inside the <extension> key whether this <name> exists.
ie: mod_type is expected to be a (possibly empty) string (or '.py', ...).
But the callee sends the tuple ('',) which is never found.

As a workaround: this patch make it send the first element.
Expect result:
> FAILED! => {"msg": "The module shell was not found in configured module paths"}