### PR TITLE
ecs_service does convert containerPort input on update

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ecs_service.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_service.py
@@ -523,6 +523,10 @@ def main():
                         loadBalancer['containerPort'] = int(loadBalancer['containerPort'])
                     loadBalancers.append(loadBalancer)
 
+                for loadBalancer in loadBalancers:
+                    if 'containerPort' in loadBalancer:
+                        loadBalancer['containerPort'] = int(loadBalancer['containerPort'])
+
                 if update:
                     if (existing['loadBalancers'] or []) != loadBalancers:
                         module.fail_json(msg="It is not possible to update the load balancers of an existing service")


### PR DESCRIPTION
##### SUMMARY
ecs_service does not always convert the containerPort value of the ecs_service module inputs to an integer, which causes the 'nice error message' to eroneously trigger.

##### ISSUE TYPE
 - Bug Report

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/ecs_service.py

##### ANSIBLE VERSION
```
ansible 2.5.4
  config file = None
  configured module search path = [u'/Users/fgray/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Library/Python/2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.10 (default, Oct  6 2017, 22:29:07) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.31)]
```

##### OS / ENVIRONMENT
N/A

##### STEPS TO REPRODUCE
- Create/Update a new ECS Task Definition
- Create a new ECS Service
- Attempt to update previously created ecs service

```yaml
---

- hosts: local

  vars:
    - container_port: "8080"

  tasks:
    - name: Create / Update ECS Task definition
      ecs_taskdefinition:
        containers:
          - name: "maintenance"
            cpu: "10"
            essential: true
            image: "XXXXXXXXX.dkr.ecr.us-west-2.amazonaws.com/maintenance:latest"
            memory: 1024
            portMappings:
              - containerPort: "{{ container_port }}"
                hostPort: 0
            entryPoint:
              - "/root/entrypoint.sh"
        family: "maintenance"
        profile: "{{ aws_profile }}"
        region: "us-west-2"
        state: present
        task_role_arn: "arn:aws:iam::XXXXXXXX:role/XXXXXXXXX"
        network_mode: bridge
      register: task_output

    - name: Create / Update ECS Service
      ecs_service:
        cluster: review
        deployment_configuration:
          minimum_healthy_percent: 50
          maximum_percent: 200
        desired_count: 1
        load_balancers:
          - targetGroupArn: "arn:aws:elasticloadbalancing:us-west-2:XXXXXX:targetgroup/maint-test/XXXXX"
            containerName: "maintenance"
            containerPort: "{{ container_port }}"
        name: maintenance
        placement_strategy:
          - type: spread
            field: 'attribute:ecs.availability-zone'
        profile: "{{ aws_profile }}"
        region: us-west-2
        role: arn:aws:iam::XXXXXXXXX:role/ecs_service_role
        state: present
        task_definition: "maintenance:{{ task_output['taskdefinition']['revision'] }}"
```

##### EXPECTED RESULTS
Updating of the ECS service with the new docker image version

##### ACTUAL RESULTS
Received "nice" error message: 
```
fatal: [localhost]: FAILED! => {"changed": false, "msg": "It is not possible to update the load balancers of an existing service"}
```
