### PR TITLE
More correct fix for status problem

### DIFF
--- a/lib/ansible/modules/network/f5/bigip_pool_member.py
+++ b/lib/ansible/modules/network/f5/bigip_pool_member.py
@@ -465,7 +465,7 @@ class ApiParameters(Parameters):
     def state(self):
         if self._values['state'] in ['user-up', 'unchecked', 'fqdn-up-no-addr'] and self._values['session'] in ['user-enabled']:
             return 'present'
-        elif self._values['state'] == 'down' and self._values['session'] == 'monitor-enabled':
+        elif self._values['state'] in ['down', 'up'] and self._values['session'] == 'monitor-enabled':
             return 'present'
         elif self._values['state'] in ['user-down'] and self._values['session'] in ['user-disabled']:
             return 'forced_offline'
@@ -521,6 +521,8 @@ class ReportableChanges(Changes):
     @property
     def state(self):
         if self._values['state'] in ['user-up', 'unchecked', 'fqdn-up-no-addr'] and self._values['session'] in ['user-enabled']:
+            return 'present'
+        elif self._values['state'] in ['down', 'up'] and self._values['session'] == 'monitor-enabled':
             return 'present'
         elif self._values['state'] in ['user-down'] and self._values['session'] in ['user-disabled']:
             return 'forced_offline'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
Status is not being determined right when monitors are enabled but
the state is up or down. This patch fixes it.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
bigip_pool_member

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0
  config file = /here/test/integration/ansible.cfg
  configured module search path = ['/here/library/modules']
  ansible python module location = /usr/local/lib/python3.6/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 3.6.5 (default, May  5 2018, 03:09:35) [GCC 4.9.2]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
