### PR TITLE
Enable to use greedy checks for outdated casks

### DIFF
--- a/lib/ansible/modules/packaging/os/homebrew_cask.py
+++ b/lib/ansible/modules/packaging/os/homebrew_cask.py
@@ -81,7 +81,7 @@ options:
               available
         type: bool
         default: 'no'
-        version_added: "2.6.0"
+        version_added: "2.7.0"
 '''
 EXAMPLES = '''
 - homebrew_cask:
@@ -120,7 +120,7 @@ EXAMPLES = '''
     state: upgraded
     install_options: force
 
-- homebrew_cask
+- homebrew_cask:
     name: 1password
     state: upgraded
     greedy: True
@@ -428,7 +428,7 @@ class HomebrewCask(object):
                 'outdated',
             ]
             + (['--greedy'] if self.greedy else [])
-            + [ self.current_cask ]
+            + [self.current_cask]
         )
 
         rc, out, err = self.module.run_command(cask_is_outdated_command)

--- a/lib/ansible/modules/packaging/os/homebrew_cask.py
+++ b/lib/ansible/modules/packaging/os/homebrew_cask.py
@@ -720,7 +720,7 @@ def main():
             greedy=dict(
                 default=False,
                 type='bool',
-            )
+            ),
         ),
         supports_check_mode=True,
     )

--- a/lib/ansible/modules/packaging/os/homebrew_cask.py
+++ b/lib/ansible/modules/packaging/os/homebrew_cask.py
@@ -74,6 +74,14 @@ options:
         type: bool
         default: 'no'
         version_added: "2.5.0"
+    greedy:
+        description:
+            - upgrade casks that auto update; passes --greedy to brew cask
+              outdated when checking if an installed cask has a newer version
+              available
+        type: bool
+        default: 'no'
+        version_added: "2.6.0"
 '''
 EXAMPLES = '''
 - homebrew_cask:
@@ -111,6 +119,11 @@ EXAMPLES = '''
     name: alfred
     state: upgraded
     install_options: force
+
+- homebrew_cask
+    name: 1password
+    state: upgraded
+    greedy: True
 
 '''
 
@@ -335,7 +348,8 @@ class HomebrewCask(object):
 
     def __init__(self, module, path=path, casks=None, state=None,
                  update_homebrew=False, install_options=None,
-                 accept_external_apps=False, upgrade_all=False):
+                 accept_external_apps=False, upgrade_all=False,
+                 greedy=False):
         if not install_options:
             install_options = list()
         self._setup_status_vars()
@@ -343,7 +357,8 @@ class HomebrewCask(object):
                                   state=state, update_homebrew=update_homebrew,
                                   install_options=install_options,
                                   accept_external_apps=accept_external_apps,
-                                  upgrade_all=upgrade_all, )
+                                  upgrade_all=upgrade_all,
+                                  greedy=greedy, )
 
         self._prep()
 
@@ -406,12 +421,17 @@ class HomebrewCask(object):
         if not self.valid_cask(self.current_cask):
             return False
 
-        rc, out, err = self.module.run_command([
-            self.brew_path,
-            'cask',
-            'outdated',
-            self.current_cask,
-        ])
+        cask_is_outdated_command = (
+            [
+                self.brew_path,
+                'cask',
+                'outdated',
+            ]
+            + (['--greedy'] if self.greedy else [])
+            + [ self.current_cask ]
+        )
+
+        rc, out, err = self.module.run_command(cask_is_outdated_command)
 
         return out != ""
 
@@ -697,6 +717,10 @@ def main():
                 aliases=["upgrade"],
                 type='bool',
             ),
+            greedy=dict(
+                default=False,
+                type='bool',
+            )
         ),
         supports_check_mode=True,
     )
@@ -724,6 +748,7 @@ def main():
 
     update_homebrew = p['update_homebrew']
     upgrade_all = p['upgrade_all']
+    greedy = p['greedy']
     p['install_options'] = p['install_options'] or []
     install_options = ['--{0}'.format(install_option)
                        for install_option in p['install_options']]
@@ -735,6 +760,7 @@ def main():
                              install_options=install_options,
                              accept_external_apps=accept_external_apps,
                              upgrade_all=upgrade_all,
+                             greedy=greedy,
                              )
     (failed, changed, message) = brew_cask.run()
     if failed:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

When using `brew cask` outdated to check if an installed cask is outdated or not, `brew cask` will skip casks that have `auto_updates` set to `true` or `version: latest`. This means that Ansible tasks using the `homebrew_cask` module to upgrade packages installed by `brew cask` will miss upgrading such packages. However such packages can still be managed by `brew cask` so we need to be able detect such packages. This can be done with the `--greedy` flag passed to `brew cask outdated` as this will also include such packages that are outdated. This commit adds a greedy parameter to the `homebrew_cask` module to enable upgrading such packages using Ansible tasks with the `homebrew_cask` module. The default behavior preserves the same behavior as today. Example usage would be:

```
- homebrew_cask:
  name: 1password
  state: upgraded
  update_homebrew: yes
  greedy: yes
```

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
homebrew_cask

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.2
  config file = None
  configured module search path = [u'/Users/jason/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/Cellar/ansible/2.5.2/libexec/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.15 (default, May  1 2018, 16:44:08) [GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.1)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

Prior to this change using Ansible to upgrade 1Password installed via `brew cask` was not possible as Ansible would use `brew cask outdated 1password` to check if 1Password was outdated or not:

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
TASK [darwin-common : install 1Password] ************************************************************************************************************************************************************************************************
ok: [<redacted>] => {"changed": false, "msg": "Cask is already upgraded: 1password"}
```

With this change it is now possible:

```
TASK [darwin-common : install 1Password] ************************************************************************************************************************************************************************************************
changed: [<redacted>] => {"changed": true, "msg": "Cask upgraded: 1password"}
```