### PR TITLE
Enabled defined/undefined tests to capture 'nested undefineds'

### DIFF
--- a/lib/ansible/playbook/conditional.py
+++ b/lib/ansible/playbook/conditional.py
@@ -214,7 +214,7 @@ class Conditional:
                     # when we compare the var names, normalize quotes because something
                     # like hostvars['foo'] may be tested against hostvars["foo"]
                     val = du_var.replace("'", '"')
-                    while val != None:
+                    while val is not None:
                         if var_name.replace("'", '"') == val:
                             # the should exist is a xor test between a negation in the logic portion
                             # against the state (defined or undefined)

--- a/lib/ansible/playbook/helpers.py
+++ b/lib/ansible/playbook/helpers.py
@@ -388,14 +388,14 @@ def _find_nested_var_assignment(var, iterbl):
         _find_nested_var_assignment('target', None) => None
 
     '''
-    if type(iterbl) == type({}) and var in iterbl:
+    if isinstance(iterbl, dict) and var in iterbl:
         return iterbl[var]
-    elif type(iterbl) == type({}):
+    elif isinstance(iterbl, dict):
         for i in iterbl:
             val = _find_nested_var_assignment(var, iterbl[i])
             if val:
                 return val
-    elif type(iterbl) == type([]):
+    elif isinstance(iterbl, list):
         for i in iterbl:
             val = _find_nested_var_assignment(var, i)
             if val:

--- a/lib/ansible/playbook/helpers.py
+++ b/lib/ansible/playbook/helpers.py
@@ -377,3 +377,27 @@ def load_list_of_roles(ds, play, current_role_path=None, variable_manager=None, 
         roles.append(i)
 
     return roles
+
+
+def _find_nested_var_assignment(var, iterbl):
+    '''
+        Helper function for the finding arbitrarily deeply nested keys in objects.
+
+        i.e
+        _find_nested_var_assignment('target', { 'a':[{ 'b':{ 'c':{'target': 'you found me'}}}]}) => 'you found me'
+        _find_nested_var_assignment('target', None) => None
+
+    '''
+    if type(iterbl) == type({}) and var in iterbl:
+        return iterbl[var]
+    elif type(iterbl) == type({}):
+        for i in iterbl:
+            val = _find_nested_var_assignment(var, iterbl[i])
+            if val:
+                return val
+    elif type(iterbl) == type([]):
+        for i in iterbl:
+            val = _find_nested_var_assignment(var, i)
+            if val:
+                return val
+    return None

--- a/test/integration/targets/conditionals/tasks/main.yml
+++ b/test/integration/targets/conditionals/tasks/main.yml
@@ -359,3 +359,16 @@
   assert:
     that:
       - "result.failed == false"
+
+- name: test a variable is undefined when assigned to a variable that itself is undefined
+  var:
+    var_a: "{{ undef_var }}"
+    var_b: "{{ var_a }}"
+  debug: msg="this should print"
+  when: var_b is undefined and var_b is not defined
+  register: result
+
+- name: assert the task did not fail
+  assert:
+    that:
+      - "result.failed == false"

--- a/test/units/playbook/test_helpers.py
+++ b/test/units/playbook/test_helpers.py
@@ -399,7 +399,7 @@ class TestLoadListOfBlocks(unittest.TestCase, MixinForMocks):
 
 class TestFindNestedVarAssignment(unittest.TestCase):
     def setUp(self):
-        self.deep = {'a':[{'b':[{'target': 'you found me'}]},{}]}
+        self.deep = {'a': [{'b': [{'target': 'you found me'}]}, {}]}
         self.shallow = {'target': 'you found me'}
 
     def test_find_target_when_deeply_nested(self):
@@ -409,12 +409,12 @@ class TestFindNestedVarAssignment(unittest.TestCase):
         assert helpers._find_nested_var_assignment('target', self.shallow) == 'you found me'
 
     def test_when_target_not_exists(self):
-        w_none = helpers._find_nested_var_assignment(None, self.shallow) == None
-        w_str = helpers._find_nested_var_assignment('', self.deep) == None
+        w_none = helpers._find_nested_var_assignment(None, self.shallow) is None
+        w_str = helpers._find_nested_var_assignment('', self.deep) is None
         assert w_none and w_str
 
     def test_when_iterbl_not_exits(self):
-        assert helpers._find_nested_var_assignment('target', None) == None
+        assert helpers._find_nested_var_assignment('target', None) is None
 
 
 if __name__ == '__main__':

--- a/test/units/playbook/test_helpers.py
+++ b/test/units/playbook/test_helpers.py
@@ -395,3 +395,27 @@ class TestLoadListOfBlocks(unittest.TestCase, MixinForMocks):
         self.assertIsInstance(res, list)
         for block in res:
             self.assertIsInstance(block, Block)
+
+
+class TestFindNestedVarAssignment(unittest.TestCase):
+    def setUp(self):
+        self.deep = {'a':[{'b':[{'target': 'you found me'}]},{}]}
+        self.shallow = {'target': 'you found me'}
+
+    def test_find_target_when_deeply_nested(self):
+        assert helpers._find_nested_var_assignment('target', self.deep) == 'you found me'
+
+    def test_find_target_when_shallowly_nested(self):
+        assert helpers._find_nested_var_assignment('target', self.shallow) == 'you found me'
+
+    def test_when_target_not_exists(self):
+        w_none = helpers._find_nested_var_assignment(None, self.shallow) == None
+        w_str = helpers._find_nested_var_assignment('', self.deep) == None
+        assert w_none and w_str
+
+    def test_when_iterbl_not_exits(self):
+        assert helpers._find_nested_var_assignment('target', None) == None
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
##### SUMMARY
This PR addresses issue #23675

Change affects  instance method `_check_conditional` of the `Conditional` class in `ansible/lib/ansible/playbook/conditional.py`.

When checking whether a conditional is undefined or not (i.e. `when: var_a is undefined`), the `_check_conditional` method referenced above fails to correctly register those variables which are undefined by proxy. In other words, if `var_a = var_b`, `var_b = var_c`, and `var_c` is undefined, the conditional `when: var_a is undefined` will not register as true and will actually cause the conditional check to fail and raise an exception.

For example:

`my_playbook.yml`
```
---
- hosts: localhost
  connection: local
  gather_facts: no
  vars:
    undef_var2: "{{ undef_var3 }}"

  tasks:
    - name: Should skip because `undef_var1` is never defined
      raw: echo "If you're seeing this, something is wrong"
      when: undef_var1 is defined

    - name: Should NOT skip because `undef_var1` is never defined
      raw: echo "You should see this"
      when: undef_var1 is undefined

    - name: Should skip because `undef_var2` is assigned to `undef_var3` which isn't defined
      raw: echo "If you're see this, something is wrong"
      when: undef_var2 is defined

    - name: Should NOT skip because `undef_var2` is assigned to `undef_var3` which isn't defined
      raw: echo "You should see this"
      when: undef_var2 is undefined
```

Results of playbook execution:

```
$ ansible-playbook my_playbook.yml

PLAY [localhost] ******************************************************************************************************************************************

TASK [Should skip because `undef_var1` is never defined] **************************************************************************************************
skipping: [localhost]

TASK [Should NOT skip because `undef_var1` is never defined] **********************************************************************************************
changed: [localhost]

TASK [Should skip because `undef_var2` is assigned to `undef_var3` which isn't defined] *******************************************************************
fatal: [localhost]: FAILED! => {"msg": "The conditional check 'undef_var2 is defined' failed. The error was: error while evaluating conditional (undef_var2 is defined): 'undef_var3' is undefined\n\nThe error appears to have been in '/Users/eakman/Development/add_item_test/my_playbook.yml': line 17, column 7, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n    - name: Should skip because `undef_var2` is assigned to `undef_var3` which isn't defined\n      ^ here\n"}
	to retry, use: --limit @/Users/eakman/Development/add_item_test/my_playbook.retry

PLAY RECAP ************************************************************************************************************************************************
localhost                  : ok=1    changed=1    unreachable=0    failed=1
```
As you can see, the first two tasks work as expected, but the third fails with the error:

`The conditional check 'undef_var2 is defined' failed. The error was: error while evaluating conditional (undef_var2 is defined): 'undef_var3' is undefined...`

In summary, `undef_var1` which was never defined is correctly registered as such. `undef_var2` on the otherhand, which is assigned, but to a variable that itself is undefined, isn't registered as undefined as you might've expected and actually causes an exception to be raised.

The problem seems to be in the `_check_conditional` instance method of the `Conditional` class at `ansible/lib/ansible/playbook/conditional.py` in the below lines.

```
...
1  except (AnsibleUndefinedVariable, UndefinedError) as e:
2     # the templating failed, meaning most likely a variable was undefined. If we happened
3     # to be looking for an undefined variable, return True, otherwise fail
4     try:
5         # first we extract the variable name from the error message
6         var_name = re.compile(r"'(hostvars\[.+\]|[\w_]+)' is undefined").search(str(e)).groups()[0]
7         # next we extract all defined/undefined tests from the conditional string
8         def_undef = self.extract_defined_undefined(conditional)
9         # then we loop through these, comparing the error variable name against
10        # each def/undef test we found above. If there is a match, we determine
11        # whether the logic/state mean the variable should exist or not and return
12        # the corresponding True/False
13        for (du_var, logic, state) in def_undef:
14            # when we compare the var names, normalize quotes because something
15            # like hostvars['foo'] may be tested against hostvars["foo"]
16            if var_name.replace("'", '"') == du_var.replace("'", '"'):
17                # the should exist is a xor test between a negation in the logic portion
18                # against the state (defined or undefined)
19                should_exist = ('not' in logic) != (state == 'defined')
20                if should_exist:
21                    return False
22                else:
23                    return True
25        # as nothing above matched the failed var name, re-raise here to
26        # trigger the AnsibleUndefinedVariable exception again below
27        raise
28    except Exception as new_e:
29        raise AnsibleUndefinedVariable("error while evaluating conditional (%s): %s" % (original, e))
...
```

If you trace the code you will see that the playbook hits this except block with an error message of `'undef_var3' is undefined`. It then extracts the variable name from the error message, `undef_var3`, and assigns it to the variable `var_name` (line 6 of the excerpt).

Next, it extracts the components of the original conditional from the task, `undef_var2 is undefined`, and stores it in a 2-dimensional list called `def_undef` on line 8.

`def_undef`, which is a list of conditionals extracted in the previous step, is then iterated over (line 13) looking for a conditional where the variable name (`du_var`) is equal to the variable name from the aforementioned error message i.e. `du_var == var_name` (line 16). In this case, `du_var`, which is equal to `undef_var2` will never equal `var_name` which is equal to `undef_var3` and `_check_conditional` will therefore raise an exception (line 27).

This commit modifies `_check_conditional` to compare the variable from the task conditional, `du_var`, to the variable name from the error message, `var_name`, and then recursively reassign `du_var` to it's value and potentially to all of it's value's values until `du_var == None` or a match is found.

Then, the same code seen on line's 19-22 in the excerpt above are used to evaluate the conditional itself.

When I run the same playbook with the changes described above I get the following output.

```
$ ansible-playbook my_playbook.yml -i hosts
 [WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'


PLAY [localhost] ******************************************************************************************************************************************

TASK [Should skip because `undef_var1` is never defined] **************************************************************************************************
skipping: [localhost]

TASK [Should NOT skip because `undef_var1` is never defined] **********************************************************************************************
changed: [localhost]

TASK [Should skip because `undef_var2` is assigned to `undef_var3` which isn't defined] *******************************************************************
skipping: [localhost]

TASK [Should NOT skip because `undef_var2` is assigned to `undef_var3` which isn't defined] ***************************************************************
changed: [localhost]

PLAY RECAP ************************************************************************************************************************************************
localhost                  : ok=2    changed=2    unreachable=0    failed=0     
```

Now `undef_var2` is being correctly registered as undefined.

The commit consists of:
  - several changes to the `_check_conditional` method in `ansible/lib/ansible/playbook/conditional.py`
  - a helper method called `_find_nested_var_assignments` in `ansible/lib/ansible/playbook/helpers.py`
  - some unit tests called `TestFindNestedVarAssignment` in `ansible/test/units/playbook/test_helpers.py`
  - and an integration test in `ansible/test/integration/targets/conditionals/tasks/main.yml`


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
`ansible/lib/ansible/playbook/conditional.py`

##### ANSIBLE VERSION
```
ansible 2.6.0 (bug_fix_23675 3e64036684) last updated 2018/06/15 13:14:06 (GMT -400)
  config file = /Users/eakman/.ansible.cfg
  configured module search path = [u'/Users/eakman/Development/ansible/lib/ansible/modules']
  ansible python module location = /Users/eakman/Development/ansible/lib/ansible
  executable location = /Users/eakman/Development/ansible/bin/ansible
  python version = 2.7.13 (v2.7.13:a06454b1afa1, Dec 17 2016, 12:39:47) [GCC 4.2.1 (Apple Inc. build 5666) (dot 3)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
