### PR TITLE
Argument spec must be dict/hash

### DIFF
--- a/docs/docsite/rst/dev_guide/testing_validate-modules.rst
+++ b/docs/docsite/rst/dev_guide/testing_validate-modules.rst
@@ -117,6 +117,7 @@ Errors
   328       Choices value from the documentation is not compatible with type defined in the argument_spec
   329       Default value from the argument_spec is not compatible with type defined in the argument_spec
   330       Choices value from the argument_spec is not compatible with type defined in the argument_spec
+  331       argument in argument_spec must be a dictionary/hash when used
   ..
 ---------   -------------------
   **4xx**   **Syntax**

--- a/test/sanity/validate-modules/main.py
+++ b/test/sanity/validate-modules/main.py
@@ -1036,6 +1036,13 @@ class ModuleValidator(Validator):
         args_from_argspec = set()
         deprecated_args_from_argspec = set()
         for arg, data in spec.items():
+            if not isinstance(data, dict):
+                self.reporter.error(
+                    path=self.object_path,
+                    code=331,
+                    msg="argument '%s' in argument_spec must be a dictionary/hash when used" % arg,
+                )
+                continue
             if not data.get('removed_in_version', None):
                 args_from_argspec.add(arg)
                 args_from_argspec.update(data.get('aliases', []))


### PR DESCRIPTION
##### SUMMARY
validate-modules should fail when argument is not dict/hash.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
docs/docsite/rst/dev_guide/testing_validate-modules.rst
test/sanity/validate-modules/main.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7-devel
```