### PR TITLE
win_chocolatey: always return the rc return value

### DIFF
--- a/changelogs/fragments/win_chocolatey-return-rc-always.yml
+++ b/changelogs/fragments/win_chocolatey-return-rc-always.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- win_chocolatey - set the rc return value to always be returned, default to 0 https://github.com/ansible/ansible/issues/41758

--- a/lib/ansible/modules/windows/win_chocolatey.ps1
+++ b/lib/ansible/modules/windows/win_chocolatey.ps1
@@ -36,6 +36,7 @@ $proxy_password = Get-AnsibleParam -obj $params -name "proxy_password" -type "st
 
 $result = @{
     changed = $false 
+    rc = 0
 }
 
 Function Chocolatey-Install-Upgrade

--- a/lib/ansible/modules/windows/win_chocolatey.py
+++ b/lib/ansible/modules/windows/win_chocolatey.py
@@ -211,7 +211,7 @@ command:
   sample: choco.exe install -r --no-progress -y sysinternals --timeout 2700 --failonunfound
 rc:
   description: The return code from the chocolatey task.
-  returned: changed
+  returned: always
   type: int
   sample: 0
 stdout:

--- a/test/integration/targets/win_chocolatey/tasks/main.yml
+++ b/test/integration/targets/win_chocolatey/tasks/main.yml
@@ -26,6 +26,7 @@
   assert:
     that:
     - 'install.changed == true'
+    - install.rc == 0
 
 - name: install chocolatey-core.extension again
   win_chocolatey:
@@ -37,6 +38,7 @@
   assert:
     that:
     - 'install_again.changed == false'
+    - install.rc == 0
 
 - name: remove chocolatey-core.extension
   win_chocolatey:
@@ -48,6 +50,7 @@
   assert:
     that:
     - 'remove.changed == true'
+    - install.rc == 0
 
 - name: remove chocolatey-core.extension again
   win_chocolatey:
@@ -59,3 +62,4 @@
   assert:
     that:
     - 'remove_again.changed == false'
+    - install.rc == 0


### PR DESCRIPTION
##### SUMMARY
Always return the `rc` value when calling the `win_chocolatey` module and not just when a change occurred. This makes it easier to build when conditions on tasks that are run multiple times.

Fixes https://github.com/ansible/ansible/issues/41758

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
win_chocolatey

##### ANSIBLE VERSION
```
devel
```