### PR TITLE
ecs_taskdefinition can absent without containers argument

### DIFF
--- a/hacking/aws_config/testing_policies/compute-policy.json
+++ b/hacking/aws_config/testing_policies/compute-policy.json
@@ -213,7 +213,8 @@
                 "arn:aws:iam::{{aws_account}}:role/ansible_lambda_role",
                 "arn:aws:iam::{{aws_account}}:role/ecsInstanceRole",
                 "arn:aws:iam::{{aws_account}}:role/ecsServiceRole",
-                "arn:aws:iam::{{aws_account}}:role/aws_eks_cluster_role"
+                "arn:aws:iam::{{aws_account}}:role/aws_eks_cluster_role",
+                "arn:aws:iam::{{aws_account}}:role/ecsTaskExecutionRole"
             ]
         },
         {

--- a/lib/ansible/modules/cloud/amazon/ecs_taskdefinition.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_taskdefinition.py
@@ -325,9 +325,10 @@ def main():
         if not module.botocore_at_least('1.10.44'):
             module.fail_json(msg='botocore needs to be version 1.10.44 or higher to use execution_role_arn')
 
-    for container in module.params.get('containers', []):
-        for environment in container.get('environment', []):
-            environment['value'] = to_text(environment['value'])
+    if module.params['containers']:
+        for container in module.params['containers']:
+            for environment in container.get('environment', []):
+                environment['value'] = to_text(environment['value'])
 
     if module.params['state'] == 'present':
         if 'containers' not in module.params or not module.params['containers']:

--- a/test/integration/targets/ecs_cluster/playbooks/roles/ecs_cluster/tasks/main.yml
+++ b/test/integration/targets/ecs_cluster/playbooks/roles/ecs_cluster/tasks/main.yml
@@ -654,6 +654,20 @@
     # ============================================================
     # End tests for Fargate
 
+    - name: create task definition for absent with arn regression test
+      ecs_taskdefinition:
+        containers: "{{ ecs_task_containers }}"
+        family: "{{ ecs_task_name }}-absent"
+        state: present
+        <<: *aws_connection_info
+      register: ecs_task_definition_absent_with_arn
+
+    - name: absent task definition by arn
+      ecs_taskdefinition:
+        arn: "{{ ecs_task_definition_absent_with_arn.taskdefinition.taskDefinitionArn }}"
+        state: absent
+        <<: *aws_connection_info
+
   always:
     # TEAR DOWN: snapshot, ec2 instance, ec2 key pair, security group, vpc
     - name: Announce teardown start
@@ -791,6 +805,15 @@
         containers: "{{ ecs_fargate_task_containers }}"
         family: "{{ ecs_task_name }}-vpc"
         revision: "{{ ecs_fargate_task_definition.taskdefinition.revision }}"
+        state: absent
+        <<: *aws_connection_info
+      ignore_errors: yes
+
+    - name: remove ecs task definition for absent with arn
+      ecs_taskdefinition:
+        containers: "{{ ecs_task_containers }}"
+        family: "{{ ecs_task_name }}-absent"
+        revision: "{{ ecs_task_definition_absent_with_arn.taskdefinition.revision }}"
         state: absent
         <<: *aws_connection_info
       ignore_errors: yes


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Issue:
Following task will raise module error
```yaml
ecs_taskdefinition:
  profile: personal
  state: absent
  arn: "{{ task_output.taskdefinition.taskDefinitionArn }}"
```
Exception:
```python
Traceback (most recent call last):
  File "/Users/CalvinWu/.pyenv/versions/3.6.1/lib/python3.6/pdb.py", line 1667, in main
    pdb._runscript(mainpyfile)
  File "/Users/CalvinWu/.pyenv/versions/3.6.1/lib/python3.6/pdb.py", line 1548, in _runscript
    self.run(statement)
  File "/Users/CalvinWu/.pyenv/versions/3.6.1/lib/python3.6/bdb.py", line 431, in run
    exec(cmd, globals, locals)
  File "<string>", line 1, in <module>
  File "/Users/CalvinWu/Documents/ansible/lib/ansible/modules/cloud/amazon/ecs_taskdefinition.py", line 17, in <module>
    ANSIBLE_METADATA = {'metadata_version': '1.1',
  File "/Users/CalvinWu/Documents/ansible/lib/ansible/modules/cloud/amazon/ecs_taskdefinition.py", line 323, in main
    for container in module.params.get('containers', []):
TypeError: 'NoneType' object is not iterable
```

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
ecs_taskdefinition

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (bugfix-ecs-taskdefiniation-absent a731ffbc56) last updated 2018/06/11 21:58:06 (GMT +800)
  config file = None
  configured module search path = ['/Users/CalvinWu/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/CalvinWu/Documents/ansible/lib/ansible
  executable location = /Users/CalvinWu/Documents/ansible/bin/ansible
  python version = 3.6.1 (default, Apr  4 2017, 14:20:20) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.38)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->
Following playbook should be able to reproduce the issue
```yaml
---
- name: Debug ecs_taskdefinition module absent
  hosts: localhost
  connection: local
  environment:
    AWS_REGION: us-east-1
  gather_facts: no
  tasks:
    - name: present
      ecs_taskdefinition:
        containers:
        - name: simple-app
          cpu: 10
          essential: true
          image: "httpd:2.4"
          memory: 300
          portMappings:
          - containerPort: 80
            hostPort: 80
        family: test-cluster-taskdef
        state: present
      register: task_output

    - name: absent
      ecs_taskdefinition:
        state: absent
        arn: "{{ task_output.taskdefinition.taskDefinitionArn }}"
```

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
