### PR TITLE
[stable-2.6] sort the port list properly (.sort() returns None)

### DIFF
--- a/lib/ansible/modules/cloud/google/gce_net.py
+++ b/lib/ansible/modules/cloud/google/gce_net.py
@@ -272,7 +272,7 @@ def sorted_allowed_list(allowed_list):
     # sort by protocol
     allowed_by_protocol = sorted(allowed_list, key=lambda x: x['IPProtocol'])
     # sort the ports list
-    return sorted(allowed_by_protocol, key=lambda y: y.get('ports', []).sort())
+    return sorted(allowed_by_protocol, key=lambda y: sorted(y.get('ports', [])))
 
 
 def main():


### PR DESCRIPTION
(cherry picked from commit 63f2ad8776314930a800076ef363f4e60a2ef1a4)

Co-authored-by: schp <schonhofen@gmail.com>

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
gce_net.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6
```