### PR TITLE
updates network examples to 2.6 (#40831)

### DIFF
--- a/docs/docsite/rst/network/user_guide/platform_eos.rst
+++ b/docs/docsite/rst/network/user_guide/platform_eos.rst
@@ -4,7 +4,7 @@
 EOS Platform Options
 ***************************************
 
-Arista EOS supports multiple connections. This page offers details on how each connection works in Ansible 2.5 and how to use it. 
+Arista EOS supports multiple connections. This page offers details on how each connection works in Ansible 2.6 and how to use it. 
 
 .. contents:: Topics
 
@@ -41,7 +41,7 @@ Connections Available
 
 For legacy playbooks, EOS still supports ``ansible_connection: local``. We recommend modernizing to use ``ansible_connection: network_cli`` or ``ansible_connection: httpapi`` as soon as possible.
 
-Using CLI in Ansible 2.5
+Using CLI in Ansible 2.6
 ================================================================================
 
 Example CLI ``group_vars/eos.yml``
@@ -76,7 +76,7 @@ Example CLI Task
 
 
 
-Using eAPI in Ansible 2.5
+Using eAPI in Ansible 2.6
 ================================================================================
 
 Enabling eAPI

--- a/docs/docsite/rst/network/user_guide/platform_ios.rst
+++ b/docs/docsite/rst/network/user_guide/platform_ios.rst
@@ -4,7 +4,7 @@
 IOS Platform Options
 ***************************************
 
-IOS supports Enable Mode (Privilege Escalation). This page offers details on how to use Enable Mode on IOS in Ansible 2.5. 
+IOS supports Enable Mode (Privilege Escalation). This page offers details on how to use Enable Mode on IOS in Ansible 2.6. 
 
 .. contents:: Topics
 
@@ -34,7 +34,7 @@ Connections Available
 
 For legacy playbooks, IOS still supports ``ansible_connection: local``. We recommend modernizing to use ``ansible_connection: network_cli`` as soon as possible.
 
-Using CLI in Ansible 2.5
+Using CLI in Ansible 2.6
 ================================================================================
 
 Example CLI ``group_vars/ios.yml``

--- a/docs/docsite/rst/network/user_guide/platform_junos.rst
+++ b/docs/docsite/rst/network/user_guide/platform_junos.rst
@@ -4,7 +4,7 @@
 Junos OS Platform Options
 ***************************************
 
-Juniper Junos OS supports multiple connections. This page offers details on how each connection works in Ansible 2.5 and how to use it. 
+Juniper Junos OS supports multiple connections. This page offers details on how each connection works in Ansible 2.6 and how to use it. 
 
 .. contents:: Topics
 
@@ -34,7 +34,7 @@ Connections Available
 
 For legacy playbooks, Ansible still supports ``ansible_connection=local`` on all JUNOS modules. We recommend modernizing to use ``ansible_connection=netconf`` or ``ansible_connection=network_cli`` as soon as possible.
 
-Using CLI in Ansible 2.5
+Using CLI in Ansible 2.6
 ================================================================================
 
 Example CLI inventory ``[junos:vars]``
@@ -65,7 +65,7 @@ Example CLI Task
      when: ansible_network_os == 'junos'
 
 
-Using NETCONF in Ansible 2.5
+Using NETCONF in Ansible 2.6
 ================================================================================
 
 Enabling NETCONF

--- a/docs/docsite/rst/network/user_guide/platform_nxos.rst
+++ b/docs/docsite/rst/network/user_guide/platform_nxos.rst
@@ -4,7 +4,7 @@
 NXOS Platform Options
 ***************************************
 
-Cisco NXOS supports multiple connections. This page offers details on how each connection works in Ansible 2.5 and how to use it.
+Cisco NXOS supports multiple connections. This page offers details on how each connection works in Ansible 2.6 and how to use it.
 
 .. contents:: Topics
 
@@ -32,7 +32,7 @@ Connections Available
 
 For legacy playbooks, NXOS still supports ``ansible_connection: local``. We recommend modernizing to use ``ansible_connection: network_cli`` or ``ansible_connection: httpapi`` as soon as possible.
 
-Using CLI in Ansible 2.5
+Using CLI in Ansible 2.6
 ================================================================================
 
 Example CLI ``group_vars/nxos.yml``
@@ -67,7 +67,7 @@ Example CLI Task
 
 
 
-Using NX-API in Ansible 2.5
+Using NX-API in Ansible 2.6
 ================================================================================
 
 Enabling NX-API


### PR DESCRIPTION
(cherry picked from commit e2146a76969a60dc7b2e81ad8884602ec82c9128)

##### SUMMARY
Updates version number on platform-specific docs from 2.5 to 2.6.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
docs.ansible.com

##### ANSIBLE VERSION
2.6

