### PR TITLE
urls: Handle ValueError raised while typecasting

### DIFF
--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -403,7 +403,10 @@ def generic_urlparse(parts):
         generic_parts['username'] = parts.username
         generic_parts['password'] = parts.password
         generic_parts['hostname'] = parts.hostname
-        generic_parts['port'] = parts.port
+        try:
+            generic_parts['port'] = parts.port
+        except ValueError:
+            generic_parts['port'] = None
     else:
         # we have to use indexes, and then parse out
         # the other parts not supported by indexing


### PR DESCRIPTION
##### SUMMARY
urlparse raises ValueError if URL is malformed (containing
trailing spaces and double quotes). Set port value to None
if we are unable to parse URL correctly.

Fixes: #39441

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/urls.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7-devel
```