### PR TITLE
eos handles error gracefully when maximum sessions is reached

### DIFF
--- a/lib/ansible/module_utils/network/eos/eos.py
+++ b/lib/ansible/module_utils/network/eos/eos.py
@@ -205,10 +205,7 @@ class Cli:
             return conn.load_config(commands, commit, replace)
         except ConnectionError as exc:
             message = getattr(exc, 'err', exc)
-            if 'ConnectionError' in to_text(message):
-                self._module.fail_json(msg="Error on executing commands %s" % commands, data=to_text(message, errors='surrogate_then_replace'))
-            else:
-                self._module.fail_json(msg="Error %s" % message, data=to_text(message, errors='surrogate_then_replace'))
+            self._module.fail_json(msg="%s" % message, data=to_text(message, errors='surrogate_then_replace'))
 
 
 class Eapi:

--- a/lib/ansible/module_utils/network/eos/eos.py
+++ b/lib/ansible/module_utils/network/eos/eos.py
@@ -205,7 +205,10 @@ class Cli:
             return conn.load_config(commands, commit, replace)
         except ConnectionError as exc:
             message = getattr(exc, 'err', exc)
-            self._module.fail_json(msg="Error on executing commands %s" % commands, data=to_text(message, errors='surrogate_then_replace'))
+            if 'ConnectionError' in to_text(message):
+                self._module.fail_json(msg="Error on executing commands %s" % commands, data=to_text(message, errors='surrogate_then_replace'))
+            else:
+                self._module.fail_json(msg="Error %s" % message, data=to_text(message, errors='surrogate_then_replace'))
 
 
 class Eapi:

--- a/lib/ansible/plugins/terminal/eos.py
+++ b/lib/ansible/plugins/terminal/eos.py
@@ -45,7 +45,8 @@ class TerminalModule(TerminalBase):
         re.compile(br"[^\r\n]+ not found", re.I),
         re.compile(br"'[^']' +returned error code: ?\d+"),
         re.compile(br"[^\r\n]\/bin\/(?:ba)?sh"),
-        re.compile(br"% More than \d+ OSPF instance", re.I)
+        re.compile(br"% More than \d+ OSPF instance", re.I),
+        re.compile(br"Maximum number of pending sessions has been reached")
     ]
 
     def on_open_shell(self):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes issue #36977
If the maximum session is reached in eos, and a new request to configure session comes user will be thrown with the error that Maximum session is reached and they can proceed if the previous session is completed or aborted.
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description, but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
eos/eos.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
