### PR TITLE
Remove an unnecessary import from the ansiballz wrapper

### DIFF
--- a/changelogs/fragments/ansiballz_streamline_imports.yaml
+++ b/changelogs/fragments/ansiballz_streamline_imports.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+- Removed an unnecessary import from the AnsiballZ wrapper

--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -143,12 +143,6 @@ if sys.version_info < (3,):
 else:
     unicode = str
     PY3 = True
-try:
-    # Python-2.6+
-    from io import BytesIO as IOStream
-except ImportError:
-    # Python < 2.6
-    from StringIO import StringIO as IOStream
 
 ZIPDATA = """%(zipdata)s"""
 


### PR DESCRIPTION
##### SUMMARY
There was an import in the AnsiballZ wrapper that was unused.  Probably was an early experiment in streaming the module and module_utils code to the second python invocation which wasn't removed when the experiment failed.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/executor/module_common.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```