### PR TITLE
add custom filename example for Fortios platform

### DIFF
--- a/lib/ansible/modules/network/fortios/fortios_config.py
+++ b/lib/ansible/modules/network/fortios/fortios_config.py
@@ -59,6 +59,17 @@ EXAMPLES = """
     password: password
     src: new_configuration.conf.j2
 
+# The date var is declared in the vars section of the playbook
+# date: "{{ lookup('pipe', 'date +%Y%m%d-%H%M') }}"`
+- name: Backup current config with custom filename
+  fortios_config:
+    host: "{{ inventory_hostname }}"
+    username: "{{ username }}"
+    password: "{{ password }}"
+    backup: yes
+    backup_path: "backup/fortios/"
+    backup_filename: "{{inventory_hostname}}-{{date}}.cfg" 
+    
 """
 
 RETURN = """

--- a/lib/ansible/modules/network/fortios/fortios_config.py
+++ b/lib/ansible/modules/network/fortios/fortios_config.py
@@ -68,8 +68,7 @@ EXAMPLES = """
     password: "{{ password }}"
     backup: yes
     backup_path: "backup/fortios/"
-    backup_filename: "{{inventory_hostname}}-{{date}}.cfg" 
-    
+    backup_filename: "{{inventory_hostname}}-{{date}}.cfg"
 """
 
 RETURN = """


### PR DESCRIPTION
Added an example of backing up a configuration using a custom filename

+label: docsite_pr
+label: issue ansible/community#311

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Added an example of backing up a configuration using a custom filename
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
fortios_config
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.2
  config file = /home/ansible.cfg
  configured module search path = [u'/usr/local/lib/python2.7/dist-packages/napalm_ansible']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```