### PR TITLE
Fix: wildcard excludes in unarchive with tar archives

### DIFF
--- a/lib/ansible/modules/files/unarchive.py
+++ b/lib/ansible/modules/files/unarchive.py
@@ -647,7 +647,7 @@ class TgzArchive(object):
         if self.opts:
             cmd.extend(['--show-transformed-names'] + self.opts)
         if self.excludes:
-            cmd.extend(['--exclude=' + quote(f) for f in self.excludes])
+            cmd.extend(['--exclude=' + f for f in self.excludes])
         cmd.extend(['-f', self.src])
         rc, out, err = self.module.run_command(cmd, cwd=self.dest, environ_update=dict(LANG='C', LC_ALL='C', LC_MESSAGES='C'))
         if rc != 0:
@@ -686,7 +686,7 @@ class TgzArchive(object):
         if self.module.params['keep_newer']:
             cmd.append('--keep-newer-files')
         if self.excludes:
-            cmd.extend(['--exclude=' + quote(f) for f in self.excludes])
+            cmd.extend(['--exclude=' + f for f in self.excludes])
         cmd.extend(['-f', self.src])
         rc, out, err = self.module.run_command(cmd, cwd=self.dest, environ_update=dict(LANG='C', LC_ALL='C', LC_MESSAGES='C'))
 
@@ -733,7 +733,7 @@ class TgzArchive(object):
         if self.module.params['keep_newer']:
             cmd.append('--keep-newer-files')
         if self.excludes:
-            cmd.extend(['--exclude=' + quote(f) for f in self.excludes])
+            cmd.extend(['--exclude=' + f for f in self.excludes])
         cmd.extend(['-f', self.src])
         rc, out, err = self.module.run_command(cmd, cwd=self.dest, environ_update=dict(LANG='C', LC_ALL='C', LC_MESSAGES='C'))
         return dict(cmd=cmd, rc=rc, out=out, err=err)

--- a/lib/ansible/modules/files/unarchive.py
+++ b/lib/ansible/modules/files/unarchive.py
@@ -658,14 +658,18 @@ class TgzArchive(object):
             # filename = filename.decode('string_escape')
             filename = to_native(codecs.escape_decode(filename)[0])
 
-            if filename and filename not in self.excludes:
-                # We don't allow absolute filenames.  If the user wants to unarchive rooted in "/"
-                # they need to use "dest: '/'".  This follows the defaults for gtar, pax, etc.
-                # Allowing absolute filenames here also causes bugs: https://github.com/ansible/ansible/issues/21397
-                if filename.startswith('/'):
-                    filename = filename[1:]
+            # We don't allow absolute filenames.  If the user wants to unarchive rooted in "/"
+            # they need to use "dest: '/'".  This follows the defaults for gtar, pax, etc.
+            # Allowing absolute filenames here also causes bugs: https://github.com/ansible/ansible/issues/21397
+            if filename.startswith('/'):
+                filename = filename[1:]
 
-                self._files_in_archive.append(filename)
+            if self.excludes:
+                for exclude in self.excludes:
+                    if not fnmatch.fnmatch(filename, exclude):
+                        self._files_in_archive.append(to_native(filename))
+            else:
+                self._files_in_archive.append(to_native(filename))
 
         return self._files_in_archive
 

--- a/test/integration/targets/unarchive/tasks/main.yml
+++ b/test/integration/targets/unarchive/tasks/main.yml
@@ -224,9 +224,9 @@
 
 - name: Unpack zip file excluding one file.
   unarchive:
-    src: "{{ output_dir }}/test-unarchive.zip"
+    src: "{{ output_dir }}/unarchive-00.zip"
     dest: "{{ output_dir }}/exclude"
-    exclude: "foo-unarchive-*.txt"
+    exclude: "exclude/exclude-*.txt"
 
 - name: verify that the file was unarchived
   shell: find {{ output_dir }}/exclude chdir={{ output_dir }}
@@ -235,7 +235,7 @@
 - name: verify that zip extraction excluded file
   assert:
     that:
-      - "'foo-unarchive-777.txt' not in unarchive_dir01.stdout"
+      - "'exclude/exclude-1.txt' not in unarchive_dir01.stdout"
 
 - name: remove our zip unarchive destination
   file: path={{output_dir}}/test-unarchive-zip state=absent

--- a/test/integration/targets/unarchive/tasks/main.yml
+++ b/test/integration/targets/unarchive/tasks/main.yml
@@ -60,6 +60,39 @@
 - name: prep a zip file
   shell: zip test-unarchive.zip foo-unarchive.txt foo-unarchive-777.txt chdir={{output_dir}}
 
+- name: Prepare - Create test dirs
+  file:
+    path: "{{output_dir}}/{{item}}"
+    state: directory
+  with_items:
+    - created/include
+    - created/exclude
+    - created/other
+
+- name: Prepare - Create test files
+  file:
+    path: "{{output_dir}}/created/{{item}}"
+    state: touch
+  with_items:
+    - include/include-1.txt
+    - include/include-2.txt
+    - include/include-3.txt
+    - exclude/exclude-1.txt
+    - exclude/exclude-2.txt
+    - exclude/exclude-3.txt
+    - other/include-1.ext
+    - other/include-2.ext
+    - other/exclude-1.ext
+    - other/exclude-2.ext
+    - other/other-1.ext
+    - other/other-2.ext
+
+- name: Prepare - zip file
+  shell: zip -r {{output_dir}}/unarchive-00.zip * chdir={{output_dir}}/created/
+
+- name: Prepare - tar file
+  shell: tar czvf unarchive-00.tar {{output_dir}}/created/ chdir={{output_dir}}
+
 - name: add a file with Windows permissions to zip file
   shell: zip -k test-unarchive.zip FOO-UNAR.TXT chdir={{output_dir}}
 

--- a/test/integration/targets/unarchive/tasks/main.yml
+++ b/test/integration/targets/unarchive/tasks/main.yml
@@ -91,7 +91,7 @@
   shell: zip -r {{output_dir}}/unarchive-00.zip * chdir={{output_dir}}/created/
 
 - name: Prepare - tar file
-  shell: tar czvf unarchive-00.tar {{output_dir}}/created/ chdir={{output_dir}}
+  shell: tar czvf {{output_dir}}/unarchive-00.tar * chdir={{output_dir}}/created/
 
 - name: add a file with Windows permissions to zip file
   shell: zip -k test-unarchive.zip FOO-UNAR.TXT chdir={{output_dir}}
@@ -220,22 +220,33 @@
 - name: "Create {{ output_dir }}/exclude directory"
   file:
     state: directory
-    path: "{{ output_dir }}/exclude"
+    path: "{{ output_dir }}/exclude-{{item}}"
+  with_items:
+    - zip
+    - tar
 
-- name: Unpack zip file excluding one file.
+- name: Unpack archive file excluding glob files.
   unarchive:
-    src: "{{ output_dir }}/unarchive-00.zip"
-    dest: "{{ output_dir }}/exclude"
+    src: "{{ output_dir }}/unarchive-00.{{item}}"
+    dest: "{{ output_dir }}/exclude-{{item}}"
     exclude: "exclude/exclude-*.txt"
+  with_items:
+    - zip
+    - tar
 
 - name: verify that the file was unarchived
-  shell: find {{ output_dir }}/exclude chdir={{ output_dir }}
-  register: unarchive_dir01
+  shell: find {{ output_dir }}/exclude-{{item}} chdir={{ output_dir }}
+  register: unarchive00
+  with_items:
+    - zip
+    - tar
 
-- name: verify that zip extraction excluded file
+- name: verify that archive extraction excluded the files
   assert:
     that:
-      - "'exclude/exclude-1.txt' not in unarchive_dir01.stdout"
+      - "'exclude/exclude-1.txt' not in item.stdout"
+  with_items:
+    - "{{ unarchive00.results }}"
 
 - name: remove our zip unarchive destination
   file: path={{output_dir}}/test-unarchive-zip state=absent


### PR DESCRIPTION
##### SUMMARY

Fixes an issue where the exclude option is used and one of the entries contains a wildcard, the unarchive module does not exclude files matching those wildcards as expected.

Fixes #37842, #22947
Related #40120

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
unarchive

##### ANSIBLE VERSION
```
ansible 2.7.0.dev0 (fix/unarchive/exclude_tar d8ef19b0c3) last updated 2018/05/31 02:04:19 (GMT -500)
  config file = None
  configured module search path = ['/home/saviles/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/saviles/data/git/github/ansible/lib/ansible
  executable location = /home/saviles/data/git/github/ansible/bin/ansible
  python version = 3.6.5 (default, Mar 29 2018, 18:20:46) [GCC 8.0.1 20180317 (Red Hat 8.0.1-0.19)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

Playbook used to test
```
- hosts: localhost
  vars:
    issue: 37842
    src_dir: "files/{{ issue }}"
    dst_dir: "/tmp/{{ issue }}"
  tasks:
    - name: Create directory
      file:
        state: directory
        path: "{{item}}"
      with_items:
        - "{{src_dir}}"
        - "{{dst_dir}}"

    - name: Create files
      shell: "touch {{src_dir}}/{include,exclude}-{0..9}.txt"

    - name: Create archive file
      archive:
        format: "tar"
        path: "{{src_dir}}/*"
        dest: "{{src_dir}}.tar"

    - name: Unpack zip file
      unarchive:
        src: "{{src_dir}}.tar"
        dest: "{{dst_dir}}"
        # remote_src: yes
        exclude:
          - "exclude-*.txt"
      register: unzipped

    - name: Debug unzipped
      debug:
        msg: "{{unzipped}}"
        # verbosity: 2
```
Before fix
```
$ ls /tmp/37842/
exclude-0.txt  exclude-2.txt  exclude-4.txt  exclude-6.txt  exclude-8.txt  include-0.txt  include-2.txt  include-4.txt  include-6.txt  include-8.txt
exclude-1.txt  exclude-3.txt  exclude-5.txt  exclude-7.txt  exclude-9.txt  include-1.txt  include-3.txt  include-5.txt  include-7.txt  include-9.txt
```

After fix
```
$ ls /tmp/37842/
include-0.txt  include-1.txt  include-2.txt  include-3.txt  include-4.txt  include-5.txt  include-6.txt  include-7.txt  include-8.txt  include-9.txt
```

I still need to include integration tests.