### PR TITLE
more integration test improvements

### DIFF
--- a/test/integration/targets/azure_rm_image/tasks/main.yml
+++ b/test/integration/targets/azure_rm_image/tasks/main.yml
@@ -1,11 +1,12 @@
 - name: Create storage account name
   set_fact:
-      rpfx: "{{ resource_group | hash('md5') | truncate(7, True, '') }}{{ 1000 | random }}"
+      blob_name: "{{ resource_group | hash('md5') | truncate(7, True, '') }}{{ 1000 | random }}"
       vm_name: "vm{{ resource_group | hash('md5') | truncate(7, True, '') }}{{ 1000 | random }}x"
       storage_name: "st{{ resource_group | hash('md5') | truncate(7, True, '') }}{{ 1000 | random }}"
       storage_container_name: "sc{{ resource_group | hash('md5') | truncate(7, True, '') }}{{ 1000 | random }}"
       public_ip_name: "pip{{ resource_group | hash('md5') | truncate(7, True, '') }}{{ 1000 | random }}"
-      security_group_name: "pip{{ resource_group | hash('md5') | truncate(7, True, '') }}{{ 1000 | random }}"
+      security_group_name: "sg{{ resource_group | hash('md5') | truncate(7, True, '') }}{{ 1000 | random }}"
+      blob_name: "blob{{ resource_group | hash('md5') | truncate(7, True, '') }}{{ 1000 | random }}"
 
 - name: Create storage account
   azure_rm_storageaccount:
@@ -53,7 +54,7 @@
       vm_size: Standard_A0
       storage_account: "{{ storage_name }}"
       storage_container: "{{ storage_container_name }}"
-      storage_blob: "blob.vhd"
+      storage_blob: "{{ blob_name }}.vhd"
       admin_username: adminuser
       admin_password: Password123!
       os_type: Linux
@@ -81,7 +82,7 @@
 - name: Create an image from VM (check mode)
   azure_rm_image:
       resource_group: "{{ resource_group }}"
-      source: "https://{{ rpfx }}.blob.core.windows.net/vn{{ rpfx }}/vn{{ rpfx }}.vhd"
+      source: "https://{{ storage_name }}.blob.core.windows.net/{{ storage_container_name }}/{{ blob_name }}.vhd"
       name: testimage001
       os_type: Linux
   check_mode: yes
@@ -93,7 +94,7 @@
 - name: Create an image from VM
   azure_rm_image:
       resource_group: "{{ resource_group }}"
-      source: "https://{{ storage_name }}.blob.core.windows.net/{{ storage_container_name }}/blob.vhd"
+      source: "https://{{ storage_name }}.blob.core.windows.net/{{ storage_container_name }}/{{ blob_name }}.vhd"
       name: testimage001
       os_type: Linux
   register: output
@@ -106,7 +107,7 @@
 - name: Create an image from VM (idempotent)
   azure_rm_image:
       resource_group: "{{ resource_group }}"
-      source: "https://{{ storage_name }}.blob.core.windows.net/{{ storage_container_name }}/blob.vhd"
+      source: "https://{{ storage_name }}.blob.core.windows.net/{{ storage_container_name }}/{{ blob_name }}.vhd"
       name: testimage001
       os_type: Linux
   register: output

--- a/test/integration/targets/azure_rm_image/tasks/main.yml
+++ b/test/integration/targets/azure_rm_image/tasks/main.yml
@@ -48,7 +48,7 @@
       vm_size: Standard_A0
       storage_account: "{{ storage_account }}"
       storage_container: "vn{{ storage_account }}"
-      storage_blob: "vn{{ storage_account }}".vhd
+      storage_blob: "vn{{ storage_account }}.vhd"
       admin_username: adminuser
       admin_password: Password123!
       os_type: Linux
@@ -76,7 +76,7 @@
 - name: Create an image from VM (check mode)
   azure_rm_image:
       resource_group: "{{ resource_group }}"
-      source: "https://{{ storage_account }}.blob.core.windows.net/"vn{{ storage_account }}"/"vn{{ storage_account }}".vhd"
+      source: "https://{{ storage_account }}.blob.core.windows.net/vn{{ storage_account }}/vn{{ storage_account }}.vhd"
       name: testimage001
       os_type: Linux
   check_mode: yes
@@ -88,7 +88,7 @@
 - name: Create an image from VM
   azure_rm_image:
       resource_group: "{{ resource_group }}"
-      source: "https://{{ storage_account }}.blob.core.windows.net/"vn{{ storage_account }}"/"vn{{ storage_account }}".vhd"
+      source: "https://{{ storage_account }}.blob.core.windows.net/vn{{ storage_account }}/vn{{ storage_account }}.vhd"
       name: testimage001
       os_type: Linux
   register: output
@@ -101,7 +101,7 @@
 - name: Create an image from VM (idempotent)
   azure_rm_image:
       resource_group: "{{ resource_group }}"
-      source: "https://{{ storage_account }}.blob.core.windows.net/"vn{{ storage_account }}"/"vn{{ storage_account }}".vhd"
+      source: "https://{{ storage_account }}.blob.core.windows.net/vn{{ storage_account }}/vn{{ storage_account }}.vhd"
       name: testimage001
       os_type: Linux
   register: output

--- a/test/integration/targets/azure_rm_image/tasks/main.yml
+++ b/test/integration/targets/azure_rm_image/tasks/main.yml
@@ -1,58 +1,64 @@
 - name: Create storage account name
   set_fact:
       rpfx: "{{ resource_group | hash('md5') | truncate(7, True, '') }}{{ 1000 | random }}"
+      first_vm_name: "vm{{ resource_group | hash('md5') | truncate(7, True, '') }}{{ 1000 | random }}"
+      second_vm_name: "vm{{ resource_group | hash('md5') | truncate(7, True, '') }}{{ 1000 | random }}x"
+      storage_name: "st{{ resource_group | hash('md5') | truncate(7, True, '') }}{{ 1000 | random }}"
+      storage_container_name: "sc{{ resource_group | hash('md5') | truncate(7, True, '') }}{{ 1000 | random }}"
+      public_ip_name: "pip{{ resource_group | hash('md5') | truncate(7, True, '') }}{{ 1000 | random }}"
+      security_group_name: "pip{{ resource_group | hash('md5') | truncate(7, True, '') }}{{ 1000 | random }}"
 
 - name: Create storage account
   azure_rm_storageaccount:
       resource_group: "{{ resource_group }}"
-      name: "{{ rpfx }}"
+      name: "{{ storage_name }}"
       account_type: Standard_LRS
 
 - name: Create virtual network
   azure_rm_virtualnetwork:
       resource_group: "{{ resource_group }}"
-      name: "vn{{ rpfx }}"
+      name: "{{ first_vm_name }}"
       address_prefixes: "10.10.0.0/16"
 
 - name: Add subnet
   azure_rm_subnet:
       resource_group: "{{ resource_group }}"
-      name: "vn{{ rpfx }}"
+      name: "{{ first_vm_name }}"
       address_prefix: "10.10.0.0/24"
-      virtual_network: "vn{{ rpfx }}"
+      virtual_network: "{{ first_vm_name }}"
 
 - name: Create public ip
   azure_rm_publicipaddress:
       resource_group: "{{ resource_group }}"
       allocation_method: Static
-      name: "vn{{ rpfx }}"
+      name: "{{ publicip_name }}"
 
 - name: Create security group
   azure_rm_securitygroup:
       resource_group: "{{ resource_group }}"
-      name: "vn{{ rpfx }}"
+      name: "{{ security_group_name }}"
 
 - name: Create NIC
   azure_rm_networkinterface:
       resource_group: "{{ resource_group }}"
-      name: "vn{{ rpfx }}"
-      virtual_network: "vn{{ rpfx }}"
-      subnet: "vn{{ rpfx }}"
-      public_ip_name: "vn{{ rpfx }}"
-      security_group: "vn{{ rpfx }}"
+      name: "{{ first_vm_name }}"
+      virtual_network: "{{ first_vm_name }}"
+      subnet: "{{ first_vm_name }}"
+      public_ip_name: "{{ public_ip_name }}"
+      security_group: "{{ security_group_name }}"
 
 - name: Create virtual machine
   azure_rm_virtualmachine:
       resource_group: "{{ resource_group }}"
-      name: "vn{{ rpfx }}x"
+      name: "{{ second_vm_name }}"
       vm_size: Standard_A0
-      storage_account: "{{ rpfx }}"
-      storage_container: "vn{{ rpfx }}"
-      storage_blob: "vn{{ rpfx }}.vhd"
+      storage_account: "{{ storage_name }}"
+      storage_container: "{{ storage_container_name }}"
+      storage_blob: "blob.vhd"
       admin_username: adminuser
       admin_password: Password123!
       os_type: Linux
-      network_interfaces: "vn{{ rpfx }}"
+      network_interfaces: "{{ first_vm_name }}"
       image:
         offer: UbuntuServer
         publisher: Canonical
@@ -62,7 +68,7 @@
 - name: Deallocate the virtual machine
   azure_rm_virtualmachine:
       resource_group: "{{ resource_group }}"
-      name: "vn{{ rpfx }}x"
+      name: "{{ second_vm_name }}"
       allocated: no 
       vm_size: Standard_A0
   register: output
@@ -70,7 +76,7 @@
 - name: Start the virtual machine
   azure_rm_virtualmachine:
       resource_group: "{{ resource_group }}"
-      name: "vn{{ rpfx }}x"
+      name: "{{ second_vm_name }}"
       vm_size: Standard_A0
 
 - name: Create an image from VM (check mode)
@@ -88,7 +94,7 @@
 - name: Create an image from VM
   azure_rm_image:
       resource_group: "{{ resource_group }}"
-      source: "https://{{ rpfx }}.blob.core.windows.net/vn{{ rpfx }}/vn{{ rpfx }}.vhd"
+      source: "https://{{ storage_name }}.blob.core.windows.net/{{ storage_container_name }}/blob.vhd"
       name: testimage001
       os_type: Linux
   register: output
@@ -101,7 +107,7 @@
 - name: Create an image from VM (idempotent)
   azure_rm_image:
       resource_group: "{{ resource_group }}"
-      source: "https://{{ rpfx }}.blob.core.windows.net/vn{{ rpfx }}/vn{{ rpfx }}.vhd"
+      source: "https://{{ storage_name }}.blob.core.windows.net/{{ storage_container_name }}/blob.vhd"
       name: testimage001
       os_type: Linux
   register: output
@@ -148,7 +154,7 @@
 - name: Delete VM
   azure_rm_virtualmachine:
       resource_group: "{{ resource_group }}"
-      name: "vn{{ rpfx }}x"
+      name: "{{ second_vm_name }}"
       state: absent
       vm_size: Standard_A0
   register: output
@@ -157,5 +163,5 @@
   azure_rm_publicipaddress:
       resource_group: "{{ resource_group }}"
       allocation_method: Static
-      name: "vn{{ rpfx }}"
+      name: "{{ first_vm_name }}"
       state: absent

--- a/test/integration/targets/azure_rm_image/tasks/main.yml
+++ b/test/integration/targets/azure_rm_image/tasks/main.yml
@@ -1,8 +1,7 @@
 - name: Create storage account name
   set_fact:
       rpfx: "{{ resource_group | hash('md5') | truncate(7, True, '') }}{{ 1000 | random }}"
-      first_vm_name: "vm{{ resource_group | hash('md5') | truncate(7, True, '') }}{{ 1000 | random }}"
-      second_vm_name: "vm{{ resource_group | hash('md5') | truncate(7, True, '') }}{{ 1000 | random }}x"
+      vm_name: "vm{{ resource_group | hash('md5') | truncate(7, True, '') }}{{ 1000 | random }}x"
       storage_name: "st{{ resource_group | hash('md5') | truncate(7, True, '') }}{{ 1000 | random }}"
       storage_container_name: "sc{{ resource_group | hash('md5') | truncate(7, True, '') }}{{ 1000 | random }}"
       public_ip_name: "pip{{ resource_group | hash('md5') | truncate(7, True, '') }}{{ 1000 | random }}"
@@ -17,21 +16,21 @@
 - name: Create virtual network
   azure_rm_virtualnetwork:
       resource_group: "{{ resource_group }}"
-      name: "{{ first_vm_name }}"
+      name: "{{ vm_name }}"
       address_prefixes: "10.10.0.0/16"
 
 - name: Add subnet
   azure_rm_subnet:
       resource_group: "{{ resource_group }}"
-      name: "{{ first_vm_name }}"
+      name: "{{ vm_name }}"
       address_prefix: "10.10.0.0/24"
-      virtual_network: "{{ first_vm_name }}"
+      virtual_network: "{{ vm_name }}"
 
 - name: Create public ip
   azure_rm_publicipaddress:
       resource_group: "{{ resource_group }}"
       allocation_method: Static
-      name: "{{ publicip_name }}"
+      name: "{{ public_ip_name }}"
 
 - name: Create security group
   azure_rm_securitygroup:
@@ -41,16 +40,16 @@
 - name: Create NIC
   azure_rm_networkinterface:
       resource_group: "{{ resource_group }}"
-      name: "{{ first_vm_name }}"
-      virtual_network: "{{ first_vm_name }}"
-      subnet: "{{ first_vm_name }}"
+      name: "{{ vm_name }}"
+      virtual_network: "{{ vm_name }}"
+      subnet: "{{ vm_name }}"
       public_ip_name: "{{ public_ip_name }}"
       security_group: "{{ security_group_name }}"
 
 - name: Create virtual machine
   azure_rm_virtualmachine:
       resource_group: "{{ resource_group }}"
-      name: "{{ second_vm_name }}"
+      name: "{{ vm_name }}"
       vm_size: Standard_A0
       storage_account: "{{ storage_name }}"
       storage_container: "{{ storage_container_name }}"
@@ -58,7 +57,7 @@
       admin_username: adminuser
       admin_password: Password123!
       os_type: Linux
-      network_interfaces: "{{ first_vm_name }}"
+      network_interfaces: "{{ vm_name }}"
       image:
         offer: UbuntuServer
         publisher: Canonical
@@ -68,7 +67,7 @@
 - name: Deallocate the virtual machine
   azure_rm_virtualmachine:
       resource_group: "{{ resource_group }}"
-      name: "{{ second_vm_name }}"
+      name: "{{ vm_name }}"
       allocated: no 
       vm_size: Standard_A0
   register: output
@@ -76,7 +75,7 @@
 - name: Start the virtual machine
   azure_rm_virtualmachine:
       resource_group: "{{ resource_group }}"
-      name: "{{ second_vm_name }}"
+      name: "{{ vm_name }}"
       vm_size: Standard_A0
 
 - name: Create an image from VM (check mode)
@@ -154,7 +153,7 @@
 - name: Delete VM
   azure_rm_virtualmachine:
       resource_group: "{{ resource_group }}"
-      name: "{{ second_vm_name }}"
+      name: "{{ vm_name }}"
       state: absent
       vm_size: Standard_A0
   register: output
@@ -163,5 +162,5 @@
   azure_rm_publicipaddress:
       resource_group: "{{ resource_group }}"
       allocation_method: Static
-      name: "{{ first_vm_name }}"
+      name: "{{ public_ip_name }}"
       state: absent

--- a/test/integration/targets/azure_rm_image/tasks/main.yml
+++ b/test/integration/targets/azure_rm_image/tasks/main.yml
@@ -1,58 +1,58 @@
 - name: Create storage account name
   set_fact:
-      storage_account: "{{ resource_group | hash('md5') | truncate(24, True, '') }}"
+      rpfx: "{{ resource_group | hash('md5') | truncate(7, True, '') }}{{ 1000 | random }}"
 
 - name: Create storage account
   azure_rm_storageaccount:
       resource_group: "{{ resource_group }}"
-      name: "{{ storage_account }}"
+      name: "{{ rpfx }}"
       account_type: Standard_LRS
 
 - name: Create virtual network
   azure_rm_virtualnetwork:
       resource_group: "{{ resource_group }}"
-      name: "vn{{ storage_account }}"
+      name: "vn{{ rpfx }}"
       address_prefixes: "10.10.0.0/16"
 
 - name: Add subnet
   azure_rm_subnet:
       resource_group: "{{ resource_group }}"
-      name: "vn{{ storage_account }}"
+      name: "vn{{ rpfx }}"
       address_prefix: "10.10.0.0/24"
-      virtual_network: "vn{{ storage_account }}"
+      virtual_network: "vn{{ rpfx }}"
 
 - name: Create public ip
   azure_rm_publicipaddress:
       resource_group: "{{ resource_group }}"
       allocation_method: Static
-      name: "vn{{ storage_account }}"
+      name: "vn{{ rpfx }}"
 
 - name: Create security group
   azure_rm_securitygroup:
       resource_group: "{{ resource_group }}"
-      name: "vn{{ storage_account }}"
+      name: "vn{{ rpfx }}"
 
 - name: Create NIC
   azure_rm_networkinterface:
       resource_group: "{{ resource_group }}"
-      name: "vn{{ storage_account }}"
-      virtual_network: "vn{{ storage_account }}"
-      subnet: "vn{{ storage_account }}"
-      public_ip_name: "vn{{ storage_account }}"
-      security_group: "vn{{ storage_account }}"
+      name: "vn{{ rpfx }}"
+      virtual_network: "vn{{ rpfx }}"
+      subnet: "vn{{ rpfx }}"
+      public_ip_name: "vn{{ rpfx }}"
+      security_group: "vn{{ rpfx }}"
 
 - name: Create virtual machine
   azure_rm_virtualmachine:
       resource_group: "{{ resource_group }}"
-      name: "vn{{ storage_account }}x"
+      name: "vn{{ rpfx }}x"
       vm_size: Standard_A0
-      storage_account: "{{ storage_account }}"
-      storage_container: "vn{{ storage_account }}"
-      storage_blob: "vn{{ storage_account }}.vhd"
+      storage_account: "{{ rpfx }}"
+      storage_container: "vn{{ rpfx }}"
+      storage_blob: "vn{{ rpfx }}.vhd"
       admin_username: adminuser
       admin_password: Password123!
       os_type: Linux
-      network_interfaces: "vn{{ storage_account }}"
+      network_interfaces: "vn{{ rpfx }}"
       image:
         offer: UbuntuServer
         publisher: Canonical
@@ -62,7 +62,7 @@
 - name: Deallocate the virtual machine
   azure_rm_virtualmachine:
       resource_group: "{{ resource_group }}"
-      name: "vn{{ storage_account }}x"
+      name: "vn{{ rpfx }}x"
       allocated: no 
       vm_size: Standard_A0
   register: output
@@ -70,13 +70,13 @@
 - name: Start the virtual machine
   azure_rm_virtualmachine:
       resource_group: "{{ resource_group }}"
-      name: "vn{{ storage_account }}x"
+      name: "vn{{ rpfx }}x"
       vm_size: Standard_A0
 
 - name: Create an image from VM (check mode)
   azure_rm_image:
       resource_group: "{{ resource_group }}"
-      source: "https://{{ storage_account }}.blob.core.windows.net/vn{{ storage_account }}/vn{{ storage_account }}.vhd"
+      source: "https://{{ rpfx }}.blob.core.windows.net/vn{{ rpfx }}/vn{{ rpfx }}.vhd"
       name: testimage001
       os_type: Linux
   check_mode: yes
@@ -88,7 +88,7 @@
 - name: Create an image from VM
   azure_rm_image:
       resource_group: "{{ resource_group }}"
-      source: "https://{{ storage_account }}.blob.core.windows.net/vn{{ storage_account }}/vn{{ storage_account }}.vhd"
+      source: "https://{{ rpfx }}.blob.core.windows.net/vn{{ rpfx }}/vn{{ rpfx }}.vhd"
       name: testimage001
       os_type: Linux
   register: output
@@ -101,7 +101,7 @@
 - name: Create an image from VM (idempotent)
   azure_rm_image:
       resource_group: "{{ resource_group }}"
-      source: "https://{{ storage_account }}.blob.core.windows.net/vn{{ storage_account }}/vn{{ storage_account }}.vhd"
+      source: "https://{{ rpfx }}.blob.core.windows.net/vn{{ rpfx }}/vn{{ rpfx }}.vhd"
       name: testimage001
       os_type: Linux
   register: output
@@ -148,7 +148,7 @@
 - name: Delete VM
   azure_rm_virtualmachine:
       resource_group: "{{ resource_group }}"
-      name: "vn{{ storage_account }}x"
+      name: "vn{{ rpfx }}x"
       state: absent
       vm_size: Standard_A0
   register: output
@@ -157,5 +157,5 @@
   azure_rm_publicipaddress:
       resource_group: "{{ resource_group }}"
       allocation_method: Static
-      name: "vn{{ storage_account }}"
+      name: "vn{{ rpfx }}"
       state: absent

--- a/test/integration/targets/azure_rm_image/tasks/main.yml
+++ b/test/integration/targets/azure_rm_image/tasks/main.yml
@@ -11,48 +11,48 @@
 - name: Create virtual network
   azure_rm_virtualnetwork:
       resource_group: "{{ resource_group }}"
-      name: testvm001
+      name: "vn{{ storage_account }}"
       address_prefixes: "10.10.0.0/16"
 
 - name: Add subnet
   azure_rm_subnet:
       resource_group: "{{ resource_group }}"
-      name: testvm001
+      name: "vn{{ storage_account }}"
       address_prefix: "10.10.0.0/24"
-      virtual_network: testvm001
+      virtual_network: "vn{{ storage_account }}"
 
 - name: Create public ip
   azure_rm_publicipaddress:
       resource_group: "{{ resource_group }}"
       allocation_method: Static
-      name: testvm001
+      name: "vn{{ storage_account }}"
 
 - name: Create security group
   azure_rm_securitygroup:
       resource_group: "{{ resource_group }}"
-      name: testvm001
+      name: "vn{{ storage_account }}"
 
 - name: Create NIC
   azure_rm_networkinterface:
       resource_group: "{{ resource_group }}"
-      name: testvm001
-      virtual_network: testvm001
-      subnet: testvm001
-      public_ip_name: testvm001
-      security_group: testvm001
+      name: "vn{{ storage_account }}"
+      virtual_network: "vn{{ storage_account }}"
+      subnet: "vn{{ storage_account }}"
+      public_ip_name: "vn{{ storage_account }}"
+      security_group: "vn{{ storage_account }}"
 
 - name: Create virtual machine
   azure_rm_virtualmachine:
       resource_group: "{{ resource_group }}"
-      name: testvm002
+      name: "vn{{ storage_account }}x"
       vm_size: Standard_A0
       storage_account: "{{ storage_account }}"
-      storage_container: testvm001
-      storage_blob: testvm001.vhd
+      storage_container: "vn{{ storage_account }}"
+      storage_blob: "vn{{ storage_account }}".vhd
       admin_username: adminuser
       admin_password: Password123!
       os_type: Linux
-      network_interfaces: testvm001
+      network_interfaces: "vn{{ storage_account }}"
       image:
         offer: UbuntuServer
         publisher: Canonical
@@ -62,7 +62,7 @@
 - name: Deallocate the virtual machine
   azure_rm_virtualmachine:
       resource_group: "{{ resource_group }}"
-      name: testvm002
+      name: "vn{{ storage_account }}x"
       allocated: no 
       vm_size: Standard_A0
   register: output
@@ -70,13 +70,13 @@
 - name: Start the virtual machine
   azure_rm_virtualmachine:
       resource_group: "{{ resource_group }}"
-      name: testvm002
+      name: "vn{{ storage_account }}x"
       vm_size: Standard_A0
 
 - name: Create an image from VM (check mode)
   azure_rm_image:
       resource_group: "{{ resource_group }}"
-      source: "https://{{ storage_account }}.blob.core.windows.net/testvm001/testvm001.vhd"
+      source: "https://{{ storage_account }}.blob.core.windows.net/"vn{{ storage_account }}"/"vn{{ storage_account }}".vhd"
       name: testimage001
       os_type: Linux
   check_mode: yes
@@ -88,7 +88,7 @@
 - name: Create an image from VM
   azure_rm_image:
       resource_group: "{{ resource_group }}"
-      source: "https://{{ storage_account }}.blob.core.windows.net/testvm001/testvm001.vhd"
+      source: "https://{{ storage_account }}.blob.core.windows.net/"vn{{ storage_account }}"/"vn{{ storage_account }}".vhd"
       name: testimage001
       os_type: Linux
   register: output
@@ -101,7 +101,7 @@
 - name: Create an image from VM (idempotent)
   azure_rm_image:
       resource_group: "{{ resource_group }}"
-      source: "https://{{ storage_account }}.blob.core.windows.net/testvm001/testvm001.vhd"
+      source: "https://{{ storage_account }}.blob.core.windows.net/"vn{{ storage_account }}"/"vn{{ storage_account }}".vhd"
       name: testimage001
       os_type: Linux
   register: output
@@ -148,7 +148,14 @@
 - name: Delete VM
   azure_rm_virtualmachine:
       resource_group: "{{ resource_group }}"
-      name: testvm002
+      name: "vn{{ storage_account }}x"
       state: absent
       vm_size: Standard_A0
   register: output
+
+- name: Delete public ip
+  azure_rm_publicipaddress:
+      resource_group: "{{ resource_group }}"
+      allocation_method: Static
+      name: "vn{{ storage_account }}"
+      state: absent

--- a/test/integration/targets/azure_rm_image/tasks/main.yml
+++ b/test/integration/targets/azure_rm_image/tasks/main.yml
@@ -1,6 +1,5 @@
 - name: Create storage account name
   set_fact:
-      blob_name: "{{ resource_group | hash('md5') | truncate(7, True, '') }}{{ 1000 | random }}"
       vm_name: "vm{{ resource_group | hash('md5') | truncate(7, True, '') }}{{ 1000 | random }}x"
       storage_name: "st{{ resource_group | hash('md5') | truncate(7, True, '') }}{{ 1000 | random }}"
       storage_container_name: "sc{{ resource_group | hash('md5') | truncate(7, True, '') }}{{ 1000 | random }}"

--- a/test/integration/targets/azure_rm_loadbalancer/tasks/main.yml
+++ b/test/integration/targets/azure_rm_loadbalancer/tasks/main.yml
@@ -2,8 +2,11 @@
   set_fact:
     pipaname: "pipa{{ resource_group | hash('md5') | truncate(7, True, '') }}{{ 1000 | random }}"
     pipbname: "pipb{{ resource_group | hash('md5') | truncate(7, True, '') }}{{ 1000 | random }}"
-    lbname: "lb{{ resource_group | hash('md5') | truncate(7, True, '') }}{{ 1000 | random }}"
     lbvnname: "lbvn{{ resource_group | hash('md5') | truncate(7, True, '') }}{{ 1000 | random }}"
+    lbname_a: "lba{{ resource_group | hash('md5') | truncate(7, True, '') }}{{ 1000 | random }}"
+    lbname_b: "lbb{{ resource_group | hash('md5') | truncate(7, True, '') }}{{ 1000 | random }}"
+    lbname_c: "lbc{{ resource_group | hash('md5') | truncate(7, True, '') }}{{ 1000 | random }}"
+    lbname_d: "lbd{{ resource_group | hash('md5') | truncate(7, True, '') }}{{ 1000 | random }}"
   run_once: yes
 
 - name: create public ip
@@ -21,13 +24,13 @@
 - name: clear load balancer
   azure_rm_loadbalancer:
     resource_group: '{{ resource_group }}'
-    name: "{{ lbname }}"
+    name: "{{ lbname_a }}"
     state: absent
 
 - name: create load balancer
   azure_rm_loadbalancer:
     resource_group: '{{ resource_group }}'
-    name: "{{ lbname }}"
+    name: "{{ lbname_a }}"
     public_ip: "{{ pipaname }}"
   register: output
 
@@ -38,7 +41,7 @@
 - name: delete load balancer
   azure_rm_loadbalancer:
     resource_group: '{{ resource_group }}'
-    name: "{{ lbname }}"
+    name: "{{ lbname_a }}"
     state: absent
   register: output
 
@@ -49,7 +52,7 @@
 - name: delete load balancer (idempotent)
   azure_rm_loadbalancer:
     resource_group: '{{ resource_group }}'
-    name: "{{ lbname }}"
+    name: "{{ lbname_a }}"
     state: absent
   register: output
 
@@ -60,7 +63,7 @@
 - name: create another load balancer with more options
   azure_rm_loadbalancer:
     resource_group: '{{ resource_group }}'
-    name: "{{ lbname }}"
+    name: "{{ lbname_b }}"
     sku: Standard
     public_ip_address: "{{ pipbname }}"
     probe_protocol: Tcp
@@ -87,13 +90,13 @@
 - name: delete load balancer
   azure_rm_loadbalancer:
     resource_group: '{{ resource_group }}'
-    name: "{{ lbname }}"
+    name: "{{ lbname_b }}"
     state: absent
 
 - name: create load balancer with multiple parameters
   azure_rm_loadbalancer:
     resource_group: '{{ resource_group }}'
-    name: "{{ lbname }}"
+    name: "{{ lbname_c }}"
     frontend_ip_configurations:
       - name: frontendipconf0
         public_ip_address: "{{ pipaname }}"
@@ -125,7 +128,7 @@
 - name: delete load balancer
   azure_rm_loadbalancer:
     resource_group: '{{ resource_group }}'
-    name: "{{ lbname }}"
+    name: "{{ lbname_c }}"
     state: absent
 
 - name: Create virtual network
@@ -145,7 +148,7 @@
 - name: create internal loadbalancer
   azure_rm_loadbalancer:
     resource_group: '{{ resource_group }}'
-    name: "{{ lbname }}"
+    name: "{{ lbname_d }}"
     frontend_ip_configurations:
       - name: frontendipconf0
         private_ip_address: 10.10.0.10
@@ -179,7 +182,7 @@
 - name: delete load balancer
   azure_rm_loadbalancer:
     resource_group: '{{ resource_group }}'
-    name: "{{ lbname }}"
+    name: "{{ lbname_d }}"
     state: absent
 
 - name: cleanup public ip

--- a/test/integration/targets/azure_rm_managed_disk/tasks/main.yml
+++ b/test/integration/targets/azure_rm_managed_disk/tasks/main.yml
@@ -1,7 +1,8 @@
  - name: Setup variables...
    set_fact:
-       managed_disk1: "{{ resource_group | hash('md5') | truncate(24, True, '') }}"
-       managed_disk2: "{{ resource_group | hash('md5') | truncate(18, True, '') }}"
+       managed_disk1: "{{ resource_group | hash('md5') | truncate(20, True, '') }}{{ 1000 | random }}"
+       managed_disk2: "{{ resource_group | hash('md5') | truncate(14, True, '') }}{{ 1000 | random }}"
+       test_resource_name: "{{ resource_group | hash('md5') | truncate(14, True, '') }}{{ 1000 | random }}"
 
  - name: Clearing (if) previous disks were created
    azure_rm_managed_disk:
@@ -190,46 +191,46 @@
  - name: Create virtual network
    azure_rm_virtualnetwork:
        resource_group: "{{ resource_group }}"
-       name: testvm001
+       name: "{{ test_resource_name }}"
        address_prefixes: "10.10.0.0/16"
 
  - name: Add subnet
    azure_rm_subnet:
        resource_group: "{{ resource_group }}"
-       name: testvm001
+       name: "{{ test_resource_name }}"
        address_prefix: "10.10.0.0/24"
-       virtual_network: testvm001
+       virtual_network: "{{ test_resource_name }}"
 
  - name: Create public ip
    azure_rm_publicipaddress:
        resource_group: "{{ resource_group }}"
        allocation_method: Static
-       name: testvm001
+       name: "{{ test_resource_name }}"
 
  - name: Create security group
    azure_rm_securitygroup:
        resource_group: "{{ resource_group }}"
-       name: testvm001
+       name: "{{ test_resource_name }}"
 
  - name: Create NIC
    azure_rm_networkinterface:
        resource_group: "{{ resource_group }}"
-       name: testvm001
-       virtual_network: testvm001
-       subnet: testvm001
-       public_ip_name: testvm001
-       security_group: testvm001
+       name: "{{ test_resource_name }}"
+       virtual_network: "{{ test_resource_name }}"
+       subnet: "{{ test_resource_name }}"
+       public_ip_name: "{{ test_resource_name }}"
+       security_group: "{{ test_resource_name }}"
 
  - name: Create virtual machine
    azure_rm_virtualmachine:
        resource_group: "{{ resource_group }}"
-       name: testvm001
+       name: "{{ test_resource_name }}"
        admin_username: adminuser
        admin_password: Password123!
        os_type: Linux
        managed_disk_type: Premium_LRS
        vm_size: Standard_DS1_v2
-       network_interfaces: testvm001
+       network_interfaces: "{{ test_resource_name }}"
        image:
          offer: UbuntuServer
          publisher: Canonical
@@ -241,7 +242,7 @@
        resource_group: "{{ resource_group }}"
        name: "{{ managed_disk1 }}"
        disk_size_gb: 2
-       managed_by: testvm001
+       managed_by: "{{ test_resource_name }}"
        tags:
            testing: testing
            delete: never
@@ -257,7 +258,7 @@
        resource_group: "{{ resource_group }}"
        name: "{{ managed_disk1 }}"
        disk_size_gb: 2
-       managed_by: testvm001
+       managed_by: "{{ test_resource_name }}"
        tags:
            testing: testing
            delete: never
@@ -265,14 +266,14 @@
 
  - assert:
      that:
-       - "'testvm001' in mounted.state.managed_by"
+       - "'"{{ test_resource_name }}"' in mounted.state.managed_by"
 
  - name: Mount the disk to virtual machine (idempotent)
    azure_rm_managed_disk:
        resource_group: "{{ resource_group }}"
        name: "{{ managed_disk1 }}"
        disk_size_gb: 2
-       managed_by: testvm001
+       managed_by: "{{ test_resource_name }}"
        tags:
            testing: testing
            delete: never
@@ -281,7 +282,7 @@
  - assert:
      that:
        - not mounted.changed
-       - "'testvm001' in mounted.state.managed_by"
+       - "'"{{ test_resource_name }}"' in mounted.state.managed_by"
  
  - name: Unmount the disk to virtual machine (check mode)
    azure_rm_managed_disk:
@@ -347,7 +348,7 @@
        resource_group: "{{ resource_group }}"
        name: "{{ managed_disk1 }}"
        disk_size_gb: 4
-       managed_by: testvm001
+       managed_by: "{{ test_resource_name }}"
        tags:
            testing: testing
            delete: never
@@ -356,14 +357,14 @@
  - assert:
      that:
        - mounted.changed
-       - "'testvm001' in mounted.state.managed_by"
+       - "'"{{ test_resource_name }}"' in mounted.state.managed_by"
 
  - name: Change disk size to incompatible size
    azure_rm_managed_disk:
        resource_group: "{{ resource_group }}"
        name: "{{ managed_disk1 }}"
        state: absent
-       managed_by: testvm001
+       managed_by: "{{ test_resource_name }}"
    register: output
    ignore_errors: yes
 
@@ -402,6 +403,14 @@
  - name: Delete virtual machine
    azure_rm_virtualmachine:
        resource_group: "{{ resource_group }}"
-       name: testvm001
+       name: "{{ test_resource_name }}"
        state: absent
        vm_size: Standard_DS1_v2
+
+ - name: Delete public ip
+   azure_rm_publicipaddress:
+       resource_group: "{{ resource_group }}"
+       allocation_method: Static
+       name: "{{ test_resource_name }}"
+       state: absent
+

--- a/test/integration/targets/azure_rm_managed_disk/tasks/main.yml
+++ b/test/integration/targets/azure_rm_managed_disk/tasks/main.yml
@@ -1,8 +1,7 @@
- - name: Setup variables...
+ - name: Prepare random number
    set_fact:
-       managed_disk1: "{{ resource_group | hash('md5') | truncate(20, True, '') }}{{ 1000 | random }}"
-       managed_disk2: "{{ resource_group | hash('md5') | truncate(14, True, '') }}{{ 1000 | random }}"
-       test_resource_name: "{{ resource_group | hash('md5') | truncate(14, True, '') }}{{ 1000 | random }}"
+     rpfx: "{{ resource_group | hash('md5') | truncate(7, True, '') }}{{ 1000 | random }}"
+   run_once: yes
 
  - name: Clearing (if) previous disks were created
    azure_rm_managed_disk:
@@ -10,13 +9,13 @@
        name: "{{item }}"
        state: absent
    with_items:
-     - "{{ managed_disk2 }}"
-     - "{{ managed_disk1 }}"
+     - "md{{ rpfx }}2"
+     - "md{{ rpfx }}1"
 
  - name: Create managed disk (Check Mode)
    azure_rm_managed_disk:
        resource_group: "{{ resource_group }}"
-       name: "{{ managed_disk1 }}"
+       name: "md{{ rpfx }}1"
        disk_size_gb: 1
        tags:
            testing: testing
@@ -46,7 +45,7 @@
  - name: Create new managed disk succesfully
    azure_rm_managed_disk:
        resource_group: "{{ resource_group }}"
-       name: "{{ managed_disk1 }}"
+       name: "md{{ rpfx }}1"
        storage_account_type: "Standard_LRS"
        disk_size_gb: 1
        tags:
@@ -63,7 +62,7 @@
  - name: Copy disk to a new managed disk
    azure_rm_managed_disk:
        resource_group: "{{ resource_group }}"
-       name: "{{ managed_disk2 }}"
+       name: "md{{ rpfx }}2"
        create_option: "copy"
        source_resource_uri: "{{ output.state.id }}"
        disk_size_gb: 1
@@ -78,7 +77,7 @@
  - name: Update a new disk without changes
    azure_rm_managed_disk:
        resource_group: "{{ resource_group }}"
-       name: "{{ managed_disk1 }}"
+       name: "md{{ rpfx }}1"
        storage_account_type: "Standard_LRS"
        disk_size_gb: 1
    register: output
@@ -92,7 +91,7 @@
  - name: Change storage account type to an invalid type
    azure_rm_managed_disk:
        resource_group: "{{ resource_group }}"
-       name: "{{ managed_disk1 }}"
+       name: "md{{ rpfx }}1"
        storage_account_type: "PremiumL"
        disk_size_gb: 1
    register: output
@@ -104,7 +103,7 @@
  - name: Change disk size to incompatible size
    azure_rm_managed_disk:
        resource_group: "{{ resource_group }}"
-       name: "{{ managed_disk1 }}"
+       name: "md{{ rpfx }}1"
        disk_size_gb: 30000
    register: output
    ignore_errors: yes
@@ -115,7 +114,7 @@
  - name: Change disk to bigger size
    azure_rm_managed_disk:
        resource_group: "{{ resource_group }}"
-       name: "{{ managed_disk1 }}"
+       name: "md{{ rpfx }}1"
        disk_size_gb: 2
    register: output
 
@@ -127,7 +126,7 @@
  - name: Change disk to Premium
    azure_rm_managed_disk:
        resource_group: "{{ resource_group }}"
-       name: "{{ managed_disk1 }}"
+       name: "md{{ rpfx }}1"
        storage_account_type: "Premium_LRS"
        disk_size_gb: 2
    register: output
@@ -140,7 +139,7 @@
  - name: Update disk tags
    azure_rm_managed_disk:
        resource_group: "{{ resource_group }}"
-       name: "{{ managed_disk1 }}"
+       name: "md{{ rpfx }}1"
        disk_size_gb: 2
        tags:
            testing: testing
@@ -157,7 +156,7 @@
  - name: Update disk tags
    azure_rm_managed_disk:
        resource_group: "{{ resource_group }}"
-       name: "{{ managed_disk1 }}"
+       name: "md{{ rpfx }}1"
        disk_size_gb: 2
        tags:
            testing: testing
@@ -174,7 +173,7 @@
  - name: Gather facts to one specific disk
    azure_rm_managed_disk_facts:
        resource_group: "{{ resource_group }}"
-       name: "{{ managed_disk1 }}"
+       name: "md{{ rpfx }}1"
 
  - assert:
        that:
@@ -191,46 +190,46 @@
  - name: Create virtual network
    azure_rm_virtualnetwork:
        resource_group: "{{ resource_group }}"
-       name: "{{ test_resource_name }}"
+       name: "tr{{ rpfx }}"
        address_prefixes: "10.10.0.0/16"
 
  - name: Add subnet
    azure_rm_subnet:
        resource_group: "{{ resource_group }}"
-       name: "{{ test_resource_name }}"
+       name: "tr{{ rpfx }}"
        address_prefix: "10.10.0.0/24"
-       virtual_network: "{{ test_resource_name }}"
+       virtual_network: "tr{{ rpfx }}"
 
  - name: Create public ip
    azure_rm_publicipaddress:
        resource_group: "{{ resource_group }}"
        allocation_method: Static
-       name: "{{ test_resource_name }}"
+       name: "tr{{ rpfx }}"
 
  - name: Create security group
    azure_rm_securitygroup:
        resource_group: "{{ resource_group }}"
-       name: "{{ test_resource_name }}"
+       name: "tr{{ rpfx }}"
 
  - name: Create NIC
    azure_rm_networkinterface:
        resource_group: "{{ resource_group }}"
-       name: "{{ test_resource_name }}"
-       virtual_network: "{{ test_resource_name }}"
-       subnet: "{{ test_resource_name }}"
-       public_ip_name: "{{ test_resource_name }}"
-       security_group: "{{ test_resource_name }}"
+       name: "tr{{ rpfx }}"
+       virtual_network: "tr{{ rpfx }}"
+       subnet: "tr{{ rpfx }}"
+       public_ip_name: "tr{{ rpfx }}"
+       security_group: "tr{{ rpfx }}"
 
  - name: Create virtual machine
    azure_rm_virtualmachine:
        resource_group: "{{ resource_group }}"
-       name: "{{ test_resource_name }}"
+       name: "tr{{ rpfx }}"
        admin_username: adminuser
        admin_password: Password123!
        os_type: Linux
        managed_disk_type: Premium_LRS
        vm_size: Standard_DS1_v2
-       network_interfaces: "{{ test_resource_name }}"
+       network_interfaces: "tr{{ rpfx }}"
        image:
          offer: UbuntuServer
          publisher: Canonical
@@ -240,9 +239,9 @@
  - name: Mount the disk to virtual machine (check mode)
    azure_rm_managed_disk:
        resource_group: "{{ resource_group }}"
-       name: "{{ managed_disk1 }}"
+       name: "md{{ rpfx }}1"
        disk_size_gb: 2
-       managed_by: "{{ test_resource_name }}"
+       managed_by: "tr{{ rpfx }}"
        tags:
            testing: testing
            delete: never
@@ -256,9 +255,9 @@
  - name: Mount the disk to virtual machine
    azure_rm_managed_disk:
        resource_group: "{{ resource_group }}"
-       name: "{{ managed_disk1 }}"
+       name: "md{{ rpfx }}1"
        disk_size_gb: 2
-       managed_by: "{{ test_resource_name }}"
+       managed_by: "tr{{ rpfx }}"
        tags:
            testing: testing
            delete: never
@@ -266,14 +265,14 @@
 
  - assert:
      that:
-       - "'{{ test_resource_name }}' in mounted.state.managed_by"
+       - "'tr{{ rpfx }}' in mounted.state.managed_by"
 
  - name: Mount the disk to virtual machine (idempotent)
    azure_rm_managed_disk:
        resource_group: "{{ resource_group }}"
-       name: "{{ managed_disk1 }}"
+       name: "md{{ rpfx }}1"
        disk_size_gb: 2
-       managed_by: "{{ test_resource_name }}"
+       managed_by: "tr{{ rpfx }}"
        tags:
            testing: testing
            delete: never
@@ -282,12 +281,12 @@
  - assert:
      that:
        - not mounted.changed
-       - "'{{ test_resource_name }}' in mounted.state.managed_by"
+       - "'tr{{ rpfx }}' in mounted.state.managed_by"
  
  - name: Unmount the disk to virtual machine (check mode)
    azure_rm_managed_disk:
        resource_group: "{{ resource_group }}"
-       name: "{{ managed_disk1 }}"
+       name: "md{{ rpfx }}1"
        disk_size_gb: 2
        tags:
            testing: testing
@@ -302,7 +301,7 @@
  - name: Unmount the disk to virtual machine
    azure_rm_managed_disk:
        resource_group: "{{ resource_group }}"
-       name: "{{ managed_disk1 }}"
+       name: "md{{ rpfx }}1"
        disk_size_gb: 2
        tags:
            testing: testing
@@ -317,7 +316,7 @@
  - name: Unmount the disk to virtual machine (idempotent)
    azure_rm_managed_disk:
        resource_group: "{{ resource_group }}"
-       name: "{{ managed_disk1 }}"
+       name: "md{{ rpfx }}1"
        disk_size_gb: 2
        tags:
            testing: testing
@@ -332,7 +331,7 @@
  - name: Update disk size
    azure_rm_managed_disk:
        resource_group: "{{ resource_group }}"
-       name: "{{ managed_disk1 }}"
+       name: "md{{ rpfx }}1"
        disk_size_gb: 4
        tags:
            testing: testing
@@ -346,9 +345,9 @@
  - name: Attach the disk to virtual machine again
    azure_rm_managed_disk:
        resource_group: "{{ resource_group }}"
-       name: "{{ managed_disk1 }}"
+       name: "md{{ rpfx }}1"
        disk_size_gb: 4
-       managed_by: "{{ test_resource_name }}"
+       managed_by: "tr{{ rpfx }}"
        tags:
            testing: testing
            delete: never
@@ -357,14 +356,14 @@
  - assert:
      that:
        - mounted.changed
-       - "'{{ test_resource_name }}' in mounted.state.managed_by"
+       - "'tr{{ rpfx }}' in mounted.state.managed_by"
 
  - name: Change disk size to incompatible size
    azure_rm_managed_disk:
        resource_group: "{{ resource_group }}"
-       name: "{{ managed_disk1 }}"
+       name: "md{{ rpfx }}1"
        state: absent
-       managed_by: "{{ test_resource_name }}"
+       managed_by: "tr{{ rpfx }}"
    register: output
    ignore_errors: yes
 
@@ -374,7 +373,7 @@
  - name: Delete managed disk (Check Mode)
    azure_rm_managed_disk:
        resource_group: "{{ resource_group }}"
-       name: "{{ managed_disk1 }}"
+       name: "md{{ rpfx }}1"
        state: absent
    register: output
    check_mode: yes
@@ -388,14 +387,14 @@
  - name: Delete managed disk
    azure_rm_managed_disk:
        resource_group: "{{ resource_group }}"
-       name: "{{ managed_disk2 }}"
+       name: "md{{ rpfx }}2"
        state: absent
    check_mode: no
 
  - name: Delete copied managed disk
    azure_rm_managed_disk:
        resource_group: "{{ resource_group }}"
-       name: "{{ managed_disk1 }}"
+       name: "md{{ rpfx }}1"
        disk_size_gb: 2
        state: absent
    check_mode: no
@@ -403,7 +402,7 @@
  - name: Delete virtual machine
    azure_rm_virtualmachine:
        resource_group: "{{ resource_group }}"
-       name: "{{ test_resource_name }}"
+       name: "tr{{ rpfx }}"
        state: absent
        vm_size: Standard_DS1_v2
 
@@ -411,6 +410,5 @@
    azure_rm_publicipaddress:
        resource_group: "{{ resource_group }}"
        allocation_method: Static
-       name: "{{ test_resource_name }}"
+       name: "tr{{ rpfx }}"
        state: absent
-

--- a/test/integration/targets/azure_rm_managed_disk/tasks/main.yml
+++ b/test/integration/targets/azure_rm_managed_disk/tasks/main.yml
@@ -266,7 +266,7 @@
 
  - assert:
      that:
-       - "'"{{ test_resource_name }}"' in mounted.state.managed_by"
+       - "'{{ test_resource_name }}' in mounted.state.managed_by"
 
  - name: Mount the disk to virtual machine (idempotent)
    azure_rm_managed_disk:
@@ -282,7 +282,7 @@
  - assert:
      that:
        - not mounted.changed
-       - "'"{{ test_resource_name }}"' in mounted.state.managed_by"
+       - "'{{ test_resource_name }}' in mounted.state.managed_by"
  
  - name: Unmount the disk to virtual machine (check mode)
    azure_rm_managed_disk:
@@ -357,7 +357,7 @@
  - assert:
      that:
        - mounted.changed
-       - "'"{{ test_resource_name }}"' in mounted.state.managed_by"
+       - "'{{ test_resource_name }}' in mounted.state.managed_by"
 
  - name: Change disk size to incompatible size
    azure_rm_managed_disk:

--- a/test/integration/targets/azure_rm_networkinterface/tasks/main.yml
+++ b/test/integration/targets/azure_rm_networkinterface/tasks/main.yml
@@ -238,7 +238,7 @@
 - name: IP configuration without public IP and NSG
   azure_rm_networkinterface:
       resource_group: "{{ resource_group }}"
-      name: "tn{{ rpfx }}"noip
+      name: "tn{{ rpfx }}noip"
       create_with_security_group: False
       virtual_network: "{{ vn.state.id }}"
       subnet: "tn{{ rpfx }}"
@@ -271,7 +271,7 @@
       state: absent
   with_items:
     - "tn{{ rpfx }}"
-    - "tn{{ rpfx }}"noip
+    - "tn{{ rpfx }}noip"
   register: output
 
 - assert:

--- a/test/integration/targets/azure_rm_networkinterface/tasks/main.yml
+++ b/test/integration/targets/azure_rm_networkinterface/tasks/main.yml
@@ -289,6 +289,35 @@
     that:
       - not output.changed
 
+- name: delete load balancer
+  azure_rm_loadbalancer:
+    resource_group: '{{ resource_group }}'
+    name: "lb{{ rpfx }}"
+    frontend_ip_configurations:
+      - name: frontendipconf0
+        public_ip_address: "pip{{ rpfx }}"
+    backend_address_pools:
+      - name: backendaddrpool0
+      - name: backendaddrpool1
+    probes:
+      - name: prob0
+        port: 80
+    inbound_nat_pools:
+      - name: inboundnatpool0
+        frontend_ip_configuration_name: frontendipconf0
+        protocol: Tcp
+        frontend_port_range_start: 80
+        frontend_port_range_end: 81
+        backend_port: 8080
+    load_balancing_rules:
+      - name: lbrbalancingrule0
+        frontend_ip_configuration: frontendipconf0
+        backend_address_pool: backendaddrpool0
+        frontend_port: 80
+        backend_port: 80
+        probe: prob0
+    state: absent
+
 - name: delete public ip
   azure_rm_publicipaddress:
     name: "pip{{ rpfx }}"

--- a/test/integration/targets/azure_rm_networkinterface/tasks/main.yml
+++ b/test/integration/targets/azure_rm_networkinterface/tasks/main.yml
@@ -1,29 +1,34 @@
+- name: Prepare random number
+  set_fact:
+    rpfx: "{{ resource_group | hash('md5') | truncate(7, True, '') }}{{ 1000 | random }}"
+  run_once: yes
+
 - name: Create virtual network
   azure_rm_virtualnetwork:
       resource_group: "{{ resource_group_secondary }}"
-      name: testnic001
+      name: "tn{{ rpfx }}"
       address_prefixes: "10.10.0.0/16"
   register: vn
 
 - name: Add subnet
   azure_rm_subnet:
       resource_group: "{{ resource_group_secondary }}"
-      name: testnic001
+      name: "tn{{ rpfx }}"
       address_prefix: "10.10.0.0/24"
-      virtual_network: testnic001
+      virtual_network: "tn{{ rpfx }}"
 
 - name: create public ip
   azure_rm_publicipaddress:
-    name: ansiblepip3
+    name: "pip{{ rpfx }}"
     resource_group: '{{ resource_group }}'
 
 - name: create load balancer with multiple parameters
   azure_rm_loadbalancer:
     resource_group: '{{ resource_group }}'
-    name: lbtestfromansible
+    name: "lb{{ rpfx }}"
     frontend_ip_configurations:
       - name: frontendipconf0
-        public_ip_address: ansiblepip3
+        public_ip_address: "pip{{ rpfx }}"
     backend_address_pools:
       - name: backendaddrpool0
       - name: backendaddrpool1
@@ -48,18 +53,18 @@
 
 - name: create public ip
   azure_rm_publicipaddress:
-    name: ansiblepip3
+    name: "pip{{ rpfx }}"
     resource_group: '{{ resource_group }}'
 
 - name: Create NIC (check mode)
   azure_rm_networkinterface:
       resource_group: "{{ resource_group }}"
-      name: testnic001
+      name: "tn{{ rpfx }}"
       virtual_network: "{{ vn.state.id }}"
-      subnet: testnic001
-      public_ip_name: testnic001
+      subnet: "tn{{ rpfx }}"
+      public_ip_name: "tn{{ rpfx }}"
       public_ip_allocation_method: Static
-      security_group: testnic001
+      security_group: "tn{{ rpfx }}"
   register: output
   check_mode: yes
 
@@ -70,27 +75,27 @@
 - name: Create NIC using virtual_network resource_group parameter
   azure_rm_networkinterface:
       resource_group: "{{ resource_group }}"
-      name: testnic001rg
+      name: "tn{{ rpfx }}"rg
       virtual_network:
-        name: testnic001
+        name: "tn{{ rpfx }}"
         resource_group: "{{ resource_group_secondary }}"
-      subnet: testnic001
-      public_ip_name: testnic001rg
+      subnet: "tn{{ rpfx }}"
+      public_ip_name: "tn{{ rpfx }}"rg
       public_ip_allocation_method: Static
-      security_group: testnic001
+      security_group: "tn{{ rpfx }}"
   register: output
 
 - name: Create NIC using virtual_network resource_group parameter (idempotent)
   azure_rm_networkinterface:
       resource_group: "{{ resource_group }}"
-      name: testnic001rg
+      name: "tn{{ rpfx }}"rg
       virtual_network:
-        name: testnic001
+        name: "tn{{ rpfx }}"
         resource_group: "{{ resource_group_secondary }}"
-      subnet: testnic001
-      public_ip_name: testnic001rg
+      subnet: "tn{{ rpfx }}"
+      public_ip_name: "tn{{ rpfx }}"rg
       public_ip_allocation_method: Static
-      security_group: testnic001
+      security_group: "tn{{ rpfx }}"
   register: output
 
 - assert:
@@ -100,16 +105,16 @@
 - name: Delete NIC
   azure_rm_networkinterface:
       resource_group: "{{ resource_group }}"
-      name: testnic001rg
+      name: "tn{{ rpfx }}"rg
       state: absent
 
 - name: Create NIC
   azure_rm_networkinterface:
       resource_group: "{{ resource_group }}"
-      name: testnic001
+      name: "tn{{ rpfx }}"
       virtual_network: "{{ vn.state.id }}"
-      subnet: testnic001
-      public_ip_name: testnic001
+      subnet: "tn{{ rpfx }}"
+      public_ip_name: "tn{{ rpfx }}"
       public_ip_allocation_method: Static
       security_group:
         name: testnic002
@@ -119,22 +124,22 @@
 - assert:
     that:
       - output.changed
-      - output.state.ip_configuration.subnet.name == 'testnic001'
+      - output.state.ip_configuration.subnet.name == '"tn{{ rpfx }}"'
 
 - name: Update the NIC with mutilple ip configurations (check mode)
   azure_rm_networkinterface:
       resource_group: "{{ resource_group }}"
-      name: testnic001
+      name: "tn{{ rpfx }}"
       security_group:
         name: testnic002
         resource_group: "{{ resource_group_secondary }}"
       virtual_network: "{{ vn.state.id }}"
-      subnet: testnic001
+      subnet: "tn{{ rpfx }}"
       ip_configurations:
         - name: ipconfig-add
           public_ip_name: testnic002
         - name: default
-          public_ip_name: testnic001
+          public_ip_name: "tn{{ rpfx }}"
           primary: True
           public_ip_allocation_method: Static
         - name: ipconfig1
@@ -149,17 +154,17 @@
 - name: Update the NIC with mutilple ip configurations
   azure_rm_networkinterface:
       resource_group: "{{ resource_group }}"
-      name: testnic001
+      name: "tn{{ rpfx }}"
       security_group: 
         name: testnic002
         resource_group: "{{ resource_group_secondary }}"
       virtual_network: "{{ vn.state.id }}"
-      subnet: testnic001
+      subnet: "tn{{ rpfx }}"
       ip_configurations:
         - name: ipconfig-add
           public_ip_name: testnic002
         - name: default
-          public_ip_name: testnic001
+          public_ip_name: "tn{{ rpfx }}"
           primary: True
           public_ip_allocation_method: Static
         - name: ipconfig1
@@ -167,7 +172,7 @@
           load_balancer_backend_address_pools:
           - "{{ lb.state.backend_address_pools[0].id }}"
           - name: backendaddrpool1
-            load_balancer: lbtestfromansible
+            load_balancer: "lb{{ rpfx }}"
   register: output
 
 - assert:
@@ -180,15 +185,15 @@
 - name: Update the NIC with mutilple ip configurations (idempotent)
   azure_rm_networkinterface:
       resource_group: "{{ resource_group }}"
-      name: testnic001
+      name: "tn{{ rpfx }}"
       security_group: "{{ output.state.network_security_group.id }}"
       virtual_network: "{{ vn.state.id }}"
-      subnet: testnic001
+      subnet: "tn{{ rpfx }}"
       ip_configurations:
         - name: ipconfig-add
           public_ip_name: testnic002
         - name: default
-          public_ip_name: testnic001
+          public_ip_name: "tn{{ rpfx }}"
           primary: True
           public_ip_allocation_method: Static
         - name: ipconfig1
@@ -196,7 +201,7 @@
           load_balancer_backend_address_pools:
           - "{{ lb.state.backend_address_pools[0].id }}"
           - name: backendaddrpool1
-            load_balancer: lbtestfromansible
+            load_balancer: "lb{{ rpfx }}"
   register: output
 
 - assert:
@@ -206,21 +211,21 @@
 - name: Remove one ip configuration
   azure_rm_networkinterface:
       resource_group: "{{ resource_group }}"
-      name: testnic001
+      name: "tn{{ rpfx }}"
       security_group:
         name: testnic002
         resource_group: "{{ resource_group_secondary }}"
       virtual_network: "{{ vn.state.id }}"
-      subnet: testnic001
+      subnet: "tn{{ rpfx }}"
       ip_configurations:
         - name: ipconfig1
           public_ip_name: testnic003
           load_balancer_backend_address_pools:
           - "{{ lb.state.backend_address_pools[0].id }}"
           - name: backendaddrpool1
-            load_balancer: lbtestfromansible
+            load_balancer: "lb{{ rpfx }}"
         - name: default
-          public_ip_name: testnic001
+          public_ip_name: "tn{{ rpfx }}"
           public_ip_allocation_method: Static
           primary: True
   register: output
@@ -233,10 +238,10 @@
 - name: IP configuration without public IP and NSG
   azure_rm_networkinterface:
       resource_group: "{{ resource_group }}"
-      name: testnic001noip
+      name: "tn{{ rpfx }}"noip
       create_with_security_group: False
       virtual_network: "{{ vn.state.id }}"
-      subnet: testnic001
+      subnet: "tn{{ rpfx }}"
       ip_configurations:
         - name: ipconfig1
           primary: True
@@ -250,7 +255,7 @@
 - name: Delete the NIC (check mode)
   azure_rm_networkinterface:
       resource_group: "{{ resource_group }}"
-      name: testnic001
+      name: "tn{{ rpfx }}"
       state: absent
   check_mode: yes
   register: output
@@ -265,8 +270,8 @@
       name: "{{ item }}"
       state: absent
   with_items:
-    - testnic001
-    - testnic001noip
+    - "tn{{ rpfx }}"
+    - "tn{{ rpfx }}"noip
   register: output
 
 - assert:
@@ -276,10 +281,16 @@
 - name: Delete the NIC (idempotent)
   azure_rm_networkinterface:
       resource_group: "{{ resource_group }}"
-      name: testnic001
+      name: "tn{{ rpfx }}"
       state: absent
   register: output
 
 - assert:
     that:
       - not output.changed
+
+- name: delete public ip
+  azure_rm_publicipaddress:
+    name: "pip{{ rpfx }}"
+    resource_group: '{{ resource_group }}'
+    state: absent

--- a/test/integration/targets/azure_rm_networkinterface/tasks/main.yml
+++ b/test/integration/targets/azure_rm_networkinterface/tasks/main.yml
@@ -75,12 +75,12 @@
 - name: Create NIC using virtual_network resource_group parameter
   azure_rm_networkinterface:
       resource_group: "{{ resource_group }}"
-      name: "tn{{ rpfx }}"rg
+      name: "tn{{ rpfx }}rg"
       virtual_network:
         name: "tn{{ rpfx }}"
         resource_group: "{{ resource_group_secondary }}"
       subnet: "tn{{ rpfx }}"
-      public_ip_name: "tn{{ rpfx }}"rg
+      public_ip_name: "tn{{ rpfx }}rg"
       public_ip_allocation_method: Static
       security_group: "tn{{ rpfx }}"
   register: output
@@ -88,12 +88,12 @@
 - name: Create NIC using virtual_network resource_group parameter (idempotent)
   azure_rm_networkinterface:
       resource_group: "{{ resource_group }}"
-      name: "tn{{ rpfx }}"rg
+      name: "tn{{ rpfx }}rg"
       virtual_network:
         name: "tn{{ rpfx }}"
         resource_group: "{{ resource_group_secondary }}"
       subnet: "tn{{ rpfx }}"
-      public_ip_name: "tn{{ rpfx }}"rg
+      public_ip_name: "tn{{ rpfx }}rg"
       public_ip_allocation_method: Static
       security_group: "tn{{ rpfx }}"
   register: output
@@ -105,7 +105,7 @@
 - name: Delete NIC
   azure_rm_networkinterface:
       resource_group: "{{ resource_group }}"
-      name: "tn{{ rpfx }}"rg
+      name: "tn{{ rpfx }}rg"
       state: absent
 
 - name: Create NIC
@@ -117,27 +117,27 @@
       public_ip_name: "tn{{ rpfx }}"
       public_ip_allocation_method: Static
       security_group:
-        name: testnic002
+        name: "tn{{ rpfx }}2"
         resource_group: "{{ resource_group_secondary }}"
   register: output
 
 - assert:
     that:
       - output.changed
-      - output.state.ip_configuration.subnet.name == '"tn{{ rpfx }}"'
+      - output.state.ip_configuration.subnet.name == 'tn{{ rpfx }}'
 
 - name: Update the NIC with mutilple ip configurations (check mode)
   azure_rm_networkinterface:
       resource_group: "{{ resource_group }}"
       name: "tn{{ rpfx }}"
       security_group:
-        name: testnic002
+        name: "tn{{ rpfx }}2"
         resource_group: "{{ resource_group_secondary }}"
       virtual_network: "{{ vn.state.id }}"
       subnet: "tn{{ rpfx }}"
       ip_configurations:
         - name: ipconfig-add
-          public_ip_name: testnic002
+          public_ip_name: "tn{{ rpfx }}2"
         - name: default
           public_ip_name: "tn{{ rpfx }}"
           primary: True
@@ -156,13 +156,13 @@
       resource_group: "{{ resource_group }}"
       name: "tn{{ rpfx }}"
       security_group: 
-        name: testnic002
+        name: "tn{{ rpfx }}2"
         resource_group: "{{ resource_group_secondary }}"
       virtual_network: "{{ vn.state.id }}"
       subnet: "tn{{ rpfx }}"
       ip_configurations:
         - name: ipconfig-add
-          public_ip_name: testnic002
+          public_ip_name: "tn{{ rpfx }}2"
         - name: default
           public_ip_name: "tn{{ rpfx }}"
           primary: True
@@ -180,7 +180,7 @@
       - output.changed
       - not output.state.ip_configuration
       - output.state.ip_configurations | length == 3
-      - output.state.network_security_group.name == 'testnic002'
+      - output.state.network_security_group.name == 'tn{{ rpfx }}2'
 
 - name: Update the NIC with mutilple ip configurations (idempotent)
   azure_rm_networkinterface:
@@ -191,7 +191,7 @@
       subnet: "tn{{ rpfx }}"
       ip_configurations:
         - name: ipconfig-add
-          public_ip_name: testnic002
+          public_ip_name: "tn{{ rpfx }}2"
         - name: default
           public_ip_name: "tn{{ rpfx }}"
           primary: True
@@ -213,7 +213,7 @@
       resource_group: "{{ resource_group }}"
       name: "tn{{ rpfx }}"
       security_group:
-        name: testnic002
+        name: "tn{{ rpfx }}2"
         resource_group: "{{ resource_group_secondary }}"
       virtual_network: "{{ vn.state.id }}"
       subnet: "tn{{ rpfx }}"

--- a/test/integration/targets/azure_rm_publicipaddress/tasks/main.yml
+++ b/test/integration/targets/azure_rm_publicipaddress/tasks/main.yml
@@ -1,17 +1,18 @@
 - name: Create domain name
   set_fact:
       domain_name: "ansible-{{ resource_group | hash('md5') | truncate(24, True, '') }}"
+      rpfx: "{{ resource_group | hash('md5') | truncate(7, True, '') }}{{ 1000 | random }}"
 
 - name: Remove public ip
   azure_rm_publicipaddress:
       resource_group: "{{ resource_group }}"
-      name: testing01
+      name: "pip{{ rpfx }}"
       state:  absent
 
 - name: Create public ip
   azure_rm_publicipaddress:
       resource_group: "{{ resource_group }}"
-      name: testing01
+      name: "pip{{ rpfx }}"
       allocation_method: Static
       domain_name: "{{ domain_name }}"
       tags:
@@ -29,7 +30,7 @@
 - name: Should be idempotent
   azure_rm_publicipaddress:
       resource_group: "{{ resource_group }}"
-      name: testing01
+      name: "pip{{ rpfx }}"
       allocation_method: Static
       domain_name: "{{ domain_name }}"
       tags:
@@ -43,7 +44,7 @@
 - name: Update tags
   azure_rm_publicipaddress:
       resource_group: "{{ resource_group }}"
-      name: testing01
+      name: "pip{{ rpfx }}"
       tags:
           testing: testing
           delete: never
@@ -68,7 +69,7 @@
 - name: Purge all tags
   azure_rm_publicipaddress:
       resource_group: "{{ resource_group }}"
-      name: testing01
+      name: "pip{{ rpfx }}"
       tags: {}
   register: output
 
@@ -79,7 +80,7 @@
 - name: Gather facts for a public ip
   azure_rm_publicipaddress_facts:
       resource_group: "{{ resource_group }}"
-      name: testing01
+      name: "pip{{ rpfx }}"
 
 - assert:
       that: azure_publicipaddresses | length == 1
@@ -94,13 +95,13 @@
 - name: Remove public ip
   azure_rm_publicipaddress:
       resource_group: "{{ resource_group }}"
-      name: testing01
+      name: "pip{{ rpfx }}"
       state:  absent
 
 - name: Gather facts for a public ip
   azure_rm_publicipaddress_facts:
       resource_group: "{{ resource_group }}"
-      name: testing01
+      name: "pip{{ rpfx }}"
 
 - assert:
       that: azure_publicipaddresses | length == 0

--- a/test/runner/requirements/integration.cloud.azure.txt
+++ b/test/runner/requirements/integration.cloud.azure.txt
@@ -17,3 +17,4 @@ azure-mgmt-containerservice>=3.0.1
 azure-mgmt-containerregistry>=1.0.1
 azure-mgmt-rdbms>=0.2.0rc1,<0.3.0
 azure-mgmt-containerinstance==0.4.0
+

--- a/test/runner/requirements/integration.cloud.azure.txt
+++ b/test/runner/requirements/integration.cloud.azure.txt
@@ -17,4 +17,3 @@ azure-mgmt-containerservice>=3.0.1
 azure-mgmt-containerregistry>=1.0.1
 azure-mgmt-rdbms>=0.2.0rc1,<0.3.0
 azure-mgmt-containerinstance==0.4.0
-


### PR DESCRIPTION
##### SUMMARY
Fixing issues related to Azure integration tests.
This PR is supposed to fix too many azure_rm_publicip resources create and not deleted by tests.
Also assigning random names to resources to avoid conflicts.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
azure_rm_networkinterface
azure_rm_publicipaddress
azure_rm_image
azure_rm_managed_disk
azure_rm_loadbalancer

##### ANSIBLE VERSION
2.6


##### ADDITIONAL INFORMATION
