### PR TITLE
Put example umask value in quotation marks

### DIFF
--- a/lib/ansible/modules/packaging/language/pip.py
+++ b/lib/ansible/modules/packaging/language/pip.py
@@ -186,7 +186,7 @@ EXAMPLES = '''
 # Install (Bottle) while ensuring the umask is 0022 (to ensure other users can use it)
 - pip:
     name: bottle
-    umask: 0022
+    umask: "0022"
   become: True
 '''
 


### PR DESCRIPTION
+label: docsite_pr

##### SUMMARY
The given example causes the pip module to fail. If the umask is given as an octal string without quotation marks, the pip module converts it into an integer (i.e., an invalid umask). This is known behavior, but the example is misleading. This change should make using the umask argument more intuitive.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
Pip

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.3
  config file = /home/kevin/ansible/ansible.cfg
  configured module search path = [u'/home/kevin/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```

