### PR TITLE
Fix vyos_vlan aggregate issue & added tests CP into 2.6 (#41638)

### DIFF
--- a/lib/ansible/modules/network/vyos/vyos_vlan.py
+++ b/lib/ansible/modules/network/vyos/vyos_vlan.py
@@ -185,6 +185,10 @@ def map_params_to_obj(module):
                     item[key] = module.params[key]
 
             d = item.copy()
+
+            if not d['vlan_id']:
+                module.fail_json(msg='vlan_id is required')
+
             d['vlan_id'] = str(d['vlan_id'])
             module._check_required_one_of(module.required_one_of, item)
 
@@ -269,7 +273,7 @@ def main():
     """ main entry point for module execution
     """
     element_spec = dict(
-        vlan_id=dict(type='int', required=True),
+        vlan_id=dict(type='int'),
         name=dict(),
         address=dict(),
         interfaces=dict(type='list'),
@@ -293,7 +297,7 @@ def main():
     argument_spec.update(vyos_argument_spec)
 
     required_one_of = [['vlan_id', 'aggregate'],
-                       ['interfaces', 'associated_interfaces']]
+                       ['aggregate', 'interfaces', 'associated_interfaces']]
 
     mutually_exclusive = [['vlan_id', 'aggregate']]
     module = AnsibleModule(argument_spec=argument_spec,

--- a/test/integration/targets/vyos_vlan/tests/cli/basic.yaml
+++ b/test/integration/targets/vyos_vlan/tests/cli/basic.yaml
@@ -7,6 +7,8 @@
       - delete interfaces ethernet eth1 vif 100
       - delete interfaces ethernet eth0 vif 5
       - delete interfaces ethernet eth0 vif 100
+      - delete interfaces ethernet eth0 vif 101
+      - delete interfaces ethernet eth1 vif 201
 
 - name: set vlan with name
   vyos_vlan: &name
@@ -68,8 +70,32 @@
     that:
       - "result.changed == false"
 
+- name: Create VLANs using aggregate
+  vyos_vlan: &agg_vlan
+    aggregate:
+      - { vlan_id: 101, name: voice, interfaces: "eth0" }
+      - { vlan_id: 201, name: mgm, interfaces: "eth1" }
+    state: present
+  register: result
+
+- assert:
+    that:
+      - "result.changed == true"
+      - "'set interfaces ethernet eth0 vif 101 description voice' in result.commands"
+      - "'set interfaces ethernet eth1 vif 201 description mgm' in result.commands"
+
+- name: Create VLANs using aggregate (idempotent)
+  vyos_vlan: *agg_vlan
+  register: result
+
+- assert:
+    that:
+      - "result.changed == false"
+
 - name: teardown
   vyos_config:
     lines:
       - delete interfaces ethernet eth1 vif 100
       - delete interfaces ethernet eth0 vif 5
+      - delete interfaces ethernet eth0 vif 101
+      - delete interfaces ethernet eth1 vif 201


### PR DESCRIPTION
* Fix vyos_vlan aggregate issue & Added tests

* Fix # 2 for vyos_vlan aggregate issue

(cherry picked from commit 837c2165872422d6b7ec51a6320f78065647dedb)

##### SUMMARY
- Fixes issue: #41528
- With this fix, VLANs can now be configured using aggregate
- Checks for and throws appropriate error message when vlan_id is not provided in an aggregate item
- Added integration tests

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
vyos_vlan.py

##### ANSIBLE VERSION

```
stable-2.6
```
