### PR TITLE
Meraki module utility - get_net() downloads networks if data isn't provided

### DIFF
--- a/lib/ansible/module_utils/network/meraki/meraki.py
+++ b/lib/ansible/module_utils/network/meraki/meraki.py
@@ -209,19 +209,16 @@ class MerakiModule(object):
         return self.nets
 
     def get_net(self, org_name, net_name, data=None):
-        """Return network information about a particular network."""
-        # TODO: Allow method to download data on its own
-        # if not data:
-        #     org_id = self.get_org_id(org_name)
-        #     path = '/organizations/{org_id}/networks/{net_id}'.format(
-        #         org_id=org_id,
-        #         net_id=self.get_net_id(
-        #             org_name=org_name,
-        #             net_name=net_name,
-        #             data=data)
-        #     )
-        #     return json.loads(self.request('GET', path))
-        # else:
+        path = self.construct_path('get_all', function='network', org_id=org_id)
+        r = self.request(path, method='GET')
+        return r
+
+    def get_net(self, org_name, net_name, org_id=None, data=None):
+        ''' Return network information '''
+        if not data:
+            if not org_id:
+                org_id = self.get_org_id(org_name)
+            data = self.get_nets(org_id=org_id)
         for n in data:
             if n['name'] == net_name:
                 return n

--- a/lib/ansible/module_utils/network/meraki/meraki.py
+++ b/lib/ansible/module_utils/network/meraki/meraki.py
@@ -208,10 +208,10 @@ class MerakiModule(object):
         self.nets = self.request(path, method='GET')
         return self.nets
 
-    def get_net(self, org_name, net_name, data=None):
-        path = self.construct_path('get_all', function='network', org_id=org_id)
-        r = self.request(path, method='GET')
-        return r
+    # def get_net(self, org_name, net_name, data=None):
+    #     path = self.construct_path('get_all', function='network', org_id=org_id)
+    #     r = self.request(path, method='GET')
+    #     return r
 
     def get_net(self, org_name, net_name, org_id=None, data=None):
         ''' Return network information '''

--- a/lib/ansible/modules/network/meraki/meraki_network.py
+++ b/lib/ansible/modules/network/meraki/meraki_network.py
@@ -206,7 +206,7 @@ def main():
         elif meraki.params['net_name'] or meraki.params['net_id'] is not None:
             meraki.result['data'] = meraki.get_net(meraki.params['org_name'],
                                                    meraki.params['net_name'],
-                                                   nets
+                                                   data=nets
                                                    )
     elif meraki.params['state'] == 'present':
         if meraki.params['net_name']:  # FIXME: Idempotency check is ugly here, improve


### PR DESCRIPTION
##### SUMMARY
- Currently, get_net() requires data to be passed to it
- PR enables get_net() to download all networks if data isn't passed
- Slightly simpler code
- Best practice is to download nets early in execution

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
Meraki