### PR TITLE
make doc templates not case sensitive for the default value

### DIFF
--- a/docs/bin/plugin_formatter.py
+++ b/docs/bin/plugin_formatter.py
@@ -160,14 +160,14 @@ def rst_xline(width, char="="):
 test_list = partial(is_sequence, include_strings=False)
 
 
-def to_boolean(value):
+def normalize_options(value):
     """Normalize boolean option value."""
 
     if value.get('type') == 'bool' and 'default' in value:
-        temp = boolean(value['default'])
-        new_value = value.copy()
-        new_value['default'] = temp
-        return new_value
+        try:
+            value['default'] = boolean(value['default'], strict=True)
+        except TypeError:
+            pass
     return value
 
 
@@ -286,11 +286,8 @@ def get_plugin_info(module_dir, limit_to=None, verbose=False):
         # use ansible core library to parse out doc metadata YAML and plaintext examples
         doc, examples, returndocs, metadata = plugin_docs.get_docstring(module_path, fragment_loader, verbose=verbose)
 
-        for key, opt in (doc.get('options') or {}).items():
-            try:
-                doc['options'][key] = to_boolean(opt)
-            except TypeError:
-                pass
+        for key, opt in doc.get('options', {}).items():
+            doc['options'][key] = normalize_options(opt)
 
         # save all the information
         module_info[module] = {'path': module_path,

--- a/docs/bin/plugin_formatter.py
+++ b/docs/bin/plugin_formatter.py
@@ -51,6 +51,7 @@ from six import iteritems, string_types
 from ansible.errors import AnsibleError
 from ansible.module_utils._text import to_bytes, to_text
 from ansible.module_utils.common.collections import is_sequence
+from ansible.module_utils.parsing.convert_bool import boolean
 from ansible.plugins.loader import fragment_loader
 from ansible.utils import plugin_docs
 from ansible.utils.display import Display
@@ -157,6 +158,18 @@ def rst_xline(width, char="="):
 
 
 test_list = partial(is_sequence, include_strings=False)
+
+
+def to_boolean(value):
+    ''' convert default value to boolean if it intends to be boolean '''
+
+    if value.get('type') == 'bool' and 'default' in value:
+        temp = boolean(value['default'])
+        new_value = value.copy()
+        new_value['default'] = temp
+        return new_value
+    else:
+        return value
 
 
 def write_data(text, output_dir, outputname, module=None):
@@ -273,6 +286,12 @@ def get_plugin_info(module_dir, limit_to=None, verbose=False):
 
         # use ansible core library to parse out doc metadata YAML and plaintext examples
         doc, examples, returndocs, metadata = plugin_docs.get_docstring(module_path, fragment_loader, verbose=verbose)
+
+        for key in (doc.get('options') or {}):
+            try:
+                doc['options'][key] = to_boolean(doc['options'][key])
+            except TypeError:
+                pass
 
         # save all the information
         module_info[module] = {'path': module_path,

--- a/docs/bin/plugin_formatter.py
+++ b/docs/bin/plugin_formatter.py
@@ -286,6 +286,13 @@ def get_plugin_info(module_dir, limit_to=None, verbose=False):
         # use ansible core library to parse out doc metadata YAML and plaintext examples
         doc, examples, returndocs, metadata = plugin_docs.get_docstring(module_path, fragment_loader, verbose=verbose)
 
+        if 'options' in doc and doc['options'] is None:
+            display.error("*** ERROR: DOCUMENTATION.options must be a dictionary/hash when used. ***")
+            pos = getattr(doc, "ansible_pos", None)
+            if pos is not None:
+                display.error("Module position: %s, %d, %d" % doc.ansible_pos)
+            doc['options'] = dict()
+
         for key, opt in doc.get('options', {}).items():
             doc['options'][key] = normalize_options(opt)
 

--- a/docs/bin/plugin_formatter.py
+++ b/docs/bin/plugin_formatter.py
@@ -161,15 +161,14 @@ test_list = partial(is_sequence, include_strings=False)
 
 
 def to_boolean(value):
-    ''' convert default value to boolean if it intends to be boolean '''
+    """Normalize boolean option value."""
 
     if value.get('type') == 'bool' and 'default' in value:
         temp = boolean(value['default'])
         new_value = value.copy()
         new_value['default'] = temp
         return new_value
-    else:
-        return value
+    return value
 
 
 def write_data(text, output_dir, outputname, module=None):
@@ -287,9 +286,9 @@ def get_plugin_info(module_dir, limit_to=None, verbose=False):
         # use ansible core library to parse out doc metadata YAML and plaintext examples
         doc, examples, returndocs, metadata = plugin_docs.get_docstring(module_path, fragment_loader, verbose=verbose)
 
-        for key in (doc.get('options') or {}):
+        for key, opt in (doc.get('options') or {}).items():
             try:
-                doc['options'][key] = to_boolean(doc['options'][key])
+                doc['options'][key] = to_boolean(opt)
             except TypeError:
                 pass
 

--- a/lib/ansible/plugins/inventory/auto.py
+++ b/lib/ansible/plugins/inventory/auto.py
@@ -15,7 +15,6 @@ DOCUMENTATION = '''
           C(plugin) key at its root will automatically cause the named plugin to be loaded and executed with that
           config. This effectively provides automatic whitelisting of all installed/accessible inventory plugins.
         - To disable this behavior, remove C(auto) from the C(INVENTORY_ENABLED) config element.
-    options:
 '''
 
 EXAMPLES = '''


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
make doc templates not case sensitive for the default value
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
Follow up for #41149
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
docs/templates/plugin.rst.j2
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (fix-doc-typo 4592bb53ac) last updated 2018/06/05 16:36:02 (GMT -400)
  config file = None
  configured module search path = [u'/home/zhikangzhang/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/zhikangzhang/workspace/github/hd650/ansible/lib/ansible
  executable location = /home/zhikangzhang/workspace/github/hd650/ansible/bin/ansible
  python version = 2.7.15 (default, May 16 2018, 17:50:09) [GCC 8.1.1 20180502 (Red Hat 8.1.1-1)]
```