### PR TITLE
Yum: add support for downloadonly

### DIFF
--- a/test/integration/targets/yum/tasks/yum.yml
+++ b/test/integration/targets/yum/tasks/yum.yml
@@ -260,6 +260,32 @@
     state: removed
   register: yum_result
 
+# Test download_only
+- name: install sos
+  yum:
+    name: sos
+    state: latest
+    download_only: true
+  register: yum_result
+
+- name: verify download of sos (part 1 -- yum "install" succeeded)
+  assert:
+    that:
+        - "yum_result is success"
+        - "yum_result is changed"
+
+- name: uninstall sos (noop)
+  yum:
+    name: sos
+    state: removed
+  register: yum_result
+
+- name: verify download of sos (part 2 -- nothing removed during uninstall)
+  assert:
+    that:
+        - "yum_result is success"
+        - "not yum_result is changed"
+
 - name: install group
   yum:
     name: "@Development Tools"


### PR DESCRIPTION
##### SUMMARY
Add support for the yum command line option `downloadonly`.

Some operators need to use this feature of yum, and without it are unable to use the yum module for some operations. The workaround of using the shell module to call yum is valid but very suboptimal.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
yum

##### ANSIBLE VERSION
```
ansible 2.7.0.dev0 (yum_mods f0aff087b2) last updated 2018/07/12 14:48:52 (GMT -700)
  config file = None
  configured module search path = [u'/home/rm_you/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/rm_you/ansible/lib/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Apr 11 2018, 07:36:10) [GCC 4.8.5 20150623 (Red Hat 4.8.5-28)]
```


##### ADDITIONAL INFORMATION
For example, to do a quick test of the download_only flag:
```
- hosts: localhost
  tasks:
    - name: download mariadb package
      yum:
        name: mariadb
        state: latest
        download_only: true
      become: true
```
The output of this in -vvv mode:
```
changed: [localhost] => {
    "changed": true,
    "invocation": {
        "module_args": {
            "allow_downgrade": false,
            "bugfix": false,
            "conf_file": null,
            "disable_excludes": "all",
            "disable_gpg_check": false,
            "disable_plugin": [],
            "disablerepo": null,
            "download_only": true,
            "enable_plugin": [],
            "enablerepo": null,
            "exclude": null,
            "install_repoquery": true,
            "installroot": "/",
            "list": null,
            "name": [
                "mariadb"
            ],
            "security": false,
            "skip_broken": false,
            "state": "latest",
            "update_cache": false,
            "update_only": false,
            "validate_certs": true
        }
    },
    "msg": "",
    "rc": 0,
    "results": [
        "Loaded plugins: changelog, fastestmirror, versionlock\nLoading mirror speeds from cached hostfile\nResolving Dependencies\n--> Running transaction check\n---> Package mariadb.x86_64 1:5.5.56-2.el7 will be installed\n--> Finished Dependency Resolution\n\nDependencies Resolved\n\n================================================================================\n Package       Arch         Version                Repository              Size\n================================================================================\nInstalling:\n mariadb       x86_64       1:5.5.56-2.el7         centos-base-prod       8.7 M\n\nTransaction Summary\n================================================================================\nInstall  1 Package\n\nTotal size: 8.7 M\nInstalled size: 49 M\nBackground downloading packages, then exiting:\nexiting because \"Download Only\" specified\n"
    ]
}
```

The use of an underscore in this flag is a style choice that I wasn't sure about -- it seems like there's a mix between using underscores and not, even though yum does not use them for most of these things. I'm open to doing it either way.
