### PR TITLE
initial upload of yum_versionlock

### DIFF
--- a/lib/ansible/modules/packaging/os/yum_versionlock.py
+++ b/lib/ansible/modules/packaging/os/yum_versionlock.py
@@ -9,7 +9,7 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-ANSIBLE_METADATA = {'metadata_version': '1.0',
+ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],
                     'supported_by': 'community'}
 
@@ -45,6 +45,19 @@ EXAMPLES = '''
   yum_versionlock:
     state: absent
     package: httpd
+'''
+
+RETURN = '''
+package:
+    description: name of used package
+    returned: everytime 
+    type: string
+    sample: httpd
+state:
+    description: state of used package
+    returned: everytime 
+    type: string
+    sample: present
 '''
 
 import os.path

--- a/lib/ansible/modules/packaging/os/yum_versionlock.py
+++ b/lib/ansible/modules/packaging/os/yum_versionlock.py
@@ -79,7 +79,7 @@ def get_state_yum_versionlock(module, yum_binary):
     else:
         module.fail_json(msg="Error: Please install rpm package yum-plugin-versionlock | " + str(err) + str(out))
 
-        
+
 def get_versionlock_packages(module, yum_binary):
     """ Get an overview of all packages on yum versionlock """
     rc_code, out, err = module.run_command("%s -q versionlock list"

--- a/lib/ansible/modules/packaging/os/yum_versionlock.py
+++ b/lib/ansible/modules/packaging/os/yum_versionlock.py
@@ -16,30 +16,34 @@ ANSIBLE_METADATA = {'metadata_version': '1.0',
 DOCUMENTATION = '''
 ---
 module: yum_versionlock
-short_description: Locks/prevents an installed package from beeing updates by yum
+version_added: 2.7
+short_description: Locks/prevents an installed package from beeing updates by (yum) package mamanger.
 description:
-  - This module adds installed packages to yum versionlock to prevent it from beeing updated.
-    To run this module you need to install rpm package 'yum-versionlock'.
+     - This module adds installed packages to yum versionlock to prevent it from beeing updated.
 options:
-  state:
-    description:
-      - Adds/removes a package to yum versionlock to prevent it from beeing updated
-  version_added: "2.7"
   package:
     description:
-      - Wildcard package name (e.g. 'httpd')
-  version_added: "2.7"
+      - A package name or package specifier with version, like C(name-1.0).
+  state:
+    description:
+      - Whether to lock (C(present) or unlock (C(absent) a package.
+    choices: [ present, absent ]
 # informational: requirements for nodes
 requirements:
-    - yum
-    - yum-versionlock
+- yum
+- yum-versionlock
 author:
     - Florian Paul Hoberg <florian.hoberg@credativ.de>
 '''
+
 EXAMPLES = '''
 - name: Prevent Apache / httpd from beeing updated
   yum_versionlock:
     state: present
+    package: httpd
+- name:  Unlock Apache / httpd to be updated again
+  yum_versionlock:
+    state: absent
     package: httpd
 '''
 

--- a/lib/ansible/modules/packaging/os/yum_versionlock.py
+++ b/lib/ansible/modules/packaging/os/yum_versionlock.py
@@ -76,7 +76,7 @@ def main():
             state         = dict(required=True, type='str'),
             package        = dict(required=True, type='str'),
         ),
-        supports_check_mode=True
+        supports_check_mode=False
     )
 
     state       = module.params['state']

--- a/lib/ansible/modules/packaging/os/yum_versionlock.py
+++ b/lib/ansible/modules/packaging/os/yum_versionlock.py
@@ -41,7 +41,7 @@ def get_overview_versionlock_packages(module):
     """ Get an overview of all packages on yum versionlock """
     rc, out, err = module.run_command("%s -q versionlock list"
                                       % (yum_binary))
-    if rc is 0: 
+    if rc is 0:
         return out
     else:
         module.fail_json(msg="Error: " + str(err))
@@ -51,7 +51,7 @@ def add_package_versionlock(module, package):
     """ Add package to yum versionlock """
     rc, out, err = module.run_command("%s -q versionlock add %s"
                                       % (yum_binary, package))
-    if rc is 0: 
+    if rc is 0:
         changed = True
         return changed
     else:
@@ -62,7 +62,7 @@ def remove_package_versionlock(module, package):
     """ Remove package from yum versionlock """
     rc, out, err = module.run_command("%s -q versionlock delete %s"
                                       % (yum_binary, package))
-    if rc is 0: 
+    if rc is 0:
         changed = True
         return changed
     else:
@@ -89,7 +89,7 @@ def main():
         module.fail_json(msg="Error: Please install yum-versionlock")
 
     # Get an overview of all packages that have a version lock
-    versionlock_packages = get_overview_versionlock_packages(module) 
+    versionlock_packages = get_overview_versionlock_packages(module)
 
     # Add a package to versionlock
     if state == "present":

--- a/lib/ansible/modules/packaging/os/yum_versionlock.py
+++ b/lib/ansible/modules/packaging/os/yum_versionlock.py
@@ -23,7 +23,7 @@ description:
 options:
   package:
     description:
-      - A package name or package specifier with version, like C(name-1.0).
+      - A package name like C(httpd).
   state:
     description:
       - Whether to lock (C(present) or unlock (C(absent) a package.
@@ -95,7 +95,7 @@ def main():
     """ start main program to add/remove a package to yum versionlock"""
     module = AnsibleModule(
         argument_spec=dict(
-            state=dict(required=True, type='str'),
+            state=dict(required=True, type='str', choices=['present', 'absent']),
             package=dict(required=True, type='str'),
         ),
         supports_check_mode=False

--- a/lib/ansible/modules/packaging/os/yum_versionlock.py
+++ b/lib/ansible/modules/packaging/os/yum_versionlock.py
@@ -128,7 +128,7 @@ def main():
 
     # Add a package to versionlock
     if state == "present":
-        if not package in versionlock_packages:
+        if package not in versionlock_packages:
             changed = add_package_versionlock(module, package)
 
     # Remove a package from versionlock

--- a/lib/ansible/modules/packaging/os/yum_versionlock.py
+++ b/lib/ansible/modules/packaging/os/yum_versionlock.py
@@ -50,12 +50,12 @@ EXAMPLES = '''
 RETURN = '''
 package:
     description: name of used package
-    returned: everytime 
+    returned: everytime
     type: string
     sample: httpd
 state:
     description: state of used package
-    returned: everytime 
+    returned: everytime
     type: string
     sample: present
 '''

--- a/lib/ansible/modules/packaging/os/yum_versionlock.py
+++ b/lib/ansible/modules/packaging/os/yum_versionlock.py
@@ -63,6 +63,7 @@ state:
 
 from ansible.module_utils.basic import AnsibleModule
 
+
 def get_yum_path(module):
     """ Get yum path """
     yum_binary = module.get_bin_path('yum')
@@ -78,6 +79,7 @@ def get_state_yum_versionlock(module, yum_binary):
     else:
         module.fail_json(msg="Error: Please install rpm package yum-plugin-versionlock | " + str(err) + str(out))
 
+        
 def get_versionlock_packages(module, yum_binary):
     """ Get an overview of all packages on yum versionlock """
     rc_code, out, err = module.run_command("%s -q versionlock list"

--- a/lib/ansible/modules/packaging/os/yum_versionlock.py
+++ b/lib/ansible/modules/packaging/os/yum_versionlock.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python
+
+# Copyright (c) 2018, Florian Paul Hoberg <florian.hoberg@credativ.de>
+
+import os.path
+from ansible.module_utils.basic import *
+
+DOCUMENTATION = '''
+---
+module: yum_versionlock
+short_description: Locks/prevents an installed package from beeing updates by yum
+description:
+  - This module adds installed packages to yum versionlock to prevent it from beeing updated.
+    To run this module you need to install rpm package 'yum-versionlock'.
+options:
+  state:
+    description:
+      - Adds/removes a package to yum versionlock to prevent it from beeing updated
+  package:
+    description:
+      - Wildcard package name (e.g. 'httpd')
+author:
+- Florian Paul Hoberg <florian.hoberg@credativ.de>
+'''
+EXAMPLES = '''
+- name: Prevent Apache / httpd from beeing updated
+  yum_versionlock:
+    state: present
+    package: httpd
+'''
+
+yum_binary = "/bin/yum"
+
+
+def get_state_yum_versionlock():
+    state = os.path.exists("/etc/yum/pluginconf.d/versionlock.conf")
+    return state
+
+
+def get_overview_versionlock_packages(module):
+    """ Get an overview of all packages on yum versionlock """
+    rc, out, err = module.run_command("%s -q versionlock list"
+                                      % (yum_binary))
+    if rc is 0: 
+        return out
+    else:
+        module.fail_json(msg="Error: " + str(err))
+
+
+def add_package_versionlock(module, package):
+    """ Add package to yum versionlock """
+    rc, out, err = module.run_command("%s -q versionlock add %s"
+                                      % (yum_binary, package))
+    if rc is 0: 
+        changed = True
+        return changed
+    else:
+        module.fail_json(msg="Error: " + str(err))
+
+
+def remove_package_versionlock(module, package):
+    """ Remove package from yum versionlock """
+    rc, out, err = module.run_command("%s -q versionlock delete %s"
+                                      % (yum_binary, package))
+    if rc is 0: 
+        changed = True
+        return changed
+    else:
+        module.fail_json(msg="Error: " + str(err))
+
+
+def main():
+    """ start main program to add/remove a package to yum versionlock"""
+    module = AnsibleModule(
+        argument_spec       = dict(
+            state         = dict(required=True, type='str'),
+            package        = dict(required=True, type='str'),
+        ),
+        supports_check_mode=True
+    )
+
+    state       = module.params['state']
+    package      = module.params['package']
+    changed = False
+
+    # Check for yum version lock plugin
+    versionlock_plugin = get_state_yum_versionlock()
+    if versionlock_plugin is False:
+        module.fail_json(msg="Error: Please install yum-versionlock")
+
+    # Get an overview of all packages that have a version lock
+    versionlock_packages = get_overview_versionlock_packages(module) 
+
+    # Add a package to versionlock
+    if state == "present":
+        if not package in versionlock_packages:
+            changed = add_package_versionlock(module, package)
+
+    # Remove a package from versionlock
+    if state == "absent":
+        if package in versionlock_packages:
+            changed = remove_package_versionlock(module, package)
+
+    # Create Ansible meta output
+    response = {"package": package, "state": state}
+    if changed is True:
+        module.exit_json(changed=True, meta=response)
+    else:
+        module.exit_json(changed=False, meta=response)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Adds support to lock packages in their version to prevent these from updating by yum.

##### SUMMARY
This module adds support to lock packages in their version to prevent these from updating by yum.

Fixes #13086 

##### ISSUE TYPE
 - New Module Pull Request

##### COMPONENT NAME
- yum_versionlock

##### ANSIBLE VERSION
```
ansible 2.4.2.0
```

##### ADDITIONAL INFORMATION
An example run in local playbook

```
TASK [version_lock : lock nginx to prevent updates] **********************************************************************************************************
changed: [localhost]

TASK [version_lock : update nginx] ***************************************************************************************************************************
ok: [localhost]

TASK [version_lock : unlock nginx from updates] **************************************************************************************************************
changed: [localhost]

TASK [version_lock : update nginx] ***************************************************************************************************************************
changed: [localhost]
```