### PR TITLE
Fixes lxc container start with possibly invalid config

### DIFF
--- a/lib/ansible/modules/cloud/lxc/lxc_container.py
+++ b/lib/ansible/modules/cloud/lxc/lxc_container.py
@@ -903,6 +903,9 @@ class LxcContainerManagement(object):
         else:
             self.state_change = True
 
+        # Perform initial configuration
+        self._config()
+
     def _container_data(self):
         """Returns a dict of container information.
 


### PR DESCRIPTION
##### SUMMARY
Apply container config options right after container creation and before starting it.
Otherwise the container config is possibly invalid or incomplete and lxc fails to start it. I added `self._config()` as last command of the `_create(self)` function to fix this, independent of the container state.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lxc_container

##### ANSIBLE VERSION
```
ansible 2.5.2
  python version = 2.7.15 (default, May  1 2018, 16:44:37) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```


##### ADDITIONAL INFORMATION
```
- name: create container
  lxc_container:
    name: test
    template: alpine
    state: started
    container_config:
      - "lxc.network.ipv4 = 172.16.0.2"
```
In this example it's important to set the static IP for the container before starting it.