### PR TITLE
add keywords handling to ansible-doc

### DIFF
--- a/changelogs/fragments/adoc_keys.yml
+++ b/changelogs/fragments/adoc_keys.yml
@@ -1,0 +1,2 @@
+- bugfixes:
+    - allow ansible-doc to handle 'keywords' configuration entries https://github.com/ansible/ansible/pull/40620


### PR DESCRIPTION
 also add check for sequence of string types before we force a join

(cherry picked from commit 73b98926052ee62b7df2c91916b6961e77ff74dc)

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
ansible-doc
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```