### PR TITLE
Install choco client from local source

### DIFF
--- a/lib/ansible/modules/windows/win_chocolatey.ps1
+++ b/lib/ansible/modules/windows/win_chocolatey.ps1
@@ -42,7 +42,13 @@ Function Chocolatey-Install-Upgrade
 {
     [CmdletBinding()]
 
-    param()
+    param([string] $source)
+    $ext_source = 'https://chocolatey.org'
+    if ($source)
+    {
+      if ($source -match "^https?:\/\/([^\/]+)/") {$source =$ Matches[0]} else {$source = $ext_source}
+    } 
+      else {$source = $ext_source}
 
     $ChocoAlreadyInstalled = Get-Command -Name "choco.exe" -ErrorAction SilentlyContinue
     if ($ChocoAlreadyInstalled -eq $null)
@@ -63,7 +69,7 @@ Function Chocolatey-Install-Upgrade
                 $wp.Credentials = New-Object System.Management.Automation.PSCredential($proxy_username, $passwd)
             }
         }
-        $install_output = $wc.DownloadString("https://chocolatey.org/install.ps1") | powershell -
+        $install_output = $wc.DownloadString($source + '/install.ps1') | powershell -
         $result.rc = $LastExitCode
         $result.stdout = $install_output | Out-String
         if ($result.rc -ne 0) {
@@ -502,7 +508,7 @@ Function Choco-Uninstall
     $result.failed = $false
 }
 
-Chocolatey-Install-Upgrade
+Chocolatey-Install-Upgrade -source $source
 
 if ($state -in ("absent", "reinstalled")) {
 


### PR DESCRIPTION
##### SUMMARY
Add feature , you can install choco client from internal source if source present.
https://github.com/ansible/ansible/issues/24569

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
win_chocolatey

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.2
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/anpetrov/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
 ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Feb 20 2018, 09:19:12) [GCC 4.8.5 20150623 (Red Hat 4.8.5-28)]

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
