### PR TITLE
Adding module to manage NFS file shares on an AWS Storage Gateway instance

### DIFF
--- a/lib/ansible/modules/cloud/amazon/storage_gateway_file_share.py
+++ b/lib/ansible/modules/cloud/amazon/storage_gateway_file_share.py
@@ -1,0 +1,295 @@
+#!/usr/bin/python
+
+# Copyright: (c) 2018, Aaron Smith <ajsmith10381@gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = r'''
+---
+module: storage_gateway_file_share
+short_description: Manage NFS file shares on an AWS Storage Gateway instance
+description:
+    - Add, modify, or remove NFS file shares on an AWS Storage Gateway instance
+version_added: "2.7"
+requirements: [ 'botocore', 'boto3' ]
+author:
+    - "Aaron Smith (@slapula)"
+options:
+  gateway_arn:
+    description:
+    - The Amazon Resource Name (ARN) of the file gateway on which you want to create a file share.
+    required: true
+  state:
+    description:
+     - Whether the lexicon should be exist or not.
+    required: true
+    choices: ['present', 'absent']
+  nfs_token:
+    description:
+    - A unique string value that you supply that is used by file gateway to ensure idempotent file share creation.
+    required: true
+  iam_role:
+    description:
+    - The ARN of the AWS Identity and Access Management (IAM) role that a file gateway assumes when it accesses the underlying storage.
+    required: true
+  location_arn:
+    description:
+    - The ARN of the backed storage used for storing file data.
+    required: true
+  nfs_defaults:
+    description:
+    - File share default values.
+    suboptions:
+      file_mode:
+        description:
+        - The Unix file mode in the form "nnnn".
+      directory_mode:
+        description:
+        - The Unix directory mode in the form "nnnn".
+      group_id:
+        description:
+        - The default group ID for the file share.
+      owner_id:
+        description:
+        - The default owner ID for files in the file share.
+  kms_encrypted:
+    description:
+    - True to use Amazon S3 server side encryption with your own AWS KMS key, or false to use a key managed by Amazon S3.
+    type: bool
+  kms_key:
+    description:
+    - The KMS key used for Amazon S3 server side encryption.
+  default_storage_class:
+    description:
+    - The default storage class for objects put into an Amazon S3 bucket by file gateway.
+    default: 'S3_STANDARD'
+    choices: ['S3_STANDARD', 'S3_STANDARD_IA']
+  object_acl:
+    description:
+    - Sets the access control list permission for objects in the Amazon S3 bucket that a file gateway puts objects into.
+    default: 'private'
+  client_list:
+    description:
+    - The list of clients that are allowed to access the file gateway. The list must contain either valid IP addresses or valid CIDR blocks.
+  squash:
+    description:
+    - Maps a user to anonymous user.
+    choices: ['RootSquash', 'NoSquash', 'AllSquash']
+  read_only:
+    description:
+    - Sets the write status of a file share.
+    type: bool
+  guess_mime_type_enabled:
+    description:
+    - Enables guessing of the MIME type for uploaded objects based on file extensions.
+    type: bool
+    default: 'true'
+  requester_pays:
+    description:
+    - Sets who pays the cost of the request and the data download from the Amazon S3 bucket.
+    type: bool
+    default: 'false'
+extends_documentation_fragment:
+  - aws
+  - ec2
+'''
+
+EXAMPLES = r'''
+  - name: Create NFS file share on a storage gateway instance
+    storage_gateway_file_share:
+      gateway_arn: 'arn:aws:storagegateway:us-east-1:123456789012:gateway/sgw-12A3456B'
+      nfs_token: '5734980946'
+      iam_role: 'arn:aws:iam::123456789012:role/StorageGatewatRole'
+      location_arn: "arn:aws:s3:::storage-gateway-nfs-test-bucket"
+'''
+
+RETURN = r'''
+file_share_arn:
+    description: The ARN of the NFS file share you just created or updated.
+    returned: always
+    type: string
+'''
+
+try:
+    import botocore
+    from botocore.exceptions import BotoCoreError, ClientError
+except ImportError:
+    pass  # handled by AnsibleAWSModule
+
+from ansible.module_utils.aws.core import AnsibleAWSModule
+from ansible.module_utils.ec2 import boto3_conn, get_aws_connection_info, AWSRetry
+from ansible.module_utils.ec2 import camel_dict_to_snake_dict, boto3_tag_list_to_ansible_dict
+
+
+def share_exists(client, module, params, result):
+    try:
+        file_share_list = client.list_file_shares()
+        for i in file_share_list['FileShareInfoList']:
+            file_share_deets = client.describe_nfs_file_shares(
+                FileShareARNList=[i['FileShareARN']]
+            )
+            if file_share_deets['NFSFileShareInfoList'][0]['LocationARN'] == params['LocationARN']:
+                result['file_share_arn'] = i['FileShareARN']
+                return True
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError):
+        return False
+
+    return False
+
+
+def create_share(client, module, params, result):
+    try:
+        response = client.create_nfs_file_share(**params)
+        result['file_share_arn'] = response['FileShareARN']
+        result['changed'] = True
+        return result
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+        module.fail_json_aws(e, msg="Couldn't create NFS file share")
+
+    return result
+
+
+def update_share(client, module, params, result):
+    current_config = client.describe_nfs_file_shares(
+        FileShareARNList=[result['file_share_arn']]
+    )
+
+    param_changed = []
+    param_keys = list(params.keys())
+    current_keys = list(current_config['NFSFileShareInfoList'][0].keys())
+    common_keys = set(param_keys) - (set(param_keys) - set(current_keys))
+    for key in common_keys:
+        if (params[key] != current_config['NFSFileShareInfoList'][0][key]):
+            param_changed.append(True)
+        else:
+            param_changed.append(False)
+
+    params['FileShareARN'] = result['file_share_arn']
+    del params['ClientToken']
+    del params['GatewayARN']
+    del params['LocationARN']
+    del params['Role']
+
+    if any(param_changed):
+        try:
+            response = client.update_nfs_file_share(**params)
+            result['file_share_arn'] = response['FileShareARN']
+            result['changed'] = True
+            return result
+        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+            module.fail_json_aws(e, msg="Couldn't update NFS file share")
+
+    return result
+
+
+def delete_share(client, module, result):
+    try:
+        response = client.delete_file_share(
+            FileShareARN=result['file_share_arn']
+        )
+        result['changed'] = True
+        return result
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+        module.fail_json_aws(e, msg="Couldn't delete NFS file share")
+
+    return result
+
+
+def main():
+    module = AnsibleAWSModule(
+        argument_spec={
+            'gateway_arn': dict(type='str', required=True),
+            'state': dict(type='str', choices=['present', 'absent'], required=True),
+            'nfs_token': dict(type='str', required=True),
+            'iam_role': dict(type='str', required=True),
+            'location_arn': dict(type='str', required=True),
+            'nfs_defaults': dict(type='dict'),
+            'kms_encrypted': dict(type='bool', default=False),
+            'kms_key': dict(type='str'),
+            'default_storage_class': dict(type='str', default='S3_STANDARD', choices=['S3_STANDARD', 'S3_STANDARD_IA']),
+            'object_acl': dict(type='str', default='private'),
+            'client_list': dict(type='list'),
+            'squash': dict(type='str', choices=['RootSquash', 'NoSquash', 'AllSquash']),
+            'read_only': dict(type='bool', default=False),
+            'guess_mime_type_enabled': dict(type='bool', default=True),
+            'requester_pays': dict(type='bool', default=False),
+        },
+        supports_check_mode=False,
+    )
+
+    result = {
+        'changed': False,
+        'file_share_arn': ''
+    }
+
+    desired_state = module.params.get('state')
+
+    params = {}
+    params['GatewayARN'] = module.params.get('gateway_arn')
+    params['ClientToken'] = module.params.get('nfs_token')
+    params['Role'] = module.params.get('iam_role')
+    params['LocationARN'] = module.params.get('location_arn')
+    if module.params.get('nfs_defaults'):
+        params['NFSFileShareDefaults'] = {}
+        if module.params.get('nfs_defaults').get('file_mode'):
+            params['NFSFileShareDefaults'].update({
+                'FileMode': module.params.get('nfs_defaults').get('file_mode')
+            })
+        if module.params.get('nfs_defaults').get('directory_mode'):
+            params['NFSFileShareDefaults'].update({
+                'DirectoryMode': module.params.get('nfs_defaults').get('directory_mode')
+            })
+        if module.params.get('nfs_defaults').get('group_id'):
+            params['NFSFileShareDefaults'].update({
+                'GroupId': module.params.get('nfs_defaults').get('group_id')
+            })
+        if module.params.get('nfs_defaults').get('owner_id'):
+            params['NFSFileShareDefaults'].update({
+                'OwnerId': module.params.get('nfs_defaults').get('owner_id')
+            })
+    if module.params.get('kms_encrypted'):
+        params['KMSEncrypted'] = module.params.get('kms_encrypted')
+    if module.params.get('kms_key'):
+        params['KMSKey'] = module.params.get('kms_key')
+    if module.params.get('default_storage_class'):
+        params['DefaultStorageClass'] = module.params.get('default_storage_class')
+    if module.params.get('object_acl'):
+        params['ObjectACL'] = module.params.get('object_acl')
+    if module.params.get('client_list'):
+        params['ClientList'] = module.params.get('client_list')
+    if module.params.get('squash'):
+        params['Squash'] = module.params.get('squash')
+    if module.params.get('read_only'):
+        params['ReadOnly'] = module.params.get('read_only')
+    if module.params.get('guess_mime_type_enabled'):
+        params['GuessMIMETypeEnabled'] = module.params.get('guess_mime_type_enabled')
+    if module.params.get('requester_pays'):
+        params['RequesterPays'] = module.params.get('requester_pays')
+
+    client = module.client('storagegateway')
+
+    share_status = share_exists(client, module, params, result)
+
+    if desired_state == 'present':
+        if not share_status:
+            create_share(client, module, params, result)
+        if share_status:
+            update_share(client, module, params, result)
+
+    if desired_state == 'absent':
+        if share_status:
+            delete_share(client, module, result)
+
+    module.exit_json(changed=result['changed'], file_share_arn=result['file_share_arn'])
+
+
+if __name__ == '__main__':
+    main()

--- a/test/integration/targets/storage_gateway_file_share/aliases
+++ b/test/integration/targets/storage_gateway_file_share/aliases
@@ -1,0 +1,2 @@
+cloud/aws
+posix/ci/cloud/group4/aws

--- a/test/integration/targets/storage_gateway_file_share/defaults/main.yaml
+++ b/test/integration/targets/storage_gateway_file_share/defaults/main.yaml
@@ -1,0 +1,18 @@
+---
+ec2_file_ami_image:
+  # amazon/aws-storage-gateway-file-2018-03-21
+  ap-northeast-1: ami-798cdc1f
+  ap-northeast-2: ami-d10ca0bf
+  ap-south-1: ami-e238638d
+  ap-southeast-1: ami-48114d34
+  ap-southeast-2: ami-47d41925
+  ca-central-1: ami-edd95f89
+  eu-central-1: ami-9aa9f971
+  eu-west-1: ami-10f1a569
+  eu-west-2: ami-4c34d22b
+  eu-west-3: ami-38388e45
+  sa-east-1: ami-0f481c63
+  us-east-1: ami-6e14c313
+  us-east-2: ami-7845741d
+  us-west-1: ami-ba9483da
+  us-west-2: ami-be21bdc6

--- a/test/integration/targets/storage_gateway_file_share/files/storagegateway-trust-policy.json
+++ b/test/integration/targets/storage_gateway_file_share/files/storagegateway-trust-policy.json
@@ -1,0 +1,13 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "storagegateway.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}

--- a/test/integration/targets/storage_gateway_file_share/meta/main.yaml
+++ b/test/integration/targets/storage_gateway_file_share/meta/main.yaml
@@ -1,0 +1,3 @@
+dependencies:
+  - prepare_tests
+  - setup_ec2

--- a/test/integration/targets/storage_gateway_file_share/tasks/main.yaml
+++ b/test/integration/targets/storage_gateway_file_share/tasks/main.yaml
@@ -1,0 +1,402 @@
+---
+- block:
+
+    # ============================================================
+    # Prerequisites
+    # ============================================================
+    - name: set connection information for all tasks
+      set_fact:
+        aws_connection_info: &aws_connection_info
+          aws_access_key: "{{ aws_access_key }}"
+          aws_secret_key: "{{ aws_secret_key }}"
+          region: "{{ aws_region }}"
+      no_log: true
+
+    - name: Create VPC for use in testing
+      ec2_vpc_net:
+        name: "{{ resource_prefix }}-vpc"
+        cidr_block: 10.22.32.0/23
+        tags:
+          Name: Ansible ec2_instance Testing VPC
+        tenancy: default
+        <<: *aws_connection_info
+      register: testing_vpc
+
+    - name: Create internet gateway for use in testing
+      ec2_vpc_igw:
+        vpc_id: "{{ testing_vpc.vpc.id }}"
+        state: present
+        <<: *aws_connection_info
+      register: igw
+
+    - name: Create testing subnet
+      ec2_vpc_subnet:
+        state: present
+        vpc_id: "{{ testing_vpc.vpc.id }}"
+        cidr: 10.22.32.0/24
+        az: "{{ aws_region }}a"
+        resource_tags:
+          Name: "{{ resource_prefix }}-subnet"
+        <<: *aws_connection_info
+      register: testing_subnet
+
+    - name: create routing rules
+      ec2_vpc_route_table:
+        vpc_id: "{{ testing_vpc.vpc.id }}"
+        tags:
+          created: "{{ resource_prefix }}-route"
+        routes:
+          - dest: 0.0.0.0/0
+            gateway_id: "{{ igw.gateway_id }}"
+        subnets:
+          - "{{ testing_subnet.subnet.id }}"
+        <<: *aws_connection_info
+
+    - name: create a security group with the vpc
+      ec2_group:
+        name: "{{ resource_prefix }}-sg"
+        description: a security group for ansible tests
+        vpc_id: "{{ testing_vpc.vpc.id }}"
+        rules:
+          - proto: tcp
+            from_port: 22
+            to_port: 22
+            cidr_ip: 0.0.0.0/0
+          - proto: tcp
+            from_port: 80
+            to_port: 80
+            cidr_ip: 0.0.0.0/0
+        <<: *aws_connection_info
+      register: sg
+
+    - name: ensure S3 bucket exists
+      s3_bucket:
+        state: present
+        name: "{{ resource_prefix }}-test-nfs-bucket"
+        <<: *aws_connection_info
+
+    - name: ensure IAM role exists
+      iam_role:
+        name: "{{ resource_prefix }}-test-storage-iam-role"
+        assume_role_policy_document: "{{ lookup('file','storagegateway-trust-policy.json') }}"
+        state: present
+        create_instance_profile: no
+        <<: *aws_connection_info
+      register: storage_iam_role
+
+    - name: ensure S3 access for IAM role
+      iam_policy:
+        <<: *aws_connection_info
+        iam_type: role
+        iam_name: "{{ resource_prefix }}-test-storage-iam-role"
+        policy_name: "{{ resource_prefix }}-test-storage-iam-policy"
+        state: present
+        policy_json: "{{ lookup( 'template', 's3-bucket-policy.json.j2') }}"
+
+    - name: Create storage gateway instance
+      ec2_instance:
+        name: "{{ resource_prefix }}-test-file-gateway"
+        image_id: "{{ ec2_file_ami_image[aws_region] }}"
+        tags:
+          TestId: "{{ resource_prefix }}"
+        security_groups: "{{ sg.group_id }}"
+        vpc_subnet_id: "{{ testing_subnet.subnet.id }}"
+        network:
+          assign_public_ip: true
+        instance_type: m4.xlarge
+        volumes:
+          - device_name: /dev/sdb
+            ebs:
+              volume_size: 150
+              delete_on_termination: true
+              volume_type: standard
+        <<: *aws_connection_info
+      register: gateway_instance
+
+    - name: Send storage gateway activation code request
+      uri:
+        url: "http://{{ gateway_instance.instances[0].public_ip_address }}/?activationRegion={{ aws_region }}"
+      retries: 10
+      register: code_request
+
+    - name: Extract activation code from request
+      shell: echo "{{ code_request.url }}" | awk -F'[=&]' '{print $2}'
+      register: activation_code
+
+    - name: Activate file gateway for testing
+      storage_gateway:
+        name: "{{ resource_prefix }}-test-file-gateway"
+        state: present
+        activation_key: "{{ activation_code.stdout }}"
+        timezone: 'GMT-6:00'
+        gateway_region: "{{ aws_region }}"
+        gateway_type: 'FILE_S3'
+        <<: *aws_connection_info
+      register: file_gateway
+
+    # ============================================================
+    # Parameter Tests
+    # ============================================================
+    - name: test with no parameters
+      storage_gateway_file_share:
+      register: result
+      ignore_errors: true
+
+    - name: assert failure when called with no parameters
+      assert:
+        that:
+           - 'result.failed'
+           - 'result.msg.startswith("missing required arguments:")'
+
+    - name: test for missing parameters
+      storage_gateway_file_share:
+        gateway_arn: "{{ file_gateway.gateway_arn }}"
+      register: result
+      ignore_errors: true
+
+    - name: assert failure when called with missing parameters
+      assert:
+        that:
+           - 'result.failed'
+           - 'result.msg.startswith("missing required arguments:")'
+
+    - name: test for missing parameters
+      storage_gateway_file_share:
+        gateway_arn: "{{ file_gateway.gateway_arn }}"
+        nfs_token: '5734980946'
+      register: result
+      ignore_errors: true
+
+    - name: assert failure when called with missing parameters
+      assert:
+        that:
+           - 'result.failed'
+           - 'result.msg.startswith("missing required arguments:")'
+
+    - name: test for missing parameters
+      storage_gateway_file_share:
+        gateway_arn: "{{ file_gateway.gateway_arn }}"
+        nfs_token: '5734980946'
+        iam_role: "{{ storage_iam_role.arn }}"
+      register: result
+      ignore_errors: true
+
+    - name: assert failure when called with missing parameters
+      assert:
+        that:
+           - 'result.failed'
+           - 'result.msg.startswith("missing required arguments:")'
+
+
+    # ============================================================
+    # Resource Tests
+    # ===========================================================+
+
+    - name: Create NFS file share
+      storage_gateway_file_share:
+        gateway_arn: "{{ file_gateway.gateway_arn }}"
+        state: present
+        nfs_token: '5734980946'
+        iam_role: "{{ storage_iam_role.arn }}"
+        location_arn: "arn:aws:s3:::{{ resource_prefix }}-test-nfs-bucket"
+        <<: *aws_connection_info
+      register: nfs_file_share
+
+    - name: assert correct keys are returned
+      assert:
+        that:
+          - nfs_file_share.changed
+          - nfs_file_share.file_share_arn is not none
+
+    - name: No changes to NFS file share
+      storage_gateway_file_share:
+        gateway_arn: "{{ file_gateway.gateway_arn }}"
+        state: present
+        nfs_token: '5734980946'
+        iam_role: "{{ storage_iam_role.arn }}"
+        location_arn: "arn:aws:s3:::{{ resource_prefix }}-test-nfs-bucket"
+        <<: *aws_connection_info
+      register: nfs_file_share
+
+    - name: assert correct keys are returned
+      assert:
+        that:
+          - not nfs_file_share.changed
+          - nfs_file_share.file_share_arn is not none
+
+    - name: Update NFS file share
+      storage_gateway_file_share:
+        gateway_arn: "{{ file_gateway.gateway_arn }}"
+        state: present
+        nfs_token: '5734980946'
+        iam_role: "{{ storage_iam_role.arn }}"
+        location_arn: "arn:aws:s3:::{{ resource_prefix }}-test-nfs-bucket"
+        default_storage_class: 'S3_STANDARD_IA'
+        <<: *aws_connection_info
+      register: nfs_file_share
+
+    - name: assert correct keys are returned
+      assert:
+        that:
+          - nfs_file_share.changed
+          - nfs_file_share.file_share_arn is not none
+
+  always:
+
+    # ============================================================
+    # Teardown testing resources
+    # ============================================================
+
+    - name: Tear down NFS file share
+      storage_gateway_file_share:
+        gateway_arn: "{{ file_gateway.gateway_arn }}"
+        state: absent
+        nfs_token: '5734980946'
+        iam_role: "{{ storage_iam_role.arn }}"
+        location_arn: "arn:aws:s3:::{{ resource_prefix }}-test-nfs-bucket"
+        <<: *aws_connection_info
+      register: removed
+      until: removed is not failed
+      ignore_errors: yes
+      retries: 5
+
+    - name: Deactivate NFS gateway
+      storage_gateway:
+        name: "{{ resource_prefix }}-test-file-gateway"
+        state: absent
+        activation_key: "{{ activation_code.stdout }}"
+        timezone: 'GMT-6:00'
+        gateway_region: "{{ aws_region }}"
+        gateway_type: 'FILE_S3'
+        <<: *aws_connection_info
+      register: removed
+      until: removed is not failed
+      ignore_errors: yes
+      retries: 5
+
+    - name: Tear down S3 access for IAM role
+      iam_policy:
+        <<: *aws_connection_info
+        iam_type: role
+        iam_name: "{{ resource_prefix }}-test-storage-iam-role"
+        policy_name: "{{ resource_prefix }}-test-storage-iam-policy"
+        state: absent
+        policy_json: "{{ lookup( 'template', 's3-bucket-policy.json.j2') }}"
+      register: removed
+      until: removed is not failed
+      ignore_errors: yes
+      retries: 5
+
+    - name: Tear down IAM role
+      iam_role:
+        name: "{{ resource_prefix }}-test-storage-iam-role"
+        assume_role_policy_document: "{{ lookup('file','storagegateway-trust-policy.json') }}"
+        state: absent
+        create_instance_profile: no
+        <<: *aws_connection_info
+      register: removed
+      until: removed is not failed
+      ignore_errors: yes
+      retries: 5
+
+    - name: Tear down S3 bucket
+      s3_bucket:
+        state: absent
+        name: "{{ resource_prefix }}-test-nfs-bucket"
+        <<: *aws_connection_info
+      register: removed
+      until: removed is not failed
+      ignore_errors: yes
+      retries: 5
+
+    - name: remove any instances in the test VPC
+      ec2_instance:
+        filters:
+          vpc_id: "{{ testing_vpc.vpc.id }}"
+        state: absent
+        <<: *aws_connection_info
+      register: removed
+      until: removed is not failed
+      ignore_errors: yes
+      retries: 10
+
+    - name: remove ENIs
+      ec2_eni_facts:
+        filters:
+          vpc-id: "{{ testing_vpc.vpc.id }}"
+        <<: *aws_connection_info
+      register: enis
+
+    - name: delete all ENIs
+      ec2_eni:
+        eni_id: "{{ item.id }}"
+        state: absent
+        <<: *aws_connection_info
+      until: removed is not failed
+      with_items: "{{ enis.network_interfaces }}"
+      ignore_errors: yes
+      retries: 10
+
+    - name: remove the security group
+      ec2_group:
+        name: "{{ resource_prefix }}-sg"
+        description: a security group for ansible tests
+        vpc_id: "{{ testing_vpc.vpc.id }}"
+        state: absent
+        <<: *aws_connection_info
+      register: removed
+      until: removed is not failed
+      ignore_errors: yes
+      retries: 10
+
+    - name: remove routing rules
+      ec2_vpc_route_table:
+        state: absent
+        vpc_id: "{{ testing_vpc.vpc.id }}"
+        tags:
+          created: "{{ resource_prefix }}-route"
+        routes:
+          - dest: 0.0.0.0/0
+            gateway_id: "{{ igw.gateway_id }}"
+        subnets:
+          - "{{ testing_subnet.subnet.id }}"
+        <<: *aws_connection_info
+      register: removed
+      until: removed is not failed
+      ignore_errors: yes
+      retries: 10
+
+    - name: remove internet gateway
+      ec2_vpc_igw:
+        vpc_id: "{{ testing_vpc.vpc.id }}"
+        state: absent
+        <<: *aws_connection_info
+      register: removed
+      until: removed is not failed
+      ignore_errors: yes
+      retries: 10
+
+    - name: remove testing subnet
+      ec2_vpc_subnet:
+        state: absent
+        vpc_id: "{{ testing_vpc.vpc.id }}"
+        cidr: 10.22.32.0/24
+        <<: *aws_connection_info
+      register: removed
+      until: removed is not failed
+      ignore_errors: yes
+      retries: 10
+
+    - name: remove the VPC
+      ec2_vpc_net:
+        name: "{{ resource_prefix }}-vpc"
+        cidr_block: 10.22.32.0/23
+        state: absent
+        tags:
+          Name: Ansible Testing VPC
+        tenancy: default
+        <<: *aws_connection_info
+      register: removed
+      until: removed is not failed
+      ignore_errors: yes
+      retries: 10

--- a/test/integration/targets/storage_gateway_file_share/tasks/main.yaml
+++ b/test/integration/targets/storage_gateway_file_share/tasks/main.yaml
@@ -9,6 +9,7 @@
         aws_connection_info: &aws_connection_info
           aws_access_key: "{{ aws_access_key }}"
           aws_secret_key: "{{ aws_secret_key }}"
+          security_token: "{{ security_token }}"
           region: "{{ aws_region }}"
       no_log: true
 

--- a/test/integration/targets/storage_gateway_file_share/templates/s3-bucket-policy.json.j2
+++ b/test/integration/targets/storage_gateway_file_share/templates/s3-bucket-policy.json.j2
@@ -1,0 +1,32 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Action": [
+                "s3:GetAccelerateConfiguration",
+                "s3:GetBucketLocation",
+                "s3:GetBucketVersioning",
+                "s3:ListBucket",
+                "s3:ListBucketVersions",
+                "s3:ListBucketMultipartUploads"
+            ],
+            "Resource": "arn:aws:s3:::{{ resource_prefix }}-test-nfs-bucket",
+            "Effect": "Allow"
+        },
+        {
+            "Action": [
+                "s3:AbortMultipartUpload",
+                "s3:DeleteObject",
+                "s3:DeleteObjectVersion",
+                "s3:GetObject",
+                "s3:GetObjectAcl",
+                "s3:GetObjectVersion",
+                "s3:ListMultipartUploadParts",
+                "s3:PutObject",
+                "s3:PutObjectAcl"
+            ],
+            "Resource": "arn:aws:s3:::{{ resource_prefix }}-test-nfs-bucket/*",
+            "Effect": "Allow"
+        }
+    ]
+}


### PR DESCRIPTION
##### SUMMARY
This is another pull request of several that adds support for AWS Storage Gateway resources.  This one manages NFS file shares on a storage gateway instance.  This instance needs to be activated and set to the `FILE_S3` type to designate it as an file gateway (this can be done with a module I already submitted in #40494 ). This module can then be run against the storage gateway to provision a file share.  Integration testing depends on the `storage_gateway` module in referenced PR so that will likely need to be merged first once everything has been sufficiently reviewed and tested.

##### ISSUE TYPE
 - New Module Pull Request

##### COMPONENT NAME
`storage_gateway_file_share`

##### ANSIBLE VERSION
```
ansible 2.4.1.0
  config file = None
  configured module search path = [u'/Users/asmith/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/asmith/.pyenv/versions/2.7.13/lib/python2.7/site-packages/ansible
  executable location = /Users/asmith/.pyenv/versions/2.7.13/bin/ansible
  python version = 2.7.13 (default, Sep  8 2017, 15:16:38) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```
