### PR TITLE
Scaleway inventory public: handle host without public IP (backport #41878)

### DIFF
--- a/lib/ansible/plugins/inventory/scaleway.py
+++ b/lib/ansible/plugins/inventory/scaleway.py
@@ -97,7 +97,8 @@ class InventoryModule(BaseInventoryPlugin):
             self.inventory.set_variable(server_id, attribute, server_info[attribute])
 
         self.inventory.set_variable(server_id, "tags", server_info["tags"])
-        self.inventory.set_variable(server_id, "ipv4", server_info["public_ip"]["address"])
+        if server_info.get("public_ip") and server_info["public_ip"].get("address"):
+            self.inventory.set_variable(server_id, "ipv4", server_info["public_ip"]["address"])
 
     def _get_zones(self, config_zones):
         return set(SCALEWAY_LOCATION.keys()).intersection(config_zones)


### PR DESCRIPTION
**Cherry picked from commit b6a4f85dcbe212fa950211eb799a300126ae28f4 / backport #41878**

Scaleway inventory plugin: handle host without public IP.

Fix this exception:

    $ SCW_TOKEN=XXXX ANSIBLE_INVENTORY_ENABLED=scaleway ansible-inventory --list -i scaleway.yml -vvvv
    [WARNING]:  * Failed to parse scaleway.yml with scaleway plugin: 'NoneType' object is not subscriptable
     File "ansible/lib/ansible/inventory/manager.py", line 269, in parse_source
       plugin.parse(self._inventory, self._loader, source, cache=cache)
     File "ansible/lib/ansible/plugins/inventory/scaleway.py", line 146, in parse
       self.do_zone_inventory(zone=zone, token=token, tags=tags)
     File "ansible/lib/ansible/plugins/inventory/scaleway.py", line 135, in do_zone_inventory
       self._fill_host_variables(server_id=server_id, server_info=server_info)
     File "ansible/lib/ansible/plugins/inventory/scaleway.py", line 100, in _fill_host_variables
       self.inventory.set_variable(server_id, "ipv4", server_info["public_ip"]["address"])