### PR TITLE
Backport #41287 - Fix typeo in param name in edgeos_command

### DIFF
--- a/lib/ansible/modules/network/edgeos/edgeos_command.py
+++ b/lib/ansible/modules/network/edgeos/edgeos_command.py
@@ -178,7 +178,7 @@ def main():
     if conditionals:
         failed_conditions = [item.raw for item in conditionals]
         msg = 'One or more conditional statements have not been satisfied'
-        module.fail_json(msg=msg, falied_conditions=failed_conditions)
+        module.fail_json(msg=msg, failed_conditions=failed_conditions)
 
     result = {
         'changed': False,


### PR DESCRIPTION
##### SUMMARY
Backport of #41287 for Ansible 2.6

##### ISSUE TYPE
 - Bugfix Pull Request


##### COMPONENT NAME
`edgeos_command.py`

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6
```
