### PR TITLE
Fixes #34992 - azure_rm_networkinterface and azure_rm_virtualmachine inconsistent "location" param

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_networkinterface.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_networkinterface.py
@@ -311,7 +311,7 @@ except ImportError:
     # This is handled in azure_rm_common
     pass
 
-from ansible.module_utils.azure_rm_common import AzureRMModuleBase, azure_id_to_dict
+from ansible.module_utils.azure_rm_common import AzureRMModuleBase, azure_id_to_dict, normalize_location_name
 from ansible.module_utils._text import to_native
 
 
@@ -446,6 +446,7 @@ class AzureRMNetworkInterface(AzureRMModuleBase):
         if not self.location:
             # Set default location
             self.location = resource_group.location
+        self.location = normalize_location_name(self.location)
 
         # parse the virtual network resource group and name
         self.virtual_network = self.parse_resource_to_dict(self.virtual_network)

--- a/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
@@ -614,7 +614,7 @@ except ImportError:
     pass
 
 from ansible.module_utils.basic import to_native, to_bytes
-from ansible.module_utils.azure_rm_common import AzureRMModuleBase, azure_id_to_dict
+from ansible.module_utils.azure_rm_common import AzureRMModuleBase, azure_id_to_dict, normalize_location_name
 
 
 AZURE_OBJECT_CLASS = 'VirtualMachine'
@@ -741,6 +741,8 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
         if not self.location:
             # Set default location
             self.location = resource_group.location
+
+        self.location = normalize_location_name(self.location)
 
         if self.state == 'present':
             # Verify parameters and resolve any defaults


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
Fixes #34992 - azure_rm_networkinterface and azure_rm_virtualmachine inconsistent "location" param

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5.2
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Try this PR's change by installing ansible role via git

`ansible-galaxy install git+https://github.com/Azure/azure_preview_modules.git,yuwzho-location`

And add a role definition in the playbook

```yaml
---
- name: XXXXXXXXXXX
  hosts: localhost
  connection: local
  roles:
  - azure_preview_modules
  tasks:
```
