### PR TITLE
Junos: Add Vlan ID Range in description

### DIFF
--- a/lib/ansible/modules/network/junos/junos_vlan.py
+++ b/lib/ansible/modules/network/junos/junos_vlan.py
@@ -28,7 +28,7 @@ options:
     required: true
   vlan_id:
     description:
-      - ID of the VLAN.
+      - ID of the VLAN. Range 1-4094.
     required: true
   description:
     description:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Junos Vlan: Add Vlan ID Range to vlan_id description under Documentation section.

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
Refers #40323 and https://github.com/ansible/community/issues/311

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
junos_vlan.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0
  config file = None
  configured module search path = ['/Users/jacksonisaac/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /anaconda3/lib/python3.6/site-packages/ansible-2.6.0-py3.6.egg/ansible
  executable location = /anaconda3/bin/ansible
  python version = 3.6.4 |Anaconda, Inc.| (default, Jan 16 2018, 12:04:33) [GCC 4.2.1 Compatible Clang 4.0.1 (tags/RELEASE_401/final)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->
No test required. Include additional information to description about valid Range of vlan_id for Junos. 

For reference on valid vlan_id range: https://www.juniper.net/documentation/en_US/junos/topics/reference/configuration-statement/vlan-id-range-edit-interfaces.html
https://kb.juniper.net/InfoCenter/index?page=content&id=KB11000 