### PR TITLE
fixes an issue with dict_merge in network utils

### DIFF
--- a/lib/ansible/module_utils/network/common/utils.py
+++ b/lib/ansible/module_utils/network/common/utils.py
@@ -275,7 +275,10 @@ def dict_merge(base, other):
             if key in other:
                 item = other.get(key)
                 if item is not None:
-                    combined[key] = dict_merge(value, other[key])
+                    if isinstance(other[key], dict):
+                        combined[key] = dict_merge(value, other[key])
+                    else:
+                        combined[key] = other[key]
                 else:
                     combined[key] = item
             else:


### PR DESCRIPTION
This change address a problem where the dict_merge function would fail
due to the value being a nested dict.  This will now recursively pass
the value back through the dict_merge function.

