### PR TITLE
Bug #41503 - Bugfix for idempotency bug in meraki_network

### DIFF
--- a/lib/ansible/modules/network/meraki/meraki_network.py
+++ b/lib/ansible/modules/network/meraki/meraki_network.py
@@ -184,11 +184,14 @@ def main():
     if meraki.params['state'] == 'present':
         payload = {'name': meraki.params['net_name'],
                    'type': meraki.params['type'],
+                   'tags': meraki.params['tags'],
                    }
         if meraki.params['tags']:
             payload['tags'] = construct_tags(meraki.params['tags'])
         if meraki.params['timezone']:
             payload['timeZone'] = meraki.params['timezone']
+        else:
+            payload['timeZone'] = 'America/Los_Angeles'
         if meraki.params['type'] == 'combined':
             payload['type'] = 'switch wireless appliance'
 


### PR DESCRIPTION
##### SUMMARY
- Comparison was not happening properly as it lacked full data
- Module now creates a full data structure on payload
- Defaults to America/Los_Angeles as that's what Meraki seems to do

Fixes #41503 

##### ISSUE TYPE
 - Bugfix Pull Request
 
##### COMPONENT NAME
meraki_network

##### ANSIBLE VERSION
```
ansible 2.7.0.dev0 (meraki/bug-41503 9eed90c1c7) last updated 2018/06/24 21:31:40 (GMT -500)
  config file = None
  configured module search path = ['/Users/kbreit/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/kbreit/Documents/Programming/ansible/lib/ansible
  executable location = /Users/kbreit/Documents/Programming/ansible/bin/ansible
  python version = 3.5.4 (default, Feb 25 2018, 14:56:02) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```