### PR TITLE
don't retrieve config in running_config when config is provided for diff

### DIFF
--- a/lib/ansible/modules/network/eos/eos_config.py
+++ b/lib/ansible/modules/network/eos/eos_config.py
@@ -410,7 +410,7 @@ def main():
 
             result['changed'] = True
 
-    running_config = None
+    running_config = module.params['running_config']
     startup_config = None
 
     diff_ignore_lines = module.params['diff_ignore_lines']
@@ -435,7 +435,7 @@ def main():
             output = run_commands(module, {'command': 'show running-config', 'output': 'text'})
             contents = output[0]
         else:
-            contents = running_config.config_text
+            contents = running_config
 
         # recreate the object in order to process diff_ignore_lines
         running_config = NetworkConfig(indent=1, contents=contents, ignore_lines=diff_ignore_lines)

--- a/lib/ansible/modules/network/ios/ios_config.py
+++ b/lib/ansible/modules/network/ios/ios_config.py
@@ -447,7 +447,7 @@ def main():
 
             result['changed'] = True
 
-    running_config = None
+    running_config = module.params['running_config']
     startup_config = None
 
     diff_ignore_lines = module.params['diff_ignore_lines']
@@ -470,7 +470,7 @@ def main():
             output = run_commands(module, 'show running-config')
             contents = output[0]
         else:
-            contents = running_config.config_text
+            contents = running_config
 
         # recreate the object in order to process diff_ignore_lines
         running_config = NetworkConfig(indent=1, contents=contents, ignore_lines=diff_ignore_lines)

--- a/lib/ansible/modules/network/nxos/nxos_config.py
+++ b/lib/ansible/modules/network/nxos/nxos_config.py
@@ -444,7 +444,7 @@ def main():
 
             result['changed'] = True
 
-    running_config = None
+    running_config = module.params['running_config']
     startup_config = None
 
     diff_ignore_lines = module.params['diff_ignore_lines']
@@ -467,7 +467,7 @@ def main():
             output = execute_show_commands(module, 'show running-config')
             contents = output[0]
         else:
-            contents = running_config.config_text
+            contents = running_config
 
         # recreate the object in order to process diff_ignore_lines
         running_config = NetworkConfig(indent=1, contents=contents, ignore_lines=diff_ignore_lines)

--- a/test/integration/targets/ios_config/templates/basic/base_running_config
+++ b/test/integration/targets/ios_config/templates/basic/base_running_config
@@ -1,0 +1,9 @@
+version 15.6
+service timestamps debug datetime msec
+service timestamps log datetime msec
+no service password-encryption
+!
+hostname an-ios-01.ansible.com
+!
+boot-start-marker
+boot-end-marker

--- a/test/integration/targets/ios_config/templates/basic/intended_running_config
+++ b/test/integration/targets/ios_config/templates/basic/intended_running_config
@@ -1,0 +1,9 @@
+version 15.6
+service timestamps debug datetime msec
+service timestamps log datetime msec
+no service password-encryption
+!
+hostname an-ios-02.ansible.com
+!
+boot-start-marker
+boot-end-marker

--- a/test/integration/targets/ios_config/tests/cli/diff.yaml
+++ b/test/integration/targets/ios_config/tests/cli/diff.yaml
@@ -1,0 +1,29 @@
+---
+- debug: msg="START cli/diff.yaml on connection={{ ansible_connection }}"
+
+- name: ios_config diff against retrieved config
+  ios_config:
+    diff_against: intended
+    intended_config: "{{ lookup('file', '{{ role_path }}/templates/basic/intended_running_config') }}"
+  diff: true
+  register: result
+
+- assert:
+    that:
+      - "'hostname an-ios-02.ansible.com' in result['diff']['after']"
+      - "'hostname {{ shorter_hostname }}' in result['diff']['before']"
+
+- name: ios_config diff against provided running_config
+  ios_config:
+    diff_against: intended
+    intended_config: "{{ lookup('file', '{{ role_path }}/templates/basic/intended_running_config') }}"
+    running_config: "{{ lookup('file', '{{ role_path }}/templates/basic/base_running_config') }}"
+  diff: true
+  register: result
+
+- assert:
+    that:
+      - "'hostname an-ios-02.ansible.com' in result['diff']['after']"
+      - "'hostname an-ios-01.ansible.com' in result['diff']['before']"
+
+- debug: msg="END cli/diff.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/nxos_config/templates/basic/base_running_config
+++ b/test/integration/targets/nxos_config/templates/basic/base_running_config
@@ -1,0 +1,10 @@
+version 7.0(3)I6(1)
+hostname an-nxos9k-02.ansible.com
+vdc an-nxos9k-02 id 1
+  limit-resource vlan minimum 16 maximum 4094
+  limit-resource vrf minimum 2 maximum 4096
+  limit-resource port-channel minimum 0 maximum 511
+  limit-resource u4route-mem minimum 96 maximum 96
+  limit-resource u6route-mem minimum 24 maximum 24
+  limit-resource m4route-mem minimum 58 maximum 58
+  limit-resource m6route-mem minimum 8 maximum 8

--- a/test/integration/targets/nxos_config/templates/basic/intended_running_config
+++ b/test/integration/targets/nxos_config/templates/basic/intended_running_config
@@ -1,0 +1,10 @@
+version 7.0(3)I6(1)
+hostname an-nxos9k-01.ansible.com
+vdc an-nxos9k-01 id 1
+  limit-resource vlan minimum 16 maximum 4094
+  limit-resource vrf minimum 2 maximum 4096
+  limit-resource port-channel minimum 0 maximum 511
+  limit-resource u4route-mem minimum 96 maximum 96
+  limit-resource u6route-mem minimum 24 maximum 24
+  limit-resource m4route-mem minimum 58 maximum 58
+  limit-resource m6route-mem minimum 8 maximum 8

--- a/test/integration/targets/nxos_config/tests/cli/diff.yaml
+++ b/test/integration/targets/nxos_config/tests/cli/diff.yaml
@@ -1,0 +1,33 @@
+---
+- debug: msg="START cli/diff.yaml on connection={{ ansible_connection }}"
+
+- name: setup hostname
+  nxos_config:
+    lines: hostname switch
+
+- name: nxos_config diff against retrieved config
+  nxos_config:
+    diff_against: intended
+    intended_config: "{{ lookup('file', '{{ role_path }}/templates/basic/intended_running_config') }}"
+  diff: true
+  register: result
+
+- assert:
+    that:
+      - "'hostname an-nxos9k-01.ansible.com' in result['diff']['after']"
+      - "'hostname switch' in result['diff']['before']"
+
+- name: nxos_config diff against provided running_config
+  nxos_config:
+    diff_against: intended
+    intended_config: "{{ lookup('file', '{{ role_path }}/templates/basic/intended_running_config') }}"
+    running_config: "{{ lookup('file', '{{ role_path }}/templates/basic/base_running_config') }}"
+  diff: true
+  register: result
+
+- assert:
+    that:
+      - "'hostname an-nxos9k-01.ansible.com' in result['diff']['after']"
+      - "'hostname an-nxos9k-02.ansible.com' in result['diff']['before']"
+
+- debug: msg="END cli/diff.yaml on connection={{ ansible_connection }}"


### PR DESCRIPTION
Signed-off-by: Trishna Guha <trishnaguha17@gmail.com>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
fixes https://github.com/ansible/ansible/issues/41150
when `config` is provided in `running_config`, the module ignores it as `running_config` is set to None and uses retrieved config from device for diff
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
modules/network/{eos,ios,nxos}/{eos,ios,nxos}_config.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```