### PR TITLE
wait_for: Adding unlocked state to check for a file flock.

### DIFF
--- a/lib/ansible/modules/utilities/logic/wait_for.py
+++ b/lib/ansible/modules/utilities/logic/wait_for.py
@@ -662,5 +662,6 @@ def main():
     elapsed = datetime.datetime.utcnow() - start
     module.exit_json(state=state, port=port, search_regex=search_regex, path=path, elapsed=elapsed.seconds)
 
+
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
##### SUMMARY
Adding ability to `wait_for` a file lock to be `unlocked`.

Various discussions in:
#4241
#16593


##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
wait_for.py

##### ANSIBLE VERSION

```
ansible 2.7.0.dev0 (wait_for_flock fb90946e89) last updated 2018/06/14 00:15:24 (GMT +1100)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/johni/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/johni/ansible/hacking/ansible/lib/ansible
  executable location = /home/johni/ansible/hacking/ansible/bin/ansible
  python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]

```


##### ADDITIONAL INFORMATION
People were getting around flock's with a shell command like:

```
while sudo fuser /var/lib/dpkg/lock >/dev/null 2>&1; do
    sleep 1;
done
```

Which did the job, but, doesn't seem elegant.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
- name: Testing wait_for path and locking
  hosts: localhost
  gather_facts: false

  tasks:
    - name: Wait for /var/lib/dpkg/lock
      wait_for:
        path: /var/lib/dpkg/lock
        state: unlocked
        timeout: 5
      become: true
```
Then locking `/var/lib/dpkg/lock` for 20 seconds:

Temporary script to lock a file:
```
#!/usr/bin/python2.7

import fcntl
import sys
import time

path = '/var/lib/dpkg/lock'

try:
    fd = open(path, 'w')
    try:
        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
        print "got lock"
        time.sleep(20)
    except IOError as e:
        # Might receive: Resource temporarily unavailable
        print "Unable to obtain lock on file %s: %s" % (path, e.strerror)
        fd.close()
except IOError as e:
    print "Failed to open file %s: %s" % (path, e.strerror)

```

Running the play will fail with a timeout:

```
$ ansible-playbook test_wait_for.yml --ask-sudo-pass
SUDO password:

PLAY [Testing wait_for path and locking] *********************************************************************

TASK [Wait for /var/lib/dpkg/lock] ***************************************************************************
fatal: [localhost -> localhost]: FAILED! => {"changed": false, "elapsed": 5, "msg": "Timeout when waiting for /var/lib/dpkg/lock to be unlocked."}
        to retry, use: --limit @/home/johni/ansible/hacking/ansible/test_wait_for.retry

PLAY RECAP ***************************************************************************************************
localhost                  : ok=0    changed=0    unreachable=0    failed=1

```

If, we got the lock:

```
PLAY [Testing wait_for path and locking] *********************************************************************

TASK [Wait for /var/lib/dpkg/lock] ***************************************************************************
ok: [localhost -> localhost]

PLAY RECAP ***************************************************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=0

```

