### PR TITLE
Do not try to import simplejson in jsonfile.py

### DIFF
--- a/lib/ansible/plugins/cache/jsonfile.py
+++ b/lib/ansible/plugins/cache/jsonfile.py
@@ -43,11 +43,7 @@ DOCUMENTATION = '''
 '''
 
 import codecs
-
-try:
-    import simplejson as json
-except ImportError:
-    import json
+import json
 
 from ansible.parsing.ajson import AnsibleJSONEncoder, AnsibleJSONDecoder
 from ansible.plugins.cache import BaseFileCacheModule


### PR DESCRIPTION
##### SUMMARY
With the addition on `ajson.py` in cbb6a7f4e831abd2d56375fb0aa22465e0cc7c0c, two new classes were created: `AnsibleJSONDecoder` and `AnsibleJSONEncoder`. These classes are used when calling `json.looads()` and `json.dumps()`.

This works fine with everything except the` jsonfile.py` cache plugin, which would first try to import `simplejson` as `json`, then fall back to `json`.

When `simplejson` is installed, the `load()` or `dump()` methods from `simplejson` are called, which then try to use the `AnsibleJSONEncoder/AnsibleJSONDecoder` subclass from `ajson.py`. But `asjon.py` imports `json`, not `simplejson`, and things blow up.


<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
`lib/ansible/plugins/cache/jsonfile.py`

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6
```


##### ADDITIONAL INFORMATION

**Steps to reproduce**

1. `pip install simplejson`
1. Enable jsonfile fact caching
   ```ini
    fact_caching = jsonfile
    fact_caching_connection = ~/.cache/facts
    fact_caching_timout = 3600
   ```
1. Run any playbook

**Expected results**

The playbook runs successfully and facts are cached.

**Actual results**
```
> ansible-playbook test.yml

PLAY [lab-centos7] **********************************************************************
ERROR! Error while decoding the cache file /Users/sdoran/.cache/facts/lab-centos7: b"__init__() got an unexpected keyword argument 'encoding'"
```

A more detailed stack trace, purposefully induced for troubleshooting purposes:

```
> ansible-playbook testlocal.yml

PLAY [localhost] *********************************************************************************************************
Traceback (most recent call last):
  File "/Users/sdoran/Source/ansible/lib/ansible/plugins/cache/__init__.py", line 128, in get
    value = self._load(cachefile)
  File "/Users/sdoran/Source/ansible/lib/ansible/plugins/cache/jsonfile.py", line 66, in _load
    return json.load(f, cls=AnsibleJSONDecoder)
  File "/Users/sdoran/.pyenv/versions/3.6.4/lib/python3.6/site-packages/simplejson/__init__.py", line 460, in load
    use_decimal=use_decimal, **kw)
  File "/Users/sdoran/.pyenv/versions/3.6.4/lib/python3.6/site-packages/simplejson/__init__.py", line 534, in loads
    return cls(encoding=encoding, **kw).decode(s)
TypeError: __init__() got an unexpected keyword argument 'encoding'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/sdoran/Source/ansible/bin/ansible-playbook", line 118, in <module>
    exit_code = cli.run()
  File "/Users/sdoran/Source/ansible/lib/ansible/cli/playbook.py", line 122, in run
    results = pbex.run()
  File "/Users/sdoran/Source/ansible/lib/ansible/executor/playbook_executor.py", line 159, in run
    result = self._tqm.run(play=play)
  File "/Users/sdoran/Source/ansible/lib/ansible/executor/task_queue_manager.py", line 289, in run
    play_return = strategy.run(iterator, play_context)
  File "/Users/sdoran/Source/ansible/lib/ansible/plugins/strategy/linear.py", line 222, in run
    host_tasks = self._get_next_task_lockstep(hosts_left, iterator)
  File "/Users/sdoran/Source/ansible/lib/ansible/plugins/strategy/linear.py", line 100, in _get_next_task_lockstep
    host_tasks[host.name] = iterator.get_next_task_for_host(host, peek=True)
  File "/Users/sdoran/Source/ansible/lib/ansible/executor/play_iterator.py", line 261, in get_next_task_for_host
    (s, task) = self._get_next_task_from_state(s, host=host, peek=peek)
  File "/Users/sdoran/Source/ansible/lib/ansible/executor/play_iterator.py", line 304, in _get_next_task_from_state
    (gathering == 'smart' and implied and not (self._variable_manager._fact_cache.get(host.name, {}).get('module_setup', False))):
  File "/Users/sdoran/.pyenv/versions/3.6.4/lib/python3.6/_collections_abc.py", line 660, in get
    return self[key]
  File "/Users/sdoran/Source/ansible/lib/ansible/plugins/cache/__init__.py", line 269, in __getitem__
    return self._plugin.get(key)
  File "/Users/sdoran/Source/ansible/lib/ansible/plugins/cache/__init__.py", line 141, in get
    raise AnsibleError("Error while decoding the cache file %s: %s" % (cachefile, to_bytes(e)))
ansible.errors.AnsibleError: Error while decoding the cache file /Users/sdoran/.cache/facts/localhost: b"__init__() got an unexpected keyword argument 'encoding'"
```


