### PR TITLE
Only update essential tower role parameters

### DIFF
--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_role.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_role.py
@@ -86,7 +86,7 @@ def update_resources(module, p):
     '''update_resources attempts to fetch any of the resources given
     by name using their unique field (identity)
     '''
-    params = p.copy()
+    params = dict()
     identity_map = {
         'user': 'username',
         'team': 'name',
@@ -99,9 +99,9 @@ def update_resources(module, p):
     }
     for k, v in identity_map.items():
         try:
-            if params[k]:
+            if p[k]:
                 key = 'team' if k == 'target_team' else k
-                result = tower_cli.get_resource(key).get(**{v: params[k]})
+                result = tower_cli.get_resource(key).get(**{v: p[k]})
                 params[k] = result['id']
         except (exc.NotFound) as excinfo:
             module.fail_json(msg='Failed to update role, {0} not found: {1}'.format(k, excinfo), changed=False)
@@ -128,7 +128,6 @@ def main():
 
     if not HAS_TOWER_CLI:
         module.fail_json(msg='ansible-tower-cli required for this module')
-
     role_type = module.params.pop('role')
     state = module.params.pop('state')
 


### PR DESCRIPTION
##### SUMMARY

Copying all tower_role parameters means that parameters such as
`tower_verify_ssl` gets passed to role.grant, which errors with:

```
    Response: {"detail":"Role has no field named 'tower_verify_ssl'"}
```

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
tower_role

##### ANSIBLE VERSION

```
ansible 2.7.0.dev0 (devel dc7e50fa90) last updated 2018/06/18 15:27:16 (GMT +1000)
  config file = None
  configured module search path = [u'/Users/will/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/will/src/opensource/ansible/lib/ansible
  executable location = /Users/will/src/opensource/ansible/bin/ansible
  python version = 2.7.15 (default, May  1 2018, 16:44:08) [GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.1)]

```


##### ADDITIONAL INFORMATION

