### PR TITLE
Fix multiple var files combining (followup to #36357)

### DIFF
--- a/lib/ansible/playbook/role/__init__.py
+++ b/lib/ansible/playbook/role/__init__.py
@@ -258,7 +258,7 @@ class Role(Base, Become, Conditional, Taggable):
                         data = combine_vars(data, new_data)
                     else:
                         data = new_data
-                    return data
+                return data
             elif main is not None:
                 raise AnsibleParserError("Could not find specified file in role: %s/%s" % (subdir, main))
         return None

--- a/test/units/playbook/role/test_role.py
+++ b/test/units/playbook/role/test_role.py
@@ -250,6 +250,28 @@ class TestRole(unittest.TestCase):
         self.assertEqual(r._role_vars, dict(foo='bam'))
 
     @patch('ansible.playbook.role.definition.unfrackpath', mock_unfrackpath_noop)
+    def test_load_role_with_vars_nested_dirs_combined(self):
+
+        fake_loader = DictDataLoader({
+            "/etc/ansible/roles/foo_vars/defaults/main/foo/bar.yml": """
+            foo: bar
+            a: 1
+            """,
+            "/etc/ansible/roles/foo_vars/defaults/main/bar/foo.yml": """
+            foo: bam
+            b: 2
+            """,
+        })
+
+        mock_play = MagicMock()
+        mock_play.ROLE_CACHE = {}
+
+        i = RoleInclude.load('foo_vars', play=mock_play, loader=fake_loader)
+        r = Role.load(i, play=mock_play)
+
+        self.assertEqual(r._default_vars, dict(foo='bar', a=1, b=2))
+
+    @patch('ansible.playbook.role.definition.unfrackpath', mock_unfrackpath_noop)
     def test_load_role_with_vars_dir_vs_file(self):
 
         fake_loader = DictDataLoader({


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fix multiple var files combining (followup to #36357)

When `defaults/main` or `vars/main` is a directory, then only the first file gets loaded. This PR fixes that.

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
vars loading

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
`ansible 2.7.0.dev0 (role_defaults_vars_dirs f94f32d449) last updated 2018/06/20 23:49:34 (GMT +300)`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->
N/A

<!--- Paste verbatim command output below, e.g. before and after your change -->
