### PR TITLE
clarify module functionality in docstrings

### DIFF
--- a/lib/ansible/modules/cloud/digital_ocean/digital_ocean_domain.py
+++ b/lib/ansible/modules/cloud/digital_ocean/digital_ocean_domain.py
@@ -16,9 +16,9 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = '''
 ---
 module: digital_ocean_domain
-short_description: Create/delete a DNS record in DigitalOcean
+short_description: Create/delete a DNS domain in DigitalOcean
 description:
-     - Create/delete a DNS record in DigitalOcean.
+     - Create/delete a DNS domain in DigitalOcean.
 version_added: "1.6"
 author: "Michael Gregson (@mgregson)"
 options:
@@ -36,7 +36,7 @@ options:
      - String, this is the name of the droplet - must be formatted by hostname rules, or the name of a SSH key, or the name of a domain.
   ip:
     description:
-     - The IP address to point a domain at.
+     - An 'A' record for '@' ($ORIGIN) will be created with the value 'ip'.  'ip' is an IP version 4 address.
 extends_documentation_fragment: digital_ocean.documentation
 notes:
   - Environment variables DO_OAUTH_TOKEN can be used for the oauth_token.
@@ -49,14 +49,14 @@ requirements:
 
 
 EXAMPLES = '''
-# Create a domain record
+# Create a domain
 
 - digital_ocean_domain:
     state: present
     name: my.digitalocean.domain
     ip: 127.0.0.1
 
-# Create a droplet and a corresponding domain record
+# Create a droplet and a corresponding domain
 
 - digital_ocean:
     state: present


### PR DESCRIPTION
##### SUMMARY
Fix part of issue #35669

Module documentation is misleading. This module only creates new domain name objects and only 1 associated record (A record associated with the @ $ORIGIN).

See https://github.com/ansible/ansible/issues/35669 for a perfect description of the problem.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
digital_ocean_domain

##### ANSIBLE VERSION
```
ansible 2.5.5
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/elkcloner/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.15 (default, May  1 2018, 05:55:50) [GCC 7.3.0]

```


##### ADDITIONAL INFORMATION
None.
