### PR TITLE
Support `--separate-git-dir` option in Git module

### DIFF
--- a/lib/ansible/modules/source_control/git.py
+++ b/lib/ansible/modules/source_control/git.py
@@ -443,6 +443,8 @@ def clone(git_path, module, repo, dest, remote, depth, version, bare,
         module.warn("Ignoring separate_git_dir argument. "
                     "Can not do bare clone with argument separate_git_dir.")
     elif separate_git_dir:
+        if os.path.exists(os.path.abspath(separate_git_dir)):
+            module.fail_json(msg='Separate-git-dir path %s already exists.' % os.path.abspath(separate_git_dir))
         git_version_used = git_version(git_path, module)
         if git_version_used is None:
             module.fail_json(msg='Can not find git executable at %s' % git_path)

--- a/lib/ansible/modules/source_control/git.py
+++ b/lib/ansible/modules/source_control/git.py
@@ -163,7 +163,7 @@ options:
 
     separate_git_dir:
         description:
-            - The path to place the cloned repository. If specified, Git repository 
+            - The path to place the cloned repository. If specified, Git repository
               can be separated from working tree.
         version_added: "2.7"
 
@@ -445,8 +445,8 @@ def clone(git_path, module, repo, dest, remote, depth, version, bare,
     elif separate_git_dir:
         git_version_used = git_version(git_path, module)
         if git_version_used is None:
-            raise AnsibleError("Can not find git executable.")
-        if git_version_used > LooseVersion('1.7.5'):
+            module.fail_json(msg='Can not find git executable at %s' % git_path)
+        if git_version_used < LooseVersion('1.7.5'):
             # git before 1.7.5 doesn't have separate-git-dir argument, do fallback
             separate_git_dir_fallback = True
         else:
@@ -477,7 +477,7 @@ def clone(git_path, module, repo, dest, remote, depth, version, bare,
             dot_git_file.write("gitdir: %s" % separate_git_dir)
             dot_git_file.close()
         except IOError:
-            raise AnsibleError("Can not create and write .git file!")
+            module.fail_json(msg='Unable to create and wirte %s' % os.path.join(dest, '.git'))
 
 
 def has_local_mods(module, git_path, dest, bare):

--- a/lib/ansible/modules/source_control/git.py
+++ b/lib/ansible/modules/source_control/git.py
@@ -258,12 +258,10 @@ from ansible.module_utils._text import to_native
 
 def separate_repo_fallback(module, separate_git_dir, dest):
     separate_git_dir = os.path.abspath(separate_git_dir)
-    fallback_cmd = ['mv', os.path.join(dest, '.git'), separate_git_dir]
-    module.run_command(fallback_cmd, check_rc=True, cwd=dest)
+    shutil.move(os.path.join(dest, '.git'), separate_git_dir)
     try:
-        dot_git_file = open(os.path.join(dest, ".git"), "w")
-        dot_git_file.write("gitdir: %s" % separate_git_dir)
-        dot_git_file.close()
+        with open(os.path.join(dest, '.git'), 'w') as dot_git_file:
+            dot_git_file.write('gitdir: %s' % separate_git_dir)
     except IOError:
         module.fail_json(msg='Unable to create and wirte %s' % os.path.join(dest, '.git'))
 
@@ -424,7 +422,6 @@ def get_submodule_versions(git_path, module, dest, version='HEAD'):
 def clone(git_path, module, repo, dest, remote, depth, version, bare,
           reference, refspec, verify_commit, separate_git_dir):
     ''' makes a new git repo if it does not already exist '''
-
     dest_dirname = os.path.dirname(dest)
     try:
         os.makedirs(dest_dirname)
@@ -465,7 +462,7 @@ def clone(git_path, module, repo, dest, remote, depth, version, bare,
             separate_git_dir_fallback = True
         else:
             separate_git_dir = os.path.abspath(separate_git_dir)
-            cmd.extend(['--separate-git-dir=%s' % separate_git_dir])
+            cmd.append('--separate-git-dir=%s' % separate_git_dir)
 
     cmd.extend([repo, dest])
     module.run_command(cmd, check_rc=True, cwd=dest_dirname)

--- a/lib/ansible/modules/source_control/git.py
+++ b/lib/ansible/modules/source_control/git.py
@@ -1062,7 +1062,7 @@ def main():
         module.warn("Ignoring separate_git_dir argument. "
                     "Can not do bare clone with argument separate_git_dir.")
         separate_git_dir = None
-    else:
+    elif separate_git_dir:
         separate_git_dir = os.path.abspath(separate_git_dir)
 
     gitconfig = None

--- a/lib/ansible/modules/source_control/git.py
+++ b/lib/ansible/modules/source_control/git.py
@@ -262,9 +262,9 @@ def relocate_repo(module, repo_dir, old_repo_dir, worktree_dir=None):
     if worktree_dir:
         dot_git_file_path = os.path.join(worktree_dir, '.git')
         try:
+            shutil.move(old_repo_dir, repo_dir)
             with open(dot_git_file_path, 'w') as dot_git_file:
                 dot_git_file.write('gitdir: %s' % repo_dir)
-            shutil.move(old_repo_dir, repo_dir)
         except (IOError, OSError) as err:
             module.fail_json(msg='Unable to move git dir. %s' % str(err))
 
@@ -1060,7 +1060,7 @@ def main():
     module.run_command_environ_update = dict(LANG='C', LC_ALL='C', LC_MESSAGES='C', LC_CTYPE='C')
 
     if separate_git_dir:
-        separate_git_dir = os.path.abspath(separate_git_dir)
+        separate_git_dir = os.path.realpath(separate_git_dir)
 
     gitconfig = None
     if not dest and allow_clone:
@@ -1072,7 +1072,6 @@ def main():
             if separate_git_dir and os.path.exists(repo_path) and separate_git_dir != repo_path:
                 result.update(changed=True)
                 if not module.check_mode:
-                    module.warn("***********%s and %s**********" % (separate_git_dir, repo_path))
                     relocate_repo(module, separate_git_dir, repo_path, dest)
                     repo_path = separate_git_dir
         except (IOError, ValueError) as err:

--- a/lib/ansible/modules/source_control/git.py
+++ b/lib/ansible/modules/source_control/git.py
@@ -1007,7 +1007,7 @@ def main():
             archive=dict(type='path'),
             separate_git_dir=dict(type='path'),
         ),
-        mutually_exclusive=['separate_git_dir', ''],
+        mutually_exclusive=['separate_git_dir', 'bare'],
         supports_check_mode=True
     )
 

--- a/lib/ansible/modules/source_control/git.py
+++ b/lib/ansible/modules/source_control/git.py
@@ -267,6 +267,9 @@ def relocate_repo(module, repo_dir, old_repo_dir, worktree_dir=None):
                 dot_git_file.write('gitdir: %s' % repo_dir)
         except (IOError, OSError) as err:
             module.fail_json(msg='Unable to move git dir. %s' % str(err))
+            # if we already moved the .git dir, roll it back
+            if os.path.exists(repo_dir):
+                shutil.move(repo_dir, old_repo_dir)
 
 
 def head_splitter(headfile, remote, module=None, fail_on_error=False):

--- a/lib/ansible/modules/source_control/git.py
+++ b/lib/ansible/modules/source_control/git.py
@@ -216,6 +216,11 @@ EXAMPLES = '''
     dest: /src/ansible-examples
     archive: /tmp/ansible-examples.zip
 
+# Example clone a repo with separate git directory
+- git:
+    repo: https://github.com/ansible/ansible-examples.git
+    dest: /src/ansible-examples
+    separate_git_dir: /src/ansible-examples.git
 '''
 
 RETURN = '''

--- a/lib/ansible/modules/source_control/git.py
+++ b/lib/ansible/modules/source_control/git.py
@@ -278,10 +278,10 @@ def relocate_repo(module, result, repo_dir, old_repo_dir, worktree_dir):
             result['old_git_dir'] = old_repo_dir
             result['new_git_dir'] = repo_dir
         except (IOError, OSError) as err:
-            module.fail_json(msg='Unable to move git dir. %s' % str(err))
             # if we already moved the .git dir, roll it back
             if os.path.exists(repo_dir):
                 shutil.move(repo_dir, old_repo_dir)
+            module.fail_json(msg='Unable to move git dir. %s' % str(err))
 
 
 def head_splitter(headfile, remote, module=None, fail_on_error=False):

--- a/lib/ansible/modules/source_control/git.py
+++ b/lib/ansible/modules/source_control/git.py
@@ -442,7 +442,7 @@ def get_submodule_versions(git_path, module, dest, version='HEAD'):
     return submodules
 
 
-def clone(git_path, module, repo, dest, remote, depth, version, bare,
+def clone(git_path, module, result, repo, dest, remote, depth, version, bare,
           reference, refspec, verify_commit, separate_git_dir):
     ''' makes a new git repo if it does not already exist '''
     dest_dirname = os.path.dirname(dest)
@@ -1137,7 +1137,7 @@ def main():
                     result['diff'] = diff
             module.exit_json(**result)
         # there's no git config, so clone
-        clone(git_path, module, repo, dest, remote, depth, version, bare, reference, refspec, verify_commit, separate_git_dir)
+        clone(git_path, module, result, repo, dest, remote, depth, version, bare, reference, refspec, verify_commit, separate_git_dir)
     elif not update:
         # Just return having found a repo already in the dest path
         # this does no checking that the repo is the actual repo

--- a/test/integration/targets/git/tasks/main.yml
+++ b/test/integration/targets/git/tasks/main.yml
@@ -37,5 +37,3 @@
 - include_tasks: ambiguous-ref.yml
 - include_tasks: archive.yml
 - include_tasks: separate-git-dir.yml
-  when:
-    - git_version.stdout is version("1.7.5", '>=')

--- a/test/integration/targets/git/tasks/separate-git-dir.yml
+++ b/test/integration/targets/git/tasks/separate-git-dir.yml
@@ -12,12 +12,21 @@
   register: tempdir
 
 - name: SEPARATE-GIT-DIR | clone with a separate git dir
-  command: git clone {{ repo_format1 }} {{ checkout_dir }} --separate-git-dir={{ tempdir.stdout }}
+  git:
+    repo: '{{ repo_format1 }}'
+    dest: '{{ checkout_dir }}'
+    separate_git_dir: '{{ tempdir.stdout }}'
 
 - name: SEPARATE-GIT-DIR | update repo the usual way
   git:
     repo: "{{ repo_format1 }}"
     dest: "{{ checkout_dir }}"
+  register: result
+
+- name: SEPARATE-GIT-DIR | update should not fail
+  assert:
+    that:
+      - result is not failed
 
 - name: SEPARATE-GIT-DIR | set git dir to non-existent dir
   shell: "echo gitdir: /dev/null/non-existent-dir > .git"

--- a/test/integration/targets/git/tasks/separate-git-dir.yml
+++ b/test/integration/targets/git/tasks/separate-git-dir.yml
@@ -7,23 +7,82 @@
     state: absent
     path: '{{ checkout_dir }}'
 
-- name: create a tempdir for separate git dir
-  local_action: shell mktemp -du
-  register: tempdir
+- name: SEPARATE-GIT-DIR | make a pre-exist repo dir
+  file:
+    state: directory
+    path: '{{ separate_git_dir }}'
 
 - name: SEPARATE-GIT-DIR | clone with a separate git dir
   git:
     repo: '{{ repo_format1 }}'
     dest: '{{ checkout_dir }}'
-    separate_git_dir: '{{ tempdir.stdout }}'
+    separate_git_dir: '{{ separate_git_dir }}'
+  ignore_errors: yes
+  register: result
+
+- name: SEPARATE-GIT-DIR | the clone will fail due to pre-exist dir
+  assert:
+    that: 'result is failed'
+
+- name: SEPARATE-GIT-DIR | delete pre-exist dir
+  file:
+    state: absent
+    path: '{{ separate_git_dir }}'
+
+- name: SEPARATE-GIT-DIR | clone again with a separate git dir
+  git:
+    repo: '{{ repo_format1 }}'
+    dest: '{{ checkout_dir }}'
+    separate_git_dir: '{{ separate_git_dir }}'
+
+- name: SEPARATE-GIT-DIR | check the stat of git dir
+  stat:
+    path: '{{ separate_git_dir }}'
+  register: stat_result
+
+- name: SEPARATE-GIT-DIR | the git dir should exist
+  assert:
+    that: 'stat_result.stat.exists == True'
 
 - name: SEPARATE-GIT-DIR | update repo the usual way
   git:
-    repo: "{{ repo_format1 }}"
-    dest: "{{ checkout_dir }}"
+    repo: '{{ repo_format1 }}'
+    dest: '{{ checkout_dir }}'
+    separate_git_dir: '{{ separate_git_dir }}'
   register: result
 
 - name: SEPARATE-GIT-DIR | update should not fail
+  assert:
+    that:
+      - result is not failed
+
+- name: SEPARATE-GIT-DIR | move the git dir to new place
+  git:
+    repo: '{{ repo_format1 }}'
+    dest: '{{ checkout_dir }}'
+    separate_git_dir: '{{ separate_git_dir }}_new'
+  register: result
+
+- name: SEPARATE-GIT-DIR | the movement should not failed
+  assert:
+    that: 'result is not failed'
+
+- name: SEPARATE-GIT-DIR | check the stat of new git dir
+  stat:
+    path: '{{ separate_git_dir }}_new'
+  register: stat_result
+
+- name: SEPARATE-GIT-DIR | the new git dir should exist
+  assert:
+    that: 'stat_result.stat.exists == True'
+
+- name: SEPARATE-GIT-DIR | test the update
+  git:
+    repo: '{{ repo_format1 }}'
+    dest: '{{ checkout_dir }}'
+  register: result
+
+- name: SEPARATE-GIT-DIR | the update should not failed
   assert:
     that:
       - result is not failed
@@ -65,7 +124,7 @@
 - name: SEPARATE-GIT-DIR | clear separate git dir
   file:
     state: absent
-    path: "{{ tempdir.stdout }}"
+    path: "{{ separate_git_dir }}_new"
 
 - name: SEPARATE-GIT-DIR | clear checkout_dir
   file:

--- a/test/integration/targets/git/vars/main.yml
+++ b/test/integration/targets/git/vars/main.yml
@@ -11,6 +11,7 @@ git_archive_extensions:
 
 checkout_dir: '{{ output_dir }}/git'
 repo_dir: '{{ output_dir }}/local_repos'
+separate_git_dir: '{{ output_dir }}/sep_git_dir'
 repo_format1: 'https://github.com/jimi-c/test_role'
 repo_format2: 'git@github.com:jimi-c/test_role.git'
 repo_format3: 'ssh://git@github.com/jimi-c/test_role.git'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Make git module support `--separate-git-dir` option. When git version is higher than 1.7.5, use built-in `--separate-git-dir` option during the clone. When lower, adjust the location of git dir manually after clone to achieve the same effect.
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
Resolves #41611 
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
git.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (sep-git-dir ae723e1afd) last updated 2018/06/19 16:48:37 (GMT -400)
  config file = None
  configured module search path = [u'/home/zhikangzhang/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/zhikangzhang/Desktop/ansible/lib/ansible
  executable location = /home/zhikangzhang/Desktop/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 14 2018, 16:45:33) [GCC 8.0.1 20180222 (Red Hat 8.0.1-0.16)]
```
ADDITIONAL INFORMATION
```
- name: use sep-git-dir to indicate a separated git directory
  git:
    repo: 'https://github.com/ansible/ansible'
    dest: '/some/dest/path'
    separate_git_dir: '/some/other/path'

- name: use sep-git-dir again to move the existing .git dir
  git:
    repo: 'https://github.com/ansible/ansible'
    dest: '/some/dest/path'
    separate_git_dir: '/new/path/for/dot_git'
```