### PR TITLE
updated maintainer list for modules/monitoring/zabbix folder

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -417,9 +417,9 @@ files:
   $modules/monitoring/stackdriver.py: bwhaley
   $modules/monitoring/statusio_maintenance.py: bhcopeland
   $modules/monitoring/uptimerobot.py: nate-kingsley
-  $modules/monitoring/zabbix: eikef
+  $modules/monitoring/zabbix: eikef D3DeFi
   $modules/monitoring/zabbix/zabbix_group.py: cove harrisongu
-  $modules/monitoring/zabbix/zabbix_host.py: cove harrisongu D3DeFi
+  $modules/monitoring/zabbix/zabbix_host.py: cove harrisongu
   $modules/monitoring/zabbix/zabbix_hostmacro.py: cave
   $modules/monitoring/zabbix/zabbix_maintenance.py: abulimov
   $modules/monitoring/zabbix/zabbix_screen.py: cove harrisongu


### PR DESCRIPTION
##### SUMMARY
Adding myself as a maintainer for all zabbix modules instead of just for zabbix_host module

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
.github/BOTMETA.yml

##### ANSIBLE VERSION
```
ansible 2.7.0.dev0 (zabbix_modules_maintainers 697238b166) last updated 2018/06/06 13:33:36 (GMT +200)
  config file = None
  configured module search path = [u'/home/user/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/user/ansible-fork/lib/ansible
  executable location = /home/user/ansible-fork/bin/ansible
  python version = 2.7.14 (default, Oct 31 2017, 21:12:13) [GCC 6.4.0]

```
