### PR TITLE
adds alias parameter to nios_host_record (#39469)

### DIFF
--- a/lib/ansible/modules/net_tools/nios/nios_host_record.py
+++ b/lib/ansible/modules/net_tools/nios/nios_host_record.py
@@ -66,6 +66,12 @@ options:
         required: true
         aliases:
           - address
+  aliases:
+    version_added: "2.6"
+    description:
+      - Configures an optional list of additional aliases to add to the host
+        record. These are equivalent to CNAMEs but held within a host
+        record. Must be in list format.
   ttl:
     description:
       - Configures the TTL to be associated with this host record
@@ -97,6 +103,8 @@ EXAMPLES = '''
     name: host.ansible.com
     ipv4:
       - address: 192.168.10.1
+    aliases:
+      - cname.ansible.com
     state: present
     provider:
       host: "{{ inventory_hostname_short }}"
@@ -182,6 +190,7 @@ def main():
 
         ipv4addrs=dict(type='list', aliases=['ipv4'], elements='dict', options=ipv4addr_spec, transform=ipv4addrs),
         ipv6addrs=dict(type='list', aliases=['ipv6'], elements='dict', options=ipv6addr_spec, transform=ipv6addrs),
+        aliases=dict(type='list'),
 
         ttl=dict(type='int'),
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Adds support for the "aliases" parameter to the nios_host_record module. The aliases parameter allows the addition of CNAME records in an Infoblox host record. This was requested in #38209.
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Reques

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
nios_host_record.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0 
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->
N/A
<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
