### PR TITLE
skip winrm unit tests if winrm is not installed

### DIFF
--- a/test/units/plugins/connection/test_winrm.py
+++ b/test/units/plugins/connection/test_winrm.py
@@ -17,6 +17,8 @@ from ansible.playbook.play_context import PlayContext
 from ansible.plugins.loader import connection_loader
 from ansible.plugins.connection import winrm
 
+pytest.importorskip("winrm")
+
 
 class TestConnectionWinRM(object):
 


### PR DESCRIPTION
##### SUMMARY
fixes test failures in envs where winrm is not installed (eg Fedora build env)

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
test_winrm.py

##### ANSIBLE VERSION
2.7


