### PR TITLE
Fix openstack inventory script for multi-cloud case

### DIFF
--- a/contrib/inventory/openstack_inventory.py
+++ b/contrib/inventory/openstack_inventory.py
@@ -192,8 +192,12 @@ def is_cache_stale(cache_file, cache_expiration_time, refresh=False):
 
 def get_cache_settings(cloud=None):
     config_files = cloud_config.CONFIG_FILES + CONFIG_FILES
-    config = cloud_config.OpenStackConfig(
-        config_files=config_files).get_one(cloud=cloud)
+    if cloud:
+        config = cloud_config.OpenStackConfig(
+            config_files=config_files).get_one(cloud=cloud)
+    else:
+        config = cloud_config.OpenStackConfig(
+            config_files=config_files).get_all()[0]
     # For inventory-wide caching
     cache_expiration_time = config.get_cache_expiration_time()
     cache_path = config.get_cache_path()


### PR DESCRIPTION
##### SUMMARY
The shift to openstacksdk left us with a bug in that when running bare
with --list, the cloud argument to get_one is None. We just need _one_
of the clouds to pull the cache settings, since they are global (yet,
we'll go back and fix this in sdk)

If it's None, just use get_all and grab the first one.

##### ISSUE TYPE
 - Bugfix Pull Request