### PR TITLE
Fixed typo and changed requirements to doc

### DIFF
--- a/lib/ansible/modules/source_control/gitlab_deploy_key.py
+++ b/lib/ansible/modules/source_control/gitlab_deploy_key.py
@@ -60,6 +60,8 @@ options:
     default: present
     choices: [ "present", "absent" ]
 author: "Marcus Watkins (@marwatk)"
+requirements:
+    - python-gitlab python module
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/source_control/gitlab_deploy_key.py
+++ b/lib/ansible/modules/source_control/gitlab_deploy_key.py
@@ -60,8 +60,6 @@ options:
     default: present
     choices: [ "present", "absent" ]
 author: "Marcus Watkins (@marwatk)"
-requirements:
-    - python-gitlab python module
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/source_control/gitlab_group.py
+++ b/lib/ansible/modules/source_control/gitlab_group.py
@@ -186,7 +186,7 @@ def main():
     )
 
     if not HAS_GITLAB_PACKAGE:
-        module.fail_json(msg="Missing requried gitlab module (check docs or install with: pip install python-gitlab")
+        module.fail_json(msg="Missing required gitlab module (check docs or install with: pip install python-gitlab")
 
     server_url = module.params['server_url']
     validate_certs = module.params['validate_certs']


### PR DESCRIPTION
##### SUMMARY
fixed typo
added requirements for gitlab_deploy_key

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
gitlab_deploy_key, gitlab_group

##### ANSIBLE VERSION
```
ansible 2.5.4
  config file = None
  configured module search path = [u'/home/jlozadad/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /data/git/roles/lmao/lib/python2.7/site-packages/ansible
  executable location = /data/git/roles/lmao/bin/ansible
  python version = 2.7.15 (default, May 15 2018, 15:37:31) [GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]
```


##### ADDITIONAL INFORMATION
Looking at the module `gitlab_group` it lists `python-gitlab python module` as a new requirement. Is this change going to be the same for the rest of the gitlab modules? this might cause confusion and have users install both `python-gitlab python module` and `pyapi-gitlab python module`. I think also cause issues since both will have `import gitlab`.

