### PR TITLE
openstack: Document the python-novaclient requirement

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_server.py
+++ b/lib/ansible/modules/cloud/openstack/os_server.py
@@ -199,6 +199,7 @@ options:
      required: false
 requirements:
     - "python >= 2.6"
+    - "python-novaclient"
     - "shade"
 '''
 

--- a/lib/ansible/modules/cloud/openstack/os_server_action.py
+++ b/lib/ansible/modules/cloud/openstack/os_server_action.py
@@ -66,6 +66,7 @@ options:
      required: false
 requirements:
     - "python >= 2.6"
+    - "python-novaclient"
     - "shade"
 '''
 


### PR DESCRIPTION
##### SUMMARY
Without also installing the python-novaclient library, these modules
simply do not work.

Rather than backporting the fixes implemented in 2.6+ we simply make
sure that we document the requirement.

Fixes: #35484

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
openstack os_server and os_server_action modules

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.4.0 (document-novaclient-dependency-2.4 026628e465) last updated 2018/05/29 18:51:59 (GMT +100)
  config file = ~/.ansible.cfg
  configured module search path = [u'~/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = ~/code/ansible/lib/ansible
  executable location = ~/venvs/ansible-2.5/bin/ansible
  python version = 2.7.10 (default, Oct  6 2017, 22:29:07) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.31)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
