### PR TITLE
Add multi-parition vhd(x) support to module win_disk_image

### DIFF
--- a/lib/ansible/modules/windows/win_disk_image.ps1
+++ b/lib/ansible/modules/windows/win_disk_image.ps1
@@ -34,6 +34,7 @@ $result = @{changed=$false}
 $image_path = Get-AnsibleParam $parsed_args "image_path" -failifempty $result
 $state = Get-AnsibleParam $parsed_args "state" -default "present" -validateset "present","absent"
 $check_mode = Get-AnsibleParam $parsed_args "_ansible_check_mode" -default $false
+$vhd_part = Get-AnsibleParam $parsed_args "vhd_part" -default 0
 
 $di = Get-DiskImage $image_path
 
@@ -67,8 +68,7 @@ If($state -eq "present") {
       $drive_letter = ($di | Get-Volume).DriveLetter
     }
     ElseIf($di.StorageType -in @(2,3)) { # VHD/VHDX, need Get-Disk + Get-Partition to discover mountpoint
-      # FUTURE: support multi-partition VHDs
-      $drive_letter = ($di | Get-Disk | Get-Partition)[0].DriveLetter
+      $drive_letter = ($di | Get-Disk | Get-Partition)[$vhd_part].DriveLetter
     }
 
 

--- a/lib/ansible/modules/windows/win_disk_image.py
+++ b/lib/ansible/modules/windows/win_disk_image.py
@@ -26,6 +26,11 @@ options:
       - Whether the image should be present as a drive-letter mount or not.
     choices: [ absent, present ]
     default: present
+  vhd_part:
+    description:
+      - The VHD/VHDX partition number that will be mounted.
+    default: 0
+    version_added: 2.7
 author:
     - Matt Davis (@nitzmahone)
 '''
@@ -56,4 +61,12 @@ EXAMPLES = r'''
   win_disk_image:
     image_path: C:\install.iso
     state: absent
+
+# Mount a specific VHDX Partition and record the drive letter for future use.
+- name: Mount VHDX partition 3
+  win_disk_image:
+    image_path: C:\multi-part.vhdx
+    state: present
+    vhd_part: 3
+  register: disk_image_out
 '''


### PR DESCRIPTION
##### SUMMARY
Add support for VHD(X)s with multiple partitions. Currently module is hard coded for partition 0. Add a param to pass in (vhd_part) to specify a particular VHD(X) partition to mount. Applicable code only changes in retrieving the drive letter. Mounting without specifying partition is fine, but retrieving the drive letter from the mounted image file requires specifying a particular partition.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
win_disk_image

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.3
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/ttaylor/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Apr 11 2018, 07:36:10) [GCC 4.8.5 20150623 (Red Hat 4.8.5-28)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
