### PR TITLE
Cast scaling factor to int

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_service.py
@@ -1013,7 +1013,7 @@ class ContainerManager(DockerBaseClass):
                 containers = service.containers(stopped=True)
                 if len(containers) != self.scale[service.name]:
                     result['changed'] = True
-                    service_res['scale'] = self.scale[service.name] - len(containers)
+                    service_res['scale'] = int(self.scale[service.name]) - len(containers)
                     if not self.check_mode:
                         try:
                             service.scale(int(self.scale[service.name]))


### PR DESCRIPTION
##### SUMMARY
Without this patch in 2.5.5, I see a failure similar to https://github.com/ansible/ansible-modules-core/pull/4943. In my case I am using a hostvars variable to specify the value of scale. The host is localhost.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
docker_service

##### ANSIBLE VERSION
```
ansible 2.5.5
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.12 (default, Nov 20 2017, 18:23:56) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION
My task looks like:
```
- name: scale mycontainer containers
  docker_service:
    state: present
    project_src: /path/to/project
    scale:
      mycontainer: "{{ hostvars[ansible_nodename]['my_scale_num'] }}"
```

And my inventory has `my_nodename my_scale_num=6`. Debug output from:
```
    - name: a
      debug:
        var: hostvars[ansible_nodename]['my_scale_num']

    - name: ad1
      assert:
        that:
          - hostvars[ansible_nodename]['my_scale_num'] == 6

    - name: ad2
      assert:
        that:
          - hostvars[ansible_nodename]['my_scale_num'] == "6"
      ignore_errors: yes

    - name: b
      debug:
        var: "{{ hostvars[ansible_nodename]['my_scale_num'] }}"

    - name: bd1
      assert:
        that:
          - '{{ hostvars[ansible_nodename]["my_scale_num"] }} == 6'

    - name: bd2
      assert:
        that:
          - '{{ hostvars[ansible_nodename]["my_scale_num"] }} == "6"'
      ignore_errors: yes

    - name: c
      debug:
        var: '{{ hostvars[ansible_nodename]["my_scale_num"] | int }}'

    - name: cd1
      assert:
        that:
          - '{{ hostvars[ansible_nodename]["my_scale_num"] | int }} == 6'

    - name: cd2
      assert:
        that:
          - '{{ hostvars[ansible_nodename]["my_scale_num"] | int }} == "6"'
      ignore_errors: yes

```

is
```
TASK [a] ***********************************************************************
ok: [localhost] => {
    "hostvars[ansible_nodename]['my_scale_num']": "6"
}

TASK [ad1] *********************************************************************
ok: [localhost] => {
    "changed": false,
    "msg": "All assertions passed"
}

TASK [ad2] *********************************************************************
fatal: [localhost]: FAILED! => {
    "assertion": "hostvars[ansible_nodename]['my_scale_num'] == \"6\"",
    "changed": false,
    "evaluated_to": false
}
...ignoring

TASK [b] ***********************************************************************
ok: [localhost] => {
    "6": "6"
}

TASK [bd1] *********************************************************************
ok: [localhost] => {
    "changed": false,
    "msg": "All assertions passed"
}

TASK [bd2] *********************************************************************
fatal: [localhost]: FAILED! => {
    "assertion": "6 == \"6\"",
    "changed": false,
    "evaluated_to": false
}
...ignoring

TASK [c] ***********************************************************************
ok: [localhost] => {
    "6": "6"
}

TASK [cd1] *********************************************************************
ok: [localhost] => {
    "changed": false,
    "msg": "All assertions passed"
}

TASK [cd2] *********************************************************************
fatal: [localhost]: FAILED! => {
    "assertion": "6 == \"6\"",
    "changed": false,
    "evaluated_to": false
}
...ignoring

```

But the module raises an exception identical to the one fixed by the earlier PR referenced above.
```
task path: /path/to/tasks/main.yml:22
Using module file /usr/lib/python2.7/dist-packages/ansible/modules/cloud/docker/docker_service.py
<localhost> ESTABLISH LOCAL CONNECTION FOR USER: root
<localhost> EXEC /bin/sh -c 'echo ~root && sleep 0'
<localhost> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /root/.ansible/tmp/ansible-tmp-1529950056.97-61228986393446 `" && echo ansible-tmp-1529950056.97-61228986393446="` echo /root/.ansible/tmp/ansible-tmp-1529950056.97-61228986393446 `" ) && sleep 0'
<localhost> PUT /root/.ansible/tmp/ansible-local-14345ZZBmdf/tmpHSvGX7 TO /root/.ansible/tmp/ansible-tmp-1529950056.97-61228986393446/docker_service.py
<localhost> EXEC /bin/sh -c 'chmod u+x /root/.ansible/tmp/ansible-tmp-1529950056.97-61228986393446/ /root/.ansible/tmp/ansible-tmp-1529950056.97-61228986393446/docker_service.py && sleep 0'
<localhost> EXEC /bin/sh -c '/usr/bin/python /root/.ansible/tmp/ansible-tmp-1529950056.97-61228986393446/docker_service.py && sleep 0'
<localhost> EXEC /bin/sh -c 'rm -f -r /root/.ansible/tmp/ansible-tmp-1529950056.97-61228986393446/ > /dev/null 2>&1 && sleep 0'
The full traceback is:
  File "/tmp/ansible__KMAP_/ansible_module_docker_service.py", line 1017, in cmd_scale
    service_res['scale'] = self.scale[service.name] - len(containers)

fatal: [localhost]: FAILED! => {
    "changed": false,
    "invocation": {
        "module_args": {
            "api_version": null,
            "build": false,
            "cacert_path": null,
            "cert_path": null,
            "debug": false,
            "definition": null,
            "dependencies": true,
            "docker_host": null,
            "files": null,
            "filter_logger": false,
            "hostname_check": false,
            "key_path": null,
            "nocache": false,
            "project_name": null,
            "project_src": "/path/to/project",
            "pull": false,
            "recreate": "smart",
            "remove_images": null,
            "remove_orphans": false,
            "remove_volumes": false,
            "restarted": false,
            "scale": {
                "mycontainer": "6"
            },
            "services": null,
            "ssl_version": null,
            "state": "present",
            "stopped": false,
            "timeout": 10,
            "tls": null,
            "tls_hostname": null,
            "tls_verify": null
        }
    },
    "msg": "Error getting scale factor. (6) unsupported operand type(s) for -: 'str' and 'int'"
}
```
