### PR TITLE
fix nxos edit_config for httpapi and have uniform load_config

### DIFF
--- a/lib/ansible/module_utils/network/nxos/nxos.py
+++ b/lib/ansible/module_utils/network/nxos/nxos.py
@@ -152,8 +152,34 @@ class Cli:
     def load_config(self, config, return_error=False, opts=None):
         """Sends configuration commands to the remote device
         """
+        if opts is None:
+            opts = {}
+
         connection = self._get_connection()
-        return connection.load_config(config, return_error, opts)
+
+        msgs = []
+        try:
+            responses = connection.edit_config(config)
+            msg = json.loads(responses)
+        except ConnectionError as e:
+            code = getattr(e, 'code', 1)
+            message = getattr(e, 'err', e)
+            err = to_text(message, errors='surrogate_then_replace')
+            if opts.get('ignore_timeout') and code:
+                msgs.append(code)
+                return msgs
+            elif code and 'no graceful-restart' in err:
+                if 'ISSU/HA will be affected if Graceful Restart is disabled' in err:
+                    msg = ['']
+                    msgs.extend(msg)
+                    return msgs
+                else:
+                    self._module.fail_json(msg=err)
+            elif code:
+                self._module.fail_json(msg=err)
+
+        msgs.extend(msg)
+        return msgs
 
     def get_capabilities(self):
         """Returns platform info of the remove device

--- a/lib/ansible/module_utils/network/nxos/nxos.py
+++ b/lib/ansible/module_utils/network/nxos/nxos.py
@@ -152,35 +152,8 @@ class Cli:
     def load_config(self, config, return_error=False, opts=None):
         """Sends configuration commands to the remote device
         """
-        if opts is None:
-            opts = {}
-
         connection = self._get_connection()
-
-        msgs = []
-        try:
-            responses = connection.edit_config(config)
-            out = json.loads(responses)[1:-1]
-            msg = out
-        except ConnectionError as e:
-            code = getattr(e, 'code', 1)
-            message = getattr(e, 'err', e)
-            err = to_text(message, errors='surrogate_then_replace')
-            if opts.get('ignore_timeout') and code:
-                msgs.append(code)
-                return msgs
-            elif code and 'no graceful-restart' in err:
-                if 'ISSU/HA will be affected if Graceful Restart is disabled' in err:
-                    msg = ['']
-                    msgs.extend(msg)
-                    return msgs
-                else:
-                    self._module.fail_json(msg=err)
-            elif code:
-                self._module.fail_json(msg=err)
-
-        msgs.extend(msg)
-        return msgs
+        return connection.load_config(config, return_error, opts)
 
     def get_capabilities(self):
         """Returns platform info of the remove device

--- a/lib/ansible/plugins/cliconf/nxos.py
+++ b/lib/ansible/plugins/cliconf/nxos.py
@@ -54,8 +54,10 @@ class Cliconf(CliconfBase):
 
     def send_config(self, config):
         if isinstance(self._connection, NetworkCli):
+            # call cliconf edit_config
             resp = self._connection.edit_config(config)
         else:
+            # call edit_config httpapi/nxos.py
             resp = self._connection.edit_config(config)
         return resp
 

--- a/lib/ansible/plugins/httpapi/nxos.py
+++ b/lib/ansible/plugins/httpapi/nxos.py
@@ -82,18 +82,11 @@ class HttpApi:
     def edit_config(self, command):
         resp = list()
         responses = self.send_request(command, output='config')
-        if isinstance(responses, list):
-            for r in responses:
-                if '{}' in r:
-                    continue
-                resp.append(r)
-            if not resp:
-                resp = ['']
-        else:
-            if responses == '{}':
-                resp = ['']
-            else:
-                resp.append(responses)
+        for response in to_list(responses):
+            if response != '{}':
+                resp.append(response)
+        if not resp:
+            resp = ['']
 
         return json.dumps(resp)
 

--- a/lib/ansible/plugins/httpapi/nxos.py
+++ b/lib/ansible/plugins/httpapi/nxos.py
@@ -80,8 +80,22 @@ class HttpApi:
 
     # Migrated from module_utils
     def edit_config(self, command):
+        resp = list()
         responses = self.send_request(command, output='config')
-        return json.dumps(responses)
+        if isinstance(responses, list):
+            for r in responses:
+                if '{}' in r:
+                    continue
+                resp.append(r)
+            if not resp:
+                resp = ['']
+        else:
+            if responses == '{}':
+                resp = ['']
+            else:
+                resp.append(responses)
+
+        return json.dumps(resp)
 
     def run_commands(self, commands, check_rc=True):
         """Runs list of commands on remote device and returns results


### PR DESCRIPTION
Signed-off-by: Trishna Guha <trishnaguha17@gmail.com>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes https://github.com/ansible/ansible/issues/41269
Migrate load_config from module_utils to cliconf.
Handle json loading of response for httpapi and network_cli in cliconf
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
module_utils/network/nxos/nxos.py
plugins/cliconf/nxos.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel, 2.6
```