### PR TITLE
FreeIPA/RHIdM API dynamic inventory script & plugin (Mk II)

### DIFF
--- a/contrib/inventory/freeipa.py
+++ b/contrib/inventory/freeipa.py
@@ -177,6 +177,7 @@ def initialize(
         )
         return client
 
+
 def get_host(
     ipaconnection,
     host,

--- a/contrib/inventory/freeipa.py
+++ b/contrib/inventory/freeipa.py
@@ -1,123 +1,292 @@
 #!/usr/bin/env python
 # Copyright (c) 2017 Ansible Project
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# This script can create an Ansible Dynamic Inventory with either:
+# - the FreeIPA API over HTTPS with the `python_freeipa` module
+# - using kerberos authentication with the `ipalib` and `ipaclient` module
+#
+# DEPENDENCIES: before this script will work the python_freeipa or ipalib module has to be installed
+#
+# For Ansible AWX or Tower add this to your Docker image
+# RUN pip install python_freeipa urllib3
+# or
+# RUN pip install ipalib ipaclient
+#
+# The script assumes Kerberos authentication mode, arguments passed to the scipt will override environment variables.
+# Set the following variables in Inventory Source:
+# - `ipahttps`: if True the script will attemt to use HTTPS and freeipa_python, if false the script will attemt to use Kerberos and ipalib. Default is False.
+# - `ipaserver`: the FQDN of the FreeIPA/RHIdM server
+# - `ipauser`: an unprivileged user account for connecting to the API
+# - `ipapassword`: password for freeipauser
+# - `ipaversion`: specifies the FreeIPA API version, default is 2.228
 
-import argparse
+from argparse import ArgumentParser
 from distutils.version import LooseVersion
-import json
+from os import environ as env
 import os
 import sys
-from ipalib import api, errors, __version__ as IPA_VERSION
-from ansible.module_utils.six import u
+import json
 
 
-def initialize():
-    '''
-    This function initializes the FreeIPA/IPA API. This function requires
-    no arguments. A kerberos key must be present in the users keyring in
-    order for this to work. IPA default configuration directory is /etc/ipa,
-    this path could be overridden with IPA_CONFDIR environment variable.
-    '''
+# Parse command line arguments
+def parse_args():
+    parser = ArgumentParser(description="AWX FreeIPA API dynamic host inventory")
+    parser.add_argument(
+        '--list',
+        default=False,
+        dest="list",
+        action="store_true",
+        help="Produce a JSON consumable grouping of servers for Ansible"
+    )
+    parser.add_argument(
+        '--host',
+        default=None,
+        dest="host",
+        help="Generate additional host specific details for given host for Ansible"
+    )
+    parser.add_argument(
+        '-a'
+        '--api',
+        default=False,
+        dest="useapi",
+        action="store_true",
+        help="Use the FreeIPA API, otherwise use Kerberos"
+    )
+    parser.add_argument(
+        '-u',
+        '--user',
+        default=None,
+        dest="ipauser",
+        help="username to log into FreeIPA API, ignored if --api or -a not set"
+    )
+    parser.add_argument(
+        '-w',
+        '--password',
+        default=None,
+        dest="ipapassword",
+        help="password to log into FreeIPA API, ignored if --api or -a not set"
+    )
+    parser.add_argument(
+        '-s',
+        '--server',
+        default=None,
+        dest="ipaserver",
+        help="hostname of FreeIPA server, ignored if --api or -a not set"
+    )
+    parser.add_argument(
+        '--ipa-version',
+        default=None,
+        dest="ipaversion",
+        help="version of FreeIPA server"
+    )
+    return parser.parse_args()
 
-    api.bootstrap(context='cli')
 
-    if not os.path.isdir(api.env.confdir):
-        print("WARNING: IPA configuration directory (%s) is missing. "
-              "Environment variable IPA_CONFDIR could be used to override "
-              "default path." % api.env.confdir)
+def initialize(
+    use_kerberos=False
+):
 
-    if LooseVersion(IPA_VERSION) >= LooseVersion('4.6.2'):
-        # With ipalib < 4.6.0 'server' and 'domain' have default values
-        # ('localhost:8888', 'example.com'), newer versions don't and
-        # DNS autodiscovery is broken, then one of jsonrpc_uri / xmlrpc_uri is
-        # required.
-        # ipalib 4.6.0 is unusable (https://pagure.io/freeipa/issue/7132)
-        # that's why 4.6.2 is explicitely tested.
+    # Use Kerberos authenication or use the FreeIPA API
+    if use_kerberos:
+        '''
+        This function initializes the FreeIPA/IPA API. This function requires
+        no arguments. A kerberos key must be present in the users keyring in
+        order for this to work. IPA default configuration directory is /etc/ipa,
+        this path could be overridden with IPA_CONFDIR environment variable.
+        '''
+
+        api.bootstrap(context='cli')
+
+        if not os.path.isdir(api.env.confdir):
+            print("WARNING: IPA configuration directory (%s) is missing. "
+                  "Environment variable IPA_CONFDIR could be used to override "
+                  "default path." % api.env.confdir)
+
+        if LooseVersion(IPA_VERSION) < LooseVersion('4.6.2'):
+            # With ipalib < 4.6.0 'server' and 'domain' have default values
+            # ('localhost:8888', 'example.com'), newer versions don't and
+            # DNS autodiscovery is broken, then one of jsonrpc_uri / xmlrpc_uri is
+            # required.
+            # ipalib 4.6.0 is unusable (https://pagure.io/freeipa/issue/7132)
+            # that's why 4.6.2 is explicitely tested.
+            sys.exit(
+                "ERROR: ipalib version newer than 4.6.2 required, current version is %s" %
+                IPA_VERSION
+            )
+
         if 'server' not in api.env or 'domain' not in api.env:
-            sys.exit("ERROR: ('jsonrpc_uri' or 'xmlrpc_uri') or 'domain' are not "
-                     "defined in '[global]' section of '%s' nor in '%s'." %
-                     (api.env.conf, api.env.conf_default))
+            sys.exit(
+                "ERROR: ('jsonrpc_uri' or 'xmlrpc_uri') or 'domain' are not "
+                "defined in '[global]' section of '%s' nor in '%s'." %
+                (api.env.conf, api.env.conf_default)
+            )
 
-    api.finalize()
-    try:
-        api.Backend.rpcclient.connect()
-    except AttributeError:
-        # FreeIPA < 4.0 compatibility
-        api.Backend.xmlclient.connect()
+        api.finalize()
+        try:
+            api.Backend.rpcclient.connect()
+        except AttributeError:
+            # FreeIPA < 4.0 compatibility
+            api.Backend.xmlclient.connect()
 
-    return api
+        return api
+    else:
+        # We don't need warnings
+        urllib3.disable_warnings()
+
+        ipaserver = None
+        if args.ipaserver:
+            ipaserver = args.ipaserver
+        elif 'ipaserver' in env:
+            ipaserver = env['ipaserver']
+
+        ipauser = None
+        if args.ipauser:
+            ipauser = args.ipauser
+        elif 'ipauser' in env:
+            ipauser = env['ipauser']
+
+        ipapassword = None
+        if args.ipapassword:
+            ipapassword = args.ipapassword
+        elif 'ipapassword' in env:
+            ipapassword = env['ipapassword']
+
+        ipaversion = '2.228'
+        if args.ipaversion:
+            ipaversion = args.ipaversion
+        elif 'ipaversion' in env:
+            ipaversion = env['ipaversion']
+
+        if not ipaserver:
+            sys.exit("ERROR: No IPA server given with -s/--server argument, or set with ipaserver environment variable")
+
+        if not ipauser:
+            sys.exit("ERROR: No IPA user given with -u/--user argument, or set with ipapassword environment variable")
+
+        if not ipapassword:
+            sys.exit("ERROR: No IPA password given with -w/--password argument, or set with ipapassword environment variable")
+
+        client = Client(
+            ipaserver,
+            version=ipaversion,
+            verify_ssl=False
+        )
+        client.login(
+            ipauser,
+            ipapassword
+        )
+        return client
+
+def get_host(
+    ipaconnection,
+    host,
+    use_kerberos=False
+):
+    """
+    This function expects one string, this hostname to lookup variables for.
+    Args:
+        ipaconnection: FreeIPA API Object
+        host: Name of Hostname
+        use_kerberos: if True Kerberos authentication with ipalib is used, if False HTTPS auth with python_freeipa is used
+
+    Returns: Dict of Host vars if found else None
+    """
+    if use_kerberos:
+        try:
+            result = ipaconnection.Command.host_show(host)['result']
+            if 'usercertificate' in result:
+                del result['usercertificate']
+        except errors.NotFound as e:
+            result = {}
+    else:
+        # We don't need warnings
+        urllib3.disable_warnings()
+        result = ipaconnection._request(
+            'host_show',
+            host,
+            {'all': True, 'raw': False}
+        )['result']
+        if 'usercertificate' in result:
+            del result['usercertificate']
+
+    return result
 
 
-def list_groups(api):
+def get_hostgroups(
+    ipaconnection,
+    use_kerberos=False
+):
     '''
     This function prints a list of all host groups. This function requires
     one argument, the FreeIPA/IPA API object.
     '''
-
     inventory = {}
     hostvars = {}
+    result = {}
 
-    result = api.Command.hostgroup_find(all=True)['result']
+    if use_kerberos:
+        result = ipaconnection.Command.hostgroup_find(all=True)['result']
+    else:
+        # We don't need warnings
+        urllib3.disable_warnings()
+        result = ipaconnection._request(
+            'hostgroup_find',
+            '',
+            {'all': True, 'raw': False}
+        )['result']
 
     for hostgroup in result:
-        # Get direct and indirect members (nested hostgroups) of hostgroup
         members = []
+        children = []
 
         if 'member_host' in hostgroup:
             members = [host for host in hostgroup['member_host']]
-        if 'memberindirect_host' in hostgroup:
-            members += (host for host in hostgroup['memberindirect_host'])
-        inventory[hostgroup['cn'][0]] = {'hosts': [host for host in members]}
+        if 'member_hostgroup' in hostgroup:
+            children = hostgroup['member_hostgroup']
+        inventory[hostgroup['cn'][0]] = {
+            'hosts': [host for host in members],
+            'children': children
+        }
 
         for member in members:
-            hostvars[member] = {}
+            # This should actually grab the hostvars for the hosts
+            hostvars[member] = get_host(ipaconnection, member, use_kerberos)
 
     inventory['_meta'] = {'hostvars': hostvars}
-    inv_string = json.dumps(inventory, indent=1, sort_keys=True)
-    print(inv_string)
-
-    return None
-
-
-def parse_args():
-    '''
-    This function parses the arguments that were passed in via the command line.
-    This function expects no arguments.
-    '''
-
-    parser = argparse.ArgumentParser(description='Ansible FreeIPA/IPA '
-                                     'inventory module')
-    group = parser.add_mutually_exclusive_group(required=True)
-    group.add_argument('--list', action='store_true',
-                       help='List active servers')
-    group.add_argument('--host', help='List details about the specified host')
-
-    return parser.parse_args()
-
-
-def get_host_attributes(api, host):
-    """
-    This function expects one string, this hostname to lookup variables for.
-    Args:
-        api: FreeIPA API Object
-        host: Name of Hostname
-
-    Returns: Dict of Host vars if found else None
-    """
-    try:
-        result = api.Command.host_show(u(host))['result']
-        if 'usercertificate' in result:
-            del result['usercertificate']
-        return json.dumps(result, indent=1)
-    except errors.NotFound as e:
-        return {}
+    return inventory
 
 
 if __name__ == '__main__':
     args = parse_args()
-    api = initialize()
+
+    use_kerberos = True
+    if 'ipahttps' in env:
+        if env['ipahttps'].strip() in ['True', 'true']:
+            use_kerberos = False
+    if args.useapi:
+        use_kerberos = False
+
+    # Load the correct module
+    if use_kerberos:
+        try:
+            from ipalib import api, errors, __version__ as IPA_VERSION
+        except ImportError:
+            print('The ipa dynamic inventory script requires ipalib for Kerberos authentication')
+    else:
+        try:
+            from python_freeipa import Client
+            import urllib3
+        except ImportError:
+            print(
+                'The ipa dynamic inventory script requires python_freeipa'
+                'to use the FreeIPA API with HTTPS authentication'
+            )
+
+    ipaconnection = initialize(use_kerberos)
 
     if args.host:
-        print(get_host_attributes(api, args.host))
+        hostvars = get_host(ipaconnection, args.host, use_kerberos)
+        print(json.dumps(hostvars, indent=1, sort_keys=True))
     elif args.list:
-        list_groups(api)
+        inventory = get_hostgroups(ipaconnection, use_kerberos)
+        print(json.dumps(inventory, indent=1, sort_keys=True))

--- a/lib/ansible/plugins/inventory/ipa.py
+++ b/lib/ansible/plugins/inventory/ipa.py
@@ -1,0 +1,302 @@
+# Copyright (c) 2017 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+DOCUMENTATION = '''
+    inventory: ipa
+    version_added: "2.5"
+    short_description: Uses the FreeIPA/RHIdM API to populate an inventory
+    description:
+        - "FreeIPA/RHIdM based inventory, starts with the 'all' group and has hosts/vars/children entries."
+        - Host entries can have sub-entries defined, which will be treated as variables.
+        - Vars entries are normal group vars.
+    notes:
+        - To function it requires being whitelisted in configuration.
+        - Requires [python_freeipa](https://pypi.org/project/python-freeipa/) and [urllib3](https://pypi.org/project/urllib3/) for HTTPS authentication
+        - Requires  [ipalib](https://pypi.org/project/ipalib/) and [ipaclient](https://pypi.org/project/ipaclient/) to use Kerberos authentication
+        - Kerberos authentication requires that the Ansible user/process environment has valid Kerberos authentication & keytab
+    options:
+      ipahttps:
+        description: toggles the use of HTTPS authentication (with `python_freeipa`) or Kerberos Authentication (with `ipalib`)
+        type: boolean
+        default: False
+        env:
+          - name: ANSIBLE_IPAHTTPS
+        ini:
+          - key: ipa_https
+            section: defaults
+          - section: inventory_ipa
+            key: ipa_server
+      ipaserver:
+        description: the FQDN of the FreeIPA/RHIdM server for HTTPS authentication
+        type: string
+        default: None
+        env:
+          - name: ANSIBLE_IPASERVER
+        ini:
+          - key: ipa_server
+            section: defaults
+          - section: inventory_ipa
+            key: ipa_server
+      ipauser:
+        description: an unprivileged user account from the FreeIPA/RHIdM directory for HTTPS authentication
+        type: string
+        default: None
+        env:
+          - name: ANSIBLE_IPAUSER
+        ini:
+          - key: ipa_user
+            section: defaults
+          - section: inventory_ipa
+            key: ipa_user
+      ipapassword:
+        description: the password for the FreeIPA/RHIdM user account for HTTPS authentication
+        type: string
+        default: None
+        env:
+          - name: ANSIBLE_IPAPASSWORD
+        ini:
+          - key: ipa_password
+            section: defaults
+          - section: inventory_ipa
+            key: ipa_password
+      ipaversion:
+        description: the FreeIPA API version for the FreeIPA/RHIdM user account for HTTPS authentication
+        type: string
+        default: None
+        env:
+          - name: ANSIBLE_IPAVERSION
+        ini:
+          - key: ipa_version
+            section: defaults
+          - section: inventory_ipa
+            key: ipa_version
+'''
+
+EXAMPLES = '''
+plugin: ipa
+ipahttps: true
+ipaserver: ipa.example.org
+ipauser: username
+ipapassword: password
+ipaversion: 2.228
+'''
+
+# Imports for Ansible AWX
+from collections import MutableMapping
+from ansible.errors import AnsibleParserError, AnsibleConnectionFailure, AnsibleError
+from ansible.module_utils.six import string_types
+from ansible.module_utils._text import to_native
+from ansible.parsing.utils.addresses import parse_address
+from ansible.plugins.inventory import BaseInventoryPlugin, Constructable, Cacheable
+
+# Imports for this plugin
+from distutils.version import LooseVersion
+from ansible.module_utils.six import iteritems
+from os import environ as env
+import os
+import sys
+import json
+
+
+class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
+
+    NAME = 'ipa'
+
+    def __init__(self):
+        super(InventoryModule, self).__init__()
+
+        self.ipahttps = False
+        self.ipaserver = None
+        self.ipauser = None
+        self.ipapassword = None
+        self.ipaversion = '2.228'
+        self.ipaconnection = None
+        self._hosts = set()
+
+    def parse(self, inventory, loader, path, cache=True):
+        ''' parses the inventory file '''
+
+        super(InventoryModule, self).parse(inventory, loader, path)
+        self._read_config_data(path)
+
+        self.ipahttps = bool(self.get_option('ipahttps'))
+        self.ipaserver = self.get_option('ipaserver')
+        self.ipauser = self.get_option('ipauser')
+        self.ipapassword = self.get_option('ipapassword')
+        self.ipaversion = str(self.get_option('ipaversion'))
+
+        if self.ipahttps:
+            # Connect via HTTPS and python_freeipa
+            try:
+                from python_freeipa import Client
+                import urllib3
+                # We don't need warnings
+                urllib3.disable_warnings()
+            except ImportError:
+                sys.exit(
+                    'The ipa dynamic inventory script requires python_freeipa '
+                    'to use the FreeIPA API with HTTPS authentication'
+                )
+
+            try:
+                self.ipaconnection = Client(
+                    self.ipaserver,
+                    version=self.ipaversion,
+                    verify_ssl=False
+                )
+                self.ipaconnection.login(
+                    self.ipauser,
+                    self.ipapassword
+                )
+            except Exception as e:
+                raise AnsibleConnectionFailure(e)
+        else:
+            # Connect via Kerberos using ipalib
+            try:
+                from ipalib import api, __version__ as IPA_VERSION
+            except ImportError:
+                sys.exit('The ipa dynamic inventory script requires ipalib for Kerberos authentication')
+
+            # Connect via Kerberos using ipalib
+
+            try:
+                api = api.bootstrap(context='cli')
+            except Exception as e:
+                raise AnsibleConnectionFailure(e)
+
+            if not os.path.isdir(api.env.confdir):
+                print("WARNING: IPA configuration directory (%s) is missing. "
+                      "Environment variable IPA_CONFDIR could be used to override "
+                      "default path." % api.env.confdir)
+
+            if LooseVersion(IPA_VERSION) < LooseVersion('4.6.2'):
+                # With ipalib < 4.6.0 'server' and 'domain' have default values
+                # ('localhost:8888', 'example.com'), newer versions don't and
+                # DNS autodiscovery is broken, then one of jsonrpc_uri / xmlrpc_uri is
+                # required.
+                # ipalib 4.6.0 is unusable (https://pagure.io/freeipa/issue/7132)
+                # that's why 4.6.2 is explicitely tested.
+                sys.exit(
+                    "ERROR: ipalib version newer than 4.6.2 required, current version is %s" %
+                    IPA_VERSION
+                )
+
+            if 'server' not in api.env or 'domain' not in api.env:
+                sys.exit(
+                    "ERROR: ('jsonrpc_uri' or 'xmlrpc_uri') or 'domain' are not "
+                    "defined in '[global]' section of '%s' nor in '%s'." %
+                    (api.env.conf, api.env.conf_default)
+                )
+
+            api.finalize()
+            try:
+                api.Backend.rpcclient.connect()
+            except AttributeError:
+                # FreeIPA < 4.0 compatibility
+                api.Backend.xmlclient.connect()
+
+            self.ipaconnection = api
+
+        hostgroups = self._get_hostgroups()
+
+        if isinstance(hostgroups, MutableMapping):
+            for group_name in hostgroups:
+                self._parse_group(group_name, hostgroups[group_name])
+        else:
+            raise AnsibleParserError("Invalid hostgrousp from FreeIPA, expected dictionary and got:\n\n%s" % to_native(hostgroups))
+
+    def _parse_group(self, group, data):
+
+        self.inventory.add_group(group)
+
+        if not isinstance(data, dict):
+            data = {'hosts': data}
+        # is not those subkeys, then simplified syntax, host with vars
+        elif not any(k in data for k in ('hosts', 'vars', 'children')):
+            data = {'hosts': [group], 'vars': data}
+
+        if 'hosts' in data:
+            if not isinstance(data['hosts'], list):
+                raise AnsibleError("You defined a group '%s' with bad data for the host list:\n %s" % (group, data))
+
+            for hostname in data['hosts']:
+                self._hosts.add(hostname)
+                self.inventory.add_host(hostname, group)
+
+        if 'vars' in data:
+            if not isinstance(data['vars'], dict):
+                raise AnsibleError("You defined a group '%s' with bad data for variables:\n %s" % (group, data))
+
+            for k, v in iteritems(data['vars']):
+                self.inventory.set_variable(group, k, v)
+
+        if group != '_meta' and isinstance(data, dict) and 'children' in data:
+            for child_name in data['children']:
+                self.inventory.add_group(child_name)
+                self.inventory.add_child(group, child_name)
+
+    def _get_hostgroups(
+        self
+    ):
+        inventory = {}
+        hostvars = {}
+        result = {}
+
+        if self.ipahttps:
+            result = self.ipaconnection._request(
+                'hostgroup_find',
+                '',
+                {'all': True, 'raw': False}
+            )['result']
+        else:
+            result = self.ipaconnection.Command.hostgroup_find(all=True)['result']
+
+        for hostgroup in result:
+            members = []
+            children = []
+
+            if 'member_host' in hostgroup:
+                members = [host for host in hostgroup['member_host']]
+            if 'member_hostgroup' in hostgroup:
+                children = hostgroup['member_hostgroup']
+            inventory[hostgroup['cn'][0]] = {
+                'hosts': [host for host in members],
+                'children': children
+            }
+
+            for member in members:
+                # This should actually grab the hostvars for the hosts
+                hostvars[member] = self._get_host(member)
+
+        inventory['_meta'] = {'hostvars': hostvars}
+
+        return inventory
+
+    def _get_host(
+        self,
+        host
+    ):
+        if self.ipahttps:
+            result = self.ipaconnection._request(
+                'host_show',
+                host,
+                {'all': True, 'raw': False}
+            )['result']
+            if 'usercertificate' in result:
+                del result['usercertificate']
+        else:
+            try:
+                try:
+                    from ipalib import errors
+                except ImportError:
+                    sys.exit('The ipa dynamic inventory script requires ipalib for Kerberos authentication')
+                result = self.ipaconnection.Command.host_show(host)['result']
+                if 'usercertificate' in result:
+                    del result['usercertificate']
+            except errors.NotFound:
+                result = {}
+
+        return result

--- a/lib/ansible/plugins/inventory/ipa.py
+++ b/lib/ansible/plugins/inventory/ipa.py
@@ -85,7 +85,7 @@ ipaversion: 2.228
 '''
 
 # Imports for Ansible AWX
-from collections import MutableMapping
+from ansible.module_utils.common._collections_compat import MutableMapping
 from ansible.errors import AnsibleParserError, AnsibleConnectionFailure, AnsibleError
 from ansible.module_utils.six import string_types
 from ansible.module_utils._text import to_native


### PR DESCRIPTION
A dynamic inventory script that uses the FreeIPA API with HTTPS authentication. No Kerberos required. Requires the python_freeipa module.

This is a duplicate of https://github.com/ansible/ansible/pull/41570 because I forgot to branch before developing a new feature.

SUMMARY
Adds a dynamic inventory script  and inventory plugin that uses the FreeIPA/RHIdM API with HTTPS authentication. The inventory should be the same with using either the script or the plugin.

## Dynamic Inventory Script
- dynamic inventory script works when run as a user with Kerberos authentication (requires a Kerberos ticket for the user/process calling the script)
- dynamic inventory script works when run with:
-- correct command line arguments
-- correct environment variables set either from the command line or Ansible variables
-- can be cut-pasted into Ansible AWX/Tower

## Inventory Plugins
- has to be whitelisted in an `ansible.cgf` somewhere
- works with an appropriate inventory YAML file
- Kerberos version requires the user/role/process to have a valid Kerberos ticket*

\* um... I don't have a sensible method for that... I suspect it's one of the reasons the original ipalib based dynamic inventory script wasn't converted into a plugin.

## New Featured
- Behavior of the plug-in _matches_ the behavior of the inventory script.
- Inventory replicates the nested host groups from IPA, this enhancement should not interfere with previous use of the old script as the 'old' groups still exist, they just now include nested relationships.
- Allows a host group to be specified to act as the parent for the inventory, allowing the inventory to be limited to part of the IPA hosts directory (important for host licensing for Tower)

## Dependencies
- HTTPS connections requires [python_freeipa](https://pypi.org/project/python-freeipa/) and [urllib3](https://pypi.org/project/urllib3/) for HTTPS authentication
- Kerberos authentication requires  [ipalib](https://pypi.org/project/ipalib/) and [ipaclient](https://pypi.org/project/ipaclient/) to use Kerberos authentication
-- Kerberos authentication requires that the Ansible user/process environment has valid Kerberos authentication & keytab

ISSUE TYPE
Feature Pull Request
COMPONENT NAME
Dynamic Inventory Script
Inventory Plugin

ANSIBLE VERSION
ansible 2.4.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /bin/ansible
  python version = 2.7.5 (default, Nov  6 2016, 00:28:07) [GCC 4.8.5 20150623 (Red Hat 4.8.5-11)]