### PR TITLE
Validate and reject if csr_path is not supplied when provider is not …

### DIFF
--- a/lib/ansible/modules/crypto/openssl_certificate.py
+++ b/lib/ansible/modules/crypto/openssl_certificate.py
@@ -854,6 +854,9 @@ def main():
         except AttributeError:
             module.fail_json(msg='You need to have PyOpenSSL>=0.15')
 
+    if module.params['provider'] != 'assertonly' and module.params['csr_path'] is None:
+        module.fail_json(msg='csr_path is required when provider is not assertonly')
+
     base_dir = os.path.dirname(module.params['path'])
     if not os.path.isdir(base_dir):
         module.fail_json(


### PR DESCRIPTION
…assertonly

##### SUMMARY
Enforce the situations when csr_path, and return more helpful information when it is missing.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
openssl_certificate

##### ANSIBLE VERSION
```
ansible 2.7.0.dev0 (openssl_certificate-csr_path 00dcb1f255) last updated 2018/06/11 09:46:36 (GMT +100)
  config file = None
  configured module search path = ['/home/xyon/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/xyon/Workspace/ansible/lib/ansible
  executable location = /home/xyon/Workspace/ansible/bin/ansible
  python version = 3.5.5 (default, Apr 18 2018, 09:24:20) [GCC 6.4.0]

```


##### ADDITIONAL INFORMATION
csr_path in the doc says it is not required when the provider is assertonly, but it is not validated to be provided if the provider is not assertonly. This leads to a TypeError:

```
", "module_stdout": "Traceback (most recent call last):
  File \"/tmp/ansible_hNWGzI/ansible_module_openssl_certificate.py\", line 808, in <module>
    main()
  File \"/tmp/ansible_hNWGzI/ansible_module_openssl_certificate.py\", line 773, in main
    certificate = SelfSignedCertificate(module)
  File \"/tmp/ansible_hNWGzI/ansible_module_openssl_certificate.py\", line 377, in __init__
    self.csr = crypto_utils.load_certificate_request(self.csr_path)
  File \"/tmp/ansible_hNWGzI/ansible_modlib.zip/ansible/module_utils/crypto.py\", line 92, in load_certificate_request
TypeError: coercing to Unicode: need string or buffer, NoneType found
```

This change instead leads to Ansible returning a more helpful message about what went wrong.