### PR TITLE
add notes to service_facts about accessing fact data

### DIFF
--- a/lib/ansible/modules/system/service_facts.py
+++ b/lib/ansible/modules/system/service_facts.py
@@ -28,7 +28,7 @@ notes:
     character in their name which would result in invalid "dot notation", such as
     C(ansible_facts.services.zuul-gateway). It is instead recommended to
     using the string value of the service name as the key in order to obtain
-    the fact data value, as follows: C(ansible_facts.services['zuul-gateway'])
+    the fact data value like C(ansible_facts.services['zuul-gateway'])
 
 
 author:

--- a/lib/ansible/modules/system/service_facts.py
+++ b/lib/ansible/modules/system/service_facts.py
@@ -22,6 +22,15 @@ description:
 version_added: "2.5"
 requirements: ["Any of the following supported init systems: systemd, sysv, upstart"]
 
+notes:
+  - When accessing the C(ansible_facts.services) facts collected by this module,
+    it is recommended to not use "dot notation" because services can have a C(-)
+    character in their name which would result in invalid "dot notation", such as
+    C(ansible_facts.services.zuul-gateway). It is instead recommended to
+    using the string value of the service name as the key in order to obtain
+    the fact data value, as follows: C(ansible_facts.services['zuul-gateway'])
+
+
 author:
   - Matthew Jones
   - Adam Miller (@maxamillion)


### PR DESCRIPTION
Signed-off-by: Adam Miller <admiller@redhat.com>

##### SUMMARY
Add notes to the `service_facts` module docs about accessing the fact data using string value keys instead of dot notation. This adds the missing information as it was brought to our attention in #41467

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
service_facts

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (service_facts f9bf4c1e9d) last updated 2018/06/15 13:54:38 (GMT -500)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/admiller/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/admiller/src/dev/ansible/lib/ansible
  executable location = /home/admiller/src/dev/ansible/bin/ansible
  python version = 2.7.15 (default, May 15 2018, 15:37:31) [GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]
```

