### PR TITLE
sort the port list properly (.sort() returns None)

### DIFF
--- a/lib/ansible/modules/cloud/google/gce_net.py
+++ b/lib/ansible/modules/cloud/google/gce_net.py
@@ -272,7 +272,7 @@ def sorted_allowed_list(allowed_list):
     # sort by protocol
     allowed_by_protocol = sorted(allowed_list, key=lambda x: x['IPProtocol'])
     # sort the ports list
-    return sorted(allowed_by_protocol, key=lambda y: y.get('ports', []).sort())
+    return sorted(allowed_by_protocol, key=lambda y: sorted(y.get('ports', [])))
 
 
 def main():


### PR DESCRIPTION
##### SUMMARY
Sort the list of ports properly. The `sort` function sorts the list in place and returns `None`, which was surely not the intended effect.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
gce_net

##### ANSIBLE VERSION
```
ansible 2.5.4
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/sp/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.15rc1 (default, Apr 15 2018, 21:51:34) [GCC 7.3.0]
```
