### PR TITLE
Fixes usage of popen in bigip iapplx package

### DIFF
--- a/lib/ansible/modules/network/f5/bigip_iapplx_package.py
+++ b/lib/ansible/modules/network/f5/bigip_iapplx_package.py
@@ -148,11 +148,10 @@ class Parameters(AnsibleF5Parameters):
         :return:
         """
         cmd = ['rpm', '-qp', '--queryformat', '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}', self.package]
-        p = subprocess.Popen(cmd, stdout=subprocess.PIPE)
-        stdout, stderr = p.communicate()
-        if not stdout:
+        rc, out, err = self._module.run_command(cmd)
+        if not out:
             return str(self.package_file)
-        return stdout.decode('utf-8')
+        return out
 
     @property
     def package_root(self):
@@ -177,7 +176,7 @@ class ModuleManager(object):
     def __init__(self, *args, **kwargs):
         self.module = kwargs.get('module', None)
         self.client = kwargs.get('client', None)
-        self.want = Parameters(params=self.module.params)
+        self.want = Parameters(module=self.module, params=self.module.params)
         self.changes = Parameters()
 
     def exec_module(self):

--- a/test/units/modules/network/f5/test_bigip_iapplx_package.py
+++ b/test/units/modules/network/f5/test_bigip_iapplx_package.py
@@ -84,7 +84,7 @@ class TestManager(unittest.TestCase):
         set_module_args(dict(
             content='fixtures/MyApp-0.1.0-0001.noarch.rpm',
             state='present',
-            password='passsword',
+            password='password',
             server='localhost',
             user='admin'
         ))


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
This functionality is superceeded by the run_command method in the
ansible module class.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
bigip_iapplx_package

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0
  config file = None
  configured module search path = ['/root/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python3.6/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 3.6.5 (default, May  5 2018, 03:09:35) [GCC 4.9.2]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
