### PR TITLE
When using ANSIBLE_JINJA2_NATIVE bypass our None filtering in _finalze

### DIFF
--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -609,8 +609,13 @@ class Templar:
 
     def _finalize(self, thing):
         '''
-        A custom finalize method for jinja2, which prevents None from being returned
+        A custom finalize method for jinja2, which prevents None from being returned. This
+        avoids a string of ``"None"`` as ``None`` has no importance in YAML.
+
+        If using ANSIBLE_JINJA2_NATIVE we bypass this and return the actual value always
         '''
+        if USE_JINJA2_NATIVE:
+            return thing
         return thing if thing is not None else ''
 
     def _fail_lookup(self, name, *args, **kwargs):

--- a/test/integration/targets/jinja2_native_types/runtests.yml
+++ b/test/integration/targets/jinja2_native_types/runtests.yml
@@ -29,6 +29,7 @@
       b_false: False
       s_true: "True"
       s_false: "False"
+      yaml_none: ~
   tasks:
       - name: check jinja version
         shell: python -c 'import jinja2; print(jinja2.__version__)'
@@ -44,4 +45,5 @@
             - import_tasks: test_bool.yml
             - import_tasks: test_dunder.yml
             - import_tasks: test_types.yml
+            - import_tasks: test_none.yml
         when: is_native

--- a/test/integration/targets/jinja2_native_types/test_casting.yml
+++ b/test/integration/targets/jinja2_native_types/test_casting.yml
@@ -11,11 +11,11 @@
 - assert:
     that:
         - 'int_to_str == "2"'
-        - 'int_to_str|type_debug in ["string", "unicode"]'
+        - 'int_to_str|type_debug in ["str", "unicode"]'
         - 'str_to_int == 2'
         - 'str_to_int|type_debug == "int"'
-        - 'dict_to_str|type_debug in ["string", "unicode"]'
-        - 'list_to_str|type_debug in ["string", "unicode"]'
+        - 'dict_to_str|type_debug in ["str", "unicode"]'
+        - 'list_to_str|type_debug in ["str", "unicode"]'
         - 'int_to_bool is sameas true'
         - 'int_to_bool|type_debug == "bool"'
         - 'str_true_to_bool is sameas true'

--- a/test/integration/targets/jinja2_native_types/test_concatentation.yml
+++ b/test/integration/targets/jinja2_native_types/test_concatentation.yml
@@ -23,7 +23,7 @@
 - assert:
     that:
         - 'string_sum == "12"'
-        - 'string_sum|type_debug in ["string", "unicode"]'
+        - 'string_sum|type_debug in ["str", "unicode"]'
 
 - name: add two lists
   set_fact:
@@ -40,7 +40,7 @@
 
 - assert:
     that:
-        - 'list_sum_multi|type_debug in ["string", "unicode"]'
+        - 'list_sum_multi|type_debug in ["str", "unicode"]'
 
 - name: add two dicts
   set_fact:
@@ -58,7 +58,7 @@
 - assert:
     that:
         - 'list_for_strings == "onetwo"'
-        - 'list_for_strings|type_debug in ["string", "unicode"]'
+        - 'list_for_strings|type_debug in ["str", "unicode"]'
 
 - name: loop through list with int
   set_fact:

--- a/test/integration/targets/jinja2_native_types/test_dunder.yml
+++ b/test/integration/targets/jinja2_native_types/test_dunder.yml
@@ -20,4 +20,4 @@
 
 - assert:
     that:
-        - 'const_dunder|type_debug in ["string", "unicode"]'
+        - 'const_dunder|type_debug in ["str", "unicode"]'

--- a/test/integration/targets/jinja2_native_types/test_none.yml
+++ b/test/integration/targets/jinja2_native_types/test_none.yml
@@ -1,0 +1,11 @@
+- name: test none
+  set_fact:
+      none_var: "{{ yaml_none }}"
+      none_var_direct: "{{ None }}"
+
+- assert:
+    that:
+        - 'none_var is sameas none'
+        - 'none_var|type_debug == "NoneType"'
+        - 'none_var_direct is sameas none'
+        - 'none_var_direct|type_debug == "NoneType"'


### PR DESCRIPTION
##### SUMMARY
When using ANSIBLE_JINJA2_NATIVE bypass our None filtering in _finalze. Fixes #41392

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
`lib/ansible/template/__init__.py`

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```