### PR TITLE
Fix typos in blocks documentation examples. (#41508)

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_blocks.rst
+++ b/docs/docsite/rst/user_guide/playbooks_blocks.rst
@@ -50,7 +50,7 @@ Blocks also introduce the ability to handle errors in a way similar to exception
 
 
   tasks:
-  - name: Attempt and gracefull roll back demo
+  - name: Attempt and graceful roll back demo
     block:
       - debug:
           msg: 'I execute normally'
@@ -65,7 +65,7 @@ Blocks also introduce the ability to handle errors in a way similar to exception
           msg: 'I also never execute :-('
     always:
       - debug:
-          msg: "this always executes"
+          msg: "This always executes"
 
 The tasks in the ``block`` would execute normally, if there is any error the ``rescue`` section would get executed
 with whatever you need to do to recover from the previous error. The ``always`` section runs no matter what previous
@@ -81,7 +81,7 @@ Another example is how to run handlers after an error occurred :
 
 
   tasks:
-    - name: Attempt and gracefull roll back demo
+    - name: Attempt and graceful roll back demo
       block:
         - debug:
             msg: 'I execute normally'
@@ -93,7 +93,7 @@ Another example is how to run handlers after an error occurred :
   handlers:
      - name: run me even after an error
        debug:
-         msg: 'this handler runs even on error'
+         msg: 'This handler runs even on error'
 
 .. seealso::
 


### PR DESCRIPTION
(cherry picked from commit a4f49ed64899630946209d643bb84255f279e284)

##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/41508

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
user_guide/playbooks_blocks

##### ANSIBLE VERSION
```
2.5
```