### PR TITLE
fix ansible-doc regression from missing plugins

### DIFF
--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -156,7 +156,10 @@ class DocCLI(CLI):
         # process command line list
         text = ''
         for plugin in self.args:
-            text += self.format_plugin_doc(plugin, loader, plugin_type, search_paths)
+            textret = self.format_plugin_doc(plugin, loader, plugin_type, search_paths)
+
+            if textret:
+                text += textret
 
         if text:
             self.pager(text)


### PR DESCRIPTION
##### SUMMARY
fixes refactor regression of traceback on missing plugin name

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ansible-doc

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
2.6.0a2

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
