### PR TITLE
gluster_volume: add 'volume' alias to 'name' param

### DIFF
--- a/lib/ansible/modules/storage/glusterfs/gluster_volume.py
+++ b/lib/ansible/modules/storage/glusterfs/gluster_volume.py
@@ -22,6 +22,7 @@ options:
     description:
       - The volume name.
     required: true
+    aliases: ['volume']
   state:
     description:
       - Use present/absent ensure if a volume exists or not.

--- a/test/sanity/validate-modules/ignore.txt
+++ b/test/sanity/validate-modules/ignore.txt
@@ -1123,7 +1123,6 @@ lib/ansible/modules/source_control/gitlab_project.py E324
 lib/ansible/modules/source_control/gitlab_project.py E326
 lib/ansible/modules/source_control/gitlab_user.py E326
 lib/ansible/modules/source_control/subversion.py E322
-lib/ansible/modules/storage/glusterfs/gluster_volume.py E322
 lib/ansible/modules/storage/infinidat/infini_export.py E323
 lib/ansible/modules/storage/infinidat/infini_export.py E324
 lib/ansible/modules/storage/infinidat/infini_export_client.py E323


### PR DESCRIPTION
##### SUMMARY
Fix CI https://app.shippable.com/github/ansible/ansible/runs/67688/1/tests

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/storage/glusterfs/gluster_volume.py

##### ANSIBLE VERSION
```
2.7.0dev0
```
