### PR TITLE
Fix ssh connection plugin hiding module errors with 255 exit code

### DIFF
--- a/changelogs/fragments/cleanup__file__.yaml
+++ b/changelogs/fragments/cleanup__file__.yaml
@@ -1,0 +1,6 @@
+---
+minor_changes:
+- The apt, ec2_elb_lb, elb_classic_lb, and unarchive modules have been ported
+  away from using __file__.  This is futureproofing as__file__ won't work if we
+  switch to using python -m to invoke modules in the future or if we figure out
+  a way to make a module never touch disk for pipelining purposes.

--- a/changelogs/fragments/fix-255-exit-code.yaml
+++ b/changelogs/fragments/fix-255-exit-code.yaml
@@ -1,0 +1,6 @@
+---
+bugfixes:
+- 'The ssh connection plugin was categorizing all 255 exit statuses as an ssh
+  error but modules can return exit code 255 as well.  The connection plugin
+  has now been changed to know that certain instances of exit code 255 are not
+  ssh-related.  (https://github.com/ansible/ansible/pull/41716)'

--- a/lib/ansible/modules/cloud/amazon/ec2_elb_lb.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_elb_lb.py
@@ -980,7 +980,7 @@ class ElbManager(object):
             self.elb_conn.modify_lb_attribute(self.name, 'ConnectingSettings', attributes.connecting_settings)
 
     def _policy_name(self, policy_type):
-        return __file__.split('/')[-1].split('.')[0].replace('_', '-') + '-' + policy_type
+        return 'ec2-elb-lb-{0}'.format(to_native(policy_type, errors='surrogate_or_strict'))
 
     def _create_policy(self, policy_param, policy_meth, policy):
         getattr(self.elb_conn, policy_meth)(policy_param, self.elb.name, policy)

--- a/lib/ansible/modules/cloud/amazon/elb_classic_lb.py
+++ b/lib/ansible/modules/cloud/amazon/elb_classic_lb.py
@@ -977,7 +977,7 @@ class ElbManager(object):
             self.elb_conn.modify_lb_attribute(self.name, 'ConnectingSettings', attributes.connecting_settings)
 
     def _policy_name(self, policy_type):
-        return __file__.split('/')[-1].split('.')[0].replace('_', '-') + '-' + policy_type
+        return 'elb-classic-lb-{0}'.format(to_native(policy_type, errors='surrogate_or_strict'))
 
     def _create_policy(self, policy_param, policy_meth, policy):
         getattr(self.elb_conn, policy_meth)(policy_param, self.elb.name, policy)

--- a/lib/ansible/modules/files/unarchive.py
+++ b/lib/ansible/modules/files/unarchive.py
@@ -817,8 +817,7 @@ def main():
             module.fail_json(msg="Source '%s' failed to transfer" % src)
         # If remote_src=true, and src= contains ://, try and download the file to a temp directory.
         elif '://' in src:
-            tempdir = os.path.dirname(os.path.realpath(__file__))
-            package = os.path.join(tempdir, str(src.rsplit('/', 1)[1]))
+            new_src = os.path.join(module.tmpdir, to_native(src.rsplit('/', 1)[1], errors='surrogate_or_strict'))
             try:
                 rsp, info = fetch_url(module, src)
                 # If download fails, raise a proper exception
@@ -826,7 +825,7 @@ def main():
                     raise Exception(info['msg'])
 
                 # open in binary mode for python3
-                f = open(package, 'wb')
+                f = open(new_src, 'wb')
                 # Read 1kb at a time to save on ram
                 while True:
                     data = rsp.read(BUFSIZE)
@@ -837,7 +836,7 @@ def main():
 
                     f.write(data)
                 f.close()
-                src = package
+                src = new_src
             except Exception as e:
                 module.fail_json(msg="Failure downloading %s, %s" % (src, to_native(e)))
         else:

--- a/lib/ansible/modules/packaging/os/apt.py
+++ b/lib/ansible/modules/packaging/os/apt.py
@@ -846,8 +846,7 @@ def upgrade(m, mode="yes", force=False, default_release=None,
 
 
 def download(module, deb):
-    tempdir = os.path.dirname(__file__)
-    package = os.path.join(tempdir, str(deb.rsplit('/', 1)[1]))
+    package = os.path.join(module.tmpdir, to_native(deb.rsplit('/', 1)[1], errors='surrogate_or_strict'))
     # When downloading a deb, how much of the deb to download before
     # saving to a tempfile (64k)
     BUFSIZE = 65536


### PR DESCRIPTION
<strike>Since we no longer have to support Python-2.4 on the client, we can now
use -m to invoke the ansible module. This is possible because of the
changes to the -m switch in PEP-0338:

https://www.python.org/dev/peps/pep-0338/

The change to the ssh connection plugin is because it is overzealous in
thinking that error code 255 can only come from ssh.  Python-2.6 can
return 255 in some circumstances and apparently any php error does as
well.

**IMPORTANT NOTE**: With this change, ```__file__``` referenced in the module changes.  It becomes an "offset" into the zipfile (/path/to/ansible_modlib.zip/ansible_module_ping.py for instance).  This is an incompatible change but it's not expected that most third party modules will be using that.  We'll have to decide whether this is an acceptable backwards incompatible break.</strike>

We found a way to only invoke python once ( https://github.com/ansible/ansible/pull/41749 ) so the -m portion of this PR is no longer necessary.

The removal of __file__ is still a nice cleanup and the ssh connection plugin fix for modules using exit code 255 is still good.

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME
* executor/module_common.py
* plugins/connection/ssh.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```