### PR TITLE
VMware dvPG description and uplink failover order features

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_dvs_portgroup.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_dvs_portgroup.py
@@ -145,6 +145,7 @@ extends_documentation_fragment: vmware.documentation
 '''
 
 EXAMPLES = '''
+<<<<<<< HEAD
 - name: Create vlan portgroup
   vmware_dvs_portgroup:
     hostname: '{{ vcenter_hostname }}'
@@ -247,6 +248,94 @@ EXAMPLES = '''
         - Uplink 1
         - Uplink 2
   delegate_to: localhost
+=======
+   - name: Create vlan portgroup
+     connection: local
+     vmware_dvs_portgroup:
+        hostname: vcenter_ip_or_hostname
+        username: vcenter_username
+        password: vcenter_password
+        portgroup_name: vlan-123-portrgoup
+        switch_name: dvSwitch
+        vlan_id: 123
+        num_ports: 120
+        portgroup_type: earlyBinding
+        state: present
+
+   - name: Create vlan trunk portgroup
+     connection: local
+     vmware_dvs_portgroup:
+        hostname: vcenter_ip_or_hostname
+        username: vcenter_username
+        password: vcenter_password
+        portgroup_name: vlan-trunk-portrgoup
+        switch_name: dvSwitch
+        vlan_id: 1-1000
+        vlan_trunk: True
+        num_ports: 120
+        portgroup_type: earlyBinding
+        state: present
+
+   - name: Create no-vlan portgroup
+     connection: local
+     vmware_dvs_portgroup:
+        hostname: vcenter_ip_or_hostname
+        username: vcenter_username
+        password: vcenter_password
+        portgroup_name: no-vlan-portrgoup
+        switch_name: dvSwitch
+        vlan_id: 0
+        num_ports: 120
+        portgroup_type: earlyBinding
+        state: present
+
+   - name: Create vlan portgroup with all security and port policies
+     connection: local
+     vmware_dvs_portgroup:
+        hostname: vcenter_ip_or_hostname
+        username: vcenter_username
+        password: vcenter_password
+        portgroup_name: vlan-123-portrgoup
+        switch_name: dvSwitch
+        vlan_id: 123
+        num_ports: 120
+        portgroup_type: earlyBinding
+        state: present
+        network_policy:
+          promiscuous: yes
+          forged_transmits: yes
+          mac_changes: yes
+        port_policy:
+          block_override: yes
+          ipfix_override: yes
+          live_port_move: yes
+          network_rp_override: yes
+          port_config_reset_at_disconnect: yes
+          security_override: yes
+          shaping_override: yes
+          traffic_filter_override: yes
+          uplink_teaming_override: yes
+          vendor_config_override: yes
+          vlan_override: yes
+
+    - name: Create vlan portgroup with LACP LAG as an uplink
+      connection: local
+      vmware_dvs_portgroup_2:
+        hostname: vcenter_ip_or_hostname
+        username: vcenter_username
+        password: vcenter_password
+        validate_certs: false
+        portgroup_name: testpg-1337
+        portgroup_description: ansible test portgroup
+        switch_name: Production01
+        vlan_id: 1337
+        num_ports: 120
+        portgroup_type: ephemeral
+        teaming_policy:
+          active_uplinkport: lag1
+        state: present
+
+>>>>>>> Deleted unnecessary quote
 '''
 
 try:

--- a/lib/ansible/modules/cloud/vmware/vmware_dvs_portgroup.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_dvs_portgroup.py
@@ -39,6 +39,7 @@ options:
         description:
             - The description of the portgroup that is to be created.
         required: False
+        version_added: '2.8'
     switch_name:
         description:
             - The name of the distributed vSwitch the port group should be created on.
@@ -100,8 +101,8 @@ options:
             - '- C(inbound_policy) (bool): Indicate whether or not the teaming policy is applied to inbound frames as well. (default: False)'
             - '- C(notify_switches) (bool): Indicate whether or not to notify the physical switch if a link fails. (default: True)'
             - '- C(rolling_order) (bool): Indicate whether or not to use a rolling policy when restoring links. (default: False)'
-            - '. C(active_uplinks) (list): List of active uplink ports used for load balancing. Default uplink is used if not defined. (default: [])'
-            - '. C(standby_uplinks) (list): List of standby uplink ports used for failover. This parameter is ignored unless active_uplinks is defined. (default: [])'
+            - '. C(active_uplinks) (list): List of active uplinks used for load balancing. Default uplink is used if not defined. (default: [])'
+            - '. C(standby_uplinks) (list): List of standby uplinks used for failover. Parameter is ignored unless active_uplinks is defined. (default: [])'
         required: False
         version_added: '2.5'
         default: {
@@ -425,16 +426,16 @@ def main():
                                                  'failover_explicit',
                                              ],
                                              ),
-                    active_uplinks=dict(type='list', default=None),
-                    standby_uplinks=dict(type='list', default=None)
+                    active_uplinks=dict(type='list', default=[]),
+                    standby_uplinks=dict(type='list', default=[])
                 ),
                 default=dict(
                     inbound_policy=False,
                     notify_switches=True,
                     rolling_order=False,
                     load_balance_policy='loadbalance_srcid',
-                    active_uplinks=None,
-                    standby_uplinks=None
+                    active_uplinks=[],
+                    standby_uplinks=[]
                 ),
             ),
             port_policy=dict(

--- a/lib/ansible/modules/cloud/vmware/vmware_dvs_portgroup.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_dvs_portgroup.py
@@ -109,9 +109,9 @@ options:
             'notify_switches': True,
             'load_balance_policy': 'loadbalance_srcid',
             'inbound_policy': False,
-            'rolling_order': False
+            'rolling_order': False,
             'active_uplinkport': [],
-            'standby_uplinkport': [],
+            'standby_uplinkport': []
         }
     port_policy:
         description:

--- a/lib/ansible/modules/cloud/vmware/vmware_dvs_portgroup.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_dvs_portgroup.py
@@ -110,6 +110,8 @@ options:
             'load_balance_policy': 'loadbalance_srcid',
             'inbound_policy': False,
             'rolling_order': False
+            'active_uplinkport': [],
+            'standby_uplinkport': [],
         }
     port_policy:
         description:

--- a/lib/ansible/modules/cloud/vmware/vmware_dvs_portgroup.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_dvs_portgroup.py
@@ -145,7 +145,6 @@ extends_documentation_fragment: vmware.documentation
 '''
 
 EXAMPLES = '''
-<<<<<<< HEAD
 - name: Create vlan portgroup
   vmware_dvs_portgroup:
     hostname: '{{ vcenter_hostname }}'
@@ -248,94 +247,6 @@ EXAMPLES = '''
         - Uplink 1
         - Uplink 2
   delegate_to: localhost
-=======
-   - name: Create vlan portgroup
-     connection: local
-     vmware_dvs_portgroup:
-        hostname: vcenter_ip_or_hostname
-        username: vcenter_username
-        password: vcenter_password
-        portgroup_name: vlan-123-portrgoup
-        switch_name: dvSwitch
-        vlan_id: 123
-        num_ports: 120
-        portgroup_type: earlyBinding
-        state: present
-
-   - name: Create vlan trunk portgroup
-     connection: local
-     vmware_dvs_portgroup:
-        hostname: vcenter_ip_or_hostname
-        username: vcenter_username
-        password: vcenter_password
-        portgroup_name: vlan-trunk-portrgoup
-        switch_name: dvSwitch
-        vlan_id: 1-1000
-        vlan_trunk: True
-        num_ports: 120
-        portgroup_type: earlyBinding
-        state: present
-
-   - name: Create no-vlan portgroup
-     connection: local
-     vmware_dvs_portgroup:
-        hostname: vcenter_ip_or_hostname
-        username: vcenter_username
-        password: vcenter_password
-        portgroup_name: no-vlan-portrgoup
-        switch_name: dvSwitch
-        vlan_id: 0
-        num_ports: 120
-        portgroup_type: earlyBinding
-        state: present
-
-   - name: Create vlan portgroup with all security and port policies
-     connection: local
-     vmware_dvs_portgroup:
-        hostname: vcenter_ip_or_hostname
-        username: vcenter_username
-        password: vcenter_password
-        portgroup_name: vlan-123-portrgoup
-        switch_name: dvSwitch
-        vlan_id: 123
-        num_ports: 120
-        portgroup_type: earlyBinding
-        state: present
-        network_policy:
-          promiscuous: yes
-          forged_transmits: yes
-          mac_changes: yes
-        port_policy:
-          block_override: yes
-          ipfix_override: yes
-          live_port_move: yes
-          network_rp_override: yes
-          port_config_reset_at_disconnect: yes
-          security_override: yes
-          shaping_override: yes
-          traffic_filter_override: yes
-          uplink_teaming_override: yes
-          vendor_config_override: yes
-          vlan_override: yes
-
-    - name: Create vlan portgroup with LACP LAG as an uplink
-      connection: local
-      vmware_dvs_portgroup_2:
-        hostname: vcenter_ip_or_hostname
-        username: vcenter_username
-        password: vcenter_password
-        validate_certs: false
-        portgroup_name: testpg-1337
-        portgroup_description: ansible test portgroup
-        switch_name: Production01
-        vlan_id: 1337
-        num_ports: 120
-        portgroup_type: ephemeral
-        teaming_policy:
-          active_uplinkport: lag1
-        state: present
-
->>>>>>> Deleted unnecessary quote
 '''
 
 try:

--- a/lib/ansible/modules/cloud/vmware/vmware_dvs_portgroup.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_dvs_portgroup.py
@@ -110,8 +110,8 @@ options:
             'load_balance_policy': 'loadbalance_srcid',
             'inbound_policy': False,
             'rolling_order': False,
-            'active_uplinkport': [],
-            'standby_uplinkport': []
+            'active_uplinks': [],
+            'standby_uplinks': []
         }
     port_policy:
         description:


### PR DESCRIPTION
##### SUMMARY
Added two new features. Ability to:
- Add description to a portgroup
- Change portgroup uplink failover order

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
vmware_dvs_portgroup

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0
  config file = None
  configured module search path = [u'/home/tomi/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Nov 20 2015, 02:00:19) [GCC 4.8.5 20150623 (Red Hat 4.8.5-4)]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->
With existing vmware_dvs_portgroup module creating a new portgroup always inherits the uplink failover settings. These needs to be changed e.g. in cases where LAG is used as an uplink since standard Uplinks are always inherited by default.

<!--- Paste verbatim command output below, e.g. before and after your change -->
Example plays for usage:
```
    - name: Create vlan distributed portgroup 112
      connection: local
      vmware_dvs_portgroup:
        hostname: "{{ vcenter_ip }}"
        username: "{{ vcenter_user }}"
        password: "{{ vcenter_pw }}"
        validate_certs: false
        portgroup_name: test-pg-112
        portgroup_description: Test portgroup VLAN 112
        switch_name: Production01
        vlan_id: 112
        num_ports: 120
        portgroup_type: ephemeral
        teaming_policy:
          active_uplinkport: lag1
        state: present

    - name: Create vlan distributed portgroup 113
      connection: local
      vmware_dvs_portgroup:
        hostname: "{{ vcenter_ip }}"
        username: "{{ vcenter_user }}"
        password: "{{ vcenter_pw }}"
        validate_certs: false
        portgroup_name: test-pg-113
        portgroup_description: Test portgroup VLAN 113
        switch_name: Production01
        vlan_id: 113
        num_ports: 120
        portgroup_type: ephemeral
        teaming_policy:
          active_uplinkport:
            - Uplink 1
            - Uplink 2
        state: present
```
