### PR TITLE
Mark azure_networkinterface test as unstable

### DIFF
--- a/test/integration/targets/azure_rm_networkinterface/aliases
+++ b/test/integration/targets/azure_rm_networkinterface/aliases
@@ -1,3 +1,5 @@
 cloud/azure
 posix/ci/cloud/group2/azure
 destructive
+unstable
+


### PR DESCRIPTION
##### SUMMARY
This is necessary as Azure restriction regarding public ip addresses is causing problems

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
azure_rm_networkinterface

##### ANSIBLE VERSION
2.5

##### ADDITIONAL INFORMATION

