### PR TITLE
Backport - Remove notes since it's already specified in the doc fragment

### DIFF
--- a/lib/ansible/modules/network/meraki/meraki_admin.py
+++ b/lib/ansible/modules/network/meraki/meraki_admin.py
@@ -20,9 +20,6 @@ short_description: Manage administrators in the Meraki cloud
 version_added: '2.6'
 description:
 - Allows for creation, management, and visibility into administrators within Meraki.
-notes:
-- More information about the Meraki API can be found at U(https://dashboard.meraki.com/api_docs).
-- Some of the options are likely only used for developers within Meraki.
 options:
     name:
         description:

--- a/lib/ansible/modules/network/meraki/meraki_network.py
+++ b/lib/ansible/modules/network/meraki/meraki_network.py
@@ -21,10 +21,6 @@ version_added: "2.6"
 description:
 - Allows for creation, management, and visibility into networks within Meraki.
 
-notes:
-- More information about the Meraki API can be found at U(https://dashboard.meraki.com/api_docs).
-- Some of the options are likely only used for developers within Meraki.
-
 options:
     auth_key:
         description:

--- a/lib/ansible/modules/network/meraki/meraki_organization.py
+++ b/lib/ansible/modules/network/meraki/meraki_organization.py
@@ -20,9 +20,6 @@ short_description: Manage organizations in the Meraki cloud
 version_added: "2.6"
 description:
 - Allows for creation, management, and visibility into organizations within Meraki.
-notes:
-- More information about the Meraki API can be found at U(https://dashboard.meraki.com/api_docs).
-- Some of the options are likely only used for developers within Meraki.
 options:
     state:
         description:

--- a/lib/ansible/modules/network/meraki/meraki_snmp.py
+++ b/lib/ansible/modules/network/meraki/meraki_snmp.py
@@ -20,9 +20,6 @@ short_description: Manage organizations in the Meraki cloud
 version_added: "2.6"
 description:
 - Allows for management of SNMP settings for Meraki.
-notes:
-- More information about the Meraki API can be found at U(https://dashboard.meraki.com/api_docs).
-- Some of the options are likely only used for developers within Meraki.
 options:
     state:
         description:


### PR DESCRIPTION
##### SUMMARY
Backport of #41614 which fixes notes in the documentation

(cherry picked from commit 12a4dd44b59e35718524aafb52bae9e7705c168e)

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
meraki_organization
meraki_snmp
meraki_network
meraki_admin

##### ANSIBLE VERSION
```
ansible 2.6.0rc3.dev0 (backport/2.6/41614 b42619d4cb) last updated 2018/06/20 09:38:19 (GMT -500)
  config file = None
  configured module search path = ['/Users/kbreit/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/kbreit/Documents/Programming/ansible/lib/ansible
  executable location = /Users/kbreit/Documents/Programming/ansible/bin/ansible
  python version = 3.5.4 (default, Feb 25 2018, 14:56:02) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```