### PR TITLE
Backport #41907 for 2.6 - fix password lookup loading

### DIFF
--- a/changelogs/fragments/fix_password_lookup_loading.yaml
+++ b/changelogs/fragments/fix_password_lookup_loading.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- password lookup - Do not load password lookup in network filters, allowing the password lookup to be overriden (https://github.com/ansible/ansible/pull/41907)

--- a/lib/ansible/plugins/filter/network.py
+++ b/lib/ansible/plugins/filter/network.py
@@ -28,11 +28,11 @@ import string
 from collections import Mapping
 from xml.etree.ElementTree import fromstring
 
+from ansible.module_utils._text import to_text
 from ansible.module_utils.network.common.utils import Template
 from ansible.module_utils.six import iteritems, string_types
 from ansible.errors import AnsibleError, AnsibleFilterError
 from ansible.utils.encrypt import random_password
-from ansible.plugins.lookup import password as ansible_password
 
 
 try:
@@ -362,7 +362,11 @@ def type5_pw(password, salt=None):
     if not isinstance(password, string_types):
         raise AnsibleFilterError("type5_pw password input should be a string, but was given a input of %s" % (type(password).__name__))
 
-    salt_chars = ansible_password._gen_candidate_chars(['ascii_letters', 'digits', './'])
+    salt_chars = u''.join((
+        to_text(string.ascii_letters),
+        to_text(string.digits),
+        u'./'
+    ))
     if salt is not None and not isinstance(salt, string_types):
         raise AnsibleFilterError("type5_pw salt input should be a string, but was given a input of %s" % (type(salt).__name__))
     elif not salt:


### PR DESCRIPTION
##### SUMMARY
Backport #41907 for 2.6 - fix password lookup loading

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/filter/network.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6.x
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
