### PR TITLE
meraki module utility - Add documentation to each method

### DIFF
--- a/lib/ansible/module_utils/network/meraki/meraki.py
+++ b/lib/ansible/module_utils/network/meraki/meraki.py
@@ -267,7 +267,6 @@ class MerakiModule(object):
             pass
 
     def exit_json(self, **kwargs):
-
         """Custom written method to exit from module."""
         self.result['response'] = self.response
         self.result['status'] = self.status

--- a/lib/ansible/module_utils/network/meraki/meraki.py
+++ b/lib/ansible/module_utils/network/meraki/meraki.py
@@ -104,7 +104,7 @@ class MerakiModule(object):
         if self.module._debug or self.params['output_level'] == 'debug':
             self.module.warn('Enable debug output because ANSIBLE_DEBUG was set or output_level is set to debug.')
 
-        # TODO: This should be removed as org_name isn't always requireds
+        # TODO: This should be removed as org_name isn't always required
         self.module.required_if = [('state', 'present', ['org_name']),
                                    ('state', 'absent', ['org_name']),
                                    ]

--- a/lib/ansible/module_utils/network/meraki/meraki.py
+++ b/lib/ansible/module_utils/network/meraki/meraki.py
@@ -117,14 +117,14 @@ class MerakiModule(object):
                         }
 
     def define_protocol(self):
-        ''' Set protocol based on use_https parameters '''
+        """ Set protocol based on use_https parameters """
         if self.params['use_https'] is True:
             self.params['protocol'] = 'https'
         else:
             self.params['protocol'] = 'http'
 
     def is_update_required(self, original, proposed, optional_ignore=None):
-        ''' Compare original and proposed data to see if an update is needed '''
+        """ Compare original and proposed data to see if an update is needed """
         is_changed = False
         ignored_keys = ('id', 'organizationId')
         if not optional_ignore:
@@ -149,12 +149,12 @@ class MerakiModule(object):
         return is_changed
 
     def get_orgs(self):
-        ''' Downloads all organizations for a user '''
+        """ Downloads all organizations for a user """
         return self.request('/organizations', method='GET')
 
     def is_org_valid(self, data, org_name=None, org_id=None):
-        ''' Checks whether a specific org exists and is duplicated '''
-        ''' If 0, doesn't exist. 1, exists and not duplicated. >1 duplicated '''
+        """ Checks whether a specific org exists and is duplicated """
+        """ If 0, doesn't exist. 1, exists and not duplicated. >1 duplicated """
         org_count = 0
         if org_name is not None:
             for o in data:
@@ -167,9 +167,9 @@ class MerakiModule(object):
         return org_count
 
     def get_org_id(self, org_name):
-        ''' Returns an organization id based on organization name, only if unique
+        """ Returns an organization id based on organization name, only if unique
             If org_id is specified as parameter, return that instead of a lookup
-        '''
+        """
         orgs = self.get_orgs()
         # self.fail_json(msg='ogs', orgs=orgs)
         if self.params['org_id'] is not None:
@@ -187,7 +187,7 @@ class MerakiModule(object):
                     return str(i['id'])
 
     def get_nets(self, org_name=None, org_id=None):
-        ''' Downloads all networks in an organization '''
+        """ Downloads all networks in an organization """
         if org_name:
             org_id = self.get_org_id(org_name)
         path = self.construct_path('get_all', org_id=org_id)
@@ -195,8 +195,8 @@ class MerakiModule(object):
         return r
 
     def get_net(self, org_name, net_name, data=None):
-        ''' Return network information about a particular network '''
-        ''' TODO: Allow method to download data on its own '''
+        """ Return network information about a particular network """
+        # TODO: Allow method to download data on its own
         # if not data:
         #     org_id = self.get_org_id(org_name)
         #     path = '/organizations/{org_id}/networks/{net_id}'.format(
@@ -214,7 +214,7 @@ class MerakiModule(object):
         return False
 
     def get_net_id(self, org_name=None, net_name=None, data=None):
-        ''' Return network id from lookup or existing data '''
+        """ Return network id from lookup or existing data """
         if data is None:
             self.fail_json(msg='Must implement lookup')
         for n in data:
@@ -223,9 +223,9 @@ class MerakiModule(object):
         self.fail_json(msg='No network found with the name {0}'.format(net_name))
 
     def construct_path(self, action, function=None, org_id=None, net_id=None, org_name=None):
-        ''' Build a path from the URL catalog
+        """ Build a path from the URL catalog 
             Intelligently inserts org_id and net_id
-        '''
+        """
         built_path = None
         if function is None:
             built_path = self.url_catalog[action][self.function]
@@ -238,7 +238,7 @@ class MerakiModule(object):
         return built_path
 
     def request(self, path, method=None, payload=None):
-        ''' Generic HTTP method for Meraki requests '''
+        """ Generic HTTP method for Meraki requests """
         self.path = path
         self.define_protocol()
 
@@ -263,9 +263,10 @@ class MerakiModule(object):
             pass
 
     def exit_json(self, **kwargs):
-        ''' Custom written method to exit from module
+
+        """ Custom written method to exit from module 
             Provides different information if output_level is debug
-        '''
+        """
         self.result['response'] = self.response
         self.result['status'] = self.status
         # Return the gory details when we need it
@@ -277,9 +278,9 @@ class MerakiModule(object):
         self.module.exit_json(**self.result)
 
     def fail_json(self, msg, **kwargs):
-        ''' Custom written method to return info on failure
+        """ Custom written method to return info on failure
             Provides different information if output_level is debug
-        '''
+        """
         self.result['response'] = self.response
         self.result['status'] = self.status
 

--- a/lib/ansible/module_utils/network/meraki/meraki.py
+++ b/lib/ansible/module_utils/network/meraki/meraki.py
@@ -117,14 +117,14 @@ class MerakiModule(object):
                         }
 
     def define_protocol(self):
-        """ Set protocol based on use_https parameters """
+        """Set protocol based on use_https parameters."""
         if self.params['use_https'] is True:
             self.params['protocol'] = 'https'
         else:
             self.params['protocol'] = 'http'
 
     def is_update_required(self, original, proposed, optional_ignore=None):
-        """ Compare original and proposed data to see if an update is needed """
+        """Compare original and proposed data to see if an update is needed."""
         is_changed = False
         ignored_keys = ('id', 'organizationId')
         if not optional_ignore:
@@ -149,12 +149,14 @@ class MerakiModule(object):
         return is_changed
 
     def get_orgs(self):
-        """ Downloads all organizations for a user """
+        """Downloads all organizations for a user."""
         return self.request('/organizations', method='GET')
 
     def is_org_valid(self, data, org_name=None, org_id=None):
-        """ Checks whether a specific org exists and is duplicated """
-        """ If 0, doesn't exist. 1, exists and not duplicated. >1 duplicated """
+        """Checks whether a specific org exists and is duplicated.
+        
+        If 0, doesn't exist. 1, exists and not duplicated. >1 duplicated.
+        """
         org_count = 0
         if org_name is not None:
             for o in data:
@@ -167,8 +169,9 @@ class MerakiModule(object):
         return org_count
 
     def get_org_id(self, org_name):
-        """ Returns an organization id based on organization name, only if unique
-            If org_id is specified as parameter, return that instead of a lookup
+        """Returns an organization id based on organization name, only if unique.
+
+        If org_id is specified as parameter, return that instead of a lookup.
         """
         orgs = self.get_orgs()
         # self.fail_json(msg='ogs', orgs=orgs)
@@ -187,7 +190,7 @@ class MerakiModule(object):
                     return str(i['id'])
 
     def get_nets(self, org_name=None, org_id=None):
-        """ Downloads all networks in an organization """
+        """Downloads all networks in an organization."""
         if org_name:
             org_id = self.get_org_id(org_name)
         path = self.construct_path('get_all', org_id=org_id)
@@ -195,7 +198,7 @@ class MerakiModule(object):
         return r
 
     def get_net(self, org_name, net_name, data=None):
-        """ Return network information about a particular network """
+        """Return network information about a particular network."""
         # TODO: Allow method to download data on its own
         # if not data:
         #     org_id = self.get_org_id(org_name)
@@ -214,7 +217,7 @@ class MerakiModule(object):
         return False
 
     def get_net_id(self, org_name=None, net_name=None, data=None):
-        """ Return network id from lookup or existing data """
+        """Return network id from lookup or existing data."""
         if data is None:
             self.fail_json(msg='Must implement lookup')
         for n in data:
@@ -223,8 +226,9 @@ class MerakiModule(object):
         self.fail_json(msg='No network found with the name {0}'.format(net_name))
 
     def construct_path(self, action, function=None, org_id=None, net_id=None, org_name=None):
-        """ Build a path from the URL catalog
-            Intelligently inserts org_id and net_id
+        """Build a path from the URL catalog.
+
+        Uses function property from class for catalog lookup.
         """
         built_path = None
         if function is None:
@@ -238,7 +242,7 @@ class MerakiModule(object):
         return built_path
 
     def request(self, path, method=None, payload=None):
-        """ Generic HTTP method for Meraki requests """
+        """Generic HTTP method for Meraki requests."""
         self.path = path
         self.define_protocol()
 
@@ -264,9 +268,7 @@ class MerakiModule(object):
 
     def exit_json(self, **kwargs):
 
-        """ Custom written method to exit from module
-            Provides different information if output_level is debug
-        """
+        """Custom written method to exit from module."""
         self.result['response'] = self.response
         self.result['status'] = self.status
         # Return the gory details when we need it
@@ -278,9 +280,7 @@ class MerakiModule(object):
         self.module.exit_json(**self.result)
 
     def fail_json(self, msg, **kwargs):
-        """ Custom written method to return info on failure
-            Provides different information if output_level is debug
-        """
+        """Custom written method to return info on failure."""
         self.result['response'] = self.response
         self.result['status'] = self.status
 

--- a/lib/ansible/module_utils/network/meraki/meraki.py
+++ b/lib/ansible/module_utils/network/meraki/meraki.py
@@ -223,7 +223,7 @@ class MerakiModule(object):
         self.fail_json(msg='No network found with the name {0}'.format(net_name))
 
     def construct_path(self, action, function=None, org_id=None, net_id=None, org_name=None):
-        ''' Build a path from the URL catalog 
+        ''' Build a path from the URL catalog
             Intelligently inserts org_id and net_id
         '''
         built_path = None
@@ -263,7 +263,7 @@ class MerakiModule(object):
             pass
 
     def exit_json(self, **kwargs):
-        ''' Custom written method to exit from module 
+        ''' Custom written method to exit from module
             Provides different information if output_level is debug
         '''
         self.result['response'] = self.response

--- a/lib/ansible/module_utils/network/meraki/meraki.py
+++ b/lib/ansible/module_utils/network/meraki/meraki.py
@@ -154,7 +154,7 @@ class MerakiModule(object):
 
     def is_org_valid(self, data, org_name=None, org_id=None):
         """Checks whether a specific org exists and is duplicated.
-        
+
         If 0, doesn't exist. 1, exists and not duplicated. >1 duplicated.
         """
         org_count = 0

--- a/lib/ansible/module_utils/network/meraki/meraki.py
+++ b/lib/ansible/module_utils/network/meraki/meraki.py
@@ -223,7 +223,7 @@ class MerakiModule(object):
         self.fail_json(msg='No network found with the name {0}'.format(net_name))
 
     def construct_path(self, action, function=None, org_id=None, net_id=None, org_name=None):
-        """ Build a path from the URL catalog 
+        """ Build a path from the URL catalog
             Intelligently inserts org_id and net_id
         """
         built_path = None
@@ -264,7 +264,7 @@ class MerakiModule(object):
 
     def exit_json(self, **kwargs):
 
-        """ Custom written method to exit from module 
+        """ Custom written method to exit from module
             Provides different information if output_level is debug
         """
         self.result['response'] = self.response


### PR DESCRIPTION
##### SUMMARY
All methods in the module utility should have documentation associated to it. Further documentation, such as return options, may make sense. But currently, each method is now described.

Resolves #41283 

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
meraki

##### ANSIBLE VERSION
```
ansible 2.7.0.dev0 (meraki/docs_module_util 48a5514637) last updated 2018/06/09 21:00:15 (GMT -500)
  config file = None
  configured module search path = ['/Users/kbreit/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/kbreit/Documents/Programming/ansible/lib/ansible
  executable location = /Users/kbreit/Documents/Programming/ansible/bin/ansible
  python version = 3.5.4 (default, Feb 25 2018, 14:56:02) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```