### PR TITLE
Fixes ios_logging idempotency issues in 2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Ansible Changes By Release
   (https://github.com/ansible/ansible/pull/38646)
 * Fix eos_logging idempotency issue when trying to set both logging destination & facility
   (https://github.com/ansible/ansible/pull/40604)
+* Fix ios_logging idempotency issue when trying to set both logging destination & facility
+  (https://github.com/ansible/ansible/pull/41076)
 
 
 

--- a/lib/ansible/modules/network/ios/ios_logging.py
+++ b/lib/ansible/modules/network/ios/ios_logging.py
@@ -218,18 +218,12 @@ def parse_size(line, dest):
     size = None
 
     if dest == 'buffered':
-        match = re.search(r'logging buffered (\S+)', line, re.M)
+        match = re.search(r'logging buffered(?: (\d+))?(?: [a-z]+)?', line, re.M)
         if match:
-            try:
-                int_size = int(match.group(1))
-            except ValueError:
-                int_size = None
-
-            if int_size:
-                if isinstance(int_size, int):
-                    size = str(match.group(1))
-                else:
-                    size = str(4096)
+            if match.group(1) is not None:
+                size = match.group(1)
+            else:
+                size = "4096"
 
     return size
 
@@ -253,19 +247,13 @@ def parse_level(line, dest):
         level = 'debugging'
 
     else:
-
         if dest == 'buffered':
-            match = re.search(r'logging buffered (?:\d+ )([a-z]+)', line, re.M)
-
+            match = re.search(r'logging buffered(?: \d+)?(?: ([a-z]+))?', line, re.M)
         else:
             match = re.search(r'logging {0} (\S+)'.format(dest), line, re.M)
 
-        if match:
-            if match.group(1) in level_group:
-                level = match.group(1)
-            else:
-                level = 'debugging'
-
+        if match and match.group(1) in level_group:
+            level = match.group(1)
         else:
             level = 'debugging'
 

--- a/lib/ansible/modules/network/ios/ios_logging.py
+++ b/lib/ansible/modules/network/ios/ios_logging.py
@@ -190,7 +190,10 @@ def map_obj_to_commands(updates, module):
                         present = True
 
                 if not present:
-                    commands.append('logging buffered {0} {1}'.format(size, level))
+                    if level and level != 'debugging':
+                        commands.append('logging buffered {0} {1}'.format(size, level))
+                    else:
+                        commands.append('logging buffered {0}'.format(size))
 
             else:
                 dest_cmd = 'logging {0}'.format(dest)

--- a/test/integration/targets/ios_logging/tests/cli/basic.yaml
+++ b/test/integration/targets/ios_logging/tests/cli/basic.yaml
@@ -97,7 +97,7 @@
 - assert:
     that:
       - 'result.changed == true'
-      - '"logging buffered 8000" in result.commands'
+      - '"logging buffered 8000 debugging" in result.commands'
 
 - name: Change logging parameters using aggregate
   ios_logging:
@@ -110,14 +110,45 @@
 - assert:
     that:
       - 'result.changed == true'
-      - '"logging buffered 9000" in result.commands'
+      - '"logging buffered 9000 debugging" in result.commands'
       - '"logging console notifications" in result.commands'
+
+- name: Set both logging destination and facility
+  ios_logging:
+    dest: buffered
+    facility: uucp
+    level: alerts
+    size: 4096
+    state: present
+    authorize: yes
+  register: result
+
+- assert:
+    that:
+      - 'result.changed == true'
+      - '"logging buffered 4096 alerts" in result.commands'
+      - '"logging facility uucp" in result.commands'
+
+- name: Set both logging destination and facility (idempotent)
+  ios_logging:
+    dest: buffered
+    facility: uucp
+    level: alerts
+    size: 4096
+    state: present
+    authorize: yes
+  register: result
+
+- assert:
+    that:
+      - 'result.changed == false'
 
 - name: remove logging as collection tearDown
   ios_logging:
     aggregate:
       - { dest: console, level: notifications }
-      - { dest: buffered, size: 9000 }
+      - { dest: buffered, size: 4096, level: alerts }
+      - { facility: uucp }
     state: absent
     authorize: yes
   register: result
@@ -127,3 +158,4 @@
       - 'result.changed == true'
       - '"no logging console" in result.commands'
       - '"no logging buffered" in result.commands'
+      - '"no logging facility uucp" in result.commands'

--- a/test/integration/targets/ios_logging/tests/cli/basic.yaml
+++ b/test/integration/targets/ios_logging/tests/cli/basic.yaml
@@ -97,7 +97,7 @@
 - assert:
     that:
       - 'result.changed == true'
-      - '"logging buffered 8000 debugging" in result.commands'
+      - '"logging buffered 8000" in result.commands'
 
 - name: Change logging parameters using aggregate
   ios_logging:
@@ -110,7 +110,7 @@
 - assert:
     that:
       - 'result.changed == true'
-      - '"logging buffered 9000 debugging" in result.commands'
+      - '"logging buffered 9000" in result.commands'
       - '"logging console notifications" in result.commands'
 
 - name: Set both logging destination and facility

--- a/test/integration/targets/ios_logging/tests/cli/basic.yaml
+++ b/test/integration/targets/ios_logging/tests/cli/basic.yaml
@@ -1,7 +1,7 @@
 ---
 # ensure logging configs are empty
 - name: Remove host logging
-  ios_logging:
+  ios_logging: &remove_host
     dest: host
     name: 172.16.0.1
     state: absent
@@ -45,16 +45,12 @@
     authorize: yes
   register: result
 
-- assert:
+- assert: &unchanged
     that:
       - 'result.changed == false'
 
 - name: Delete/disable host logging
-  ios_logging:
-    dest: host
-    name: 172.16.0.1
-    state: absent
-    authorize: yes
+  ios_logging: *remove_host
   register: result
 
 - assert:
@@ -63,16 +59,10 @@
       - '"no logging host 172.16.0.1" in result.commands'
 
 - name: Delete/disable host logging (idempotent)
-  ios_logging:
-    dest: host
-    name: 172.16.0.1
-    state: absent
-    authorize: yes
+  ios_logging: *remove_host
   register: result
 
-- assert:
-    that:
-      - 'result.changed == false'
+- assert: *unchanged
 
 - name: Console logging with level warnings
   ios_logging:
@@ -114,7 +104,7 @@
       - '"logging console notifications" in result.commands'
 
 - name: Set both logging destination and facility
-  ios_logging:
+  ios_logging: &set_both
     dest: buffered
     facility: uucp
     level: alerts
@@ -130,18 +120,10 @@
       - '"logging facility uucp" in result.commands'
 
 - name: Set both logging destination and facility (idempotent)
-  ios_logging:
-    dest: buffered
-    facility: uucp
-    level: alerts
-    size: 4096
-    state: present
-    authorize: yes
+  ios_logging: *set_both
   register: result
 
-- assert:
-    that:
-      - 'result.changed == false'
+- assert: *unchanged
 
 - name: remove logging as collection tearDown
   ios_logging:


### PR DESCRIPTION
##### SUMMARY
- Fixes ios_logging idempotency issue while trying to set both facility and destination together
- Added more integration tests

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
stable-2.4
```
