### PR TITLE
Tasks that are expected to fail need to begin with a special string

### DIFF
--- a/test/integration/targets/no_log/no_log_local.yml
+++ b/test/integration/targets/no_log/no_log_local.yml
@@ -73,7 +73,7 @@
   gather_facts: no
   connection: ssh
   tasks:
-    - name: Fail to run a lineinfile task
+    - name: 'EXPECTED FAILURE: Fail to run a lineinfile task'
       vars:
         logins:
           - machine: foo


### PR DESCRIPTION
(cherry picked from commit a5fd86cf6d62bb6ecb624edfc0b3775705e46f06)

##### SUMMARY
Backports fix for the new no_log tests.  Note that this currently was only a problem on 2.4 but it does no harm in the intermediate branches (and since we don't know why it isn't broken on the intermediate branches it's better that we apply it).

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME
no_log integration tests

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```