### PR TITLE
Backport 2.6: Fix rabbitmq_* integration tests (#41836)

### DIFF
--- a/test/integration/targets/rabbitmq_plugin/aliases
+++ b/test/integration/targets/rabbitmq_plugin/aliases
@@ -3,4 +3,3 @@ posix/ci/group1
 skip/osx
 skip/freebsd
 skip/rhel
-disabled

--- a/test/integration/targets/rabbitmq_user/aliases
+++ b/test/integration/targets/rabbitmq_user/aliases
@@ -3,4 +3,3 @@ posix/ci/group1
 skip/osx
 skip/freebsd
 skip/rhel
-disabled

--- a/test/integration/targets/rabbitmq_vhost/aliases
+++ b/test/integration/targets/rabbitmq_vhost/aliases
@@ -3,4 +3,3 @@ posix/ci/group1
 skip/osx
 skip/freebsd
 skip/rhel
-disabled

--- a/test/integration/targets/setup_rabbitmq/tasks/ubuntu.yml
+++ b/test/integration/targets/setup_rabbitmq/tasks/ubuntu.yml
@@ -1,5 +1,18 @@
 ---
 
+# https://www.rabbitmq.com/install-debian.html#apt-pinning
+- name: Pin erlang version that rabbitmq supports
+  copy:
+    dest: /etc/apt/preferences.d/erlang
+    content: |
+        Package: erlang*
+        Pin: version 1:20.1-1
+        Pin-Priority: 1000
+
+        Package: esl-erlang
+        Pin: version 1:20.1.7
+        Pin-Priority: 1000
+
 - name: Install https transport for apt
   apt: name=apt-transport-https state=latest force=yes
 


### PR DESCRIPTION
##### SUMMARY
(cherry picked from commit a8d4bf86421d151d8df7132e8e87d04b6662f45a)


<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
rabbitmq_* tests

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6
```


##### ADDITIONAL INFORMATION
