### PR TITLE
Pass FieldLevelEncryptionId as a parameter for all cache behaviors

### DIFF
--- a/lib/ansible/modules/cloud/amazon/cloudfront_distribution.py
+++ b/lib/ansible/modules/cloud/amazon/cloudfront_distribution.py
@@ -152,6 +152,7 @@ options:
               I(lambda_function_associations[])
                 I(lambda_function_arn)
                 I(event_type)
+              I(field_level_encryption_id)
 
     cache_behaviors:
       description:
@@ -180,6 +181,7 @@ options:
             I(max_ttl)
             I(compress)
             I(lambda_function_associations[])
+            I(field_level_encryption_id)
 
     purge_cache_behaviors:
       description: Whether to remove any cache behaviors that aren't listed in I(cache_behaviors). This switch
@@ -1505,6 +1507,7 @@ class CloudFrontValidationManager(object):
         cache_behavior = self.validate_allowed_methods(config, cache_behavior.get('allowed_methods'), cache_behavior)
         cache_behavior = self.validate_lambda_function_associations(config, cache_behavior.get('lambda_function_associations'), cache_behavior)
         cache_behavior = self.validate_trusted_signers(config, cache_behavior.get('trusted_signers'), cache_behavior)
+        cache_behavior = self.validate_field_level_encryption_id(config, cache_behavior.get('field_level_encryption_id'), cache_behavior)
         return cache_behavior
 
     def validate_cache_behavior_first_level_keys(self, config, cache_behavior, valid_origins, is_default_cache):
@@ -1586,6 +1589,14 @@ class CloudFrontValidationManager(object):
             return cache_behavior
         except Exception as e:
             self.module.fail_json_aws(e, msg="Error validating lambda function associations")
+
+    def validate_field_level_encryption_id(self, config, field_level_encryption_id, cache_behavior):
+        # only set field_level_encryption_id if it's already set or if it was passed
+        if field_level_encryption_id is not None:
+            cache_behavior['field_level_encryption_id'] = field_level_encryption_id
+        elif 'field_level_encryption_id' in config:
+            cache_behavior['field_level_encryption_id'] = config.get('field_level_encryption_id')
+        return cache_behavior
 
     def validate_allowed_methods(self, config, allowed_methods, cache_behavior):
         try:

--- a/test/integration/targets/cloudfront_distribution/meta/main.yml
+++ b/test/integration/targets/cloudfront_distribution/meta/main.yml
@@ -1,3 +1,1 @@
-dependencies:
-  - prepare_tests
-  - setup_ec2
+dependencies: []

--- a/test/integration/targets/cloudfront_distribution/tasks/main.yml
+++ b/test/integration/targets/cloudfront_distribution/tasks/main.yml
@@ -124,7 +124,6 @@
         custom_origin_config:
           http_port: 8080
       - domain_name: "{{ resource_prefix }}2.example.com"
-      - domain_name: "{{ test_identifier }}2.example.com"
       default_root_object: index.html
       wait: yes
       state: present
@@ -178,7 +177,7 @@
     cloudfront_distribution:
       alias: "{{ cloudfront_alias }}"
       origins:
-      - domain_name: "{{ test_identifier }}2.example.com"
+      - domain_name: "{{ resource_prefix }}2.example.com"
       default_root_object: index.php
       state: present
       <<: *aws_connection_info


### PR DESCRIPTION
##### SUMMARY

FieldLevelEncryptionId is a mandatory parameter for UpdateDistribution.
We can't delete with an UpdateDistribution, and it's difficult to not
set FieldLevelEncryptionId just for CreateDistribution.

As a result cloudfront_distribution now requires 1.9.22

Ensure botocore >= 1.10 gets installed through installing boto3 >= 1.7
otherwise tests fail!

Update cloudfront_distribution tests to remove references to
test_identifier so test suite actually works

Fixes #40724

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
cloudfront_distribution

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (devel c4a6bce69f) last updated 2018/06/21 14:22:31 (GMT +1000)
  config file = None
  configured module search path = [u'/Users/will/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/will/src/ansible/lib/ansible
  executable location = /Users/will/src/ansible/bin/ansible
  python version = 2.7.14 (default, Mar  9 2018, 23:57:12) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```


##### ADDITIONAL INFORMATION
Tested using cloudfront_distribution test suite