### PR TITLE
Remove redundant API method from foreman inventory

### DIFF
--- a/contrib/inventory/foreman.py
+++ b/contrib/inventory/foreman.py
@@ -229,10 +229,6 @@ class ForemanInventory(object):
 
         return params
 
-    def _get_facts_by_id(self, hid):
-        url = "%s/api/v2/hosts/%s/facts" % (self.foreman_url, hid)
-        return self._get_json(url)
-
     def _get_facts(self, host):
         """Fetch all host facts of the host"""
         if not self.want_facts:


### PR DESCRIPTION
##### SUMMARY
Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
contrib/inventory/foreman.py

##### ANSIBLE VERSION
```
2.7-devel
```