### PR TITLE
ldap_attr: Use byte values instead of str

### DIFF
--- a/lib/ansible/modules/net_tools/ldap/ldap_attr.py
+++ b/lib/ansible/modules/net_tools/ldap/ldap_attr.py
@@ -152,7 +152,7 @@ modlist:
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils._text import to_native, to_bytes
 from ansible.module_utils.ldap import LdapGeneric, gen_specs
 
 try:
@@ -173,9 +173,9 @@ class LdapAttr(LdapGeneric):
 
         # Normalize values
         if isinstance(self.module.params['values'], list):
-            self.values = map(str, self.module.params['values'])
+            self.values = map(to_bytes, self.module.params['values'])
         else:
-            self.values = [str(self.module.params['values'])]
+            self.values = [to_bytes(self.module.params['values'])]
 
     def add(self):
         values_to_add = filter(self._is_value_absent, self.values)


### PR DESCRIPTION
##### SUMMARY
The LDAP values may be of any kind (pictures, bytes, etc.) thus, ldap module enforce a "bytes" type.
We should pass properly encoded values instead of str

Fixes: #39569

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/net_tools/ldap/ldap_attr.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7-devel
```