### PR TITLE
Fix typeo in output parameter name in vyos_command

### DIFF
--- a/lib/ansible/modules/network/edgeos/edgeos_command.py
+++ b/lib/ansible/modules/network/edgeos/edgeos_command.py
@@ -178,7 +178,7 @@ def main():
     if conditionals:
         failed_conditions = [item.raw for item in conditionals]
         msg = 'One or more conditional statements have not been satisfied'
-        module.fail_json(msg=msg, falied_conditions=failed_conditions)
+        module.fail_json(msg=msg, failed_conditions=failed_conditions)
 
     result = {
         'changed': False,


### PR DESCRIPTION
##### SUMMARY

Should be `failed_json`

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
`vyos_command.py`

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7
```
