### PR TITLE
[vmware_guest] Add video card support 

### DIFF
--- a/test/integration/targets/vmware_guest/tasks/create_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/create_d1_c1_f0.yml
@@ -56,6 +56,10 @@
         # mem_reservation: 4096
         # cpu_limit: 8096
         # cpu_reservation: 4096
+        video_card:
+            video_memory_kb: 16384
+            enable_3d: true
+            num_display: 2
         max_connections: 10
     disk:
         - size: 1gb
@@ -122,6 +126,11 @@
     hardware:
         num_cpus: 2
         memory_mb: 1024
+        ## Commenting out video_card as I know the code can't update it
+        #video_card:
+        #    video_memory_kb: 8192
+        #    enable_3d: false 
+        #    num_display: 3
     state: present
     folder: "{{ item|dirname }}"
   with_items: "{{ vmlist['json'] }}"


### PR DESCRIPTION
SUMMARY

This pull requests replaces #31925 which I completely broke somehow.
This change allows configuring video cards: one can set the 3d support, the video memory and the number of displays.

It currently only works for new VM (no edition).

Fixes #31810
ISSUE TYPE

    Feature Pull Request

COMPONENT NAME

vmware_guest