### PR TITLE
Add syslog_facility parameter handling with systemd.journal

### DIFF
--- a/changelogs/fragments/syslog_facility-for-journald.yml
+++ b/changelogs/fragments/syslog_facility-for-journald.yml
@@ -1,0 +1,5 @@
+---
+bugfixes:
+- Fixed runtime module to be able to handle syslog_facility properly
+  when python systemd module installed in a target system.
+  (https://github.com/ansible/ansible/pull/41078)

--- a/docs/docsite/rst/porting_guides/porting_guide_2.7.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.7.rst
@@ -54,7 +54,13 @@ Modules
 
 Major changes in popular modules are detailed here
 
-
+* The :ref:`DEFAULT_SYSLOG_FACILITY` configuration option tells Ansible modules to use a specific
+  `syslog facility <https://en.wikipedia.org/wiki/Syslog#Facility>`_ when logging information on the
+  managed machine.  This was broken for machines which used journald and had the python bindings for
+  journald installed.  The bug meant that machines without journald could be logging to a different
+  location than machines which did use journald.  Ansible-2.7 fixes this bug which means that the
+  location of remote logs on systems which use journald could change if
+  :ref:`DEFAULT_SYSLOG_FACILITY` is configured.
 
 Modules removed
 ---------------

--- a/docs/docsite/rst/porting_guides/porting_guide_2.7.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.7.rst
@@ -55,12 +55,14 @@ Modules
 Major changes in popular modules are detailed here
 
 * The :ref:`DEFAULT_SYSLOG_FACILITY` configuration option tells Ansible modules to use a specific
-  `syslog facility <https://en.wikipedia.org/wiki/Syslog#Facility>`_ when logging information on the
-  managed machine.  This was broken for machines which used journald and had the python bindings for
-  journald installed.  The bug meant that machines without journald could be logging to a different
-  location than machines which did use journald.  Ansible-2.7 fixes this bug which means that the
-  location of remote logs on systems which use journald could change if
-  :ref:`DEFAULT_SYSLOG_FACILITY` is configured.
+  `syslog facility <https://en.wikipedia.org/wiki/Syslog#Facility>`_ when logging information on all
+  managed machines. Due to a bug with older Ansible versions, this setting did not affect machines
+  using journald with the systemd Python bindings installed. On those machines, Ansible log
+  messages were sent to ``/var/log/messages``, even if you set :ref:`DEFAULT_SYSLOG_FACILITY`.
+  Ansible 2.7 fixes this bug, routing all Ansible log messages according to the value set for
+  :ref:`DEFAULT_SYSLOG_FACILITY`. If you have :ref:`DEFAULT_SYSLOG_FACILITY` configured, the
+  location of remote logs on systems which use journald may change.
+
 
 Modules removed
 ---------------


### PR DESCRIPTION
##### SUMMARY

Fixed: syslog_facility setting is no effect when it using systemd-python #41072

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- lib/ansible/module_utils/basic.py

##### ANSIBLE VERSION

```
ansible 2.7.0.dev0 (bug/41072 a3216fbdad) last updated 2018/06/04 17:25:40 (GMT +900)
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
