### PR TITLE
Do not consider an empty version string as a version

### DIFF
--- a/lib/ansible/modules/packaging/language/pip.py
+++ b/lib/ansible/modules/packaging/language/pip.py
@@ -219,7 +219,7 @@ def _get_cmd_options(module, cmd):
 
 
 def _get_full_name(name, version=None):
-    if version is None:
+    if version is None or version == "":
         resp = name
     else:
         resp = name + '==' + version

--- a/test/integration/targets/pip/tasks/pip.yml
+++ b/test/integration/targets/pip/tasks/pip.yml
@@ -256,3 +256,17 @@
   assert:
     that:
       - not pip_install_empty.changed
+
+# https://github.com/ansible/ansible/issues/41043
+- name: do not consider an empty string as a version
+  pip:
+    name: q
+    state: present
+    version: ""
+    virtualenv: "{{ output_dir }}/pipenv"
+  register: pip_install_empty_version_string
+
+- name: ensure that task installation did not fail
+  assert:
+    that:
+      - pip_install_empty_version_string is successful


### PR DESCRIPTION
##### SUMMARY
When using an empty string as the version argument, the module would
before attempt to run something akin to:

    pip install module==""

This changes the behavior to:

    pip install module

Fixes #41043

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
pip

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.4
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /tmp/reproducer/lib/python2.7/site-packages/ansible
  executable location = /tmp/reproducer/bin/ansible
  python version = 2.7.5 (default, Aug  4 2017, 00:39:18) [GCC 4.8.5 20150623 (Red Hat 4.8.5-16)]
```

##### ADDITIONAL INFORMATION
See https://github.com/ansible/ansible/issues/41043#issue-328709552