### PR TITLE
oc: add protocol string depending on user input

### DIFF
--- a/lib/ansible/modules/clustering/openshift/_oc.py
+++ b/lib/ansible/modules/clustering/openshift/_oc.py
@@ -152,14 +152,10 @@ class ApiEndpoint(object):
         self.version = version
 
     def __str__(self):
-        url = "https://"
-        url += self.host
-        url += ":"
-        url += str(self.port)
-        url += "/"
-        url += self.api
-        url += "/"
-        url += self.version
+        url = ""
+        if not self.host.startswith("https://"):
+            url = "https://"
+        url += "%s:%s/%s/%s" % (self.host, str(self.port), self.api, self.version)
         return url
 
 


### PR DESCRIPTION
##### SUMMARY
Before fix oc module adds https:// unconditionally.
After this fix oc module will add https:// depending upon
user input.

Fixes: #31590

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/clustering/openshift/_oc.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7-devel
```