### PR TITLE
fix stack_model and stack_serialnum case matching

### DIFF
--- a/lib/ansible/modules/network/ios/ios_facts.py
+++ b/lib/ansible/modules/network/ios/ios_facts.py
@@ -204,11 +204,11 @@ class Default(FactsBase):
             return match.group(1)
 
     def parse_stacks(self, data):
-        match = re.findall(r'^Model number\s+: (\S+)', data, re.M)
+        match = re.findall(r'^Model [Nn]umber\s+: (\S+)', data, re.M)
         if match:
             self.facts['stacked_models'] = match
 
-        match = re.findall(r'^System serial number\s+: (\S+)', data, re.M)
+        match = re.findall(r'^System [Ss]erial [Nn]umber\s+: (\S+)', data, re.M)
         if match:
             self.facts['stacked_serialnums'] = match
 


### PR DESCRIPTION
Account for upper/lower case match occurrences of "[Nn]umber" and "[Ss]erial"

Model Number                       : WS-C3850-12X48U
System Serial Number          :  <removed>

##### SUMMARY
For stack type switches, string matching for "Model number" and "serial number" need to account for upper and lower case.  "Number" or "number", and "Serial" or "serial" are all valid depending on switch model and/or IOS version.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ios_facts

##### ANSIBLE VERSION
```
ansible 2.7.0dev0
  config file = /home/vagrant/ansible.cfg
  configured module search path = [u'/home/vagrant/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]

```


##### ADDITIONAL INFORMATION
BEFORE CHANGES:
- A 3750X-48 (IOS 12.2(55)SE7) stack works, i.e. the models and serial #'s are returned as the strings "Model number" and "System serial number" are matched.
- Both C3850-48U (IOS 03.07.03E) and 3850-12X48U (IOS 03.07.05) stacks do not work, i.e. the models and serial #'s ARE NOT returned as the strings "Model Number" and "System Serial Number" ARE NOT matched.

AFTER CHANGES:  All three scenarios of 3750X-48, 3850-48U and 3850-12X48U return models and serial #s as expected.

```
**** BEFORE AND AFTER CHANGE with 3750X-48 (12.2(55)SE7) ****
TASK [debug ansible_net_version] ***********************************************
ok: [hostname removed] => {
    "hostvars[inventory_hostname]['ansible_net_version']": "12.2(55)SE7"
}

TASK [debug ansible_net_stacked_models] ****************************************
ok: [hostname removed] => {
    "hostvars[inventory_hostname]['ansible_net_stacked_models']": [
        "WS-C3750X-48PF-S", 
        "WS-C3750X-48PF-S", 
        "WS-C3750X-48PF-S", 
        "WS-C3750X-48PF-S"
    ]
}

TASK [debug ansible_net_stacked_serialnums] ************************************
ok: [hostname removed] => {
    "hostvars[inventory_hostname]['ansible_net_stacked_serialnums']": [
        "FXXXXXXXXX1", 
        "FXXXXXXXXX2", 
        "FXXXXXXXXX3", 
        "FXXXXXXXXX4", 
    ]
}


**** BEFORE CHANGE with 3850-12X48U (03.07.05) ****
TASK [debug ansible_net_version] ***********************************************
ok: [hostname removed] => {
    "hostvars[inventory_hostname]['ansible_net_version']": "03.07.05E"
}

TASK [debug ansible_net_stacked_models] ****************************************
ok: [hostname removed] => {
    "hostvars[inventory_hostname]['ansible_net_stacked_models']": "VARIABLE IS NOT DEFINED!"
}

TASK [debug ansible_net_stacked_serialnums] ************************************
ok: [hostname removed] => {
    "hostvars[inventory_hostname]['ansible_net_stacked_serialnums']": "VARIABLE IS NOT DEFINED!"
}

**** AFTER CHANGE with 3850-12X48U (03.07.05) ****
TASK [debug ansible_net_version] ***********************************************
ok: [hostname removed] => {
    "hostvars[inventory_hostname]['ansible_net_version']": "03.07.05E"
}

TASK [debug ansible_net_stacked_models] ****************************************
ok: [hostname removed] => {
    "hostvars[inventory_hostname]['ansible_net_stacked_models']": [
        "WS-C3850-12X48U", 
        "WS-C3850-12X48U", 
        "WS-C3850-12X48U", 
        "WS-C3850-12X48U", 
        "WS-C3850-12X48U", 
        "WS-C3850-12X48U", 
        "WS-C3850-12X48U"
    ]
}

TASK [debug ansible_net_stacked_serialnums] ************************************
ok: [hostname removed] => {
    "hostvars[inventory_hostname]['ansible_net_stacked_serialnums']": [
        "FXXXXXXXXX1", 
        "FXXXXXXXXX2", 
        "FXXXXXXXXX3", 
        "FXXXXXXXXX4", 
        "FXXXXXXXXX5", 
        "FXXXXXXXXX6", 
        "FXXXXXXXXX7"
    ]
}

```
