### PR TITLE
2.6 backport #40720 - fix cache timeout behavior

### DIFF
--- a/lib/ansible/plugins/cache/__init__.py
+++ b/lib/ansible/plugins/cache/__init__.py
@@ -153,7 +153,7 @@ class BaseFileCacheModule(BaseCacheModule):
     def has_expired(self, key):
 
         if self._timeout == 0:
-            return True
+            return False
 
         cachefile = "%s/%s" % (self._cache_dir, key)
         try:


### PR DESCRIPTION
(cherry picked from commit c1400ce9091a6fcf2c2db465b5c1fbd01cce9447)

##### SUMMARY
Backport https://github.com/ansible/ansible/pull/40720

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
`lib/ansible/plugins/cache/__init__.py`

##### ANSIBLE VERSION
```
ansible 2.6.0.dev0
```
