### PR TITLE
fix assign_public ip for ecs_service

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ecs_service.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_service.py
@@ -102,6 +102,7 @@ options:
           - network configuration of the service. Only applicable for task definitions created with C(awsvpc) I(network_mode).
           - I(network_configuration) has two keys, I(subnets), a list of subnet IDs to which the task is attached and I(security_groups),
             a list of group names or group IDs for the task
+          - assign_public_ip requires botocore >= 1.8.4
         version_added: 2.6
     launch_type:
         description:
@@ -285,6 +286,7 @@ ansible_facts:
             type: complex
 '''
 import time
+import distutils.version
 
 DEPLOYMENT_CONFIGURATION_TYPE_MAP = {
     'maximum_percent': 'int',
@@ -311,6 +313,7 @@ class EcsServiceManager:
 
     def format_network_configuration(self, network_config):
         result = dict()
+        botocore_version = distutils.version.StrictVersion(botocore.__version__)
         if 'subnets' in network_config:
             result['subnets'] = network_config['subnets']
         else:
@@ -324,6 +327,10 @@ class EcsServiceManager:
                 except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
                     self.module.fail_json_aws(e, msg="Couldn't look up security groups")
             result['securityGroups'] = groups
+        if 'assign_public_ip' in network_config and botocore_version >= distutils.version.StrictVersion('1.8.4'):
+            result['assign_public_ip'] = 'assign_public_ip'
+        else:
+            self.module.fail_json(msg='botocore needs to be version 1.8.4 or higher to use assign_public_ip in network_configuration')
         return dict(awsvpcConfiguration=result)
 
     def find_in_array(self, array_of_services, service_name, field_name='serviceArn'):

--- a/lib/ansible/modules/cloud/amazon/ecs_service.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_service.py
@@ -286,7 +286,6 @@ ansible_facts:
             type: complex
 '''
 import time
-import distutils.version
 
 DEPLOYMENT_CONFIGURATION_TYPE_MAP = {
     'maximum_percent': 'int',
@@ -313,7 +312,6 @@ class EcsServiceManager:
 
     def format_network_configuration(self, network_config):
         result = dict()
-        botocore_version = distutils.version.StrictVersion(botocore.__version__)
         if 'subnets' in network_config:
             result['subnets'] = network_config['subnets']
         else:
@@ -327,7 +325,7 @@ class EcsServiceManager:
                 except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
                     self.module.fail_json_aws(e, msg="Couldn't look up security groups")
             result['securityGroups'] = groups
-        if 'assign_public_ip' in network_config and botocore_version >= distutils.version.StrictVersion('1.8.4'):
+        if 'assign_public_ip' in network_config and self.module.botocore_at_least('1.8.4'):
             result['assign_public_ip'] = 'assign_public_ip'
         else:
             self.module.fail_json(msg='botocore needs to be version 1.8.4 or higher to use assign_public_ip in network_configuration')

--- a/test/integration/targets/ecs_cluster/playbooks/network_assign_public_ip_fail.yml
+++ b/test/integration/targets/ecs_cluster/playbooks/network_assign_public_ip_fail.yml
@@ -1,0 +1,129 @@
+- hosts: localhost
+  connection: local
+  vars:
+     resource_prefix: 'ansible-testing'
+
+  tasks:
+    - block:
+        - name: set up aws connection info
+          set_fact:
+            aws_connection_info: &aws_connection_info
+              aws_access_key: "{{ aws_access_key }}"
+              aws_secret_key: "{{ aws_secret_key }}"
+              security_token: "{{ security_token }}"
+              region: "{{ aws_region }}"
+          no_log: True
+
+        - name: create ecs cluster
+          ecs_cluster:
+            name: "{{ resource_prefix }}"
+            state: present
+            <<: *aws_connection_info
+
+        - name: create ecs_taskdefinition with bridged network
+          ecs_taskdefinition:
+            containers:
+              - name: my_container
+                image: ubuntu
+                memory: 128
+            family: "{{ resource_prefix }}"
+            state: present
+            network_mode: bridge
+            <<: *aws_connection_info
+          register: ecs_taskdefinition_creation
+
+        - name: create ecs_taskdefinition with awsvpc network
+          ecs_taskdefinition:
+            containers:
+              - name: my_container
+                image: ubuntu
+                memory: 128
+            family: "{{ resource_prefix }}-vpc"
+            state: present
+            network_mode: awsvpc
+            <<: *aws_connection_info
+          register: ecs_taskdefinition_creation_vpc
+
+        - name: ecs_taskdefinition works fine even when older botocore is used
+          assert:
+            that:
+              - ecs_taskdefinition_creation_vpc.changed
+
+        - name: create ecs_service using awsvpc network_configuration
+          ecs_service:
+            name: "{{ resource_prefix }}-vpc"
+            cluster: "{{ resource_prefix }}"
+            task_definition: "{{ resource_prefix }}-vpc"
+            desired_count: 1
+            network_configuration:
+              subnets:
+                - subnet-abcd1234
+              groups:
+                - sg-abcd1234
+              assign_public_ip: true
+            state: present
+            <<: *aws_connection_info
+          register: ecs_service_creation_vpc
+          ignore_errors: yes
+
+        - name: check that graceful failure message is returned from ecs_service
+          assert:
+            that:
+              - ecs_service_creation_vpc.failed
+              - 'ecs_service_creation_vpc.msg == "botocore needs to be version 1.8.4 or higher to use assign_public_ip in network_configuration"'
+
+      always:
+        - name: scale down ecs service
+          ecs_service:
+            name: "{{ resource_prefix }}"
+            cluster: "{{ resource_prefix }}"
+            task_definition: "{{ resource_prefix }}"
+            desired_count: 0
+            state: present
+            <<: *aws_connection_info
+          ignore_errors: yes
+
+        - name: pause to wait for scale down
+          pause:
+            seconds: 30
+
+        - name: remove ecs service
+          ecs_service:
+            name: "{{ resource_prefix }}"
+            cluster: "{{ resource_prefix }}"
+            task_definition: "{{ resource_prefix }}"
+            desired_count: 1
+            state: absent
+            <<: *aws_connection_info
+          ignore_errors: yes
+
+        - name: remove ecs task definition
+          ecs_taskdefinition:
+            containers:
+              - name: my_container
+                image: ubuntu
+                memory: 128
+            family: "{{ resource_prefix }}"
+            revision: "{{ ecs_taskdefinition_creation.taskdefinition.revision }}"
+            state: absent
+            <<: *aws_connection_info
+          ignore_errors: yes
+
+        - name: remove ecs task definition vpc
+          ecs_taskdefinition:
+            containers:
+              - name: my_container
+                image: ubuntu
+                memory: 128
+            family: "{{ resource_prefix }}-vpc"
+            revision: "{{ ecs_taskdefinition_creation_vpc.taskdefinition.revision }}"
+            state: absent
+            <<: *aws_connection_info
+          ignore_errors: yes
+
+        - name: remove ecs cluster
+          ecs_cluster:
+            name: "{{ resource_prefix }}"
+            state: absent
+            <<: *aws_connection_info
+          ignore_errors: yes

--- a/test/integration/targets/ecs_cluster/runme.sh
+++ b/test/integration/targets/ecs_cluster/runme.sh
@@ -18,6 +18,13 @@ source "${MYTMPDIR}/botocore-1.7.40/bin/activate"
 $PYTHON -m pip install 'botocore<=1.7.40' boto3
 ansible-playbook -i ../../inventory -e @../../integration_config.yml -e @../../cloud-config-aws.yml -v playbooks/network_fail.yml "$@"
 
+# Test graceful failure for assign public ip
+# applies for botocore >= 1.7.44 and < 1.8.4
+virtualenv --system-site-packages --python "${PYTHON}" "${MYTMPDIR}/botocore-1.7.44"
+source "${MYTMPDIR}/botocore-1.7.44/bin/activate"
+$PYTHON -m pip install 'botocore>=1.7.44,<1.8.4' boto3
+ansible-playbook -i ../../inventory -e @../../integration_config.yml -e @../../cloud-config-aws.yml -v playbooks/network_assign_public_ip_fail.yml "$@"
+
 # Run full test suite
 virtualenv --system-site-packages --python "${PYTHON}" "${MYTMPDIR}/botocore-recent"
 source "${MYTMPDIR}/botocore-recent/bin/activate"


### PR DESCRIPTION
##### SUMMARY
ecs_service.py: "network_configuration" for "awsvpc" is missing "assign_public_ip"  #41291

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/ecs_service.py

##### ANSIBLE VERSION
```
ansible 2.7.0.dev0 (fix/EcsServiceAutoAssignPublicIP 4f159fe36a) last updated 2018/06/19 13:21:17 (GMT +200)
  config file = None
  configured module search path = [u'/Users/deepak/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/deepak/devel/python/ansible/lib/ansible
  executable location = /Users/deepak/devel/python/ansible/bin/ansible
  python version = 2.7.10 (default, Oct  6 2017, 22:29:07) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.31)]
```
