### PR TITLE
Add execution_role_arn parameter

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ecs_taskdefinition.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_taskdefinition.py
@@ -285,12 +285,6 @@ class EcsTaskManager:
         response = self.ecs.deregister_task_definition(taskDefinition=taskArn)
         return response['taskDefinition']
 
-    def ecs_api_supports_requirescompatibilities(self):
-        from distutils.version import LooseVersion
-        # Checking to make sure botocore is greater than a specific version.
-        # Support for requiresCompatibilities is only available in versions beyond 1.8.4
-        return LooseVersion(botocore.__version__) >= LooseVersion('1.8.4')
-
 
 def main():
     argument_spec = ec2_argument_spec()
@@ -323,7 +317,7 @@ def main():
     results = dict(changed=False)
 
     if module.params['launch_type']:
-        if not task_mgr.ecs_api_supports_requirescompatibilities():
+        if not module.botocore_at_least('1.8.4'):
             module.fail_json(msg='botocore needs to be version 1.8.4 or higher to use launch_type')
 
     if module.params['task_role_arn']:

--- a/lib/ansible/modules/cloud/amazon/ecs_taskdefinition.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_taskdefinition.py
@@ -230,7 +230,6 @@ class EcsTaskManager:
         params = dict(
             family=family,
             taskRoleArn=task_role_arn,
-            executionRoleArn=execution_role_arn,
             networkMode=network_mode,
             containerDefinitions=container_definitions,
             volumes=volumes
@@ -241,6 +240,8 @@ class EcsTaskManager:
             params['memory'] = memory
         if launch_type:
             params['requiresCompatibilities'] = [launch_type]
+        if execution_role_arn:
+            params['executionRoleArn'] = execution_role_arn
 
         try:
             response = self.ecs.register_task_definition(**params)

--- a/lib/ansible/modules/cloud/amazon/ecs_taskdefinition.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_taskdefinition.py
@@ -323,7 +323,7 @@ def main():
 
     if module.params['execution_role_arn']:
         if not module.botocore_at_least('1.10.44'):
-            module.fail_jason(msg='botocore needs to be version 1.10.44 or higher to use task_role_arn')
+            module.fail_json(msg='botocore needs to be version 1.10.44 or higher to use execution_role_arn')
 
     for container in module.params.get('containers', []):
         for environment in container.get('environment', []):

--- a/lib/ansible/modules/cloud/amazon/ecs_taskdefinition.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_taskdefinition.py
@@ -321,7 +321,7 @@ def main():
         if not module.botocore_at_least('1.8.4'):
             module.fail_json(msg='botocore needs to be version 1.8.4 or higher to use launch_type')
 
-    if module.params['task_role_arn']:
+    if module.params['execution_role_arn']:
         if not module.botocore_at_least('1.10.44'):
             module.fail_jason(msg='botocore needs to be version 1.10.44 or higher to use task_role_arn')
 

--- a/test/integration/targets/ecs_cluster/playbooks/network_fail.yml
+++ b/test/integration/targets/ecs_cluster/playbooks/network_fail.yml
@@ -44,6 +44,26 @@
             <<: *aws_connection_info
           register: ecs_taskdefinition_creation_vpc
 
+        - name: create ecs_taskdefinition and execution_role_arn (expected to fail)
+          ecs_taskdefinition:
+            containers:
+              - name: my_container
+                image: ubuntu
+                memory: 128
+            family: "{{ resource_prefix }}-vpc"
+            execution_role_arn: not_a_real_arn
+            state: present
+            network_mode: awsvpc
+            <<: *aws_connection_info
+          ignore_errors: yes
+          register: ecs_taskdefinition_arn
+
+        - name: check that graceful failure message is returned from ecs_taskdefinition_arn
+          assert:
+            that:
+              - ecs_taskdefinition_arn.failed
+              - 'ecs_taskdefinition_arn.msg == "botocore needs to be version 1.10.44 or higher to use execution_role_arn"'
+
         - name: ecs_taskdefinition works fine even when older botocore is used
           assert:
             that:

--- a/test/integration/targets/ecs_cluster/playbooks/roles/ecs_cluster/tasks/main.yml
+++ b/test/integration/targets/ecs_cluster/playbooks/roles/ecs_cluster/tasks/main.yml
@@ -541,6 +541,23 @@
     # ============================================================
     # Begin tests for Fargate
 
+    - name: ensure AmazonECSTaskExecutionRolePolicy exists
+      iam_role:
+        name: ecsTaskExecutionRole
+        assume_role_policy_document: "{{ lookup('file','ecs-trust-policy.json') }}"
+        description: "Allows ECS containers to make calls to ECR"
+        state: present
+        create_instance_profile: no
+        managed_policy:
+        - AmazonEC2ContainerServiceRole
+        <<: *aws_connection_info
+
+    - name: gather facts for the ecsTaskExecutionRole
+      iam_role_facts:
+        name: ecsTaskExecutionRole
+        <<: *aws_connection_info
+      register: iam_execution_role
+
     - name: create Fargate VPC-networked task definition with host port set to 8080 and unsupported network mode (expected to fail)
       ecs_taskdefinition:
         containers: "{{ ecs_fargate_task_containers }}"
@@ -579,7 +596,7 @@
           - ecs_fargate_task_definition_vpc_no_mem is failed
           - 'ecs_fargate_task_definition_vpc_no_mem.msg == "launch_type is FARGATE but all of the following are missing: cpu, memory"' 
 
-    - name: create Fargate VPC-networked task definition with CPU or Memory 
+    - name: create Fargate VPC-networked task definition with CPU or Memory and execution role
       ecs_taskdefinition:
         containers: "{{ ecs_fargate_task_containers }}"
         family: "{{ ecs_task_name }}-vpc"
@@ -587,6 +604,7 @@
         launch_type: FARGATE
         cpu: 512
         memory: 1024
+        execution_role_arn: "{{ iam_execution_role.iam_roles.0.arn }}"
         state: present
         <<: *aws_connection_info
       vars:

--- a/test/integration/targets/ecs_cluster/playbooks/roles/ecs_cluster/tasks/main.yml
+++ b/test/integration/targets/ecs_cluster/playbooks/roles/ecs_cluster/tasks/main.yml
@@ -551,11 +551,6 @@
         managed_policy:
         - AmazonEC2ContainerServiceRole
         <<: *aws_connection_info
-
-    - name: gather facts for the ecsTaskExecutionRole
-      iam_role_facts:
-        name: ecsTaskExecutionRole
-        <<: *aws_connection_info
       register: iam_execution_role
 
     - name: create Fargate VPC-networked task definition with host port set to 8080 and unsupported network mode (expected to fail)
@@ -604,7 +599,7 @@
         launch_type: FARGATE
         cpu: 512
         memory: 1024
-        execution_role_arn: "{{ iam_execution_role.iam_roles.0.arn }}"
+        execution_role_arn: "{{ iam_execution_role.arn }}"
         state: present
         <<: *aws_connection_info
       vars:


### PR DESCRIPTION
##### SUMMARY
Fargate support requires containers to have the executionRoleArn defined. This PR adds that parameter.
Fixes #41848
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
ecs_taskdefinition

##### ANSIBLE VERSION
```
ansible 2.7.0.dev0 (devel 46dbb3e1e8) last updated 2018/06/22 10:32:41 (GMT -700)
  config file = None
  configured module search path = [u'/home/mjmayer/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/mjmayer/ansible/lib/ansible
  executable location = /home/mjmayer/ansible/bin/ansible
  python version = 2.7.5 (default, Apr 11 2018, 17:41:36) [GCC 4.8.5 20150623 (Red Hat 4.8.5-28.0.1)]

```
