### PR TITLE
Include "_facts" in module name (examples section)

### DIFF
--- a/lib/ansible/modules/cloud/amazon/cloudwatchlogs_log_group_facts.py
+++ b/lib/ansible/modules/cloud/amazon/cloudwatchlogs_log_group_facts.py
@@ -30,7 +30,7 @@ extends_documentation_fragment:
 
 EXAMPLES = '''
 # Note: These examples do not set authentication details, see the AWS Guide for details.
-- cloudwatchlogs_log_group:
+- cloudwatchlogs_log_group_facts:
     log_group_name: test-log-group
 '''
 


### PR DESCRIPTION
+label: docsite_pr

##### SUMMARY
The example says module name: "cloudwatchlogs_log_group"
where it should say: "cloudwatchlogs_log_group_facts"

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
cloudwatchlogs_log_group_facts

##### ANSIBLE VERSION
2.5.0

#####  REPRODUCE
Running the example as it currently is, will in fact create a new log group
The commandline equivalent:
`$ ansible localhost  -m cloudwatchlogs_log_group -a "log_group_name=createThisLogGroup"`

Whereas the following will output facts on log groups:
`$ ansible localhost  -m cloudwatchlogs_log_group_facts -a "log_group_name=/aws/rds"`
