### PR TITLE
To fix eos_vrf failure when transport method is eapi

### DIFF
--- a/lib/ansible/module_utils/network/eos/eos.py
+++ b/lib/ansible/module_utils/network/eos/eos.py
@@ -409,10 +409,7 @@ def is_eapi(module):
 
 
 def to_command(module, commands):
-    if isinstance(commands, dict):
-        default_output = commands['output']
-        commands = commands['command']
-    elif is_eapi(module):
+    if is_eapi(module):
         default_output = 'json'
     else:
         default_output = 'text'

--- a/lib/ansible/module_utils/network/eos/eos.py
+++ b/lib/ansible/module_utils/network/eos/eos.py
@@ -409,7 +409,9 @@ def is_eapi(module):
 
 
 def to_command(module, commands):
-    if is_eapi(module):
+    if 'text' in commands[0].split('| '):
+        default_output = 'text'
+    elif is_eapi(module):
         default_output = 'json'
     else:
         default_output = 'text'

--- a/lib/ansible/module_utils/network/eos/eos.py
+++ b/lib/ansible/module_utils/network/eos/eos.py
@@ -409,8 +409,9 @@ def is_eapi(module):
 
 
 def to_command(module, commands):
-    if 'text' in commands[0].split('| '):
-        default_output = 'text'
+    if isinstance(commands, dict):
+        default_output = commands['output']
+        commands = commands['command']
     elif is_eapi(module):
         default_output = 'json'
     else:

--- a/lib/ansible/modules/network/eos/eos_vrf.py
+++ b/lib/ansible/modules/network/eos/eos_vrf.py
@@ -189,7 +189,7 @@ def map_obj_to_commands(updates, module):
 
 def map_config_to_obj(module):
     objs = []
-    output = run_commands(module, ['show vrf | text'])
+    output = run_commands(module, {'command': 'show vrf', 'output': 'text'})
 
     lines = output[0].strip().splitlines()[3:]
 

--- a/lib/ansible/modules/network/eos/eos_vrf.py
+++ b/lib/ansible/modules/network/eos/eos_vrf.py
@@ -189,7 +189,7 @@ def map_obj_to_commands(updates, module):
 
 def map_config_to_obj(module):
     objs = []
-    output = run_commands(module, ['show vrf'])
+    output = run_commands(module, ['show vrf | text'])
 
     lines = output[0].strip().splitlines()[3:]
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This PR is raised to resolve `eos_vrf` failure when the transport method is `eapi`, and this issue was raised in bug #40930  
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description, but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
eos
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
User faces `unconverted error` when transport method `eapi` is used in `eos_vrf` module and this happened because, in `eos`,  not all show commands have been converted
to return formatted data, and trying to run the command with the format parameter set to json will result in an error, and in such cases, output format needs to be changed `text`.
```
