### PR TITLE
document a cleaner way to install multiple packages

### DIFF
--- a/lib/ansible/modules/packaging/os/apt.py
+++ b/lib/ansible/modules/packaging/os/apt.py
@@ -157,11 +157,9 @@ EXAMPLES = '''
   apt:
     name: foo
 
-- name: Install a list of packages
+- name: Install multiple packages
   apt:
-    name: "{{ packages }}"
-  vars:
-    packages:
+    name:
     - foo
     - foo-tools
 
@@ -206,18 +204,18 @@ EXAMPLES = '''
     update_cache: yes
     dpkg_options: 'force-confold,force-confdef'
 
-- name: Install a .deb package
+- name: Install a local .deb package
   apt:
     deb: /tmp/mypackage.deb
+
+- name: Install a .deb package from the internet
+  apt:
+    deb: https://example.com/python-ppq_0.1-1_all.deb
 
 - name: Install the build dependencies for package "foo"
   apt:
     pkg: foo
     state: build-dep
-
-- name: Install a .deb package from the internet.
-  apt:
-    deb: https://example.com/python-ppq_0.1-1_all.deb
 
 - name: Remove useless packages from the cache
   apt:


### PR DESCRIPTION
I propose to use this shorter way to install multiple packages at once via the apt-module

+label: docsite_pr

##### SUMMARY
I find this way to install more than one package at once way easier to remember than using a loop or an extra variable.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
apt_module

##### ANSIBLE VERSION
```
ansible 2.5.3
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/hennr/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.15 (default, May  1 2018, 05:55:50) [GCC 7.3.0]
```

##### ADDITIONAL INFORMATION
I re-ordered the both *.deb related commands for a better readability of the docs as well.