### PR TITLE
makes the arguments of assert less ambiguous

### DIFF
--- a/lib/ansible/modules/utilities/logic/assert.py
+++ b/lib/ansible/modules/utilities/logic/assert.py
@@ -27,9 +27,11 @@ options:
       - "A string expression of the same form that can be passed to the 'when' statement"
       - "Alternatively, a list of string expressions"
     required: true
-  msg:
+  fail_msg:
     description:
       - "The customized message used for a failing assertion"
+    aliases:
+      - msg
   success_msg:
     version_added: "2.7"
     description:
@@ -53,6 +55,6 @@ EXAMPLES = '''
     that:
       - "my_param <= 100"
       - "my_param >= 0"
-    msg: "'my_param' must be between 0 and 100"
+    fail_msg: "'my_param' must be between 0 and 100"
     success_msg: "'my_param' is between 0 and 100"
 '''

--- a/lib/ansible/modules/utilities/logic/assert.py
+++ b/lib/ansible/modules/utilities/logic/assert.py
@@ -31,6 +31,7 @@ options:
     version_added: "2.7"
     description:
       - "The customized message used for a failing assertion"
+      - "This argument was called 'msg' before version 2.7, now it's renamed to 'fail_msg' with alias 'msg'"
     aliases:
       - msg
   success_msg:
@@ -52,10 +53,18 @@ EXAMPLES = '''
       - "'foo' in some_command_result.stdout"
       - "number_of_the_counting == 3"
 
+# after version 2.7 both 'msg' and 'fail_msg' can customize failing assertion message
 - assert:
     that:
       - "my_param <= 100"
       - "my_param >= 0"
     fail_msg: "'my_param' must be between 0 and 100"
     success_msg: "'my_param' is between 0 and 100"
+
+# please use 'msg' when ansible version is smaller than 2.7
+- assert:
+    that:
+      - "my_param <= 100"
+      - "my_param >= 0"
+    msg: "'my_param' must be between 0 and 100"
 '''

--- a/lib/ansible/modules/utilities/logic/assert.py
+++ b/lib/ansible/modules/utilities/logic/assert.py
@@ -53,16 +53,16 @@ EXAMPLES = '''
       - "'foo' in some_command_result.stdout"
       - "number_of_the_counting == 3"
 
-# after version 2.7 both 'msg' and 'fail_msg' can customize failing assertion message
-- assert:
+- name: after version 2.7 both 'msg' and 'fail_msg' can customize failing assertion message
+  assert:
     that:
       - "my_param <= 100"
       - "my_param >= 0"
     fail_msg: "'my_param' must be between 0 and 100"
     success_msg: "'my_param' is between 0 and 100"
 
-# please use 'msg' when ansible version is smaller than 2.7
-- assert:
+- name: please use 'msg' when ansible version is smaller than 2.7
+  assert:
     that:
       - "my_param <= 100"
       - "my_param >= 0"

--- a/lib/ansible/modules/utilities/logic/assert.py
+++ b/lib/ansible/modules/utilities/logic/assert.py
@@ -28,6 +28,7 @@ options:
       - "Alternatively, a list of string expressions"
     required: true
   fail_msg:
+    version_added: "2.7"
     description:
       - "The customized message used for a failing assertion"
     aliases:

--- a/lib/ansible/plugins/action/assert.py
+++ b/lib/ansible/plugins/action/assert.py
@@ -38,10 +38,13 @@ class ActionModule(ActionBase):
         if 'that' not in self._task.args:
             raise AnsibleError('conditional required in "that" string')
 
-        msg = None
+        fail_msg = None
         success_msg = None
-        if 'msg' in self._task.args and isinstance(self._task.args['msg'], string_types):
-            msg = self._task.args['msg']
+        if 'fail_msg' in self._task.args and isinstance(self._task.args['fail_msg'], string_types):
+            fail_msg = self._task.args['fail_msg']
+        elif 'msg' in self._task.args and isinstance(self._task.args['msg'], string_types):
+            fail_msg = self._task.args['msg']
+
         if 'success_msg' in self._task.args and isinstance(self._task.args['success_msg'], string_types):
             success_msg = self._task.args['success_msg']
 
@@ -65,8 +68,8 @@ class ActionModule(ActionBase):
                 result['evaluated_to'] = test_result
                 result['assertion'] = that
 
-                if msg:
-                    result['msg'] = msg
+                if fail_msg:
+                    result['msg'] = fail_msg
 
                 return result
 

--- a/lib/ansible/plugins/action/assert.py
+++ b/lib/ansible/plugins/action/assert.py
@@ -44,13 +44,13 @@ class ActionModule(ActionBase):
         fail_msg = self._task.args.get('fail_msg', self._task.args.get('msg'))
         if fail_msg is None:
             fail_msg = 'Assertion failed'
-        if not isinstance(fail_msg, string_types):
+        elif not isinstance(fail_msg, string_types):
             raise AnsibleError('Incorrect type for fail_msg or msg, expected string and got %s' % type(fail_msg))
 
         success_msg = self._task.args.get('success_msg')
         if success_msg is None:
             success_msg = 'All assertions passed'
-        if not isinstance(success_msg, string_types):
+        elif not isinstance(success_msg, string_types):
             raise AnsibleError('Incorrect type for success_msg, expected string and got %s' % type(success_msg))
 
         # make sure the 'that' items are a list

--- a/lib/ansible/plugins/action/assert.py
+++ b/lib/ansible/plugins/action/assert.py
@@ -40,13 +40,18 @@ class ActionModule(ActionBase):
 
         fail_msg = None
         success_msg = None
-        if 'fail_msg' in self._task.args and isinstance(self._task.args['fail_msg'], string_types):
-            fail_msg = self._task.args['fail_msg']
-        elif 'msg' in self._task.args and isinstance(self._task.args['msg'], string_types):
-            fail_msg = self._task.args['msg']
 
-        if 'success_msg' in self._task.args and isinstance(self._task.args['success_msg'], string_types):
-            success_msg = self._task.args['success_msg']
+        fail_msg = self._task.args.get('fail_msg', self._task.args.get('msg'))
+        if fail_msg is None:
+            fail_msg = 'Assertion failed'
+        if not isinstance(fail_msg, string_types):
+            raise AnsibleError('Incorrect type for fail_msg or msg, expected string and got %s' % type(fail_msg))
+
+        success_msg = self._task.args.get('success_msg')
+        if success_msg is None:
+            success_msg = 'All assertions passed'
+        if not isinstance(success_msg, string_types):
+            raise AnsibleError('Incorrect type for success_msg, expected string and got %s' % type(success_msg))
 
         # make sure the 'that' items are a list
         thats = self._task.args['that']
@@ -68,14 +73,10 @@ class ActionModule(ActionBase):
                 result['evaluated_to'] = test_result
                 result['assertion'] = that
 
-                if fail_msg:
-                    result['msg'] = fail_msg
+                result['msg'] = fail_msg
 
                 return result
 
         result['changed'] = False
-        if success_msg is not None:
-            result['msg'] = success_msg
-        else:
-            result['msg'] = 'All assertions passed'
+        result['msg'] = success_msg
         return result


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Since #41048 adds a new argument to assert module called success_msg, we need to rename the msg argument to fail_msg, makes it less ambiguous.
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
assert module
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (msg_aliase 1008bdb2f6) last updated 2018/06/14 13:42:07 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/zhikangzhang/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/zhikangzhang/hd650/ansible/lib/ansible
  executable location = /home/zhikangzhang/hd650/ansible/bin/ansible
  python version = 2.7.15 (default, May 16 2018, 17:50:09) [GCC 8.1.1 20180502 (Red Hat 8.1.1-1)]
```
