### PR TITLE
Digital Ocean Block Storage Bug

### DIFF
--- a/lib/ansible/modules/cloud/digital_ocean/digital_ocean_block_storage.py
+++ b/lib/ansible/modules/cloud/digital_ocean/digital_ocean_block_storage.py
@@ -199,7 +199,7 @@ class DOBlockStorage(object):
         json = response.json
         if status == 201:
             self.module.exit_json(changed=True, id=json['volume']['id'])
-        elif status == 409 and json['id'] == 'already_exists':
+        elif status == 409 and json['id'] == 'conflict':
             self.module.exit_json(changed=False)
         else:
             raise DOBlockStorageException(json['message'])


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Digital Ocean Volumes API changed causing Ansible to recieve an unexpected value in the response. This resulted in Ansible not being able to validate the state of existing volumes.

This resolves #39655 by changing the ID to conflict.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
lib/ansible/modules/cloud/digital_ocean/digital_ocean_block_storage.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (bugfix/issue-39655 57f681c926) last updated 2018/06/10 19:45:01 (GMT -400)
  config file = /Users/abond/ansible/ansible.cfg
  configured module search path = ['/Users/abond/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/abond/Development/github/ansible/lib/ansible
  executable location = /Users/abond/Development/github/ansible/bin/ansible
  python version = 3.6.5 (default, Mar 30 2018, 06:41:49) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]
```
