### PR TITLE
Convert valid_date to bytes for comparison

### DIFF
--- a/lib/ansible/modules/crypto/openssl_certificate.py
+++ b/lib/ansible/modules/crypto/openssl_certificate.py
@@ -661,7 +661,7 @@ class AssertOnlyCertificate(Certificate):
 
         def _validate_valid_at():
             if self.valid_at:
-                if not (self.valid_at >= self.cert.get_notBefore() and self.valid_at <= self.cert.get_notAfter()):
+                if not (self.cert.get_notBefore() <= self.valid_at <= self.cert.get_notAfter()):
                     self.message.append(
                         'Certificate is not valid for the specified date (%s) - notBefore: %s - notAfter: %s' % (self.valid_at,
                                                                                                                  self.cert.get_notBefore(),
@@ -680,8 +680,8 @@ class AssertOnlyCertificate(Certificate):
         def _validate_valid_in():
             if self.valid_in:
                 valid_in_date = datetime.datetime.utcnow() + datetime.timedelta(seconds=self.valid_in)
-                valid_in_date = valid_in_date.strftime('%Y%m%d%H%M%SZ')
-                if not (valid_in_date >= self.cert.get_notBefore() and valid_in_date <= self.cert.get_notAfter()):
+                valid_in_date = to_bytes(valid_in_date.strftime('%Y%m%d%H%M%SZ'), errors='surrogate_or_strict')
+                if not (self.cert.get_notBefore() <= valid_in_date <= self.cert.get_notAfter()):
                     self.message.append(
                         'Certificate is not valid in %s seconds from now (%s) - notBefore: %s - notAfter: %s' % (self.valid_in,
                                                                                                                  valid_in_date,


### PR DESCRIPTION
##### SUMMARY
For Python 3, convert valid_date to bytes for comparison

Fixes: #40523

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
lib/ansible/modules/crypto/openssl_certificate.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7devel
```