### PR TITLE
skip winrm unit tests if winrm is not installed (#41596)

### DIFF
--- a/test/units/plugins/connection/test_winrm.py
+++ b/test/units/plugins/connection/test_winrm.py
@@ -17,6 +17,8 @@ from ansible.playbook.play_context import PlayContext
 from ansible.plugins.loader import connection_loader
 from ansible.plugins.connection import winrm
 
+pytest.importorskip("winrm")
+
 
 class TestConnectionWinRM(object):
 


### PR DESCRIPTION
##### SUMMARY
backport of #41596 for 2.6; ensures winrm tests aren't run if pywinrm is not present

(cherry picked from commit b01779ad1813bb2a07e4abc007154860a900a6e0)

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - New Module Pull Request
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
test_winrm.py

##### ANSIBLE VERSION
2.6.0


##### ADDITIONAL INFORMATION
