### PR TITLE
FreeIPA: Add support for TTL in dnsrecord

### DIFF
--- a/lib/ansible/modules/identity/ipa/ipa_dnsrecord.py
+++ b/lib/ansible/modules/identity/ipa/ipa_dnsrecord.py
@@ -1,14 +1,17 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 # Copyright: (c) 2017, Abhijeet Kasurde (akasurde@redhat.com)
+#
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'community'}
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
 
 
 DOCUMENTATION = '''
@@ -46,6 +49,11 @@ options:
     - In the case of 'PTR' record type, this will be the hostname.
     - In the case of 'TXT' record type, this will be a text.
     required: true
+  record_ttl:
+    description:
+    - Set the TTL for the record.
+    - Applies only when adding a new or changing the value of record_value.
+    version_added: "2.7"
   state:
     description: State to ensure
     required: false
@@ -65,6 +73,17 @@ EXAMPLES = '''
     record_name: vm-001
     record_type: 'AAAA'
     record_value: '::1'
+
+# Ensure that dns record exists with a TTL
+- ipa_dnsrecord:
+    name: host02
+    zone_name: example.com
+    record_type: 'AAAA'
+    record_value: '::1'
+    record_ttl: 300
+    ipa_host: ipa.example.com
+    ipa_pass: topsecret
+    state: present
 
 # Ensure a PTR record is present
 - ipa_dnsrecord:
@@ -117,7 +136,7 @@ class DNSRecordIPAClient(IPAClient):
         super(DNSRecordIPAClient, self).__init__(module, host, port, protocol)
 
     def dnsrecord_find(self, zone_name, record_name):
-        return self._post_json(method='dnsrecord_find', name=zone_name, item={'idnsname': record_name})
+        return self._post_json(method='dnsrecord_find', name=zone_name, item={'idnsname': record_name, 'all': True})
 
     def dnsrecord_add(self, zone_name=None, record_name=None, details=None):
         item = dict(idnsname=record_name)
@@ -136,11 +155,16 @@ class DNSRecordIPAClient(IPAClient):
         elif details['record_type'] == 'TXT':
             item.update(txtrecord=details['record_value'])
 
+        if details.get('record_ttl'):
+            item.update(dnsttl=details['record_ttl'])
+
         return self._post_json(method='dnsrecord_add', name=zone_name, item=item)
 
     def dnsrecord_mod(self, zone_name=None, record_name=None, details=None):
         item = get_dnsrecord_dict(details)
         item.update(idnsname=record_name)
+        if details.get('record_ttl'):
+            item.update(dnsttl=details['record_ttl'])
         return self._post_json(method='dnsrecord_mod', name=zone_name, item=item)
 
     def dnsrecord_del(self, zone_name=None, record_name=None, details=None):
@@ -165,6 +189,10 @@ def get_dnsrecord_dict(details=None):
         module_dnsrecord.update(ptrrecord=details['record_value'])
     elif details['record_type'] == 'TXT' and details['record_value']:
         module_dnsrecord.update(txtrecord=details['record_value'])
+
+    if details.get('record_ttl'):
+        module_dnsrecord.update(dnsttl=details['record_ttl'])
+
     return module_dnsrecord
 
 
@@ -176,11 +204,15 @@ def get_dnsrecord_diff(client, ipa_dnsrecord, module_dnsrecord):
 def ensure(module, client):
     zone_name = module.params['zone_name']
     record_name = module.params['record_name']
+    record_ttl = module.params.get('record_ttl')
     state = module.params['state']
 
     ipa_dnsrecord = client.dnsrecord_find(zone_name, record_name)
-    module_dnsrecord = dict(record_type=module.params['record_type'],
-                            record_value=module.params['record_value'])
+    module_dnsrecord = dict(
+        record_type=module.params['record_type'],
+        record_value=module.params['record_value'],
+        record_ttl=to_native(record_ttl),
+    )
 
     changed = False
     if state == 'present':
@@ -212,25 +244,32 @@ def ensure(module, client):
 def main():
     record_types = ['A', 'AAAA', 'A6', 'CNAME', 'DNAME', 'PTR', 'TXT']
     argument_spec = ipa_argument_spec()
-    argument_spec.update(zone_name=dict(type='str', required=True),
-                         record_name=dict(type='str', aliases=['name'], required=True),
-                         record_type=dict(type='str', default='A', choices=record_types),
-                         record_value=dict(type='str', required=True),
-                         state=dict(type='str', default='present', choices=['present', 'absent']),
-                         )
+    argument_spec.update(
+        zone_name=dict(type='str', required=True),
+        record_name=dict(type='str', aliases=['name'], required=True),
+        record_type=dict(type='str', default='A', choices=record_types),
+        record_value=dict(type='str', required=True),
+        state=dict(type='str', default='present', choices=['present', 'absent']),
+        record_ttl=dict(type='int'),
+    )
 
-    module = AnsibleModule(argument_spec=argument_spec,
-                           supports_check_mode=True
-                           )
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True
+    )
 
-    client = DNSRecordIPAClient(module=module,
-                                host=module.params['ipa_host'],
-                                port=module.params['ipa_port'],
-                                protocol=module.params['ipa_prot'])
+    client = DNSRecordIPAClient(
+        module=module,
+        host=module.params['ipa_host'],
+        port=module.params['ipa_port'],
+        protocol=module.params['ipa_prot']
+    )
 
     try:
-        client.login(username=module.params['ipa_user'],
-                     password=module.params['ipa_pass'])
+        client.login(
+            username=module.params['ipa_user'],
+            password=module.params['ipa_pass']
+        )
         changed, record = ensure(module, client)
         module.exit_json(changed=changed, record=record)
     except Exception as e:


### PR DESCRIPTION
##### SUMMARY
Fixes: #33969

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/identity/ipa/ipa_dnsrecord.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7-devel
```