### PR TITLE
provide a more comprehensive module import error

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -294,6 +294,13 @@ def get_distribution():
     return distribution
 
 
+def missing_required_lib(library):
+
+    hostname = platform.node().split('.')[0]
+    return "Cannot run as we are missing required library (%s) on %s's python %s."
+    "Please read module documentation and install in the appropriate location." % (library, hostname, sys.executable)
+
+
 def get_distribution_version():
     ''' return the distribution version '''
     if platform.system() == 'Linux':


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
create reusable more comprehensive error message on missing import dependency

now we can have modules use directly, try to capture existing at fail_json and/or add excepthook for ImportError.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
module_utils/basic
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7
```
