### PR TITLE
reinstates connection:local as an option for nxapi (#40834)

### DIFF
--- a/docs/docsite/rst/network/user_guide/platform_nxos.rst
+++ b/docs/docsite/rst/network/user_guide/platform_nxos.rst
@@ -22,6 +22,10 @@ Connections Available
 | **Indirect Access**       | via a bastion (jump host)                     | via a web proxy                         |
 +---------------------------+-----------------------------------------------+-----------------------------------------+
 | | **Connection Settings** | | ``ansible_connection: network_cli``         | | ``ansible_connection: httpapi``       |
+| |                         | |                                             | | OR                                    |
+| |                         | |                                             | | ``ansible_connection: local``         |
+| |                         | |                                             | | with ``transport: nxapi``             |
+| |                         | |                                             | | in the ``provider`` dictionary        |
 +---------------------------+-----------------------------------------------+-----------------------------------------+
 | | **Enable Mode**         | | supported - use ``ansible_become: yes``     | | not supported by NX-API               |
 | | (Privilege Escalation)  | | with ``ansible_become_method: enable``      | |                                       |


### PR DESCRIPTION
(cherry picked from commit 0e0a5243c8baa6c706ab27efaaa89b82c7958688)

##### SUMMARY
Reinstates `connection: local` as a documented option for nxapi.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
docs.ansible.com

##### ANSIBLE VERSION
2.6

