### PR TITLE
[Closed] Fix handling of inventory and credential options for tower_job_launch

### DIFF
--- a/changelogs/fragments/tower_job_launch-options.yaml
+++ b/changelogs/fragments/tower_job_launch-options.yaml
@@ -1,4 +1,4 @@
 ---
 bugfixes:
   - Fixed to handle arguments correctly even if inventory and credential
-    variables are not specified
+    variables are not specified (https://github.com/ansible/ansible/pull/41497)

--- a/changelogs/fragments/tower_job_launch-options.yaml
+++ b/changelogs/fragments/tower_job_launch-options.yaml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - Fixed to handle arguments correctly even if inventory and credential
+    variables are not specified

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_launch.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_launch.py
@@ -58,9 +58,22 @@ extends_documentation_fragment: tower
 '''
 
 EXAMPLES = '''
+# Launch job template
 - name: Launch a job
   tower_job_launch:
     job_template: "My Job Template"
+  register: job
+- name: Wait for job max 120s
+  tower_job_wait:
+    job_id: job.id
+    timeout: 120
+
+# Launch job template with inventory and credential for prompt on launch
+- name: Launch a job with inventory and credential
+  tower_job_launch:
+    job_template: "My Job Template"
+    inventory: "My Inventory"
+    credential: "My Credential"
   register: job
 - name: Wait for job max 120s
   tower_job_wait:
@@ -98,10 +111,10 @@ except ImportError:
 def main():
     argument_spec = tower_argument_spec()
     argument_spec.update(dict(
-        job_template=dict(required=True),
+        job_template=dict(required=True, type='str'),
         job_type=dict(choices=['run', 'check', 'scan']),
-        inventory=dict(),
-        credential=dict(),
+        inventory=dict(type='str', default=None),
+        credential=dict(type='str', default=None),
         limit=dict(),
         tags=dict(type='list'),
         extra_vars=dict(type='list'),
@@ -131,8 +144,9 @@ def main():
             for field in lookup_fields:
                 try:
                     name = params.pop(field)
-                    result = tower_cli.get_resource(field).get(name=name)
-                    params[field] = result['id']
+                    if name:
+                        result = tower_cli.get_resource(field).get(name=name)
+                        params[field] = result['id']
                 except exc.NotFound as excinfo:
                     module.fail_json(msg='Unable to launch job, {0}/{1} was not found: {2}'.format(field, name, excinfo), changed=False)
 

--- a/test/integration/targets/tower_job_launch/tasks/main.yml
+++ b/test/integration/targets/tower_job_launch/tasks/main.yml
@@ -1,6 +1,16 @@
 - name: Launch a Job Template
   tower_job_launch:
     job_template: "Demo Job Template"
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+      - "result.status == 'pending'"
+
+- name: Launch job template with inventory and credential for prompt on launch
+  tower_job_launch:
+    job_template: "Demo Job Template"
     inventory: "Demo Inventory"
     credential: "Demo Credential"
   register: result

--- a/test/integration/targets/tower_job_launch/tasks/main.yml
+++ b/test/integration/targets/tower_job_launch/tasks/main.yml
@@ -8,9 +8,20 @@
       - "result is changed"
       - "result.status == 'pending'"
 
+- name: Create a Job Template for testing prompt on launch
+  tower_job_template:
+    name: "Demo Job Template - ask inventory and credential"
+    project: Demo Project
+    playbook: hello_world.yml
+    job_type: run
+    ask_credential: yes
+    ask_inventory: yes
+    state: present
+  register: result
+
 - name: Launch job template with inventory and credential for prompt on launch
   tower_job_launch:
-    job_template: "Demo Job Template"
+    job_template: "Demo Job Template - ask inventory and credential"
     inventory: "Demo Inventory"
     credential: "Demo Credential"
   register: result


### PR DESCRIPTION
##### SUMMARY
- Fixed issue #25017,#37567
- Add example for prompt on launch
- inventory and credential variables are option(only need to set when a job template turned on `prompt on launch` option), both of them unnecessary to specify when `prompt on launch` is turned off

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - tower_job_launch.py

##### ANSIBLE VERSION

```
Devel
```

##### ADDITIONAL INFORMATION

None