### PR TITLE
Meraki module utility - Properties for org and net information

### DIFF
--- a/lib/ansible/modules/network/meraki/meraki_admin.py
+++ b/lib/ansible/modules/network/meraki/meraki_admin.py
@@ -123,33 +123,6 @@ data:
                 "tags": []
             }
         ]
-changed:
-    description: Whether object changed as a result of the request.
-    returned: info
-    type: string
-    sample:
-        "changed": false
-
-status:
-    description: HTTP response code
-    returned: info
-    type: int
-    sample:
-        "status": 200
-
-response:
-    description: HTTP response description and bytes
-    returned: info
-    type: string
-    sample:
-        "response": "OK (unknown bytes)"
-
-failed:
-    description: Boolean value whether the task failed
-    returned: info
-    type: bool
-    sample:
-        "failed": false
 '''
 
 import os


### PR DESCRIPTION
##### SUMMARY
Organization and network information are commonly referenced in the Meraki modules. This Pull Request adds properties in the module utility to store the following information: all organizations, all networks, specified network ID, and specified organization ID.

This has two benefits. First, it will allow for slightly simplified code as a method in the utility can be developed to pull this information. Second, it will reduce the number of parameters which need to be passed from module to module utility methods since the information is stored in the module utility instance.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
Meraki