### PR TITLE
ecs_service: make assign_public_ip option a boolean

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ecs_service.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_service.py
@@ -113,7 +113,7 @@ options:
           assign_public_ip:
             description:
               - Whether the task's elastic network interface receives a public IP address. This option requires botocore >= 1.8.4.
-            choices: ["ENABLED", "DISABLED"]
+            type: bool
             version_added: 2.7
     launch_type:
         description:
@@ -338,7 +338,10 @@ class EcsServiceManager:
             result['securityGroups'] = groups
         if network_config['assign_public_ip'] is not None:
             if self.module.botocore_at_least('1.8.4'):
-                result['assignPublicIp'] = network_config['assign_public_ip']
+                if network_config['assign_public_ip'] is True:
+                    result['assignPublicIp'] = "ENABLED"
+                else:
+                    result['assignPublicIp'] = "DISABLED"
             else:
                 self.module.fail_json(msg='botocore needs to be version 1.8.4 or higher to use assign_public_ip in network_configuration')
         return dict(awsvpcConfiguration=result)
@@ -461,7 +464,7 @@ def main():
         network_configuration=dict(required=False, type='dict', options=dict(
             subnets=dict(type='list'),
             security_groups=dict(type='list'),
-            assign_public_ip=dict(choices=['ENABLED', 'DISABLED']),
+            assign_public_ip=dict(type='bool'),
         )),
         launch_type=dict(required=False, choices=['EC2', 'FARGATE'])
     ))

--- a/test/integration/targets/ecs_cluster/playbooks/network_assign_public_ip_fail.yml
+++ b/test/integration/targets/ecs_cluster/playbooks/network_assign_public_ip_fail.yml
@@ -60,7 +60,7 @@
                 - subnet-abcd1234
               security_groups:
                 - sg-abcd1234
-              assign_public_ip: ENABLED
+              assign_public_ip: true
             state: present
             <<: *aws_connection_info
           register: ecs_service_creation_vpc

--- a/test/integration/targets/ecs_cluster/playbooks/roles/ecs_cluster/tasks/main.yml
+++ b/test/integration/targets/ecs_cluster/playbooks/roles/ecs_cluster/tasks/main.yml
@@ -629,7 +629,7 @@
           subnets: "{{ setup_subnet.results | json_query('[].subnet.id') }}"
           security_groups:
             - '{{ setup_sg.group_id }}'
-          assign_public_ip: ENABLED
+          assign_public_ip: true
         <<: *aws_connection_info
       register: ecs_fargate_service_network_with_awsvpc
 


### PR DESCRIPTION
##### SUMMARY
New feature in devel and not a stableinterface module. Fixing a new option to be a boolean instead.
https://github.com/ansible/ansible/pull/41689#issuecomment-398569845

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/ecs_service.py

##### ANSIBLE VERSION
```
ansible 2.7.0.dev0
```