### PR TITLE
add example using the "when" keyword

### DIFF
--- a/lib/ansible/modules/network/ios/ios_config.py
+++ b/lib/ansible/modules/network/ios/ios_config.py
@@ -276,13 +276,12 @@ EXAMPLES = """
 # Set boot image based on comparison to a group_var (version) and the version
 # that is returned from the `ios_facts` module
 - name: SETTING BOOT IMAGE
-    ios_config:
-       lines:
-         - no boot system
-         - boot system flash bootflash:{{new_image}}
-       provider: "{{cli}}"
-       host: "{{ inventory_hostname }}"
-    when: ansible_net_version != version
+  ios_config:
+    lines:
+      - no boot system
+      - boot system flash bootflash:{{new_image}}
+    host: "{{ inventory_hostname }}"
+  when: ansible_net_version != version
 """
 
 RETURN = """

--- a/lib/ansible/modules/network/ios/ios_config.py
+++ b/lib/ansible/modules/network/ios/ios_config.py
@@ -272,6 +272,17 @@ EXAMPLES = """
       - shutdown
     # parents: int gig1/0/11
     parents: interface GigabitEthernet1/0/11
+    
+# Set boot image based on comparison to a group_var (version) and the version 
+# that is returned from the `ios_facts` module
+- name: SETTING BOOT IMAGE
+    ios_config:
+       lines:
+         - no boot system
+         - boot system flash bootflash:{{new_image}}
+       provider: "{{cli}}"
+       host: "{{ inventory_hostname }}"
+    when: ansible_net_version != version
 """
 
 RETURN = """

--- a/lib/ansible/modules/network/ios/ios_config.py
+++ b/lib/ansible/modules/network/ios/ios_config.py
@@ -272,8 +272,8 @@ EXAMPLES = """
       - shutdown
     # parents: int gig1/0/11
     parents: interface GigabitEthernet1/0/11
-    
-# Set boot image based on comparison to a group_var (version) and the version 
+
+# Set boot image based on comparison to a group_var (version) and the version
 # that is returned from the `ios_facts` module
 - name: SETTING BOOT IMAGE
     ios_config:


### PR DESCRIPTION
<!--- Your description here -->
add example using the "when" keyword comparing group_var variable to returned value from ios_facts
+label: docsite_pr
+label: issue ansible/community#311

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Add example using the "when" keyword comparing group_var variable to returned value from ios_facts

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
iOS_config
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.2
  config file = /home/ansible.cfg
  configured module search path = [u'/usr/local/lib/python2.7/dist-packages/napalm_ansible']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```