### PR TITLE
Fix ec2_ami block_device_mapping volume_size to be int in 2.5

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_ami.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_ami.py
@@ -420,8 +420,8 @@ def create_image(module, connection):
                 device = rename_item_if_exists(device, 'volume_type', 'VolumeType', 'Ebs')
                 device = rename_item_if_exists(device, 'snapshot_id', 'SnapshotId', 'Ebs')
                 device = rename_item_if_exists(device, 'delete_on_termination', 'DeleteOnTermination', 'Ebs')
-                device = rename_item_if_exists(device, 'size', 'VolumeSize', 'Ebs', type=int)
-                device = rename_item_if_exists(device, 'volume_size', 'VolumeSize', 'Ebs', type=int)
+                device = rename_item_if_exists(device, 'size', 'VolumeSize', 'Ebs', attribute_type=int)
+                device = rename_item_if_exists(device, 'volume_size', 'VolumeSize', 'Ebs', attribute_type=int)
                 device = rename_item_if_exists(device, 'iops', 'Iops', 'Ebs')
                 device = rename_item_if_exists(device, 'encrypted', 'Encrypted', 'Ebs')
                 block_device_mapping.append(device)
@@ -626,16 +626,15 @@ def get_image_by_id(module, connection, image_id):
         module.fail_json_aws(e, msg="Error retrieving image by image_id")
 
 
-def rename_item_if_exists(dict_object, attribute, new_attribute, child_node=None, type=None):
+def rename_item_if_exists(dict_object, attribute, new_attribute, child_node=None, attribute_type=None):
     new_item = dict_object.get(attribute)
     if new_item is not None:
-        value = dict_object.get(attribute)
-        if type is not None:
-            value = type(dict_object.get(attribute))
+        if attribute_type is not None:
+            new_item = attribute_type(new_item)
         if child_node is None:
-            dict_object[new_attribute] = value
+            dict_object[new_attribute] = new_item
         else:
-            dict_object[child_node][new_attribute] = value
+            dict_object[child_node][new_attribute] = new_item
         dict_object.pop(attribute)
     return dict_object
 

--- a/lib/ansible/modules/cloud/amazon/ec2_ami.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_ami.py
@@ -420,8 +420,8 @@ def create_image(module, connection):
                 device = rename_item_if_exists(device, 'volume_type', 'VolumeType', 'Ebs')
                 device = rename_item_if_exists(device, 'snapshot_id', 'SnapshotId', 'Ebs')
                 device = rename_item_if_exists(device, 'delete_on_termination', 'DeleteOnTermination', 'Ebs')
-                device = rename_item_if_exists(device, 'size', 'VolumeSize', 'Ebs')
-                device = rename_item_if_exists(device, 'volume_size', 'VolumeSize', 'Ebs')
+                device = rename_item_if_exists(device, 'size', 'VolumeSize', 'Ebs', type=int)
+                device = rename_item_if_exists(device, 'volume_size', 'VolumeSize', 'Ebs', type=int)
                 device = rename_item_if_exists(device, 'iops', 'Iops', 'Ebs')
                 device = rename_item_if_exists(device, 'encrypted', 'Encrypted', 'Ebs')
                 block_device_mapping.append(device)
@@ -626,13 +626,16 @@ def get_image_by_id(module, connection, image_id):
         module.fail_json_aws(e, msg="Error retrieving image by image_id")
 
 
-def rename_item_if_exists(dict_object, attribute, new_attribute, child_node=None):
+def rename_item_if_exists(dict_object, attribute, new_attribute, child_node=None, type=None):
     new_item = dict_object.get(attribute)
     if new_item is not None:
+        value = dict_object.get(attribute)
+        if type is not None:
+            value = type(dict_object.get(attribute))
         if child_node is None:
-            dict_object[new_attribute] = dict_object.get(attribute)
+            dict_object[new_attribute] = value
         else:
-            dict_object[child_node][new_attribute] = dict_object.get(attribute)
+            dict_object[child_node][new_attribute] = value
         dict_object.pop(attribute)
     return dict_object
 


### PR DESCRIPTION
##### SUMMARY
boto3 added type validation to many methods #28506. Similar to #18999 and #32291, the ec2_ami module didn't cast the volume_size parameter to int before passing it to boto. This was fine if the yaml used an integer value, but if a string was used (because of templating, or variable substitution mostly), a type error was raised.

This #32738 PR will make this PR obsolete. But until then, i think this is a valid fix.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ec2_ami

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.3
  config file = None
  configured module search path = ['/root/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /app/vendor/python3/lib/python3.5/site-packages/ansible
  executable location = /app/vendor/python3/bin/ansible
  python version = 3.5.3 (default, Jan 19 2017, 14:11:04) [GCC 6.3.0 20170118]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
If we have a task like this:
```
- ec2_ami:
    name: "{{ ami_name }}"
    state: present
    device_mapping:
      - device_name: /dev/sda1
        volume_size: "{{ ami_size|int }}"
# ...
```
We will get an error that `volume_size` isn't correct type:
```
TASK [ec2_ami] *****************************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: Invalid type for parameter BlockDeviceMappings[0].Ebs.VolumeSize, value: 10, type: <class 'str'>, valid types: <class 'int'>
```
After applying the PR, there is no issues anymore.
