### PR TITLE
inventory plugins: add test about config API usage

### DIFF
--- a/lib/ansible/plugins/__init__.py
+++ b/lib/ansible/plugins/__init__.py
@@ -67,7 +67,7 @@ class AnsiblePlugin(with_metaclass(ABCMeta, object)):
         Sets the _options attribute with the configuration/keyword information for this plugin
 
         :arg task_keys: Dict with playbook keywords that affect this option
-        :arg var_options: Dict with either 'conneciton variables'
+        :arg var_options: Dict with either 'connection variables'
         :arg direct: Dict with 'direct assignment'
         '''
         self._options = C.config.get_plugin_options(get_plugin_class(self), self._load_name, keys=task_keys, variables=var_options, direct=direct)

--- a/test/integration/targets/inventory_plugin_config/aliases
+++ b/test/integration/targets/inventory_plugin_config/aliases
@@ -1,0 +1,1 @@
+posix/ci/group3

--- a/test/integration/targets/inventory_plugin_config/config_with_parameter.yml
+++ b/test/integration/targets/inventory_plugin_config/config_with_parameter.yml
@@ -1,0 +1,3 @@
+plugin: test_inventory
+departments:
+  - paris

--- a/test/integration/targets/inventory_plugin_config/config_without_parameter.yml
+++ b/test/integration/targets/inventory_plugin_config/config_without_parameter.yml
@@ -1,0 +1,1 @@
+plugin: test_inventory

--- a/test/integration/targets/inventory_plugin_config/runme.sh
+++ b/test/integration/targets/inventory_plugin_config/runme.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o xtrace
+
+export ANSIBLE_INVENTORY_PLUGINS=./
+export ANSIBLE_INVENTORY_ENABLED=test_inventory
+
+# check default values
+ansible-inventory --list -i ./config_without_parameter.yml --export | \
+    env python -c "import json, sys; inv = json.loads(sys.stdin.read()); \
+                   assert set(inv['_meta']['hostvars']['test_host']['departments']) == set(['seine-et-marne', 'haute-garonne'])"
+
+# check values
+ansible-inventory --list -i ./config_with_parameter.yml --export | \
+    env python -c "import json, sys; inv = json.loads(sys.stdin.read()); \
+                   assert set(inv['_meta']['hostvars']['test_host']['departments']) == set(['paris'])"

--- a/test/integration/targets/inventory_plugin_config/test_inventory.py
+++ b/test/integration/targets/inventory_plugin_config/test_inventory.py
@@ -1,0 +1,51 @@
+from __future__ import (absolute_import, division, print_function)
+
+__metaclass__ = type
+
+DOCUMENTATION = '''
+    name: test_inventory
+    plugin_type: inventory
+    authors:
+      - Pierre-Louis Bonicoli (@pilou-)
+    short_description: test inventory
+    description:
+        - test inventory (fetch parameters using config API)
+    options:
+        departments:
+            description: test parameter
+            type: list
+            default:
+                - seine-et-marne
+                - haute-garonne
+            required: False
+'''
+
+EXAMPLES = '''
+# Example command line: ansible-inventory --list -i test_inventory.yml
+
+plugin: test_inventory
+departments:
+  - paris
+'''
+
+from ansible.plugins.inventory import BaseInventoryPlugin
+
+
+class InventoryModule(BaseInventoryPlugin):
+    NAME = 'test_inventory'
+
+    def verify_file(self, path):
+        return True
+
+    def parse(self, inventory, loader, path, cache=True):
+        super(InventoryModule, self).parse(inventory, loader, path)
+        self._read_config_data(path=path)
+
+        departments = self.get_option('departments')
+
+        group = 'test_group'
+        host = 'test_host'
+
+        self.inventory.add_group(group)
+        self.inventory.add_host(group=group, host=host)
+        self.inventory.set_variable(host, 'departments', departments)


### PR DESCRIPTION
##### SUMMARY

1. Check that `config` API works well with inventory plugins (integration tests)
2. ~Fix `config` API usage (regression introduced by 0102e422722afbadb65e93bcdd1b8f2fe80794b4)~ (fixed in #41913)
3. Fix a typo in docstring

Since 0102e422722afbadb65e93bcdd1b8f2fe80794b4, the first call to [`AnsiblePlugin.set_options`](https://github.com/ansible/ansible/blob/0b2ec9b11c1348b1d3d9ddc8b2319b4382497d79/lib/ansible/plugins/__init__.py#L65) set `_options` attribute and subsequent calls don't modify this attribute - even if `direct` parameter is used - because `_options` attribute is [already set](https://github.com/ansible/ansible/blob/0b2ec9b11c1348b1d3d9ddc8b2319b4382497d79/lib/ansible/plugins/__init__.py#L74).

This causes a regression for inventory plugins which:
1. store configuration in the inventory file
2. and use [BaseInventoryPlugin._read_config_data](https://github.com/ansible/ansible/blob/0b2ec9b11c1348b1d3d9ddc8b2319b4382497d79/lib/ansible/plugins/inventory/__init__.py#L191) method
3. then call [`AnsiblePlugin.get_option`](https://github.com/ansible/ansible/blob/0b2ec9b11c1348b1d3d9ddc8b2319b4382497d79/lib/ansible/plugins/__init__.py#L56) to retrieve their configuration ([`foreman`](https://github.com/ansible/ansible/blob/0b2ec9b11c1348b1d3d9ddc8b2319b4382497d79/lib/ansible/plugins/inventory/foreman.py#L221), [`constructed`](https://github.com/ansible/ansible/blob/0b2ec9b11c1348b1d3d9ddc8b2319b4382497d79/lib/ansible/plugins/inventory/constructed.py#L96), [`nmap`](https://github.com/ansible/ansible/blob/0b2ec9b11c1348b1d3d9ddc8b2319b4382497d79/lib/ansible/plugins/inventory/nmap.py#L99), [`scaleway`](https://github.com/ansible/ansible/blob/0b2ec9b11c1348b1d3d9ddc8b2319b4382497d79/lib/ansible/plugins/inventory/scaleway.py#L141))

In such cases, `AnsiblePlugin.set_options` is called first in [`InventoryManager._setup_inventory_plugins`](https://github.com/ansible/ansible/blob/0b2ec9b11c1348b1d3d9ddc8b2319b4382497d79/lib/ansible/inventory/manager.py#L186), next by [`BaseInventoryPlugin._read_config_data`](https://github.com/ansible/ansible/blob/0b2ec9b11c1348b1d3d9ddc8b2319b4382497d79/lib/ansible/plugins/inventory/__init__.py#L191). This second call doesn't update `_options` attribute and following calls to` AnsiblePlugin.get_option` will return default plugin configuration (instead of the configuration from the inventory file).

Without this patch, added integration test [fails](https://app.shippable.com/github/ansible/ansible/runs/71261/48/console):
```
Running inventory_plugin_config integration test script
Run command: ./runme.sh -v
[...]
+ ansible-inventory --list -i ./config_with_parameter.yml --export
+ env python -c 'import json, sys; inv = json.loads(sys.stdin.read()); assert set(inv['\''_meta'\'']['\''hostvars'\'']['\''test_host'\'']['\''departments'\'']) == set(['\''paris'\''])'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
AssertionError
```

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
inventory plugins

##### ANSIBLE VERSION
```
ansible 2.7.0.dev0 (devel f30e0b833d) last updated 2018/06/24 16:11:47 (GMT +200)
```

##### ADDITIONAL INFORMATION
Commit adding the regressing has been backported (#41823), the fix should be **backported** too.

Another fix could be to:
1. keep the call to `set_options` in `InventoryManager._setup_inventory_plugins`
2. calls `C.config.get_plugin_options` in `AnsiblePlugin.set_options` when direct parameter is set.
The disadvantage is that `ConfigManager.get_configuration_definitions()` would be called twice.