### PR TITLE
Added Source username and password support (#30784)

### DIFF
--- a/lib/ansible/modules/windows/win_chocolatey.ps1
+++ b/lib/ansible/modules/windows/win_chocolatey.ps1
@@ -20,8 +20,8 @@ $package = Get-AnsibleParam -obj $params -name "name" -type "str" -failifempty $
 $force = Get-AnsibleParam -obj $params -name "force" -type "bool" -default $false
 $version = Get-AnsibleParam -obj $params -name "version" -type "str"
 $source = Get-AnsibleParam -obj $params -name "source" -type "str"
-$user = Get-AnsibleParam -obj $params -name "user" -type "str"
-$password = Get-AnsibleParam -obj $params -name "password" -type "str" -failifempty ($user -ne $null)
+$username = Get-AnsibleParam -obj $params -name "username" -type "str"
+$password = Get-AnsibleParam -obj $params -name "password" -type "str" -failifempty ($username -ne $null)
 $showlog = Get-AnsibleParam -obj $params -name "showlog" -type "bool" -default $false
 $timeout = Get-AnsibleParam -obj $params -name "timeout" -type "int" -default 2700 -aliases "execution_timeout"
 $state = Get-AnsibleParam -obj $params -name "state" -type "str" -default "present" -validateset "absent","downgrade","latest","present","reinstalled"
@@ -175,7 +175,7 @@ Function Choco-Upgrade
         [int] $timeout,
         [bool] $skipscripts,
         [string] $source,
-        [string] $user,
+        [string] $username,
         [string] $password,
         [string] $installargs,
         [string] $packageparams,
@@ -211,9 +211,9 @@ Function Choco-Upgrade
         $options += "--source", $source
     }
 
-    if ($user)
+    if ($username)
     {
-        $options += "--user=`"'$user'`""
+        $options += "--user=`"'$username'`""
     }
 
     if ($password)
@@ -322,7 +322,7 @@ Function Choco-Install
         [int] $timeout,
         [bool] $skipscripts,
         [string] $source,
-        [string] $user,
+        [string] $username,
         [string] $password,
         [string] $installargs,
         [string] $packageparams,
@@ -346,7 +346,7 @@ Function Choco-Install
                 -ignorechecksums $ignorechecksums -ignoredependencies $ignoredependencies `
                 -allowdowngrade $allowdowngrade -proxy_url $proxy_url `
                 -proxy_username $proxy_username -proxy_password $proxy_password `
-                -allowprerelease $allowprerelease
+                -allowprerelease $allowprerelease  -username $username -password $password
             return
         }
         elseif (-not $force)
@@ -372,9 +372,9 @@ Function Choco-Install
         $options += "--source", $source
     }
 
-    if ($user)
+    if ($username)
     {
-        $options += "--user=`"'$user'`""
+        $options += "--user=`"'$username'`""
     }
 
     if ($password)
@@ -545,7 +545,7 @@ if ($state -in ("downgrade", "latest", "present", "reinstalled")) {
         -ignorechecksums $ignorechecksums -ignoredependencies $ignoredependencies `
         -allowdowngrade ($state -eq "downgrade") -proxy_url $proxy_url `
         -proxy_username $proxy_username -proxy_password $proxy_password `
-        -allowprerelease $allowprerelease -user $user -password $password
+        -allowprerelease $allowprerelease -username $username -password $password
 }
 
 Exit-Json -obj $result

--- a/lib/ansible/modules/windows/win_chocolatey.ps1
+++ b/lib/ansible/modules/windows/win_chocolatey.ps1
@@ -374,12 +374,12 @@ Function Choco-Install
 
     if ($username)
     {
-        $options += "--user=`"'$username'`""
+        $options += "--user=$username"
     }
 
     if ($password)
     {
-        $options += "--password=`"'$password'`""
+        $options += "--password=$password"
     }
     
     if ($force)

--- a/lib/ansible/modules/windows/win_chocolatey.ps1
+++ b/lib/ansible/modules/windows/win_chocolatey.ps1
@@ -20,8 +20,8 @@ $package = Get-AnsibleParam -obj $params -name "name" -type "str" -failifempty $
 $force = Get-AnsibleParam -obj $params -name "force" -type "bool" -default $false
 $version = Get-AnsibleParam -obj $params -name "version" -type "str"
 $source = Get-AnsibleParam -obj $params -name "source" -type "str"
-$username = Get-AnsibleParam -obj $params -name "username" -type "str"
-$password = Get-AnsibleParam -obj $params -name "password" -type "str" -failifempty ($username -ne $null)
+$source_username = Get-AnsibleParam -obj $params -name "username" -type "str" -failifempty ($source -ne $null)
+$source_password = Get-AnsibleParam -obj $params -name "password" -type "str" -failifempty ($source_username -ne $null)
 $showlog = Get-AnsibleParam -obj $params -name "showlog" -type "bool" -default $false
 $timeout = Get-AnsibleParam -obj $params -name "timeout" -type "int" -default 2700 -aliases "execution_timeout"
 $state = Get-AnsibleParam -obj $params -name "state" -type "str" -default "present" -validateset "absent","downgrade","latest","present","reinstalled"
@@ -175,8 +175,8 @@ Function Choco-Upgrade
         [int] $timeout,
         [bool] $skipscripts,
         [string] $source,
-        [string] $username,
-        [string] $password,
+        [string] $source_username,
+        [string] $source_password,
         [string] $installargs,
         [string] $packageparams,
         [bool] $allowemptychecksums,
@@ -211,14 +211,14 @@ Function Choco-Upgrade
         $options += "--source", $source
     }
 
-    if ($username)
+    if ($source_username)
     {
-        $options += "--user=$username"
+        $options += "--user=$source_username"
     }
 
-    if ($password)
+    if ($source_password)
     {
-        $options += "--password=$password"
+        $options += "--password=$source_password"
     }
 
     if ($force)
@@ -322,8 +322,8 @@ Function Choco-Install
         [int] $timeout,
         [bool] $skipscripts,
         [string] $source,
-        [string] $username,
-        [string] $password,
+        [string] $source_username,
+        [string] $source_password,
         [string] $installargs,
         [string] $packageparams,
         [bool] $allowemptychecksums,
@@ -341,12 +341,12 @@ Function Choco-Install
         if ($state -in ("downgrade", "latest"))
         {
             Choco-Upgrade -package $package -version $version -force $force -timeout $timeout `
-                -skipscripts $skipscripts -source $source -installargs $installargs `
-                -packageparams $packageparams -allowemptychecksums $allowemptychecksums `
-                -ignorechecksums $ignorechecksums -ignoredependencies $ignoredependencies `
-                -allowdowngrade $allowdowngrade -proxy_url $proxy_url `
-                -proxy_username $proxy_username -proxy_password $proxy_password `
-                -allowprerelease $allowprerelease  -username $username -password $password
+                -skipscripts $skipscripts -source $source -username $source_username `
+                -password $source_password -installargs $installargs -packageparams $packageparams `
+                -allowemptychecksums $allowemptychecksums -ignorechecksums $ignorechecksums `
+                -ignoredependencies $ignoredependencies -allowdowngrade $allowdowngrade `
+                -proxy_url $proxy_url -proxy_username $proxy_username -proxy_password $proxy_password `
+                -allowprerelease $allowprerelease  
             return
         }
         elseif (-not $force)
@@ -372,14 +372,14 @@ Function Choco-Install
         $options += "--source", $source
     }
 
-    if ($username)
+    if ($source_username)
     {
-        $options += "--user=$username"
+        $options += "--user=$source_username"
     }
 
-    if ($password)
+    if ($source_password)
     {
-        $options += "--password=$password"
+        $options += "--password=$source_password"
     }
     
     if ($force)
@@ -540,12 +540,12 @@ if ($state -in ("absent", "reinstalled")) {
 if ($state -in ("downgrade", "latest", "present", "reinstalled")) {
 
     Choco-Install -package $package -version $version -force $force -timeout $timeout `
-        -skipscripts $skipscripts -source $source -installargs $installargs `
-        -packageparams $packageparams -allowemptychecksums $allowemptychecksums `
+        -skipscripts $skipscripts -source $source -username $source_username -password $source_password `
+        -installargs $installargs -packageparams $packageparams -allowemptychecksums $allowemptychecksums `
         -ignorechecksums $ignorechecksums -ignoredependencies $ignoredependencies `
         -allowdowngrade ($state -eq "downgrade") -proxy_url $proxy_url `
         -proxy_username $proxy_username -proxy_password $proxy_password `
-        -allowprerelease $allowprerelease -username $username -password $password
+        -allowprerelease $allowprerelease 
 }
 
 Exit-Json -obj $result

--- a/lib/ansible/modules/windows/win_chocolatey.ps1
+++ b/lib/ansible/modules/windows/win_chocolatey.ps1
@@ -213,12 +213,12 @@ Function Choco-Upgrade
 
     if ($username)
     {
-        $options += "--user=`"'$username'`""
+        $options += "--user=$username"
     }
 
     if ($password)
     {
-        $options += "--password=`"'$password'`""
+        $options += "--password=$password"
     }
 
     if ($force)

--- a/lib/ansible/modules/windows/win_chocolatey.ps1
+++ b/lib/ansible/modules/windows/win_chocolatey.ps1
@@ -20,6 +20,8 @@ $package = Get-AnsibleParam -obj $params -name "name" -type "str" -failifempty $
 $force = Get-AnsibleParam -obj $params -name "force" -type "bool" -default $false
 $version = Get-AnsibleParam -obj $params -name "version" -type "str"
 $source = Get-AnsibleParam -obj $params -name "source" -type "str"
+$user = Get-AnsibleParam -obj $params -name "user" -type "str"
+$password = Get-AnsibleParam -obj $params -name "password" -type "str" -failifempty ($user -ne $null)
 $showlog = Get-AnsibleParam -obj $params -name "showlog" -type "bool" -default $false
 $timeout = Get-AnsibleParam -obj $params -name "timeout" -type "int" -default 2700 -aliases "execution_timeout"
 $state = Get-AnsibleParam -obj $params -name "state" -type "str" -default "present" -validateset "absent","downgrade","latest","present","reinstalled"
@@ -173,6 +175,8 @@ Function Choco-Upgrade
         [int] $timeout,
         [bool] $skipscripts,
         [string] $source,
+        [string] $user,
+        [string] $password,
         [string] $installargs,
         [string] $packageparams,
         [bool] $allowemptychecksums,
@@ -205,6 +209,16 @@ Function Choco-Upgrade
     if ($source)
     {
         $options += "--source", $source
+    }
+
+    if ($user)
+    {
+        $options += "--user=`"'$user'`""
+    }
+
+    if ($password)
+    {
+        $options += "--password=`"'$password'`""
     }
 
     if ($force)
@@ -308,6 +322,8 @@ Function Choco-Install
         [int] $timeout,
         [bool] $skipscripts,
         [string] $source,
+        [string] $user,
+        [string] $password,
         [string] $installargs,
         [string] $packageparams,
         [bool] $allowemptychecksums,
@@ -356,6 +372,16 @@ Function Choco-Install
         $options += "--source", $source
     }
 
+    if ($user)
+    {
+        $options += "--user=`"'$user'`""
+    }
+
+    if ($password)
+    {
+        $options += "--password=`"'$password'`""
+    }
+    
     if ($force)
     {
         $options += "--force"
@@ -519,7 +545,7 @@ if ($state -in ("downgrade", "latest", "present", "reinstalled")) {
         -ignorechecksums $ignorechecksums -ignoredependencies $ignoredependencies `
         -allowdowngrade ($state -eq "downgrade") -proxy_url $proxy_url `
         -proxy_username $proxy_username -proxy_password $proxy_password `
-        -allowprerelease $allowprerelease
+        -allowprerelease $allowprerelease -user $user -password $password
 }
 
 Exit-Json -obj $result

--- a/lib/ansible/modules/windows/win_chocolatey.ps1
+++ b/lib/ansible/modules/windows/win_chocolatey.ps1
@@ -20,8 +20,8 @@ $package = Get-AnsibleParam -obj $params -name "name" -type "str" -failifempty $
 $force = Get-AnsibleParam -obj $params -name "force" -type "bool" -default $false
 $version = Get-AnsibleParam -obj $params -name "version" -type "str"
 $source = Get-AnsibleParam -obj $params -name "source" -type "str"
-$source_username = Get-AnsibleParam -obj $params -name "username" -type "str" -failifempty ($source -ne $null)
-$source_password = Get-AnsibleParam -obj $params -name "password" -type "str" -failifempty ($source_username -ne $null)
+$source_username = Get-AnsibleParam -obj $params -name "source_username" -type "str" -failifempty ($source -ne $null)
+$source_password = Get-AnsibleParam -obj $params -name "source_password" -type "str" -failifempty ($source_username -ne $null)
 $showlog = Get-AnsibleParam -obj $params -name "showlog" -type "bool" -default $false
 $timeout = Get-AnsibleParam -obj $params -name "timeout" -type "int" -default 2700 -aliases "execution_timeout"
 $state = Get-AnsibleParam -obj $params -name "state" -type "str" -default "present" -validateset "absent","downgrade","latest","present","reinstalled"
@@ -341,7 +341,7 @@ Function Choco-Install
         if ($state -in ("downgrade", "latest"))
         {
             Choco-Upgrade -package $package -version $version -force $force -timeout $timeout `
-                -skipscripts $skipscripts -source $source -username $source_username `
+                -skipscripts $skipscripts -source $source -user $source_username `
                 -password $source_password -installargs $installargs -packageparams $packageparams `
                 -allowemptychecksums $allowemptychecksums -ignorechecksums $ignorechecksums `
                 -ignoredependencies $ignoredependencies -allowdowngrade $allowdowngrade `
@@ -540,7 +540,7 @@ if ($state -in ("absent", "reinstalled")) {
 if ($state -in ("downgrade", "latest", "present", "reinstalled")) {
 
     Choco-Install -package $package -version $version -force $force -timeout $timeout `
-        -skipscripts $skipscripts -source $source -username $source_username -password $source_password `
+        -skipscripts $skipscripts -source $source -user $source_username -password $source_password `
         -installargs $installargs -packageparams $packageparams -allowemptychecksums $allowemptychecksums `
         -ignorechecksums $ignorechecksums -ignoredependencies $ignoredependencies `
         -allowdowngrade ($state -eq "downgrade") -proxy_url $proxy_url `

--- a/lib/ansible/modules/windows/win_chocolatey.ps1
+++ b/lib/ansible/modules/windows/win_chocolatey.ps1
@@ -341,12 +341,12 @@ Function Choco-Install
         if ($state -in ("downgrade", "latest"))
         {
             Choco-Upgrade -package $package -version $version -force $force -timeout $timeout `
-                -skipscripts $skipscripts -source $source -user $source_username `
-                -password $source_password -installargs $installargs -packageparams $packageparams `
-                -allowemptychecksums $allowemptychecksums -ignorechecksums $ignorechecksums `
-                -ignoredependencies $ignoredependencies -allowdowngrade $allowdowngrade `
-                -proxy_url $proxy_url -proxy_username $proxy_username -proxy_password $proxy_password `
-                -allowprerelease $allowprerelease  
+                -skipscripts $skipscripts -source $source -installargs $installargs `
+                -packageparams $packageparams -allowemptychecksums $allowemptychecksums `
+                -ignorechecksums $ignorechecksums -ignoredependencies $ignoredependencies `
+                -allowdowngrade $allowdowngrade -allowprerelease $allowprerelease `
+                -proxy_url $proxy_url -proxy_username $proxy_username -proxy_password $proxy_password
+                 
             return
         }
         elseif (-not $force)
@@ -540,12 +540,11 @@ if ($state -in ("absent", "reinstalled")) {
 if ($state -in ("downgrade", "latest", "present", "reinstalled")) {
 
     Choco-Install -package $package -version $version -force $force -timeout $timeout `
-        -skipscripts $skipscripts -source $source -user $source_username -password $source_password `
-        -installargs $installargs -packageparams $packageparams -allowemptychecksums $allowemptychecksums `
-        -ignorechecksums $ignorechecksums -ignoredependencies $ignoredependencies `
-        -allowdowngrade ($state -eq "downgrade") -proxy_url $proxy_url `
-        -proxy_username $proxy_username -proxy_password $proxy_password `
-        -allowprerelease $allowprerelease 
+        -skipscripts $skipscripts -source $source -installargs $installargs -packageparams $packageparams `
+        -allowemptychecksums $allowemptychecksums -ignorechecksums $ignorechecksums `
+        -ignoredependencies $ignoredependencies -allowdowngrade ($state -eq "downgrade") `
+        -proxy_url $proxy_url -proxy_username $proxy_username -proxy_password $proxy_password `
+        -allowprerelease $allowprerelease
 }
 
 Exit-Json -obj $result

--- a/lib/ansible/modules/windows/win_chocolatey.py
+++ b/lib/ansible/modules/windows/win_chocolatey.py
@@ -51,13 +51,14 @@ options:
   source:
     description:
       - Specify source rather than using default chocolatey repository.
-  username:
+      - This will statelessly pull a package from a non-configured source.
+  source_username:
     description:
-      - Username used to authenticate against a source.
+      - Username used to authenticate against C(source).
     version_added: '2.7'
-  password:
+  source_password:
     description:
-      - Password used to authenticate against a source.
+      - Password used to authenticate against C(source).
     version_added: '2.7'
   install_args:
     description:

--- a/lib/ansible/modules/windows/win_chocolatey.py
+++ b/lib/ansible/modules/windows/win_chocolatey.py
@@ -54,12 +54,10 @@ options:
   username:
     description:
       - Username used to authenticate against a source.
-    default: 'no'
     version_added: '2.7'
   password:
     description:
       - Password used to authenticate against a source.
-    default: 'no'
     version_added: '2.7'
   install_args:
     description:

--- a/lib/ansible/modules/windows/win_chocolatey.py
+++ b/lib/ansible/modules/windows/win_chocolatey.py
@@ -55,10 +55,12 @@ options:
     description:
       - Username used to authenticate against a source.
     default: 'no'
+    version_added: '2.7'
   password:
     description:
       - Password used to authenticate against a source.
     default: 'no'
+    version_added: '2.7'
   install_args:
     description:
       - Arguments to pass to the native installer.

--- a/lib/ansible/modules/windows/win_chocolatey.py
+++ b/lib/ansible/modules/windows/win_chocolatey.py
@@ -51,6 +51,14 @@ options:
   source:
     description:
       - Specify source rather than using default chocolatey repository.
+  user:
+    description:
+      - Username used to authenticate against a source.
+    default: 'no'
+  password:
+    description:
+      - Password used to authenticate against a source.
+    default: 'no'
   install_args:
     description:
       - Arguments to pass to the native installer.

--- a/lib/ansible/modules/windows/win_chocolatey.py
+++ b/lib/ansible/modules/windows/win_chocolatey.py
@@ -51,7 +51,7 @@ options:
   source:
     description:
       - Specify source rather than using default chocolatey repository.
-  user:
+  username:
     description:
       - Username used to authenticate against a source.
     default: 'no'


### PR DESCRIPTION
##### SUMMARY
This PR adds the ability to add username and password args be used when defining a source.
Fixes #30784

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
win_chocolatey

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.4
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/kwinten/slinfraVE/local/lib/python2.7/site-packages/ara/plugins/modules']
  ansible python module location = /home/kwinten/slinfraVE/local/lib/python2.7/site-packages/ansible
  executable location = /home/kwinten/slinfraVE/bin/ansible
  python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]
```
