### PR TITLE
revert #40655 fixes output getting truncated issue for nxos cherry-pick

### DIFF
--- a/changelogs/fragments/nxos_bugfixes_2.5.4.yaml
+++ b/changelogs/fragments/nxos_bugfixes_2.5.4.yaml
@@ -6,3 +6,4 @@ bugfixes:
 - fixes bug with matching nxos prompts (https://github.com/ansible/ansible/pull/40655).
 - fix nxos_vrf and migrate get_interface_type to module_utils (https://github.com/ansible/ansible/pull/40825).
 - Fix nxos_vlan vlan creation failure (https://github.com/ansible/ansible/pull/40822).
+- Revert PR40655 fixes output getting truncated issue for nxos (https://github.com/ansible/ansible/pull/40940).

--- a/lib/ansible/plugins/terminal/nxos.py
+++ b/lib/ansible/plugins/terminal/nxos.py
@@ -30,8 +30,8 @@ from ansible.module_utils._text import to_bytes, to_text
 class TerminalModule(TerminalBase):
 
     terminal_stdout_re = [
-        re.compile(br'[\r\n]?(?!\s*<)?(\x1b\S+)*[a-zA-Z_0-9]{1}[a-zA-Z0-9-_.]*[>|#|%](?:\s*)*(\x1b\S+)*$'),
-        re.compile(br'[\r\n]?[a-zA-Z0-9]{1}[a-zA-Z0-9-_.]*\(.+\)#(?:\s*)$')
+        re.compile(br'[\r\n]?(?!\s*<)?(\x1b\S+)*[a-zA-Z_]{1}[a-zA-Z0-9-_.]*[>|#|%](?:\s*)*(\x1b\S+)*$'),
+        re.compile(br'[\r\n]?[a-zA-Z]{1}[a-zA-Z0-9-_.]*\(.+\)#(?:\s*)$')
     ]
 
     terminal_stderr_re = [


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
revert #40655 fixes output getting truncated issue for nxos cherry-pick
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

