### PR TITLE
Better error message if the template is not utf-8 encoded (#41030)

### DIFF
--- a/docs/docsite/rst/porting_guides/porting_guide_2.5.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.5.rst
@@ -197,6 +197,12 @@ desired.
   * The :ref:`blockinfile module <blockinfile_module>` had its ``follow`` parameter removed because
     it inherently modifies the content of an existing file so it makes no sense to operate on the
     link itself.
+  * In Ansible-2.5.3, the :ref:`template module <template_module>` became more strict about its
+    ``src`` file being proper utf-8.  Previously, non-utf8 contents in a template module src file
+    would result in a mangled output file (the non-utf8 characters would be replaced with a unicode
+    replacement character).  Now, on Python2, the module will error out with the message, "Template
+    source files must be utf-8 encoded".  On Python3, the module will first attempt to pass the
+    non-utf8 characters through verbatim and fail if that does not succeed.
 
 Plugins
 =======

--- a/lib/ansible/plugins/action/template.py
+++ b/lib/ansible/plugins/action/template.py
@@ -85,7 +85,10 @@ class ActionModule(ActionBase):
             # template the source data locally & get ready to transfer
             try:
                 with open(b_tmp_source, 'rb') as f:
-                    template_data = to_text(f.read(), errors='surrogate_or_strict')
+                    try:
+                        template_data = to_text(f.read(), errors='surrogate_or_strict')
+                    except UnicodeError:
+                        raise AnsibleActionFail("Template source files must be utf-8 encoded")
 
                 # set jinja2 internal search path for includes
                 searchpath = task_vars.get('ansible_search_path', [])


### PR DESCRIPTION
* Better error message if the template is not utf-8 encoded

Also document this in the porting guide
(cherry picked from commit cef4d862bc944fbcab082f2710575f2c14c7cd54)

##### SUMMARY
In 2.5.3, the template module changed from mangling non-utf8 template files to throwing an error. Document that that is the case and also improve the error message.

This change should be included in both 2.6 and 2.5 as well as on devel - backporting to 2.5 here.

##### ISSUE TYPE
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
docs.ansible.com
template plugin

##### ANSIBLE VERSION
2.5
