### PR TITLE
win_updates fix when win_updates is run with async (#41756)

### DIFF
--- a/changelogs/fragments/win_updates-async-fix.yml
+++ b/changelogs/fragments/win_updates-async-fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_updates - Fixed issue where running win_updates on async fails without any error

--- a/lib/ansible/plugins/action/win_updates.py
+++ b/lib/ansible/plugins/action/win_updates.py
@@ -190,7 +190,7 @@ class ActionModule(ActionBase):
         # so we just return the result as is
         # https://github.com/ansible/ansible/issues/38232
         failed = result.get('failed', False)
-        if "updates" not in result.keys() or failed:
+        if ("updates" not in result.keys() and self._task.async_val == 0) or failed:
             result['failed'] = True
             return result
 


### PR DESCRIPTION
(cherry picked from commit 11bd3fd318244264e8dbb95ce1412d9817e53fbe)

##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/41756 sans tests as the 2.5 branch doesn't have the unit tests.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
win_updates

##### ANSIBLE VERSION
```
2.5
```