### PR TITLE
Fix ios_logging idempotence CP into 2.5

### DIFF
--- a/changelogs/fragments/ios_logging_fix.yaml
+++ b/changelogs/fragments/ios_logging_fix.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- Fix ios_logging issue (https://github.com/ansible/ansible/pull/41029)

--- a/lib/ansible/modules/network/ios/ios_logging.py
+++ b/lib/ansible/modules/network/ios/ios_logging.py
@@ -205,18 +205,12 @@ def parse_size(line, dest):
     size = None
 
     if dest == 'buffered':
-        match = re.search(r'logging buffered (\S+)', line, re.M)
+        match = re.search(r'logging buffered(?: (\d+))?(?: [a-z]+)?', line, re.M)
         if match:
-            try:
-                int_size = int(match.group(1))
-            except ValueError:
-                int_size = None
-
-            if int_size:
-                if isinstance(int_size, int):
-                    size = str(match.group(1))
-                else:
-                    size = str(4096)
+            if match.group(1) is not None:
+                size = match.group(1)
+            else:
+                size = "4096"
 
     return size
 
@@ -241,15 +235,12 @@ def parse_level(line, dest):
 
     else:
         if dest == 'buffered':
-            match = re.search(r'logging buffered (?:\d+ )([a-z]+)', line, re.M)
+            match = re.search(r'logging buffered(?: \d+)?(?: ([a-z]+))?', line, re.M)
         else:
             match = re.search(r'logging {0} (\S+)'.format(dest), line, re.M)
 
-        if match:
-            if match.group(1) in level_group:
-                level = match.group(1)
-            else:
-                level = 'debugging'
+        if match and match.group(1) in level_group:
+            level = match.group(1)
         else:
             level = 'debugging'
 

--- a/test/integration/targets/ios_logging/tests/cli/basic.yaml
+++ b/test/integration/targets/ios_logging/tests/cli/basic.yaml
@@ -1,7 +1,7 @@
 ---
 # ensure logging configs are empty
 - name: Remove host logging
-  ios_logging:
+  ios_logging: &remove_host
     dest: host
     name: 172.16.0.1
     state: absent
@@ -45,16 +45,12 @@
     provider: "{{ cli }}"
   register: result
 
-- assert:
+- assert: &unchanged
     that:
       - 'result.changed == false'
 
 - name: Delete/disable host logging
-  ios_logging:
-    dest: host
-    name: 172.16.0.1
-    state: absent
-    provider: "{{ cli }}"
+  ios_logging: *remove_host
   register: result
 
 - assert:
@@ -63,16 +59,10 @@
       - '"no logging host 172.16.0.1" in result.commands'
 
 - name: Delete/disable host logging (idempotent)
-  ios_logging:
-    dest: host
-    name: 172.16.0.1
-    state: absent
-    provider: "{{ cli }}"
+  ios_logging: *remove_host
   register: result
 
-- assert:
-    that:
-      - 'result.changed == false'
+- assert: *unchanged
 
 - name: Console logging with level warnings
   ios_logging:
@@ -113,11 +103,34 @@
       - '"logging buffered 9000" in result.commands'
       - '"logging console notifications" in result.commands'
 
+- name: Set both logging destination and facility
+  ios_logging: &set_both
+    dest: buffered
+    facility: uucp
+    level: alerts
+    size: 4096
+    state: present
+    provider: "{{ cli }}"
+  register: result
+
+- assert:
+    that:
+      - 'result.changed == true'
+      - '"logging buffered 4096 alerts" in result.commands'
+      - '"logging facility uucp" in result.commands'
+
+- name: Set both logging destination and facility (idempotent)
+  ios_logging: *set_both
+  register: result
+
+- assert: *unchanged
+
 - name: remove logging as collection tearDown
   ios_logging:
     aggregate:
       - { dest: console, level: notifications }
-      - { dest: buffered, size: 9000 }
+      - { dest: buffered, size: 4096, level: alerts }
+      - { facility: uucp }
     state: absent
     provider: "{{ cli }}"
   register: result
@@ -127,3 +140,4 @@
       - 'result.changed == true'
       - '"no logging console" in result.commands'
       - '"no logging buffered" in result.commands'
+      - '"no logging facility uucp" in result.commands'


### PR DESCRIPTION
##### SUMMARY
- Fixes ios_logging idempotency issue when setting both destination and facility together
- Added more integration tests
- PR from devel : https://github.com/ansible/ansible/pull/41029


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
ios_logging.py

##### ANSIBLE VERSION
```
stable-2.5
```
