### PR TITLE
Ensure we raise the exception caught by _post_validate_environment->_parse_env_kv

### DIFF
--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -280,7 +280,8 @@ class Task(Base, Conditional, Taggable, Become):
                 except AnsibleUndefinedVariable as e:
                     if self.action in ('setup', 'gather_facts') and 'ansible_env' in to_native(e):
                         # ignore as fact gathering sets ansible_env
-                        pass
+                        return
+                    raise
 
             if isinstance(value, list):
                 for env_item in value:


### PR DESCRIPTION
##### SUMMARY
Ensure we raise the exception caught by `_post_validate_environment`->`_parse_env_kv`. Fixes #41322

Looking at the code, we seemed to have the intention of ignoring this in some cases, but the omission of `raise` meant we always ignored it.

Ref: https://github.com/ansible/ansible/commit/df5895e585e

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/playbook/task.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
2.6
2.7
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```