### PR TITLE
password_hash() should fail when invoked with bad parameters

### DIFF
--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -289,7 +289,7 @@ def get_encrypted_password(password, hashtype='sha512', salt=None):
 
         return encrypted
 
-    return None
+    raise AnsibleFilterError("invalid hashtype: '{0}'. Must be one of [{1}]".format(hashtype, ", ".join(["'{0}'".format(key) for key in cryptmethod.keys()])))
 
 
 def to_uuid(string):

--- a/test/integration/targets/filters/tasks/main.yml
+++ b/test/integration/targets/filters/tasks/main.yml
@@ -235,3 +235,16 @@
     that:
             - "'00:00:00' | random_mac is match('^00:00:00:[a-f0-9][a-f0-9]:[a-f0-9][a-f0-9]:[a-f0-9][a-f0-9]$')"
             - "'00:00:00' | random_mac != '00:00:00' | random_mac"
+
+- name: Invoke password_hash with a wrong algorithm
+  debug:
+    var: "'somestring' | password_hash('WRONG_ALGORITHM')"
+  register: _bad_password_hash_filter
+  ignore_errors: yes
+
+- name: Verify password_hash filter failed when invoked with wrong algorithm
+  assert:
+    that:
+      - _bad_password_hash_filter is failed
+      - "'invalid hashtype' in _bad_password_hash_filter.msg"
+    msg: "password_hash('WRONG_ALGORITHM') has to fail with 'invalid hashtype'"


### PR DESCRIPTION
##### SUMMARY
When invoked with an invalid parameter (i.e., a non-existing hashing algorithm), `password_hash` returns an empty string (`""`) without failing.
Since this filter is often used to set user password, **this can lead to locking out a user due to setting a different password than the intended one**.
If the oversight is caught at execution time with a clear error, it can be fixed easily by the developer.

This change:
- stops the play, raising an `AnsibleFilterError` exception when `password_hash` is invoked with a
  non-existent algorithm
- prints the offending parameter (i.e.: `WRONG_ALGO`)
- prints the list of the acceptable algorithms (i.e.: `['md5', 'blowfish', 'sha256', 'sha512']`), generating it from the code

Fixes #38149.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
`password_hash` jinja filter

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0
  config file = None
  configured module search path = [u'/usr/share/ansible/plugins/modules']
  ansible python module location = /mnt/md/tmp/ansible/lib/ansible
  executable location = /mnt/md/tmp/ansible/bin/ansible
  python version = 2.7.15rc1 (default, Apr 15 2018, 21:51:34) [GCC 7.3.0]
```


##### ADDITIONAL INFORMATION
Example of an execution before the change:
```
$ ansible all -i "localhost," -c local -a "echo The hash is: \'{{ 'somestring' | password_hash('WRONG_ALGO') }}\'"
localhost | SUCCESS | rc=0 >>
The hash is: ''
```

Example of an execution after the change:
```
$ ansible all -i "localhost," -c local -a "echo The hash is: \'{{ 'somestring' | password_hash('WRONG_ALGO') }}\'"
localhost | FAILED | rc=-1 >>
invalid hashtype: 'WRONG_ALGO'. Must be one of ['md5', 'blowfish', 'sha256', 'sha512']
```
