### PR TITLE
ini lookup plugin: fix documentation layout

### DIFF
--- a/lib/ansible/plugins/lookup/ini.py
+++ b/lib/ansible/plugins/lookup/ini.py
@@ -17,26 +17,26 @@ DOCUMENTATION = """
       _terms:
         description: they key(s) too look up
         required: True
-    type:
-      description: ini Type of the file. 'properties' refers to the Java properties files.
-      default: 'ini'
-      choices: ['ini', 'properties']
-    file:
-      description: Name of the file to load
-      default: ansible.ini
-    section:
-      default: global
-      description: section where to lookup for key.
-    re:
-      default: False
-      type: boolean
-      description:  Flag to indicate if the key supplied is a regexp.
-    encoding:
-      default: utf-8
-      description:  Text encoding to use.
-    default:
-      description: return value if the key is not in the ini file
-      default: ''
+      type:
+        description: ini Type of the file. 'properties' refers to the Java properties files.
+        default: 'ini'
+        choices: ['ini', 'properties']
+      file:
+        description: Name of the file to load
+        default: ansible.ini
+      section:
+        default: global
+        description: section where to lookup for key.
+      re:
+        default: False
+        type: boolean
+        description:  Flag to indicate if the key supplied is a regexp.
+      encoding:
+        default: utf-8
+        description:  Text encoding to use.
+      default:
+        description: return value if the key is not in the ini file
+        default: ''
 """
 
 EXAMPLES = """


### PR DESCRIPTION
##### SUMMARY
ini lookup plugin documentation: fix plugin options layout

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->

##### ANSIBLE VERSION
```
ansible 2.7.0.dev0 (lookup-ini-doc ee8a32d895) last updated 2018/06/10 20:32:17 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/seb/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /u/seb/ghq/github.com/stoned/ansible/lib/ansible
  executable location = /u/seb/ghq/github.com/stoned/ansible/bin/ansible
  python version = 2.7.15 (default, May 16 2018, 17:50:09) [GCC 8.1.1 20180502 (Red Hat 8.1.1-1)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
