### PR TITLE
Use _remote_is_local=True for local connection in synchronize

### DIFF
--- a/lib/ansible/plugins/action/synchronize.py
+++ b/lib/ansible/plugins/action/synchronize.py
@@ -301,6 +301,9 @@ class ActionModule(ActionBase):
 
             new_connection = connection_loader.get('local', self._play_context, new_stdin)
             self._connection = new_connection
+            # Override _remote_is_local as an instance attribute specifically for the synchronize use case
+            # ensuring we set local tmpdir correctly
+            self._connection._remote_is_local = True
             self._override_module_replaced_vars(task_vars)
 
         # SWITCH SRC AND DEST HOST PER MODE

--- a/lib/ansible/plugins/connection/local.py
+++ b/lib/ansible/plugins/connection/local.py
@@ -55,8 +55,6 @@ class Connection(ConnectionBase):
 
     transport = 'local'
     has_pipelining = True
-    # Do not use _remote_is_local in other connections
-    _remote_is_local = True
 
     def _connect(self):
         ''' connect to the local host; nothing to do here '''

--- a/lib/ansible/plugins/connection/local.py
+++ b/lib/ansible/plugins/connection/local.py
@@ -55,6 +55,8 @@ class Connection(ConnectionBase):
 
     transport = 'local'
     has_pipelining = True
+    # Do not use _remote_is_local in other connections
+    _remote_is_local = True
 
     def _connect(self):
         ''' connect to the local host; nothing to do here '''


### PR DESCRIPTION
##### SUMMARY
All instances of local connection should use _remote_is_local=True. Fixes #40551

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/connection/local.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5.3
2.6
2.7
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```