### PR TITLE
meraki_config_template - Remove extraneous json.loads() which was moved to the utility.

### DIFF
--- a/lib/ansible/modules/network/meraki/meraki_config_template.py
+++ b/lib/ansible/modules/network/meraki/meraki_config_template.py
@@ -111,7 +111,7 @@ def delete_template(meraki, org_id, name, data):
     path = meraki.construct_path('delete', org_id=org_id)
     path = path + '/' + template_id
     response = meraki.request(path, 'DELETE')
-    return json.loads(response)
+    return response
 
 
 def bind(meraki, org_name, net_name, name, data):


### PR DESCRIPTION
##### SUMMARY
The `meraki_config_template` module has a line which uses `json.loads()` for a HTTP call. This functionality was moved to the utility so this is causing an error. Removing the `loads()` call fixes the problem.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
meraki_config_template

##### ANSIBLE VERSION
```
ansible 2.7.0.dev0 (meraki/config_template_loads_fix 5f7b66d202) last updated 2018/06/20 09:00:18 (GMT -500)
  config file = None
  configured module search path = ['/Users/kbreit/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/kbreit/Documents/Programming/ansible/lib/ansible
  executable location = /Users/kbreit/Documents/Programming/ansible/bin/ansible
  python version = 3.5.4 (default, Feb 25 2018, 14:56:02) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```