### PR TITLE
Fix test-module failing to validate args (#41004)

### DIFF
--- a/hacking/test-module
+++ b/hacking/test-module
@@ -125,7 +125,7 @@ def boilerplate_module(modfile, args, interpreters, check, destfile):
 
     # default selinux fs list is pass in as _ansible_selinux_special_fs arg
     complex_args['_ansible_selinux_special_fs'] = C.DEFAULT_SELINUX_SPECIAL_FS
-    complex_args['_ansible_tmp'] = C.DEFAULT_LOCAL_TMP
+    complex_args['_ansible_tmpdir'] = C.DEFAULT_LOCAL_TMP
     complex_args['_ansible_keep_remote_files'] = C.DEFAULT_KEEP_REMOTE_FILES
 
     if args.startswith("@"):

--- a/test/integration/targets/test_infra/runme.sh
+++ b/test/integration/targets/test_infra/runme.sh
@@ -21,3 +21,7 @@ echo "rc was $APB_RC (must be non-zero)"
 echo "ensure playbook output shows assert/fail works (True)"
 echo "$PB_OUT" | grep -F "fail works (True)" || exit 1
 echo "$PB_OUT" | grep -F "assert works (True)" || exit 1
+
+# ensure test-module script works well
+PING_MODULE_PATH="$(pwd)/../../../../lib/ansible/modules/system/ping.py"
+../../../../hacking/test-module -m "$PING_MODULE_PATH" -I ansible_python_interpreter="$(which python)"


### PR DESCRIPTION
* Fix test-module failing to validate args

The test-module pass a wrong argument _ansible_tmp cause the validation failed.
Change the argument _ansible_tmp to _ansible_tmpdir to fix this.

* Add a integration test for test-module.

Prior to this change, we don't have a test for test-module.

This change ensure the correctness of test-module script.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
A backport to pull request number #41004 
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - New Module Pull Request
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
