### PR TITLE
Add a helper to PlayIterator to recursively find the active state

### DIFF
--- a/lib/ansible/executor/play_iterator.py
+++ b/lib/ansible/executor/play_iterator.py
@@ -514,6 +514,18 @@ class PlayIterator:
         s = self.get_host_state(host)
         return self._check_failed_state(s)
 
+    def get_active_state(self, state):
+        '''
+        Finds the active state, recursively if necessary when there are child states.
+        '''
+        if state.run_state == self.ITERATING_TASKS and state.tasks_child_state is not None:
+            return self.get_active_state(state.tasks_child_state)
+        elif state.run_state == self.ITERATING_RESCUE and state.rescue_child_state is not None:
+            return self.get_active_state(state.rescue_child_state)
+        elif state.run_state == self.ITERATING_ALWAYS and state.always_child_state is not None:
+            return self.get_active_state(state.always_child_state)
+        return state
+
     def get_original_task(self, host, task):
         # now a noop because we've changed the way we do caching
         return (None, None)

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -493,7 +493,7 @@ class StrategyBase:
                     if iterator.is_failed(original_host) and state and state.run_state == iterator.ITERATING_COMPLETE:
                         self._tqm._failed_hosts[original_host.name] = True
 
-                    if state and state.run_state == iterator.ITERATING_RESCUE:
+                    if state and iterator.get_active_state(state).run_state == iterator.ITERATING_RESCUE:
                         self._variable_manager.set_nonpersistent_facts(
                             original_host,
                             dict(


### PR DESCRIPTION
Also fixes a discovered bug in block rescue detection related to inserting
the ansible_failed_{result|task} variables when the rescue is in a nested
block.
