### PR TITLE
updates docs links to changelogs for all versions

### DIFF
--- a/docs/docsite/rst/porting_guides/porting_guide_2.0.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.0.rst
@@ -9,7 +9,7 @@ This section discusses the behavioral changes between Ansible 1.x and Ansible 2.
 It is intended to assist in updating your playbooks, plugins and other parts of your Ansible infrastructure so they will work with this version of Ansible.
 
 
-We suggest you read this page along with `Ansible Changelog <https://github.com/ansible/ansible/blob/devel/CHANGELOG.md#2.0>`_ to understand what updates you may need to make.
+We suggest you read this page along with `Ansible Changelog for 2.0 <https://github.com/ansible/ansible/blob/stable-2.0/CHANGELOG.md>`_ to understand what updates you may need to make.
 
 This document is part of a collection on porting. The complete list of porting guides can be found at :ref:`porting guides <porting_guides>`.
 

--- a/docs/docsite/rst/porting_guides/porting_guide_2.3.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.3.rst
@@ -9,7 +9,7 @@ This section discusses the behavioral changes between Ansible 2.2 and Ansible 2.
 It is intended to assist in updating your playbooks, plugins and other parts of your Ansible infrastructure so they will work with this version of Ansible.
 
 
-We suggest you read this page along with `Ansible Changelog <https://github.com/ansible/ansible/blob/devel/CHANGELOG.md#2.3>`_ to understand what updates you may need to make.
+We suggest you read this page along with `Ansible Changelog for 2.3 <https://github.com/ansible/ansible/blob/stable-2.3/CHANGELOG.md>`_ to understand what updates you may need to make.
 
 This document is part of a collection on porting. The complete list of porting guides can be found at :ref:`porting guides <porting_guides>`.
 

--- a/docs/docsite/rst/porting_guides/porting_guide_2.4.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.4.rst
@@ -9,7 +9,7 @@ This section discusses the behavioral changes between Ansible 2.3 and Ansible 2.
 It is intended to assist in updating your playbooks, plugins and other parts of your Ansible infrastructure so they will work with this version of Ansible.
 
 
-We suggest you read this page along with `Ansible Changelog <https://github.com/ansible/ansible/blob/stable-2.4/CHANGELOG.md#2.4>`_ to understand what updates you may need to make.
+We suggest you read this page along with `Ansible Changelog for 2.4 <https://github.com/ansible/ansible/blob/stable-2.4/CHANGELOG.md>`_ to understand what updates you may need to make.
 
 This document is part of a collection on porting. The complete list of porting guides can be found at :ref:`porting guides <porting_guides>`.
 

--- a/docs/docsite/rst/porting_guides/porting_guide_2.5.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.5.rst
@@ -8,7 +8,7 @@ This section discusses the behavioral changes between Ansible 2.4 and Ansible 2.
 
 It is intended to assist in updating your playbooks, plugins and other parts of your Ansible infrastructure so they will work with this version of Ansible.
 
-We suggest you read this page along with `Ansible Changelog <https://github.com/ansible/ansible/blob/devel/CHANGELOG.md#2.5>`_ to understand what updates you may need to make.
+We suggest you read this page along with `Ansible Changelog for 2.5 <https://github.com/ansible/ansible/blob/stable-2.5/changelogs/CHANGELOG-v2.5.rst>`_ to understand what updates you may need to make.
 
 This document is part of a collection on porting. The complete list of porting guides can be found at :ref:`porting guides <porting_guides>`.
 

--- a/docs/docsite/rst/porting_guides/porting_guide_2.6.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.6.rst
@@ -8,7 +8,7 @@ This section discusses the behavioral changes between Ansible 2.5 and Ansible 2.
 
 It is intended to assist in updating your playbooks, plugins and other parts of your Ansible infrastructure so they will work with this version of Ansible.
 
-We suggest you read this page along with `Ansible Changelog <https://github.com/ansible/ansible/blob/devel/CHANGELOG.md#2.6>`_ to understand what updates you may need to make.
+We suggest you read this page along with `Ansible Changelog for 2.6 <https://github.com/ansible/ansible/blob/stable-2.6/changelogs/CHANGELOG-v2.6.rst>`_ to understand what updates you may need to make.
 
 This document is part of a collection on porting. The complete list of porting guides can be found at :ref:`porting guides <porting_guides>`.
 

--- a/docs/docsite/rst/porting_guides/porting_guide_2.7.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.7.rst
@@ -8,7 +8,7 @@ This section discusses the behavioral changes between Ansible 2.6 and Ansible 2.
 
 It is intended to assist in updating your playbooks, plugins and other parts of your Ansible infrastructure so they will work with this version of Ansible.
 
-We suggest you read this page along with `Ansible Changelog <https://github.com/ansible/ansible/blob/devel/CHANGELOG.md#2.7>`_ to understand what updates you may need to make.
+We suggest you read this page along with `Ansible Changelog for 2.7 <https://github.com/ansible/ansible/blob/devel/changelogs/CHANGELOG-v2.7.rst>`_ to understand what updates you may need to make.
 
 This document is part of a collection on porting. The complete list of porting guides can be found at :ref:`porting guides <porting_guides>`.
 

--- a/docs/docsite/rst/reference_appendices/release_and_maintenance.rst
+++ b/docs/docsite/rst/reference_appendices/release_and_maintenance.rst
@@ -41,7 +41,7 @@ Release status
 Ansible Release   Latest Version               Status
 ===============   ==========================   =================================================
 devel             2.6 (unreleased, trunk)      In development
-`2.5`_            2.5.0 (2018-03-23)           Supported (security **and** general bugfixes)
+`2.5`_            2.5.4 (2018-05-31)           Supported (security **and** general bugfixes)
 `2.4`_            2.4.4 (2018-01-31)           Supported (security **and** critical bug fixes)
 `2.3`_            2.3.3 (2017-12-20)           Unsupported (end of life)
 `2.2`_            2.2.3 (2017-05-09)           Unsupported (end of life)

--- a/docs/docsite/rst/reference_appendices/release_and_maintenance.rst
+++ b/docs/docsite/rst/reference_appendices/release_and_maintenance.rst
@@ -40,14 +40,14 @@ Release status
 ===============   ==========================   =================================================
 Ansible Release   Latest Version               Status
 ===============   ==========================   =================================================
-devel             `2.6` (unreleased, trunk)    In development
-2.5               `2.5.5`_ (2018-06-14)        Supported (security **and** general bug fixes)
-2.4               `2.4.5`_ (2018-06-21)        Supported (security **and** critical bug fixes)
-2.3               `2.3.3`_ (2017-12-20)        Unsupported (end of life)
-2.2               `2.2.3`_ (2017-05-09)        Unsupported (end of life)
-2.1               `2.1.6`_ (2017-06-01)        Unsupported (end of life)
-2.0               `2.0.2`_ (2016-04-19)        Unsupported (end of life)
-1.9               `1.9.6`_ (2016-04-15)        Unsupported (end of life)
+devel             2.6 (unreleased, trunk)      In development
+`2.5`_            2.5.0 (2018-03-23)           Supported (security **and** general bugfixes)
+`2.4`_            2.4.4 (2018-01-31)           Supported (security **and** critical bug fixes)
+`2.3`_            2.3.3 (2017-12-20)           Unsupported (end of life)
+`2.2`_            2.2.3 (2017-05-09)           Unsupported (end of life)
+`2.1`_            2.1.6 (2017-06-01)           Unsupported (end of life)
+`2.0`_            2.0.2 (2016-04-19)           Unsupported (end of life)
+`1.9`_            1.9.6 (2016-04-15)           Unsupported (end of life)
 <1.9              n/a                          Unsupported (end of life)
 ===============   ==========================   =================================================
 
@@ -57,13 +57,14 @@ devel             `2.6` (unreleased, trunk)    In development
 
 .. Comment: devel used to point here but we're currently revamping our changelog process and have no
    link to a static changelog for devel _2.6: https://github.com/ansible/ansible/blob/devel/CHANGELOG.md
-.. _2.5.5: https://github.com/ansible/ansible/blob/stable-2.5/changelogs/CHANGELOG-v2.5.rst
-.. _2.4.5: https://github.com/ansible/ansible/blob/stable-2.4/CHANGELOG.md
-.. _2.3.3: https://github.com/ansible/ansible/blob/stable-2.3/CHANGELOG.md
-.. _2.2.3: https://github.com/ansible/ansible/blob/stable-2.2/CHANGELOG.md
-.. _2.1.6: https://github.com/ansible/ansible/blob/stable-2.1/CHANGELOG.md
-.. _2.0.2: https://github.com/ansible/ansible/blob/stable-2.0/CHANGELOG.md
-.. _1.9.6: https://github.com/ansible/ansible/blob/stable-1.9/CHANGELOG.md
+.. _2.6: https://github.com/ansible/ansible/blob/stable-2.6/changelogs/CHANGELOG-v2.6.rst
+.. _2.5: https://github.com/ansible/ansible/blob/stable-2.5/changelogs/CHANGELOG-v2.5.rst
+.. _2.4: https://github.com/ansible/ansible/blob/stable-2.4/CHANGELOG.md
+.. _2.3: https://github.com/ansible/ansible/blob/stable-2.3/CHANGELOG.md
+.. _2.2: https://github.com/ansible/ansible/blob/stable-2.2/CHANGELOG.md
+.. _2.1: https://github.com/ansible/ansible/blob/stable-2.1/CHANGELOG.md
+.. _2.0: https://github.com/ansible/ansible/blob/stable-2.0/CHANGELOG.md
+.. _1.9: https://github.com/ansible/ansible/blob/stable-1.9/CHANGELOG.md
 
 .. _support_life:
 .. _methods:
@@ -90,14 +91,19 @@ security fixes to releases which are two releases old. This work is tracked on t
 The fixes that land in supported stable branches will eventually be released
 as a new version when necessary.
 
-For more information on the changes included in each new version, you can refer
-to the changelog_, available on GitHub.
-
 Note that while there are no guarantees for providing fixes for unsupported
 releases of Ansible, there can sometimes be exceptions for critical issues.
 
 .. _GitHub: https://github.com/ansible/ansible
-.. _changelog: https://github.com/ansible/ansible/blob/devel/CHANGELOG.md
+
+Changelogs
+~~~~~~~~~~~~~~~~~~
+
+Since 2.5, we've logged changes to ``stable-<version>`` git branches at ``stable-<version>/changelogs/CHANGELOG-v<version>.rst``.
+For example, here's the changelog for 2.5_ on GitHub.
+
+Older versions logged changes to ``stable-<version>/CHANGELOG.md``. For example,
+here's the CHANGELOG for 2.4_.
 
 
 Release candidates
@@ -158,8 +164,6 @@ For modules/plugins, we keep the documentation after the removal for users of ol
        Testing strategies
    :ref:`ansible_community_guide`
        Community information and contributing
-   `Ansible Changelog <https://github.com/ansible/ansible/blob/devel/CHANGELOG.md>`_
-       Documentation of the improvements for each version of Ansible
    `Ansible release tarballs <https://releases.ansible.com/ansible/>`_
        Ansible release tarballs
    `Development Mailing List <http://groups.google.com/group/ansible-devel>`_


### PR DESCRIPTION
##### SUMMARY
Closes #40997.

Updates link from docs.ansible.com to the changelogs on GitHub. Since we changed the way we generate the changelog files, there's no comprehensive single file of all changes in all versions. This PR makes that clear in the information about releases and also updates the links on the individual porting guides.

This fix will need to be made on old docs versions, though backporting this commit won't work because some of these files don't exist on earlier versions. 

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
docs.ansible.com

##### ANSIBLE VERSION
2.7