### PR TITLE
Fixed openstack inventory link

### DIFF
--- a/docs/docsite/rst/user_guide/intro_dynamic_inventory.rst
+++ b/docs/docsite/rst/user_guide/intro_dynamic_inventory.rst
@@ -248,7 +248,7 @@ Example: OpenStack External Inventory Script
 
 If you use an OpenStack based cloud, instead of manually maintaining your own inventory file, you can use the openstack.py dynamic inventory to pull information about your compute instances directly from OpenStack.
 
-You can download the latest version of the OpenStack inventory script `here <https://raw.githubusercontent.com/ansible/ansible/devel/contrib/inventory/openstack.py>`_
+You can download the latest version of the OpenStack inventory script `here <https://raw.githubusercontent.com/ansible/ansible/devel/contrib/inventory/openstack_inventory.py>`_
 
 You can use the inventory script explicitly (by passing the `-i openstack.py` argument to Ansible) or implicitly (by placing the script at `/etc/ansible/hosts`).
 


### PR DESCRIPTION
Fixed openstack dynamic inventory link

+label: docsite_pr

##### SUMMARY

Fixed docs link to OpenStack dynamic inventory script

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME

OpenStack dynamic inventory

##### ANSIBLE VERSION
```
ansible 2.7.0.dev0 (devel ad8e13e9f8) last updated 2018/06/06 15:15:52 (GMT -700)
  config file = None
  configured module search path = [u'/Users/lhill/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/lhill/github/ansible/lib/ansible
  executable location = /Users/lhill/github/ansible/bin/ansible
  python version = 2.7.10 (default, Oct  6 2017, 22:29:07) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.31)]
```

##### ADDITIONAL INFORMATION

The link under https://docs.ansible.com/ansible/latest/user_guide/intro_dynamic_inventory.html#example-openstack-external-inventory-script

pointing to the openstack inventory script is outdated. 

Probably should have been updated with this commit: https://github.com/ansible/ansible/commit/89ce826a9fb53c304238923a73667ab820711338#diff-dbfc3349f531ad2540267f8bb5188239
