### PR TITLE
Python3 fix: Decode output from popen in iocage connection

### DIFF
--- a/lib/ansible/plugins/connection/iocage.py
+++ b/lib/ansible/plugins/connection/iocage.py
@@ -70,6 +70,13 @@ class Connection(Jail):
                              stderr=subprocess.STDOUT)
 
         stdout, stderr = p.communicate()
+
+        if stdout is not None:
+            stdout = stdout.decode('utf-8')
+
+        if stderr is not None:
+            stderr = stderr.decode('utf-8')
+
         # otherwise p.returncode would not be set
         p.wait()
 

--- a/lib/ansible/plugins/connection/iocage.py
+++ b/lib/ansible/plugins/connection/iocage.py
@@ -32,8 +32,9 @@ DOCUMENTATION = """
 """
 
 import subprocess
-from ansible.plugins.connection.jail import Connection as Jail
 
+from ansible.plugins.connection.jail import Connection as Jail
+from ansible.module_utils._text import to_native
 from ansible.errors import AnsibleError
 
 try:
@@ -72,10 +73,10 @@ class Connection(Jail):
         stdout, stderr = p.communicate()
 
         if stdout is not None:
-            stdout = stdout.decode('utf-8')
+            stdout = to_native(stdout)
 
         if stderr is not None:
-            stderr = stderr.decode('utf-8')
+            stderr = to_native(stderr)
 
         # otherwise p.returncode would not be set
         p.wait()


### PR DESCRIPTION
##### SUMMARY

The semantic type of the stdout and stderr outputs from `subprocess.Popen` is bytes (`str` on py2 and `bytes` on py3). It must first be decoded to the semantic type text, since it is used to A) be stripped of `'\n'` on line 86, and B) formatted into other strings on line 58.

This fix converts the output data to text, in a way that works on both python2 and python3.

Without this fix, the iocage connection crashes if using python3.

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

`iocage` connection

##### ANSIBLE VERSION

```
ansible-playbook 2.7.0.dev0 (fix_crash_iocage_py3 6921d3fa65) last updated 2018/06/23 13:11:42 (GMT +200)
  config file = /usr/home/thnee/code/my_project/ansible.cfg
  configured module search path = ['/usr/home/thnee/code/my_project/ext/library']
  ansible python module location = /usr/home/thnee/code/github/ansible/ansible/lib/ansible
  executable location = /home/thnee/code/github/ansible/ansible/bin/ansible-playbook
  python version = 3.6.5 (default, May 26 2018, 01:11:38) [GCC 4.2.1 Compatible FreeBSD Clang 4.0.0 (tags/RELEASE_400/final 297347)]
```


##### ADDITIONAL INFORMATION

This is what the traceback looks like when running ansible with python 3.

```
Traceback (most recent call last):
  File "/usr/home/thnee/code/github/ansible/ansible/lib/ansible/executor/task_executor.py", line 138, in run
    res = self._execute()
  File "/usr/home/thnee/code/github/ansible/ansible/lib/ansible/executor/task_executor.py", line 525, in _execute
    self._connection = self._get_connection(variables=variables, templar=templar)
  File "/usr/home/thnee/code/github/ansible/ansible/lib/ansible/executor/task_executor.py", line 811, in _get_connection
    ansible_playbook_pid=to_text(os.getppid())
  File "/usr/home/thnee/code/github/ansible/ansible/lib/ansible/plugins/loader.py", line 397, in get
    obj = obj(*args, **kwargs)
  File "/usr/home/thnee/code/github/ansible/ansible/lib/ansible/plugins/connection/iocage.py", line 56, in __init__
    jail_uuid = self.get_jail_uuid()
  File "/usr/home/thnee/code/github/ansible/ansible/lib/ansible/plugins/connection/iocage.py", line 86, in get_jail_uuid
    return stdout.strip('\n')
TypeError: a bytes-like object is required, not 'str'
```