### PR TITLE
Fix idempotency in pip for tasks with empty version argument

### DIFF
--- a/lib/ansible/modules/packaging/language/pip.py
+++ b/lib/ansible/modules/packaging/language/pip.py
@@ -251,7 +251,7 @@ def _is_present(name, version, installed_pkgs, pkg_command):
         else:
             continue
 
-        if pkg_name == name and (version is None or version == pkg_version):
+        if pkg_name == name and (version is None or version == "" or version == pkg_version):
             return True
 
     return False
@@ -443,7 +443,7 @@ def main():
     if umask is not None:
         old_umask = os.umask(umask)
     try:
-        if state == 'latest' and version is not None:
+        if state == 'latest' and (version is not None and version != ""):
             module.fail_json(msg='version is incompatible with state=latest')
 
         if chdir is None:

--- a/test/integration/targets/pip/tasks/pip.yml
+++ b/test/integration/targets/pip/tasks/pip.yml
@@ -216,7 +216,7 @@
     state: absent
     name: "{{ output_dir }}/pipenv"
 
-- name: install pip throught pip into fresh virtualenv
+- name: install pip through pip into fresh virtualenv
   pip:
     name: pip
     virtualenv: "{{ output_dir }}/pipenv"
@@ -258,15 +258,48 @@
       - not pip_install_empty.changed
 
 # https://github.com/ansible/ansible/issues/41043
-- name: do not consider an empty string as a version
-  pip:
-    name: q
-    state: present
-    version: ""
-    virtualenv: "{{ output_dir }}/pipenv"
-  register: pip_install_empty_version_string
+- block:
+    - name: Ensure previous virtualenv no longer exists
+      file:
+        state: absent
+        name: "{{ output_dir }}/pipenv"
 
-- name: ensure that task installation did not fail
-  assert:
-    that:
-      - pip_install_empty_version_string is successful
+    - name: do not consider an empty string as a version
+      pip:
+        name: q
+        state: present
+        version: ""
+        virtualenv: "{{ output_dir }}/pipenv"
+      register: pip_empty_version_string
+
+    - name: test idempotency with empty string
+      pip:
+        name: q
+        state: present
+        version: ""
+        virtualenv: "{{ output_dir }}/pipenv"
+      register: pip_empty_version_string_idempotency
+
+    - name: test idempotency without empty string
+      pip:
+        name: q
+        state: present
+        virtualenv: "{{ output_dir }}/pipenv"
+      register: pip_no_empty_version_string_idempotency
+
+      # 'present' and version=="" is analogous to latest when first installed
+    - name: ensure we installed the latest version
+      pip:
+        name: q
+        state: latest
+        virtualenv: "{{ output_dir }}/pipenv"
+      register: pip_empty_version_idempotency
+
+    - name: ensure that installation worked and is idempotent
+      assert:
+        that:
+          - pip_empty_version_string is changed
+          - pip_empty_version_string is successful
+          - pip_empty_version_idempotency is not changed
+          - pip_no_empty_version_string_idempotency is not changed
+          - pip_empty_version_string_idempotency is not changed


### PR DESCRIPTION
This is a follow up to the fix where we improved the pip module to
handle empty version strings (#41044).

It also adds more integration tests.

##### SUMMARY
Follow up to address comments in #41044

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
pip

##### ANSIBLE VERSION
```
ansible 2.5.4
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /tmp/reproducer/lib/python2.7/site-packages/ansible
  executable location = /tmp/reproducer/bin/ansible
  python version = 2.7.5 (default, Aug  4 2017, 00:39:18) [GCC 4.8.5 20150623 (Red Hat 4.8.5-16)]
```