### PR TITLE
aireos_config: Further fixes to #35622

### DIFF
--- a/lib/ansible/modules/network/aireos/aireos_config.py
+++ b/lib/ansible/modules/network/aireos/aireos_config.py
@@ -268,7 +268,10 @@ def main():
             configobjs = candidate.items
 
         if configobjs:
-            commands = dumps(configobjs, 'commands').split('\n')
+            if module.params['src']:
+                commands = dumps(configobjs, 'commands').split('\n')
+            else:
+                commands = module.params['lines']
 
             if module.params['before']:
                 commands[:0] = module.params['before']


### PR DESCRIPTION
##### SUMMARY
Further testing showed that #41522 only provided a partial fix for #35622.

Prompts now work for "before" and "after" parameters as aireos_config pulls their value directly from module.params:

```
            if module.params['before']:
                commands[:0] = module.params['before']

            if module.params['after']:
                commands.extend(module.params['after'])
```

Whereas commands passed in via "lines" or "src" are pulled as:

```
        if configobjs:
            commands = dumps(configobjs, 'commands').split('\n')
```



##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
aireos_config

##### ANSIBLE VERSION
```
ansible 2.7.0.dev0 (devel 0db643da6c) last updated 2018/06/14 10:55:52 (GMT +800)
  config file = None
  configured module search path = ['/Users/james/PycharmProjects/ansible/library']
  ansible python module location = /Users/james/PycharmProjects/ansible/lib/ansible
  executable location = /Users/james/PycharmProjects/ansible/bin/ansible
  python version = 3.6.4 (default, Jan 31 2018, 13:04:35) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.38)]
```


##### ADDITIONAL INFORMATION
Playbook parameters:
```
      aireos_config:
        lines:
          - "ap name {{ ap_name }} {{ ap_mac }}"
          - "ap location \"{{ ap_location }}\" {{ ap_name }}"
          - "ap enable {{ ap_name }}"
          - command: "ap group-name {{ ap_group}} {{ ap_name }}"
            prompt: "Are you sure you want to continue"
            answer: "y"
```
Output Before:
```
PLAY [Initial WAP Configuration] ***************************************************************************************

TASK [Execute Config] **************************************************************************************************
fatal: [wlc_001]: FAILED! => {"changed": false, "command": "{\"command\": \"{'command': 'ap group-name group_a wap_001', 'prompt': 'Are you sure you want to continue', 'answer': 'y'}\", \"prompt\": null, \"answer\": null}", "msg": "{'command': 'ap group-name group_a wap_001', 'prompt': 'Are you sure you want to continue', 'answer': 'y'}\r\n\r\nIncorrect usage.  Use the '?' or <TAB> key to list commands.\r\n\r\n(Cisco Controller) config>", "rc": -32603}
        to retry, use: --limit @/Users/james/PycharmProjects/ansible/testmod.retry

PLAY RECAP *************************************************************************************************************
wlc_001              : ok=0    changed=0    unreachable=0    failed=1
```
Output After:
```
PLAY [Initial WAP Configuration] ***************************************************************************************

TASK [Execute Config] **************************************************************************************************
changed: [wlc_001]

TASK [debug] ***********************************************************************************************************
ok: [wlc_001] => {
    "msg": {
        "changed": true,
        "commands": [
            "ap disable wap_001",
            "flexconnect group 9992 ap add 00:00:00:00:00:00",
            "ap name wap_001 00:00:00:00:00:00",
            "ap location \"Test Lab\" wap_001",
            "end",
            "ap enable wap_001",
            {
                "answer": "y",
                "command": "ap group-name group_a wap_001",
                "prompt": "Are you sure you want to continue"
            }
        ],
        "failed": false,
        "updates": [
            "ap disable wap_001",
            "flexconnect group 9992 ap add 00:00:00:00:00:00",
            "ap name wap_001 00:00:00:00:00:00",
            "ap location \"Test Lab\" wap_001",
            "end",
            "ap enable wap_001",
            {
                "answer": "y",
                "command": "ap group-name group_a wap_001",
                "prompt": "Are you sure you want to continue"
            }
        ]
    }
}

PLAY RECAP *************************************************************************************************************
wlc_001              : ok=2    changed=1    unreachable=0    failed=0
```

