### PR TITLE
Nxos test reorganize

### DIFF
--- a/test/integration/targets/nxos_aaa_server/tasks/cli.yaml
+++ b/test/integration/targets/nxos_aaa_server/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common cli test cases
+- name: collect common test cases
   find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -21,13 +21,7 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=network_cli)
-  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={}"
+  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={{ cli }}"
   with_items: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local connection={{ cli }}"
-  with_first_found: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_aaa_server/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_aaa_server/tasks/nxapi.yaml
@@ -21,7 +21,13 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=httpapi)
-  include: "{{ test_case_to_run }} ansible_connection=httpapi"
+  include: "{{ test_case_to_run }} ansible_connection=httpapi connection={{ nxapi }}"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test cases (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_aaa_server_host/tasks/cli.yaml
+++ b/test/integration/targets/nxos_aaa_server_host/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common cli test cases
+- name: collect common test cases
   find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -21,13 +21,7 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=network_cli)
-  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={}"
+  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={{ cli }}"
   with_items: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local connection={{ cli }}"
-  with_first_found: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_aaa_server_host/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_aaa_server_host/tasks/nxapi.yaml
@@ -21,7 +21,13 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=httpapi)
-  include: "{{ test_case_to_run }} ansible_connection=httpapi"
+  include: "{{ test_case_to_run }} ansible_connection=httpapi connection={{ nxapi }}"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test cases (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_acl/tasks/cli.yaml
+++ b/test/integration/targets/nxos_acl/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common cli test cases
+- name: collect common test cases
   find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -21,13 +21,7 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=network_cli)
-  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={}"
+  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={{ cli }}"
   with_items: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local connection={{ cli }}"
-  with_first_found: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_acl/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_acl/tasks/nxapi.yaml
@@ -21,7 +21,13 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=httpapi)
-  include: "{{ test_case_to_run }} ansible_connection=httpapi"
+  include: "{{ test_case_to_run }} ansible_connection=httpapi connection={{ nxapi }}"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test cases (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_acl_interface/tasks/cli.yaml
+++ b/test/integration/targets/nxos_acl_interface/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common cli test cases
+- name: collect common test cases
   find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -21,13 +21,7 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=network_cli)
-  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={}"
+  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={{ cli }}"
   with_items: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local connection={{ cli }}"
-  with_first_found: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_acl_interface/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_acl_interface/tasks/nxapi.yaml
@@ -21,7 +21,13 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=httpapi)
-  include: "{{ test_case_to_run }} ansible_connection=httpapi"
+  include: "{{ test_case_to_run }} ansible_connection=httpapi connection={{ nxapi }}"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test cases (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_banner/tasks/cli.yaml
+++ b/test/integration/targets/nxos_banner/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common cli test cases
+- name: collect common test cases
   find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -21,13 +21,7 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=network_cli)
-  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={}"
+  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={{ cli }}"
   with_items: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local connection={{ cli }}"
-  with_first_found: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_banner/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_banner/tasks/nxapi.yaml
@@ -21,7 +21,13 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=httpapi)
-  include: "{{ test_case_to_run }} ansible_connection=httpapi"
+  include: "{{ test_case_to_run }} ansible_connection=httpapi connection={{ nxapi }}"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test cases (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_become/tasks/cli.yaml
+++ b/test/integration/targets/nxos_become/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common cli test cases
+- name: collect common test cases
   find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -21,13 +21,7 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=network_cli)
-  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={}"
+  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={{ cli }}"
   with_items: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local connection={{ cli }}"
-  with_first_found: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_become/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_become/tasks/nxapi.yaml
@@ -21,7 +21,13 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=httpapi)
-  include: "{{ test_case_to_run }} ansible_connection=httpapi"
+  include: "{{ test_case_to_run }} ansible_connection=httpapi connection={{ nxapi }}"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test cases (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_bgp/tasks/cli.yaml
+++ b/test/integration/targets/nxos_bgp/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common cli test cases
+- name: collect common test cases
   find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -21,13 +21,7 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=network_cli)
-  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={}"
+  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={{ cli }}"
   with_items: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local connection={{ cli }}"
-  with_first_found: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_bgp/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_bgp/tasks/nxapi.yaml
@@ -21,7 +21,13 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=httpapi)
-  include: "{{ test_case_to_run }} ansible_connection=httpapi"
+  include: "{{ test_case_to_run }} ansible_connection=httpapi connection={{ nxapi }}"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test cases (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_bgp_af/tasks/cli.yaml
+++ b/test/integration/targets/nxos_bgp_af/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common cli test cases
+- name: collect common test cases
   find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -21,13 +21,7 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=network_cli)
-  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={}"
+  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={{ cli }}"
   with_items: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local connection={{ cli }}"
-  with_first_found: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_bgp_af/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_bgp_af/tasks/nxapi.yaml
@@ -21,7 +21,13 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=httpapi)
-  include: "{{ test_case_to_run }} ansible_connection=httpapi"
+  include: "{{ test_case_to_run }} ansible_connection=httpapi connection={{ nxapi }}"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test cases (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_bgp_neighbor/tasks/cli.yaml
+++ b/test/integration/targets/nxos_bgp_neighbor/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common cli test cases
+- name: collect common test cases
   find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -21,13 +21,7 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=network_cli)
-  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={}"
+  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={{ cli }}"
   with_items: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local connection={{ cli }}"
-  with_first_found: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_bgp_neighbor/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_bgp_neighbor/tasks/nxapi.yaml
@@ -21,7 +21,13 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=httpapi)
-  include: "{{ test_case_to_run }} ansible_connection=httpapi"
+  include: "{{ test_case_to_run }} ansible_connection=httpapi connection={{ nxapi }}"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test cases (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_bgp_neighbor_af/tasks/cli.yaml
+++ b/test/integration/targets/nxos_bgp_neighbor_af/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common cli test cases
+- name: collect common test cases
   find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -21,13 +21,7 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=network_cli)
-  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={}"
+  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={{ cli }}"
   with_items: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local connection={{ cli }}"
-  with_first_found: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_bgp_neighbor_af/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_bgp_neighbor_af/tasks/nxapi.yaml
@@ -21,7 +21,13 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=httpapi)
-  include: "{{ test_case_to_run }} ansible_connection=httpapi"
+  include: "{{ test_case_to_run }} ansible_connection=httpapi connection={{ nxapi }}"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test cases (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_command/tasks/cli.yaml
+++ b/test/integration/targets/nxos_command/tasks/cli.yaml
@@ -21,7 +21,7 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=network_cli)
-  include: "{{ test_case_to_run }} ansible_connection=network_cli"
+  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={{ cli }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_command/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_command/tasks/nxapi.yaml
@@ -21,7 +21,13 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=httpapi)
-  include: "{{ test_case_to_run }} ansible_connection=httpapi"
+  include: "{{ test_case_to_run }} ansible_connection=httpapi connection={{ nxapi }}"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test cases (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_config/tasks/cli.yaml
+++ b/test/integration/targets/nxos_config/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common cli test cases
+- name: collect common test cases
   find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -21,7 +21,7 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=network_cli)
-  include: "{{ test_case_to_run }} ansible_connection=network_cli"
+  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={{ cli }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_config/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_config/tasks/nxapi.yaml
@@ -21,7 +21,13 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=httpapi)
-  include: "{{ test_case_to_run }} ansible_connection=httpapi"
+  include: "{{ test_case_to_run }} ansible_connection=httpapi connection={{ nxapi }}"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test cases (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_evpn_global/tasks/cli.yaml
+++ b/test/integration/targets/nxos_evpn_global/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common cli test cases
+- name: collect common test cases
   find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -21,13 +21,7 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=network_cli)
-  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={}"
+  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={{ cli }}"
   with_items: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local connection={{ cli }}"
-  with_first_found: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_evpn_global/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_evpn_global/tasks/nxapi.yaml
@@ -21,7 +21,13 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=httpapi)
-  include: "{{ test_case_to_run }} ansible_connection=httpapi"
+  include: "{{ test_case_to_run }} ansible_connection=httpapi connection={{ nxapi }}"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test cases (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_evpn_vni/tasks/cli.yaml
+++ b/test/integration/targets/nxos_evpn_vni/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common cli test cases
+- name: collect common test cases
   find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -21,13 +21,7 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=network_cli)
-  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={}"
+  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={{ cli }}"
   with_items: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local connection={{ cli }}"
-  with_first_found: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_evpn_vni/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_evpn_vni/tasks/nxapi.yaml
@@ -21,7 +21,13 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=httpapi)
-  include: "{{ test_case_to_run }} ansible_connection=httpapi"
+  include: "{{ test_case_to_run }} ansible_connection=httpapi connection={{ nxapi }}"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test cases (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_facts/tasks/cli.yaml
+++ b/test/integration/targets/nxos_facts/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common cli test cases
+- name: collect common test cases
   find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -21,13 +21,7 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=network_cli)
-  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={}"
+  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={{ cli }}"
   with_items: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local connection={{ cli }}"
-  with_first_found: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_facts/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_facts/tasks/nxapi.yaml
@@ -21,7 +21,13 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=httpapi)
-  include: "{{ test_case_to_run }} ansible_connection=httpapi"
+  include: "{{ test_case_to_run }} ansible_connection=httpapi connection={{ nxapi }}"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test cases (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_feature/tasks/cli.yaml
+++ b/test/integration/targets/nxos_feature/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common cli test cases
+- name: collect common test cases
   find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -21,7 +21,7 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=network_cli)
-  include: "{{ test_case_to_run }} ansible_connection=network_cli"
+  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={{ cli }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_feature/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_feature/tasks/nxapi.yaml
@@ -21,7 +21,13 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=httpapi)
-  include: "{{ test_case_to_run }} ansible_connection=httpapi"
+  include: "{{ test_case_to_run }} ansible_connection=httpapi connection={{ nxapi }}"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test cases (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_gir/tasks/cli.yaml
+++ b/test/integration/targets/nxos_gir/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common cli test cases
+- name: collect common test cases
   find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -21,13 +21,7 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=network_cli)
-  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={}"
+  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={{ cli }}"
   with_items: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local connection={{ cli }}"
-  with_first_found: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_gir/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_gir/tasks/nxapi.yaml
@@ -21,7 +21,13 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=httpapi)
-  include: "{{ test_case_to_run }} ansible_connection=httpapi"
+  include: "{{ test_case_to_run }} ansible_connection=httpapi connection={{ nxapi }}"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test cases (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_gir_profile_management/tasks/cli.yaml
+++ b/test/integration/targets/nxos_gir_profile_management/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common cli test cases
+- name: collect common test cases
   find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -21,13 +21,7 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=network_cli)
-  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={}"
+  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={{ cli }}"
   with_items: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local connection={{ cli }}"
-  with_first_found: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_gir_profile_management/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_gir_profile_management/tasks/nxapi.yaml
@@ -21,7 +21,13 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=httpapi)
-  include: "{{ test_case_to_run }} ansible_connection=httpapi"
+  include: "{{ test_case_to_run }} ansible_connection=httpapi connection={{ nxapi }}"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test cases (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_hsrp/tasks/cli.yaml
+++ b/test/integration/targets/nxos_hsrp/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common cli test cases
+- name: collect common test cases
   find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -21,13 +21,7 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=network_cli)
-  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={}"
+  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={{ cli }}"
   with_items: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local connection={{ cli }}"
-  with_first_found: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_hsrp/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_hsrp/tasks/nxapi.yaml
@@ -21,7 +21,13 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=httpapi)
-  include: "{{ test_case_to_run }} ansible_connection=httpapi"
+  include: "{{ test_case_to_run }} ansible_connection=httpapi connection={{ nxapi }}"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test cases (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_igmp/tasks/cli.yaml
+++ b/test/integration/targets/nxos_igmp/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common cli test cases
+- name: collect common test cases
   find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -21,13 +21,7 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=network_cli)
-  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={}"
+  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={{ cli }}"
   with_items: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local connection={{ cli }}"
-  with_first_found: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_igmp/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_igmp/tasks/nxapi.yaml
@@ -21,7 +21,13 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=httpapi)
-  include: "{{ test_case_to_run }} ansible_connection=httpapi"
+  include: "{{ test_case_to_run }} ansible_connection=httpapi connection={{ nxapi }}"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test cases (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_igmp_interface/tasks/cli.yaml
+++ b/test/integration/targets/nxos_igmp_interface/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common cli test cases
+- name: collect common test cases
   find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -21,13 +21,7 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=network_cli)
-  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={}"
+  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={{ cli }}"
   with_items: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local connection={{ cli }}"
-  with_first_found: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_igmp_interface/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_igmp_interface/tasks/nxapi.yaml
@@ -21,7 +21,13 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=httpapi)
-  include: "{{ test_case_to_run }} ansible_connection=httpapi"
+  include: "{{ test_case_to_run }} ansible_connection=httpapi connection={{ nxapi }}"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test cases (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_igmp_snooping/tasks/cli.yaml
+++ b/test/integration/targets/nxos_igmp_snooping/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common cli test cases
+- name: collect common test cases
   find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -21,13 +21,7 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=network_cli)
-  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={}"
+  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={{ cli }}"
   with_items: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local connection={{ cli }}"
-  with_first_found: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_igmp_snooping/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_igmp_snooping/tasks/nxapi.yaml
@@ -21,7 +21,13 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=httpapi)
-  include: "{{ test_case_to_run }} ansible_connection=httpapi"
+  include: "{{ test_case_to_run }} ansible_connection=httpapi connection={{ nxapi }}"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test cases (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_install_os/tasks/network_local.yaml
+++ b/test/integration/targets/nxos_install_os/tasks/network_local.yaml
@@ -9,8 +9,8 @@
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test case (ansible_connection=local transport=ssh)
+- name: run test cases (ansible_connection=local transport=ssh)
   include: "{{ test_case_to_run }} ansible_connection=local connection={{ cli }}"
-  with_first_found: "{{ test_items }}"
+  with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_interface/tasks/cli.yaml
+++ b/test/integration/targets/nxos_interface/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common cli test cases
+- name: collect common test cases
   find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -21,13 +21,7 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=network_cli)
-  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={}"
+  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={{ cli }}"
   with_items: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local connection={{ cli }}"
-  with_first_found: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_interface/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_interface/tasks/nxapi.yaml
@@ -21,7 +21,13 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=httpapi)
-  include: "{{ test_case_to_run }} ansible_connection=httpapi"
+  include: "{{ test_case_to_run }} ansible_connection=httpapi connection={{ nxapi }}"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test cases (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_interface_ospf/tasks/cli.yaml
+++ b/test/integration/targets/nxos_interface_ospf/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common cli test cases
+- name: collect common test cases
   find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -21,13 +21,7 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=network_cli)
-  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={}"
+  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={{ cli }}"
   with_items: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local connection={{ cli }}"
-  with_first_found: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_interface_ospf/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_interface_ospf/tasks/nxapi.yaml
@@ -21,7 +21,13 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=httpapi)
-  include: "{{ test_case_to_run }} ansible_connection=httpapi"
+  include: "{{ test_case_to_run }} ansible_connection=httpapi connection={{ nxapi }}"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test cases (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_ip_interface/tasks/cli.yaml
+++ b/test/integration/targets/nxos_ip_interface/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common cli test cases
+- name: collect common test cases
   find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -21,13 +21,7 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=network_cli)
-  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={}"
+  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={{ cli }}"
   with_items: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local connection={{ cli }}"
-  with_first_found: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_ip_interface/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_ip_interface/tasks/nxapi.yaml
@@ -21,7 +21,13 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=httpapi)
-  include: "{{ test_case_to_run }} ansible_connection=httpapi"
+  include: "{{ test_case_to_run }} ansible_connection=httpapi connection={{ nxapi }}"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test cases (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_l2_interface/tasks/cli.yaml
+++ b/test/integration/targets/nxos_l2_interface/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common cli test cases
+- name: collect common test cases
   find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -21,13 +21,7 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=network_cli)
-  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={}"
+  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={{ cli }}"
   with_items: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local connection={{ cli }}"
-  with_first_found: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_l2_interface/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_l2_interface/tasks/nxapi.yaml
@@ -21,7 +21,13 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=httpapi)
-  include: "{{ test_case_to_run }} ansible_connection=httpapi"
+  include: "{{ test_case_to_run }} ansible_connection=httpapi connection={{ nxapi }}"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test cases (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_l3_interface/tasks/cli.yaml
+++ b/test/integration/targets/nxos_l3_interface/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common cli test cases
+- name: collect common test cases
   find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -21,13 +21,7 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=network_cli)
-  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={}"
+  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={{ cli }}"
   with_items: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local connection={{ cli }}"
-  with_first_found: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_l3_interface/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_l3_interface/tasks/nxapi.yaml
@@ -21,7 +21,13 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=httpapi)
-  include: "{{ test_case_to_run }} ansible_connection=httpapi"
+  include: "{{ test_case_to_run }} ansible_connection=httpapi connection={{ nxapi }}"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test cases (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_linkagg/tasks/cli.yaml
+++ b/test/integration/targets/nxos_linkagg/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common cli test cases
+- name: collect common test cases
   find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -21,13 +21,7 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=network_cli)
-  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={}"
+  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={{ cli }}"
   with_items: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local connection={{ cli }}"
-  with_first_found: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_linkagg/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_linkagg/tasks/nxapi.yaml
@@ -21,7 +21,13 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=httpapi)
-  include: "{{ test_case_to_run }} ansible_connection=httpapi"
+  include: "{{ test_case_to_run }} ansible_connection=httpapi connection={{ nxapi }}"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test cases (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_lldp/tasks/cli.yaml
+++ b/test/integration/targets/nxos_lldp/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common cli test cases
+- name: collect common test cases
   find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -21,13 +21,7 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=network_cli)
-  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={}"
+  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={{ cli }}"
   with_items: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local connection={{ cli }}"
-  with_first_found: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_lldp/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_lldp/tasks/nxapi.yaml
@@ -21,7 +21,13 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=httpapi)
-  include: "{{ test_case_to_run }} ansible_connection=httpapi"
+  include: "{{ test_case_to_run }} ansible_connection=httpapi connection={{ nxapi }}"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test cases (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_logging/tasks/cli.yaml
+++ b/test/integration/targets/nxos_logging/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common cli test cases
+- name: collect common test cases
   find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -21,13 +21,7 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=network_cli)
-  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={}"
+  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={{ cli }}"
   with_items: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local connection={{ cli }}"
-  with_first_found: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_logging/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_logging/tasks/nxapi.yaml
@@ -21,7 +21,13 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=httpapi)
-  include: "{{ test_case_to_run }} ansible_connection=httpapi"
+  include: "{{ test_case_to_run }} ansible_connection=httpapi connection={{ nxapi }}"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test cases (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_ntp/tasks/cli.yaml
+++ b/test/integration/targets/nxos_ntp/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common cli test cases
+- name: collect common test cases
   find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -21,13 +21,7 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=network_cli)
-  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={}"
+  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={{ cli }}"
   with_items: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local connection={{ cli }}"
-  with_first_found: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_ntp/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_ntp/tasks/nxapi.yaml
@@ -21,7 +21,13 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=httpapi)
-  include: "{{ test_case_to_run }} ansible_connection=httpapi"
+  include: "{{ test_case_to_run }} ansible_connection=httpapi connection={{ nxapi }}"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test cases (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_ntp_auth/tasks/cli.yaml
+++ b/test/integration/targets/nxos_ntp_auth/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common cli test cases
+- name: collect common test cases
   find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -21,13 +21,7 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=network_cli)
-  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={}"
+  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={{ cli }}"
   with_items: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local connection={{ cli }}"
-  with_first_found: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_ntp_auth/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_ntp_auth/tasks/nxapi.yaml
@@ -21,7 +21,13 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=httpapi)
-  include: "{{ test_case_to_run }} ansible_connection=httpapi"
+  include: "{{ test_case_to_run }} ansible_connection=httpapi connection={{ nxapi }}"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test cases (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_ntp_options/tasks/cli.yaml
+++ b/test/integration/targets/nxos_ntp_options/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common cli test cases
+- name: collect common test cases
   find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -21,13 +21,7 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=network_cli)
-  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={}"
+  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={{ cli }}"
   with_items: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local connection={{ cli }}"
-  with_first_found: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_ntp_options/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_ntp_options/tasks/nxapi.yaml
@@ -21,7 +21,13 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=httpapi)
-  include: "{{ test_case_to_run }} ansible_connection=httpapi"
+  include: "{{ test_case_to_run }} ansible_connection=httpapi connection={{ nxapi }}"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test cases (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_nxapi/tasks/cli.yaml
+++ b/test/integration/targets/nxos_nxapi/tasks/cli.yaml
@@ -21,7 +21,7 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=network_cli)
-  include: "{{ test_case_to_run }} ansible_connection=network_cli"
+  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={{ cli }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_nxapi/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_nxapi/tasks/nxapi.yaml
@@ -21,7 +21,7 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=httpapi)
-  include: "{{ test_case_to_run }} ansible_connection=httpapi"
+  include: "{{ test_case_to_run }} ansible_connection=httpapi connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_ospf/tasks/cli.yaml
+++ b/test/integration/targets/nxos_ospf/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common cli test cases
+- name: collect common test cases
   find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -21,13 +21,7 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=network_cli)
-  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={}"
+  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={{ cli }}"
   with_items: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local connection={{ cli }}"
-  with_first_found: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_ospf/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_ospf/tasks/nxapi.yaml
@@ -21,7 +21,13 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=httpapi)
-  include: "{{ test_case_to_run }} ansible_connection=httpapi"
+  include: "{{ test_case_to_run }} ansible_connection=httpapi connection={{ nxapi }}"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test cases (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_ospf_vrf/tasks/cli.yaml
+++ b/test/integration/targets/nxos_ospf_vrf/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common cli test cases
+- name: collect common test cases
   find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -21,13 +21,7 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=network_cli)
-  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={}"
+  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={{ cli }}"
   with_items: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local connection={{ cli }}"
-  with_first_found: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_ospf_vrf/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_ospf_vrf/tasks/nxapi.yaml
@@ -21,7 +21,13 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=httpapi)
-  include: "{{ test_case_to_run }} ansible_connection=httpapi"
+  include: "{{ test_case_to_run }} ansible_connection=httpapi connection={{ nxapi }}"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test cases (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_overlay_global/tasks/cli.yaml
+++ b/test/integration/targets/nxos_overlay_global/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common cli test cases
+- name: collect common test cases
   find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -21,13 +21,7 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=network_cli)
-  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={}"
+  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={{ cli }}"
   with_items: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local connection={{ cli }}"
-  with_first_found: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_overlay_global/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_overlay_global/tasks/nxapi.yaml
@@ -21,7 +21,13 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=httpapi)
-  include: "{{ test_case_to_run }} ansible_connection=httpapi"
+  include: "{{ test_case_to_run }} ansible_connection=httpapi connection={{ nxapi }}"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test cases (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_pim/tasks/cli.yaml
+++ b/test/integration/targets/nxos_pim/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common cli test cases
+- name: collect common test cases
   find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -21,13 +21,7 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=network_cli)
-  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={}"
+  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={{ cli }}"
   with_items: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local connection={{ cli }}"
-  with_first_found: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_pim/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_pim/tasks/nxapi.yaml
@@ -21,7 +21,13 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=httpapi)
-  include: "{{ test_case_to_run }} ansible_connection=httpapi"
+  include: "{{ test_case_to_run }} ansible_connection=httpapi connection={{ nxapi }}"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test cases (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_pim_interface/tasks/cli.yaml
+++ b/test/integration/targets/nxos_pim_interface/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common cli test cases
+- name: collect common test cases
   find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -21,13 +21,7 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=network_cli)
-  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={}"
+  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={{ cli }}"
   with_items: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local connection={{ cli }}"
-  with_first_found: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_pim_interface/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_pim_interface/tasks/nxapi.yaml
@@ -21,7 +21,13 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=httpapi)
-  include: "{{ test_case_to_run }} ansible_connection=httpapi"
+  include: "{{ test_case_to_run }} ansible_connection=httpapi connection={{ nxapi }}"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test cases (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_pim_rp_address/tasks/cli.yaml
+++ b/test/integration/targets/nxos_pim_rp_address/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common cli test cases
+- name: collect common test cases
   find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -21,13 +21,7 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=network_cli)
-  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={}"
+  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={{ cli }}"
   with_items: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local connection={{ cli }}"
-  with_first_found: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_pim_rp_address/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_pim_rp_address/tasks/nxapi.yaml
@@ -21,7 +21,13 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=httpapi)
-  include: "{{ test_case_to_run }} ansible_connection=httpapi"
+  include: "{{ test_case_to_run }} ansible_connection=httpapi connection={{ nxapi }}"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test cases (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_portchannel/tasks/cli.yaml
+++ b/test/integration/targets/nxos_portchannel/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common cli test cases
+- name: collect common test cases
   find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -21,13 +21,7 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=network_cli)
-  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={}"
+  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={{ cli }}"
   with_items: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local connection={{ cli }}"
-  with_first_found: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_portchannel/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_portchannel/tasks/nxapi.yaml
@@ -21,7 +21,13 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=httpapi)
-  include: "{{ test_case_to_run }} ansible_connection=httpapi"
+  include: "{{ test_case_to_run }} ansible_connection=httpapi connection={{ nxapi }}"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test cases (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_rollback/tasks/cli.yaml
+++ b/test/integration/targets/nxos_rollback/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common cli test cases
+- name: collect common test cases
   find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -21,13 +21,7 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=network_cli)
-  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={}"
+  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={{ cli }}"
   with_items: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local connection={{ cli }}"
-  with_first_found: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_rollback/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_rollback/tasks/nxapi.yaml
@@ -21,7 +21,13 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=httpapi)
-  include: "{{ test_case_to_run }} ansible_connection=httpapi"
+  include: "{{ test_case_to_run }} ansible_connection=httpapi connection={{ nxapi }}"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test cases (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_smoke/tasks/cli.yaml
+++ b/test/integration/targets/nxos_smoke/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common cli test cases
+- name: collect common test cases
   find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"

--- a/test/integration/targets/nxos_smoke/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_smoke/tasks/nxapi.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common nxapi test cases
+- name: collect common test cases
   find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"

--- a/test/integration/targets/nxos_snapshot/tasks/cli.yaml
+++ b/test/integration/targets/nxos_snapshot/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common cli test cases
+- name: collect common test cases
   find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -21,13 +21,7 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=network_cli)
-  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={}"
+  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={{ cli }}"
   with_items: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local connection={{ cli }}"
-  with_first_found: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_snapshot/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_snapshot/tasks/nxapi.yaml
@@ -21,7 +21,13 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=httpapi)
-  include: "{{ test_case_to_run }} ansible_connection=httpapi"
+  include: "{{ test_case_to_run }} ansible_connection=httpapi connection={{ nxapi }}"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test cases (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_snmp_community/tasks/cli.yaml
+++ b/test/integration/targets/nxos_snmp_community/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common cli test cases
+- name: collect common test cases
   find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -21,13 +21,7 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=network_cli)
-  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={}"
+  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={{ cli }}"
   with_items: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local connection={{ cli }}"
-  with_first_found: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_snmp_community/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_snmp_community/tasks/nxapi.yaml
@@ -21,7 +21,13 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=httpapi)
-  include: "{{ test_case_to_run }} ansible_connection=httpapi"
+  include: "{{ test_case_to_run }} ansible_connection=httpapi connection={{ nxapi }}"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test cases (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_snmp_contact/tasks/cli.yaml
+++ b/test/integration/targets/nxos_snmp_contact/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common cli test cases
+- name: collect common test cases
   find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -21,13 +21,7 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=network_cli)
-  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={}"
+  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={{ cli }}"
   with_items: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local connection={{ cli }}"
-  with_first_found: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_snmp_contact/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_snmp_contact/tasks/nxapi.yaml
@@ -21,7 +21,13 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=httpapi)
-  include: "{{ test_case_to_run }} ansible_connection=httpapi"
+  include: "{{ test_case_to_run }} ansible_connection=httpapi connection={{ nxapi }}"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test cases (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_snmp_host/tasks/cli.yaml
+++ b/test/integration/targets/nxos_snmp_host/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common cli test cases
+- name: collect common test cases
   find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -21,13 +21,7 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=network_cli)
-  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={}"
+  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={{ cli }}"
   with_items: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local connection={{ cli }}"
-  with_first_found: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_snmp_host/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_snmp_host/tasks/nxapi.yaml
@@ -21,7 +21,13 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=httpapi)
-  include: "{{ test_case_to_run }} ansible_connection=httpapi"
+  include: "{{ test_case_to_run }} ansible_connection=httpapi connection={{ nxapi }}"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test cases (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_snmp_location/tasks/cli.yaml
+++ b/test/integration/targets/nxos_snmp_location/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common cli test cases
+- name: collect common test cases
   find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -21,13 +21,7 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=network_cli)
-  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={}"
+  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={{ cli }}"
   with_items: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local connection={{ cli }}"
-  with_first_found: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_snmp_location/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_snmp_location/tasks/nxapi.yaml
@@ -21,7 +21,13 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=httpapi)
-  include: "{{ test_case_to_run }} ansible_connection=httpapi"
+  include: "{{ test_case_to_run }} ansible_connection=httpapi connection={{ nxapi }}"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test cases (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_snmp_traps/tasks/cli.yaml
+++ b/test/integration/targets/nxos_snmp_traps/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common cli test cases
+- name: collect common test cases
   find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -21,13 +21,7 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=network_cli)
-  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={}"
+  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={{ cli }}"
   with_items: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local connection={{ cli }}"
-  with_first_found: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_snmp_traps/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_snmp_traps/tasks/nxapi.yaml
@@ -21,7 +21,13 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=httpapi)
-  include: "{{ test_case_to_run }} ansible_connection=httpapi"
+  include: "{{ test_case_to_run }} ansible_connection=httpapi connection={{ nxapi }}"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test cases (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_snmp_user/tasks/cli.yaml
+++ b/test/integration/targets/nxos_snmp_user/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common cli test cases
+- name: collect common test cases
   find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -21,13 +21,7 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=network_cli)
-  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={}"
+  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={{ cli }}"
   with_items: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local connection={{ cli }}"
-  with_first_found: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_snmp_user/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_snmp_user/tasks/nxapi.yaml
@@ -21,7 +21,13 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=httpapi)
-  include: "{{ test_case_to_run }} ansible_connection=httpapi"
+  include: "{{ test_case_to_run }} ansible_connection=httpapi connection={{ nxapi }}"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test cases (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_static_route/tasks/cli.yaml
+++ b/test/integration/targets/nxos_static_route/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common cli test cases
+- name: collect common test cases
   find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -21,13 +21,7 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=network_cli)
-  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={}"
+  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={{ cli }}"
   with_items: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local connection={{ cli }}"
-  with_first_found: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_static_route/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_static_route/tasks/nxapi.yaml
@@ -21,7 +21,13 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=httpapi)
-  include: "{{ test_case_to_run }} ansible_connection=httpapi"
+  include: "{{ test_case_to_run }} ansible_connection=httpapi connection={{ nxapi }}"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test cases (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_switchport/tasks/cli.yaml
+++ b/test/integration/targets/nxos_switchport/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common cli test cases
+- name: collect common test cases
   find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -21,13 +21,7 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=network_cli)
-  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={}"
+  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={{ cli }}"
   with_items: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local connection={{ cli }}"
-  with_first_found: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_switchport/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_switchport/tasks/nxapi.yaml
@@ -21,7 +21,13 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=httpapi)
-  include: "{{ test_case_to_run }} ansible_connection=httpapi"
+  include: "{{ test_case_to_run }} ansible_connection=httpapi connection={{ nxapi }}"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test cases (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_system/tasks/cli.yaml
+++ b/test/integration/targets/nxos_system/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common cli test cases
+- name: collect common test cases
   find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -21,13 +21,7 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=network_cli)
-  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={}"
+  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={{ cli }}"
   with_items: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local connection={{ cli }}"
-  with_first_found: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_system/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_system/tasks/nxapi.yaml
@@ -21,7 +21,13 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=httpapi)
-  include: "{{ test_case_to_run }} ansible_connection=httpapi"
+  include: "{{ test_case_to_run }} ansible_connection=httpapi connection={{ nxapi }}"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test cases (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_udld/tasks/cli.yaml
+++ b/test/integration/targets/nxos_udld/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common cli test cases
+- name: collect common test cases
   find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -21,13 +21,7 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=network_cli)
-  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={}"
+  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={{ cli }}"
   with_items: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local connection={{ cli }}"
-  with_first_found: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_udld/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_udld/tasks/nxapi.yaml
@@ -21,7 +21,13 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=httpapi)
-  include: "{{ test_case_to_run }} ansible_connection=httpapi"
+  include: "{{ test_case_to_run }} ansible_connection=httpapi connection={{ nxapi }}"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test cases (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_udld_interface/tasks/cli.yaml
+++ b/test/integration/targets/nxos_udld_interface/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common cli test cases
+- name: collect common test cases
   find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -21,13 +21,7 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=network_cli)
-  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={}"
+  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={{ cli }}"
   with_items: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local connection={{ cli }}"
-  with_first_found: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_udld_interface/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_udld_interface/tasks/nxapi.yaml
@@ -21,7 +21,13 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=httpapi)
-  include: "{{ test_case_to_run }} ansible_connection=httpapi"
+  include: "{{ test_case_to_run }} ansible_connection=httpapi connection={{ nxapi }}"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test cases (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_user/tasks/cli.yaml
+++ b/test/integration/targets/nxos_user/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common cli test cases
+- name: collect common test cases
   find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -21,13 +21,7 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=network_cli)
-  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={}"
+  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={{ cli }}"
   with_items: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local connection={{ cli }}"
-  with_first_found: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_user/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_user/tasks/nxapi.yaml
@@ -21,7 +21,13 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=httpapi)
-  include: "{{ test_case_to_run }} ansible_connection=httpapi"
+  include: "{{ test_case_to_run }} ansible_connection=httpapi connection={{ nxapi }}"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test cases (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_vlan/tasks/cli.yaml
+++ b/test/integration/targets/nxos_vlan/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common cli test cases
+- name: collect common test cases
   find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -21,13 +21,7 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=network_cli)
-  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={}"
+  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={{ cli }}"
   with_items: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local connection={{ cli }}"
-  with_first_found: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_vlan/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_vlan/tasks/nxapi.yaml
@@ -21,7 +21,13 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=httpapi)
-  include: "{{ test_case_to_run }} ansible_connection=httpapi"
+  include: "{{ test_case_to_run }} ansible_connection=httpapi connection={{ nxapi }}"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test cases (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_vpc/tasks/cli.yaml
+++ b/test/integration/targets/nxos_vpc/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common cli test cases
+- name: collect common test cases
   find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -21,13 +21,7 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=network_cli)
-  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={}"
+  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={{ cli }}"
   with_items: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local connection={{ cli }}"
-  with_first_found: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_vpc/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_vpc/tasks/nxapi.yaml
@@ -21,7 +21,13 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=httpapi)
-  include: "{{ test_case_to_run }} ansible_connection=httpapi"
+  include: "{{ test_case_to_run }} ansible_connection=httpapi connection={{ nxapi }}"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test cases (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_vpc_interface/tasks/cli.yaml
+++ b/test/integration/targets/nxos_vpc_interface/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common cli test cases
+- name: collect common test cases
   find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -21,13 +21,7 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=network_cli)
-  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={}"
+  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={{ cli }}"
   with_items: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local connection={{ cli }}"
-  with_first_found: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_vpc_interface/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_vpc_interface/tasks/nxapi.yaml
@@ -21,7 +21,13 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=httpapi)
-  include: "{{ test_case_to_run }} ansible_connection=httpapi"
+  include: "{{ test_case_to_run }} ansible_connection=httpapi connection={{ nxapi }}"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test cases (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_vrf/tasks/cli.yaml
+++ b/test/integration/targets/nxos_vrf/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common cli test cases
+- name: collect common test cases
   find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -21,13 +21,7 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=network_cli)
-  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={}"
+  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={{ cli }}"
   with_items: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local connection={{ cli }}"
-  with_first_found: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_vrf/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_vrf/tasks/nxapi.yaml
@@ -21,7 +21,13 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=httpapi)
-  include: "{{ test_case_to_run }} ansible_connection=httpapi"
+  include: "{{ test_case_to_run }} ansible_connection=httpapi connection={{ nxapi }}"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test cases (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_vrf_af/tasks/cli.yaml
+++ b/test/integration/targets/nxos_vrf_af/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common cli test cases
+- name: collect common test cases
   find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -21,13 +21,7 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=network_cli)
-  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={}"
+  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={{ cli }}"
   with_items: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local connection={{ cli }}"
-  with_first_found: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_vrf_af/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_vrf_af/tasks/nxapi.yaml
@@ -21,7 +21,13 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=httpapi)
-  include: "{{ test_case_to_run }} ansible_connection=httpapi"
+  include: "{{ test_case_to_run }} ansible_connection=httpapi connection={{ nxapi }}"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test cases (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_vrf_interface/tasks/cli.yaml
+++ b/test/integration/targets/nxos_vrf_interface/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common cli test cases
+- name: collect common test cases
   find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -21,13 +21,7 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=network_cli)
-  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={}"
+  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={{ cli }}"
   with_items: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local connection={{ cli }}"
-  with_first_found: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_vrf_interface/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_vrf_interface/tasks/nxapi.yaml
@@ -21,7 +21,13 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=httpapi)
-  include: "{{ test_case_to_run }} ansible_connection=httpapi"
+  include: "{{ test_case_to_run }} ansible_connection=httpapi connection={{ nxapi }}"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test cases (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_vrrp/tasks/cli.yaml
+++ b/test/integration/targets/nxos_vrrp/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common cli test cases
+- name: collect common test cases
   find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -21,13 +21,7 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=network_cli)
-  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={}"
+  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={{ cli }}"
   with_items: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local connection={{ cli }}"
-  with_first_found: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_vrrp/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_vrrp/tasks/nxapi.yaml
@@ -21,7 +21,13 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=httpapi)
-  include: "{{ test_case_to_run }} ansible_connection=httpapi"
+  include: "{{ test_case_to_run }} ansible_connection=httpapi connection={{ nxapi }}"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test cases (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_vtp_domain/tasks/cli.yaml
+++ b/test/integration/targets/nxos_vtp_domain/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common cli test cases
+- name: collect common test cases
   find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -21,13 +21,7 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=network_cli)
-  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={}"
+  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={{ cli }}"
   with_items: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local connection={{ cli }}"
-  with_first_found: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_vtp_domain/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_vtp_domain/tasks/nxapi.yaml
@@ -21,7 +21,13 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=httpapi)
-  include: "{{ test_case_to_run }} ansible_connection=httpapi"
+  include: "{{ test_case_to_run }} ansible_connection=httpapi connection={{ nxapi }}"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test cases (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_vtp_password/tasks/cli.yaml
+++ b/test/integration/targets/nxos_vtp_password/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common cli test cases
+- name: collect common test cases
   find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -21,13 +21,7 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=network_cli)
-  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={}"
+  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={{ cli }}"
   with_items: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local connection={{ cli }}"
-  with_first_found: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_vtp_password/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_vtp_password/tasks/nxapi.yaml
@@ -21,7 +21,13 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=httpapi)
-  include: "{{ test_case_to_run }} ansible_connection=httpapi"
+  include: "{{ test_case_to_run }} ansible_connection=httpapi connection={{ nxapi }}"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test cases (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_vtp_version/tasks/cli.yaml
+++ b/test/integration/targets/nxos_vtp_version/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common cli test cases
+- name: collect common test cases
   find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -21,13 +21,7 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=network_cli)
-  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={}"
+  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={{ cli }}"
   with_items: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local connection={{ cli }}"
-  with_first_found: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_vtp_version/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_vtp_version/tasks/nxapi.yaml
@@ -21,7 +21,13 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=httpapi)
-  include: "{{ test_case_to_run }} ansible_connection=httpapi"
+  include: "{{ test_case_to_run }} ansible_connection=httpapi connection={{ nxapi }}"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test cases (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_vxlan_vtep/tasks/cli.yaml
+++ b/test/integration/targets/nxos_vxlan_vtep/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common cli test cases
+- name: collect common test cases
   find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -21,13 +21,7 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=network_cli)
-  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={}"
+  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={{ cli }}"
   with_items: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local connection={{ cli }}"
-  with_first_found: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_vxlan_vtep/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_vxlan_vtep/tasks/nxapi.yaml
@@ -21,7 +21,13 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=httpapi)
-  include: "{{ test_case_to_run }} ansible_connection=httpapi"
+  include: "{{ test_case_to_run }} ansible_connection=httpapi connection={{ nxapi }}"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test cases (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_vxlan_vtep_vni/tasks/cli.yaml
+++ b/test/integration/targets/nxos_vxlan_vtep_vni/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common cli test cases
+- name: collect common test cases
   find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -21,13 +21,7 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=network_cli)
-  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={}"
+  include: "{{ test_case_to_run }} ansible_connection=network_cli connection={{ cli }}"
   with_items: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local connection={{ cli }}"
-  with_first_found: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/nxos_vxlan_vtep_vni/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_vxlan_vtep_vni/tasks/nxapi.yaml
@@ -21,7 +21,13 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=httpapi)
-  include: "{{ test_case_to_run }} ansible_connection=httpapi"
+  include: "{{ test_case_to_run }} ansible_connection=httpapi connection={{ nxapi }}"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test cases (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
Removes `connection=local` from most nxos cli tests. Unless specific inconsistencies are found between `network_cli` and `local`, `local` is tested by `nxos_smoke`.

Reintroduces `local` to nxapi tests. `connection=local` should be removed from said tests when `httpapi` is known to work.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Test Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
nxos

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7
```