### PR TITLE
Prefer readthedocs.io instead of readthedocs.org for doc links

### DIFF
--- a/contrib/inventory/azure_rm.py
+++ b/contrib/inventory/azure_rm.py
@@ -24,7 +24,7 @@ Azure External Inventory Script
 ===============================
 Generates dynamic inventory by making API requests to the Azure Resource
 Manager using the Azure Python SDK. For instruction on installing the
-Azure Python SDK see http://azure-sdk-for-python.readthedocs.org/
+Azure Python SDK see https://azure-sdk-for-python.readthedocs.io/
 
 Authentication
 --------------

--- a/contrib/inventory/consul_io.py
+++ b/contrib/inventory/consul_io.py
@@ -200,7 +200,7 @@ try:
     import consul
 except ImportError as e:
     sys.exit("""failed=True msg='python-consul required for this module.
-See http://python-consul.readthedocs.org/en/latest/#installation'""")
+See https://python-consul.readthedocs.io/en/latest/#installation'""")
 
 from six import iteritems
 

--- a/contrib/inventory/docker.py
+++ b/contrib/inventory/docker.py
@@ -32,7 +32,7 @@ script contacts can be defined using environment variables or a configuration fi
 Requirements
 ------------
 
-Using the docker modules requires having docker-py <https://docker-py.readthedocs.org/en/stable/>
+Using the docker modules requires having docker-py <https://docker-py.readthedocs.io/en/stable/>
 installed on the host running Ansible. To install docker-py:
 
    pip install docker-py

--- a/contrib/inventory/ec2.ini
+++ b/contrib/inventory/ec2.ini
@@ -196,7 +196,7 @@ stack_filters = False
 # iam_role = role-arn
 
 # A boto configuration profile may be used to separate out credentials
-# see http://boto.readthedocs.org/en/latest/boto_config_tut.html
+# see https://boto.readthedocs.io/en/latest/boto_config_tut.html
 # boto_profile = some-boto-profile-name
 
 

--- a/contrib/inventory/softlayer.py
+++ b/contrib/inventory/softlayer.py
@@ -6,7 +6,7 @@ The SoftLayer Python API client is required. Use `pip install softlayer` to inst
 You have a few different options for configuring your username and api_key. You can pass
 environment variables (SL_USERNAME and SL_API_KEY). You can also write INI file to
 ~/.softlayer or /etc/softlayer.conf. For more information see the SL API at:
-- https://softlayer-python.readthedocs.org/en/latest/config_file.html
+- https://softlayer-python.readthedocs.io/en/latest/config_file.html
 
 The SoftLayer Python client has a built in command for saving this configuration file
 via the command `sl config setup`.

--- a/docs/docsite/rst/scenario_guides/guide_docker.rst
+++ b/docs/docsite/rst/scenario_guides/guide_docker.rst
@@ -42,7 +42,7 @@ There's more planned. See the latest ideas and thinking at the `Ansible proposal
 Requirements
 ------------
 
-Using the docker modules requires having `docker-py <https://docker-py.readthedocs.org/en/stable/>`_
+Using the docker modules requires having `docker-py <https://docker-py.readthedocs.io/en/stable/>`_
 installed on the host running Ansible. You will need to have >= 1.7.0 installed.
 
 .. code-block:: bash

--- a/lib/ansible/modules/cloud/amazon/GUIDELINES.md
+++ b/lib/ansible/modules/cloud/amazon/GUIDELINES.md
@@ -214,7 +214,7 @@ are a number of possibilities for handling it.
 * Use fail_json() to report the failure without using `ansible.module_utils.aws.core`
 * Do something custom in the case where you know how to handle the exception
 
-For more information on botocore exception handling see [the botocore error documentation](http://botocore.readthedocs.org/en/latest/client_upgrades.html#error-handling).
+For more information on botocore exception handling see [the botocore error documentation](https://botocore.readthedocs.io/en/latest/client_upgrades.html#error-handling).
 
 ### Using is_boto3_error_code
 

--- a/lib/ansible/modules/cloud/amazon/ecs_service.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_service.py
@@ -27,7 +27,7 @@ description:
   - Creates or terminates ecs services.
 notes:
   - the service role specified must be assumable (i.e. have a trust relationship for the ecs service, ecs.amazonaws.com)
-  - for details of the parameters and returns see U(http://boto3.readthedocs.org/en/latest/reference/services/ecs.html)
+  - for details of the parameters and returns see U(https://boto3.readthedocs.io/en/latest/reference/services/ecs.html)
   - An IAM role must have been previously created
 version_added: "2.1"
 author:

--- a/lib/ansible/modules/clustering/consul.py
+++ b/lib/ansible/modules/clustering/consul.py
@@ -520,7 +520,7 @@ class ConsulCheck(object):
 
 def test_dependencies(module):
     if not python_consul_installed:
-        module.fail_json(msg="python-consul required for this module. see http://python-consul.readthedocs.org/en/latest/#installation")
+        module.fail_json(msg="python-consul required for this module. see https://python-consul.readthedocs.io/en/latest/#installation")
 
 
 def main():

--- a/lib/ansible/modules/clustering/consul_acl.py
+++ b/lib/ansible/modules/clustering/consul_acl.py
@@ -606,7 +606,7 @@ def check_dependencies():
     """
     if not python_consul_installed:
         raise ImportError("python-consul required for this module. "
-                          "See: http://python-consul.readthedocs.org/en/latest/#installation")
+                          "See: https://python-consul.readthedocs.io/en/latest/#installation")
 
     if not pyhcl_installed:
         raise ImportError("pyhcl required for this module. "

--- a/lib/ansible/modules/clustering/consul_kv.py
+++ b/lib/ansible/modules/clustering/consul_kv.py
@@ -283,7 +283,7 @@ def get_consul_api(module, token=None):
 def test_dependencies(module):
     if not python_consul_installed:
         module.fail_json(msg="python-consul required for this module. "
-                             "see http://python-consul.readthedocs.org/en/latest/#installation")
+                             "see https://python-consul.readthedocs.io/en/latest/#installation")
 
 
 def main():

--- a/lib/ansible/modules/clustering/consul_session.py
+++ b/lib/ansible/modules/clustering/consul_session.py
@@ -233,7 +233,7 @@ def get_consul_api(module):
 def test_dependencies(module):
     if not python_consul_installed:
         module.fail_json(msg="python-consul required for this module. "
-                             "see http://python-consul.readthedocs.org/en/latest/#installation")
+                             "see https://python-consul.readthedocs.io/en/latest/#installation")
 
 
 def main():

--- a/lib/ansible/plugins/lookup/consul_kv.py
+++ b/lib/ansible/plugins/lookup/consul_kv.py
@@ -13,7 +13,7 @@ DOCUMENTATION = """
         Values can be easily set in the kv store with simple rest commands
       - C(curl -X PUT -d 'some-value' http://localhost:8500/v1/kv/ansible/somedata)
     requirements:
-      - 'python-consul python library U(http://python-consul.readthedocs.org/en/latest/#installation)'
+      - 'python-consul python library U(https://python-consul.readthedocs.io/en/latest/#installation)'
     options:
       _raw:
         description: List of key(s) to retrieve.
@@ -84,7 +84,7 @@ class LookupModule(LookupBase):
     def run(self, terms, variables=None, **kwargs):
 
         if not HAS_CONSUL:
-            raise AnsibleError('python-consul is required for consul_kv lookup. see http://python-consul.readthedocs.org/en/latest/#installation')
+            raise AnsibleError('python-consul is required for consul_kv lookup. see https://python-consul.readthedocs.io/en/latest/#installation')
 
         values = []
         try:

--- a/lib/ansible/utils/module_docs_fragments/aws.py
+++ b/lib/ansible/utils/module_docs_fragments/aws.py
@@ -61,7 +61,7 @@ notes:
     C(AWS_SECURITY_TOKEN) or C(EC2_SECURITY_TOKEN),
     C(AWS_REGION) or C(EC2_REGION)
   - Ansible uses the boto configuration file (typically ~/.boto) if no
-    credentials are provided. See http://boto.readthedocs.org/en/latest/boto_config_tut.html
+    credentials are provided. See https://boto.readthedocs.io/en/latest/boto_config_tut.html
   - C(AWS_REGION) or C(EC2_REGION) can be typically be used to specify the
     AWS region, when required, but this can also be configured in the boto config file
 """

--- a/lib/ansible/utils/module_docs_fragments/docker.py
+++ b/lib/ansible/utils/module_docs_fragments/docker.py
@@ -85,5 +85,5 @@ notes:
       You can define DOCKER_HOST, DOCKER_TLS_HOSTNAME, DOCKER_API_VERSION, DOCKER_CERT_PATH, DOCKER_SSL_VERSION,
       DOCKER_TLS, DOCKER_TLS_VERIFY and DOCKER_TIMEOUT. If you are using docker machine, run the script shipped
       with the product that sets up the environment. It will set these variables for you. See
-      https://docker-py.readthedocs.org/en/stable/machine/ for more details.
+      https://docker-py.readthedocs.io/en/stable/machine/ for more details.
 '''


### PR DESCRIPTION
Read the Docs moved hosting to readthedocs.io instead of readthedocs.org. Fix all links in the project.

For additional details, see:

https://blog.readthedocs.com/securing-subdomains/

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.