### PR TITLE
Handle typing of vars_files in Play.get_vars_files

### DIFF
--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -286,6 +286,8 @@ class Play(Base, Taggable, Become):
     def get_vars_files(self):
         if self.vars_files is None:
             return []
+        elif not isinstance(self.vars_files, list):
+            return [self.vars_files]
         return self.vars_files
 
     def get_handlers(self):


### PR DESCRIPTION
##### SUMMARY
Handle typing of `vars_files` in `Play.get_vars_files`. Fixes #14708

This would normally be handled by the `Base.post_validate` using the configuration of the `FieldAttribute` for `vars_files`, however, `Play.get_vars_files` is called to build a `Templar` that is used to call `post_validate`.  As such, we cannot reply on the `FieldAttribute` to validate early enough.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/playbook/play.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```