### PR TITLE
fix vars hostname fallback

### DIFF
--- a/changelogs/fragments/vars_lk.yml
+++ b/changelogs/fragments/vars_lk.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - correctly check hostvars for vars term https://github.com/ansible/ansible/pull/41819

--- a/lib/ansible/plugins/lookup/vars.py
+++ b/lib/ansible/plugins/lookup/vars.py
@@ -78,15 +78,15 @@ class LookupModule(LookupBase):
                 raise AnsibleError('Invalid setting identifier, "%s" is not a string, its a %s' % (term, type(term)))
 
             try:
-                if term in myvars:
+                try:
                     value = myvars[term]
-                elif 'hostvars' in myvars and term in myvars['hostvars']:
-                    # maybe it is a host var?
-                    value = myvars['hostvars'][term]
-                else:
-                    raise AnsibleUndefinedVariable('No variable found with this name: %s' % term)
-                ret.append(self._templar.template(value, fail_on_undefined=True))
+                except KeyError:
+                    try:
+                        value = myvars['hostvars'][myvars['inventory_hostname']][term]
+                    except KeyError:
+                        raise AnsibleUndefinedVariable('No variable found with this name: %s' % term)
 
+                ret.append(self._templar.template(value, fail_on_undefined=True))
             except AnsibleUndefinedVariable:
                 if default is not None:
                     ret.append(default)


### PR DESCRIPTION
also made it optimistic, rely on exceptions instead of copmlex if chains

(cherry picked from commit 11dbed1350b81e7959beb5c55118d3bcce793cd5)

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
plugins/lookup/vars
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```

```

```
