### PR TITLE
windows dsc docs: fix missing colon in example (#41886)

### DIFF
--- a/docs/docsite/rst/user_guide/windows_dsc.rst
+++ b/docs/docsite/rst/user_guide/windows_dsc.rst
@@ -128,7 +128,7 @@ a custom class defined by that resource. Defining a value that takes in a
 For example, to define a ``[CimInstance]`` value in Ansible::
 
     # [CimInstance]AuthenticationInfo == MSFT_xWebAuthenticationInformation
-    AuthenticationInfo
+    AuthenticationInfo:
       Anonymous: no
       Basic: yes
       Digest: no


### PR DESCRIPTION
(cherry picked from commit 0b2ec9b11c1348b1d3d9ddc8b2319b4382497d79)

##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/41886

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
windows_dsc.rst

##### ANSIBLE VERSION
```
2.5
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
