### PR TITLE
fix get_vpc() issue for nxos_vpc module

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_vpc.py
+++ b/lib/ansible/modules/network/nxos/nxos_vpc.py
@@ -190,7 +190,15 @@ def get_auto_recovery_default(module):
 
 def get_vpc(module):
     body = run_commands(module, ['show vpc | json'])[0]
-    domain = str(body['vpc-domain-id'])
+    if body:
+        domain = str(body['vpc-domain-id'])
+    else:
+        body = run_commands(module, ['show run vpc | inc domain'])[0]
+        if body:
+            domain = body.split()[2]
+        else:
+            domain = 'not configured'
+
     vpc = {}
     if domain != 'not configured':
         run = get_config(module, flags=['vpc'])


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #41428 
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
nxos_vpc
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (devel 9a4ad89ec5) last updated 2018/06/11 14:58:42 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /root/agents-ci/ansible/lib/ansible
  executable location = /root/agents-ci/ansible/bin/ansible
  python version = 2.7.6 (default, Oct 26 2016, 20:30:19) [GCC 4.8.4]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

* This PR fixes #41428 
* As mentioned in the issue, the output of "show vpc | json" is empty under some conditions for some new platforms. Basically the output of this command is used to get ```vpc domain id``` only.
* To fix this, use "show run vpc | inc domain" (which works always ) in case the above command returns no output and parse it to get the ```vpc domain id```.
* Integration tests are run
* PLEASE CONSIDER cherry picking this change to stable-2.6 branch as it is failing there too.