### PR TITLE
ovirt_auth: In case of token is passed username/pass is not requierd

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_auth.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_auth.py
@@ -267,8 +267,8 @@ def main():
     if url is None and hostname is not None:
         url = 'https://{0}/ovirt-engine/api'.format(hostname)
 
-    username = get_required_parameter('username', 'OVIRT_USERNAME', required=True)
-    password = get_required_parameter('password', 'OVIRT_PASSWORD', required=True)
+    username = get_required_parameter('username', 'OVIRT_USERNAME')
+    password = get_required_parameter('password', 'OVIRT_PASSWORD')
     token = get_required_parameter('token', 'OVIRT_TOKEN')
     ca_file = get_required_parameter('ca_file', 'OVIRT_CAFILE')
     insecure = params.get('insecure') if params.get('insecure') is not None else not bool(ca_file)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
When user pass `token`, `username` and `password` are not required parameters for `ovirt_auth` module.

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
ovirt_auth

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5.2
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
