### PR TITLE
Make admin_users only contain root and toor because admin is used for…

### DIFF
--- a/changelogs/fragments/admin-users-default-change.yaml
+++ b/changelogs/fragments/admin-users-default-change.yaml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - Changed the admin_users config option to not include "admin" by default as
+    admin is frequently used for a non-privileged account  (https://github.com/ansible/ansible/pull/41164)

--- a/lib/ansible/utils/module_docs_fragments/shell_common.py
+++ b/lib/ansible/utils/module_docs_fragments/shell_common.py
@@ -47,9 +47,10 @@ options:
       - dictionary of environment variables and their values to use when executing commands.
   admin_users:
     type: list
-    default: ['root', 'toor', 'admin']
+    default: ['root', 'toor']
     description:
-      - list of users to be expected to have admin privileges, for BSD you might want to add 'toor' for windows 'Administrator'.
+      - list of users to be expected to have admin privileges. This is used by the controller to
+        determine how to share temporary files between the remote user and the become user.
     env:
       - name: ANSIBLE_ADMIN_USERS
     ini:


### PR DESCRIPTION
… non-privileged accounts

This fixes one specific instance of failure to chown from a privileged
account:
https://github.com/ansible/ansible/issues/16052#issuecomment-384976615

Fixes #41160

(cherry picked from commit 461a2733e6962c6c61a6042e25a0b0d3fbec1b7f)



##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/action/__init__.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```