### PR TITLE
Remove unused imports from aws_direct_connect_connection module

### DIFF
--- a/lib/ansible/modules/cloud/amazon/aws_direct_connect_connection.py
+++ b/lib/ansible/modules/cloud/amazon/aws_direct_connect_connection.py
@@ -147,7 +147,7 @@ connection:
 
 import traceback
 from ansible.module_utils.aws.core import AnsibleAWSModule
-from ansible.module_utils.ec2 import (camel_dict_to_snake_dict AWSRetry)
+from ansible.module_utils.ec2 import (camel_dict_to_snake_dict, AWSRetry)
 from ansible.module_utils.aws.direct_connect import (DirectConnectError, delete_connection,
                                                      associate_connection_and_lag, disassociate_connection_and_lag)
 

--- a/lib/ansible/modules/cloud/amazon/aws_direct_connect_connection.py
+++ b/lib/ansible/modules/cloud/amazon/aws_direct_connect_connection.py
@@ -147,8 +147,7 @@ connection:
 
 import traceback
 from ansible.module_utils.aws.core import AnsibleAWSModule
-from ansible.module_utils.ec2 import (camel_dict_to_snake_dict, ec2_argument_spec, HAS_BOTO3,
-                                      get_aws_connection_info, boto3_conn, AWSRetry)
+from ansible.module_utils.ec2 import (camel_dict_to_snake_dict AWSRetry)
 from ansible.module_utils.aws.direct_connect import (DirectConnectError, delete_connection,
                                                      associate_connection_and_lag, disassociate_connection_and_lag)
 
@@ -279,8 +278,7 @@ def ensure_absent(client, connection_id):
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(dict(
+    argument_spec = dict(
         state=dict(required=True, choices=['present', 'absent']),
         name=dict(),
         location=dict(),
@@ -288,7 +286,7 @@ def main():
         link_aggregation_group=dict(),
         connection_id=dict(),
         forced_update=dict(type='bool', default=False)
-    ))
+    )
 
     module = AnsibleAWSModule(
         argument_spec=argument_spec,


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
Issue raised by [LGTM](ttps://lgtm.com/projects/g/ansible/ansible/latest/files/lib/ansible/modules/cloud/amazon/aws_direct_connect_connection.py?sort=alerts&dir=DESC&mode=heatmap&showExcluded=false)

Also stops duplicating ec2 argspec since that's built in to AnsibleAWSModule now. 

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
aws_direct_connect_connection

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
