### PR TITLE
ios_facts: Report space of file systems

### DIFF
--- a/test/integration/targets/ios_facts/tests/cli/all_facts.yaml
+++ b/test/integration/targets/ios_facts/tests/cli/all_facts.yaml
@@ -28,4 +28,8 @@
       - "result.ansible_facts.ansible_net_memfree_mb > 1"
       - "result.ansible_facts.ansible_net_memtotal_mb > 1"
 
+- assert:
+    that: "{{ item.value.spacetotal_kb }} > {{ item.value.spacefree_kb }}"
+  loop: "{{ lookup('dict', result.ansible_facts.ansible_net_filesystems_info, wantlist=True) }}"
+
 - debug: msg="END cli/all_facts.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/ios_facts/tests/cli/default_facts.yaml
+++ b/test/integration/targets/ios_facts/tests/cli/default_facts.yaml
@@ -28,4 +28,8 @@
       # ... and not present
       - "result.ansible_facts.ansible_net_config is not defined" # config
 
+- assert:
+    that: "{{ item.value.spacetotal_kb }} > {{ item.value.spacefree_kb }}"
+  loop: "{{ lookup('dict', result.ansible_facts.ansible_net_filesystems_info, wantlist=True) }}"
+
 - debug: msg="END cli/default.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/ios_facts/tests/cli/not_hardware.yaml
+++ b/test/integration/targets/ios_facts/tests/cli/not_hardware.yaml
@@ -26,5 +26,6 @@
       - "result.ansible_facts.ansible_net_interfaces | length > 1" # more than one interface returned
       # ... and not present
       - "result.ansible_facts.ansible_net_filesystems is not defined"
+      - "result.ansible_facts.ansible_net_filesystems_info is not defined"
 
 - debug: msg="END cli/not_hardware_facts.yaml on connection={{ ansible_connection }}"

--- a/test/units/modules/network/ios/fixtures/ios_facts_dir
+++ b/test/units/modules/network/ios/fixtures/ios_facts_dir
@@ -1,0 +1,23 @@
+Directory of bootflash:/
+
+   11  drwx            16384   Jun 1 2017 13:03:27 +00:00  lost+found
+325121  drwx             4096   Jun 1 2017 13:03:54 +00:00  .super.iso.dir
+   12  -rw-               31  Jun 22 2018 15:17:06 +00:00  .CsrLxc_LastInstall
+   13  -rw-               69   Jun 1 2017 13:05:53 +00:00  virtual-instance.conf
+438913  drwx             4096   Jun 1 2017 13:04:57 +00:00  core
+   15  -rw-        125736960   Jun 1 2017 13:03:54 +00:00  iosxe-remote-mgmt.16.03.04.ova
+105667  -rw-        292164568   Jun 1 2017 13:04:04 +00:00  csr1000v-mono-universalk9.16.03.04.SPA.pkg
+105668  -rw-         34370768   Jun 1 2017 13:04:10 +00:00  csr1000v-rpboot.16.03.04.SPA.pkg
+105666  -rw-             5317   Jun 1 2017 13:04:10 +00:00  packages.conf
+195073  drwx             4096   Jun 1 2017 13:04:51 +00:00  .prst_sync
+414529  drwx             4096   Jun 1 2017 13:04:57 +00:00  .rollback_timer
+   16  -rw-                0   Jun 1 2017 13:05:00 +00:00  tracelogs.kZn
+16257  drwx            24576  Jun 22 2018 16:03:11 +00:00  tracelogs
+349505  drwx             4096   Jun 1 2017 13:05:08 +00:00  .installer
+292609  drwx             4096   Jun 1 2017 13:05:59 +00:00  virtual-instance
+   17  -rw-               30  Jun 22 2018 15:17:59 +00:00  throughput_monitor_params
+48769  drwx             4096   Jun 1 2017 13:06:04 +00:00  onep
+   19  -rw-              376  Jun 22 2018 15:18:11 +00:00  csrlxc-cfg.log
+   20  -rw-                0  Jun 22 2018 15:17:59 +00:00  cvac.log
+
+7897796608 bytes total (6608056320 bytes free)

--- a/test/units/modules/network/ios/test_ios_facts.py
+++ b/test/units/modules/network/ios/test_ios_facts.py
@@ -77,3 +77,13 @@ class TestIosFactsModule(TestIosModule):
         self.assertIsNone(
             result['ansible_facts']['ansible_net_interfaces']['Tunnel1110']['macaddress']
         )
+
+    def test_ios_facts_filesystems_info(self):
+        set_module_args(dict(gather_subset='hardware'))
+        result = self.execute_module()
+        self.assertEqual(
+            result['ansible_facts']['ansible_net_filesystems_info']['bootflash:']['spacetotal_kb'], 7712692.0
+        )
+        self.assertEqual(
+            result['ansible_facts']['ansible_net_filesystems_info']['bootflash:']['spacefree_kb'], 6453180.0
+        )


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
It would be a good feature for the ios_facts module to report the total and free space of the file systems instead of just the names. Therefore, this change converts ansible_net_filesystems from a list of strings into a dict.
As this breaks the existing interface of ios_facts and introduces inconsistency with regards to the other *_facts modules, I am very keen on hearing your feedback. If you have any objections or concerns, please let me know.
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
ios_facts

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (ios-facts-fs c7b78bf25e) last updated 2018/06/22 19:24:49 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/paul/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/paul/ansible-dev/ansible/lib/ansible
  executable location = /home/paul/ansible-dev/ansible/bin/ansible
  python version = 3.6.5 (default, May 11 2018, 04:00:52) [GCC 8.1.0]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before:
```
...
            "ansible_net_filesystems": [
                "bootflash:"
            ],
...
```
After:
```
...
            "ansible_net_filesystems": {
                "bootflash:": {
                    "spacefree_kb": 6453180.0,
                    "spacetotal_kb": 7712692.0
                }
            },
...
```
