### PR TITLE
Docs fix: ansible_group_priority defaults to 1

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_variables.rst
+++ b/docs/docsite/rst/user_guide/playbooks_variables.rst
@@ -868,7 +868,7 @@ Basically, anything that goes into "role defaults" (the defaults folder inside t
           If you define a variable twice in a play's ``vars:`` section, the second one wins.
 .. note:: The previous describes the default config ``hash_behaviour=replace``, switch to ``merge`` to only partially overwrite.
 .. note:: Group loading follows parent/child relationships. Groups of the same 'patent/child' level are then merged following alphabetical order.
-          This last one can be superceeded by the user via ``ansible_group_priority``, which defaults to 0 for all groups.
+          This last one can be superceeded by the user via ``ansible_group_priority``, which defaults to ``1`` for all groups.
 
 
 Another important thing to consider (for all versions) is that connection variables override config, command line and play/role/task specific options and keywords.  For example::


### PR DESCRIPTION
##### SUMMARY
The docs committed in #28777 were inconsistent.
This clarifies that the default `ansible_group_priority` is `1`.[1][2]

[1] https://github.com/ansible/ansible/blob/153c9bd/lib/ansible/inventory/group.py#L40
[2] https://github.com/ansible/ansible/blob/153c9bd/lib/ansible/cli/inventory.py#L236

##### ISSUE TYPE
 - Docs Pull Request

##### ANSIBLE VERSION
applies to 2.4+

##### ADDITIONAL INFORMATION
Peaches and Cream! Yum!