### PR TITLE
Modified setup.ps1 in order to show Windows Installation type

### DIFF
--- a/changelogs/fragments/win_setup-install-type.yaml
+++ b/changelogs/fragments/win_setup-install-type.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- windows setup - Added ``ansible_os_installation_type`` to denote the type of Windows installation the remote host is.

--- a/lib/ansible/modules/windows/setup.ps1
+++ b/lib/ansible/modules/windows/setup.ps1
@@ -207,6 +207,13 @@ if($gather_subset.Contains('distribution')) {
         default { "unknown" }
     }
 
+    $installation_type = $null
+    $current_version_path = "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion"
+    if (Test-Path -LiteralPath $current_version_path) {
+        $install_type_prop = Get-ItemProperty -LiteralPath $current_version_path -ErrorAction SilentlyContinue
+        $installation_type = [String]$install_type_prop.InstallationType
+    }
+
     $ansible_facts += @{
         ansible_distribution = $win32_os.Caption
         ansible_distribution_version = $osversion.Version.ToString()
@@ -214,7 +221,7 @@ if($gather_subset.Contains('distribution')) {
         ansible_os_family = "Windows"
         ansible_os_name = ($win32_os.Name.Split('|')[0]).Trim()
         ansible_os_product_type = $product_type
-        ansible_os_installation_type=[string](Get-ItemProperty "hklm:/software/microsoft/windows nt/currentversion" -ea SilentlyContinue ).InstallationType
+        ansible_os_installation_type = $installation_type
     }
 }
 

--- a/lib/ansible/modules/windows/setup.ps1
+++ b/lib/ansible/modules/windows/setup.ps1
@@ -214,6 +214,7 @@ if($gather_subset.Contains('distribution')) {
         ansible_os_family = "Windows"
         ansible_os_name = ($win32_os.Name.Split('|')[0]).Trim()
         ansible_os_product_type = $product_type
+        ansible_os_installation_type=[string](Get-ItemProperty "hklm:/software/microsoft/windows nt/currentversion" -ea SilentlyContinue ).InstallationType
     }
 }
 


### PR DESCRIPTION
##### SUMMARY
I added a line in setup.ps1 in order to present a new fact that states if the Windows installation is core or not. The variable is **ansible_os_installation_type** and its possible value is "Server Core" or "Server".

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
setup.ps1

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.3
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/usr/share/ansible/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.13 (default, Nov 24 2017, 17:33:09) [GCC 6.3.0 20170516]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
$ ansible -m setup server1
...
"ansible_os_installation_type": "Server Core"
...

$ ansible -m setup server2
...
"ansible_os_installation_type": "Server"
...
```
