### PR TITLE
k8s module: Ensure kind=*List just gets facts

### DIFF
--- a/lib/ansible/modules/clustering/k8s/k8s.py
+++ b/lib/ansible/modules/clustering/k8s/k8s.py
@@ -95,6 +95,11 @@ EXAMPLES = '''
     namespace: testing
   register: service_list
 
+- name: Get a list of all pods from any namespace
+  k8s:
+    kind: PodList
+  register: pod_list
+
 - name: Remove an existing Service object
   k8s:
     state: absent


### PR DESCRIPTION
##### SUMMARY

Using `kind=*List` should just perform a query but the `List`
ending gets stripped off, so need another mechanism to identify
that it's a query.

Add a PodList example with minimal information to show that it works.


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
k8s

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (devel 13c7d149bb) last updated 2018/06/04 21:51:42 (GMT +1000)
  config file = None
  configured module search path = [u'/Users/will/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/will/src/ansible/lib/ansible
  executable location = /Users/will/src/ansible/bin/ansible
  python version = 2.7.14 (default, Mar  9 2018, 23:57:12) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```

##### ADDITIONAL INFORMATION
Candidate for backport to 2.6 (as PodList is broken without this fix)

```
The full traceback is:
Traceback (most recent call last):
  File "/var/folders/7q/dxr6_bf51zb12fs7rld5_7zc0000gp/T/ansible_pazOPS/ansible_module_k8s.py", line 165, in <module>
    main()
  File "/var/folders/7q/dxr6_bf51zb12fs7rld5_7zc0000gp/T/ansible_pazOPS/ansible_module_k8s.py", line 161, in main
    KubernetesRawModule().execute_module()
  File "/var/folders/7q/dxr6_bf51zb12fs7rld5_7zc0000gp/T/ansible_pazOPS/ansible_modlib.zip/ansible/module_utils/k8s/raw.py", line 80, in execute_module
  File "/var/folders/7q/dxr6_bf51zb12fs7rld5_7zc0000gp/T/ansible_pazOPS/ansible_modlib.zip/ansible/module_utils/k8s/raw.py", line 171, in perform_action
  File "/usr/local/Cellar/python@2/2.7.14_3/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/openshift/dynamic/client.py", line 31, in inner
    resp = func(self, resource, *args, **kwargs)
  File "/usr/local/Cellar/python@2/2.7.14_3/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/openshift/dynamic/client.py", line 184, in patch
    raise ValueError("name is required to patch {}.{}".format(resource.group_version, resource.kind))
ValueError: name is required to patch v1.Pod

localhost | FAILED! => {
    "changed": false, 
    "module_stderr": "Traceback (most recent call last):\n  File \"/var/folders/7q/dxr6_bf51zb12fs7rld5_7zc0000gp/T/ansible_pazOPS/ansible_module_k8s.py\", line 165, in <module>\n    main()\n  File \"/var/folders/7q/dxr6_bf51zb12fs7rld5_7zc0000gp/T/ansible_pazOPS/ansible_module_k8s.py\", line 161, in main\n    KubernetesRawModule().execute_module()\n  File \"/var/folders/7q/dxr6_bf51zb12fs7rld5_7zc0000gp/T/ansible_pazOPS/ansible_modlib.zip/ansible/module_utils/k8s/raw.py\", line 80, in execute_module\n  File \"/var/folders/7q/dxr6_bf51zb12fs7rld5_7zc0000gp/T/ansible_pazOPS/ansible_modlib.zip/ansible/module_utils/k8s/raw.py\", line 171, in perform_action\n  File \"/usr/local/Cellar/python@2/2.7.14_3/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/openshift/dynamic/client.py\", line 31, in inner\n    resp = func(self, resource, *args, **kwargs)\n  File \"/usr/local/Cellar/python@2/2.7.14_3/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/openshift/dynamic/client.py\", line 184, in patch\n    raise ValueError(\"name is required to patch {}.{}\".format(resource.group_version, resource.kind))\nValueError: name is required to patch v1.Pod\n", 
    "module_stdout": "", 
    "msg": "MODULE FAILURE", 
    "rc": 1
}
```