### PR TITLE
only accept non-empty values for ENV config overrides

### DIFF
--- a/lib/ansible/config/manager.py
+++ b/lib/ansible/config/manager.py
@@ -269,7 +269,7 @@ class ConfigManager(object):
         for entry in entry_list:
             name = entry.get('name')
             temp_value = container.get(name, None)
-            if temp_value is not None:  # only set if env var is defined
+            if temp_value:  # only set if env var is defined and is non-empty value
                 value = temp_value
                 origin = name
 


### PR DESCRIPTION
Signed-off-by: Adam Miller <admiller@redhat.com>

##### SUMMARY

Previously we were only checking for `None` type data for ENV vars to ensure they were defined, this ensures the ENV var defined contains a non-empty string.

Fixes #22469
Fixes #22470


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
lib/ansible/config/manager.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (config/manager 4a7e7479ec) last updated 2018/05/31 09:09:19 (GMT -500)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/admiller/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/admiller/src/dev/ansible/lib/ansible
  executable location = /home/admiller/src/dev/ansible/bin/ansible
  python version = 2.7.15 (default, May 15 2018, 15:37:31) [GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]

```

