### PR TITLE
pip: combine chdir and env only when env is set

### DIFF
--- a/lib/ansible/modules/packaging/language/pip.py
+++ b/lib/ansible/modules/packaging/language/pip.py
@@ -457,7 +457,7 @@ def main():
     env = module.params['virtualenv']
 
     venv_created = False
-    if chdir:
+    if env and chdir:
         env = os.path.join(chdir, env)
 
     if umask and not isinstance(umask, int):

--- a/test/integration/targets/pip/files/ansible_test_pip_chdir/__init__.py
+++ b/test/integration/targets/pip/files/ansible_test_pip_chdir/__init__.py
@@ -1,0 +1,2 @@
+def main():
+    print("success")

--- a/test/integration/targets/pip/files/setup.py
+++ b/test/integration/targets/pip/files/setup.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+
+from setuptools import setup, find_packages
+
+setup(
+    name="ansible_test_pip_chdir",
+    version="0",
+    packages=find_packages(),
+    entry_points={
+        'console_scripts': [
+            'ansible_test_pip_chdir = ansible_test_pip_chdir:main'
+        ]
+    }
+)

--- a/test/integration/targets/pip/tasks/pip.yml
+++ b/test/integration/targets/pip/tasks/pip.yml
@@ -230,6 +230,48 @@
     that:
       - "pip_install_venv is changed"
 
+# https://github.com/ansible/ansible/issues/37912
+# support chdir without virtualenv
+- name: create chdir test directories
+  file:
+    state: directory
+    name: "{{ output_dir }}/{{ item }}"
+  loop:
+    - pip_module
+    - pip_root
+    - pip_module/ansible_test_pip_chdir
+
+- name: copy test module
+  copy:
+    src: "{{ item }}"
+    dest: "{{ output_dir }}/pip_module/{{ item }}"
+  loop:
+    - setup.py
+    - ansible_test_pip_chdir/__init__.py
+
+- name: install test module
+  pip:
+    name: .
+    chdir: "{{ output_dir }}/pip_module"
+    extra_args: --user --upgrade --root {{ output_dir }}/pip_root
+
+- name: register python_site_lib
+  command: 'python -c "import site; print(site.USER_SITE)"'
+  register: pip_python_site_lib
+
+- name: register python_user_base
+  command: 'python -c "import site; print(site.USER_BASE)"'
+  register: pip_python_user_base
+
+- name: run test module
+  shell: "PYTHONPATH=$(echo {{ output_dir }}/pip_root{{ pip_python_site_lib.stdout }}) {{ output_dir }}/pip_root{{ pip_python_user_base.stdout }}/bin/ansible_test_pip_chdir"
+  register: pip_chdir_command
+
+- name: make sure command ran
+  assert:
+    that:
+      - pip_chdir_command.stdout == "success"
+
 # https://github.com/ansible/ansible/issues/25122
 - name: ensure is a fresh virtualenv
   file:


### PR DESCRIPTION
#### SUMMARY
This fixes an AttributeError when chdir without virtualenv is specified:

 File "/tmp/ansible_2UAFsZ/ansible_module_pip.py", line 387, in main
    env = os.path.join(chdir, env)
 File "/usr/lib64/python2.7/posixpath.py", line 75, in join
    if b.startswith('/'):
AttributeError: 'NoneType' object has no attribute 'startswith'

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
pip

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.2
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/till/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.15 (default, May 16 2018, 17:50:09) [GCC 8.1.1 20180502 (Red Hat 8.1.1-1)]

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->
```
---
cat > 'bug_pip_chdir.yml' <<EOF
- name: Show pip chdir bug
  hosts: all
  tasks:
    - pip:
        name: pip
        extra_args: --user --upgrade
        chdir: /tmp
EOF
```

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
ansible-playbook -i rhel7, bug_pip_chdir.yml 

PLAY [Run tox tests and nmctl show] *********************************************************************

TASK [Gathering Facts] **********************************************************************************
ok: [rhel7]

TASK [pip] **********************************************************************************************
fatal: [rhel7]: FAILED! => {"changed": false, "module_stderr": "Shared connection to 192.168.122.177 closed.\r\n", "module_stdout": "Traceback (most recent call last):\r\n  File \"/tmp/ansible_Q3ae1r/ansible_module_pip.py\", line 562, in <module>\r\n    main()\r\n  File \"/tmp/ansible_Q3ae1r/ansible_module_pip.py\", line 387, in main\r\n    env = os.path.join(chdir, env)\r\n  File \"/usr/lib64/python2.7/posixpath.py\", line 75, in join\r\n    if b.startswith('/'):\r\nAttributeError: 'NoneType' object has no attribute 'startswith'\r\n", "msg": "MODULE FAILURE", "rc": 1}

PLAY RECAP **********************************************************************************************
rhel7                      : ok=1    changed=0    unreachable=0    failed=1   
```
