### PR TITLE
Fix virtualization role for DigitalOcean droplets (#41061)

### DIFF
--- a/lib/ansible/module_utils/facts/virtual/linux.py
+++ b/lib/ansible/module_utils/facts/virtual/linux.py
@@ -111,13 +111,13 @@ class LinuxVirtual(Virtual):
             virtual_facts['virtualization_type'] = 'virtualbox'
             return virtual_facts
 
-        if bios_vendor in ('Amazon EC2', 'Hetzner'):
+        if bios_vendor in ('Amazon EC2', 'DigitalOcean', 'Hetzner'):
             virtual_facts['virtualization_type'] = 'kvm'
             return virtual_facts
 
         sys_vendor = get_file_content('/sys/devices/virtual/dmi/id/sys_vendor')
 
-        KVM_SYS_VENDORS = ('QEMU', 'oVirt', 'Amazon EC2', 'Google', 'Scaleway')
+        KVM_SYS_VENDORS = ('QEMU', 'oVirt', 'Amazon EC2', 'DigitalOcean', 'Google', 'Scaleway')
         if sys_vendor in KVM_SYS_VENDORS:
             virtual_facts['virtualization_type'] = 'kvm'
             return virtual_facts


### PR DESCRIPTION
Fixes #41061

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
Fixes `ansible_virtualization_role` for DigitalOcean droplets - it was incorrectly set to `host`, this PR changes it to `guest`.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
core

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.3
  config file = /Users/tomkins/Admin/blazingfast.net/ansible.cfg
  configured module search path = ['/Users/tomkins/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/tomkins/.virtualenvs/blazingfast/lib/python3.5/site-packages/ansible
  executable location = /Users/tomkins/.virtualenvs/blazingfast/bin/ansible
  python version = 3.5.6 (default, Aug  4 2018, 07:39:57) [GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.2)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

DigitalOcean droplets have the following DMI files available:

```console
root@ubuntu-s-1vcpu-1gb-lon1-01:~# cat /sys/devices/virtual/dmi/id/product_name
Droplet
root@ubuntu-s-1vcpu-1gb-lon1-01:~# cat /sys/devices/virtual/dmi/id/bios_vendor
DigitalOcean
root@ubuntu-s-1vcpu-1gb-lon1-01:~# cat /sys/devices/virtual/dmi/id/sys_vendor
DigitalOcean
```


<!--- Paste verbatim command output below, e.g. before and after your change -->
Before:
```console
$ ansible -m setup -a "filter=ansible_virtualization_*" ubuntu-s-1vcpu-1gb-lon1-01
ubuntu-s-1vcpu-1gb-lon1-01 | SUCCESS => {
    "ansible_facts": {
        "ansible_virtualization_role": "host",
        "ansible_virtualization_type": "kvm"
    },
    "changed": false
}
```

After:
```console
$ ansible -m setup -a "filter=ansible_virtualization_*" ubuntu-s-1vcpu-1gb-lon1-01
ubuntu-s-1vcpu-1gb-lon1-01 | SUCCESS => {
    "ansible_facts": {
        "ansible_virtualization_role": "guest",
        "ansible_virtualization_type": "kvm"
    },
    "changed": false
}
```

I've taken the same approach as #35063 for consistency.