### PR TITLE
Add support for Tower Smart inventories

### DIFF
--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_inventory.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_inventory.py
@@ -37,6 +37,13 @@ options:
     variables:
       description:
         - Inventory variables. Use C(@) to get from file.
+    kind:
+      description:
+        - The kind field. Cannot be modified after created.
+      default: ""
+      choices: ["", "smart"]
+    host_filter:
+        -  The host_filter field. Only useful when kind=smart.
     state:
       description:
         - Desired state of the resource.

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_inventory.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_inventory.py
@@ -43,7 +43,8 @@ options:
       default: ""
       choices: ["", "smart"]
     host_filter:
-        -  The host_filter field. Only useful when kind=smart.
+      description:
+        -  The host_filter field. Only useful when C(kind=smart).
     state:
       description:
         - Desired state of the resource.

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_inventory.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_inventory.py
@@ -42,11 +42,11 @@ options:
         - The kind field. Cannot be modified after created.
       default: ""
       choices: ["", "smart"]
-      version_added: "2.6"
+      version_added: "2.7"
     host_filter:
       description:
         -  The host_filter field. Only useful when C(kind=smart).
-      version_added: "2.6"
+      version_added: "2.7"
     state:
       description:
         - Desired state of the resource.

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_inventory.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_inventory.py
@@ -42,9 +42,11 @@ options:
         - The kind field. Cannot be modified after created.
       default: ""
       choices: ["", "smart"]
+      version_added: "2.6"
     host_filter:
       description:
         -  The host_filter field. Only useful when C(kind=smart).
+      version_added: "2.6"
     state:
       description:
         - Desired state of the resource.

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_inventory.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_inventory.py
@@ -75,6 +75,8 @@ def main():
         description=dict(),
         organization=dict(required=True),
         variables=dict(),
+        kind=dict(choices=['', 'smart'], default=''),
+        host_filter=dict(),
         state=dict(choices=['present', 'absent'], default='present'),
     ))
 
@@ -88,6 +90,8 @@ def main():
     organization = module.params.get('organization')
     variables = module.params.get('variables')
     state = module.params.get('state')
+    kind = module.params.get('kind')
+    host_filter = module.params.get('host_filter')
 
     json_output = {'inventory': name, 'state': state}
 
@@ -102,7 +106,8 @@ def main():
 
             if state == 'present':
                 result = inventory.modify(name=name, organization=org['id'], variables=variables,
-                                          description=description, create_on_missing=True)
+                                          description=description, kind=kind, host_filter=host_filter,
+                                          create_on_missing=True)
                 json_output['id'] = result['id']
             elif state == 'absent':
                 result = inventory.delete(name=name, organization=org['id'])


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Add support for tower_inventory with kind smart. Fixes #41456

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
tower_inventory

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.4
  config file = None
  configured module search path = [u'/Users/evanjame/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/Cellar/ansible/2.5.4/libexec/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.15 (default, May  1 2018, 16:44:37) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->
This simply adds support for the kind and host_filter parameters, which are passed to the tower_cli module.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
