### PR TITLE
Pass cloud parameter to get_one call

### DIFF
--- a/contrib/inventory/openstack_inventory.py
+++ b/contrib/inventory/openstack_inventory.py
@@ -191,8 +191,9 @@ def is_cache_stale(cache_file, cache_expiration_time, refresh=False):
 
 
 def get_cache_settings(cloud=None):
+    config_files = cloud_config.CONFIG_FILES + CONFIG_FILES
     config = cloud_config.OpenStackConfig(
-        config_files=cloud_config.CONFIG_FILES + CONFIG_FILES).get_one()
+        config_files=config_files).get_one(cloud=cloud)
     # For inventory-wide caching
     cache_expiration_time = config.get_cache_expiration_time()
     cache_path = config.get_cache_path()


### PR DESCRIPTION
When we switch this to pull from the CloudRegion object, we missed
passing the parameter along.
