### PR TITLE
Fixes to ios_logging

### DIFF
--- a/lib/ansible/modules/network/ios/ios_logging.py
+++ b/lib/ansible/modules/network/ios/ios_logging.py
@@ -225,7 +225,7 @@ def parse_size(line, dest):
     size = None
 
     if dest == 'buffered':
-        match = re.search(r'logging buffered (?:(\d+) )?\S+', line, re.M)
+        match = re.search(r'logging buffered(?: (\d+))?(?: [a-z]+)?', line, re.M)
         if match:
             if match.group(1) is not None:
                 size = match.group(1)
@@ -255,15 +255,12 @@ def parse_level(line, dest):
 
     else:
         if dest == 'buffered':
-            match = re.search(r'logging buffered (?:\d+ )?([a-z]+)', line, re.M)
+            match = re.search(r'logging buffered(?: \d+)?(?: ([a-z]+))?', line, re.M)
         else:
             match = re.search(r'logging {0} (\S+)'.format(dest), line, re.M)
 
-        if match:
-            if match.group(1) in level_group:
-                level = match.group(1)
-            else:
-                level = 'debugging'
+        if match and match.group(1) in level_group:
+            level = match.group(1)
         else:
             level = 'debugging'
 

--- a/lib/ansible/modules/network/ios/ios_logging.py
+++ b/lib/ansible/modules/network/ios/ios_logging.py
@@ -225,7 +225,7 @@ def parse_size(line, dest):
     size = None
 
     if dest == 'buffered':
-        match = re.search(r'logging buffered (\S+)', line, re.M)
+        match = re.search(r'logging buffered (?:(\d+) )?\S+', line, re.M)
         if match:
             try:
                 int_size = int(match.group(1))
@@ -261,7 +261,7 @@ def parse_level(line, dest):
 
     else:
         if dest == 'buffered':
-            match = re.search(r'logging buffered (?:\d+ )([a-z]+)', line, re.M)
+            match = re.search(r'logging buffered (?:\d+ )?([a-z]+)', line, re.M)
         else:
             match = re.search(r'logging {0} (\S+)'.format(dest), line, re.M)
 

--- a/lib/ansible/modules/network/ios/ios_logging.py
+++ b/lib/ansible/modules/network/ios/ios_logging.py
@@ -227,16 +227,10 @@ def parse_size(line, dest):
     if dest == 'buffered':
         match = re.search(r'logging buffered (?:(\d+) )?\S+', line, re.M)
         if match:
-            try:
-                int_size = int(match.group(1))
-            except ValueError:
-                int_size = None
-
-            if int_size:
-                if isinstance(int_size, int):
-                    size = str(match.group(1))
-                else:
-                    size = str(4096)
+            if match.group(1) is not None:
+                size = match.group(1)
+            else:
+                size = "4096"
 
     return size
 

--- a/test/integration/targets/ios_logging/tests/cli/basic.yaml
+++ b/test/integration/targets/ios_logging/tests/cli/basic.yaml
@@ -1,7 +1,7 @@
 ---
 # ensure logging configs are empty
 - name: Remove host logging
-  ios_logging:
+  ios_logging: &remove_host
     dest: host
     name: 172.16.0.1
     state: absent
@@ -45,16 +45,12 @@
     provider: "{{ cli }}"
   register: result
 
-- assert:
+- assert: &unchanged
     that:
       - 'result.changed == false'
 
 - name: Delete/disable host logging
-  ios_logging:
-    dest: host
-    name: 172.16.0.1
-    state: absent
-    provider: "{{ cli }}"
+  ios_logging: *remove_host
   register: result
 
 - assert:
@@ -63,16 +59,10 @@
       - '"no logging host 172.16.0.1" in result.commands'
 
 - name: Delete/disable host logging (idempotent)
-  ios_logging:
-    dest: host
-    name: 172.16.0.1
-    state: absent
-    provider: "{{ cli }}"
+  ios_logging: *remove_host
   register: result
 
-- assert:
-    that:
-      - 'result.changed == false'
+- assert: *unchanged
 
 - name: Console logging with level warnings
   ios_logging:
@@ -115,7 +105,7 @@
       - '"logging console notifications" in result.commands'
 
 - name: Set both logging destination and facility
-  ios_logging:
+  ios_logging: &set_both
     dest: buffered
     facility: uucp
     level: alerts
@@ -131,18 +121,10 @@
       - '"logging facility uucp" in result.commands'
 
 - name: Set both logging destination and facility (idempotent)
-  ios_logging:
-    dest: buffered
-    facility: uucp
-    level: alerts
-    size: 4096
-    state: present
-    provider: "{{ cli }}"
+  ios_logging: *set_both
   register: result
 
-- assert:
-    that:
-      - 'result.changed == false'
+- assert: *unchanged
 
 - name: remove logging as collection tearDown
   ios_logging:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
IOS XE omits certain defaults from config that cause idempotency issues for ios_logging. This changes regexes to mark those sections as optional.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
ios_logging

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6
```