### PR TITLE
Update os_server docs when removing an instance

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_server.py
+++ b/lib/ansible/modules/cloud/openstack/os_server.py
@@ -27,7 +27,8 @@ description:
 options:
    name:
      description:
-        - Name that has to be given to the instance
+        - Name that has to be given to the instance. It is also possible to
+          specify the ID of the instance instead of its name if I(state) is I(absent).
      required: true
    image:
      description:
@@ -380,6 +381,15 @@ EXAMPLES = '''
           echo "  down ip route del 10.0.0.0/8" >> /etc/network/interfaces.d/eth0.conf
           ifdown eth0 && ifup eth0
           {% endraw %}
+
+# Deletes an instance via its ID
+- name: remove an instance
+  hosts: localhost
+  tasks:
+    - name: remove an instance
+      os_server:
+        name: abcdef01-2345-6789-0abc-def0123456789
+        state: absent
 
 '''
 


### PR DESCRIPTION
+label: docsite_pr

##### SUMMARY
When removing an instance via its ID, it is not clearly explained that one should use the `name` parameter.

Also a simple example is provided.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
os_server module

##### ANSIBLE VERSION
```
ansible 2.5.5
```
