### PR TITLE
Add generic file locking feature

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -2513,7 +2513,7 @@ class AnsibleModule(object):
         lock_file = os.path.join(tmpdir, 'ansible-{0}.lock'.format(os.path.basename(filename)))
         l_wait = 0.2
         if lock_timeout > 0:
-            e_secs=0
+            e_secs = 0
             while e_secs < lock_timeout:
                 try:
                     self.lockfd = open(lock_file, 'w')


### PR DESCRIPTION
##### SUMMARY
Fixes #29962
This adds a simple and generic file locking feature through fcntl.flock.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
basic.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (29962-feature-file-locking d77e8b36ff) last updated 2018/06/17 21:44:54 (GMT +200)
  config file = None
  configured module search path = ['/home/acalm/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/acalm/venv/ansible/lib/python3.6/site-packages/ansible
  executable location = /home/acalm/venv/ansible/bin/ansible

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->
Call lock_file() before any actions are performed on file and call unlock_file() when operations are done. lock_file also accepts a timeout, if reached False will be returned.

This could be used to solve issues like #30413, also slightly related to #31096, however this PR just provides exclusive access to a given file. Also due to the nature of file locking on Linux, above only works IF all processes accessing the file utilizes flock of course. There's a slight risk of dangling file handlers if a module terminates before managing to call unlock_file, this could potentially be done more safely by using context, but then module(s) potentially using this feature would possibly have to wrap larger parts of their code into a with clause.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
