### PR TITLE
Nxos restore provider to nxapi tests

### DIFF
--- a/test/integration/targets/nxos_aaa_server/tests/common/radius.yaml
+++ b/test/integration/targets/nxos_aaa_server/tests/common/radius.yaml
@@ -9,6 +9,7 @@
     deadtime: default
     server_timeout: default
     directed_request: default
+    provider: "{{ connection }}"
     state: default
   ignore_errors: yes
 
@@ -16,6 +17,7 @@
   - name: "Configure radius server defaults"
     nxos_aaa_server: &configure_default_radius
       server_type: radius
+      provider: "{{ connection }}"
       state: present
     register: result
 
@@ -33,6 +35,7 @@
       server_timeout: 9
       deadtime: 20
       directed_request: enabled
+      provider: "{{ connection }}"
       state: present
     register: result
   
@@ -57,6 +60,7 @@
       server_type: radius
       encrypt_type: 7
       global_key: test_key
+      provider: "{{ connection }}"
       state: present
     register: result
    
@@ -75,6 +79,7 @@
       server_timeout: default
       global_key: default
       directed_request: default
+      provider: "{{ connection }}"
       state: default
     register: result
 

--- a/test/integration/targets/nxos_aaa_server/tests/common/tacacs.yaml
+++ b/test/integration/targets/nxos_aaa_server/tests/common/tacacs.yaml
@@ -6,6 +6,7 @@
 - name: "Enable feature tacacs+"
   nxos_feature:
     feature: tacacs+
+    provider: "{{ connection }}"
     state: enabled
 
 - name: "Setup"
@@ -14,6 +15,7 @@
     deadtime: default
     server_timeout: default
     directed_request: default
+    provider: "{{ connection }}"
     state: default
   ignore_errors: yes
 
@@ -21,6 +23,7 @@
   - name: "Configure tacacs server defaults"
     nxos_aaa_server: &configure_default_tacacs
       server_type: tacacs
+      provider: "{{ connection }}"
       state: present
     register: result
 
@@ -38,6 +41,7 @@
       server_timeout: 9
       deadtime: 20
       directed_request: enabled
+      provider: "{{ connection }}"
       state: present
     register: result
   
@@ -62,6 +66,7 @@
       server_type: tacacs
       encrypt_type: 7
       global_key: test_key
+      provider: "{{ connection }}"
       state: present
     register: result
    
@@ -80,6 +85,7 @@
       server_timeout: default
       global_key: default
       directed_request: default
+      provider: "{{ connection }}"
       state: default
     register: result
 
@@ -104,6 +110,7 @@
   - name: "Disable feature tacacs+"
     nxos_feature:
       feature: tacacs+
+      provider: "{{ connection }}"
       state: disabled
 
 - debug: msg="END connection={{ ansible_connection }} nxos_aaa_server tacacs.yaml sanity test"

--- a/test/integration/targets/nxos_aaa_server_host/tests/common/radius.yaml
+++ b/test/integration/targets/nxos_aaa_server_host/tests/common/radius.yaml
@@ -7,6 +7,7 @@
   nxos_aaa_server_host: &remove
     server_type: radius
     address: 8.8.8.8
+    provider: "{{ connection }}"
     state: absent
   ignore_errors: yes
 
@@ -15,6 +16,7 @@
     nxos_aaa_server_host: &configure_default_radius
       server_type: radius
       address: 8.8.8.8
+      provider: "{{ connection }}"
       state: present
     register: result
 
@@ -49,6 +51,7 @@
       host_timeout: 25
       auth_port: 2083
       acct_port: 2084
+      provider: "{{ connection }}"
       state: present
     register: result
  
@@ -67,6 +70,7 @@
       host_timeout: default
       auth_port: 1000
       acct_port: default
+      provider: "{{ connection }}"
       state: present
     register: result
 
@@ -87,6 +91,7 @@
       acct_port: 2084
       encrypt_type: 0
       key: hello
+      provider: "{{ connection }}"
       state: present
     register: result
 
@@ -113,6 +118,7 @@
       acct_port: 2084
       encrypt_type: 7
       key: hello
+      provider: "{{ connection }}"
       state: present
     register: result
 
@@ -133,6 +139,7 @@
       acct_port: default
       encrypt_type: 7
       key: default
+      provider: "{{ connection }}"
       state: present
     register: result
 
@@ -152,6 +159,7 @@
       auth_port: default
       acct_port: default
       key: default
+      provider: "{{ connection }}"
       state: present
     register: result
 

--- a/test/integration/targets/nxos_aaa_server_host/tests/common/tacacs.yaml
+++ b/test/integration/targets/nxos_aaa_server_host/tests/common/tacacs.yaml
@@ -6,12 +6,14 @@
 - name: "Enable feature tacacs+"
   nxos_feature:
     feature: tacacs+
+    provider: "{{ connection }}"
     state: enabled
 
 - name: "Setup"
   nxos_aaa_server_host: &remove
     server_type: tacacs
     address: 8.8.8.8
+    provider: "{{ connection }}"
     state: absent
   ignore_errors: yes
 
@@ -21,6 +23,7 @@
     nxos_aaa_server_host: &configure_default_tacacs
       server_type: tacacs
       address: 8.8.8.8
+      provider: "{{ connection }}"
       state: present
     register: result
 
@@ -54,6 +57,7 @@
       address: 8.8.8.8
       host_timeout: 25
       tacacs_port: 89
+      provider: "{{ connection }}"
       state: present
     register: result
  
@@ -71,6 +75,7 @@
       address: 8.8.8.8
       host_timeout: default
       tacacs_port: 100
+      provider: "{{ connection }}"
       state: present
     register: result
 
@@ -90,6 +95,7 @@
       tacacs_port: default
       encrypt_type: 0
       key: hello
+      provider: "{{ connection }}"
       state: present
     register: result
    
@@ -115,6 +121,7 @@
       tacacs_port: 89
       encrypt_type: 7
       key: hello
+      provider: "{{ connection }}"
       state: present
     register: result
 
@@ -134,6 +141,7 @@
       tacacs_port: 89
       encrypt_type: 7
       key: default
+      provider: "{{ connection }}"
       state: present
     register: result
 
@@ -152,6 +160,7 @@
       host_timeout: default
       tacacs_port: default
       key: default
+      provider: "{{ connection }}"
       state: present
     register: result
 
@@ -176,6 +185,7 @@
   - name: "Disable feature tacacs+"
     nxos_feature:
       feature: tacacs+
+      provider: "{{ connection }}"
       state: disabled
 
   - debug: msg="END connection={{ ansible_connection }} nxos_aaa_server_host tacacs.yaml sanity test"  

--- a/test/integration/targets/nxos_acl/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_acl/tests/common/sanity.yaml
@@ -10,6 +10,7 @@
   nxos_acl: &remove
     name: TEST_ACL
     seq: 10
+    provider: "{{ connection }}"
     state: delete_acl
   ignore_errors: yes
 
@@ -36,6 +37,7 @@
     rst: 'enable'
     syn: 'enable'
     time_range: "{{time_range|default(omit)}}"
+    provider: "{{ connection }}"
     state: present
   register: result
 
@@ -74,6 +76,7 @@
     rst: 'enable'
     syn: 'enable'
     time_range: "{{time_range|default(omit)}}"
+    provider: "{{ connection }}"
     state: present
   register: result
 
@@ -91,6 +94,7 @@
     seq: 20
     action: remark
     remark: test_remark
+    provider: "{{ connection }}"
     state: present
   register: result
 
@@ -108,6 +112,7 @@
     seq: 20
     action: remark
     remark: changed_remark
+    provider: "{{ connection }}"
     state: present
   register: result
 
@@ -129,6 +134,7 @@
     dest: any
     fragments: enable
     precedence: network
+    provider: "{{ connection }}"
     state: present
   register: result
 
@@ -149,6 +155,7 @@
     src: any
     dest: any
     precedence: network
+    provider: "{{ connection }}"
     state: present
   register: result
 
@@ -171,6 +178,7 @@
     src_port1: 1200
     dest: any
     precedence: network
+    provider: "{{ connection }}"
     state: present
   register: result
 
@@ -191,6 +199,7 @@
     src: any
     dest: any
     precedence: network
+    provider: "{{ connection }}"
     state: present
   register: result
 
@@ -206,6 +215,7 @@
   nxos_acl: &remace30
     name: TEST_ACL
     seq: 30
+    provider: "{{ connection }}"
     state: absent
   register: result
 

--- a/test/integration/targets/nxos_acl_interface/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_acl_interface/tests/common/sanity.yaml
@@ -13,6 +13,7 @@
   nxos_config: &default
     lines:
       - "default interface {{ intname }}"
+    provider: "{{ connection }}"
   ignore_errors: yes
 
 - name: "Setup: Put interface into no switch port mode"
@@ -22,6 +23,7 @@
     parents:
       - "interface {{ intname }}"
     match: none
+    provider: "{{ connection }}"
   ignore_errors: yes
 
 - name: "Setup: Cleanup possibly existing acl"
@@ -40,6 +42,7 @@
     proto: tcp
     src: 192.0.2.1/24
     dest: any
+    provider: "{{ connection }}"
 
 - block:
   - name: Configure acl interface egress

--- a/test/integration/targets/nxos_acl_interface/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_acl_interface/tests/common/sanity.yaml
@@ -28,6 +28,7 @@
   nxos_acl: &remove
     name: ANSIBLE_ACL
     seq: 10
+    provider: "{{ connection }}"
     state: delete_acl
   ignore_errors: yes
 
@@ -46,6 +47,7 @@
       name: ANSIBLE_ACL
       interface: "{{ intname }}"
       direction: egress
+      provider: "{{ connection }}"
       state: present
     register: result
 
@@ -66,6 +68,7 @@
       name: ANSIBLE_ACL
       interface: "{{ intname }}"
       direction: ingress
+      provider: "{{ connection }}"
       state: present
     register: result
 
@@ -82,6 +85,7 @@
       name: ANSIBLE_ACL
       interface: "{{ intname }}"
       direction: egress
+      provider: "{{ connection }}"
       state: absent
     register: result
 
@@ -98,6 +102,7 @@
       name: ANSIBLE_ACL
       interface: "{{ intname }}"
       direction: ingress
+      provider: "{{ connection }}"
       state: absent
     register: result
 

--- a/test/integration/targets/nxos_banner/tests/nxapi/basic-exec.yaml
+++ b/test/integration/targets/nxos_banner/tests/nxapi/basic-exec.yaml
@@ -5,6 +5,7 @@
     - name: setup - remove exec
       nxos_banner: &remove
         banner: exec
+        provider: "{{ connection }}"
         state: absent
 
     - name: Set exec
@@ -14,6 +15,7 @@
           this is my exec banner
           that has a multiline
           string
+        provider: "{{ connection }}"
         state: present
       register: result
 

--- a/test/integration/targets/nxos_banner/tests/nxapi/basic-motd.yaml
+++ b/test/integration/targets/nxos_banner/tests/nxapi/basic-motd.yaml
@@ -4,6 +4,7 @@
 - name: setup - remove motd
   nxos_banner: &remove
     banner: motd
+    provider: "{{ connection }}"
     state: absent
 
 - name: Set motd
@@ -13,6 +14,7 @@
       this is my motd banner
       that has a multiline
       string
+    provider: "{{ connection }}"
     state: present
   register: result
 

--- a/test/integration/targets/nxos_banner/tests/nxapi/basic-no-motd.yaml
+++ b/test/integration/targets/nxos_banner/tests/nxapi/basic-no-motd.yaml
@@ -7,11 +7,13 @@
     text: |
       Junk motd banner
       over multiple lines
+    provider: "{{ connection }}"
     state: present
 
 - name: remove motd
   nxos_banner: &rm-motd
     banner: motd
+    provider: "{{ connection }}"
     state: absent
   register: result
 

--- a/test/integration/targets/nxos_bgp/tests/common/dis_policy.yaml
+++ b/test/integration/targets/nxos_bgp/tests/common/dis_policy.yaml
@@ -12,12 +12,14 @@
 - name: "Disable feature BGP"
   nxos_feature:
     feature: bgp
+    provider: "{{ connection }}"
     state: disabled
   ignore_errors: yes
 
 - name: "Enable feature BGP"
   nxos_feature:
     feature: bgp
+    provider: "{{ connection }}"
     state: enabled
   ignore_errors: yes
 
@@ -73,6 +75,7 @@
   - name: "Disable feature bgp"
     nxos_feature:
       feature: bgp
+      provider: "{{ connection }}"
       state: disabled
     ignore_errors: yes
 

--- a/test/integration/targets/nxos_bgp/tests/common/dis_policy.yaml
+++ b/test/integration/targets/nxos_bgp/tests/common/dis_policy.yaml
@@ -30,6 +30,7 @@
       disable_policy_batching: true
       disable_policy_batching_ipv4_prefix_list: v4_p
       disable_policy_batching_ipv6_prefix_list: v6_p
+      provider: "{{ connection }}"
     register: result
     when: bgp_disable_policy
 
@@ -54,6 +55,7 @@
       disable_policy_batching: false
       disable_policy_batching_ipv4_prefix_list: default
       disable_policy_batching_ipv6_prefix_list: default
+      provider: "{{ connection }}"
     register: result
     when: bgp_disable_policy
 

--- a/test/integration/targets/nxos_bgp/tests/common/hels.yaml
+++ b/test/integration/targets/nxos_bgp/tests/common/hels.yaml
@@ -12,6 +12,7 @@
 - name: "Disable feature BGP"
   nxos_feature:
     feature: bgp
+    provider: "{{ connection }}"
     state: disabled
   ignore_errors: yes
   when: test_helsinki
@@ -19,6 +20,7 @@
 - name: "Enable feature BGP"
   nxos_feature:
     feature: bgp
+    provider: "{{ connection }}"
     state: enabled
   ignore_errors: yes
   when: test_helsinki
@@ -90,6 +92,7 @@
   - name: "Disable feature bgp"
     nxos_feature:
       feature: bgp
+      provider: "{{ connection }}"
       state: disabled
     ignore_errors: yes
     when: test_helsinki

--- a/test/integration/targets/nxos_bgp/tests/common/hels.yaml
+++ b/test/integration/targets/nxos_bgp/tests/common/hels.yaml
@@ -38,6 +38,7 @@
       reconnect_interval: 55
       timer_bgp_hold: 110
       timer_bgp_keepalive: 45
+      provider: "{{ connection }}"
     with_items: "{{ vrfs }}"
     register: result
     when: test_helsinki
@@ -69,6 +70,7 @@
       reconnect_interval: default
       timer_bgp_hold: default
       timer_bgp_keepalive: default
+      provider: "{{ connection }}"
     with_items: "{{ vrfs }}"
     register: result
     when: test_helsinki

--- a/test/integration/targets/nxos_bgp/tests/common/isolate.yaml
+++ b/test/integration/targets/nxos_bgp/tests/common/isolate.yaml
@@ -31,6 +31,7 @@
     nxos_bgp: &set1
       asn: 65535
       isolate: false
+      provider: "{{ connection }}"
     register: result
     when: bgp_isolate
 
@@ -53,6 +54,7 @@
     nxos_bgp: &reset1
       asn: 65535
       isolate: true
+      provider: "{{ connection }}"
     register: result
     when: bgp_isolate
 

--- a/test/integration/targets/nxos_bgp/tests/common/isolate.yaml
+++ b/test/integration/targets/nxos_bgp/tests/common/isolate.yaml
@@ -13,12 +13,14 @@
 - name: "Disable feature BGP"
   nxos_feature:
     feature: bgp
+    provider: "{{ connection }}"
     state: disabled
   ignore_errors: yes
 
 - name: "Enable feature BGP"
   nxos_feature:
     feature: bgp
+    provider: "{{ connection }}"
     state: enabled
   ignore_errors: yes
 
@@ -72,6 +74,7 @@
   - name: "Disable feature bgp"
     nxos_feature:
       feature: bgp
+      provider: "{{ connection }}"
       state: disabled
     ignore_errors: yes
 

--- a/test/integration/targets/nxos_bgp/tests/common/param.yaml
+++ b/test/integration/targets/nxos_bgp/tests/common/param.yaml
@@ -35,6 +35,7 @@
       graceful_restart_helper: true
       log_neighbor_changes: true
       maxas_limit: 50
+      provider: "{{ connection }}"
     with_items: "{{ vrfs }}"
     register: result
 
@@ -66,6 +67,7 @@
       log_neighbor_changes: false
       maxas_limit: default
       router_id: default
+      provider: "{{ connection }}"
     with_items: "{{ vrfs }}"
     register: result
 
@@ -83,6 +85,7 @@
       asn: 65535
       vrf: "{{ item }}"
       cluster_id: 10.0.0.1
+      provider: "{{ connection }}"
     with_items: "{{ vrfs }}"
     register: result
 
@@ -100,6 +103,7 @@
       asn: 65535
       vrf: "{{ item }}"
       cluster_id: default
+      provider: "{{ connection }}"
     with_items: "{{ vrfs }}"
     register: result
 
@@ -120,6 +124,7 @@
         - 16
         - 22
         - 18
+      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -135,6 +140,7 @@
       asn: 65535
       confederation_id: default
       confederation_peers: default
+      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -155,6 +161,7 @@
         - 16
         - 22
         - 18
+      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -172,6 +179,7 @@
       local_as: default
       confederation_id: default
       confederation_peers: default
+      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -188,6 +196,7 @@
       vrf: myvrf
       local_as: 33
       confederation_id: 99
+      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -204,6 +213,7 @@
       vrf: myvrf
       confederation_id: default
       local_as: default
+      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -225,6 +235,7 @@
       fast_external_fallover: false
       flush_routes: true
       shutdown: true
+      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -243,6 +254,7 @@
       fast_external_fallover: true
       flush_routes: false
       shutdown: false
+      provider: "{{ connection }}"
     register: result
 
   - assert: *true

--- a/test/integration/targets/nxos_bgp/tests/common/param.yaml
+++ b/test/integration/targets/nxos_bgp/tests/common/param.yaml
@@ -6,12 +6,14 @@
 - name: "Disable feature BGP"
   nxos_feature:
     feature: bgp
+    provider: "{{ connection }}"
     state: disabled
   ignore_errors: yes
 
 - name: "Enable feature BGP"
   nxos_feature:
     feature: bgp
+    provider: "{{ connection }}"
     state: enabled
   ignore_errors: yes
 
@@ -255,6 +257,7 @@
   - name: "Disable feature bgp"
     nxos_feature:
       feature: bgp
+      provider: "{{ connection }}"
       state: disabled
     ignore_errors: yes
 

--- a/test/integration/targets/nxos_bgp/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_bgp/tests/common/sanity.yaml
@@ -15,12 +15,14 @@
 - name: "Enable feature BGP"
   nxos_feature:
     feature: bgp
+    provider: "{{ connection }}"
     state: enabled
   ignore_errors: yes
 
 - name: "Setup"
   nxos_bgp: &remove
     asn: 65535
+    provider: "{{ connection }}"
     state: absent
   ignore_errors: yes
   register: result
@@ -30,6 +32,7 @@
     nxos_bgp: &configure_default
       asn: 65535
       router_id: 192.0.2.1
+      provider: "{{ connection }}"
       state: present
     register: result
 
@@ -91,6 +94,7 @@
       event_history_events: size_medium
       event_history_periodic: size_small
       suppress_fib_pending: true
+      provider: "{{ connection }}"
       state: present
     register: result
 
@@ -117,6 +121,7 @@
   - name: "Disable feature bgp"
     nxos_feature:
       feature: bgp
+      provider: "{{ connection }}"
       state: disabled
 
   rescue:
@@ -127,6 +132,7 @@
   - name: "Disable feature bgp"
     nxos_feature:
       feature: bgp
+      provider: "{{ connection }}"
       state: disabled
     ignore_errors: yes
 

--- a/test/integration/targets/nxos_bgp/tests/common/supp_fib.yaml
+++ b/test/integration/targets/nxos_bgp/tests/common/supp_fib.yaml
@@ -14,12 +14,14 @@
 - name: "Disable feature BGP"
   nxos_feature:
     feature: bgp
+    provider: "{{ connection }}"
     state: disabled
   ignore_errors: yes
 
 - name: "Enable feature BGP"
   nxos_feature:
     feature: bgp
+    provider: "{{ connection }}"
     state: enabled
   ignore_errors: yes
 
@@ -109,6 +111,7 @@
   - name: "Disable feature bgp"
     nxos_feature:
       feature: bgp
+      provider: "{{ connection }}"
       state: disabled
     ignore_errors: yes
 

--- a/test/integration/targets/nxos_bgp/tests/common/supp_fib.yaml
+++ b/test/integration/targets/nxos_bgp/tests/common/supp_fib.yaml
@@ -33,6 +33,7 @@
       asn: 65535
       vrf: "{{ item }}"
       timer_bestpath_limit: 255
+      provider: "{{ connection }}"
     with_items: "{{ vrfs }}"
     register: result
 
@@ -54,6 +55,7 @@
       asn: 65535
       vrf: "{{ item }}"
       timer_bestpath_limit: default
+      provider: "{{ connection }}"
     with_items: "{{ vrfs }}"
     register: result
 
@@ -74,6 +76,7 @@
     nxos_bgp: &set2
       asn: 65535
       suppress_fib_pending: false
+      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -91,6 +94,7 @@
     nxos_bgp: &reset2
       asn: 65535
       suppress_fib_pending: true
+      provider: "{{ connection }}"
     register: result
 
   - assert: *true

--- a/test/integration/targets/nxos_bgp_af/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_bgp_af/tests/common/sanity.yaml
@@ -9,18 +9,21 @@
 - name: "Enable feature BGP"
   nxos_feature:
     feature: bgp
+    provider: "{{ connection }}"
     state: enabled
   ignore_errors: yes
 
 - name: "Enable feature nv overlay"
   nxos_feature:
     feature: nv overlay
+    provider: "{{ connection }}"
     state: enabled
   ignore_errors: yes
 
 - name: "Setup"
   nxos_bgp: &remove
     asn: 65535
+    provider: "{{ connection }}"
     state: absent
   ignore_errors: yes
 
@@ -38,6 +41,7 @@
       afi: ipv4
       safi: unicast
       advertise_l2vpn_evpn: "{{advertise_l2vpn_evpn|default(omit)}}"
+      provider: "{{ connection }}"
       state: present
     register: result
 
@@ -59,6 +63,7 @@
       vrf: testing
       afi: ipv4
       safi: unicast
+      provider: "{{ connection }}"
       state: absent
     register: result
 
@@ -77,6 +82,7 @@
       additional_paths_send: true
       client_to_client: False
       default_information_originate: true
+      provider: "{{ connection }}"
       state: present
     with_items: "{{ vrfs }}"
     register: result
@@ -103,6 +109,7 @@
       additional_paths_send: False
       client_to_client: True
       default_information_originate: False
+      provider: "{{ connection }}"
       state: present
     with_items: "{{ vrfs }}"
     register: result
@@ -122,6 +129,7 @@
       vrf: "{{ item }}"
       afi: ipv4
       safi: unicast
+      provider: "{{ connection }}"
       state: absent
     with_items: "{{ vrfs }}"
     register: result
@@ -145,6 +153,7 @@
       suppress_inactive: true
       table_map: RouteMap
       table_map_filter: true
+      provider: "{{ connection }}"
       state: present
     with_items: "{{ vrfs }}"
     register: result
@@ -175,6 +184,7 @@
       suppress_inactive: False
       table_map: default
       table_map_filter: False
+      provider: "{{ connection }}"
       state: present
     with_items: "{{ vrfs }}"
     register: result
@@ -209,6 +219,7 @@
       inject_map: [['lax_inject_map', 'lax_exist_map'], ['nyc_inject_map', 'nyc_exist_map', 'copy-attributes'], ['fsd_inject_map', 'fsd_exist_map']]
       networks: [['10.0.0.0/16', 'routemap_LA'], ['192.168.1.1/32', 'Chicago'], ['192.168.2.0/24'], ['192.168.3.0/24', 'routemap_NYC']]
       redistribute: [['direct', 'rm_direct'], ['lisp', 'rm_lisp']]
+      provider: "{{ connection }}"
       state: present
     with_items: "{{ vrfs }}"
     register: result
@@ -236,6 +247,7 @@
       inject_map: [['fsd_inject_map', 'fsd_exist_map']]
       networks: [['192.168.2.0/24']]
       redistribute: [['lisp', 'rm_lisp']]
+      provider: "{{ connection }}"
       state: present
     with_items: "{{ vrfs }}"
     register: result
@@ -263,6 +275,7 @@
       inject_map: default
       networks: default
       redistribute: default
+      provider: "{{ connection }}"
       state: present
     with_items: "{{ vrfs }}"
     register: result
@@ -299,11 +312,13 @@
   - name: "Disable feature bgp"
     nxos_feature: &disable_bgp
       feature: bgp
+      provider: "{{ connection }}"
       state: disabled
 
   - name: "Disable feature nv overlay"
     nxos_feature: &disable_nvoverlay
       feature: nv overlay
+      provider: "{{ connection }}"
       state: disabled
     ignore_errors: yes
 

--- a/test/integration/targets/nxos_bgp_neighbor/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_bgp_neighbor/tests/common/sanity.yaml
@@ -18,6 +18,7 @@
 - name: "Enable feature BGP"
   nxos_feature:
     feature: bgp
+    provider: "{{ connection }}"
     state: enabled
   ignore_errors: yes
 
@@ -26,6 +27,7 @@
     asn: 65535
     neighbor: 192.0.2.3
     vrf: "{{ item }}"
+    provider: "{{ connection }}"
     state: absent
   with_items: "{{ vrfs }}"
   ignore_errors: yes
@@ -35,6 +37,7 @@
     asn: 65535
     neighbor: 192.0.2.3/32
     vrf: "{{ item }}"
+    provider: "{{ connection }}"
     state: absent
   with_items: "{{ vrfs }}"
   ignore_errors: yes
@@ -60,6 +63,7 @@
       description: "just a description"
       update_source: "{{ intname.capitalize() }}"
       shutdown: true
+      provider: "{{ connection }}"
       state: present
     with_items: "{{ vrfs }}"
     register: result
@@ -97,6 +101,7 @@
       description: default
       update_source: default
       shutdown: False
+      provider: "{{ connection }}"
       state: present
     with_items: "{{ vrfs }}"
     register: result
@@ -131,6 +136,7 @@
       vrf: "{{ item }}"
       description: "tested by ansible"
       remove_private_as: "{{remove_private_asa|default(omit)}}"
+      provider: "{{ connection }}"
       state: present
     with_items: "{{ vrfs }}"
     register: result
@@ -151,6 +157,7 @@
       vrf: "{{ item }}"
       description: "tested by ansible"
       remove_private_as: "{{remove_private_asr|default(omit)}}"
+      provider: "{{ connection }}"
       state: present
     with_items: "{{ vrfs }}"
     register: result
@@ -307,6 +314,7 @@
   - name: "Disable feature bgp"
     nxos_feature: &disable_bgp
       feature: bgp
+      provider: "{{ connection }}"
       state: disabled
 
 - debug: msg="END connection={{ ansible_connection }} nxos_bgp_neighbor sanity test"

--- a/test/integration/targets/nxos_bgp_neighbor_af/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_bgp_neighbor_af/tests/common/sanity.yaml
@@ -9,12 +9,14 @@
 - name: "Disable feature BGP"
   nxos_feature: &disable_bgp
     feature: bgp
+    provider: "{{ connection }}"
     state: disabled
   ignore_errors: yes
 
 - name: "Enable feature BGP"
   nxos_feature:
     feature: bgp
+    provider: "{{ connection }}"
     state: enabled
   ignore_errors: yes
 
@@ -45,6 +47,7 @@
       suppress_inactive: True
       unsuppress_map: 'unsup_map'
       weight: '30'
+      provider: "{{ connection }}"
       state: present
     register: result
 
@@ -86,6 +89,7 @@
       suppress_inactive: False
       unsuppress_map: default
       weight: default
+      provider: "{{ connection }}"
       state: present
     register: result
 
@@ -103,6 +107,7 @@
       neighbor: '192.0.2.3'
       afi: ipv4
       safi: unicast
+      provider: "{{ connection }}"
       state: absent
     register: result
 
@@ -128,6 +133,7 @@
       max_prefix_threshold: 50
       route_map_in: 'rm_in'
       route_map_out: 'rm_out'
+      provider: "{{ connection }}"
       state: present
     register: result
 
@@ -153,6 +159,7 @@
       max_prefix_threshold: default
       route_map_in: default
       route_map_out: default
+      provider: "{{ connection }}"
       state: present
     register: result
 
@@ -196,6 +203,7 @@
       send_community: 'standard'
       soft_reconfiguration_in: "{{soft_reconfiguration_ina|default(omit)}}"
       soo: '3:3'
+      provider: "{{ connection }}"
       state: present
     register: result
 
@@ -219,6 +227,7 @@
       as_override: False
       send_community: default
       soo: default
+      provider: "{{ connection }}"
       state: present
     register: result
 
@@ -233,6 +242,7 @@
   - name: "Setup: Remove BGP config"
     nxos_bgp: &remove
       asn: 65535
+      provider: "{{ connection }}"
       state: absent
     register: result
 

--- a/test/integration/targets/nxos_bgp_neighbor_af/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_bgp_neighbor_af/tests/common/sanity.yaml
@@ -189,6 +189,7 @@
       vrf: 'blue'
       neighbor: '192.0.2.3'
       remote_as: 2
+      provider: "{{ connection }}"
 
   - name: "Configure BGP neighbor 3"
     nxos_bgp_neighbor_af: &configure3
@@ -253,6 +254,7 @@
       asn: 65535
       neighbor: '192.0.2.2'
       remote_as: 65535
+      provider: "{{ connection }}"
 
   - name: "Configure BGP neighbor 4"
     nxos_bgp_neighbor_af: &configure4
@@ -261,6 +263,7 @@
       afi: ipv4
       safi: unicast
       route_reflector_client: 'true'
+      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -278,6 +281,7 @@
       afi: ipv4
       safi: unicast
       route_reflector_client: False
+      provider: "{{ connection }}"
     register: result
 
   - assert: *true

--- a/test/integration/targets/nxos_command/tests/common/bad_operator.yaml
+++ b/test/integration/targets/nxos_command/tests/common/bad_operator.yaml
@@ -8,6 +8,7 @@
       - show interface mgmt0 | json
     wait_for:
       - "result[1].TABLE_interface.ROW_interface.state foo up"
+    provider: "{{ connection }}"
   register: result
   ignore_errors: yes
 

--- a/test/integration/targets/nxos_command/tests/common/contains.yaml
+++ b/test/integration/targets/nxos_command/tests/common/contains.yaml
@@ -9,6 +9,7 @@
     wait_for:
       - "result[0] contains NX-OS"
       - "result[1].TABLE_interface.ROW_interface.interface contains mgmt"
+    provider: "{{ connection }}"
   register: result
 
 - assert:

--- a/test/integration/targets/nxos_command/tests/common/equal.yaml
+++ b/test/integration/targets/nxos_command/tests/common/equal.yaml
@@ -8,6 +8,7 @@
       - show interface mgmt0 | json
     wait_for:
       - "result[1].TABLE_interface.ROW_interface.state eq up"
+    provider: "{{ connection }}"
   register: result
 
 - assert:
@@ -21,6 +22,7 @@
       - show interface mgmt0 | json
     wait_for:
       - "result[1].TABLE_interface.ROW_interface.state == up"
+    provider: "{{ connection }}"
   register: result
 
 - assert:

--- a/test/integration/targets/nxos_command/tests/common/greaterthan.yaml
+++ b/test/integration/targets/nxos_command/tests/common/greaterthan.yaml
@@ -8,6 +8,7 @@
       - show interface mgmt0 | json
     wait_for:
       - "result[1].TABLE_interface.ROW_interface.eth_ip_mask gt 0"
+    provider: "{{ connection }}"
   register: result
 
 - assert:
@@ -21,6 +22,7 @@
       - show interface mgmt0 | json
     wait_for:
       - "result[1].TABLE_interface.ROW_interface.eth_ip_mask > 0"
+    provider: "{{ connection }}"
   register: result
 
 - assert:

--- a/test/integration/targets/nxos_command/tests/common/greaterthanorequal.yaml
+++ b/test/integration/targets/nxos_command/tests/common/greaterthanorequal.yaml
@@ -8,6 +8,7 @@
       - show interface mgmt0 | json
     wait_for:
       - "result[1].TABLE_interface.ROW_interface.eth_ip_mask ge 0"
+    provider: "{{ connection }}"
   register: result
 
 - assert:
@@ -21,6 +22,7 @@
       - show interface mgmt0 | json
     wait_for:
       - "result[1].TABLE_interface.ROW_interface.eth_ip_mask >= 0"
+    provider: "{{ connection }}"
   register: result
 
 - assert:

--- a/test/integration/targets/nxos_command/tests/common/invalid.yaml
+++ b/test/integration/targets/nxos_command/tests/common/invalid.yaml
@@ -4,6 +4,7 @@
 - name: run invalid command
   nxos_command:
     commands: ['show foo']
+    provider: "{{ connection }}"
   register: result
   ignore_errors: yes
 
@@ -16,6 +17,7 @@
     commands:
       - show version
       - show foo
+    provider: "{{ connection }}"
   register: result
   ignore_errors: yes
 

--- a/test/integration/targets/nxos_command/tests/common/lessthan.yaml
+++ b/test/integration/targets/nxos_command/tests/common/lessthan.yaml
@@ -8,6 +8,7 @@
       - show interface mgmt0 | json
     wait_for:
       - "result[1].TABLE_interface.ROW_interface.eth_ip_mask lt 33"
+    provider: "{{ connection }}"
   register: result
 
 - assert:
@@ -21,6 +22,7 @@
       - show interface mgmt0 | json
     wait_for:
       - "result[1].TABLE_interface.ROW_interface.eth_ip_mask lt 33"
+    provider: "{{ connection }}"
   register: result
 
 - assert:

--- a/test/integration/targets/nxos_command/tests/common/lessthanorequal.yaml
+++ b/test/integration/targets/nxos_command/tests/common/lessthanorequal.yaml
@@ -8,6 +8,7 @@
       - show interface mgmt0 | json
     wait_for:
       - "result[1].TABLE_interface.ROW_interface.eth_ip_mask le 32"
+    provider: "{{ connection }}"
   register: result
 
 - assert:
@@ -21,6 +22,7 @@
       - show interface mgmt0 | json
     wait_for:
       - "result[1].TABLE_interface.ROW_interface.eth_ip_mask <= 32"
+    provider: "{{ connection }}"
   register: result
 
 - assert:

--- a/test/integration/targets/nxos_command/tests/common/notequal.yaml
+++ b/test/integration/targets/nxos_command/tests/common/notequal.yaml
@@ -8,6 +8,7 @@
       - show interface mgmt0 | json
     wait_for:
       - "result[1].TABLE_interface.ROW_interface.state neq down"
+    provider: "{{ connection }}"
   register: result
 
 - assert:
@@ -22,6 +23,7 @@
       - show interface mgmt0 | json
     wait_for:
       - "result[1].TABLE_interface.ROW_interface.state != down"
+    provider: "{{ connection }}"
   register: result
 
 - assert:

--- a/test/integration/targets/nxos_command/tests/common/output.yaml
+++ b/test/integration/targets/nxos_command/tests/common/output.yaml
@@ -4,6 +4,7 @@
 - name: get output for single command
   nxos_command:
     commands: ['show version']
+    provider: "{{ connection }}"
   register: result
 
 - assert:
@@ -15,6 +16,7 @@
     commands:
       - show version
       - show interface
+    provider: "{{ connection }}"
   register: result
 
 - assert:

--- a/test/integration/targets/nxos_command/tests/common/timeout.yaml
+++ b/test/integration/targets/nxos_command/tests/common/timeout.yaml
@@ -7,6 +7,7 @@
       - show version
     wait_for:
       - "result[0] contains bad_value_string"
+    provider: "{{ connection }}"
   register: result
   ignore_errors: yes
 

--- a/test/integration/targets/nxos_command/tests/nxapi/sanity.yaml
+++ b/test/integration/targets/nxos_command/tests/nxapi/sanity.yaml
@@ -4,6 +4,7 @@
 - name: "Disable feature BGP"
   nxos_feature:
     feature: bgp
+    provider: "{{ connection }}"
     state: disabled
 
 - block:
@@ -21,12 +22,14 @@
   - name: "Enable feature BGP"
     nxos_feature:
       feature: bgp
+      provider: "{{ connection }}"
       state: enabled
 
   - name: "Configure BGP defaults"
     nxos_bgp: &configure_default
       asn: 65535
       router_id: 192.0.2.1
+      provider: "{{ connection }}"
       state: present
     register: result
 
@@ -61,6 +64,7 @@
   - name: "Disable feature bgp"
     nxos_feature:
       feature: bgp
+      provider: "{{ connection }}"
       state: disabled
 
 - debug: msg="END nxapi/sanity.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/nxos_config/tests/common/backup.yaml
+++ b/test/integration/targets/nxos_config/tests/common/backup.yaml
@@ -12,6 +12,7 @@
     parents:
       - "interface {{ intname }}"
     match: none
+    provider: "{{ connection }}"
 
 - name: collect any backup files
   find: &backups
@@ -23,7 +24,6 @@
 - name: delete backup files
   file:
     path: "{{ item.path }}"
-    provider: "{{ connection }}"
     state: absent
   with_items: "{{backup_files.files|default([])}}"
 
@@ -35,6 +35,7 @@
     parents:
       - "interface {{ intname }}"
     backup: yes
+    provider: "{{ connection }}"
   register: result
 
 - assert:

--- a/test/integration/targets/nxos_config/tests/common/backup.yaml
+++ b/test/integration/targets/nxos_config/tests/common/backup.yaml
@@ -23,6 +23,7 @@
 - name: delete backup files
   file:
     path: "{{ item.path }}"
+    provider: "{{ connection }}"
     state: absent
   with_items: "{{backup_files.files|default([])}}"
 

--- a/test/integration/targets/nxos_config/tests/common/defaults.yaml
+++ b/test/integration/targets/nxos_config/tests/common/defaults.yaml
@@ -12,6 +12,7 @@
     parents:
       - "interface {{ intname }}"
     match: none
+    provider: "{{ connection }}"
 
 - name: configure device with defaults included
   nxos_config:
@@ -21,6 +22,7 @@
     parents:
       - "interface {{ intname }}"
     defaults: yes
+    provider: "{{ connection }}"
   register: result
 
 - debug: var=result
@@ -38,6 +40,7 @@
     parents:
       - "interface {{ intname }}"
     defaults: yes
+    provider: "{{ connection }}"
   register: result
 
 - debug: var=result

--- a/test/integration/targets/nxos_config/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_config/tests/common/sanity.yaml
@@ -5,6 +5,7 @@
   nxos_config:
     lines: ip access-list test
     match: none
+    provider: "{{ connection }}"
 
 - name: "nxos_config sanity test"
   nxos_config:
@@ -17,6 +18,7 @@
     parents: ip access-list test
     before: no ip access-list test
     match: exact
+    provider: "{{ connection }}"
 
 - name: "nxos_config sanity test - replace block"
   nxos_config:
@@ -28,10 +30,12 @@
     parents: ip access-list test
     before: no ip access-list test
     replace: block
+    provider: "{{ connection }}"
 
 - name: teardown
   nxos_config:
     lines: no ip access-list test
     match: none
+    provider: "{{ connection }}"
 
 - debug: msg="END common/sanity.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/nxos_config/tests/common/save.yaml
+++ b/test/integration/targets/nxos_config/tests/common/save.yaml
@@ -12,11 +12,13 @@
     parents:
       - "interface {{ intname }}"
     match: none
+    provider: "{{ connection }}"
 
 - name: save config
   nxos_config:
     save_when: always
     timeout: 300
+    provider: "{{ connection }}"
   register: result
 
 - assert:
@@ -27,6 +29,7 @@
   nxos_config:
     save_when: always
     timeout: 300
+    provider: "{{ connection }}"
   register: result
 
 - assert:

--- a/test/integration/targets/nxos_config/tests/common/src_basic.yaml
+++ b/test/integration/targets/nxos_config/tests/common/src_basic.yaml
@@ -12,6 +12,7 @@
     parents:
       - "interface {{ intname }}"
     match: none
+    provider: "{{ connection }}"
 
 - name: configure device with config
   nxos_config:
@@ -21,6 +22,7 @@
     parents:
       - "interface {{ intname }}"
     defaults: yes
+    provider: "{{ connection }}"
   register: result
 
 - assert:
@@ -37,6 +39,7 @@
     parents:
       - "interface {{ intname }}"
     defaults: yes
+    provider: "{{ connection }}"
   register: result
 
 - assert:

--- a/test/integration/targets/nxos_config/tests/common/src_invalid.yaml
+++ b/test/integration/targets/nxos_config/tests/common/src_invalid.yaml
@@ -6,6 +6,7 @@
 - name: configure with invalid src
   nxos_config:
     src: basic/foobar.j2
+    provider: "{{ connection }}"
   register: result
   ignore_errors: yes
 

--- a/test/integration/targets/nxos_config/tests/common/src_match_none.yaml
+++ b/test/integration/targets/nxos_config/tests/common/src_match_none.yaml
@@ -12,6 +12,7 @@
     parents:
       - "interface {{ intname }}"
     match: none
+    provider: "{{ connection }}"
 
 - name: configure device with config
   nxos_config:
@@ -22,6 +23,7 @@
       - "interface {{ intname }}"
     match: none
     defaults: yes
+    provider: "{{ connection }}"
   register: result
 
 - assert:
@@ -38,6 +40,7 @@
     parents:
       - "interface {{ intname }}"
     defaults: yes
+    provider: "{{ connection }}"
   register: result
 
 - assert:

--- a/test/integration/targets/nxos_config/tests/common/sublevel_block.yaml
+++ b/test/integration/targets/nxos_config/tests/common/sublevel_block.yaml
@@ -5,6 +5,7 @@
   nxos_config: &clear
     lines: no ip access-list test
     match: none
+    provider: "{{ connection }}"
   ignore_errors: yes
 
 - name: configure sub level command using block replace
@@ -16,6 +17,7 @@
       - 40 permit ip 192.0.2.4/32 any log
     parents: ip access-list test
     replace: block
+    provider: "{{ connection }}"
   register: result
 
 - assert:
@@ -36,6 +38,7 @@
       - 40 permit ip 192.0.2.4/32 any log
     parents: ip access-list test
     replace: block
+    provider: "{{ connection }}"
   register: result
 
 - assert:

--- a/test/integration/targets/nxos_config/tests/common/toplevel.yaml
+++ b/test/integration/targets/nxos_config/tests/common/toplevel.yaml
@@ -5,10 +5,12 @@
   nxos_config:
     lines: hostname switch
     match: none
+    provider: "{{ connection }}"
 
 - name: configure top level command
   nxos_config:
     lines: hostname foo
+    provider: "{{ connection }}"
   register: result
 
 - assert:
@@ -19,6 +21,7 @@
 - name: configure top level command idempotent check
   nxos_config:
     lines: hostname foo
+    provider: "{{ connection }}"
   register: result
 
 - assert:
@@ -29,5 +32,6 @@
   nxos_config:
     lines: hostname switch
     match: none
+    provider: "{{ connection }}"
 
 - debug: msg='END common/toplevel.yaml on connection={{ ansible_connection }}'

--- a/test/integration/targets/nxos_config/tests/common/toplevel_nonidempotent.yaml
+++ b/test/integration/targets/nxos_config/tests/common/toplevel_nonidempotent.yaml
@@ -5,11 +5,13 @@
   nxos_config:
     lines: hostname switch
     match: none
+    provider: "{{ connection }}"
 
 - name: configure top level command
   nxos_config:
     lines: hostname foo
     match: strict
+    provider: "{{ connection }}"
   register: result
 
 - assert:
@@ -21,6 +23,7 @@
   nxos_config:
     lines: hostname foo
     match: strict
+    provider: "{{ connection }}"
   register: result
 
 - assert:
@@ -31,5 +34,6 @@
   nxos_config:
     lines: hostname switch
     match: none
+    provider: "{{ connection }}"
 
 - debug: msg="END common/nonidempotent.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/nxos_config/tests/nxapi/multilevel.yaml
+++ b/test/integration/targets/nxos_config/tests/nxapi/multilevel.yaml
@@ -5,6 +5,7 @@
   nxos_config:
     lines: feature bgp
     match: none
+    provider: "{{ connection }}"
 
 - name: configure multi level command
   nxos_config:
@@ -12,6 +13,7 @@
     parents:
       - router bgp 1
       - address-family ipv4 unicast
+    provider: "{{ connection }}"
   register: result
 
 - assert:
@@ -27,6 +29,7 @@
     parents:
       - router bgp 1
       - address-family ipv4 unicast
+    provider: "{{ connection }}"
   register: result
 
 - assert:
@@ -37,5 +40,6 @@
   nxos_config:
     lines: no feature bgp
     match: none
+    provider: "{{ connection }}"
 
 - debug: msg="END nxapi/mulitlevel.yaml"

--- a/test/integration/targets/nxos_config/tests/nxapi/sublevel.yaml
+++ b/test/integration/targets/nxos_config/tests/nxapi/sublevel.yaml
@@ -5,12 +5,14 @@
   nxos_config:
     lines: no ip access-list test
     match: none
+    provider: "{{ connection }}"
   ignore_errors: yes
 
 - name: configure sub level command
   nxos_config:
     lines: 10 permit ip any any log
     parents: ip access-list test
+    provider: "{{ connection }}"
   register: result
 
 - assert:
@@ -23,6 +25,7 @@
   nxos_config:
     lines: 10 permit ip any any log
     parents: ip access-list test
+    provider: "{{ connection }}"
   register: result
 
 - assert:
@@ -33,5 +36,6 @@
   nxos_config:
     lines: no ip access-list test
     match: none
+    provider: "{{ connection }}"
 
 - debug: msg="END nxapi/sublevel.yaml"

--- a/test/integration/targets/nxos_config/tests/nxapi/sublevel_exact.yaml
+++ b/test/integration/targets/nxos_config/tests/nxapi/sublevel_exact.yaml
@@ -11,6 +11,7 @@
       - 50 permit ip 192.0.2.5/32 any log
     parents: ip access-list test
     match: none
+    provider: "{{ connection }}"
   ignore_errors: yes
 
 - name: configure sub level command using exact match
@@ -24,6 +25,7 @@
     before: no ip access-list test
     match: exact
     replace: block
+    provider: "{{ connection }}"
   register: result
 
 - assert:
@@ -45,6 +47,7 @@
       - 40 permit ip 192.0.2.4/32 any log
     parents: ip access-list test
     match: exact
+    provider: "{{ connection }}"
   register: result
 
 - assert:
@@ -55,5 +58,6 @@
   nxos_config:
     lines: no ip access-list test
     match: none
+    provider: "{{ connection }}"
 
 - debug: msg="END nxapi/sublevel_exact.yaml"

--- a/test/integration/targets/nxos_config/tests/nxapi/sublevel_strict.yaml
+++ b/test/integration/targets/nxos_config/tests/nxapi/sublevel_strict.yaml
@@ -11,6 +11,7 @@
       - 50 permit ip 192.0.2.5/32 any log
     parents: ip access-list test
     match: none
+    provider: "{{ connection }}"
 
 - name: configure sub level command using strict match
   nxos_config:
@@ -23,6 +24,7 @@
     before: no ip access-list test
     match: strict
     replace: block
+    provider: "{{ connection }}"
   register: result
 
 - assert:
@@ -44,6 +46,7 @@
       - 40 permit ip 192.0.2.4/32 any log
     parents: ip access-list test
     match: strict
+    provider: "{{ connection }}"
   register: result
 
 - assert:
@@ -54,5 +57,6 @@
   nxos_config:
     lines: no ip access-list test
     match: none
+    provider: "{{ connection }}"
 
 - debug: msg="END nxapi/sublevel_strict.yaml"

--- a/test/integration/targets/nxos_config/tests/nxapi/toplevel_after.yaml
+++ b/test/integration/targets/nxos_config/tests/nxapi/toplevel_after.yaml
@@ -6,12 +6,14 @@
     lines:
       - "snmp-server contact ansible"
       - "hostname switch"
+    provider: "{{ connection }}"
     match: none
 
 - name: configure top level command with before
   nxos_config:
     lines: hostname foo
     after: snmp-server contact bar
+    provider: "{{ connection }}"
   register: result
 
 - assert:
@@ -24,6 +26,7 @@
   nxos_config:
     lines: hostname foo
     after: snmp-server contact foo
+    provider: "{{ connection }}"
   register: result
 
 - assert:
@@ -36,5 +39,6 @@
       - "no snmp-server contact ansible"
       - "hostname switch"
     match: none
+    provider: "{{ connection }}"
 
 - debug: msg="END nxapi/toplevel_after.yaml"

--- a/test/integration/targets/nxos_config/tests/nxapi/toplevel_before.yaml
+++ b/test/integration/targets/nxos_config/tests/nxapi/toplevel_before.yaml
@@ -7,11 +7,13 @@
       - "snmp-server contact ansible"
       - "hostname switch"
     match: none
+    provider: "{{ connection }}"
 
 - name: configure top level command with before
   nxos_config:
     lines: hostname foo
     before: snmp-server contact bar
+    provider: "{{ connection }}"
   register: result
 
 - assert:
@@ -24,6 +26,7 @@
   nxos_config:
     lines: hostname foo
     before: snmp-server contact foo
+    provider: "{{ connection }}"
   register: result
 
 - assert:
@@ -36,5 +39,6 @@
       - "no snmp-server contact ansible"
       - "hostname switch"
     match: none
+    provider: "{{ connection }}"
 
 - debug: msg="END nxapi/toplevel_before.yaml"

--- a/test/integration/targets/nxos_evpn_global/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_evpn_global/tests/common/sanity.yaml
@@ -12,6 +12,7 @@
 - name: "Disable feature nv overlay"
   nxos_feature: &disable_feature_nv_overlay
     feature: nv overlay
+    provider: "{{ connection }}"
     state: disabled
   ignore_errors: yes
 
@@ -19,6 +20,7 @@
   - name: "Enable feature nv overlay"
     nxos_feature: &enable_feature_nv_overlay
       feature: nv overlay
+      provider: "{{ connection }}"
       state: enabled
     ignore_errors: yes
 

--- a/test/integration/targets/nxos_evpn_vni/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_evpn_vni/tests/common/sanity.yaml
@@ -13,6 +13,7 @@
   - name: "Enable feature BGP"
     nxos_feature:
       feature: bgp
+      provider: "{{ connection }}"
       state: enabled
 
   - name: "Enable nv overlay evpn"
@@ -81,6 +82,7 @@
   - name: "remove nxos_evpn_vni"
     nxos_evpn_vni: &rvni
       vni: 6000
+      provider: "{{ connection }}"
       state: absent
     register: result
 
@@ -102,6 +104,7 @@
   - name: "Disable feature bgp"
     nxos_feature:
       feature: bgp
+      provider: "{{ connection }}"
       state: disabled
     ignore_errors: yes
 

--- a/test/integration/targets/nxos_evpn_vni/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_evpn_vni/tests/common/sanity.yaml
@@ -7,6 +7,7 @@
   nxos_config: &remove_evpn
     lines: no nv overlay evpn
     match: none
+    provider: "{{ connection }}"
   ignore_errors: yes
 
 - block:
@@ -20,6 +21,7 @@
     nxos_config:
       lines: nv overlay evpn
       match: none
+      provider: "{{ connection }}"
 
   - name: "Configure nxos_evpn_vni"
     nxos_evpn_vni: &evpn_vni
@@ -33,6 +35,7 @@
           - auto
           - "5000:10"
           - "192.0.2.1:43"
+      provider: "{{ connection }}"
     register: result
 
   - assert: &true
@@ -53,6 +56,7 @@
       route_distinguisher: "50:20"
       route_target_import: auto
       route_target_export: auto
+      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -69,6 +73,7 @@
       route_distinguisher: default
       route_target_import: default
       route_target_export: default
+      provider: "{{ connection }}"
     register: result
 
   - assert: *true

--- a/test/integration/targets/nxos_facts/tests/common/all_facts.yaml
+++ b/test/integration/targets/nxos_facts/tests/common/all_facts.yaml
@@ -9,6 +9,7 @@
     gather_subset:
       - all
     timeout: 60
+    provider: "{{ connection }}"
   register: result
 
 

--- a/test/integration/targets/nxos_facts/tests/common/default_facts.yaml
+++ b/test/integration/targets/nxos_facts/tests/common/default_facts.yaml
@@ -6,6 +6,7 @@
 
 - name: test getting default facts
   nxos_facts:
+    provider: "{{ connection }}"
   register: result
 
 - assert:

--- a/test/integration/targets/nxos_facts/tests/common/invalid_subset.yaml
+++ b/test/integration/targets/nxos_facts/tests/common/invalid_subset.yaml
@@ -8,6 +8,7 @@
   nxos_facts:
     gather_subset:
       - "foobar"
+    provider: "{{ connection }}"
   register: result
   ignore_errors: true
 
@@ -30,6 +31,7 @@
     gather_subset:
       - "!hardware"
       - "hardware"
+    provider: "{{ connection }}"
   register: result
   ignore_errors: true
 

--- a/test/integration/targets/nxos_facts/tests/common/not_hardware.yaml
+++ b/test/integration/targets/nxos_facts/tests/common/not_hardware.yaml
@@ -9,6 +9,7 @@
     gather_subset:
       - "!hardware"
     timeout: 30
+    provider: "{{ connection }}"
   register: result
 
 - assert:

--- a/test/integration/targets/nxos_facts/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_facts/tests/common/sanity.yaml
@@ -6,6 +6,7 @@
 - name: "nxos_facts gather hardware facts"
   nxos_facts:
     gather_subset: hardware
+    provider: "{{ connection }}"
   register: result
 
 - assert:
@@ -30,6 +31,7 @@
 - name: "nxos_facts gather config facts"
   nxos_facts:
     gather_subset: config
+    provider: "{{ connection }}"
   register: result
 
 - assert:
@@ -52,6 +54,7 @@
     gather_subset:
       - hardware
       - config
+    provider: "{{ connection }}"
   register: result
 
 - assert:

--- a/test/integration/targets/nxos_feature/tests/common/configure.yaml
+++ b/test/integration/targets/nxos_feature/tests/common/configure.yaml
@@ -5,6 +5,7 @@
   nxos_config:
     lines: no feature bgp
     match: none
+    provider: "{{ connection }}"
 
 - name: enable bgp
   nxos_feature:
@@ -54,5 +55,6 @@
   nxos_config:
     lines: no feature bgp
     match: none
+    provider: "{{ connection }}"
 
 - debug: msg="END connection={{ ansible_connection }}/configure.yaml"

--- a/test/integration/targets/nxos_feature/tests/common/configure.yaml
+++ b/test/integration/targets/nxos_feature/tests/common/configure.yaml
@@ -9,6 +9,7 @@
 - name: enable bgp
   nxos_feature:
     feature: bgp
+    provider: "{{ connection }}"
     state: enabled
   register: result
 
@@ -19,6 +20,7 @@
 - name: verify bgp
   nxos_feature:
     feature: bgp
+    provider: "{{ connection }}"
     state: enabled
   register: result
 
@@ -29,6 +31,7 @@
 - name: disable bgp
   nxos_feature:
     feature: bgp
+    provider: "{{ connection }}"
     state: disabled
   register: result
 
@@ -39,6 +42,7 @@
 - name: verify bgp
   nxos_feature:
     feature: bgp
+    provider: "{{ connection }}"
     state: disabled
   register: result
 

--- a/test/integration/targets/nxos_feature/tests/common/invalid.yaml
+++ b/test/integration/targets/nxos_feature/tests/common/invalid.yaml
@@ -4,6 +4,7 @@
 - name: configure invalid feature name
   nxos_feature:
     feature: invalid
+    provider: "{{ connection }}"
   register: result
   ignore_errors: yes
 

--- a/test/integration/targets/nxos_gir_profile_management/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_gir_profile_management/tests/common/sanity.yaml
@@ -6,18 +6,21 @@
 - name: "Setup - Remove maintenace mode profiles"
   nxos_gir_profile_management: &remove_maintenance
     mode: maintenance
+    provider: "{{ connection }}"
     state: absent    
   ignore_errors: yes
 
 - name: "Setup - Remove normal mode profiles"
   nxos_gir_profile_management: &remove_normal
     mode: normal
+    provider: "{{ connection }}"
     state: absent
   ignore_errors: yes
 
 - name: "Setup - Turn on feature eigrp"
   nxos_feature: 
     feature: eigrp
+    provider: "{{ connection }}"
     state: enabled
   ignore_errors: yes
 
@@ -28,6 +31,7 @@
       commands:
         - router eigrp 11
         - isolate
+      provider: "{{ connection }}"
       state: present
     register: result
 
@@ -49,6 +53,7 @@
       commands:
         - router eigrp 11
         - isolate
+      provider: "{{ connection }}"
       state: present
     register: result
 
@@ -101,6 +106,7 @@
   - name: "Turn off feature eigrp"
     nxos_feature:
       feature: eigrp
+      provider: "{{ connection }}"
       state: disabled
 
   - debug: msg="END connection={{ ansible_connection }} nxos_gir_profile_management sanity test"  

--- a/test/integration/targets/nxos_hsrp/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_hsrp/tests/common/sanity.yaml
@@ -11,6 +11,7 @@
   - name: "Enable feature hsrp"
     nxos_feature: 
       feature: hsrp
+      provider: "{{ connection }}"
       state: enabled
 
   - name: "change int1 mode"
@@ -133,6 +134,7 @@
     nxos_hsrp: &remove
       group: 1000
       interface: "{{ intname1 }}"
+      provider: "{{ connection }}"
       state: absent
     register: result
 
@@ -148,6 +150,7 @@
   - name: "Disable feature hsrp"
     nxos_feature: 
       feature: hsrp
+      provider: "{{ connection }}"
       state: disabled
     ignore_errors: yes
 

--- a/test/integration/targets/nxos_hsrp/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_hsrp/tests/common/sanity.yaml
@@ -21,6 +21,7 @@
       parents:
         - "interface {{ intname1 }}"
       match: none
+      provider: "{{ connection }}"
 
   - name: "change int2 mode"
     nxos_config:
@@ -29,6 +30,7 @@
       parents:
         - "interface {{ intname2 }}"
       match: none
+      provider: "{{ connection }}"
 
   - name: "configure nxos_hsrp"
     nxos_hsrp: &conf1000
@@ -40,6 +42,7 @@
       preempt: enabled
       auth_type: md5
       auth_string: "7 1234"
+      provider: "{{ connection }}"
     register: result
 
   - assert: &true
@@ -64,6 +67,7 @@
       preempt: enabled
       auth_type: md5
       auth_string: "0 1234"
+      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -84,6 +88,7 @@
       preempt: disabled
       auth_type: md5
       auth_string: "0 1234"
+      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -102,6 +107,7 @@
       interface: "{{ intname2 }}"
       auth_type: text
       auth_string: "1234"
+      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -120,6 +126,7 @@
       interface: "{{ intname2 }}"
       auth_type: text
       auth_string: default
+      provider: "{{ connection }}"
     register: result
 
   - assert: *true

--- a/test/integration/targets/nxos_igmp/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_igmp/tests/common/sanity.yaml
@@ -13,6 +13,7 @@
       flush_routes: true
       enforce_rtr_alert: true
       restart: false
+      provider: "{{ connection }}"
       state: present
     register: result
 
@@ -33,6 +34,7 @@
       flush_routes: false
       enforce_rtr_alert: false
       restart: "{{restart|default(omit)}}"
+      provider: "{{ connection }}"
       state: present
     register: result
 
@@ -50,6 +52,7 @@
 
   - name: Configure igmp state as values
     nxos_igmp: &sdefault
+      provider: "{{ connection }}"
       state: default
     register: result
 

--- a/test/integration/targets/nxos_igmp_interface/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_igmp_interface/tests/common/sanity.yaml
@@ -12,6 +12,7 @@
 - name: "Enable feature PIM"
   nxos_feature:
     feature: pim
+    provider: "{{ connection }}"
     state: enabled
   ignore_errors: yes
 
@@ -51,6 +52,7 @@
       # deprecated
       oif_prefix: 239.255.255.2
       oif_source: 192.0.2.1
+      provider: "{{ connection }}"
       state: present
     register: result
 
@@ -83,6 +85,7 @@
         - {'prefix': '238.2.2.6'}
         - {'prefix': '238.2.2.5'}
         - {'source': '192.0.2.1', 'prefix': '238.2.2.5'}
+      provider: "{{ connection }}"
       state: present
     register: result
 
@@ -103,6 +106,7 @@
     nxos_igmp_interface: &defoif
       interface: "{{ intname }}"
       oif_ps: default
+      provider: "{{ connection }}"
       state: present
     register: result
 
@@ -122,6 +126,7 @@
       startup_query_count: 5
       robustness: 6
       oif_routemap: abcd
+      provider: "{{ connection }}"
       state: present
     register: result
 
@@ -136,6 +141,7 @@
   - name: Configure igmp interface with default state
     nxos_igmp_interface: &default
       interface: "{{ intname }}"
+      provider: "{{ connection }}"
       state: default
     register: result
 
@@ -150,6 +156,7 @@
   - name: Configure igmp interface with absent state
     nxos_igmp_interface: &absent
       interface: "{{ intname }}"
+      provider: "{{ connection }}"
       state: absent
     register: result
 
@@ -175,6 +182,7 @@
   - name: "Disable feature PIM"
     nxos_feature:
       feature: pim
+      provider: "{{ connection }}"
       state: disabled
 
   - debug: msg="END connection={{ ansible_connection }} nxos_igmp_interface sanity test"

--- a/test/integration/targets/nxos_igmp_interface/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_igmp_interface/tests/common/sanity.yaml
@@ -21,6 +21,7 @@
     commands:
     - "default interface {{ intname }}"
     match: none
+    provider: "{{ connection }}"
   ignore_errors: yes
 
 - block:
@@ -33,6 +34,7 @@
       parents:
         - "interface {{ intname }}"
       match: none
+      provider: "{{ connection }}"
 
   - name: Configure igmp interface with non-default values
     nxos_igmp_interface: &non-default
@@ -101,6 +103,7 @@
     nxos_igmp_interface: &restart
       interface: "{{ intname }}"
       restart: "{{restart|default(omit)}}"
+      provider: "{{ connection }}"
 
   - name: Configure igmp interface with default oif_ps
     nxos_igmp_interface: &defoif
@@ -178,6 +181,7 @@
       commands:
       - "default interface {{ intname }}"
       match: none
+      provider: "{{ connection }}"
 
   - name: "Disable feature PIM"
     nxos_feature:

--- a/test/integration/targets/nxos_igmp_snooping/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_igmp_snooping/tests/common/sanity.yaml
@@ -22,6 +22,7 @@
       link_local_grp_supp: false
       report_supp: false
       v3_report_supp: true
+      provider: "{{ connection }}"
       state: present
     register: result
 
@@ -41,6 +42,7 @@
   - name: Configure igmp snooping with default group timeout
     nxos_igmp_snooping: &defgt
       group_timeout: "{{def_group_timeout|default(omit)}}"
+      provider: "{{ connection }}"
       state: present
     register: result
 
@@ -57,6 +59,7 @@
 
   - name: Configure igmp snooping with default values
     nxos_igmp_snooping: &default
+      provider: "{{ connection }}"
       state: default
     register: result
 

--- a/test/integration/targets/nxos_interface/tests/common/intent.yaml
+++ b/test/integration/targets/nxos_interface/tests/common/intent.yaml
@@ -10,6 +10,7 @@
     lines:
       - "default interface {{ testint1 }}"
       - "default interface {{ testint2 }}"
+    provider: "{{ connection }}"
   ignore_errors: yes
 
 - name: Check intent arguments
@@ -18,6 +19,7 @@
     admin_state: up
     tx_rate: ge(0)
     rx_rate: ge(0)
+    provider: "{{ connection }}"
   register: result
 
 - assert:
@@ -30,6 +32,7 @@
     admin_state: down
     tx_rate: gt(0)
     rx_rate: lt(0)
+    provider: "{{ connection }}"
   ignore_errors: yes
   register: result
 
@@ -44,6 +47,7 @@
     aggregate:
       - { name: "{{ testint1 }}", description: "Test aggregation on first interface" }
       - { name: "{{ testint2 }}", mode: layer3 }
+    provider: "{{ connection }}"
   register: result
 
 - assert:
@@ -55,6 +59,7 @@
     lines:
       - "default interface {{ testint1 }}"
       - "default interface {{ testint2 }}"
+    provider: "{{ connection }}"
   ignore_errors: yes
 
 - debug: msg="END connection={{ ansible_connection }} nxos_interface intent test"

--- a/test/integration/targets/nxos_interface/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_interface/tests/common/sanity.yaml
@@ -8,6 +8,7 @@
 - name: "Setup: Enable feature interface-vlan"
   nxos_feature:
     feature: interface-vlan
+    provider: "{{ connection }}"
     state: enabled
   ignore_errors: yes
 
@@ -33,6 +34,7 @@
       mode: layer3
       description: 'Configured by Ansible - Layer3'
       admin_state: up
+      provider: "{{ connection }}"
       state: present
     register: result
 
@@ -54,6 +56,7 @@
       mode: layer2
       description: 'Configured by Ansible - Layer2'
       admin_state: down
+      provider: "{{ connection }}"
       state: present
     register: result
 
@@ -118,6 +121,7 @@
   - name: "Setup: Disable feature interface-vlan"
     nxos_feature:
       feature: interface-vlan
+      provider: "{{ connection }}"
       state: disabled
     ignore_errors: yes
 

--- a/test/integration/targets/nxos_interface/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_interface/tests/common/sanity.yaml
@@ -16,6 +16,7 @@
   nxos_config: &intcleanup
     lines:
       - "default interface {{ testint }}"
+    provider: "{{ connection }}"
   ignore_errors: yes
 
 - name: "Setup: Remove possibly existing vlan interfaces"
@@ -25,6 +26,7 @@
       - "no interface vlan 710"
       - "no interface vlan 711"
       - "no interface vlan 712"
+    provider: "{{ connection }}"
   ignore_errors: yes
 
 - block:
@@ -72,6 +74,7 @@
     nxos_interface: &createvlans
       interface: "{{ item.os_svi_int }}"
       description: "{{ item.os_svi_desc }}"
+      provider: "{{ connection }}"
     with_items: &vlanitems
       - {os_svi_int: vlan2, os_svi_desc: SVI_VLAN2}
       - {os_svi_int: vlan710, os_svi_desc: SVI_VLAN710}
@@ -87,6 +90,7 @@
       addr: "{{ item.ipv4_addr }}"
       mask: "{{ item.ipv4_mask }}"
       version: "{{ item.ipv4_ver }}"
+      provider: "{{ connection }}"
     with_items: &vlanips
       - {os_svi_int: vlan2, ipv4_addr: 192.168.2.1, ipv4_mask: 24, ipv4_ver: v4}
       - {os_svi_int: vlan710, ipv4_addr: 192.168.3.1, ipv4_mask: 24, ipv4_ver: v4}

--- a/test/integration/targets/nxos_interface/tests/common/set_state_absent.yaml
+++ b/test/integration/targets/nxos_interface/tests/common/set_state_absent.yaml
@@ -11,6 +11,7 @@
 - name: set state=absent
   nxos_interface:
     interface: Loopback1
+    provider: "{{ connection }}"
     state: absent
   register: result
 
@@ -21,6 +22,7 @@
 - name: verify state=absent
   nxos_interface:
     interface: Loopback1
+    provider: "{{ connection }}"
     state: absent
   register: result
 

--- a/test/integration/targets/nxos_interface/tests/common/set_state_absent.yaml
+++ b/test/integration/targets/nxos_interface/tests/common/set_state_absent.yaml
@@ -7,6 +7,7 @@
   nxos_config:
     lines:
       - interface Loopback1
+    provider: "{{ connection }}"
 
 - name: set state=absent
   nxos_interface:

--- a/test/integration/targets/nxos_interface/tests/common/set_state_present.yaml
+++ b/test/integration/targets/nxos_interface/tests/common/set_state_present.yaml
@@ -12,6 +12,7 @@
 - name: set state=present
   nxos_interface:
     interface: Loopback1
+    provider: "{{ connection }}"
     state: present
     description: 'Configured by Ansible - Layer3'
   register: result
@@ -23,6 +24,7 @@
 - name: verify state=present
   nxos_interface:
     interface: Loopback1
+    provider: "{{ connection }}"
     state: present
     description: 'Configured by Ansible - Layer3'
   register: result

--- a/test/integration/targets/nxos_interface/tests/common/set_state_present.yaml
+++ b/test/integration/targets/nxos_interface/tests/common/set_state_present.yaml
@@ -7,6 +7,7 @@
   nxos_config:
     lines:
       - no interface Loopback1
+    provider: "{{ connection }}"
   ignore_errors: yes # Fails if the interface is already absent
 
 - name: set state=present

--- a/test/integration/targets/nxos_interface/tests/common/sub_int.yaml
+++ b/test/integration/targets/nxos_interface/tests/common/sub_int.yaml
@@ -16,6 +16,7 @@
   nxos_interface:
     name: "{{ testint }}"
     mode: layer3
+    provider: "{{ connection }}"
 
 - name: Create sub-interface
   nxos_interface: &sub_int
@@ -23,6 +24,7 @@
     description: "sub-interface Configured by Ansible"
     admin_state: up
     mtu: 800
+    provider: "{{ connection }}"
   register: result
 
 - assert:
@@ -43,6 +45,7 @@
     description: "sub-interface Configured by Ansible"
     admin_state: down
     mtu: 800
+    provider: "{{ connection }}"
   register: result
 
 - assert:

--- a/test/integration/targets/nxos_interface/tests/common/sub_int.yaml
+++ b/test/integration/targets/nxos_interface/tests/common/sub_int.yaml
@@ -8,6 +8,7 @@
 - name: Setup - delete sub-interface
   nxos_interface: &rm
     name: "{{ testint }}.20"
+    provider: "{{ connection }}"
     state: absent
   ignore_errors: yes
 

--- a/test/integration/targets/nxos_interface_ospf/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_interface_ospf/tests/common/sanity.yaml
@@ -8,12 +8,14 @@
 - name: "Setup - Disable feature OSPF"
   nxos_feature: &disable
     feature: ospf
+    provider: "{{ connection }}"
     state: disabled
   ignore_errors: yes
 
 - name: "Setup - Enable feature OSPF"
   nxos_feature: &enable
     feature: ospf
+    provider: "{{ connection }}"
     state: enabled
   ignore_errors: yes
 
@@ -50,6 +52,7 @@
       passive_interface: true
       hello_interval: 15
       dead_interval: 75
+      provider: "{{ connection }}"
       state: present
     register: result
 
@@ -74,6 +77,7 @@
       passive_interface: false
       hello_interval: 17
       dead_interval: 70
+      provider: "{{ connection }}"
       state: present
     register: result
 
@@ -93,6 +97,7 @@
       cost: default
       hello_interval: 10
       dead_interval: default
+      provider: "{{ connection }}"
       state: present
     register: result
 
@@ -114,6 +119,7 @@
       message_digest_algorithm_type: md5
       message_digest_encryption_type: 3des
       message_digest_password: b69f7bc54725b1bfd1ea93afa7b09400
+      provider: "{{ connection }}"
       state: present
     register: result
 
@@ -135,6 +141,7 @@
       message_digest_algorithm_type: default
       message_digest_encryption_type: default
       message_digest_password: default
+      provider: "{{ connection }}"
       state: present
     register: result
 
@@ -174,6 +181,7 @@
       passive_interface: true
       hello_interval: 15
       dead_interval: 75
+      provider: "{{ connection }}"
       state: present
     register: result
 
@@ -194,6 +202,7 @@
       passive_interface: true
       hello_interval: 15
       dead_interval: 75
+      provider: "{{ connection }}"
       state: present
     register: result
 
@@ -213,6 +222,7 @@
       cost: 55
       hello_interval: 15
       dead_interval: 75
+      provider: "{{ connection }}"
       state: present
     register: result
 
@@ -232,6 +242,7 @@
       cost: 77
       hello_interval: 45
       dead_interval: 75
+      provider: "{{ connection }}"
       state: present
     register: result
 
@@ -252,6 +263,7 @@
       passive_interface: true
       hello_interval: 15
       dead_interval: 75
+      provider: "{{ connection }}"
       state: absent
     register: result
 

--- a/test/integration/targets/nxos_interface_ospf/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_interface_ospf/tests/common/sanity.yaml
@@ -23,6 +23,7 @@
   nxos_config: &intdefault
     lines:
       - "default interface {{ testint }}"
+    provider: "{{ connection }}"
   ignore_errors: yes
 
 - name: "Remove switchport config"
@@ -31,6 +32,7 @@
       - no switchport
     parents:
       - "interface {{ testint }}"
+    provider: "{{ connection }}"
   ignore_errors: yes
 
 - name: "Remove possibly existing port-channel and loopback ints"
@@ -40,6 +42,7 @@
       - no interface port-channel11
       - no interface loopback55
       - no interface loopback77
+    provider: "{{ connection }}"
   ignore_errors: yes
 
 - block:
@@ -161,6 +164,7 @@
         - interface loopback55
         - interface loopback77
       match: none
+      provider: "{{ connection }}"
 
   - name: "Ensure port-channels are layer3"
     nxos_config:
@@ -168,6 +172,7 @@
         - no switchport
       parents:
         - "interface {{ item }}"
+      provider: "{{ connection }}"
     with_items:
       - port-channel10
       - port-channel11

--- a/test/integration/targets/nxos_ip_interface/tests/nxapi/sanity.yaml
+++ b/test/integration/targets/nxos_ip_interface/tests/nxapi/sanity.yaml
@@ -24,6 +24,7 @@
     mode: layer3
     description: 'Configured by Ansible - Layer3'
     admin_state: 'up'
+    provider: "{{ connection }}"
     state: present
 
 - name: "Make {{testint2}} a layer3 interface"
@@ -32,6 +33,7 @@
     mode: layer3
     description: 'Configured by Ansible - Layer3'
     admin_state: 'up'
+    provider: "{{ connection }}"
     state: present
 
 # For titanium
@@ -39,6 +41,7 @@
   nxos_ip_interface:
     interface: "{{ testint1 }}"
     version: v4
+    provider: "{{ connection }}"
     state: absent
     addr: 20.20.20.20
     mask: 24
@@ -48,6 +51,7 @@
   nxos_ip_interface:
     interface: "{{ testint2 }}"
     version: v6
+    provider: "{{ connection }}"
     state: absent
     addr: 'fd56:31f7:e4ad:5585::1'
     mask: 64
@@ -56,6 +60,7 @@
   nxos_ip_interface: &ipv4
     interface: "{{ testint1 }}"
     version: v4
+    provider: "{{ connection }}"
     state: present
     addr: 20.20.20.20
     mask: 24
@@ -77,6 +82,7 @@
   nxos_ip_interface: &ipv6
     interface: "{{ testint2 }}"
     version: v6
+    provider: "{{ connection }}"
     state: present
     addr: 'fd56:31f7:e4ad:5585::1'
     mask: 64

--- a/test/integration/targets/nxos_l2_interface/tests/common/agg.yaml
+++ b/test/integration/targets/nxos_l2_interface/tests/common/agg.yaml
@@ -10,6 +10,7 @@
 - name: "Setup vlans"
   nxos_vlan:
     vlan_range: "6,15"
+    provider: "{{ connection }}"
 
 - name: Setup - Ensure interfaces are layer2
   nxos_interface:
@@ -17,6 +18,7 @@
       - { name: "{{ intname1 }}" }
       - { name: "{{ intname2 }}" }
     mode: layer2
+    provider: "{{ connection }}"
 
 - name: Setup - Remove interface aggregate before testing
   nxos_l2_interface:
@@ -36,6 +38,7 @@
       aggregate:
         - { name: "{{ intname1 }}", mode: access, access_vlan: 6 }
         - { name: "{{ intname2 }}", mode: access, access_vlan: 15 }
+      provider: "{{ connection }}"
     register: result
 
   - assert:

--- a/test/integration/targets/nxos_l2_interface/tests/common/agg.yaml
+++ b/test/integration/targets/nxos_l2_interface/tests/common/agg.yaml
@@ -23,6 +23,7 @@
     aggregate:
       - { name: "{{ intname1 }}", mode: access, access_vlan: 6 }
       - { name: "{{ intname2 }}", mode: access, access_vlan: 15 }
+    provider: "{{ connection }}"
     state: absent
 
 - name: Sleep for 2 seconds on Fretta Platform
@@ -58,6 +59,7 @@
       aggregate:
         - { name: "{{ intname1 }}", mode: access, access_vlan: 6 }
         - { name: "{{ intname2 }}", mode: access, access_vlan: 15 }
+      provider: "{{ connection }}"
       state: absent
     register: result
 
@@ -81,6 +83,7 @@
   - name: "remove vlans"
     nxos_vlan:
       vlan_range: "6,15"
+      provider: "{{ connection }}"
       state: absent
     ignore_errors: yes
 
@@ -89,6 +92,7 @@
       aggregate:
         - { name: "{{ intname1 }}", mode: access, access_vlan: 6 }
         - { name: "{{ intname2 }}", mode: access, access_vlan: 15 }
+      provider: "{{ connection }}"
       state: absent
     ignore_errors: yes
 

--- a/test/integration/targets/nxos_l2_interface/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_l2_interface/tests/common/sanity.yaml
@@ -28,6 +28,7 @@
   - name: Ensure interface is in its default switchport state
     nxos_l2_interface: &def_swi
       name: "{{ intname }}"
+      provider: "{{ connection }}"
       state: unconfigured
 
   - name: Ensure interface is configured for access vlan 20
@@ -90,6 +91,7 @@
       name: "{{ intname }}"
       mode: trunk
       trunk_vlans: 2-50
+      provider: "{{ connection }}"
       state: absent
     register: result
 
@@ -118,6 +120,7 @@
       name: "{{ intname }}"
       mode: trunk
       trunk_vlans: 30-4094
+      provider: "{{ connection }}"
       state: absent
     register: result
 
@@ -145,6 +148,7 @@
   - name: "remove vlans"
     nxos_vlan:
       vlan_range: "5-10,20"
+      provider: "{{ connection }}"
       state: absent
     ignore_errors: yes
 

--- a/test/integration/targets/nxos_l2_interface/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_l2_interface/tests/common/sanity.yaml
@@ -13,16 +13,19 @@
   nxos_config: &default
     lines:
       - "default interface {{ intname }}"
+    provider: "{{ connection }}"
   ignore_errors: yes
 
 - name: Setup - Ensure interface is layer2
   nxos_interface:
     interface: "{{ intname }}"
     mode: layer2
+    provider: "{{ connection }}"
 
 - name: "Setup vlans"
   nxos_vlan:
     vlan_range: "5-10,20"
+    provider: "{{ connection }}"
 
 - block:
   - name: Ensure interface is in its default switchport state
@@ -36,6 +39,7 @@
       name: "{{ intname }}"
       mode: access
       access_vlan: 20
+      provider: "{{ connection }}"
     register: result
 
   - assert: &true
@@ -60,6 +64,7 @@
       mode: trunk
       native_vlan: 10
       trunk_allowed_vlans: 5-10
+      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -76,6 +81,7 @@
       mode: trunk
       native_vlan: 10
       trunk_vlans: 2-50
+      provider: "{{ connection }}"
     register: result
 
   - assert: *true

--- a/test/integration/targets/nxos_l3_interface/tests/nxapi/sanity.yaml
+++ b/test/integration/targets/nxos_l3_interface/tests/nxapi/sanity.yaml
@@ -16,6 +16,7 @@
     aggregate:
       - { name: "{{ testint2 }}", ipv4: 192.168.22.1/24 }
       - { name: "{{ testint3 }}", ipv4: 192.168.20.1/24, ipv6: "{{ ipv6_address }}" }
+    provider: "{{ connection }}"
     state: absent
   ignore_errors: yes
 
@@ -48,6 +49,7 @@
   nxos_l3_interface: &rm
     name: "{{ testint2 }}"
     ipv4: 192.168.22.1/24
+    provider: "{{ connection }}"
     state: absent
   register: result
 
@@ -87,6 +89,7 @@
     aggregate:
       - { name: "{{ testint2 }}", ipv4: 192.168.22.1/24 }
       - { name: "{{ testint3 }}", ipv4: 192.168.20.1/24, ipv6: "{{ ipv6_address }}" }
+    provider: "{{ connection }}"
     state: absent
   register: result
 

--- a/test/integration/targets/nxos_l3_interface/tests/nxapi/sanity.yaml
+++ b/test/integration/targets/nxos_l3_interface/tests/nxapi/sanity.yaml
@@ -26,11 +26,13 @@
       - name: "{{ testint2 }}"
       - name: "{{ testint3 }}"
     mode: layer3
+    provider: "{{ connection }}"
 
 - name: Configure ipv4 address to interface
   nxos_l3_interface: &conf
     name: "{{ testint2 }}"
     ipv4: 192.168.22.1/24
+    provider: "{{ connection }}"
   register: result
 
 - assert:
@@ -70,6 +72,7 @@
     aggregate:
       - { name: "{{ testint2 }}", ipv4: 192.168.22.1/24 }
       - { name: "{{ testint3 }}", ipv4: 192.168.20.1/24, ipv6: "{{ ipv6_address }}" }
+    provider: "{{ connection }}"
   register: result
 
 - assert:

--- a/test/integration/targets/nxos_linkagg/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_linkagg/tests/common/sanity.yaml
@@ -9,6 +9,7 @@
 - name: "Enable feature LACP"
   nxos_feature:
     feature: lacp
+    provider: "{{ connection }}"
     state: enabled
   ignore_errors: yes
 
@@ -39,6 +40,7 @@
 - name: create linkagg
   nxos_linkagg: &create
     group: 20
+    provider: "{{ connection }}"
     state: present
   register: result
 
@@ -107,6 +109,7 @@
 - name: remove linkagg
   nxos_linkagg: &remove
     group: 20
+    provider: "{{ connection }}"
     state: absent
   register: result
 
@@ -151,6 +154,7 @@
     aggregate:
       - { group: 20, min_links: 3 }
       - { group: 100, min_links: 4 }
+    provider: "{{ connection }}"
     state: absent
   register: result
 
@@ -187,6 +191,7 @@
 - name: "Disable feature LACP"
   nxos_feature:
     feature: lacp
+    provider: "{{ connection }}"
     state: disabled
     timeout: 60
 

--- a/test/integration/targets/nxos_linkagg/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_linkagg/tests/common/sanity.yaml
@@ -18,6 +18,7 @@
     lines:
       - no interface port-channel 20
       - no interface port-channel 100
+    provider: "{{ connection }}"
 
 - name: setup - remove config used in test(part2)
   nxos_config:
@@ -35,6 +36,7 @@
     - { name: "{{testint1}}" }
     - { name: "{{testint2}}" }
     mode: layer2
+    provider: "{{ connection }}"
   when: platform is match("N35")
 
 - name: create linkagg
@@ -65,6 +67,7 @@
     members:
       - "{{ testint1 }}"
       - "{{ testint2 }}"
+    provider: "{{ connection }}"
   register: result
 
 - assert:
@@ -90,6 +93,7 @@
     force: True
     members:
       - "{{ testint2 }}"
+    provider: "{{ connection }}"
   register: result
 
 - assert:
@@ -131,6 +135,7 @@
     aggregate:
       - { group: 20, min_links: 3 }
       - { group: 100, min_links: 4 }
+    provider: "{{ connection }}"
   register: result
 
 - assert:
@@ -177,12 +182,14 @@
     lines:
       - no interface port-channel 20
       - no interface port-channel 100
+    provider: "{{ connection }}"
 
 - name: teardown - remove config used in test(part2)
   nxos_config:
     lines:
       - no channel-group 20
     parents: "{{ item }}"
+    provider: "{{ connection }}"
   ignore_errors: yes
   loop:
     - "interface {{ testint1 }}"

--- a/test/integration/targets/nxos_lldp/tests/nxapi/sanity.yaml
+++ b/test/integration/targets/nxos_lldp/tests/nxapi/sanity.yaml
@@ -6,10 +6,12 @@
 - name: Make sure LLDP is not running before tests
   nxos_feature:
     feature: lldp
+    provider: "{{ connection }}"
     state: disabled
 
 - name: Enable LLDP service
   nxos_lldp:
+    provider: "{{ connection }}"
     state: present
   register: result
 
@@ -20,6 +22,7 @@
 
 - name: Enable LLDP service again (idempotent)
   nxos_lldp:
+    provider: "{{ connection }}"
     state: present
   register: result
 
@@ -29,6 +32,7 @@
 
 - name: Disable LLDP service
   nxos_lldp:
+    provider: "{{ connection }}"
     state: absent
   register: result
 
@@ -39,6 +43,7 @@
 
 - name: Disable LLDP service (idempotent)
   nxos_lldp:
+    provider: "{{ connection }}"
     state: absent
   register: result
 

--- a/test/integration/targets/nxos_logging/tests/common/basic.yaml
+++ b/test/integration/targets/nxos_logging/tests/common/basic.yaml
@@ -48,6 +48,7 @@
   nxos_logging: &molog
     dest: module
     dest_level: 2
+    provider: "{{ connection }}"
   register: result
 
 - assert:
@@ -65,6 +66,7 @@
   nxos_logging: &mlog
     dest: monitor
     dest_level: 3
+    provider: "{{ connection }}"
   register: result
 
 - assert:
@@ -82,6 +84,7 @@
   nxos_logging: &flog
     facility: daemon
     facility_level: 4
+    provider: "{{ connection }}"
   register: result
 
 - assert:

--- a/test/integration/targets/nxos_logging/tests/common/basic.yaml
+++ b/test/integration/targets/nxos_logging/tests/common/basic.yaml
@@ -7,6 +7,7 @@
   nxos_logging: &clog
     dest: console
     dest_level: 0
+    provider: "{{ connection }}"
     state: present
   register: result
 
@@ -28,6 +29,7 @@
     dest: logfile
     name: test
     dest_level: 1
+    provider: "{{ connection }}"
     state: present
   register: result
 
@@ -101,6 +103,7 @@
       - { dest: monitor, dest_level: 3 }
       - { dest: logfile, dest_level: 1, name: test }
       - { facility: daemon, facility_level: 4 }
+    provider: "{{ connection }}"
     state: absent
   register: result
 

--- a/test/integration/targets/nxos_logging/tests/common/net_logging.yaml
+++ b/test/integration/targets/nxos_logging/tests/common/net_logging.yaml
@@ -10,6 +10,7 @@
   net_logging:
     dest: console
     dest_level: 0
+    provider: "{{ connection }}"
     state: absent
   register: result
 
@@ -17,6 +18,7 @@
   net_logging:
     dest: console
     dest_level: 0
+    provider: "{{ connection }}"
     state: present
   register: result
 
@@ -29,6 +31,7 @@
   net_logging:
     dest: console
     dest_level: 0
+    provider: "{{ connection }}"
     state: absent
   register: result
 

--- a/test/integration/targets/nxos_ntp/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_ntp/tests/common/sanity.yaml
@@ -10,6 +10,7 @@
     prefer: disabled
     vrf_name: management
     source_addr: 192.0.2.5
+    provider: "{{ connection }}"
     state: absent
   ignore_errors: yes
 
@@ -22,6 +23,7 @@
       prefer: enabled
       vrf_name: management
       source_addr: 192.0.2.5
+      provider: "{{ connection }}"
       state: present
     register: result
 
@@ -44,6 +46,7 @@
       prefer: enabled
       vrf_name: default
       source_addr: default
+      provider: "{{ connection }}"
       state: present
     register: result
 
@@ -72,6 +75,7 @@
       source_int: Ethernet1/3
       peer: 1.2.3.4
       prefer: enabled
+      provider: "{{ connection }}"
       state: present
     register: result
 
@@ -86,6 +90,7 @@
   - name: Remove source interface
     nxos_ntp: &config3
       source_int: default
+      provider: "{{ connection }}"
       state: present
     register: result
 

--- a/test/integration/targets/nxos_ntp_auth/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_ntp_auth/tests/common/sanity.yaml
@@ -7,6 +7,7 @@
   nxos_ntp_auth: &setup
     key_id: 32
     md5string: hello
+    provider: "{{ connection }}"
     state: absent
   ignore_errors: yes
 
@@ -17,6 +18,7 @@
       key_id: 32
       md5string: hello
       authentication: off
+      provider: "{{ connection }}"
       state: present
     register: result
 
@@ -29,6 +31,7 @@
       key_id: 32
       md5string: hello
       authentication: off
+      provider: "{{ connection }}"
       state: absent
     register: result
 
@@ -39,6 +42,7 @@
       key_id: 32
       md5string: hello
       auth_type: encrypt
+      provider: "{{ connection }}"
       state: present
     register: result
 
@@ -55,6 +59,7 @@
   - name: Turn on authentication
     nxos_ntp_auth: &authon
       authentication: on
+      provider: "{{ connection }}"
       state: present
     register: result
 
@@ -69,6 +74,7 @@
   - name: Turn off authentication
     nxos_ntp_auth: &authoff
       authentication: off
+      provider: "{{ connection }}"
       state: present
     register: result
 
@@ -84,6 +90,7 @@
     nxos_ntp_auth: &tkey
       key_id: 32
       trusted_key: true
+      provider: "{{ connection }}"
       state: present
     register: result
 
@@ -99,6 +106,7 @@
     nxos_ntp_auth: &rtkey
       key_id: 32
       trusted_key: false
+      provider: "{{ connection }}"
       state: present
     register: result
 
@@ -116,6 +124,7 @@
       md5string: hello
       auth_type: encrypt
       authentication: on
+      provider: "{{ connection }}"
       state: absent
     register: result
 

--- a/test/integration/targets/nxos_ntp_options/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_ntp_options/tests/common/sanity.yaml
@@ -5,6 +5,7 @@
 
 - name: "Apply default ntp config" 
   nxos_ntp_options: &default
+    provider: "{{ connection }}"
     state: absent
   ignore_errors: yes
 
@@ -14,6 +15,7 @@
     nxos_ntp_options: &configure_master_default_stratum
       master: true
       logging: true
+      provider: "{{ connection }}"
       state: present
     register: result
 
@@ -33,6 +35,7 @@
     nxos_ntp_options: &configure_master_non_default_stratum
       master: true
       stratum: 10
+      provider: "{{ connection }}"
       state: present
     register: result
 
@@ -49,6 +52,7 @@
       master: true
       stratum: 10
       logging: false
+      provider: "{{ connection }}"
       state: present
     register: result
 
@@ -64,6 +68,7 @@
     nxos_ntp_options: &configure_no_master
       master: false
       logging: true
+      provider: "{{ connection }}"
       state: present
     register: result
 

--- a/test/integration/targets/nxos_ospf/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_ospf/tests/common/sanity.yaml
@@ -6,6 +6,7 @@
 - name: "Enable feature OSPF"
   nxos_feature:
     feature: ospf
+    provider: "{{ connection }}"
     state: enabled
   ignore_errors: yes
 
@@ -13,6 +14,7 @@
   - name: Configure ospf
     nxos_ospf: &config
       ospf: 1
+      provider: "{{ connection }}"
       state: present
     register: result
 
@@ -32,6 +34,7 @@
   - name: "Disable feature OSPF"
     nxos_feature:
       feature: ospf
+      provider: "{{ connection }}"
       state: disabled
     ignore_errors: yes
 
@@ -39,6 +42,7 @@
   - name: Unconfigure ospf
     nxos_ospf: &unconfig
       ospf: 1
+      provider: "{{ connection }}"
       state: absent
     register: result
 

--- a/test/integration/targets/nxos_ospf_vrf/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_ospf_vrf/tests/common/sanity.yaml
@@ -6,6 +6,7 @@
 - name: "Enable feature OSPF"
   nxos_feature:
     feature: ospf
+    provider: "{{ connection }}"
     state: enabled
   ignore_errors: yes
 
@@ -22,6 +23,7 @@
       timer_throttle_lsa_max: 3000
       vrf: test
       passive_interface: true
+      provider: "{{ connection }}"
       state: present
     register: result
 
@@ -47,6 +49,7 @@
       log_adjacency: log
       vrf: default
       passive_interface: true
+      provider: "{{ connection }}"
       state: present
     register: result
 
@@ -67,6 +70,7 @@
       timer_throttle_spf_hold: default
       passive_interface: false
       vrf: default
+      provider: "{{ connection }}"
       state: present
     register: result
 
@@ -82,6 +86,7 @@
     nxos_ospf_vrf: &unconfig1
       ospf: 2
       vrf: default
+      provider: "{{ connection }}"
       state: absent
     register: result
 
@@ -97,6 +102,7 @@
     nxos_ospf_vrf: &unconfig
       ospf: 1
       vrf: test
+      provider: "{{ connection }}"
       state: absent
     register: result
 
@@ -112,6 +118,7 @@
   - name: "Disable feature OSPF"
     nxos_feature:
       feature: ospf
+      provider: "{{ connection }}"
       state: disabled
     ignore_errors: yes
 

--- a/test/integration/targets/nxos_overlay_global/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_overlay_global/tests/common/sanity.yaml
@@ -16,6 +16,7 @@
   - name: "Enable nv overlay evpn"
     nxos_evpn_global: &enable_evpn
       nv_overlay_evpn: true
+      provider: "{{ connection }}"
 
   - name: "Apply N7K specific setup config"
     include: targets/nxos_overlay_global/tasks/platform/n7k/setup.yaml
@@ -27,11 +28,13 @@
         - feature-set fabric
         - feature fabric forwarding
       match: none
+      provider: "{{ connection }}"
     when: platform is match('N7K')
 
   - name: "Remove possibly existing mac"
     nxos_overlay_global:
       anycast_gateway_mac: "default"
+      provider: "{{ connection }}"
     ignore_errors: yes
 
   when: overlay_global_supported
@@ -42,6 +45,7 @@
   - name: Configure overlay global
     nxos_overlay_global: &configure
       anycast_gateway_mac: "b.b.b"
+      provider: "{{ connection }}"
     register: result
 
   - assert: &true
@@ -59,6 +63,7 @@
   - name: Update anycast gateway mac
     nxos_overlay_global: &update
       anycast_gateway_mac: "a.a.a"
+      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -73,6 +78,7 @@
   - name: Remove anycast gateway mac
     nxos_overlay_global: &remove
       anycast_gateway_mac: "default"
+      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -93,6 +99,7 @@
   - name: "Disable nv overlay evpn"
     nxos_evpn_global: &disable_evpn
       nv_overlay_evpn: false
+      provider: "{{ connection }}"
     ignore_errors: yes
     when: overlay_global_supported
 

--- a/test/integration/targets/nxos_pim/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_pim/tests/common/sanity.yaml
@@ -6,11 +6,13 @@
 - name: "Setup: Disable feature PIM"
   nxos_feature: &disable_feature
     feature: pim
+    provider: "{{ connection }}"
     state: disabled
 
 - name: "Setup: Enable feature PIM"
   nxos_feature:
     feature: pim
+    provider: "{{ connection }}"
     state: enabled
 
 - name: "Setup: Configure ssm_range none"

--- a/test/integration/targets/nxos_pim/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_pim/tests/common/sanity.yaml
@@ -18,6 +18,7 @@
 - name: "Setup: Configure ssm_range none"
   nxos_pim: &none
     ssm_range: "none"
+    provider: "{{ connection }}"
 
 - block:
   - name: Configure ssm_range
@@ -25,6 +26,7 @@
       ssm_range: 
         - "239.128.1.0/24"
         - "224.0.0.0/8"
+      provider: "{{ connection }}"
     register: result
 
   - assert: &true
@@ -42,6 +44,7 @@
   - name: Configure ssm_range default
     nxos_pim: &conf_default
       ssm_range: "default"
+      provider: "{{ connection }}"
     register: result
 
   - assert: *true

--- a/test/integration/targets/nxos_pim_interface/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_pim_interface/tests/common/sanity.yaml
@@ -21,6 +21,7 @@
   nxos_config:
     lines:
       - "default interface {{ testint }}"
+    provider: "{{ connection }}"
   ignore_errors: yes
 
 - name: "Ensure {{testint}} is layer3"
@@ -48,6 +49,7 @@
       jp_type_out: routemap
       sparse: True
       border: True
+      provider: "{{ connection }}"
     register: result
 
   - assert: &true
@@ -67,6 +69,7 @@
       interface: "{{ testint }}"
       neighbor_policy: NPR
       neighbor_type: routemap
+      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -85,6 +88,7 @@
       interface: "{{ testint }}"
       neighbor_policy: NPPF
       neighbor_type: prefix
+      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -99,6 +103,7 @@
     nxos_pim_interface: &confighak1
       interface: "{{ testint }}"
       hello_auth_key: password1
+      provider: "{{ connection }}"
     register: result
 
   - assert: *true

--- a/test/integration/targets/nxos_pim_interface/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_pim_interface/tests/common/sanity.yaml
@@ -6,11 +6,13 @@
 - name: "Disable feature PIM"
   nxos_feature: &disable_feature
     feature: pim
+    provider: "{{ connection }}"
     state: disabled
 
 - name: "Enable feature PIM"
   nxos_feature:
     feature: pim
+    provider: "{{ connection }}"
     state: enabled
 
 - set_fact: testint="{{ nxos_int1 }}"
@@ -27,12 +29,14 @@
     mode: layer3
     description: 'Configured by Ansible - Layer3'
     admin_state: 'up'
+    provider: "{{ connection }}"
     state: present
 
 - block:
   - name: Configure nxos_pim_interface state absent
     nxos_pim_interface: &pimabsent
       interface: "{{ testint }}"
+      provider: "{{ connection }}"
       state: absent
 
   - name: configure jp policy and type
@@ -106,6 +110,7 @@
       hello_interval: 40
       sparse: True
       border: True
+      provider: "{{ connection }}"
       state: present
     register: result
 
@@ -122,6 +127,7 @@
       interface: "{{ testint }}"
       sparse: False
       border: False
+      provider: "{{ connection }}"
       state: present
     register: result
 
@@ -139,6 +145,7 @@
   - name: configure state default
     nxos_pim_interface: &configdefault
       interface: "{{ testint }}"
+      provider: "{{ connection }}"
       state: default
     register: result
 
@@ -154,6 +161,7 @@
     nxos_pim_interface: &configb
       interface: "{{ testint }}"
       border: True
+      provider: "{{ connection }}"
       state: present
     register: result
 

--- a/test/integration/targets/nxos_pim_rp_address/tests/common/configure.yaml
+++ b/test/integration/targets/nxos_pim_rp_address/tests/common/configure.yaml
@@ -11,11 +11,13 @@
   - name: "Disable feature PIM"
     nxos_feature: &disable_feature
       feature: pim
+      provider: "{{ connection }}"
       state: disabled
 
   - name: "Enable feature PIM"
     nxos_feature: &enable_feature
       feature: pim
+      provider: "{{ connection }}"
       state: enabled
 
   - name: Configure rp_address + group_list 
@@ -23,6 +25,7 @@
       rp_address: "10.1.1.20"
       group_list: "224.0.0.0/8"
       bidir: "{{ bidir }}"
+      provider: "{{ connection }}"
       state: present
     register: result
 
@@ -43,6 +46,7 @@
       rp_address: "10.1.1.20"
       group_list: "224.0.0.0/8"
       bidir: False
+      provider: "{{ connection }}"
       state: present
     register: result
     when: platform is not match("N3L")
@@ -62,6 +66,7 @@
     nxos_pim_rp_address: &configbi
       rp_address: "10.1.1.20"
       bidir: "{{ bidir }}"
+      provider: "{{ connection }}"
       state: present
     register: result
 
@@ -77,6 +82,7 @@
     nxos_pim_rp_address: &confignbi
       rp_address: "10.1.1.20"
       bidir: False
+      provider: "{{ connection }}"
       state: present
     register: result
     when: platform is not match("N3L")
@@ -96,6 +102,7 @@
     nxos_pim_rp_address: &configglr
       rp_address: "10.1.1.20"
       group_list: "224.0.0.0/8"
+      provider: "{{ connection }}"
       state: absent
     register: result
 
@@ -110,6 +117,7 @@
   - name: Remove rp_address
     nxos_pim_rp_address: &configbir
       rp_address: "10.1.1.20"
+      provider: "{{ connection }}"
       state: absent
     register: result
 
@@ -126,6 +134,7 @@
       rp_address: "10.1.1.20"
       prefix_list: "pim_prefix_list"
       bidir: "{{ bidir }}"
+      provider: "{{ connection }}"
       state: present
     register: result
 
@@ -142,6 +151,7 @@
       rp_address: "10.1.1.20"
       prefix_list: "pim_prefix_list"
       bidir: False
+      provider: "{{ connection }}"
       state: present
     register: result
     when: platform is not match("N3L")
@@ -162,6 +172,7 @@
       rp_address: "10.1.1.20"
       prefix_list: "pim_prefix_list"
       bidir: False
+      provider: "{{ connection }}"
       state: absent
     register: result
 
@@ -178,6 +189,7 @@
       rp_address: "10.1.1.20"
       route_map: "pim_routemap"
       bidir: "{{ bidir }}"
+      provider: "{{ connection }}"
       state: present
     register: result
 
@@ -194,6 +206,7 @@
       rp_address: "10.1.1.20"
       route_map: "pim_routemap"
       bidir: False
+      provider: "{{ connection }}"
       state: present
     register: result
     when: platform is not match("N3L")
@@ -214,6 +227,7 @@
       rp_address: "10.1.1.20"
       route_map: "pim_routemap"
       bidir: False
+      provider: "{{ connection }}"
       state: absent
     register: result
 

--- a/test/integration/targets/nxos_portchannel/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_portchannel/tests/common/sanity.yaml
@@ -9,6 +9,7 @@
 - name: "Enable feature LACP"
   nxos_feature:
     feature: lacp
+    provider: "{{ connection }}"
     state: enabled
   ignore_errors: yes
 
@@ -29,6 +30,7 @@
     group: 99
     members: ["{{ testint1 }}", "{{ testint2 }}"]
     force: 'true'
+    provider: "{{ connection }}"
     state: absent
     timeout: 60
 
@@ -39,6 +41,7 @@
       members: ["{{ testint1 }}", "{{ testint2 }}"]
       mode: active
       force: 'true'
+      provider: "{{ connection }}"
       state: present
       timeout: 60
     register: result
@@ -61,6 +64,7 @@
       members: ["{{ testint1 }}", "{{ testint2 }}"]
       mode: passive
       force: 'true'
+      provider: "{{ connection }}"
       state: present
       timeout: 60
     register: result
@@ -83,6 +87,7 @@
   - name: "Disable feature LACP"
     nxos_feature:
       feature: lacp
+      provider: "{{ connection }}"
       state: disabled
       timeout: 60
 

--- a/test/integration/targets/nxos_portchannel/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_portchannel/tests/common/sanity.yaml
@@ -17,12 +17,14 @@
   nxos_config: &intdefault1
     lines:
       - "default interface {{ testint1 }}"
+    provider: "{{ connection }}"
   ignore_errors: yes
 
 - name: "Put interface {{testint2}} into default state"
   nxos_config: &intdefault2
     lines:
       - "default interface {{ testint2 }}"
+    provider: "{{ connection }}"
   ignore_errors: yes
 
 - name: Remove possibly configured port-channel 99

--- a/test/integration/targets/nxos_rollback/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_rollback/tests/common/sanity.yaml
@@ -9,16 +9,19 @@
       - terminal dont-ask
       - delete backup.cfg
     match: none
+    provider: "{{ connection }}"
   ignore_errors: yes
 
 - name: Create checkpoint file
   nxos_rollback:
     checkpoint_file: backup.cfg
+    provider: "{{ connection }}"
     timeout: 300
 
 - name: rollback to the previously created checkpoint file
   nxos_rollback:
     rollback_to: backup.cfg
+    provider: "{{ connection }}"
     timeout: 300
 
 - name: cleanup checkpoint file

--- a/test/integration/targets/nxos_rpm/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_rpm/tests/common/sanity.yaml
@@ -40,6 +40,7 @@
   - name: Remove smu RPM
     nxos_rpm: &rsmurpm
       pkg: "nxos.sample-n9k_ALL-1.0.0-7.0.3.I6.1.lib32_n9000.rpm"
+      provider: "{{ connection }}"
       state: absent
     register: result
 
@@ -79,6 +80,7 @@
       aggregate:
           - { pkg: "healthMonitor-1.0-1.5.0.x86_64.rpm" }
           - { pkg: "customCliApp-1.0-1.0.0.x86_64.rpm" }
+      provider: "{{ connection }}"
       state: absent
     register: result
 
@@ -103,6 +105,7 @@
   - name: Wait for device to come back up
     wait_for:
       port: 22
+      provider: "{{ connection }}"
       state: started
       timeout: 600
       delay: 60
@@ -123,6 +126,7 @@
   - name: Remove reload smu RPM
     nxos_rpm: &rrsmurpm
       pkg: "nxos.CSCve91311-n9k_ALL-1.0.0-7.0.3.I6.1.lib32_n9000.rpm"
+      provider: "{{ connection }}"
       state: absent
     register: result
 
@@ -131,6 +135,7 @@
   - name: Wait for device to come back up
     wait_for:
       port: 22
+      provider: "{{ connection }}"
       state: started
       timeout: 600
       delay: 60

--- a/test/integration/targets/nxos_smoke/tests/common/common_config.yaml
+++ b/test/integration/targets/nxos_smoke/tests/common/common_config.yaml
@@ -30,6 +30,7 @@
 - name: delete backup files
   file:
     path: "{{ item.path }}"
+    provider: "{{ connection }}"
     state: absent
   with_items: "{{backup_files.files|default([])}}"
 
@@ -131,6 +132,7 @@
       pref: 100
       tag: 5500
       vrf: testing
+      provider: "{{ connection }}"
       state: absent
       provider: "{{ connection }}"
     register: result
@@ -146,6 +148,7 @@
       pref: 100
       tag: 5500
       vrf: testing
+      provider: "{{ connection }}"
       state: absent
       provider: "{{ connection }}"
     ignore_errors: yes
@@ -155,6 +158,7 @@
       aggregate:
         - { prefix: "192.168.22.64/24", next_hop: "192.0.2.3" }
         - { prefix: "192.168.24.64/24", next_hop: "192.0.2.3" }
+      provider: "{{ connection }}"
       state: absent
       provider: "{{ connection }}"
     ignore_errors: yes

--- a/test/integration/targets/nxos_smoke/tests/common/common_config.yaml
+++ b/test/integration/targets/nxos_smoke/tests/common/common_config.yaml
@@ -132,7 +132,6 @@
       pref: 100
       tag: 5500
       vrf: testing
-      provider: "{{ connection }}"
       state: absent
       provider: "{{ connection }}"
     register: result
@@ -148,7 +147,6 @@
       pref: 100
       tag: 5500
       vrf: testing
-      provider: "{{ connection }}"
       state: absent
       provider: "{{ connection }}"
     ignore_errors: yes
@@ -158,7 +156,6 @@
       aggregate:
         - { prefix: "192.168.22.64/24", next_hop: "192.0.2.3" }
         - { prefix: "192.168.24.64/24", next_hop: "192.0.2.3" }
-      provider: "{{ connection }}"
       state: absent
       provider: "{{ connection }}"
     ignore_errors: yes

--- a/test/integration/targets/nxos_smoke/tests/common/common_utils.yaml
+++ b/test/integration/targets/nxos_smoke/tests/common/common_utils.yaml
@@ -12,6 +12,7 @@
   nxos_command:
     commands:
       - show version
+    provider: "{{ connection }}"
 
 # hit to_list()
 - name: setup

--- a/test/integration/targets/nxos_snapshot/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_snapshot/tests/common/sanity.yaml
@@ -22,6 +22,7 @@
       snapshot_name: test_snapshot1
       description: Ansible
       save_snapshot_locally: True
+      provider: "{{ connection }}"
     register: result
 
   - assert: &true
@@ -45,6 +46,7 @@
         row_id: ROW_intf
         element_key1: intf-name
         element_key2: intf-name
+        provider: "{{ connection }}"
       register: result
 
     - assert: *true
@@ -66,6 +68,7 @@
       show_command: show ip interface brief
       row_id: ROW_intf
       element_key1: intf-name
+      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -84,11 +87,13 @@
       comparison_results_file: compare_snapshots.txt
       compare_option: summary
       path: '.'
+      provider: "{{ connection }}"
 
   - name: delete snapshot
     nxos_snapshot: &del
       snapshot_name: test_snapshot2
       action: delete
+      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -102,6 +107,7 @@
   - name: delete all snapshots
     nxos_snapshot: &delall
       action: delete_all
+      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -120,11 +126,13 @@
       commands:
         - snapshot section delete myshow
       match: none
+      provider: "{{ connection }}"
     ignore_errors: yes
 
   - name: delete all snapshots
     nxos_snapshot:
       action: delete_all
+      provider: "{{ connection }}"
     ignore_errors: yes
 
 - debug: msg="END connection={{ ansible_connection }} nxos_snapshot sanity test"

--- a/test/integration/targets/nxos_snmp_community/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_snmp_community/tests/common/sanity.yaml
@@ -7,6 +7,7 @@
   nxos_snmp_community: &remove
     community: TESTING7
     group: network-operator
+    provider: "{{ connection }}"
     state: absent 
   ignore_errors: yes
 
@@ -16,6 +17,7 @@
     nxos_snmp_community: &config
       community: TESTING7
       group: network-operator
+      provider: "{{ connection }}"
       state: present
     register: result
 
@@ -35,6 +37,7 @@
     nxos_snmp_community: &chg
       community: TESTING7
       group: network-admin
+      provider: "{{ connection }}"
       state: present
     register: result
 
@@ -62,6 +65,7 @@
     nxos_snmp_community: &configaccess
       community: TESTING7
       access: ro
+      provider: "{{ connection }}"
       state: present
     register: result
 
@@ -90,6 +94,7 @@
       community: TESTING7
       access: rw
       acl: ansible_acl
+      provider: "{{ connection }}"
       state: present
     register: result
 
@@ -106,6 +111,7 @@
       community: TESTING7
       access: rw
       acl: new_acl
+      provider: "{{ connection }}"
       state: present
     register: result
 
@@ -122,6 +128,7 @@
       community: TESTING7
       access: rw
       acl: default
+      provider: "{{ connection }}"
       state: present
     register: result
 

--- a/test/integration/targets/nxos_snmp_contact/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_snmp_contact/tests/common/sanity.yaml
@@ -6,6 +6,7 @@
 - name: Setup - Remove snmp_contact if configured
   nxos_snmp_contact: &remove
     contact: Test
+    provider: "{{ connection }}"
     state: absent 
 
 - block:
@@ -13,6 +14,7 @@
   - name: Configure snmp contact
     nxos_snmp_contact: &config
       contact: Testing
+      provider: "{{ connection }}"
       state: present
     register: result
 
@@ -31,6 +33,7 @@
   - name: Change snmp contact
     nxos_snmp_contact: &config1
       contact: Test
+      provider: "{{ connection }}"
       state: present
     register: result
 

--- a/test/integration/targets/nxos_snmp_host/tests/common/sanity_snmp_v1_trap.yaml
+++ b/test/integration/targets/nxos_snmp_host/tests/common/sanity_snmp_v1_trap.yaml
@@ -20,6 +20,7 @@
     vrf_filter: management
     src_intf: "{{ intname|default(omit) }}"
     udp: 222
+    provider: "{{ connection }}"
     state: absent 
   ignore_errors: yes
 
@@ -35,6 +36,7 @@
       vrf_filter: management
       src_intf: "{{ intname|default(omit) }}"
       udp: 222
+      provider: "{{ connection }}"
       state: present 
     register: result
 
@@ -56,6 +58,7 @@
         snmp_host: 192.0.2.3
         vrf_filter: default
         udp: 222
+        provider: "{{ connection }}"
         state: present 
       register: result
 
@@ -75,6 +78,7 @@
       src_intf: "{{ intname|default(omit) }}"
       vrf: management
       vrf_filter: management
+      provider: "{{ connection }}"
       state: absent
     register: result
 
@@ -92,6 +96,7 @@
         snmp_host: 192.0.2.3
         udp: 222
         vrf_filter: default
+        provider: "{{ connection }}"
         state: absent
       register: result
 

--- a/test/integration/targets/nxos_snmp_host/tests/common/sanity_snmp_v2_inform.yaml
+++ b/test/integration/targets/nxos_snmp_host/tests/common/sanity_snmp_v2_inform.yaml
@@ -20,6 +20,7 @@
     vrf_filter: management
     src_intf: "{{ intname|default(omit) }}"
     udp: 222
+    provider: "{{ connection }}"
     state: absent 
   ignore_errors: yes
 
@@ -35,6 +36,7 @@
       vrf_filter: management
       src_intf: "{{ intname|default(omit) }}"
       udp: 222
+      provider: "{{ connection }}"
       state: present 
     register: result
 
@@ -56,6 +58,7 @@
         snmp_host: 192.0.2.3
         vrf_filter: default
         udp: 222
+        provider: "{{ connection }}"
         state: present 
       register: result
 
@@ -75,6 +78,7 @@
       src_intf: "{{ intname|default(omit) }}"
       vrf: management
       vrf_filter: management
+      provider: "{{ connection }}"
       state: absent
     register: result
 
@@ -92,6 +96,7 @@
         snmp_host: 192.0.2.3
         udp: 222
         vrf_filter: default
+        provider: "{{ connection }}"
         state: absent
       register: result
 

--- a/test/integration/targets/nxos_snmp_host/tests/common/sanity_snmp_v3_inform.yaml
+++ b/test/integration/targets/nxos_snmp_host/tests/common/sanity_snmp_v3_inform.yaml
@@ -25,6 +25,7 @@
     vrf: management
     vrf_filter: management
     src_intf: "{{ intname|default(omit) }}"
+    provider: "{{ connection }}"
     state: absent 
   ignore_errors: yes
 
@@ -40,6 +41,7 @@
       vrf: management
       vrf_filter: management
       src_intf: "{{ intname|default(omit) }}"
+      provider: "{{ connection }}"
       state: present 
     register: result
 
@@ -60,6 +62,7 @@
       nxos_snmp_host: &config1
         snmp_host: 192.0.2.3
         vrf_filter: default
+        provider: "{{ connection }}"
         state: present 
       register: result
 
@@ -78,6 +81,7 @@
       src_intf: "{{ intname|default(omit) }}"
       vrf: management
       vrf_filter: management
+      provider: "{{ connection }}"
       state: absent
     register: result
 
@@ -94,6 +98,7 @@
       nxos_snmp_host: &rem2
         snmp_host: 192.0.2.3
         vrf_filter: default
+        provider: "{{ connection }}"
         state: absent
       register: result
 

--- a/test/integration/targets/nxos_snmp_host/tests/common/sanity_snmp_v3_trap.yaml
+++ b/test/integration/targets/nxos_snmp_host/tests/common/sanity_snmp_v3_trap.yaml
@@ -22,6 +22,7 @@
     vrf: management
     vrf_filter: management
     src_intf: "{{ intname|default(omit) }}"
+    provider: "{{ connection }}"
     state: absent 
   ignore_errors: yes
 
@@ -38,6 +39,7 @@
       vrf: management
       vrf_filter: management
       src_intf: "{{ intname|default(omit) }}"
+      provider: "{{ connection }}"
       state: present 
     register: result
 
@@ -59,6 +61,7 @@
         snmp_host: 192.0.2.3
         udp: 222
         vrf_filter: default
+        provider: "{{ connection }}"
         state: present 
       register: result
 
@@ -78,6 +81,7 @@
       src_intf: "{{ intname|default(omit) }}"
       vrf: management
       vrf_filter: management
+      provider: "{{ connection }}"
       state: absent
     register: result
 
@@ -95,6 +99,7 @@
         snmp_host: 192.0.2.3
         udp: 222
         vrf_filter: default
+        provider: "{{ connection }}"
         state: absent
       register: result
 

--- a/test/integration/targets/nxos_snmp_location/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_snmp_location/tests/common/sanity.yaml
@@ -6,12 +6,14 @@
 - name: Setup - Remove snmp_location if configured
   nxos_snmp_location: &remove
     location: Test 
+    provider: "{{ connection }}"
     state: absent
 
 - block:
   - name: Configure snmp location 
     nxos_snmp_location: &config
       location: Testing
+      provider: "{{ connection }}"
       state: present
     register: result
 
@@ -30,6 +32,7 @@
   - name: Change snmp location 
     nxos_snmp_location: &config1
       location: Test
+      provider: "{{ connection }}"
       state: present
     register: result
 

--- a/test/integration/targets/nxos_snmp_traps/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_snmp_traps/tests/common/sanity.yaml
@@ -6,12 +6,14 @@
 - name: Setup - Remove snmp_traps if configured
   nxos_snmp_traps: &remove
     group: all 
+    provider: "{{ connection }}"
     state: disabled
 
 - block:
   - name: Configure one snmp trap group 
     nxos_snmp_traps: &config
       group: bridge 
+      provider: "{{ connection }}"
       state: enabled
     register: result
 
@@ -30,6 +32,7 @@
   - name: Remove snmp trap group
     nxos_snmp_traps: &rem1
       group: bridge
+      provider: "{{ connection }}"
       state: disabled
     register: result
 
@@ -44,6 +47,7 @@
   - name: Configure all snmp trap groups
     nxos_snmp_traps: &config1
       group: all
+      provider: "{{ connection }}"
       state: enabled
     register: result
 

--- a/test/integration/targets/nxos_snmp_user/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_snmp_user/tests/common/sanity.yaml
@@ -6,6 +6,7 @@
 - name: Remove snmp user
   nxos_snmp_user: &remove
     user: ntc
+    provider: "{{ connection }}"
     state: absent
 
 - pause:
@@ -46,6 +47,7 @@
     nxos_snmp_user: &remg
       user: ntc
       group: network-admin
+      provider: "{{ connection }}"
       state: absent
     register: result
 
@@ -64,6 +66,7 @@
     nxos_snmp_user: &remove1
       user: ntc
       group: network-operator
+      provider: "{{ connection }}"
       state: absent
     register: result
 

--- a/test/integration/targets/nxos_snmp_user/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_snmp_user/tests/common/sanity.yaml
@@ -21,6 +21,7 @@
       pwd: N$tOpe%1
       privacy: HelloU$er1
       encrypt: true
+      provider: "{{ connection }}"
     register: result
 
   - assert: &true
@@ -31,6 +32,7 @@
     nxos_snmp_user: &chg
       user: ntc
       group: network-admin
+      provider: "{{ connection }}"
     register: result
 
   - assert: *true

--- a/test/integration/targets/nxos_static_route/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_static_route/tests/common/sanity.yaml
@@ -55,6 +55,7 @@
       route_name: testing
       pref: 100
       vrf: "{{ item }}"
+      provider: "{{ connection }}"
       state: absent
     with_items: "{{ vrfs }}"
     register: result
@@ -92,6 +93,7 @@
       aggregate:
         - { prefix: "192.168.22.64/24", next_hop: "192.0.2.3" }
         - { prefix: "192.168.24.64/24", next_hop: "192.0.2.3" }
+      provider: "{{ connection }}"
       state: absent
     register: result
 
@@ -116,6 +118,7 @@
       pref: 100
       tag: 5500
       vrf: "{{ item }}"
+      provider: "{{ connection }}"
       state: absent
     with_items: "{{ vrfs }}"
     ignore_errors: yes
@@ -125,6 +128,7 @@
       aggregate:
         - { prefix: "192.168.22.64/24", next_hop: "192.0.2.3" }
         - { prefix: "192.168.24.64/24", next_hop: "192.0.2.3" }
+      provider: "{{ connection }}"
       state: absent
     ignore_errors: yes
 

--- a/test/integration/targets/nxos_static_route/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_static_route/tests/common/sanity.yaml
@@ -12,6 +12,7 @@
       pref: 100
       tag: 5500
       vrf: "{{ item }}"
+      provider: "{{ connection }}"
     with_items: "{{ vrfs }}"
     register: result
 
@@ -36,6 +37,7 @@
       pref: 10
       tag: default
       vrf: "{{ item }}"
+      provider: "{{ connection }}"
     with_items: "{{ vrfs }}"
     register: result
 
@@ -74,6 +76,7 @@
       aggregate:
         - { prefix: "192.168.22.64/24", next_hop: "192.0.2.3" }
         - { prefix: "192.168.24.64/24", next_hop: "192.0.2.3" }
+      provider: "{{ connection }}"
     register: result
 
   - assert:

--- a/test/integration/targets/nxos_switchport/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_switchport/tests/common/sanity.yaml
@@ -28,6 +28,7 @@
   - name: Ensure interface is in its default switchport state
     nxos_switchport: &def_swi
       interface: "{{ intname }}"
+      provider: "{{ connection }}"
       state: unconfigured
 
   - name: Ensure interface is configured for access vlan 20
@@ -86,6 +87,7 @@
       interface: "{{ intname }}"
       mode: trunk
       trunk_vlans: 2-50
+      provider: "{{ connection }}"
       state: absent
     register: result
 
@@ -114,6 +116,7 @@
       interface: "{{ intname }}"
       mode: trunk
       trunk_vlans: 30-4094
+      provider: "{{ connection }}"
       state: absent
     register: result
 
@@ -141,6 +144,7 @@
   - name: "remove vlans"
     nxos_vlan:
       vlan_range: "5-10,20"
+      provider: "{{ connection }}"
       state: absent
     ignore_errors: yes
 

--- a/test/integration/targets/nxos_system/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_system/tests/common/sanity.yaml
@@ -22,6 +22,7 @@
     nxos_system: &hostname
       hostname: switch
       domain_name: test.example.com
+      provider: "{{ connection }}"
     register: result
 
   - assert: &true
@@ -41,6 +42,7 @@
       name_servers:
         - 8.8.8.8
         - 8.8.4.4
+      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -56,6 +58,7 @@
       name_servers:
         - { server: 8.8.8.8, vrf: management }
         - { server: 8.8.4.4, vrf: management }
+      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -69,6 +72,7 @@
   - name: configure domain lookup1
     nxos_system: &ndlo
       domain_lookup: false
+      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -94,6 +98,7 @@
   - name: configure system mtu
     nxos_system: &sysmtu
       system_mtu: 3000
+      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -110,6 +115,7 @@
       domain_name: default
       name_servers: default
       system_mtu: default
+      provider: "{{ connection }}"
     register: result
 
   - assert: *true

--- a/test/integration/targets/nxos_system/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_system/tests/common/sanity.yaml
@@ -6,6 +6,7 @@
 - block:
   - name: remove configuration
     nxos_system: &remove
+      provider: "{{ connection }}"
       state: absent
     register: result
     ignore_errors: yes
@@ -13,6 +14,7 @@
   - name: configure domain lookup
     nxos_system: &dlo
       domain_lookup: true
+      provider: "{{ connection }}"
       state: present
     register: result
 

--- a/test/integration/targets/nxos_system/tests/common/set_hostname.yaml
+++ b/test/integration/targets/nxos_system/tests/common/set_hostname.yaml
@@ -8,10 +8,12 @@
     nxos_config:
       lines: "hostname switch"
       match: none
+      provider: "{{ connection }}"
 
   - name: configure hostname
     nxos_system:
       hostname: foo
+      provider: "{{ connection }}"
     register: result
 
   - assert:
@@ -21,6 +23,7 @@
   - name: verify hostname
     nxos_system:
       hostname: foo
+      provider: "{{ connection }}"
     register: result
 
   - assert:
@@ -32,6 +35,7 @@
     nxos_config:
       lines: "hostname switch"
       match: none
+      provider: "{{ connection }}"
 
 
   - debug: msg="END connection={{ ansible_connection }}/set_hostname.yaml"

--- a/test/integration/targets/nxos_system/tests/nxapi/net_system.yaml
+++ b/test/integration/targets/nxos_system/tests/nxapi/net_system.yaml
@@ -10,6 +10,7 @@
       - no ip domain-list ansible.com
       - no ip domain-list redhat.com
     match: none
+    provider: "{{ connection }}"
   ignore_errors: yes
 
 - name: configure domain_list using platform agnostic module
@@ -17,6 +18,7 @@
     domain_search:
       - ansible.com
       - redhat.com
+    provider: "{{ connection }}"
   register: result
 
 - assert:
@@ -31,5 +33,6 @@
       - no ip domain-list ansible.com
       - no ip domain-list redhat.com
     match: none
+    provider: "{{ connection }}"
 
 - debug: msg="END nxos nxapi/net_system.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/nxos_system/tests/nxapi/set_domain_list.yaml
+++ b/test/integration/targets/nxos_system/tests/nxapi/set_domain_list.yaml
@@ -9,6 +9,7 @@
     lines:
       - no ip domain-list {{ item }}
     match: none
+    provider: "{{ connection }}"
   ignore_errors: yes
   with_items:
       - ansible.com
@@ -19,6 +20,7 @@
     domain_search:
       - ansible.com
       - redhat.com
+    provider: "{{ connection }}"
   register: result
 
 - assert:
@@ -32,6 +34,7 @@
     domain_search:
       - ansible.com
       - redhat.com
+    provider: "{{ connection }}"
   register: result
 
 - assert:
@@ -42,6 +45,7 @@
   nxos_system:
     domain_search:
       - ansible.com
+    provider: "{{ connection }}"
   register: result
 
 - assert:
@@ -53,6 +57,7 @@
   nxos_system:
     domain_search:
       - ansible.com
+    provider: "{{ connection }}"
   register: result
 
 - assert:
@@ -64,6 +69,7 @@
     domain_search:
       - ansible.com
       - redhat.com
+    provider: "{{ connection }}"
   register: result
 
 - assert:
@@ -76,6 +82,7 @@
     domain_search:
       - ansible.com
       - redhat.com
+    provider: "{{ connection }}"
   register: result
 
 - assert:
@@ -87,6 +94,7 @@
     domain_search:
       - ansible.com
       - eng.ansible.com
+    provider: "{{ connection }}"
   register: result
 
 - assert:
@@ -101,6 +109,7 @@
     domain_search:
       - ansible.com
       - eng.ansible.com
+    provider: "{{ connection }}"
   register: result
 
 - assert:
@@ -112,6 +121,7 @@
     lines:
       - no ip domain-list {{ item }}
     match: none
+    provider: "{{ connection }}"
   ignore_errors: yes
   with_items:
       - ansible.com

--- a/test/integration/targets/nxos_system/tests/nxapi/set_domain_name.yaml
+++ b/test/integration/targets/nxos_system/tests/nxapi/set_domain_name.yaml
@@ -5,12 +5,14 @@
   nxos_config:
     lines: no ip domain-name eng.ansible.com
     match: none
+    provider: "{{ connection }}"
 # NXAPI errors if you try to remove something that doesn't exist
   ignore_errors: yes
 
 - name: configure domain_name
   nxos_system:
     domain_name: eng.ansible.com
+    provider: "{{ connection }}"
   register: result
 
 - assert:
@@ -20,6 +22,7 @@
 - name: verify domain_name
   nxos_system:
     domain_name: eng.ansible.com
+    provider: "{{ connection }}"
   register: result
 
 - assert:
@@ -30,5 +33,6 @@
   nxos_config:
     lines: no ip domain-name eng.ansible.com
     match: none
+    provider: "{{ connection }}"
 
 - debug: msg="END nxapi/set_domain_name.yaml"

--- a/test/integration/targets/nxos_system/tests/nxapi/set_name_servers.yaml
+++ b/test/integration/targets/nxos_system/tests/nxapi/set_name_servers.yaml
@@ -9,6 +9,7 @@
     lines:
       - no ip name-server {{ item }}
     match: none
+    provider: "{{ connection }}"
   ignore_errors: yes
   with_items:
       - 192.0.2.1
@@ -21,6 +22,7 @@
       - 192.0.2.1
       - 192.0.2.2
       - 192.0.2.3
+    provider: "{{ connection }}"
   register: result
 
 - assert:
@@ -36,6 +38,7 @@
       - 192.0.2.1
       - 192.0.2.2
       - 192.0.2.3
+    provider: "{{ connection }}"
   register: result
 
 - assert:
@@ -74,6 +77,7 @@
     name_servers:
       - 192.0.2.1
       - 192.0.2.2
+    provider: "{{ connection }}"
   register: result
 
 - assert:
@@ -85,6 +89,7 @@
 - name: default name server
   nxos_system: &defns
     name_servers: default
+    provider: "{{ connection }}"
   register: result
 
 - assert:

--- a/test/integration/targets/nxos_udld/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_udld/tests/common/sanity.yaml
@@ -13,6 +13,7 @@
   - name: "Enable feature udld"
     nxos_feature: 
       feature: udld
+      provider: "{{ connection }}"
       state: enabled
 
   - name: Configure udld
@@ -71,6 +72,7 @@
 
   - name: Remove udld config
     nxos_udld: &conf4
+      provider: "{{ connection }}"
       state: absent
     register: result
 
@@ -88,6 +90,7 @@
   - name: "Disable udld"
     nxos_feature: 
       feature: udld
+      provider: "{{ connection }}"
       state: disabled
     ignore_errors: yes
 

--- a/test/integration/targets/nxos_udld/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_udld/tests/common/sanity.yaml
@@ -20,6 +20,7 @@
     nxos_udld: &conf1
       aggressive: enabled
       msg_time: 20
+      provider: "{{ connection }}"
     register: result
 
   - assert: &true
@@ -37,10 +38,12 @@
   - name: Reset udld
     nxos_udld:
       reset: True
+      provider: "{{ connection }}"
 
   - name: Configure udld2
     nxos_udld: &conf2
       aggressive: disabled
+      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -54,6 +57,7 @@
   - name: Configure udld3
     nxos_udld: &conf3
       msg_time: default
+      provider: "{{ connection }}"
     register: result
 
   - assert: *true

--- a/test/integration/targets/nxos_udld_interface/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_udld_interface/tests/common/sanity.yaml
@@ -19,6 +19,7 @@
   - name: "Enable feature udld"
     nxos_feature: 
       feature: udld
+      provider: "{{ connection }}"
       state: enabled
 
   - name: "put the interface into default state"
@@ -31,6 +32,7 @@
     nxos_udld_interface: &conf1
       interface: "{{ intname }}"
       mode: aggressive
+      provider: "{{ connection }}"
       state: present
     register: result
 
@@ -52,6 +54,7 @@
       nxos_udld_interface: &conf2
         interface: "{{ intname }}"
         mode: enabled
+        provider: "{{ connection }}"
         state: present
       register: result
 
@@ -79,6 +82,7 @@
       nxos_udld_interface: &conf3
         interface: "{{ intname }}"
         mode: disabled
+        provider: "{{ connection }}"
         state: present
       register: result
 
@@ -96,6 +100,7 @@
     nxos_udld_interface: &remove
       interface: "{{ intname }}"
       mode: enabled
+      provider: "{{ connection }}"
       state: absent
 
   when: udld_run
@@ -104,6 +109,7 @@
   - name: "Disable udld"
     nxos_feature: 
       feature: udld
+      provider: "{{ connection }}"
       state: disabled
     ignore_errors: yes
 

--- a/test/integration/targets/nxos_udld_interface/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_udld_interface/tests/common/sanity.yaml
@@ -27,6 +27,7 @@
       commands:
         - "default interface {{intname}}"
       match: none
+      provider: "{{ connection }}"
 
   - name: ensure interface is configured to be in aggressive mode
     nxos_udld_interface: &conf1

--- a/test/integration/targets/nxos_user/tests/common/auth.yaml
+++ b/test/integration/targets/nxos_user/tests/common/auth.yaml
@@ -4,6 +4,7 @@
     nxos_user:
       name: auth_user
       role: network-operator
+      provider: "{{ connection }}"
       state: present
       configured_password: pass123
 
@@ -30,5 +31,6 @@
   - name: delete user
     nxos_user:
       name: auth_user
+      provider: "{{ connection }}"
       state: absent
     register: result

--- a/test/integration/targets/nxos_user/tests/common/basic.yaml
+++ b/test/integration/targets/nxos_user/tests/common/basic.yaml
@@ -9,6 +9,7 @@
       - { name: ansibletest1 }
       - { name: ansibletest2 }
       - { name: ansibletest3 }
+    provider: "{{ connection }}"
     state: absent
 
 # Start tests
@@ -16,6 +17,7 @@
   nxos_user:
     name: ansibletest1
     roles: network-operator
+    provider: "{{ connection }}"
     state: present
   register: result
 
@@ -30,6 +32,7 @@
     aggregate:
       - { name: ansibletest2 }
       - { name: ansibletest3 }
+    provider: "{{ connection }}"
     state: present
     roles: network-admin
   register: result
@@ -44,6 +47,7 @@
       - { name: ansibletest1 }
       - { name: ansibletest2 }
       - { name: ansibletest3 }
+    provider: "{{ connection }}"
     state: absent
   register: result
 

--- a/test/integration/targets/nxos_user/tests/common/net_user.yaml
+++ b/test/integration/targets/nxos_user/tests/common/net_user.yaml
@@ -9,6 +9,7 @@
 - name: "Remove old entries of user - setup"
   net_user:
     name: ansibletest1
+    provider: "{{ connection }}"
     state: absent
 
 # Start tests
@@ -16,6 +17,7 @@
   net_user:
     name: ansibletest1
     roles: network-operator
+    provider: "{{ connection }}"
     state: present
   register: result
 
@@ -28,6 +30,7 @@
 - name: teardown
   net_user:
     name: ansibletest1
+    provider: "{{ connection }}"
     state: absent
 
 - debug: msg="END connection={{ ansible_connection }} nxos common/net_user.yaml"

--- a/test/integration/targets/nxos_user/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_user/tests/common/sanity.yaml
@@ -14,6 +14,7 @@
       configured_password: Hello!23$
       update_password: on_create
       roles: network-operator
+      provider: "{{ connection }}"
       state: present
     register: result
 
@@ -34,6 +35,7 @@
   - name: Remove user
     nxos_user: &remove
       name: netend
+      provider: "{{ connection }}"
       state: absent
     register: result
 
@@ -51,6 +53,7 @@
 #    nxos_user: &conf1
 #      name: ansible
 #      sshkey: "{{ lookup('file', '~/.ssh/id_rsa.pub') }}"
+#      provider: "{{ connection }}"
 #      state: present
 #    register: result
 #
@@ -72,6 +75,7 @@
         - name: test2
       configured_password: Hello!23$
       update_password: on_create
+      provider: "{{ connection }}"
       state: present
       roles: 
         - network-admin

--- a/test/integration/targets/nxos_user/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_user/tests/common/sanity.yaml
@@ -97,6 +97,7 @@
     nxos_user: &tear
       name: ansible
       purge: yes
+      provider: "{{ connection }}"
     register: result
 
   - assert: *true

--- a/test/integration/targets/nxos_vlan/tests/common/agg.yaml
+++ b/test/integration/targets/nxos_vlan/tests/common/agg.yaml
@@ -8,6 +8,7 @@
     lines:
       - no vlan 102
       - no vlan 103
+    provider: "{{ connection }}"
   ignore_errors: yes
 
 
@@ -18,6 +19,7 @@
       - { name: app03, vlan_id: 103 }
     vlan_state: active
     admin_state: up
+    provider: "{{ connection }}"
   register: result
 
 - assert:
@@ -43,6 +45,7 @@
       - { name: app03, vlan_id: 103 }
     vlan_state: active
     admin_state: down
+    provider: "{{ connection }}"
   register: result
 
 - assert:
@@ -64,6 +67,7 @@
   nxos_vlan: &purge
     vlan_id: 1
     purge: yes
+    provider: "{{ connection }}"
   register: result
 
 - assert:

--- a/test/integration/targets/nxos_vlan/tests/common/interface.yaml
+++ b/test/integration/targets/nxos_vlan/tests/common/interface.yaml
@@ -6,6 +6,7 @@
   nxos_config:
     lines:
       - no vlan 100
+    provider: "{{ connection }}"
   ignore_errors: yes
 
 - name: setup - remove vlan from interfaces used in test(part1)
@@ -14,6 +15,7 @@
       - no switchport access vlan 100
     parents: switchport
     before: "interface {{ testint1 }}"
+    provider: "{{ connection }}"
 
 - name: setup - remove vlan from interfaces used in test(part2)
   nxos_config:
@@ -21,10 +23,12 @@
       - no switchport access vlan 100
     parents: switchport
     before: "interface {{ testint2 }}"
+    provider: "{{ connection }}"
 
 - name: create vlan
   nxos_vlan:
     vlan_id: 100
+    provider: "{{ connection }}"
 
 - name: Add interfaces to vlan and check intent (config + intent)
   nxos_vlan: &interfaces
@@ -35,6 +39,7 @@
     associated_interfaces:
       - "{{ testint1 }}"
       - "{{ testint2 }}"
+    provider: "{{ connection }}"
   register: result
 
 - assert:
@@ -63,6 +68,7 @@
     associated_interfaces:
       - "{{ testint1 }}"
       - "{{ testint2 }}"
+    provider: "{{ connection }}"
   register: result
 
 - assert:
@@ -74,6 +80,7 @@
     vlan_id: 100
     associated_interfaces:
       - test
+    provider: "{{ connection }}"
   register: result
   ignore_errors: yes
 
@@ -86,6 +93,7 @@
     vlan_id: 100
     interfaces:
       - "{{ testint2 }}"
+    provider: "{{ connection }}"
   register: result
 
 - assert:
@@ -108,6 +116,7 @@
   nxos_config:
     lines:
       - no vlan 100
+    provider: "{{ connection }}"
 
 - name: teardown - remove vlan from interfaces used in test(part1)
   nxos_config:
@@ -115,6 +124,7 @@
       - no switchport access vlan 100
     parents: switchport
     before: "interface {{ testint1 }}"
+    provider: "{{ connection }}"
 
 - name: teardown - remove vlan from interfaces used in test(part2)
   nxos_config:
@@ -122,3 +132,4 @@
       - no switchport access vlan 100
     parents: switchport
     before: "interface {{ testint2 }}"
+    provider: "{{ connection }}"

--- a/test/integration/targets/nxos_vlan/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_vlan/tests/common/sanity.yaml
@@ -160,6 +160,7 @@
   - name: Ensure VLAN is NOT on the device
     nxos_vlan: &no_vlan
       vlan_id: 50
+      provider: "{{ connection }}"
       state: absent
     register: result
 
@@ -210,12 +211,14 @@
     - name: remove vlans
       nxos_vlan:
         vlan_range: "2-10,20,50,55-60,100-150"
+        provider: "{{ connection }}"
         state: absent
       ignore_errors: yes
 
     - name: "Disable feature vn segement"
       nxos_feature: 
         feature: vn-segment-vlan-based
+        provider: "{{ connection }}"
         state: disabled
       ignore_errors: yes
       when: platform is search('N9K')

--- a/test/integration/targets/nxos_vlan/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_vlan/tests/common/sanity.yaml
@@ -12,6 +12,7 @@
       lines:
         - install feature-set fabricpath
         - feature-set fabricpath
+      provider: "{{ connection }}"
     when: platform is search('N5K|N7K')
 
   - name: "Enable feature vn segment"
@@ -19,11 +20,13 @@
       commands:
         - feature vn-segment-vlan-based
       match: none
+      provider: "{{ connection }}"
     when: platform is search('N9K')
 
   - name: Ensure a range of VLANs are present on the switch
     nxos_vlan: &conf_vlan
       vlan_range: "2-10,20,50,55-60,100-150"
+      provider: "{{ connection }}"
     register: result
 
   - assert: &true
@@ -45,6 +48,7 @@
       admin_state: down
       name: WEB
       mapped_vni: 5555
+      provider: "{{ connection }}"
     register: result
     when: platform is search('N9K')
 
@@ -66,6 +70,7 @@
       admin_state: up
       name: default
       mapped_vni: default
+      provider: "{{ connection }}"
     register: result
     when: platform is search('N9K')
 
@@ -86,6 +91,7 @@
       vlan_state: suspend
       admin_state: down
       name: WEB
+      provider: "{{ connection }}"
     register: result
     when: platform is search('N3K|N7K')
 
@@ -106,6 +112,7 @@
       vlan_state: active
       admin_state: up
       name: default
+      provider: "{{ connection }}"
     register: result
     when: platform is search('N3K|N7K')
 
@@ -125,6 +132,7 @@
     nxos_vlan: &mode1
       vlan_id: 50
       mode: fabricpath
+      provider: "{{ connection }}"
     register: result
     when: platform is search('N5K|N7K')
 
@@ -143,6 +151,7 @@
     nxos_vlan: &mode2
       vlan_id: 50
       mode: ce
+      provider: "{{ connection }}"
     register: result
     when: platform is search('N5K|N7K')
 
@@ -179,6 +188,7 @@
       interfaces:
         - "{{ testint1 }}"
         - "{{ testint2 }}"
+      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -193,6 +203,7 @@
     nxos_vlan: &remint
       vlan_id: 101
       interfaces: default
+      provider: "{{ connection }}"
     register: result
 
   - assert: *true

--- a/test/integration/targets/nxos_vpc/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_vpc/tests/common/sanity.yaml
@@ -7,6 +7,7 @@
   - name: enable feature vpc
     nxos_feature:
       feature: vpc
+      provider: "{{ connection }}"
       state: enabled
 
   - name: Ensure ntc VRF exists on switch
@@ -15,6 +16,7 @@
 
   - name: Configure vpc
     nxos_vpc: &conf_vpc
+      provider: "{{ connection }}"
       state: present
       domain: 100
       pkl_dest: 192.168.100.4
@@ -36,6 +38,7 @@
 
   - name: Configure vpc1
     nxos_vpc: &conf_vpc1
+      provider: "{{ connection }}"
       state: present
       domain: 100
       role_priority: 500
@@ -55,6 +58,7 @@
   - block:
     - name: Configure auto1
       nxos_vpc: &auto_false
+        provider: "{{ connection }}"
         state: present
         domain: 100
         auto_recovery: False
@@ -70,6 +74,7 @@
 
     - name: Configure auto2
       nxos_vpc: &auto_true
+        provider: "{{ connection }}"
         state: present
         domain: 100
         auto_recovery: True
@@ -88,6 +93,7 @@
   - block:
     - name: Configure auto1
       nxos_vpc: &auto_true1
+        provider: "{{ connection }}"
         state: present
         domain: 100
         auto_recovery: True
@@ -103,6 +109,7 @@
 
     - name: Configure auto2
       nxos_vpc: &auto_false1
+        provider: "{{ connection }}"
         state: present
         domain: 100
         auto_recovery: False
@@ -120,6 +127,7 @@
 
   - name: Configure vpc2
     nxos_vpc: &conf_vpc2
+      provider: "{{ connection }}"
       state: present
       domain: 100
       role_priority: default
@@ -138,6 +146,7 @@
 
   - name: Configure vpc3
     nxos_vpc: &conf_vpc3
+      provider: "{{ connection }}"
       state: present
       domain: 100
       peer_gw: False
@@ -153,6 +162,7 @@
 
   - name: remove vpc
     nxos_vpc: &rem_vpc
+      provider: "{{ connection }}"
       state: absent
       domain: 100
     register: result
@@ -169,12 +179,14 @@
   - name: remove vrf
     nxos_vrf:
       vrf: ntc
+      provider: "{{ connection }}"
       state: absent
     ignore_errors: yes
 
   - name: disable feature vpc
     nxos_feature:
       feature: vpc
+      provider: "{{ connection }}"
       state: disabled
     ignore_errors: yes
 

--- a/test/integration/targets/nxos_vpc/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_vpc/tests/common/sanity.yaml
@@ -13,6 +13,7 @@
   - name: Ensure ntc VRF exists on switch
     nxos_vrf:
       vrf: ntc
+      provider: "{{ connection }}"
 
   - name: Configure vpc
     nxos_vpc: &conf_vpc

--- a/test/integration/targets/nxos_vpc_interface/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_vpc_interface/tests/common/sanity.yaml
@@ -7,6 +7,7 @@
   - name: enable feature vpc
     nxos_feature:
       feature: vpc
+      provider: "{{ connection }}"
       state: enabled
 
   - name: create port-channel10
@@ -25,6 +26,7 @@
 
   - name: configure vpc
     nxos_vpc:
+      provider: "{{ connection }}"
       state: present
       domain: 100
       role_priority: 32667
@@ -84,6 +86,7 @@
     nxos_vpc_interface: &remove
       portchannel: 10
       vpc: 10
+      provider: "{{ connection }}"
       state: absent
     register: result
 
@@ -98,6 +101,7 @@
   always:
   - name: remove vpc
     nxos_vpc:
+      provider: "{{ connection }}"
       state: absent
       domain: 100
       role_priority: 32667
@@ -112,6 +116,7 @@
     nxos_vpc_interface:
       portchannel: 10
       vpc: 10
+      provider: "{{ connection }}"
       state: absent
     ignore_errors: yes
 
@@ -126,6 +131,7 @@
   - name: disable feature vpc
     nxos_feature:
       feature: vpc
+      provider: "{{ connection }}"
       state: disabled
 
 - debug: msg="END connection={{ ansible_connection }} nxos_vpc_interface sanity test"

--- a/test/integration/targets/nxos_vpc_interface/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_vpc_interface/tests/common/sanity.yaml
@@ -16,6 +16,7 @@
         - interface port-channel10
         - switchport
       match: none
+      provider: "{{ connection }}"
 
   - name: create port-channel11
     nxos_config:
@@ -23,6 +24,7 @@
         - interface port-channel11
         - switchport
       match: none
+      provider: "{{ connection }}"
 
   - name: configure vpc
     nxos_vpc:
@@ -40,6 +42,7 @@
     nxos_vpc_interface: &conf
       portchannel: 10
       vpc: 10
+      provider: "{{ connection }}"
     register: result
 
   - assert: &true
@@ -58,6 +61,7 @@
     nxos_vpc_interface: &conf1
       portchannel: 11
       peer_link: True
+      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -72,6 +76,7 @@
     nxos_vpc_interface: &conf2
       portchannel: 11
       peer_link: False
+      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -126,6 +131,7 @@
         - no interface port-channel10
         - no interface port-channel11
       match: none
+      provider: "{{ connection }}"
     ignore_errors: yes
 
   - name: disable feature vpc

--- a/test/integration/targets/nxos_vrf/tests/common/intent.yaml
+++ b/test/integration/targets/nxos_vrf/tests/common/intent.yaml
@@ -12,6 +12,7 @@
       - no vrf member test1
     parents: no switchport
     before: "interface {{ testint1 }}"
+    provider: "{{ connection }}"
   ignore_errors: yes
 
 - name: setup - remove vrf from interfaces used in test(part2)
@@ -20,18 +21,21 @@
       - no vrf member test1
     parents: no switchport
     before: "interface {{ testint2 }}"
+    provider: "{{ connection }}"
   ignore_errors: yes
 
 - name: setup - delete VRF test1 used in test
   nxos_config:
     lines:
       - no vrf context test1
+    provider: "{{ connection }}"
   ignore_errors: yes
 
 - name: setup - remove VRF test2 used in test
   nxos_config:
     lines:
       - no vrf context test2
+    provider: "{{ connection }}"
   ignore_errors: yes
 
 - name: aggregate definitions of VRFs
@@ -39,6 +43,7 @@
     aggregate:
       - { name: test1, description: Configured by Ansible }
       - { name: test2, description: Testing, admin_state: down }
+    provider: "{{ connection }}"
   register: result
 
 - assert:
@@ -68,6 +73,7 @@
     associated_interfaces:
       - "{{ testint1 }}"
       - "{{ testint2 }}"
+    provider: "{{ connection }}"
   register: result
 
 - assert:
@@ -93,6 +99,7 @@
     associated_interfaces:
       - "{{ testint1 }}"
       - "{{ testint2 }}"
+    provider: "{{ connection }}"
   register: result
 
 - assert:
@@ -104,6 +111,7 @@
     name: test1
     associated_interfaces:
       - test
+    provider: "{{ connection }}"
   register: result
   ignore_errors: yes
 
@@ -116,6 +124,7 @@
     name: test1
     interfaces:
       - "{{ testint2 }}"
+    provider: "{{ connection }}"
   register: result
 
 - assert:
@@ -169,18 +178,21 @@
       - no vrf member test1
     parents: no switchport
     before: "interface {{ testint2 }}"
+    provider: "{{ connection }}"
   ignore_errors: yes
 
 - name: setup - delete VRF test1 used in test
   nxos_config:
     lines:
       - no vrf context test1
+    provider: "{{ connection }}"
   ignore_errors: yes
 
 - name: setup - remove VRF test2 used in test
   nxos_config:
     lines:
       - no vrf context test2
+    provider: "{{ connection }}"
   ignore_errors: yes
 
 - debug: msg="END connection={{ ansible_connection }} nxos_vrf intent & aggregate test"

--- a/test/integration/targets/nxos_vrf/tests/common/intent.yaml
+++ b/test/integration/targets/nxos_vrf/tests/common/intent.yaml
@@ -170,6 +170,7 @@
       - no vrf member test1
     parents: no switchport
     before: "interface {{ testint1 }}"
+    provider: "{{ connection }}"
   ignore_errors: yes
 
 - name: setup - remove vrf from interfaces used in test(part2)

--- a/test/integration/targets/nxos_vrf/tests/common/intent.yaml
+++ b/test/integration/targets/nxos_vrf/tests/common/intent.yaml
@@ -137,6 +137,7 @@
     aggregate:
       - { name: test1, description: Configured by Ansible }
       - { name: test2, description: Testing, admin_state: down }
+    provider: "{{ connection }}"
     state: absent
   register: result
 

--- a/test/integration/targets/nxos_vrf/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_vrf/tests/common/sanity.yaml
@@ -21,6 +21,7 @@
 - name: "Enable feature BGP"
   nxos_feature:
     feature: bgp
+    provider: "{{ connection }}"
     state: enabled
   ignore_errors: yes
 
@@ -72,6 +73,7 @@
   - name: Ensure ntc VRF does not exist on switch
     nxos_vrf: &remove
       vrf: ntc
+      provider: "{{ connection }}"
       state: absent
     register: result
 
@@ -90,6 +92,7 @@
   - name: "Disable feature BGP"
     nxos_feature:
       feature: bgp
+      provider: "{{ connection }}"
       state: disabled
     ignore_errors: yes
 

--- a/test/integration/targets/nxos_vrf/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_vrf/tests/common/sanity.yaml
@@ -36,6 +36,7 @@
       interfaces:
         - "{{ intname1 }}"
         - "{{ intname2 }}"
+      provider: "{{ connection }}"
     register: result
 
   - assert: &true
@@ -60,6 +61,7 @@
       vni: "{{vnid|default(omit)}}"
       rd: "{{rdd|default(omit)}}"
       interfaces: default
+      provider: "{{ connection }}"
     register: result
 
   - assert: *true

--- a/test/integration/targets/nxos_vrf_af/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_vrf_af/tests/common/sanity.yaml
@@ -12,11 +12,13 @@
 - name: Configure feature nv overlay
   nxos_config:
     commands: "feature nv overlay"
+    provider: "{{ connection }}"
   ignore_errors: yes
 
 - name: Configure nv overlay evpn
   nxos_config:
     commands: "nv overlay evpn"
+    provider: "{{ connection }}"
   ignore_errors: yes
 
 - block:
@@ -25,6 +27,7 @@
       vrf: ansible
       afi: ipv4
       route_target_both_auto_evpn: True
+      provider: "{{ connection }}"
     register: result
 
   - assert: &true
@@ -44,6 +47,7 @@
       vrf: ansible
       afi: ipv6
       route_target_both_auto_evpn: True
+      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -59,6 +63,7 @@
       vrf: ansible
       afi: ipv4
       route_target_both_auto_evpn: False
+      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -74,6 +79,7 @@
       vrf: ansible
       afi: ipv6
       route_target_both_auto_evpn: False
+      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -130,16 +136,19 @@
   - name: Remove vrf
     nxos_config:
       commands: "no vrf context ansible"
+      provider: "{{ connection }}"
     ignore_errors: yes
 
   - name: Remove nv overlay evpn
     nxos_config:
       commands: "no nv overlay evpn"
+      provider: "{{ connection }}"
     ignore_errors: yes
 
   - name: Remove feature nv overlay
     nxos_config:
       commands: "no feature nv overlay"
+      provider: "{{ connection }}"
     ignore_errors: yes
 
   - name: Remove feature bgp

--- a/test/integration/targets/nxos_vrf_af/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_vrf_af/tests/common/sanity.yaml
@@ -6,6 +6,7 @@
 - name: Configure feature bgp
   nxos_feature:
     feature: bgp
+    provider: "{{ connection }}"
     state: enabled
 
 - name: Configure feature nv overlay
@@ -88,6 +89,7 @@
       vrf: ansible
       afi: ipv6
       route_target_both_auto_evpn: True
+      provider: "{{ connection }}"
       state: absent
     register: result
 
@@ -107,6 +109,7 @@
       vrf: ansible
       afi: ipv4
       route_target_both_auto_evpn: True
+      provider: "{{ connection }}"
       state: absent
     register: result
 
@@ -142,6 +145,7 @@
   - name: Remove feature bgp
     nxos_feature:
       feature: bgp
+      provider: "{{ connection }}"
       state: disabled
     ignore_errors: yes
 

--- a/test/integration/targets/nxos_vrf_interface/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_vrf_interface/tests/common/sanity.yaml
@@ -14,6 +14,7 @@
       parents:
         - "interface {{ intname }}"
       match: none
+      provider: "{{ connection }}"
 
   - name: Ensure vrf ntc exists on interface
     nxos_vrf_interface: &configure
@@ -56,6 +57,7 @@
     nxos_config:
       lines: "default interface {{ intname }}"
       match: none
+      provider: "{{ connection }}"
     ignore_errors: yes
 
 - debug: msg="END connection={{ ansible_connection }} nxos_vrf_interface sanity test"

--- a/test/integration/targets/nxos_vrf_interface/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_vrf_interface/tests/common/sanity.yaml
@@ -19,6 +19,7 @@
     nxos_vrf_interface: &configure
       vrf: ntc
       interface: "{{ intname }}"
+      provider: "{{ connection }}"
       state: present
     register: result
 
@@ -38,6 +39,7 @@
     nxos_vrf_interface: &remove
       vrf: ntc
       interface: "{{ intname }}"
+      provider: "{{ connection }}"
       state: absent
     register: result
 

--- a/test/integration/targets/nxos_vrrp/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_vrrp/tests/common/sanity.yaml
@@ -19,6 +19,7 @@
   - name: "create int vlan 10"
     nxos_config: 
       commands: "int vlan 10"
+      provider: "{{ connection }}"
 
   - name: Ensure vrrp group 100 and vip 10.1.100.1 is on vlan10
     nxos_vrrp: &configure
@@ -26,6 +27,7 @@
       group: 100
       vip: 10.1.100.1
       admin_state: 'no shutdown'
+      provider: "{{ connection }}"
     register: result
 
   - assert: &true
@@ -46,6 +48,7 @@
       group: 100
       vip: default
       admin_state: default
+      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -87,6 +90,7 @@
       interval: 10
       priority: 130
       authentication: AUTHKEY
+      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -106,6 +110,7 @@
       interval: default
       priority: default
       authentication: default
+      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -126,6 +131,7 @@
         commands:
           - no feature interface-vlan
         match: none
+        provider: "{{ connection }}"
       ignore_errors: yes
 
     - name: "Disable vrrp"

--- a/test/integration/targets/nxos_vrrp/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_vrrp/tests/common/sanity.yaml
@@ -7,11 +7,13 @@
   - name: "Enable interface-vlan"
     nxos_feature: 
       feature: interface-vlan
+      provider: "{{ connection }}"
       state: enabled
 
   - name: "Enable vrrp"
     nxos_feature: 
       feature: vrrp
+      provider: "{{ connection }}"
       state: enabled
 
   - name: "create int vlan 10"
@@ -58,6 +60,7 @@
     nxos_vrrp: &remove
       interface: vlan10
       group: 100
+      provider: "{{ connection }}"
       state: absent
     register: result
 
@@ -128,6 +131,7 @@
     - name: "Disable vrrp"
       nxos_feature: 
         feature: vrrp
+        provider: "{{ connection }}"
         state: disabled
       ignore_errors: yes
 

--- a/test/integration/targets/nxos_vtp_domain/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_vtp_domain/tests/common/sanity.yaml
@@ -13,6 +13,7 @@
   - name: configure vtp domain
     nxos_vtp_domain: &configure
       domain: ntc
+      provider: "{{ connection }}"
     register: result
 
   - assert: &true

--- a/test/integration/targets/nxos_vtp_domain/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_vtp_domain/tests/common/sanity.yaml
@@ -7,6 +7,7 @@
   - name: enable feature vtp
     nxos_feature:
       feature: vtp
+      provider: "{{ connection }}"
       state: enabled
 
   - name: configure vtp domain
@@ -30,6 +31,7 @@
   - name: disable feature vtp
     nxos_feature:
       feature: vtp
+      provider: "{{ connection }}"
       state: disabled
 
 - debug: msg="END connection={{ ansible_connection }} nxos_vtp_domain sanity test"

--- a/test/integration/targets/nxos_vtp_password/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_vtp_password/tests/common/sanity.yaml
@@ -7,6 +7,7 @@
   - name: enable feature vtp
     nxos_feature:
       feature: vtp
+      provider: "{{ connection }}"
       state: enabled
 
   - name: configure vtp domain
@@ -16,6 +17,7 @@
   - name: configure vtp password
     nxos_vtp_password: &configure
       vtp_password: ntc
+      provider: "{{ connection }}"
       state: present
     register: result
 
@@ -34,6 +36,7 @@
   - name: remove vtp password
     nxos_vtp_password: &remove
       vtp_password: ntc
+      provider: "{{ connection }}"
       state: absent
     register: result
 
@@ -49,6 +52,7 @@
   - name: disable feature vtp
     nxos_feature:
       feature: vtp
+      provider: "{{ connection }}"
       state: disabled
 
 - debug: msg="END connection={{ ansible_connection }} nxos_vtp_password sanity test"

--- a/test/integration/targets/nxos_vtp_password/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_vtp_password/tests/common/sanity.yaml
@@ -13,6 +13,7 @@
   - name: configure vtp domain
     nxos_vtp_domain:
       domain: testing
+      provider: "{{ connection }}"
 
   - name: configure vtp password
     nxos_vtp_password: &configure

--- a/test/integration/targets/nxos_vtp_version/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_vtp_version/tests/common/sanity.yaml
@@ -7,6 +7,7 @@
   - name: enable feature vtp
     nxos_feature:
       feature: vtp
+      provider: "{{ connection }}"
       state: enabled
 
   - name: configure vtp version
@@ -30,6 +31,7 @@
   - name: disable feature vtp
     nxos_feature:
       feature: vtp
+      provider: "{{ connection }}"
       state: disabled
 
 - debug: msg="END connection={{ ansible_connection }} nxos_vtp_version sanity test"

--- a/test/integration/targets/nxos_vtp_version/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_vtp_version/tests/common/sanity.yaml
@@ -13,6 +13,7 @@
   - name: configure vtp version
     nxos_vtp_version: &configure
       version: 2
+      provider: "{{ connection }}"
     register: result
 
   - assert: &true

--- a/test/integration/targets/nxos_vxlan_vtep/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_vxlan_vtep/tests/common/sanity.yaml
@@ -106,6 +106,7 @@
       source_interface: Loopback0
       source_interface_hold_down_time: 30
       shutdown: true
+      provider: "{{ connection }}"
       state: absent
     register: result
 
@@ -131,6 +132,7 @@
   - name: "Disable feature nv overlay"
     nxos_feature: 
       feature: nve
+      provider: "{{ connection }}"
       state: disabled
     ignore_errors: yes
 

--- a/test/integration/targets/nxos_vxlan_vtep/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_vxlan_vtep/tests/common/sanity.yaml
@@ -13,6 +13,7 @@
       commands:
         - feature nv overlay
       match: none
+      provider: "{{ connection }}"
 
   - block:
     - name: configure vxlan_vtep
@@ -23,6 +24,7 @@
         source_interface: Loopback0
         source_interface_hold_down_time: 30
         shutdown: false
+        provider: "{{ connection }}"
       register: result
   
     - assert: &true
@@ -45,6 +47,7 @@
         source_interface_hold_down_time: default
         source_interface: default
         shutdown: true
+        provider: "{{ connection }}"
       register: result
   
     - assert: *true
@@ -65,6 +68,7 @@
         host_reachability: true
         source_interface: Loopback0
         shutdown: false
+        provider: "{{ connection }}"
       register: result
   
     - assert:
@@ -86,6 +90,7 @@
         host_reachability: false
         source_interface: default
         shutdown: true
+        provider: "{{ connection }}"
       register: result
   
     - assert: *true

--- a/test/integration/targets/nxos_vxlan_vtep_vni/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_vxlan_vtep_vni/tests/common/sanity.yaml
@@ -43,6 +43,7 @@
       interface: nve1
       vni: 6000
       assoc_vrf: True
+      provider: "{{ connection }}"
       state: absent
 
   - name: configure vxlan_vtep_vni
@@ -87,6 +88,7 @@
     nxos_vxlan_vtep_vni: &remove
       interface: nve1
       vni: 8000
+      provider: "{{ connection }}"
       state: absent
 
   - name: configure vxlan_vtep
@@ -121,6 +123,7 @@
     - name: Remove and reconfigure vxlan_vtep
       nxos_vxlan_vtep: &remove_vtep
         interface: nve1
+        provider: "{{ connection }}"
         state: absent
 
     - name: Configure vxlan_vtep with host reachability bgp
@@ -241,12 +244,14 @@
     nxos_vxlan_vtep:
       interface: nve1
       shutdown: true
+      provider: "{{ connection }}"
       state: absent
     ignore_errors: yes
 
   - name: "Disable feature nv overlay"
     nxos_feature: 
       feature: nve
+      provider: "{{ connection }}"
       state: disabled
     ignore_errors: yes
 

--- a/test/integration/targets/nxos_vxlan_vtep_vni/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_vxlan_vtep_vni/tests/common/sanity.yaml
@@ -13,17 +13,20 @@
       commands:
         - feature nv overlay
       match: none
+      provider: "{{ connection }}"
 
   - name: configure vxlan_vtep
     nxos_vxlan_vtep:
       interface: nve1
       host_reachability: True
+      provider: "{{ connection }}"
 
   - name: configure vxlan_vtep_vni assoc-vrf
     nxos_vxlan_vtep_vni: &conf1
       interface: nve1
       vni: 6000
       assoc_vrf: True
+      provider: "{{ connection }}"
     register: result
 
   - assert: &true
@@ -50,6 +53,7 @@
     nxos_vxlan_vtep_vni: &conf2
       interface: nve1
       vni: 8000
+      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -59,6 +63,7 @@
       interface: nve1
       vni: 8000
       multicast_group: 224.1.1.1
+      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -74,6 +79,7 @@
       interface: nve1
       vni: 8000
       multicast_group: default
+      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -95,12 +101,14 @@
     nxos_vxlan_vtep:
       interface: nve1
       host_reachability: False
+      provider: "{{ connection }}"
 
   - block:
     - name: configure vxlan_vtep_vni
       nxos_vxlan_vtep_vni: &conf5
         interface: nve1
         vni: 8000
+        provider: "{{ connection }}"
       register: result
   
     - assert: *true
@@ -110,6 +118,7 @@
         interface: nve1
         vni: 8000
         ingress_replication: static
+        provider: "{{ connection }}"
       register: result
   
     - assert: *true
@@ -130,17 +139,20 @@
       nxos_vxlan_vtep:
         interface: nve1
         host_reachability: True
+        provider: "{{ connection }}"
 
     - name: configure vxlan_vtep_vni
       nxos_vxlan_vtep_vni: &config_vni
         interface: nve1
         vni: 8000
+        provider: "{{ connection }}"
 
     - name: configure vxlan_vtep_vni ingress bgp
       nxos_vxlan_vtep_vni: &conf7
         interface: nve1
         vni: 8000
         ingress_replication: bgp
+        provider: "{{ connection }}"
       register: result
   
     - assert: *true
@@ -156,6 +168,7 @@
         interface: nve1
         vni: 8000
         ingress_replication: default
+        provider: "{{ connection }}"
       register: result
   
     - assert: *true
@@ -173,6 +186,7 @@
       nxos_vxlan_vtep:
         interface: nve1
         host_reachability: False
+        provider: "{{ connection }}"
 
     - name: configure vxlan_vtep_vni
       nxos_vxlan_vtep_vni: *config_vni
@@ -187,6 +201,7 @@
           - 192.0.2.3
           - 192.0.2.4
         ingress_replication: static
+        provider: "{{ connection }}"
       register: result
   
     - assert: *true
@@ -203,6 +218,7 @@
         vni: 8000
         peer_list: default
         ingress_replication: static
+        provider: "{{ connection }}"
       register: result
   
     - assert: *true


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
Otherwise, `connection: local` tests will default to cli

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
nxos

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7
```
