### PR TITLE
Lenovo typofix

### DIFF
--- a/lib/ansible/plugins/action/cnos.py
+++ b/lib/ansible/plugins/action/cnos.py
@@ -10,7 +10,7 @@
 #
 # (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 #
-# Contains Action Plugin methods for ENOS Config Module
+# Contains Action Plugin methods for CNOS Config Module
 # Lenovo Networking
 #
 

--- a/lib/ansible/plugins/action/cnos_config.py
+++ b/lib/ansible/plugins/action/cnos_config.py
@@ -10,7 +10,7 @@
 #
 # (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 #
-# Contains Action Plugin methods for ENOS Config Module
+# Contains Action Plugin methods for CNOS Config Module
 # Lenovo Networking
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type

--- a/lib/ansible/plugins/action/enos_config.py
+++ b/lib/ansible/plugins/action/enos_config.py
@@ -2,8 +2,6 @@
 # Copyright (C) 2017 Lenovo.
 #
 # GNU General Public License v3.0+
-# Copyright (C) 2017 Lenovo.
-# All rights reserved.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/lib/ansible/plugins/cliconf/cnos.py
+++ b/lib/ansible/plugins/cliconf/cnos.py
@@ -10,7 +10,7 @@
 #
 # (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 #
-# Contains CLIConf Plugin methods for ENOS Modules
+# Contains CLIConf Plugin methods for CNOS Modules
 # Lenovo Networking
 #
 from __future__ import (absolute_import, division, print_function)

--- a/lib/ansible/plugins/terminal/cnos.py
+++ b/lib/ansible/plugins/terminal/cnos.py
@@ -10,7 +10,7 @@
 #
 # (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 #
-# Contains terminal Plugin methods for ENOS Config Module
+# Contains terminal Plugin methods for CNOS Config Module
 # Lenovo Networking
 #
 from __future__ import (absolute_import, division, print_function)

--- a/lib/ansible/plugins/terminal/enos.py
+++ b/lib/ansible/plugins/terminal/enos.py
@@ -2,8 +2,6 @@
 # Copyright (C) 2017 Lenovo.
 #
 # GNU General Public License v3.0+
-# Copyright (C) 2017 Lenovo.
-# All rights reserved.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of


### PR DESCRIPTION
##### SUMMARY
This PR is to correct typo ENOS to CNOS.
The licesnse files are also getting updated for correctness

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/action/cnos.py
lib/ansible/plugins/action/cnos_config.py
lib/ansible/plugins/cliconf/cnos.py
lib/ansible/plugins/terminal/cnos.py

##### ANSIBLE VERSION
ansible 2.6.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/sha                                                                                        re/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansibl                                                                                        e-2.6.0-py2.7.egg/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.6 (default, Nov 23 2017, 15:49:48) [GCC 4.8.4]

##### ADDITIONAL INFORMATION
This is a copy paste error for the plugins from ENOS to CNOS. Missed to change the documentation from ENOS to CNOS