### PR TITLE
Clean internal variables from results['ansible_facts']

### DIFF
--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -624,7 +624,8 @@ class TaskExecutor:
                 else:
                     vars_copy.update(namespace_facts(result['ansible_facts']))
                     if C.INJECT_FACTS_AS_VARS:
-                        vars_copy.update(clean_facts(result['ansible_facts']))
+                        result['ansible_facts'] = clean_facts(result['ansible_facts'])
+                        vars_copy.update(result['ansible_facts'])
 
             # set the failed property if it was missing.
             if 'failed' not in result:
@@ -685,7 +686,8 @@ class TaskExecutor:
             else:
                 variables.update(namespace_facts(result['ansible_facts']))
                 if C.INJECT_FACTS_AS_VARS:
-                    variables.update(clean_facts(result['ansible_facts']))
+                    result['ansible_facts'] = clean_facts(result['ansible_facts'])
+                    variables.update(result['ansible_facts'])
 
         # save the notification target in the result, if it was specified, as
         # this task may be running in a loop in which case the notification


### PR DESCRIPTION
Fixes #41684

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This change ensures that we run clean_facts on all the ansible_facts in the task result (not just in the task variables) before returning it so that we strip all internal variables that might conflict with the internal ansible ones.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
task_executor

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (devel 0f1114fd78) last updated 2018/06/19 17:30:50 (GMT +100)
  config file = None
  configured module search path = [u'/home/sam/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/sam/Work/src/github.com/ansible/ansible/lib/ansible
  executable location = /home/sam/pythonEnv/bin/ansible
  python version = 2.7.12+ (default, Sep  1 2016, 20:27:38) [GCC 6.2.0 20160927]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
