### PR TITLE
Make alias autodetection for symlinked modules independent of glob() …

### DIFF
--- a/docs/bin/plugin_formatter.py
+++ b/docs/bin/plugin_formatter.py
@@ -251,7 +251,7 @@ def get_plugin_info(module_dir, limit_to=None, verbose=False):
         module_info[module] = {'path': module_path,
                                'source': os.path.relpath(module_path, module_dir),
                                'deprecated': deprecated,
-                               'aliases': set(),
+                               'aliases': module_info[module].get('aliases', set()),
                                'metadata': metadata,
                                'doc': doc,
                                'examples': examples,


### PR DESCRIPTION
…order. (#40293)

(cherry picked from commit 2a29b2ff7f0cbda712e88331b6f98a5e226000c0)

##### SUMMARY
In #39948 I tried to catch all the changes to the docs generation that were in `devel` but not in `stable-2.5`. I missed this one. 

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
docs.ansible.com

##### ANSIBLE VERSION
2.5
