### PR TITLE
Allow fuse type mounts without :/ in device string

### DIFF
--- a/lib/ansible/module_utils/facts/hardware/linux.py
+++ b/lib/ansible/module_utils/facts/hardware/linux.py
@@ -454,7 +454,7 @@ class LinuxHardware(Hardware):
         for fields in mtab_entries:
             device, mount, fstype, options = fields[0], fields[1], fields[2], fields[3]
 
-            if not device.startswith('/') and ':/' not in device:
+            if not device.startswith('/') and ':/' not in device and not fstype.startswith('fuse'):
                 continue
 
             if fstype == 'none':


### PR DESCRIPTION
##### SUMMARY
Allow fuse type mounts in the gathered mount information when not matching traditional formatting with ":/"

Fixes #41494

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
setup

##### ANSIBLE VERSION
```
ansible 2.5.3
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /bin/ansible
  python version = 2.7.5 (default, Feb 20 2018, 09:19:12) [GCC 4.8.5 20150623 (Red Hat 4.8.5-28)]
```