### PR TITLE
fix 'doas' become_method support, previously committed patch not subm…

### DIFF
--- a/changelogs/fragments/fix_doas.yml
+++ b/changelogs/fragments/fix_doas.yml
@@ -1,0 +1,2 @@
+- bugfix:
+    - fix doas construction for become https://github.com/ansible/ansible/pull/37511

--- a/lib/ansible/playbook/play_context.py
+++ b/lib/ansible/playbook/play_context.py
@@ -544,7 +544,7 @@ class PlayContext(Base):
                     flags += ' -u %s ' % self.become_user
 
                 # FIXME: make shell independent
-                becomecmd = '%s %s echo %s && %s %s env ANSIBLE=true %s' % (exe, flags, success_key, exe, flags, cmd)
+                becomecmd = '%s %s %s -c %s' % (exe, flags, executable, success_cmd)
 
             elif self.become_method == 'dzdo':
 

--- a/test/units/playbook/test_play_context.py
+++ b/test/units/playbook/test_play_context.py
@@ -153,8 +153,7 @@ def test_play_context_make_become_cmd(parser):
 
     play_context.become_method = 'doas'
     cmd = play_context.make_become_cmd(cmd=default_cmd, executable="/bin/bash")
-    assert (cmd == """%s %s echo %s && %s %s env ANSIBLE=true %s""" % (doas_exe, doas_flags, play_context.
-                                                                       success_key, doas_exe, doas_flags, default_cmd))
+    assert (cmd == """%s %s %s -c 'echo %s; %s'""" % (doas_exe, doas_flags, default_exe, play_context.success_key, default_cmd))
 
     play_context.become_method = 'ksu'
     cmd = play_context.make_become_cmd(cmd=default_cmd, executable="/bin/bash")


### PR DESCRIPTION
…itted to devel branch (#37511)

* fix become_method 'doas' support by properly specifying becomecmd

a repatch of https://github.com/ansible/ansible/pull/13451/ which was never committed to 'devel' branch.

* fix play_context test for become_method doas to match new becomecmd

(cherry picked from commit be3670f5285a4eebfa5b4947806618cab59d969c)

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
become/doas
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```