### PR TITLE
FR #41748 Added no-data option to dump  process so only an empty schema can be …

### DIFF
--- a/lib/ansible/modules/database/mysql/mysql_db.py
+++ b/lib/ansible/modules/database/mysql/mysql_db.py
@@ -135,7 +135,7 @@ def db_delete(cursor, db):
     return True
 
 
-def db_dump(module, host, user, password, db_name, target, all_databases, no_data=None port, config_file, socket=None, ssl_cert=None, ssl_key=None, ssl_ca=None,
+def db_dump(module, host, user, password, db_name, target, all_databases, no_data=None, port, config_file, socket=None, ssl_cert=None, ssl_key=None, ssl_ca=None,
             single_transaction=None, quick=None, ignore_tables=None):
     cmd = module.get_bin_path('mysqldump', True)
     # If defined, mysqldump demands --defaults-extra-file be the first option

--- a/lib/ansible/modules/database/mysql/mysql_db.py
+++ b/lib/ansible/modules/database/mysql/mysql_db.py
@@ -141,7 +141,11 @@ def db_delete(cursor, db):
     return True
 
 
+<<<<<<< HEAD
 def db_dump(module, host, user, password, db_name, target, all_databases, no_data, port, config_file, socket=None, ssl_cert=None, ssl_key=None, ssl_ca=None,
+=======
+def db_dump(module, host, user, password, db_name, target, all_databases, port, config_file, no_data=None, socket=None, ssl_cert=None, ssl_key=None, ssl_ca=None,
+>>>>>>> pushed fixes for no-data fr
             single_transaction=None, quick=None, ignore_tables=None):
     cmd = module.get_bin_path('mysqldump', True)
     # If defined, mysqldump demands --defaults-extra-file be the first option
@@ -168,7 +172,11 @@ def db_dump(module, host, user, password, db_name, target, all_databases, no_dat
     if single_transaction:
         cmd += " --single-transaction=true"
     if no_data:
+<<<<<<< HEAD
         cmd += " --no-data=true"
+=======
+        cmd += " --no-data=true"      
+>>>>>>> pushed fixes for no-data fr
     if quick:
         cmd += " --quick"
     if ignore_tables:

--- a/lib/ansible/modules/database/mysql/mysql_db.py
+++ b/lib/ansible/modules/database/mysql/mysql_db.py
@@ -142,10 +142,14 @@ def db_delete(cursor, db):
 
 
 <<<<<<< HEAD
+<<<<<<< HEAD
 def db_dump(module, host, user, password, db_name, target, all_databases, no_data, port, config_file, socket=None, ssl_cert=None, ssl_key=None, ssl_ca=None,
 =======
 def db_dump(module, host, user, password, db_name, target, all_databases, port, config_file, no_data=None, socket=None, ssl_cert=None, ssl_key=None, ssl_ca=None,
 >>>>>>> pushed fixes for no-data fr
+=======
+def db_dump(module, host, user, password, db_name, target, all_databases, no_data=None port, config_file, socket=None, ssl_cert=None, ssl_key=None, ssl_ca=None,
+>>>>>>> Added no-data option to dump  process so only an empty schema can be dumped as per FR #41748
             single_transaction=None, quick=None, ignore_tables=None):
     cmd = module.get_bin_path('mysqldump', True)
     # If defined, mysqldump demands --defaults-extra-file be the first option
@@ -173,10 +177,14 @@ def db_dump(module, host, user, password, db_name, target, all_databases, port, 
         cmd += " --single-transaction=true"
     if no_data:
 <<<<<<< HEAD
+<<<<<<< HEAD
         cmd += " --no-data=true"
 =======
         cmd += " --no-data=true"      
 >>>>>>> pushed fixes for no-data fr
+=======
+        cmd += " --no-data=true"        
+>>>>>>> Added no-data option to dump  process so only an empty schema can be dumped as per FR #41748
     if quick:
         cmd += " --quick"
     if ignore_tables:

--- a/lib/ansible/modules/database/mysql/mysql_db.py
+++ b/lib/ansible/modules/database/mysql/mysql_db.py
@@ -135,7 +135,7 @@ def db_delete(cursor, db):
     return True
 
 
-def db_dump(module, host, user, password, db_name, target, all_databases, no_data=None, port, config_file, socket=None, ssl_cert=None, ssl_key=None, ssl_ca=None,
+def db_dump(module, host, user, password, db_name, target, all_databases, no_data, port, config_file, socket=None, ssl_cert=None, ssl_key=None, ssl_ca=None,
             single_transaction=None, quick=None, ignore_tables=None):
     cmd = module.get_bin_path('mysqldump', True)
     # If defined, mysqldump demands --defaults-extra-file be the first option

--- a/lib/ansible/modules/database/mysql/mysql_db.py
+++ b/lib/ansible/modules/database/mysql/mysql_db.py
@@ -141,8 +141,8 @@ def db_delete(cursor, db):
     return True
 
 
-def db_dump(module, host, user, password, db_name, target, all_databases, port, config_file, no_data=None, socket=None, ssl_cert=None, ssl_key=None, ssl_ca=None,
-            single_transaction=None, quick=None, ignore_tables=None):
+def db_dump(module, host, user, password, db_name, target, all_databases, port, config_file, no_data=None, socket=None,
+            ssl_cert=None, ssl_key=None, ssl_ca=None, single_transaction=None, quick=None, ignore_tables=None):
     cmd = module.get_bin_path('mysqldump', True)
     # If defined, mysqldump demands --defaults-extra-file be the first option
     if config_file:

--- a/lib/ansible/modules/database/mysql/mysql_db.py
+++ b/lib/ansible/modules/database/mysql/mysql_db.py
@@ -162,7 +162,7 @@ def db_dump(module, host, user, password, db_name, target, all_databases, no_dat
     if single_transaction:
         cmd += " --single-transaction=true"
     if no_data:
-        cmd += " --no-data=true"        
+        cmd += " --no-data=true"
     if quick:
         cmd += " --quick"
     if ignore_tables:
@@ -298,6 +298,7 @@ def main():
     ssl_ca = module.params["ssl_ca"]
     connect_timeout = module.params['connect_timeout']
     config_file = module.params['config_file']
+    no_data = module.params["no_data"]
     login_password = module.params["login_password"]
     login_user = module.params["login_user"]
     login_host = module.params["login_host"]

--- a/lib/ansible/modules/database/mysql/mysql_db.py
+++ b/lib/ansible/modules/database/mysql/mysql_db.py
@@ -50,6 +50,12 @@ options:
     type: bool
     default: 'no'
     version_added: "2.1"
+  no_data:
+    description:
+      - Execute the dump as an empty schema (with no data)
+    type: bool
+    default: 'no'
+    version_added: "TBD"    
   quick:
     description:
       - Option used for dumping large tables

--- a/lib/ansible/modules/database/mysql/mysql_db.py
+++ b/lib/ansible/modules/database/mysql/mysql_db.py
@@ -55,7 +55,7 @@ options:
       - Execute the dump as an empty schema (with no data)
     type: bool
     default: 'no'
-    version_added: "TBD"    
+    version_added: "2.7"
   quick:
     description:
       - Option used for dumping large tables

--- a/lib/ansible/modules/database/mysql/mysql_db.py
+++ b/lib/ansible/modules/database/mysql/mysql_db.py
@@ -141,15 +141,7 @@ def db_delete(cursor, db):
     return True
 
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-def db_dump(module, host, user, password, db_name, target, all_databases, no_data, port, config_file, socket=None, ssl_cert=None, ssl_key=None, ssl_ca=None,
-=======
 def db_dump(module, host, user, password, db_name, target, all_databases, port, config_file, no_data=None, socket=None, ssl_cert=None, ssl_key=None, ssl_ca=None,
->>>>>>> pushed fixes for no-data fr
-=======
-def db_dump(module, host, user, password, db_name, target, all_databases, no_data=None port, config_file, socket=None, ssl_cert=None, ssl_key=None, ssl_ca=None,
->>>>>>> Added no-data option to dump  process so only an empty schema can be dumped as per FR #41748
             single_transaction=None, quick=None, ignore_tables=None):
     cmd = module.get_bin_path('mysqldump', True)
     # If defined, mysqldump demands --defaults-extra-file be the first option
@@ -176,15 +168,7 @@ def db_dump(module, host, user, password, db_name, target, all_databases, no_dat
     if single_transaction:
         cmd += " --single-transaction=true"
     if no_data:
-<<<<<<< HEAD
-<<<<<<< HEAD
         cmd += " --no-data=true"
-=======
-        cmd += " --no-data=true"      
->>>>>>> pushed fixes for no-data fr
-=======
-        cmd += " --no-data=true"        
->>>>>>> Added no-data option to dump  process so only an empty schema can be dumped as per FR #41748
     if quick:
         cmd += " --quick"
     if ignore_tables:
@@ -328,6 +312,7 @@ def main():
     for a_table in ignore_tables:
         if a_table == "":
             module.fail_json(msg="Name of ignored table cannot be empty")
+    no_data = module.params["no_data"]
     single_transaction = module.params["single_transaction"]
     quick = module.params["quick"]
 

--- a/lib/ansible/modules/database/mysql/mysql_db.py
+++ b/lib/ansible/modules/database/mysql/mysql_db.py
@@ -135,7 +135,7 @@ def db_delete(cursor, db):
     return True
 
 
-def db_dump(module, host, user, password, db_name, target, all_databases, port, config_file, socket=None, ssl_cert=None, ssl_key=None, ssl_ca=None,
+def db_dump(module, host, user, password, db_name, target, all_databases, no_data=None port, config_file, socket=None, ssl_cert=None, ssl_key=None, ssl_ca=None,
             single_transaction=None, quick=None, ignore_tables=None):
     cmd = module.get_bin_path('mysqldump', True)
     # If defined, mysqldump demands --defaults-extra-file be the first option
@@ -161,6 +161,8 @@ def db_dump(module, host, user, password, db_name, target, all_databases, port, 
         cmd += " %s" % pipes.quote(db_name)
     if single_transaction:
         cmd += " --single-transaction=true"
+    if no_data:
+        cmd += " --no-data=true"        
     if quick:
         cmd += " --quick"
     if ignore_tables:
@@ -271,6 +273,7 @@ def main():
             ssl_ca=dict(default=None, type='path'),
             connect_timeout=dict(default=30, type='int'),
             config_file=dict(default="~/.my.cnf", type='path'),
+            no_data=dict(default=False, type='bool'),
             single_transaction=dict(default=False, type='bool'),
             quick=dict(default=True, type='bool'),
             ignore_tables=dict(default=[], type='list')
@@ -346,7 +349,7 @@ def main():
             else:
                 rc, stdout, stderr = db_dump(module, login_host, login_user,
                                              login_password, db, target, all_databases,
-                                             login_port, config_file, socket, ssl_cert, ssl_key,
+                                             login_port, config_file, no_data, socket, ssl_cert, ssl_key,
                                              ssl_ca, single_transaction, quick, ignore_tables)
                 if rc != 0:
                     module.fail_json(msg="%s" % stderr)


### PR DESCRIPTION
…dumped as per FR #41748

##### SUMMARY
changes to mysql_db module to include --no-data dump option (to dump just a DB schema)

##### ISSUE TYPE

 - Feature Pull Request


##### COMPONENT NAME
mysql_db

##### ANSIBLE VERSION
ansible 2.5.5
  config file = None
  configured module search path = [u'/home/jwolfe/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/jwolfe/venvs/vibrent/local/lib/python2.7/site-packages/ansible
  executable location = /home/jwolfe/venvs/vibrent/bin/ansible
  python version = 2.7.15rc1 (default, Apr 15 2018, 21:51:34) [GCC 7.3.0]


##### ADDITIONAL INFORMATION
modified mysql_db.py to include no-data dump option. 
