### PR TITLE
[aws] Remove unused return in ec2_vpc_dhcp_option_facts module

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_dhcp_option_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_dhcp_option_facts.py
@@ -108,10 +108,8 @@ def list_dhcp_options(client, module):
         module.fail_json(msg=str(e), exception=traceback.format_exc(),
                          **camel_dict_to_snake_dict(e.response))
 
-    results = [camel_dict_to_snake_dict(get_dhcp_options_info(option))
-               for option in all_dhcp_options['DhcpOptions']]
-
-    module.exit_json(dhcp_options=results)
+    return [camel_dict_to_snake_dict(get_dhcp_options_info(option))
+            for option in all_dhcp_options['DhcpOptions']]
 
 
 def main():
@@ -144,7 +142,7 @@ def main():
     # call your function here
     results = list_dhcp_options(connection, module)
 
-    module.exit_json(result=results)
+    module.exit_json(dhcp_options=results)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
Issue raised by LGTM

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
ec2_vpc_dhcp_option_facts

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
