### PR TITLE
Do not disable SSH connection sharing for synchronize

### DIFF
--- a/lib/ansible/modules/files/synchronize.py
+++ b/lib/ansible/modules/files/synchronize.py
@@ -472,7 +472,7 @@ def main():
 
         # if the user has not supplied an --rsh option go ahead and add ours
         if not has_rsh:
-            ssh_cmd = [module.get_bin_path('ssh', required=True), '-S', 'none']
+            ssh_cmd = [module.get_bin_path('ssh', required=True)]
             if private_key is not None:
                 ssh_cmd.extend(['-i', private_key])
             # If the user specified a port value


### PR DESCRIPTION
##### SUMMARY
Removed hard-coded ssh control path "none" to make sure synchronize module respects ansible_ssh_common_args. When users want to configure (disable/enable) connection sharing they can do so either in Ansible or in their SSH config outside Ansible. Either way the synchronize module should respect that and not override the ability to use connection sharing by setting the control path to "none" hard-coded.

Fixes #24365

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
synchronize module

##### ANSIBLE VERSION
```
ansible 2.4.2.0
  config file = None
  configured module search path = [u'/Users/pneerincx/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/Cellar/ansible/2.4.2.0_1/libexec/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.14 (default, Oct  4 2017, 17:32:51) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]
```


##### ADDITIONAL INFORMATION
