### PR TITLE
Backport 2.6: apt: fix apt-mark on debian6

### DIFF
--- a/changelogs/fragments/41530-apt-mark-deb6.yaml
+++ b/changelogs/fragments/41530-apt-mark-deb6.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - apt: fix apt-mark on debian6 (https://github.com/ansible/ansible/pull/41530)

--- a/changelogs/fragments/41530-apt-mark-deb6.yaml
+++ b/changelogs/fragments/41530-apt-mark-deb6.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - apt: fix apt-mark on debian6 (https://github.com/ansible/ansible/pull/41530)
+  - fix apt-mark on debian6 (https://github.com/ansible/ansible/pull/41530)

--- a/lib/ansible/modules/packaging/os/apt.py
+++ b/lib/ansible/modules/packaging/os/apt.py
@@ -286,6 +286,7 @@ APTITUDE_ZERO = "\n0 packages upgraded, 0 newly installed"
 APT_LISTS_PATH = "/var/lib/apt/lists"
 APT_UPDATE_SUCCESS_STAMP_PATH = "/var/lib/apt/periodic/update-success-stamp"
 APT_MARK_INVALID_OP = 'Invalid operation'
+APT_MARK_INVALID_OP_DEB6 = 'Usage: apt-mark [options] {markauto|unmarkauto} packages'
 
 CLEAN_OP_CHANGED_STR = dict(
     autoremove='The following packages will be REMOVED',
@@ -502,7 +503,7 @@ def mark_installed_manually(m, packages):
     cmd = "%s manual %s" % (apt_mark_cmd_path, ' '.join(packages))
     rc, out, err = m.run_command(cmd)
 
-    if APT_MARK_INVALID_OP in err:
+    if APT_MARK_INVALID_OP in err or APT_MARK_INVALID_OP_DEB6 in err:
         cmd = "%s unmarkauto %s" % (apt_mark_cmd_path, ' '.join(packages))
         rc, out, err = m.run_command(cmd)
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
https://github.com/ansible/ansible/pull/41530
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
apt

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6
```


##### ADDITIONAL INFORMATION