### PR TITLE
Removing deprecation of task args as dict

### DIFF
--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -513,8 +513,6 @@ class TaskExecutor:
         if '_variable_params' in self._task.args:
             variable_params = self._task.args.pop('_variable_params')
             if isinstance(variable_params, dict):
-                display.deprecated("Using variables for task params is unsafe, especially if the variables come from an external source like facts",
-                                   version="2.6")
                 variable_params.update(self._task.args)
                 self._task.args = variable_params
 


### PR DESCRIPTION
##### SUMMARY
I would like to use this PR for revisiting the removal of the functionality which allows to use a `dict` as a value of the `args` task option:

> [DEPRECATION WARNING]: Using variables for task params is unsafe, especially if the variables come from an external source like facts.

I was given a [promise to revisit](https://meetbot.fedoraproject.org/ansible-meeting/2017-09-28/ansible_dev_meeting.2017-09-28-15.00.log.html#l-51) the removal of this feature during the discussion about [removal of `params` option](https://github.com/ansible/ansible/issues/30874) from several modules which I'm author of (e.g. `yum_repository`, `jenkns_plugin`, `ldap_attr`, ...). The `params` option was used to pass additional options to the module via variable which allowed to create roles easily extensible by the user without the need to modify the role if some option was missing in the task definition. That significantly simplified the work of role authors as they didn't need to parametrize all possible task options which could easily reach tens of parametrized option in the case of modules like `yum_repository`. Unfortunately the `params` implementation didn't sanitize the `param` values which could lead to exposure of sensitive information in the log.

The `args` task option provide the same functionality like `params`. But if the ability of using `dict` as the `args` value is removed, there is [no simple alternative](https://groups.google.com/forum/#!msg/ansible-project/Qrq76VLIqKg/deRwjIQ-AQAJ;context-place=msg/ansible-project/Qrq76VLIqKg/deRwjIQ-AQAJ) to achieve the goal described above - creation of easily extensible roles.

I have run several tests (see _Additional Information_ bellow) which don't indicate that the exposure of sensitive information from options marked as `no_log` is still an issue when passing a `dict` to the `args` task option. I would be very grateful if we would come to a conclusion that this very useful feature is safe and can stay in Ansible even after the 2.6 release.

##### ISSUE TYPE
Feature Pull Request

##### COMPONENT NAME
`task_executor`

##### ANSIBLE VERSION
```
ansible 2.5.4
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python3.6/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 3.6.5 (default, May 11 2018, 04:00:52) [GCC 8.1.0]
```

##### ADDITIONAL INFORMATION

I have created a testing module to confirm that the option marked as `no_log` won't be logged:

```python
#!/usr/bin/python
# encoding: utf-8

from ansible.module_utils.basic import AnsibleModule

def main():
    module = AnsibleModule(
        argument_spec=dict(
            name=dict(required=True),
            something=dict(no_log=True),
            state=dict(choices=['present', 'absent'], default='present'),
        )
    )

    name = module.params['name']
    state = module.params['state']
    changed = False

    module.exit_json(changed=changed, name=name, state=state)


if __name__ == '__main__':
    main()
```

The `something` options is called like that to exclude the possibility that Ansible is using some kind of heuristic on the option name to prevent its logging (e.g. option called `password`).

Then I have created this playbook to test several possible scenarios:

```yaml
---

- hosts: all
  gather_facts: no
  connection: local
  vars:
    my_name: John Doe
    my_pass: Some Text

    my_args1:
      something: "{{ my_pass }}"
  tasks:
    - name: Without args
      mytest:
        name: "{{ my_name }}"
        something: "{{ my_pass }}"

    - name: With args 1
      mytest:
        name: "{{ my_name }}"
      args: "{{ my_args1 }}"

    - name: Setting fact
      set_fact:
        my_args2:
          something: "{{ my_pass }}"

    - name: With args 2
      mytest:
        name: "{{ my_name }}"
      args: "{{ my_args1 }}"
```

And this is the output (excluding the connection messages):

```
$ ansible-playbook -i localhost, -vvv site.yaml 2>/dev/null | egrep -v '(<localhost>|DEPRECATION)'
ansible-playbook 2.5.4
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python3.6/site-packages/ansible
  executable location = /usr/bin/ansible-playbook
  python version = 3.6.5 (default, May 11 2018, 04:00:52) [GCC 8.1.0]
Using /etc/ansible/ansible.cfg as config file
Parsed localhost, inventory source with host_list plugin

PLAYBOOK: site.yaml ************************************************************************
1 plays in site.yaml

PLAY [all] *********************************************************************************
META: ran handlers

TASK [Without args] ************************************************************************
task path: /tmp/site.yaml:13
Using module file /tmp/library/mytest.py
ok: [localhost] => {
    "changed": false,
    "invocation": {
        "module_args": {
            "name": "John Doe",
            "something": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "state": "present"
        }
    },
    "name": "John Doe",
    "state": "present"
}

TASK [With args 1] *************************************************************************
task path: /tmp/site.yaml:18
Using module file /tmp/library/mytest.py
ok: [localhost] => {
    "changed": false,
    "invocation": {
        "module_args": {
            "name": "John Doe",
            "something": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "state": "present"
        }
    },
    "name": "John Doe",
    "state": "present"
}

TASK [Setting fact] ************************************************************************
task path: /tmp/site.yaml:23
ok: [localhost] => {
    "ansible_facts": {
        "my_args2": {
            "something": "Some Text"
        }
    },
    "changed": false
}

TASK [With args 2] *************************************************************************
task path: /tmp/site.yaml:28
Using module file /tmp/library/mytest.py
ok: [localhost] => {
    "changed": false,
    "invocation": {
        "module_args": {
            "name": "John Doe",
            "something": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "state": "present"
        }
    },
    "name": "John Doe",
    "state": "present"
}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************************
localhost                  : ok=4    changed=0    unreachable=0    failed=0   
```

As visible from the above output, the content of the `no_log` option has not been logged.