### PR TITLE
[2.6 backport] Do not try to import simplejson in jsonfile.py (#40983)

### DIFF
--- a/lib/ansible/plugins/cache/jsonfile.py
+++ b/lib/ansible/plugins/cache/jsonfile.py
@@ -43,11 +43,7 @@ DOCUMENTATION = '''
 '''
 
 import codecs
-
-try:
-    import simplejson as json
-except ImportError:
-    import json
+import json
 
 from ansible.parsing.ajson import AnsibleJSONEncoder, AnsibleJSONDecoder
 from ansible.plugins.cache import BaseFileCacheModule


### PR DESCRIPTION
With the addition on ajson.py in cbb6a7f4e831abd2d56375fb0aa22465e0cc7c0c, two
new classes were created: AnsibleJSONDecoder and AnsibleJSONEncoder. These
classes are used when calling json.looads() and json.dumps().

This works fine with everything except the jsonfile.py cache plugin, which would
first try to import simplejson as json, then fall back to json. When simplejson
is installed, the load() or dump methods from simplejson are called, which then
try to use the AnsibleJSONEncoder/AnsibleJSONDecoder subclass from ajson.py.
But asjon.py imports json, not simplejson, and things blow up.

(cherry picked from commit 479b26fe31d5eff5e7e6a4504aa174591414a8be)

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
plugins/cache/jsonfile.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
2.6.0a2

##### ADDITIONAL INFORMATION

