### PR TITLE
no_log even when task_result doesn't provide key

### DIFF
--- a/changelogs/fragments/no_log_fix_for_connection_exceptions.yaml
+++ b/changelogs/fragments/no_log_fix_for_connection_exceptions.yaml
@@ -1,0 +1,9 @@
+---
+bugfixes:
+- '**Security Fix** - Some connection exceptions would cause no_log specified on
+  a task to be ignored.  If this happened, the task information, including any
+  private information could have been displayed to stdout and (if enabled, not
+  the default) logged to a log file specified in ansible.cfg''s log_path.
+  Additionally, sites which redirected stdout from ansible runs to a log file
+  may have stored that private information onto disk that way as well.
+  (https://github.com/ansible/ansible/pull/41414)'

--- a/lib/ansible/executor/task_result.py
+++ b/lib/ansible/executor/task_result.py
@@ -112,7 +112,7 @@ class TaskResult:
         else:
             ignore = _IGNORE
 
-        if self._result.get('_ansible_no_log', False):
+        if self._task.no_log or self._result.get('_ansible_no_log', False):
             x = {"censored": "the output has been hidden due to the fact that 'no_log: true' was specified for this result"}
             for preserve in _PRESERVE:
                 if preserve in self._result:

--- a/test/integration/targets/no_log/no_log_local.yml
+++ b/test/integration/targets/no_log/no_log_local.yml
@@ -63,3 +63,30 @@
       - name: args should be logged when task-level no_log overrides play-level
         shell: echo "LOG_ME_OVERRIDE"
         no_log: false
+
+      - name: Add a fake host for next play
+        add_host:
+            hostname: fake
+
+- name: use 'fake' unreachable host to force unreachable error
+  hosts: fake
+  gather_facts: no
+  connection: ssh
+  tasks:
+    - name: Fail to run a lineinfile task
+      vars:
+        logins:
+          - machine: foo
+            login: bar
+            password: DO_NOT_LOG_UNREACHABLE_ITEM
+          - machine: two
+            login: three
+            password: DO_NOT_LOG_UNREACHABLE_ITEM
+      lineinfile:
+        path: /dev/null
+        mode: 0600
+        create: true
+        insertafter: EOF
+        line: "machine {{ item.machine }} login {{ item.login }} password {{ item.password }}"
+      loop: "{{ logins }}"
+      no_log: true


### PR DESCRIPTION
##### SUMMARY
 - now also checks task property
 - added reproducer to tests for unreachable status on item loop


<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
task result
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
>=2.4
```

