### PR TITLE
reset connection is not run once

### DIFF
--- a/changelogs/fragments/meta_rc_runone.yml
+++ b/changelogs/fragments/meta_rc_runone.yml
@@ -1,0 +1,2 @@
+- bugfixes:
+    - reset connection is not run once https://github.com/ansible/ansible/issues/39364

--- a/lib/ansible/plugins/strategy/linear.py
+++ b/lib/ansible/plugins/strategy/linear.py
@@ -263,7 +263,7 @@ class StrategyModule(StrategyBase):
                         # for the linear strategy, we run meta tasks just once and for
                         # all hosts currently being iterated over rather than one host
                         results.extend(self._execute_meta(task, play_context, iterator, host))
-                        if task.args.get('_raw_params', None) != 'noop':
+                        if task.args.get('_raw_params', None) not in ('noop', 'reset_connection'):
                             run_once = True
                     else:
                         # handle step if needed, skip meta actions as they are used internally


### PR DESCRIPTION
(cherry picked from commit 062f0444a1c48bc3c24c00ba4150cfa9fac1d05d)

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
meta
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```
