### PR TITLE
Add a module parameter to configure the max fetched AWS CFN stack events

### DIFF
--- a/lib/ansible/modules/cloud/amazon/cloudformation.py
+++ b/lib/ansible/modules/cloud/amazon/cloudformation.py
@@ -715,7 +715,8 @@ def main():
                     cfn.delete_stack(StackName=stack_params['StackName'])
                 else:
                     cfn.delete_stack(StackName=stack_params['StackName'], RoleARN=stack_params['RoleARN'])
-                result = stack_operation(cfn, stack_params['StackName'], 'DELETE', module.params.get('events_limit'), stack_params.get('ClientRequestToken', None))
+                result = stack_operation(cfn, stack_params['StackName'], 'DELETE', module.params.get('events_limit'),
+                                         stack_params.get('ClientRequestToken', None))
         except Exception as err:
             module.fail_json(msg=boto_exception(err), exception=traceback.format_exc())
 

--- a/lib/ansible/modules/cloud/amazon/cloudformation.py
+++ b/lib/ansible/modules/cloud/amazon/cloudformation.py
@@ -117,7 +117,7 @@ options:
     description:
     - Maximum number of CloudFormation events to fetch from a stack when creating or updating it.
     default: 100
-    version_added: "2.6"
+    version_added: "2.7"
 
 author: "James S. Martin (@jsmartin)"
 extends_documentation_fragment:

--- a/lib/ansible/modules/cloud/amazon/cloudformation.py
+++ b/lib/ansible/modules/cloud/amazon/cloudformation.py
@@ -117,6 +117,7 @@ options:
     description:
     - Maximum number of CloudFormation events to fetch from a stack when creating or updating it.
     default: 100
+    version_added: "2.6"
 
 author: "James S. Martin (@jsmartin)"
 extends_documentation_fragment:

--- a/lib/ansible/modules/cloud/amazon/cloudformation.py
+++ b/lib/ansible/modules/cloud/amazon/cloudformation.py
@@ -116,7 +116,7 @@ options:
   events_limit:
     description:
     - Maximum number of CloudFormation events to fetch from a stack when creating or updating it.
-    default: 100
+    default: 200
     version_added: "2.7"
 
 author: "James S. Martin (@jsmartin)"
@@ -574,7 +574,7 @@ def main():
         role_arn=dict(default=None, required=False),
         tags=dict(default=None, type='dict'),
         termination_protection=dict(default=None, type='bool'),
-        events_limit=dict(default=100, type='int'),
+        events_limit=dict(default=200, type='int'),
     )
     )
 

--- a/test/units/modules/cloud/amazon/test_cloudformation.py
+++ b/test/units/modules/cloud/amazon/test_cloudformation.py
@@ -44,6 +44,8 @@ bad_json_tpl = """{
   }
 }"""
 
+default_events_limit = 10
+
 
 class FakeModule(object):
     def __init__(self, **kwargs):
@@ -68,7 +70,7 @@ def test_invalid_template_json(placeboify):
     }
     m = FakeModule(disable_rollback=False)
     with pytest.raises(Exception, message='Malformed JSON should cause the test to fail') as exc_info:
-        cfn_module.create_stack(m, params, connection)
+        cfn_module.create_stack(m, params, connection, default_events_limit)
     assert exc_info.match('FAIL')
     assert "ValidationError" in m.exit_kwargs['msg']
 
@@ -81,7 +83,7 @@ def test_client_request_token_s3_stack(maybe_sleep, placeboify):
         'ClientRequestToken': '3faf3fb5-b289-41fc-b940-44151828f6cf',
     }
     m = FakeModule(disable_rollback=False)
-    result = cfn_module.create_stack(m, params, connection)
+    result = cfn_module.create_stack(m, params, connection, default_events_limit)
     assert result['changed']
     assert len(result['events']) > 1
     # require that the final recorded stack state was CREATE_COMPLETE
@@ -97,7 +99,7 @@ def test_basic_s3_stack(maybe_sleep, placeboify):
         'TemplateBody': basic_yaml_tpl
     }
     m = FakeModule(disable_rollback=False)
-    result = cfn_module.create_stack(m, params, connection)
+    result = cfn_module.create_stack(m, params, connection, default_events_limit)
     assert result['changed']
     assert len(result['events']) > 1
     # require that the final recorded stack state was CREATE_COMPLETE
@@ -108,7 +110,7 @@ def test_basic_s3_stack(maybe_sleep, placeboify):
 
 def test_delete_nonexistent_stack(maybe_sleep, placeboify):
     connection = placeboify.client('cloudformation')
-    result = cfn_module.stack_operation(connection, 'ansible-test-nonexist', 'DELETE')
+    result = cfn_module.stack_operation(connection, 'ansible-test-nonexist', 'DELETE', default_events_limit)
     assert result['changed']
     assert 'Stack does not exist.' in result['log']
 
@@ -124,7 +126,8 @@ def test_missing_template_body(placeboify):
         cfn_module.create_stack(
             module=m,
             stack_params={},
-            cfn=None
+            cfn=None,
+            events_limit=default_events_limit
         )
     assert exc_info.match('FAIL')
     assert not m.exit_args


### PR DESCRIPTION
##### SUMMARY
This change will add a parameter to the `cloudformation` module which allows configuring the maximum number of fetched events from AWS CloudFormation stacks when creating or updating them.

The limit is useful if a stack e.g. exists for a long time or accumulated a lot of changes and therefore iterating over all events using pagination takes too long. Additionally this can be used to prevent running into rate limits when the list of events is very long. 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
cloudformation

##### ANSIBLE VERSION
```
2.6.0rc2
```

##### ADDITIONAL INFORMATION
