### PR TITLE
Digital Ocean Block Storage volume creation bug

### DIFF
--- a/lib/ansible/modules/cloud/digital_ocean/digital_ocean_block_storage.py
+++ b/lib/ansible/modules/cloud/digital_ocean/digital_ocean_block_storage.py
@@ -207,7 +207,7 @@ class DOBlockStorage(object):
         json = response.json
         if status == 201:
             self.module.exit_json(changed=True, id=json['volume']['id'])
-        elif status == 409 and json['id'] == 'already_exists':
+        elif status == 409 and json['id'] == 'conflict':
             self.module.exit_json(changed=False)
         else:
             raise DOBlockStorageException(json['message'])


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Digital Ocean Volumes API changed causing Ansible to recieve an unexpected value in the response. This resulted in Ansible not being able to validate the state of existing volumes.

This resolves #39655 by changing the ID to conflict.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
lib/ansible/modules/cloud/digital_ocean/digital_ocean_block_storage.p
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.3 (bugfix/issue-39655 5973b9c806) last updated 2018/05/27 16:12:29 (GMT -400)
  config file = /Users/apebox/Dev/github/ansible.cfg
  configured module search path = [u'/Users/apebox/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/apebox/Dev/github/ansible/lib/ansible
  executable location = /Users/apebox/Dev/github/ansible/bin/ansible
  python version = 2.7.10 (default, Feb  7 2017, 00:08:15) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.34)]
```
