### PR TITLE
Add upgrade ('latest') support to pkgng module

### DIFF
--- a/lib/ansible/modules/packaging/os/pkgng.py
+++ b/lib/ansible/modules/packaging/os/pkgng.py
@@ -107,7 +107,7 @@ EXAMPLES = '''
     state: absent
 
 # Upgrade package baz
-- pkgng
+- pkgng:
     name: baz
     state: latest
 '''

--- a/lib/ansible/modules/packaging/os/pkgng.py
+++ b/lib/ansible/modules/packaging/os/pkgng.py
@@ -33,7 +33,7 @@ options:
     state:
         description:
             - State of the package.
-        choices: [ 'present', 'absent' ]
+        choices: [ 'present', 'latest', 'absent' ]
         required: false
         default: present
     cached:
@@ -105,6 +105,11 @@ EXAMPLES = '''
 - pkgng:
     name: foo,bar
     state: absent
+
+# Upgrade package baz
+- pkgng
+    name: baz
+    state: latest
 '''
 
 
@@ -163,7 +168,7 @@ def remove_packages(module, pkgng_path, packages, dir_arg):
     return (False, "package(s) already absent")
 
 
-def install_packages(module, pkgng_path, packages, cached, pkgsite, dir_arg):
+def install_packages(module, pkgng_path, packages, cached, pkgsite, dir_arg, state):
 
     install_c = 0
 
@@ -189,17 +194,35 @@ def install_packages(module, pkgng_path, packages, cached, pkgsite, dir_arg):
             module.fail_json(msg="Could not update catalogue")
 
     for package in packages:
-        if query_package(module, pkgng_path, package, dir_arg):
+        already_installed = query_package(module, pkgng_path, package, dir_arg)
+        if already_installed and state != "latest":
             continue
 
         if not module.check_mode:
-            if old_pkgng:
-                rc, out, err = module.run_command("%s %s %s install -g -U -y %s" % (batch_var, pkgsite, pkgng_path, package))
+            if already_installed:
+                # Check to see if a package upgrade is available.
+                # rc = 0, no updates available
+                # rc = 1, updates available
+                if old_pkgng:
+                    rc, out, err = module.run_command("%s %s %s upgrade -n -g -U -y %s" % (batch_var, pkgsite, pkgng_path, package))
+                else:
+                    rc, out, err = module.run_command("%s %s %s upgrade %s -n -g -U -y %s" % (batch_var, pkgng_path, dir_arg, pkgsite, package))
+
+                if old_pkgng and rc == 1:
+                    rc, out, err = module.run_command("%s %s %s upgrade -g -U -y %s" % (batch_var, pkgsite, pkgng_path, package))
+                elif rc == 1:
+                    rc, out, err = module.run_command("%s %s %s upgrade %s -g -U -y %s" % (batch_var, pkgng_path, dir_arg, pkgsite, package))
+                else:
+                    continue
+
             else:
-                rc, out, err = module.run_command("%s %s %s install %s -g -U -y %s" % (batch_var, pkgng_path, dir_arg, pkgsite, package))
+                if old_pkgng:
+                    rc, out, err = module.run_command("%s %s %s install -g -U -y %s" % (batch_var, pkgsite, pkgng_path, package))
+                else:
+                    rc, out, err = module.run_command("%s %s %s install %s -g -U -y %s" % (batch_var, pkgng_path, dir_arg, pkgsite, package))
 
         if not module.check_mode and not query_package(module, pkgng_path, package, dir_arg):
-            module.fail_json(msg="failed to install %s: %s" % (package, out), stderr=err)
+            module.fail_json(msg="failed to install or upgrade %s: %s" % (package, out), stderr=err)
 
         install_c += 1
 
@@ -312,7 +335,7 @@ def autoremove_packages(module, pkgng_path, dir_arg):
 def main():
     module = AnsibleModule(
         argument_spec=dict(
-            state=dict(default="present", choices=["present", "absent"], required=False),
+            state=dict(default="present", choices=["present", "latest", "absent"], required=False),
             name=dict(aliases=["pkg"], required=True, type='list'),
             cached=dict(default=False, type='bool'),
             annotation=dict(default="", required=False),
@@ -347,8 +370,8 @@ def main():
     if p["jail"] != "":
         dir_arg = '--jail %s' % (p["jail"])
 
-    if p["state"] == "present":
-        _changed, _msg = install_packages(module, pkgng_path, pkgs, p["cached"], p["pkgsite"], dir_arg)
+    if p["state"] == "present" or p["state"] == "latest":
+        _changed, _msg = install_packages(module, pkgng_path, pkgs, p["cached"], p["pkgsite"], dir_arg, p["state"])
         changed = changed or _changed
         msgs.append(_msg)
 

--- a/lib/ansible/modules/packaging/os/pkgng.py
+++ b/lib/ansible/modules/packaging/os/pkgng.py
@@ -130,12 +130,15 @@ def query_package(module, pkgng_path, name, dir_arg):
     return False
 
 
-def query_update(module, pkgng_path, name, dir_arg):
+def query_update(module, pkgng_path, name, dir_arg, old_pkgng, pkgsite):
 
     # Check to see if a package upgrade is available.
     # rc = 0, no updates available or package not installed
     # rc = 1, updates available
-    rc, out, err = module.run_command("%s %s upgrade -g -n %s" % (pkgng_path, dir_arg, name))
+    if old_pkgng:
+        rc, out, err = module.run_command("%s %s upgrade -g -n %s" % (pkgsite, pkgng_path, name))
+    else:
+        rc, out, err = module.run_command("%s %s upgrade %s -g -n %s" % (pkgng_path, dir_arg, pkgsite, name))
 
     if rc == 1:
         return True
@@ -214,7 +217,7 @@ def install_packages(module, pkgng_path, packages, cached, pkgsite, dir_arg, sta
         if already_installed and state == "present":
             continue
 
-        update_available = query_update(module, pkgng_path, package, dir_arg)
+        update_available = query_update(module, pkgng_path, package, dir_arg, old_pkgng, pkgsite)
         if not update_available and already_installed and state == "latest":
             continue
 

--- a/lib/ansible/modules/packaging/os/pkgng.py
+++ b/lib/ansible/modules/packaging/os/pkgng.py
@@ -37,7 +37,6 @@ options:
         choices: [ 'present', 'latest', 'absent' ]
         required: false
         default: present
-        version_added: "2.7"
     cached:
         description:
             - Use local package base instead of fetching an updated one.

--- a/lib/ansible/modules/packaging/os/pkgng.py
+++ b/lib/ansible/modules/packaging/os/pkgng.py
@@ -220,9 +220,9 @@ def install_packages(module, pkgng_path, packages, cached, pkgsite, dir_arg, sta
 
         if not module.check_mode:
             if already_installed:
-                   action = "upgrade"
+                action = "upgrade"
             else:
-                   action = "install"
+                action = "install"
             if old_pkgng:
                 rc, out, err = module.run_command("%s %s %s %s -g -U -y %s" % (batch_var, pkgsite, pkgng_path, action, package))
             else:


### PR DESCRIPTION
##### SUMMARY
Adding support to upgrade FreeBSD packages via the `pkgng` module.

Currently, the module only supports package adds (`present`) and removes (`absent`).



##### ISSUE TYPE

 - Feature Pull Request


##### COMPONENT NAME
pkgng

##### ANSIBLE VERSION

```
ansible 2.7.0.dev0 (add-pkgng-latest-support 9c76797b8b) last updated 2018/06/16 19:02:14 (GMT -400)
  config file = None
  configured module search path = [u'/home/jyundt/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/jyundt/git/ansible/lib/ansible
  executable location = /home/jyundt/git/ansible/bin/ansible
  python version = 2.7.13 (default, Feb  8 2017, 06:57:18) [GCC 4.8.5 20150623 (Red Hat 4.8.5-11)]

```


##### ADDITIONAL INFORMATION
I'm open to any suggestions on this PR. I poked around some of the other package modules and wasn't sure if there were any best practices for handling package upgrades.