### PR TITLE
Update additional pypi.python.org URLs to pypi.org

### DIFF
--- a/docs/docsite/rst/scenario_guides/guide_cloudstack.rst
+++ b/docs/docsite/rst/scenario_guides/guide_cloudstack.rst
@@ -13,7 +13,7 @@ Ansible contains a number of extra modules for interacting with CloudStack based
 
 Prerequisites
 `````````````
-Prerequisites for using the CloudStack modules are minimal. In addition to Ansible itself, all of the modules require the python library ``cs`` https://pypi.python.org/pypi/cs.
+Prerequisites for using the CloudStack modules are minimal. In addition to Ansible itself, all of the modules require the python library ``cs`` https://pypi.org/project/cs/
 
 You'll need this Python module installed on the execution host, usually your workstation.
 

--- a/hacking/update_bundled.py
+++ b/hacking/update_bundled.py
@@ -24,11 +24,11 @@ for filename in glob.glob(os.path.join(basedir, '../lib/ansible/compat/*/__init_
             print('WARNING: {0} contained no metadata.  Could not check for updates'.format(filename))
             continue
         metadata = json.loads(data)
-        pypi_fh = open_url('https://pypi.python.org/pypi/{0}/json'.format(metadata['pypi_name']))
+        pypi_fh = open_url('https://pypi.org/pypi/{0}/json'.format(metadata['pypi_name']))
         pypi_data = json.loads(pypi_fh.read().decode('utf-8'))
         if LooseVersion(metadata['version']) < LooseVersion(pypi_data['info']['version']):
             print('UPDATE: {0} from {1} to {2} {3}'.format(
                 metadata['pypi_name'],
                 metadata['version'],
                 pypi_data['info']['version'],
-                'https://pypi.python.org/pypi/{0}/'.format(metadata['pypi_name'])))
+                'https://pypi.org/pypi/{0}/json'.format(metadata['pypi_name'])))


### PR DESCRIPTION
For details on the new PyPI, see the blog post:

https://pythoninsider.blogspot.ca/2018/04/new-pypi-launched-legacy-pypi-shutting.html