### PR TITLE
facts: suse: Fix major version detection for SUSE (#41416)

### DIFF
--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -256,6 +256,7 @@ class DistributionFiles:
                 distribution_version = re.search(r'^VERSION_ID="?([0-9]+\.?[0-9]*)"?', line)
                 if distribution_version:
                     suse_facts['distribution_version'] = distribution_version.group(1)
+                    suse_facts['distribution_major_version'] = distribution_version.group(1).split('.')[0]
                 if 'open' in data.lower():
                     release = re.search(r'^VERSION_ID="?[0-9]+\.?([0-9]*)"?', line)
                     if release:

--- a/test/units/module_utils/test_distribution_version.py
+++ b/test/units/module_utils/test_distribution_version.py
@@ -221,9 +221,31 @@ ID_LIKE="suse"
         "result": {
             "distribution_release": "",
             "distribution": "openSUSE Tumbleweed",
-            "distribution_major_version": "NA",
+            "distribution_major_version": "20160917",
             "os_family": "Suse",
             "distribution_version": "20160917"
+        }
+    },
+    {
+        "platform.dist": [
+            "",
+            "",
+            ""
+        ],
+        "input": {
+            "/etc/os-release": (
+                "NAME=\"openSUSE Leap\"\n# VERSION=\"15.0\"\nID=opensuse-leap\nID_LIKE=\"suse opensuse\"\nVERSION_ID=\"15.0\"\n"
+                "PRETTY_NAME=\"openSUSE Leap 15.0\"\nANSI_COLOR=\"0;32\"\nCPE_NAME=\"cpe:/o:opensuse:leap:15.0\"\n"
+                "BUG_REPORT_URL=\"https://bugs.opensuse.org\"\nHOME_URL=\"https://www.opensuse.org/\"\n"
+            )
+        },
+        "name": "openSUSE Leap 15.0",
+        "result": {
+            "distribution_release": "0",
+            "distribution": "openSUSE Leap",
+            "distribution_major_version": "15",
+            "os_family": "Suse",
+            "distribution_version": "15.0"
         }
     },
     {  # see https://github.com/ansible/ansible/issues/14837


### PR DESCRIPTION
When parsing the distribution files such as /etc/os-release, we extract
the full distribution version but not the major version. As such, the
ansible_distribution_major_version ends up being 'NA' whereas the
ansible_distribution_version contains the full version.

Before this patch we get this on openSUSE Leap 15

ansible -o localhost -m setup -a filter=ansible_distribution_major_version
localhost | SUCCESS => {"ansible_facts": {"ansible_distribution_major_version": "NA"}, "changed": false}

After this patch we get this

ansible -o localhost -m setup -a filter=ansible_distribution_major_version
localhost | SUCCESS => {"ansible_facts": {"ansible_distribution_major_version": "15"}, "changed": false}

This also fixes the Tumbleweed distribution test to report a proper
major version and also adds a test for openSUSE Leap 15.0 to avoid
potential future regressions.

Fixes: #41410
(cherry picked from commit 1737b7be3ecaa6fea9372fe9ba7d8fe659a4e95f)