### PR TITLE
Stop displaying kinit pass input on a failure

### DIFF
--- a/changelogs/fragments/winrm_kinit-remove-pass-log.yml
+++ b/changelogs/fragments/winrm_kinit-remove-pass-log.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- winrm - ensure pexpect is set to not echo the input on a failure and have a manual sanity check afterwards https://github.com/ansible/ansible/issues/41865

--- a/lib/ansible/plugins/connection/winrm.py
+++ b/lib/ansible/plugins/connection/winrm.py
@@ -294,7 +294,7 @@ class Connection(ConnectionBase):
                          % principal)
             try:
                 child = pexpect.spawn(command, kinit_cmdline, timeout=60,
-                                      env=krb5env)
+                                      env=krb5env, echo=False)
             except pexpect.ExceptionPexpect as err:
                 err_msg = "Kerberos auth failure when calling kinit cmd " \
                           "'%s': %s" % (command, to_native(err))
@@ -328,8 +328,12 @@ class Connection(ConnectionBase):
                                      env=krb5env)
 
             except OSError as err:
+                # one last attempt at making sure the password does not exist
+                # in the output
+                exp_msg = to_native(err)
+                exp_msg.replace(to_native(password), "<redacted>")
                 err_msg = "Kerberos auth failure when calling kinit cmd " \
-                          "'%s': %s" % (self._kinit_cmd, to_native(err))
+                          "'%s': %s" % (self._kinit_cmd, exp_msg)
                 raise AnsibleConnectionFailure(err_msg)
 
             stdout, stderr = p.communicate(password + b'\n')

--- a/test/units/plugins/connection/test_winrm.py
+++ b/test/units/plugins/connection/test_winrm.py
@@ -271,6 +271,7 @@ class TestWinRMKerbAuth(object):
         actual_env = mock_calls[0][2]['env']
         assert list(actual_env.keys()) == ['KRB5CCNAME']
         assert actual_env['KRB5CCNAME'].startswith("FILE:/")
+        assert mock_calls[0][2]['echo'] is False
         assert mock_calls[1][0] == "().expect"
         assert mock_calls[1][1] == (".*:",)
         assert mock_calls[2][0] == "().sendline"
@@ -367,3 +368,48 @@ class TestWinRMKerbAuth(object):
         assert str(err.value) == \
             "Kerberos auth failure for principal invaliduser with " \
             "pexpect: %s" % (expected_err)
+
+    def test_kinit_error_pass_in_output_subprocess(self, monkeypatch):
+        def mock_communicate(input=None, timeout=None):
+            return b"", b"Error with kinit\n" + input
+
+        mock_popen = MagicMock()
+        mock_popen.return_value.communicate = mock_communicate
+        mock_popen.return_value.returncode = 1
+        monkeypatch.setattr("subprocess.Popen", mock_popen)
+
+        winrm.HAS_PEXPECT = False
+        pc = PlayContext()
+        new_stdin = StringIO()
+        conn = connection_loader.get('winrm', pc, new_stdin)
+        conn.set_options(var_options={"_extras": {}})
+
+        with pytest.raises(AnsibleConnectionFailure) as err:
+            conn._kerb_auth("username", "password")
+        assert str(err.value) == \
+            "Kerberos auth failure for principal username with subprocess: " \
+            "Error with kinit\n<redacted>"
+
+    def test_kinit_error_pass_in_output_pexpect(self, monkeypatch):
+        pytest.importorskip("pexpect")
+
+        mock_pexpect = MagicMock()
+        mock_pexpect.return_value.expect = MagicMock()
+        mock_pexpect.return_value.read.return_value = \
+            b"Error with kinit\npassword\n"
+        mock_pexpect.return_value.exitstatus = 1
+
+        monkeypatch.setattr("pexpect.spawn", mock_pexpect)
+
+        winrm.HAS_PEXPECT = True
+        pc = PlayContext()
+        pc = PlayContext()
+        new_stdin = StringIO()
+        conn = connection_loader.get('winrm', pc, new_stdin)
+        conn.set_options(var_options={"_extras": {}})
+
+        with pytest.raises(AnsibleConnectionFailure) as err:
+            conn._kerb_auth("username", "password")
+        assert str(err.value) == \
+            "Kerberos auth failure for principal username with pexpect: " \
+            "Error with kinit\n<redacted>"


### PR DESCRIPTION
##### SUMMARY
When using kinit with pexpect, there is a chance that on a failure the password is included with the error message. This should not happen and this PR attempts to stop that from happening in 2 different ways;

1. Set `echo=False` on the init for `pexpect.spawn` so the input is not echo'd out
2. Manually replace the password with `<redacted>` as a last minute catch in case the above didn't work

Fixes https://github.com/ansible/ansible/issues/41865

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
winrm

##### ANSIBLE VERSION
```
devel
2.6
2.5
```