### PR TITLE
Devel ios vrf submode

### DIFF
--- a/lib/ansible/modules/network/ios/ios_vrf.py
+++ b/lib/ansible/modules/network/ios/ios_vrf.py
@@ -103,10 +103,30 @@ options:
     description:
       - Adds an import list of extended route target communities to the VRF.
     version_added: "2.5"
-  mode:
+  route_both_ipv4:
     description:
-      - Configure the VRF in .
-    version_added: "2.5"
+      - Adds an export and import list of extended route target communities in address-family configuration submode to the VRF.
+    version_added: "2.7"
+  route_export_ipv4:
+    description:
+      - Adds an export list of extended route target communities in address-family configuration submode to the VRF.
+    version_added: "2.7"
+  route_import_ipv4:
+    description:
+      - Adds an import list of extended route target communities in address-family configuration submode to the VRF.
+    version_added: "2.7"
+  route_both_ipv6:
+    description:
+      - Adds an export and import list of extended route target communities in address-family configuration submode to the VRF.
+    version_added: "2.7"
+  route_export_ipv6:
+    description:
+      - Adds an export list of extended route target communities in address-family configuration submode to the VRF.
+    version_added: "2.7"
+  route_import_ipv6:
+    description:
+      - Adds an import list of extended route target communities in address-family configuration submode to the VRF.
+    version_added: "2.7"
 
 """
 EXAMPLES = """

--- a/lib/ansible/modules/network/ios/ios_vrf.py
+++ b/lib/ansible/modules/network/ios/ios_vrf.py
@@ -15,7 +15,6 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
-from collections import OrderedDict
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],
@@ -260,6 +259,7 @@ from ansible.module_utils.network.ios.ios import load_config, get_config
 from ansible.module_utils.network.ios.ios import ios_argument_spec, check_args
 from ansible.module_utils.network.common.config import NetworkConfig
 from ansible.module_utils.six import iteritems
+from collections import OrderedDict
 
 
 def get_interface_type(interface):

--- a/lib/ansible/modules/network/ios/ios_vrf.py
+++ b/lib/ansible/modules/network/ios/ios_vrf.py
@@ -431,17 +431,18 @@ def parse_export(configobj, name):
 def parse_both(configobj, name, address_family='global'):
     rd_pattern = re.compile('(?P<rd>.+:.+)')
     matches = list()
+    export_match = None
+    import_match = None
     if address_family == "global":
         export_match = parse_export(configobj, name)
         import_match = parse_import(configobj, name)
     elif address_family == "ipv4":
         export_match = parse_export_ipv4(configobj, name)
         import_match = parse_import_ipv4(configobj, name)
-
     elif address_family == "ipv6":
         export_match = parse_export_ipv6(configobj, name)
         import_match = parse_import_ipv6(configobj, name)
-    if len(import_match) != 0 or len(export_match) != 0:
+    if import_match and export_match:
         for ex in export_match:
             exrd = rd_pattern.search(ex)
             exrd = exrd.groupdict().get('rd')
@@ -462,7 +463,7 @@ def parse_import_ipv4(configobj, name):
         matches = re.findall(r'route-target\s+import\s+(.+)', subcfg, re.M)
         return matches
     except KeyError:
-        return []
+        pass
 
 
 def parse_export_ipv4(configobj, name):
@@ -473,7 +474,7 @@ def parse_export_ipv4(configobj, name):
         matches = re.findall(r'route-target\s+export\s+(.+)', subcfg, re.M)
         return matches
     except KeyError:
-        return []
+        pass
 
 
 def parse_import_ipv6(configobj, name):
@@ -484,7 +485,7 @@ def parse_import_ipv6(configobj, name):
         matches = re.findall(r'route-target\s+import\s+(.+)', subcfg, re.M)
         return matches
     except KeyError:
-        return []
+        pass
 
 
 def parse_export_ipv6(configobj, name):
@@ -495,7 +496,7 @@ def parse_export_ipv6(configobj, name):
         matches = re.findall(r'route-target\s+export\s+(.+)', subcfg, re.M)
         return matches
     except KeyError:
-        return []
+        pass
 
 
 def map_config_to_obj(module):

--- a/lib/ansible/modules/network/ios/ios_vrf.py
+++ b/lib/ansible/modules/network/ios/ios_vrf.py
@@ -181,7 +181,7 @@ EXAMPLES = """
     route_export:
       - 1:100
       - 3:100
-      
+
 - name: Creates a list of export RTs in address-family configuration submode for the VRF with the same parameters
   ios_vrf:
     name: test_export_ipv4
@@ -205,7 +205,7 @@ EXAMPLES = """
     route_both:
       - 1:100
       - 3:100
-      
+
 - name: Creates a list of import and export route targets in address-family configuration submode for the VRF with the same parameters
   ios_vrf:
     name: test_both_ipv4
@@ -221,7 +221,7 @@ EXAMPLES = """
     route_both_ipv6:
       - 1:100
       - 3:100
-    
+  
 """
 
 RETURN = """
@@ -699,7 +699,7 @@ def main():
     argument_spec.update(ios_argument_spec)
 
     mutually_exclusive = [('name', 'vrfs'), ('route_import', 'route_both'), ('route_export', 'route_both'),
-                          ('route_import_ipv4', 'route_both_ipv4'),('route_export_ipv4', 'route_both_ipv4'),
+                          ('route_import_ipv4', 'route_both_ipv4'), ('route_export_ipv4', 'route_both_ipv4'),
                           ('route_import_ipv6', 'route_both_ipv6'), ('route_export_ipv6', 'route_both_ipv6')]
     module = AnsibleModule(argument_spec=argument_spec,
                            mutually_exclusive=mutually_exclusive,

--- a/lib/ansible/modules/network/ios/ios_vrf.py
+++ b/lib/ansible/modules/network/ios/ios_vrf.py
@@ -518,12 +518,21 @@ def map_params_to_obj(module):
         item['route_import'] = get_value('route_import')
         item['route_export'] = get_value('route_export')
         item['route_both'] = get_value('route_both')
+        if item['route_both']:
+            # The parsing will have import and export aggregated
+            item['route_both'].extend(get_value('route_both'))
         item['route_import_ipv4'] = get_value('route_import_ipv4')
         item['route_export_ipv4'] = get_value('route_export_ipv4')
         item['route_both_ipv4'] = get_value('route_both_ipv4')
+        if item['route_both_ipv4']:
+            # The parsing will have import and export aggregated
+            item['route_both_ipv4'].extend(get_value('route_both_ipv4'))
         item['route_import_ipv6'] = get_value('route_import_ipv6')
         item['route_export_ipv6'] = get_value('route_export_ipv6')
         item['route_both_ipv6'] = get_value('route_both_ipv6')
+        if item['route_both_ipv6']:
+            # The parsing will have import and export aggregated
+            item['route_both_ipv6'].extend(get_value('route_both_ipv6'))
         item['associated_interfaces'] = get_value('associated_interfaces')
         objects.append(item)
 

--- a/lib/ansible/modules/network/ios/ios_vrf.py
+++ b/lib/ansible/modules/network/ios/ios_vrf.py
@@ -259,7 +259,6 @@ from ansible.module_utils.network.ios.ios import load_config, get_config
 from ansible.module_utils.network.ios.ios import ios_argument_spec, check_args
 from ansible.module_utils.network.common.config import NetworkConfig
 from ansible.module_utils.six import iteritems
-from collections import OrderedDict
 
 
 def get_interface_type(interface):
@@ -331,7 +330,9 @@ def map_obj_to_commands(updates, module):
                 add_command_to_vrf(want['name'], cmd, commands)
 
         if needs_update(want, have, 'route_both'):
-            for route in list(OrderedDict.fromkeys(want['route_both'])):
+            proceed = []
+            needs = [item for item in want['route_both'] if not (item in proceed or proceed.append(item))]
+            for route in needs:
                 cmd = 'route-target both %s' % route
                 add_command_to_vrf(want['name'], cmd, commands)
 
@@ -356,7 +357,9 @@ def map_obj_to_commands(updates, module):
         if needs_update(want, have, 'route_both_ipv4'):
                 cmd = 'address-family ipv4'
                 add_command_to_vrf(want['name'], cmd, commands)
-                for route in list(OrderedDict.fromkeys(want['route_both_ipv4'])):
+                proceed = []
+                needs = [item for item in want['route_both_ipv4'] if not (item in proceed or proceed.append(item))]
+                for route in needs:
                     cmd = 'route-target both %s' % route
                     add_command_to_vrf(want['name'], cmd, commands)
                 cmd = 'exit-address-family'
@@ -383,7 +386,9 @@ def map_obj_to_commands(updates, module):
         if needs_update(want, have, 'route_both_ipv6'):
                 cmd = 'address-family ipv6'
                 add_command_to_vrf(want['name'], cmd, commands)
-                for route in list(OrderedDict.fromkeys(want['route_both_ipv6'])):
+                proceed = []
+                needs = [item for item in want['route_both_ipv6'] if not (item in proceed or proceed.append(item))]
+                for route in needs:
                     cmd = 'route-target both %s' % route
                     add_command_to_vrf(want['name'], cmd, commands)
                 cmd = 'exit-address-family'

--- a/lib/ansible/modules/network/ios/ios_vrf.py
+++ b/lib/ansible/modules/network/ios/ios_vrf.py
@@ -718,7 +718,6 @@ def main():
 
     want = map_params_to_obj(module)
     have = map_config_to_obj(module)
-    # import epdb; epdb.serve(20000)
     commands = map_obj_to_commands(update_objects(want, have), module)
 
     if module.params['purge']:

--- a/lib/ansible/modules/network/ios/ios_vrf.py
+++ b/lib/ansible/modules/network/ios/ios_vrf.py
@@ -15,8 +15,6 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
-from ansible.errors import AnsibleError
-
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],
                     'supported_by': 'network'}
@@ -470,9 +468,6 @@ def parse_both(configobj, name, address_family='global'):
     elif address_family == "ipv6":
         export_match = parse_export_ipv6(configobj, name)
         import_match = parse_import_ipv6(configobj, name)
-    else:
-        raise AnsibleError(message="Pass a valid address_family type")
-
     if len(import_match) != 0 or len(export_match) != 0:
         for ex in export_match:
             exrd = rd_pattern.search(ex)
@@ -620,12 +615,11 @@ def map_params_to_obj(module):
                     item["route_export%s" % address_family].extend(get_value("route_both%s" % address_family))
                     item["route_import%s" % address_family].extend(get_value("route_both%s" % address_family))
         except AttributeError:
-           pass
+            pass
         item['associated_interfaces'] = get_value('associated_interfaces')
         objects.append(item)
 
     return objects
-
 
 def update_objects(want, have):
     updates = list()

--- a/lib/ansible/modules/network/ios/ios_vrf.py
+++ b/lib/ansible/modules/network/ios/ios_vrf.py
@@ -461,18 +461,24 @@ def parse_both(configobj, name):
 
 def parse_import_ipv4(configobj, name):
     cfg = configobj['vrf definition %s' % name]
-    subcfg = cfg['address-family ipv4']
-    subcfg = '\n'.join(subcfg.children)
-    matches = re.findall(r'route-target\s+import\s+(.+)', subcfg, re.M)
-    return matches
+    try:
+        subcfg = cfg['address-family ipv4']
+        subcfg = '\n'.join(subcfg.children)
+        matches = re.findall(r'route-target\s+import\s+(.+)', subcfg, re.M)
+        return matches
+    except KeyError:
+        return []
 
 
 def parse_export_ipv4(configobj, name):
     cfg = configobj['vrf definition %s' % name]
-    subcfg = cfg['address-family ipv4']
-    subcfg = '\n'.join(subcfg.children)
-    matches = re.findall(r'route-target\s+export\s+(.+)', subcfg, re.M)
-    return matches
+    try:
+        subcfg = cfg['address-family ipv4']
+        subcfg = '\n'.join(subcfg.children)
+        matches = re.findall(r'route-target\s+export\s+(.+)', subcfg, re.M)
+        return matches
+    except KeyError:
+        return []
 
 
 def parse_both_ipv4(configobj, name):
@@ -486,18 +492,24 @@ def parse_both_ipv4(configobj, name):
 
 def parse_import_ipv6(configobj, name):
     cfg = configobj['vrf definition %s' % name]
-    subcfg = cfg['address-family ipv6']
-    subcfg = '\n'.join(subcfg.children)
-    matches = re.findall(r'route-target\s+import\s+(.+)', subcfg, re.M)
-    return matches
+    try:
+        subcfg = cfg['address-family ipv6']
+        subcfg = '\n'.join(subcfg.children)
+        matches = re.findall(r'route-target\s+import\s+(.+)', subcfg, re.M)
+        return matches
+    except KeyError:
+        return []
 
 
 def parse_export_ipv6(configobj, name):
     cfg = configobj['vrf definition %s' % name]
-    subcfg = cfg['address-family ipv6']
-    subcfg = '\n'.join(subcfg.children)
-    matches = re.findall(r'route-target\s+export\s+(.+)', subcfg, re.M)
-    return matches
+    try:
+        subcfg = cfg['address-family ipv6']
+        subcfg = '\n'.join(subcfg.children)
+        matches = re.findall(r'route-target\s+export\s+(.+)', subcfg, re.M)
+        return matches
+    except KeyError:
+        return []
 
 
 def parse_both_ipv6(configobj, name):

--- a/lib/ansible/modules/network/ios/ios_vrf.py
+++ b/lib/ansible/modules/network/ios/ios_vrf.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
+from collections import OrderedDict
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],
@@ -330,7 +331,7 @@ def map_obj_to_commands(updates, module):
                 add_command_to_vrf(want['name'], cmd, commands)
 
         if needs_update(want, have, 'route_both'):
-            for route in list(set(want['route_both'])):
+            for route in list(OrderedDict.fromkeys(want['route_both'])):
                 cmd = 'route-target both %s' % route
                 add_command_to_vrf(want['name'], cmd, commands)
 
@@ -355,7 +356,7 @@ def map_obj_to_commands(updates, module):
         if needs_update(want, have, 'route_both_ipv4'):
                 cmd = 'address-family ipv4'
                 add_command_to_vrf(want['name'], cmd, commands)
-                for route in list(set(want['route_both_ipv4'])):
+                for route in list(OrderedDict.fromkeys(want['route_both_ipv4'])):
                     cmd = 'route-target both %s' % route
                     add_command_to_vrf(want['name'], cmd, commands)
                 cmd = 'exit-address-family'
@@ -382,7 +383,7 @@ def map_obj_to_commands(updates, module):
         if needs_update(want, have, 'route_both_ipv6'):
                 cmd = 'address-family ipv6'
                 add_command_to_vrf(want['name'], cmd, commands)
-                for route in list(set(want['route_both_ipv6'])):
+                for route in list(OrderedDict.fromkeys(want['route_both_ipv6'])):
                     cmd = 'route-target both %s' % route
                     add_command_to_vrf(want['name'], cmd, commands)
                 cmd = 'exit-address-family'

--- a/lib/ansible/modules/network/ios/ios_vrf.py
+++ b/lib/ansible/modules/network/ios/ios_vrf.py
@@ -621,6 +621,7 @@ def map_params_to_obj(module):
 
     return objects
 
+
 def update_objects(want, have):
     updates = list()
     for entry in want:

--- a/lib/ansible/modules/network/ios/ios_vrf.py
+++ b/lib/ansible/modules/network/ios/ios_vrf.py
@@ -221,7 +221,7 @@ EXAMPLES = """
     route_both_ipv6:
       - 1:100
       - 3:100
-  
+
 """
 
 RETURN = """

--- a/test/units/modules/network/ios/fixtures/ios_vrf_config.cfg
+++ b/test/units/modules/network/ios/fixtures/ios_vrf_config.cfg
@@ -8,6 +8,70 @@ vrf definition test_2
 !
 vrf definition test_3
 !
+vrf definition test_17
+ rd 2:100
+ !
+ address-family ipv4
+ exit-address-family
+ !
+ address-family ipv6
+  route-target export 168.0.0.15:100
+  route-target export 4:100
+  route-target export 2:100
+  route-target export 168.0.0.13:100
+  route-target import 168.0.0.14:100
+  route-target import 2:100
+  route-target import 168.0.0.13:100
+ exit-address-family
+!
+vrf definition test_18
+ rd 168.0.0.9:100
+ !
+ address-family ipv4
+  route-target export 168.0.0.10:100
+  route-target export 168.0.0.9:100
+  route-target export 3:100
+  route-target import 168.0.0.9:100
+  route-target import 3:100
+  route-target import 168.0.0.10:600
+ exit-address-family
+ !
+ address-family ipv6
+ exit-address-family
+!
+vrf definition test_19
+ rd 10:700
+ route-target export 2:102
+ route-target export 2:103
+ route-target export 2:100
+ route-target export 2:101
+ route-target import 2:104
+ route-target import 2:105
+ route-target import 2:100
+ route-target import 2:101
+ !
+ address-family ipv4
+  route-target export 2:102
+  route-target export 2:103
+  route-target export 2:100
+  route-target export 2:101
+  route-target import 2:104
+  route-target import 2:105
+  route-target import 2:100
+  route-target import 2:101
+ exit-address-family
+ !
+ address-family ipv6
+  route-target export 2:102
+  route-target export 2:103
+  route-target export 2:100
+  route-target export 2:101
+  route-target import 2:104
+  route-target import 2:105
+  route-target import 2:100
+  route-target import 2:101
+ exit-address-family
+!
 interface Ethernet1
  ip address 1.2.3.4/5
 !

--- a/test/units/modules/network/ios/test_ios_vrf.py
+++ b/test/units/modules/network/ios/test_ios_vrf.py
@@ -129,8 +129,8 @@ class TestIosVrfModule(TestIosModule):
 
     def test_ios_vrf_route_both(self):
         set_module_args(dict(name='test_5', rd='2:100', route_both=['2:100', '3:100']))
-        commands = ['vrf definition test_5', 'address-family ipv4', 'exit', 'address-family ipv6', 'exit', 'rd 2:100', 'route-target both 2:100',
-                    'route-target both 3:100']
+        commands = ['vrf definition test_5', 'address-family ipv4', 'exit', 'address-family ipv6', 'exit', 'rd 2:100', 'route-target import 2:100',
+                    'route-target import 3:100', 'route-target export 2:100', 'route-target export 3:100']
         self.execute_module(changed=True, commands=commands, sort=False)
 
     def test_ios_vrf_route_import(self):
@@ -152,7 +152,8 @@ class TestIosVrfModule(TestIosModule):
     def test_ios_vrf_route_both_ipv4(self):
         set_module_args(dict(name='test_9', rd='168.0.0.9:100', route_both_ipv4=['168.0.0.9:100', '3:100']))
         commands = ['vrf definition test_9', 'address-family ipv4', 'exit', 'address-family ipv6', 'exit', 'rd 168.0.0.9:100', 'address-family ipv4',
-                    'route-target both 168.0.0.9:100', 'route-target both 3:100', 'exit-address-family']
+                    'route-target import 168.0.0.9:100', 'route-target import 3:100', 'exit-address-family',  'address-family ipv4',
+                    'route-target export 168.0.0.9:100', 'route-target export 3:100', 'exit-address-family']
         self.execute_module(changed=True, commands=commands, sort=False)
 
     def test_ios_vrf_route_import_ipv4(self):
@@ -174,7 +175,8 @@ class TestIosVrfModule(TestIosModule):
     def test_ios_vrf_route_both_ipv6(self):
         set_module_args(dict(name='test_13', rd='2:100', route_both_ipv6=['2:100', '168.0.0.13:100']))
         commands = ['vrf definition test_13', 'address-family ipv4', 'exit', 'address-family ipv6', 'exit', 'rd 2:100', 'address-family ipv6',
-                    'route-target both 2:100', 'route-target both 168.0.0.13:100', 'exit-address-family']
+                    'route-target import 2:100', 'route-target import 168.0.0.13:100', 'exit-address-family',  'address-family ipv6',
+                    'route-target export 2:100', 'route-target export 168.0.0.13:100', 'exit-address-family']
         self.execute_module(changed=True, commands=commands, sort=False)
 
     def test_ios_vrf_route_import_ipv6(self):

--- a/test/units/modules/network/ios/test_ios_vrf.py
+++ b/test/units/modules/network/ios/test_ios_vrf.py
@@ -154,14 +154,14 @@ class TestIosVrfModule(TestIosModule):
 
     def test_ios_vrf_route_import_ipv4(self):
         set_module_args(dict(name='test_10', rd='168.0.0.10:100', route_import_ipv4=['168.0.0.10:100', '3:100']))
-        commands = ['vrf definition test_10', 'address-family ipv4', 'exit', 'address-family ipv6', 'exit', 'rd 3:100', 'route-target import 3:100',
-                    'route-target import 4:100']
+        commands = ['vrf definition test_10', 'address-family ipv4', 'exit', 'address-family ipv6', 'exit', 'rd 168.0.0.10:100', 'address-family ipv4',
+                    'route-target import 168.0.0.10:100','route-target import 3:100', 'exit-address-family']
         self.execute_module(changed=True, commands=commands, sort=False)
 
     def test_ios_vrf_route_export_ipv4(self):
         set_module_args(dict(name='test_11', rd='168.0.0.11:100', route_export_ipv4=['168.0.0.11:100', '3:100']))
-        commands = ['vrf definition test_11', 'address-family ipv4', 'exit', 'address-family ipv6', 'exit', 'rd 4:100', 'route-target export 3:100',
-                    'route-target export 4:100']
+        commands = ['vrf definition test_11', 'address-family ipv4', 'exit', 'address-family ipv6', 'exit', 'rd 168.0.0.11:100', 'address-family ipv4',
+                    'route-target export 168.0.0.11:100','route-target export 3:100', 'exit-address-family']
         self.execute_module(changed=True, commands=commands, sort=False)
 
     def test_ios_vrf_route_both_ipv4_exclusive(self):
@@ -170,20 +170,20 @@ class TestIosVrfModule(TestIosModule):
 
     def test_ios_vrf_route_both_ipv6(self):
         set_module_args(dict(name='test_13', rd='2:100', route_both_ipv6=['2:100', '168.0.0.13:100']))
-        commands = ['vrf definition test_13', 'address-family ipv4', 'exit', 'address-family ipv6', 'exit', 'rd 2:100', 'route-target both 2:100',
-                    'route-target both 3:100']
+        commands = ['vrf definition test_13', 'address-family ipv4', 'exit', 'address-family ipv6', 'exit', 'rd 2:100', 'address-family ipv6',
+                    'route-target both 2:100','route-target both 168.0.0.13:100', 'exit-address-family']
         self.execute_module(changed=True, commands=commands, sort=False)
 
     def test_ios_vrf_route_import_ipv6(self):
         set_module_args(dict(name='test_14', rd='3:100', route_import_ipv6=['3:100', '168.0.0.14:100']))
-        commands = ['vrf definition test_14', 'address-family ipv4', 'exit', 'address-family ipv6', 'exit', 'rd 3:100', 'route-target import 3:100',
-                    'route-target import 4:100']
+        commands = ['vrf definition test_14', 'address-family ipv4', 'exit', 'address-family ipv6', 'exit', 'rd 3:100', 'address-family ipv6',
+                    'route-target import 3:100','route-target import 168.0.0.14:100', 'exit-address-family']
         self.execute_module(changed=True, commands=commands, sort=False)
 
     def test_ios_vrf_route_export_ipv6(self):
         set_module_args(dict(name='test_15', rd='4:100', route_export_ipv6=['168.0.0.15:100', '4:100']))
-        commands = ['vrf definition test_15', 'address-family ipv4', 'exit', 'address-family ipv6', 'exit', 'rd 4:100', 'route-target export 3:100',
-                    'route-target export 4:100']
+        commands = ['vrf definition test_15', 'address-family ipv4', 'exit', 'address-family ipv6', 'exit', 'rd 4:100', 'address-family ipv6',
+                    'route-target export 168.0.0.15:100','route-target export 4:100', 'exit-address-family']
         self.execute_module(changed=True, commands=commands, sort=False)
 
     def test_ios_vrf_route_both_ipv6_exclusive(self):

--- a/test/units/modules/network/ios/test_ios_vrf.py
+++ b/test/units/modules/network/ios/test_ios_vrf.py
@@ -128,7 +128,7 @@ class TestIosVrfModule(TestIosModule):
         set_module_args(dict(name='test_5', rd='2:100', route_both=['2:100', '3:100']))
         commands = ['vrf definition test_5', 'address-family ipv4', 'exit', 'address-family ipv6', 'exit', 'rd 2:100', 'route-target both 2:100',
                     'route-target both 3:100']
-        self.execute_module(changed=True, commands=commands, sort=True)
+        self.execute_module(changed=True, commands=commands, sort=False)
 
     def test_ios_vrf_route_import(self):
         set_module_args(dict(name='test_6', rd='3:100', route_import=['3:100', '4:100']))
@@ -150,7 +150,7 @@ class TestIosVrfModule(TestIosModule):
         set_module_args(dict(name='test_9', rd='168.0.0.9:100', route_both_ipv4=['168.0.0.9:100', '3:100']))
         commands = ['vrf definition test_9', 'address-family ipv4', 'exit', 'address-family ipv6', 'exit', 'rd 168.0.0.9:100', 'address-family ipv4',
                     'route-target both 168.0.0.9:100', 'route-target both 3:100', 'exit-address-family']
-        self.execute_module(changed=True, commands=commands, sort=True)
+        self.execute_module(changed=True, commands=commands, sort=False)
 
     def test_ios_vrf_route_import_ipv4(self):
         set_module_args(dict(name='test_10', rd='168.0.0.10:100', route_import_ipv4=['168.0.0.10:100', '3:100']))
@@ -172,7 +172,7 @@ class TestIosVrfModule(TestIosModule):
         set_module_args(dict(name='test_13', rd='2:100', route_both_ipv6=['2:100', '168.0.0.13:100']))
         commands = ['vrf definition test_13', 'address-family ipv4', 'exit', 'address-family ipv6', 'exit', 'rd 2:100', 'address-family ipv6',
                     'route-target both 2:100', 'route-target both 168.0.0.13:100', 'exit-address-family']
-        self.execute_module(changed=True, commands=commands, sort=True)
+        self.execute_module(changed=True, commands=commands, sort=False)
 
     def test_ios_vrf_route_import_ipv6(self):
         set_module_args(dict(name='test_14', rd='3:100', route_import_ipv6=['3:100', '168.0.0.14:100']))

--- a/test/units/modules/network/ios/test_ios_vrf.py
+++ b/test/units/modules/network/ios/test_ios_vrf.py
@@ -152,7 +152,7 @@ class TestIosVrfModule(TestIosModule):
     def test_ios_vrf_route_both_ipv4(self):
         set_module_args(dict(name='test_9', rd='168.0.0.9:100', route_both_ipv4=['168.0.0.9:100', '3:100']))
         commands = ['vrf definition test_9', 'address-family ipv4', 'exit', 'address-family ipv6', 'exit', 'rd 168.0.0.9:100', 'address-family ipv4',
-                    'route-target import 168.0.0.9:100', 'route-target import 3:100', 'exit-address-family',  'address-family ipv4',
+                    'route-target import 168.0.0.9:100', 'route-target import 3:100', 'exit-address-family', 'address-family ipv4',
                     'route-target export 168.0.0.9:100', 'route-target export 3:100', 'exit-address-family']
         self.execute_module(changed=True, commands=commands, sort=False)
 
@@ -175,7 +175,7 @@ class TestIosVrfModule(TestIosModule):
     def test_ios_vrf_route_both_ipv6(self):
         set_module_args(dict(name='test_13', rd='2:100', route_both_ipv6=['2:100', '168.0.0.13:100']))
         commands = ['vrf definition test_13', 'address-family ipv4', 'exit', 'address-family ipv6', 'exit', 'rd 2:100', 'address-family ipv6',
-                    'route-target import 2:100', 'route-target import 168.0.0.13:100', 'exit-address-family',  'address-family ipv6',
+                    'route-target import 2:100', 'route-target import 168.0.0.13:100', 'exit-address-family', 'address-family ipv6',
                     'route-target export 2:100', 'route-target export 168.0.0.13:100', 'exit-address-family']
         self.execute_module(changed=True, commands=commands, sort=False)
 

--- a/test/units/modules/network/ios/test_ios_vrf.py
+++ b/test/units/modules/network/ios/test_ios_vrf.py
@@ -145,3 +145,47 @@ class TestIosVrfModule(TestIosModule):
     def test_ios_vrf_route_both_exclusive(self):
         set_module_args(dict(name='test_8', rd='5:100', route_both=['3:100', '4:100'], route_export=['3:100', '4:100']))
         self.execute_module(failed=True)
+
+    def test_ios_vrf_route_both_ipv4(self):
+        set_module_args(dict(name='test_9', rd='168.0.0.9:100', route_both_ipv4=['168.0.0.9:100', '3:100']))
+        commands = ['vrf definition test_9', 'address-family ipv4', 'exit', 'address-family ipv6', 'exit', 'rd 168.0.0.9:100', 'address-family ipv4',
+                    'route-target both 168.0.0.9:100', 'route-target both 3:100', 'exit-address-family']
+        self.execute_module(changed=True, commands=commands, sort=False)
+
+    def test_ios_vrf_route_import_ipv4(self):
+        set_module_args(dict(name='test_10', rd='168.0.0.10:100', route_import_ipv4=['168.0.0.10:100', '3:100']))
+        commands = ['vrf definition test_10', 'address-family ipv4', 'exit', 'address-family ipv6', 'exit', 'rd 3:100', 'route-target import 3:100',
+                    'route-target import 4:100']
+        self.execute_module(changed=True, commands=commands, sort=False)
+
+    def test_ios_vrf_route_export_ipv4(self):
+        set_module_args(dict(name='test_11', rd='168.0.0.11:100', route_export_ipv4=['168.0.0.11:100', '3:100']))
+        commands = ['vrf definition test_11', 'address-family ipv4', 'exit', 'address-family ipv6', 'exit', 'rd 4:100', 'route-target export 3:100',
+                    'route-target export 4:100']
+        self.execute_module(changed=True, commands=commands, sort=False)
+
+    def test_ios_vrf_route_both_ipv4_exclusive(self):
+        set_module_args(dict(name='test_12', rd='168.0.0.12:100', route_both_ipv4=['168.0.0.12:100','3:100'], route_export_ipv4=['168.0.0.12:100', '3:100']))
+        self.execute_module(failed=True)
+
+    def test_ios_vrf_route_both_ipv6(self):
+        set_module_args(dict(name='test_13', rd='2:100', route_both_ipv6=['2:100', '168.0.0.13:100']))
+        commands = ['vrf definition test_13', 'address-family ipv4', 'exit', 'address-family ipv6', 'exit', 'rd 2:100', 'route-target both 2:100',
+                    'route-target both 3:100']
+        self.execute_module(changed=True, commands=commands, sort=False)
+
+    def test_ios_vrf_route_import_ipv6(self):
+        set_module_args(dict(name='test_14', rd='3:100', route_import_ipv6=['3:100', '168.0.0.14:100']))
+        commands = ['vrf definition test_14', 'address-family ipv4', 'exit', 'address-family ipv6', 'exit', 'rd 3:100', 'route-target import 3:100',
+                    'route-target import 4:100']
+        self.execute_module(changed=True, commands=commands, sort=False)
+
+    def test_ios_vrf_route_export_ipv6(self):
+        set_module_args(dict(name='test_15', rd='4:100', route_export_ipv6=['168.0.0.15:100', '4:100']))
+        commands = ['vrf definition test_15', 'address-family ipv4', 'exit', 'address-family ipv6', 'exit', 'rd 4:100', 'route-target export 3:100',
+                    'route-target export 4:100']
+        self.execute_module(changed=True, commands=commands, sort=False)
+
+    def test_ios_vrf_route_both_ipv6_exclusive(self):
+        set_module_args(dict(name='test_16', rd='5:100', route_both_ipv6=['168.0.0.9:100', '4:100'], route_export_ipv6=['168.0.0.9:100', '4:100']))
+        self.execute_module(failed=True)

--- a/test/units/modules/network/ios/test_ios_vrf.py
+++ b/test/units/modules/network/ios/test_ios_vrf.py
@@ -155,35 +155,35 @@ class TestIosVrfModule(TestIosModule):
     def test_ios_vrf_route_import_ipv4(self):
         set_module_args(dict(name='test_10', rd='168.0.0.10:100', route_import_ipv4=['168.0.0.10:100', '3:100']))
         commands = ['vrf definition test_10', 'address-family ipv4', 'exit', 'address-family ipv6', 'exit', 'rd 168.0.0.10:100', 'address-family ipv4',
-                    'route-target import 168.0.0.10:100','route-target import 3:100', 'exit-address-family']
+                    'route-target import 168.0.0.10:100', 'route-target import 3:100', 'exit-address-family']
         self.execute_module(changed=True, commands=commands, sort=False)
 
     def test_ios_vrf_route_export_ipv4(self):
         set_module_args(dict(name='test_11', rd='168.0.0.11:100', route_export_ipv4=['168.0.0.11:100', '3:100']))
         commands = ['vrf definition test_11', 'address-family ipv4', 'exit', 'address-family ipv6', 'exit', 'rd 168.0.0.11:100', 'address-family ipv4',
-                    'route-target export 168.0.0.11:100','route-target export 3:100', 'exit-address-family']
+                    'route-target export 168.0.0.11:100', 'route-target export 3:100', 'exit-address-family']
         self.execute_module(changed=True, commands=commands, sort=False)
 
     def test_ios_vrf_route_both_ipv4_exclusive(self):
-        set_module_args(dict(name='test_12', rd='168.0.0.12:100', route_both_ipv4=['168.0.0.12:100','3:100'], route_export_ipv4=['168.0.0.12:100', '3:100']))
+        set_module_args(dict(name='test_12', rd='168.0.0.12:100', route_both_ipv4=['168.0.0.12:100', '3:100'], route_export_ipv4=['168.0.0.12:100', '3:100']))
         self.execute_module(failed=True)
 
     def test_ios_vrf_route_both_ipv6(self):
         set_module_args(dict(name='test_13', rd='2:100', route_both_ipv6=['2:100', '168.0.0.13:100']))
         commands = ['vrf definition test_13', 'address-family ipv4', 'exit', 'address-family ipv6', 'exit', 'rd 2:100', 'address-family ipv6',
-                    'route-target both 2:100','route-target both 168.0.0.13:100', 'exit-address-family']
+                    'route-target both 2:100', 'route-target both 168.0.0.13:100', 'exit-address-family']
         self.execute_module(changed=True, commands=commands, sort=True)
 
     def test_ios_vrf_route_import_ipv6(self):
         set_module_args(dict(name='test_14', rd='3:100', route_import_ipv6=['3:100', '168.0.0.14:100']))
         commands = ['vrf definition test_14', 'address-family ipv4', 'exit', 'address-family ipv6', 'exit', 'rd 3:100', 'address-family ipv6',
-                    'route-target import 3:100','route-target import 168.0.0.14:100', 'exit-address-family']
+                    'route-target import 3:100', 'route-target import 168.0.0.14:100', 'exit-address-family']
         self.execute_module(changed=True, commands=commands, sort=False)
 
     def test_ios_vrf_route_export_ipv6(self):
         set_module_args(dict(name='test_15', rd='4:100', route_export_ipv6=['168.0.0.15:100', '4:100']))
         commands = ['vrf definition test_15', 'address-family ipv4', 'exit', 'address-family ipv6', 'exit', 'rd 4:100', 'address-family ipv6',
-                    'route-target export 168.0.0.15:100','route-target export 4:100', 'exit-address-family']
+                    'route-target export 168.0.0.15:100', 'route-target export 4:100', 'exit-address-family']
         self.execute_module(changed=True, commands=commands, sort=False)
 
     def test_ios_vrf_route_both_ipv6_exclusive(self):

--- a/test/units/modules/network/ios/test_ios_vrf.py
+++ b/test/units/modules/network/ios/test_ios_vrf.py
@@ -128,7 +128,7 @@ class TestIosVrfModule(TestIosModule):
         set_module_args(dict(name='test_5', rd='2:100', route_both=['2:100', '3:100']))
         commands = ['vrf definition test_5', 'address-family ipv4', 'exit', 'address-family ipv6', 'exit', 'rd 2:100', 'route-target both 2:100',
                     'route-target both 3:100']
-        self.execute_module(changed=True, commands=commands, sort=False)
+        self.execute_module(changed=True, commands=commands, sort=True)
 
     def test_ios_vrf_route_import(self):
         set_module_args(dict(name='test_6', rd='3:100', route_import=['3:100', '4:100']))
@@ -150,7 +150,7 @@ class TestIosVrfModule(TestIosModule):
         set_module_args(dict(name='test_9', rd='168.0.0.9:100', route_both_ipv4=['168.0.0.9:100', '3:100']))
         commands = ['vrf definition test_9', 'address-family ipv4', 'exit', 'address-family ipv6', 'exit', 'rd 168.0.0.9:100', 'address-family ipv4',
                     'route-target both 168.0.0.9:100', 'route-target both 3:100', 'exit-address-family']
-        self.execute_module(changed=True, commands=commands, sort=False)
+        self.execute_module(changed=True, commands=commands, sort=True)
 
     def test_ios_vrf_route_import_ipv4(self):
         set_module_args(dict(name='test_10', rd='168.0.0.10:100', route_import_ipv4=['168.0.0.10:100', '3:100']))
@@ -172,7 +172,7 @@ class TestIosVrfModule(TestIosModule):
         set_module_args(dict(name='test_13', rd='2:100', route_both_ipv6=['2:100', '168.0.0.13:100']))
         commands = ['vrf definition test_13', 'address-family ipv4', 'exit', 'address-family ipv6', 'exit', 'rd 2:100', 'address-family ipv6',
                     'route-target both 2:100','route-target both 168.0.0.13:100', 'exit-address-family']
-        self.execute_module(changed=True, commands=commands, sort=False)
+        self.execute_module(changed=True, commands=commands, sort=True)
 
     def test_ios_vrf_route_import_ipv6(self):
         set_module_args(dict(name='test_14', rd='3:100', route_import_ipv6=['3:100', '168.0.0.14:100']))

--- a/test/units/modules/network/ios/test_ios_vrf.py
+++ b/test/units/modules/network/ios/test_ios_vrf.py
@@ -18,6 +18,7 @@
 
 # Make coding more python3-ish
 from __future__ import (absolute_import, division, print_function)
+
 __metaclass__ = type
 
 from ansible.compat.tests.mock import patch
@@ -83,12 +84,14 @@ class TestIosVrfModule(TestIosModule):
 
     def test_ios_vrf_purge_all(self):
         set_module_args(dict(purge=True))
-        commands = ['no vrf definition test_1', 'no vrf definition test_2', 'no vrf definition test_3']
+        commands = ['no vrf definition test_1', 'no vrf definition test_2', 'no vrf definition test_3', 'no vrf definition test_17',
+                    'no vrf definition test_18', 'no vrf definition test_19']
         self.execute_module(changed=True, commands=commands)
 
     def test_ios_vrf_purge_all_but_one(self):
         set_module_args(dict(name='test_1', purge=True))
-        commands = ['no vrf definition test_2', 'no vrf definition test_3']
+        commands = ['no vrf definition test_2', 'no vrf definition test_3', 'no vrf definition test_17', 'no vrf definition test_18',
+                    'no vrf definition test_19']
         self.execute_module(changed=True, commands=commands)
 
     def test_ios_vrfs_no_purge(self):
@@ -101,7 +104,7 @@ class TestIosVrfModule(TestIosModule):
         vrfs = [{'name': 'test_1'}, {'name': 'test_4'}]
         set_module_args(dict(vrfs=vrfs, purge=True))
         commands = ['vrf definition test_4', 'address-family ipv4', 'exit', 'address-family ipv6', 'exit', 'no vrf definition test_2',
-                    'no vrf definition test_3']
+                    'no vrf definition test_3', 'no vrf definition test_17', 'no vrf definition test_18', 'no vrf definition test_19']
         self.execute_module(changed=True, commands=commands)
 
     def test_ios_vrfs_global_arg(self):
@@ -142,9 +145,9 @@ class TestIosVrfModule(TestIosModule):
                     'route-target export 4:100']
         self.execute_module(changed=True, commands=commands, sort=False)
 
-    def test_ios_vrf_route_both_exclusive(self):
+    def test_ios_vrf_route_both_mixed(self):
         set_module_args(dict(name='test_8', rd='5:100', route_both=['3:100', '4:100'], route_export=['3:100', '4:100']))
-        self.execute_module(failed=True)
+        self.execute_module(changed=True)
 
     def test_ios_vrf_route_both_ipv4(self):
         set_module_args(dict(name='test_9', rd='168.0.0.9:100', route_both_ipv4=['168.0.0.9:100', '3:100']))
@@ -164,9 +167,9 @@ class TestIosVrfModule(TestIosModule):
                     'route-target export 168.0.0.11:100', 'route-target export 3:100', 'exit-address-family']
         self.execute_module(changed=True, commands=commands, sort=False)
 
-    def test_ios_vrf_route_both_ipv4_exclusive(self):
-        set_module_args(dict(name='test_12', rd='168.0.0.12:100', route_both_ipv4=['168.0.0.12:100', '3:100'], route_export_ipv4=['168.0.0.12:100', '3:100']))
-        self.execute_module(failed=True)
+    def test_ios_vrf_route_both_ipv4_mixed(self):
+        set_module_args(dict(name='test_12', rd='168.0.0.12:100', route_both_ipv4=['168.0.0.12:100', '3:100'], route_export_ipv4=['168.0.0.15:100', '6:100']))
+        self.execute_module(changed=True)
 
     def test_ios_vrf_route_both_ipv6(self):
         set_module_args(dict(name='test_13', rd='2:100', route_both_ipv6=['2:100', '168.0.0.13:100']))
@@ -186,6 +189,22 @@ class TestIosVrfModule(TestIosModule):
                     'route-target export 168.0.0.15:100', 'route-target export 4:100', 'exit-address-family']
         self.execute_module(changed=True, commands=commands, sort=False)
 
-    def test_ios_vrf_route_both_ipv6_exclusive(self):
-        set_module_args(dict(name='test_16', rd='5:100', route_both_ipv6=['168.0.0.9:100', '4:100'], route_export_ipv6=['168.0.0.9:100', '4:100']))
-        self.execute_module(failed=True)
+    def test_ios_vrf_route_both_ipv6_mixed(self):
+        set_module_args(dict(name='test_16', rd='5:100', route_both_ipv6=['168.0.0.9:100', '4:100'], route_export_ipv6=['168.0.0.12:100', '6:100']))
+        self.execute_module(changed=True)
+
+    def test_ios_vrf_route_both_ipv6_mixed_idempotent(self):
+        set_module_args(dict(name='test_17', rd='2:100', route_import_ipv6=['168.0.0.14:100'], route_both_ipv6=['2:100', '168.0.0.13:100'],
+                             route_export_ipv6=['168.0.0.15:100', '4:100']))
+        self.execute_module(changed=False, commands=[], sort=False)
+
+    def test_ios_vrf_route_both_ipv4_mixed_idempotent(self):
+        set_module_args(dict(name='test_18', rd='168.0.0.9:100', route_import_ipv4=['168.0.0.10:600'], route_export_ipv4=['168.0.0.10:100'],
+                             route_both_ipv4=['168.0.0.9:100', '3:100']))
+        self.execute_module(changed=False, commands=[], sort=False)
+
+    def test_ios_vrf_all_route_both_idempotent(self):
+        set_module_args(dict(name='test_19', rd='10:700', route_both=['2:100', '2:101'], route_export=['2:102', '2:103'], route_import=['2:104', '2:105'],
+                             route_both_ipv4=['2:100', '2:101'], route_export_ipv4=['2:102', '2:103'], route_import_ipv4=['2:104', '2:105'],
+                             route_both_ipv6=['2:100', '2:101'], route_export_ipv6=['2:102', '2:103'], route_import_ipv6=['2:104', '2:105']))
+        self.execute_module(changed=False, commands=[], sort=False)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
This PR include 3 changes:
- Add the submode configuration feature for the issue  https://github.com/ansible/ansible/issues/41191.
- Fix the indepotence of the module, the parameters both_ * were not idempotent, in what is read in the configuration we have a list with 2 entries (import, export) while the input parameter has only one parameter which will be applied twice. We should be able to mix the parameters for the routes targets , while remaining imdepotent. During the first implementation we did not take this into account, which did not correspond to the reality of the needs in production (to be able to use each parameter indifferently together)
- Add a try/except to avoid the behavior describe in the issue https://github.com/ansible/ansible/issues/41581 when a VRF is already removed and state: absent

Fixes: 
- https://github.com/ansible/ansible/issues/41581
- https://github.com/ansible/ansible/issues/41191

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
ios_vrf

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
(venv) [clement@clemo ansible]$ ansible --version
ansible 2.7.0.dev0 (devel_ios_vrf_submode bae025818a) last updated 2018/06/18 18:44:35 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/clement/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/clement/Documents/PROJECTS/ansible_env_setup/ansible/lib/ansible
  executable location = /home/clement/Documents/PROJECTS/ansible_env_setup/ansible/bin/ansible
  python version = 3.6.5 (default, Mar 29 2018, 18:20:46) [GCC 8.0.1 20180317 (Red Hat 8.0.1-0.19)]
(venv) [clement@clemo ansible]$ 

```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

- It is now possible to configure the VRF in submode if needed.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```bash

GEEK CONSULTING INC.

clementroutertest>
clementroutertest>en
clementroutertest>enable 
Password: 
clementroutertest#sh run
clementroutertest#sh running-config | s vrf
vrf definition management
 !
 address-family ipv4
 exit-address-family
 !
 address-family ipv6
 exit-address-family
vrf definition test_13
 rd 2:100
 !
 address-family ipv4
 exit-address-family
 !
 address-family ipv6
  route-target export 168.0.0.15:100
  route-target export 4:100
  route-target export 2:100
  route-target export 168.0.0.13:100
  route-target import 168.0.0.14:100
  route-target import 2:100
  route-target import 168.0.0.13:100
 exit-address-family
vrf definition test_20
 rd 10:700
 route-target export 2:102
 route-target export 2:103
 route-target export 2:100
 route-target export 2:101
 route-target import 2:104
 route-target import 2:105
 route-target import 2:100
 route-target import 2:101
!        
 address-family ipv4
  route-target export 2:102
  route-target export 2:103
  route-target export 2:100
  route-target export 2:101
  route-target import 2:104
  route-target import 2:105
  route-target import 2:100
  route-target import 2:101
 exit-address-family
 !
 address-family ipv6
  route-target export 2:102
  route-target export 2:103
  route-target export 2:100
  route-target export 2:101
  route-target import 2:104
  route-target import 2:105
  route-target import 2:100
  route-target import 2:101
 exit-address-family
vrf definition test_9
 rd 168.0.0.9:100
 !        
 address-family ipv4
  route-target export 168.0.0.10:100
  route-target export 168.0.0.9:100
  route-target export 3:100
  route-target import 168.0.0.9:100
  route-target import 3:100
  route-target import 168.0.0.10:600
 exit-address-family
 !        
 address-family ipv6
 exit-address-family
```
```yaml

---
- name: Set the test_9 vrf route_both_ipv4 with route_export_ipv4 and route_import_ipv4
  ios_vrf:
    name: test_9
    rd: 168.0.0.9:100
    route_import_ipv4:
      - "168.0.0.10:600"
    route_export_ipv4:
      - "168.0.0.10:100"
    route_both_ipv4:
      - "168.0.0.9:100"
      - "3:100"
    state: present

- name: Test idempotence of the VRF module in a loop context
  ios_vrf:
    name: test_bug
    rd: 65004:100
    route_both_ipv4:
      -  65003:100
    route_export_ipv4:
      - "{{ item }}"
    state: present
  loop: "{{ ipv4_import_rd }}"

- name: Set the test_20 vrf route_both, route_export, route_import, route_both_ipv4/v6, route_export_ipv4v6, route_import_ipv4v6.
  ios_vrf:
    name: test_20
    rd: 10:700
    route_both:
      - 2:100
      - 2:101
    route_export:
      - 2:102
      - 2:103
    route_import:
      - 2:104
      - 2:105
    route_both_ipv4:
      - 2:100
      - 2:101
    route_export_ipv4:
      - 2:102
      - 2:103
    route_import_ipv4:
      - 2:104
      - 2:105
    route_both_ipv6:
      - 2:100
      - 2:101
    route_export_ipv6:
      - 2:102
      - 2:103
    route_import_ipv6:
      - 2:104
      - 2:105
    state: present

- name: Set the test_13 vrf route_both_ipv6 and route_import_ipv6 and route_export_ipv6
  ios_vrf:
    name: test_13
    rd: 2:100
    route_import_ipv6:
      - "168.0.0.14:100"
    route_both_ipv6:
      - 2:100
      - "168.0.0.13:100"
    route_export_ipv6:
      - "168.0.0.15:100"
      - 4:100
    state: present
```
![image](https://user-images.githubusercontent.com/8559910/42120542-3a740316-7c1d-11e8-9aef-dbd353179d68.png)
![image](https://user-images.githubusercontent.com/8559910/42120551-61039c4e-7c1d-11e8-830f-b812dcff6d12.png)
