### PR TITLE
setting LANG, LC_ALL and LC_NUMERIC to C

### DIFF
--- a/lib/ansible/module_utils/facts/hardware/linux.py
+++ b/lib/ansible/module_utils/facts/hardware/linux.py
@@ -78,6 +78,7 @@ class LinuxHardware(Hardware):
 
     def populate(self, collected_facts=None):
         hardware_facts = {}
+        self.module.run_command_environ_update = {'LANG': 'C', 'LC_ALL': 'C', 'LC_NUMERIC': 'C'}
 
         cpu_facts = self.get_cpu_facts(collected_facts=collected_facts)
         memory_facts = self.get_memory_facts()

--- a/lib/ansible/module_utils/facts/hardware/linux.py
+++ b/lib/ansible/module_utils/facts/hardware/linux.py
@@ -31,7 +31,7 @@ from ansible.module_utils.basic import bytes_to_human
 from ansible.module_utils.facts.hardware.base import Hardware, HardwareCollector
 from ansible.module_utils.facts.utils import get_file_content, get_file_lines, get_mount_size
 
-# import this as a module to ensure we get the same module isntance
+# import this as a module to ensure we get the same module instance
 from ansible.module_utils.facts import timeout
 
 


### PR DESCRIPTION
##### SUMMARY
Sets LANG, LC_ALL and LC_NUMERIC to C
Fixes #33617 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
hardware/linux.py

##### ANSIBLE VERSION
```
ansible 2.4.2.0
  config file = /Users/ivica.kolenkas/projects/syseng/ansible.cfg
  configured module search path = [u'/Users/ivica.kolenkas/projects/syseng/library']
  ansible python module location = /Users/ivica.kolenkas/virtualenvs/bse-aws-prod/lib/python2.7/site-packages/ansible
  executable location = /Users/ivica.kolenkas/virtualenvs/bse-aws-prod/bin/ansible
  python version = 2.7.10 (default, Feb  7 2017, 00:08:15) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.34)]
```
