### PR TITLE
Fix for updating the name in case of host record and network view and also display meaningful error in case of connection timeout

### DIFF
--- a/lib/ansible/module_utils/net_tools/nios/api.py
+++ b/lib/ansible/module_utils/net_tools/nios/api.py
@@ -26,10 +26,9 @@
 # USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-
 import os
 from functools import partial
-
+from ansible.module_utils._text import to_native
 from ansible.module_utils.six import iteritems
 from ansible.module_utils._text import to_text
 
@@ -40,7 +39,15 @@ try:
 except ImportError:
     HAS_INFOBLOX_CLIENT = False
 
-nios_provider_spec = {
+# defining nios constants
+NIOS_DNS_VIEW = 'view'
+NIOS_NETWORK_VIEW = 'networkview'
+NIOS_HOST_RECORD = 'record:host'
+NIOS_IPV4_NETWORK = 'network'
+NIOS_IPV6_NETWORK = 'ipv6network'
+NIOS_ZONE = 'zone_auth'
+
+NIOS_PROVIDER_SPEC = {
     'host': dict(),
     'username': dict(),
     'password': dict(no_log=True),
@@ -57,10 +64,8 @@ nios_provider_spec = {
 
 def get_connector(*args, **kwargs):
     ''' Returns an instance of infoblox_client.connector.Connector
-
     :params args: positional arguments are silently ignored
     :params kwargs: dict that is passed to Connector init
-
     :returns: Connector
     '''
     if not HAS_INFOBLOX_CLIENT:
@@ -68,12 +73,11 @@ def get_connector(*args, **kwargs):
                         'to be installed.  It can be installed using the '
                         'command `pip install infoblox-client`')
 
-    if not set(kwargs.keys()).issubset(nios_provider_spec.keys()):
+    if not set(kwargs.keys()).issubset(NIOS_PROVIDER_SPEC.keys()):
         raise Exception('invalid or unsupported keyword argument for connector')
-
-    for key, value in iteritems(nios_provider_spec):
+    for key, value in iteritems(NIOS_PROVIDER_SPEC):
         if key not in kwargs:
-            # apply default values from nios_provider_spec since we cannot just
+            # apply default values from NIOS_PROVIDER_SPEC since we cannot just
             # assume the provider values are coming from AnsibleModule
             if 'default' in value:
                 kwargs[key] = value['default']
@@ -89,11 +93,9 @@ def get_connector(*args, **kwargs):
 
 def normalize_extattrs(value):
     ''' Normalize extattrs field to expected format
-
     The module accepts extattrs as key/value pairs.  This method will
     transform the key/value pairs into a structure suitable for
     sending across WAPI in the format of:
-
         extattrs: {
             key: {
                 value: <value>
@@ -105,29 +107,23 @@ def normalize_extattrs(value):
 
 def flatten_extattrs(value):
     ''' Flatten the key/value struct for extattrs
-
     WAPI returns extattrs field as a dict in form of:
-
         extattrs: {
             key: {
                 value: <value>
             }
         }
-
     This method will flatten the structure to:
-
         extattrs: {
             key: value
         }
-
     '''
     return dict([(k, v['value']) for k, v in iteritems(value)])
 
 
 class WapiBase(object):
     ''' Base class for implementing Infoblox WAPI API '''
-
-    provider_spec = {'provider': dict(type='dict', options=nios_provider_spec)}
+    provider_spec = {'provider': dict(type='dict', options=NIOS_PROVIDER_SPEC)}
 
     def __init__(self, provider):
         self.connector = get_connector(**provider)
@@ -163,7 +159,6 @@ class WapiInventory(WapiBase):
 
 class WapiModule(WapiBase):
     ''' Implements WapiBase for executing a NIOS module '''
-
     def __init__(self, module):
         self.module = module
         provider = module.params['provider']
@@ -174,29 +169,29 @@ class WapiModule(WapiBase):
 
     def handle_exception(self, method_name, exc):
         ''' Handles any exceptions raised
-
         This method will be called if an InfobloxException is raised for
-        any call to the instance of Connector.  This method will then
-        gracefully fail the module.
-
+        any call to the instance of Connector and also, in case of generic
+        exception. This method will then gracefully fail the module.
         :args exc: instance of InfobloxException
         '''
-        self.module.fail_json(
-            msg=exc.response['text'],
-            type=exc.response['Error'].split(':')[0],
-            code=exc.response.get('code'),
-            operation=method_name
-        )
+        if ('text' in exc.response):
+            self.module.fail_json(
+                msg=exc.response['text'],
+                type=exc.response['Error'].split(':')[0],
+                code=exc.response.get('code'),
+                operation=method_name
+            )
+        else:
+            self.module.fail_json(msg=to_native(exc))
 
     def run(self, ib_obj_type, ib_spec):
         ''' Runs the module and performans configuration tasks
-
         :args ib_obj_type: the WAPI object type to operate against
         :args ib_spec: the specification for the WAPI object as a dict
-
         :returns: a results dict
         '''
 
+        update = new_name = None
         state = self.module.params['state']
         if state not in ('present', 'absent'):
             self.module.fail_json(msg='state must be one of `present`, `absent`, got `%s`' % state)
@@ -204,10 +199,14 @@ class WapiModule(WapiBase):
         result = {'changed': False}
 
         obj_filter = dict([(k, self.module.params[k]) for k, v in iteritems(ib_spec) if v.get('ib_req')])
-        ib_obj = self.get_object(ib_obj_type, obj_filter.copy(), return_fields=ib_spec.keys())
 
-        if ib_obj:
-            current_object = ib_obj[0]
+        if('name' in obj_filter):
+            ib_obj_ref, update, new_name = self.get_object_ref(ib_obj_type, obj_filter, ib_spec)
+        else:
+            ib_obj_ref = self.get_object(ib_obj_type, obj_filter.copy(), return_fields=ib_spec.keys())
+
+        if ib_obj_ref:
+            current_object = ib_obj_ref[0]
             if 'extattrs' in current_object:
                 current_object['extattrs'] = flatten_extattrs(current_object['extattrs'])
             ref = current_object.pop('_ref')
@@ -223,25 +222,28 @@ class WapiModule(WapiBase):
                 else:
                     proposed_object[key] = self.module.params[key]
 
-        modified = not self.compare_objects(current_object, proposed_object)
+        # checks if the name's field has been updated
+        if update and new_name:
+            proposed_object['name'] = new_name
 
+        res = None
+        modified = not self.compare_objects(current_object, proposed_object)
         if 'extattrs' in proposed_object:
             proposed_object['extattrs'] = normalize_extattrs(proposed_object['extattrs'])
-
         if state == 'present':
             if ref is None:
                 if not self.module.check_mode:
                     self.create_object(ib_obj_type, proposed_object)
                 result['changed'] = True
             elif modified:
-                if 'network_view' in proposed_object:
-                    self.check_if_network_view_exists(proposed_object['network_view'])
-                    proposed_object.pop('network_view')
-                elif 'view' in proposed_object:
-                    self.check_if_dns_view_exists(proposed_object['view'])
-                if not self.module.check_mode:
+                if (ib_obj_type in (NIOS_HOST_RECORD, NIOS_NETWORK_VIEW, NIOS_DNS_VIEW)):
                     proposed_object = self.on_update(proposed_object, ib_spec)
                     res = self.update_object(ref, proposed_object)
+                elif 'network_view' in proposed_object:
+                    proposed_object.pop('network_view')
+                if not self.module.check_mode and res is None:
+                    proposed_object = self.on_update(proposed_object, ib_spec)
+                    self.update_object(ref, proposed_object)
                 result['changed'] = True
 
         elif state == 'absent':
@@ -252,42 +254,10 @@ class WapiModule(WapiBase):
 
         return result
 
-    def check_if_dns_view_exists(self, name, fail_on_missing=True):
-        ''' Checks if the specified DNS view is already configured
-
-        :args name: the name of the  DNS view to check
-        :args fail_on_missing: fail the module if the DNS view does not exist
-
-        :returns: True if the network_view exists and False if the  DNS view
-            does not exist and fail_on_missing is False
-        '''
-        res = self.get_object('view', {'name': name}) is not None
-        if not res and fail_on_missing:
-            self.module.fail_json(msg='DNS view %s does not exist, please create '
-                                      'it using nios_dns_view first' % name)
-        return res
-
-    def check_if_network_view_exists(self, name, fail_on_missing=True):
-        ''' Checks if the specified network_view is already configured
-
-        :args name: the name of the network view to check
-        :args fail_on_missing: fail the module if the network_view does not exist
-
-        :returns: True if the network_view exists and False if the network_view
-            does not exist and fail_on_missing is False
-        '''
-        res = self.get_object('networkview', {'name': name}) is not None
-        if not res and fail_on_missing:
-            self.module.fail_json(msg='Network view %s does not exist, please create '
-                                      'it using nios_network_view first' % name)
-        return res
-
     def issubset(self, item, objects):
         ''' Checks if item is a subset of objects
-
         :args item: the subset item to validate
         :args objects: superset list of objects to validate against
-
         :returns: True if item is a subset of one entry in objects otherwise
             this method will return None
         '''
@@ -322,16 +292,45 @@ class WapiModule(WapiBase):
 
         return True
 
+    def get_object_ref(self, ib_obj_type, obj_filter, ib_spec):
+        ''' this function gets and returns the current object based on name/old_name passed'''
+        update = False
+        old_name = new_name = None
+        try:
+            name_obj = self.module._check_type_dict(obj_filter['name'])
+            old_name = name_obj['old_name']
+            new_name = name_obj['new_name']
+        except TypeError:
+            name = obj_filter['name']
+
+        if old_name and new_name:
+            if (ib_obj_type == NIOS_HOST_RECORD):
+                test_obj_filter = dict([('name', old_name), ('view', obj_filter['view'])])
+            else:
+                test_obj_filter = dict([('name', old_name)])
+            # get the object reference
+            ib_obj = self.get_object(ib_obj_type, test_obj_filter, return_fields=ib_spec.keys())
+            if ib_obj:
+                obj_filter['name'] = new_name
+            else:
+                test_obj_filter['name'] = new_name
+                ib_obj = self.get_object(ib_obj_type, test_obj_filter, return_fields=ib_spec.keys())
+            update = True
+            return ib_obj, update, new_name
+        if (ib_obj_type == NIOS_HOST_RECORD):
+            test_obj_filter = dict([('name', name), ('view', obj_filter['view'])])
+        else:
+            test_obj_filter = dict([('name', name)])
+        ib_obj = self.get_object(ib_obj_type, test_obj_filter.copy(), return_fields=ib_spec.keys())
+        return ib_obj, update, new_name
+
     def on_update(self, proposed_object, ib_spec):
         ''' Event called before the update is sent to the API endpoing
-
         This method will allow the final proposed object to be changed
         and/or keys filtered before it is sent to the API endpoint to
         be processed.
-
         :args proposed_object: A dict item that will be encoded and sent
             the the API endpoint with the updated data structure
-
         :returns: updated object to be sent to API endpoint
         '''
         keys = set()
@@ -339,5 +338,4 @@ class WapiModule(WapiBase):
             update = ib_spec[key].get('update', True)
             if not update:
                 keys.add(key)
-
         return dict([(k, v) for k, v in iteritems(proposed_object) if k not in keys])

--- a/lib/ansible/modules/net_tools/nios/nios_dns_view.py
+++ b/lib/ansible/modules/net_tools/nios/nios_dns_view.py
@@ -20,14 +20,16 @@ description:
   - Adds and/or removes instances of DNS view objects from
     Infoblox NIOS servers.  This module manages NIOS C(view) objects
     using the Infoblox WAPI interface over REST.
+  - Updates instances of DNS view object from Infoblox NIOS servers.
 requirements:
   - infoblox_client
 extends_documentation_fragment: nios
 options:
   name:
     description:
-      - Specifies the name of the DNS view to add and/or remove from the
-        system configuration based on the setting of the C(state) argument.
+      - Specifies the fully qualified hostname to add or remove from
+        the system. User can also update the hostname as it is possible
+        to pass a dict containing I(new_name), I(old_name). See examples.
     required: true
     aliases:
       - view
@@ -73,7 +75,6 @@ EXAMPLES = '''
       username: admin
       password: admin
   connection: local
-
 - name: update the comment for dns view
   nios_dns_view:
     name: ansible-dns
@@ -84,11 +85,19 @@ EXAMPLES = '''
       username: admin
       password: admin
   connection: local
-
 - name: remove the dns view instance
   nios_dns_view:
     name: ansible-dns
     state: absent
+    provider:
+      host: "{{ inventory_hostname_short }}"
+      username: admin
+      password: admin
+  connection: local
+- name: update the dns view instance
+  nios_dns_view:
+    name: {new_name: ansible-dns-new, old_name: ansible-dns}
+    state: present
     provider:
       host: "{{ inventory_hostname_short }}"
       username: admin
@@ -100,6 +109,7 @@ RETURN = ''' # '''
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.net_tools.nios.api import WapiModule
+from ansible.module_utils.net_tools.nios.api import NIOS_DNS_VIEW
 
 
 def main():
@@ -125,7 +135,7 @@ def main():
                            supports_check_mode=True)
 
     wapi = WapiModule(module)
-    result = wapi.run('view', ib_spec)
+    result = wapi.run(NIOS_DNS_VIEW, ib_spec)
 
     module.exit_json(**result)
 

--- a/lib/ansible/modules/net_tools/nios/nios_host_record.py
+++ b/lib/ansible/modules/net_tools/nios/nios_host_record.py
@@ -20,6 +20,7 @@ description:
   - Adds and/or removes instances of host record objects from
     Infoblox NIOS servers.  This module manages NIOS C(record:host) objects
     using the Infoblox WAPI interface over REST.
+  - Updates instances of host record object from Infoblox NIOS servers.
 requirements:
   - infoblox_client
 extends_documentation_fragment: nios
@@ -27,7 +28,8 @@ options:
   name:
     description:
       - Specifies the fully qualified hostname to add or remove from
-        the system
+        the system. User can also update the hostname as it is possible
+        to pass a dict containing I(new_name), I(old_name). See examples.
     required: true
   view:
     description:
@@ -103,7 +105,6 @@ EXAMPLES = '''
       username: admin
       password: admin
   connection: local
-
 - name: add a comment to an existing host record
   nios_host_record:
     name: host.ansible.com
@@ -116,11 +117,21 @@ EXAMPLES = '''
       username: admin
       password: admin
   connection: local
-
 - name: remove a host record from the system
   nios_host_record:
     name: host.ansible.com
     state: absent
+    provider:
+      host: "{{ inventory_hostname_short }}"
+      username: admin
+      password: admin
+  connection: local
+- name: update an ipv4 host record
+  nios_host_record:
+    name: {new_name: host-new.ansible.com, old_name: host.ansible.com}
+    ipv4:
+      - address: 192.168.10.1
+    state: present
     provider:
       host: "{{ inventory_hostname_short }}"
       username: admin
@@ -133,19 +144,17 @@ RETURN = ''' # '''
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six import iteritems
 from ansible.module_utils.net_tools.nios.api import WapiModule
+from ansible.module_utils.net_tools.nios.api import NIOS_HOST_RECORD
 
 
 def ipaddr(module, key, filtered_keys=None):
     ''' Transforms the input value into a struct supported by WAPI
-
     This function will transform the input from the playbook into a struct
     that is valid for WAPI in the form of:
-
         {
             ipv4addr: <value>,
             mac: <value>
         }
-
     This function does not validate the values are properly formatted or in
     the acceptable range, that is left to WAPI.
     '''
@@ -201,7 +210,7 @@ def main():
                            supports_check_mode=True)
 
     wapi = WapiModule(module)
-    result = wapi.run('record:host', ib_spec)
+    result = wapi.run(NIOS_HOST_RECORD, ib_spec)
 
     module.exit_json(**result)
 

--- a/lib/ansible/modules/net_tools/nios/nios_network.py
+++ b/lib/ansible/modules/net_tools/nios/nios_network.py
@@ -98,7 +98,6 @@ EXAMPLES = '''
       username: admin
       password: admin
   connection: local
-
 - name: configure a network ipv6
   nios_network:
     network: fe80::/64
@@ -109,7 +108,6 @@ EXAMPLES = '''
       username: admin
       password: admin
   connection: local
-
 - name: set dhcp options for a network ipv4
   nios_network:
     network: 192.168.10.0/24
@@ -123,7 +121,6 @@ EXAMPLES = '''
       username: admin
       password: admin
   connection: local
-
 - name: remove a network ipv4
   nios_network:
     network: 192.168.10.0/24
@@ -141,14 +138,14 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six import iteritems
 from ansible.module_utils.net_tools.nios.api import WapiModule
 from ansible.module_utils.network.common.utils import validate_ip_address, validate_ip_v6_address
+from ansible.module_utils.net_tools.nios.api import NIOS_IPV4_NETWORK
+from ansible.module_utils.net_tools.nios.api import NIOS_IPV6_NETWORK
 
 
 def options(module):
     ''' Transforms the module argument into a valid WAPI struct
-
     This function will transform the options argument into a structure that
     is a valid WAPI structure in the format of:
-
         {
             name: <value>,
             num: <value>,
@@ -156,11 +153,9 @@ def options(module):
             use_option: <value>,
             vendor_class: <value>
         }
-
     It will remove any options that are set to None since WAPI will error on
     that condition.  It will also verify that either `name` or `num` is
     set in the structure but does not validate the values are equal.
-
     The remainder of the value validation is performed by WAPI
     '''
     options = list()
@@ -178,9 +173,9 @@ def check_ip_addr_type(ip):
     check_ip = ip.split('/')
 
     if validate_ip_address(check_ip[0]):
-        return 'network'
+        return NIOS_IPV4_NETWORK
     elif validate_ip_v6_address(check_ip[0]):
-        return 'ipv6network'
+        return NIOS_IPV6_NETWORK
 
 
 def main():

--- a/lib/ansible/modules/net_tools/nios/nios_network_view.py
+++ b/lib/ansible/modules/net_tools/nios/nios_network_view.py
@@ -20,14 +20,16 @@ description:
   - Adds and/or removes instances of network view objects from
     Infoblox NIOS servers.  This module manages NIOS C(networkview) objects
     using the Infoblox WAPI interface over REST.
+  - Updates instances of network view object from Infoblox NIOS servers.
 requirements:
   - infoblox_client
 extends_documentation_fragment: nios
 options:
   name:
     description:
-      - Specifies the name of the network view to either add or remove
-        from the configuration.
+      - Specifies the fully qualified hostname to add or remove from
+        the system. User can also update the hostname as it is possible
+        to pass a dict containing I(new_name), I(old_name). See examples.
     required: true
     aliases:
       - network_view
@@ -63,7 +65,6 @@ EXAMPLES = '''
       username: admin
       password: admin
   connection: local
-
 - name: update the comment for network view
   nios_network_view:
     name: ansible
@@ -74,11 +75,19 @@ EXAMPLES = '''
       username: admin
       password: admin
   connection: local
-
 - name: remove the network view
   nios_network_view:
     name: ansible
     state: absent
+    provider:
+      host: "{{ inventory_hostname_short }}"
+      username: admin
+      password: admin
+  connection: local
+- name: update a existing network view
+  nios_network_view:
+    name: {new_name: ansible-new, old_name: ansible}
+    state: present
     provider:
       host: "{{ inventory_hostname_short }}"
       username: admin
@@ -90,6 +99,7 @@ RETURN = ''' # '''
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.net_tools.nios.api import WapiModule
+from ansible.module_utils.net_tools.nios.api import NIOS_NETWORK_VIEW
 
 
 def main():
@@ -97,7 +107,6 @@ def main():
     '''
     ib_spec = dict(
         name=dict(required=True, aliases=['network_view'], ib_req=True),
-
         extattrs=dict(type='dict'),
         comment=dict(),
     )
@@ -114,7 +123,7 @@ def main():
                            supports_check_mode=True)
 
     wapi = WapiModule(module)
-    result = wapi.run('networkview', ib_spec)
+    result = wapi.run(NIOS_NETWORK_VIEW, ib_spec)
 
     module.exit_json(**result)
 

--- a/lib/ansible/modules/net_tools/nios/nios_zone.py
+++ b/lib/ansible/modules/net_tools/nios/nios_zone.py
@@ -88,7 +88,6 @@ EXAMPLES = '''
       username: admin
       password: admin
   connection: local
-
 - name: update the comment and ext attributes for an existing zone
   nios_zone:
     name: ansible.com
@@ -101,7 +100,6 @@ EXAMPLES = '''
       username: admin
       password: admin
   connection: local
-
 - name: remove the dns zone
   nios_zone:
     name: ansible.com
@@ -117,6 +115,7 @@ RETURN = ''' # '''
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.net_tools.nios.api import WapiModule
+from ansible.module_utils.net_tools.nios.api import NIOS_ZONE
 
 
 def main():
@@ -149,7 +148,7 @@ def main():
                            supports_check_mode=True)
 
     wapi = WapiModule(module)
-    result = wapi.run('zone_auth', ib_spec)
+    result = wapi.run(NIOS_ZONE, ib_spec)
 
     module.exit_json(**result)
 

--- a/lib/ansible/plugins/lookup/nios.py
+++ b/lib/ansible/plugins/lookup/nios.py
@@ -107,7 +107,7 @@ class LookupModule(LookupBase):
         extattrs = normalize_extattrs(kwargs.pop('extattrs', {}))
         provider = kwargs.pop('provider', {})
         wapi = WapiLookup(provider)
-        res = wapi.get_object(obj_type, filter_data, return_fields=return_fields)
+        res = wapi.get_object(obj_type, filter_data, return_fields=return_fields, extattrs=extattrs)
         if res is not None:
             for obj in res:
                 if 'extattrs' in obj:

--- a/test/units/module_utils/net_tools/nios/test_api.py
+++ b/test/units/module_utils/net_tools/nios/test_api.py
@@ -56,7 +56,7 @@ class TestNiosApi(unittest.TestCase):
             {
                 "comment": "test comment",
                 "_ref": "networkview/ZG5zLm5ldHdvcmtfdmlldyQw:default/true",
-                "name": "default",
+                "name": self.module._check_type_dict().__getitem__(),
                 "extattrs": {}
             }
         ]
@@ -144,6 +144,7 @@ class TestNiosApi(unittest.TestCase):
 
         kwargs = copy.deepcopy(test_object[0])
         kwargs['extattrs']['Site']['value'] = 'update'
+        kwargs['name'] = self.module._check_type_dict().__getitem__()
         del kwargs['_ref']
 
         wapi = self._get_wapi(test_object)
@@ -159,7 +160,7 @@ class TestNiosApi(unittest.TestCase):
         test_object = [{
             "comment": "test comment",
             "_ref": "networkview/ZG5zLm5ldHdvcmtfdmlldyQw:default/true",
-            "name": "default",
+            "name": self.module._check_type_dict().__getitem__(),
             "extattrs": {'Site': {'value': 'test'}}
         }]
 
@@ -190,7 +191,7 @@ class TestNiosApi(unittest.TestCase):
         res = wapi.run('testobject', test_spec)
 
         self.assertTrue(res['changed'])
-        wapi.create_object.assert_called_once_with('testobject', {'name': 'ansible'})
+        wapi.create_object.assert_called_once_with('testobject', {'name': self.module._check_type_dict().__getitem__()})
 
     def test_wapi_delete(self):
         self.module.params = {'provider': None, 'state': 'absent', 'name': 'ansible',
@@ -240,6 +241,7 @@ class TestNiosApi(unittest.TestCase):
         kwargs = test_object[0].copy()
         ref = kwargs.pop('_ref')
         kwargs['comment'] = 'updated comment'
+        kwargs['name'] = self.module._check_type_dict().__getitem__()
         del kwargs['network_view']
         del kwargs['extattrs']
 

--- a/test/units/modules/net_tools/nios/test_nios_dns_view.py
+++ b/test/units/modules/net_tools/nios/test_nios_dns_view.py
@@ -75,7 +75,7 @@ class TestNiosDnsViewModule(TestNiosModule):
         res = wapi.run('testobject', test_spec)
 
         self.assertTrue(res['changed'])
-        wapi.create_object.assert_called_once_with('testobject', {'name': 'ansible-dns'})
+        wapi.create_object.assert_called_once_with('testobject', {'name': self.module._check_type_dict().__getitem__()})
 
     def test_nios_dns_view_update_comment(self):
         self.module.params = {'provider': None, 'state': 'present', 'name': 'ansible-dns',

--- a/test/units/modules/net_tools/nios/test_nios_host_record.py
+++ b/test/units/modules/net_tools/nios/test_nios_host_record.py
@@ -64,7 +64,6 @@ class TestNiosHostRecordModule(TestNiosModule):
                               'comment': None, 'extattrs': None}
 
         test_object = None
-
         test_spec = {
             "name": {"ib_req": True},
             "comment": {},
@@ -76,7 +75,7 @@ class TestNiosHostRecordModule(TestNiosModule):
         res = wapi.run('testobject', test_spec)
 
         self.assertTrue(res['changed'])
-        wapi.create_object.assert_called_once_with('testobject', {'name': 'ansible'})
+        wapi.create_object.assert_called_once_with('testobject', {'name': self.module._check_type_dict().__getitem__()})
 
     def test_nios_host_record_remove(self):
         self.module.params = {'provider': None, 'state': 'absent', 'name': 'ansible',
@@ -128,7 +127,7 @@ class TestNiosHostRecordModule(TestNiosModule):
         wapi.update_object.called_once_with(test_object)
 
     def test_nios_host_record_update_record_name(self):
-        self.module.params = {'provider': None, 'state': 'present', 'name': 'default', 'old_name': 'old_default',
+        self.module.params = {'provider': None, 'state': 'present', 'name': {'new_name': 'default', 'old_name': 'old_default'},
                               'comment': 'comment', 'extattrs': None}
 
         test_object = [

--- a/test/units/modules/net_tools/nios/test_nios_network.py
+++ b/test/units/modules/net_tools/nios/test_nios_network.py
@@ -100,20 +100,20 @@ class TestNiosNetworkModule(TestNiosModule):
         self.assertTrue(res['changed'])
 
     def test_nios_network_ipv6_dhcp_update(self):
-        self.module.params = {'provider': None, 'state': 'present', 'network': 'fe80::/64',
+        self.module.params = {'provider': None, 'state': 'present', 'ipv6network': 'fe80::/64',
                               'comment': 'updated comment', 'extattrs': None}
 
         test_object = [
             {
                 "comment": "test comment",
                 "_ref": "ipv6network/ZG5zLm5ldHdvcmtfdmlldyQw:default/true",
-                "network": "fe80::/64",
+                "ipv6network": "fe80::/64",
                 "extattrs": {'options': {'name': 'test', 'value': 'ansible.com'}}
             }
         ]
 
         test_spec = {
-            "network": {"ib_req": True},
+            "ipv6network": {"ib_req": True},
             "comment": {},
             "extattrs": {}
         }
@@ -148,13 +148,13 @@ class TestNiosNetworkModule(TestNiosModule):
         wapi.delete_object.assert_called_once_with(ref)
 
     def test_nios_network_ipv6_create(self):
-        self.module.params = {'provider': None, 'state': 'present', 'network': 'fe80::/64',
+        self.module.params = {'provider': None, 'state': 'present', 'ipv6network': 'fe80::/64',
                               'comment': None, 'extattrs': None}
 
         test_object = None
 
         test_spec = {
-            "network": {"ib_req": True},
+            "ipv6network": {"ib_req": True},
             "comment": {},
             "extattrs": {}
         }
@@ -164,10 +164,10 @@ class TestNiosNetworkModule(TestNiosModule):
         res = wapi.run('testobject', test_spec)
 
         self.assertTrue(res['changed'])
-        wapi.create_object.assert_called_once_with('testobject', {'network': 'fe80::/64'})
+        wapi.create_object.assert_called_once_with('testobject', {'ipv6network': 'fe80::/64'})
 
     def test_nios_network_ipv6_remove(self):
-        self.module.params = {'provider': None, 'state': 'absent', 'network': 'fe80::/64',
+        self.module.params = {'provider': None, 'state': 'absent', 'ipv6network': 'fe80::/64',
                               'comment': None, 'extattrs': None}
 
         ref = "ipv6network/ZG5zLm5ldHdvcmtfdmlldyQw:ansible/false"
@@ -175,12 +175,12 @@ class TestNiosNetworkModule(TestNiosModule):
         test_object = [{
             "comment": "test comment",
             "_ref": ref,
-            "network": "fe80::/64",
+            "ipv6network": "fe80::/64",
             "extattrs": {'Site': {'value': 'test'}}
         }]
 
         test_spec = {
-            "network": {"ib_req": True},
+            "ipv6network": {"ib_req": True},
             "comment": {},
             "extattrs": {}
         }

--- a/test/units/modules/net_tools/nios/test_nios_network_view.py
+++ b/test/units/modules/net_tools/nios/test_nios_network_view.py
@@ -75,7 +75,7 @@ class TestNiosNetworkViewModule(TestNiosModule):
         res = wapi.run('testobject', test_spec)
 
         self.assertTrue(res['changed'])
-        wapi.create_object.assert_called_once_with('testobject', {'name': 'ansible'})
+        wapi.create_object.assert_called_once_with('testobject', {'name': self.module._check_type_dict().__getitem__()})
 
     def test_nios_network_view_update_comment(self):
         self.module.params = {'provider': None, 'state': 'present', 'name': 'default',

--- a/test/units/modules/net_tools/nios/test_nios_zone.py
+++ b/test/units/modules/net_tools/nios/test_nios_zone.py
@@ -59,13 +59,13 @@ class TestNiosZoneModule(TestNiosModule):
         self.load_config.return_value = dict(diff=None, session='session')
 
     def test_nios_zone_create(self):
-        self.module.params = {'provider': None, 'state': 'present', 'name': 'ansible.com',
+        self.module.params = {'provider': None, 'state': 'present', 'fqdn': 'ansible.com',
                               'comment': None, 'extattrs': None}
 
         test_object = None
 
         test_spec = {
-            "name": {"ib_req": True},
+            "fqdn": {"ib_req": True},
             "comment": {},
             "extattrs": {}
         }
@@ -75,10 +75,10 @@ class TestNiosZoneModule(TestNiosModule):
         res = wapi.run('testobject', test_spec)
 
         self.assertTrue(res['changed'])
-        wapi.create_object.assert_called_once_with('testobject', {'name': 'ansible.com'})
+        wapi.create_object.assert_called_once_with('testobject', {'fqdn': 'ansible.com'})
 
     def test_nios_zone_remove(self):
-        self.module.params = {'provider': None, 'state': 'absent', 'name': 'ansible.com',
+        self.module.params = {'provider': None, 'state': 'absent', 'fqdn': 'ansible.com',
                               'comment': None, 'extattrs': None}
 
         ref = "zone/ZG5zLm5ldHdvcmtfdmlldyQw:ansible/false"
@@ -86,12 +86,12 @@ class TestNiosZoneModule(TestNiosModule):
         test_object = [{
             "comment": "test comment",
             "_ref": ref,
-            "name": "ansible.com",
+            "fqdn": "ansible.com",
             "extattrs": {'Site': {'value': 'test'}}
         }]
 
         test_spec = {
-            "name": {"ib_req": True},
+            "fqdn": {"ib_req": True},
             "comment": {},
             "extattrs": {}
         }
@@ -102,20 +102,20 @@ class TestNiosZoneModule(TestNiosModule):
         wapi.delete_object.assert_called_once_with(ref)
 
     def test_nios_zone_update_comment(self):
-        self.module.params = {'provider': None, 'state': 'present', 'name': 'ansible.com',
+        self.module.params = {'provider': None, 'state': 'present', 'fqdn': 'ansible.com',
                               'comment': 'updated comment', 'extattrs': None}
 
         test_object = [
             {
                 "comment": "test comment",
                 "_ref": "zone/ZG5zLm5ldHdvcmtfdmlldyQw:default/true",
-                "name": "ansible.com",
+                "fqdn": "ansible.com",
                 "extattrs": {'Site': {'value': 'test'}}
             }
         ]
 
         test_spec = {
-            "name": {"ib_req": True},
+            "fqdn": {"ib_req": True},
             "comment": {},
             "extattrs": {}
         }


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Introducing the fix for feature #35774 and #36574, and now user can update name field for support modules. Also, including the fix for #39494 where connection timed out error will be displayed if NIOS connection is not successful/times out and fix for #40709 where filtering was not done properly.
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
NIOS

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->
Respective PR fixes feature request from NIOS community, and now user can update existing object with new fields like name, comments, and other supported attributes. This PR also includes the fix for generic exception handling and graceful fail of the module.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
