### PR TITLE
Fixes eos_logging DCI issue in 2.5

### DIFF
--- a/test/integration/targets/eos_logging/tests/cli/basic.yaml
+++ b/test/integration/targets/eos_logging/tests/cli/basic.yaml
@@ -96,6 +96,8 @@
     facility: local7
     level: informational
     state: present
+    authorize: yes
+    provider: "{{ cli }}"
   become: yes
   register: result
 
@@ -112,6 +114,8 @@
     facility: local7
     level: informational
     state: present
+    authorize: yes
+    provider: "{{ cli }}"
   become: yes
   register: result
 


### PR DESCRIPTION
##### SUMMARY
- Fixes DCI failure for eos_logging: **_ansible.module_utils.connection.ConnectionError: operation requires privilege escalation_**
- Changes added to tests to ensure green CI on stable-2.5 branch & hence changelog not added.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
eos_logging.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
stable-2.5
```