### PR TITLE
Fix aws_config_aggregator argument count error

### DIFF
--- a/lib/ansible/modules/cloud/amazon/aws_config_aggregator.py
+++ b/lib/ansible/modules/cloud/amazon/aws_config_aggregator.py
@@ -90,7 +90,7 @@ from ansible.module_utils.ec2 import boto3_conn, get_aws_connection_info, AWSRet
 from ansible.module_utils.ec2 import camel_dict_to_snake_dict, boto3_tag_list_to_ansible_dict
 
 
-def resource_exists(client, module, resource_type, params):
+def resource_exists(client, module, params):
     try:
         aggregator = client.describe_configuration_aggregators(
             ConfigurationAggregatorNames=[params['name']]


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

The `resource_exists` function accepted the wrong number of arguments and would raise an error when called.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
aws_config_aggregator

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
