### PR TITLE
win_security_policy: allow removing values (resolves #40869)

### DIFF
--- a/lib/ansible/modules/windows/win_security_policy.ps1
+++ b/lib/ansible/modules/windows/win_security_policy.ps1
@@ -196,8 +196,6 @@ if ($will_change -eq $true) {
             }
         } elseif ($value -eq "") {
             # Value was empty, so OK if no longer in the result
-            # Just print a warning
-            Add-Warning -obj $result -message "The key '$key' in section '$section' was reset to empty value."
         } else {
             Fail-Json $result "The key '$key' in section '$section' is not a valid key, cannot set this value"
         }

--- a/lib/ansible/modules/windows/win_security_policy.ps1
+++ b/lib/ansible/modules/windows/win_security_policy.ps1
@@ -194,7 +194,7 @@ if ($will_change -eq $true) {
             if ($new_value -cne $value) {
                 Fail-Json $result "Failed to change the value for key '$key' in section '$section', the value is still $new_value"
             }
-        } elseif ($value -eq "") {
+        } elseif ([string]$value -eq "") {
             # Value was empty, so OK if no longer in the result
         } else {
             Fail-Json $result "The key '$key' in section '$section' is not a valid key, cannot set this value"

--- a/lib/ansible/modules/windows/win_security_policy.ps1
+++ b/lib/ansible/modules/windows/win_security_policy.ps1
@@ -194,6 +194,10 @@ if ($will_change -eq $true) {
             if ($new_value -cne $value) {
                 Fail-Json $result "Failed to change the value for key '$key' in section '$section', the value is still $new_value"
             }
+        } elseif ($value -eq "") {
+            # Value was empty, so OK if no longer in the result
+            # Just print a warning
+            Add-Warning -obj $result -message "The key '$key' in section '$section' was reset to empty value."
         } else {
             Fail-Json $result "The key '$key' in section '$section' is not a valid key, cannot set this value"
         }

--- a/test/integration/targets/win_security_policy/tasks/tests.yml
+++ b/test/integration/targets/win_security_policy/tasks/tests.yml
@@ -131,3 +131,41 @@
     that:
     - change_existing_string_again is not changed
     - change_existing_string_again.value == "New Guest"
+
+- name: add policy setting
+  win_security_policy:
+    section: Privilege Rights
+    # following key is empty by default
+    key: SeCreateTokenPrivilege
+    # add Guests
+    value: '*S-1-5-32-546'
+    
+- name: get actual policy setting
+  test_win_security_policy:
+    section: Privilege Rights
+    key: SeCreateTokenPrivilege
+  register: add_policy_setting_actual
+  
+- name: assert remove policy setting
+  assert:
+    that:
+    - add_policy_setting_actual.value == '*S-1-5-32-546'
+  
+- name: remove policy setting
+  win_security_policy:
+    section: Privilege Rights
+    key: SeCreateTokenPrivilege
+    value: ''
+  register: remove_policy_setting
+
+- name: get actual policy setting
+  test_win_security_policy:
+    section: Privilege Rights
+    key: SeCreateTokenPrivilege
+  register: remove_policy_setting_actual
+
+- name: assert remove policy setting
+  assert:
+    that:
+    - remove_policy_setting is changed
+    - remove_policy_setting_actual.value is none


### PR DESCRIPTION
##### SUMMARY
This fix allows resetting a value (setting it to empty) using `win_security_policy`. 
Note that it throws a warning when doing this, as it might not be the typically expected behavior; but it is very useful in certain use cases,

Fixes #40869

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
win_security_policy

##### ANSIBLE VERSION

```
ansible 2.5.2
  config file = /home_local/ansible/automation/ansible.cfg
  configured module search path = [u'/home_local/ansible/automation/library']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /bin/ansible
  python version = 2.7.5 (default, Aug  4 2017, 00:39:18) [GCC 4.8.5 20150623 (Red Hat 4.8.5-16)]
```
