### PR TITLE
Remove local from most eos tests now that provider is out

### DIFF
--- a/test/integration/targets/eos_eapi/tasks/cli.yaml
+++ b/test/integration/targets/eos_eapi/tasks/cli.yaml
@@ -14,9 +14,3 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local ansible_become=no"
-  with_first_found: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run

--- a/test/integration/targets/eos_interface/tasks/cli.yaml
+++ b/test/integration/targets/eos_interface/tasks/cli.yaml
@@ -14,9 +14,3 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local ansible_become=no"
-  with_first_found: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run

--- a/test/integration/targets/eos_l2_interface/tasks/cli.yaml
+++ b/test/integration/targets/eos_l2_interface/tasks/cli.yaml
@@ -14,9 +14,3 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local ansible_become=no"
-  with_first_found: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run

--- a/test/integration/targets/eos_l3_interface/tasks/cli.yaml
+++ b/test/integration/targets/eos_l3_interface/tasks/cli.yaml
@@ -14,9 +14,3 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local ansible_become=no"
-  with_first_found: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run

--- a/test/integration/targets/eos_linkagg/tasks/cli.yaml
+++ b/test/integration/targets/eos_linkagg/tasks/cli.yaml
@@ -14,9 +14,3 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local ansible_become=no"
-  with_first_found: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run

--- a/test/integration/targets/eos_lldp/tasks/cli.yaml
+++ b/test/integration/targets/eos_lldp/tasks/cli.yaml
@@ -14,9 +14,3 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local ansible_become=no"
-  with_first_found: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run

--- a/test/integration/targets/eos_logging/tasks/cli.yaml
+++ b/test/integration/targets/eos_logging/tasks/cli.yaml
@@ -14,9 +14,3 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local ansible_become=no"
-  with_first_found: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run

--- a/test/integration/targets/eos_smoke/tasks/cli.yaml
+++ b/test/integration/targets/eos_smoke/tasks/cli.yaml
@@ -15,7 +15,7 @@
   loop_control:
     loop_var: test_case_to_run
 
-- name: run test case (connection=local)
+- name: run test cases (connection=local)
   include: "{{ test_case_to_run }} ansible_connection=local ansible_become=no"
   with_items: "{{ test_items }}"
   loop_control:

--- a/test/integration/targets/eos_static_route/tasks/cli.yaml
+++ b/test/integration/targets/eos_static_route/tasks/cli.yaml
@@ -14,9 +14,3 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local ansible_become=no"
-  with_first_found: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run

--- a/test/integration/targets/eos_system/tasks/cli.yaml
+++ b/test/integration/targets/eos_system/tasks/cli.yaml
@@ -14,9 +14,3 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local ansible_become=no"
-  with_first_found: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run

--- a/test/integration/targets/eos_user/tasks/cli.yaml
+++ b/test/integration/targets/eos_user/tasks/cli.yaml
@@ -14,9 +14,3 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local ansible_become=no"
-  with_first_found: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run

--- a/test/integration/targets/eos_vlan/tasks/cli.yaml
+++ b/test/integration/targets/eos_vlan/tasks/cli.yaml
@@ -14,9 +14,3 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local ansible_become=no"
-  with_first_found: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run

--- a/test/integration/targets/eos_vrf/tasks/cli.yaml
+++ b/test/integration/targets/eos_vrf/tasks/cli.yaml
@@ -14,9 +14,3 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local ansible_become=no"
-  with_first_found: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
I cleaned up some cli tests to remove provider (& match eapi), but did not remove the connection=local test cases. This should rectify that.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
eos

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6
```

