### PR TITLE
Make example work: "Import Zabbix Temlate"

### DIFF
--- a/lib/ansible/modules/monitoring/zabbix/zabbix_template.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_template.py
@@ -125,7 +125,7 @@ EXAMPLES = '''
     server_url: http://127.0.0.1
     template_name: Test Template
     template_json:
-        zabbix_export:
+      zabbix_export:
         version: '3.2'
         templates:
           - name: Template for Testing


### PR DESCRIPTION
+label: docsite_pr

##### SUMMARY
Fix non-working example for zabbix_template module.

It was a small typo, but it was hard to find, why the ansible module execution failed.

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
zabbix_template

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0
  config file = /home/d0e01962/.ansible.cfg
  configured module search path = [u'/home/d0e01962/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/d0e01962/.local/lib/python2.7/site-packages/ansible
  executable location = /home/d0e01962/.local/bin/ansible
  python version = 2.7.15rc1 (default, Apr 15 2018, 21:51:34) [GCC 7.3.0]
```


