### PR TITLE
Applying santization logic more broadly

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ecs_service.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_service.py
@@ -410,6 +410,10 @@ def main():
                 clientToken = module.params['client_token']
                 loadBalancers = module.params['load_balancers']
 
+                for loadBalancer in loadBalancers:
+                    if 'containerPort' in loadBalancer:
+                        loadBalancer['containerPort'] = int(loadBalancer['containerPort'])
+
                 if update:
                     if (existing['loadBalancers'] or []) != loadBalancers:
                         module.fail_json(msg="It is not possible to update the load balancers of an existing service")
@@ -420,9 +424,6 @@ def main():
                                                           module.params['desired_count'],
                                                           deploymentConfiguration)
                 else:
-                    for loadBalancer in loadBalancers:
-                        if 'containerPort' in loadBalancer:
-                            loadBalancer['containerPort'] = int(loadBalancer['containerPort'])
                     # doesn't exist. create it.
                     response = service_mgr.create_service(module.params['name'],
                                                           module.params['cluster'],


### PR DESCRIPTION
##### SUMMARY
ecs_service does not always convert the containerPort value of the ecs_service module inputs to an integer, which causes the 'nice error message' to eroneously trigger.

##### ISSUE TYPE
 - Bug Report

Fixes issue: #41351 