### PR TITLE
Update roadmap schedule for 2.6.

### DIFF
--- a/docs/docsite/rst/roadmap/ROADMAP_2_6.rst
+++ b/docs/docsite/rst/roadmap/ROADMAP_2_6.rst
@@ -12,13 +12,13 @@ Actual
 
 - 2018-05-17 Core Freeze (Engine and Core Modules/Plugins)
 - 2018-05-21 Alpha Release 1
+- 2018-05-25 Community Freeze (Non-Core Modules/Plugins)
+- 2018-05-25 Branch stable-2.6
+- 2018-05-30 Alpha Release 2
 
 Expected
 ========
 
-- 2018-05-24 Alpha Release 2
-- 2018-05-25 Community Freeze (Non-Core Modules/Plugins)
-- 2018-05-25 Branch stable-2.6
 - 2018-05-31 Release Candidate 1
 - 2018-06-07 Release Candidate 2
 - 2018-06-14 Release Candidate 3


### PR DESCRIPTION
##### SUMMARY

Update roadmap schedule for 2.6.

##### ISSUE TYPE

Docs Pull Request

##### COMPONENT NAME

ROADMAP_2_6.rst

##### ANSIBLE VERSION

```
ansible 2.7.0.dev0 (roadmap-update 424c58554a) last updated 2018/05/31 12:41:09 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
