### PR TITLE
Fix ios and vyos cliconf edit_config return type

### DIFF
--- a/lib/ansible/module_utils/network/ios/ios.py
+++ b/lib/ansible/module_utils/network/ios/ios.py
@@ -166,7 +166,8 @@ def load_config(module, commands):
     connection = get_connection(module)
 
     try:
-        diff, response = connection.edit_config(commands)
-        return response
+        resp = connection.edit_config(commands)
+        resp = json.loads(resp)
+        return resp.get('response')
     except ConnectionError as exc:
         module.fail_json(msg=to_text(exc))

--- a/lib/ansible/module_utils/network/vyos/vyos.py
+++ b/lib/ansible/module_utils/network/vyos/vyos.py
@@ -133,7 +133,9 @@ def load_config(module, commands, commit=False, comment=None):
     connection = get_connection(module)
 
     try:
-        diff_config, resp = connection.edit_config(candidate=commands, commit=commit, diff=module._diff, comment=comment)
+        resp = connection.edit_config(candidate=commands, commit=commit, diff=module._diff, comment=comment)
+        resp = json.loads(resp)
+        diff_config = resp.get('diff')
     except ConnectionError as exc:
         module.fail_json(msg=to_text(exc))
 

--- a/lib/ansible/plugins/cliconf/__init__.py
+++ b/lib/ansible/plugins/cliconf/__init__.py
@@ -206,9 +206,13 @@ class CliconfBase(with_metaclass(ABCMeta, object)):
         :param diff: Boolean flag to indicate if configuration that is applied on remote host should
                      generated and returned in response or not
         :param comment: Commit comment provided it is supported by remote host
-        :return: Returns a tuple, the first entry of tupe is configuration diff if diff flag is enable else
-                it is None. Second entry is the list of response received from remote host on executing
-                configuration commands.
+        :return: Returns a json string with contains configuration applied on remote host, the returned
+                 response on executing configuration commands and platform relevant data.
+               {
+                   'diff': '',
+                   'response': ''
+               }
+
         """
         pass
 

--- a/lib/ansible/plugins/cliconf/__init__.py
+++ b/lib/ansible/plugins/cliconf/__init__.py
@@ -209,8 +209,8 @@ class CliconfBase(with_metaclass(ABCMeta, object)):
         :return: Returns a json string with contains configuration applied on remote host, the returned
                  response on executing configuration commands and platform relevant data.
                {
-                   'diff': '',
-                   'response': ''
+                   "diff": "",
+                   "response": []
                }
 
         """

--- a/lib/ansible/plugins/cliconf/ios.py
+++ b/lib/ansible/plugins/cliconf/ios.py
@@ -125,6 +125,7 @@ class Cliconf(CliconfBase):
 
     @enable_mode
     def edit_config(self, candidate=None, commit=True, replace=False, diff=False, comment=None):
+        resp = {}
         if not candidate:
             raise ValueError("must provide a candidate config to load")
 
@@ -154,7 +155,9 @@ class Cliconf(CliconfBase):
         if diff:
             diff_config = candidate
 
-        return diff_config, results[1:-1]
+        resp['diff'] = diff_config
+        resp['response'] = results[1:-1]
+        return json.dumps(resp)
 
     def get(self, command=None, prompt=None, answer=None, sendonly=False):
         if not command:

--- a/lib/ansible/plugins/cliconf/vyos.py
+++ b/lib/ansible/plugins/cliconf/vyos.py
@@ -61,6 +61,7 @@ class Cliconf(CliconfBase):
         return out
 
     def edit_config(self, candidate=None, commit=True, replace=False, diff=False, comment=None):
+        resp = {}
         if not candidate:
             raise ValueError('must provide a candidate config to load')
 
@@ -98,7 +99,9 @@ class Cliconf(CliconfBase):
         else:
             self.discard_changes()
 
-        return diff_config, results[1:]
+        resp['diff'] = diff_config
+        resp['response'] = results[1:]
+        return json.dumps(resp)
 
     def get(self, command=None, prompt=None, answer=None, sendonly=False):
         if not command:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Modify cliconf edit_config api to return a json string with
diff and response received from remote host for ios and vyos.

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
module_utils/network/ios/ios.py
module_utils/network/vyos/vyos.py
plugins/cliconf/ios.py
plugins/cliconf/vyos.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
