### PR TITLE
add --save or --no-save based on npm version

### DIFF
--- a/changelogs/fragments/npm_no_save.yml
+++ b/changelogs/fragments/npm_no_save.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - npm - add `no_save` parameter which prevent saving changes to package.json and package-lock.json with npm 5 and later

--- a/test/integration/targets/npm/files/package-lock.json
+++ b/test/integration/targets/npm/files/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "ansible-test",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "ansible-dummy-package": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ansible-dummy-package/-/ansible-dummy-package-1.0.0.tgz",
+      "integrity": "sha512-ri6UMtQDOM//Kw5eE1tTUlLmEuHa/Xac5jneKotfj2GJ2e7bODRaofGIyBoQzjZOYcAMdyOiK1J47Tni819nEg=="
+    }
+  }
+}

--- a/test/integration/targets/npm/files/package.json
+++ b/test/integration/targets/npm/files/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "ansible-test",
+  "version": "1.0.0",
+  "description": "",
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "ansible-dummy-package": ">=1.0.0"
+  }
+}

--- a/test/integration/targets/npm/tasks/run.yml
+++ b/test/integration/targets/npm/tasks/run.yml
@@ -1,2 +1,13 @@
 - include_tasks: setup.yml
-- include_tasks: test.yml
+- include_tasks: test_single_package.yml
+- include_tasks: test_package_json.yml
+  vars:
+    npm_has_package_lock: '{{ npm_testcase.0 }}'
+    npm_no_save: '{{ npm_testcase.1 }}'
+    npm_state: '{{ npm_testcase.2 }}'
+  with_nested:
+    - [yes, no]
+    - [yes, no]
+    - ['present', 'latest']
+  loop_control:
+    loop_var: npm_testcase

--- a/test/integration/targets/npm/tasks/test_package_json.yml
+++ b/test/integration/targets/npm/tasks/test_package_json.yml
@@ -1,0 +1,107 @@
+- name: 'Remove any node modules or package.json file'
+  file:
+    path: '{{ remote_dir }}/{{ filename }}'
+    state: absent
+  with_items:
+    - 'node_modules'
+    - 'package.json'
+    - 'package-lock.json'
+  loop_control:
+    loop_var: filename
+
+- name: 'Create package.json file'
+  copy:
+    dest: '{{ remote_dir }}/package.json'
+    src: 'package.json'
+
+- name: 'Create package-lock.json file'
+  copy:
+    dest: '{{ remote_dir }}/package-lock.json'
+    src: 'package-lock.json'
+  when: npm_has_package_lock
+
+- vars:
+    # sample: node-v8.2.0-linux-x64.tar.xz
+    node_path: '{{ remote_dir }}/{{ nodejs_path }}/bin'
+  block:
+    - shell: npm --version
+      environment:
+        PATH: '{{ node_path }}:{{ ansible_env.PATH }}'
+      register: npm_version
+
+    - debug:
+        var: npm_version.stdout
+
+    - name: 'Install package.json content (npm: {{ npm_version.stdout }}, package-lock.json: {{ npm_has_package_lock }}'
+      npm:
+        path: '{{ remote_dir }}'
+        executable: '{{ node_path }}/npm'
+        state: '{{ npm_state }}'
+        no_save: '{{ npm_no_save }}'
+      environment:
+        PATH: '{{ node_path }}:{{ ansible_env.PATH }}'
+      register: npm_install
+
+    - assert:
+        that:
+        - npm_install is success
+        - npm_install is changed
+
+    - name: 'Check package.json version'
+      command: grep ">=1.0.0" {{ remote_dir }}/package.json
+      ignore_errors: yes
+      register: package_json_version
+      changed_when: package_json_version is failed
+
+    - assert:
+        that:
+          - package_json_version is not changed
+      when: npm_no_save
+
+    - assert:
+        that:
+          - package_json_version is changed
+      when: not npm_no_save and npm_state == 'latest'
+
+    - name: 'Check package-lock.json has been created'
+      stat:
+        path: '{{ remote_dir }}/package-lock.json'
+      register: package_lock
+      when: nodejs_version is version('8.0.0', '>=') and not npm_has_package_lock
+
+    - assert:
+        that:
+          - package_lock.stat.exists != npm_no_save
+      when: nodejs_version is version('8.0.0', '>=') and not npm_has_package_lock
+
+    - name: 'Check package-lock.json version'
+      command: grep Xac5jneKotfj2GJ2e7bODRaofGIyBoQzjZOYcAMdyOiK1J47Tni819nEg {{ remote_dir }}/package-lock.json
+      ignore_errors: yes
+      register: package_lock_version
+      changed_when: package_lock_version is failed
+      when: nodejs_version is version('8.0.0', '>=') and (npm_has_package_lock or package_lock.stat.exists)
+
+    - assert:
+        that:
+          - package_lock_version is not changed
+      when: nodejs_version is version('8.0.0', '>=') and npm_has_package_lock and (npm_state == 'present' or npm_no_save)
+
+    - assert:
+        that:
+          - package_lock_version is changed
+      when: nodejs_version is version('8.0.0', '>=') and not npm_no_save and (npm_state == 'latest' or not npm_has_package_lock)
+
+    - name: 'Reinstall package.json content (npm: {{ npm_version.stdout }}, package-lock.json: {{ npm_has_package_lock }}'
+      npm:
+        path: '{{ remote_dir }}'
+        executable: '{{ node_path }}/npm'
+        state: '{{ npm_state }}'
+        no_save: '{{ npm_no_save }}'
+      environment:
+        PATH: '{{ node_path }}:{{ ansible_env.PATH }}'
+      register: npm_reinstall
+
+    - assert:
+        that:
+        - npm_reinstall is success
+        - npm_reinstall is not changed

--- a/test/integration/targets/npm/tasks/test_single_package.yml
+++ b/test/integration/targets/npm/tasks/test_single_package.yml
@@ -6,7 +6,7 @@
 - vars:
     # sample: node-v8.2.0-linux-x64.tar.xz
     node_path: '{{ remote_dir }}/{{ nodejs_path }}/bin'
-    package: 'iconv-lite'
+    package: 'ansible-dummy-package'
   block:
     - shell: npm --version
       environment:


### PR DESCRIPTION
##### SUMMARY
Before npm5, `install` and `update` npm subcommands did not create any changes on the `package.json` file. After npm5, a new `package-lock.json` file is created and updated by `npm install`. If given a package name, `npm install` save the dependency to `package.json` which was not the case before npm 5. Furthermore, in npm > 5, the `package.json` can also be modified by `npm update`.

We can assume on deployment situation, we do not want the files (most often cloned from a git repository) to be modified on package installation. This was the behavior of this ansible module before npm 5.

The behavior of this ansible module should be consistent whatever the version of npm is installed on the host. The current behavior is not consistent (this could be considered a bug, not sure).

What does this PR add :
- a `no_save` parameter to the module, default "yes"
- a automatic detection of npm version, adding `--no-save` to command executions if npm > 5 and `no_save` is `yes` and adding `--save` to command executions if npm < 5 and `no_save` is 'no'

##### COMPONENT NAME
npm