### PR TITLE
Do not gather mem facts if command invalid

### DIFF
--- a/lib/ansible/modules/network/ios/ios_facts.py
+++ b/lib/ansible/modules/network/ios/ios_facts.py
@@ -232,7 +232,7 @@ class Hardware(FactsBase):
                 warnings.append('Unable to gather memory statistics')
             else:
                 processor_line = [l for l in data.splitlines()
-                                if 'Processor' in l].pop()
+                                  if 'Processor' in l].pop()
                 match = re.findall(r'\s(\d+)\s', processor_line)
                 if match:
                     self.facts['memtotal_mb'] = int(match[0]) / 1024
@@ -451,6 +451,7 @@ VALID_SUBSETS = frozenset(FACT_SUBSETS.keys())
 
 global warnings
 warnings = list()
+
 
 def main():
     """main entry point for module execution

--- a/lib/ansible/modules/network/ios/ios_facts.py
+++ b/lib/ansible/modules/network/ios/ios_facts.py
@@ -227,7 +227,7 @@ class Hardware(FactsBase):
             self.facts['filesystems'] = self.parse_filesystems(data)
 
         data = self.responses[1]
-        if data:
+        if data and not 'Invalid input detected' in data:
             processor_line = [l for l in data.splitlines()
                               if 'Processor' in l].pop()
             match = re.findall(r'\s(\d+)\s', processor_line)

--- a/lib/ansible/modules/network/ios/ios_facts.py
+++ b/lib/ansible/modules/network/ios/ios_facts.py
@@ -227,13 +227,16 @@ class Hardware(FactsBase):
             self.facts['filesystems'] = self.parse_filesystems(data)
 
         data = self.responses[1]
-        if data and 'Invalid input detected' not in data:
-            processor_line = [l for l in data.splitlines()
-                              if 'Processor' in l].pop()
-            match = re.findall(r'\s(\d+)\s', processor_line)
-            if match:
-                self.facts['memtotal_mb'] = int(match[0]) / 1024
-                self.facts['memfree_mb'] = int(match[3]) / 1024
+        if data:
+            if 'Invalid input detected' in data:
+                warnings.append('Unable to gather memory statistics')
+            else:
+                processor_line = [l for l in data.splitlines()
+                                if 'Processor' in l].pop()
+                match = re.findall(r'\s(\d+)\s', processor_line)
+                if match:
+                    self.facts['memtotal_mb'] = int(match[0]) / 1024
+                    self.facts['memfree_mb'] = int(match[3]) / 1024
 
     def parse_filesystems(self, data):
         return re.findall(r'^Directory of (\S+)/', data, re.M)
@@ -446,6 +449,8 @@ FACT_SUBSETS = dict(
 
 VALID_SUBSETS = frozenset(FACT_SUBSETS.keys())
 
+global warnings
+warnings = list()
 
 def main():
     """main entry point for module execution
@@ -508,7 +513,6 @@ def main():
         key = 'ansible_net_%s' % key
         ansible_facts[key] = value
 
-    warnings = list()
     check_args(module, warnings)
 
     module.exit_json(ansible_facts=ansible_facts, warnings=warnings)

--- a/lib/ansible/modules/network/ios/ios_facts.py
+++ b/lib/ansible/modules/network/ios/ios_facts.py
@@ -227,7 +227,7 @@ class Hardware(FactsBase):
             self.facts['filesystems'] = self.parse_filesystems(data)
 
         data = self.responses[1]
-        if data and not 'Invalid input detected' in data:
+        if data and 'Invalid input detected' not in data:
             processor_line = [l for l in data.splitlines()
                               if 'Processor' in l].pop()
             match = re.findall(r'\s(\d+)\s', processor_line)


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
In some firmwares, 'show memory statistics' fail, thus
do not populate mem if we got a failure after running that command.

Fixes #39576 
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
ios_facts
