### PR TITLE
Update mysql_db.py

### DIFF
--- a/lib/ansible/modules/database/mysql/mysql_db.py
+++ b/lib/ansible/modules/database/mysql/mysql_db.py
@@ -68,6 +68,7 @@ requirements:
    - mysqldump (command line binary)
 notes:
    - Requires the python-mysqldb package on the remote host, as well as mysql and mysqldump binaries.
+   - This module is B(not idempotent) when I(state) is C(import), and will import the dump file each time if run more than once.
 extends_documentation_fragment: mysql
 '''
 


### PR DESCRIPTION
Add note to inform that mysql_db is not idempotent when state is "import".

+label: docsite_pr

##### SUMMARY
Add a small line to the notes section on https://docs.ansible.com/ansible/latest/modules/mysql_db_module.html to indicate that the module is not idempotent in a specific scenario.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
mysql_db module documentation

##### ANSIBLE VERSION
```
ansible 2.4.1.0
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.14 (default, Dec 14 2017, 15:51:29) [GCC 6.4.0]
```