### PR TITLE
Documentation exemple missmatch

### DIFF
--- a/lib/ansible/modules/network/f5/bigip_configsync_action.py
+++ b/lib/ansible/modules/network/f5/bigip_configsync_action.py
@@ -62,7 +62,7 @@ author:
 
 EXAMPLES = r'''
 - name: Sync configuration from device to group
-  bigip_configsync_actions:
+  bigip_configsync_action:
     device_group: foo-group
     sync_device_to_group: yes
     server: lb.mydomain.com
@@ -72,7 +72,7 @@ EXAMPLES = r'''
   delegate_to: localhost
 
 - name: Sync configuration from most recent device to the current host
-  bigip_configsync_actions:
+  bigip_configsync_action:
     device_group: foo-group
     sync_most_recent_to_device: yes
     server: lb.mydomain.com
@@ -82,7 +82,7 @@ EXAMPLES = r'''
   delegate_to: localhost
 
 - name: Perform an initial sync of a device to a new device group
-  bigip_configsync_actions:
+  bigip_configsync_action:
     device_group: new-device-group
     sync_device_to_group: yes
     server: lb.mydomain.com


### PR DESCRIPTION
##### SUMMARY
The module name, missmatch in documentation.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
bigip_configsync_action

##### ANSIBLE VERSION
```
ansible 2.5.4
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/rosiney/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.15rc1 (default, Apr 15 2018, 21:51:34) [GCC 7.3.0]
```