### PR TITLE
Backport #41767 for 2.5 -Skip if insertbefore is using BOF until later in the module

### DIFF
--- a/changelogs/fragments/lineinfile-insertbefore-bof-bugfix.yaml
+++ b/changelogs/fragments/lineinfile-insertbefore-bof-bugfix.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - lineinfile - fix insertbefore when used with BOF to not insert duplicate lines (https://github.com/ansible/ansible/issues/38219)

--- a/lib/ansible/modules/files/lineinfile.py
+++ b/lib/ansible/modules/files/lineinfile.py
@@ -289,8 +289,8 @@ def present(module, dest, regexp, line, insertafter, insertbefore, create,
 
     msg = ''
     changed = False
-    # Regexp matched a line in the file
     b_linesep = to_bytes(os.linesep, errors='surrogate_or_strict')
+    # Regexp matched a line in the file
     if index[0] != -1:
         if backrefs:
             b_new_line = m.expand(b_line)
@@ -301,13 +301,12 @@ def present(module, dest, regexp, line, insertafter, insertbefore, create,
         if not b_new_line.endswith(b_linesep):
             b_new_line += b_linesep
 
-        # If a regexp is specified and a match is found anywhere in the file, do
-        # not insert the line before or after.
+        # If no regexp was given and a line match is found anywhere in the file,
+        # insert the line appropriately if using insertbefore or insertafter
         if regexp is None and m:
 
             # Insert lines
             if insertafter and insertafter != 'EOF':
-
                 # Ensure there is a line separator after the found string
                 # at the end of the file.
                 if b_lines and not b_lines[-1][-1:] in (b('\n'), b('\r')):
@@ -325,7 +324,7 @@ def present(module, dest, regexp, line, insertafter, insertbefore, create,
                     msg = 'line added'
                     changed = True
 
-            elif insertbefore:
+            elif insertbefore and insertbefore != 'BOF':
                 # If the line to insert before is at the beginning of the file
                 # use the appropriate index value.
                 if index[1] == 0:

--- a/test/integration/targets/lineinfile/tasks/main.yml
+++ b/test/integration/targets/lineinfile/tasks/main.yml
@@ -36,18 +36,27 @@
     line: "New line at the beginning"
     insertbefore: "BOF"
     backup: yes
-  register: result
+  register: result1
+
+- name: insert a line at the beginning of the file again
+  lineinfile:
+    dest: "{{ output_dir }}/test.txt"
+    state: present
+    line: "New line at the beginning"
+    insertbefore: "BOF"
+  register: result2
 
 - name: assert that the line was inserted at the head of the file
   assert:
     that:
-      - result is changed
-      - "result.msg == 'line added'"
-      - "result.backup != ''"
+      - result1 is changed
+      - result2 is not changed
+      - result1.msg == 'line added'
+      - result1.backup != ''
 
 - name: stat the backup file
   stat:
-    path: "{{ result.backup }}"
+    path: "{{ result1.backup }}"
   register: result
 
 - name: assert the backup file matches the previous hash


### PR DESCRIPTION
##### SUMMARY
Backport of #41767 for Ansible 2.5

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT NAME
`lineinfile.py`

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
