### PR TITLE
Docs fix: ansible_group_priority defaults to 1

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_variables.rst
+++ b/docs/docsite/rst/user_guide/playbooks_variables.rst
@@ -892,7 +892,7 @@ Basically, anything that goes into "role defaults" (the defaults folder inside t
           If you define a variable twice in a play's vars: section, the 2nd one wins.
 .. note:: the previous describes the default config `hash_behavior=replace`, switch to 'merge' to only partially overwrite.
 .. note:: Group loading follows parent/child relationships. Groups of the same 'patent/child' level are then merged following alphabetical order.
-          This last one can be superceeded by the user via `ansible_group_priority`, which defaults to 0 for all groups.
+          This last one can be superceeded by the user via ``ansible_group_priority``, which defaults to ``1`` for all groups.
 
 
 Another important thing to consider (for all versions) is that connection variables override config, command line and play/role/task specific options and directives.  For example::


### PR DESCRIPTION
The docs committed in #28777 were inconsistent.
This clarifies that the default `ansible_group_priority` is `1`.[1][2]

[1] https://github.com/ansible/ansible/blob/153c9bd/lib/ansible/inventory/group.py#L40
[2] https://github.com/ansible/ansible/blob/153c9bd/lib/ansible/cli/inventory.py#L236

(cherry picked from commit 4fa2fb9c8963f1873fe20f365f43ebaa1e2db613)

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
docs
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2,5
```
