### PR TITLE
DigitalOcean - Fix TypeError when users have tags named the same as droplets

### DIFF
--- a/contrib/inventory/digital_ocean.py
+++ b/contrib/inventory/digital_ocean.py
@@ -437,6 +437,9 @@ class DigitalOceanInventory(object):
 
     def add_host(self, group, host):
         """ Helper method to reduce host duplication """
+        if group not in self.inventory:
+            self.add_inventory_group(group)
+
         if host not in self.inventory[group]['hosts']:
             self.inventory[group]['hosts'].append(host)
         return
@@ -461,13 +464,9 @@ class DigitalOceanInventory(object):
 
             self.inventory['all']['hosts'].append(dest)
 
-            if droplet['id'] not in self.inventory:
-                self.add_inventory_group(droplet['id'])
-            self.inventory[droplet['id']]['hosts'].append(dest)
+            self.add_host(droplet['id'], dest)
 
-            if droplet['name'] not in self.inventory:
-                self.add_inventory_group(droplet['name'])
-            self.inventory[droplet['name']]['hosts'].append(dest)
+            self.add_host(droplet['name'], dest)
 
             # groups that are always present
             for group in ('digital_ocean',
@@ -476,23 +475,17 @@ class DigitalOceanInventory(object):
                           'size_' + droplet['size']['slug'],
                           'distro_' + DigitalOceanInventory.to_safe(droplet['image']['distribution']),
                           'status_' + droplet['status']):
-                if group not in self.inventory:
-                    self.add_inventory_group(group)
-                self.inventory[group]['hosts'].append(dest)
+                self.add_host(group, dest)
 
             # groups that are not always present
             for group in (droplet['image']['slug'],
                           droplet['image']['name']):
                 if group:
                     image = 'image_' + DigitalOceanInventory.to_safe(group)
-                    if image not in self.inventory:
-                        self.add_inventory_group(image)
-                    self.inventory[image]['hosts'].append(dest)
+                    self.add_host(image, dest)
 
             if droplet['tags']:
                 for tag in droplet['tags']:
-                    if tag not in self.inventory:
-                        self.add_inventory_group(tag)
                     self.add_host(tag, dest)
 
             # hostvars

--- a/contrib/inventory/digital_ocean.py
+++ b/contrib/inventory/digital_ocean.py
@@ -429,6 +429,18 @@ class DigitalOceanInventory(object):
             self.data['tags'] = self.manager.all_tags()
             self.cache_refreshed = True
 
+    def add_inventory_group(self, key):
+        """ Method to create group dict """
+        host_dict = {'hosts': [], 'vars': {}}
+        self.inventory[key] = host_dict
+        return
+
+    def add_host(self, group, host):
+        """ Helper method to reduce host duplication """
+        if host not in self.inventory[group]['hosts']:
+            self.inventory[group]['hosts'].append(host)
+        return
+
     def build_inventory(self):
         """ Build Ansible inventory of droplets """
         self.inventory = {
@@ -449,8 +461,13 @@ class DigitalOceanInventory(object):
 
             self.inventory['all']['hosts'].append(dest)
 
-            self.inventory[droplet['id']] = [dest]
-            self.inventory[droplet['name']] = [dest]
+            if droplet['id'] not in self.inventory:
+                self.add_inventory_group(droplet['id'])
+            self.inventory[droplet['id']]['hosts'].append(dest)
+
+            if droplet['name'] not in self.inventory:
+                self.add_inventory_group(droplet['name'])
+            self.inventory[droplet['name']]['hosts'].append(dest)
 
             # groups that are always present
             for group in ('digital_ocean',
@@ -460,7 +477,7 @@ class DigitalOceanInventory(object):
                           'distro_' + DigitalOceanInventory.to_safe(droplet['image']['distribution']),
                           'status_' + droplet['status']):
                 if group not in self.inventory:
-                    self.inventory[group] = {'hosts': [], 'vars': {}}
+                    self.add_inventory_group(group)
                 self.inventory[group]['hosts'].append(dest)
 
             # groups that are not always present
@@ -469,14 +486,14 @@ class DigitalOceanInventory(object):
                 if group:
                     image = 'image_' + DigitalOceanInventory.to_safe(group)
                     if image not in self.inventory:
-                        self.inventory[image] = {'hosts': [], 'vars': {}}
+                        self.add_inventory_group(image)
                     self.inventory[image]['hosts'].append(dest)
 
             if droplet['tags']:
                 for tag in droplet['tags']:
                     if tag not in self.inventory:
-                        self.inventory[tag] = {'hosts': [], 'vars': {}}
-                    self.inventory[tag]['hosts'].append(dest)
+                        self.add_inventory_group(tag)
+                    self.add_host(tag, dest)
 
             # hostvars
             info = self.do_namespace(droplet)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
The Digital Ocean inventory script could hit a TypeError when users have tags that match a droplet hostname. This PR will fix issue #37220  

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
contrib/inventory/digital_ocean.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (bugfix/issue-37220 c832c2ebaf) last updated 2018/06/09 20:26:04 (GMT -400)
  config file = /Users/abond/ansible/ansible.cfg
  configured module search path = ['/Users/abond/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/abond/Development/github/ansible/lib/ansible
  executable location = /Users/abond/Development/github/ansible/bin/ansible
  python version = 3.6.5 (default, Mar 30 2018, 06:41:49) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]
```