### PR TITLE
Add groupby_custom_field exclusions to VMware Inventory

### DIFF
--- a/contrib/inventory/vmware_inventory.ini
+++ b/contrib/inventory/vmware_inventory.ini
@@ -89,6 +89,11 @@ password=vmware
 # Warning: This required max_object_level to be set to 2 or greater.
 #groupby_custom_field = False
 
+# Exclude a set of fields from being grouped from the "Group by custom fields"
+# function. Has effect only when groupby_custom_field is set to True.
+# If the value is comma separated multiple exclusions will take place.
+#groupby_custom_field_excludes = ''
+
 # You can customize prefix used by custom field hostgroups generation here.
 # vmware_tag_ prefix is the default and consistent with ec2_tag_
 #custom_field_group_prefix = 'vmware_tag_'

--- a/contrib/inventory/vmware_inventory.py
+++ b/contrib/inventory/vmware_inventory.py
@@ -99,6 +99,7 @@ class VMWareInventory(object):
     host_filters = []
     skip_keys = []
     groupby_patterns = []
+    groupby_custom_field_excludes = []
 
     safe_types = [bool, str, float, None] + list(integer_types)
     iter_types = [dict, list]
@@ -230,6 +231,7 @@ class VMWareInventory(object):
             'groupby_patterns': '{{ guest.guestid }},{{ "templates" if config.template else "guests"}}',
             'lower_var_keys': True,
             'custom_field_group_prefix': 'vmware_tag_',
+            'groupby_custom_field_excludes': '',
             'groupby_custom_field': False}
         }
 
@@ -304,6 +306,10 @@ class VMWareInventory(object):
                     groupby_pattern += "}}"
                 self.groupby_patterns.append(groupby_pattern)
         self.debugl('groupby patterns are %s' % self.groupby_patterns)
+        
+        temp_groupby_custom_field_excludes = config.get('vmware', 'groupby_custom_field_excludes')
+        self.groupby_custom_field_excludes = [x.strip('"') for x in [y.strip("'") for y in temp_groupby_custom_field_excludes.split(',')]]
+        self.debugl('groupby exclude strings are %s' % self.groupby_custom_field_excludes)
         # Special feature to disable the brute force serialization of the
         # virtulmachine objects. The key name for these properties does not
         # matter because the values are just items for a larger list.
@@ -496,6 +502,7 @@ class VMWareInventory(object):
                     for tv in v['customvalue']:
                         newkey = None
                         field_name = self.custom_fields[tv['key']] if tv['key'] in self.custom_fields else tv['key']
+                        if field_name in self.groupby_custom_field_excludes: continue
                         values = []
                         keylist = map(lambda x: x.strip(), tv['value'].split(','))
                         for kl in keylist:

--- a/contrib/inventory/vmware_inventory.py
+++ b/contrib/inventory/vmware_inventory.py
@@ -306,7 +306,7 @@ class VMWareInventory(object):
                     groupby_pattern += "}}"
                 self.groupby_patterns.append(groupby_pattern)
         self.debugl('groupby patterns are %s' % self.groupby_patterns)
-        
+
         temp_groupby_custom_field_excludes = config.get('vmware', 'groupby_custom_field_excludes')
         self.groupby_custom_field_excludes = [x.strip('"') for x in [y.strip("'") for y in temp_groupby_custom_field_excludes.split(',')]]
         self.debugl('groupby exclude strings are %s' % self.groupby_custom_field_excludes)
@@ -502,7 +502,8 @@ class VMWareInventory(object):
                     for tv in v['customvalue']:
                         newkey = None
                         field_name = self.custom_fields[tv['key']] if tv['key'] in self.custom_fields else tv['key']
-                        if field_name in self.groupby_custom_field_excludes: continue
+                        if field_name in self.groupby_custom_field_excludes:
+                            continue
                         values = []
                         keylist = map(lambda x: x.strip(), tv['value'].split(','))
                         for kl in keylist:


### PR DESCRIPTION
##### SUMMARY
The `vmware_inventory.py` script has an option to add hosts to groups based on custom fields and their values as they appear on vCenter. By default all fields are fetched, and the addition to groups is always in append - this is not desirable in some scenario where external components (i.e. Backup Softwares) modify frequently the field values, triggering the creation of new groups on each inventory refresh.

With this setting we're able to control which field name will be exempted from becoming a group.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
`vmware_inventory.py`

##### ANSIBLE VERSION
```
ansible 2.5.2
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Aug  4 2017, 00:39:18) [GCC 4.8.5 20150623 (Red Hat 4.8.5-16)]
```


##### ADDITIONAL INFORMATION
Tested successfully using AWX 