### PR TITLE
fix truncated list functions in ansible-doc (#41281)

### DIFF
--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -118,7 +118,7 @@ class DocCLI(CLI):
         if self.options.list_files:
             paths = loader._get_paths()
             for path in paths:
-                self.plugin_list = self.find_plugins(path, plugin_type)
+                self.plugin_list.update(self.find_plugins(path, plugin_type))
 
             list_text = self.get_plugin_list_filenames(loader)
             self.pager(list_text)
@@ -128,7 +128,7 @@ class DocCLI(CLI):
         if self.options.list_dir:
             paths = loader._get_paths()
             for path in paths:
-                self.plugin_list = self.find_plugins(path, plugin_type)
+                self.plugin_list.update(self.find_plugins(path, plugin_type))
 
             self.pager(self.get_plugin_list_text(loader))
             return 0


### PR DESCRIPTION
##### SUMMARY
backport #41281 to stable-2.6

* fixed incomplete refactor of instance-level plugin list var

(cherry picked from commit 25ab2a8153de46e0fc6886a508bea1594c3f2faa)

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ansible-doc

##### ANSIBLE VERSION
2.6.0rc1

##### ADDITIONAL INFORMATION
