### PR TITLE
more detail error on bad http code return for modules vmware vmware_guest_file_operation.py

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest_file_operation.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_file_operation.py
@@ -21,7 +21,7 @@ description:
     - Module to copy a file to a VM, fetch a file from a VM and create or delete a directory in the guest OS.
 version_added: "2.5"
 author:
-  - Stéphane Travassac (@stravassac)
+  - Stéphane Travassac (stravassac@gmail.com)
 notes:
     - Tested on vSphere 6
     - Only the first match against vm_id is used, even if there are multiple matches
@@ -348,7 +348,7 @@ class VmwareGuestFileManager(PyVmomi):
 
             status_code = info["status"]
             if status_code != 200:
-                self.module.fail_json(msg='initiateFileTransferToGuest : problem during file transfer',
+                self.module.fail_json(msg='problem during file transfer, http message:%s' % info["msg"],
                                       uuid=self.vm.summary.config.uuid)
         except vim.fault.FileAlreadyExists:
             result['changed'] = False

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_file_operation.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_file_operation.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# Copyright: (c) 2017, Stéphane Travassac <stravassac () gmail.com>
+# Copyright: (c) 2017, Stéphane Travassac <stravassac@gmail.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
@@ -348,7 +348,7 @@ class VmwareGuestFileManager(PyVmomi):
 
             status_code = info["status"]
             if status_code != 200:
-                self.module.fail_json(msg='problem during file transfer, http message:%s' % info["msg"],
+                self.module.fail_json(msg='problem during file transfer, http message:%s' % info,
                                       uuid=self.vm.summary.config.uuid)
         except vim.fault.FileAlreadyExists:
             result['changed'] = False

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_file_operation.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_file_operation.py
@@ -21,7 +21,7 @@ description:
     - Module to copy a file to a VM, fetch a file from a VM and create or delete a directory in the guest OS.
 version_added: "2.5"
 author:
-  - Stéphane Travassac (stravassac@gmail.com)
+  - Stéphane Travassac (@stravassac)
 notes:
     - Tested on vSphere 6
     - Only the first match against vm_id is used, even if there are multiple matches


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
more detail error on bad http code return for modules vmware vmware_guest_file_operation.py
Fixes #41721
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
  - Bugfix Pull Request
 

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
vmware_guest_file_operation.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0
  config file = None
  configured module search path = [u'/home/stravassac/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/stravassac/virtualenvs/ansible_dev/local/lib/python2.7/site-packages/ansible
  executable location = /home/stravassac/virtualenvs/ansible_dev/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
