### PR TITLE
Adding module to manage database subnet groups on AWS Neptune

### DIFF
--- a/lib/ansible/module_utils/aws/waiters.py
+++ b/lib/ansible/module_utils/aws/waiters.py
@@ -204,6 +204,50 @@ eks_data = {
     }
 }
 
+
+neptune_data = {
+    "version": 2,
+    "waiters": {
+        "DBSubnetGroupAvailable": {
+            "delay": 5,
+            "maxAttempts": 25,
+            "operation": "DescribeDBSubnetGroups",
+            "acceptors": [
+                {
+                    "matcher": "path",
+                    "expected": True,
+                    "argument": "DBSubnetGroups[0].SubnetGroupStatus == 'Complete'",
+                    "state": "success"
+                },
+                {
+                    "matcher": "error",
+                    "expected": "DBSubnetGroupNotFoundFault",
+                    "state": "retry"
+                },
+            ]
+        },
+        "DBSubnetGroupDeleted": {
+            "delay": 5,
+            "maxAttempts": 25,
+            "operation": "DescribeDBSubnetGroups",
+            "acceptors": [
+                {
+                    "matcher": "path",
+                    "expected": True,
+                    "argument": "DBSubnetGroups[0]",
+                    "state": "retry"
+                },
+                {
+                    "matcher": "error",
+                    "expected": "DBSubnetGroupNotFoundFault",
+                    "state": "success"
+                },
+            ]
+        }
+    }
+}
+
+
 rds_data = {
     "version": 2,
     "waiters": {
@@ -224,29 +268,6 @@ rds_data = {
 }
 
 
-<<<<<<< HEAD
-rds_data = {
-    "version": 2,
-    "waiters": {
-        "DBInstanceStopped": {
-            "delay": 20,
-            "maxAttempts": 60,
-            "operation": "DescribeDBInstances",
-            "acceptors": [
-                {
-                    "state": "success",
-                    "matcher": "pathAll",
-                    "argument": "DBInstances[].DBInstanceStatus",
-                    "expected": "stopped"
-                },
-            ]
-        }
-    }
-}
-
-
-=======
->>>>>>> Adding module to manage database subnet groups on AWS Neptune
 def ec2_model(name):
     ec2_models = core_waiter.WaiterModel(waiter_config=ec2_data)
     return ec2_models.get_waiter(name)

--- a/lib/ansible/module_utils/aws/waiters.py
+++ b/lib/ansible/module_utils/aws/waiters.py
@@ -204,43 +204,19 @@ eks_data = {
     }
 }
 
-
-neptune_data = {
+rds_data = {
     "version": 2,
     "waiters": {
-        "DBSubnetGroupAvailable": {
-            "delay": 5,
-            "maxAttempts": 25,
-            "operation": "DescribeDBSubnetGroups",
+        "DBInstanceStopped": {
+            "delay": 20,
+            "maxAttempts": 60,
+            "operation": "DescribeDBInstances",
             "acceptors": [
                 {
-                    "matcher": "path",
-                    "expected": True,
-                    "argument": "DBSubnetGroups[0].SubnetGroupStatus == 'Complete'",
-                    "state": "success"
-                },
-                {
-                    "matcher": "error",
-                    "expected": "DBSubnetGroupNotFoundFault",
-                    "state": "retry"
-                },
-            ]
-        },
-        "DBSubnetGroupDeleted": {
-            "delay": 5,
-            "maxAttempts": 25,
-            "operation": "DescribeDBSubnetGroups",
-            "acceptors": [
-                {
-                    "matcher": "path",
-                    "expected": True,
-                    "argument": "DBSubnetGroups[0]",
-                    "state": "retry"
-                },
-                {
-                    "matcher": "error",
-                    "expected": "DBSubnetGroupNotFoundFault",
-                    "state": "success"
+                    "state": "success",
+                    "matcher": "pathAll",
+                    "argument": "DBInstances[].DBInstanceStatus",
+                    "expected": "stopped"
                 },
             ]
         }
@@ -290,6 +266,9 @@ def neptune_model(name):
     neptune_models = core_waiter.WaiterModel(waiter_config=neptune_data)
     return neptune_models.get_waiter(name)
 
+def rds_model(name):
+    rds_models = core_waiter.WaiterModel(waiter_config=rds_data)
+    return rds_models.get_waiter(name)
 
 def rds_model(name):
     rds_models = core_waiter.WaiterModel(waiter_config=rds_data)

--- a/lib/ansible/module_utils/aws/waiters.py
+++ b/lib/ansible/module_utils/aws/waiters.py
@@ -248,6 +248,7 @@ neptune_data = {
 }
 
 
+<<<<<<< HEAD
 rds_data = {
     "version": 2,
     "waiters": {
@@ -268,6 +269,8 @@ rds_data = {
 }
 
 
+=======
+>>>>>>> Adding module to manage database subnet groups on AWS Neptune
 def ec2_model(name):
     ec2_models = core_waiter.WaiterModel(waiter_config=ec2_data)
     return ec2_models.get_waiter(name)

--- a/lib/ansible/module_utils/aws/waiters.py
+++ b/lib/ansible/module_utils/aws/waiters.py
@@ -287,9 +287,6 @@ def neptune_model(name):
     neptune_models = core_waiter.WaiterModel(waiter_config=neptune_data)
     return neptune_models.get_waiter(name)
 
-def rds_model(name):
-    rds_models = core_waiter.WaiterModel(waiter_config=rds_data)
-    return rds_models.get_waiter(name)
 
 def rds_model(name):
     rds_models = core_waiter.WaiterModel(waiter_config=rds_data)

--- a/lib/ansible/modules/cloud/amazon/aws_neptune_subnet_group.py
+++ b/lib/ansible/modules/cloud/amazon/aws_neptune_subnet_group.py
@@ -18,7 +18,7 @@ module: aws_neptune_subnet_group
 short_description: Manage database subnet groups on AWS Neptune.
 description:
     - Create, modify, and destroy database subnet groups on AWS Neptune
-version_added: "2.7"
+version_added: "2.8"
 requirements: [ 'botocore>=1.10.30', 'boto3' ]
 author:
     - "Aaron Smith (@slapula)"

--- a/lib/ansible/modules/cloud/amazon/aws_neptune_subnet_group.py
+++ b/lib/ansible/modules/cloud/amazon/aws_neptune_subnet_group.py
@@ -1,0 +1,187 @@
+#!/usr/bin/python
+
+# Copyright: (c) 2018, Aaron Smith <ajsmith10381@gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = r'''
+---
+module: aws_neptune_subnet_group
+short_description: Manage database subnet groups on AWS Neptune.
+description:
+    - Create, modify, and destroy database subnet groups on AWS Neptune
+version_added: "2.7"
+requirements: [ 'botocore>=1.10.0', 'boto3' ]
+author:
+    - "Aaron Smith (@slapula)"
+options:
+  name:
+    description:
+    - The name for the DB subnet group.
+    - This value is stored as a lowercase string.
+    required: true
+  state:
+    description:
+    - Whether the resource should be present or absent.
+    default: present
+    choices: ['present', 'absent']
+  description:
+    description:
+    - The description for the DB subnet group.
+    required: true
+  subnet_ids:
+    description:
+    - The EC2 Subnet IDs for the DB subnet group.
+    required: true
+extends_documentation_fragment:
+  - aws
+  - ec2
+'''
+
+EXAMPLES = r'''
+  - name: Create a new database subnet group
+    aws_neptune_subnet_group:
+      name: "example-subnet-group"
+      state: present
+      description: 'This is an example of what you can do with this module.'
+      subnet_ids:
+        - 'subnet-1q2w3e4r'
+        - 'subnet-4r3e2w1q'
+'''
+
+RETURN = r'''
+db_subnet_group_arn:
+    description: The ARN of the database subnet group you just created or updated.
+    returned: always
+    type: string
+'''
+
+try:
+    import botocore
+    from botocore.exceptions import BotoCoreError, ClientError
+except ImportError:
+    pass  # handled by AnsibleAWSModule
+
+from ansible.module_utils.aws.core import AnsibleAWSModule
+from ansible.module_utils.aws.waiters import get_waiter
+
+
+def group_exists(client, module, params):
+    try:
+        response = client.describe_db_subnet_groups(
+            DBSubnetGroupName=params['DBSubnetGroupName']
+        )
+    except client.exceptions.from_code('DBSubnetGroupNotFound'):
+        return {'exists': False}
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+        module.fail_json_aws(e, msg="Couldn't verify existence of database subnet group")
+
+    return {'current_config': response['DBSubnetGroups'][0], 'exists': True}
+
+
+def create_group(client, module, params):
+    try:
+        response = client.create_db_subnet_group(**params)
+        get_waiter(
+            client, 'subnet_group_available'
+        ).wait(
+            DBSubnetGroupName=params['DBSubnetGroupName']
+        )
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+        module.fail_json_aws(e, msg="Couldn't create database subnet group")
+
+    return {'db_subnet_group_arn': response['DBSubnetGroup']['DBSubnetGroupArn'], 'changed': True}
+
+
+def update_group(client, module, params, group_status):
+    param_changed = []
+    param_keys = list(params.keys())
+    current_keys = list(group_status['current_config'].keys())
+    common_keys = set(param_keys) - (set(param_keys) - set(current_keys))
+    for key in common_keys:
+        if (params[key] != group_status['current_config'][key]):
+            param_changed.append(True)
+        else:
+            param_changed.append(False)
+
+    if any(param_changed):
+        try:
+            response = client.modify_db_subnet_group(**params)
+            get_waiter(
+                client, 'subnet_group_available'
+            ).wait(
+                DBSubnetGroupName=params['DBSubnetGroupName']
+            )
+        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+            module.fail_json_aws(e, msg="Couldn't update database subnet group")
+        return {'db_subnet_group_arn': response['DBSubnetGroup']['DBSubnetGroupArn'], 'changed': True}
+    else:
+        return {'db_subnet_group_arn': group_status['current_config']['DBSubnetGroupArn'], 'changed': False}
+
+
+def delete_group(client, module, params):
+    try:
+        response = client.delete_db_subnet_group(
+            DBSubnetGroupName=params['DBSubnetGroupName']
+        )
+        get_waiter(
+            client, 'subnet_group_deleted'
+        ).wait(
+            DBSubnetGroupName=params['DBSubnetGroupName']
+        )
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+        module.fail_json_aws(e, msg="Couldn't delete database subnet group")
+
+    return {'db_subnet_group_arn': '', 'changed': True}
+
+
+def main():
+    module = AnsibleAWSModule(
+        argument_spec={
+            'name': dict(type='str', required=True),
+            'state': dict(type='str', choices=['present', 'absent'], default='present'),
+            'description': dict(type='str', required=True),
+            'subnet_ids': dict(type='list', required=True),
+        },
+        supports_check_mode=True,
+    )
+
+    result = {
+        'changed': False,
+        'db_subnet_group_arn': ''
+    }
+
+    desired_state = module.params.get('state')
+
+    params = {}
+    params['DBSubnetGroupName'] = module.params.get('name')
+    params['DBSubnetGroupDescription'] = module.params.get('description')
+    params['SubnetIds'] = module.params.get('subnet_ids')
+
+    client = module.client('neptune')
+
+    group_status = group_exists(client, module, params)
+
+    if desired_state == 'present':
+        if not group_status['exists']:
+            result = create_group(client, module, params)
+        if group_status['exists']:
+            result = update_group(client, module, params, group_status)
+
+    if desired_state == 'absent':
+        if group_status['exists']:
+            result = delete_group(client, module, params)
+
+    module.exit_json(changed=result['changed'], db_subnet_group_arn=result['db_subnet_group_arn'])
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/cloud/amazon/aws_neptune_subnet_group.py
+++ b/lib/ansible/modules/cloud/amazon/aws_neptune_subnet_group.py
@@ -75,6 +75,8 @@ from ansible.module_utils.aws.waiters import get_waiter
 
 
 def group_exists(client, module, params):
+    if module.check_mode and module.params.get('state') == 'absent':
+        return {'exists': False}
     try:
         response = client.describe_db_subnet_groups(
             DBSubnetGroupName=params['DBSubnetGroupName']
@@ -91,6 +93,8 @@ def group_exists(client, module, params):
 
 
 def create_group(client, module, params):
+    if module.check_mode:
+        module.exit_json(changed=True)
     try:
         response = client.create_db_subnet_group(**params)
         get_waiter(
@@ -105,6 +109,8 @@ def create_group(client, module, params):
 
 
 def update_group(client, module, params, group_status):
+    if module.check_mode:
+        module.exit_json(changed=True)
     param_changed = []
     param_keys = list(params.keys())
     current_keys = list(group_status['current_config'].keys())
@@ -131,6 +137,8 @@ def update_group(client, module, params, group_status):
 
 
 def delete_group(client, module, params):
+    if module.check_mode:
+        module.exit_json(changed=True)
     try:
         response = client.delete_db_subnet_group(
             DBSubnetGroupName=params['DBSubnetGroupName']

--- a/test/integration/targets/aws_neptune_subnet_group/aliases
+++ b/test/integration/targets/aws_neptune_subnet_group/aliases
@@ -1,0 +1,2 @@
+cloud/aws
+posix/ci/cloud/group4/aws

--- a/test/integration/targets/aws_neptune_subnet_group/aliases
+++ b/test/integration/targets/aws_neptune_subnet_group/aliases
@@ -1,2 +1,3 @@
 cloud/aws
 posix/ci/cloud/group4/aws
+shippable/aws/group[1-2]

--- a/test/integration/targets/aws_neptune_subnet_group/aliases
+++ b/test/integration/targets/aws_neptune_subnet_group/aliases
@@ -1,3 +1,3 @@
 cloud/aws
 posix/ci/cloud/group4/aws
-shippable/aws/group[1-2]
+shippable/aws/group2

--- a/test/integration/targets/aws_neptune_subnet_group/meta/main.yaml
+++ b/test/integration/targets/aws_neptune_subnet_group/meta/main.yaml
@@ -1,0 +1,3 @@
+dependencies:
+  - prepare_tests
+  - setup_ec2

--- a/test/integration/targets/aws_neptune_subnet_group/tasks/main.yaml
+++ b/test/integration/targets/aws_neptune_subnet_group/tasks/main.yaml
@@ -4,7 +4,7 @@
     aws_connection_info: &aws_connection_info
       aws_access_key: "{{ aws_access_key }}"
       aws_secret_key: "{{ aws_secret_key }}"
-      #security_token: "{{ security_token }}"
+      security_token: "{{ security_token }}"
       region: "{{ aws_region }}"
   no_log: true
 

--- a/test/integration/targets/aws_neptune_subnet_group/tasks/main.yaml
+++ b/test/integration/targets/aws_neptune_subnet_group/tasks/main.yaml
@@ -1,0 +1,284 @@
+---
+- name: set connection information for all tasks
+  set_fact:
+    aws_connection_info: &aws_connection_info
+      aws_access_key: "{{ aws_access_key }}"
+      aws_secret_key: "{{ aws_secret_key }}"
+      #security_token: "{{ security_token }}"
+      region: "{{ aws_region }}"
+  no_log: true
+
+- block:
+
+    # ============================================================
+    # Prerequisites
+    # ============================================================
+
+    - name: Create VPC for use in testing
+      ec2_vpc_net:
+        name: "{{ resource_prefix }}-vpc"
+        cidr_block: 10.23.0.0/16
+        tags:
+          Name: Ansible ec2_instance Testing VPC
+        tenancy: default
+        <<: *aws_connection_info
+      register: testing_vpc
+
+    - name: Create internet gateway for use in testing
+      ec2_vpc_igw:
+        vpc_id: "{{ testing_vpc.vpc.id }}"
+        state: present
+        <<: *aws_connection_info
+      register: igw
+
+    - name: Create testing subnet A
+      ec2_vpc_subnet:
+        state: present
+        vpc_id: "{{ testing_vpc.vpc.id }}"
+        cidr: 10.23.32.0/24
+        az: "{{ aws_region }}a"
+        resource_tags:
+          Name: "{{ resource_prefix }}-subnet-a"
+        <<: *aws_connection_info
+      register: testing_subnet_a
+
+    - name: Create testing subnet B
+      ec2_vpc_subnet:
+        state: present
+        vpc_id: "{{ testing_vpc.vpc.id }}"
+        cidr: 10.23.33.0/24
+        az: "{{ aws_region }}b"
+        resource_tags:
+          Name: "{{ resource_prefix }}-subnet-b"
+        <<: *aws_connection_info
+      register: testing_subnet_b
+
+    - name: Create testing subnet C
+      ec2_vpc_subnet:
+        state: present
+        vpc_id: "{{ testing_vpc.vpc.id }}"
+        cidr: 10.23.34.0/24
+        az: "{{ aws_region }}c"
+        resource_tags:
+          Name: "{{ resource_prefix }}-subnet-c"
+        <<: *aws_connection_info
+      register: testing_subnet_c
+
+    - name: create routing rules
+      ec2_vpc_route_table:
+        vpc_id: "{{ testing_vpc.vpc.id }}"
+        tags:
+          created: "{{ resource_prefix }}-route"
+        routes:
+          - dest: 0.0.0.0/0
+            gateway_id: "{{ igw.gateway_id }}"
+        subnets:
+          - "{{ testing_subnet_a.subnet.id }}"
+          - "{{ testing_subnet_b.subnet.id }}"
+          - "{{ testing_subnet_c.subnet.id }}"
+        <<: *aws_connection_info
+
+    # ============================================================
+    # Parameter Tests
+    # ============================================================
+
+    - name: test with no parameters
+      aws_neptune_subnet_group:
+      register: result
+      ignore_errors: true
+
+    - name: assert failure when called with no parameters
+      assert:
+        that:
+           - 'result.failed'
+           - 'result.msg.startswith("missing required arguments:")'
+
+    - name: test with missing parameters
+      aws_neptune_subnet_group:
+        name: 'example-subnet-group'
+      register: result
+      ignore_errors: true
+
+    - name: assert failure when called with missing parameters
+      assert:
+        that:
+           - 'result.failed'
+           - 'result.msg.startswith("missing required arguments:")'
+
+    - name: test with missing parameters
+      aws_neptune_subnet_group:
+        name: 'example-subnet-group'
+        description: 'this is a test'
+      register: result
+      ignore_errors: true
+
+    - name: assert failure when called with missing parameters
+      assert:
+        that:
+           - 'result.failed'
+           - 'result.msg.startswith("missing required arguments:")'
+
+    - name: test with missing parameters
+      aws_neptune_subnet_group:
+        name: 'example-subnet-group'
+        subnet_ids:
+          - 'subnet-1q2w3e4r'
+          - 'subnet-4r3e2w1q'
+      register: result
+      ignore_errors: true
+
+    - name: assert failure when called with missing parameters
+      assert:
+        that:
+           - 'result.failed'
+           - 'result.msg.startswith("missing required arguments:")'
+
+    # ============================================================
+    # Resource Tests
+    # ============================================================
+
+    - name: Create database subnet group
+      aws_neptune_subnet_group:
+        <<: *aws_connection_info
+        name: "{{ resource_prefix }}-test-group"
+        state: present
+        description: 'this is a test'
+        subnet_ids:
+          - "{{ testing_subnet_a.subnet.id }}"
+          - "{{ testing_subnet_b.subnet.id }}"
+      register: result
+
+    - name: assert correct keys are returned
+      assert:
+        that:
+          - result.changed
+          - result.db_subnet_group_arn is not none
+
+    - name: No changes to database subnet group
+      aws_neptune_subnet_group:
+        <<: *aws_connection_info
+        name: "{{ resource_prefix }}-test-group"
+        state: present
+        description: 'this is a test'
+        subnet_ids:
+          - "{{ testing_subnet_a.subnet.id }}"
+          - "{{ testing_subnet_b.subnet.id }}"
+      register: result
+
+    - name: assert correct keys are returned
+      assert:
+        that:
+          - not result.changed
+          - result.db_subnet_group_arn is not none
+
+    - name: Update database subnet group
+      aws_neptune_subnet_group:
+        <<: *aws_connection_info
+        name: "{{ resource_prefix }}-test-group"
+        state: present
+        description: 'this is an updated test'
+        subnet_ids:
+          - "{{ testing_subnet_a.subnet.id }}"
+          - "{{ testing_subnet_b.subnet.id }}"
+          - "{{ testing_subnet_c.subnet.id }}"
+      register: result
+
+    - name: assert correct keys are returned
+      assert:
+        that:
+          - result.changed
+          - result.db_subnet_group_arn is not none
+
+  always:
+
+    # ============================================================
+    # Teardown testing resources
+    # ============================================================
+
+    - name: Destroy database subnet group
+      aws_neptune_subnet_group:
+        <<: *aws_connection_info
+        name: "{{ resource_prefix }}-test-group"
+        state: absent
+        description: 'this is a test'
+        subnet_ids:
+          - "{{ testing_subnet_a.subnet.id }}"
+          - "{{ testing_subnet_b.subnet.id }}"
+          - "{{ testing_subnet_c.subnet.id }}"
+      ignore_errors: yes
+
+    - name: remove routing rules
+      ec2_vpc_route_table:
+        state: absent
+        vpc_id: "{{ testing_vpc.vpc.id }}"
+        tags:
+          created: "{{ resource_prefix }}-route"
+        routes:
+          - dest: 0.0.0.0/0
+            gateway_id: "{{ igw.gateway_id }}"
+        subnets:
+          - "{{ testing_subnet_a.subnet.id }}"
+          - "{{ testing_subnet_b.subnet.id }}"
+          - "{{ testing_subnet_c.subnet.id }}"
+        <<: *aws_connection_info
+      register: removed
+      until: removed is not failed
+      ignore_errors: yes
+      retries: 10
+
+    - name: remove internet gateway
+      ec2_vpc_igw:
+        vpc_id: "{{ testing_vpc.vpc.id }}"
+        state: absent
+        <<: *aws_connection_info
+      register: removed
+      until: removed is not failed
+      ignore_errors: yes
+      retries: 10
+
+    - name: remove testing subnet A
+      ec2_vpc_subnet:
+        state: absent
+        vpc_id: "{{ testing_vpc.vpc.id }}"
+        cidr: 10.23.32.0/24
+        <<: *aws_connection_info
+      register: removed
+      until: removed is not failed
+      ignore_errors: yes
+      retries: 10
+
+    - name: remove testing subnet B
+      ec2_vpc_subnet:
+        state: absent
+        vpc_id: "{{ testing_vpc.vpc.id }}"
+        cidr: 10.23.33.0/24
+        <<: *aws_connection_info
+      register: removed
+      until: removed is not failed
+      ignore_errors: yes
+      retries: 10
+
+    - name: remove testing subnet C
+      ec2_vpc_subnet:
+        state: absent
+        vpc_id: "{{ testing_vpc.vpc.id }}"
+        cidr: 10.23.34.0/24
+        <<: *aws_connection_info
+      register: removed
+      until: removed is not failed
+      ignore_errors: yes
+      retries: 10
+
+    - name: remove the VPC
+      ec2_vpc_net:
+        name: "{{ resource_prefix }}-vpc"
+        cidr_block: 10.23.0.0/16
+        state: absent
+        tags:
+          Name: Ansible Testing VPC
+        tenancy: default
+        <<: *aws_connection_info
+      register: removed
+      until: removed is not failed
+      ignore_errors: yes
+      retries: 10

--- a/test/runner/requirements/constraints.txt
+++ b/test/runner/requirements/constraints.txt
@@ -16,12 +16,12 @@ requests < 2.20.0 ; python_version < '2.7' # requests 2.20.0 drops support for p
 requests-ntlm >= 1.1.0 # message encryption support
 requests-credssp >= 0.1.0 # message encryption support
 voluptuous >= 0.11.0 # Schema recursion via Self
-<<<<<<< HEAD
 openshift >= 0.6.2 # merge_type support
 virtualenv < 16.0.0 ; python_version < '2.7' # virtualenv 16.0.0 and later require python 2.7 or later
 pyopenssl < 18.0.0 ; python_version < '2.7' # pyOpenSSL 18.0.0 and later require python 2.7 or later
 pyfmg == 0.6.1 # newer versions do not pass current unit tests
 pycparser < 2.19 ; python_version < '2.7' # pycparser 2.19 and later require python 2.7 or later
+botocore >= 1.10.30 # adds support for the following AWS services: secretsmanager, fms, acm-pca, neptune
 
 # freeze pylint and its requirements for consistent test results
 astroid == 2.0.4
@@ -32,6 +32,3 @@ pylint == 2.1.1
 six == 1.11.0
 typed-ast == 1.1.0
 wrapt == 1.10.11
-=======
-botocore >= 1.10.0 # adds support for the following AWS services: secretsmanager, fms, acm-pca, neptune
->>>>>>> Adding module to manage database subnet groups on AWS Neptune

--- a/test/runner/requirements/constraints.txt
+++ b/test/runner/requirements/constraints.txt
@@ -16,7 +16,6 @@ requests < 2.20.0 ; python_version < '2.7' # requests 2.20.0 drops support for p
 requests-ntlm >= 1.1.0 # message encryption support
 requests-credssp >= 0.1.0 # message encryption support
 voluptuous >= 0.11.0 # Schema recursion via Self
-<<<<<<< HEAD
 openshift >= 0.6.2 # merge_type support
 virtualenv < 16.0.0 ; python_version < '2.7' # virtualenv 16.0.0 and later require python 2.7 or later
 pyopenssl < 18.0.0 ; python_version < '2.7' # pyOpenSSL 18.0.0 and later require python 2.7 or later
@@ -33,5 +32,3 @@ pylint == 2.1.1
 six == 1.11.0
 typed-ast == 1.1.0
 wrapt == 1.10.11
-=======
->>>>>>> Make requested changes

--- a/test/runner/requirements/constraints.txt
+++ b/test/runner/requirements/constraints.txt
@@ -16,6 +16,7 @@ requests < 2.20.0 ; python_version < '2.7' # requests 2.20.0 drops support for p
 requests-ntlm >= 1.1.0 # message encryption support
 requests-credssp >= 0.1.0 # message encryption support
 voluptuous >= 0.11.0 # Schema recursion via Self
+<<<<<<< HEAD
 openshift >= 0.6.2 # merge_type support
 virtualenv < 16.0.0 ; python_version < '2.7' # virtualenv 16.0.0 and later require python 2.7 or later
 pyopenssl < 18.0.0 ; python_version < '2.7' # pyOpenSSL 18.0.0 and later require python 2.7 or later
@@ -31,3 +32,6 @@ pylint == 2.1.1
 six == 1.11.0
 typed-ast == 1.1.0
 wrapt == 1.10.11
+=======
+botocore >= 1.10.0 # adds support for the following AWS services: secretsmanager, fms, acm-pca, neptune
+>>>>>>> Adding module to manage database subnet groups on AWS Neptune

--- a/test/runner/requirements/constraints.txt
+++ b/test/runner/requirements/constraints.txt
@@ -16,6 +16,7 @@ requests < 2.20.0 ; python_version < '2.7' # requests 2.20.0 drops support for p
 requests-ntlm >= 1.1.0 # message encryption support
 requests-credssp >= 0.1.0 # message encryption support
 voluptuous >= 0.11.0 # Schema recursion via Self
+<<<<<<< HEAD
 openshift >= 0.6.2 # merge_type support
 virtualenv < 16.0.0 ; python_version < '2.7' # virtualenv 16.0.0 and later require python 2.7 or later
 pyopenssl < 18.0.0 ; python_version < '2.7' # pyOpenSSL 18.0.0 and later require python 2.7 or later
@@ -32,3 +33,5 @@ pylint == 2.1.1
 six == 1.11.0
 typed-ast == 1.1.0
 wrapt == 1.10.11
+=======
+>>>>>>> Make requested changes

--- a/test/runner/requirements/integration.cloud.aws.txt
+++ b/test/runner/requirements/integration.cloud.aws.txt
@@ -1,2 +1,3 @@
 boto
 boto3
+botocore>=1.10.30

--- a/test/runner/requirements/integration.cloud.aws.txt
+++ b/test/runner/requirements/integration.cloud.aws.txt
@@ -1,3 +1,3 @@
 boto
 boto3
-botocore>=1.10.30
+botocore


### PR DESCRIPTION
##### SUMMARY
This PR is one of several that will be adding support for the recently release AWS Neptune service. 
 This module manages database subnet groups in Neptune much like RDS subnet groups. Like my Secrets Manager module (#40093), this one also requires botocore>=1.10.0.

##### ISSUE TYPE
 - New Module Pull Request

##### COMPONENT NAME
`aws_neptune_subnet_group`

##### ANSIBLE VERSION
```
ansible 2.4.1.0
  config file = None
  configured module search path = [u'/Users/asmith/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/asmith/.pyenv/versions/2.7.13/lib/python2.7/site-packages/ansible
  executable location = /Users/asmith/.pyenv/versions/2.7.13/bin/ansible
  python version = 2.7.13 (default, Sep  8 2017, 15:16:38) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```