### PR TITLE
Introduce inventory.any_errors_fatal configuration setting

### DIFF
--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1375,6 +1375,18 @@ HOST_KEY_CHECKING:
   ini:
   - {key: host_key_checking, section: defaults}
   type: boolean
+INVENTORY_ANY_ERRORS_FATAL:
+  name: Controls whether any unparseable inventory source is a fatal error
+  default: False
+  description: >
+    If 'true', it is a fatal error when any given inventory source
+    cannot be successfully parsed by any available inventory plugin;
+    otherwise, this situation only attracts a warning.
+  type: boolean
+  env: [{name: ANSIBLE_INVENTORY_ERRORS_FATAL}]
+  ini:
+    - {key: any_errors_fatal, section: inventory}
+  version_added: "2.7"
 INVENTORY_ENABLED:
   name: Active Inventory plugins
   default: ['host_list', 'script', 'yaml', 'ini', 'auto']
@@ -1412,7 +1424,10 @@ INVENTORY_IGNORE_PATTERNS:
 INVENTORY_UNPARSED_IS_FAILED:
   name: Unparsed Inventory failure
   default: False
-  description: If 'true' unparsed inventory sources become fatal errors, they are warnings otherwise.
+  description: >
+    If 'true' it is a fatal error if every single potential inventory
+    source fails to parse, otherwise this situation will only attract a
+    warning.
   env: [{name: ANSIBLE_INVENTORY_UNPARSED_FAILED}]
   ini:
   - {key: unparsed_is_failed, section: inventory}

--- a/lib/ansible/inventory/manager.py
+++ b/lib/ansible/inventory/manager.py
@@ -285,6 +285,8 @@ class InventoryManager(object):
                         display.warning(u'\n* Failed to parse %s with %s plugin: %s' % (to_text(fail['src']), fail['plugin'], to_text(fail['exc'])))
                         if hasattr(fail['exc'], 'tb'):
                             display.vvv(to_text(fail['exc'].tb))
+                    if C.INVENTORY_ANY_ERRORS_FATAL:
+                        raise AnsibleError(u'Completely failed to parse inventory source %s' % (to_text(source)))
         if not parsed:
             display.warning("Unable to parse %s as an inventory source" % to_text(source))
 


### PR DESCRIPTION
##### SUMMARY

First, we clarify that "unparsed_is_failed=true" causes a fatal error
only if ALL available inventory sources completely fail to parse. In
other words, if there is a static inventory source (yaml/ini-format)
defined, then no combination of parsing failures and the setting can
result in a fatal error.

This is not what everyone needs. When you have a complex inventory with
multiple sources, it is useful to treat any error as fatal, rather than
proceeding with playbook execution with an incomplete inventory.

This commit introduces an "any_errors_fatal" setting that does exactly
this: if we completely fail to parse any given inventory source, it is
treated as a fatal error.

See also issue #40996

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
core

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
HEAD
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->
N/A