### PR TITLE
cloudfront_distribution: backport #37340

### DIFF
--- a/lib/ansible/modules/cloud/amazon/cloudfront_distribution.py
+++ b/lib/ansible/modules/cloud/amazon/cloudfront_distribution.py
@@ -1408,10 +1408,10 @@ class CloudFrontValidationManager(object):
                 all_origins[origin['domain_name']] = origin
                 new_domains.append(origin['domain_name'])
             if purge_origins:
-                for domain in all_origins:
+                for domain in list(all_origins.keys()):
                     if domain not in new_domains:
                         del(all_origins[domain])
-            return ansible_list_to_cloudfront_list(all_origins.values())
+            return ansible_list_to_cloudfront_list(list(all_origins.values()))
         except Exception as e:
             self.module.fail_json_aws(e, msg="Error validating distribution origins")
 
@@ -1491,7 +1491,7 @@ class CloudFrontValidationManager(object):
             if purge_cache_behaviors:
                 for target_origin_id in set(all_cache_behaviors.keys()) - set([cb['path_pattern'] for cb in cache_behaviors]):
                     del(all_cache_behaviors[target_origin_id])
-            return ansible_list_to_cloudfront_list(all_cache_behaviors.values())
+            return ansible_list_to_cloudfront_list(list(all_cache_behaviors.values()))
         except Exception as e:
             self.module.fail_json_aws(e, msg="Error validating distribution cache behaviors")
 
@@ -1543,6 +1543,8 @@ class CloudFrontValidationManager(object):
                 forwarded_values = dict()
             existing_config = config.get('forwarded_values', {})
             headers = forwarded_values.get('headers', existing_config.get('headers', {}).get('items'))
+            if headers:
+                headers.sort()
             forwarded_values['headers'] = ansible_list_to_cloudfront_list(headers)
             if 'cookies' not in forwarded_values:
                 forward = existing_config.get('cookies', {}).get('forward', self.__default_cache_behavior_forwarded_values_forward_cookies)

--- a/test/integration/targets/cloudfront_distribution/defaults/main.yml
+++ b/test/integration/targets/cloudfront_distribution/defaults/main.yml
@@ -1,12 +1,16 @@
-cloudfront_hostname: "{{ resource_prefix | lower }}01"
+cloudfront_hostname: "{{ resource_prefix }}01"
 # Use a domain that has a wildcard DNS
-cloudfront_alias: "{{ cloudfront_hostname | lower }}.github.io"
+cloudfront_alias: "{{ cloudfront_hostname }}.github.io"
 
 cloudfront_test_cache_behaviors:
   - path_pattern: /test/path
     forwarded_values:
       headers:
         - Host
+        - X-HTTP-Forwarded-For
+        - CloudFront-Forwarded-Proto
+        - Origin
+        - Referer
     allowed_methods:
       items:
         - GET


### PR DESCRIPTION
##### SUMMARY

cloudfront_distribution: fix the order of headers to avoid updates again and again (#37340)

* Fix python2/3 compatibilities issues

* Sort cloudfront_distribution headers to avoid useless updates

(cherry picked from commit ec2e0279807729b04dbaaf6477758fa6f75c10ff)

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
cloudfront_distribution

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
stable-2.5
```


##### ADDITIONAL INFORMATION
Raised again today in #41307
