### PR TITLE
Revert "Fixes #35622 (#41522)"

### DIFF
--- a/lib/ansible/module_utils/network/aireos/aireos.py
+++ b/lib/ansible/module_utils/network/aireos/aireos.py
@@ -114,14 +114,13 @@ def run_commands(module, commands, check_rc=True):
 
 
 def load_config(module, commands):
+
     rc, out, err = exec_command(module, 'config')
     if rc != 0:
         module.fail_json(msg='unable to enter configuration mode', err=to_text(out, errors='surrogate_then_replace'))
 
-    commands = to_commands(module, to_list(commands))
-    for command in commands:
-        command = module.jsonify(command)
-        if "\"command\": \"end\"" in command:
+    for command in to_list(commands):
+        if command == 'end':
             continue
         rc, out, err = exec_command(module, command)
         if rc != 0:


### PR DESCRIPTION
This reverts commit 8357ae69e71081a6eabada733974204a11efd225.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Reverting #41522 because there isnt a way to keep idemotency with `*_config` modules and prompt & response for `lines`.  Allowing a dictionary of options does not work because the whole json object gets turned into a string in [config.py#L47](https://github.com/ansible/ansible/blob/devel/lib/ansible/module_utils/network/common/config.py#L47). We cannot compare configs to a prompt and answer since that string will not be present in the config, therefore the differences check in `NetworkConfig` will not work.

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
aireos.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (revert_#41522 f2112cfe84) last updated 2018/06/21 10:53:07 (GMT -700)
  config file = None
  configured module search path = [u'/Users/james/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/james/Documents/git/ansible/lib/ansible
  executable location = /Users/james/Documents/git/ansible/bin/ansible
  python version = 2.7.15 (default, May  1 2018, 16:44:08) [GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.1)]
```
