### PR TITLE
Fix ec2_ami block_device_mapping volume_size to be int in 2.5 (#40938)

### DIFF
--- a/changelogs/fragments/ec2_ami_fix_block_device_mapping_volume_size_type.yaml
+++ b/changelogs/fragments/ec2_ami_fix_block_device_mapping_volume_size_type.yaml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-- cast the device_mapping volume size to an int in the ec2_ami module (https://github.com/ansible/ansible/pull/40938)
+- ec2_ami - cast the device_mapping volume size to an int (https://github.com/ansible/ansible/pull/40938)

--- a/changelogs/fragments/ec2_ami_fix_block_device_mapping_volume_size_type.yaml
+++ b/changelogs/fragments/ec2_ami_fix_block_device_mapping_volume_size_type.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- cast the device_mapping volume size to an int in the ec2_ami module (https://github.com/ansible/ansible/pull/40938)

--- a/lib/ansible/modules/cloud/amazon/ec2_ami.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_ami.py
@@ -429,8 +429,8 @@ def create_image(module, connection):
                 device = rename_item_if_exists(device, 'volume_type', 'VolumeType', 'Ebs')
                 device = rename_item_if_exists(device, 'snapshot_id', 'SnapshotId', 'Ebs')
                 device = rename_item_if_exists(device, 'delete_on_termination', 'DeleteOnTermination', 'Ebs')
-                device = rename_item_if_exists(device, 'size', 'VolumeSize', 'Ebs')
-                device = rename_item_if_exists(device, 'volume_size', 'VolumeSize', 'Ebs')
+                device = rename_item_if_exists(device, 'size', 'VolumeSize', 'Ebs', attribute_type=int)
+                device = rename_item_if_exists(device, 'volume_size', 'VolumeSize', 'Ebs', attribute_type=int)
                 device = rename_item_if_exists(device, 'iops', 'Iops', 'Ebs')
                 device = rename_item_if_exists(device, 'encrypted', 'Encrypted', 'Ebs')
                 block_device_mapping.append(device)
@@ -635,13 +635,15 @@ def get_image_by_id(module, connection, image_id):
         module.fail_json_aws(e, msg="Error retrieving image by image_id")
 
 
-def rename_item_if_exists(dict_object, attribute, new_attribute, child_node=None):
+def rename_item_if_exists(dict_object, attribute, new_attribute, child_node=None, attribute_type=None):
     new_item = dict_object.get(attribute)
     if new_item is not None:
+        if attribute_type is not None:
+            new_item = attribute_type(new_item)
         if child_node is None:
-            dict_object[new_attribute] = dict_object.get(attribute)
+            dict_object[new_attribute] = new_item
         else:
-            dict_object[child_node][new_attribute] = dict_object.get(attribute)
+            dict_object[child_node][new_attribute] = new_item
         dict_object.pop(attribute)
     return dict_object
 


### PR DESCRIPTION
##### SUMMARY

* fix ec2_ami block_device_mapping size to be int

* fixed cr issues

renamed `type` to `attribute_type`
reused `new_item` instead of creating new variable `value`

(cherry picked from commit ab96a841542478189a6195a05ff748565613056f)

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ec2_ami

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
stable-2.5
```


##### ADDITIONAL INFORMATION
Backport of #40938