### PR TITLE
Several kubectl fixes

### DIFF
--- a/lib/ansible/module_utils/k8s/inventory.py
+++ b/lib/ansible/module_utils/k8s/inventory.py
@@ -173,11 +173,14 @@ class K8sInventoryHelper(object):
                 if container.state.waiting:
                     self.inventory.set_variable(container_name, 'container_state', 'Waiting')
                 self.inventory.set_variable(container_name, 'container_ready', container.ready)
+                self.inventory.set_variable(container_name, 'ansible_remote_tmp', '/tmp/')
                 self.inventory.set_variable(container_name, 'ansible_connection', self.transport)
                 self.inventory.set_variable(container_name, 'ansible_{0}_pod'.format(self.transport),
                                             pod_name)
                 self.inventory.set_variable(container_name, 'ansible_{0}_container'.format(self.transport),
                                             container.name)
+                self.inventory.set_variable(container_name, 'ansible_{0}_namespace'.format(self.transport),
+                                            namespace)
 
     def get_services_for_namespace(self, name, namespace):
         self.helper.set_model('v1', 'service_list')

--- a/lib/ansible/module_utils/k8s/inventory.py
+++ b/lib/ansible/module_utils/k8s/inventory.py
@@ -68,7 +68,7 @@ class K8sInventoryHelper(object):
                 self.authenticate(connection)
                 name = connection.get('name', self.get_default_host_name(self.helper.api_client.host))
                 if connection.get('namespaces'):
-                    namespaces = connections['namespaces']
+                    namespaces = connection['namespaces']
                 else:
                     namespaces = self.get_available_namespaces()
                 for namespace in namespaces:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes several bugs which make use of kubectl connection impossible.
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
k8s / kubectl

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.3
  config file = /Users/~~~/ansible/ansible.cfg
  configured module search path = ['/Users/~~~/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/~~~/ansible/env/lib/python3.6/site-packages/ansible
  executable location = /Users/~~~/ansible/env/bin/ansible
  python version = 3.6.4 (default, Mar 20 2018, 23:32:11) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.37)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

Fixes these errors when using k8s inventory and kubectl connection:

Typo in inventory parsing:
```
 [WARNING]:  * Failed to parse /Users/~~~/ansible/inventory/k8s.yml with auto plugin: list indices must be integers or slices, not str
  
  ...
  File "/Users/~~~/ansible/env/lib/python3.6/site-packages/ansible/module_utils/k8s/inventory.py", line 71, in fetch_objects
    namespaces = connections['namespaces']
```

Absence of `--namespace` parameter when executing command on pods from non-default namespace:
```
<~~~> EXEC ['/usr/local/bin/kubectl', 'exec', '-I', '~~~', '-c', '~~~', '--', '/bin/sh', '-c', "/bin/sh -c 'echo ~None && sleep 0'"]
```

Invalid temp directory (note `None`):
```
<~~~> EXEC ['/usr/local/bin/kubectl', '-n', '~~~', 'exec', '-I', '~~~', '-c', '~~~', '--', '/bin/sh', '-c', '/bin/sh -c \'( umask 77 && mkdir -p "` echo ~None/.ansible/tmp/ansible-tmp-1527688125.119122-3174488126227 `" && echo ansible-tmp-1527688125.119122-3174488126227="` echo ~None/.ansible/tmp/ansible-tmp-1527688125.119122-3174488126227 `" ) && sleep 0\'']
```