### PR TITLE
Pass module targets to terraform plan as well as apply

### DIFF
--- a/lib/ansible/modules/cloud/misc/terraform.py
+++ b/lib/ansible/modules/cloud/misc/terraform.py
@@ -259,7 +259,7 @@ def main():
     needs_application, changed = True, True
 
     if state == 'planned':
-        plan_file, needs_application = build_plan(command[0], project_path, variables_args, state_file, targets, plan_file)
+        plan_file, needs_application = build_plan(command[0], project_path, variables_args, state_file, module.params.get('targets'), plan_file)
     if state == 'absent':
         # deleting cannot use a statefile
         needs_application = True

--- a/lib/ansible/modules/cloud/misc/terraform.py
+++ b/lib/ansible/modules/cloud/misc/terraform.py
@@ -165,11 +165,15 @@ def init_plugins(bin_path, project_path):
         module.fail_json(msg="Failed to initialize Terraform modules:\r\n{0}".format(err))
 
 
-def build_plan(bin_path, project_path, variables_args, state_file, plan_path=None):
+def build_plan(bin_path, project_path, variables_args, state_file, targets, plan_path=None):
     if plan_path is None:
         f, plan_path = tempfile.mkstemp(suffix='.tfplan')
 
     command = [bin_path, 'plan', '-input=false', '-no-color', '-detailed-exitcode', '-out', plan_path]
+
+    for t in (module.params.get('targets') or []):
+        command.extend(['-target', t])
+
     command.extend(_state_args(state_file))
 
     rc, out, err = module.run_command(command + variables_args, cwd=project_path)
@@ -255,7 +259,7 @@ def main():
     needs_application, changed = True, True
 
     if state == 'planned':
-        plan_file, needs_application = build_plan(command[0], project_path, variables_args, state_file, plan_file)
+        plan_file, needs_application = build_plan(command[0], project_path, variables_args, state_file, targets, plan_file)
     if state == 'absent':
         # deleting cannot use a statefile
         needs_application = True

--- a/lib/ansible/modules/cloud/misc/terraform.py
+++ b/lib/ansible/modules/cloud/misc/terraform.py
@@ -270,7 +270,7 @@ def main():
     elif plan_file and not os.path.exists(plan_file):
         module.fail_json(msg='Could not find plan_file "{0}", check the path and try again.'.format(plan_file))
     else:
-        plan_file, needs_application = build_plan(command[0], project_path, variables_args, state_file, plan_file)
+        plan_file, needs_application = build_plan(command[0], project_path, variables_args, state_file, module.params.get('targets'), plan_file)
         command.append(plan_file)
 
     if needs_application and not module.check_mode and not state == 'planned':


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Add `targets` to the `terraform plan` command as well, otherwise it will build the plan for *all* modules instead of the targeted ones. 

Fixes #40273 

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
