### PR TITLE
Fixed SLX-OS docstring inconsistency

### DIFF
--- a/lib/ansible/modules/network/slxos/slxos_l2_interface.py
+++ b/lib/ansible/modules/network/slxos/slxos_l2_interface.py
@@ -29,7 +29,7 @@ DOCUMENTATION = """
 ---
 module: slxos_l2_interface
 version_added: "2.6"
-short_description: Manage Layer-2 interface on Extreme Networks SLXOS devices.
+short_description: Manage Layer-2 interface on Extreme Networks SLX-OS devices.
 description:
   - This module provides declarative management of Layer-2 interface on
     Extreme slxos devices.

--- a/lib/ansible/modules/network/slxos/slxos_l3_interface.py
+++ b/lib/ansible/modules/network/slxos/slxos_l3_interface.py
@@ -30,7 +30,7 @@ DOCUMENTATION = """
 module: slxos_l3_interface
 version_added: "2.6"
 author: "Matthew Stone (@bigmstone)"
-short_description: Manage L3 interfaces on Extreme Networks SLXOS network devices.
+short_description: Manage L3 interfaces on Extreme Networks SLX-OS network devices.
 description:
   - This module provides declarative management of L3 interfaces
     on slxos network devices.

--- a/lib/ansible/modules/network/slxos/slxos_linkagg.py
+++ b/lib/ansible/modules/network/slxos/slxos_linkagg.py
@@ -29,10 +29,10 @@ DOCUMENTATION = """
 module: slxos_linkagg
 version_added: "2.6"
 author: "Matthew Stone (@bigmstone)"
-short_description: Manage link aggregation groups on Extreme Networks SLXOS network devices
+short_description: Manage link aggregation groups on Extreme Networks SLX-OS network devices
 description:
   - This module provides declarative management of link aggregation groups
-    on Extreme Networks SLXOS network devices.
+    on Extreme Networks SLX-OS network devices.
 notes:
   - Tested against SLX-OS 17s.1.02
 options:


### PR DESCRIPTION
##### SUMMARY

Fixed small docs inconsistency with Extreme SLX-OS (vs SLXOS)

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME

slxos_l2_interface
slxos_l3_interface
slxo2_linkagg

##### ANSIBLE VERSION
```
ansible 2.7.0.dev0 (devel 13ed9a36fa) last updated 2018/06/18 11:27:05 (GMT -700)
  config file = None
  configured module search path = [u'/Users/lhill/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/lhill/github/ansible/lib/ansible
  executable location = /Users/lhill/github/ansible/bin/ansible
  python version = 2.7.10 (default, Oct  6 2017, 22:29:07) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.31)]
```


##### ADDITIONAL INFORMATION

Extreme SLX-OS is supposed to be written as "SLX-OS", not "SLXOS". We had some inconsistencies in the slxos_* modules. This fix standardizes all modules on using "SLX-OS".