### PR TITLE
os_server: Remove nova_client usage

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_server.py
+++ b/lib/ansible/modules/cloud/openstack/os_server.py
@@ -562,10 +562,12 @@ def _update_server(module, cloud, server):
     return (changed, server)
 
 
-def _delete_floating_ip_list(cloud, server, extra_ips):
+def _detach_ip_list(cloud, server, extra_ips):
     for ip in extra_ips:
-        cloud.nova_client.servers.remove_floating_ip(
-            server=server.id, address=ip)
+        ip_id = cloud.get_floating_ip(
+            id=None, filters={'floating_ip_address': ip})
+        cloud.detach_ip_from_server(
+            server_id=server.id, floating_ip_id=ip_id)
 
 
 def _check_ips(module, cloud, server):
@@ -606,7 +608,7 @@ def _check_ips(module, cloud, server):
                 if ip not in floating_ips:
                     extra_ips.append(ip)
             if extra_ips:
-                _delete_floating_ip_list(cloud, server, extra_ips)
+                _detach_ip_list(cloud, server, extra_ips)
                 changed = True
     elif auto_ip:
         if server['interface_ip']:


### PR DESCRIPTION
##### SUMMARY
The os_server module uses the deprecated nova_client function, and
therefore ends up requiring python-novaclient installed. In this
patch we switch the ip detachment to make use of a shade function,
removing the need for python-novaclient.

(cherry picked from commit 055d89cd32385fa891e17a24aadc2c68397f307d)

Backports https://github.com/ansible/ansible/pull/40462

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
openstack os_server module

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.3 (backport/2.5/40462 09e6cd53c8) last updated 2018/05/27 10:54:20 (GMT +100)
  config file = ~/.ansible.cfg
  configured module search path = [u'~/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = ~/code/ansible/lib/ansible
  executable location = ~/venvs/ansible-2.5/bin/ansible
  python version = 2.7.10 (default, Oct  6 2017, 22:29:07) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.31)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
