### PR TITLE
win_updates fix when win_updates is run with async

### DIFF
--- a/changelogs/fragments/win_updates-async-fix.yml
+++ b/changelogs/fragments/win_updates-async-fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_updates - Fixed issue where running win_updates on async fails without any error

--- a/lib/ansible/plugins/action/win_updates.py
+++ b/lib/ansible/plugins/action/win_updates.py
@@ -213,7 +213,7 @@ class ActionModule(ActionBase):
         # so we just return the result as is
         # https://github.com/ansible/ansible/issues/38232
         failed = result.get('failed', False)
-        if "updates" not in result.keys() or failed:
+        if ("updates" not in result.keys() and self._task.async_val == 0) or failed:
             result['failed'] = True
             return result
 


### PR DESCRIPTION
##### SUMMARY
When running win_updates with async it currently fails due to the check after the first run to see if `updates` has been returned. In the case of async that will never happen so we ignore that particular check if async is greater than 0.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
win_updates

##### ANSIBLE VERSION
```
devel
```