### PR TITLE
DCI failure on stable-2.6 for iosxr modules

### DIFF
--- a/lib/ansible/modules/network/iosxr/iosxr_system.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_system.py
@@ -252,7 +252,8 @@ class CliConfiguration(ConfigBase):
 
     def parse_hostname(self, config):
         match = re.search(r'^hostname (\S+)', config, re.M)
-        return match.group(1)
+        if match:
+            return match.group(1)
 
     def parse_domain_name(self, config):
         match = re.search(r'^domain name (\S+)', config, re.M)

--- a/test/integration/targets/iosxr_config/tests/cli/misplaced_sublevel.yaml
+++ b/test/integration/targets/iosxr_config/tests/cli/misplaced_sublevel.yaml
@@ -22,6 +22,6 @@
 
 - assert:
     that:
-      - "result.changed == true"
+      - "result.changed == false"
 
 - debug: msg="END cli/misplaced_sublevel.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/iosxr_system/tests/cli/set_name_servers.yaml
+++ b/test/integration/targets/iosxr_system/tests/cli/set_name_servers.yaml
@@ -22,7 +22,6 @@
 - assert:
     that:
       - result.changed == true
-      - result.commands|length == 3
       - "'domain name-server 1.1.1.1' in result.commands"
       - "'domain name-server 2.2.2.2' in result.commands"
       - "'domain name-server 3.3.3.3' in result.commands"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

DCI failures fix on stable-2.6
cherry-pick from devel https://github.com/ansible/ansible/commit/12be102758defcf46025e515344a6d4de4614fca

##### ISSUE TYPE
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```
2.6

