### PR TITLE
Fix FreeBSD package install in test setup.sh.

### DIFF
--- a/test/runner/setup/remote.sh
+++ b/test/runner/setup/remote.sh
@@ -16,6 +16,9 @@ if [ "${platform}" = "freebsd" ]; then
             curl \
             gtar \
             python \
+            py27-Jinja2 \
+            py27-virtualenv \
+            py27-cryptography \
             sudo \
          && break
          echo "Failed to install packages. Sleeping before trying again..."


### PR DESCRIPTION
##### SUMMARY

Fix FreeBSD package install in test setup.sh.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.7.0dev0 (freebsd-fix ea4d5c9c4b) last updated 2018/05/29 22:01:17 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
