### PR TITLE
Add an example on how to use regexp_replace to modify list items

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters.rst
@@ -910,6 +910,9 @@ To replace text in a string with regex, use the "regex_replace" filter::
 
     # convert "localhost:80" to "localhost"
     {{ 'localhost:80' | regex_replace(':80') }}
+    
+    # add "https://" prefix to each item in a list
+    {{ hosts | map('regex_replace', '^(.*)$', 'https://\\1') | list }}
 
 .. note:: Prior to ansible 2.0, if "regex_replace" filter was used with variables inside YAML arguments (as opposed to simpler 'key=value' arguments),
    then you needed to escape backreferences (e.g. ``\\1``) with 4 backslashes (``\\\\``) instead of 2 (``\\``).


### PR DESCRIPTION
Add an example on how to use regexp_replace to modify list items.

##### SUMMARY

I believe finding out how to map list items is a common issue for new Ansible developers so I added a simple example.

##### ISSUE TYPE

 - Docs Pull Request

##### COMPONENT NAME

playbooks_filters

##### ANSIBLE VERSION

```
ansible 2.5.4
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/vagrant/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```

##### ADDITIONAL INFORMATION
None