### PR TITLE
meraki_network - Fixes idempotency check for partial configurations

### DIFF
--- a/lib/ansible/modules/network/meraki/meraki_network.py
+++ b/lib/ansible/modules/network/meraki/meraki_network.py
@@ -184,14 +184,11 @@ def main():
     if meraki.params['state'] == 'present':
         payload = {'name': meraki.params['net_name'],
                    'type': meraki.params['type'],
-                   'tags': meraki.params['tags'],
                    }
         if meraki.params['tags']:
             payload['tags'] = construct_tags(meraki.params['tags'])
         if meraki.params['timezone']:
             payload['timeZone'] = meraki.params['timezone']
-        else:
-            payload['timeZone'] = 'America/Los_Angeles'
         if meraki.params['type'] == 'combined':
             payload['type'] = 'switch wireless appliance'
 
@@ -225,6 +222,16 @@ def main():
                 meraki.result['changed'] = True
             else:
                 net = meraki.get_net(meraki.params['org_name'], meraki.params['net_name'], data=nets)
+                proposed = payload
+                if meraki.params['timezone']:
+                    proposed['timeZone'] = meraki.params['timezone']
+                else:
+                    proposed['timeZone'] = 'America/Los_Angeles'
+                if not meraki.params['tags']:
+                    proposed['tags'] = None
+                if not proposed['type']:
+                    proposed['type'] = net['type']
+
                 if meraki.is_update_required(net, payload):
                     path = meraki.construct_path('update',
                                                  net_id=meraki.get_net_id(net_name=meraki.params['net_name'], data=nets)

--- a/test/integration/targets/meraki_network/tasks/main.yml
+++ b/test/integration/targets/meraki_network/tasks/main.yml
@@ -66,7 +66,18 @@
     timezone: America/Chicago
   delegate_to: localhost
   register: create_net_wireless
-  
+
+- name: Create network with type wireless and check for idempotency
+  meraki_network:
+    auth_key: '{{ auth_key }}'
+    state: present
+    org_name: '{{test_org_name}}'
+    net_name: IntTestNetworkWireless
+    type: wireless
+    timezone: America/Chicago
+  delegate_to: localhost
+  register: create_net_wireless_idempotent
+
 - name: Create network with type combined
   meraki_network:
     auth_key: '{{ auth_key }}'
@@ -142,6 +153,7 @@
       - '"IntTestNetworkSwitch" in create_net_switch.data.name'
       - '"IntTestNetworkSwitchOrgID" in create_net_switch_org_id.data.name'
       - '"IntTestNetworkWireless" in create_net_wireless.data.name'
+      - create_net_wireless_idempotent.changed == False
       - '"first_tag" in create_net_tag.data.tags'
       - '"second_tag" in create_net_tags.data.tags'
       - '"third_tag" in create_net_modified.data.tags'


### PR DESCRIPTION
##### SUMMARY
- Previous PR would overwrite new and existing values improperly

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
meraki_network

##### ANSIBLE VERSION
```
ansible 2.7.0.dev0 (meraki/net-overwrite-fix baeafbefee) last updated 2018/06/25 20:18:45 (GMT -500)
  config file = None
  configured module search path = ['/Users/kbreit/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/kbreit/Documents/Programming/ansible/lib/ansible
  executable location = /Users/kbreit/Documents/Programming/ansible/bin/ansible
  python version = 3.5.4 (default, Feb 25 2018, 14:56:02) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```