### PR TITLE
Improved support for parameter testing and checks for org_id

### DIFF
--- a/lib/ansible/modules/network/meraki/meraki_snmp.py
+++ b/lib/ansible/modules/network/meraki/meraki_snmp.py
@@ -205,8 +205,11 @@ def main():
 
     # manipulate or modify the state as needed (this is going to be the
     # part where your module will do what it needs to do)
-    org_id = meraki.params['org_id']
 
+    if not meraki.params['org_name'] and not meraki.params['org_id']:
+        meraki.fail_json(msg='org_name or org_id is required')
+
+    org_id = meraki.params['org_id']
     if org_id is None:
         org_id = meraki.get_org_id(meraki.params['org_name'])
 

--- a/test/integration/targets/meraki_snmp/tasks/main.yml
+++ b/test/integration/targets/meraki_snmp/tasks/main.yml
@@ -45,13 +45,41 @@
   delegate_to: localhost
   register: snmp_v2_disable
 
-# - debug:
-#     msg: '{{snmp_v2_disable}}'
-
 - assert:
     that:
       - snmp_v2_disable.data.v2CommunityString is not defined
       - snmp_v2_disable.data.v2cEnabled == False
+
+- name: Enable SNMPv2c with org_id
+  meraki_snmp:
+    auth_key: '{{auth_key}}'
+    org_id: '{{test_org_id}}'
+    state: present
+    v2c_enabled: true
+  delegate_to: localhost
+  register: snmp_v2_enable_id
+
+- debug:
+    msg: '{{snmp_v2_enable_id}}'
+
+- assert:
+    that:
+      - snmp_v2_enable_id.data.v2CommunityString is defined
+      - snmp_v2_enable_id.data.v2cEnabled == true
+
+- name: Disable SNMPv2c with org_id
+  meraki_snmp:
+    auth_key: '{{auth_key}}'
+    org_id: '{{test_org_id}}'
+    state: present
+    v2c_enabled: False
+  delegate_to: localhost
+  register: snmp_v2_disable_id
+
+- assert:
+    that:
+      - snmp_v2_disable_id.data.v2CommunityString is not defined
+      - snmp_v2_disable_id.data.v2cEnabled == False
 
 - name: Enable SNMPv3
   meraki_snmp:


### PR DESCRIPTION
##### SUMMARY
Fixes bug #41300 

`org_id` is a parameter which can be passed to a module. While it's less intuitive and clean for a playbook, it's also faster since less calls need to be performed. `org_id` was used in this module but there were no integration tests or checks for no organization being referenced. Checks are now performed for either `org_id` or `org_name` and there are integration tests.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
meraki_snmp

##### ANSIBLE VERSION
```
ansible 2.7.0.dev0 (meraki/snmp-orgnetid 7d3f1013d8) last updated 2018/06/13 18:02:13 (GMT -500)
  config file = None
  configured module search path = ['/Users/kbreit/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/kbreit/Documents/Programming/ansible/lib/ansible
  executable location = /Users/kbreit/Documents/Programming/ansible/bin/ansible
  python version = 3.5.4 (default, Feb 25 2018, 14:56:02) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```