### PR TITLE
Correct typo from 'Valut' to 'Vault'

### DIFF
--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_credential.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_credential.py
@@ -105,7 +105,7 @@ options:
         - Become password. Use ASK for prompting.
     vault_password:
       description:
-        - Valut password. Use ASK for prompting.
+        - Vault password. Use ASK for prompting.
     state:
       description:
         - Desired state of the resource.


### PR DESCRIPTION
##### SUMMARY
Correct typo from 'Valut' to 'Vault'

+label: docsite_pr

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
lib/ansible/modules/web_infrastructure/ansible_tower/tower_credential.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7-devel
```