### PR TITLE
Add some dots at the end of sentences (#41176)

### DIFF
--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -931,9 +931,9 @@ DEFAULT_SCP_IF_SSH:
   # TODO: move to ssh plugin
   default: smart
   description:
-    - "Prefered method to use when transfering files over ssh"
-    - When set to smart, Ansible will try them until one succeeds or they all fail
-    - If set to True, it will force 'scp', if False it will use 'sftp'
+    - "Prefered method to use when transfering files over ssh."
+    - When set to smart, Ansible will try them until one succeeds or they all fail.
+    - If set to True, it will force 'scp', if False it will use 'sftp'.
   env: [{name: ANSIBLE_SCP_IF_SSH}]
   ini:
   - {key: scp_if_ssh, section: ssh_connection}
@@ -963,7 +963,7 @@ DEFAULT_SQUASH_ACTIONS:
   description:
     - Ansible can optimise actions that call modules that support list parameters when using ``with_`` looping.
       Instead of calling the module once for each item, the module is called once with the full list.
-    - The default value for this setting is only for certain package managers, but it can be used for any module
+    - The default value for this setting is only for certain package managers, but it can be used for any module.
     - Currently, this is only supported for modules that have a name or pkg parameter, and only when the item is the only thing being passed to the parameter.
   env: [{name: ANSIBLE_SQUASH_ACTIONS}]
   ini:


### PR DESCRIPTION
See e.g. https://docs.ansible.com/ansible/devel/reference_appendices/config.html#default-scp-if-ssh
In the docs the list of strings is just concatenated without additional interpunctuation.

+label: docsite_pr

(cherry picked from commit edb1735ca07059a3b644867045f70f9f4ee63edd)

##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/41176

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
lib/ansib.e/config/base.yml

##### ANSIBLE VERSION
```
2.6
```