### PR TITLE
Add support for newer FreeIPA SHA256 SSH public key hashes

### DIFF
--- a/lib/ansible/modules/identity/ipa/ipa_user.py
+++ b/lib/ansible/modules/identity/ipa/ipa_user.py
@@ -194,7 +194,10 @@ def get_user_diff(client, ipa_user, module_user):
     # These are used for comparison.
     sshpubkey = None
     if 'ipasshpubkey' in module_user:
-        module_user['sshpubkeyfp'] = [get_ssh_key_fingerprint(pubkey) for pubkey in module_user['ipasshpubkey']]
+        hash_algo = 'md5'
+        if 'sshpubkeyfp' in ipa_user and ipa_user['sshpubkeyfp'][0][:7].upper() == 'SHA256:':
+            hash_algo = 'sha256'
+        module_user['sshpubkeyfp'] = [get_ssh_key_fingerprint(pubkey, hash_algo) for pubkey in module_user['ipasshpubkey']]
         # Remove the ipasshpubkey element as it is not returned from IPA but save it's value to be used later on
         sshpubkey = module_user['ipasshpubkey']
         del module_user['ipasshpubkey']
@@ -208,11 +211,16 @@ def get_user_diff(client, ipa_user, module_user):
     return result
 
 
-def get_ssh_key_fingerprint(ssh_key):
+def get_ssh_key_fingerprint(ssh_key, hash_algo='sha256'):
     """
     Return the public key fingerprint of a given public SSH key
-    in format "FB:0C:AC:0A:07:94:5B:CE:75:6E:63:32:13:AD:AD:D7 [user@host] (ssh-rsa)"
+    in format "[fp] [user@host] (ssh-rsa)" where fp is of the format:
+    FB:0C:AC:0A:07:94:5B:CE:75:6E:63:32:13:AD:AD:D7
+    for md5 or
+    SHA256:[base64]
+    for sha256
     :param ssh_key:
+    :param hash_algo:
     :return:
     """
     parts = ssh_key.strip().split()
@@ -221,8 +229,12 @@ def get_ssh_key_fingerprint(ssh_key):
     key_type = parts[0]
     key = base64.b64decode(parts[1].encode('ascii'))
 
-    fp_plain = hashlib.md5(key).hexdigest()
-    key_fp = ':'.join(a + b for a, b in zip(fp_plain[::2], fp_plain[1::2])).upper()
+    if hash_algo == 'md5':
+        fp_plain = hashlib.md5(key).hexdigest()
+        key_fp = ':'.join(a + b for a, b in zip(fp_plain[::2], fp_plain[1::2])).upper()
+    elif hash_algo == 'sha256':
+        fp_plain = base64.b64encode(hashlib.sha256(key).digest()).decode('ascii').rstrip('=')
+        key_fp = 'SHA256:{fp}'.format(fp=fp_plain)
     if len(parts) < 3:
         return "%s (%s)" % (key_fp, key_type)
     else:


### PR DESCRIPTION
Previous versions of FreeIPA used `md5` hash for creating SSH public key fingerprints, but this was changed[1,2] to use SHA256 hash. This resulted in the Ansible module computed SSH public key fingerprint disagreeing with the FreeIPA computed SSH public key fingerprint when present.

[1] https://pagure.io/freeipa/issue/5695
[2] https://pagure.io/freeipa/c/721105c53de6fbc0abc7799ec7f48920e02089bd

##### SUMMARY
 * lib/ansible/modules/identity/ipa/ipa_user.py:
    - Check any existing `ipa_user` SSH public key fingerprints for the hash algorithm to use
    - Generate `module_user` SSH public key fingerprint based on detected or default algorithm

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
FreeIPA

##### ANSIBLE VERSION
```
ansible 2.7.0dev0 (devel 9d52e54ae6) last updated 2018/05/28 16:13:03 (GMT -400)
  config file = /home/Matthew/src/ners-jcl-cluster/ansible/ansible.cfg
  configured module search path = [u'/home/Matthew/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/Matthew/src/ansible/lib/ansible
  executable location = /home/Matthew/src/ansible/bin/ansible
  python version = 2.7.15 (default, May 16 2018, 17:50:09) [GCC 8.1.1 20180502 (Red Hat 8.1.1-1)]
```


##### ADDITIONAL INFORMATION
To reproduce the issue:
* Have a user in the FreeIPA (v4.5+?) database with a public SSH key
* Try to set the user state to `'present'` in `ipa_user` module with the same SSH key
* `ipa_user` module will detect difference between FreeIPA user SSH key fingerprint and module SSH key fingerprint, thus attempting to update it
* `user_mod` will fail when it sees that there is no update to be made with error message `'response user_mod: no modifications to be performed'`

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
