### PR TITLE
Adding the Ansible way how to create a password hash

### DIFF
--- a/docs/docsite/rst/reference_appendices/faq.rst
+++ b/docs/docsite/rst/reference_appendices/faq.rst
@@ -359,12 +359,17 @@ Remote environment variables are available via facts in the 'ansible_env' variab
 How do I generate crypted passwords for the user module?
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-The mkpasswd utility that is available on most Linux systems is a great option:
+Ansible ad-hoc command is the easiest option:
+
+.. code-block:: shell-session
+
+    ansible all -i localhost, -m debug -a "msg={{ 'mypassword' | password_hash('sha512', 'mysecretsalt') }}"
+
+The mkpasswd utility that is available on most Linux systems is also a great option:
 
 .. code-block:: shell-session
 
     mkpasswd --method=sha-512
-    
 
 If this utility is not installed on your system (e.g. you are using OS X) then you can still easily
 generate these passwords using Python. First, ensure that the `Passlib <https://bitbucket.org/ecollins/passlib/wiki/Home>`_


### PR DESCRIPTION
##### SUMMARY

This PR is improving documentation about how to create password hash for the `user` module. It shows how to use Ansible ad-hoc command to do that. That requires nothing else to be installed than Ansible.

##### ISSUE TYPE
Docs Pull Request

##### COMPONENT NAME
None

##### ANSIBLE VERSION
```
ansible 2.5.4
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python3.6/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 3.6.5 (default, May 11 2018, 04:00:52) [GCC 8.1.0]
```

##### ADDITIONAL INFORMATION
None