### PR TITLE
cliconf: Fix use of multiple prompts in send_command

### DIFF
--- a/lib/ansible/plugins/cliconf/__init__.py
+++ b/lib/ansible/plugins/cliconf/__init__.py
@@ -101,7 +101,7 @@ class CliconfBase(with_metaclass(ABCMeta, object)):
         logging of any commands based on the `nolog` argument.
 
         :param command: The command to send over the connection to the device
-        :param prompt: A regex pattern to evalue the expected prompt from the command
+        :param prompt: A single regex pattern or a sequence of patterns to evaluate the expected prompt from the command
         :param answer: The answer to respond with if the prompt is matched.
         :param sendonly: Bool value that will send the command but not wait for a result.
         :param newline: Bool value that will append the newline character to the command
@@ -117,7 +117,10 @@ class CliconfBase(with_metaclass(ABCMeta, object)):
         }
 
         if prompt is not None:
-            kwargs['prompt'] = to_bytes(prompt)
+            if isinstance(prompt, list):
+                kwargs['prompt'] = [to_bytes(p) for p in prompt]
+            else:
+                kwargs['prompt'] = to_bytes(prompt)
         if answer is not None:
             kwargs['answer'] = to_bytes(answer)
 


### PR DESCRIPTION
As I understood from reading the _handle_prompt method from network_cli, modules such as ios_command may take a list of prompts the output of a certain command will be checked against. If one of the prompts matches, the specified answer is given. However, this seems to be broken.

Upon preparing the commands for sending to the device, cliconf converts the optional prompt to a byte string. However, since there might be multiple prompts specified, the conversion has to happen for each prompt individually. Otherwise, wrong regexes will be compiled in _handle_prompt from network_cli Connection.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
cliconf
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.5
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/paul/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python3.6/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 3.6.5 (default, May 11 2018, 04:00:52) [GCC 8.1.0]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Consider the following playbook:
```
tasks:
  - name: copy running-config
    ios_command:
      commands:
        - command: 'copy running-config bootflash:router-confg'
          prompt:
            - 'Dummy'
            - 'Address or name of remote host'
          answer: ''
```
This should not be completing successfully, as none of the prompts appear in the output of the command:
```
csr-test1#copy running-config bootflash:router-confg
Destination filename [router-confg]? 
2047 bytes copied in 0.067 secs (30552 bytes/sec)
csr-test1#
```
Without this patch, the answer will indeed be sent, as the regex in _handle_prompt will be built using the string representation of the list of prompts.