### PR TITLE
Added example on consul_kv.py with remote Consul server with ACL enabled.

### DIFF
--- a/lib/ansible/plugins/lookup/consul_kv.py
+++ b/lib/ansible/plugins/lookup/consul_kv.py
@@ -56,7 +56,7 @@ EXAMPLES = """
       
   - name: retrieving a KV from a remote cluster on non default port with ACL enabled
     debug:
-      msg: "{{ lookup('consul_kv', 'my/key', host='10.10.10.10 token=a20f2009-a1cf-4e19-8286-0632ea3bcad6', port='2000') }}"
+      msg: "{{ lookup('consul_kv', 'my/key', host='10.10.10.10 token=a20f2009-a1cf-4e19-8286-0632ea3bcad6 recurse=yes', port='2000') }}"
 """
 
 RETURN = """

--- a/lib/ansible/plugins/lookup/consul_kv.py
+++ b/lib/ansible/plugins/lookup/consul_kv.py
@@ -53,6 +53,10 @@ EXAMPLES = """
   - name: retrieving a KV from a remote cluster on non default port
     debug:
       msg: "{{ lookup('consul_kv', 'my/key', host='10.10.10.10', port='2000') }}"
+      
+  - name: retrieving a KV from a remote cluster on non default port with ACL enabled
+    debug:
+      msg: "{{ lookup('consul_kv', 'my/key', host='10.10.10.10 token=a20f2009-a1cf-4e19-8286-0632ea3bcad6', port='2000') }}"
 """
 
 RETURN = """

--- a/lib/ansible/plugins/lookup/consul_kv.py
+++ b/lib/ansible/plugins/lookup/consul_kv.py
@@ -53,7 +53,7 @@ EXAMPLES = """
   - name: retrieving a KV from a remote cluster on non default port
     debug:
       msg: "{{ lookup('consul_kv', 'my/key', host='10.10.10.10', port='2000') }}"
-      
+
   - name: retrieving a KV from a remote cluster on non default port with ACL enabled
     debug:
       msg: "{{ lookup('consul_kv', 'my/key', host='10.10.10.10 token=a20f2009-a1cf-4e19-8286-0632ea3bcad6 recurse=yes', port='2000') }}"


### PR DESCRIPTION
##### SUMMARY
There is no information about retreiving information from Consul from a remote server with ACL enabled.
Currently there is a mix in the lookup section, as you definde "host", "port" and "key" but if token is needed it goes inside "key" parameter as showned below

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
consul module

##### ANSIBLE VERSION
```
ansible 2.5.2
  config file = None
  configured module search path = [u'/home/user/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION
Said in summary, is an additional example using token ACL with consul_kv lookup

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
ansible-playbook -i inventory consul_kv_test.yml
```
