### PR TITLE
Correct the OpenStack plugin example config

### DIFF
--- a/lib/ansible/plugins/inventory/openstack.py
+++ b/lib/ansible/plugins/inventory/openstack.py
@@ -91,11 +91,9 @@ DOCUMENTATION = '''
 EXAMPLES = '''
 # file must be named openstack.yaml or openstack.yml
 # Make the plugin behave like the default behavior of the old script
-simple_config_file:
-    plugin: openstack
-    inventory_hostname: 'name'
-    expand_hostvars: true
-    fail_on_errors: true
+plugin: openstack
+expand_hostvars: yes
+fail_on_errors: yes
 '''
 
 import collections


### PR DESCRIPTION
##### SUMMARY
The current example configuration is not
quite right, so this patch implements a
fix which corrects it

The 'inventory_hostname' argument is removed
as it's the same value as the default.

(cherry picked from commit 12218f33a5c429676da8f3db0f91553c63a0314f)

Backports https://github.com/ansible/ansible/pull/40460

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
openstack inventory plugin

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.4.0 (backport/2.4/40460 38367ac5e7) last updated 2018/05/29 19:02:02 (GMT +100)
  config file = ~/.ansible.cfg
  configured module search path = [u'~/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = ~/code/ansible/lib/ansible
  executable location = ~/venvs/ansible-2.5/bin/ansible
  python version = 2.7.10 (default, Oct  6 2017, 22:29:07) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.31)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
