### PR TITLE
[aws] Remove double-defined variable from iam_policy module

### DIFF
--- a/lib/ansible/modules/cloud/amazon/iam_policy.py
+++ b/lib/ansible/modules/cloud/amazon/iam_policy.py
@@ -286,7 +286,6 @@ def main():
     if not HAS_BOTO:
         module.fail_json(msg='boto required for this module')
 
-    state = module.params.get('state').lower()
     iam_type = module.params.get('iam_type').lower()
     state = module.params.get('state')
     name = module.params.get('iam_name')


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
Raised by [lgtm](https://lgtm.com/projects/g/ansible/ansible/latest/files/lib/ansible/modules/cloud/amazon/iam_policy.py?sort=alerts&dir=DESC&mode=heatmap&showExcluded=false) testing. 

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
iam_policy

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
