### PR TITLE
fix issue #41081 in azure_rm_securitygroup

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_securitygroup.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_securitygroup.py
@@ -536,7 +536,6 @@ class AzureRMSecurityGroup(AzureRMModuleBase):
         self.rules = None
         self.state = None
         self.tags = None
-        self.client = None  # type: azure.mgmt.network.NetworkManagementClient
         self.nsg_models = None  # type: azure.mgmt.network.models
 
         self.results = dict(
@@ -547,12 +546,11 @@ class AzureRMSecurityGroup(AzureRMModuleBase):
         super(AzureRMSecurityGroup, self).__init__(self.module_arg_spec,
                                                    supports_check_mode=True)
 
-    def exec_module(self, **kwargs):
-        self.client = self.network_client
+    def exec_module(self, **kwargs):        
         # tighten up poll interval for security groups; default 30s is an eternity
         # this value is still overridden by the response Retry-After header (which is set on the initial operation response to 10s)
-        self.client.config.long_running_operation_timeout = 3
-        self.nsg_models = self.client.network_security_groups.models
+        self.network_client.config.long_running_operation_timeout = 3
+        self.nsg_models = self.network_client.network_security_groups.models
 
         for key in list(self.module_arg_spec.keys()) + ['tags']:
             setattr(self, key, kwargs[key])
@@ -580,7 +578,7 @@ class AzureRMSecurityGroup(AzureRMModuleBase):
                     self.fail("Error validating default rule {0} - {1}".format(rule, str(exc)))
 
         try:
-            nsg = self.client.network_security_groups.get(self.resource_group, self.name)
+            nsg = self.network_client.network_security_groups.get(self.resource_group, self.name)
             results = create_network_security_group_dict(nsg)
             self.log("Found security group:")
             self.log(results, pretty_print=True)
@@ -668,7 +666,7 @@ class AzureRMSecurityGroup(AzureRMModuleBase):
         parameters.location = results.get('location')
 
         try:
-            poller = self.client.network_security_groups.create_or_update(resource_group_name=self.resource_group,
+            poller = self.network_client.network_security_groups.create_or_update(resource_group_name=self.resource_group,
                                                                           network_security_group_name=self.name,
                                                                           parameters=parameters)
             result = self.get_poller_result(poller)
@@ -678,7 +676,7 @@ class AzureRMSecurityGroup(AzureRMModuleBase):
 
     def delete(self):
         try:
-            poller = self.client.network_security_groups.delete(resource_group_name=self.resource_group, network_security_group_name=self.name)
+            poller = self.network_client.network_security_groups.delete(resource_group_name=self.resource_group, network_security_group_name=self.name)
             result = self.get_poller_result(poller)
         except CloudError as exc:
             raise Exception("Error deleting security group {0} - {1}".format(self.name, str(exc)))

--- a/lib/ansible/modules/cloud/azure/azure_rm_securitygroup.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_securitygroup.py
@@ -546,7 +546,7 @@ class AzureRMSecurityGroup(AzureRMModuleBase):
         super(AzureRMSecurityGroup, self).__init__(self.module_arg_spec,
                                                    supports_check_mode=True)
 
-    def exec_module(self, **kwargs):        
+    def exec_module(self, **kwargs):
         # tighten up poll interval for security groups; default 30s is an eternity
         # this value is still overridden by the response Retry-After header (which is set on the initial operation response to 10s)
         self.network_client.config.long_running_operation_timeout = 3
@@ -667,8 +667,8 @@ class AzureRMSecurityGroup(AzureRMModuleBase):
 
         try:
             poller = self.network_client.network_security_groups.create_or_update(resource_group_name=self.resource_group,
-                                                                          network_security_group_name=self.name,
-                                                                          parameters=parameters)
+                                                                                  network_security_group_name=self.name,
+                                                                                  parameters=parameters)
             result = self.get_poller_result(poller)
         except CloudError as exc:
             self.fail("Error creating/updating security group {0} - {1}".format(self.name, str(exc)))

--- a/lib/ansible/modules/cloud/azure/azure_rm_securitygroup.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_securitygroup.py
@@ -548,7 +548,7 @@ class AzureRMSecurityGroup(AzureRMModuleBase):
                                                    supports_check_mode=True)
 
     def exec_module(self, **kwargs):
-        self.client = self.get_mgmt_svc_client(NetworkManagementClient)
+        self.client = self.network_client
         # tighten up poll interval for security groups; default 30s is an eternity
         # this value is still overridden by the response Retry-After header (which is set on the initial operation response to 10s)
         self.client.config.long_running_operation_timeout = 3


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
Fixing issue #41081 .  azure_rm_securitygroup use a network  client without specifying cloud resource url, so when user used it in non-public azure cloud, it  failed to get subscription.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
azure_rm_securitygroup
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
