### PR TITLE
aws_s3: don't decrypt file before uploading - fixes #39287 (#39634)

### DIFF
--- a/changelogs/fragments/aws_s3_decryption_fix.yaml
+++ b/changelogs/fragments/aws_s3_decryption_fix.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- fix decrypting vault files for the aws_s3 module (https://github.com/ansible/ansible/pull/39634)

--- a/changelogs/fragments/aws_s3_decryption_fix.yaml
+++ b/changelogs/fragments/aws_s3_decryption_fix.yaml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-- fix decrypting vault files for the aws_s3 module (https://github.com/ansible/ansible/pull/39634)
+- aws_s3 - fix decrypting vault files (https://github.com/ansible/ansible/pull/39634)

--- a/lib/ansible/plugins/action/aws_s3.py
+++ b/lib/ansible/plugins/action/aws_s3.py
@@ -47,7 +47,7 @@ class ActionModule(ActionBase):
                 # For backward compatibility check if the file exists on the remote; it should take precedence
                 if not self._remote_file_exists(source):
                     try:
-                        source = self._loader.get_real_file(self._find_needle('files', source))
+                        source = self._loader.get_real_file(self._find_needle('files', source), decrypt=False)
                         new_module_args['src'] = source
                     except AnsibleFileNotFound as e:
                         # module handles error message for nonexistent files


### PR DESCRIPTION
* aws_s3: do not decrypt file before uploading to bucket

* changelog

(cherry picked from commit 387c37e255393ad68c4a80c9a304b14aeee02d91)

##### SUMMARY
Backport https://github.com/ansible/ansible/pull/39634

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/action/aws_s3.py

##### ANSIBLE VERSION
```
2.5.5.dev0
```