### PR TITLE
Add checking that ansible is running in chroot jail to system manager detection. (Fix #41830)

### DIFF
--- a/lib/ansible/module_utils/facts/system/service_mgr.py
+++ b/lib/ansible/module_utils/facts/system/service_mgr.py
@@ -94,6 +94,18 @@ class ServiceMgrFactCollector(BaseFactCollector):
             proc_1 = to_native(proc_1)
             proc_1 = proc_1.strip()
 
+            # if you are in chroot jail, proc_1 does not manage services there.
+            try:
+                proc_1_root_stat = os.stat('/proc/1/root')
+                self_root_stat = os.stat('/proc/%d/root' % os.getpid())
+                if proc_1_root_stat.st_dev != self_root_stat.st_dev :
+                    proc_1 = None
+                if proc_1_root_stat.st_ino != self_root_stat.st_ino :
+                    proc_1 = None
+            except OSError:
+                pass
+
+
         if proc_1 is not None and (proc_1 == 'init' or proc_1.endswith('sh')):
             # many systems return init, so this cannot be trusted, if it ends in 'sh' it probalby is a shell in a container
             proc_1 = None

--- a/lib/ansible/module_utils/facts/system/service_mgr.py
+++ b/lib/ansible/module_utils/facts/system/service_mgr.py
@@ -98,13 +98,12 @@ class ServiceMgrFactCollector(BaseFactCollector):
             try:
                 proc_1_root_stat = os.stat('/proc/1/root')
                 self_root_stat = os.stat('/proc/%d/root' % os.getpid())
-                if proc_1_root_stat.st_dev != self_root_stat.st_dev :
+                if proc_1_root_stat.st_dev != self_root_stat.st_dev:
                     proc_1 = None
-                if proc_1_root_stat.st_ino != self_root_stat.st_ino :
+                if proc_1_root_stat.st_ino != self_root_stat.st_ino:
                     proc_1 = None
             except OSError:
                 pass
-
 
         if proc_1 is not None and (proc_1 == 'init' or proc_1.endswith('sh')):
             # many systems return init, so this cannot be trusted, if it ends in 'sh' it probalby is a shell in a container


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Add checking that ansible is running in chroot jail to system manager detection.

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

Fixes #41830.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
system_mgr

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.5
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/mcadm/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.9 (default, Mar  1 2015, 12:57:24) [GCC 4.9.2]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

1. setup a linux box that running under systemd.
2. create a chroot jail by debootstrap. the chroot jail has no system manager such as systemd.
3. setup services (ex: naemon) in the chroot jail by ansible.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
fatal: [fwnaemon.mppfcpdwa01nc]: FAILED! => {
    "changed": false,
    "invocation": {
        "module_args": {
            "daemon_reload": false,
            "enabled": null,
            "masked": null,
            "name": "naemon",
            "no_block": false,
            "state": "restarted",
            "user": false
        }
    },
    "msg": "Failed to find required executable systemctl in paths: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"  
}
```

system_mgr detects non-chroot environment status
instead of target environment ( the chroot  jail ).
