### PR TITLE
Update playbooks_variables.rst

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_variables.rst
+++ b/docs/docsite/rst/user_guide/playbooks_variables.rst
@@ -835,8 +835,8 @@ Here is the order of precedence from least to greatest (the last listed variable
   * inventory group_vars/* [3]_
   * playbook group_vars/* [3]_
   * inventory file or script host vars [2]_
-  * inventory host_vars/*
-  * playbook host_vars/*
+  * inventory host_vars/all [3]_
+  * playbook host_vars/all [3]_
   * host facts / cached set_facts [4]_
   * inventory host_vars/* [3]_
   * playbook host_vars/* [3]_


### PR DESCRIPTION
<!--- Your description here -->
There are 2 instances of both "inventory host_vars/*" and "playbook host_vars/*" in the precedence list.
The intention was probably to have "../all" files have lower precedence. 
+label: docsite_pr

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - New Module Pull Request
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
