### PR TITLE
homebrew_tap: fixes #40853

### DIFF
--- a/lib/ansible/modules/packaging/os/homebrew_tap.py
+++ b/lib/ansible/modules/packaging/os/homebrew_tap.py
@@ -111,7 +111,7 @@ def add_tap(module, brew_path, tap, url=None):
             tap,
             url,
         ])
-        if already_tapped(module, brew_path, tap):
+        if rc == 0:
             changed = True
             msg = 'successfully tapped: %s' % tap
         else:


### PR DESCRIPTION
##### SUMMARY
This change fixes #40853.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
homebrew_tap

##### ANSIBLE VERSION
```
ansible 2.7.0dev0 (homebrew_tap_already_tapped_fix 69e7ab242d) last updated 2018/05/30 01:27:50 (GMT -400)
  config file = /Users/dan/.ansible.cfg
  configured module search path = ['/Users/dan/src/ansible/library']
  ansible python module location = /Users/dan/src/ansible/lib/ansible
  executable location = /Users/dan/src/ansible/bin/ansible
  python version = 3.6.3 (default, Oct 21 2017, 11:37:52) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]
```