### PR TITLE
Command authorization failed ios regex

### DIFF
--- a/lib/ansible/plugins/terminal/ios.py
+++ b/lib/ansible/plugins/terminal/ios.py
@@ -47,7 +47,7 @@ class TerminalModule(TerminalBase):
         re.compile(br"% ?(\S+) ?overlaps with ?(\S+)", re.I),
         re.compile(br"[%\S] ?Error: ?[\s]+", re.I),
         re.compile(br"[%\S] ?Informational: ?[\s]+", re.I),
-        re.compile(br"Command authorization failed"),
+        re.compile(br"Command authorization failed")
     ]
 
     def on_open_shell(self):

--- a/lib/ansible/plugins/terminal/ios.py
+++ b/lib/ansible/plugins/terminal/ios.py
@@ -47,6 +47,7 @@ class TerminalModule(TerminalBase):
         re.compile(br"% ?(\S+) ?overlaps with ?(\S+)", re.I),
         re.compile(br"[%\S] ?Error: ?[\s]+", re.I),
         re.compile(br"[%\S] ?Informational: ?[\s]+", re.I)
+        re.compile(br"Command authorization failed"),
     ]
 
     def on_open_shell(self):

--- a/lib/ansible/plugins/terminal/ios.py
+++ b/lib/ansible/plugins/terminal/ios.py
@@ -46,7 +46,7 @@ class TerminalModule(TerminalBase):
         re.compile(br"Bad mask", re.I),
         re.compile(br"% ?(\S+) ?overlaps with ?(\S+)", re.I),
         re.compile(br"[%\S] ?Error: ?[\s]+", re.I),
-        re.compile(br"[%\S] ?Informational: ?[\s]+", re.I)
+        re.compile(br"[%\S] ?Informational: ?[\s]+", re.I),
         re.compile(br"Command authorization failed"),
     ]
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
ios_command not failing in case of receiving 'command authorization failed' in TACACS environments.
Adding that regex to terminal plugin makes the task to fail correctly.

Fixes #31575 

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
terminal/ios
