### PR TITLE
os_project_access: clean up some things

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_project_access.py
+++ b/lib/ansible/modules/cloud/openstack/os_project_access.py
@@ -57,7 +57,7 @@ requirements:
 
 EXAMPLES = '''
 - name: "Enable access to tiny flavor to your tenant."
-  os_project_Access:
+  os_project_access:
     cloud: mycloud
     state: present
     target_project_id: f0f1f2f3f4f5f67f8f9e0e1
@@ -66,7 +66,7 @@ EXAMPLES = '''
 
 
 - name: "Disable access to the given flavor to project"
-  os_project_Access:
+  os_project_access:
     cloud: mycloud
     state: absent
     target_project_id: f0f1f2f3f4f5f67f8f9e0e1

--- a/lib/ansible/modules/cloud/openstack/os_project_access.py
+++ b/lib/ansible/modules/cloud/openstack/os_project_access.py
@@ -104,13 +104,6 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.openstack import openstack_full_argument_spec, openstack_module_kwargs
 
 
-def _get_allowed_projects(cloud, flavor_id):
-    return [x.tenant_id
-            for x
-            in cloud.nova_client.flavor_access.list(flavor=flavor_id)
-            ]
-
-
 def main():
     argument_spec = openstack_full_argument_spec(
         state=dict(required=False, default='present',


### PR DESCRIPTION
##### SUMMARY
Remove an unused function and correct the documentation.

Backports https://github.com/ansible/ansible/pull/40464

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
openstack os_project_access module

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.3 (backport/2.5/40464 190ccf88c5) last updated 2018/05/27 10:48:30 (GMT +100)
  config file = ~/.ansible.cfg
  configured module search path = [u'~/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = ~/code/ansible/lib/ansible
  executable location = ~/venvs/ansible-2.5/bin/ansible
  python version = 2.7.10 (default, Oct  6 2017, 22:29:07) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.31)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
