### PR TITLE
ensure copy action plugin returns an invocation in result

### DIFF
--- a/lib/ansible/plugins/action/copy.py
+++ b/lib/ansible/plugins/action/copy.py
@@ -209,10 +209,18 @@ class ActionModule(ActionBase):
     TRANSFERS_FILES = True
 
     def _ensure_invocation(self, result):
-        if result.get('failed', False) and self._play_context.no_log:
-            result['invocation'] = "CENSORED: no_log is set"
-        elif not result.has_key("invocation"):
-            result["invocation"] = self._task.args
+        # NOTE: adding invocation arguments here needs to be kept in sync with
+        # any no_log specified in the argument_spec in the module.
+        # This is not automatic.
+        if 'invocation' not in result:
+            if self._play_context.no_log:
+                result['invocation'] = "CENSORED: no_log is set"
+            else:
+                result["invocation"] = self._task.args.copy()
+
+        if isinstance(result['invocation'], dict) and 'content' in result['invocation']:
+            result['invocation']['content'] = 'CENSORED: content is a no_log parameter'
+
         return result
 
     def _copy_file(self, source_full, source_rel, content, content_tempfile,


### PR DESCRIPTION
Signed-off-by: Adam Miller <admiller@redhat.com>

##### SUMMARY

Fixes #18232

Previously the action plugin for copy, which runs operations on the
control host to orchestrate executing both local actions on the
control host and remote actions on the remote host, is not returning
invocation dict in the result dict, this happens here where the
return from _copy_file() is None

When force is True, the _execute_module() method is called, which
returns the dict containing the invocation key. This patch ensures
there is always an invocation key.


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
copy

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (plugins/action/copy f729467d30) last updated 2018/06/11 16:00:24 (GMT -500)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/admiller/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/admiller/src/dev/ansible/lib/ansible
  executable location = /home/admiller/src/dev/ansible/bin/ansible
  python version = 2.7.15 (default, May 15 2018, 15:37:31) [GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]
```


