### PR TITLE
Fixing copy paste issue

### DIFF
--- a/lib/ansible/modules/network/cnos/cnos_facts.py
+++ b/lib/ansible/modules/network/cnos/cnos_facts.py
@@ -277,11 +277,11 @@ class Default(FactsBase):
         return "NA"
 
     def parse_image(self, data):
-        match = re.search(r'(.*) image1(.*)', data, re.M | re.I)
+        match = re.search(r'(.*) image(.*)', data, re.M | re.I)
         if match:
             return "Image1"
         else:
-            return "Image1"
+            return "Image2"
 
     def parse_serialnum(self, data):
         for line in data.split('\n'):


### PR DESCRIPTION
##### SUMMARY
This is to fix an issue came up during coverity scan. It identified that both if and else loops are giving Image1 as the active image. Corrected this typo.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/network/cnos/cnos_facts.py

##### ANSIBLE VERSION
ansible 2.6.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible-2.6.0-py2.7.egg/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.6 (default, Nov 23 2017, 15:49:48) [GCC 4.8.4]

##### ADDITIONAL INFORMATION
Copy Paste error being fixed
