### PR TITLE
add example using peer keepalive vrf and delay restore

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_vpc.py
+++ b/lib/ansible/modules/network/nxos/nxos_vpc.py
@@ -102,7 +102,7 @@ EXAMPLES = '''
     pkl_dest: 192.168.100.4
     auto_recovery: true
 
-- name: Configure VPC with delay restore and keepalive VRF
+- name: Configure VPC with delay restore and existing keepalive VRF
   nxos_vpc:
     domain: 10
     role_priority: 28672

--- a/lib/ansible/modules/network/nxos/nxos_vpc.py
+++ b/lib/ansible/modules/network/nxos/nxos_vpc.py
@@ -101,6 +101,18 @@ EXAMPLES = '''
     pkl_src: 10.1.100.2
     pkl_dest: 192.168.100.4
     auto_recovery: true
+
+- name: Configure VPC with delay restore and keepalive VRF
+  nxos_vpc:
+    domain: 10
+    role_priority: 28672
+    system_priority: 2000
+    delay_restore: 180
+    peer_gw: true
+    pkl_src: 1.1.1.2
+    pkl_dest: 1.1.1.1
+    pkl_vrf: vpckeepalive
+    auto_recovery: true
 '''
 
 RETURN = '''


### PR DESCRIPTION
<!--- Your description here -->
add example using peer keepalive vrf and delay restore
+label: docsite_pr
+label: issue ansible/community#311

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
add example using peer keepalive vrf and delay restore

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
nxos_vpc
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.2
  config file = /home/ansible.cfg
  configured module search path = [u'/usr/local/lib/python2.7/dist-packages/napalm_ansible']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```