### PR TITLE
Update 2.6 roadmap schedule.

### DIFF
--- a/docs/docsite/rst/roadmap/ROADMAP_2_6.rst
+++ b/docs/docsite/rst/roadmap/ROADMAP_2_6.rst
@@ -15,12 +15,12 @@ Actual
 - 2018-05-25 Community Freeze (Non-Core Modules/Plugins)
 - 2018-05-25 Branch stable-2.6
 - 2018-05-30 Alpha Release 2
+- 2018-06-05 Release Candidate 1
+- 2018-06-08 Release Candidate 2
 
 Expected
 ========
 
-- 2018-05-31 Release Candidate 1
-- 2018-06-07 Release Candidate 2
 - 2018-06-14 Release Candidate 3
 - 2018-06-28 Final Release
 


### PR DESCRIPTION
##### SUMMARY

Update 2.6 roadmap schedule.

##### ISSUE TYPE

Docs Pull Request

##### COMPONENT NAME

ROADMAP_2_6.rst

##### ANSIBLE VERSION

```
ansible 2.7.0.dev0 (roadmap 6930c69426) last updated 2018/06/08 23:40:52 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
