### PR TITLE
nxos_vlan fix

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_vlan.py
+++ b/lib/ansible/modules/network/nxos/nxos_vlan.py
@@ -454,21 +454,31 @@ def parse_vni(module, vlan_id):
     return str(vni)
 
 
+def get_vlan_int(interfaces):
+    vlan_int = []
+    for i in interfaces.split(','):
+        if 'eth' in i.lower() and '-' in i:
+            int_range = i.split('-')
+            stop = int((int_range)[1])
+            start = int(int_range[0].split('/')[1])
+            eth = int_range[0].split('/')[0]
+            for r in range(start, stop + 1):
+                vlan_int.append(eth + '/' + str(r))
+        else:
+            vlan_int.append(i)
+    return vlan_int
+
+
 def parse_interfaces(module, vlan):
     vlan_int = []
     interfaces = vlan.get('vlanshowplist-ifidx')
     if interfaces:
-        for i in interfaces.split(','):
-            if 'eth' in i.lower() and '-' in i:
-                int_range = i.split('-')
-                stop = int((int_range)[1])
-                start = int(int_range[0].split('/')[1])
-                eth = int_range[0].split('/')[0]
-                for r in range(start, stop + 1):
-                    vlan_int.append(eth + '/' + str(r))
-            else:
-                vlan_int.append(i)
-
+        if isinstance(interfaces, list):
+            interfaces_list = [i.strip() for i in interfaces]
+            interfaces_str = ','.join(interfaces_list)
+            vlan_int = get_vlan_int(interfaces_str)
+        else:
+            vlan_int = get_vlan_int(interfaces)
     return vlan_int
 
 

--- a/test/integration/targets/nxos_vlan/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_vlan/tests/common/sanity.yaml
@@ -7,6 +7,13 @@
 - set_fact: testint2="{{ nxos_int2 }}"
 
 - block:
+  - name: Install and Enable FabricPath feature set
+    nxos_config:
+      lines:
+        - install feature-set fabricpath
+        - feature-set fabricpath
+    when: platform is search('N5K|N7K')
+
   - name: "Enable feature vn segment"
     nxos_config: 
       commands:
@@ -114,41 +121,41 @@
     when: platform is search('N3K|N7K')
 
 # Uncomment this once the get_capabilities() work on nxapi as well
-#  - name: Change mode
-#    nxos_vlan: &mode1
-#      vlan_id: 50
-#      mode: fabricpath
-#    register: result
-#    when: platform is search('N5k|N7K')
-#
-#  - assert: *true
-#    when: platform is search('N5k|N7K')
-#
-#  - name: "mode1 Idempotence"
-#    nxos_vlan: *mode1
-#    register: result
-#    when: platform is search('N5k|N7K')
-#
-#  - assert: *false
-#    when: platform is search('N5k|N7K')
-#
-#  - name: Change mode again
-#    nxos_vlan: &mode2
-#      vlan_id: 50
-#      mode: ce
-#    register: result
-#    when: platform is search('N5k|N7K')
-#
-#  - assert: *true
-#    when: platform is search('N5k|N7K')
-#
-#  - name: "mode2 Idempotence"
-#    nxos_vlan: *mode2
-#    register: result
-#    when: platform is search('N5k|N7K')
-#
-#  - assert: *false
-#    when: platform is search('N5k|N7K')
+  - name: Change mode
+    nxos_vlan: &mode1
+      vlan_id: 50
+      mode: fabricpath
+    register: result
+    when: platform is search('N5K|N7K')
+
+  - assert: *true
+    when: platform is search('N5K|N7K')
+
+  - name: "mode1 Idempotence"
+    nxos_vlan: *mode1
+    register: result
+    when: platform is search('N5K|N7K')
+
+  - assert: *false
+    when: platform is search('N5K|N7K')
+
+  - name: Change mode again
+    nxos_vlan: &mode2
+      vlan_id: 50
+      mode: ce
+    register: result
+    when: platform is search('N5K|N7K')
+
+  - assert: *true
+    when: platform is search('N5K|N7K')
+
+  - name: "mode2 Idempotence"
+    nxos_vlan: *mode2
+    register: result
+    when: platform is search('N5K|N7K')
+
+  - assert: *false
+    when: platform is search('N5K|N7K')
 
   - name: Ensure VLAN is NOT on the device
     nxos_vlan: &no_vlan


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
- fixes https://github.com/ansible/ansible/issues/39471
- uncomment test for `mode` param as we now have get_capabilities with httpapi
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
modules/network/nxos/nxos_vlan.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel, 2.6, 2.5
```