### PR TITLE
Add RVI Example for Juniper Junos platform

### DIFF
--- a/lib/ansible/modules/network/junos/junos_config.py
+++ b/lib/ansible/modules/network/junos/junos_config.py
@@ -149,6 +149,13 @@ EXAMPLES = """
       - set vlans vlan01 description "Test vlan"
     comment: update config
 
+- name: Set routed VLAN interface (RVI) IPv4 address
+  junos_config:
+    lines:
+      - set vlans vlan01 vlan-id 1
+      - set interfaces irb unit 10 family inet address 10.0.0.1/24
+      - set vlans vlan01 l3-interface irb.10
+
 - name: rollback the configuration to id 10
   junos_config:
     rollback: 10


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Add routed VLAN interface example for Juniper Junos platform

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
Refers #40323 and ansible/community#311

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
junos_config

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0
  config file = None
  configured module search path = ['/Users/jacksonisaac/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /anaconda3/lib/python3.6/site-packages/ansible-2.6.0-py3.6.egg/ansible
  executable location = /anaconda3/bin/ansible
  python version = 3.6.4 |Anaconda, Inc.| (default, Jan 16 2018, 12:04:33) [GCC 4.2.1 Compatible Clang 4.0.1 (tags/RELEASE_401/final)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->
For reference: https://kb.juniper.net/InfoCenter/index?page=content&id=KB11000

<!--- Paste verbatim command output below, e.g. before and after your change -->
Playbook output for validation:
```
Jacksons-MacBook-Pro:ansible-networking-vagrant-demo jacksonisaac$ vagrant provision
==> junos01: Running provisioner: ansible...
Vagrant has automatically selected the compatibility mode '2.0'
according to the Ansible version installed (2.6.0).

Alternatively, the compatibility mode can be specified in your Vagrantfile:
https://www.vagrantup.com/docs/provisioning/ansible_common.html#compatibility_mode

    junos01: Running ansible-playbook...
PYTHONUNBUFFERED=1 ANSIBLE_FORCE_COLOR=true ANSIBLE_HOST_KEY_CHECKING=false ANSIBLE_SSH_ARGS='-o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes -o ControlMaster=auto -o ControlPersist=60s' ansible-playbook --connection=ssh --timeout=30 --limit="junos01" --inventory-file=/Users/jacksonisaac/Development/ansible/ansible-networking-vagrant-demo/.vagrant/provisioners/ansible/inventory -v training-course/exercise01/junos.yml
No config file found; using defaults

PLAY [all] *********************************************************************

TASK [Retrieve Junos OS version] ***********************************************
ok: [junos01] => {"changed": false, "stdout": ["fpc0:\n--------------------------------------------------------------------------\nHostname: vqfx-re\nModel: vqfx-10000\nJunos: 17.4R1.16 limited\nJUNOS Base OS boot [17.4R1.16]\nJUNOS Base OS Software Suite [17.4R1.16]\nJUNOS Crypto Software Suite [17.4R1.16]\nJUNOS Online Documentation [17.4R1.16]\nJUNOS Kernel Software Suite [17.4R1.16]\nJUNOS Packet Forwarding Engine Support (qfx-10-f) [17.4R1.16]\nJUNOS Routing Software Suite [17.4R1.16]\nJUNOS jsd [i386-17.4R1.16-jet-1]\nJUNOS SDN Software Suite [17.4R1.16]\nJUNOS Enterprise Software Suite [17.4R1.16]\nJUNOS Web Management [17.4R1.16]\nJUNOS py-base-i386 [17.4R1.16]\nJUNOS py-extensions-i386 [17.4R1.16]"], "stdout_lines": [["fpc0:", "--------------------------------------------------------------------------", "Hostname: vqfx-re", "Model: vqfx-10000", "Junos: 17.4R1.16 limited", "JUNOS Base OS boot [17.4R1.16]", "JUNOS Base OS Software Suite [17.4R1.16]", "JUNOS Crypto Software Suite [17.4R1.16]", "JUNOS Online Documentation [17.4R1.16]", "JUNOS Kernel Software Suite [17.4R1.16]", "JUNOS Packet Forwarding Engine Support (qfx-10-f) [17.4R1.16]", "JUNOS Routing Software Suite [17.4R1.16]", "JUNOS jsd [i386-17.4R1.16-jet-1]", "JUNOS SDN Software Suite [17.4R1.16]", "JUNOS Enterprise Software Suite [17.4R1.16]", "JUNOS Web Management [17.4R1.16]", "JUNOS py-base-i386 [17.4R1.16]", "JUNOS py-extensions-i386 [17.4R1.16]"]]}

TASK [Enable NETCONF] **********************************************************
ok: [junos01] => {"changed": false, "commands": []}

TASK [Set interface Vlan1 (RVI) IPv4 address] **********************************
changed: [junos01] => {"changed": true}

PLAY RECAP *********************************************************************
junos01                    : ok=3    changed=1    unreachable=0    failed=0

 [WARNING]: Failure using method (v2_playbook_on_stats) in callback plugin (<an
sible.plugins.callback./Users/jacksonisaac/.ansible/roles/Juniper.junos/callbac
k_plugins/jsnapy.CallbackModule object at 0x10e036fd0>): 'dict' object has no
attribute 'iteritems'
```

Playbook:
```
---  
- hosts: all
  roles:
    - Juniper.junos 
  connection: local
  #become: yes
  gather_facts: False
  tasks:
    - name: Retrieve Junos OS version
      junos_command:
        commands: show version
      when: ansible_network_os == 'junos'
    - name: Enable NETCONF
      connection: network_cli
      junos_netconf:
      when: ansible_network_os == 'junos'
    - name: Set interface Vlan1 (RVI) IPv4 address
      connection: netconf
      junos_config:
        lines:
          - set vlans vlan01 vlan-id 3
          - set interfaces irb unit 10 family inet address 10.0.0.3/24
          - set vlans vlan01 l3-interface irb.10
      when: ansible_network_os == 'junos'

```

Testing if configured properly on JunOS:
```
--- JUNOS 17.4R1.16 built 2017-12-19 20:03:37 UTC
{master:0}
vagrant@vqfx-re> configure
Entering configuration mode

{master:0}[edit]
vagrant@vqfx-re# show interfaces irb
unit 10 {
    family inet {
        address 10.0.0.3/24;
    }
}

{master:0}[edit]
```