### PR TITLE
To fix eos_vrf failure when transport method is eapi (#41470)

### DIFF
--- a/changelogs/fragments/eos_vrf_failure-fix.yml
+++ b/changelogs/fragments/eos_vrf_failure-fix.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - Changed the output to "text" for "show vrf" command as default "json" output format
+    with respect to "eapi" transport was failing (https://github.com/ansible/ansible/pull/41470)

--- a/lib/ansible/modules/network/eos/eos_vrf.py
+++ b/lib/ansible/modules/network/eos/eos_vrf.py
@@ -189,7 +189,7 @@ def map_obj_to_commands(updates, module):
 
 def map_config_to_obj(module):
     objs = []
-    output = run_commands(module, ['show vrf'])
+    output = run_commands(module, {'command': 'show vrf', 'output': 'text'})
 
     lines = output[0].strip().splitlines()[3:]
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This PR is cherry-picked from PR #41470 which resolves the bug #40930. 
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description, but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
eos
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
(cherry picked from commit c989b62eefd58c33bd8d620c7bce1ebfa9766c7c)
```
