### PR TITLE
New k8s_facts module

### DIFF
--- a/lib/ansible/module_utils/k8s/common.py
+++ b/lib/ansible/module_utils/k8s/common.py
@@ -189,6 +189,17 @@ class K8sAnsibleMixin(object):
             if fail:
                 self.fail(msg='Failed to find exact match for {0}.{1} by [kind, name, singularName, shortNames]'.format(api_version, kind))
 
+    def kubernetes_facts(self, kind, api_version, name=None, namespace=None, label_selectors=None, field_selectors=None):
+        resource = self.find_resource(kind, api_version)
+        result = resource.get(name=name,
+                              namespace=namespace,
+                              label_selector=','.join(label_selectors),
+                              field_selector=','.join(field_selectors)).to_dict()
+        if 'items' in result:
+            return result
+        else:
+            return dict(items=[result])
+
     def remove_aliases(self):
         """
         The helper doesn't know what to do with aliased keys

--- a/lib/ansible/modules/clustering/k8s/k8s.py
+++ b/lib/ansible/modules/clustering/k8s/k8s.py
@@ -30,6 +30,7 @@ description:
   - Pass the object definition from a source file or inline. See examples for reading
     files and using Jinja templates.
   - Access to the full range of K8s APIs.
+  - Use the M(k8s_facts) module to obtain a list of items about an object of type C(kind)
   - Authenticate using either a config file, certificates, password or token.
   - Supports check mode.
 
@@ -79,21 +80,6 @@ EXAMPLES = '''
   k8s:
     state: present
     src: /testing/service.yml
-
-- name: Get an existing Service object
-  k8s:
-    api_version: v1
-    kind: Service
-    name: web
-    namespace: testing
-  register: web_service
-
-- name: Get a list of all service objects
-  k8s:
-    api_version: v1
-    kind: ServiceList
-    namespace: testing
-  register: service_list
 
 - name: Remove an existing Service object
   k8s:

--- a/lib/ansible/modules/clustering/k8s/k8s_facts.py
+++ b/lib/ansible/modules/clustering/k8s/k8s_facts.py
@@ -1,0 +1,171 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2018, Will Thames <@willthames>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = '''
+module: k8s_facts
+
+short_description: Describe Kubernetes (K8s) objects
+
+version_added: "2.7"
+
+author:
+    - "Will Thames (@willthames)"
+
+description:
+  - Use the OpenShift Python client to perform read operations on K8s objects.
+  - Access to the full range of K8s APIs.
+  - Authenticate using either a config file, certificates, password or token.
+  - Supports check mode.
+
+options:
+  api_version:
+    description:
+    - Use to specify the API version. in conjunction with I(kind), I(name), and I(namespace) to identify a
+      specific object.
+    default: v1
+    aliases:
+    - api
+    - version
+  kind:
+    description:
+    - Use to specify an object model. Use in conjunction with I(api_version), I(name), and I(namespace) to identify a
+      specific object.
+    required: yes
+  name:
+    description:
+    - Use to specify an object name.  Use in conjunction with I(api_version), I(kind) and I(namespace) to identify a
+      specific object.
+  namespace:
+    description:
+    - Use to specify an object namespace. Use in conjunction with I(api_version), I(kind), and I(name)
+      to identify a specfic object.
+  label_selectors:
+    description: List of label selectors to use to filter results
+  field_selectors:
+    description: List of field selectors to use to filter results
+
+extends_documentation_fragment:
+  - k8s_auth_options
+
+requirements:
+  - "python >= 2.7"
+  - "openshift >= 0.6"
+  - "PyYAML >= 3.11"
+'''
+
+EXAMPLES = '''
+- name: Get an existing Service object
+  k8s_facts:
+    api_version: v1
+    kind: Service
+    name: web
+    namespace: testing
+  register: web_service
+
+- name: Get a list of all service objects
+  k8s_facts:
+    api_version: v1
+    kind: Service
+    namespace: testing
+  register: service_list
+
+- name: Get a list of all pods from any namespace
+  k8s_facts:
+    kind: Pod
+  register: pod_list
+
+- name: Search for all Pods labelled app=web
+  k8s_facts:
+    kind: Pod
+    label_selectors:
+      - app = web
+      - tier in (dev, test)
+
+- name: Search for all running pods
+  k8s_facts:
+    kind: Pod
+    field_selectors:
+      - status.phase = running
+'''
+
+RETURN = '''
+items:
+  description:
+  - The object(s) that exists
+  returned: success
+  type: complex
+  contains:
+    api_version:
+      description: The versioned schema of this representation of an object.
+      returned: success
+      type: str
+    kind:
+      description: Represents the REST resource this object represents.
+      returned: success
+      type: str
+    metadata:
+      description: Standard object metadata. Includes name, namespace, annotations, labels, etc.
+      returned: success
+      type: dict
+    spec:
+      description: Specific attributes of the object. Will vary based on the I(api_version) and I(kind).
+      returned: success
+      type: dict
+    status:
+      description: Current status details for the object.
+      returned: success
+      type: dict
+'''
+
+
+from ansible.module_utils.k8s.common import KubernetesAnsibleModule, AUTH_ARG_SPEC
+import copy
+
+
+class KubernetesFactsModule(KubernetesAnsibleModule):
+
+    def execute_module(self):
+        self.client = self.get_api_client()
+
+        self.exit_json(changed=False,
+                       **self.kubernetes_facts(self.params['kind'],
+                                               self.params['api_version'],
+                                               self.params['name'],
+                                               self.params['namespace'],
+                                               self.params['label_selectors'],
+                                               self.params['field_selectors']))
+
+    @property
+    def argspec(self):
+        args = copy.deepcopy(AUTH_ARG_SPEC)
+        args.update(
+            dict(
+                kind=dict(required=True),
+                api_version=dict(default='v1', aliases=['api', 'version']),
+                name=dict(),
+                namespace=dict(),
+                label_selectors=dict(type='list', default=[]),
+                field_selectors=dict(type='list', default=[]),
+            )
+        )
+        return args
+
+
+def main():
+    KubernetesFactsModule().execute_module()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
##### SUMMARY
Provide a very simple k8s_facts that mostly just reuses existing
code.

Deprecate k8s modules with kind=*List in favour of k8s_facts

Provide label selector functionality through k8s_facts

##### ISSUE TYPE
 - New Module Pull Request

##### COMPONENT NAME
k8s_facts

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (devel 02135d5278) last updated 2018/06/05 22:26:48 (GMT +1000)
  config file = None
  configured module search path = [u'/Users/will/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/will/src/ansible/lib/ansible
  executable location = /Users/will/src/ansible/bin/ansible
  python version = 2.7.14 (default, Mar  9 2018, 23:57:12) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```


##### ADDITIONAL INFORMATION

We don't necessarily need to deprecate `kind=*List` behaviour, but as it was broken previously (see #41088 on which this PR is based) and the k8s modules are very new, I don't see much harm in moving to a more familiar mechanism that meets Ansible best practices.
