### PR TITLE
First pass at a toml inventory

### DIFF
--- a/changelogs/fragments/toml-inventory.yaml
+++ b/changelogs/fragments/toml-inventory.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- inventory - added new TOML inventory plugin (https://github.com/ansible/ansible/pull/41593)

--- a/docs/docsite/rst/user_guide/intro_inventory.rst
+++ b/docs/docsite/rst/user_guide/intro_inventory.rst
@@ -16,6 +16,8 @@ Not only is this inventory configurable, but you can also use multiple inventory
 pull inventory from dynamic or cloud sources or different formats (YAML, ini, etc), as described in :ref:`intro_dynamic_inventory`.
 Introduced in version 2.4, Ansible has inventory plugins to make this flexible and customizable.
 
+The TOML inventory format was introduced in version 2.8.
+
 .. _inventoryformat:
 
 Hosts and Groups

--- a/docs/docsite/rst/user_guide/intro_inventory.rst
+++ b/docs/docsite/rst/user_guide/intro_inventory.rst
@@ -62,7 +62,7 @@ A YAML version would look like:
 
 A TOML version would look like:
 
-.. code-block:: toml
+.. code-block:: guess
 
     [ungrouped.hosts]
     mail.example.com = {}
@@ -110,7 +110,7 @@ In YAML:
 
 In TOML:
 
-.. code-block:: toml
+.. code-block:: guess
 
     ...
     [ungrouped.hosts.jumper]
@@ -119,7 +119,7 @@ In TOML:
 
 or in inline TOML format:
 
-.. code-block:: toml
+.. code-block:: guess
 
     ...
     [ungrouped.hosts]
@@ -205,7 +205,7 @@ The YAML version:
 
 The TOML version:
 
-.. code-block:: toml
+.. code-block:: guess
 
    [atlanta.hosts]
    host1 = {}
@@ -282,7 +282,7 @@ In YAML:
 
 In TOML:
 
-.. code-block:: toml
+.. code-block:: guess
 
    [atlanta.hosts]
    host1 = {}

--- a/docs/docsite/rst/user_guide/intro_inventory.rst
+++ b/docs/docsite/rst/user_guide/intro_inventory.rst
@@ -16,8 +16,6 @@ Not only is this inventory configurable, but you can also use multiple inventory
 pull inventory from dynamic or cloud sources or different formats (YAML, ini, etc), as described in :ref:`intro_dynamic_inventory`.
 Introduced in version 2.4, Ansible has inventory plugins to make this flexible and customizable.
 
-The TOML inventory format was introduced in version 2.8.
-
 .. _inventoryformat:
 
 Hosts and Groups
@@ -60,22 +58,6 @@ A YAML version would look like:
           two.example.com:
           three.example.com:
 
-A TOML version would look like:
-
-.. code-block:: guess
-
-    [ungrouped.hosts]
-    mail.example.com = {}
-
-    [webservers.hosts]
-    foo.example.com = {}
-    bar.example.com = {}
-
-    [dbservers.hosts]
-    one.example.com = {}
-    two.example.com = {}
-    three.example.com = {}
-
 
 It is ok to put systems in more than one group, for instance a server could be both a webserver and a dbserver.
 If you do, note that variables will come from all of the groups they are a member of. Variable precedence is detailed in a later chapter.
@@ -107,23 +89,6 @@ In YAML:
         jumper:
           ansible_port: 5555
           ansible_host: 192.0.2.50
-
-In TOML:
-
-.. code-block:: guess
-
-    ...
-    [ungrouped.hosts.jumper]
-    ansible_port = 5555
-    ansible_host = "192.0.2.50"
-
-or in inline TOML format:
-
-.. code-block:: guess
-
-    ...
-    [ungrouped.hosts]
-    jumper = { ansible_port = 5555, ansible_host = "192.0.2.50" }
 
 In the above example, trying to ansible against the host alias "jumper" (which may not even be a real hostname) will contact 192.0.2.50 on port 5555.
 Note that this is using a feature of the inventory file to define some special variables.
@@ -203,18 +168,6 @@ The YAML version:
         ntp_server: ntp.atlanta.example.com
         proxy: proxy.atlanta.example.com
 
-The TOML version:
-
-.. code-block:: guess
-
-   [atlanta.hosts]
-   host1 = {}
-   host2 = {}
-
-   [atlanta.vars]
-   ntp_server = "ntp.atlanta.example.com"
-   proxy = "proxy.atlanta.example.com"
-
 Be aware that this is only a convenient way to apply variables to multiple hosts at once; even though you can target hosts by group, **variables are always flattened to the host level** before a play is executed.
 
 .. _subgroups:
@@ -225,7 +178,6 @@ Groups of Groups, and Group Variables
 It is also possible to make groups of groups using the ``:children`` suffix in INI or the ``children:`` entry in YAML.
 You can apply variables using ``:vars`` or ``vars:``:
 
-In INI:
 
 .. code-block:: guess
 
@@ -253,8 +205,6 @@ In INI:
    southwest
    northwest
 
-In YAML:
-
 .. code-block:: yaml
 
   all:
@@ -279,38 +229,6 @@ In YAML:
           northeast:
           northwest:
           southwest:
-
-In TOML:
-
-.. code-block:: guess
-
-   [atlanta.hosts]
-   host1 = {}
-   host2 = {}
-
-   [raleigh.hosts]
-   host2 = {}
-   host3 = {}
-
-   [southeast]
-   children = [
-       "atlanta",
-       "raleigh"
-   ]
-
-   [southeast.vars]
-   some_server = "foo.southeast.example.com"
-   halon_system_timeout = 30
-   self_destruct_countdown = 60
-   escape_pods = 2
-
-   [usa]
-   children = [
-       "southeast",
-       "northeast",
-       "southwest",
-       "northwest"
-   ]
 
 If you need to store lists or hash data, or prefer to keep host and group specific variables separate from the inventory file, see the next section.
 Child groups have a couple of properties to note:

--- a/docs/docsite/rst/user_guide/intro_inventory.rst
+++ b/docs/docsite/rst/user_guide/intro_inventory.rst
@@ -58,6 +58,22 @@ A YAML version would look like:
           two.example.com:
           three.example.com:
 
+A TOML version would look like:
+
+.. code-block:: toml
+
+    [ungrouped.hosts]
+    mail.example.com = {}
+
+    [webservers.hosts]
+    foo.example.com = {}
+    bar.example.com = {}
+
+    [dbservers.hosts]
+    one.example.com = {}
+    two.example.com = {}
+    three.example.com = {}
+
 
 It is ok to put systems in more than one group, for instance a server could be both a webserver and a dbserver.
 If you do, note that variables will come from all of the groups they are a member of. Variable precedence is detailed in a later chapter.
@@ -89,6 +105,23 @@ In YAML:
         jumper:
           ansible_port: 5555
           ansible_host: 192.0.2.50
+
+In TOML:
+
+.. code-block:: toml
+
+    ...
+    [ungrouped.hosts.jumper]
+    ansible_port = 5555
+    ansible_host = "192.0.2.50"
+
+or in inline TOML format:
+
+.. code-block:: toml
+
+    ...
+    [ungrouped.hosts]
+    jumper = { ansible_port = 5555, ansible_host = "192.0.2.50" }
 
 In the above example, trying to ansible against the host alias "jumper" (which may not even be a real hostname) will contact 192.0.2.50 on port 5555.
 Note that this is using a feature of the inventory file to define some special variables.
@@ -168,6 +201,18 @@ The YAML version:
         ntp_server: ntp.atlanta.example.com
         proxy: proxy.atlanta.example.com
 
+The TOML version:
+
+.. code-block:: toml
+
+   [atlanta.hosts]
+   host1 = {}
+   host2 = {}
+
+   [atlanta.vars]
+   ntp_server = "ntp.atlanta.example.com"
+   proxy = "proxy.atlanta.example.com"
+
 Be aware that this is only a convenient way to apply variables to multiple hosts at once; even though you can target hosts by group, **variables are always flattened to the host level** before a play is executed.
 
 .. _subgroups:
@@ -178,6 +223,7 @@ Groups of Groups, and Group Variables
 It is also possible to make groups of groups using the ``:children`` suffix in INI or the ``children:`` entry in YAML.
 You can apply variables using ``:vars`` or ``vars:``:
 
+In INI:
 
 .. code-block:: guess
 
@@ -205,6 +251,8 @@ You can apply variables using ``:vars`` or ``vars:``:
    southwest
    northwest
 
+In YAML:
+
 .. code-block:: yaml
 
   all:
@@ -229,6 +277,38 @@ You can apply variables using ``:vars`` or ``vars:``:
           northeast:
           northwest:
           southwest:
+
+In TOML:
+
+.. code-block:: toml
+
+   [atlanta.hosts]
+   host1 = {}
+   host2 = {}
+
+   [raleigh.hosts]
+   host2 = {}
+   host3 = {}
+
+   [southeast]
+   children = [
+       "atlanta",
+       "raleigh"
+   ]
+
+   [southeast.vars]
+   some_server = "foo.southeast.example.com"
+   halon_system_timeout = 30
+   self_destruct_countdown = 60
+   escape_pods = 2
+
+   [usa]
+   children = [
+       "southeast",
+       "northeast",
+       "southwest",
+       "northwest"
+   ]
 
 If you need to store lists or hash data, or prefer to keep host and group specific variables separate from the inventory file, see the next section.
 Child groups have a couple of properties to note:

--- a/lib/ansible/cli/inventory.py
+++ b/lib/ansible/cli/inventory.py
@@ -399,7 +399,7 @@ class InventoryCLI(CLI):
 
     def toml_inventory(self, top):
         seen = set()
-        has_ungrouped = bool([g.hosts for g in top.child_groups if g.name == 'ungrouped'][0])
+        has_ungrouped = bool(next(g.hosts for g in top.child_groups if g.name == 'ungrouped'))
 
         def format_group(group):
             results = {}

--- a/lib/ansible/cli/inventory.py
+++ b/lib/ansible/cli/inventory.py
@@ -206,7 +206,7 @@ class InventoryCLI(CLI):
                     'The python "toml" library is required when using the TOML output format'
                 )
             if AnsibleTomlEncoder:
-                results = toml.dumps(stuff, encoder=encoder)
+                results = toml.dumps(stuff, encoder=AnsibleTomlEncoder())
             else:
                 results = toml.dumps(convert_yaml_objects_to_native(stuff))
         else:

--- a/lib/ansible/cli/inventory.py
+++ b/lib/ansible/cli/inventory.py
@@ -200,9 +200,13 @@ class InventoryCLI(CLI):
         elif self.options.toml:
             try:
                 import toml
+                from ansible.plugins.inventory.toml import AnsibleTomlEncoder
             except ImportError:
-                raise AnsibleError('The python "toml" library is required when using the TOML output format')
-            results = toml.dumps(stuff)
+                raise AnsibleError(
+                    'Version 0.10.0 or newer of the python "toml" library is required when using the TOML output format'
+                )
+            encoder = AnsibleTomlEncoder()
+            results = toml.dumps(stuff, encoder=encoder)
         else:
             import json
             from ansible.parsing.ajson import AnsibleJSONEncoder

--- a/lib/ansible/cli/inventory.py
+++ b/lib/ansible/cli/inventory.py
@@ -200,11 +200,13 @@ class InventoryCLI(CLI):
         elif self.options.toml:
             try:
                 import toml
-                from ansible.plugins.inventory.toml import AnsibleTomlEncoder, convert_yaml_objects_to_native
             except ImportError:
                 raise AnsibleError(
                     'The python "toml" library is required when using the TOML output format'
                 )
+            else:
+                from ansible.plugins.inventory.toml import AnsibleTomlEncoder, convert_yaml_objects_to_native
+
             if AnsibleTomlEncoder:
                 results = toml.dumps(stuff, encoder=AnsibleTomlEncoder())
             else:

--- a/lib/ansible/cli/inventory.py
+++ b/lib/ansible/cli/inventory.py
@@ -200,13 +200,15 @@ class InventoryCLI(CLI):
         elif self.options.toml:
             try:
                 import toml
-                from ansible.plugins.inventory.toml import AnsibleTomlEncoder
+                from ansible.plugins.inventory.toml import AnsibleTomlEncoder, convert_yaml_objects_to_native
             except ImportError:
                 raise AnsibleError(
-                    'Version 0.10.0 or newer of the python "toml" library is required when using the TOML output format'
+                    'The python "toml" library is required when using the TOML output format'
                 )
-            encoder = AnsibleTomlEncoder()
-            results = toml.dumps(stuff, encoder=encoder)
+            if AnsibleTomlEncoder:
+                results = toml.dumps(stuff, encoder=encoder)
+            else:
+                results = toml.dumps(convert_yaml_objects_to_native(stuff))
         else:
             import json
             from ansible.parsing.ajson import AnsibleJSONEncoder

--- a/lib/ansible/cli/inventory.py
+++ b/lib/ansible/cli/inventory.py
@@ -199,18 +199,12 @@ class InventoryCLI(CLI):
             results = yaml.dump(stuff, Dumper=AnsibleDumper, default_flow_style=False)
         elif self.options.toml:
             try:
-                import toml
+                from ansible.plugins.inventory.toml import toml_dumps
             except ImportError:
                 raise AnsibleError(
                     'The python "toml" library is required when using the TOML output format'
                 )
-            else:
-                from ansible.plugins.inventory.toml import AnsibleTomlEncoder, convert_yaml_objects_to_native
-
-            if AnsibleTomlEncoder:
-                results = toml.dumps(stuff, encoder=AnsibleTomlEncoder())
-            else:
-                results = toml.dumps(convert_yaml_objects_to_native(stuff))
+            results = toml_dumps(stuff)
         else:
             import json
             from ansible.parsing.ajson import AnsibleJSONEncoder

--- a/lib/ansible/cli/inventory.py
+++ b/lib/ansible/cli/inventory.py
@@ -433,6 +433,8 @@ class InventoryCLI(CLI):
                 results[group.name]['vars'] = self._get_group_variables(group)
 
             self._remove_empty(results[group.name])
+            if not results[group.name]:
+                del results[group.name]
 
             return results
 

--- a/lib/ansible/cli/inventory.py
+++ b/lib/ansible/cli/inventory.py
@@ -94,6 +94,8 @@ class InventoryCLI(CLI):
         # graph
         self.parser.add_option("-y", "--yaml", action="store_true", default=False, dest='yaml',
                                help='Use YAML format instead of default JSON, ignored for --graph')
+        self.parser.add_option('--toml', action='store_true', default=False, dest='toml',
+                               help='Use TOML format instead of default JSON, ignored for --graph')
         self.parser.add_option("--vars", action="store_true", default=False, dest='show_vars',
                                help='Add vars to graph display, ignored unless used with --graph')
 
@@ -174,7 +176,7 @@ class InventoryCLI(CLI):
             results = self.inventory_graph()
         elif self.options.list:
             top = self._get_group('all')
-            if self.options.yaml:
+            if self.options.yaml or self.options.toml:
                 results = self.yaml_inventory(top)
             else:
                 results = self.json_inventory(top)
@@ -193,6 +195,12 @@ class InventoryCLI(CLI):
             import yaml
             from ansible.parsing.yaml.dumper import AnsibleDumper
             results = yaml.dump(stuff, Dumper=AnsibleDumper, default_flow_style=False)
+        elif self.options.toml:
+            try:
+                import toml
+            except ImportError:
+                raise AnsibleError('The python "toml" library is required when using the TOML output format')
+            results = toml.dumps(stuff)
         else:
             import json
             from ansible.parsing.ajson import AnsibleJSONEncoder

--- a/lib/ansible/cli/inventory.py
+++ b/lib/ansible/cli/inventory.py
@@ -198,9 +198,8 @@ class InventoryCLI(CLI):
             from ansible.parsing.yaml.dumper import AnsibleDumper
             results = yaml.dump(stuff, Dumper=AnsibleDumper, default_flow_style=False)
         elif self.options.toml:
-            try:
-                from ansible.plugins.inventory.toml import toml_dumps
-            except ImportError:
+            from ansible.plugins.inventory.toml import toml_dumps, HAS_TOML
+            if not HAS_TOML:
                 raise AnsibleError(
                     'The python "toml" library is required when using the TOML output format'
                 )

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1419,7 +1419,7 @@ INVENTORY_ANY_UNPARSED_IS_FAILED:
   version_added: "2.7"
 INVENTORY_ENABLED:
   name: Active Inventory plugins
-  default: ['host_list', 'script', 'yaml', 'toml', 'ini', 'auto']
+  default: ['host_list', 'script', 'yaml', 'ini', 'auto', 'toml']
   description: List of enabled inventory plugins, it also determines the order in which they are used.
   env: [{name: ANSIBLE_INVENTORY_ENABLED}]
   ini:

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1419,7 +1419,7 @@ INVENTORY_ANY_UNPARSED_IS_FAILED:
   version_added: "2.7"
 INVENTORY_ENABLED:
   name: Active Inventory plugins
-  default: ['host_list', 'script', 'yaml', 'ini', 'auto', 'toml']
+  default: ['host_list', 'script', 'yaml', 'ini', 'toml', 'auto']
   description: List of enabled inventory plugins, it also determines the order in which they are used.
   env: [{name: ANSIBLE_INVENTORY_ENABLED}]
   ini:

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1419,7 +1419,7 @@ INVENTORY_ANY_UNPARSED_IS_FAILED:
   version_added: "2.7"
 INVENTORY_ENABLED:
   name: Active Inventory plugins
-  default: ['host_list', 'script', 'yaml', 'ini', 'auto']
+  default: ['host_list', 'script', 'yaml', 'toml', 'ini', 'auto']
   description: List of enabled inventory plugins, it also determines the order in which they are used.
   env: [{name: ANSIBLE_INVENTORY_ENABLED}]
   ini:

--- a/lib/ansible/plugins/inventory/__init__.py
+++ b/lib/ansible/plugins/inventory/__init__.py
@@ -226,6 +226,31 @@ class BaseInventoryPlugin(AnsiblePlugin):
             if k in data:
                 self._options[k] = data.pop(k)
 
+    def _expand_hostpattern(self, hostpattern):
+        '''
+        Takes a single host pattern and returns a list of hostnames and an
+        optional port number that applies to all of them.
+        '''
+        # Can the given hostpattern be parsed as a host with an optional port
+        # specification?
+
+        try:
+            (pattern, port) = parse_address(hostpattern, allow_ranges=True)
+        except Exception:
+            # not a recognizable host pattern
+            pattern = hostpattern
+            port = None
+
+        # Once we have separated the pattern, we expand it into list of one or
+        # more hostnames, depending on whether it contains any [x:y] ranges.
+
+        if detect_range(pattern):
+            hostnames = expand_hostname_range(pattern)
+        else:
+            hostnames = [pattern]
+
+        return (hostnames, port)
+
     def clear_cache(self):
         pass
 

--- a/lib/ansible/plugins/inventory/__init__.py
+++ b/lib/ansible/plugins/inventory/__init__.py
@@ -25,6 +25,7 @@ import re
 import string
 
 from ansible.errors import AnsibleError, AnsibleParserError
+from ansible.parsing.utils.addresses import parse_address
 from ansible.plugins import AnsiblePlugin
 from ansible.plugins.cache import InventoryFileCacheModule
 from ansible.module_utils._text import to_bytes, to_native

--- a/lib/ansible/plugins/inventory/advanced_host_list.py
+++ b/lib/ansible/plugins/inventory/advanced_host_list.py
@@ -25,8 +25,7 @@ import os
 
 from ansible.errors import AnsibleError, AnsibleParserError
 from ansible.module_utils._text import to_bytes, to_native
-from ansible.parsing.utils.addresses import parse_address
-from ansible.plugins.inventory import BaseInventoryPlugin, detect_range, expand_hostname_range
+from ansible.plugins.inventory import BaseInventoryPlugin
 
 
 class InventoryModule(BaseInventoryPlugin):

--- a/lib/ansible/plugins/inventory/advanced_host_list.py
+++ b/lib/ansible/plugins/inventory/advanced_host_list.py
@@ -62,28 +62,3 @@ class InventoryModule(BaseInventoryPlugin):
                             self.inventory.add_host(host, group='ungrouped', port=port)
         except Exception as e:
             raise AnsibleParserError("Invalid data from string, could not parse: %s" % to_native(e))
-
-    def _expand_hostpattern(self, hostpattern):
-        '''
-        Takes a single host pattern and returns a list of hostnames and an
-        optional port number that applies to all of them.
-        '''
-        # Can the given hostpattern be parsed as a host with an optional port
-        # specification?
-
-        try:
-            (pattern, port) = parse_address(hostpattern, allow_ranges=True)
-        except:
-            # not a recognizable host pattern
-            pattern = hostpattern
-            port = None
-
-        # Once we have separated the pattern, we expand it into list of one or
-        # more hostnames, depending on whether it contains any [x:y] ranges.
-
-        if detect_range(pattern):
-            hostnames = expand_hostname_range(pattern)
-        else:
-            hostnames = [pattern]
-
-        return (hostnames, port)

--- a/lib/ansible/plugins/inventory/ini.py
+++ b/lib/ansible/plugins/inventory/ini.py
@@ -311,32 +311,6 @@ class InventoryModule(BaseFileInventoryPlugin):
 
         return hostnames, port, variables
 
-    def _expand_hostpattern(self, hostpattern):
-        '''
-        Takes a single host pattern and returns a list of hostnames and an
-        optional port number that applies to all of them.
-        '''
-
-        # Can the given hostpattern be parsed as a host with an optional port
-        # specification?
-
-        try:
-            (pattern, port) = parse_address(hostpattern, allow_ranges=True)
-        except Exception:
-            # not a recognizable host pattern
-            pattern = hostpattern
-            port = None
-
-        # Once we have separated the pattern, we expand it into list of one or
-        # more hostnames, depending on whether it contains any [x:y] ranges.
-
-        if detect_range(pattern):
-            hostnames = expand_hostname_range(pattern)
-        else:
-            hostnames = [pattern]
-
-        return (hostnames, port)
-
     @staticmethod
     def _parse_value(v):
         '''

--- a/lib/ansible/plugins/inventory/ini.py
+++ b/lib/ansible/plugins/inventory/ini.py
@@ -73,8 +73,7 @@ EXAMPLES = '''
 import ast
 import re
 
-from ansible.plugins.inventory import BaseFileInventoryPlugin, detect_range, expand_hostname_range
-from ansible.parsing.utils.addresses import parse_address
+from ansible.plugins.inventory import BaseFileInventoryPlugin
 
 from ansible.errors import AnsibleError, AnsibleParserError
 from ansible.module_utils._text import to_bytes, to_text

--- a/lib/ansible/plugins/inventory/toml.py
+++ b/lib/ansible/plugins/inventory/toml.py
@@ -106,12 +106,6 @@ except ImportError:
 class InventoryModule(BaseFileInventoryPlugin):
     NAME = 'toml'
 
-    def __init__(self):
-        if not HAS_TOML:
-            raise AnsibleParserError('The TOML inventory plugin requires the python "toml" library')
-
-        super(InventoryModule, self).__init__()
-
     def _parse_group(self, group, group_data):
         if not isinstance(group_data, (MutableMapping, type(None))):
             self.display.warning("Skipping '%s' as this is not a valid group definition" % group)
@@ -183,6 +177,9 @@ class InventoryModule(BaseFileInventoryPlugin):
 
     def parse(self, inventory, loader, path, cache=True):
         ''' parses the inventory file '''
+        if not HAS_TOML:
+            raise AnsibleParserError('The TOML inventory plugin requires the python "toml" library')
+
         super(InventoryModule, self).parse(inventory, loader, path)
         self.set_options()
 

--- a/lib/ansible/plugins/inventory/toml.py
+++ b/lib/ansible/plugins/inventory/toml.py
@@ -4,6 +4,10 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
 DOCUMENTATION = '''
     inventory: toml
     version_added: "2.8"

--- a/lib/ansible/plugins/inventory/toml.py
+++ b/lib/ansible/plugins/inventory/toml.py
@@ -17,8 +17,8 @@ DOCUMENTATION = '''
     notes:
         - To function it requires the 'toml' plugin being whitelisted in configuration.
         - Requires the 'toml' python library
-
 '''
+
 EXAMPLES = '''
 example1: |
     [all.vars]
@@ -61,7 +61,6 @@ except ImportError:
 
 
 class InventoryModule(YAMLInventoryModule):
-
     NAME = 'toml'
 
     def __init__(self):
@@ -91,4 +90,7 @@ class InventoryModule(YAMLInventoryModule):
             with open(b_file_name, 'r') as f:
                 return toml.load(f)
         except (IOError, OSError) as e:
-            raise AnsibleParserError("an error occurred while trying to read the file '%s': %s" % (file_name, to_native(e)), orig_exc=e)
+            raise AnsibleParserError(
+                "an error occurred while trying to read the file '%s': %s" % (file_name, to_native(e)),
+                orig_exc=e
+            )

--- a/lib/ansible/plugins/inventory/toml.py
+++ b/lib/ansible/plugins/inventory/toml.py
@@ -6,7 +6,7 @@ __metaclass__ = type
 
 DOCUMENTATION = '''
     inventory: toml
-    version_added: "2.7"
+    version_added: "2.8"
     short_description: Uses a specific TOML file as an inventory source.
     description:
         - TOML based inventory format

--- a/lib/ansible/plugins/inventory/toml.py
+++ b/lib/ansible/plugins/inventory/toml.py
@@ -244,6 +244,6 @@ class InventoryModule(BaseFileInventoryPlugin):
     def verify_file(self, path):
         if super(InventoryModule, self).verify_file(path):
             file_name, ext = os.path.splitext(path)
-            if not ext or ext == '.toml':
+            if ext == '.toml':
                 return True
         return False

--- a/lib/ansible/plugins/inventory/toml.py
+++ b/lib/ansible/plugins/inventory/toml.py
@@ -130,6 +130,9 @@ def convert_yaml_objects_to_native(obj):
     This function recurses an object and ensures we cast any of the types from
     ``ansible.parsing.yaml.objects`` into their native types, effectively cleansing
     the data before we hand it over to ``toml``
+
+    This function doesn't directly check for the types from ``ansible.parsing.yaml.objects``
+    but instead checks for the types those objects inherit from, to offer more flexibility.
     """
     if isinstance(obj, dict):
         return dict((k, convert_yaml_objects_to_native(v)) for k, v in obj.items())

--- a/lib/ansible/plugins/inventory/toml.py
+++ b/lib/ansible/plugins/inventory/toml.py
@@ -20,28 +20,29 @@ DOCUMENTATION = '''
 
 '''
 EXAMPLES = '''
-[all.vars]
-group_var1 = "value2"
+example1: |
+    [all.vars]
+    group_var1 = "value2"
 
-[all.hosts.test1]
+    [all.hosts.test1]
 
-[all.hosts.test2]
-var1 = "value1"
+    [all.hosts.test2]
+    var1 = "value1"
 
-[all.children.last_group]
-hosts = "test1"
+    [all.children.last_group]
+    hosts = "test1"
 
-[all.children.other_group.vars]
-g2_var2 = "value3"
+    [all.children.other_group.vars]
+    g2_var2 = "value3"
 
-[all.children.last_group.vars]
-last_var = "MYVALUE"
+    [all.children.last_group.vars]
+    last_var = "MYVALUE"
 
-[all.children.other_group.children.group_x]
-hosts = "test5"
+    [all.children.other_group.children.group_x]
+    hosts = "test5"
 
-[all.children.other_group.hosts.test4]
-ansible_host = "127.0.0.1"
+    [all.children.other_group.hosts.test4]
+    ansible_host = "127.0.0.1"
 '''
 
 import os

--- a/lib/ansible/plugins/inventory/toml.py
+++ b/lib/ansible/plugins/inventory/toml.py
@@ -126,7 +126,7 @@ def convert_yaml_objects_to_native(obj):
     the data before we hand it over to ``toml``
     """
     if isinstance(obj, dict):
-        return {k: convert_yaml_objects_to_native(v) for k, v in obj.items()}
+        return dict((k, convert_yaml_objects_to_native(v)) for k, v in obj.items())
     elif isinstance(obj, list):
         return [convert_yaml_objects_to_native(v) for v in obj]
     elif isinstance(obj, text_type):

--- a/lib/ansible/plugins/inventory/toml.py
+++ b/lib/ansible/plugins/inventory/toml.py
@@ -108,6 +108,7 @@ if HAS_TOML and hasattr(toml, 'TomlEncoder'):
     class AnsibleTomlEncoder(toml.TomlEncoder):
         def __init__(self, *args, **kwargs):
             super(AnsibleTomlEncoder, self).__init__(*args, **kwargs)
+            # Map our custom YAML object types to dump_funcs from ``toml``
             self.dump_funcs.update({
                 AnsibleSequence: self.dump_funcs.get(list),
                 AnsibleUnicode: self.dump_funcs.get(str),

--- a/lib/ansible/plugins/inventory/toml.py
+++ b/lib/ansible/plugins/inventory/toml.py
@@ -16,7 +16,6 @@ DOCUMENTATION = '''
         - TOML based inventory format
         - File MUST have a valid '.toml' file extension
     notes:
-        - To function it requires the 'toml' plugin being whitelisted in configuration.
         - Requires the 'toml' python library
 '''
 

--- a/lib/ansible/plugins/inventory/toml.py
+++ b/lib/ansible/plugins/inventory/toml.py
@@ -126,24 +126,13 @@ def convert_yaml_objects_to_native(obj):
     the data before we hand it over to ``toml``
     """
     if isinstance(obj, dict):
-        new_obj = {}
-        items = obj.items()
+        return {k: convert_yaml_objects_to_native(v) for k, v in obj.items()}
     elif isinstance(obj, list):
-        new_obj = []
-        items = enumerate(obj)
+        return [convert_yaml_objects_to_native(v) for v in obj]
     elif isinstance(obj, text_type):
         return text_type(obj)
     else:
         return obj
-
-    for k, v in items:
-        casted_v = convert_yaml_objects_to_native(v)
-        try:
-            new_obj[k] = casted_v
-        except IndexError:
-            new_obj.append(casted_v)
-
-    return new_obj
 
 
 class InventoryModule(BaseFileInventoryPlugin):

--- a/lib/ansible/plugins/inventory/toml.py
+++ b/lib/ansible/plugins/inventory/toml.py
@@ -9,10 +9,7 @@ DOCUMENTATION = '''
     version_added: "2.7"
     short_description: Uses a specific TOML file as an inventory source.
     description:
-        - "TOML based inventory, starts with the 'all' group and has hosts/vars/children entries."
-        - Host entries can have sub-entries defined, which will be treated as variables.
-        - Vars entries are normal group vars.
-        - "Children are 'child groups', which can also have their own vars/hosts/children and so on."
+        - TOML based inventory format
         - File MUST have a valid '.toml' file extension
     notes:
         - To function it requires the 'toml' plugin being whitelisted in configuration.
@@ -196,10 +193,6 @@ class InventoryModule(BaseFileInventoryPlugin):
 
         if not data:
             raise AnsibleParserError('Parsed empty TOML file')
-        elif not isinstance(data, MutableMapping):
-            raise AnsibleParserError(
-                'TOML inventory has an invalid structure, it should be a dict, got: %s' % type(data)
-            )
         elif data.get('plugin'):
             raise AnsibleParserError('Plugin configuration TOML file, not TOML inventory')
 
@@ -207,9 +200,8 @@ class InventoryModule(BaseFileInventoryPlugin):
             self._parse_group(group_name, data[group_name])
 
     def verify_file(self, path):
-        valid = False
-        if BaseFileInventoryPlugin.verify_file(self, path):
+        if super(InventoryModule, self).verify_file(path):
             file_name, ext = os.path.splitext(path)
             if ext == '.toml':
-                valid = True
-        return valid
+                return True
+        return False

--- a/lib/ansible/plugins/inventory/toml.py
+++ b/lib/ansible/plugins/inventory/toml.py
@@ -1,0 +1,95 @@
+# Copyright (c) 2018 Matt Martz <matt@sivel.net>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+DOCUMENTATION = '''
+    inventory: toml
+    version_added: "2.7"
+    short_description: Uses a specific TOML file as an inventory source.
+    description:
+        - "TOML based inventory, starts with the 'all' group and has hosts/vars/children entries."
+        - Host entries can have sub-entries defined, which will be treated as variables.
+        - Vars entries are normal group vars.
+        - "Children are 'child groups', which can also have their own vars/hosts/children and so on."
+        - File MUST have a valid '.toml' file extension
+    notes:
+        - To function it requires the 'toml' plugin being whitelisted in configuration.
+        - Requires the 'toml' python library
+
+'''
+EXAMPLES = '''
+[all.vars]
+group_var1 = "value2"
+
+[all.hosts.test1]
+
+[all.hosts.test2]
+var1 = "value1"
+
+[all.children.last_group]
+hosts = "test1"
+
+[all.children.other_group.vars]
+g2_var2 = "value3"
+
+[all.children.last_group.vars]
+last_var = "MYVALUE"
+
+[all.children.other_group.children.group_x]
+hosts = "test5"
+
+[all.children.other_group.hosts.test4]
+ansible_host = "127.0.0.1"
+'''
+
+import os
+
+from ansible.errors import AnsibleFileNotFound, AnsibleParserError
+from ansible.module_utils.six import string_types
+from ansible.module_utils._text import to_bytes, to_native
+from ansible.plugins.inventory import BaseFileInventoryPlugin
+from ansible.plugins.inventory.yaml import InventoryModule as YAMLInventoryModule
+
+try:
+    import toml
+    HAS_TOML = True
+except ImportError:
+    HAS_TOML = False
+
+
+class InventoryModule(YAMLInventoryModule):
+
+    NAME = 'toml'
+
+    def __init__(self):
+        if not HAS_TOML:
+            raise AnsibleParserError('The TOML inventory plugin requires the python "toml" library')
+
+        super(InventoryModule, self).__init__()
+
+    def verify_file(self, path):
+
+        valid = False
+        if BaseFileInventoryPlugin.verify_file(self, path):
+            file_name, ext = os.path.splitext(path)
+            if ext == '.toml':
+                valid = True
+        return valid
+
+    def _load_file(self, file_name):
+        if not file_name or not isinstance(file_name, string_types):
+            raise AnsibleParserError("Invalid filename: '%s'" % to_native(file_name))
+
+        b_file_name = to_bytes(self.loader.path_dwim(file_name))
+        # This is what we really want but have to fix unittests to make it pass
+        # if not os.path.exists(b_file_name) or not os.path.isfile(b_file_name):
+        if not self.loader.path_exists(b_file_name):
+            raise AnsibleFileNotFound("Unable to retrieve file contents", file_name=file_name)
+
+        try:
+            with open(b_file_name, 'r') as f:
+                return toml.load(f)
+        except (IOError, OSError) as e:
+            raise AnsibleParserError("an error occurred while trying to read the file '%s': %s" % (file_name, to_native(e)), orig_exc=e)

--- a/lib/ansible/plugins/inventory/toml.py
+++ b/lib/ansible/plugins/inventory/toml.py
@@ -84,8 +84,6 @@ class InventoryModule(YAMLInventoryModule):
             raise AnsibleParserError("Invalid filename: '%s'" % to_native(file_name))
 
         b_file_name = to_bytes(self.loader.path_dwim(file_name))
-        # This is what we really want but have to fix unittests to make it pass
-        # if not os.path.exists(b_file_name) or not os.path.isfile(b_file_name):
         if not self.loader.path_exists(b_file_name):
             raise AnsibleFileNotFound("Unable to retrieve file contents", file_name=file_name)
 

--- a/lib/ansible/plugins/inventory/toml.py
+++ b/lib/ansible/plugins/inventory/toml.py
@@ -80,8 +80,8 @@ example2: |
 example3: |
     [ungrouped.hosts]
     host1 = {}
-    host2 = { ansible_host = 127.0.0.1, ansible_port = 44 }
-    host3 = { ansible_host = 127.0.0.1, ansible_port = 45 }
+    host2 = { ansible_host = "127.0.0.1", ansible_port = 44 }
+    host3 = { ansible_host = "127.0.0.1", ansible_port = 45 }
 
     [g1.hosts]
     host4 = {}

--- a/lib/ansible/plugins/inventory/toml.py
+++ b/lib/ansible/plugins/inventory/toml.py
@@ -202,6 +202,6 @@ class InventoryModule(BaseFileInventoryPlugin):
     def verify_file(self, path):
         if super(InventoryModule, self).verify_file(path):
             file_name, ext = os.path.splitext(path)
-            if ext == '.toml':
+            if not ext or ext == '.toml':
                 return True
         return False

--- a/lib/ansible/plugins/inventory/toml.py
+++ b/lib/ansible/plugins/inventory/toml.py
@@ -121,7 +121,9 @@ def convert_yaml_objects_to_native(obj):
     way to tell the encoder about custom types, so we need to ensure objects
     that we pass are native types.
 
-    This funciton recurses an object and ensures we cast any of the types from
+    Only used on ``toml<0.10.0`` where ``toml.TomlEncoder`` is missing.
+
+    This function recurses an object and ensures we cast any of the types from
     ``ansible.parsing.yaml.objects`` into their native types, effectively cleansing
     the data before we hand it over to ``toml``
     """

--- a/lib/ansible/plugins/inventory/toml.py
+++ b/lib/ansible/plugins/inventory/toml.py
@@ -100,7 +100,7 @@ from ansible.plugins.inventory import BaseFileInventoryPlugin
 try:
     import toml
     HAS_TOML = True
-except (ImportError, AttributeError):
+except ImportError:
     HAS_TOML = False
 
 

--- a/lib/ansible/plugins/inventory/toml.py
+++ b/lib/ansible/plugins/inventory/toml.py
@@ -92,20 +92,19 @@ import os
 from collections import MutableMapping, MutableSequence
 
 from ansible.errors import AnsibleFileNotFound, AnsibleParserError
-from ansible.module_utils.six import string_types
+from ansible.module_utils.six import string_types, text_type
 from ansible.module_utils._text import to_bytes, to_native
 from ansible.parsing.yaml.objects import AnsibleSequence, AnsibleUnicode
 from ansible.plugins.inventory import BaseFileInventoryPlugin
 
 try:
     import toml
-    toml_version = tuple(int(x) for x in toml.__version__.split('.'))
     HAS_TOML = True
 except (ImportError, AttributeError):
     HAS_TOML = False
 
 
-if HAS_TOML and toml_version >= (0, 10, 0):
+if HAS_TOML and hasattr(toml, 'TomlEncoder'):
     class AnsibleTomlEncoder(toml.TomlEncoder):
         def __init__(self, *args, **kwargs):
             super(AnsibleTomlEncoder, self).__init__(*args, **kwargs)
@@ -113,6 +112,38 @@ if HAS_TOML and toml_version >= (0, 10, 0):
                 AnsibleSequence: self.dump_funcs.get(list),
                 AnsibleUnicode: self.dump_funcs.get(str),
             })
+else:
+    AnsibleTomlEncoder = None
+
+
+def convert_yaml_objects_to_native(obj):
+    """Older versions of the ``toml`` python library, don't have a pluggable
+    way to tell the encoder about custom types, so we need to ensure objects
+    that we pass are native types.
+
+    This funciton recurses an object and ensures we cast any of the types from
+    ``ansible.parsing.yaml.objects`` into their native types, effectively cleansing
+    the data before we hand it over to ``toml``
+    """
+    if isinstance(obj, dict):
+        new_obj = {}
+        items = obj.items()
+    elif isinstance(obj, list):
+        new_obj = []
+        items = enumerate(obj)
+    elif isinstance(obj, text_type):
+        return text_type(obj)
+    else:
+        return obj
+
+    for k, v in items:
+        casted_v = convert_yaml_objects_to_native(v)
+        try:
+            new_obj[k] = casted_v
+        except IndexError:
+            new_obj.append(casted_v)
+
+    return new_obj
 
 
 class InventoryModule(BaseFileInventoryPlugin):
@@ -189,9 +220,9 @@ class InventoryModule(BaseFileInventoryPlugin):
 
     def parse(self, inventory, loader, path, cache=True):
         ''' parses the inventory file '''
-        if not HAS_TOML or toml_version < (0, 10, 0):
+        if not HAS_TOML:
             raise AnsibleParserError(
-                'The TOML inventory plugin requires version 0.10.0 or newer of the python "toml" library'
+                'The TOML inventory plugin requires the python "toml" library'
             )
 
         super(InventoryModule, self).parse(inventory, loader, path)

--- a/lib/ansible/plugins/inventory/yaml.py
+++ b/lib/ansible/plugins/inventory/yaml.py
@@ -159,28 +159,3 @@ class InventoryModule(BaseFileInventoryPlugin):
         (hostnames, port) = self._expand_hostpattern(host_pattern)
 
         return hostnames, port
-
-    def _expand_hostpattern(self, hostpattern):
-        '''
-        Takes a single host pattern and returns a list of hostnames and an
-        optional port number that applies to all of them.
-        '''
-        # Can the given hostpattern be parsed as a host with an optional port
-        # specification?
-
-        try:
-            (pattern, port) = parse_address(hostpattern, allow_ranges=True)
-        except Exception:
-            # not a recognizable host pattern
-            pattern = hostpattern
-            port = None
-
-        # Once we have separated the pattern, we expand it into list of one or
-        # more hostnames, depending on whether it contains any [x:y] ranges.
-
-        if detect_range(pattern):
-            hostnames = expand_hostname_range(pattern)
-        else:
-            hostnames = [pattern]
-
-        return (hostnames, port)

--- a/lib/ansible/plugins/inventory/yaml.py
+++ b/lib/ansible/plugins/inventory/yaml.py
@@ -85,6 +85,9 @@ class InventoryModule(BaseFileInventoryPlugin):
                 valid = True
         return valid
 
+    def _load_file(self, path):
+        return self.loader.load_from_file(path, cache=False)
+
     def parse(self, inventory, loader, path, cache=True):
         ''' parses the inventory file '''
 
@@ -92,16 +95,16 @@ class InventoryModule(BaseFileInventoryPlugin):
         self.set_options()
 
         try:
-            data = self.loader.load_from_file(path, cache=False)
+            data = self._load_file(path)
         except Exception as e:
             raise AnsibleParserError(e)
 
         if not data:
-            raise AnsibleParserError('Parsed empty YAML file')
+            raise AnsibleParserError('Parsed empty %s file' % self.NAME.upper())
         elif not isinstance(data, MutableMapping):
-            raise AnsibleParserError('YAML inventory has invalid structure, it should be a dictionary, got: %s' % type(data))
+            raise AnsibleParserError('%s inventory has invalid structure, it should be a dictionary, got: %s' % (self.NAME.upper(), type(data)))
         elif data.get('plugin'):
-            raise AnsibleParserError('Plugin configuration YAML file, not YAML inventory')
+            raise AnsibleParserError('Plugin configuration %s file, not %s inventory' % (self.NAME.upper(), self.NAME.upper()))
 
         # We expect top level keys to correspond to groups, iterate over them
         # to get host, vars and subgroups (which we iterate over recursivelly)

--- a/lib/ansible/plugins/inventory/yaml.py
+++ b/lib/ansible/plugins/inventory/yaml.py
@@ -85,9 +85,6 @@ class InventoryModule(BaseFileInventoryPlugin):
                 valid = True
         return valid
 
-    def _load_file(self, path):
-        return self.loader.load_from_file(path, cache=False)
-
     def parse(self, inventory, loader, path, cache=True):
         ''' parses the inventory file '''
 
@@ -95,16 +92,16 @@ class InventoryModule(BaseFileInventoryPlugin):
         self.set_options()
 
         try:
-            data = self._load_file(path)
+            data = self.loader.load_from_file(path, cache=False)
         except Exception as e:
             raise AnsibleParserError(e)
 
         if not data:
-            raise AnsibleParserError('Parsed empty %s file' % self.NAME.upper())
+            raise AnsibleParserError('Parsed empty YAML file')
         elif not isinstance(data, MutableMapping):
-            raise AnsibleParserError('%s inventory has invalid structure, it should be a dictionary, got: %s' % (self.NAME.upper(), type(data)))
+            raise AnsibleParserError('YAML inventory has invalid structure, it should be a dictionary, got: %s' % type(data))
         elif data.get('plugin'):
-            raise AnsibleParserError('Plugin configuration %s file, not %s inventory' % (self.NAME.upper(), self.NAME.upper()))
+            raise AnsibleParserError('Plugin configuration YAML file, not YAML inventory')
 
         # We expect top level keys to correspond to groups, iterate over them
         # to get host, vars and subgroups (which we iterate over recursivelly)

--- a/lib/ansible/plugins/inventory/yaml.py
+++ b/lib/ansible/plugins/inventory/yaml.py
@@ -64,8 +64,7 @@ from ansible.errors import AnsibleParserError
 from ansible.module_utils.six import string_types
 from ansible.module_utils._text import to_native
 from ansible.module_utils.common._collections_compat import MutableMapping
-from ansible.parsing.utils.addresses import parse_address
-from ansible.plugins.inventory import BaseFileInventoryPlugin, detect_range, expand_hostname_range
+from ansible.plugins.inventory import BaseFileInventoryPlugin
 
 
 class InventoryModule(BaseFileInventoryPlugin):


### PR DESCRIPTION
##### SUMMARY
First pass at a toml inventory

I made a few small modifications to the YAML inventory plugin, so that I could inherit from it.  The majority of the functionality is identical to the YAML plugin.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
lib/ansible/plugins/inventory/toml.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7
```


##### ADDITIONAL INFORMATION
Example TOML inventory, converted from the INI example:

```
[web]
children = [ "apache", "nginx",]

[all.vars]
has_java = false

[web.vars]
http_port = 8080
myvar = 23

[nginx.vars]
has_java = true

[web.hosts.host1]

[web.hosts.host2]
ansible_port = 222

[apache.hosts.tomcat1]

[apache.hosts.tomcat2]
myvar = 34

[apache.hosts.tomcat3]
mysecret = "03#pa33w0rd"

[nginx.hosts.jenkins1]
```
