### PR TITLE
Default squash actions add pip

### DIFF
--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -969,7 +969,7 @@ DEFAULT_SFTP_BATCH_MODE:
   yaml: {key: ssh_connection.sftp_batch_mode}
 DEFAULT_SQUASH_ACTIONS:
   name: Squashable actions
-  default: apk, apt, dnf, homebrew, openbsd_pkg, pacman, pkgng, yum, zypper
+  default: apk, apt, dnf, homebrew, openbsd_pkg, pacman, pip, pkgng, yum, zypper
   description:
     - Ansible can optimise actions that call modules that support list parameters when using ``with_`` looping.
       Instead of calling the module once for each item, the module is called once with the full list.

--- a/test/integration/targets/pip/tasks/pip.yml
+++ b/test/integration/targets/pip/tasks/pip.yml
@@ -45,7 +45,7 @@
 - name: removing an unremoved package should return unchanged
   assert:
     that:
-       - "not uninstall_result.changed"
+       - "not (uninstall_result is changed)"
 
 - shell: "{{ ansible_python.executable }} -c 'import {{ pip_test_package }}'"
   register: absent_result
@@ -68,8 +68,8 @@
 - name: verify we recorded a change
   assert:
     that:
-      - "install_result.changed == True"
- 
+      - "install_result is changed"
+
 - shell: "{{ ansible_python.executable }} -c 'import {{ pip_test_package }}'"
   register: installed_result
 
@@ -84,7 +84,7 @@
 - name: assert a change occurred on uninstallation
   assert:
     that:
-      - "absent2.changed"
+      - "absent2 is changed"
 
 # put the test package back
 
@@ -122,7 +122,7 @@
 - name: check that a change occurred
   assert:
     that:
-      - "req_installed.changed"
+      - "req_installed is changed"
 
 - name: "repeat installation to check status didn't change"
   pip:
@@ -133,7 +133,7 @@
 - name: "check that a change didn't occurr this time (bug ansible#1705)"
   assert:
     that:
-      - "not req_installed.changed"
+      - "not (req_installed is changed)"
 
 - name: install the same module from url
   pip: 
@@ -145,7 +145,7 @@
 - name: "check that a change didn't occurr (bug ansible-modules-core#1645)"
   assert:
     that:
-      - "not url_installed.changed"
+      - "not (url_installed is changed)"
 
 # Test pip package in check mode doesn't always report changed.
 
@@ -167,7 +167,7 @@
 - name: make sure pip in check_mode doesn't report changed
   assert:
     that:
-      - "not pip_check_mode.changed"
+      - "not (pip_check_mode is changed)"
 
 # Special case for setuptools
 - name: check for setuptools package
@@ -187,7 +187,7 @@
 - name: make sure setuptools in check_mode doesn't report changed
   assert:
     that:
-      - "not setuptools_check_mode.changed"
+      - "not (setuptools_check_mode is changed)"
 
 
 # Normal case
@@ -208,7 +208,7 @@
 - name: make sure q in check_mode doesn't report changed
   assert:
     that:
-      - "not q_check_mode.changed"
+      - "not (q_check_mode is changed)"
 
 # ansible#23204
 - name: ensure is a fresh virtualenv
@@ -225,7 +225,7 @@
 - name: make sure pip in fresh virtualenv report changed
   assert:
     that:
-      - "pip_install_venv.changed"
+      - "pip_install_venv is changed"
 
 # https://github.com/ansible/ansible/issues/25122
 - name: ensure is a fresh virtualenv
@@ -244,7 +244,7 @@
 - name: make sure fresh virtualenv + chdir report changed
   assert:
     that:
-      - "venv_chdir.changed"
+      - "venv_chdir is changed"
 
 # ansible#38785
 - name: allow empty list of packages
@@ -255,7 +255,7 @@
 - name: ensure empty install is successful
   assert:
     that:
-      - not pip_install_empty.changed
+      - "not (pip_install_empty is changed)"
 
 # https://github.com/ansible/ansible/issues/41043
 - name: do not consider an empty string as a version

--- a/test/integration/targets/pip/tasks/pip.yml
+++ b/test/integration/targets/pip/tasks/pip.yml
@@ -43,7 +43,7 @@
   register: uninstall_result
 
 - name: removing an unremoved package should return unchanged
-  assert: 
+  assert:
     that:
        - "not uninstall_result.changed"
 
@@ -79,7 +79,7 @@
   pip:
     name: "{{ pip_test_package }}"
     state: absent
-  register: absent2  
+  register: absent2
 
 - name: assert a change occurred on uninstallation
   assert:

--- a/test/integration/targets/pip/tasks/pip.yml
+++ b/test/integration/targets/pip/tasks/pip.yml
@@ -27,41 +27,37 @@
 # first some tests installed system-wide
 # verify things were not installed to start with
 
-- name: ensure a package is not installed (precondition setup)
+- name: ensure packages are not installed (precondition setup)
   pip:
-    name: "{{ pip_test_package }}"
+    name: "{{ pip_test_packages }}"
     state: absent
 
 # verify that a package that is uninstalled being set to absent
 # results in an unchanged state and that the test package is not
 # installed
 
-- name: ensure a package is not installed
+- name: ensure packages are not installed
   pip:
-    name: "{{ pip_test_package }}"
+    name: "{{ pip_test_packages }}"
     state: absent
   register: uninstall_result
 
-- name: removing an unremoved package should return unchanged
+- name: removing unremoved packages should return unchanged
   assert:
     that:
        - "not (uninstall_result is changed)"
 
-- command: "{{ ansible_python.executable }} -c 'import {{ pip_test_package }}'"
+- command: "{{ ansible_python.executable }} -c 'import {{ item }}'"
   register: absent_result
-  ignore_errors: True
-
-- name: verify {{ pip_test_package }} is not present
-  assert:
-    that:
-       - "absent_result.rc != 0"
+  failed_when: "absent_result.rc == 0"
+  loop: '{{ pip_test_modules }}'
 
 # now we're going to install the test package knowing it is uninstalled
 # and check that installation was ok
 
-- name: ensure a package is installed
+- name: ensure packages are installed
   pip:
-    name: "{{ pip_test_package }}"
+    name: "{{ pip_test_packages }}"
     state: present
   register: install_result
 
@@ -70,13 +66,14 @@
     that:
       - "install_result is changed"
 
-- command: "{{ ansible_python.executable }} -c 'import {{ pip_test_package }}'"
+- command: "{{ ansible_python.executable }} -c 'import {{ item }}'"
+  loop: '{{ pip_test_modules }}'
 
 # now remove it to test uninstallation of a package we are sure is installed
 
 - name: now uninstall so we can see that a change occurred
   pip:
-    name: "{{ pip_test_package }}"
+    name: "{{ pip_test_packages }}"
     state: absent
   register: absent2
 
@@ -85,11 +82,11 @@
     that:
       - "absent2 is changed"
 
-# put the test package back
+# put the test packages back
 
 - name: now put it back in case someone wanted it (like us!)
   pip:
-    name: "{{ pip_test_package }}"
+    name: "{{ pip_test_packages }}"
     state: present
 
 

--- a/test/integration/targets/pip/tasks/pip.yml
+++ b/test/integration/targets/pip/tasks/pip.yml
@@ -47,7 +47,7 @@
     that:
        - "not (uninstall_result is changed)"
 
-- shell: "{{ ansible_python.executable }} -c 'import {{ pip_test_package }}'"
+- command: "{{ ansible_python.executable }} -c 'import {{ pip_test_package }}'"
   register: absent_result
   ignore_errors: True
 
@@ -70,7 +70,7 @@
     that:
       - "install_result is changed"
 
-- shell: "{{ ansible_python.executable }} -c 'import {{ pip_test_package }}'"
+- command: "{{ ansible_python.executable }} -c 'import {{ pip_test_package }}'"
   register: installed_result
 
 # now remove it to test uninstallation of a package we are sure is installed

--- a/test/integration/targets/pip/tasks/pip.yml
+++ b/test/integration/targets/pip/tasks/pip.yml
@@ -71,7 +71,6 @@
       - "install_result is changed"
 
 - command: "{{ ansible_python.executable }} -c 'import {{ pip_test_package }}'"
-  register: installed_result
 
 # now remove it to test uninstallation of a package we are sure is installed
 

--- a/test/integration/targets/pip/tasks/pip.yml
+++ b/test/integration/targets/pip/tasks/pip.yml
@@ -52,7 +52,7 @@
   ignore_errors: True
 
 - name: verify {{ pip_test_package }} is not present
-  assert: 
+  assert:
     that:
        - "absent_result.rc != 0"
 

--- a/test/integration/targets/pip/tasks/pip.yml
+++ b/test/integration/targets/pip/tasks/pip.yml
@@ -86,9 +86,16 @@
 
 - name: now put it back in case someone wanted it (like us!)
   pip:
-    name: "{{ pip_test_packages }}"
+    name: "{{ item }}"
     state: present
+  with_items: "{{ pip_test_packages }}"
+  register: squash_param
 
+- name: check that list has been condensed
+  assert:
+    that:
+      - squash_param.results|length == 1
+      - squash_param.results[0].name|sort == pip_test_packages|sort
 
 # Test virtualenv installations
 

--- a/test/integration/targets/pip/vars/main.yml
+++ b/test/integration/targets/pip/vars/main.yml
@@ -1,1 +1,1 @@
-pip_test_package: tex
+pip_test_package: sampleproject

--- a/test/integration/targets/pip/vars/main.yml
+++ b/test/integration/targets/pip/vars/main.yml
@@ -1,1 +1,7 @@
 pip_test_package: sampleproject
+pip_test_packages:
+  - sampleproject
+  - decorator
+pip_test_modules:
+  - sample
+  - decorator


### PR DESCRIPTION
##### SUMMARY

- `pip` module: squash `name` parameters. Note that squashing will be removed in 2.11, new code should directly use a list with the `name` parameter.
- pip integration tests:
  - use a package with fewer dependencies
  - minors updates

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
pip

##### ANSIBLE VERSION
```
ansible 2.7.0.dev0 (devel 63ae1a9acd) last updated 2018/06/11 11:21:20 (GMT +200)
```