### PR TITLE
Fix eapi tests to use become (#40838)

### DIFF
--- a/lib/ansible/plugins/httpapi/eos.py
+++ b/lib/ansible/plugins/httpapi/eos.py
@@ -45,8 +45,11 @@ class HttpApi:
         return results
 
     def get_prompt(self):
-        # Hack to keep @enable_mode working
-        return '#'
+        # Fake a prompt for @enable_mode
+        if self._become:
+            return '#'
+        else:
+            return '>'
 
     def set_become(self, play_context):
         self._become = play_context.become

--- a/test/integration/targets/eos_banner/tests/cli/basic-login.yaml
+++ b/test/integration/targets/eos_banner/tests/cli/basic-login.yaml
@@ -4,19 +4,15 @@
 - name: Remove previous login banner
   eos_config:
     lines: no banner login
-    authorize: yes
-    provider: "{{ cli }}"
   become: yes
 
 - name: Create login banner
-  eos_banner:
+  eos_banner: &multiline
     banner: login
     text: |
       Junk login banner
       over multiple lines
     state: present
-    authorize: yes
-    provider: "{{ cli }}"
   become: yes
   register: result
 
@@ -28,14 +24,7 @@
       - "'ansible_1' in result.session_name"
 
 - name: Create login banner again (idempotent)
-  eos_banner:
-    banner: login
-    text: |
-      Junk login banner
-      over multiple lines
-    state: present
-    authorize: yes
-    provider: "{{ cli }}"
+  eos_banner: *multiline
   become: yes
   register: result
 
@@ -47,11 +36,9 @@
       - "result.session_name is not defined"
 
 - name: Remove login
-  eos_banner:
+  eos_banner: &remove
     banner: login
     state: absent
-    authorize: yes
-    provider: "{{ cli }}"
   become: yes
   register: result
 
@@ -63,11 +50,7 @@
       - "'ansible_1' in result.session_name"
 
 - name: Remove login again (idempotent)
-  eos_banner:
-    banner: login
-    state: absent
-    authorize: yes
-    provider: "{{ cli }}"
+  eos_banner: *remove
   become: yes
   register: result
 

--- a/test/integration/targets/eos_banner/tests/cli/basic-motd.yaml
+++ b/test/integration/targets/eos_banner/tests/cli/basic-motd.yaml
@@ -4,11 +4,9 @@
 - name: Remove previous motd banner
   eos_config:
     lines: no banner motd
-    authorize: yes
-    provider: "{{ cli }}"
   become: yes
 
-- name: Create motd
+- name: Set motd
   eos_banner:
     banner: motd
     text: |
@@ -16,8 +14,6 @@
       that has a multiline
       string
     state: present
-    authorize: yes
-    provider: "{{ cli }}"
   become: yes
   register: result
 
@@ -29,7 +25,7 @@
       # Ensure sessions contains epoc. Will fail after 18th May 2033
       - "'ansible_1' in result.session_name"
 
-- name: Create motd again (idempotent)
+- name: Set motd again (idempotent)
   eos_banner:
     banner: motd
     text: |
@@ -37,8 +33,6 @@
       that has a multiline
       string
     state: present
-    authorize: yes
-    provider: "{{ cli }}"
   become: yes
   register: result
 
@@ -57,8 +51,6 @@
       that has a multiline
       string
     state: absent
-    authorize: yes
-    provider: "{{ cli }}"
   become: yes
   register: result
 
@@ -77,8 +69,6 @@
       that has a multiline
       string
     state: absent
-    authorize: yes
-    provider: "{{ cli }}"
   become: yes
   register: result
 

--- a/test/integration/targets/eos_banner/tests/cli/net_banner.yaml
+++ b/test/integration/targets/eos_banner/tests/cli/net_banner.yaml
@@ -7,18 +7,13 @@
 - name: Remove previous motd banner (setup)
   eos_config:
     lines: no banner motd
-    authorize: yes
-    provider: "{{ cli }}"
   become: yes
-
 
 - name: create motd
   net_banner:
     banner: motd
     text: this is my motd banner configure by net_banner
     state: present
-    authorize: yes
-    provider: "{{ cli }}"
   become: yes
   register: result
 
@@ -32,8 +27,6 @@
 - name: Remove previous motd banner (teardown)
   eos_config:
     lines: no banner motd
-    authorize: yes
-    provider: "{{ cli }}"
   become: yes
 
 - debug: msg="END eos cli/net_banner.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/eos_banner/tests/eapi/basic-login.yaml
+++ b/test/integration/targets/eos_banner/tests/eapi/basic-login.yaml
@@ -4,19 +4,17 @@
 - name: Remove previous login banner
   eos_config:
     lines: no banner login
-    authorize: yes
-    provider: "{{ eapi }}"
+  become: yes
 
 - name: Create login banner
-  eos_banner:
+  eos_banner: &multiline
     banner: login
     text: |
       this is my login banner
       that has a multiline
       string
     state: present
-    authorize: yes
-    provider: "{{ eapi }}"
+  become: yes
   register: result
 
 - assert:
@@ -27,15 +25,8 @@
       - "'ansible_1' in result.session_name"
 
 - name: Create login banner again (idempotent)
-  eos_banner:
-    banner: login
-    text: |
-      this is my login banner
-      that has a multiline
-      string
-    state: present
-    authorize: yes
-    provider: "{{ eapi }}"
+  eos_banner: *multiline
+  become: yes
   register: result
 
 - assert:
@@ -46,15 +37,14 @@
       - "result.session_name is not defined"
 
 - name: Remove login
-  eos_banner:
+  eos_banner: &remove
     banner: login
     text: |
       this is my login banner
       that has a multiline
       string
     state: absent
-    authorize: yes
-    provider: "{{ eapi }}"
+  become: yes
   register: result
 
 - assert:
@@ -65,15 +55,8 @@
       - "'ansible_1' in result.session_name"
 
 - name: Remove login again (idempotent)
-  eos_banner:
-    banner: login
-    text: |
-      this is my login banner
-      that has a multiline
-      string
-    state: absent
-    authorize: yes
-    provider: "{{ eapi }}"
+  eos_banner: *remove
+  become: yes
   register: result
 
 - assert:

--- a/test/integration/targets/eos_banner/tests/eapi/basic-motd.yaml
+++ b/test/integration/targets/eos_banner/tests/eapi/basic-motd.yaml
@@ -1,10 +1,10 @@
 ---
+- debug: msg="START eapi/basic-motd.yaml on connection={{ ansible_connection }}"
 
 - name: Remove previous motd banner
   eos_config:
     lines: no banner motd
-    authorize: yes
-    provider: "{{ eapi }}"
+  become: yes
 
 - name: Set motd
   eos_banner:
@@ -14,8 +14,7 @@
       that has a multiline
       string
     state: present
-    authorize: yes
-    provider: "{{ eapi }}"
+  become: yes
   register: result
 
 - assert:
@@ -34,8 +33,7 @@
       that has a multiline
       string
     state: present
-    authorize: yes
-    provider: "{{ eapi }}"
+  become: yes
   register: result
 
 - assert:
@@ -53,8 +51,7 @@
       that has a multiline
       string
     state: absent
-    authorize: yes
-    provider: "{{ eapi }}"
+  become: yes
   register: result
 
 - assert:
@@ -72,8 +69,7 @@
       that has a multiline
       string
     state: absent
-    authorize: yes
-    provider: "{{ eapi }}"
+  become: yes
   register: result
 
 - assert:
@@ -82,6 +78,7 @@
       - "result.commands | length == 0"
       # Ensure sessions contains epoc. Will fail after 18th May 2033
       - "result.session_name is not defined"
+
 # FIXME add in tests for everything defined in docs
 # FIXME Test state:absent + test:
 # FIXME Without powers ensure "privileged mode required"

--- a/test/integration/targets/eos_banner/tests/eapi/net_banner.yaml
+++ b/test/integration/targets/eos_banner/tests/eapi/net_banner.yaml
@@ -7,16 +7,14 @@
 - name: Remove previous motd banner (setup)
   eos_config:
     lines: no banner motd
-    authorize: yes
-    provider: "{{ eapi }}"
+  become: yes
 
 - name: create motd
   net_banner:
     banner: motd
     text: this is my motd banner configure by net_banner
     state: present
-    authorize: yes
-    provider: "{{ eapi }}"
+  become: yes
   register: result
 
 - assert:
@@ -29,7 +27,6 @@
 - name: Remove previous motd banner (teardown)
   eos_config:
     lines: no banner motd
-    authorize: yes
-    provider: "{{ eapi }}"
+  become: yes
 
 - debug: msg="END eos eapi/net_banner.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/eos_config/tests/cli/save.yaml
+++ b/test/integration/targets/eos_config/tests/cli/save.yaml
@@ -13,23 +13,20 @@
 
 
 - name: save config always
-  eos_config:
+  eos_config: &always
     save_when: always
   become: yes
   register: result
 
-- assert:
+- assert: &changed
     that:
       - "result.changed == true"
 
-- name: save always again (not idempotent)
-  eos_config:
-    save_when: always
+- name: save should always run
+  eos_config: *always
   become: yes
   register: result
 
-- assert:
-    that:
-      - "result.changed == true"
+- assert: *changed
 
 - debug: msg="END cli/save.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/eos_config/tests/cli/sublevel.yaml
+++ b/test/integration/targets/eos_config/tests/cli/sublevel.yaml
@@ -37,5 +37,4 @@
     match: none
   become: yes
 
-
 - debug: msg="END cli/sublevel.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/eos_config/tests/cli/toplevel.yaml
+++ b/test/integration/targets/eos_config/tests/cli/toplevel.yaml
@@ -3,7 +3,7 @@
 
 - name: setup
   eos_config:
-    lines: hostname veos01
+    lines: hostname {{ inventory_hostname_short }}
     match: none
   become: yes
 
@@ -30,7 +30,7 @@
 
 - name: teardown
   eos_config:
-    lines: hostname veos01
+    lines: hostname {{ inventory_hostname_short }}
     match: none
   become: yes
 

--- a/test/integration/targets/eos_config/tests/cli/toplevel_after.yaml
+++ b/test/integration/targets/eos_config/tests/cli/toplevel_after.yaml
@@ -5,7 +5,7 @@
   eos_config:
     lines:
       - snmp-server contact ansible
-      - hostname veos01
+      - "hostname {{ inventory_hostname_short }}"
     match: none
   become: yes
 
@@ -37,7 +37,7 @@
   eos_config:
     lines:
       - no snmp-server contact
-      - hostname veos01
+      - hostname {{ inventory_hostname_short }}
     match: none
   become: yes
 

--- a/test/integration/targets/eos_config/tests/cli/toplevel_before.yaml
+++ b/test/integration/targets/eos_config/tests/cli/toplevel_before.yaml
@@ -4,8 +4,8 @@
 - name: setup
   eos_config:
     lines:
-      - snmp-server contact ansible
-      - hostname veos01
+      - "snmp-server contact ansible"
+      - "hostname {{ inventory_hostname_short }}"
     match: none
   become: yes
 
@@ -36,8 +36,8 @@
 - name: teardown
   eos_config:
     lines:
-      - hostname veos01
       - no snmp-server contact
+      - "hostname {{ inventory_hostname_short }}"
     match: none
   become: yes
 

--- a/test/integration/targets/eos_config/tests/eapi/defaults.yaml
+++ b/test/integration/targets/eos_config/tests/eapi/defaults.yaml
@@ -9,11 +9,13 @@
     parents:
       - interface Ethernet2
     match: none
+  become: yes
 
 - name: configure device with defaults included
   eos_config:
     src: defaults/config.j2
     defaults: yes
+  become: yes
   register: result
 
 - debug: var=result
@@ -27,6 +29,7 @@
   eos_config:
     src: defaults/config.j2
     defaults: yes
+  become: yes
   register: result
 
 - debug: var=result

--- a/test/integration/targets/eos_config/tests/eapi/save.yaml
+++ b/test/integration/targets/eos_config/tests/eapi/save.yaml
@@ -9,24 +9,24 @@
     parents:
       - interface Ethernet2
     match: none
+  become: yes
 
 
-- name: save config
-  eos_config:
+- name: save config always
+  eos_config: &always
     save_when: always
+  become: yes
   register: result
 
-- assert:
+- assert: &changed
     that:
       - "result.changed == true"
 
 - name: save should always run
-  eos_config:
-    save_when: always
+  eos_config: *always
+  become: yes
   register: result
 
-- assert:
-    that:
-      - "result.changed == true"
+- assert: *changed
 
 - debug: msg="END eapi/save.yaml"

--- a/test/integration/targets/eos_config/tests/eapi/src_basic.yaml
+++ b/test/integration/targets/eos_config/tests/eapi/src_basic.yaml
@@ -9,10 +9,12 @@
     parents:
       - interface Ethernet2
     match: none
+  become: yes
 
 - name: configure device with config
   eos_config:
     src: basic/config.j2
+  become: yes
   register: result
 
 - assert:
@@ -24,6 +26,7 @@
 - name: check device with config
   eos_config:
     src: basic/config.j2
+  become: yes
   register: result
 
 - assert:

--- a/test/integration/targets/eos_config/tests/eapi/src_match_none.yaml
+++ b/test/integration/targets/eos_config/tests/eapi/src_match_none.yaml
@@ -9,11 +9,13 @@
     parents:
       - interface Ethernet2
     match: none
+  become: yes
 
 - name: configure device with config
   eos_config:
     src: basic/config.j2
     match: none
+  become: yes
   register: result
 
 - assert:
@@ -25,6 +27,7 @@
 - name: check device with config
   eos_config:
     src: basic/config.j2
+  become: yes
   register: result
 
 - assert:

--- a/test/integration/targets/eos_config/tests/eapi/sublevel.yaml
+++ b/test/integration/targets/eos_config/tests/eapi/sublevel.yaml
@@ -5,12 +5,14 @@
   eos_config:
     lines: no ip access-list test
     match: none
+  become: yes
 
 - name: configure sub level command
   eos_config:
     lines: 10 permit ip any any log
     parents: ip access-list test
     after: exit
+  become: yes
   register: result
 
 - assert:
@@ -23,6 +25,7 @@
   eos_config:
     lines: 10 permit ip any any log
     parents: ip access-list test
+  become: yes
   register: result
 
 - assert:
@@ -33,5 +36,6 @@
   eos_config:
     lines: no ip access-list test
     match: none
+  become: yes
 
 - debug: msg="END eapi/sublevel.yaml"

--- a/test/integration/targets/eos_config/tests/eapi/sublevel_block.yaml
+++ b/test/integration/targets/eos_config/tests/eapi/sublevel_block.yaml
@@ -10,6 +10,7 @@
     parents: ip access-list test
     before: no ip access-list test
     match: none
+  become: yes
 
 - name: configure sub level command using block resplace
   eos_config:
@@ -21,6 +22,7 @@
     parents: ip access-list test
     after: end
     replace: block
+  become: yes
   register: result
 
 - assert:
@@ -41,6 +43,7 @@
       - 40 permit ip host 4.4.4.4 any log
     parents: ip access-list test
     replace: block
+  become: yes
   register: result
 
 - assert:
@@ -51,5 +54,6 @@
   eos_config:
     lines: no ip access-list test
     match: none
+  become: yes
 
 - debug: msg="END eapi/sublevel_block.yaml"

--- a/test/integration/targets/eos_config/tests/eapi/sublevel_exact.yaml
+++ b/test/integration/targets/eos_config/tests/eapi/sublevel_exact.yaml
@@ -13,6 +13,7 @@
     before: no ip access-list test
     after: exit
     match: none
+  become: yes
 
 - name: configure sub level command using exact match
   eos_config:
@@ -21,10 +22,11 @@
       - 20 permit ip host 2.2.2.2 any log
       - 30 permit ip host 3.3.3.3 any log
       - 40 permit ip host 4.4.4.4 any log
-    before: no ip access-list test
     parents: ip access-list test
+    before: no ip access-list test
     after: exit
     match: exact
+  become: yes
   register: result
 
 - assert:
@@ -47,6 +49,7 @@
     before: no ip access-list test
     parents: ip access-list test
     match: exact
+  become: yes
   register: result
 
 - assert:
@@ -57,5 +60,6 @@
   eos_config:
     lines: no ip access-list test
     match: none
+  become: yes
 
 - debug: msg="END eapi/sublevel_exact.yaml"

--- a/test/integration/targets/eos_config/tests/eapi/sublevel_strict.yaml
+++ b/test/integration/targets/eos_config/tests/eapi/sublevel_strict.yaml
@@ -12,6 +12,7 @@
     parents: ip access-list test
     before: no ip access-list test
     match: none
+  become: yes
 
 - name: configure sub level command using strict match
   eos_config:
@@ -25,6 +26,7 @@
     after: exit
     match: strict
     replace: block
+  become: yes
   register: result
 
 - assert:
@@ -46,6 +48,7 @@
       - 40 permit ip host 4.4.4.4 any log
     parents: ip access-list test
     match: strict
+  become: yes
   register: result
 
 - assert:
@@ -56,5 +59,6 @@
   eos_config:
     lines: no ip access-list test
     match: none
+  become: yes
 
 - debug: msg="END eapi/sublevel_strict.yaml"

--- a/test/integration/targets/eos_config/tests/eapi/toplevel.yaml
+++ b/test/integration/targets/eos_config/tests/eapi/toplevel.yaml
@@ -5,10 +5,12 @@
   eos_config:
     lines: hostname {{ inventory_hostname_short }}
     match: none
+  become: yes
 
 - name: configure top level command
   eos_config:
     lines: hostname foo
+  become: yes
   register: result
 
 - assert:
@@ -19,6 +21,7 @@
 - name: configure top level command idempotent check
   eos_config:
     lines: hostname foo
+  become: yes
   register: result
 
 - assert:
@@ -29,5 +32,6 @@
   eos_config:
     lines: hostname {{ inventory_hostname_short }}
     match: none
+  become: yes
 
 - debug: msg="END eapi/toplevel.yaml"

--- a/test/integration/targets/eos_config/tests/eapi/toplevel_after.yaml
+++ b/test/integration/targets/eos_config/tests/eapi/toplevel_after.yaml
@@ -4,14 +4,16 @@
 - name: setup
   eos_config:
     lines:
-      - "snmp-server contact ansible"
+      - snmp-server contact ansible
       - "hostname {{ inventory_hostname_short }}"
     match: none
+  become: yes
 
 - name: configure top level command with before
   eos_config:
     lines: hostname foo
     after: snmp-server contact bar
+  become: yes
   register: result
 
 - assert:
@@ -24,6 +26,7 @@
   eos_config:
     lines: hostname foo
     after: snmp-server contact foo
+  become: yes
   register: result
 
 - assert:
@@ -36,5 +39,6 @@
       - no snmp-server contact
       - hostname {{ inventory_hostname_short }}
     match: none
+  become: yes
 
 - debug: msg="END eapi/toplevel_after.yaml"

--- a/test/integration/targets/eos_config/tests/eapi/toplevel_before.yaml
+++ b/test/integration/targets/eos_config/tests/eapi/toplevel_before.yaml
@@ -7,11 +7,13 @@
       - "snmp-server contact ansible"
       - "hostname {{ inventory_hostname_short }}"
     match: none
+  become: yes
 
 - name: configure top level command with before
   eos_config:
     lines: hostname foo
     before: snmp-server contact bar
+  become: yes
   register: result
 
 - assert:
@@ -24,6 +26,7 @@
   eos_config:
     lines: hostname foo
     before: snmp-server contact foo
+  become: yes
   register: result
 
 - assert:
@@ -33,8 +36,9 @@
 - name: teardown
   eos_config:
     lines:
-      - no snmp-server contact ansible
-      - hostname {{ inventory_hostname_short }}
+      - no snmp-server contact
+      - "hostname {{ inventory_hostname_short }}"
     match: none
+  become: yes
 
 - debug: msg="END eapi/toplevel_before.yaml"

--- a/test/integration/targets/eos_eapi/tasks/cli.yaml
+++ b/test/integration/targets/eos_eapi/tasks/cli.yaml
@@ -14,9 +14,3 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local ansible_become=no"
-  with_first_found: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run

--- a/test/integration/targets/eos_facts/tests/cli/all_facts.yaml
+++ b/test/integration/targets/eos_facts/tests/cli/all_facts.yaml
@@ -9,8 +9,6 @@
   become: yes
   register: result
 
-
-
 - assert:
     that:
       # _facts modules should never report a change

--- a/test/integration/targets/eos_facts/tests/cli/not_hardware.yaml
+++ b/test/integration/targets/eos_facts/tests/cli/not_hardware.yaml
@@ -1,5 +1,5 @@
 ---
-- debug: msg="START cli/not_hardware_facts.yaml on connection={{ ansible_connection }}"
+- debug: msg="START cli/not_hardware.yaml on connection={{ ansible_connection }}"
 
 
 - name: test not hardware
@@ -27,4 +27,4 @@
       # ... and not present
       - "result.ansible_facts.ansible_net_filesystems is not defined"
 
-- debug: msg="END cli/not_hardware_facts.yaml on connection={{ ansible_connection }}"
+- debug: msg="END cli/not_hardware.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/eos_facts/tests/eapi/all_facts.yaml
+++ b/test/integration/targets/eos_facts/tests/eapi/all_facts.yaml
@@ -4,12 +4,13 @@
 - name: Make sure LLDP is running (setup)
   eos_config:
     lines: lldp run
-    authorize: yes
+  become: yes
 
 - name: test getting all facts
   eos_facts:
     gather_subset:
       - all
+  become: yes
   register: result
 
 - assert:
@@ -28,10 +29,5 @@
       # Check that these facts not only are present, but are valid (positive integers)
       - "result.ansible_facts.ansible_net_memfree_mb > 1"
       - "result.ansible_facts.ansible_net_memtotal_mb > 1"
-
-- name: Make sure LLDP is running (teardown)
-  eos_config:
-    lines: no lldp run
-    authorize: yes
 
 - debug: msg="END eapi/all_facts.yaml"

--- a/test/integration/targets/eos_facts/tests/eapi/default_facts.yaml
+++ b/test/integration/targets/eos_facts/tests/eapi/default_facts.yaml
@@ -4,10 +4,11 @@
 - name: Make sure LLDP is running (setup)
   eos_config:
     lines: lldp run
-    authorize: yes
+  become: yes
 
 - name: test getting default facts
   eos_facts:
+  become: yes
   register: result
 
 - assert:
@@ -30,10 +31,5 @@
 
       # ... and not present
       - "result.ansible_facts.ansible_net_config is not defined" # config
-
-- name: Make sure LLDP is running (setup)
-  eos_config:
-    lines: lldp run
-    authorize: yes
 
 - debug: msg="END eapi/default.yaml"

--- a/test/integration/targets/eos_facts/tests/eapi/not_hardware.yaml
+++ b/test/integration/targets/eos_facts/tests/eapi/not_hardware.yaml
@@ -1,15 +1,16 @@
 ---
-- debug: msg="START eapi/not_hardware_facts.yaml"
+- debug: msg="START eapi/not_hardware.yaml"
 
 - name: Make sure LLDP is running (setup)
   eos_config:
     lines: lldp run
-    authorize: yes
+  become: yes
 
 - name: test not hardware
   eos_facts:
     gather_subset:
       - "!hardware"
+  become: yes
   register: result
 
 - assert:
@@ -30,9 +31,4 @@
       # ... and not present
       - "result.ansible_facts.ansible_net_filesystems is not defined"
 
-- name: Make sure LLDP is running (teardown)
-  eos_config:
-    lines: no lldp run
-    authorize: yes
-
-- debug: msg="END eapi/not_hardware_facts.yaml"
+- debug: msg="END eapi/not_hardware.yaml"

--- a/test/integration/targets/eos_interface/tasks/cli.yaml
+++ b/test/integration/targets/eos_interface/tasks/cli.yaml
@@ -14,9 +14,3 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local ansible_become=no"
-  with_first_found: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run

--- a/test/integration/targets/eos_interface/tests/cli/basic.yaml
+++ b/test/integration/targets/eos_interface/tests/cli/basic.yaml
@@ -12,8 +12,6 @@
     description: test-interface-1
     mtu: 1800
     state: present
-    authorize: yes
-    provider: "{{ cli }}"
   become: yes
   register: result
 
@@ -22,8 +20,6 @@
     name: "{{ test_interface_1 }}"
     description: test-interface-initial
     state: present
-    authorize: yes
-    provider: "{{ cli }}"
   become: yes
   register: result
 
@@ -38,8 +34,6 @@
     name: "{{ test_interface_1 }}"
     description: test-interface-initial
     state: present
-    authorize: yes
-    provider: "{{ cli }}"
   become: yes
   register: result
 
@@ -53,8 +47,6 @@
     description: test-interface
     mtu: 2000
     state: present
-    authorize: yes
-    provider: "{{ cli }}"
   become: yes
   register: result
 
@@ -71,8 +63,6 @@
     description: test-interface-1
     mtu: 1800
     state: present
-    authorize: yes
-    provider: "{{ cli }}"
   become: yes
   register: result
 
@@ -87,8 +77,6 @@
   eos_interface:
     name: "{{ test_interface_1 }}"
     enabled: False
-    authorize: yes
-    provider: "{{ cli }}"
   become: yes
   register: result
 
@@ -102,8 +90,6 @@
   eos_interface:
     name: "{{ test_interface_1 }}"
     enabled: True
-    authorize: yes
-    provider: "{{ cli }}"
   become: yes
   register: result
 
@@ -119,8 +105,6 @@
     description: test-interface-initial
     mtu: 1800
     state: present
-    authorize: yes
-    provider: "{{ cli }}"
   become: yes
   register: result
 
@@ -130,8 +114,6 @@
     - { name: "{{ test_interface_1 }}", mtu: 2000, description: test-interface-1 }
     - { name: "{{ test_interface_2 }}", mtu: 2000, description: test-interface-2 }
     state: present
-    authorize: yes
-    provider: "{{ cli }}"
   become: yes
   register: result
 
@@ -150,8 +132,6 @@
     - { name: "{{ test_interface_1 }}", mtu: 2000, description: test-interface-1 }
     - { name: "{{ test_interface_2 }}", mtu: 2000, description: test-interface-2 }
     state: present
-    authorize: yes
-    provider: "{{ cli }}"
   become: yes
   register: result
 
@@ -166,8 +146,6 @@
     - { name: "{{ test_interface_2 }}" }
     enabled: False
     state: present
-    authorize: yes
-    provider: "{{ cli }}"
   become: yes
   register: result
 
@@ -186,8 +164,6 @@
     - { name: "{{ test_interface_2 }}" }
     enabled: True
     state: present
-    authorize: yes
-    provider: "{{ cli }}"
   become: yes
   register: result
 
@@ -205,8 +181,6 @@
     - name: loopback9
     - name: loopback10
     state: absent
-    authorize: yes
-    provider: "{{ cli }}"
   become: yes
 
 - name: Create loopback interface aggregate
@@ -215,8 +189,6 @@
     - name: loopback9
     - name: loopback10
     state: present
-    authorize: yes
-    provider: "{{ cli }}"
   become: yes
   register: result
 
@@ -232,8 +204,6 @@
     - name: loopback9
     - name: loopback10
     state: absent
-    authorize: yes
-    provider: "{{ cli }}"
   become: yes
   register: result
 
@@ -249,8 +219,6 @@
     - name: loopback9
     - name: loopback10
     state: absent
-    authorize: yes
-    provider: "{{ cli }}"
   become: yes
   register: result
 

--- a/test/integration/targets/eos_interface/tests/cli/intent.yaml
+++ b/test/integration/targets/eos_interface/tests/cli/intent.yaml
@@ -13,7 +13,6 @@
     tx_rate: ge(0)
     rx_rate: ge(0)
     authorize: yes
-    provider: "{{ cli }}"
   become: yes
   register: result
 
@@ -27,8 +26,6 @@
     state: down
     tx_rate: gt(0)
     rx_rate: lt(0)
-    authorize: yes
-    provider: "{{ cli }}"
   ignore_errors: yes
   become: yes
   register: result
@@ -45,8 +42,6 @@
     name: "{{ test_interface_1 }}"
     enabled: False
     state: down
-    authorize: yes
-    provider: "{{ cli }}"
   become: yes
   register: result
 
@@ -58,9 +53,7 @@
   eos_interface:
     name: "{{ test_interface_1 }}"
     enabled: False
-    authorize: yes
     state: up
-    provider: "{{ cli }}"
   ignore_errors: yes
   become: yes
   register: result
@@ -74,8 +67,6 @@
   eos_command:
     commands:
       - show lldp neighbors management1
-    authorize: yes
-    provider: "{{ cli }}"
   become: yes
   register: show_lldp_neighbors_result
 
@@ -86,8 +77,6 @@
         neighbors:
           - port: eth0
             host: an-vyos-02
-        authorize: yes
-        provider: "{{ cli }}"
       become: yes
       register: result
 
@@ -101,8 +90,6 @@
         neighbors:
           - port: dummy_port
             host: dummy_host
-        authorize: yes
-        provider: "{{ cli }}"
       ignore_errors: yes
       become: yes
       register: result
@@ -120,8 +107,6 @@
       - name: "{{ test_interface_1 }}"
         enabled: True
         state: up
-    authorize: yes
-    provider: "{{ cli }}"
   ignore_errors: yes
   become: yes
   register: result
@@ -138,8 +123,6 @@
             neighbors:
               - port: eth0
                 host: an-vyos-02
-        authorize: yes
-        provider: "{{ cli }}"
       ignore_errors: yes
       become: yes
       register: result
@@ -157,8 +140,6 @@
             host: an-vyos-02
           - port: dummy_port
             host: dummy_host
-        authorize: yes
-        provider: "{{ cli }}"
       ignore_errors: yes
       become: yes
       register: result

--- a/test/integration/targets/eos_interface/tests/cli/net_interface.yaml
+++ b/test/integration/targets/eos_interface/tests/cli/net_interface.yaml
@@ -14,8 +14,6 @@
     description: test-interface-1
     mtu: 1800
     state: present
-    authorize: yes
-    provider: "{{ cli }}"
   become: yes
   register: result
 
@@ -24,8 +22,6 @@
     name: "{{ test_interface_1 }}"
     description: test-interface-initial
     state: present
-    authorize: yes
-    provider: "{{ cli }}"
   become: yes
   register: result
 
@@ -41,8 +37,6 @@
     description: test-interface
     mtu: 2000
     state: present
-    authorize: yes
-    provider: "{{ cli }}"
   become: yes
   register: result
 

--- a/test/integration/targets/eos_interface/tests/eapi/basic.yaml
+++ b/test/integration/targets/eos_interface/tests/eapi/basic.yaml
@@ -12,8 +12,7 @@
     description: test-interface-1
     mtu: 1800
     state: present
-    authorize: yes
-    provider: "{{ eapi }}"
+  become: yes
   register: result
 
 - name: Configure interface
@@ -21,8 +20,7 @@
     name: "{{ test_interface_1 }}"
     description: test-interface-initial
     state: present
-    authorize: yes
-    provider: "{{ eapi }}"
+  become: yes
   register: result
 
 - assert:
@@ -36,8 +34,7 @@
     name: "{{ test_interface_1 }}"
     description: test-interface-initial
     state: present
-    authorize: yes
-    provider: "{{ eapi }}"
+  become: yes
   register: result
 
 - assert:
@@ -50,8 +47,7 @@
     description: test-interface
     mtu: 2000
     state: present
-    authorize: yes
-    provider: "{{ eapi }}"
+  become: yes
   register: result
 
 - assert:
@@ -67,8 +63,7 @@
     description: test-interface-1
     mtu: 1800
     state: present
-    authorize: yes
-    provider: "{{ eapi }}"
+  become: yes
   register: result
 
 - assert:
@@ -82,8 +77,7 @@
   eos_interface:
     name: "{{ test_interface_1 }}"
     enabled: False
-    authorize: yes
-    provider: "{{ eapi }}"
+  become: yes
   register: result
 
 - assert:
@@ -96,8 +90,7 @@
   eos_interface:
     name: "{{ test_interface_1 }}"
     enabled: True
-    authorize: yes
-    provider: "{{ eapi }}"
+  become: yes
   register: result
 
 - assert:
@@ -112,8 +105,7 @@
     description: test-interface-initial
     mtu: 1800
     state: present
-    authorize: yes
-    provider: "{{ eapi }}"
+  become: yes
   register: result
 
 - name: Add interface aggregate
@@ -122,8 +114,7 @@
     - { name: "{{ test_interface_1 }}", mtu: 2000, description: test-interface-1 }
     - { name: "{{ test_interface_2 }}", mtu: 2000, description: test-interface-2 }
     state: present
-    authorize: yes
-    provider: "{{ eapi }}"
+  become: yes
   register: result
 
 - assert:
@@ -141,8 +132,7 @@
     - { name: "{{ test_interface_1 }}", mtu: 2000, description: test-interface-1 }
     - { name: "{{ test_interface_2 }}", mtu: 2000, description: test-interface-2 }
     state: present
-    authorize: yes
-    provider: "{{ eapi }}"
+  become: yes
   register: result
 
 - assert:
@@ -156,8 +146,7 @@
     - { name: "{{ test_interface_2 }}" }
     enabled: False
     state: present
-    authorize: yes
-    provider: "{{ eapi }}"
+  become: yes
   register: result
 
 - assert:
@@ -175,8 +164,7 @@
     - { name: "{{ test_interface_2 }}" }
     enabled: True
     state: present
-    authorize: yes
-    provider: "{{ eapi }}"
+  become: yes
   register: result
 
 - assert:
@@ -193,8 +181,7 @@
     - name: loopback9
     - name: loopback10
     state: absent
-    authorize: yes
-    provider: "{{ eapi }}"
+  become: yes
 
 - name: Create loopback interface aggregate
   eos_interface:
@@ -202,8 +189,7 @@
     - name: loopback9
     - name: loopback10
     state: present
-    authorize: yes
-    provider: "{{ eapi }}"
+  become: yes
   register: result
 
 - assert:
@@ -218,8 +204,7 @@
     - name: loopback9
     - name: loopback10
     state: absent
-    authorize: yes
-    provider: "{{ eapi }}"
+  become: yes
   register: result
 
 - assert:
@@ -234,8 +219,7 @@
     - name: loopback9
     - name: loopback10
     state: absent
-    authorize: yes
-    provider: "{{ eapi }}"
+  become: yes
   register: result
 
 - assert:

--- a/test/integration/targets/eos_interface/tests/eapi/intent.yaml
+++ b/test/integration/targets/eos_interface/tests/eapi/intent.yaml
@@ -9,8 +9,6 @@
 - name: Make sure LLDP is running
   eos_config:
     lines: lldp run
-    authorize: yes
-    provider: "{{ eapi }}"
   become: yes
 
 - name: Check intent arguments
@@ -20,7 +18,7 @@
     tx_rate: ge(0)
     rx_rate: ge(0)
     authorize: yes
-    provider: "{{ eapi }}"
+  become: yes
   register: result
 
 - assert:
@@ -33,9 +31,8 @@
     state: down
     tx_rate: gt(0)
     rx_rate: lt(0)
-    authorize: yes
-    provider: "{{ eapi }}"
   ignore_errors: yes
+  become: yes
   register: result
 
 - assert:
@@ -50,8 +47,7 @@
     name: "{{ test_interface_1 }}"
     enabled: False
     state: down
-    authorize: yes
-    provider: "{{ eapi }}"
+  become: yes
   register: result
 
 - assert:
@@ -62,10 +58,9 @@
   eos_interface:
     name: "{{ test_interface_1 }}"
     enabled: False
-    authorize: yes
     state: up
-    provider: "{{ eapi }}"
   ignore_errors: yes
+  become: yes
   register: result
 
 - assert:
@@ -77,8 +72,7 @@
   eos_command:
     commands:
       - show lldp neighbors management1
-    authorize: yes
-    provider: "{{ eapi }}"
+  become: yes
   register: show_lldp_neighbors_result
 
 - block:
@@ -88,8 +82,7 @@
         neighbors:
           - port: eth0
             host: an-vyos-02
-        authorize: yes
-        provider: "{{ eapi }}"
+      become: yes
       register: result
 
     - assert:
@@ -102,9 +95,8 @@
         neighbors:
           - port: dummy_port
             host: dummy_host
-        authorize: yes
-        provider: "{{ eapi }}"
       ignore_errors: yes
+      become: yes
       register: result
 
     - assert:
@@ -120,9 +112,8 @@
       - name: "{{ test_interface_1 }}"
         enabled: True
         state: up
-    authorize: yes
-    provider: "{{ eapi }}"
   ignore_errors: yes
+  become: yes
   register: result
 
 - assert:
@@ -137,9 +128,8 @@
             neighbors:
               - port: eth0
                 host: an-vyos-02
-        authorize: yes
-        provider: "{{ eapi }}"
       ignore_errors: yes
+      become: yes
       register: result
 
     - assert:
@@ -155,9 +145,8 @@
             host: an-vyos-02
           - port: dummy_port
             host: dummy_host
-        authorize: yes
-        provider: "{{ eapi }}"
       ignore_errors: yes
+      become: yes
       register: result
 
     - assert:
@@ -166,9 +155,3 @@
           - "'host dummy_host' in result.failed_conditions"
           - "'port dummy_port' in result.failed_conditions"
   when: "'an-vyos-02' in show_lldp_neighbors_result.stdout[0]"
-
-- name: Make sure LLDP is running (teardown)
-  eos_config:
-    lines: no lldp run
-    authorize: yes
-    provider: "{{ eapi }}"

--- a/test/integration/targets/eos_interface/tests/eapi/net_interface.yaml
+++ b/test/integration/targets/eos_interface/tests/eapi/net_interface.yaml
@@ -14,8 +14,7 @@
     description: test-interface-1
     mtu: 1800
     state: present
-    authorize: yes
-    provider: "{{ eapi }}"
+  become: yes
   register: result
 
 - name: Configure interface description using platform agnostic module
@@ -23,8 +22,7 @@
     name: "{{ test_interface_1 }}"
     description: test-interface-initial
     state: present
-    authorize: yes
-    provider: "{{ eapi }}"
+  become: yes
   register: result
 
 - assert:
@@ -39,8 +37,7 @@
     description: test-interface
     mtu: 2000
     state: present
-    authorize: yes
-    provider: "{{ eapi }}"
+  become: yes
   register: result
 
 - assert:

--- a/test/integration/targets/eos_l2_interface/tasks/cli.yaml
+++ b/test/integration/targets/eos_l2_interface/tasks/cli.yaml
@@ -14,9 +14,3 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local ansible_become=no"
-  with_first_found: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run

--- a/test/integration/targets/eos_l3_interface/tasks/cli.yaml
+++ b/test/integration/targets/eos_l3_interface/tasks/cli.yaml
@@ -14,9 +14,3 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local ansible_become=no"
-  with_first_found: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run

--- a/test/integration/targets/eos_l3_interface/tests/cli/basic.yaml
+++ b/test/integration/targets/eos_l3_interface/tests/cli/basic.yaml
@@ -10,8 +10,6 @@
   eos_l3_interface:
     name: "{{ test_interface_1 }}"
     state: absent
-    authorize: yes
-    provider: "{{ cli }}"
   become: yes
   register: result
 
@@ -20,8 +18,6 @@
     name: "{{ test_interface_1 }}"
     ipv4: 192.108.1.1/24
     state: present
-    authorize: yes
-    provider: "{{ cli }}"
   become: yes
   register: result
 
@@ -36,8 +32,6 @@
     name: "{{ test_interface_1 }}"
     ipv4: 192.108.1.1/24
     state: present
-    authorize: yes
-    provider: "{{ cli }}"
   become: yes
   register: result
 
@@ -50,8 +44,6 @@
     name: "{{ test_interface_1 }}"
     ipv4: 197.108.0.1/24
     state: present
-    authorize: yes
-    provider: "{{ cli }}"
   become: yes
   register: result
 
@@ -66,8 +58,6 @@
     name: "{{ test_interface_1 }}"
     ipv6: fd5d:12c9:2201:1::1/64
     state: present
-    authorize: yes
-    provider: "{{ cli }}"
   become: yes
   register: result
 
@@ -82,8 +72,6 @@
     name: "{{ test_interface_1 }}"
     ipv6: fd5d:12c9:2201:1::1/64
     state: present
-    authorize: yes
-    provider: "{{ cli }}"
   become: yes
   register: result
 
@@ -96,8 +84,6 @@
     name: "{{ test_interface_1 }}"
     ipv6: fd58:12c9:2201:1::1/64
     state: present
-    authorize: yes
-    provider: "{{ cli }}"
   become: yes
   register: result
 
@@ -111,8 +97,6 @@
   eos_l3_interface:
     name: "{{ test_interface_1 }}"
     state: absent
-    authorize: yes
-    provider: "{{ cli }}"
   become: yes
   register: result
 
@@ -127,8 +111,6 @@
   eos_l3_interface:
     name: "{{ test_interface_1 }}"
     state: absent
-    authorize: yes
-    provider: "{{ cli }}"
   become: yes
   register: result
 
@@ -136,8 +118,6 @@
   eos_l3_interface:
     name: "{{ test_interface_2 }}"
     state: absent
-    authorize: yes
-    provider: "{{ cli }}"
   become: yes
   register: result
 
@@ -146,8 +126,6 @@
     aggregate:
     - { name: "{{ test_interface_1 }}", ipv4: 192.108.1.1/24, ipv6: "fd5d:12c9:2201:2::2/64" }
     - { name: "{{ test_interface_2 }}", ipv4: 192.109.1.2/16, ipv6: "fd5e:12c9:2201:3::3/32" }
-    authorize: yes
-    provider: "{{ cli }}"
   become: yes
   register: result
 
@@ -166,8 +144,6 @@
     aggregate:
     - { name: "{{ test_interface_1 }}", ipv4: 192.108.1.1/24, ipv6: "fd5d:12c9:2201:2::2/64" }
     - { name: "{{ test_interface_2 }}", ipv4: 192.109.1.2/16, ipv6: "fd5e:12c9:2201:3::3/32" }
-    authorize: yes
-    provider: "{{ cli }}"
   become: yes
   register: result
 
@@ -180,8 +156,6 @@
     aggregate:
     - { name: "{{ test_interface_1 }}", ipv4: 193.118.1.1/8, ipv6: "fd5a:12c9:2201:4::4/32" }
     - { name: "{{ test_interface_2 }}", ipv4: 192.119.2.2/24, ipv6: "fd5b:12c9:2201:5::5/90" }
-    authorize: yes
-    provider: "{{ cli }}"
   become: yes
   register: result
 
@@ -202,8 +176,6 @@
     - { name: "{{ test_interface_1 }}" }
     - { name: "{{ test_interface_2 }}" }
     state: absent
-    authorize: yes
-    provider: "{{ cli }}"
   become: yes
   register: result
 
@@ -223,8 +195,6 @@
     - { name: "{{ test_interface_1 }}" }
     - { name: "{{ test_interface_2 }}" }
     state: absent
-    authorize: yes
-    provider: "{{ cli }}"
   become: yes
   register: result
 

--- a/test/integration/targets/eos_l3_interface/tests/cli/net_l3_interface.yaml
+++ b/test/integration/targets/eos_l3_interface/tests/cli/net_l3_interface.yaml
@@ -12,8 +12,6 @@
   net_l3_interface:
     name: "{{ test_interface_1 }}"
     state: absent
-    authorize: yes
-    provider: "{{ cli }}"
   become: yes
   register: result
 
@@ -22,8 +20,6 @@
     name: "{{ test_interface_1 }}"
     ipv4: 192.108.0.1/24
     state: present
-    authorize: yes
-    provider: "{{ cli }}"
   become: yes
   register: result
 
@@ -37,8 +33,6 @@
   net_l3_interface:
     name: "{{ test_interface_1 }}"
     state: absent
-    authorize: yes
-    provider: "{{ cli }}"
   become: yes
   register: result
 

--- a/test/integration/targets/eos_l3_interface/tests/eapi/basic.yaml
+++ b/test/integration/targets/eos_l3_interface/tests/eapi/basic.yaml
@@ -10,8 +10,7 @@
   eos_l3_interface:
     name: "{{ test_interface_1 }}"
     state: absent
-    authorize: yes
-    provider: "{{ eapi }}"
+  become: yes
   register: result
 
 - name: Configure interface ipv4 address
@@ -19,8 +18,7 @@
     name: "{{ test_interface_1 }}"
     ipv4: 192.168.1.1/24
     state: present
-    authorize: yes
-    provider: "{{ eapi }}"
+  become: yes
   register: result
 
 - assert:
@@ -34,8 +32,7 @@
     name: "{{ test_interface_1 }}"
     ipv4: 192.168.1.1/24
     state: present
-    authorize: yes
-    provider: "{{ eapi }}"
+  become: yes
   register: result
 
 - assert:
@@ -47,8 +44,7 @@
     name: "{{ test_interface_1 }}"
     ipv4: 197.168.0.1/24
     state: present
-    authorize: yes
-    provider: "{{ eapi }}"
+  become: yes
   register: result
 
 - assert:
@@ -62,8 +58,7 @@
     name: "{{ test_interface_1 }}"
     ipv6: fd5d:12c9:2201:1::1/64
     state: present
-    authorize: yes
-    provider: "{{ eapi }}"
+  become: yes
   register: result
 
 - assert:
@@ -77,8 +72,7 @@
     name: "{{ test_interface_1 }}"
     ipv6: fd5d:12c9:2201:1::1/64
     state: present
-    authorize: yes
-    provider: "{{ eapi }}"
+  become: yes
   register: result
 
 - assert:
@@ -90,8 +84,7 @@
     name: "{{ test_interface_1 }}"
     ipv6: fd58:12c9:2201:1::1/64
     state: present
-    authorize: yes
-    provider: "{{ eapi }}"
+  become: yes
   register: result
 
 - assert:
@@ -104,8 +97,7 @@
   eos_l3_interface:
     name: "{{ test_interface_1 }}"
     state: absent
-    authorize: yes
-    provider: "{{ eapi }}"
+  become: yes
   register: result
 
 - assert:
@@ -119,16 +111,14 @@
   eos_l3_interface:
     name: "{{ test_interface_1 }}"
     state: absent
-    authorize: yes
-    provider: "{{ eapi }}"
+  become: yes
   register: result
 
 - name: Delete second interface ipv4 and ipv6 address (setup)
   eos_l3_interface:
     name: "{{ test_interface_2 }}"
     state: absent
-    authorize: yes
-    provider: "{{ eapi }}"
+  become: yes
   register: result
 
 - name: Configure ipv4 and ipv6 address using aggregate
@@ -136,8 +126,7 @@
     aggregate:
     - { name: "{{ test_interface_1 }}", ipv4: 192.161.0.1/24, ipv6: "fd5d:12c9:2201:2::2/64" }
     - { name: "{{ test_interface_2 }}", ipv4: 192.162.0.2/16, ipv6: "fd5e:12c9:2201:3::3/32" }
-    authorize: yes
-    provider: "{{ eapi }}"
+  become: yes
   register: result
 
 - assert:
@@ -155,8 +144,7 @@
     aggregate:
     - { name: "{{ test_interface_1 }}", ipv4: 192.161.0.1/24, ipv6: "fd5d:12c9:2201:2::2/64" }
     - { name: "{{ test_interface_2 }}", ipv4: 192.162.0.2/16, ipv6: "fd5e:12c9:2201:3::3/32" }
-    authorize: yes
-    provider: "{{ eapi }}"
+  become: yes
   register: result
 
 - assert:
@@ -168,8 +156,7 @@
     aggregate:
     - { name: "{{ test_interface_1 }}", ipv4: 193.167.1.1/8, ipv6: "fd5a:12c9:2201:4::4/32" }
     - { name: "{{ test_interface_2 }}", ipv4: 192.169.2.2/24, ipv6: "fd5b:12c9:2201:5::5/90" }
-    authorize: yes
-    provider: "{{ eapi }}"
+  become: yes
   register: result
 
 - assert:
@@ -189,8 +176,7 @@
     - { name: "{{ test_interface_1 }}" }
     - { name: "{{ test_interface_2 }}" }
     state: absent
-    authorize: yes
-    provider: "{{ eapi }}"
+  become: yes
   register: result
 
 - assert:
@@ -209,8 +195,7 @@
     - { name: "{{ test_interface_1 }}" }
     - { name: "{{ test_interface_2 }}" }
     state: absent
-    authorize: yes
-    provider: "{{ eapi }}"
+  become: yes
   register: result
 
 - assert:

--- a/test/integration/targets/eos_l3_interface/tests/eapi/net_l3_interface.yaml
+++ b/test/integration/targets/eos_l3_interface/tests/eapi/net_l3_interface.yaml
@@ -12,8 +12,7 @@
   net_l3_interface:
     name: "{{ test_interface_1 }}"
     state: absent
-    authorize: yes
-    provider: "{{ eapi }}"
+  become: yes
   register: result
 
 - name: Configure interface ipv4 address using platform agnostic module
@@ -21,8 +20,7 @@
     name: "{{ test_interface_1 }}"
     ipv4: 192.108.0.1/24
     state: present
-    authorize: yes
-    provider: "{{ eapi }}"
+  become: yes
   register: result
 
 - assert:
@@ -35,8 +33,7 @@
   net_l3_interface:
     name: "{{ test_interface_1 }}"
     state: absent
-    authorize: yes
-    provider: "{{ eapi }}"
+  become: yes
   register: result
 
 - debug: msg="END eos eapi/net_l3_interface.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/eos_linkagg/tasks/cli.yaml
+++ b/test/integration/targets/eos_linkagg/tasks/cli.yaml
@@ -14,9 +14,3 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local ansible_become=no"
-  with_first_found: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run

--- a/test/integration/targets/eos_lldp/tasks/cli.yaml
+++ b/test/integration/targets/eos_lldp/tasks/cli.yaml
@@ -14,9 +14,3 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local ansible_become=no"
-  with_first_found: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run

--- a/test/integration/targets/eos_lldp/tests/cli/basic.yaml
+++ b/test/integration/targets/eos_lldp/tests/cli/basic.yaml
@@ -4,15 +4,11 @@
 - name: Make sure LLDP is not running before tests
   eos_config:
     lines: no lldp run
-    authorize: yes
-    provider: "{{ cli }}"
   become: yes
 
 - name: Enable LLDP service
   eos_lldp:
     state: present
-    authorize: yes
-    provider: "{{ cli }}"
   register: result
   become: yes
 
@@ -24,8 +20,6 @@
 - name: Enable LLDP service again (idempotent)
   eos_lldp:
     state: present
-    authorize: yes
-    provider: "{{ cli }}"
   register: result
   become: yes
 
@@ -36,8 +30,6 @@
 - name: Disable LLDP service
   eos_lldp:
     state: absent
-    authorize: yes
-    provider: "{{ cli }}"
   register: result
   become: yes
 
@@ -49,8 +41,6 @@
 - name: Disable LLDP service (idempotent)
   eos_lldp:
     state: absent
-    authorize: yes
-    provider: "{{ cli }}"
   register: result
   become: yes
 

--- a/test/integration/targets/eos_lldp/tests/eapi/basic.yaml
+++ b/test/integration/targets/eos_lldp/tests/eapi/basic.yaml
@@ -4,14 +4,12 @@
 - name: Make sure LLDP is not running before tests
   eos_config:
     lines: no lldp run
-    authorize: yes
-    provider: "{{ eapi }}"
+  become: yes
 
 - name: Enable LLDP service
   eos_lldp:
     state: present
-    authorize: yes
-    provider: "{{ eapi }}"
+  become: yes
   register: result
 
 - assert:
@@ -22,8 +20,7 @@
 - name: Enable LLDP service again (idempotent)
   eos_lldp:
     state: present
-    authorize: yes
-    provider: "{{ eapi }}"
+  become: yes
   register: result
 
 - assert:
@@ -33,8 +30,7 @@
 - name: Disable LLDP service
   eos_lldp:
     state: absent
-    authorize: yes
-    provider: "{{ eapi }}"
+  become: yes
   register: result
 
 - assert:
@@ -45,8 +41,7 @@
 - name: Disable LLDP service (idempotent)
   eos_lldp:
     state: absent
-    authorize: yes
-    provider: "{{ eapi }}"
+  become: yes
   register: result
 
 - assert:

--- a/test/integration/targets/eos_logging/tasks/cli.yaml
+++ b/test/integration/targets/eos_logging/tasks/cli.yaml
@@ -14,9 +14,3 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local ansible_become=no"
-  with_first_found: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run

--- a/test/integration/targets/eos_logging/tests/cli/basic.yaml
+++ b/test/integration/targets/eos_logging/tests/cli/basic.yaml
@@ -6,8 +6,6 @@
     dest: host
     name: 172.16.0.1
     state: present
-    authorize: yes
-    provider: "{{ cli }}"
   become: yes
   register: result
 
@@ -21,8 +19,6 @@
     dest: host
     name: 172.16.0.1
     state: present
-    authorize: yes
-    provider: "{{ cli }}"
   become: yes
   register: result
 
@@ -35,8 +31,6 @@
     dest: host
     name: 172.16.0.1
     state: absent
-    authorize: yes
-    provider: "{{ cli }}"
   become: yes
   register: result
 
@@ -50,8 +44,6 @@
     dest: host
     name: 172.16.0.1
     state: absent
-    authorize: yes
-    provider: "{{ cli }}"
   become: yes
   register: result
 
@@ -64,8 +56,6 @@
     dest: console
     level: warnings
     state: present
-    authorize: yes
-    provider: "{{ cli }}"
   become: yes
   register: result
 
@@ -78,8 +68,6 @@
   eos_logging:
     dest: buffered
     size: 480000
-    authorize: yes
-    provider: "{{ cli }}"
   become: yes
   register: result
 
@@ -93,8 +81,6 @@
     aggregate:
       - { dest: console, level: warnings, state: absent }
       - { dest: buffered, size: 480000, state: absent }
-    authorize: yes
-    provider: "{{ cli }}"
   become: yes
   register: result
 

--- a/test/integration/targets/eos_logging/tests/cli/net_logging.yaml
+++ b/test/integration/targets/eos_logging/tests/cli/net_logging.yaml
@@ -9,8 +9,6 @@
     dest: host
     name: 172.16.0.1
     state: absent
-    authorize: yes
-    provider: "{{ cli }}"
   become: yes
   register: result
 
@@ -19,8 +17,6 @@
     dest: host
     name: 172.16.0.1
     state: present
-    authorize: yes
-    provider: "{{ cli }}"
   become: yes
   register: result
 
@@ -34,8 +30,6 @@
     dest: host
     name: 172.16.0.1
     state: absent
-    authorize: yes
-    provider: "{{ cli }}"
   become: yes
   register: result
 

--- a/test/integration/targets/eos_logging/tests/eapi/basic.yaml
+++ b/test/integration/targets/eos_logging/tests/eapi/basic.yaml
@@ -1,11 +1,12 @@
 ---
+- debug: msg="START eapi/basic.yaml on connection={{ ansible_connection }}"
+
 - name: Set up host logging
   eos_logging:
     dest: host
     name: 172.16.0.1
     state: present
-    authorize: yes
-    provider: "{{ eapi }}"
+  become: yes
   register: result
 
 - assert:
@@ -18,8 +19,7 @@
     dest: host
     name: 172.16.0.1
     state: present
-    authorize: yes
-    provider: "{{ eapi }}"
+  become: yes
   register: result
 
 - assert:
@@ -31,8 +31,7 @@
     dest: host
     name: 172.16.0.1
     state: absent
-    authorize: yes
-    provider: "{{ eapi }}"
+  become: yes
   register: result
 
 - assert:
@@ -45,8 +44,7 @@
     dest: host
     name: 172.16.0.1
     state: absent
-    authorize: yes
-    provider: "{{ eapi }}"
+  become: yes
   register: result
 
 - assert:
@@ -58,8 +56,7 @@
     dest: console
     level: warnings
     state: present
-    authorize: yes
-    provider: "{{ eapi }}"
+  become: yes
   register: result
 
 - assert:
@@ -71,8 +68,7 @@
   eos_logging:
     dest: buffered
     size: 480000
-    authorize: yes
-    provider: "{{ eapi }}"
+  become: yes
   register: result
 
 - assert:
@@ -85,8 +81,7 @@
     aggregate:
       - { dest: console, level: warnings, state: absent }
       - { dest: buffered, size: 480000, state: absent }
-    authorize: yes
-    provider: "{{ eapi }}"
+  become: yes
   register: result
 
 - assert:

--- a/test/integration/targets/eos_logging/tests/eapi/net_logging.yaml
+++ b/test/integration/targets/eos_logging/tests/eapi/net_logging.yaml
@@ -9,8 +9,7 @@
     dest: host
     name: 172.16.0.1
     state: absent
-    authorize: yes
-    provider: "{{ eapi }}"
+  become: yes
   register: result
 
 - name: Set up host logging using platform agnostic module
@@ -18,8 +17,7 @@
     dest: host
     name: 172.16.0.1
     state: present
-    authorize: yes
-    provider: "{{ eapi }}"
+  become: yes
   register: result
 
 - assert:
@@ -32,8 +30,7 @@
     dest: host
     name: 172.16.0.1
     state: absent
-    authorize: yes
-    provider: "{{ eapi }}"
+  become: yes
   register: result
 
 - debug: msg="END eos eapi/net_logging.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/eos_smoke/tasks/cli.yaml
+++ b/test/integration/targets/eos_smoke/tasks/cli.yaml
@@ -15,7 +15,7 @@
   loop_control:
     loop_var: test_case_to_run
 
-- name: run test case (connection=local)
+- name: run test cases (connection=local)
   include: "{{ test_case_to_run }} ansible_connection=local ansible_become=no"
   with_items: "{{ test_items }}"
   loop_control:

--- a/test/integration/targets/eos_smoke/tests/cli/common_utils.yaml
+++ b/test/integration/targets/eos_smoke/tests/cli/common_utils.yaml
@@ -54,7 +54,6 @@
 
 - debug: msg="END cli/common_utils.yaml on connection={{ ansible_connection }}"
 
-
 # hit conditional()
 - name: Set test interface
   set_fact:

--- a/test/integration/targets/eos_smoke/tests/eapi/common_config.yaml
+++ b/test/integration/targets/eos_smoke/tests/eapi/common_config.yaml
@@ -8,11 +8,13 @@
     lines: hostname {{ inventory_hostname_short }}
     match: none
     provider: "{{ eapi }}"
+  become: yes
 
 - name: get current running-config
   eos_command:
     commands: show running-config
     provider: "{{ eapi }}"
+  become: yes
   register: config
 
 - name: configure hostname
@@ -20,6 +22,7 @@
     lines: hostname foo
     config: "{{ config.stdout[0] }}"
     provider: "{{ eapi }}"
+  become: yes
   register: result
 
 - assert:
@@ -31,6 +34,7 @@
   eos_command:
     commands: show running-config
     provider: "{{ eapi }}"
+  become: yes
   register: config
 
 - name: teardown
@@ -38,6 +42,7 @@
     lines: hostname {{ inventory_hostname_short }}
     match: none
     provider: "{{ eapi }}"
+  become: yes
 
 # hit block and diffs
 - block:
@@ -52,6 +57,7 @@
         after: exit
         match: strict
         provider: "{{ eapi }}"
+      become: yes
 
     - name: configure sub level command using block replace
       eos_config:
@@ -65,6 +71,7 @@
         after: exit
         provider: "{{ eapi }}"
         match: line
+      become: yes
       register: result
 
     - assert:
@@ -88,6 +95,7 @@
         after: exit
         provider: "{{ eapi }}"
         match: exact
+      become: yes
       register: result
 
   always:
@@ -96,5 +104,6 @@
         lines: no ip access-list test
         match: none
         provider: "{{ eapi }}"
+      become: yes
 
 - debug: msg="END cli/common_config.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/eos_smoke/tests/eapi/common_utils.yaml
+++ b/test/integration/targets/eos_smoke/tests/eapi/common_utils.yaml
@@ -12,6 +12,7 @@
     - no ip route 192.168.3.0/24 192.168.0.1
     authorize: yes
     provider: "{{ eapi }}"
+  become: yes
 
 - name: configure static route
   eos_static_route:
@@ -20,6 +21,7 @@
     admin_distance: 2
     authorize: yes
     provider: "{{ eapi }}"
+  become: yes
   register: result
 
 - assert:
@@ -34,6 +36,7 @@
     admin_distance: 2
     authorize: yes
     provider: "{{ eapi }}"
+  become: yes
   register: result
   ignore_errors: yes
 
@@ -47,6 +50,7 @@
     - no ip route 192.168.3.0/24 192.168.0.1
     authorize: yes
     provider: "{{ eapi }}"
+  become: yes
 
 - debug: msg="END cli/common_utils.yaml on connection={{ ansible_connection }}"
 
@@ -63,4 +67,5 @@
     rx_rate: ge(0)
     authorize: yes
     provider: "{{ eapi }}"
+  become: yes
   register: result

--- a/test/integration/targets/eos_static_route/tasks/cli.yaml
+++ b/test/integration/targets/eos_static_route/tasks/cli.yaml
@@ -14,9 +14,3 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local ansible_become=no"
-  with_first_found: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run

--- a/test/integration/targets/eos_system/tasks/cli.yaml
+++ b/test/integration/targets/eos_system/tasks/cli.yaml
@@ -14,9 +14,3 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local ansible_become=no"
-  with_first_found: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run

--- a/test/integration/targets/eos_system/tests/cli/net_system.yaml
+++ b/test/integration/targets/eos_system/tests/cli/net_system.yaml
@@ -10,7 +10,6 @@
       - no ip domain-list ansible.com
       - no ip domain-list redhat.com
     match: none
-    provider: "{{ cli }}"
   become: yes
 
 - name: configure domain_list using platform agnostic module
@@ -18,7 +17,6 @@
     domain_list:
       - ansible.com
       - redhat.com
-    provider: "{{ cli }}"
   become: yes
   register: result
 
@@ -34,7 +32,6 @@
       - no ip domain-list ansible.com
       - no ip domain-list redhat.com
     match: none
-    provider: "{{ cli }}"
   become: yes
 
 - debug: msg="END eos cli/net_system.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/eos_system/tests/cli/set_domain_list.yaml
+++ b/test/integration/targets/eos_system/tests/cli/set_domain_list.yaml
@@ -7,7 +7,6 @@
       - no ip domain-list ansible.com
       - no ip domain-list redhat.com
     match: none
-    provider: "{{ cli }}"
   become: yes
 
 - name: configure domain_list
@@ -15,7 +14,6 @@
     domain_list:
       - ansible.com
       - redhat.com
-    provider: "{{ cli }}"
   become: yes
   register: result
 
@@ -30,7 +28,6 @@
     domain_list:
       - ansible.com
       - redhat.com
-    provider: "{{ cli }}"
   become: yes
   register: result
 
@@ -42,7 +39,6 @@
   eos_system:
     domain_list:
       - ansible.com
-    provider: "{{ cli }}"
   become: yes
   register: result
 
@@ -55,7 +51,6 @@
   eos_system:
     domain_list:
       - ansible.com
-    provider: "{{ cli }}"
   become: yes
   register: result
 
@@ -68,7 +63,6 @@
     domain_list:
       - ansible.com
       - redhat.com
-    provider: "{{ cli }}"
   become: yes
   register: result
 
@@ -82,7 +76,6 @@
     domain_list:
       - ansible.com
       - redhat.com
-    provider: "{{ cli }}"
   become: yes
   register: result
 
@@ -95,7 +88,6 @@
     domain_list:
       - ansible.com
       - eng.ansible.com
-    provider: "{{ cli }}"
   become: yes
   register: result
 
@@ -111,7 +103,6 @@
     domain_list:
       - ansible.com
       - eng.ansible.com
-    provider: "{{ cli }}"
   become: yes
   register: result
 
@@ -126,7 +117,6 @@
       - no ip domain-list redhat.com
       - no ip domain-list eng.ansible.com
     match: none
-    provider: "{{ cli }}"
   become: yes
 
 - debug: msg="END cli/set_domain_list.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/eos_system/tests/cli/set_domain_name.yaml
+++ b/test/integration/targets/eos_system/tests/cli/set_domain_name.yaml
@@ -5,13 +5,11 @@
   eos_config:
     lines: no ip domain-name
     match: none
-    provider: "{{ cli }}"
   become: yes
 
 - name: configure domain_name
   eos_system:
     domain_name: eng.ansible.com
-    provider: "{{ cli }}"
   become: yes
   register: result
 
@@ -22,7 +20,6 @@
 - name: verify domain_name
   eos_system:
     domain_name: eng.ansible.com
-    provider: "{{ cli }}"
   become: yes
   register: result
 
@@ -34,7 +31,6 @@
   eos_config:
     lines: no ip domain-name
     match: none
-    provider: "{{ cli }}"
   become: yes
 
 - debug: msg="END cli/set_domain_name.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/eos_system/tests/cli/set_hostname.yaml
+++ b/test/integration/targets/eos_system/tests/cli/set_hostname.yaml
@@ -5,13 +5,11 @@
   eos_config:
     lines: hostname switch
     match: none
-    provider: "{{ cli }}"
   become: yes
 
 - name: configure hostname
   eos_system:
     hostname: foo
-    provider: "{{ cli }}"
   become: yes
   register: result
 
@@ -22,7 +20,6 @@
 - name: verify hostname
   eos_system:
     hostname: foo
-    provider: "{{ cli }}"
   become: yes
   register: result
 
@@ -34,7 +31,6 @@
   eos_config:
     lines: "hostname {{ inventory_hostname }}"
     match: none
-    provider: "{{ cli }}"
   become: yes
 
 - debug: msg="END cli/set_hostname.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/eos_system/tests/cli/set_lookup_source.yaml
+++ b/test/integration/targets/eos_system/tests/cli/set_lookup_source.yaml
@@ -7,13 +7,11 @@
       - no ip domain lookup source-interface
       - vrf definition ansible
     match: none
-    provider: "{{ cli }}"
   become: yes
 
 - name: configure lookup_source
   eos_system:
     lookup_source: Management1
-    provider: "{{ cli }}"
   become: yes
   register: result
 
@@ -25,7 +23,6 @@
 - name: verify lookup_source
   eos_system:
     lookup_source: Management1
-    provider: "{{ cli }}"
   become: yes
   register: result
 
@@ -38,7 +35,6 @@
     lookup_source:
       - interface: Management1
         vrf: ansible
-    provider: "{{ cli }}"
   become: yes
   register: result
 
@@ -54,7 +50,6 @@
     lookup_source:
       - interface: Management1
         vrf: ansible
-    provider: "{{ cli }}"
   become: yes
   register: result
 
@@ -68,7 +63,6 @@
       - no ip domain lookup source-interface
       - no vrf definition ansible
     match: none
-    provider: "{{ cli }}"
   become: yes
 
 - debug: msg="END cli/set_lookup_source.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/eos_system/tests/cli/set_name_servers.yaml
+++ b/test/integration/targets/eos_system/tests/cli/set_name_servers.yaml
@@ -7,7 +7,6 @@
       - no ip name-server
       - vrf definition ansible
     match: none
-    provider: "{{ cli }}"
   become: yes
 
 - name: configure name_servers
@@ -16,7 +15,6 @@
       - 1.1.1.1
       - 2.2.2.2
       - 3.3.3.3
-    provider: "{{ cli }}"
   become: yes
   register: result
 
@@ -34,7 +32,6 @@
       - 1.1.1.1
       - 2.2.2.2
       - 3.3.3.3
-    provider: "{{ cli }}"
   become: yes
   register: result
 
@@ -48,7 +45,7 @@
 #      - 1.1.1.1
 #      - { server: 2.2.2.2, vrf: ansible }
 #      - 3.3.3.3
-#    provider: "{{ cli }}"
+#  become: yes
 #  register: result
 
 #- assert:
@@ -64,7 +61,7 @@
 #      - 1.1.1.1
 #      - { server: 2.2.2.2, vrf: ansible }
 #      - 3.3.3.3
-#    provider: "{{ cli }}"
+#  become: yes
 #  register: result
 #
 #- assert:
@@ -76,7 +73,6 @@
     name_servers:
       - 1.1.1.1
       - 2.2.2.2
-    provider: "{{ cli }}"
   become: yes
   register: result
 
@@ -92,7 +88,6 @@
       - no ip domain lookup source-interface
       - no vrf definition ansible
     match: none
-    provider: "{{ cli }}"
   become: yes
 
 - debug: msg="END cli/set_name_servers.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/eos_system/tests/eapi/net_system.yaml
+++ b/test/integration/targets/eos_system/tests/eapi/net_system.yaml
@@ -10,14 +10,14 @@
       - no ip domain-list ansible.com
       - no ip domain-list redhat.com
     match: none
-    provider: "{{ eapi }}"
+  become: yes
 
 - name: configure domain_list using platform agnostic module
   net_system:
     domain_list:
       - ansible.com
       - redhat.com
-    provider: "{{ eapi }}"
+  become: yes
   register: result
 
 - assert:
@@ -32,6 +32,6 @@
       - no ip domain-list ansible.com
       - no ip domain-list redhat.com
     match: none
-    provider: "{{ eapi }}"
+  become: yes
 
 - debug: msg="END eos eapi/net_system.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/eos_system/tests/eapi/set_domain_list.yaml
+++ b/test/integration/targets/eos_system/tests/eapi/set_domain_list.yaml
@@ -6,17 +6,15 @@
     lines:
       - no ip domain-list ansible.com
       - no ip domain-list redhat.com
-    timeout: 30
     match: none
-    provider: "{{ eapi }}"
+  become: yes
 
 - name: configure domain_list
   eos_system:
     domain_list:
       - ansible.com
       - redhat.com
-    timeout: 30
-    provider: "{{ eapi }}"
+  become: yes
   register: result
 
 - assert:
@@ -30,8 +28,7 @@
     domain_list:
       - ansible.com
       - redhat.com
-    timeout: 30
-    provider: "{{ eapi }}"
+  become: yes
   register: result
 
 - assert:
@@ -42,8 +39,7 @@
   eos_system:
     domain_list:
       - ansible.com
-    timeout: 30
-    provider: "{{ eapi }}"
+  become: yes
   register: result
 
 - assert:
@@ -55,8 +51,7 @@
   eos_system:
     domain_list:
       - ansible.com
-    timeout: 30
-    provider: "{{ eapi }}"
+  become: yes
   register: result
 
 - assert:
@@ -68,8 +63,7 @@
     domain_list:
       - ansible.com
       - redhat.com
-    timeout: 30
-    provider: "{{ eapi }}"
+  become: yes
   register: result
 
 - assert:
@@ -82,8 +76,7 @@
     domain_list:
       - ansible.com
       - redhat.com
-    timeout: 30
-    provider: "{{ eapi }}"
+  become: yes
   register: result
 
 - assert:
@@ -95,8 +88,7 @@
     domain_list:
       - ansible.com
       - eng.ansible.com
-    timeout: 30
-    provider: "{{ eapi }}"
+  become: yes
   register: result
 
 - assert:
@@ -111,8 +103,7 @@
     domain_list:
       - ansible.com
       - eng.ansible.com
-    timeout: 30
-    provider: "{{ eapi }}"
+  become: yes
   register: result
 
 - assert:
@@ -125,8 +116,7 @@
       - no ip domain-list ansible.com
       - no ip domain-list redhat.com
       - no ip domain-list eng.ansible.com
-    timeout: 30
     match: none
-    provider: "{{ eapi }}"
+  become: yes
 
 - debug: msg="END eapi/set_domain_list.yaml"

--- a/test/integration/targets/eos_system/tests/eapi/set_domain_name.yaml
+++ b/test/integration/targets/eos_system/tests/eapi/set_domain_name.yaml
@@ -4,15 +4,13 @@
 - name: setup
   eos_config:
     lines: no ip domain-name
-    timeout: 30
     match: none
-    provider: "{{ eapi }}"
+  become: yes
 
 - name: configure domain_name
   eos_system:
     domain_name: eng.ansible.com
-    timeout: 30
-    provider: "{{ eapi }}"
+  become: yes
   register: result
 
 - assert:
@@ -22,8 +20,7 @@
 - name: verify domain_name
   eos_system:
     domain_name: eng.ansible.com
-    timeout: 30
-    provider: "{{ eapi }}"
+  become: yes
   register: result
 
 - assert:
@@ -33,8 +30,7 @@
 - name: teardown
   eos_config:
     lines: no ip domain-name
-    timeout: 30
     match: none
-    provider: "{{ eapi }}"
+  become: yes
 
 - debug: msg="END eapi/set_domain_name.yaml"

--- a/test/integration/targets/eos_system/tests/eapi/set_hostname.yaml
+++ b/test/integration/targets/eos_system/tests/eapi/set_hostname.yaml
@@ -5,14 +5,12 @@
   eos_config:
     lines: hostname switch
     match: none
-    timeout: 30
-    provider: "{{ eapi }}"
+  become: yes
 
 - name: configure hostname
   eos_system:
     hostname: foo
-    timeout: 30
-    provider: "{{ eapi }}"
+  become: yes
   register: result
 
 - assert:
@@ -22,8 +20,7 @@
 - name: verify hostname
   eos_system:
     hostname: foo
-    timeout: 30
-    provider: "{{ eapi }}"
+  become: yes
   register: result
 
 - assert:
@@ -34,7 +31,6 @@
   eos_config:
     lines: "hostname {{ inventory_hostname }}"
     match: none
-    timeout: 30
-    provider: "{{ eapi }}"
+  become: yes
 
 - debug: msg="END eapi/set_hostname.yaml"

--- a/test/integration/targets/eos_system/tests/eapi/set_lookup_source.yaml
+++ b/test/integration/targets/eos_system/tests/eapi/set_lookup_source.yaml
@@ -6,15 +6,13 @@
     lines:
       - no ip domain lookup source-interface
       - vrf definition ansible
-    timeout: 30
     match: none
-    provider: "{{ eapi }}"
+  become: yes
 
 - name: configure lookup_source
   eos_system:
     lookup_source: Management1
-    timeout: 30
-    provider: "{{ eapi }}"
+  become: yes
   register: result
 
 - assert:
@@ -25,8 +23,7 @@
 - name: verify lookup_source
   eos_system:
     lookup_source: Management1
-    timeout: 30
-    provider: "{{ eapi }}"
+  become: yes
   register: result
 
 - assert:
@@ -38,8 +35,7 @@
     lookup_source:
       - interface: Management1
         vrf: ansible
-    timeout: 30
-    provider: "{{ eapi }}"
+  become: yes
   register: result
 
 - assert:
@@ -54,8 +50,7 @@
     lookup_source:
       - interface: Management1
         vrf: ansible
-    timeout: 30
-    provider: "{{ eapi }}"
+  become: yes
   register: result
 
 - assert:
@@ -67,8 +62,7 @@
     lines:
       - no ip domain lookup source-interface
       - no vrf definition ansible
-    timeout: 30
     match: none
-    provider: "{{ eapi }}"
+  become: yes
 
 - debug: msg="END eapi/set_lookup_source.yaml"

--- a/test/integration/targets/eos_system/tests/eapi/set_name_servers.yaml
+++ b/test/integration/targets/eos_system/tests/eapi/set_name_servers.yaml
@@ -6,9 +6,8 @@
     lines:
       - no ip name-server
       - vrf definition ansible
-    timeout: 30
     match: none
-    provider: "{{ eapi }}"
+  become: yes
 
 - name: configure name_servers
   eos_system:
@@ -16,8 +15,7 @@
       - 1.1.1.1
       - 2.2.2.2
       - 3.3.3.3
-    timeout: 30
-    provider: "{{ eapi }}"
+  become: yes
   register: result
 
 - assert:
@@ -34,8 +32,7 @@
       - 1.1.1.1
       - 2.2.2.2
       - 3.3.3.3
-    timeout: 30
-    provider: "{{ eapi }}"
+  become: yes
   register: result
 
 - assert:
@@ -48,7 +45,7 @@
 #      - 1.1.1.1
 #      - { server: 2.2.2.2, vrf: ansible }
 #      - 3.3.3.3
-#    provider: "{{ eapi }}"
+#  become: yes
 #  register: result
 
 #- assert:
@@ -64,9 +61,9 @@
 #      - 1.1.1.1
 #      - { server: 2.2.2.2, vrf: ansible }
 #      - 3.3.3.3
-#    provider: "{{ eapi }}"
+#  become: yes
 #  register: result
-
+#
 #- assert:
 #    that:
 #      - result.changed == false
@@ -76,8 +73,7 @@
     name_servers:
       - 1.1.1.1
       - 2.2.2.2
-    timeout: 30
-    provider: "{{ eapi }}"
+  become: yes
   register: result
 
 - assert:
@@ -91,8 +87,7 @@
     lines:
       - no ip domain lookup source-interface
       - no vrf definition ansible
-    timeout: 30
     match: none
-    provider: "{{ eapi }}"
+  become: yes
 
 - debug: msg="END eapi/set_name_servers.yaml"

--- a/test/integration/targets/eos_user/tasks/cli.yaml
+++ b/test/integration/targets/eos_user/tasks/cli.yaml
@@ -14,9 +14,3 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local ansible_become=no"
-  with_first_found: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run

--- a/test/integration/targets/eos_vlan/tasks/cli.yaml
+++ b/test/integration/targets/eos_vlan/tasks/cli.yaml
@@ -14,9 +14,3 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local ansible_become=no"
-  with_first_found: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run

--- a/test/integration/targets/eos_vrf/tasks/cli.yaml
+++ b/test/integration/targets/eos_vrf/tasks/cli.yaml
@@ -14,9 +14,3 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local ansible_become=no"
-  with_first_found: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run


### PR DESCRIPTION
* Return the expected prompt character based on become status

* Update eos tests for eapi

(cherry picked from commit 20f93816d6f0bd997ee72e6a5ee7daf2aa90b8a1)

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
eos

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6
```
