### PR TITLE
Raise Exception in virtualbox inventory plugin

### DIFF
--- a/changelogs/fragments/virtualbox_inventory.yaml
+++ b/changelogs/fragments/virtualbox_inventory.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+- Raise AnsibleParserError which was missing previously

--- a/lib/ansible/plugins/inventory/virtualbox.py
+++ b/lib/ansible/plugins/inventory/virtualbox.py
@@ -250,7 +250,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             try:
                 p = Popen(cmd, stdout=PIPE)
             except Exception as e:
-                AnsibleParserError(to_native(e))
+                raise AnsibleParserError(to_native(e))
 
             source_data = p.stdout.read().splitlines()
 


### PR DESCRIPTION

##### SUMMARY
Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

(cherry picked from commit 37293dec3dc528979412821f7c32a0ff69508814)

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/virtualbox_inventory.yaml
lib/ansible/plugins/inventory/virtualbox.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
Stable-2.6
```