### PR TITLE
Backport - Digital Ocean Block Storage Bug

### DIFF
--- a/changelogs/fragments/digital_ocean_block_storage_fix.yaml
+++ b/changelogs/fragments/digital_ocean_block_storage_fix.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- Fix added for Digital Ocean Volumes API change causing Ansible to recieve an unexpected value in the response. (https://github.com/ansible/ansible/pull/41431)

--- a/lib/ansible/modules/cloud/digital_ocean/digital_ocean_block_storage.py
+++ b/lib/ansible/modules/cloud/digital_ocean/digital_ocean_block_storage.py
@@ -199,7 +199,7 @@ class DOBlockStorage(object):
         json = response.json
         if status == 201:
             self.module.exit_json(changed=True, id=json['volume']['id'])
-        elif status == 409 and json['id'] == 'already_exists':
+        elif status == 409 and json['id'] == 'conflict':
             self.module.exit_json(changed=False)
         else:
             raise DOBlockStorageException(json['message'])


### PR DESCRIPTION
##### SUMMARY
Fix added for Digital Ocean Volumes API change causing Ansible to recieve an unexpected value in the response.

Signed-off-by: ABond <ajbond2005@gmail.com>
Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

(cherry picked from commit 4efe53edd5fe0f643cadf8a5bfda7c4833faeb07)

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/digital_ocean_block_storage_fix.yaml
lib/ansible/modules/cloud/digital_ocean/digital_ocean_block_storage.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
Stable-2.6
```