### PR TITLE
fixes #41592, #34559

### DIFF
--- a/lib/ansible/modules/cloud/misc/virt.py
+++ b/lib/ansible/modules/cloud/misc/virt.py
@@ -25,6 +25,7 @@ options:
     description:
       - name of the guest VM being managed. Almost always required (see examples). When defining a new VM,
         name is taken from xml.
+        C(name) is an optional parameter from version 2.7 and onwards.
   state:
     description:
       - Note that there may be some lag for state requests like C(shutdown)

--- a/lib/ansible/modules/cloud/misc/virt.py
+++ b/lib/ansible/modules/cloud/misc/virt.py
@@ -446,6 +446,12 @@ def core(module):
             res = {command: res}
         return VIRT_SUCCESS, res
 
+    if autostart is not None and command != 'define':
+        if v.autostart(guest, autostart):
+            res['changed'] = True
+        if not command and not state:
+            return VIRT_SUCCESS, res
+
     if state:
         if not guest:
             module.fail_json(msg="state change requires a guest specified")
@@ -474,9 +480,6 @@ def core(module):
 
         return VIRT_SUCCESS, res
 
-    if autostart is not None and v.autostart(guest, autostart):
-        res['changed'] = True
-
     if command:
         if command in VM_COMMANDS:
             if not guest:
@@ -489,6 +492,8 @@ def core(module):
                 except VMNotFound:
                     v.define(xml)
                     res = {'changed': True, 'created': guest}
+                if autostart is not None and v.autostart(guest, autostart):
+                    res['changed'] = True
                 return VIRT_SUCCESS, res
             res = getattr(v, command)(guest)
             if not isinstance(res, dict):

--- a/lib/ansible/modules/cloud/misc/virt.py
+++ b/lib/ansible/modules/cloud/misc/virt.py
@@ -136,6 +136,8 @@ except ImportError:
 else:
     HAS_VIRT = True
 
+import re
+
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 
@@ -517,8 +519,6 @@ def core(module):
                 if guest:
                     # there might be a mismatch between quest 'name' in the module and in the xml
                     module.warn("'xml' is given - ignoring 'name'")
-                # Is there a better way to get 'name' ?
-                import re
                 found_name = re.search('<name>(.*)</name>', xml).groups()
                 if found_name:
                     domain_name = found_name[0]

--- a/lib/ansible/modules/cloud/misc/virt.py
+++ b/lib/ansible/modules/cloud/misc/virt.py
@@ -23,7 +23,7 @@ version_added: "0.2"
 options:
   name:
     description:
-      - name of the guest VM being managed. Almost always required (see examples). When defining a new VM, 
+      - name of the guest VM being managed. Almost always required (see examples). When defining a new VM,
         name is taken from xml.
   state:
     description:
@@ -88,10 +88,10 @@ EXAMPLES = '''
     name: foo
     autostart: yes
 
-# Defining a VM and making is autostart with host. VM will be off after this task 
+# Defining a VM and making is autostart with host. VM will be off after this task
 - name: define vm from xml and set autostart
   virt:
-    command: define 
+    command: define
     xml: "{{ lookup('template', 'vm_template.xml.j2') }}"
     autostart: yes
 
@@ -546,7 +546,7 @@ def core(module):
                     else:
                         res = {'changed': True, 'created': domain.name()}
                 except libvirtError as e:
-                    if e.get_error_code() != 9: # 9 means 'domain already exists' error
+                    if e.get_error_code() != 9:  # 9 means 'domain already exists' error
                         module.fail_json(msg='libvirtError: %s' % e.message)
                 if autostart is not None and v.autostart(domain_name, autostart):
                     res = {'changed': True, 'change_reason': 'autostart'}

--- a/lib/ansible/modules/cloud/misc/virt.py
+++ b/lib/ansible/modules/cloud/misc/virt.py
@@ -23,14 +23,15 @@ version_added: "0.2"
 options:
   name:
     description:
-      - name of the guest VM being managed. Note that VM must be previously
-        defined with xml.
-    required: true
+      - name of the guest VM being managed. Almost always required (see examples). When defining a new VM, 
+        name is taken from xml.
   state:
     description:
       - Note that there may be some lag for state requests like C(shutdown)
         since these refer only to VM states. After starting a guest, it may not
         be immediately accessible.
+        state and command are mutually exclusive except when command=list_vms. In
+        this case all VMs in specified state will be listed.
     choices: [ destroyed, paused, running, shutdown ]
   command:
     description:
@@ -74,7 +75,6 @@ EXAMPLES = '''
 tasks:
   - name: define vm
     virt:
-        name: foo
         command: define
         xml: "{{ lookup('template', 'container-template.xml.j2') }}"
         uri: 'lxc:///'
@@ -83,6 +83,33 @@ tasks:
         name: foo
         state: running
         uri: 'lxc:///'
+
+# setting autostart on a qemu VM (default uri)
+tasks:
+  - name: set autostart for a VM
+    virt:
+        name: foo
+        autostart: yes
+
+# Defining a VM and making is autostart with host. VM will be off after this task 
+tasks:
+  - name: define vm from xml and set autostart
+    virt:
+        command: define 
+        xml: "{{ lookup('template', 'vm_template.xml.j2') }}"
+        autostart: yes
+
+# Listing VMs
+tasks:
+  - name: list all VMs
+    virt:
+        command: list_vms
+    register: all_vms
+  - name: list only running VMs
+    virt:
+        command: list_vms
+        state: running
+    register: running_vms
 '''
 
 RETURN = '''

--- a/lib/ansible/modules/cloud/misc/virt.py
+++ b/lib/ansible/modules/cloud/misc/virt.py
@@ -70,46 +70,42 @@ EXAMPLES = '''
 # ansible host -m virt -a "name=alpha command=get_xml"
 # ansible host -m virt -a "name=alpha command=create uri=lxc:///"
 
----
-# a playbook example of defining and launching an LXC guest
-tasks:
-  - name: define vm
-    virt:
-        command: define
-        xml: "{{ lookup('template', 'container-template.xml.j2') }}"
-        uri: 'lxc:///'
-  - name: start vm
-    virt:
-        name: foo
-        state: running
-        uri: 'lxc:///'
+# defining and launching an LXC guest
+- name: define vm
+  virt:
+    command: define
+    xml: "{{ lookup('template', 'container-template.xml.j2') }}"
+    uri: 'lxc:///'
+- name: start vm
+  virt:
+    name: foo
+    state: running
+    uri: 'lxc:///'
 
 # setting autostart on a qemu VM (default uri)
-tasks:
-  - name: set autostart for a VM
-    virt:
-        name: foo
-        autostart: yes
+- name: set autostart for a VM
+  virt:
+    name: foo
+    autostart: yes
 
 # Defining a VM and making is autostart with host. VM will be off after this task 
-tasks:
-  - name: define vm from xml and set autostart
-    virt:
-        command: define 
-        xml: "{{ lookup('template', 'vm_template.xml.j2') }}"
-        autostart: yes
+- name: define vm from xml and set autostart
+  virt:
+    command: define 
+    xml: "{{ lookup('template', 'vm_template.xml.j2') }}"
+    autostart: yes
 
 # Listing VMs
-tasks:
-  - name: list all VMs
-    virt:
-        command: list_vms
-    register: all_vms
-  - name: list only running VMs
-    virt:
-        command: list_vms
-        state: running
-    register: running_vms
+- name: list all VMs
+  virt:
+    command: list_vms
+  register: all_vms
+
+- name: list only running VMs
+  virt:
+    command: list_vms
+    state: running
+  register: running_vms
 '''
 
 RETURN = '''

--- a/lib/ansible/modules/cloud/misc/virt.py
+++ b/lib/ansible/modules/cloud/misc/virt.py
@@ -528,7 +528,7 @@ def core(module):
                     domain_name = found_name[0]
                 else:
                     module.fail_json(msg="Could not find domain 'name' in xml")
-                    
+
                 # From libvirt docs (https://libvirt.org/html/libvirt-libvirt-domain.html#virDomainDefineXML):
                 # -- A previous definition for this domain would be overridden if it already exists.
                 #
@@ -537,7 +537,6 @@ def core(module):
                 # operation failed: domain '<name>' already exists with <uuid>
                 #
                 # In case a domain would be indeed overwritten, we should protect idempotency:
-
                 try:
                     existing_domain = v.get_vm(domain_name)
                 except VMNotFound:

--- a/lib/ansible/modules/cloud/misc/virt.py
+++ b/lib/ansible/modules/cloud/misc/virt.py
@@ -25,7 +25,7 @@ options:
     description:
       - name of the guest VM being managed. Note that VM must be previously
         defined with xml.
-      - This option is required unless I(command) is C(list_vms).
+      - This option is required unless I(command) is C(list_vms) or with I(xml). In the latter case I(name) is taken from the xml definition.
   state:
     description:
       - Note that there may be some lag for state requests like C(shutdown)

--- a/lib/ansible/modules/cloud/misc/virt.py
+++ b/lib/ansible/modules/cloud/misc/virt.py
@@ -23,9 +23,9 @@ version_added: "0.2"
 options:
   name:
     description:
-      - name of the guest VM being managed. Almost always required (see examples). When defining a new VM,
-        name is taken from xml.
-        C(name) is an optional parameter from version 2.7 and onwards.
+      - name of the guest VM being managed. Note that VM must be previously
+        defined with xml.
+      - This option is required unless I(command) is C(list_vms).
   state:
     description:
       - Note that there may be some lag for state requests like C(shutdown)

--- a/lib/ansible/modules/cloud/misc/virt.py
+++ b/lib/ansible/modules/cloud/misc/virt.py
@@ -25,7 +25,7 @@ options:
     description:
       - name of the guest VM being managed. Note that VM must be previously
         defined with xml.
-      - This option is required unless I(command) is C(list_vms) or with I(xml). In the latter case I(name) is taken from the xml definition.
+      - This option is required unless I(command) is C(list_vms).
   state:
     description:
       - Note that there may be some lag for state requests like C(shutdown)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
When both ```name``` and ```xml``` are specified, there might be a mismatch of domain names in
```name``` and inside ```xml```. This code ignores name and prints a warning.

Allows ```autostart``` to be used with ```command``` and ```state```. Allows standalone ```autostart``` tasks.

Fixes: #41592 
Fixes: #34559

Added handling of errors thrown by libvirt when ```command=define```

Added handling of a situation when a repeated ```define``` task overrides the domain.
From libvirt [docs](https://libvirt.org/html/libvirt-libvirt-domain.html#virDomainDefineXML):
-- A previous definition for this domain would be overridden if it already exists.
In real world testing with libvirt versions 1.2.17-13, 2.0.0-10 and 3.9.0-14
on qemu and lxc domains results in:
```operation failed: domain '/name/' already exists with /uuid/```
In case a domain would be indeed overwritten, we should try protecting idempotency.
This code should handle such situation, but it needs testing, because for qemu and lxc domains libvirt refuses to re-define. When re-defining fails, task will end with changed=false
Maybe it's worth to fail when running ```define``` on existing domain.

Updated documentation and added some examples.
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
virt

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.2
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/user/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Aug  4 2017, 00:39:18) [GCC 4.8.5 20150623 (Red Hat 4.8.5-16)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
