### PR TITLE
[WIP] Issue 24215: Enable verbosity setting on a per-task basis.

### DIFF
--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -953,7 +953,7 @@ class TaskExecutor:
                 display.vvvv('%s' % msg, host=self._play_context.remote_addr)
 
         if 'error' in result:
-            if self._play_context.verbosity > 2:
+            if self._play_context.verbosity > 2 or self._task.verbosity > 2:
                 if result.get('exception'):
                     msg = "The full traceback is:\n" + result['exception']
                     display.display(msg, color=C.COLOR_ERROR)

--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -82,6 +82,7 @@ class Task(Base, Conditional, Taggable, Become):
     _register = FieldAttribute(isa='string')
     _retries = FieldAttribute(isa='int', default=3)
     _until = FieldAttribute(isa='list', default=[])
+    _verbosity = FieldAttribute(isa='int', default=0)
 
     # deprecated, used to be loop and loop_args but loop has been repurposed
     _loop_with = FieldAttribute(isa='string', private=True, inherit=False)

--- a/lib/ansible/plugins/callback/actionable.py
+++ b/lib/ansible/plugins/callback/actionable.py
@@ -57,7 +57,7 @@ class CallbackModule(CallbackModule_default):
         self._last_task_banner = self.last_task._uuid
 
     def _print_task_path(self, task):
-        if self._display.verbosity >= 2:
+        if self._display.verbosity >= 2 or self.task.verbosity >= 2:
             path = task.get_path()
             if path:
                 self._display.display(u"task path: %s" % path, color=C.COLOR_DEBUG)

--- a/lib/ansible/plugins/callback/default.py
+++ b/lib/ansible/plugins/callback/default.py
@@ -100,7 +100,9 @@ class CallbackModule(CallbackBase):
         else:
             self._clean_results(result._result, result._task.action)
 
-            if (self._display.verbosity > 0 or result._task.verbosity > 0 or '_ansible_verbose_always' in result._result) and '_ansible_verbose_override' not in result._result:
+            if (self._display.verbosity > 0 or
+                    result._task.verbosity > 0 or
+                    '_ansible_verbose_always' in result._result) and '_ansible_verbose_override' not in result._result:
                 msg += " => %s" % (self._dump_results(result._result),)
             self._display.display(msg, color=color)
 
@@ -119,7 +121,9 @@ class CallbackModule(CallbackBase):
                 self._process_items(result)
             else:
                 msg = "skipping: [%s]" % result._host.get_name()
-                if (self._display.verbosity > 0 or result._task.verbosity > 0 or '_ansible_verbose_always' in result._result) and '_ansible_verbose_override' not in result._result:
+                if (self._display.verbosity > 0 or
+                        result._task.verbosity > 0 or
+                        '_ansible_verbose_always' in result._result) and '_ansible_verbose_override' not in result._result:
                     msg += " => %s" % self._dump_results(result._result)
                 self._display.display(msg, color=C.COLOR_SKIP)
 
@@ -222,7 +226,9 @@ class CallbackModule(CallbackBase):
 
         msg += " => (item=%s)" % (self._get_item(result._result),)
 
-        if (self._display.verbosity > 0 or result._task.verbosity > 0 or '_ansible_verbose_always' in result._result) and '_ansible_verbose_override' not in result._result:
+        if (self._display.verbosity > 0 or
+                result._task.verbosity > 0 or
+                '_ansible_verbose_always' in result._result) and '_ansible_verbose_override' not in result._result:
             msg += " => %s" % self._dump_results(result._result)
         self._display.display(msg, color=color)
 
@@ -250,7 +256,9 @@ class CallbackModule(CallbackBase):
         if self._plugin_options.get('show_skipped_hosts', C.DISPLAY_SKIPPED_HOSTS):  # fallback on constants for inherited plugins missing docs
             self._clean_results(result._result, result._task.action)
             msg = "skipping: [%s] => (item=%s) " % (result._host.get_name(), self._get_item(result._result))
-            if (self._display.verbosity > 0 or result._task.verbosity > 0 or '_ansible_verbose_always' in result._result) and '_ansible_verbose_override' not in result._result:
+            if (self._display.verbosity > 0 or
+                    result._task.verbosity > 0 or
+                    '_ansible_verbose_always' in result._result) and '_ansible_verbose_override' not in result._result:
                 msg += " => %s" % self._dump_results(result._result)
             self._display.display(msg, color=C.COLOR_SKIP)
 
@@ -319,7 +327,9 @@ class CallbackModule(CallbackBase):
     def v2_runner_retry(self, result):
         task_name = result.task_name or result._task
         msg = "FAILED - RETRYING: %s (%d retries left)." % (task_name, result._result['retries'] - result._result['attempts'])
-        if (self._display.verbosity > 2 or result._task.verbosity > 2 or '_ansible_verbose_always' in result._result) and '_ansible_verbose_override' not in result._result:
+        if (self._display.verbosity > 2 or
+                result._task.verbosity > 2 or
+                '_ansible_verbose_always' in result._result) and '_ansible_verbose_override' not in result._result:
             msg += "Result was: %s" % self._dump_results(result._result)
         self._display.display(msg, color=C.COLOR_DEBUG)
 

--- a/lib/ansible/plugins/callback/default.py
+++ b/lib/ansible/plugins/callback/default.py
@@ -43,6 +43,9 @@ class CallbackModule(CallbackBase):
 
     def v2_runner_on_failed(self, result, ignore_errors=False):
 
+        if result._task.verbosity > 2:
+            result._result['_ansible_verbose_always'] = True
+
         delegated_vars = result._result.get('_ansible_delegated_vars', None)
         self._clean_results(result._result, result._task.action)
 
@@ -66,6 +69,9 @@ class CallbackModule(CallbackBase):
             self._display.display("...ignoring", color=C.COLOR_SKIP)
 
     def v2_runner_on_ok(self, result):
+
+        if result._task.verbosity > 2:
+            result._result['_ansible_verbose_always'] = True
 
         delegated_vars = result._result.get('_ansible_delegated_vars', None)
 
@@ -99,6 +105,9 @@ class CallbackModule(CallbackBase):
             self._display.display(msg, color=color)
 
     def v2_runner_on_skipped(self, result):
+        if result._task.verbosity > 2:
+            result._result['_ansible_verbose_always'] = True
+
         if self._plugin_options.get('show_skipped_hosts', C.DISPLAY_SKIPPED_HOSTS):  # fallback on constants for inherited plugins missing docs
 
             self._clean_results(result._result, result._task.action)
@@ -115,6 +124,9 @@ class CallbackModule(CallbackBase):
                 self._display.display(msg, color=C.COLOR_SKIP)
 
     def v2_runner_on_unreachable(self, result):
+        if result._task.verbosity > 2:
+            result._result['_ansible_verbose_always'] = True
+
         if self._play.strategy == 'free' and self._last_task_banner != result._task._uuid:
             self._print_task_banner(result._task)
 
@@ -189,6 +201,9 @@ class CallbackModule(CallbackBase):
                 self._display.display(diff)
 
     def v2_runner_item_on_ok(self, result):
+        if task.verbosity > 2:
+            result._result['_ansible_verbose_always'] = True
+
         delegated_vars = result._result.get('_ansible_delegated_vars', None)
         self._clean_results(result._result, result._task.action)
         if isinstance(result._task, TaskInclude):
@@ -212,6 +227,8 @@ class CallbackModule(CallbackBase):
         self._display.display(msg, color=color)
 
     def v2_runner_item_on_failed(self, result):
+        if task.verbosity > 2:
+            result._result['_ansible_verbose_always'] = True
 
         delegated_vars = result._result.get('_ansible_delegated_vars', None)
         self._clean_results(result._result, result._task.action)
@@ -227,6 +244,9 @@ class CallbackModule(CallbackBase):
         self._display.display(msg + " (item=%s) => %s" % (self._get_item(result._result), self._dump_results(result._result)), color=C.COLOR_ERROR)
 
     def v2_runner_item_on_skipped(self, result):
+        if task.verbosity > 2:
+            result._result['_ansible_verbose_always'] = True
+
         if self._plugin_options.get('show_skipped_hosts', C.DISPLAY_SKIPPED_HOSTS):  # fallback on constants for inherited plugins missing docs
             self._clean_results(result._result, result._task.action)
             msg = "skipping: [%s] => (item=%s) " % (result._host.get_name(), self._get_item(result._result))

--- a/lib/ansible/plugins/callback/default.py
+++ b/lib/ansible/plugins/callback/default.py
@@ -110,7 +110,7 @@ class CallbackModule(CallbackBase):
                 self._process_items(result)
             else:
                 msg = "skipping: [%s]" % result._host.get_name()
-                if (self._display.verbosity > 0 or '_ansible_verbose_always' in result._result) and '_ansible_verbose_override' not in result._result:
+                if (self._display.verbosity > 0 or result._task.verbosity > 0 or '_ansible_verbose_always' in result._result) and '_ansible_verbose_override' not in result._result:
                     msg += " => %s" % self._dump_results(result._result)
                 self._display.display(msg, color=C.COLOR_SKIP)
 
@@ -152,7 +152,7 @@ class CallbackModule(CallbackBase):
             args = u' %s' % args
 
         self._display.banner(u"TASK [%s%s]" % (task.get_name().strip(), args))
-        if self._display.verbosity >= 2:
+        if self._display.verbosity >= 2 or task.verbosity >= 2:
             path = task.get_path()
             if path:
                 self._display.display(u"task path: %s" % path, color=C.COLOR_DEBUG)
@@ -207,7 +207,7 @@ class CallbackModule(CallbackBase):
 
         msg += " => (item=%s)" % (self._get_item(result._result),)
 
-        if (self._display.verbosity > 0 or '_ansible_verbose_always' in result._result) and '_ansible_verbose_override' not in result._result:
+        if (self._display.verbosity > 0 or result._task.verbosity > 0 or '_ansible_verbose_always' in result._result) and '_ansible_verbose_override' not in result._result:
             msg += " => %s" % self._dump_results(result._result)
         self._display.display(msg, color=color)
 
@@ -230,7 +230,7 @@ class CallbackModule(CallbackBase):
         if self._plugin_options.get('show_skipped_hosts', C.DISPLAY_SKIPPED_HOSTS):  # fallback on constants for inherited plugins missing docs
             self._clean_results(result._result, result._task.action)
             msg = "skipping: [%s] => (item=%s) " % (result._host.get_name(), self._get_item(result._result))
-            if (self._display.verbosity > 0 or '_ansible_verbose_always' in result._result) and '_ansible_verbose_override' not in result._result:
+            if (self._display.verbosity > 0 or result._task.verbosity > 0 or '_ansible_verbose_always' in result._result) and '_ansible_verbose_override' not in result._result:
                 msg += " => %s" % self._dump_results(result._result)
             self._display.display(msg, color=C.COLOR_SKIP)
 
@@ -299,7 +299,7 @@ class CallbackModule(CallbackBase):
     def v2_runner_retry(self, result):
         task_name = result.task_name or result._task
         msg = "FAILED - RETRYING: %s (%d retries left)." % (task_name, result._result['retries'] - result._result['attempts'])
-        if (self._display.verbosity > 2 or '_ansible_verbose_always' in result._result) and '_ansible_verbose_override' not in result._result:
+        if (self._display.verbosity > 2 or result._task.verbosity > 2 or '_ansible_verbose_always' in result._result) and '_ansible_verbose_override' not in result._result:
             msg += "Result was: %s" % self._dump_results(result._result)
         self._display.display(msg, color=C.COLOR_DEBUG)
 

--- a/lib/ansible/plugins/callback/default.py
+++ b/lib/ansible/plugins/callback/default.py
@@ -94,7 +94,7 @@ class CallbackModule(CallbackBase):
         else:
             self._clean_results(result._result, result._task.action)
 
-            if (self._display.verbosity > 0 or '_ansible_verbose_always' in result._result) and '_ansible_verbose_override' not in result._result:
+            if (self._display.verbosity > 0 or result._task.verbosity > 0 or '_ansible_verbose_always' in result._result) and '_ansible_verbose_override' not in result._result:
                 msg += " => %s" % (self._dump_results(result._result),)
             self._display.display(msg, color=color)
 


### PR DESCRIPTION
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
Fixes #24215

This PR adds a new attribute/directive to the base Task class that enables users to specify verbosity level on a per-task basis, as described in #24215

It was also suggested in IRC that this behavior be added to the Block class, but I am leaving that alone for now since it's not yet clear to me how task instances can inherit from enclosing block instances.

<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

<!--- Name of the module, plugin, module or task -->
`lib/ansible/playbook/task.py`
`lib/ansible/plugins/callback/default.py`

<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (issue-24215 25ef461a44) last updated 2018/06/16 11:10:53 (GMT -500)
  config file = /home/wayne/projects/personal-networks/ansible/ansible.cfg
  configured module search path = ['/home/wayne/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/wayne/projects/ansible/ansible/lib/ansible
  executable location = /home/wayne/.virtualenvs/ansible--XOPnghv/bin/ansible
  python version = 3.6.2 (default, Sep  1 2017, 07:48:59) [GCC 6.3.0 20170516]
```


<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

The current implementation in the PR branch doesn't quite work as expected, so I am submitting this WIP PR to solicit advice from those more experienced with the codebase.

Left TODO:
* [ ] Implement test cases for the new behavior.
* [x] Get the new behavior working as expected.

Behavior before this change:
```
TASK [common : users/login | wayne | create necessary directories] *********************************************************************
ok: [agora]

TASK [common : users/login | push Makefile to userdir] *********************************************************************************
ok: [agora]

TASK [common : users/login | execute Makefile] *****************************************************************************************
changed: [agora]
```

Behavior after this change:
```
TASK [common : users/login | wayne | create necessary directories] *********************************************************************
ok: [agora]                                                                                                                             
              
TASK [common : users/login | push Makefile to userdir] *********************************************************************************
task path: /home/wayne/projects/personal-networks/ansible/roles/common/tasks/users/login/install_source.yml:9
ok: [agora] => {"changed": false, "checksum": "ced3ec0b7d5b73f3a25708d1b139a8770ab00bc8", "dest": "/home/wayne/usr/src/Makefile", "gid": 11571, "group": "wayne", "mode": "0700", "owner": "wayne", "path": "/home/wayne/usr/src/Makefile", "size": 493, "state": "file", "uid": 11571}

TASK [common : users/login | execute Makefile] *****************************************************************************************
task path: /home/wayne/projects/personal-networks/ansible/roles/common/tasks/users/login/install_source.yml:18
changed: [agora] => {"changed": true, "cmd": ["make", "all", "PREFIX=/home/wayne/usr"], "delta": "0:00:00.005516", "end": "2018-06-16 11:29:33.873340", "rc": 0, "start": "2018-06-16 11:29:33.867824", "stderr": "", "stderr_lines": [], "stdout": "make: Nothing to be done for 'all'.", "stdout_lines": ["make: Nothing to be done for 'all'."]}
```

Note that the first two tasks are simply `ok` and the third one is `changed` in both the before and the after examples shown above. The first task has no task-specific verbosity set; the second task has `verbosity: 3`, and the third has `verbosity: 5`.

Also, please forgive my lazyness in not putting together a full contrived example and instead using a snippet from the output of an existing playbook.

Also also, I'm not quite sure why the output shown here isn't even more verbose. The additional output resulting from this implementation doesn't match what I would expect from output when passing `-vvv` on the command line where the additional output shown here would be pretty print formatted and task stdout/stderr would be shown as if the tasks' command had been run locally.