### PR TITLE
Update APB templates

### DIFF
--- a/lib/ansible/galaxy/data/apb/.travis.yml
+++ b/lib/ansible/galaxy/data/apb/.travis.yml
@@ -6,9 +6,7 @@ python:
   - '2.7'
 
 env:
-  - OPENSHIFT_VERSION=latest
-  - OPENSHIFT_VERSION=v3.9
-  - KUBERNETES_VERSION=latest
+  - OPENSHIFT_VERSION=v3.9.0
   - KUBERNETES_VERSION=v1.9.0
 
 script:
@@ -16,11 +14,12 @@ script:
   - export apb_name=APB_NAME
 
   # Download test shim.
-  - wget -O ${PWD}/apb-test.sh https://raw.githubusercontent.com/djzager/apb-test-shim/ansible-galaxy/apb-test.sh
+  - wget -O ${PWD}/apb-test.sh https://raw.githubusercontent.com/ansibleplaybookbundle/apb-test-shim/master/apb-test.sh
   - chmod +x ${PWD}/apb-test.sh
 
   # Run tests.
   - ${PWD}/apb-test.sh
 
+# Uncomment to allow travis to notify galaxy
 # notifications:
 #  webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/lib/ansible/galaxy/data/apb/apb.yml.j2
+++ b/lib/ansible/galaxy/data/apb/apb.yml.j2
@@ -1,4 +1,4 @@
-version: 1.0
+version: '1.0.0'
 name: {{ role_name }}
 description: {{ description }}
 bindable: False

--- a/lib/ansible/galaxy/data/apb/playbooks/deprovision.yml.j2
+++ b/lib/ansible/galaxy/data/apb/playbooks/deprovision.yml.j2
@@ -6,4 +6,3 @@
     apb_action: deprovision
   roles:
   - role: {{ role_name }}
-    

--- a/lib/ansible/galaxy/data/apb/playbooks/provision.yml.j2
+++ b/lib/ansible/galaxy/data/apb/playbooks/provision.yml.j2
@@ -6,4 +6,3 @@
     apb_action: provision
   roles:
   - role: {{ role_name }}
-    


### PR DESCRIPTION
##### SUMMARY

Update the APB templates used when `ansible-galaxy init --type=apb` is invoked. Specifically:

- Update travis template to use the upstream fork of the apb-test-shim
- Update apb.yml template so that version is semver compatible
- Cleanup some whitespace in a few other templates

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
`ansible-galaxy init --type=apb` templates

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0
  config file = None
  configured module search path = [u'/home/dzager/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /tmp/ansible/lib/python2.7/site-packages/ansible-2.7.0.dev0-py2.7.egg/ansible
  executable location = /tmp/ansible/bin/ansible
  python version = 2.7.15 (default, May 16 2018, 17:50:09) [GCC 8.1.1 20180502 (Red Hat 8.1.1-1)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->


