### PR TITLE
fix nxos output truncated issue

### DIFF
--- a/lib/ansible/plugins/terminal/nxos.py
+++ b/lib/ansible/plugins/terminal/nxos.py
@@ -30,7 +30,7 @@ from ansible.module_utils._text import to_bytes, to_text
 class TerminalModule(TerminalBase):
 
     terminal_stdout_re = [
-        re.compile(br'[\r\n]?(?!\s*<)?(\x1b\S+)*[a-zA-Z_0-9]{1}[a-zA-Z0-9-_.]*[>|#|%](?:\s*)*(\x1b\S+)*$'),
+        re.compile(br'[\r\n]?(?!\s*<)?(\x1b\S+)*[a-zA-Z_0-9]{1}[a-zA-Z0-9-_.]*[>|#](?:\s*)*(\x1b\S+)*$'),
         re.compile(br'[\r\n]?[a-zA-Z0-9]{1}[a-zA-Z0-9-_.]*\(.+\)#(?:\s*)$')
     ]
 


### PR DESCRIPTION
Signed-off-by: Trishna Guha <trishnaguha17@gmail.com>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
fix nxos output truncated issue https://github.com/ansible/ansible/issues/40683
Related to https://github.com/ansible/ansible/pull/40960
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
plugins/terminal/nxos.py
