### PR TITLE
Enforcing NXAPI default HTTP behavior

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_nxapi.py
+++ b/lib/ansible/modules/network/nxos/nxos_nxapi.py
@@ -180,9 +180,9 @@ def map_obj_to_commands(want, have, module):
 
     if want.get('https') is None or want.get('https') is False:
         if have.get('https') is True or needs_update('state'):
-            commands.append('no nxapi https');
+            commands.append('no nxapi https')
         if want.get('http') is None and (needs_update('state') and have.get('http') is None):
-            commands.append('nxapi http port 80');
+            commands.append('nxapi http port 80')
 
     if needs_update('http') or (have.get('http') and needs_update('http_port')):
         if want['http'] is True or (want['http'] is None and have['http'] is True):

--- a/lib/ansible/modules/network/nxos/nxos_nxapi.py
+++ b/lib/ansible/modules/network/nxos/nxos_nxapi.py
@@ -171,6 +171,18 @@ def map_obj_to_commands(want, have, module):
         if want['state'] == 'absent':
             return ['no feature nxapi']
         commands.append('feature nxapi')
+    elif want['state'] == 'absent':
+        return commands
+
+    # The latest version (9.2) of NXOS software has changed the platform default
+    # nxapi transfer to https. Enforce the default nxapi http behavior unless
+    # explicitly asking for https.
+
+    if want.get('https') is None or want.get('https') is False:
+        if have.get('https') is True or needs_update('state'):
+            commands.append('no nxapi https');
+        if want.get('http') is None and (needs_update('state') and have.get('http') is None):
+            commands.append('nxapi http port 80');
 
     if needs_update('http') or (have.get('http') and needs_update('http_port')):
         if want['http'] is True or (want['http'] is None and have['http'] is True):

--- a/test/integration/targets/nxos_nxapi/tasks/platform/default/assert_changes.yaml
+++ b/test/integration/targets/nxos_nxapi/tasks/platform/default/assert_changes.yaml
@@ -5,3 +5,12 @@
       - result.stdout[0]['TABLE_listen_on_port']['ROW_listen_on_port'].l_port
       - result.stdout[0]['TABLE_listen_on_port']['ROW_listen_on_port'].l_port|string is search("9443")
       - result.stdout[0]['operation_status'].o_status == 'nxapi enabled'
+  when: major_version is version('9.2', '<')
+
+- name: Assert configuration changes Hamilton
+  assert:
+    that:
+      - result.stdout[0]['https_port']
+      - result.stdout[0]['https_port']|string is search("9443")
+      - result.stdout[0]['nxapi_status'] == 'nxapi enabled'
+  when: major_version is version('9.2', '>=')

--- a/test/integration/targets/nxos_nxapi/tasks/platform/default/assert_changes_http.yaml
+++ b/test/integration/targets/nxos_nxapi/tasks/platform/default/assert_changes_http.yaml
@@ -7,7 +7,7 @@
       - result.stdout[0]['operation_status'].o_status == 'nxapi enabled'
   when: major_version is version('9.2', '<')
 
-- name: Assert HTTP configuration changes Hamilton
+- name: Assert HTTP configuration changes 9.2 or greater
   assert:
     that:
       - result.stdout[0]['http_port']

--- a/test/integration/targets/nxos_nxapi/tasks/platform/default/assert_changes_http.yaml
+++ b/test/integration/targets/nxos_nxapi/tasks/platform/default/assert_changes_http.yaml
@@ -1,16 +1,16 @@
 ---
-- name: Assert configuration changes
+- name: Assert HTTP configuration changes
   assert:
     that:
       - result.stdout[0]['TABLE_listen_on_port']['ROW_listen_on_port'].l_port
-      - result.stdout[0]['TABLE_listen_on_port']['ROW_listen_on_port'].l_port|string is search("9443")
+      - result.stdout[0]['TABLE_listen_on_port']['ROW_listen_on_port'].l_port|string is search("80")
       - result.stdout[0]['operation_status'].o_status == 'nxapi enabled'
   when: major_version is version('9.2', '<')
 
-- name: Assert configuration changes Hamilton
+- name: Assert HTTP configuration changes Hamilton
   assert:
     that:
-      - result.stdout[0]['https_port']
-      - result.stdout[0]['https_port']|string is search("9443")
+      - result.stdout[0]['http_port']
+      - result.stdout[0]['http_port']|string is search("80")
       - result.stdout[0]['nxapi_status'] == 'nxapi enabled'
   when: major_version is version('9.2', '>=')

--- a/test/integration/targets/nxos_nxapi/tasks/platform/default/assert_changes_https.yaml
+++ b/test/integration/targets/nxos_nxapi/tasks/platform/default/assert_changes_https.yaml
@@ -7,7 +7,7 @@
       - result.stdout[0]['operation_status'].o_status == 'nxapi enabled'
   when: major_version is version('9.2', '<')
 
-- name: Assert HTTPS configuration changes Hamilton
+- name: Assert HTTPS configuration changes 9.2 or greater
   assert:
     that:
       - result.stdout[0]['https_port']

--- a/test/integration/targets/nxos_nxapi/tasks/platform/default/assert_changes_https.yaml
+++ b/test/integration/targets/nxos_nxapi/tasks/platform/default/assert_changes_https.yaml
@@ -1,0 +1,16 @@
+---
+- name: Assert HTTPS configuration changes
+  assert:
+    that:
+      - result.stdout[0]['TABLE_listen_on_port']['ROW_listen_on_port'].l_port
+      - result.stdout[0]['TABLE_listen_on_port']['ROW_listen_on_port'].l_port|string is search("9443")
+      - result.stdout[0]['operation_status'].o_status == 'nxapi enabled'
+  when: major_version is version('9.2', '<')
+
+- name: Assert HTTPS configuration changes Hamilton
+  assert:
+    that:
+      - result.stdout[0]['https_port']
+      - result.stdout[0]['https_port']|string is search("9443")
+      - result.stdout[0]['nxapi_status'] == 'nxapi enabled'
+  when: major_version is version('9.2', '>=')

--- a/test/integration/targets/nxos_nxapi/tasks/platform/default/assert_changes_https_http.yaml
+++ b/test/integration/targets/nxos_nxapi/tasks/platform/default/assert_changes_https_http.yaml
@@ -1,0 +1,20 @@
+---
+- name: Assert HTTPS & HTTP configuration changes
+  assert:
+    that:
+      - result.stdout[0]['TABLE_listen_on_port']['ROW_listen_on_port'][1].l_port
+      - result.stdout[0]['TABLE_listen_on_port']['ROW_listen_on_port'][1].l_port|string is search("9443")
+      - result.stdout[0]['TABLE_listen_on_port']['ROW_listen_on_port'][0].l_port
+      - result.stdout[0]['TABLE_listen_on_port']['ROW_listen_on_port'][0].l_port|string is search("80")
+      - result.stdout[0]['operation_status'].o_status == 'nxapi enabled'
+  when: major_version is version('9.2', '<')
+
+- name: Assert HTTPS & HTTP configuration changes Hamilton
+  assert:
+    that:
+      - result.stdout[0]['https_port']
+      - result.stdout[0]['https_port']|string is search("9443")
+      - result.stdout[0]['http_port']
+      - result.stdout[0]['http_port']|string is search("80")
+      - result.stdout[0]['nxapi_status'] == 'nxapi enabled'
+  when: major_version is version('9.2', '>=')

--- a/test/integration/targets/nxos_nxapi/tasks/platform/default/assert_changes_https_http.yaml
+++ b/test/integration/targets/nxos_nxapi/tasks/platform/default/assert_changes_https_http.yaml
@@ -9,7 +9,7 @@
       - result.stdout[0]['operation_status'].o_status == 'nxapi enabled'
   when: major_version is version('9.2', '<')
 
-- name: Assert HTTPS & HTTP configuration changes Hamilton
+- name: Assert HTTPS & HTTP configuration changes 9.2 or greater
   assert:
     that:
       - result.stdout[0]['https_port']

--- a/test/integration/targets/nxos_nxapi/tasks/platform/default/assert_changes_https_http_ports.yaml
+++ b/test/integration/targets/nxos_nxapi/tasks/platform/default/assert_changes_https_http_ports.yaml
@@ -1,0 +1,20 @@
+---
+- name: Assert HTTPS & HTTP configuration changes
+  assert:
+    that:
+      - result.stdout[0]['TABLE_listen_on_port']['ROW_listen_on_port'][1].l_port
+      - result.stdout[0]['TABLE_listen_on_port']['ROW_listen_on_port'][1].l_port|string is search("500")
+      - result.stdout[0]['TABLE_listen_on_port']['ROW_listen_on_port'][0].l_port
+      - result.stdout[0]['TABLE_listen_on_port']['ROW_listen_on_port'][0].l_port|string is search("99")
+      - result.stdout[0]['operation_status'].o_status == 'nxapi enabled'
+  when: major_version is version('9.2', '<')
+
+- name: Assert HTTPS & HTTP configuration changes 9.2 or greater
+  assert:
+    that:
+      - result.stdout[0]['https_port']
+      - result.stdout[0]['https_port']|string is search("500")
+      - result.stdout[0]['http_port']
+      - result.stdout[0]['http_port']|string is search("99")
+      - result.stdout[0]['nxapi_status'] == 'nxapi enabled'
+  when: major_version is version('9.2', '>=')

--- a/test/integration/targets/nxos_nxapi/tasks/platform/n5k/assert_changes_http.yaml
+++ b/test/integration/targets/nxos_nxapi/tasks/platform/n5k/assert_changes_http.yaml
@@ -1,0 +1,6 @@
+---
+- name: Assert HTTP configuration changes
+  assert:
+    that:
+      - result.stdout[0].https_port is not defined
+      - result.stdout[0].http_port|string is search("80")

--- a/test/integration/targets/nxos_nxapi/tasks/platform/n5k/assert_changes_https.yaml
+++ b/test/integration/targets/nxos_nxapi/tasks/platform/n5k/assert_changes_https.yaml
@@ -1,5 +1,5 @@
 ---
-- name: Assert configuration changes
+- name: Assert HTTPS configuration changes
   assert:
     that:
       - result.stdout[0].http_port is not defined

--- a/test/integration/targets/nxos_nxapi/tasks/platform/n5k/assert_changes_https_http.yaml
+++ b/test/integration/targets/nxos_nxapi/tasks/platform/n5k/assert_changes_https_http.yaml
@@ -1,0 +1,8 @@
+---
+- name: Assert HTTPS && HTTP configuration changes
+  assert:
+    that:
+      - result.stdout[0].https_port is defined
+      - result.stdout[0].http_port is defined
+      - result.stdout[0].https_port|string is search("9443")
+      - result.stdout[0].http_port|string is search("80")

--- a/test/integration/targets/nxos_nxapi/tasks/platform/n5k/assert_changes_https_http_ports.yaml
+++ b/test/integration/targets/nxos_nxapi/tasks/platform/n5k/assert_changes_https_http_ports.yaml
@@ -1,0 +1,8 @@
+---
+- name: Assert HTTPS && HTTP configuration changes
+  assert:
+    that:
+      - result.stdout[0].https_port is defined
+      - result.stdout[0].http_port is defined
+      - result.stdout[0].https_port|string is search("500")
+      - result.stdout[0].http_port|string is search("99")

--- a/test/integration/targets/nxos_nxapi/tasks/platform/n7k/assert_changes_http.yaml
+++ b/test/integration/targets/nxos_nxapi/tasks/platform/n7k/assert_changes_http.yaml
@@ -1,0 +1,7 @@
+---
+- name: Assert HTTP configuration changes
+  assert:
+    that:
+      - result.stdout[0].https_port is not defined
+      - result.stdout[0].http_port|string is search("80")
+      - result.stdout[0].sandbox_status == 'Enabled'

--- a/test/integration/targets/nxos_nxapi/tasks/platform/n7k/assert_changes_https.yaml
+++ b/test/integration/targets/nxos_nxapi/tasks/platform/n7k/assert_changes_https.yaml
@@ -1,5 +1,5 @@
 ---
-- name: Assert configuration changes
+- name: Assert HTTPS configuration changes
   assert:
     that:
       - result.stdout[0].http_port is not defined

--- a/test/integration/targets/nxos_nxapi/tasks/platform/n7k/assert_changes_https_http.yaml
+++ b/test/integration/targets/nxos_nxapi/tasks/platform/n7k/assert_changes_https_http.yaml
@@ -1,0 +1,9 @@
+---
+- name: Assert HTTPS & HTTP configuration changes
+  assert:
+    that:
+      - result.stdout[0].https_port is defined
+      - result.stdout[0].http_port is defined
+      - result.stdout[0].https_port|string is search("9443")
+      - result.stdout[0].http_port|string is search("80")
+      - result.stdout[0].sandbox_status == 'Enabled'

--- a/test/integration/targets/nxos_nxapi/tasks/platform/n7k/assert_changes_https_http_ports.yaml
+++ b/test/integration/targets/nxos_nxapi/tasks/platform/n7k/assert_changes_https_http_ports.yaml
@@ -1,0 +1,9 @@
+---
+- name: Assert HTTPS & HTTP configuration changes
+  assert:
+    that:
+      - result.stdout[0].https_port is defined
+      - result.stdout[0].http_port is defined
+      - result.stdout[0].https_port|string is search("500")
+      - result.stdout[0].http_port|string is search("99")
+      - result.stdout[0].sandbox_status == 'Enabled'

--- a/test/integration/targets/nxos_nxapi/tests/cli/configure.yaml
+++ b/test/integration/targets/nxos_nxapi/tests/cli/configure.yaml
@@ -9,7 +9,7 @@
     state: absent
 
 - block:
-  - name: Configure NXAPI
+  - name: Configure NXAPI HTTPS
     nxos_nxapi:
       enable_http: no
       enable_sandbox: "{{nxapi_sandbox_option|default(omit)}}"
@@ -22,16 +22,16 @@
         - show nxapi | json
     register: result
 
-  - include: targets/nxos_nxapi/tasks/platform/n7k/assert_changes.yaml
+  - include: targets/nxos_nxapi/tasks/platform/n7k/assert_changes_https.yaml
     when: platform is match('N7K')
 
-  - include: targets/nxos_nxapi/tasks/platform/n5k/assert_changes.yaml
+  - include: targets/nxos_nxapi/tasks/platform/n5k/assert_changes_https.yaml
     when: platform is match('N5K')
 
-  - include: targets/nxos_nxapi/tasks/platform/default/assert_changes.yaml
+  - include: targets/nxos_nxapi/tasks/platform/default/assert_changes_https.yaml
     when: not ( platform is search('N7K')) and not (platform is search('N5K')) and not (platform is search('N35'))
 
-  - name: Configure NXAPI again
+  - name: Configure NXAPI HTTPS again
     nxos_nxapi:
       enable_http: no
       enable_sandbox: "{{nxapi_sandbox_option|default(omit)}}"
@@ -43,6 +43,77 @@
     assert:
       that:
         - result.changed == false
+
+
+  - name: Configure NXAPI HTTPS & HTTP
+    nxos_nxapi:
+      enable_http: yes
+      enable_sandbox: "{{nxapi_sandbox_option|default(omit)}}"
+      enable_https: yes
+      https_port: 9443
+    register: result
+
+  - nxos_command:
+      commands:
+        - show nxapi | json
+    register: result
+
+  - include: targets/nxos_nxapi/tasks/platform/n7k/assert_changes_https_http.yaml
+    when: platform is match('N7K')
+
+  - include: targets/nxos_nxapi/tasks/platform/n5k/assert_changes_https_http.yaml
+    when: platform is match('N5K')
+
+  - include: targets/nxos_nxapi/tasks/platform/default/assert_changes_https_http.yaml
+    when: not ( platform is search('N7K')) and not (platform is search('N5K')) and not (platform is search('N35'))
+
+  - name: Configure NXAPI HTTPS & HTTP again
+    nxos_nxapi:
+      enable_http: yes
+      enable_sandbox: "{{nxapi_sandbox_option|default(omit)}}"
+      enable_https: yes
+      https_port: 9443
+    register: result
+
+  - name: Assert configuration is idempotent
+    assert:
+      that:
+        - result.changed == false
+
+
+  - name: Configure NXAPI HTTP
+    nxos_nxapi:
+      enable_http: yes
+      enable_sandbox: "{{nxapi_sandbox_option|default(omit)}}"
+      enable_https: no
+    register: result
+
+  - nxos_command:
+      commands:
+        - show nxapi | json
+    register: result
+
+  - include: targets/nxos_nxapi/tasks/platform/n7k/assert_changes_http.yaml
+    when: platform is match('N7K')
+
+  - include: targets/nxos_nxapi/tasks/platform/n5k/assert_changes_http.yaml
+    when: platform is match('N5K')
+
+  - include: targets/nxos_nxapi/tasks/platform/default/assert_changes_http.yaml
+    when: not ( platform is search('N7K')) and not (platform is search('N5K')) and not (platform is search('N35'))
+
+  - name: Configure NXAPI HTTP again
+    nxos_nxapi:
+      enable_http: yes
+      enable_sandbox: "{{nxapi_sandbox_option|default(omit)}}"
+      enable_https: no
+    register: result
+
+  - name: Assert configuration is idempotent
+    assert:
+      that:
+        - result.changed == false
+
 
   always:
   - name: Cleanup - Disable NXAPI

--- a/test/integration/targets/nxos_nxapi/tests/cli/configure.yaml
+++ b/test/integration/targets/nxos_nxapi/tests/cli/configure.yaml
@@ -127,4 +127,3 @@
     register: result
 
   - debug: msg="END cli/configure.yaml"
-

--- a/test/integration/targets/nxos_nxapi/tests/cli/configure.yaml
+++ b/test/integration/targets/nxos_nxapi/tests/cli/configure.yaml
@@ -10,7 +10,7 @@
 
 - block:
   - name: Configure NXAPI HTTPS
-    nxos_nxapi:
+    nxos_nxapi: &configure_https
       enable_http: no
       enable_sandbox: "{{nxapi_sandbox_option|default(omit)}}"
       enable_https: yes
@@ -32,21 +32,17 @@
     when: not ( platform is search('N7K')) and not (platform is search('N5K')) and not (platform is search('N35'))
 
   - name: Configure NXAPI HTTPS again
-    nxos_nxapi:
-      enable_http: no
-      enable_sandbox: "{{nxapi_sandbox_option|default(omit)}}"
-      enable_https: yes
-      https_port: 9443
+    nxos_nxapi: *configure_https
     register: result
 
   - name: Assert configuration is idempotent
-    assert:
+    assert: &assert_false
       that:
         - result.changed == false
 
 
   - name: Configure NXAPI HTTPS & HTTP
-    nxos_nxapi:
+    nxos_nxapi: &configure_https_http
       enable_http: yes
       enable_sandbox: "{{nxapi_sandbox_option|default(omit)}}"
       enable_https: yes
@@ -68,21 +64,14 @@
     when: not ( platform is search('N7K')) and not (platform is search('N5K')) and not (platform is search('N35'))
 
   - name: Configure NXAPI HTTPS & HTTP again
-    nxos_nxapi:
-      enable_http: yes
-      enable_sandbox: "{{nxapi_sandbox_option|default(omit)}}"
-      enable_https: yes
-      https_port: 9443
+    nxos_nxapi: *configure_https_http
     register: result
 
   - name: Assert configuration is idempotent
-    assert:
-      that:
-        - result.changed == false
-
+    assert: *assert_false
 
   - name: Configure NXAPI HTTP
-    nxos_nxapi:
+    nxos_nxapi: &configure_http
       enable_http: yes
       enable_sandbox: "{{nxapi_sandbox_option|default(omit)}}"
       enable_https: no
@@ -103,17 +92,11 @@
     when: not ( platform is search('N7K')) and not (platform is search('N5K')) and not (platform is search('N35'))
 
   - name: Configure NXAPI HTTP again
-    nxos_nxapi:
-      enable_http: yes
-      enable_sandbox: "{{nxapi_sandbox_option|default(omit)}}"
-      enable_https: no
+    nxos_nxapi: *configure_http
     register: result
 
   - name: Assert configuration is idempotent
-    assert:
-      that:
-        - result.changed == false
-
+    assert: *assert_false
 
   always:
   - name: Cleanup - Disable NXAPI

--- a/test/integration/targets/nxos_nxapi/tests/cli/configure.yaml
+++ b/test/integration/targets/nxos_nxapi/tests/cli/configure.yaml
@@ -8,39 +8,52 @@
   nxos_nxapi:
     state: absent
 
-- name: Configure NXAPI
-  nxos_nxapi:
-    enable_http: no
-    enable_sandbox: "{{nxapi_sandbox_option|default(omit)}}"
-    enable_https: yes
-    https_port: 9443
-  register: result
+- block:
+  - name: Configure NXAPI
+    nxos_nxapi:
+      enable_http: no
+      enable_sandbox: "{{nxapi_sandbox_option|default(omit)}}"
+      enable_https: yes
+      https_port: 9443
+    register: result
 
-- nxos_command:
-    commands:
-      - show nxapi | json
-  register: result
+  - nxos_command:
+      commands:
+        - show nxapi | json
+    register: result
 
-- include: targets/nxos_nxapi/tasks/platform/n7k/assert_changes.yaml
-  when: platform is match('N7K')
+  - include: targets/nxos_nxapi/tasks/platform/n7k/assert_changes.yaml
+    when: platform is match('N7K')
 
-- include: targets/nxos_nxapi/tasks/platform/n5k/assert_changes.yaml
-  when: platform is match('N5K')
+  - include: targets/nxos_nxapi/tasks/platform/n5k/assert_changes.yaml
+    when: platform is match('N5K')
 
-- include: targets/nxos_nxapi/tasks/platform/default/assert_changes.yaml
-  when: not ( platform is search('N7K')) and not (platform is search('N5K')) and not (platform is search('N35'))
+  - include: targets/nxos_nxapi/tasks/platform/default/assert_changes.yaml
+    when: not ( platform is search('N7K')) and not (platform is search('N5K')) and not (platform is search('N35'))
 
-- name: Configure NXAPI again
-  nxos_nxapi:
-    enable_http: no
-    enable_sandbox: "{{nxapi_sandbox_option|default(omit)}}"
-    enable_https: yes
-    https_port: 9443
-  register: result
+  - name: Configure NXAPI again
+    nxos_nxapi:
+      enable_http: no
+      enable_sandbox: "{{nxapi_sandbox_option|default(omit)}}"
+      enable_https: yes
+      https_port: 9443
+    register: result
 
-- name: Assert configuration is idempotent
-  assert:
-    that:
-      - result.changed == false
+  - name: Assert configuration is idempotent
+    assert:
+      that:
+        - result.changed == false
 
-- debug: msg="END cli/configure.yaml"
+  always:
+  - name: Cleanup - Disable NXAPI
+    nxos_nxapi:
+      state: absent
+    register: result
+
+  - name: Cleanup - Re-enable NXAPI
+    nxos_nxapi:
+      state: present
+    register: result
+
+  - debug: msg="END cli/configure.yaml"
+

--- a/test/integration/targets/nxos_nxapi/tests/cli/configure.yaml
+++ b/test/integration/targets/nxos_nxapi/tests/cli/configure.yaml
@@ -70,6 +70,36 @@
   - name: Assert configuration is idempotent
     assert: *assert_false
 
+  - name: Configure different NXAPI HTTPS & HTTP ports
+    nxos_nxapi: &configure_https_http_ports
+      enable_http: yes
+      enable_sandbox: "{{nxapi_sandbox_option|default(omit)}}"
+      enable_https: yes
+      http_port: 99
+      https_port: 500
+    register: result
+
+  - nxos_command:
+      commands:
+        - show nxapi | json
+    register: result
+
+  - include: targets/nxos_nxapi/tasks/platform/n7k/assert_changes_https_http_ports.yaml
+    when: platform is match('N7K')
+
+  - include: targets/nxos_nxapi/tasks/platform/n5k/assert_changes_https_http_ports.yaml
+    when: platform is match('N5K')
+
+  - include: targets/nxos_nxapi/tasks/platform/default/assert_changes_https_http_ports.yaml
+    when: not ( platform is search('N7K')) and not (platform is search('N5K')) and not (platform is search('N35'))
+
+  - name: Configure different NXAPI HTTPS & HTTP ports again
+    nxos_nxapi: *configure_https_http_ports
+    register: result
+
+  - name: Assert configuration is idempotent
+    assert: *assert_false
+
   - name: Configure NXAPI HTTP
     nxos_nxapi: &configure_http
       enable_http: yes

--- a/test/integration/targets/prepare_nxos_tests/tasks/main.yml
+++ b/test/integration/targets/prepare_nxos_tests/tasks/main.yml
@@ -93,6 +93,7 @@
 # 8.0(1)
 # 7.3(0)D1(1)
 # 7.0(3)IHD8(1)
+- set_fact: major_version="{{ image_version[0:3] }}"
 - set_fact: imagetag="{{ image_version[0:3] }}"
   when: image_version is search("\d\.\d\(\d\)")
 - set_fact: imagetag="{{ image_version[6:8] }}"

--- a/test/integration/targets/prepare_nxos_tests/tasks/main.yml
+++ b/test/integration/targets/prepare_nxos_tests/tasks/main.yml
@@ -10,11 +10,6 @@
   nxos_nxapi:
     state: present
   connection: network_cli
-  ignore_errors: yes
-
-- name: Set nxapi to default state
-  nxos_nxapi:
-  connection: network_cli
 
 # Gather the list of interfaces on this device and make the list
 # available for integration tests that need them.

--- a/test/integration/targets/prepare_nxos_tests/tasks/main.yml
+++ b/test/integration/targets/prepare_nxos_tests/tasks/main.yml
@@ -1,11 +1,16 @@
 ---
-- name: Toggle feature nxapi - Enable
+- name: Enable Feature Privilage
   nxos_config:
     lines:
-      - feature nxapi
       - feature privilege
   connection: network_cli
   ignore_errors: yes
+
+- name: Enable Feature NXAPI
+  nxos_nxapi:
+    state: present
+  connection: network_cli
+  gnore_errors: yes
 
 - name: Set nxapi to default state
   nxos_nxapi:

--- a/test/integration/targets/prepare_nxos_tests/tasks/main.yml
+++ b/test/integration/targets/prepare_nxos_tests/tasks/main.yml
@@ -10,7 +10,7 @@
   nxos_nxapi:
     state: present
   connection: network_cli
-  gnore_errors: yes
+  ignore_errors: yes
 
 - name: Set nxapi to default state
   nxos_nxapi:

--- a/test/sanity/validate-modules/ignore.txt
+++ b/test/sanity/validate-modules/ignore.txt
@@ -944,7 +944,6 @@ lib/ansible/modules/network/nxos/nxos_gir.py E326
 lib/ansible/modules/network/nxos/nxos_igmp_interface.py E326
 lib/ansible/modules/network/nxos/nxos_interface.py E324
 lib/ansible/modules/network/nxos/nxos_lldp.py E326
-lib/ansible/modules/network/nxos/nxos_nxapi.py E324
 lib/ansible/modules/network/nxos/nxos_nxapi.py E326
 lib/ansible/modules/network/nxos/nxos_pim_interface.py E326
 lib/ansible/modules/network/nxos/nxos_pim_rp_address.py E326


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
In the upcoming release of NXOS 9.2 nxapi has changed the default transport from HTTP to HTTPS.  Because of this, test cases that expect HTTP to be enabled by default are failing.

This change-set includes enforcing the default HTTP transport behavior unless explicitly requesting HTTPS.  This ensures backwards compatibility.  Extended nxos_nxapi test cases to cover more HTTPS & HTTP configuration permutations.  Test cases now cover https, https & http and http

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
nxos_nxapi

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (devel 0b253df055) last updated 2018/06/21 16:51:18 (GMT -400)
  config file = None
  configured module search path = [u'/Users/tmstoner/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/tmstoner/ansible/ansible/lib/ansible
  executable location = /Users/tmstoner/ansible/ansible/bin/ansible
  python version = 2.7.10 (default, Oct  6 2017, 22:29:07) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.31)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```