### PR TITLE
Remove VC scaleway

### DIFF
--- a/lib/ansible/modules/cloud/scaleway/scaleway_compute.py
+++ b/lib/ansible/modules/cloud/scaleway/scaleway_compute.py
@@ -95,9 +95,10 @@ options:
       - C2S
       - C2M
       - C2L
-      - VC1S
-      - VC1M
-      - VC1L
+      - START1-XS
+      - START1-S
+      - START1-M
+      - START1-L
       - X64-15GB
       - X64-30GB
       - X64-60GB
@@ -180,9 +181,10 @@ SCALEWAY_COMMERCIAL_TYPES = [
     'C2L',  # x86-64 (8 cores) - 32 GB
 
     # Virtual X86-64 compute instance
-    'VC1S',  # Starter X86-64 (2 cores) - 2GB
-    'VC1M',  # Starter X86-64 (4 cores) - 4GB
-    'VC1L',  # Starter X86-64 (6 cores) - 8GB
+    'START1-XS',  # Starter X86-64 (1 core) - 1GB - 25 GB NVMe
+    'START1-S',  # Starter X86-64 (2 cores) - 2GB - 50 GB NVMe
+    'START1-M',  # Starter X86-64 (4 cores) - 4GB - 100 GB NVMe
+    'START1-L',  # Starter X86-64 (8 cores) - 8GB - 200 GB NVMe
     'X64-15GB',
     'X64-30GB',
     'X64-60GB',

--- a/test/legacy/scaleway_compute.yml
+++ b/test/legacy/scaleway_compute.yml
@@ -16,7 +16,7 @@
       image: 89ee4018-f8c3-4dc4-a6b5-bca14f985ebe
       organization: 951df375-e094-4d26-97c1-ba548eeb9c42
       region: ams1
-      commercial_type: VC1S
+      commercial_type: START1-S
 
     register: server_creation_check_task
 
@@ -34,7 +34,7 @@
       image: 89ee4018-f8c3-4dc4-a6b5-bca14f985ebe
       organization: 951df375-e094-4d26-97c1-ba548eeb9c42
       region: ams1
-      commercial_type: VC1S
+      commercial_type: START1-S
       wait: true
 
     register: server_creation_task
@@ -53,7 +53,7 @@
       image: 89ee4018-f8c3-4dc4-a6b5-bca14f985ebe
       organization: 951df375-e094-4d26-97c1-ba548eeb9c42
       region: ams1
-      commercial_type: VC1S
+      commercial_type: START1-S
       wait: true
 
     register: server_creation_confirmation_task
@@ -73,7 +73,7 @@
       image: 89ee4018-f8c3-4dc4-a6b5-bca14f985ebe
       organization: 951df375-e094-4d26-97c1-ba548eeb9c42
       region: ams1
-      commercial_type: VC1S
+      commercial_type: START1-S
       tags:
         - test
         - www
@@ -93,7 +93,7 @@
       image: 89ee4018-f8c3-4dc4-a6b5-bca14f985ebe
       organization: 951df375-e094-4d26-97c1-ba548eeb9c42
       region: ams1
-      commercial_type: VC1S
+      commercial_type: START1-S
       wait: true
       tags:
         - test
@@ -114,7 +114,7 @@
       image: 89ee4018-f8c3-4dc4-a6b5-bca14f985ebe
       organization: 951df375-e094-4d26-97c1-ba548eeb9c42
       region: ams1
-      commercial_type: VC1S
+      commercial_type: START1-S
       wait: true
       tags:
         - test
@@ -136,7 +136,7 @@
       image: 89ee4018-f8c3-4dc4-a6b5-bca14f985ebe
       organization: 951df375-e094-4d26-97c1-ba548eeb9c42
       region: ams1
-      commercial_type: VC1S
+      commercial_type: START1-S
       tags:
         - test
         - www
@@ -156,7 +156,7 @@
       image: 89ee4018-f8c3-4dc4-a6b5-bca14f985ebe
       organization: 951df375-e094-4d26-97c1-ba548eeb9c42
       region: ams1
-      commercial_type: VC1S
+      commercial_type: START1-S
       wait: true
       tags:
         - test
@@ -177,7 +177,7 @@
       image: 89ee4018-f8c3-4dc4-a6b5-bca14f985ebe
       organization: 951df375-e094-4d26-97c1-ba548eeb9c42
       region: ams1
-      commercial_type: VC1S
+      commercial_type: START1-S
       wait: true
       tags:
         - test
@@ -199,7 +199,7 @@
       image: 89ee4018-f8c3-4dc4-a6b5-bca14f985ebe
       organization: 951df375-e094-4d26-97c1-ba548eeb9c42
       region: ams1
-      commercial_type: VC1S
+      commercial_type: START1-S
       tags:
         - test
         - www
@@ -219,7 +219,7 @@
       image: 89ee4018-f8c3-4dc4-a6b5-bca14f985ebe
       organization: 951df375-e094-4d26-97c1-ba548eeb9c42
       region: ams1
-      commercial_type: VC1S
+      commercial_type: START1-S
       wait: true
       tags:
         - test
@@ -241,7 +241,7 @@
       image: 89ee4018-f8c3-4dc4-a6b5-bca14f985ebe
       organization: 951df375-e094-4d26-97c1-ba548eeb9c42
       region: ams1
-      commercial_type: VC1S
+      commercial_type: START1-S
       tags:
         - test
         - www
@@ -261,7 +261,7 @@
       image: 89ee4018-f8c3-4dc4-a6b5-bca14f985ebe
       organization: 951df375-e094-4d26-97c1-ba548eeb9c42
       region: ams1
-      commercial_type: VC1S
+      commercial_type: START1-S
       wait: true
       tags:
         - test
@@ -282,7 +282,7 @@
       image: 89ee4018-f8c3-4dc4-a6b5-bca14f985ebe
       organization: 951df375-e094-4d26-97c1-ba548eeb9c42
       region: ams1
-      commercial_type: VC1S
+      commercial_type: START1-S
       wait: true
       tags:
         - test
@@ -304,7 +304,7 @@
       image: 89ee4018-f8c3-4dc4-a6b5-bca14f985ebe
       organization: 951df375-e094-4d26-97c1-ba548eeb9c42
       region: ams1
-      commercial_type: VC1S
+      commercial_type: START1-S
       tags:
         - test
         - www
@@ -324,7 +324,7 @@
       image: 89ee4018-f8c3-4dc4-a6b5-bca14f985ebe
       organization: 951df375-e094-4d26-97c1-ba548eeb9c42
       region: ams1
-      commercial_type: VC1S
+      commercial_type: START1-S
       wait: true
       tags:
         - test
@@ -345,7 +345,7 @@
       image: 89ee4018-f8c3-4dc4-a6b5-bca14f985ebe
       organization: 951df375-e094-4d26-97c1-ba548eeb9c42
       region: ams1
-      commercial_type: VC1S
+      commercial_type: START1-S
       wait: true
       tags:
         - test
@@ -367,7 +367,7 @@
       image: 89ee4018-f8c3-4dc4-a6b5-bca14f985ebe
       organization: this-organization-does-not-exists
       region: ams1
-      commercial_type: VC1S
+      commercial_type: START1-S
     register: unauthorized_organization_task
 
   - debug: var=unauthorized_organization_task
@@ -385,7 +385,7 @@
       image: this-image-does-not-exists
       organization: 951df375-e094-4d26-97c1-ba548eeb9c42
       region: ams1
-      commercial_type: VC1S
+      commercial_type: START1-S
     register: unexisting_image_check
 
   - debug: var=unexisting_image_check


### PR DESCRIPTION
##### SUMMARY

The VC product line is going to be replaced with the START1 product line.

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

- scaleway_compute.py

##### ANSIBLE VERSION

```
ansible 2.7.0dev0 (remove_vc 4a2509d751) last updated 2018/05/28 14:35:23 (GMT +200)
  config file = None
  configured module search path = [u'/Users/sieben/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/sieben/workspace/ansible/lib/ansible
  executable location = /Users/sieben/workspace/ansible/bin/ansible
  python version = 2.7.15 (default, May  1 2018, 16:44:08) [GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.1)]
```

##### ADDITIONAL INFORMATION

You should be able to test with the following command:

```
$ python ./bin/ansible-playbook -vvvvv -i /dev/null ./test/legacy/scaleway_compute.yml
```