### PR TITLE
fix minor issues with debug and item labels

### DIFF
--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -278,14 +278,19 @@ class TaskExecutor:
         label = None
         loop_pause = 0
         templar = Templar(loader=self._loader, shared_loader_obj=self._shared_loader_obj, variables=self._job_vars)
+
+        # FIXME: move this to the object itself to allow post_validate to take care of templating (loop_control.post_validate)
         if self._task.loop_control:
-            # FIXME: move this to the object itself to allow post_validate to take care of templating
             loop_var = templar.template(self._task.loop_control.loop_var)
             index_var = templar.template(self._task.loop_control.index_var)
             loop_pause = templar.template(self._task.loop_control.pause)
-            # the these may be 'None', so we still need to default to something useful
-            # this is tempalted below after an item is assigned
-            label = (self._task.loop_control.label or ('{{' + loop_var + '}}'))
+
+            # This may be 'None',so it is tempalted below after we ensure a value and an item is assigned
+            label = self._task.loop_control.label
+
+        # ensure we always have a label
+        if not label:
+            label = '{{' + loop_var + '}}'
 
         if loop_var in task_vars:
             display.warning(u"The loop variable '%s' is already in use. "
@@ -339,8 +344,8 @@ class TaskExecutor:
             res['_ansible_item_result'] = True
             res['_ansible_ignore_errors'] = task_fields.get('ignore_errors')
 
-            if label is not None:
-                res['_ansible_item_label'] = templar.template(label, cache=False)
+            # gets templated here unlike rest of loop_control fields, depends on loop_var above
+            res['_ansible_item_label'] = templar.template(label, cache=False)
 
             self._rslt_q.put(
                 TaskResult(

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -289,7 +289,7 @@ class TaskExecutor:
             label = self._task.loop_control.label
 
         # ensure we always have a label
-        if not label:
+        if label is None:
             label = '{{' + loop_var + '}}'
 
         if loop_var in task_vars:

--- a/lib/ansible/plugins/callback/__init__.py
+++ b/lib/ansible/plugins/callback/__init__.py
@@ -233,8 +233,8 @@ class CallbackBase(AnsiblePlugin):
         return item
 
     def _get_item(self, result):
-        ''' here for backwards compat, really should have always been named: '''
-        cback = getattr(self, NAME, os.basename(__file__))
+        ''' here for backwards compat, really should have always been named: _get_item_label'''
+        cback = getattr(self, 'NAME', os.basename(__file__))
         self._display.deprecated("The %s callback plugin should be updated to use the _get_item_label method instead" % cback, version="2.11")
         return self._get_item_label(result)
 

--- a/lib/ansible/plugins/callback/__init__.py
+++ b/lib/ansible/plugins/callback/__init__.py
@@ -21,6 +21,7 @@ __metaclass__ = type
 
 import difflib
 import json
+import os
 import sys
 import warnings
 
@@ -233,8 +234,8 @@ class CallbackBase(AnsiblePlugin):
 
     def _get_item(self, result):
         ''' here for backwards compat, really should have always been named: '''
-        cback = getattr(self, NAME, 'callback')
-        self._display.deprecated("The %s plugin should be updated to use the _get_item_label method instead" % cback, version="2.11")
+        cback = getattr(self, NAME, os.basename(__file__))
+        self._display.deprecated("The %s callback plugin should be updated to use the _get_item_label method instead" % cback, version="2.11")
         return self._get_item_label(result)
 
     def _process_items(self, result):

--- a/lib/ansible/plugins/callback/__init__.py
+++ b/lib/ansible/plugins/callback/__init__.py
@@ -233,7 +233,8 @@ class CallbackBase(AnsiblePlugin):
 
     def _get_item(self, result):
         ''' here for backwards compat, really should have always been named: '''
-        self._display.deprecated("This callback should be updated to use the _get_item_label method instead", version="2.11")
+        cback = getattr(self, NAME, 'callback')
+        self._display.deprecated("The %s plugin should be updated to use the _get_item_label method instead" % cback, version="2.11")
         return self._get_item_label(result)
 
     def _process_items(self, result):
@@ -248,9 +249,7 @@ class CallbackBase(AnsiblePlugin):
             if 'msg' in result:
                 # msg should be alone
                 for key in list(result.keys()):
-                    if key.startswith('_'):
-                        continue  # but leave 'control keys' in
-                    if key != 'msg':
+                    if key != 'msg' and not key.startswith('_'):
                         result.pop(key)
             else:
                 # 'var' value as field, so eliminate others and what is left should be varname

--- a/lib/ansible/plugins/callback/__init__.py
+++ b/lib/ansible/plugins/callback/__init__.py
@@ -234,7 +234,7 @@ class CallbackBase(AnsiblePlugin):
 
     def _get_item(self, result):
         ''' here for backwards compat, really should have always been named: _get_item_label'''
-        cback = getattr(self, 'NAME', os.basename(__file__))
+        cback = getattr(self, 'NAME', os.path.basename(__file__))
         self._display.deprecated("The %s callback plugin should be updated to use the _get_item_label method instead" % cback, version="2.11")
         return self._get_item_label(result)
 

--- a/lib/ansible/plugins/callback/__init__.py
+++ b/lib/ansible/plugins/callback/__init__.py
@@ -23,7 +23,9 @@ import difflib
 import json
 import sys
 import warnings
+
 from copy import deepcopy
+from collections import MutableMapping
 
 from ansible import constants as C
 from ansible.parsing.ajson import AnsibleJSONEncoder
@@ -78,7 +80,7 @@ class CallbackBase(AnsiblePlugin):
         if options is not None:
             self.set_options(options)
 
-        self._hide_in_debug = ('changed', 'failed', 'skipped', 'invocation')
+        self._hide_in_debug = ('changed', 'failed', 'skipped', 'invocation', 'skip_reason')
 
     ''' helper for callbacks, so they don't all have to include deepcopy '''
     _copy_result = deepcopy
@@ -172,7 +174,7 @@ class CallbackBase(AnsiblePlugin):
                     if 'before' in diff and 'after' in diff:
                         # format complex structures into 'files'
                         for x in ['before', 'after']:
-                            if isinstance(diff[x], dict):
+                            if isinstance(diff[x], MutableMapping):
                                 diff[x] = json.dumps(diff[x], sort_keys=True, indent=4, separators=(',', ': ')) + '\n'
                         if 'before_header' in diff:
                             before_header = "before: %s" % diff['before_header']
@@ -221,15 +223,18 @@ class CallbackBase(AnsiblePlugin):
                 ret.append(">> the files are different, but the diff library cannot compare unicode strings\n\n")
         return u''.join(ret)
 
-    def _get_item(self, result):
+    def _get_item_label(self, result):
+        ''' retrieves the value to be displayed as a label for an item entry from a result object'''
         if result.get('_ansible_no_log', False):
             item = "(censored due to no_log)"
-        elif result.get('_ansible_item_label', False):
-            item = result.get('_ansible_item_label')
         else:
-            item = result.get('item', None)
-
+            item = result.get('_ansible_item_label', result.get('item'))
         return item
+
+    def _get_item(self, result):
+        ''' here for backwards compat, really should have always been named: '''
+        self._display.deprecated("This callback should be updated to use the _get_item_label method instead", version="2.11")
+        return self._get_item_label(result)
 
     def _process_items(self, result):
         # just remove them as now they get handled by individual callbacks
@@ -237,11 +242,20 @@ class CallbackBase(AnsiblePlugin):
 
     def _clean_results(self, result, task_name):
         ''' removes data from results for display '''
+
+        # mostly controls that debug only outputs what it was meant to
         if task_name in ['debug']:
-            for hideme in self._hide_in_debug:
-                result.pop(hideme, None)
-                if 'msg' in result:
-                    result.pop('item', None)
+            if 'msg' in result:
+                # msg should be alone
+                for key in list(result.keys()):
+                    if key.startswith('_'):
+                        continue  # but leave 'control keys' in
+                    if key != 'msg':
+                        result.pop(key)
+            else:
+                # 'var' value as field, so eliminate others and what is left should be varname
+                for hidme in self._hide_in_debug:
+                    result.pop(hidme, None)
 
     def set_play_context(self, play_context):
         pass
@@ -324,7 +338,7 @@ class CallbackBase(AnsiblePlugin):
     def v2_runner_on_skipped(self, result):
         if C.DISPLAY_SKIPPED_HOSTS:
             host = result._host.get_name()
-            self.runner_on_skipped(host, self._get_item(getattr(result._result, 'results', {})))
+            self.runner_on_skipped(host, self._get_item_label(getattr(result._result, 'results', {})))
 
     def v2_runner_on_unreachable(self, result):
         host = result._host.get_name()

--- a/lib/ansible/plugins/callback/default.py
+++ b/lib/ansible/plugins/callback/default.py
@@ -205,7 +205,7 @@ class CallbackModule(CallbackBase):
         else:
             msg += ": [%s]" % result._host.get_name()
 
-        msg += " => (item=%s)" % (self._get_item(result._result),)
+        msg += " => (item=%s)" % (self._get_item_label(result._result),)
 
         if (self._display.verbosity > 0 or '_ansible_verbose_always' in result._result) and '_ansible_verbose_override' not in result._result:
             msg += " => %s" % self._dump_results(result._result)
@@ -224,12 +224,12 @@ class CallbackModule(CallbackBase):
             msg += "[%s]" % (result._host.get_name())
 
         self._handle_warnings(result._result)
-        self._display.display(msg + " (item=%s) => %s" % (self._get_item(result._result), self._dump_results(result._result)), color=C.COLOR_ERROR)
+        self._display.display(msg + " (item=%s) => %s" % (self._get_item_label(result._result), self._dump_results(result._result)), color=C.COLOR_ERROR)
 
     def v2_runner_item_on_skipped(self, result):
         if self._plugin_options.get('show_skipped_hosts', C.DISPLAY_SKIPPED_HOSTS):  # fallback on constants for inherited plugins missing docs
             self._clean_results(result._result, result._task.action)
-            msg = "skipping: [%s] => (item=%s) " % (result._host.get_name(), self._get_item(result._result))
+            msg = "skipping: [%s] => (item=%s) " % (result._host.get_name(), self._get_item_label(result._result))
             if (self._display.verbosity > 0 or '_ansible_verbose_always' in result._result) and '_ansible_verbose_override' not in result._result:
                 msg += " => %s" % self._dump_results(result._result)
             self._display.display(msg, color=C.COLOR_SKIP)

--- a/test/units/plugins/callback/test_callback.py
+++ b/test/units/plugins/callback/test_callback.py
@@ -51,6 +51,7 @@ class TestCallback(unittest.TestCase):
 
 
 class TestCallbackResults(unittest.TestCase):
+
     def test_get_item(self):
         cb = CallbackBase()
         results = {'item': 'some_item'}
@@ -65,6 +66,22 @@ class TestCallbackResults(unittest.TestCase):
 
         results = {'item': 'some_item', '_ansible_no_log': False}
         res = cb._get_item(results)
+        self.assertEquals(res, "some_item")
+
+    def test_get_item_label(self):
+        cb = CallbackBase()
+        results = {'item': 'some_item'}
+        res = cb._get_item_label(results)
+        self.assertEquals(res, 'some_item')
+
+    def test_get_item_label_no_log(self):
+        cb = CallbackBase()
+        results = {'item': 'some_item', '_ansible_no_log': True}
+        res = cb._get_item_label(results)
+        self.assertEquals(res, "(censored due to no_log)")
+
+        results = {'item': 'some_item', '_ansible_no_log': False}
+        res = cb._get_item_label(results)
         self.assertEquals(res, "some_item")
 
     def test_clean_results_debug_task(self):


### PR DESCRIPTION
##### SUMMARY
 - no more `item=None`, we always have a label now
 - debug should only show expected information, either msg= or the var in var=
 - also fixed method name, deprecated misleading _get_item


<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
fixes #41571
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
callbacks
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
>=2.5
```