### PR TITLE
[stable-2.6] Fix file state=touch not returning diff information

### DIFF
--- a/changelogs/fragments/file_touch_diff.yaml
+++ b/changelogs/fragments/file_touch_diff.yaml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+- file module - The touch subcommand had its diff output broken during the
+  2.6.x development cycle.  This is now fixed (https://github.com/ansible/ansible/issues/41755)

--- a/lib/ansible/modules/files/file.py
+++ b/lib/ansible/modules/files/file.py
@@ -370,7 +370,7 @@ def execute_touch(path, follow):
             raise
 
     # Unfortunately, touch always changes the file because it updates file's timestamp
-    return {'dest': path, 'changed': True}
+    return {'dest': path, 'changed': True, 'diff': diff}
 
 
 def ensure_file_attributes(path, follow):


### PR DESCRIPTION
Fixes #41755
(cherry picked from commit 8bd245a)

Co-authored-by: Toshio Kuratomi <a.badger@gmail.com>


##### ISSUE TYPE

 - Bugfix Pull Request


##### COMPONENT NAME
lib/ansible/modules/files/file.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
