### PR TITLE
windows dsc docs: fix missing colon in example

### DIFF
--- a/docs/docsite/rst/user_guide/windows_dsc.rst
+++ b/docs/docsite/rst/user_guide/windows_dsc.rst
@@ -128,7 +128,7 @@ a custom class defined by that resource. Defining a value that takes in a
 For example, to define a ``[CimInstance]`` value in Ansible::
 
     # [CimInstance]AuthenticationInfo == MSFT_xWebAuthenticationInformation
-    AuthenticationInfo
+    AuthenticationInfo:
       Anonymous: no
       Basic: yes
       Digest: no


### PR DESCRIPTION
##### SUMMARY
Added missing colon to the docs example for Windows DSC

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
windows_dsc.rst

##### ANSIBLE VERSION
```
devel
```