### PR TITLE
Fix wrong python keyword (followup to #36357)

### DIFF
--- a/lib/ansible/parsing/dataloader.py
+++ b/lib/ansible/parsing/dataloader.py
@@ -422,7 +422,7 @@ class DataLoader:
                     if allow_dir:
                         found.extend(self._get_dir_vars_files(to_text(full_path), extensions))
                     else:
-                        next
+                        continue
                 else:
                     found.append(full_path)
                 break

--- a/test/units/playbook/role/test_role.py
+++ b/test/units/playbook/role/test_role.py
@@ -148,6 +148,26 @@ class TestRole(unittest.TestCase):
         assert isinstance(r._task_blocks[0], Block)
 
     @patch('ansible.playbook.role.definition.unfrackpath', mock_unfrackpath_noop)
+    def test_load_role_with_tasks_dir_vs_file(self):
+
+        fake_loader = DictDataLoader({
+            "/etc/ansible/roles/foo_tasks/tasks/custom_main/foo.yml": """
+            - command: bar
+            """,
+            "/etc/ansible/roles/foo_tasks/tasks/custom_main.yml": """
+            - command: baz
+            """,
+        })
+
+        mock_play = MagicMock()
+        mock_play.ROLE_CACHE = {}
+
+        i = RoleInclude.load('foo_tasks', play=mock_play, loader=fake_loader)
+        r = Role.load(i, play=mock_play, from_files=dict(tasks='custom_main'))
+
+        self.assertEqual(r._task_blocks[0]._ds[0]['command'], 'baz')
+
+    @patch('ansible.playbook.role.definition.unfrackpath', mock_unfrackpath_noop)
     def test_load_role_with_handlers(self):
 
         fake_loader = DictDataLoader({


### PR DESCRIPTION
##### SUMMARY
Fix wrong python keyword (followup to #36357)

It seems very difficult to actually hit this code, but it should be fixed anyway

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
dataloader

##### ANSIBLE VERSION
```
ansible 2.7.0.dev0 (role_defaults_vars_dirs_2 dfe5edda9c) last updated 2018/06/03 16:00:12 (GMT -500)
```

##### ADDITIONAL INFORMATION
N/A