### PR TITLE
backport #41259 (2.6) - read scaleway option after the options have been set (#41259)

### DIFF
--- a/lib/ansible/plugins/inventory/scaleway.py
+++ b/lib/ansible/plugins/inventory/scaleway.py
@@ -82,7 +82,7 @@ class InventoryModule(BaseInventoryPlugin):
     def __init__(self):
         super(InventoryModule, self).__init__()
 
-        self.token = self.get_option("oauth_token")
+        self.token = None
         self.config_data = None
 
     def verify_file(self, path):
@@ -146,6 +146,7 @@ class InventoryModule(BaseInventoryPlugin):
     def parse(self, inventory, loader, path, cache=True):
         super(InventoryModule, self).parse(inventory, loader, path)
         self.config_data = self._read_config_data(path=path)
+        self.token = self.get_option("oauth_token")
 
         for zone in self._get_zones():
             self.do_zone_inventory(zone=zone)


### PR DESCRIPTION
(cherry picked from commit 8047d97ffc3f7b366eb7cf5a394a47f8c565cd1d)

##### SUMMARY
Backport #41259

Fixes error `ERROR! Unexpected Exception, this is probably a bug: 'InventoryModule' object has no attribute '_load_name'`. get_option requires _load_name which is only set after `__init__` has been called for the plugin. 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/inventory/scaleway.py

##### ANSIBLE VERSION
```
ansible 2.6.0.dev0
```