### PR TITLE
[backport] Fix wrong python keyword (followup to #36357) (#41067)

### DIFF
--- a/lib/ansible/parsing/dataloader.py
+++ b/lib/ansible/parsing/dataloader.py
@@ -422,7 +422,7 @@ class DataLoader:
                     if allow_dir:
                         found.extend(self._get_dir_vars_files(to_text(full_path), extensions))
                     else:
-                        next
+                        continue
                 else:
                     found.append(full_path)
                 break

--- a/test/units/playbook/role/test_role.py
+++ b/test/units/playbook/role/test_role.py
@@ -148,6 +148,26 @@ class TestRole(unittest.TestCase):
         assert isinstance(r._task_blocks[0], Block)
 
     @patch('ansible.playbook.role.definition.unfrackpath', mock_unfrackpath_noop)
+    def test_load_role_with_tasks_dir_vs_file(self):
+
+        fake_loader = DictDataLoader({
+            "/etc/ansible/roles/foo_tasks/tasks/custom_main/foo.yml": """
+            - command: bar
+            """,
+            "/etc/ansible/roles/foo_tasks/tasks/custom_main.yml": """
+            - command: baz
+            """,
+        })
+
+        mock_play = MagicMock()
+        mock_play.ROLE_CACHE = {}
+
+        i = RoleInclude.load('foo_tasks', play=mock_play, loader=fake_loader)
+        r = Role.load(i, play=mock_play, from_files=dict(tasks='custom_main'))
+
+        self.assertEqual(r._task_blocks[0]._ds[0]['command'], 'baz')
+
+    @patch('ansible.playbook.role.definition.unfrackpath', mock_unfrackpath_noop)
     def test_load_role_with_handlers(self):
 
         fake_loader = DictDataLoader({


### PR DESCRIPTION
Also add tests around that code path

##### SUMMARY
There was a regression introduced during the 2.6 devel cycle and made it into `stable-2.6` which intended to [allow loading dirs from role defaults/vars](https://github.com/ansible/ansible/commit/95ce00ff00e2907e89f4106747abaf9d4e4ccd7f) which was later [fixed by the original author](https://github.com/ansible/ansible/commit/0ff04ad41b55e19af8671b8ea33030b10927771a) but after `stable-2.6` was cut. This is a backport/cherry-pick of that commit.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
lib/ansible/parsing/dataloader.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0rc3.dev0 (backport/2.6/role_default_load_dirs_fix 1cd2cb9259) last updated 2018/06/21 14:59:12 (GMT -500)
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/admiller/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/admiller/src/dev/ansible/lib/ansible
  executable location = /home/admiller/src/dev/ansible/bin/ansible
  python version = 3.6.5 (default, Apr  4 2018, 15:01:18) [GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]
```


##### ADDITIONAL INFORMATION

Playbook + role repoducer
```

$  cat /tmp/foo.yml
- name: test
  hosts: localhost
  gather_facts: False
  tasks:
  - import_role:
      name: fakerole
      tasks_from: upgrade

$  tree /tmp/fakerole/
/tmp/fakerole/
└── tasks
    ├── upgrade
    └── upgrade.yml

2 directories, 1 file

$ cat /tmp/fakerole/tasks/upgrade.yml 
- debug: msg="testing"
```

Before
```
$ ansible-playbook /tmp/foo.yml
 [WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'

ERROR! Could not find specified file in role: tasks/upgrade
```

After
```
$ ansible-playbook /tmp/foo.yml 
 [WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'


PLAY [test] ***********************************************************************************************************************************

TASK [fakerole : debug] ***********************************************************************************************************************************
ok: [localhost] => {
    "msg": "testing"
}

PLAY RECAP ***********************************************************************************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=0   
```