### PR TITLE
Add dbm lookup plugin

### DIFF
--- a/lib/ansible/plugins/lookup/dbm.py
+++ b/lib/ansible/plugins/lookup/dbm.py
@@ -1,0 +1,68 @@
+# (c) 2018 Stoned Elipot <stoned.elipot(at)gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+DOCUMENTATION = """
+    lookup: dbm
+    author: Stoned Elipot <stoned.elipot(at)gmail.com>
+    version_added: "2.6"
+    short_description: return a list of values from a DBM database
+    description:
+        - The dbm lookup fetches the values of a list of keys from a DBM database.
+    options:
+      _terms:
+        description: the list of keys to fetch from the DBM database.
+        type: list
+        elements: string
+      file:
+        description: Name of the DBM database file.
+        type: path
+        required: True
+      default:
+        description: Return value for an absent key.
+        type: string
+        default: ''
+"""
+
+EXAMPLES = """
+- debug: msg="{{ lookup('dbm','key1', 'key2', file='/tmp/my.dbm') }}"
+"""
+
+RETURN = """
+  _list:
+    description:
+      - values of keys.
+    type: list
+"""
+import anydbm
+
+from ansible.plugins.lookup import LookupBase
+from ansible.errors import AnsibleError
+from ansible.module_utils._text import to_native
+
+
+class LookupModule(LookupBase):
+
+    def run(self, terms, variables, **kwargs):
+        dbm_file = kwargs.get('file')
+        if not dbm_file:
+            raise AnsibleError('dbm lookup: missing file option')
+
+        dflt = kwargs.get('default')
+
+        try:
+            dbm = anydbm.open(dbm_file, 'r')
+        except Exception as e:
+            raise AnsibleError('dbm lookup: unable to open DBM %s: %s' % (dbm_file, to_native(e)))
+
+        ret = []
+        for term in terms:
+            try:
+                value = dbm[term]
+            except KeyError:
+                value = dflt
+            ret.append(value)
+
+        dbm.close()
+        return ret

--- a/lib/ansible/plugins/lookup/dbm.py
+++ b/lib/ansible/plugins/lookup/dbm.py
@@ -6,7 +6,7 @@ __metaclass__ = type
 DOCUMENTATION = """
     lookup: dbm
     author: Stoned Elipot <stoned.elipot(at)gmail.com>
-    version_added: "2.6"
+    version_added: "2.7"
     short_description: return a list of values from a DBM database
     description:
         - The dbm lookup fetches the values of a list of keys from a DBM database.
@@ -35,7 +35,10 @@ RETURN = """
       - values of keys.
     type: list
 """
-import anydbm
+try:
+    from anydbm import open as dbm_open
+except ImportError:
+    from dbm import open as dbm_open
 
 from ansible.plugins.lookup import LookupBase
 from ansible.errors import AnsibleError
@@ -52,7 +55,7 @@ class LookupModule(LookupBase):
         dflt = kwargs.get('default')
 
         try:
-            dbm = anydbm.open(dbm_file, 'r')
+            dbm = dbm_open(dbm_file, 'r')
         except Exception as e:
             raise AnsibleError('dbm lookup: unable to open DBM %s: %s' % (dbm_file, to_native(e)))
 

--- a/lib/ansible/plugins/lookup/dbm.py
+++ b/lib/ansible/plugins/lookup/dbm.py
@@ -5,8 +5,8 @@ __metaclass__ = type
 
 DOCUMENTATION = """
     lookup: dbm
-    author: Stoned Elipot <stoned.elipot(at)gmail.com>
-    version_added: "2.7"
+    author: Stoned Elipot (@stoned)
+    version_added: "2.8"
     short_description: return a list of values from a DBM database
     description:
         - The dbm lookup fetches the values of a list of keys from a DBM database.

--- a/lib/ansible/plugins/lookup/dbm.py
+++ b/lib/ansible/plugins/lookup/dbm.py
@@ -23,6 +23,10 @@ DOCUMENTATION = """
         description: Return value for an absent key.
         type: string
         default: ''
+      encoding:
+        description: Decode key values with encoding.
+        type: string
+        default: utf-8
 """
 
 EXAMPLES = """
@@ -42,7 +46,7 @@ except ImportError:
 
 from ansible.plugins.lookup import LookupBase
 from ansible.errors import AnsibleError
-from ansible.module_utils._text import to_native
+from ansible.module_utils._text import to_native, to_text
 
 
 class LookupModule(LookupBase):
@@ -51,6 +55,8 @@ class LookupModule(LookupBase):
         dbm_file = kwargs.get('file')
         if not dbm_file:
             raise AnsibleError('dbm lookup: missing file option')
+
+        encoding = kwargs.get('encoding', 'utf-8')
 
         dflt = kwargs.get('default')
 
@@ -62,7 +68,7 @@ class LookupModule(LookupBase):
         ret = []
         for term in terms:
             try:
-                value = dbm[term]
+                value = to_text(dbm[term], encoding=encoding)
             except KeyError:
                 value = dflt
             ret.append(value)

--- a/test/integration/targets/lookups/files/mktestdbm.py
+++ b/test/integration/targets/lookups/files/mktestdbm.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from __future__ import (absolute_import, division, print_function)                                                                      
+from __future__ import (absolute_import, division, print_function)
 
 import sys
 try:

--- a/test/integration/targets/lookups/files/mktestdbm.py
+++ b/test/integration/targets/lookups/files/mktestdbm.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python
+from __future__ import (absolute_import, division, print_function)                                                                      
+
+import sys
+try:
+    import dbm as db
+except ImportError:
+    import dbm.ndbm as db
+
+
+def main():
+    d = db.open(sys.argv[1], 'n')
+    d['k1'] = 'v1'
+    d['k2'] = 'v2'
+    d.close()
+
+if __name__ == "__main__":
+    main()

--- a/test/integration/targets/lookups/files/mktestdbm.py
+++ b/test/integration/targets/lookups/files/mktestdbm.py
@@ -14,5 +14,6 @@ def main():
     d['k2'] = 'v2'.encode('utf-8')
     d.close()
 
+
 if __name__ == "__main__":
     main()

--- a/test/integration/targets/lookups/files/mktestdbm.py
+++ b/test/integration/targets/lookups/files/mktestdbm.py
@@ -10,8 +10,8 @@ except ImportError:
 
 def main():
     d = db.open(sys.argv[1], 'n')
-    d['k1'] = 'v1'
-    d['k2'] = 'v2'
+    d['k1'] = 'v1'.encode('utf-8')
+    d['k2'] = 'v2'.encode('utf-8')
     d.close()
 
 if __name__ == "__main__":

--- a/test/integration/targets/lookups/tasks/main.yml
+++ b/test/integration/targets/lookups/tasks/main.yml
@@ -305,3 +305,57 @@
     that:
       - 'var_host_info[0] == ansible_host'
       - 'var_host_info[1] == ansible_user'
+
+# DBM LOOKUP
+- name: Set test DBM pathname
+  set_fact:
+    test_dbm: "{{output_dir|expanduser}}/testdbm"
+
+- name: Create test DBM
+  command: "{{ ansible_python.executable }} -c {{ script|quote }}"
+  vars:
+    script: "import dbm as db; d=db.open('{{test_dbm}}', 'n'); d['k1'] = 'v1'; d['k2'] = 'v2'; d.close()"
+
+- name: Lookup keys in DBM and return a list
+  set_fact:
+    dbm_values: "{{ lookup('dbm', 'k1', 'no_such_key', 'k2', file=test_dbm, wantlist=True) }}"
+
+- assert:
+    that:
+      - "dbm_values == ['v1', None, 'v2']"
+
+- name: Lookup one key in DBM and return a list
+  set_fact:
+    dbm_values: "{{ lookup('dbm', 'k1', file=test_dbm, wantlist=True) }}"
+
+- assert:
+    that:
+      - "dbm_values == ['v1']"
+
+- name: Lookup one key in DBM and return a string
+  set_fact:
+    dbm_values: "{{ lookup('dbm', 'k1', file=test_dbm) }}"
+
+- assert:
+    that:
+      - "dbm_values == 'v1'"
+
+- name: Lookup a non existent key in DBM and return a string
+  set_fact:
+    dbm_values: "{{ lookup('dbm', 'no such key', file=test_dbm) }}"
+
+- assert:
+    that:
+      - "dbm_values == ''"
+
+- name: Access to a non existent DBM should raise an error
+  debug:
+    msg: "{{ lookup('dbm', 'key', file=no_such_file) }}"
+  vars:
+    no_such_file: "{{ 'NoN_eXisTeNt_fILe' ~ 100|random }}"
+  ignore_errors: yes
+  register: dbm_error
+
+- assert:
+    that:
+      - 'dbm_error is failed'

--- a/test/integration/targets/lookups/tasks/main.yml
+++ b/test/integration/targets/lookups/tasks/main.yml
@@ -311,10 +311,22 @@
   set_fact:
     test_dbm: "{{output_dir|expanduser}}/testdbm"
 
+- name: Install python-gdbm package if we are on OpenSuSE
+  zypper:
+    name: python-gdbm
+    state: installed
+    update_cache: yes
+  become: yes
+  when: ansible_distribution in ['openSUSE Leap']
+
+- name: Copy script for creating a DBM
+  copy:
+    src: mktestdbm.py
+    dest: "{{output_dir|expanduser}}/mktestdbm.py"
+    mode: 0755
+
 - name: Create test DBM
-  command: "{{ ansible_python.executable }} -c {{ script|quote }}"
-  vars:
-    script: "import dbm as db; d=db.open('{{test_dbm}}', 'n'); d['k1'] = 'v1'; d['k2'] = 'v2'; d.close()"
+  command: "{{ ansible_python.executable }} {{output_dir|expanduser}}/mktestdbm.py {{test_dbm}}"
 
 - name: Lookup keys in DBM and return a list
   set_fact:


### PR DESCRIPTION
##### SUMMARY
Pretty simple new lookup plugin to fetch values from DBM files.

##### ISSUE TYPE
 - Feature Pull Request


##### COMPONENT NAME
lookup plugin dbm

##### ANSIBLE VERSION
```
ansible 2.7.0.dev0 (dbm-lookup b6b20383ea) last updated 2018/06/12 22:45:50 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/seb/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /u/seb/ghq/github.com/stoned/ansible/lib/ansible
  executable location = /u/seb/ghq/github.com/stoned/ansible/bin/ansible
  python version = 2.7.15 (default, May 16 2018, 17:50:09) [GCC 8.1.1 20180502 (Red Hat 8.1.1-1)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
