### PR TITLE
Tasks that are expected to fail need to begin with a special string

### DIFF
--- a/test/integration/targets/no_log/no_log_local.yml
+++ b/test/integration/targets/no_log/no_log_local.yml
@@ -73,7 +73,7 @@
   gather_facts: no
   connection: ssh
   tasks:
-    - name: Fail to run a lineinfile task
+    - name: 'EXPECTED FAILURE: Fail to run a lineinfile task'
       vars:
         logins:
           - machine: foo


### PR DESCRIPTION


##### ISSUE TYPE

 - Bugfix Pull Request


##### COMPONENT NAME
tests for no_log

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel 2.6 2.5 2.4
```


##### ADDITIONAL INFORMATION
For some reason this is only causing problems for 2.4 but it should be needed for all branches.