### PR TITLE
Remove unused imports from aws_config_aggregator

### DIFF
--- a/lib/ansible/modules/cloud/amazon/aws_config_aggregator.py
+++ b/lib/ansible/modules/cloud/amazon/aws_config_aggregator.py
@@ -81,13 +81,11 @@ RETURN = r'''#'''
 
 try:
     import botocore
-    from botocore.exceptions import BotoCoreError, ClientError
 except ImportError:
     pass  # handled by AnsibleAWSModule
 
 from ansible.module_utils.aws.core import AnsibleAWSModule, is_boto3_error_code
-from ansible.module_utils.ec2 import boto3_conn, get_aws_connection_info, AWSRetry
-from ansible.module_utils.ec2 import camel_dict_to_snake_dict, boto3_tag_list_to_ansible_dict
+from ansible.module_utils.ec2 import AWSRetry, camel_dict_to_snake_dict
 
 
 def resource_exists(client, module, params):
@@ -104,7 +102,7 @@ def resource_exists(client, module, params):
 
 def create_resource(client, module, params, result):
     try:
-        response = client.put_configuration_aggregator(
+        client.put_configuration_aggregator(
             ConfigurationAggregatorName=params['ConfigurationAggregatorName'],
             AccountAggregationSources=params['AccountAggregationSources'],
             OrganizationAggregationSource=params['OrganizationAggregationSource']


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
Issue raised by [lgtm](https://lgtm.com/projects/g/ansible/ansible/latest/files/lib/ansible/modules/cloud/amazon/aws_config_aggregator.py#x8910d994f009e0c7%3A1)

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
aws_config_aggregator

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
