### PR TITLE
fix nxos_vrf and migrate get_interface_type to module_utils

### DIFF
--- a/lib/ansible/module_utils/network/nxos/nxos.py
+++ b/lib/ansible/module_utils/network/nxos/nxos.py
@@ -479,3 +479,24 @@ def normalize_interface(name):
         proper_interface = name
 
     return proper_interface
+
+
+def get_interface_type(interface):
+    """Gets the type of interface
+    """
+    if interface.upper().startswith('ET'):
+        return 'ethernet'
+    elif interface.upper().startswith('VL'):
+        return 'svi'
+    elif interface.upper().startswith('LO'):
+        return 'loopback'
+    elif interface.upper().startswith('MG'):
+        return 'management'
+    elif interface.upper().startswith('MA'):
+        return 'management'
+    elif interface.upper().startswith('PO'):
+        return 'portchannel'
+    elif interface.upper().startswith('NV'):
+        return 'nve'
+    else:
+        return 'unknown'

--- a/lib/ansible/modules/network/nxos/_nxos_ip_interface.py
+++ b/lib/ansible/modules/network/nxos/_nxos_ip_interface.py
@@ -179,6 +179,7 @@ except ImportError:
 
 from ansible.module_utils.network.nxos.nxos import load_config, run_commands
 from ansible.module_utils.network.nxos.nxos import get_capabilities, nxos_argument_spec
+from ansible.module_utils.network.nxos.nxos import get_interface_type
 from ansible.module_utils.basic import AnsibleModule
 
 
@@ -207,23 +208,6 @@ def execute_show_command(command, module):
     body = run_commands(module, [cmd])
 
     return body
-
-
-def get_interface_type(interface):
-    if interface.upper().startswith('ET'):
-        return 'ethernet'
-    elif interface.upper().startswith('VL'):
-        return 'svi'
-    elif interface.upper().startswith('LO'):
-        return 'loopback'
-    elif interface.upper().startswith('MG'):
-        return 'management'
-    elif interface.upper().startswith('MA'):
-        return 'management'
-    elif interface.upper().startswith('PO'):
-        return 'portchannel'
-    else:
-        return 'unknown'
 
 
 def is_default(interface, module):

--- a/lib/ansible/modules/network/nxos/_nxos_switchport.py
+++ b/lib/ansible/modules/network/nxos/_nxos_switchport.py
@@ -119,32 +119,8 @@ commands:
 
 from ansible.module_utils.network.nxos.nxos import load_config, run_commands
 from ansible.module_utils.network.nxos.nxos import get_capabilities, nxos_argument_spec
+from ansible.module_utils.network.nxos.nxos import get_interface_type
 from ansible.module_utils.basic import AnsibleModule
-
-
-def get_interface_type(interface):
-    """Gets the type of interface
-    Args:
-        interface (str): full name of interface, i.e. Ethernet1/1, loopback10,
-            port-channel20, vlan20
-    Returns:
-        type of interface: ethernet, svi, loopback, management, portchannel,
-         or unknown
-    """
-    if interface.upper().startswith('ET'):
-        return 'ethernet'
-    elif interface.upper().startswith('VL'):
-        return 'svi'
-    elif interface.upper().startswith('LO'):
-        return 'loopback'
-    elif interface.upper().startswith('MG'):
-        return 'management'
-    elif interface.upper().startswith('MA'):
-        return 'management'
-    elif interface.upper().startswith('PO'):
-        return 'portchannel'
-    else:
-        return 'unknown'
 
 
 def get_interface_mode(interface, module):

--- a/lib/ansible/modules/network/nxos/nxos_hsrp.py
+++ b/lib/ansible/modules/network/nxos/nxos_hsrp.py
@@ -148,6 +148,7 @@ commands:
 
 from ansible.module_utils.network.nxos.nxos import load_config, run_commands
 from ansible.module_utils.network.nxos.nxos import get_capabilities, nxos_argument_spec
+from ansible.module_utils.network.nxos.nxos import get_interface_type
 from ansible.module_utils.basic import AnsibleModule
 
 
@@ -185,23 +186,6 @@ def apply_key_map(key_map, table):
             else:
                 new_dict[new_key] = value
     return new_dict
-
-
-def get_interface_type(interface):
-    if interface.upper().startswith('ET'):
-        return 'ethernet'
-    elif interface.upper().startswith('VL'):
-        return 'svi'
-    elif interface.upper().startswith('LO'):
-        return 'loopback'
-    elif interface.upper().startswith('MG'):
-        return 'management'
-    elif interface.upper().startswith('MA'):
-        return 'management'
-    elif interface.upper().startswith('PO'):
-        return 'portchannel'
-    else:
-        return 'unknown'
 
 
 def get_interface_mode(interface, intf_type, module):

--- a/lib/ansible/modules/network/nxos/nxos_igmp_interface.py
+++ b/lib/ansible/modules/network/nxos/nxos_igmp_interface.py
@@ -191,6 +191,7 @@ changed:
 
 from ansible.module_utils.network.nxos.nxos import get_config, load_config, run_commands
 from ansible.module_utils.network.nxos.nxos import nxos_argument_spec, check_args
+from ansible.module_utils.network.nxos.nxos import get_interface_type
 from ansible.module_utils.basic import AnsibleModule
 
 import re
@@ -225,23 +226,6 @@ def get_interface_mode(interface, intf_type, module):
     elif intf_type == 'loopback' or intf_type == 'svi':
         mode = 'layer3'
     return mode
-
-
-def get_interface_type(interface):
-    if interface.upper().startswith('ET'):
-        return 'ethernet'
-    elif interface.upper().startswith('VL'):
-        return 'svi'
-    elif interface.upper().startswith('LO'):
-        return 'loopback'
-    elif interface.upper().startswith('MG'):
-        return 'management'
-    elif interface.upper().startswith('MA'):
-        return 'management'
-    elif interface.upper().startswith('PO'):
-        return 'portchannel'
-    else:
-        return 'unknown'
 
 
 def apply_key_map(key_map, table):

--- a/lib/ansible/modules/network/nxos/nxos_interface.py
+++ b/lib/ansible/modules/network/nxos/nxos_interface.py
@@ -203,6 +203,7 @@ from copy import deepcopy
 
 from ansible.module_utils.network.nxos.nxos import load_config, run_commands
 from ansible.module_utils.network.nxos.nxos import nxos_argument_spec, normalize_interface
+from ansible.module_utils.network.nxos.nxos import get_interface_type
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.network.common.utils import conditional, remove_default_spec
 
@@ -229,27 +230,6 @@ def search_obj_in_list(name, lst):
             return o
 
     return None
-
-
-def get_interface_type(interface):
-    """Gets the type of interface
-    """
-    if interface.upper().startswith('ET'):
-        return 'ethernet'
-    elif interface.upper().startswith('VL'):
-        return 'svi'
-    elif interface.upper().startswith('LO'):
-        return 'loopback'
-    elif interface.upper().startswith('MG'):
-        return 'management'
-    elif interface.upper().startswith('MA'):
-        return 'management'
-    elif interface.upper().startswith('PO'):
-        return 'portchannel'
-    elif interface.upper().startswith('NV'):
-        return 'nve'
-    else:
-        return 'unknown'
 
 
 def get_interfaces_dict(module):

--- a/lib/ansible/modules/network/nxos/nxos_l2_interface.py
+++ b/lib/ansible/modules/network/nxos/nxos_l2_interface.py
@@ -120,34 +120,9 @@ import re
 from copy import deepcopy
 
 from ansible.module_utils.network.nxos.nxos import get_config, load_config, run_commands
-from ansible.module_utils.network.nxos.nxos import nxos_argument_spec
+from ansible.module_utils.network.nxos.nxos import nxos_argument_spec, get_interface_type
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.network.common.utils import remove_default_spec
-
-
-def get_interface_type(name):
-    """Gets the type of interface
-    Args:
-        interface (str): full name of interface, i.e. Ethernet1/1, loopback10,
-            port-channel20, vlan20
-    Returns:
-        type of interface: ethernet, svi, loopback, management, portchannel,
-         or unknown
-    """
-    if name.upper().startswith('ET'):
-        return 'ethernet'
-    elif name.upper().startswith('VL'):
-        return 'svi'
-    elif name.upper().startswith('LO'):
-        return 'loopback'
-    elif name.upper().startswith('MG'):
-        return 'management'
-    elif name.upper().startswith('MA'):
-        return 'management'
-    elif name.upper().startswith('PO'):
-        return 'portchannel'
-    else:
-        return 'unknown'
 
 
 def get_interface_mode(name, module):

--- a/lib/ansible/modules/network/nxos/nxos_pim_interface.py
+++ b/lib/ansible/modules/network/nxos/nxos_pim_interface.py
@@ -135,6 +135,7 @@ import re
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.network.nxos.nxos import get_config, load_config, run_commands
 from ansible.module_utils.network.nxos.nxos import nxos_argument_spec, check_args
+from ansible.module_utils.network.nxos.nxos import get_interface_type
 from ansible.module_utils.six import string_types
 
 
@@ -198,23 +199,6 @@ def local_existing(gexisting):
             gexisting.pop('isauth')
 
     return gexisting, jp_bidir, isauth
-
-
-def get_interface_type(interface):
-    if interface.upper().startswith('ET'):
-        return 'ethernet'
-    elif interface.upper().startswith('VL'):
-        return 'svi'
-    elif interface.upper().startswith('LO'):
-        return 'loopback'
-    elif interface.upper().startswith('MG'):
-        return 'management'
-    elif interface.upper().startswith('MA'):
-        return 'management'
-    elif interface.upper().startswith('PO'):
-        return 'portchannel'
-    else:
-        return 'unknown'
 
 
 def get_interface_mode(interface, intf_type, module):

--- a/lib/ansible/modules/network/nxos/nxos_vrf.py
+++ b/lib/ansible/modules/network/nxos/nxos_vrf.py
@@ -175,7 +175,7 @@ from copy import deepcopy
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.network.nxos.nxos import load_config, run_commands
-from ansible.module_utils.network.nxos.nxos import nxos_argument_spec
+from ansible.module_utils.network.nxos.nxos import nxos_argument_spec, get_interface_type
 from ansible.module_utils.network.common.utils import remove_default_spec
 
 
@@ -262,7 +262,8 @@ def map_obj_to_commands(updates, module):
                 if interfaces and interfaces[0] != 'default':
                     for i in interfaces:
                         commands.append('interface {0}'.format(i))
-                        commands.append('no switchport')
+                        if get_interface_type(i) in ('ethernet', 'portchannel'):
+                            commands.append('no switchport')
                         commands.append('vrf member {0}'.format(name))
 
             else:
@@ -296,7 +297,8 @@ def map_obj_to_commands(updates, module):
                             commands.append('vrf context {0}'.format(name))
                             commands.append('exit')
                             commands.append('interface {0}'.format(i))
-                            commands.append('no switchport')
+                            if get_interface_type(i) in ('ethernet', 'portchannel'):
+                                commands.append('no switchport')
                             commands.append('vrf member {0}'.format(name))
 
                     elif set(interfaces) != set(obj_in_have['interfaces']):
@@ -305,7 +307,8 @@ def map_obj_to_commands(updates, module):
                             commands.append('vrf context {0}'.format(name))
                             commands.append('exit')
                             commands.append('interface {0}'.format(i))
-                            commands.append('no switchport')
+                            if get_interface_type(i) in ('ethernet', 'portchannel'):
+                                commands.append('no switchport')
                             commands.append('vrf member {0}'.format(name))
 
                         superfluous_interfaces = list(set(obj_in_have['interfaces']) - set(interfaces))
@@ -313,7 +316,8 @@ def map_obj_to_commands(updates, module):
                             commands.append('vrf context {0}'.format(name))
                             commands.append('exit')
                             commands.append('interface {0}'.format(i))
-                            commands.append('no switchport')
+                            if get_interface_type(i) in ('ethernet', 'portchannel'):
+                                commands.append('no switchport')
                             commands.append('no vrf member {0}'.format(name))
                 elif interfaces and interfaces[0] == 'default':
                     if obj_in_have['interfaces']:
@@ -321,7 +325,8 @@ def map_obj_to_commands(updates, module):
                             commands.append('vrf context {0}'.format(name))
                             commands.append('exit')
                             commands.append('interface {0}'.format(i))
-                            commands.append('no switchport')
+                            if get_interface_type(i) in ('ethernet', 'portchannel'):
+                                commands.append('no switchport')
                             commands.append('no vrf member {0}'.format(name))
 
     if purge:

--- a/lib/ansible/modules/network/nxos/nxos_vrf_interface.py
+++ b/lib/ansible/modules/network/nxos/nxos_vrf_interface.py
@@ -82,6 +82,7 @@ import re
 
 from ansible.module_utils.network.nxos.nxos import load_config, run_commands
 from ansible.module_utils.network.nxos.nxos import get_capabilities, nxos_argument_spec
+from ansible.module_utils.network.nxos.nxos import get_interface_type
 from ansible.module_utils.basic import AnsibleModule
 
 
@@ -95,23 +96,6 @@ def execute_show_command(command, module):
         'output': output,
     }]
     return run_commands(module, cmds)[0]
-
-
-def get_interface_type(interface):
-    if interface.upper().startswith('ET'):
-        return 'ethernet'
-    elif interface.upper().startswith('VL'):
-        return 'svi'
-    elif interface.upper().startswith('LO'):
-        return 'loopback'
-    elif interface.upper().startswith('MG'):
-        return 'management'
-    elif interface.upper().startswith('MA'):
-        return 'management'
-    elif interface.upper().startswith('PO'):
-        return 'portchannel'
-    else:
-        return 'unknown'
 
 
 def get_interface_mode(interface, intf_type, module):

--- a/lib/ansible/modules/network/nxos/nxos_vrrp.py
+++ b/lib/ansible/modules/network/nxos/nxos_vrrp.py
@@ -118,6 +118,7 @@ commands:
 
 from ansible.module_utils.network.nxos.nxos import load_config, run_commands
 from ansible.module_utils.network.nxos.nxos import get_capabilities, nxos_argument_spec
+from ansible.module_utils.network.nxos.nxos import get_interface_type
 from ansible.module_utils.basic import AnsibleModule
 
 
@@ -152,23 +153,6 @@ def apply_key_map(key_map, table):
             else:
                 new_dict[new_key] = value
     return new_dict
-
-
-def get_interface_type(interface):
-    if interface.upper().startswith('ET'):
-        return 'ethernet'
-    elif interface.upper().startswith('VL'):
-        return 'svi'
-    elif interface.upper().startswith('LO'):
-        return 'loopback'
-    elif interface.upper().startswith('MG'):
-        return 'management'
-    elif interface.upper().startswith('MA'):
-        return 'management'
-    elif interface.upper().startswith('PO'):
-        return 'portchannel'
-    else:
-        return 'unknown'
 
 
 def is_default(interface, module):


### PR DESCRIPTION
Signed-off-by: Trishna Guha <trishnaguha17@gmail.com>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
fixes https://github.com/ansible/ansible/issues/40713
migrate `get_interface_type` to module_utils
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
modules/network/nxos/nxos_vrf
module_utils/network/nxos/nxos.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel, 2.6, 2.5
```