### PR TITLE
Fix pkg_mgr_name fact finding for Fedora

### DIFF
--- a/lib/ansible/module_utils/facts/system/pkg_mgr.py
+++ b/lib/ansible/module_utils/facts/system/pkg_mgr.py
@@ -94,7 +94,7 @@ class PkgMgrFactCollector(BaseFactCollector):
         # apt is easily installable and supported by distros other than those
         # that are debian based, this handles some of those scenarios as they
         # are reported/requested
-        if pkg_mgr_name == 'apt':
+        if pkg_mgr_name == 'apt' and collected_facts['ansible_os_family'] in ["RedHat", "Altlinux"]:
             if collected_facts['ansible_distribution'] == 'Fedora':
                 pkg_mgr_name = self._check_fedora_versions(collected_facts)
 
@@ -104,7 +104,7 @@ class PkgMgrFactCollector(BaseFactCollector):
         # pacman has become available by distros other than those that are Arch
         # based by virtue of a dependency to the systemd mkosi project, this
         # handles some of those scenarios as they are reported/requested
-        if pkg_mgr_name == 'pacman':
+        if pkg_mgr_name == 'pacman' and collected_facts['ansible_os_family'] in ["RedHat"]:
             if collected_facts['ansible_distribution'] == 'Fedora':
                 pkg_mgr_name = self._check_fedora_versions(collected_facts)
 

--- a/lib/ansible/module_utils/facts/system/pkg_mgr.py
+++ b/lib/ansible/module_utils/facts/system/pkg_mgr.py
@@ -70,10 +70,7 @@ class PkgMgrFactCollector(BaseFactCollector):
     _platform = 'Generic'
     required_facts = set(['distribution'])
 
-    import q
-    @q.t
     def _check_fedora_versions(self, collected_facts):
-        import q; q(collected_facts['ansible_distribution_major_version'])
         try:
             if int(collected_facts['ansible_distribution_major_version']) < 15:
                 pkg_mgr_name = 'yum'
@@ -98,7 +95,6 @@ class PkgMgrFactCollector(BaseFactCollector):
         # that are debian based, this handles some of those scenarios as they
         # are reported/requested
         if pkg_mgr_name == 'apt':
-            import q; q(collected_facts['ansible_distribution'])
             if collected_facts['ansible_distribution'] == 'Fedora':
                 pkg_mgr_name = self._check_fedora_versions(collected_facts)
 

--- a/test/integration/targets/package/tasks/main.yml
+++ b/test/integration/targets/package/tasks/main.yml
@@ -24,11 +24,33 @@
 - name: create our testing sub-directory
   file: path="{{ output_dir_test }}" state=directory
 
+# Verify correct default package manager for Fedora
+# Validates: https://github.com/ansible/ansible/issues/34014
+- block:
+    - name: install apt
+      dnf:
+        name: apt
+        state: present
+    - name: gather facts again
+      setup:
+    - name: validate output
+      assert:
+        that:
+          - 'ansible_pkg_mgr == "dnf"'
+  always:
+    - name: remove apt
+      dnf:
+        name: apt
+        state: absent
+    - name: gather facts again
+      setup:
+  when: ansible_distribution == "Fedora"
+
 ##
 ## package
 ##
 
-- name: define distros to attempt installing at on 
+- name: define distros to attempt installing at on
   set_fact:
     package_distros:
         - RedHat

--- a/test/units/module_utils/facts/test_ansible_collector.py
+++ b/test/units/module_utils/facts/test_ansible_collector.py
@@ -202,6 +202,8 @@ class TestCollectedFacts(unittest.TestCase):
                       'env']
     not_expected_facts = ['facter', 'ohai']
 
+    collected_facts = {}
+
     def _mock_module(self, gather_subset=None):
         return mock_module(gather_subset=self.gather_subset)
 
@@ -212,7 +214,8 @@ class TestCollectedFacts(unittest.TestCase):
         fact_collector = \
             ansible_collector.AnsibleFactCollector(collectors=collectors,
                                                    namespace=ns)
-        self.facts = fact_collector.collect(module=mock_module)
+        self.facts = fact_collector.collect(module=mock_module,
+                                            collected_facts=self.collected_facts)
 
     def _collectors(self, module,
                     all_collector_classes=None,
@@ -466,10 +469,14 @@ class TestOhaiCollectedFacts(TestCollectedFacts):
 class TestPkgMgrFacts(TestCollectedFacts):
     gather_subset = ['pkg_mgr']
     min_fact_count = 1
-    max_fact_count = 10
+    max_fact_count = 20
     expected_facts = ['gather_subset',
                       'module_setup',
                       'pkg_mgr']
+    collected_facts = {
+        "ansible_distribution": "Fedora",
+        "ansible_distribution_major_version": "28"
+    }
 
 
 class TestOpenBSDPkgMgrFacts(TestPkgMgrFacts):

--- a/test/units/module_utils/facts/test_ansible_collector.py
+++ b/test/units/module_utils/facts/test_ansible_collector.py
@@ -475,7 +475,8 @@ class TestPkgMgrFacts(TestCollectedFacts):
                       'pkg_mgr']
     collected_facts = {
         "ansible_distribution": "Fedora",
-        "ansible_distribution_major_version": "28"
+        "ansible_distribution_major_version": "28",
+        "ansible_os_family": "RedHat"
     }
 
 

--- a/test/units/module_utils/facts/test_collectors.py
+++ b/test/units/module_utils/facts/test_collectors.py
@@ -258,12 +258,8 @@ class TestPkgMgrFactsAptFedora(BaseFactsTest):
         "ansible_pkg_mgr": "apt"
     }
 
-    import ansible.module_utils.facts.system.pkg_mgr
-    ansible.module_utils.facts.system.pkg_mgr.os = Mock()
-    ansible.module_utils.facts.system.pkg_mgr.os.path = Mock()
-    ansible.module_utils.facts.system.pkg_mgr.os.path.exists = Mock(side_effect=_sanitize_os_path_apt_get)
-
-    def test_collect(self):
+    @patch('ansible.module_utils.facts.system.pkg_mgr.os.path.exists', side_effect=_sanitize_os_path_apt_get)
+    def test_collect(self, mock_os_path_exists):
         module = self._mock_module()
         fact_collector = self.collector_class()
         facts_dict = fact_collector.collect(module=module, collected_facts=self.collected_facts)

--- a/test/units/module_utils/facts/test_collectors.py
+++ b/test/units/module_utils/facts/test_collectors.py
@@ -226,7 +226,8 @@ class TestPkgMgrFacts(BaseFactsTest):
     collector_class = PkgMgrFactCollector
     collected_facts = {
         "ansible_distribution": "Fedora",
-        "ansible_distribution_major_version": "28"
+        "ansible_distribution_major_version": "28",
+        "ansible_os_family": "RedHat"
     }
 
     def test_collect(self):
@@ -253,6 +254,7 @@ class TestPkgMgrFactsAptFedora(BaseFactsTest):
     collected_facts = {
         "ansible_distribution": "Fedora",
         "ansible_distribution_major_version": "28",
+        "ansible_os_family": "RedHat",
         "ansible_pkg_mgr": "apt"
     }
 

--- a/test/units/module_utils/facts/test_collectors.py
+++ b/test/units/module_utils/facts/test_collectors.py
@@ -224,6 +224,42 @@ class TestPkgMgrFacts(BaseFactsTest):
     valid_subsets = ['pkg_mgr']
     fact_namespace = 'ansible_pkgmgr'
     collector_class = PkgMgrFactCollector
+    collected_facts = {
+        "ansible_distribution": "Fedora",
+        "ansible_distribution_major_version": "28"
+    }
+
+    def test_collect(self):
+        module = self._mock_module()
+        fact_collector = self.collector_class()
+        facts_dict = fact_collector.collect(module=module, collected_facts=self.collected_facts)
+        self.assertIsInstance(facts_dict, dict)
+        self.assertIn('pkg_mgr', facts_dict)
+
+
+def _sanitize_os_path_apt_get(path):
+    if path == '/usr/bin/apt-get':
+        return True
+    else:
+        return False
+
+
+class TestPkgMgrFactsAptFedora(BaseFactsTest):
+    __test__ = True
+    gather_subset = ['!all', 'pkg_mgr']
+    valid_subsets = ['pkg_mgr']
+    fact_namespace = 'ansible_pkgmgr'
+    collector_class = PkgMgrFactCollector
+    collected_facts = {
+        "ansible_distribution": "Fedora",
+        "ansible_distribution_major_version": "28",
+        "ansible_pkg_mgr": "apt"
+    }
+
+    import ansible.module_utils.facts.system.pkg_mgr
+    ansible.module_utils.facts.system.pkg_mgr.os = Mock()
+    ansible.module_utils.facts.system.pkg_mgr.os.path = Mock()
+    ansible.module_utils.facts.system.pkg_mgr.os.path.exists = Mock(side_effect=_sanitize_os_path_apt_get)
 
     def test_collect(self):
         module = self._mock_module()


### PR DESCRIPTION
Signed-off-by: Adam Miller <admiller@redhat.com>

##### SUMMARY
Raises priority of `dnf` over `apt` because it's possible to install `apt` on Fedora from the official distro repositories but not the other way around.

Add integration tests to ensure this doesn't break in the future.

Fixes #34014
Fixes #27300

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
lib/ansible/module_utils/facts/system/pkg_mgr.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0dev0 (facts/system/pkg_mgr 14a2dc89ca) last updated 2018/05/30 16:13:01 (GMT -500)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/admiller/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/admiller/src/dev/ansible/lib/ansible
  executable location = /home/admiller/src/dev/ansible/bin/ansible
  python version = 2.7.15 (default, May 15 2018, 15:37:31) [GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]
```


