### PR TITLE
[2.5] Fix problems in documentation generation (#40050)

### DIFF
--- a/docs/bin/plugin_formatter.py
+++ b/docs/bin/plugin_formatter.py
@@ -94,7 +94,7 @@ def rst_ify(text):
         t = _MODULE.sub(r":ref:`\1 <\1>`", t)
         t = _LINK.sub(r"`\1 <\2>`_", t)
         t = _URL.sub(r"\1", t)
-        t = _CONST.sub(r"`\1`", t)
+        t = _CONST.sub(r"``\1``", t)
         t = _RULER.sub(r"------------", t)
     except Exception as e:
         raise AnsibleError("Could not process (%s) : %s" % (text, e))

--- a/docs/templates/plugin.rst.j2
+++ b/docs/templates/plugin.rst.j2
@@ -116,12 +116,10 @@ Parameters
                 <td>
                     <div class="cell-border">
                         {# Turn boolean values in 'yes' and 'no' values #}
-                        {% if value.default is defined %}
-                            {% if value.default == true %}
-                                {% set _x = value.update({'default': 'yes'}) %}
-                            {% elif value.default == false %}
-                                {% set _x = value.update({'default': 'no'}) %}
-                            {% endif %}
+                        {% if value.default is sameas true %}
+                            {% set _x = value.update({'default': 'yes'}) %}
+                        {% elif value.default is sameas false %}
+                            {% set _x = value.update({'default': 'no'}) %}
                         {% endif %}
                         {% if value.type == 'bool' %}
                             {% set _x = value.update({'choices': ['no', 'yes']}) %}
@@ -131,9 +129,9 @@ Parameters
                             <ul><b>Choices:</b>
                                 {% for choice in value.choices %}
                                     {# Turn boolean values in 'yes' and 'no' values #}
-                                    {% if choice == true %}
+                                    {% if choice is sameas true %}
                                         {% set choice = 'yes' %}
-                                    {% elif choice == false %}
+                                    {% elif choice is sameas false %}
                                         {% set choice = 'no' %}
                                     {% endif %}
                                     {% if (value.default is string and value.default == choice) or (value.default is iterable and value.default is not string and choice in value.default) %}


### PR DESCRIPTION
##### SUMMARY
Backport of #40050 to 2.5, which fixed #40012 for 2.6+. Fixes two documentation bugs:
 - choices with values `0` and `1` are shown as `no` and `yes`, respectively;
 - in the synopses, `C(...)` is converted not to `<code>...</code>`, but to `<cite>...</cite>`.

##### ISSUE TYPE
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
docs/bin/plugin_formatter.py
docs/templates/plugin.rst.j2

##### ANSIBLE VERSION
```
2.5.4
```
