### PR TITLE
Validate that rescue and always have an accompanying block

### DIFF
--- a/lib/ansible/playbook/block.py
+++ b/lib/ansible/playbook/block.py
@@ -161,6 +161,12 @@ class Block(Base, Become, Conditional, Taggable):
         except AssertionError as e:
             raise AnsibleParserError("A malformed block was encountered while loading always", obj=self._ds, orig_exc=e)
 
+    def _validate_always(self, attr, name, value):
+        if value and not self.block:
+            raise AnsibleParserError("'%s' keyword cannot be used without 'block'" % name, obj=self._ds)
+
+    _validate_rescue = _validate_always
+
     def get_dep_chain(self):
         if self._dep_chain is None:
             if self._parent:


### PR DESCRIPTION
##### SUMMARY
Validate that rescue and always have an accompanying block. Fixes #26751

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/playbook/block.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```