### PR TITLE
Changes to Yum Documentation

### DIFF
--- a/lib/ansible/modules/packaging/os/yum.py
+++ b/lib/ansible/modules/packaging/os/yum.py
@@ -255,8 +255,11 @@ EXAMPLES = '''
 
 - name: Install a list of packages
   yum:
-    name: "nginx,postgresql,postgresql-server"
-    state: latest
+    name: 
+      - nginx
+      - postgresql
+      - postgresql-server
+    state: present
 '''
 
 import os

--- a/lib/ansible/modules/packaging/os/yum.py
+++ b/lib/ansible/modules/packaging/os/yum.py
@@ -28,7 +28,7 @@ options:
       - A package name or package specifier with version, like C(name-1.0).
       - If a previous version is specified, the task also needs to turn C(allow_downgrade) on.
         See the C(allow_downgrade) documentation for caveats with downgrading packages.
-      - When using state=latest, this can be '*' which means run C(yum -y update).
+      - When using state=latest, this can be C('*') which means run C(yum -y update).
       - You can also pass a url or a local path to a rpm file (using state=present).
         To operate on several packages this can accept a comma separated list of packages or (as of 2.0) a list of packages.
     aliases: [ pkg ]
@@ -52,13 +52,13 @@ options:
     description:
       - I(Repoid) of repositories to enable for the install/update operation.
         These repos will not persist beyond the transaction.
-        When specifying multiple repos, separate them with a ",".
+        When specifying multiple repos, separate them with a C(",").
     version_added: "0.9"
   disablerepo:
     description:
       - I(Repoid) of repositories to disable for the install/update operation.
         These repos will not persist beyond the transaction.
-        When specifying multiple repos, separate them with a ",".
+        When specifying multiple repos, separate them with a C(",").
     version_added: "0.9"
   conf_file:
     description:
@@ -73,8 +73,7 @@ options:
     version_added: "1.2"
   skip_broken:
     description:
-      - Resolve depsolve problems by removing packages that are causing problems from the trans‐
-        action.
+      - Skip packages with broken dependencies(devsolve) and are causing problems.
     type: bool
     default: "no"
     version_added: "2.3"
@@ -253,6 +252,11 @@ EXAMPLES = '''
   yum:
     name: sos
     disablerepo: "epel,ol7_latest"
+
+- name: Install a list of packages
+  yum:
+    name: "nginx,postgresql,postgresql-server"
+    state: latest
 '''
 
 import os

--- a/lib/ansible/modules/packaging/os/yum.py
+++ b/lib/ansible/modules/packaging/os/yum.py
@@ -255,7 +255,7 @@ EXAMPLES = '''
 
 - name: Install a list of packages
   yum:
-    name: 
+    name:
       - nginx
       - postgresql
       - postgresql-server


### PR DESCRIPTION
…me areas since it cannot be read right

##### SUMMARY
1. Added an example to install a list with ","
2. In some Browsers, having "," looks and does not render correctly. I added C() to make it look like code and it displays correctly.
3. Changed the description of `skip_broken` so its easier to understand.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
yum

##### ANSIBLE VERSION

```
ansible 2.5.3
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/root/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/jlozadad/.virtualenvs/ansible-tower-setup-3.2.2-fZdUQYWq/lib/python3.6/site-packages/ansible
  executable location = /home/jlozadad/.virtualenvs/ansible-tower-setup-3.2.2-fZdUQYWq/bin/ansible
  python version = 3.6.5 (default, Apr  4 2018, 15:01:18) [GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]


```


##### ADDITIONAL INFORMATION
Here are some screenshots that show how they look.
before the change: https://i.imgur.com/1CpAE7x.png
After the change: https://i.imgur.com/DE5GE0G.png
Fedora 27
Firefox 60.0.1
```
generating indices... genindex
writing additional pages... search opensearch
copying images... [100%] dev_guide/style_guide/images/hyphen-funny.jpg                                                                                                                                             
copying downloadable files... [100%] network/getting_started/sample_files/first_playbook.yml                                                                                                                       
copying static files... done
copying extra files... done
dumping search index in English (code: en) ... done
dumping object inventory... done
build succeeded, 80 warnings.

Build finished. The HTML pages are in _build/html.
make[1]: Leaving directory '/data/git/ansible/docs/docsite'

```
