### PR TITLE
Fix typo in decrypt doc.

### DIFF
--- a/lib/ansible/utils/module_docs_fragments/decrypt.py
+++ b/lib/ansible/utils/module_docs_fragments/decrypt.py
@@ -26,6 +26,6 @@ options:
       - This option controls the autodecryption of source files using vault.
     required: false
     type: 'bool'
-    default: 'Yes'
+    default: 'yes'
     version_added: "2.4"
 """


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Prior to this change, the document cannot render the default choice of decrypt correctly.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
utils/module_docs_fragments/decrypt
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (fix-doc-typo ee93eef2b2) last updated 2018/06/05 13:04:40 (GMT -400)
  config file = None
  configured module search path = [u'/home/zhikangzhang/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/zhikangzhang/workspace/github/hd650/ansible/lib/ansible
  executable location = /home/zhikangzhang/workspace/github/hd650/ansible/bin/ansible
  python version = 2.7.15 (default, May 16 2018, 17:50:09) [GCC 8.1.1 20180502 (Red Hat 8.1.1-1)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->
N/A