### PR TITLE
Restore correct first playbook example

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_intro.rst
+++ b/docs/docsite/rst/user_guide/playbooks_intro.rst
@@ -60,26 +60,18 @@ For starters, here's a playbook that contains just one play::
         http_port: 80
         max_clients: 200
       remote_user: root
-      tasks:
-      - name: ensure apache is at the latest version
-        yum:
-          name: httpd
-          state: latest
-      - name: write the apache config file
-        template:
-          src: /srv/httpd.j2
-          dest: /etc/httpd.conf
+    tasks:
+    - name: ensure apache is at the latest version
+      yum: name=httpd state=latest
+    - name: write the apache config file
+        template: src=/srv/httpd.j2 dest=/etc/httpd.conf
         notify:
         - restart apache
-      - name: ensure apache is running
-        service:
-          name: httpd
-          state: started
-      handlers:
+    - name: ensure apache is running (and enable it at boot)
+        service: name=httpd state=started enabled=yes
+    handlers:
         - name: restart apache
-          service:
-            name: httpd
-            state: restarted
+          service: name=httpd state=restarted
 
 Playbooks can contain multiple plays. You may have a playbook that targets first
 the web servers, and then the database servers. For example::


### PR DESCRIPTION
In previous versions of the Ansible documentation, the first playbook example uses long commands with keyword=value format in the YAML file. The documentation then explains with a second example how to achieve the same result using YAML dictionaries.

In the current version of the documentation, the first example using keyword=value format has been incorrectly replaced with the YAML dictionary example, leaving the documentation in an inconsistent state. The documentation currently falsely states that the first example uses keyword=value format. This commit reverses the change in order to make the documentation consistent and more useful.

+label: docsite_pr

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
docs
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
>=2.5
```