### PR TITLE
Remove dead 'vault_password' play attribute

### DIFF
--- a/docs/docsite/keyword_desc.yml
+++ b/docs/docsite/keyword_desc.yml
@@ -71,5 +71,4 @@ until: "This keyword implies a ':term:`retries` loop' that will go on until the 
 vars: Dictionary/map of variables
 vars_files: List of files that contain vars to include in the play.
 vars_prompt: list of variables to prompt for.
-vault_password: Secret used to decrypt vaulted files or variables.
 when: Conditional expression, determines if an iteration of a task is run or not.

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -65,7 +65,6 @@ class Play(Base, Taggable, Become):
     # Variable Attributes
     _vars_files = FieldAttribute(isa='list', default=[], priority=99)
     _vars_prompt = FieldAttribute(isa='list', default=[], always_post_validate=True)
-    _vault_password = FieldAttribute(isa='string', always_post_validate=True)
 
     # Role Attributes
     _roles = FieldAttribute(isa='list', default=[], priority=90)


### PR DESCRIPTION
##### SUMMARY
The `vault_password` play attribute appears to be a dead relic from pre-2.0, and should be removed.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
`vault_password` play attribute

##### ANSIBLE VERSION
```
ansible 2.7.0.dev0 (remove_play_vault_password_attribute 964ed7f57e) last updated 2018/06/22 12:17:53 (GMT -500)
```

##### ADDITIONAL INFORMATION
N/A