### PR TITLE
Marks select modules as stableinterface (#41741)

### DIFF
--- a/lib/ansible/modules/network/f5/bigip_command.py
+++ b/lib/ansible/modules/network/f5/bigip_command.py
@@ -9,7 +9,7 @@ __metaclass__ = type
 
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
+                    'status': ['stableinterface'],
                     'supported_by': 'community'}
 
 DOCUMENTATION = r'''

--- a/lib/ansible/modules/network/f5/bigip_configsync_action.py
+++ b/lib/ansible/modules/network/f5/bigip_configsync_action.py
@@ -9,7 +9,7 @@ __metaclass__ = type
 
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
+                    'status': ['stableinterface'],
                     'supported_by': 'community'}
 
 DOCUMENTATION = r'''

--- a/lib/ansible/modules/network/f5/bigip_device_connectivity.py
+++ b/lib/ansible/modules/network/f5/bigip_device_connectivity.py
@@ -9,7 +9,7 @@ __metaclass__ = type
 
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
+                    'status': ['stableinterface'],
                     'supported_by': 'community'}
 
 DOCUMENTATION = r'''

--- a/lib/ansible/modules/network/f5/bigip_device_dns.py
+++ b/lib/ansible/modules/network/f5/bigip_device_dns.py
@@ -9,7 +9,7 @@ __metaclass__ = type
 
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
+                    'status': ['stableinterface'],
                     'supported_by': 'community'}
 
 DOCUMENTATION = r'''

--- a/lib/ansible/modules/network/f5/bigip_device_group.py
+++ b/lib/ansible/modules/network/f5/bigip_device_group.py
@@ -9,7 +9,7 @@ __metaclass__ = type
 
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
+                    'status': ['stableinterface'],
                     'supported_by': 'community'}
 
 DOCUMENTATION = r'''

--- a/lib/ansible/modules/network/f5/bigip_device_group_member.py
+++ b/lib/ansible/modules/network/f5/bigip_device_group_member.py
@@ -8,7 +8,7 @@ __metaclass__ = type
 
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
+                    'status': ['stableinterface'],
                     'supported_by': 'community'}
 
 DOCUMENTATION = r'''

--- a/lib/ansible/modules/network/f5/bigip_device_httpd.py
+++ b/lib/ansible/modules/network/f5/bigip_device_httpd.py
@@ -9,7 +9,7 @@ __metaclass__ = type
 
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
+                    'status': ['stableinterface'],
                     'supported_by': 'community'}
 
 DOCUMENTATION = r'''

--- a/lib/ansible/modules/network/f5/bigip_device_ntp.py
+++ b/lib/ansible/modules/network/f5/bigip_device_ntp.py
@@ -8,7 +8,7 @@ __metaclass__ = type
 
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
+                    'status': ['stableinterface'],
                     'supported_by': 'community'}
 
 DOCUMENTATION = r'''

--- a/lib/ansible/modules/network/f5/bigip_device_sshd.py
+++ b/lib/ansible/modules/network/f5/bigip_device_sshd.py
@@ -8,7 +8,7 @@ __metaclass__ = type
 
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
+                    'status': ['stableinterface'],
                     'supported_by': 'community'}
 
 DOCUMENTATION = r'''

--- a/lib/ansible/modules/network/f5/bigip_device_trust.py
+++ b/lib/ansible/modules/network/f5/bigip_device_trust.py
@@ -8,7 +8,7 @@ __metaclass__ = type
 
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
+                    'status': ['stableinterface'],
                     'supported_by': 'community'}
 
 DOCUMENTATION = r'''

--- a/lib/ansible/modules/network/f5/bigip_gtm_datacenter.py
+++ b/lib/ansible/modules/network/f5/bigip_gtm_datacenter.py
@@ -9,7 +9,7 @@ __metaclass__ = type
 
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
+                    'status': ['stableinterface'],
                     'supported_by': 'community'}
 
 DOCUMENTATION = r'''

--- a/lib/ansible/modules/network/f5/bigip_gtm_pool.py
+++ b/lib/ansible/modules/network/f5/bigip_gtm_pool.py
@@ -9,7 +9,7 @@ __metaclass__ = type
 
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
+                    'status': ['stableinterface'],
                     'supported_by': 'community'}
 
 DOCUMENTATION = r'''

--- a/lib/ansible/modules/network/f5/bigip_gtm_server.py
+++ b/lib/ansible/modules/network/f5/bigip_gtm_server.py
@@ -9,7 +9,7 @@ __metaclass__ = type
 
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
+                    'status': ['stableinterface'],
                     'supported_by': 'community'}
 
 DOCUMENTATION = r'''

--- a/lib/ansible/modules/network/f5/bigip_gtm_virtual_server.py
+++ b/lib/ansible/modules/network/f5/bigip_gtm_virtual_server.py
@@ -9,7 +9,7 @@ __metaclass__ = type
 
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
+                    'status': ['stableinterface'],
                     'supported_by': 'community'}
 
 DOCUMENTATION = r'''

--- a/lib/ansible/modules/network/f5/bigip_gtm_wide_ip.py
+++ b/lib/ansible/modules/network/f5/bigip_gtm_wide_ip.py
@@ -9,7 +9,7 @@ __metaclass__ = type
 
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
+                    'status': ['stableinterface'],
                     'supported_by': 'community'}
 DOCUMENTATION = r'''
 ---

--- a/lib/ansible/modules/network/f5/bigip_hostname.py
+++ b/lib/ansible/modules/network/f5/bigip_hostname.py
@@ -9,7 +9,7 @@ __metaclass__ = type
 
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
+                    'status': ['stableinterface'],
                     'supported_by': 'community'}
 
 DOCUMENTATION = r'''

--- a/lib/ansible/modules/network/f5/bigip_iapp_service.py
+++ b/lib/ansible/modules/network/f5/bigip_iapp_service.py
@@ -9,7 +9,7 @@ __metaclass__ = type
 
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
+                    'status': ['stableinterface'],
                     'supported_by': 'community'}
 
 DOCUMENTATION = r'''

--- a/lib/ansible/modules/network/f5/bigip_iapp_template.py
+++ b/lib/ansible/modules/network/f5/bigip_iapp_template.py
@@ -9,7 +9,7 @@ __metaclass__ = type
 
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
+                    'status': ['stableinterface'],
                     'supported_by': 'community'}
 
 DOCUMENTATION = r'''

--- a/lib/ansible/modules/network/f5/bigip_irule.py
+++ b/lib/ansible/modules/network/f5/bigip_irule.py
@@ -9,7 +9,7 @@ __metaclass__ = type
 
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
+                    'status': ['stableinterface'],
                     'supported_by': 'community'}
 
 DOCUMENTATION = r'''

--- a/lib/ansible/modules/network/f5/bigip_provision.py
+++ b/lib/ansible/modules/network/f5/bigip_provision.py
@@ -9,7 +9,7 @@ __metaclass__ = type
 
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
+                    'status': ['stableinterface'],
                     'supported_by': 'community'}
 
 DOCUMENTATION = r'''

--- a/lib/ansible/modules/network/f5/bigip_remote_syslog.py
+++ b/lib/ansible/modules/network/f5/bigip_remote_syslog.py
@@ -9,7 +9,7 @@ __metaclass__ = type
 
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
+                    'status': ['stableinterface'],
                     'supported_by': 'community'}
 
 DOCUMENTATION = r'''

--- a/lib/ansible/modules/network/f5/bigip_selfip.py
+++ b/lib/ansible/modules/network/f5/bigip_selfip.py
@@ -9,7 +9,7 @@ __metaclass__ = type
 
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
+                    'status': ['stableinterface'],
                     'supported_by': 'community'}
 
 DOCUMENTATION = r'''

--- a/lib/ansible/modules/network/f5/bigip_snat_pool.py
+++ b/lib/ansible/modules/network/f5/bigip_snat_pool.py
@@ -9,7 +9,7 @@ __metaclass__ = type
 
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
+                    'status': ['stableinterface'],
                     'supported_by': 'community'}
 
 DOCUMENTATION = r'''

--- a/lib/ansible/modules/network/f5/bigip_snmp.py
+++ b/lib/ansible/modules/network/f5/bigip_snmp.py
@@ -9,7 +9,7 @@ __metaclass__ = type
 
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
+                    'status': ['stableinterface'],
                     'supported_by': 'community'}
 
 DOCUMENTATION = r'''

--- a/lib/ansible/modules/network/f5/bigip_snmp_trap.py
+++ b/lib/ansible/modules/network/f5/bigip_snmp_trap.py
@@ -9,7 +9,7 @@ __metaclass__ = type
 
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
+                    'status': ['stableinterface'],
                     'supported_by': 'community'}
 
 DOCUMENTATION = r'''

--- a/lib/ansible/modules/network/f5/bigip_software_update.py
+++ b/lib/ansible/modules/network/f5/bigip_software_update.py
@@ -9,7 +9,7 @@ __metaclass__ = type
 
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
+                    'status': ['stableinterface'],
                     'supported_by': 'community'}
 
 DOCUMENTATION = r'''

--- a/lib/ansible/modules/network/f5/bigip_ssl_certificate.py
+++ b/lib/ansible/modules/network/f5/bigip_ssl_certificate.py
@@ -9,7 +9,7 @@ __metaclass__ = type
 
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
+                    'status': ['stableinterface'],
                     'supported_by': 'community'}
 
 DOCUMENTATION = r'''

--- a/lib/ansible/modules/network/f5/bigip_ssl_key.py
+++ b/lib/ansible/modules/network/f5/bigip_ssl_key.py
@@ -9,7 +9,7 @@ __metaclass__ = type
 
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
+                    'status': ['stableinterface'],
                     'supported_by': 'community'}
 
 DOCUMENTATION = r'''

--- a/lib/ansible/modules/network/f5/bigip_static_route.py
+++ b/lib/ansible/modules/network/f5/bigip_static_route.py
@@ -9,7 +9,7 @@ __metaclass__ = type
 
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
+                    'status': ['stableinterface'],
                     'supported_by': 'community'}
 
 DOCUMENTATION = r'''

--- a/lib/ansible/modules/network/f5/bigip_vcmp_guest.py
+++ b/lib/ansible/modules/network/f5/bigip_vcmp_guest.py
@@ -9,7 +9,7 @@ __metaclass__ = type
 
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
+                    'status': ['stableinterface'],
                     'supported_by': 'community'}
 
 DOCUMENTATION = r'''

--- a/lib/ansible/modules/network/f5/bigip_vlan.py
+++ b/lib/ansible/modules/network/f5/bigip_vlan.py
@@ -9,7 +9,7 @@ __metaclass__ = type
 
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
+                    'status': ['stableinterface'],
                     'supported_by': 'community'}
 
 DOCUMENTATION = r'''

--- a/lib/ansible/modules/network/f5/bigip_wait.py
+++ b/lib/ansible/modules/network/f5/bigip_wait.py
@@ -8,7 +8,7 @@ __metaclass__ = type
 
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
+                    'status': ['stableinterface'],
                     'supported_by': 'community'}
 
 DOCUMENTATION = r'''


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
this is being required by customers so that they may adopt ansible
and F5's work in ansible.

(cherry picked from commit 58d857f235f25c0dd3b3715566fed1b70727ad4e)

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
bigip modules

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.15 (default, May  5 2018, 03:32:06) [GCC 4.9.2]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
