### PR TITLE
Scaleway inventory public: handle host without public IP

### DIFF
--- a/lib/ansible/plugins/inventory/scaleway.py
+++ b/lib/ansible/plugins/inventory/scaleway.py
@@ -91,7 +91,6 @@ class InventoryModule(BaseInventoryPlugin):
             "organization",
             "state",
             "hostname",
-            "state"
         )
         for attribute in targeted_attributes:
             self.inventory.set_variable(server_id, attribute, server_info[attribute])

--- a/lib/ansible/plugins/inventory/scaleway.py
+++ b/lib/ansible/plugins/inventory/scaleway.py
@@ -96,7 +96,8 @@ class InventoryModule(BaseInventoryPlugin):
             self.inventory.set_variable(server_id, attribute, server_info[attribute])
 
         self.inventory.set_variable(server_id, "tags", server_info["tags"])
-        self.inventory.set_variable(server_id, "ipv4", server_info["public_ip"]["address"])
+        if server_info.get("public_ip") and server_info["public_ip"].get("address"):
+            self.inventory.set_variable(server_id, "ipv4", server_info["public_ip"]["address"])
 
     def _get_zones(self, config_zones):
         return set(SCALEWAY_LOCATION.keys()).intersection(config_zones)


### PR DESCRIPTION
##### SUMMARY

Scaleway inventory plugin: handle host without public IP.

Fix this exception:

    $ SCW_TOKEN=XXXX ANSIBLE_INVENTORY_ENABLED=scaleway ansible-inventory --list -i scaleway.yml -vvvv
    [WARNING]:  * Failed to parse scaleway.yml with scaleway plugin: 'NoneType' object is not subscriptable
     File "ansible/lib/ansible/inventory/manager.py", line 269, in parse_source
       plugin.parse(self._inventory, self._loader, source, cache=cache)
     File "ansible/lib/ansible/plugins/inventory/scaleway.py", line 146, in parse
       self.do_zone_inventory(zone=zone, token=token, tags=tags)
     File "ansible/lib/ansible/plugins/inventory/scaleway.py", line 135, in do_zone_inventory
       self._fill_host_variables(server_id=server_id, server_info=server_info)
     File "ansible/lib/ansible/plugins/inventory/scaleway.py", line 100, in _fill_host_variables
       self.inventory.set_variable(server_id, "ipv4", server_info["public_ip"]["address"])

Another commit remove an useless duplication.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
scaleway inventory plugin

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (devel f30e0b833d) last updated 2018/06/24 16:11:47 (GMT +200)
```

##### ADDITIONAL INFORMATION
If not to late, it should be backported to 2.6: #41880.
