### PR TITLE
[WIP] Attempt at only updating templated _raw_params with host vars

### DIFF
--- a/lib/ansible/executor/process/worker.py
+++ b/lib/ansible/executor/process/worker.py
@@ -115,7 +115,8 @@ class WorkerProcess(multiprocessing.Process):
                 self._new_stdin,
                 self._loader,
                 self._shared_loader_obj,
-                self._rslt_q
+                self._rslt_q,
+                self._variable_manager,
             ).run()
 
             display.debug("done running TaskExecutor() for %s/%s [%s]" % (self._host, self._task, self._task._uuid))

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -503,7 +503,7 @@ class TaskExecutor:
             return dict(
                 include=include_file,
                 include_variables=include_variables,
-                _partial_tmpl_include_file=host_include_file if host_include_file != orig_include_file else orig_include_file
+                _partial_tmpl_include_file=host_include_file
             )
 
         # if this task is a IncludeRole, we just return now with a success code so the main thread can expand the task list for the given host

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -67,7 +67,7 @@ class TaskExecutor:
     # the module
     SQUASH_ACTIONS = frozenset(C.DEFAULT_SQUASH_ACTIONS)
 
-    def __init__(self, host, task, job_vars, play_context, new_stdin, loader, shared_loader_obj, rslt_q):
+    def __init__(self, host, task, job_vars, play_context, new_stdin, loader, shared_loader_obj, rslt_q, variable_manager):
         self._host = host
         self._task = task
         self._job_vars = job_vars
@@ -78,6 +78,7 @@ class TaskExecutor:
         self._connection = None
         self._rslt_q = rslt_q
         self._loop_eval_error = None
+        self._variable_manager = variable_manager
 
         self._task.squash()
 
@@ -435,6 +436,7 @@ class TaskExecutor:
             variables = self._job_vars
 
         templar = Templar(loader=self._loader, shared_loader_obj=self._shared_loader_obj, variables=variables)
+        host_templar = Templar(loader=self._loader, variables=self._variable_manager.get_vars(host=self._host))
 
         context_validation_error = None
         try:
@@ -488,12 +490,21 @@ class TaskExecutor:
         # main thread can expand the task list for the given host
         if self._task.action in ('include', 'include_tasks'):
             include_variables = self._task.args.copy()
-            include_file = include_variables.pop('_raw_params', None)
-            if not include_file:
+            orig_include_file = include_variables.pop('_raw_params', None)
+            if not orig_include_file:
                 return dict(failed=True, msg="No include file was specified to the include")
 
-            include_file = templar.template(include_file)
-            return dict(include=include_file, include_variables=include_variables)
+            # Template out just the vars that come from host vars, used later in places where we no longer
+            # carry host context
+            host_include_file = host_templar.template(orig_include_file, fail_on_undefined=False)
+
+            # Fully templated path
+            include_file = templar.template(orig_include_file)
+            return dict(
+                include=include_file,
+                include_variables=include_variables,
+                _partial_tmpl_include_file=host_include_file if host_include_file != orig_include_file else orig_include_file
+            )
 
         # if this task is a IncludeRole, we just return now with a success code so the main thread can expand the task list for the given host
         elif self._task.action == 'include_role':

--- a/lib/ansible/playbook/included_file.py
+++ b/lib/ansible/playbook/included_file.py
@@ -145,7 +145,7 @@ class IncludedFile:
 
                         include_file = templar.template(include_file)
                         # Update the task args to reflect the expanded/templated path
-                        original_task.args['_raw_params'] = include_file
+                        original_task.args['_raw_params'] = include_result['_partial_tmpl_include_file']
                         inc_file = IncludedFile(include_file, include_variables, original_task)
                     else:
                         # template the included role's name here

--- a/test/units/executor/test_task_executor.py
+++ b/test/units/executor/test_task_executor.py
@@ -44,6 +44,7 @@ class TestTaskExecutor(unittest.TestCase):
         mock_task = MagicMock()
         mock_play_context = MagicMock()
         mock_shared_loader = MagicMock()
+        mock_var_mgr = MagicMock()
         new_stdin = None
         job_vars = dict()
         mock_queue = MagicMock()
@@ -56,6 +57,7 @@ class TestTaskExecutor(unittest.TestCase):
             loader=fake_loader,
             shared_loader_obj=mock_shared_loader,
             rslt_q=mock_queue,
+            variable_manager=mock_var_mgr,
         )
 
     def test_task_executor_run(self):
@@ -70,6 +72,7 @@ class TestTaskExecutor(unittest.TestCase):
 
         mock_shared_loader = MagicMock()
         mock_queue = MagicMock()
+        mock_var_mgr = MagicMock()
 
         new_stdin = None
         job_vars = dict()
@@ -83,6 +86,7 @@ class TestTaskExecutor(unittest.TestCase):
             loader=fake_loader,
             shared_loader_obj=mock_shared_loader,
             rslt_q=mock_queue,
+            variable_manager=mock_var_mgr,
         )
 
         te._get_loop_items = MagicMock(return_value=None)
@@ -110,6 +114,7 @@ class TestTaskExecutor(unittest.TestCase):
         mock_task.loop = ['a', 'b', 'c']
 
         mock_play_context = MagicMock()
+        mock_var_mgr = MagicMock()
 
         mock_shared_loader = MagicMock()
         mock_shared_loader.lookup_loader = lookup_loader
@@ -127,6 +132,7 @@ class TestTaskExecutor(unittest.TestCase):
             loader=fake_loader,
             shared_loader_obj=mock_shared_loader,
             rslt_q=mock_queue,
+            variable_manager=mock_var_mgr,
         )
 
         items = te._get_loop_items()
@@ -147,6 +153,7 @@ class TestTaskExecutor(unittest.TestCase):
         mock_task.copy.side_effect = _copy
 
         mock_play_context = MagicMock()
+        mock_var_mgr = MagicMock()
 
         mock_shared_loader = MagicMock()
         mock_queue = MagicMock()
@@ -163,6 +170,7 @@ class TestTaskExecutor(unittest.TestCase):
             loader=fake_loader,
             shared_loader_obj=mock_shared_loader,
             rslt_q=mock_queue,
+            variable_manager=mock_var_mgr,
         )
 
         def _execute(variables):
@@ -193,6 +201,7 @@ class TestTaskExecutor(unittest.TestCase):
         mock_task.evaluate_conditional.side_effect = _evaluate_conditional
 
         mock_play_context = MagicMock()
+        mock_var_mgr = MagicMock()
 
         mock_shared_loader = None
         mock_queue = MagicMock()
@@ -209,6 +218,7 @@ class TestTaskExecutor(unittest.TestCase):
             loader=fake_loader,
             shared_loader_obj=mock_shared_loader,
             rslt_q=mock_queue,
+            variable_manager=mock_var_mgr,
         )
 
         # No replacement
@@ -377,6 +387,7 @@ class TestTaskExecutor(unittest.TestCase):
         mock_task.async_val = 1
         mock_task.poll = 0
 
+        mock_var_mgr = MagicMock()
         mock_play_context = MagicMock()
         mock_play_context.post_validate.return_value = None
         mock_play_context.update_vars.return_value = None
@@ -385,6 +396,7 @@ class TestTaskExecutor(unittest.TestCase):
         mock_connection.set_host_overrides.return_value = None
         mock_connection._connect.return_value = None
 
+        mock_var_mgr = MagicMock()
         mock_action = MagicMock()
         mock_queue = MagicMock()
 
@@ -401,6 +413,7 @@ class TestTaskExecutor(unittest.TestCase):
             loader=fake_loader,
             shared_loader_obj=shared_loader,
             rslt_q=mock_queue,
+            variable_manager=mock_var_mgr,
         )
 
         te._get_connection = MagicMock(return_value=mock_connection)
@@ -435,6 +448,7 @@ class TestTaskExecutor(unittest.TestCase):
         mock_task.poll = 0.05
 
         mock_play_context = MagicMock()
+        mock_var_mgr = MagicMock()
 
         mock_connection = MagicMock()
 
@@ -456,6 +470,7 @@ class TestTaskExecutor(unittest.TestCase):
             loader=fake_loader,
             shared_loader_obj=shared_loader,
             rslt_q=mock_queue,
+            variable_manager=mock_var_mgr,
         )
 
         te._connection = MagicMock()

--- a/test/units/playbook/test_included_file.py
+++ b/test/units/playbook/test_included_file.py
@@ -69,7 +69,7 @@ def test_process_include_results(mock_iterator, mock_variable_manager):
     task_ds = {'include': 'include_test.yml'}
     loaded_task = TaskInclude.load(task_ds, task_include=parent_task)
 
-    return_data = {'include': 'include_test.yml'}
+    return_data = {'include': 'include_test.yml', '_partial_tmpl_include_file': 'include_test.yml'}
     # The task in the TaskResult has to be a TaskInclude so it has a .static attr
     result1 = task_result.TaskResult(host=hostname, task=loaded_task, return_data=return_data)
     result2 = task_result.TaskResult(host=hostname2, task=loaded_task, return_data=return_data)
@@ -98,11 +98,11 @@ def test_process_include_diff_files(mock_iterator, mock_variable_manager):
     child_task_ds = {'include': 'other_include_test.yml'}
     loaded_child_task = TaskInclude.load(child_task_ds, task_include=loaded_task)
 
-    return_data = {'include': 'include_test.yml'}
+    return_data = {'include': 'include_test.yml', '_partial_tmpl_include_file': 'include_test.yml'}
     # The task in the TaskResult has to be a TaskInclude so it has a .static attr
     result1 = task_result.TaskResult(host=hostname, task=loaded_task, return_data=return_data)
 
-    return_data = {'include': 'other_include_test.yml'}
+    return_data = {'include': 'other_include_test.yml', '_partial_tmpl_include_file': 'other_include_test.yml'}
     result2 = task_result.TaskResult(host=hostname2, task=loaded_child_task, return_data=return_data)
     results = [result1, result2]
 
@@ -133,7 +133,7 @@ def test_process_include_simulate_free(mock_iterator, mock_variable_manager):
     loaded_task1 = TaskInclude.load(task_ds, task_include=parent_task1)
     loaded_task2 = TaskInclude.load(task_ds, task_include=parent_task2)
 
-    return_data = {'include': 'include_test.yml'}
+    return_data = {'include': 'include_test.yml', '_partial_tmpl_include_file': 'include_test.yml'}
     # The task in the TaskResult has to be a TaskInclude so it has a .static attr
     result1 = task_result.TaskResult(host=hostname, task=loaded_task1, return_data=return_data)
     result2 = task_result.TaskResult(host=hostname2, task=loaded_task2, return_data=return_data)


### PR DESCRIPTION
##### SUMMARY

In https://github.com/ansible/ansible/pull/39365 a change was made to update `_raw_params` of a `TaskInclude` to the fully templated value, which would allow relative pathing to be determined when `_raw_params` of the parent included a host variable.

Unfortunately, due to this, if the parent used a var that was determined by a loop, we could later try calculating the path incorrectly.  See #40778 

This change attempts to only template out host vars in `_raw_params` and utilize that for later templating, instead of templating all variables.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/executor/process/worker.py
lib/ansible/executor/task_executor.py
lib/ansible/playbook/included_file.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6
2.7
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```