### PR TITLE
Re-allow SSH due to broken delegation (#40978)

### DIFF
--- a/lib/ansible/plugins/action/bigip.py
+++ b/lib/ansible/plugins/action/bigip.py
@@ -80,8 +80,6 @@ class ActionModule(_ActionModule):
                     }
 
                 task_vars['ansible_socket'] = socket_path
-        else:
-            return {'failed': True, 'msg': 'Connection type %s is not valid for this module' % self._play_context.connection}
 
         if (self._play_context.connection == 'local' and transport == 'cli') or self._play_context.connection == 'network_cli':
             # make sure we are in the right cli context which should be

--- a/lib/ansible/plugins/action/bigiq.py
+++ b/lib/ansible/plugins/action/bigiq.py
@@ -78,8 +78,6 @@ class ActionModule(_ActionModule):
                                    'https://docs.ansible.com/ansible/network_debug_troubleshooting.html#unable-to-open-shell'}
 
                 task_vars['ansible_socket'] = socket_path
-        else:
-            return {'failed': True, 'msg': 'Connection type %s is not valid for this module' % self._play_context.connection}
 
         if (self._play_context.connection == 'local' and transport == 'cli') or self._play_context.connection == 'network_cli':
             # make sure we are in the right cli context which should be


### PR DESCRIPTION
Removes the SSH enforcement because it breaks situations where, for example,
an admin maintains Ansible Tower and another team needs to use Ansible
with the BIG-IP modules, but the Tower admin does not want to install
the F5-SDK on the Ansible Tower instance.

In this situation, the user needs to delegate the execution of the BIG-IP
module to another linux host that does have the dependencies installed.

Usually this is done with delegation, often over SSH. Limiting the SSH
connection here prevents this from working.

(cherry picked from commit 8bccd0830be8f2c64bfe2c6828111f5b5d6d8c94)

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
bigip action plugins

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0
  config file = /here/test/integration/ansible.cfg
  configured module search path = ['/here/library/modules']
  ansible python module location = /usr/local/lib/python3.6/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 3.6.5 (default, May  5 2018, 03:09:35) [GCC 4.9.2
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
