### PR TITLE
Update eos_vlan.py

### DIFF
--- a/lib/ansible/modules/network/eos/eos_vlan.py
+++ b/lib/ansible/modules/network/eos/eos_vlan.py
@@ -213,7 +213,7 @@ def map_obj_to_commands(updates, module):
 
 def map_config_to_obj(module):
     objs = []
-    vlans = run_commands(module, ['show vlan conf | json'])
+    vlans = run_commands(module, ['show vlan configured-ports | json'])
 
     for vlan in vlans[0]['vlans']:
         obj = {}


### PR DESCRIPTION
changing show command to work for both transport methods

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

Fixes #41851 

When using eapi as a transport method for eos_vlan module this code fails because ```show vlan conf``` needs to be expanded to ```show vlan configured-ports``` and eapi doesn't expand commands by default

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
eos_vlan
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
dt@tactools:~$ ansible --version
ansible 2.5.1
  config file = None
  configured module search path = [u'/home/dt/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Apr 10 2015, 08:09:05) [GCC 4.8.3 20140911 (Red Hat 4.8.3-7)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
