### PR TITLE
[WIP] Show deprecation message when using top-level fact vars

### DIFF
--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -871,7 +871,7 @@ class ActionBase(with_metaclass(ABCMeta, object)):
             data = json.loads(filtered_output)
 
             if 'ansible_facts' in data and isinstance(data['ansible_facts'], dict):
-                data['ansible_facts'] = wrap_var(data['ansible_facts'])
+                data['ansible_facts'] = wrap_var(data['ansible_facts'], source='facts')
             data['_ansible_parsed'] = True
         except ValueError:
             # not valid json, lets try to capture error

--- a/lib/ansible/plugins/lookup/vars.py
+++ b/lib/ansible/plugins/lookup/vars.py
@@ -60,6 +60,7 @@ _value:
 from ansible.errors import AnsibleError, AnsibleUndefinedVariable
 from ansible.module_utils.six import string_types
 from ansible.plugins.lookup import LookupBase
+from ansible.template import warn_on_top_level_fact_vars
 
 
 class LookupModule(LookupBase):
@@ -85,6 +86,8 @@ class LookupModule(LookupBase):
                         value = myvars['hostvars'][myvars['inventory_hostname']][term]
                     except KeyError:
                         raise AnsibleUndefinedVariable('No variable found with this name: %s' % term)
+
+                warn_on_top_level_fact_vars(term, value)
 
                 ret.append(self._templar.template(value, fail_on_undefined=True))
             except AnsibleUndefinedVariable:

--- a/lib/ansible/vars/hostvars.py
+++ b/lib/ansible/vars/hostvars.py
@@ -24,7 +24,7 @@ import collections
 from jinja2.runtime import Undefined
 
 from ansible.module_utils._text import to_bytes
-from ansible.template import Templar
+from ansible.template import Templar, warn_on_top_level_fact_vars
 
 STATIC_VARS = [
     'ansible_version',
@@ -125,6 +125,7 @@ class HostVarsVars(collections.Mapping):
 
     def __getitem__(self, var):
         templar = Templar(variables=self._vars, loader=self._loader)
+        warn_on_top_level_fact_vars(var, self._vars[var])
         foo = templar.template(self._vars[var], fail_on_undefined=False, static_vars=STATIC_VARS)
         return foo
 

--- a/lib/ansible/vars/manager.py
+++ b/lib/ansible/vars/manager.py
@@ -308,10 +308,10 @@ class VariableManager:
 
                 # push facts to main namespace
                 if C.INJECT_FACTS_AS_VARS:
-                    all_vars = combine_vars(all_vars, wrap_var(facts))
+                    all_vars = combine_vars(all_vars, wrap_var(facts, source='facts'))
                 else:
                     # always 'promote' ansible_local
-                    all_vars = combine_vars(all_vars, wrap_var({'ansible_local': facts.get('ansible_local', {})}))
+                    all_vars = combine_vars(all_vars, wrap_var({'ansible_local': facts.get('ansible_local', {})}, source='facts'))
             except KeyError:
                 pass
 


### PR DESCRIPTION
##### SUMMARY
Show deprecation message when using top-level fact vars

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
fact vars

##### ANSIBLE VERSION
```
ansible 2.7.0.dev0 (deprecate_top_level_facts 2f1059ead6) last updated 2018/06/21 14:41:45 (GMT -500)
```

##### ADDITIONAL INFORMATION
A few minor caveats: the deprecation warning doesn't show for something like `debug: var=ansible_processor_count` but does for `debug: var=ansible_processor_count+0`. This appears to be because `ansible.template.AnsibleContext.resolve_or_missing()` isn't being called for "simple" integer values like it is for string/dict/list values. This also does not support showing a warning for boolean values, because Python makes it almost impossible to create a `bool`-like object that works properly in all cases.