### PR TITLE
validate ANSIBLE_REMOTE_PORT input

### DIFF
--- a/lib/ansible/playbook/play_context.py
+++ b/lib/ansible/playbook/play_context.py
@@ -38,6 +38,7 @@ from ansible.playbook.attribute import FieldAttribute
 from ansible.playbook.base import Base
 from ansible.plugins import get_plugin_class
 from ansible.utils.ssh_functions import check_for_controlpersist
+from ansible.vars.manager import validate_remote_port
 
 
 try:
@@ -347,6 +348,7 @@ class PlayContext(Base):
                 if delegated_transport == 'winrm':
                     delegated_vars['ansible_port'] = 5986
                 else:
+                    validate_remote_port(C.DEFAULT_REMOTE_PORT)
                     delegated_vars['ansible_port'] = C.DEFAULT_REMOTE_PORT
 
             # and likewise for the remote user
@@ -404,6 +406,7 @@ class PlayContext(Base):
 
         # make sure we get port defaults if needed
         if new_info.port is None and C.DEFAULT_REMOTE_PORT is not None:
+            validate_remote_port(C.DEFAULT_REMOTE_PORT)
             new_info.port = int(C.DEFAULT_REMOTE_PORT)
 
         # special overrides for the connection setting

--- a/lib/ansible/vars/manager.py
+++ b/lib/ansible/vars/manager.py
@@ -72,6 +72,12 @@ def preprocess_vars(a):
 
     return data
 
+def validate_remote_port(remote_port):
+    try:
+        int(remote_port)
+    except ValueError:
+        raise AnsibleError("Invalid remote port defined, expected int but found: %r" % remote_port)
+
 
 class VariableManager:
 
@@ -522,6 +528,7 @@ class VariableManager:
             if C.DEFAULT_TRANSPORT == 'winrm':
                 new_port = 5986
 
+            validate_remote_port(new_port)
             new_delegated_host_vars = dict(
                 ansible_delegated_host=delegated_host_name,
                 ansible_host=delegated_host_name,  # not redundant as other sources can change ansible_host


### PR DESCRIPTION
Signed-off-by: Adam Miller <admiller@redhat.com>

##### SUMMARY

Validate remote port input.

Fixes #22469

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
lib/ansible/config/manager.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (validate_env_vars 216a29d4d1) last updated 2018/05/31 10:26:44 (GMT -500)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/admiller/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/admiller/src/dev/ansible/lib/ansible
  executable location = /home/admiller/src/dev/ansible/bin/ansible
  python version = 2.7.15 (default, May 15 2018, 15:37:31) [GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]
```

