### PR TITLE
Use get_option instead of _options.get API

### DIFF
--- a/lib/ansible/plugins/inventory/virtualbox.py
+++ b/lib/ansible/plugins/inventory/virtualbox.py
@@ -82,7 +82,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                 for varname in query:
                     hostvars[host][varname] = self._query_vbox_data(host, query[varname])
 
-            strict = self._options.get('strict', False)
+            strict = self.get_option('strict')
 
             # create composite vars
             self._set_composite_vars(self.get_option('compose'), hostvars[host], host, strict=strict)
@@ -223,7 +223,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
         source_data = None
         if cache:
-            cache = self._options.get('cache')
+            cache = self.get_option('cache')
 
         update_cache = False
         if cache:


### PR DESCRIPTION
##### SUMMARY
Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/inventory/virtualbox.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6devel
```