### PR TITLE
2.6 backport #36832 to fix custom s3_url

### DIFF
--- a/changelogs/fragments/aws_s3_fix_custom_endpoints.yaml
+++ b/changelogs/fragments/aws_s3_fix_custom_endpoints.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- allow custom endpoints to be used in the aws_s3 module (https://github.com/ansible/ansible/pull/36832)

--- a/lib/ansible/modules/cloud/amazon/aws_s3.py
+++ b/lib/ansible/modules/cloud/amazon/aws_s3.py
@@ -573,17 +573,6 @@ def is_fakes3(s3_url):
         return False
 
 
-def is_walrus(s3_url):
-    """ Return True if it's Walrus endpoint, not S3
-
-    We assume anything other than *.amazonaws.com is Walrus"""
-    if s3_url is not None:
-        o = urlparse(s3_url)
-        return not o.netloc.endswith('amazonaws.com')
-    else:
-        return False
-
-
 def get_s3_connection(module, aws_connect_kwargs, location, rgw, s3_url):
     if s3_url and rgw:  # TODO - test this
         rgw = urlparse(s3_url)
@@ -602,9 +591,6 @@ def get_s3_connection(module, aws_connect_kwargs, location, rgw, s3_url):
         params = dict(module=module, conn_type='client', resource='s3', region=location,
                       endpoint="%s://%s:%s" % (protocol, fakes3.hostname, to_text(port)),
                       use_ssl=fakes3.scheme == 'fakes3s', **aws_connect_kwargs)
-    elif is_walrus(s3_url):
-        walrus = urlparse(s3_url).hostname
-        params = dict(module=module, conn_type='client', resource='s3', region=location, endpoint=walrus, **aws_connect_kwargs)
     else:
         params = dict(module=module, conn_type='client', resource='s3', region=location, endpoint=s3_url, **aws_connect_kwargs)
     return boto3_conn(**params)


### PR DESCRIPTION
cherry-pick e59742eccd92b7737f355422ca270b9cdad0ab44 and resolve conflicts

[aws] Remove walrus conditional in aws_s3 module when using custom s3_url

fix aws_s3 module to use custum s3_url

##### SUMMARY
Backport #36832 
Fixed merge conflicts from merging a KMS encryption feature to aws_s3 on devel before 36832

Walrus uses an S3-compatible API and should work with this. Other S3 drop-ins have been tested with this and this fixes them.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/aws_s3.py

##### ANSIBLE VERSION
```
2.6.0.dev0
```
