### PR TITLE
Fixes the default assignment of values

### DIFF
--- a/lib/ansible/modules/network/f5/bigip_profile_client_ssl.py
+++ b/lib/ansible/modules/network/f5/bigip_profile_client_ssl.py
@@ -33,7 +33,7 @@ options:
   ciphers:
     description:
       - Specifies the list of ciphers that the system supports. When creating a new
-        profile, the default cipher list is C(DEFAULT).
+        profile, the default cipher list is provided by the parent profile.
   cert_key_chain:
     description:
       - One or more certificates and keys to associate with the SSL profile. This
@@ -402,8 +402,6 @@ class ModuleManager(object):
 
     def create(self):
         self._set_changed_options()
-        if self.want.ciphers is None:
-            self.want.update({'ciphers': 'DEFAULT'})
         if self.module.check_mode:
             return True
         self.create_on_device()

--- a/test/units/modules/network/f5/test_bigip_profile_client_ssl.py
+++ b/test/units/modules/network/f5/test_bigip_profile_client_ssl.py
@@ -107,7 +107,7 @@ class TestManager(unittest.TestCase):
                     chain='bigip_ssl_cert1'
                 )
             ],
-            password='passsword',
+            password='password',
             server='localhost',
             user='admin'
         ))


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
Fixes: #41640

The defaults should be inherited from the parent during initial
creation. This patch fixes that.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
bigip_profile_client_ssl

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0
  config file = None
  configured module search path = ['/root/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python3.6/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 3.6.5 (default, May  5 2018, 03:09:35) [GCC 4.9.2]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
