### PR TITLE
Provide kubernetes definition diffs in check_mode

### DIFF
--- a/lib/ansible/module_utils/common/dict_transformations.py
+++ b/lib/ansible/module_utils/common/dict_transformations.py
@@ -8,6 +8,7 @@ __metaclass__ = type
 
 
 import re
+from copy import deepcopy
 
 
 def camel_dict_to_snake_dict(camel_dict, reversible=False, ignore_list=()):
@@ -105,3 +106,18 @@ def _camel_to_snake(name, reversible=False):
     all_cap_pattern = r'([a-z0-9])([A-Z]+)'
     s2 = re.sub(first_cap_pattern, r'\1_\2', s1)
     return re.sub(all_cap_pattern, r'\1_\2', s2).lower()
+
+
+def dict_merge(a, b):
+    '''recursively merges dicts. not just simple a['key'] = b['key'], if
+    both a and b have a key whose value is a dict then dict_merge is called
+    on both values and the result stored in the returned dictionary.'''
+    if not isinstance(b, dict):
+        return b
+    result = deepcopy(a)
+    for k, v in b.items():
+        if k in result and isinstance(result[k], dict):
+                result[k] = dict_merge(result[k], v)
+        else:
+            result[k] = deepcopy(v)
+    return result

--- a/lib/ansible/module_utils/k8s/raw.py
+++ b/lib/ansible/module_utils/k8s/raw.py
@@ -20,6 +20,7 @@ from __future__ import absolute_import, division, print_function
 
 
 from ansible.module_utils.k8s.common import KubernetesAnsibleModule
+from ansible.module_utils.common.dict_transformations import dict_merge
 
 
 try:
@@ -133,7 +134,9 @@ class KubernetesRawModule(KubernetesAnsibleModule):
                 return result
         else:
             if not existing:
-                if not self.check_mode:
+                if self.check_mode:
+                    k8s_obj = definition
+                else:
                     try:
                         k8s_obj = resource.create(definition, namespace=namespace)
                     except ConflictError:
@@ -143,7 +146,7 @@ class KubernetesRawModule(KubernetesAnsibleModule):
                         self.warn("{0} was not found, but creating it returned a 409 Conflict error. This can happen \
                                   if the resource you are creating does not directly create a resource of the same kind.".format(name))
                         return result
-                    result['result'] = k8s_obj.to_dict()
+                result['result'] = k8s_obj.to_dict()
                 result['changed'] = True
                 result['method'] = 'create'
                 return result
@@ -152,28 +155,32 @@ class KubernetesRawModule(KubernetesAnsibleModule):
             diffs = []
 
             if existing and force:
-                if not self.check_mode:
+                if self.check_mode:
+                    k8s_obj = definition
+                else:
                     try:
                         k8s_obj = resource.replace(definition, name=name, namespace=namespace).to_dict()
-                        match, diffs = self.diff_objects(existing.to_dict(), k8s_obj)
-                        result['result'] = k8s_obj
                     except DynamicApiError as exc:
                         self.fail_json(msg="Failed to replace object: {0}".format(exc.body),
                                        error=exc.status, status=exc.status, reason=exc.reason)
+                match, diffs = self.diff_objects(existing.to_dict(), k8s_obj)
+                result['result'] = k8s_obj
                 result['changed'] = not match
                 result['method'] = 'replace'
                 result['diff'] = diffs
                 return result
 
             # Differences exist between the existing obj and requested params
-            if not self.check_mode:
+            if self.check_mode:
+                k8s_obj = dict_merge(existing.to_dict(), definition)
+            else:
                 try:
                     k8s_obj = resource.patch(definition, name=name, namespace=namespace).to_dict()
-                    match, diffs = self.diff_objects(existing.to_dict(), k8s_obj)
-                    result['result'] = k8s_obj
                 except DynamicApiError as exc:
                     self.fail_json(msg="Failed to patch object: {0}".format(exc.body),
                                    error=exc.status, status=exc.status, reason=exc.reason)
+            match, diffs = self.diff_objects(existing.to_dict(), k8s_obj)
+            result['result'] = k8s_obj
             result['changed'] = not match
             result['method'] = 'patch'
             result['diff'] = diffs

--- a/lib/ansible/modules/cloud/azure/azure_rm_resource.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_resource.py
@@ -114,7 +114,7 @@ response:
 
 from ansible.module_utils.azure_rm_common import AzureRMModuleBase
 from ansible.module_utils.azure_rm_common_rest import GenericRestClient
-from copy import deepcopy
+from ansible.module_utils.common.dict_transformations import dict_merge
 
 try:
     from msrestazure.azure_exceptions import CloudError
@@ -263,21 +263,6 @@ class AzureRMResource(AzureRMModuleBase):
         self.results['changed'] = needs_update
 
         return self.results
-
-
-def dict_merge(a, b):
-    '''recursively merges dict's. not just simple a['key'] = b['key'], if
-    both a and bhave a key who's value is a dict then dict_merge is called
-    on both values and the result stored in the returned dictionary.'''
-    if not isinstance(b, dict):
-        return b
-    result = deepcopy(a)
-    for k, v in b.items():
-        if k in result and isinstance(result[k], dict):
-                result[k] = dict_merge(result[k], v)
-        else:
-            result[k] = deepcopy(v)
-    return result
 
 
 def main():


### PR DESCRIPTION
##### SUMMARY

Move dict_merge from azure_rm_resource module to
module_utils.common.dict_transformations and add tests.

Use dict_merge to provide a fairly realistic, reliable
diff output when k8s-based modules are run in check_mode.

Rename unit tests so that they actually run and reflect
the module_utils they're based on.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
module_utils/k8s/raw

##### ANSIBLE VERSION
```
ansible 2.7.0.dev0 (detached HEAD ref: refs/) last updated 2018/06/13 16:56:12 (GMT +1000)
  config file = None
  configured module search path = [u'/Users/will/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/will/src/ansible/lib/ansible
  executable location = /Users/will/src/ansible/bin/ansible
  python version = 2.7.14 (default, Mar  9 2018, 23:57:12) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```


##### ADDITIONAL INFORMATION
