### PR TITLE
Fix file state=touch not returning diff information

### DIFF
--- a/changelogs/fragments/file_touch_diff.yaml
+++ b/changelogs/fragments/file_touch_diff.yaml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+- file module - The touch subcommand had its diff output broken during the
+  2.6.x development cycle.  This is now fixed (https://github.com/ansible/ansible/issues/41755)

--- a/lib/ansible/modules/files/file.py
+++ b/lib/ansible/modules/files/file.py
@@ -370,7 +370,7 @@ def execute_touch(path, follow):
             raise
 
     # Unfortunately, touch always changes the file because it updates file's timestamp
-    return {'dest': path, 'changed': True}
+    return {'dest': path, 'changed': True, 'diff': diff}
 
 
 def ensure_file_attributes(path, follow):


### PR DESCRIPTION
Fixes #41755

##### ISSUE TYPE

 - Bugfix Pull Request


##### COMPONENT NAME
lib/ansible/modules/files/file.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel 2.6
```
