### PR TITLE
DCI failures for IOSXR platform

### DIFF
--- a/lib/ansible/modules/network/iosxr/iosxr_system.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_system.py
@@ -252,7 +252,8 @@ class CliConfiguration(ConfigBase):
 
     def parse_hostname(self, config):
         match = re.search(r'^hostname (\S+)', config, re.M)
-        return match.group(1)
+        if match:
+            return match.group(1)
 
     def parse_domain_name(self, config):
         match = re.search(r'^domain name (\S+)', config, re.M)

--- a/test/integration/targets/iosxr_config/tests/cli/misplaced_sublevel.yaml
+++ b/test/integration/targets/iosxr_config/tests/cli/misplaced_sublevel.yaml
@@ -22,6 +22,6 @@
 
 - assert:
     that:
-      - "result.changed == true"
+      - "result.changed == false"
 
 - debug: msg="END cli/misplaced_sublevel.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/iosxr_system/tests/cli/set_name_servers.yaml
+++ b/test/integration/targets/iosxr_system/tests/cli/set_name_servers.yaml
@@ -22,7 +22,6 @@
 - assert:
     that:
       - result.changed == true
-      - result.commands|length == 3
       - "'domain name-server 192.0.2.1' in result.commands"
       - "'domain name-server 192.0.2.2' in result.commands"
       - "'domain name-server 192.0.2.3' in result.commands"


### PR DESCRIPTION
##### SUMMARY
Fixes for DCI Failures
1) After commit of #41091 config having route-policy object would not be played if there is no change in candidate and current. so result.changed would be false when same configs are played.

2) iosxr_system module might also include "domain-lookup disable" if it was enabled hence result.commands| length was 4. Objective of test failing is to make sure domain name servers are configured correctly which is checked by making sure "domain name-server ..." in results.command are present hence removed length check

3) Fix in iosxr_system.py is required as it caused crash if system did not have hostname config

##### ISSUE TYPE
 - Bugfix Pull Request
 
##### ANSIBLE VERSION
2.6
