### PR TITLE
Make admin_users only contain root for backwards compatibility.

### DIFF
--- a/changelogs/fragments/admin-users-default-change.yaml
+++ b/changelogs/fragments/admin-users-default-change.yaml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - Changed the admin_users config option to not include "admin" by default as
+    admin is frequently used for a non-privileged account  (https://github.com/ansible/ansible/pull/41164)

--- a/lib/ansible/utils/module_docs_fragments/shell_common.py
+++ b/lib/ansible/utils/module_docs_fragments/shell_common.py
@@ -47,9 +47,10 @@ options:
       - dictionary of environment variables and their values to use when executing commands.
   admin_users:
     type: list
-    default: ['root', 'toor', 'admin']
+    default: ['root', 'toor']
     description:
-      - list of users to be expected to have admin privileges, for BSD you might want to add 'toor' for windows 'Administrator'.
+      - list of users to be expected to have admin privileges. This is used by the controller to
+        determine how to share temporary files between the remote user and the become user.
     env:
       - name: ANSIBLE_ADMIN_USERS
     ini:


### PR DESCRIPTION
admin was especially problematic as people have this as a non-privileged
account in the wild.

Not sure about toor but it's not hard to add (and the documentation even
tells BSD users they may want to add it).

This fixes one specific instance of failure to chown from a privileged
account:
https://github.com/ansible/ansible/issues/16052#issuecomment-384976615

##### ISSUE TYPE

 - Bugfix Pull Request


##### COMPONENT NAME
admin_users config option

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel 2.6 2.5
```