### PR TITLE
dig lookup plugin: stop masking resolution errors

### DIFF
--- a/lib/ansible/plugins/lookup/dig.py
+++ b/lib/ansible/plugins/lookup/dig.py
@@ -279,24 +279,21 @@ class LookupModule(LookupBase):
                 if flat:
                     ret.append(s)
                 else:
-                    try:
-                        rd = make_rdata_dict(rdata)
-                        rd['owner'] = answers.canonical_name.to_text()
-                        rd['type'] = dns.rdatatype.to_text(rdata.rdtype)
-                        rd['ttl'] = answers.rrset.ttl
-                        rd['class'] = dns.rdataclass.to_text(rdata.rdclass)
+                    rd = make_rdata_dict(rdata)
+                    rd['owner'] = answers.canonical_name.to_text()
+                    rd['type'] = dns.rdatatype.to_text(rdata.rdtype)
+                    rd['ttl'] = answers.rrset.ttl
+                    rd['class'] = dns.rdataclass.to_text(rdata.rdclass)
 
-                        ret.append(rd)
-                    except Exception as e:
-                        ret.append(str(e))
+                    ret.append(rd)
 
         except dns.resolver.NXDOMAIN:
-            ret.append('NXDOMAIN')
+            raise AnsibleError("dns.resolver returned NXDOMAIN for %s" % domain)
         except dns.resolver.NoAnswer:
-            ret.append("")
+            raise AnsibleError("dns.resolver returned no answer for %s" % domain)
         except dns.resolver.Timeout:
-            ret.append('')
-        except dns.exception.DNSException as e:
+            raise AnsibleError("dns.resolver timed out trying to resolve %s" % domain)
+        except Exception as e:
             raise AnsibleError("dns.resolver unhandled exception %s" % to_native(e))
 
         return ret


### PR DESCRIPTION
##### SUMMARY

When users use the `dig` lookup plugin, it is reasonable to assume that they would like the lookup to return meaningful data. If that data is not forthcoming from the DNS, then it's more prudent to just fail the playbook run, rather than carry on and return data of questionable utility (like the empty string, or the literal `NXDOMAIN`).

Fixes #41192.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
dig

##### ANSIBLE VERSION
```
ansible 2.5.4
  config file = /home/florian/.ansible.cfg
  configured module search path = [u'/home/florian/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.15rc1 (default, Apr 15 2018, 21:51:34) [GCC 7.3.0]

```


##### ADDITIONAL INFORMATION
This is a first stab at the issue; please let me know if I'm headed in the right direction.
