### PR TITLE
ovirt_templates: Add searching by cluster

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_disk.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_disk.py
@@ -555,6 +555,18 @@ class DiskAttachmentsModule(DisksModule):
         )
 
 
+def searchable_attributes(module):
+    """
+    Return all searchable disk attributes passed to module.
+    """
+    attributes = {
+        'name': module.params.get('name'),
+        'Storage.name': module.params.get('storage_domain'),
+        'vm_names': module.params.get('vm_name'),
+    }
+    return {k: v for k, v in attributes.items() if v is not None}
+
+
 def main():
     argument_spec = ovirt_full_argument_spec(
         state=dict(
@@ -616,6 +628,7 @@ def main():
         if state in ('present', 'detached', 'attached'):
             ret = disks_module.create(
                 entity=disk,
+                search_params=searchable_attributes(module),
                 result_state=otypes.DiskStatus.OK if lun is None else None,
                 fail_condition=lambda d: d.status == otypes.DiskStatus.ILLEGAL if lun is None else False,
             )

--- a/lib/ansible/modules/cloud/ovirt/ovirt_disk.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_disk.py
@@ -564,7 +564,7 @@ def searchable_attributes(module):
         'Storage.name': module.params.get('storage_domain'),
         'vm_names': module.params.get('vm_name'),
     }
-    return {k: v for k, v in attributes.items() if v is not None}
+    return dict((k, v) for k, v in attributes.items() if v is not None)
 
 
 def main():

--- a/lib/ansible/modules/cloud/ovirt/ovirt_templates.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_templates.py
@@ -422,6 +422,17 @@ def _get_vnic_profile_mappings(module):
     return vnicProfileMappings
 
 
+def searchable_attributes(module):
+    """
+    Return all searchable template attributes passed to module.
+    """
+    attributes = {
+        'name': module.params.get('name'),
+        'cluster': module.params.get('cluster'),
+    }
+    return {k: v for k, v in attributes.items() if v is not None}
+
+
 def main():
     argument_spec = ovirt_full_argument_spec(
         state=dict(
@@ -474,6 +485,7 @@ def main():
         if state == 'present':
             ret = templates_module.create(
                 result_state=otypes.TemplateStatus.OK,
+                search_params=searchable_attributes(module),
                 clone_permissions=module.params['clone_permissions'],
                 seal=module.params['seal'],
             )

--- a/lib/ansible/modules/cloud/ovirt/ovirt_templates.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_templates.py
@@ -430,7 +430,7 @@ def searchable_attributes(module):
         'name': module.params.get('name'),
         'cluster': module.params.get('cluster'),
     }
-    return {k: v for k, v in attributes.items() if v is not None}
+    return dict((k, v) for k, v in attributes.items() if v is not None)
 
 
 def main():


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This PR fixes searching the template. Previously we searched by `name`, but it's not enough as template could have same names in different clusters, so we improve the search to search also by `cluster` name.

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
ovirt_templates

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5.3
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
