### PR TITLE
Update winrm.py (#41303)

### DIFF
--- a/lib/ansible/plugins/connection/winrm.py
+++ b/lib/ansible/plugins/connection/winrm.py
@@ -37,7 +37,7 @@ DOCUMENTATION = """
       port:
         description:
             - port for winrm to connect on remote target
-            - The default is the https (5896) port, if using http it should be 5895
+            - The default is the https (5986) port, if using http it should be 5985
         vars:
           - name: ansible_port
           - name: ansible_winrm_port


### PR DESCRIPTION
fix the typos for winrm port

(cherry picked from commit 7fb92b6f457a03357641799bf67c45b8e136df4e)

##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/41303

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
winrm

##### ANSIBLE VERSION
```
2.6
```