### PR TITLE
httpapi fix nxos

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_hsrp.py
+++ b/lib/ansible/modules/network/nxos/nxos_hsrp.py
@@ -159,21 +159,6 @@ PARAM_TO_DEFAULT_KEYMAP = {
 }
 
 
-def execute_show_command(command, module):
-    device_info = get_capabilities(module)
-    network_api = device_info.get('network_api')
-
-    if network_api == 'cliconf':
-        command += ' | json'
-        cmds = [command]
-        body = run_commands(module, cmds)
-    elif network_api == 'nxapi':
-        cmds = [command]
-        body = run_commands(module, cmds)
-
-    return body
-
-
 def apply_key_map(key_map, table):
     new_dict = {}
     for key in table:
@@ -205,11 +190,11 @@ def get_interface_type(interface):
 
 
 def get_interface_mode(interface, intf_type, module):
-    command = 'show interface {0}'.format(interface)
+    command = 'show interface {0} | json'.format(interface)
     interface = {}
     mode = 'unknown'
     try:
-        body = execute_show_command(command, module)[0]
+        body = run_commands(module, [command])[0]
     except IndexError:
         return None
 
@@ -224,7 +209,7 @@ def get_interface_mode(interface, intf_type, module):
 
 
 def get_hsrp_group(group, interface, module):
-    command = 'show hsrp group {0} all'.format(group)
+    command = 'show hsrp group {0} all | json'.format(group)
     hsrp = {}
 
     hsrp_key = {
@@ -240,9 +225,9 @@ def get_hsrp_group(group, interface, module):
     }
 
     try:
-        body = execute_show_command(command, module)[0]
+        body = run_commands(module, [command])[0]
         hsrp_table = body['TABLE_grp_detail']['ROW_grp_detail']
-    except (AttributeError, IndexError, TypeError):
+    except (AttributeError, IndexError, TypeError, KeyError):
         return {}
 
     if isinstance(hsrp_table, dict):
@@ -365,7 +350,7 @@ def is_default(interface, module):
     command = 'show run interface {0}'.format(interface)
 
     try:
-        body = execute_show_command(command, module)[0]
+        body = run_commands(module, [command], check_rc=False)[0]
         if 'invalid' in body.lower():
             return 'DNE'
         else:
@@ -429,7 +414,7 @@ def main():
             module.fail_json(msg='Inavlid auth_string, only 0 or 7 allowed')
 
     device_info = get_capabilities(module)
-    network_api = device_info.get('network_api')
+    network_api = device_info.get('network_api', 'nxapi')
 
     intf_type = get_interface_type(interface)
     if (intf_type != 'ethernet' and network_api == 'cliconf'):

--- a/lib/ansible/modules/network/nxos/nxos_hsrp.py
+++ b/lib/ansible/modules/network/nxos/nxos_hsrp.py
@@ -161,7 +161,7 @@ PARAM_TO_DEFAULT_KEYMAP = {
 
 def execute_show_command(command, module):
     device_info = get_capabilities(module)
-    network_api = device_info.get('network_api', 'nxapi')
+    network_api = device_info.get('network_api')
 
     if network_api == 'cliconf':
         command += ' | json'
@@ -429,7 +429,7 @@ def main():
             module.fail_json(msg='Inavlid auth_string, only 0 or 7 allowed')
 
     device_info = get_capabilities(module)
-    network_api = device_info.get('network_api', 'nxapi')
+    network_api = device_info.get('network_api')
 
     intf_type = get_interface_type(interface)
     if (intf_type != 'ethernet' and network_api == 'cliconf'):

--- a/lib/ansible/plugins/cliconf/eos.py
+++ b/lib/ansible/plugins/cliconf/eos.py
@@ -94,8 +94,11 @@ class Cliconf(CliconfBase):
     def get_capabilities(self):
         result = {}
         result['rpc'] = self.get_base_rpc()
-        result['network_api'] = 'cliconf'
         result['device_info'] = self.get_device_info()
+        if isinstance(self._connection, NetworkCli):
+            result['network_api'] = 'cliconf'
+        else:
+            result['network_api'] = 'eapi'
         return json.dumps(result)
 
     # Imported from module_utils

--- a/lib/ansible/plugins/cliconf/nxos.py
+++ b/lib/ansible/plugins/cliconf/nxos.py
@@ -95,8 +95,11 @@ class Cliconf(CliconfBase):
     def get_capabilities(self):
         result = {}
         result['rpc'] = self.get_base_rpc()
-        result['network_api'] = 'cliconf'
         result['device_info'] = self.get_device_info()
+        if isinstance(self._connection, NetworkCli):
+            result['network_api'] = 'cliconf'
+        else:
+            result['network_api'] = 'nxapi'
         return json.dumps(result)
 
     # Migrated from module_utils

--- a/lib/ansible/plugins/httpapi/nxos.py
+++ b/lib/ansible/plugins/httpapi/nxos.py
@@ -89,9 +89,13 @@ class HttpApi:
             out = to_text(exc)
 
         out = to_list(out)
+        if not out[0]:
+            return out
+
         for index, response in enumerate(out):
             if response[0] == '{':
                 out[index] = json.loads(response)
+
         return out
 
 


### PR DESCRIPTION
Signed-off-by: Trishna Guha <trishnaguha17@gmail.com>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
- fixes https://github.com/ansible/ansible/issues/40717 string index out of range httpapi plugin
- cliconf plugin should set `network_api` to `nxapi` or `eapi` when using httpapi connection plugin, not `cliconf`
- nxos_hsrp fix

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
plugins/httpapi/nxos.py
plugins/cliconf/nxos.py
plugins/cliconf/eos.py
modules/network/nxos/nxos_hsrp.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel, 2.6
```