### PR TITLE
fix handling of ># ending prompts for sros (Fixes #32573)

### DIFF
--- a/lib/ansible/plugins/terminal/sros.py
+++ b/lib/ansible/plugins/terminal/sros.py
@@ -28,7 +28,7 @@ from ansible.errors import AnsibleConnectionFailure
 class TerminalModule(TerminalBase):
 
     terminal_stdout_re = [
-        re.compile(br"[\r\n]?[\w+\-\.:\/\[\]]+(?:\([^\)]+\)){,3}(?:>|#|\$) ?$"),
+        re.compile(br"[\r\n]?[\w+\-\.:\/\[\]]+(?:\([^\)]+\)){,3}(?:>|#|\$|>#) ?$"),
         re.compile(br"\[\w+\@[\w\-\.]+(?: [^\]])\] ?[>#\$] ?$")
     ]
 


### PR DESCRIPTION
##### SUMMARY
Fixed `terminal_stdout_re` for SROS devices to handle prompts ending in unusual char sequence.

Most common SROS prompt look like this
```
{CPM}:{HOSTNAME}>{CONF_LEVEL1}>{CONF_LEVEL2}>...>{CONF_LEVELN}#
```
A real life example would be: `*A:huy>config>port>ethernet>lldp#`

Although, some config levels end with `>#` chars, instead of `#`:
```
*A:huy>cfg>port>eth>lldp>dstmac>#
or
A:sarinsa33# /configure test-oam 
A:sarinsa33>config>test-oam>#
``` 
Notice the trailing sequence `>#` which differs from a simple `#`.

This PR changes the regexp to support this trailing combination. The original regexp and its parsing rules can be observed live [here](https://regex101.com/r/ZmHg3r/1/). You can change the regexp as I did with this PR and see how the first prompt will be matched successfully


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
`sros.py` terminal plugin

##### ANSIBLE VERSION
```
ansible 2.4.0.0
  config file = /Users/romandodin/Dropbox/ALU/PyProjects/ansible-sros/ansible.cfg
  configured module search path = ['/Users/romandodin/PyProjects/ansible']
  ansible python module location = /Users/romandodin/venvs/awscli/lib/python3.6/site-packages/ansible
  executable location = /Users/romandodin/PyProjects/ansible/bin/ansible
  python version = 3.6.1 (default, Mar 23 2017, 16:48:45) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```


##### ADDITIONAL INFORMATION
The following playbook can be used to verify the pre-fix and post-fix conditions:
```
---
- name: mytest
  hosts: localhost
  gather_facts: no
  vars:
    cli:
      host: 10.167.63.15
      username: admin
      password: admin

  tasks:
    - name: regexp test
      sros_config:
          lines:
            - /configure test-oam
            - info
          provider: "{{ cli }}"
```

Since `/configure test-oam` command will change the prompt to an unsupported path (`A:vnspoc-PE>config>test-oam>#`), without this fix the module will fail to proceed.

Once the fix presented with this PR will be put in place, command will execute successfully. 

/cc @privateip 