### PR TITLE
Update aws_ses_identity.py

### DIFF
--- a/lib/ansible/modules/cloud/amazon/aws_ses_identity.py
+++ b/lib/ansible/modules/cloud/amazon/aws_ses_identity.py
@@ -115,7 +115,7 @@ EXAMPLES = '''
     purge_subscriptions: False
   register: topic_info
 - name: Deliver feedback to topic instead of owner email
-  ses_identity:
+  aws_ses_identity:
     identity: example@example.com
     state: present
     complaint_notifications:
@@ -135,7 +135,7 @@ EXAMPLES = '''
     purge_subscriptions: False
   register: topic_info
 - name: Delivery notifications to topic
-  ses_identity:
+  aws_ses_identity:
     identity: example@example.com
     state: present
     delivery_notifications:


### PR DESCRIPTION
Examples have a typo of ses_identity instead of aws_ses_identity. Fixed that and proposing these changes here.

+label: docsite_pr

##### SUMMARY
Examples have a typo of ses_identity instead of aws_ses_identity.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
aws_ses_identity

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION

