### PR TITLE
Fix typo in the ansible-inventory --host error

### DIFF
--- a/lib/ansible/cli/inventory.py
+++ b/lib/ansible/cli/inventory.py
@@ -161,7 +161,7 @@ class InventoryCLI(CLI):
         if self.options.host:
             hosts = self.inventory.get_hosts(self.options.host)
             if len(hosts) != 1:
-                raise AnsibleOptionsError("You must pass a single valid host to --hosts parameter")
+                raise AnsibleOptionsError("You must pass a single valid host to --host parameter")
 
             myvars = self._get_host_variables(host=hosts[0])
             self._remove_internal(myvars)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Fixes a typo in an error message in ansible-inventory --host when an invalid host is given.

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
ansible-inventory

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (ansible_inventory_fix_error_message 4961c8f3e6) last updated 2018/06/05 11:21:32 (GMT -400)
  config file = None
  configured module search path = [u'/Users/bthomass/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/bthomass/git/ansible/lib/ansible
  executable location = /Users/bthomass/.pyenv/versions/ansible-2.7.15/bin/ansible
  python version = 2.7.15 (default, May 31 2018, 14:58:20) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

Before:
ansible-inventory --host does-not-exist
...
ERROR! You must pass a single valid host to --hosts parameter


After:
ansible-inventory --host does-not-exist
...
ERROR! You must pass a single valid host to --host parameter


```
