### PR TITLE
BSDTimezone: distinguish UTC and Etc/UTC

### DIFF
--- a/lib/ansible/modules/system/timezone.py
+++ b/lib/ansible/modules/system/timezone.py
@@ -705,25 +705,6 @@ class BSDTimezone(Timezone):
             return 'UTC'
 
         # Strategy 2:
-        #   Return planned timezone as current timezone if their content matches.
-        #   This is bad design to see `self.value` here,
-        #   but it's intended to avoid useless diff.
-        planned = self.value['name']['planned']
-        try:
-            planned_zonefile = os.path.join(zoneinfo_dir, planned)
-            already_planned_state = filecmp.cmp(planned_zonefile, localtime_file)
-
-        except OSError:
-            # Even if reading planned zoneinfo file gives an OSError, don't abort here,
-            # because a bit more detailed check will be done in `set`.
-            already_planned_state = False
-        # Handle the case where the file comp previously would claim UTC and Etc/UTC
-        # are the same because they are the same file, but not the same path. This
-        # breaks idempotent task runs.
-        if already_planned_state and (planned_zonefile == os.path.realpath(planned_zonefile)):
-            return planned
-
-        # Strategy 3:
         #   Follow symlink of /etc/localtime
         zoneinfo_file = localtime_file
         while not zoneinfo_file.startswith(zoneinfo_dir):
@@ -735,15 +716,16 @@ class BSDTimezone(Timezone):
         else:
             return zoneinfo_file.replace(zoneinfo_dir, '')
 
-        # Strategy 4:
-        #   Check all files in /usr/share/zoneinfo and return first match.
-        for dname, _, fnames in os.walk(zoneinfo_dir):
-            for fname in fnames:
+        # Strategy 3:
+        #   (If /etc/localtime is not symlinked)
+        #   Check all files in /usr/share/zoneinfo and return first non-link match.
+        for dname, _, fnames in sorted(os.walk(zoneinfo_dir)):
+            for fname in sorted(fnames):
                 zoneinfo_file = os.path.join(dname, fname)
-                if filecmp.cmp(zoneinfo_file, localtime_file):
+                if not os.path.islink(zoneinfo_file) and filecmp.cmp(zoneinfo_file, localtime_file):
                     return zoneinfo_file.replace(zoneinfo_dir, '')
 
-        # Strategy 5:
+        # Strategy 4:
         #   As a fall-back, return 'UTC' as default assumption.
         self.module.warn('Could not identify timezone name from /etc/localtime. Assuming UTC.')
         return 'UTC'

--- a/test/integration/targets/timezone/tasks/test.yml
+++ b/test/integration/targets/timezone/tasks/test.yml
@@ -81,6 +81,54 @@
     that:
       - not timezone_again_checkmode.changed
 
+##
+## tests for same timezones with different names
+##
+
+- name: check dpkg-reconfigure
+  shell: type dpkg-reconfigure
+  register: check_dpkg_reconfigure
+  ignore_errors: yes
+  changed_when: no
+
+- name: check timedatectl
+  shell: type timedatectl && timedatectl
+  register: check_timedatectl
+  ignore_errors: yes
+  changed_when: no
+
+- block:
+    - name: set timezone to Etc/UTC
+      timezone:
+        name: Etc/UTC
+
+    - name: change timezone from Etc/UTC to UTC
+      timezone:
+        name: UTC
+      register: timezone_etcutc_to_utc
+
+    - name: check timezone changed from Etc/UTC to UTC
+      assert:
+        that:
+          - timezone_etcutc_to_utc.changed
+          - timezone_etcutc_to_utc.diff.before.name == 'Etc/UTC'
+          - timezone_etcutc_to_utc.diff.after.name == 'UTC'
+
+    - name: change timezone from UTC to Etc/UTC
+      timezone:
+        name: Etc/UTC
+      register: timezone_utc_to_etcutc
+
+    - name: check timezone changed from UTC to Etc/UTC
+      assert:
+        that:
+          - timezone_utc_to_etcutc.changed
+          - timezone_utc_to_etcutc.diff.before.name == 'UTC'
+          - timezone_utc_to_etcutc.diff.after.name == 'Etc/UTC'
+
+  when:
+    # FIXME: Due to the bug of the dpkg-reconfigure, those tests failed on non-systemd debian
+    - check_dpkg_reconfigure.rc != 0 or check_timedatectl.rc == 0
 
 ##
 ## no systemd tests for timezone


### PR DESCRIPTION
##### SUMMARY

Improved idempotency of the `timezone` module on BSD.

It used not to distinguish between UTC and Etc/UTC, because both represents a same timezone.
This doesn't matter on normal usage, but cause weird unwilling behavior on a specific configuration.

I fixed this to distinguish those timezones and not to determine the timezone depending on user's input, but just read only from environment

In addition to that, now the order of scanning `/usr/share/zoneinfo` when `/etc/localtime` is copied rather than symlined is deterministic, and always returns same value.

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

`timezone` module

##### ANSIBLE VERSION

```
ansible 2.7.0.dev0 (devel 63d993e07f) last updated 2018/06/08 17:39:54 (GMT +000)
  config file = None
  configured module search path = [u'/home/tmshn/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/tmshn/ansible/lib/ansible
  executable location = /home/tmshn/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 13 2017, 01:17:52) [GCC 4.2.1 Compatible FreeBSD Clang 3.8.0 (tags/RELEASE_380/final 262564)]
```

##### ADDITIONAL INFORMATION

I wrote the original code in #36715.

At that time, I was thinking that we can regard two timezones as same if their content in `/usr/share/zoneinfo/` are same, because wherever the file is coming, _only the content of the `/etc/localtime`_ decides how a system works.

Under this thought, I implemented to determine the timezone depending on a user's input. If the specified timezone can be regarded same as current one, we no need to change anything, and actually we wouldn't.

However, this meddlesome mix-up brings somewhat weird behavior with such configuration:

```yaml
- name: 1. Set timezone to Etc/UTC
  timezone:
    name: Etc/UTC
# => after:  {'name': 'Etc/UTC'}

- name: 2. Set timezone to UTC
  timezone:
    name: UTC
# => before: {'name': 'UTC'}
# => after:  {'name': 'UTC'}

- name: 3. Set timezone to Etc/UTC again
  timezone:
    name: Etc/UTC
# => before: {'name': 'Etc/UTC'}
# => after:  {'name': 'Etc/UTC'}
```

Even though you set the timezone to `Etc/UTC` on the first step, and it actually reports "after" timezone is `Etc/UTC`, you'll see the "before" timezone is reported as `UTC` rather than `Etc/UTC` on the next step. _The "before" value doesn't match the "after" value of the previous step._

Now I know this is my bad on designing the logic.

The problem was originally addressed at https://github.com/ansible/ansible/pull/40739#issuecomment-392211473, by pointing out a failure of the integration test:

```
TASK [timezone : ensure timezone reported as changed in checkmode] *********************************************************************************************************************************************
fatal: [testhost]: FAILED! => {
    "assertion": "timezone_set_checkmode.diff.before.name == 'Etc/UTC'",
    "changed": false,
    "evaluated_to": false
}
```

#40855 tried to fix this by modifying "strategy 2". However, it works only on an environment where `/usr/share/zoneinfo/Etc/UTC` is symlinked from `/usr/share/zoneinfo/UTC`

In the environment I tested, those files are physically separated and thus `sudo ansible-test integration --allow-destructive timezone -v` failed with the above error.

Now, with the patch of this pr, all clear.
I also added some test cases to make things clear.