### PR TITLE
update porting guides

### DIFF
--- a/docs/docsite/rst/porting_guides/porting_guide_2.6.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.6.rst
@@ -104,3 +104,8 @@ Networking
 ==========
 
 No notable changes.
+
+Dynamic inventory scripts
+=========================
+
+* contrib/inventory/openstack.py is renamed to contrib/inventory/openstack_inventory.py.

--- a/docs/docsite/rst/porting_guides/porting_guide_2.6.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.6.rst
@@ -50,10 +50,10 @@ Noteworthy module changes
 -------------------------
 
 * The ``upgrade`` module option for ``win_chocolatey`` has been removed; use ``state: latest`` instead.
-* The ``reboot`` module option for ``win_feature`` has been removed; use the ``win_reboot`` action plugin instead
-* The ``win_iis_webapppool`` module no longer accepts a string for the ``attributes`` module option; use the free form dictionary value instead
-* The ``name`` module option for ``win_package`` has been removed; this is not used anywhere and should just be removed from your playbooks
-* The ``win_regedit`` module no longer automatically corrects the hive path ``HCCC`` to ``HKCC``; use ``HKCC`` because this is the correct hive path
+* The ``reboot`` module option for ``win_feature`` has been removed; use the ``win_reboot`` action plugin instead.
+* The ``win_iis_webapppool`` module no longer accepts a string for the ``atributes`` module option; use the free form dictionary value instead.
+* The ``name`` module option for ``win_package`` has been removed; this is not used anywhere and should just be removed from your playbooks.
+* The ``win_regedit`` module no longer automatically corrects the hive path ``HCCC`` to ``HKCC``; use ``HKCC`` because this is the correct hive path.
 * The :ref:`file_module` now emits a deprecation warning when ``src`` is specified with a state
   other than ``hard`` or ``link`` as it is only supposed to be useful with those.  This could have
   an effect on people who were depending on a buggy interaction between src and other state's to

--- a/docs/docsite/rst/porting_guides/porting_guide_2.6.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.6.rst
@@ -65,6 +65,7 @@ Noteworthy module changes
   destination path like this::
 
     $ ansible localhost -m file -a 'path=/tmp/lib state=directory'
+
 * The ``k8s_raw`` and ``openshift_raw`` modules have been aliased to the new ``k8s`` module.
 * The ``k8s`` module supports all Kubernetes resources including those from Custom Resource Definitions and aggregated API servers. This includes all OpenShift resources.
 * The ``k8s`` module will not accept resources where subkeys have been snake_cased. This was a workaround that was suggested with the ``k8s_raw`` and ``openshift_raw`` modules.
@@ -73,7 +74,7 @@ Noteworthy module changes
 * The ``k8s`` module will not automatically change ``Project`` creation requests into ``ProjectRequest`` creation requests as the ``openshift_raw`` module did. You must now specify the ``ProjectRequest`` kind explicitly.
 * The ``k8s`` module will not automatically remove secrets from the Ansible return values (and by extension the log). In order to prevent secret values in a task from being logged, specify the ``no_log`` parameter on the task block.
 * The ``k8s_scale`` module now supports scalable OpenShift objects, such as ``DeploymentConfig``.
-
+* Openstack modules are no longer using ``shade`` library. Instead ``openstacksdk`` is used. Since ``openstacksdk`` should be already present as a dependency to ``shade`` no additional actions are required
 
 Plugins
 =======

--- a/docs/docsite/rst/porting_guides/porting_guide_2.6.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.6.rst
@@ -108,4 +108,4 @@ No notable changes.
 Dynamic inventory scripts
 =========================
 
-* contrib/inventory/openstack.py is renamed to contrib/inventory/openstack_inventory.py.
+* ``contrib/inventory/openstack.py`` has been renamed to ``contrib/inventory/openstack_inventory.py``. If you have used ``openstack.py`` as a name for your OpenStack dynamic inventory file, change it to ``openstack_inventory.py``. Otherwise the file name will conflict with imports from ``openstacksdk``.

--- a/docs/docsite/rst/porting_guides/porting_guide_2.6.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.6.rst
@@ -51,7 +51,7 @@ Noteworthy module changes
 
 * The ``upgrade`` module option for ``win_chocolatey`` has been removed; use ``state: latest`` instead.
 * The ``reboot`` module option for ``win_feature`` has been removed; use the ``win_reboot`` action plugin instead.
-* The ``win_iis_webapppool`` module no longer accepts a string for the ``atributes`` module option; use the free form dictionary value instead.
+* The ``win_iis_webapppool`` module no longer accepts a string for the ``attributes`` module option; use the free form dictionary value instead.
 * The ``name`` module option for ``win_package`` has been removed; this is not used anywhere and should just be removed from your playbooks.
 * The ``win_regedit`` module no longer automatically corrects the hive path ``HCCC`` to ``HKCC``; use ``HKCC`` because this is the correct hive path.
 * The :ref:`file_module` now emits a deprecation warning when ``src`` is specified with a state
@@ -74,7 +74,7 @@ Noteworthy module changes
 * The ``k8s`` module will not automatically change ``Project`` creation requests into ``ProjectRequest`` creation requests as the ``openshift_raw`` module did. You must now specify the ``ProjectRequest`` kind explicitly.
 * The ``k8s`` module will not automatically remove secrets from the Ansible return values (and by extension the log). In order to prevent secret values in a task from being logged, specify the ``no_log`` parameter on the task block.
 * The ``k8s_scale`` module now supports scalable OpenShift objects, such as ``DeploymentConfig``.
-* Openstack modules are no longer using ``shade`` library. Instead ``openstacksdk`` is used. Since ``openstacksdk`` should be already present as a dependency to ``shade`` no additional actions are required
+* Openstack modules are no longer using ``shade`` library. Instead ``openstacksdk`` is used. Since ``openstacksdk`` should be already present as a dependency to ``shade`` no additional actions are required.
 
 Plugins
 =======


### PR DESCRIPTION
##### SUMMARY
With PR #40532 `shade` library was retired and replaced with direct use
of `openstacksdk`. Porting guides and doc about dynamic inventory were
not updated.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
docs

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.2
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/gtema/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.15 (default, May 16 2018, 17:50:09) [GCC 8.1.1 20180502 (Red Hat 8.1.1-1)]
```


##### ADDITIONAL INFORMATION
This change need to be also merged into the stable-2.6 branch