### PR TITLE
Add productType property as an ansible fact

### DIFF
--- a/lib/ansible/modules/windows/setup.ps1
+++ b/lib/ansible/modules/windows/setup.ps1
@@ -199,20 +199,17 @@ if($gather_subset.Contains('distribution')) {
         ansible_os_family = "Windows"
         ansible_os_name = ($win32_os.Name.Split('|')[0]).Trim()
     }
-    switch ($win32_os.ProductType.ToString()) {
-      "1" {$ansible_facts += @{
+    switch ($win32_os.ProductType) {
+      1 {$ansible_facts += @{
             ansible_os_producttype = "workstation"}
           }
-      "2" {$ansible_facts += @{
+      2 {$ansible_facts += @{
             ansible_os_producttype = "domain_controller"}
           }
-      "3" {$ansible_facts += @{
+      3 {$ansible_facts += @{
             ansible_os_producttype = "server"}
           }
-      {$_ -eq "0"} {$ansible_facts += @{
-            ansible_os_producttype = "unknown"}
-          }
-      {$_ -gt "4"} {$ansible_facts += @{
+      default {$ansible_facts += @{
             ansible_os_producttype = "unknown"}
           }
     }

--- a/lib/ansible/modules/windows/setup.ps1
+++ b/lib/ansible/modules/windows/setup.ps1
@@ -198,7 +198,23 @@ if($gather_subset.Contains('distribution')) {
         ansible_distribution_major_version = $osversion.Version.Major.ToString()
         ansible_os_family = "Windows"
         ansible_os_name = ($win32_os.Name.Split('|')[0]).Trim()
-        ansible_os_producttype = $win32_os.ProductType.ToString()
+    }
+    switch ($win32_os.ProductType.ToString()) {
+      "1" {$ansible_facts += @{
+            ansible_os_producttype = "workstation"}
+          }
+      "2" {$ansible_facts += @{
+            ansible_os_producttype = "domain_controller"}
+          }
+      "3" {$ansible_facts += @{
+            ansible_os_producttype = "server"}
+          }
+      {$_ -eq "0"} {$ansible_facts += @{
+            ansible_os_producttype = "unknown"}
+          }
+      {$_ -gt "4"} {$ansible_facts += @{
+            ansible_os_producttype = "unknown"}
+          }
     }
 }
 

--- a/lib/ansible/modules/windows/setup.ps1
+++ b/lib/ansible/modules/windows/setup.ps1
@@ -190,6 +190,13 @@ if($gather_subset.Contains('date_time')) {
     }
 }
 
+$product_type = switch($win32_os.ProductType) {
+    1 { "workstation" }
+    2 { "domain_controller" }
+    3 { "server" }
+    default { "unknown" }
+}
+
 if($gather_subset.Contains('distribution')) {
     $win32_os = Get-LazyCimInstance Win32_OperatingSystem
     $ansible_facts += @{
@@ -198,20 +205,7 @@ if($gather_subset.Contains('distribution')) {
         ansible_distribution_major_version = $osversion.Version.Major.ToString()
         ansible_os_family = "Windows"
         ansible_os_name = ($win32_os.Name.Split('|')[0]).Trim()
-    }
-    switch ($win32_os.ProductType) {
-      1 {$ansible_facts += @{
-            ansible_os_producttype = "workstation"}
-          }
-      2 {$ansible_facts += @{
-            ansible_os_producttype = "domain_controller"}
-          }
-      3 {$ansible_facts += @{
-            ansible_os_producttype = "server"}
-          }
-      default {$ansible_facts += @{
-            ansible_os_producttype = "unknown"}
-          }
+        ansible_os_product_type = $product_type
     }
 }
 

--- a/lib/ansible/modules/windows/setup.ps1
+++ b/lib/ansible/modules/windows/setup.ps1
@@ -198,6 +198,7 @@ if($gather_subset.Contains('distribution')) {
         ansible_distribution_major_version = $osversion.Version.Major.ToString()
         ansible_os_family = "Windows"
         ansible_os_name = ($win32_os.Name.Split('|')[0]).Trim()
+        ansible_os_producttype = $win32_os.ProductType.ToString()
     }
 }
 

--- a/lib/ansible/modules/windows/setup.ps1
+++ b/lib/ansible/modules/windows/setup.ps1
@@ -190,15 +190,15 @@ if($gather_subset.Contains('date_time')) {
     }
 }
 
-$product_type = switch($win32_os.ProductType) {
-    1 { "workstation" }
-    2 { "domain_controller" }
-    3 { "server" }
-    default { "unknown" }
-}
-
 if($gather_subset.Contains('distribution')) {
     $win32_os = Get-LazyCimInstance Win32_OperatingSystem
+    $product_type = switch($win32_os.ProductType) {
+        1 { "workstation" }
+        2 { "domain_controller" }
+        3 { "server" }
+        default { "unknown" }
+    }
+
     $ansible_facts += @{
         ansible_distribution = $win32_os.Caption
         ansible_distribution_version = $osversion.Version.ToString()


### PR DESCRIPTION
Suggest to add productType property from win32_operatingsystem CIM instance to differentiate between versions and add new fact.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Sometimes it is necessary to differentiate between Servers, Workstations and Domain Controllers. Adding the ProductType property from the win32_operatingsystem class can help provide ansible the ability to use this property when running certain playbooks or commands and scope accordingly.

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
win_setup

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.3
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/user/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

Source: https://msdn.microsoft.com/en-us/library/aa394239(v=vs.85).aspx
Value Legend:

* '1' indicates Work Station
*  '2' indicates Domain Controller
*  '3' indicates Server