### PR TITLE
Option to avoid SHA1 hash

### DIFF
--- a/lib/ansible/modules/files/copy.py
+++ b/lib/ansible/modules/files/copy.py
@@ -338,6 +338,7 @@ def main():
 
     if checksum and checksum.upper() == "MD5":
         checksum_src = md5sum_src
+        checksum_dest = None
     else:
         checksum_src = module.sha1(src)
         checksum_dest = None


### PR DESCRIPTION
This increases performance for large files on slow devices

##### SUMMARY
I need to copy large files (movies) from my digisat-receiver but it doesn't have rsync. So I need to use the copy module
SHA1 _and_ MD5 takes ages on that device and IMHO MD5 is really sufficient for this use-case.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
files/copy

##### ANSIBLE VERSION
```
ansible 2.5.1
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/florian/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.15rc1 (default, Apr 15 2018, 21:51:34) [GCC 7.3.0]
```
