### PR TITLE
adds a new feature to the telnet action plugin

### DIFF
--- a/lib/ansible/modules/commands/telnet.py
+++ b/lib/ansible/modules/commands/telnet.py
@@ -64,6 +64,14 @@ options:
         - Seconds to pause between each command issued
     required: False
     default: 1
+  send_newline:
+    description:
+      - Sends a newline character upon successful connection to start the
+        terminal session.
+    required: False
+    default: False
+    type: bool
+    version_added: "2.7"
 notes:
     - The C(environment) keyword does not work with this task
 author:

--- a/lib/ansible/plugins/action/telnet.py
+++ b/lib/ansible/plugins/action/telnet.py
@@ -12,6 +12,12 @@ from ansible.module_utils._text import to_native
 from ansible.module_utils.six import text_type
 from ansible.plugins.action import ActionBase
 
+try:
+    from __main__ import display
+except ImportError:
+    from ansible.utils.display import Display
+    display = Display()
+
 
 class ActionModule(ActionBase):
     TRANSFERS_FILES = False
@@ -41,9 +47,11 @@ class ActionModule(ActionBase):
             timeout = self._task.args.get('timeout', 120)
             pause = self._task.args.get('pause', 1)
 
+            send_newline = self._task.args.get('send_newline', False)
+
             login_prompt = self._task.args.get('login_prompt', "login: ")
             password_prompt = self._task.args.get('password_prompt', "Password: ")
-            prompts = self._task.args.get('prompts', "$ ")
+            prompts = self._task.args.get('prompts', ["$ "])
             commands = self._task.args.get('command') or self._task.args.get('commands')
 
             if isinstance(commands, text_type):
@@ -55,6 +63,9 @@ class ActionModule(ActionBase):
 
                 output = []
                 try:
+                    if send_newline:
+                        tn.write('\n')
+
                     tn.read_until(login_prompt)
                     tn.write('%s\n' % to_native(user))
 
@@ -65,8 +76,10 @@ class ActionModule(ActionBase):
                     tn.expect(prompts)
 
                     for cmd in commands:
+                        display.vvvvv('>>> %s' % cmd)
                         tn.write('%s\n' % to_native(cmd))
                         index, match, out = tn.expect(prompts)
+                        display.vvvvv('<<< %s' % cmd)
                         output.append(out)
                         sleep(pause)
 


### PR DESCRIPTION
This change adds a new argument to the telnet action plugin that will
cause the module to send a newline character before trying to login.
This is convienent when using telnet over a console connection that
needs an initial newline character to start the login process.

This change also will cause the sent command and command response to be
displayed on stdout when running in verbose mode (5 v's).

