### PR TITLE
fix nxos_linkagg issue

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_linkagg.py
+++ b/lib/ansible/modules/network/nxos/nxos_linkagg.py
@@ -327,7 +327,7 @@ def map_config_to_obj(module):
 
     try:
         channels = output['TABLE_channel']['ROW_channel']
-    except KeyError:
+    except TypeError, KeyError:
         return objs
 
     if channels:

--- a/lib/ansible/modules/network/nxos/nxos_linkagg.py
+++ b/lib/ansible/modules/network/nxos/nxos_linkagg.py
@@ -327,7 +327,7 @@ def map_config_to_obj(module):
 
     try:
         channels = output['TABLE_channel']['ROW_channel']
-    except TypeError, KeyError:
+    except (TypeError, KeyError):
         return objs
 
     if channels:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #41547 
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
nxos_linkagg
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0.dev0 (stable-2.6 9ae2050e2f) last updated 2018/06/11 12:10:05 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /root/agents-ci/ansible/lib/ansible
  executable location = /root/agents-ci/ansible/bin/ansible
  python version = 2.7.6 (default, Oct 26 2016, 20:30:19) [GCC 4.8.4]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->
* This PR fixes #41547 
* The issue was coming because on older platforms running I2 code, if there are no port-channels configured on the device, the command ```show port-channel summary | json``` gives this output:
```
<?xml version="1.0" encoding="ISO-8859-1"?>
<nf:rpc-reply xmlns:nf="urn:ietf:params:xml:ns:netconf:base:1.0" xmlns="http://www.cisco.com/nxos:1.0:eth_pcm_dc3">
 <nf:data/>
</nf:rpc-reply>
]]>]]>

```
On all other platforms, there is no output, so it works ok. On old platforms, this is causing ```TypeError``` which results in the failure.

