### PR TITLE
elasticsearch_plugin - Show STDERR on module failures.

### DIFF
--- a/changelogs/fragments/elasticsearch_plugin-showSTDERRonFailure.yaml
+++ b/changelogs/fragments/elasticsearch_plugin-showSTDERRonFailure.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- elasticsearch_plugin - Improve error messages and show stderr of elasticsearch commands

--- a/lib/ansible/modules/database/misc/elasticsearch_plugin.py
+++ b/lib/ansible/modules/database/misc/elasticsearch_plugin.py
@@ -161,7 +161,7 @@ def install_plugin(module, plugin_bin, plugin_name, version, url, proxy_host, pr
 
     if rc != 0:
         reason = parse_error(out)
-        module.fail_json(msg='Is %s a valid plugin name?' % plugin_name, err=reason)
+        module.fail_json(msg="Installing plugin '%s' failed: %s" % (plugin_name, reason), err=err)
 
     return True, cmd, out, err
 
@@ -178,7 +178,7 @@ def remove_plugin(module, plugin_bin, plugin_name):
 
     if rc != 0:
         reason = parse_error(out)
-        module.fail_json(msg=reason)
+        module.fail_json(msg="Removing plugin '%s' failed: %s" % (plugin_name, reason), err=err)
 
     return True, cmd, out, err
 


### PR DESCRIPTION
##### SUMMARY
I tried to install a ES plugin without `become: yes`and found after debugging the module that the module failed due to permission issues.

The only error message I got was
  Is analysis-icu a valid plugin name?

That was strange considering I followed the example documentation by the letter.

I found out that when this module fails, it hides the real reason for failure.

This patch replaces the generic error with more meaningful diagnostics.


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
elasticsearch_plugin

##### ANSIBLE VERSION
```
ansible 2.5.3
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```

