### PR TITLE
Fix typo in group_by module

### DIFF
--- a/lib/ansible/modules/inventory/group_by.py
+++ b/lib/ansible/modules/inventory/group_by.py
@@ -42,7 +42,7 @@ EXAMPLES = '''
 - group_by:
     key: machine_{{ ansible_machine }}
 
-# Create groups like 'kvm-host'
+# Create groups like 'virt_kvm_host'
 - group_by:
     key: virt_{{ ansible_virtualization_type }}_{{ ansible_virtualization_role }}
 


### PR DESCRIPTION
##### SUMMARY
Fixes: #31600

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
lib/ansible/modules/inventory/group_by.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7-devel
```