### PR TITLE
playbooks_intro.rst: remove duplicite playbook (#38521)

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_intro.rst
+++ b/docs/docsite/rst/user_guide/playbooks_intro.rst
@@ -62,39 +62,6 @@ For starters, here's a playbook that contains just one play::
       remote_user: root
       tasks:
       - name: ensure apache is at the latest version
-        yum: 
-          name: httpd
-          state: latest
-      - name: write the apache config file
-        template:
-          src: /srv/httpd.j2
-          dest: /etc/httpd.conf
-        notify:
-        - restart apache
-      - name: ensure apache is running (and enable it at boot)
-        service:
-          name: httpd
-          state: started
-          enabled: yes
-      handlers:
-        - name: restart apache
-          service:
-            name: httpd
-            state: restarted
-
-When working with tasks that have really long parameters or modules that take 
-many parameters, you can break tasks items over multiple lines to improve the 
-structure. Below is another version of the above example but using
-YAML dictionaries to supply the modules with their ``key=value`` arguments.::
-
-    ---
-    - hosts: webservers
-      vars:
-        http_port: 80
-        max_clients: 200
-      remote_user: root
-      tasks:
-      - name: ensure apache is at the latest version
         yum:
           name: httpd
           state: latest


### PR DESCRIPTION
(cherry picked from commit f1e41cbb366c7625631ecefe96e835bd647afece)

##### SUMMARY
Removes duplicate playbook from the playbook intro page, along with the discussion of "short-form" vs. "long-form" YAML for listing parameters.
Related to #41473

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
docs.ansible.com

##### ANSIBLE VERSION
2.5

##### ADDITIONAL INFORMATION
Backports the fix from PR #38521 for issue #38411 to the `stable-2.5` branch.
