### PR TITLE
2.6 backport #40826 to fix async for aws_s3

### DIFF
--- a/changelogs/fragments/aws_s3_async_fix.yaml
+++ b/changelogs/fragments/aws_s3_async_fix.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- fix async for the aws_s3 module by adding async support to the action plugin (https://github.com/ansible/ansible/pull/40826)

--- a/test/integration/targets/aws_s3/tasks/main.yml
+++ b/test/integration/targets/aws_s3/tasks/main.yml
@@ -65,6 +65,23 @@
       - result.changed == True
       - result.msg == "PUT operation complete"
 # ============================================================
+- name: test using aws_s3 with async
+  aws_s3:
+    bucket: "{{ bucket_name }}"
+    mode: put
+    src: "{{ tmp1.path }}"
+    object: delete.txt
+    <<: *aws_connection_info
+  register: test_async
+  async: 30
+  poll: 0
+- name: ensure it completed
+  async_status:
+    jid: "{{ test_async.ansible_job_id }}"
+  register: status
+  until: status.finished
+  retries: 10
+# ============================================================
 - name: check that roles file lookups work as expected
   aws_s3:
     bucket: "{{ bucket_name }}"


### PR DESCRIPTION
cherry-picked from 89cea78e3002c816157e604c73e7eb4db137b107 and fixed merge conflicts from restructuring the integration tests in devel

Fix async for aws_s3

Add a test that async is able to be used on aws_s3 tasks

##### SUMMARY
Backporting #40826 which fixes async for aws_s3
I resolve conflicts in the integration tests since they have been restructured on devel.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/action/aws_s3.py

##### ANSIBLE VERSION
```
2.6.0.dev0
```