### PR TITLE
Allow aireos_config to handle prompts (Fixes #35622)

### DIFF
--- a/lib/ansible/module_utils/network/aireos/aireos.py
+++ b/lib/ansible/module_utils/network/aireos/aireos.py
@@ -114,13 +114,14 @@ def run_commands(module, commands, check_rc=True):
 
 
 def load_config(module, commands):
-
     rc, out, err = exec_command(module, 'config')
     if rc != 0:
         module.fail_json(msg='unable to enter configuration mode', err=to_text(out, errors='surrogate_then_replace'))
 
-    for command in to_list(commands):
-        if command == 'end':
+    commands = to_commands(module, to_list(commands))
+    for command in commands:
+        command = module.jsonify(command)
+        if "\"command\": \"end\"" in command:
             continue
         rc, out, err = exec_command(module, command)
         if rc != 0:


### PR DESCRIPTION
##### SUMMARY
Fixes #35622.

This PR modifies the aireos module util.

As raised in #35622, the aireos_config module does not currently allow for prompt handling. This functionality has been added by modifying how the aireos module_util executes commands sent to it by aireos_config.

Previously, commands executed by "load_config" were modified directly by "to_list" and then executed. "load_config" has been modified to work in the same way as "run_commands" (called by aireos_command), casting commands into the correct ComplexList format to allow for prompt interaction. 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
aireos.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (devel 0db643da6c) last updated 2018/06/14 10:55:52 (GMT +800)
  config file = None
  configured module search path = ['/Users/james/PycharmProjects/ansible/library']
  ansible python module location = /Users/james/PycharmProjects/ansible/lib/ansible
  executable location = /Users/james/PycharmProjects/ansible/bin/ansible
  python version = 3.6.4 (default, Jan 31 2018, 13:04:35) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.38)]
```


##### ADDITIONAL INFORMATION
Before:
```
(venv) james@Snow ~/P/ansible> ansible-playbook testmod.yml

PLAY [Initial WAP Configuration] *************************************************************************************************************************************************************

TASK [Execute Config] ************************************************************************************************************************************************************************
fatal: [wlc_001]: FAILED! => {"changed": false, "command": {"answer": "y", "command": "ap group-name group_a wap_001", "prompt": "Are you sure you want to continue"}, "msg": "{'command': 'ap group-name group_a wap_001', 'prompt': 'Are you sure you want to continue', 'answer': 'y'}\r\n\r\nIncorrect usage.  Use the '?' or <TAB> key to list commands.\r\n\r\n(Cisco Controller) config>", "rc": -32603}
	to retry, use: --limit @/Users/james/PycharmProjects/ansible/testmod.retry

PLAY RECAP ***********************************************************************************************************************************************************************************
wlc_001              : ok=0    changed=0    unreachable=0    failed=1
```
After:
```
(venv) james@Snow ~/P/ansible> ansible-playbook testmod.yml

PLAY [Initial WAP Configuration] *************************************************************************************************************************************************************

TASK [Execute Config] ************************************************************************************************************************************************************************
changed: [wlc_001]

TASK [debug] *********************************************************************************************************************************************************************************
ok: [wlc_001] => {
    "msg": {
        "changed": true,
        "commands": [
            "ap disable wap_001",
            "ap name wap_001 00:00:00:00:00:00",
            "ap location \"Test Lab\" wap_001",
            "end",
            "ap enable wap_001",
            {
                "answer": "y",
                "command": "ap group-name group_a wap_001",
                "prompt": "Are you sure you want to continue"
            }
        ],
        "failed": false,
        "updates": [
            "ap disable wap_001",
            "ap name wap_001 00:00:00:00:00:00",
            "ap location \"Test Lab\" wap_001",
            "end",
            "ap enable wap_001",
            {
                "answer": "y",
                "command": "ap group-name group_a wap_001",
                "prompt": "Are you sure you want to continue"
            }
        ]
    }
}

PLAY RECAP ***********************************************************************************************************************************************************************************
wlc_001              : ok=2    changed=1    unreachable=0    failed=0
```