### PR TITLE
Zabbix facts

### DIFF
--- a/lib/ansible/modules/monitoring/zabbix/zabbix_group_facts.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_group_facts.py
@@ -34,38 +34,13 @@ requirements:
     - "python >= 2.6"
     - zabbix-api
 options:
-    server_url:
-        description:
-            - Url of Zabbix server, with protocol (http or https).
-        required: true
-        aliases: [ "url" ]
-    login_user:
-        description:
-            - Zabbix user name, used to authenticate against the server.
-        required: true
-    login_password:
-        description:
-            - Zabbix user password.
-        required: true
-    http_login_user:
-        description:
-            - Basic Auth login
-        required: false
-        default: null
-    http_login_password:
-        description:
-            - Basic Auth password
-        required: false
-        default: null
     hostgroup_name:
         description:
             - Name of the hostgroup in Zabbix.
             - hostgroup is the unique identifier used and cannot be updated using this module.
         required: true
-    timeout:
-        description:
-            - The timeout of API request (seconds).
-        default: 10
+extends_documentation_fragment:
+    - zabbix
 '''
 
 EXAMPLES = '''
@@ -92,8 +67,8 @@ try:
     class ZabbixAPIExtends(ZabbixAPI):
         hostinterface = None
 
-        def __init__(self, server, timeout, user, passwd, **kwargs):
-            ZabbixAPI.__init__(self, server, timeout=timeout, user=user, passwd=passwd)
+        def __init__(self, server, timeout, user, passwd, validate_certs, **kwargs):
+            ZabbixAPI.__init__(self, server, timeout=timeout, user=user, passwd=passwd, validate_certs=validate_certs)
             self.hostinterface = ZabbixAPISubClass(self, dict({"prefix": "hostinterface"}, **kwargs))
 
     HAS_ZABBIX_API = True
@@ -122,6 +97,7 @@ def main():
             hostgroup_name=dict(type='list', required=True),
             http_login_user=dict(type='str', required=False, default=None),
             http_login_password=dict(type='str', required=False, default=None, no_log=True),
+            validate_certs=dict(type='bool', required=False, default=True),
             timeout=dict(type='int', default=10)
         ),
         supports_check_mode=True
@@ -135,13 +111,15 @@ def main():
     login_password = module.params['login_password']
     http_login_user = module.params['http_login_user']
     http_login_password = module.params['http_login_password']
+    validate_certs = module.params['validate_certs']
     hostgroup_name = module.params['hostgroup_name']
     timeout = module.params['timeout']
 
     zbx = None
     # login to zabbix
     try:
-        zbx = ZabbixAPIExtends(server_url, timeout=timeout, user=http_login_user, passwd=http_login_password)
+        zbx = ZabbixAPIExtends(server_url, timeout=timeout, user=http_login_user, passwd=http_login_password,
+                               validate_certs=validate_certs)
         zbx.login(login_user, login_password)
     except Exception as e:
         module.fail_json(msg="Failed to connect to Zabbix server: %s" % e)


### PR DESCRIPTION
##### SUMMARY
Implemented fixes requested in PR #39653 and #39654:
- documentation shall use appropriate module doc fragment
- all zabbix modules should have validate_certs option
- removed duplicate code

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
- zabbix_host_facts
- zabbix_group_facts

##### ANSIBLE VERSION
```
ansible 2.7.0.dev0 (devel 13c7d149bb) last updated 2018/06/04 12:36:01 (GMT +200)
  config file = None
  configured module search path = [u'~/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = ~/projects/ansible/ansible-fork/lib/ansible
  executable location = ~/projects/ansible/ansible-fork/bin/ansible
  python version = 2.7.14 (default, Oct 31 2017, 21:12:13) [GCC 6.4.0]
```
