### PR TITLE
read scaleway option after the options or _load_name have been set

### DIFF
--- a/lib/ansible/plugins/inventory/scaleway.py
+++ b/lib/ansible/plugins/inventory/scaleway.py
@@ -82,7 +82,7 @@ class InventoryModule(BaseInventoryPlugin):
     def __init__(self):
         super(InventoryModule, self).__init__()
 
-        self.token = self.get_option("oauth_token")
+        self.token = None
         self.config_data = None
 
     def verify_file(self, path):
@@ -146,6 +146,7 @@ class InventoryModule(BaseInventoryPlugin):
     def parse(self, inventory, loader, path, cache=True):
         super(InventoryModule, self).parse(inventory, loader, path)
         self.config_data = self._read_config_data(path=path)
+        self.token = self.get_option("oauth_token")
 
         for zone in self._get_zones():
             self.do_zone_inventory(zone=zone)


### PR DESCRIPTION
##### SUMMARY
Fixes error `ERROR! Unexpected Exception, this is probably a bug: 'InventoryModule' object has no attribute '_load_name'`. get_option requires _load_name which is only set after `__init__` has been called for the plugin. 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/inventory/scaleway.py

##### ANSIBLE VERSION
```
2.7.0.dev0
```