### PR TITLE
fix nxos_snapshot issues

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_snapshot.py
+++ b/lib/ansible/modules/network/nxos/nxos_snapshot.py
@@ -88,7 +88,7 @@ options:
     save_snapshot_locally:
         description:
             - Specify to locally store a new created snapshot,
-              to be used when C(action=create). This works only for nxapi transport.
+              to be used when C(action=create).
         type: bool
         default: 'no'
     path:
@@ -148,7 +148,7 @@ import re
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.network.nxos.nxos import load_config, run_commands
-from ansible.module_utils.network.nxos.nxos import nxos_argument_spec, check_args, get_capabilities
+from ansible.module_utils.network.nxos.nxos import nxos_argument_spec, check_args
 
 
 def execute_show_command(command, module):

--- a/lib/ansible/modules/network/nxos/nxos_snapshot.py
+++ b/lib/ansible/modules/network/nxos/nxos_snapshot.py
@@ -339,12 +339,6 @@ def main():
     action = module.params['action']
     comparison_results_file = module.params['comparison_results_file']
 
-    local_save = module.params['save_snapshot_locally']
-    if local_save:
-        device_info = get_capabilities(module)
-        if device_info.get('network_api', 'nxapi') != 'nxapi':
-            module.fail_json(msg="save_snapshot_locally works only for nxapi transport")
-
     if not os.path.isdir(module.params['path']):
         module.fail_json(msg='{0} is not a valid directory name.'.format(
             module.params['path']))
@@ -372,11 +366,11 @@ def main():
                 result['commands'] = action_results
                 result['changed'] = True
 
-            if action == 'create' and module.params['path'] and local_save:
-                command = 'show snapshot dump {}'.format(module.params['snapshot_name'])
+            if action == 'create' and module.params['path'] and module.params['save_snapshot_locally']:
+                command = 'show snapshot dump {} | json'.format(module.params['snapshot_name'])
                 content = execute_show_command(command, module)[0]
                 if content:
-                    write_on_file(content, module.params['snapshot_name'], module)
+                    write_on_file(str(content), module.params['snapshot_name'], module)
 
     module.exit_json(**result)
 

--- a/test/integration/targets/nxos_snapshot/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_snapshot/tests/common/sanity.yaml
@@ -11,10 +11,6 @@
 - set_fact: snapshot_run="false"
   when: platform is match('N35')
 
-- set_fact: save_snapshot_locally="False"
-- set_fact: save_snapshot_locally="True"
-  when: ansible_connection is match('nxapi')
-
 - set_fact: add_sec="true"
 - set_fact: add_sec="false"
   when: imagetag is search("D1")
@@ -25,7 +21,7 @@
       action: create
       snapshot_name: test_snapshot1
       description: Ansible
-      save_snapshot_locally: "{{save_snapshot_locally|default(omit)}}"
+      save_snapshot_locally: True
     register: result
 
   - assert: &true

--- a/test/integration/targets/nxos_snapshot/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_snapshot/tests/common/sanity.yaml
@@ -4,19 +4,65 @@
   when: ansible_connection == "local"
 
 - set_fact: snapshot_run="true"
+
 - set_fact: snapshot_run="false"
-  when: titanium and ( connection.transport is match('nxapi'))
+  when: titanium and (ansible_connection is match('nxapi'))
+
+- set_fact: snapshot_run="false"
+  when: platform is match('N35')
+
+- set_fact: save_snapshot_locally="False"
+- set_fact: save_snapshot_locally="True"
+  when: ansible_connection is match('nxapi')
+
+- set_fact: add_sec="true"
+- set_fact: add_sec="false"
+  when: imagetag is search("D1")
 
 - block:
   - name: create snapshot
-    nxos_snapshot:
+    nxos_snapshot: &crss1
       action: create
       snapshot_name: test_snapshot1
       description: Ansible
-      save_snapshot_locally: true
+      save_snapshot_locally: "{{save_snapshot_locally|default(omit)}}"
+    register: result
+
+  - assert: &true
+      that:
+        - "result.changed == true"
+
+  - name: "Conf Idempotence"
+    nxos_snapshot: *crss1
+    register: result
+
+  - assert: &false
+      that:
+        - "result.changed == false"
+
+  - block:
+    - name: Add section
+      nxos_snapshot: &add
+        action: add
+        section: myshow
+        show_command: show ip interface brief
+        row_id: ROW_intf
+        element_key1: intf-name
+        element_key2: intf-name
+      register: result
+
+    - assert: *true
+  
+    - name: "Conf Idempotence"
+      nxos_snapshot: *add
+      register: result
+
+    - assert: *false
+
+    when: add_sec
 
   - name: create another snapshot
-    nxos_snapshot:
+    nxos_snapshot: &crss2
       action: create
       snapshot_name: test_snapshot2
       description: row
@@ -24,7 +70,15 @@
       show_command: show ip interface brief
       row_id: ROW_intf
       element_key1: intf-name
-      save_snapshot_locally: true
+    register: result
+
+  - assert: *true
+  
+  - name: "Conf Idempotence"
+    nxos_snapshot: *crss2
+    register: result
+
+  - assert: *false
 
   - name: compare snapshots
     nxos_snapshot:
@@ -35,25 +89,44 @@
       compare_option: summary
       path: '.'
 
-  - name: FAIL compare snapshots
-    nxos_snapshot:
-      action: compare
-      snapshot1: test_snapshot1
-      snapshot2: test_snapshot2
-      compare_option: summary
-      path: '.'
+  - name: delete snapshot
+    nxos_snapshot: &del
+      snapshot_name: test_snapshot2
+      action: delete
     register: result
-    ignore_errors: yes
 
-  - assert:
-      that:
-        - 'result.failed == True'
-        - '"action is compare but all of the following are missing: comparison_results_file" in result.msg'
+  - assert: *true
+  
+  - name: "Conf Idempotence"
+    nxos_snapshot: *del
+    register: result
+
+  - assert: *false
+
+  - name: delete all snapshots
+    nxos_snapshot: &delall
+      action: delete_all
+    register: result
+
+  - assert: *true
+  
+  - name: "Conf Idempotence"
+    nxos_snapshot: *delall
+    register: result
+
+  - assert: *false
 
   when: snapshot_run
 
   always:
-  - name: delete snapshot
+  - name: delete all sections
+    nxos_config:
+      commands:
+        - snapshot section delete myshow
+      match: none
+    ignore_errors: yes
+
+  - name: delete all snapshots
     nxos_snapshot:
       action: delete_all
     ignore_errors: yes


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #41033 
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
nxos_snapshot
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (devel 961484e00d) last updated 2018/05/31 12:44:26 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /root/agents-ci/ansible/lib/ansible
  executable location = /root/agents-ci/ansible/bin/ansible
  python version = 2.7.6 (default, Oct 26 2016, 20:30:19) [GCC 4.8.4]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->
* Fixes issue #41033. However, because of there is no support for xml for nxos currently, the ```save_snapshot_locally``` works only for nxapi transport. It throws an error message for any other transport.
* Dead code removed
* The integration test cases are enhanced to cover all parameters, idempotent cases  and also platform differences.
