### PR TITLE
minimal callback doesn't properly respect changed

### DIFF
--- a/lib/ansible/plugins/callback/minimal.py
+++ b/lib/ansible/plugins/callback/minimal.py
@@ -55,13 +55,17 @@ class CallbackModule(CallbackBase):
 
         self._handle_warnings(result._result)
 
-        if result._task.action in C.MODULE_NO_JSON:
-            self._display.display(self._command_generic_msg(result._host.get_name(), result._result, "SUCCESS"), color=C.COLOR_OK)
+        if result._result.get('changed', False):
+            color = C.COLOR_CHANGED
+            state = 'CHANGED'
         else:
-            if 'changed' in result._result and result._result['changed']:
-                self._display.display("%s | SUCCESS => %s" % (result._host.get_name(), self._dump_results(result._result, indent=4)), color=C.COLOR_CHANGED)
-            else:
-                self._display.display("%s | SUCCESS => %s" % (result._host.get_name(), self._dump_results(result._result, indent=4)), color=C.COLOR_OK)
+            color = C.COLOR_OK
+            state = 'SUCCESS'
+
+        if result._task.action in C.MODULE_NO_JSON:
+            self._display.display(self._command_generic_msg(result._host.get_name(), result._result, state), color=color)
+        else:
+            self._display.display("%s | %s => %s" % (result._host.get_name(), state, self._dump_results(result._result, indent=4)), color=color)
 
     def v2_runner_on_skipped(self, result):
         self._display.display("%s | SKIPPED" % (result._host.get_name()), color=C.COLOR_SKIP)


### PR DESCRIPTION
##### SUMMARY
minimal callback doesn't properly respect changed, bring into alignment with oneline

Effectively duplicates changes made to oneline in https://github.com/ansible/ansible/pull/37601

Addresses https://github.com/ansible/ansible/issues/41263

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/callback/minimal.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
2.6
2.7
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```