### PR TITLE
bump version of 'vcenter-test-container' to '1.3.0' (govmomi v0.18.0)

### DIFF
--- a/test/integration/targets/vmware_guest/tasks/poweroff_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/poweroff_d1_c1_f0.yml
@@ -45,7 +45,8 @@
 
 - debug: var=poweroff_d1_c1_f0
 
-- name: make sure no changes were made
+# vcsim (v0.18.0) VMs are spawned PoweredOn
+- name: make sure changes were made
   assert:
     that:
         - "poweroff_d1_c1_f0.results|map(attribute='changed')|unique|list == [True]"

--- a/test/integration/targets/vmware_guest/tasks/poweroff_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/poweroff_d1_c1_f0.yml
@@ -22,7 +22,7 @@
     port: 443
     state: started
 
-- name: get a list of VMS from vcsim   
+- name: get a list of VMS from vcsim
   uri:
     url: http://{{ vcsim }}:5000/govc_find?filter=VM
   register: vmlist
@@ -48,4 +48,4 @@
 - name: make sure no changes were made
   assert:
     that:
-        - "poweroff_d1_c1_f0.results|map(attribute='changed')|unique|list == [False]"
+        - "poweroff_d1_c1_f0.results|map(attribute='changed')|unique|list == [True]"

--- a/test/integration/targets/vmware_guest/tasks/poweroff_d1_c1_f1.yml
+++ b/test/integration/targets/vmware_guest/tasks/poweroff_d1_c1_f1.yml
@@ -56,7 +56,8 @@
 
 - debug: var=poweroff_d1_c1_f1
 
-- name: make sure no changes were made
+# vcsim (v0.18.0) VMs are spawned PoweredOn
+- name: make sure changes were made
   assert:
     that:
         - "poweroff_d1_c1_f1.results|map(attribute='changed')|unique|list == [True]"

--- a/test/integration/targets/vmware_guest/tasks/poweroff_d1_c1_f1.yml
+++ b/test/integration/targets/vmware_guest/tasks/poweroff_d1_c1_f1.yml
@@ -27,7 +27,7 @@
     port: 443
     state: started
 
-- name: get a list of VMS from vcsim   
+- name: get a list of VMS from vcsim
   uri:
     url: http://{{ vcsim }}:5000/govc_find?filter=VM
   register: vmlist
@@ -36,7 +36,7 @@
 - debug: var=vmlist
 
 # https://github.com/ansible/ansible/issues/25011
-# Sending "-folders 1" to vcsim nests the datacenter under 
+# Sending "-folders 1" to vcsim nests the datacenter under
 # the folder so that the path prefix is no longer /vm
 #
 # /F0/DC0/vm/F0/DC0_H0_VM0
@@ -59,4 +59,4 @@
 - name: make sure no changes were made
   assert:
     that:
-        - "poweroff_d1_c1_f1.results|map(attribute='changed')|unique|list == [False]"
+        - "poweroff_d1_c1_f1.results|map(attribute='changed')|unique|list == [True]"

--- a/test/integration/targets/vmware_guest_powerstate/tasks/poweroff_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest_powerstate/tasks/poweroff_d1_c1_f0.yml
@@ -48,4 +48,4 @@
 - name: make sure no changes were made
   assert:
     that:
-        - "poweroff_d1_c1_f0.results|map(attribute='changed')|unique|list == [False]"
+        - "poweroff_d1_c1_f0.results|map(attribute='changed')|unique|list == [True]"

--- a/test/integration/targets/vmware_guest_powerstate/tasks/poweroff_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest_powerstate/tasks/poweroff_d1_c1_f0.yml
@@ -45,7 +45,8 @@
 
 - debug: var=poweroff_d1_c1_f0
 
-- name: make sure no changes were made
+# vcsim (v0.18.0) VMs are spawned PoweredOn
+- name: make sure changes were made
   assert:
     that:
         - "poweroff_d1_c1_f0.results|map(attribute='changed')|unique|list == [True]"

--- a/test/integration/targets/vmware_guest_powerstate/tasks/poweroff_d1_c1_f1.yml
+++ b/test/integration/targets/vmware_guest_powerstate/tasks/poweroff_d1_c1_f1.yml
@@ -59,4 +59,4 @@
 - name: make sure no changes were made
   assert:
     that:
-        - "poweroff_d1_c1_f1.results|map(attribute='changed')|unique|list == [False]"
+        - "poweroff_d1_c1_f1.results|map(attribute='changed')|unique|list == [True]"

--- a/test/integration/targets/vmware_guest_powerstate/tasks/poweroff_d1_c1_f1.yml
+++ b/test/integration/targets/vmware_guest_powerstate/tasks/poweroff_d1_c1_f1.yml
@@ -56,7 +56,8 @@
 
 - debug: var=poweroff_d1_c1_f1
 
-- name: make sure no changes were made
+# vcsim (v0.18.0) VMs are spawned PoweredOn
+- name: make sure changes were made
   assert:
     that:
         - "poweroff_d1_c1_f1.results|map(attribute='changed')|unique|list == [True]"

--- a/test/runner/lib/cloud/vcenter.py
+++ b/test/runner/lib/cloud/vcenter.py
@@ -43,7 +43,7 @@ class VcenterProvider(CloudProvider):
         if os.environ.get('ANSIBLE_VCSIM_CONTAINER'):
             self.image = os.environ.get('ANSIBLE_VCSIM_CONTAINER')
         else:
-            self.image = 'quay.io/ansible/vcenter-test-container:1.2.0'
+            self.image = 'quay.io/ansible/vcenter-test-container:1.3.0'
         self.container_name = ''
 
     def filter(self, targets, exclude):


### PR DESCRIPTION
##### SUMMARY
updates 'vcenter-test-container' to '1.3.0' which has the latest tagged version of 'govmomi' (vcsim) 'v0.18.0'.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - test/runner/lib/cloud/vcenter.py
 - v{center,mware}_* tests

##### ANSIBLE VERSION
```
ansible 2.7.0.dev0 (govmomi_v0.18.0 cc051a9b1d) last updated 2018/06/05 13:44:26 (GMT -400)
  config file = /Users/deric/.ansible.cfg
  configured module search path = [u'/Users/deric/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/deric/ansible/lib/ansible
  executable location = /Users/deric/ansible/bin/ansible
  python version = 2.7.14 (default, Sep 25 2017, 09:54:19) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.37)]
```

##### ADDITIONAL INFORMATION
This required updating a couple of the vmware_guest* module tests (needed to revert the `False` back to `True` from [ansible:87d6bdaf](https://github.com/ansible/ansible/commit/87d6bdaf9819fdc45a5d309e5e54f8b6f6651ada#diff-cea95d98d811de152d48d1b19ff32e67) & [ansible:66743f33](https://github.com/ansible/ansible/commit/66743f33faa71d092557f2c89788868ca32061aa#diff-64ff7b7878e4bc7c20ce303538b1e583))