### PR TITLE
Docker container init check requirements

### DIFF
--- a/lib/ansible/module_utils/docker_common.py
+++ b/lib/ansible/module_utils/docker_common.py
@@ -187,10 +187,6 @@ class AnsibleDockerClient(Client):
         except Exception as exc:
             self.fail("Error connecting: %s" % exc)
 
-        docker_api_version = self.version()["ApiVersion"]
-        if self.module.params.get("init") and LooseVersion(docker_api_version) < LooseVersion("1.25"):
-            self.fail("docker API version is %s. Minimum version required is 1.25 to set init option." % (docker_api_version,))
-
     def log(self, msg, pretty_print=False):
         pass
         # if self.debug:

--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -917,10 +917,9 @@ class TaskParameters(DockerBaseClass):
             devices='devices',
             pid_mode='pid_mode',
             tmpfs='tmpfs',
-            init='init'
         )
 
-        if HAS_DOCKER_PY_2 or HAS_DOCKER_PY_3:
+        if self.client.HAS_AUTO_REMOVE_OPT:
             # auto_remove is only supported in docker>=2
             host_config_params['auto_remove'] = 'auto_remove'
 
@@ -928,6 +927,9 @@ class TaskParameters(DockerBaseClass):
             # cpu_shares and volume_driver moved to create_host_config in > 3
             host_config_params['cpu_shares'] = 'cpu_shares'
             host_config_params['volume_driver'] = 'volume_driver'
+
+        if self.client.HAS_INIT_OPT:
+            host_config_params['init'] = 'init'
 
         params = dict()
         for key, value in host_config_params.items():
@@ -2002,6 +2004,26 @@ class ContainerManager(DockerBaseClass):
         return response
 
 
+class AnsibleDockerClientContainer(AnsibleDockerClient):
+
+    def __init__(self, **kwargs):
+        super(AnsibleDockerClientContainer, self).__init__(**kwargs)
+
+        docker_api_version = self.version()['ApiVersion']
+        init_supported = LooseVersion(docker_api_version) >= LooseVersion('1.25')
+        if self.module.params.get("init") and not init_supported:
+            self.fail('docker API version is %s. Minimum version required is 1.25 to set init option.' % (docker_api_version,))
+
+        init_supported = init_supported and LooseVersion(docker_version) >= LooseVersion('2.2')
+        if self.module.params.get("init") and not init_supported:
+            self.fail('docker-py version is %s. Minimum version required is 2.2 to set init option.' % (docker_version,))
+
+        self.HAS_INIT_OPT = init_supported
+        self.HAS_AUTO_REMOVE_OPT = HAS_DOCKER_PY_2 or HAS_DOCKER_PY_3
+        if self.module.params.get('auto_remove') and not self.HAS_AUTO_REMOVE_OPT:
+            self.fail("'auto_remove' is not compatible with the 'docker-py' Python package. It requires the newer 'docker' Python package.")
+
+
 def main():
     argument_spec = dict(
         auto_remove=dict(type='bool', default=False),
@@ -2087,21 +2109,11 @@ def main():
         ('state', 'present', ['image'])
     ]
 
-    client = AnsibleDockerClient(
+    client = AnsibleDockerClientContainer(
         argument_spec=argument_spec,
         required_if=required_if,
         supports_check_mode=True
     )
-
-    if client.params.get("init"):
-        docker_api_version = client.version()['ApiVersion']
-        if LooseVersion(docker_api_version) < LooseVersion('1.25'):
-            client.fail('docker API version is %s. Minimum version required is 1.25 to set init option.' % (docker_api_version,))
-        if LooseVersion(docker_version) < LooseVersion('2.2'):
-            client.fail('docker-py version is %s. Minimum version required is 2.2 to set init option.' % (docker_version,))
-
-    if (not (HAS_DOCKER_PY_2 or HAS_DOCKER_PY_3)) and client.module.params.get('auto_remove'):
-        client.module.fail_json(msg="'auto_remove' is not compatible with the 'docker-py' Python package. It requires the newer 'docker' Python package.")
 
     cm = ContainerManager(client)
     client.module.exit_json(**cm.results)


### PR DESCRIPTION
##### SUMMARY
`docker_container` module:
- check version of `docker-py` dependency too
- fix compatibility with `docker-py<2.2`
  Using this playbook with docker-py<2.2:
  ```
  - hosts: localhost
    gather_facts: no
    tasks:
      - name: Create a container
        docker_container:
          name: testcontainer
          hostname: testcontainer
          image: debian:stretch
          init: yes
  ```
  the following exception occurs:

  ```
  Traceback (most recent call last):",
    File /tmp/ansible_n0psgms7/ansible_module_docker_container.py, line 2081, in <module>",
      main()",
    File /tmp/ansible_n0psgms7/ansible_module_docker_container.py, line 2076, in main",
      cm = ContainerManager(client)",
    File /tmp/ansible_n0psgms7/ansible_module_docker_container.py, line 1703, in __init__",
      self.present(state)",
    File /tmp/ansible_n0psgms7/ansible_module_docker_container.py, line 1723, in present",
      new_container = self.container_create(self.parameters.image, self.parameters.create_parameters)",
    File /tmp/ansible_n0psgms7/ansible_module_docker_container.py, line 825, in create_parameters",
      host_config=self._host_config(),",
    File /tmp/ansible_n0psgms7/ansible_module_docker_container.py, line 931, in _host_config",
      return self.client.create_host_config(**params)",
    File lib/python3.6/site-packages/docker/api/container.py, line 596, in create_host_config",
      return HostConfig(*args, **kwargs)",
  TypeError: __init__() got an unexpected keyword argument 'init'"
  ```

Related: #34547.

This pull-request should be backported on 2.6.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
docker_container

##### ANSIBLE VERSION
```
ansible 2.7.0dev0 (devel 726d7fe4c3) last updated 2018/05/29 10:06:10 (GMT +200)
```