### PR TITLE
tower_project: manual projects don't require creds

### DIFF
--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_project.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_project.py
@@ -146,16 +146,19 @@ def main():
                     org = org_res.get(name=organization)
                 except (exc.NotFound) as excinfo:
                     module.fail_json(msg='Failed to update project, organization not found: {0}'.format(organization), changed=False)
-                try:
-                    cred_res = tower_cli.get_resource('credential')
-                    cred = cred_res.get(name=scm_credential)
-                except (exc.NotFound) as excinfo:
-                    module.fail_json(msg='Failed to update project, credential not found: {0}'.format(scm_credential), changed=False)
 
+                if scm_type:
+                    try:
+                        cred_res = tower_cli.get_resource('credential')
+                        cred = cred_res.get(name=scm_credential)
+                    except (exc.NotFound) as excinfo:
+                        module.fail_json(msg='Failed to update project, credential not found: {0}'.format(scm_credential), changed=False)
+
+                credential = cred['id'] if scm_type else None
                 result = project.modify(name=name, description=description,
                                         organization=org['id'],
                                         scm_type=scm_type, scm_url=scm_url, local_path=local_path,
-                                        scm_branch=scm_branch, scm_clean=scm_clean, credential=cred['id'],
+                                        scm_branch=scm_branch, scm_clean=scm_clean, credential=credential,
                                         scm_delete_on_update=scm_delete_on_update,
                                         scm_update_on_launch=scm_update_on_launch,
                                         create_on_missing=True)

--- a/test/integration/targets/tower_project/tasks/create_project_dir.yml
+++ b/test/integration/targets/tower_project/tasks/create_project_dir.yml
@@ -1,0 +1,49 @@
+- name: Fetch project_base_dir
+  uri:
+    url: "https://{{ lookup('env', 'TOWER_HOST') }}/api/v2/config/"
+    user: "{{ lookup('env', 'TOWER_USERNAME') }}"
+    password: "{{ lookup('env', 'TOWER_PASSWORD') }}"
+    validate_certs: false
+    return_content: true
+  register: awx_config
+
+- tower_inventory:
+    name: localhost
+    organization: Default
+
+- tower_host:
+    name: localhost
+    inventory: localhost
+    variables:
+      ansible_connection: local
+
+- name: Create a private key (which will not be used)
+  copy:
+    content: |
+      -----BEGIN EC PRIVATE KEY-----
+      MHcCAQEEIIUl6R1xgzR6siIUArz4XBPtGZ09aetma2eWf1v3uYymoAoGCCqGSM49
+      AwEHoUQDQgAENJNjgeZDAh/+BY860s0yqrLDprXJflY0GvHIr7lX3ieCtrzOMCVU
+      QWzw35pc5tvuP34SSi0ZE1E+7cVMDDOF3w==
+      -----END EC PRIVATE KEY-----
+    dest: "{{ output_dir }}/tower_project_unused_key"
+
+- name: create an unused SSH / Machine credential
+  tower_credential:
+    name: dummy
+    kind: ssh
+    ssh_key_data: "{{ output_dir }}/tower_project_unused_key"
+    organization: Default
+
+- name: Disable bubblewrap
+  command: tower-cli setting modify AWX_PROOT_ENABLED false
+
+- block:
+    - name: Create a directory for manual project
+      vars:
+        project_base_dir: "{{ awx_config.json.project_base_dir }}"
+      command: tower-cli ad_hoc launch --monitor --inventory localhost
+        --credential dummy --module-name command
+        --module-args "mkdir {{ project_base_dir }}/manual_test_project"
+  always:
+    - name: enable bubblewrap
+      command: tower-cli setting modify AWX_PROOT_ENABLED true

--- a/test/integration/targets/tower_project/tasks/main.yml
+++ b/test/integration/targets/tower_project/tasks/main.yml
@@ -25,3 +25,18 @@
 - assert:
     that:
       - "result is changed"
+
+- name: create a project directory for manual project
+  import_tasks: create_project_dir.yml
+
+- name: Create a manual project
+  tower_project:
+    name: manual project
+    organization: Default
+    scm_type: manual
+    local_path: "manual_test_project"
+  register: result
+
+- assert:
+    that:
+      - "result is changed"


### PR DESCRIPTION
##### SUMMARY
`tower_project`: check that `manual` projects don't require credentials. Integration test provided.

Without this fix, creation of a `manual` project [fails](https://app.shippable.com/github/ansible/ansible/runs/70275/66/console):
```
TASK [tower_project : Create a manual project] ***
An exception occurred during task execution. To see the full traceback, use -vvv. 
The error was: tower_cli.exceptions.MultipleResults: Expected one result, got 2.
Possibly caused by not providing required fields. Please tighten your criteria.

fatal: [testhost]: FAILED! => {
  "changed": false,
  "module_stderr": "Traceback (most recent call last):
    File "/tmp/ansible_ZtxFXz/ansible_module_tower_project.py, line 174, in <module>
      main()
    File /tmp/ansible_ZtxFXz/ansible_module_tower_project.py, line 151, in main
      cred = cred_res.get(name=scm_credential)
    File /usr/local/lib/python2.7/dist-packages/tower_cli/models/base.py, line 486, in get
      response = self.read(pk=pk, fail_on_no_results=True, fail_on_multiple_results=True, **kwargs)
    File /usr/local/lib/python2.7/dist-packages/tower_cli/models/base.py, line 312, in read
      'fields. Please tighten your criteria.' % resp['count'])
  tower_cli.exceptions.MultipleResults: Expected one result, got 2. Possibly caused by not providing required fields. Please tighten your criteria.",
   "module_stdout": "",
   "msg": "MODULE FAILURE",
   "rc": 1
}
```

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
tower_project

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (devel a94ddedfd3) last updated 2018/06/15 09:53:23 (GMT +200)
```