### PR TITLE
meraki_admin - Add support for org_id

### DIFF
--- a/lib/ansible/modules/network/meraki/meraki_admin.py
+++ b/lib/ansible/modules/network/meraki/meraki_admin.py
@@ -69,24 +69,37 @@ EXAMPLES = r'''
 - name: Query information about all administrators associated to the organization
   meraki_admin:
     auth_key: abc12345
+    org_name: YourOrg
     state: query
   delegate_to: localhost
 
 - name: Query information about a single administrator by name
   meraki_admin:
     auth_key: abc12345
+    org_id: 12345
     state: query
     name: Jane Doe
 
 - name: Query information about a single administrator by email
   meraki_admin:
     auth_key: abc12345
+    org_name: YourOrg
     state: query
     email: jane@doe.com
 
-- name:  new administrator with organization access
+- name: Create new administrator with organization access
   meraki_admin:
     auth_key: abc12345
+    org_name: YourOrg
+    state: present
+    name: Jane Doe
+    orgAccess: read-only
+    email: jane@doe.com
+
+- name: Create new administrator with organization access
+  meraki_admin:
+    auth_key: abc12345
+    org_name: YourOrg
     state: present
     name: Jane Doe
     orgAccess: read-only
@@ -95,6 +108,7 @@ EXAMPLES = r'''
 - name: Create a new administrator with organization access
   meraki_admin:
     auth_key: abc12345
+    org_name: YourOrg
     state: present
     name: Jane Doe
     orgAccess: read-only
@@ -103,6 +117,7 @@ EXAMPLES = r'''
 - name: Revoke access to an organization for an administrator
   meraki_admin:
     auth_key: abc12345
+    org_name: YourOrg
     state: absent
     email: jane@doe.com
 '''
@@ -171,12 +186,11 @@ def get_admins(meraki, org_id):
     return admins
 
 
-def get_admin_id(meraki, org_name, data, name=None, email=None):
+def get_admin_id(meraki, data, name=None, email=None):
     admin_id = None
     for a in data:
         if meraki.params['name'] is not None:
             if meraki.params['name'] == a['name']:
-                # meraki.fail_json(msg='HERE')
                 if admin_id is not None:
                     meraki.fail_json(msg='There are multiple administrators with the same name')
                 else:
@@ -346,18 +360,20 @@ def main():
 
     # manipulate or modify the state as needed (this is going to be the
     # part where your module will do what it needs to do)
-    org_id = meraki.get_org_id(meraki.params['org_name'])
+    org_id = meraki.params['org_id']
+    if not meraki.params['org_id']:
+        org_id = meraki.get_org_id(meraki.params['org_name'])
     if meraki.params['state'] == 'query':
         admins = get_admins(meraki, org_id)
         if not meraki.params['name'] and not meraki.params['email']:  # Return all admins for org
             meraki.result['data'] = admins
         if meraki.params['name'] is not None:  # Return a single admin for org
-            admin_id = get_admin_id(meraki, meraki.params['org_name'], admins, name=meraki.params['name'])
+            admin_id = get_admin_id(meraki, admins, name=meraki.params['name'])
             meraki.result['data'] = admin_id
             admin = get_admin(meraki, admins, admin_id)
             meraki.result['data'] = admin
         elif meraki.params['email'] is not None:
-            admin_id = get_admin_id(meraki, meraki.params['org_name'], admins, email=meraki.params['email'])
+            admin_id = get_admin_id(meraki, admins, email=meraki.params['email'])
             meraki.result['data'] = admin_id
             admin = get_admin(meraki, admins, admin_id)
             meraki.result['data'] = admin
@@ -371,7 +387,6 @@ def main():
             meraki.result['data'] = r
     elif meraki.params['state'] == 'absent':
         admin_id = get_admin_id(meraki,
-                                meraki.params['org_name'],
                                 get_admins(meraki, org_id),
                                 email=meraki.params['email']
                                 )

--- a/test/integration/targets/meraki_admin/tasks/main.yml
+++ b/test/integration/targets/meraki_admin/tasks/main.yml
@@ -20,6 +20,32 @@
       - create_orgaccess.changed == true
       - 'create_orgaccess.data.name == "Jane Doe"'
 
+- name: Delete recently created administrator
+  meraki_admin:
+    auth_key: '{{auth_key}}'
+    state: absent
+    org_name: '{{test_org_name}}'
+    email: '{{email_prefix}}+janedoe@{{email_domain}}'
+  delegate_to: localhost
+  register: delete_one
+
+- name: Create new administrator with org_id
+  meraki_admin:
+    auth_key: '{{auth_key}}'
+    state: present
+    org_id: '{{test_org_id}}'
+    name: Jane Doe
+    email: '{{email_prefix}}+janedoe@{{email_domain}}'
+    orgAccess: read-only
+  delegate_to: localhost
+  register: create_orgaccess_id
+
+- name: Create new admin assertion
+  assert:
+    that:
+      - create_orgaccess_id.changed == true
+      - 'create_orgaccess_id.data.name == "Jane Doe"'
+
 - name: Create administrator with tags
   meraki_admin:
     auth_key: '{{auth_key}}'


### PR DESCRIPTION
##### SUMMARY
- Faster execution if passed instead of org_name
- Updated documentation
- Added additional integration tests

Fixes #41299 

##### ISSUE TYPE
 - Bugfix Pull Request


##### COMPONENT NAME
meraki_admin

##### ANSIBLE VERSION
```
ansible 2.7.0.dev0 (meraki/bug-41299 9867c8133e) last updated 2018/06/13 18:39:50 (GMT -500)
  config file = None
  configured module search path = ['/Users/kbreit/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/kbreit/Documents/Programming/ansible/lib/ansible
  executable location = /Users/kbreit/Documents/Programming/ansible/bin/ansible
  python version = 3.5.4 (default, Feb 25 2018, 14:56:02) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```