### PR TITLE
Fix a process execution using lxc connection plugin on Python3.

### DIFF
--- a/lib/ansible/plugins/connection/lxc.py
+++ b/lib/ansible/plugins/connection/lxc.py
@@ -45,7 +45,7 @@ except ImportError:
 
 from ansible import constants as C
 from ansible import errors
-from ansible.module_utils._text import to_bytes
+from ansible.module_utils._text import to_bytes, to_native
 from ansible.plugins.connection import ConnectionBase
 
 
@@ -116,8 +116,9 @@ class Connection(ConnectionBase):
         ''' run a command on the chroot '''
         super(Connection, self).exec_command(cmd, in_data=in_data, sudoable=sudoable)
 
-        executable = to_bytes(self._play_context.executable, errors='surrogate_or_strict')
-        local_cmd = [executable, '-c', to_bytes(cmd, errors='surrogate_or_strict')]
+        # python2-lxc needs bytes. python3-lxc needs text.
+        executable = to_native(self._play_context.executable, errors='surrogate_or_strict')
+        local_cmd = [executable, '-c', to_native(cmd, errors='surrogate_or_strict')]
 
         read_stdout, write_stdout = None, None
         read_stderr, write_stderr = None, None


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
python2-lxc module needs bytes, on the other hand python3-lxc requires text.
To solve such incompatibility, use to_native other than to_bytes.
Fixes #41060
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
lxc connection plugin

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.3
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/toshi/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python3.6/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 3.6.5 (default, May 11 2018, 04:00:52) [GCC 8.1.0]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
