### PR TITLE
Add workaround for non-standard kerberos environments

### DIFF
--- a/docs/docsite/rst/user_guide/windows_winrm.rst
+++ b/docs/docsite/rst/user_guide/windows_winrm.rst
@@ -426,7 +426,7 @@ work. To troubleshoot Kerberos issues, ensure that:
   an alias is being used. The ``krb5.conf`` file needs to be updated so that
   the fully qualified domain name is used and not an alias.
 
-* If the default kerberos tooling has been replaced or modified (some IdM solutions may do this), it may cause issues when installing or upgrading the ``pykerberos`` python library from ``pip``. To resolve this issue, temporarily install the ``krb5-workstation`` and ``krb5-libs`` packages (for RHEL/Fedora), remove any custom kerberos tooling paths from the PATH environment variable, and retry the installation of ``pykerberos``.
+* If the default kerberos tooling has been replaced or modified (some IdM solutions may do this), this may cause issues when installing or upgrading the Python Kerberos library. As of the time of this writing, this library is called ``pykerberos`` and is known to work with both MIT and Heimdal Kerberos libraries. To resolve ``pykerberos`` installation issues, ensure the system dependencies for Kerberos have been met (see: `Installing the Kerberos Library`_), remove any custom Kerberos tooling paths from the PATH environment variable, and retry the installation of Python Kerberos library package.
 
 CredSSP
 -------

--- a/docs/docsite/rst/user_guide/windows_winrm.rst
+++ b/docs/docsite/rst/user_guide/windows_winrm.rst
@@ -426,6 +426,8 @@ work. To troubleshoot Kerberos issues, ensure that:
   an alias is being used. The ``krb5.conf`` file needs to be updated so that
   the fully qualified domain name is used and not an alias.
 
+* If the default kerberos tooling has been replaced or modified (some IdM solutions may do this), it may cause issues when installing or upgrading the ``pykerberos`` python library from ``pip``. To resolve this issue, temporarily install the ``krb5-workstation`` and ``krb5-libs`` packages (for RHEL/Fedora), remove any custom kerberos tooling paths from the PATH environment variable, and retry the installation of ``pykerberos``.
+
 CredSSP
 -------
 CredSSP authentication is a newer authentication protocol that allows


### PR DESCRIPTION
##### SUMMARY
Add general information and small workaround for environments not using the standard MIT kerberos tooling.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
Windows Remote Management

##### ANSIBLE VERSION
```
ansible 2.5.2
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/var/lib/awx/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /var/lib/awx/venv/ansible/lib/python2.7/site-packages/ansible
  executable location = /var/lib/awx/venv/ansible/bin/ansible
  python version = 2.7.5 (default, May  3 2017, 07:55:04) [GCC 4.8.5 20150623 (Red Hat 4.8.5-14)]
```


##### ADDITIONAL INFORMATION
No additional info.
