### PR TITLE
Update synchronize.py, mention variable ansible_rsync_path needed for different local rsync binary

### DIFF
--- a/lib/ansible/modules/files/synchronize.py
+++ b/lib/ansible/modules/files/synchronize.py
@@ -113,10 +113,11 @@ options:
     default: the value of the archive option
   rsync_path:
     description:
-      - Specify the rsync command to run on the remote host. See C(--rsync-path) on the rsync man page. To specifcy the rsync command to run on the local host, you need to set this your task var ansible_rsync_path.
+      - Specify the rsync command to run on the remote host. See C(--rsync-path) on the rsync man page.
+      - To specify the rsync command to run on the local host, you need to set this your task var C(ansible_rsync_path).
   rsync_timeout:
     description:
-      - Specify a --timeout for the rsync command in seconds.
+      - Specify a C(--timeout) for the rsync command in seconds.
     default: 0
   set_remote_user:
     description:
@@ -301,8 +302,8 @@ EXAMPLES = '''
     src: /tmp/path_a/foo.txt
     dest: /tmp/path_b/foo.txt
     link_dest: /tmp/path_a/
-    
-# Specify the rsync binary to use on remote host and on local host    
+
+# Specify the rsync binary to use on remote host and on local host
 - hosts: groupofhosts
   vars:
         ansible_rsync_path: "/usr/gnu/bin/rsync"

--- a/lib/ansible/modules/files/synchronize.py
+++ b/lib/ansible/modules/files/synchronize.py
@@ -113,7 +113,7 @@ options:
     default: the value of the archive option
   rsync_path:
     description:
-      - Specify the rsync command to run on the remote host. See C(--rsync-path) on the rsync man page.
+      - Specify the rsync command to run on the remote host. See C(--rsync-path) on the rsync man page. To specifcy the rsync command to run on the local host, you need to set this your task var ansible_rsync_path.
   rsync_timeout:
     description:
       - Specify a --timeout for the rsync command in seconds.
@@ -301,6 +301,19 @@ EXAMPLES = '''
     src: /tmp/path_a/foo.txt
     dest: /tmp/path_b/foo.txt
     link_dest: /tmp/path_a/
+    
+# Specify the rsync binary to use on remote host and on local host    
+- hosts: groupofhosts
+  vars:
+        ansible_rsync_path: "/usr/gnu/bin/rsync"
+
+  tasks:
+    - name: copy /tmp/localpath/ to remote location /tmp/remotepath
+      synchronize:
+        src: "/tmp/localpath/"
+        dest: "/tmp/remotepath"
+        rsync_path: "/usr/gnu/bin/rsync"
+
 '''
 
 


### PR DESCRIPTION
If you want a different rsync binary on the local side, you need to set task variable ansible_rsync_path.
See examples.

Variable ansible_rsync_path looks to not be documented anywhere. If documented, needs to be said that is does not belong to synchronise options, instead belongs to tasks. (Sorry, I have no better wording)


+label: docsite_pr

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - New Module Pull Request
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
