### PR TITLE
service_facts correct meaning of state for systemd service units (#40914)

### DIFF
--- a/lib/ansible/modules/system/service_facts.py
+++ b/lib/ansible/modules/system/service_facts.py
@@ -178,16 +178,16 @@ class SystemctlScanService(BaseService):
         systemctl_path = self.module.get_bin_path("systemctl", opt_dirs=["/usr/bin", "/usr/local/bin"])
         if systemctl_path is None:
             return None
-        rc, stdout, stderr = self.module.run_command("%s list-unit-files --type=service | tail -n +2 | head -n -2" % systemctl_path, use_unsafe_shell=True)
-        for line in stdout.split("\n"):
-            line_data = line.split()
-            if len(line_data) != 2:
-                continue
-            if line_data[1] == "enabled":
+        rc, stdout, stderr = self.module.run_command("%s list-units --no-pager --type service --all" % systemctl_path, use_unsafe_shell=True)
+        for line in [svc_line for svc_line in stdout.split('\n') if '.service' in svc_line and 'not-found' not in svc_line]:
+            service_name = line.split()[0]
+            if "running" in line:
                 state_val = "running"
             else:
+                if 'failed' in line:
+                    service_name = line.split()[1]
                 state_val = "stopped"
-            services[line_data[0]] = {"name": line_data[0], "state": state_val, "source": "systemd"}
+            services[service_name] = {"name": service_name, "state": state_val, "source": "systemd"}
         return services
 
 


### PR DESCRIPTION

Fixes #40809

Backport of https://github.com/ansible/ansible/pull/40914

Previously this module used the commend `systemctl list-unit-files
--type=service` to query state of services but list-unit-files only
shows enabled vs disabled which is not what we want for "state"

Signed-off-by: Adam Miller <admiller@redhat.com>

##### SUMMARY
Previously this module used the commend `systemctl list-unit-files
--type=service` to query state of services but list-unit-files only
shows enabled vs disabled which is not what we want for "state"

Details in the issue report https://github.com/ansible/ansible/issues/40809

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
service_facts

