### PR TITLE
Adding module that translates text files using AWS Translate engine

### DIFF
--- a/lib/ansible/modules/cloud/amazon/aws_translate_text.py
+++ b/lib/ansible/modules/cloud/amazon/aws_translate_text.py
@@ -1,0 +1,170 @@
+#!/usr/bin/python
+
+# Copyright: (c) 2018, Aaron Smith <ajsmith10381@gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = r'''
+---
+module: aws_translate_text
+short_description: Translate text using AWS Translate.
+description:
+    - Translate text from local storage or S3 using AWS Translate service.
+author: "Aaron Smith (@slapula)"
+version_added: "2.7"
+requirements: [ 'botocore', 'boto3' ]
+options:
+  source_lang:
+    description:
+    - One of the supported language codes for the target text.
+    - If the `target_language` is not "en", the `source_language` must be "en".
+    choices: ['ar', 'zh', 'fr', 'de', 'pt', 'es', 'en']
+    required: true
+  target_lang:
+    description:
+    - One of the supported language codes for the target text.
+    - If the `sourc_language` is not "en", the `target_language` must be "en".
+    choices: ['ar', 'zh', 'fr', 'de', 'pt', 'es', 'en']
+    required: true
+  source:
+    description:
+    - Input text to synthesize.
+    - Specifies where to get the text file needed for processing.
+    - If you specify ssml as the `text_type`, follow the SSML format for the input text.
+    choices: ['local', 's3']
+    required: true
+  src_bucket:
+    description:
+    - Specifies the S3 bucket that stores the text file.
+  src_path:
+    description:
+    - Specifies the local path or S3 key path where the text file resides.
+  destination:
+    description:
+    - Specifies where to save the resulting audio file.
+    choices: ['local', 's3']
+    required: true
+  dst_bucket:
+    description:
+    - Specifies the S3 bucket where the resulting audio file will reside.
+  dst_path:
+    description:
+    - Specifies the local path or S3 key path for where the resulting audio file.
+extends_documentation_fragment:
+    - ec2
+    - aws
+'''
+
+
+EXAMPLES = r'''
+- name: translate provided text from English to French
+  aws_translate_text:
+    source_lang: 'en'
+    target_lang: 'fr'
+    source: 'local'
+    src_path: "{{ lookup('file', 'tmp/migration_instructions.txt') }}"
+    destination: 'local'
+    dst_path: 'migration_instructions_fr.txt'
+'''
+
+
+RETURN = r'''#'''
+
+import os
+from tempfile import NamedTemporaryFile
+
+from ansible.module_utils.aws.core import AnsibleAWSModule
+
+try:
+    from botocore.exceptions import BotoCoreError, ClientError
+except ImportError:
+    pass  # handled by AnsibleAWSModule
+
+
+def create_translation(client, s3_client, module, params):
+    if module.check_mode:
+        module.exit_json(changed=True)
+    try:
+        response = client.translate_text(**params)
+        if module.params.get('destination') == 'local':
+            f = open(module.params.get('dst_path'), 'w')
+            f.write(response['TranslatedText'])
+            f.close()
+        if module.params.get('destination') == 's3':
+            f = NamedTemporaryFile(mode='w+', delete=False)
+            f.write(response['TranslatedText'])
+            s3_client.upload_fileobj(
+                f,
+                module.params.get('dst_bucket'),
+                module.params.get('dst_path')
+            )
+            f.close()
+            os.unlink(f.name)
+    except (BotoCoreError, ClientError) as e:
+        module.fail_json_aws(e, msg="Failed to translate text")
+
+
+def main():
+    requirements = [
+        ('source', 'local', ['src_path']),
+        ('source', 's3', ['src_bucket', 'src_path']),
+        ('destination', 'local', ['dst_path']),
+        ('destination', 's3', ['dst_bucket', 'dst_path'])
+    ]
+
+    module = AnsibleAWSModule(
+        argument_spec={
+            'source_lang': dict(
+                type='str',
+                choices=['ar', 'zh', 'fr', 'de', 'pt', 'es', 'en'],
+                required=True
+            ),
+            'target_lang': dict(
+                type='str',
+                choices=['ar', 'zh', 'fr', 'de', 'pt', 'es', 'en'],
+                required=True
+            ),
+            'source': dict(type='str', choices=['local', 's3'], required=True),
+            'src_bucket': dict(type='str'),
+            'src_path': dict(type='str'),
+            'destination': dict(type='str', choices=['local', 's3'], required=True),
+            'dst_bucket': dict(type='str'),
+            'dst_path': dict(type='str')
+        },
+        supports_check_mode=True,
+        required_if=requirements,
+    )
+
+    client = module.client('translate')
+    s3_client = module.client('s3')
+
+    params = {}
+    params['SourceLanguageCode'] = module.params.get('source_lang')
+    params['TargetLanguageCode'] = module.params.get('target_lang')
+
+    if module.params.get('source') == 'local':
+        params['Text'] = module.params.get('src_path')
+    if module.params.get('source') == 's3':
+        try:
+            response = s3_client.get_object(
+                Bucket=module.params.get('src_bucket'),
+                Key=module.params.get('src_path')
+            )
+            params['Text'] = response['Body'].read().decode("utf-8")
+        except (BotoCoreError, ClientError) as e:
+            module.fail_json_aws(e, msg="Failed to get text file from S3")
+
+    create_translation(client, s3_client, module, params)
+
+    module.exit_json(changed=True)
+
+
+if __name__ == '__main__':
+    main()

--- a/test/integration/targets/aws_translate_text/aliases
+++ b/test/integration/targets/aws_translate_text/aliases
@@ -1,0 +1,2 @@
+cloud/aws
+posix/ci/cloud/group4/aws

--- a/test/integration/targets/aws_translate_text/files/hello_world.txt
+++ b/test/integration/targets/aws_translate_text/files/hello_world.txt
@@ -1,0 +1,1 @@
+this is a test message

--- a/test/integration/targets/aws_translate_text/meta/main.yaml
+++ b/test/integration/targets/aws_translate_text/meta/main.yaml
@@ -1,0 +1,3 @@
+dependencies:
+  - prepare_tests
+  - setup_ec2

--- a/test/integration/targets/aws_translate_text/tasks/main.yaml
+++ b/test/integration/targets/aws_translate_text/tasks/main.yaml
@@ -1,0 +1,174 @@
+---
+- name: set connection information for all tasks
+  set_fact:
+    aws_connection_info: &aws_connection_info
+      aws_access_key: "{{ aws_access_key }}"
+      aws_secret_key: "{{ aws_secret_key }}"
+      #security_token: "{{ security_token }}"
+      region: "{{ aws_region }}"
+  no_log: true
+
+- block:
+
+    # ============================================================
+    # Parameter Tests
+    # ============================================================
+
+    - name: test with no parameters
+      aws_translate_text:
+      register: result
+      ignore_errors: true
+
+    - name: assert failure when called with no parameters
+      assert:
+        that:
+           - result.failed
+           - 'result.msg.startswith("missing required arguments:")'
+
+    - name: test with missing parameters
+      aws_translate_text:
+        source_lang: 'en'
+      register: result
+      ignore_errors: true
+
+    - name: assert failure when called with missing parameters
+      assert:
+        that:
+           - result.failed
+           - 'result.msg.startswith("missing required arguments:")'
+
+    - name: test with missing parameters
+      aws_translate_text:
+        source_lang: 'en'
+        target_lang: 'fr'
+      register: result
+      ignore_errors: true
+
+    - name: assert failure when called with missing parameters
+      assert:
+        that:
+           - result.failed
+           - 'result.msg.startswith("missing required arguments:")'
+
+    # ============================================================
+    # Testing prerequisites
+    # ============================================================
+
+    - name: create S3 bucket
+      s3_bucket:
+        <<: *aws_connection_info
+        name: "{{ resource_prefix }}-test-bucket"
+
+    - name: upload text file to S3 for testing
+      aws_s3:
+        <<: *aws_connection_info
+        bucket: "{{ resource_prefix }}-test-bucket"
+        object: 'hello_world.txt'
+        src: 'files/hello_world.txt'
+        mode: put
+
+    # ============================================================
+    # Resource Tests
+    # ============================================================
+
+    - name: translate local text and save to local file
+      aws_translate_text:
+        <<: *aws_connection_info
+        source_lang: 'en'
+        target_lang: 'fr'
+        source: 'local'
+        src_path: "{{ lookup('file', 'files/hello_world.txt') }}"
+        destination: 'local'
+        dst_path: "{{ resource_prefix }}-local2local-test.txt"
+      register: result
+
+    - name: assert correct keys are returned
+      assert:
+        that:
+            - result.changed
+
+    - name: stat the local file
+      stat:
+        path: "{{ resource_prefix }}-local2local-test.txt"
+      register: result
+
+    - name: assert correct keys are returned
+      assert:
+        that:
+            - result.stat.exists
+
+    - name: translate local text  and save to S3
+      aws_translate_text:
+        <<: *aws_connection_info
+        source_lang: 'en'
+        target_lang: 'fr'
+        source: 'local'
+        src_path: "{{ lookup('file', 'files/hello_world.txt') }}"
+        destination: 's3'
+        dst_bucket: "{{ resource_prefix }}-test-bucket"
+        dst_path: "{{ resource_prefix }}-local2s3-test.txt"
+      register: result
+
+    - name: assert correct keys are returned
+      assert:
+        that:
+            - result.changed
+
+    - name: translate s3 text file and save to local file
+      aws_translate_text:
+        <<: *aws_connection_info
+        source_lang: 'en'
+        target_lang: 'fr'
+        source: 's3'
+        src_bucket: "{{ resource_prefix }}-test-bucket"
+        src_path: 'hello_world.txt'
+        destination: 'local'
+        dst_path: "{{ resource_prefix }}-s32local-test.txt"
+      register: result
+
+    - name: assert correct keys are returned
+      assert:
+        that:
+            - result.changed
+
+    - name: stat the local file
+      stat:
+        path: "{{ resource_prefix }}-s32local-test.txt"
+      register: result
+
+    - name: assert correct keys are returned
+      assert:
+        that:
+            - result.stat.exists
+
+    - name: translate s3 text file and save to file on s3
+      aws_translate_text:
+        <<: *aws_connection_info
+        source_lang: 'en'
+        target_lang: 'fr'
+        source: 's3'
+        src_bucket: "{{ resource_prefix }}-test-bucket"
+        src_path: 'hello_world.txt'
+        destination: 's3'
+        dst_bucket: "{{ resource_prefix }}-test-bucket"
+        dst_path: "{{ resource_prefix }}-s32s3-test.txt"
+      register: result
+
+    - name: assert correct keys are returned
+      assert:
+        that:
+            - result.changed
+
+  always:
+
+    # ============================================================
+    # Tear down testing resources
+    # ============================================================
+
+    - name: destroy S3 bucket
+      s3_bucket:
+        <<: *aws_connection_info
+        name: "{{ resource_prefix }}-test-bucket"
+        state: absent
+        force: yes
+      ignore_errors: yes


### PR DESCRIPTION
##### SUMMARY
Much like my other text processing module (https://github.com/ansible/ansible/pull/40926), this module doesn't manage the state of a resource.  It can take a local file or a file hosted on S3 and process it using the AWS Translate engine then output the resulting translation to the local filesystem or to an S3 bucket.

##### ISSUE TYPE
 - New Module Pull Request

##### COMPONENT NAME
`aws_translate_text`

##### ANSIBLE VERSION
```
ansible 2.5.4
  config file = None
  configured module search path = [u'/home/ajsmith/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/ajsmith/.local/lib/python2.7/site-packages/ansible
  executable location = /home/ajsmith/.local/bin/ansible
  python version = 2.7.15rc1 (default, Apr 15 2018, 21:51:34) [GCC 7.3.0]
```