### PR TITLE
Add Fedora as possible ansible_distribution value

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_conditionals.rst
+++ b/docs/docsite/rst/user_guide/playbooks_conditionals.rst
@@ -337,6 +337,7 @@ Possible values::
     ClearLinux
     Coreos
     Debian
+    Fedora
     Gentoo
     Mandriva
     NA


### PR DESCRIPTION
+label: docsite_pr

##### SUMMARY
"ansible_distribution" can also be Fedora

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
setup

##### ANSIBLE VERSION
```
ansible 2.5.3
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/till/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.15 (default, May 16 2018, 17:50:09) [GCC 8.1.1 20180502 (Red Hat 8.1.1-1)]

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
