### PR TITLE
 Add root_device property to os_ironic 

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_ironic.py
+++ b/lib/ansible/modules/cloud/openstack/os_ironic.py
@@ -96,8 +96,8 @@ options:
         root_device:
           description:
             - specifying the disk for deployment (root device hints). Allow to
-              set root device hints as a dict with following keys:
-              'model', 'vendor', 'serial', 'size', 'wwn', 'wwn_with_extension',
+              set root device hints as a dict with following keys 'model',
+              'vendor', 'serial', 'size', 'wwn', 'wwn_with_extension',
               'wwn_vendor_extension', 'rotational', 'hctl', 'name'.
     skip_update_of_driver_password:
       description:

--- a/lib/ansible/modules/cloud/openstack/os_ironic.py
+++ b/lib/ansible/modules/cloud/openstack/os_ironic.py
@@ -93,6 +93,12 @@ options:
           description:
             - size of first storage device in this machine (typically /dev/sda), in GB
           default: 1
+        root_device:
+          description:
+            - specifying the disk for deployment (root device hints). Allow to
+              set root device hints as a dict with following keys:
+              'model', 'vendor', 'serial', 'size', 'wwn', 'wwn_with_extension',
+              'wwn_vendor_extension', 'rotational', 'hctl', 'name'.
     skip_update_of_driver_password:
       description:
         - Allows the code that would assert changes to nodes to skip the
@@ -150,6 +156,12 @@ def _parse_properties(module):
         memory_mb=p.get('ram') if p.get('ram') else 1,
         local_gb=p.get('disk_size') if p.get('disk_size') else 1,
     )
+    if isinstance(p.get('root_device'), dict):
+        if set(p.get('root_device').keys()).issubset(set(
+                ['model', 'vendor', 'serial', 'size', 'wwn',
+                 'wwn_with_extension', 'wwn_vendor_extension', 'rotational',
+                 'hctl', 'name'])):
+            props['root_device']=p.get('root_device')
     return props
 
 

--- a/lib/ansible/modules/cloud/openstack/os_ironic.py
+++ b/lib/ansible/modules/cloud/openstack/os_ironic.py
@@ -164,6 +164,7 @@ def _parse_properties(module):
             props['root_device'] = p.get('root_device')
     return props
 
+
 def _parse_driver_info(sdk, module):
     p = module.params['driver_info']
     info = p.get('power')

--- a/lib/ansible/modules/cloud/openstack/os_ironic.py
+++ b/lib/ansible/modules/cloud/openstack/os_ironic.py
@@ -161,9 +161,8 @@ def _parse_properties(module):
                 ['model', 'vendor', 'serial', 'size', 'wwn',
                  'wwn_with_extension', 'wwn_vendor_extension', 'rotational',
                  'hctl', 'name'])):
-            props['root_device']=p.get('root_device')
+            props['root_device'] = p.get('root_device')
     return props
-
 
 def _parse_driver_info(sdk, module):
     p = module.params['driver_info']


### PR DESCRIPTION
##### SUMMARY
Add "root_device" property support in os_ironic. 

The Bare Metal service supports passing hints to the deploy ramdisk about which disk it should pick for the deployment, but today to os_ironic is filtering that "root_device" property. This PR allow to set this property

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
Cloud/OpenStack/os_ironic

##### ANSIBLE VERSION
devel

##### ADDITIONAL INFORMATION
Openstack Ironic Root Device Hints doc: 
https://docs.openstack.org/ironic/queens/install/advanced.html#specifying-the-disk-for-deployment-root-device-hints

Tested with bifrost (stable-queens) enroll-dynamic.yaml playbook + ansible 2.5.4 to support multi disks on libvirt nodes

Example:
```
# Enroll a node with some basic properties and driver info
- os_ironic:
    cloud: "devstack"
    driver: "pxe_ipmitool"
    uuid: "00000000-0000-0000-0000-000000000002"
    properties:
      cpus: 2
      cpu_arch: "x86_64"
      ram: 8192
      disk_size: 64
      root_device:
        hctl: 0:0:0:0
    nics:
      - mac: "aa:bb:cc:aa:bb:cc"
      - mac: "dd:ee:ff:dd:ee:ff"
    driver_info:
      power:
        ipmi_address: "1.2.3.4"
        ipmi_username: "admin"
        ipmi_password: "adminpass"
    chassis_uuid: "00000000-0000-0000-0000-000000000001"

```

example with a bifrost inventory:

```
---
node1:
  name: node1
  uuid: 00000000-0000-0000-0000-000000000002
  driver_info:
    power:
      ipmi_username: admin
      ipmi_address: 192.168.122.1
      ipmi_port: 625
      ipmi_password: ***********
  nics:
    - mac: 52:54:00:fe:3b:01
  driver: agent_ipmitool
  ipv4_address: 192.168.122.11
  properties:
    cpu_arch: x86_64
    ram: 16384
    disk_size: 20
    cpus: 6
    root_device:
      hctl: 0:0:0:0
```