### PR TITLE
Fix docs for "all" test

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_tests.rst
+++ b/docs/docsite/rst/user_guide/playbooks_tests.rst
@@ -119,7 +119,7 @@ You can use `any` and `all` to check if any or all elements in a list are true o
   vars:
     mylist:
         - 1
-        - 3 == 3
+        - "{{ 3 == 3 }}"
         - True
     myotherlist:
         - False


### PR DESCRIPTION
##### SUMMARY
Fix docs for "all" test. Fixes #41956

The literal `3 == 3` or changed to `3 == 4` are both truthy.

The `all` test does not perform arbitrary evaluation.  Instead we need to document `"{{ 3 == 3 }}"`

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
docs/docsite/rst/user_guide/playbooks_tests.rst

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
2.6
2.7
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```