### PR TITLE
dnf: Call dnf.Base.close() before exit to cleanup.

### DIFF
--- a/lib/ansible/modules/packaging/os/dnf.py
+++ b/lib/ansible/modules/packaging/os/dnf.py
@@ -287,6 +287,7 @@ def list_items(module, base, command):
         packages = dnf.subject.Subject(command).get_best_query(base.sack)
         results = [_package_dict(package) for package in packages]
 
+    base.close()
     module.exit_json(results=results)
 
 
@@ -295,6 +296,7 @@ def _mark_package_install(module, base, pkg_spec):
     try:
         base.install(pkg_spec)
     except dnf.exceptions.MarkingError:
+        base.close()
         module.fail_json(msg="No package {0} available.".format(pkg_spec))
 
 
@@ -353,6 +355,7 @@ def ensure(module, base, state, names, autoremove):
                 if environment:
                     environments.append(environment.id)
                 else:
+                    base.close()
                     module.fail_json(
                         msg="No group {0} available.".format(group_spec))
 
@@ -419,6 +422,7 @@ def ensure(module, base, state, names, autoremove):
                 base.conf.clean_requirements_on_remove = autoremove
 
             if filenames:
+                base.close()
                 module.fail_json(
                     msg="Cannot remove paths -- please specify package name.")
 
@@ -450,16 +454,20 @@ def ensure(module, base, state, names, autoremove):
 
     if not base.resolve(allow_erasing=allow_erasing):
         if failures:
+            base.close()
             module.fail_json(msg='Failed to install some of the '
                                  'specified packages',
                              failures=failures)
+        base.close()
         module.exit_json(msg="Nothing to do")
     else:
         if module.check_mode:
             if failures:
+                base.close()
                 module.fail_json(msg='Failed to install some of the '
                                      'specified packages',
                                  failures=failures)
+            base.close()
             module.exit_json(changed=True)
 
         base.download_packages(base.transaction.install_set)
@@ -471,9 +479,11 @@ def ensure(module, base, state, names, autoremove):
             response['results'].append("Removed: {0}".format(package))
 
         if failures:
+            base.close()
             module.fail_json(msg='Failed to install some of the '
                                  'specified packages',
                              failures=failures)
+        base.close()
         module.exit_json(**response)
 
 


### PR DESCRIPTION
##### SUMMARY
On exit of dnf module, the dnf object still holds many file open.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
dnf
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.5
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /bin/ansible
  python version = 2.7.5 (default, Apr 13 2018, 04:32:41) [GCC 4.8.5 20150623 (Red Hat 4.8.5-28)]
```


##### ADDITIONAL INFORMATION
I'm running ansible with mitogen.  Ths was failing on Fedora with processes running out of file descriptors.  This is because mitogen runs each tasks in the same process and dnf was not closing file descriptors.  Eventually it would run out.  See https://github.com/dw/mitogen/issues/280 for more information.