### PR TITLE
Adding module to manage lexicons for AWS Polly

### DIFF
--- a/lib/ansible/modules/cloud/amazon/polly_lexicon.py
+++ b/lib/ansible/modules/cloud/amazon/polly_lexicon.py
@@ -1,0 +1,169 @@
+#!/usr/bin/python
+
+# Copyright: (c) 2018, Aaron Smith <ajsmith10381@gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = r'''
+---
+module: polly_lexicon
+short_description: Manage lexicons on AWS Polly.
+description:
+    - Add or delete lexicons for AWS Polly test-to-speech processing.
+author: "Aaron Smith (@slapula)"
+version_added: "2.7"
+requirements: [ 'botocore', 'boto3' ]
+options:
+  name:
+    description:
+     - Name of the lexicon.
+    required: true
+  state:
+    description:
+     - Whether the lexicon should be exist or not.
+    required: true
+    choices: ['present', 'absent']
+  content:
+    description:
+     - Content of the PLS lexicon as string data.
+    required: true
+extends_documentation_fragment:
+    - ec2
+    - aws
+'''
+
+
+EXAMPLES = r'''
+- name: create Polly lexicon
+  polly_lexicon:
+    name: 'ivona'
+    state: present
+    content: "{{ lookup('file', 'tmp/ivona.pls') }}"
+- name: delete Polly lexicon
+  polly_lexicon:
+    name: 'ivona'
+    state: absent
+    content: "{{ lookup('file', 'tmp/ivona.pls') }}"
+'''
+
+
+RETURN = r'''#'''
+
+
+from ansible.module_utils.aws.core import AnsibleAWSModule
+from ansible.module_utils.ec2 import boto3_conn, get_aws_connection_info, AWSRetry
+from ansible.module_utils.ec2 import camel_dict_to_snake_dict, boto3_tag_list_to_ansible_dict
+
+try:
+    from botocore.exceptions import BotoCoreError, ClientError
+except ImportError:
+    pass  # handled by AnsibleAWSModule
+
+
+def lexicon_exists(client, module, result):
+    try:
+        response = client.list_lexicons()
+        for i in response['Lexicons']:
+            if i['Name'] == module.params.get('name'):
+                lex_data = client.get_lexicon(
+                    Name=module.params.get('name')
+                )
+                result['lexicon_content'] = lex_data['Lexicon']
+                return True
+    except (ClientError, IndexError):
+        return False
+
+    return False
+
+
+def create_lexicon(client, module, params, result):
+    if module.check_mode:
+        module.exit_json(changed=True)
+    try:
+        response = client.put_lexicon(**params)
+        result['changed'] = True
+        return result
+    except (BotoCoreError, ClientError) as e:
+        module.fail_json_aws(e, msg="Failed to create lexicon")
+
+    return result
+
+
+def update_lexicon(client, module, params, result):
+    if module.check_mode:
+        module.exit_json(changed=True)
+    try:
+        if params['Content'] != result['lexicon_content']['Content']:
+            response = client.delete_lexicon(
+                Name=module.params.get('name')
+            )
+            response = client.put_lexicon(**params)
+            result['changed'] = True
+            return result
+    except (BotoCoreError, ClientError) as e:
+        module.fail_json_aws(e, msg="Failed to update lexicon")
+
+    return result
+
+
+def delete_lexicon(client, module, result):
+    if module.check_mode:
+        module.exit_json(changed=True)
+    try:
+        response = client.delete_lexicon(
+            Name=module.params.get('name')
+        )
+        result['changed'] = True
+        return result
+    except (BotoCoreError, ClientError) as e:
+        module.fail_json_aws(e, msg="Failed to delete lexicon")
+
+    return result
+
+
+def main():
+    module = AnsibleAWSModule(
+        argument_spec={
+            'name': dict(type='str', required=True),
+            'state': dict(type='str', choices=['present', 'absent'], required=True),
+            'content': dict(type='str', required=True),
+        },
+        supports_check_mode=True,
+    )
+
+    result = {
+        'changed': False
+    }
+
+    params = {}
+    params['Name'] = module.params.get('name')
+    params['Content'] = module.params.get('content')
+
+    desired_state = module.params.get('state')
+
+    client = module.client('polly')
+
+    lexicon_status = lexicon_exists(client, module, result)
+
+    if desired_state == 'present':
+        if not lexicon_status:
+            create_lexicon(client, module, params, result)
+        if lexicon_status:
+            update_lexicon(client, module, params, result)
+
+    if desired_state == 'absent':
+        if lexicon_status:
+            delete_lexicon(client, module, result)
+
+    module.exit_json(changed=result['changed'])
+
+
+if __name__ == '__main__':
+    main()

--- a/test/integration/targets/polly_lexicon/aliases
+++ b/test/integration/targets/polly_lexicon/aliases
@@ -1,0 +1,2 @@
+cloud/aws
+posix/ci/cloud/group4/aws

--- a/test/integration/targets/polly_lexicon/files/eu.pls
+++ b/test/integration/targets/polly_lexicon/files/eu.pls
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lexicon version="1.0"
+      xmlns="http://www.w3.org/2005/01/pronunciation-lexicon"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://www.w3.org/2005/01/pronunciation-lexicon
+        http://www.w3.org/TR/2007/CR-pronunciation-lexicon-20071212/pls.xsd"
+      alphabet="ipa" xml:lang="it">
+  <lexeme>
+    <grapheme>EU</grapheme>
+    <alias>Unione Europea
+      <!-- This is a substitution of the European
+      Union acronym in Italian language.  --></alias>
+  </lexeme>
+</lexicon>

--- a/test/integration/targets/polly_lexicon/files/tomato.pls
+++ b/test/integration/targets/polly_lexicon/files/tomato.pls
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lexicon version="1.0"
+      xmlns="http://www.w3.org/2005/01/pronunciation-lexicon"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://www.w3.org/2005/01/pronunciation-lexicon
+        http://www.w3.org/TR/2007/CR-pronunciation-lexicon-20071212/pls.xsd"
+      alphabet="ipa" xml:lang="en-US">
+  <lexeme>
+    <grapheme>tomato</grapheme>
+    <phoneme>təmei̥ɾou̥</phoneme>
+    <!-- IPA string is: "t&#x0259;mei&#x325;&#x027E;ou&#x325;" -->
+  </lexeme>
+</lexicon>

--- a/test/integration/targets/polly_lexicon/meta/main.yaml
+++ b/test/integration/targets/polly_lexicon/meta/main.yaml
@@ -1,0 +1,3 @@
+dependencies:
+  - prepare_tests
+  - setup_ec2

--- a/test/integration/targets/polly_lexicon/tasks/main.yaml
+++ b/test/integration/targets/polly_lexicon/tasks/main.yaml
@@ -5,6 +5,7 @@
     aws_connection_info: &aws_connection_info
       aws_access_key: "{{ aws_access_key }}"
       aws_secret_key: "{{ aws_secret_key }}"
+      security_token: "{{ security_token }}"
       region: "{{ aws_region }}"
   no_log: true
 

--- a/test/integration/targets/polly_lexicon/tasks/main.yaml
+++ b/test/integration/targets/polly_lexicon/tasks/main.yaml
@@ -1,0 +1,61 @@
+---
+
+- name: set connection information for all tasks
+  set_fact:
+    aws_connection_info: &aws_connection_info
+      aws_access_key: "{{ aws_access_key }}"
+      aws_secret_key: "{{ aws_secret_key }}"
+      region: "{{ aws_region }}"
+  no_log: true
+
+- name: create Polly lexicon
+  polly_lexicon:
+    <<: *aws_connection_info
+    name: 'ivona'
+    state: present
+    content: "{{ lookup('file', 'files/eu.pls') }}"
+  register: result
+
+- name: assert correct keys are returned
+  assert:
+    that:
+      - result.changed
+
+- name: no changes to lexicon
+  polly_lexicon:
+    <<: *aws_connection_info
+    name: 'ivona'
+    state: present
+    content: "{{ lookup('file', 'files/eu.pls') }}"
+  register: result
+
+- name: assert correct keys are returned
+  assert:
+    that:
+      - not result.changed
+
+- name: update lexicon
+  polly_lexicon:
+    <<: *aws_connection_info
+    name: 'ivona'
+    state: present
+    content: "{{ lookup('file', 'files/tomato.pls') }}"
+  register: result
+
+- name: assert correct keys are returned
+  assert:
+    that:
+      - result.changed
+
+- name: destroy lexicon
+  polly_lexicon:
+    <<: *aws_connection_info
+    name: 'ivona'
+    state: absent
+    content: "{{ lookup('file', 'files/tomato.pls') }}"
+  register: result
+
+- name: assert correct keys are returned
+  assert:
+    that:
+      - result.changed


### PR DESCRIPTION
##### SUMMARY
This is another simple module that manages lexicons for usage with the AWS Polly text-to-speech engine.

##### ISSUE TYPE
 - New Module Pull Request

##### COMPONENT NAME
`polly_lexicon`

##### ANSIBLE VERSION
```
ansible 2.4.1.0
  config file = None
  configured module search path = [u'/Users/asmith/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/asmith/.pyenv/versions/2.7.13/lib/python2.7/site-packages/ansible
  executable location = /Users/asmith/.pyenv/versions/2.7.13/bin/ansible
  python version = 2.7.13 (default, Sep  8 2017, 15:16:38) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```