### PR TITLE
CentOS/ RHEL 7 specific package for _-libcloud

### DIFF
--- a/docs/docsite/rst/scenario_guides/guide_gce.rst
+++ b/docs/docsite/rst/scenario_guides/guide_gce.rst
@@ -16,6 +16,12 @@ The GCE modules all require the apache-libcloud module which you can install fro
 .. code-block:: bash
 
     $ pip install apache-libcloud
+    
+Or directly via package manager, which for example on CentOS 7/ RHEL 7 is known as python-libcloud:
+
+.. code-block:: bash
+
+    $ sudo yum -y install python-libcloud
 
 .. note:: If you're using Ansible on Mac OS X, libcloud also needs to access a CA cert chain. You'll need to download one (you can get one for `here <http://curl.haxx.se/docs/caextract.html>`_.)
 


### PR DESCRIPTION
line 20-24:
CentOS 7 has python-libcloud, and no such yum available package as apache-libcloud, without having numerous dependency issues related to the pip install of apache-libcloud.

+label: docsite_pr

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
CentOS 7 has python-libcloud, and no such yum available package as apache-libcloud, without having numerous dependency issues related to the pip install of apache-libcloud.

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
Google Cloud Platform Guide

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.3
  config file = /home/adj/.ansible.cfg
  configured module search path = [u'/home/adj/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Apr 11 2018, 07:36:10) [GCC 4.8.5 20150623 (Red Hat 4.8.5-28)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
n/a
