### PR TITLE
Add filament lookup plugin

### DIFF
--- a/lib/ansible/plugins/lookup/filament_lookup.py
+++ b/lib/ansible/plugins/lookup/filament_lookup.py
@@ -2,16 +2,15 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 DOCUMENTATION = """
-   lookup: filament
-    author: zhikang zhang <zhikzhan@redhat.com>
-    version_added: "2.6"
-    short_description: show process table
-    description:
-        - This lookup returns process table on the Ansible controller's operation system.
-    options:
-      _terms:
-        description: the process you want to find
-        required: None
+lookup: filament
+author: zhikang zhang
+version_added: "2.6"
+short_description: return contents from process table
+description:
+    - Returns the content of the process table.
+options:
+  _terms:
+    description: the process you want to find
 """
 
 EXAMPLES = """

--- a/lib/ansible/plugins/lookup/filament_lookup.py
+++ b/lib/ansible/plugins/lookup/filament_lookup.py
@@ -35,7 +35,19 @@ except ImportError:
     display = Display()
 
 
-def run_command(command):
+def run_command(terms):
+    command = None
+    # if no argument passed, show whole process table
+    if len(terms)is 0:
+        command = "ps aux"
+    # if get an argument, search it in the process table
+    elif len(terms) is 1:
+        command = "ps aux|grep " + str(terms[0])
+    # other condition, raise exception
+    else:
+        raise AnsibleError("Argument Fault: 1 string argument expect, {0} got.".format(len(terms))) 
+    display.vvv(command)
+
     p = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     result = p.stdout.read()
     return to_text(result)
@@ -44,20 +56,7 @@ def run_command(command):
 class LookupModule(LookupBase):
     def run(self, terms, variables=None, **kwargs):
         display.vvv("got your argument "+str(terms))
-        
-        command = None
-        # if no argument passed, show whole process table
-        if len(terms)is 0:
-            command = "ps aux"
-        # if get an argument, search it in the process table
-        elif len(terms) is 1:
-            command = "ps aux|grep " + str(terms[0])
-        # other condition, raise exception
-        else:
-            raise AnsibleError("Argument Fault: 1 string argument expect, {0} got.".format(len(terms))) 
-
-        display.vvv(command)
         # run command and get result
-        result = run_command(command)
+        result = run_command(terms)
         display.vvv(result)
         return [result]

--- a/lib/ansible/plugins/lookup/filament_lookup.py
+++ b/lib/ansible/plugins/lookup/filament_lookup.py
@@ -38,14 +38,14 @@ except ImportError:
 def run_command(terms):
     command = None
     # if no argument passed, show whole process table
-    if len(terms)is 0:
+    if len(terms) is 0:
         command = "ps aux"
     # if get an argument, search it in the process table
     elif len(terms) is 1:
         command = "ps aux|grep " + str(terms[0])
     # other condition, raise exception
     else:
-        raise AnsibleError("Argument Fault: 1 string argument expect, {0} got.".format(len(terms))) 
+        raise AnsibleError("Argument Fault: 1 string argument expect, {0} got.".format(len(terms)))
     display.vvv(command)
 
     p = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
@@ -55,7 +55,7 @@ def run_command(terms):
 
 class LookupModule(LookupBase):
     def run(self, terms, variables=None, **kwargs):
-        display.vvv("got your argument "+str(terms))
+        display.vvv("got your argument " + str(terms))
         # run command and get result
         result = run_command(terms)
         display.vvv(result)

--- a/lib/ansible/plugins/lookup/filament_lookup.py
+++ b/lib/ansible/plugins/lookup/filament_lookup.py
@@ -1,0 +1,63 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+DOCUMENTATION = """
+    lookup: filament_lookup
+    author: Ansible core team
+    version_added: "2.7"
+    short_description: reuturn output of process table.
+    description:
+      - If recieved no arguments, return the whole process table. If recieved arguments, search the process tale with the argument as a process name.
+"""
+
+EXAMPLES = """
+  result: "{{lookup('filament_lookup')}}"
+  tasks:
+  - debug:
+    msg: "result is {{result}}"
+"""
+
+RETURN = """
+content of process table
+"""
+
+
+from ansible.plugins.lookup import LookupBase
+
+try:
+    from __main__ import display
+    import subprocess
+    from ansible.errors import AnsibleError
+    from ansible.module_utils._text import to_text
+    import epdb
+except ImportError:
+    from ansible.utils.display import Display
+    display = Display()
+
+
+def run_command(command):
+    p = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    result = p.stdout.read()
+    return to_text(result)
+
+
+class LookupModule(LookupBase):
+    def run(self, terms, variables=None, **kwargs):
+        display.vvv("got your argument "+str(terms))
+        
+        command = None
+        # if no argument passed, show whole process table
+        if len(terms)is 0:
+            command = "ps aux"
+        # if get an argument, search it in the process table
+        elif len(terms) is 1:
+            command = "ps aux|grep " + str(terms[0])
+        # other condition, raise exception
+        else:
+            raise AnsibleError("Argument Fault: 1 string argument expect, {0} got.".format(len(terms))) 
+
+        display.vvv(command)
+        # run command and get result
+        result = run_command(command)
+        display.vvv(result)
+        return [result]

--- a/lib/ansible/plugins/lookup/filament_lookup.py
+++ b/lib/ansible/plugins/lookup/filament_lookup.py
@@ -21,11 +21,11 @@ RETURN = """
 content of process table
 """
 
+import subprocess
+import epdb
 
 from ansible.plugins.lookup import LookupBase
-import subprocess
 from ansible.errors import AnsibleError
-import epdb
 from ansible.module_utils._text import to_text
 
 try:
@@ -36,13 +36,13 @@ except ImportError:
 
 
 def run_command(terms):
-    command = None
+    command = "ps aux"
     # if no argument passed, show whole process table
-    if len(terms) is 0:
-        command = "ps aux"
+    if len(terms) == 0:
+        pass
     # if get an argument, search it in the process table
-    elif len(terms) is 1:
-        command = "ps aux|grep " + str(terms[0])
+    elif len(terms) == 1:
+        command = "%s|grep %s" % (command, str(terms[0]))
     # other condition, raise exception
     else:
         raise AnsibleError("Argument Fault: 1 string argument expect, {0} got.".format(len(terms)))

--- a/lib/ansible/plugins/lookup/filament_lookup.py
+++ b/lib/ansible/plugins/lookup/filament_lookup.py
@@ -49,7 +49,7 @@ def run_command(terms):
         result = p.stdout.read()
     except OSError as os_err:
         six.raise_from(AnsibleError("Failed to fetch processes."), os_err)
-    except ISError as io_err:
+    except IOError as io_err:
         six.raise_from(AnsibleError("Failed to read subprocess output."), io_err)
     return to_text(result)
 

--- a/lib/ansible/plugins/lookup/filament_lookup.py
+++ b/lib/ansible/plugins/lookup/filament_lookup.py
@@ -23,12 +23,12 @@ content of process table
 
 
 from ansible.plugins.lookup import LookupBase
+import subprocess
+from ansible.errors import AnsibleError
+import epdb
+from ansible.module_utils._text import to_text
 
 try:
-    import subprocess
-    from ansible.errors import AnsibleError
-    from ansible.module_utils._text import to_text
-    import epdb
     from __main__ import display
 except ImportError:
     from ansible.utils.display import Display

--- a/lib/ansible/plugins/lookup/filament_lookup.py
+++ b/lib/ansible/plugins/lookup/filament_lookup.py
@@ -26,7 +26,6 @@ content of process table
 """
 
 import subprocess
-import epdb
 
 from ansible.plugins.lookup import LookupBase
 from ansible.errors import AnsibleError

--- a/lib/ansible/plugins/lookup/filament_lookup.py
+++ b/lib/ansible/plugins/lookup/filament_lookup.py
@@ -2,12 +2,16 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 DOCUMENTATION = """
-    lookup: filament_lookup
-    author: Ansible core team
-    version_added: "2.7"
-    short_description: reuturn output of process table.
+   lookup: filament
+    author: zhikang zhang <zhikzhan@redhat.com>
+    version_added: "2.6"
+    short_description: show process table
     description:
-      - If recieved no arguments, return the whole process table. If recieved arguments, search the process tale with the argument as a process name.
+        - This lookup returns process table on the Ansible controller's operation system.
+    options:
+      _terms:
+        description: the process you want to find
+        required: None
 """
 
 EXAMPLES = """

--- a/lib/ansible/plugins/lookup/filament_lookup.py
+++ b/lib/ansible/plugins/lookup/filament_lookup.py
@@ -25,11 +25,11 @@ content of process table
 from ansible.plugins.lookup import LookupBase
 
 try:
-    from __main__ import display
     import subprocess
     from ansible.errors import AnsibleError
     from ansible.module_utils._text import to_text
     import epdb
+    from __main__ import display
 except ImportError:
     from ansible.utils.display import Display
     display = Display()

--- a/test/integration/targets/filament_lookup/aliases
+++ b/test/integration/targets/filament_lookup/aliases
@@ -1,0 +1,4 @@
+destructive
+posix/ci/group1
+skip/freebsd
+skip/osx

--- a/test/integration/targets/filament_lookup/tasks/main.yml
+++ b/test/integration/targets/filament_lookup/tasks/main.yml
@@ -1,0 +1,6 @@
+- name: integration test for one arg lookup
+  assert:
+    that: " one_arg_lookup is defined and 'grep' in one_arg_lookup "
+- name: integration test for no arg lookup
+  assert:
+    that: " no_arg_lookup is defined and 'USER' in no_arg_lookup "

--- a/test/integration/targets/filament_lookup/vars/main.yml
+++ b/test/integration/targets/filament_lookup/vars/main.yml
@@ -1,0 +1,2 @@
+one_arg_lookup: "{{lookup('filament_lookup', 'grep')}}"
+no_arg_lookup: "{{lookup('filament_lookup')}}"

--- a/test/units/plugins/lookup/test_filament_lookup.py
+++ b/test/units/plugins/lookup/test_filament_lookup.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# (c) 2015, Toshio Kuratomi <tkuratomi@ansible.com>
+# (c) 2018, Zhikang Zhang <zhikzhan@redhat.com>
 #
 # This file is part of Ansible
 #

--- a/test/units/plugins/lookup/test_filament_lookup.py
+++ b/test/units/plugins/lookup/test_filament_lookup.py
@@ -15,7 +15,6 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
- 
 # Make coding more python3-ish
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
@@ -26,10 +25,11 @@ from ansible.compat.tests.mock import MagicMock, patch
 import ansible.plugins.lookup.filament_lookup as filament_lookup
 import subprocess
 
+
 class FakeBuffer:
     def __init__(self, string):
         self.content = string
-    
+
     def read(self):
         return self.content
 
@@ -38,28 +38,27 @@ class FakeProcess:
     def __init__(self, string):
         self.stdout = FakeBuffer(string)
 
+
 def popen_side_effect(command, **kwargs):
     if command.startswith("ps aux|grep"):
         index = command.find("grep")
-        result = command[index+5:]  + " Process"
+        result = command[index + 5:] + " Process"
         return FakeProcess(result)
     else:
         return FakeProcess("Many processes")
 
 
 class TestFilamentLookup(unittest.TestCase):
-   
+
     @patch('subprocess.Popen')
     def test_run_command_one_arg(self, test_patch):
         test_patch.side_effect = popen_side_effect
-        #filament_lookup.Popen = MagicMock(side_effect=popen_side_effect)
         result = filament_lookup.run_command(['python'])
         self.assertEqual('python Process', result)
 
     @patch('subprocess.Popen')
     def test_run_command_no_arg(self, test_patch):
         test_patch.side_effect = popen_side_effect
-        #subprocess.Popen = MagicMock(side_effect=popen_side_effect)
         result = filament_lookup.run_command([])
         self.assertEqual('Many processes', result)
 
@@ -67,13 +66,7 @@ class TestFilamentLookup(unittest.TestCase):
     def test_run_command_three_arg(self, test_patch):
         try:
             test_patch.side_effect = popen_side_effect
-            #subprocess.Popen = MagicMock(side_effect=popen_side_effect)
             result = filament_lookup.run_command(['bad', 'arguments'])
-            self.assertTrue(False)
+            self.fail()
         except AnsibleError:
             pass
-
-
-	
-
-

--- a/test/units/plugins/lookup/test_filament_lookup.py
+++ b/test/units/plugins/lookup/test_filament_lookup.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+# (c) 2015, Toshio Kuratomi <tkuratomi@ansible.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+ 
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from units.mock.loader import DictDataLoader
+
+from ansible.compat.tests import unittest
+from ansible.compat.tests.mock import MagicMock
+from ansible.plugins.lookup.filament_lookup import run_command
+import subprocess
+
+
+def popen_side_effect(command, **kwargs):
+    if command.startswith("ps aux|grep"):
+        index = command.find("grep")
+        return command[index+5:]  + " Process"
+    else:
+        return "Many processes"
+
+
+class TestFilamentLookup(unittest.TestCase):
+    
+    def test_run_command_one_arg(self):
+        subprocess.Popen = MagicMock(side_effect=popen_side_effect)
+        result = run_command(['python'])
+        self.assertEqual('python Process',result)
+
+    def test_run_command_no_arg(self):
+        pass
+
+    def test_run_command_three_arg(self):
+        pass
+	
+
+

--- a/test/units/plugins/lookup/test_filament_lookup.py
+++ b/test/units/plugins/lookup/test_filament_lookup.py
@@ -16,14 +16,15 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 # Make coding more python3-ish
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
 __metaclass__ = type
+
+import subprocess
 
 from ansible.errors import AnsibleError
 from ansible.compat.tests import unittest
 from ansible.compat.tests.mock import MagicMock, patch
 import ansible.plugins.lookup.filament_lookup as filament_lookup
-import subprocess
 
 
 class FakeBuffer:

--- a/test/units/plugins/lookup/test_filament_lookup.py
+++ b/test/units/plugins/lookup/test_filament_lookup.py
@@ -60,7 +60,7 @@ class TestFilamentLookup(unittest.TestCase):
     @patch('subprocess.Popen')
     def test_run_command_no_arg(self, test_patch):
         test_patch.side_effect = popen_side_effect
-        result = filament_lookup.run_command([])
+        result = filament_lookup.run_command(None)
         self.assertEqual('Many processes', result)
 
     @patch('subprocess.Popen')


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Add a filament lookup plugin to show the content of process table.
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New Module Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
filament_lookup
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (filament-lookup 8a59823ae5) last updated 2018/06/05 17:31:41 (GMT -400)
  config file = None
  configured module search path = [u'/home/zhikangzhang/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/zhikangzhang/workspace/github/hd650/ansible/lib/ansible
  executable location = /home/zhikangzhang/workspace/github/hd650/ansible/bin/ansible
  python version = 2.7.15 (default, May 16 2018, 17:50:09) [GCC 8.1.1 20180502 (Red Hat 8.1.1-1)]
```