### PR TITLE
VMware: Add documentation for customValue

### DIFF
--- a/contrib/inventory/vmware_inventory.ini
+++ b/contrib/inventory/vmware_inventory.ini
@@ -91,7 +91,7 @@ password=vmware
 
 # You can customize prefix used by custom field hostgroups generation here.
 # vmware_tag_ prefix is the default and consistent with ec2_tag_
-#custom_field_group_prefix = 'vmware_tag_'
+#custom_field_group_prefix = vmware_tag_
 
 # The script attempts to recurse into virtualmachine objects and serialize
 # all available data. The serialization is comprehensive but slow. If the

--- a/contrib/inventory/vmware_inventory.ini
+++ b/contrib/inventory/vmware_inventory.ini
@@ -115,3 +115,6 @@ password=vmware
 #prop10=guest.guestId
 #prop11=guest.guestState
 #prop12=runtime.maxMemoryUsage
+# In order to populate `customValue` (virtual machine's custom attributes) inside hostvars,
+# uncomment following property. Please see - https://github.com/ansible/ansible/issues/41395
+#prop13=customValue


### PR DESCRIPTION

##### SUMMARY
In order to populate custom values (custom attributes of virtual machine)
inside hostvars, customValue needs to be uncommented under the section
properties in vmware_inventory.ini

Fixes: #41395

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
contrib/inventory/vmware_inventory.ini

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7-devel
```