### PR TITLE
Update azure_rm_securitygroup.py examples

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_securitygroup.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_securitygroup.py
@@ -140,19 +140,19 @@ EXAMPLES = '''
       name: mysecgroup
       purge_rules: yes
       rules:
-          - name: DenySSH
-            protocol: TCP
-            destination_port_range: 22
-            access: Deny
-            priority: 100
-            direction: Inbound
           - name: 'AllowSSH'
-            protocol: TCP
+            protocol: Tcp
             source_address_prefix:
               - '174.109.158.0/24'
               - '174.109.159.0/24'
             destination_port_range: 22
             access: Allow
+            priority: 100
+            direction: Inbound
+          - name: DenySSH
+            protocol: Tcp
+            destination_port_range: 22
+            access: Deny
             priority: 101
             direction: Inbound
 
@@ -161,17 +161,17 @@ EXAMPLES = '''
       resource_group: mygroup
       name: mysecgroup
       rules:
-          - name: DenySSH
-            protocol: TCP
-            destination_port_range: 22-23
-            access: Deny
-            priority: 100
-            direction: Inbound
           - name: AllowSSHFromHome
-            protocol: TCP
+            protocol: Tcp
             source_address_prefix: '174.109.158.0/24'
             destination_port_range: 22-23
             access: Allow
+            priority: 100
+            direction: Inbound
+          - name: DenySSH
+            protocol: Tcp
+            destination_port_range: 22-23
+            access: Deny
             priority: 102
             direction: Inbound
       tags:


### PR DESCRIPTION

+label: docsite_pr

##### SUMMARY
The protocol defined in the examples was not valid because "TCP" must be "Tcp". The priority of the rules in the example would also not achieve the desired effect, because the deny all rule would come into effect before the allow rule. I reversed the rules in order to more clearly communicate the order in which they take effect. Notice the priority field of the rules is also changed, but appears the same because of the reorganizing 

The security rule documentation is here https://docs.microsoft.com/en-us/azure/virtual-network/security-overview#security-rules

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
azure_rm_securitygroup

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0
  config file = /Users/benwaller/.ansible.cfg
  configured module search path = [u'/Users/benwaller/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Library/Python/2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.10 (default, Oct  6 2017, 22:29:07) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.31)]
```

