### PR TITLE
Ensure the 2.7 porting guide is in the toc

### DIFF
--- a/docs/docsite/rst/porting_guides/porting_guides.rst
+++ b/docs/docsite/rst/porting_guides/porting_guides.rst
@@ -16,3 +16,4 @@ Please note that this is not a complete list. If you believe any extra informati
    porting_guide_2.4
    porting_guide_2.5
    porting_guide_2.6
+   porting_guide_2.7


### PR DESCRIPTION
##### SUMMARY
Ensure the 2.7 porting guide is in the toc
##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
docs/docsite/rst/porting_guides/porting_guides.rst

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```