### PR TITLE
Re-evaluate role conditionals at handler search time

### DIFF
--- a/changelogs/fragments/37512-reevaluate-role-conditionals-at-handler-search-time.yaml
+++ b/changelogs/fragments/37512-reevaluate-role-conditionals-at-handler-search-time.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Re-evaluate role conditionals at handler search time (https://github.com/ansible/ansible/issues/37512)

--- a/lib/ansible/playbook/handler.py
+++ b/lib/ansible/playbook/handler.py
@@ -49,6 +49,19 @@ class Handler(Task):
     def has_triggered(self, host):
         return host in self._flagged_hosts
 
+    def in_scope(self, templar, handler_vars):
+        '''
+        When handler is inside a role, this checks if the role was actually
+        included by re-evaluating its when conditional. Used at handler search time
+        to skip non-included handlers.
+
+        https://github.com/ansible/ansible/issues/37512
+        '''
+        if self._role:
+            return self._role.evaluate_conditional(templar, handler_vars)
+
+        return True
+
     def serialize(self):
         result = super(Handler, self).serialize()
         result['is_handler'] = True

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -373,6 +373,10 @@ class StrategyBase:
                     if handler_task.name:
                         handler_vars = self._variable_manager.get_vars(play=iterator._play, task=handler_task)
                         templar = Templar(loader=self._loader, variables=handler_vars)
+
+                        if not handler_task.in_scope(templar, handler_vars):
+                            continue
+
                         try:
                             # first we check with the full result of get_name(), which may
                             # include the role name (if the handler is from a role). If that
@@ -396,6 +400,10 @@ class StrategyBase:
         def search_handler_blocks_by_uuid(handler_uuid, handler_blocks):
             for handler_block in handler_blocks:
                 for handler_task in handler_block.block:
+                    handler_vars = self._variable_manager.get_vars(play=iterator._play, task=handler_task)
+                    templar = Templar(loader=self._loader, variables=handler_vars)
+                    if not handler_task.in_scope(templar, handler_vars):
+                        continue
                     if handler_uuid == handler_task._uuid:
                         return handler_task
             return None
@@ -406,6 +414,10 @@ class StrategyBase:
                     try:
                         handler_vars = self._variable_manager.get_vars(play=iterator._play, task=target_handler)
                         templar = Templar(loader=self._loader, variables=handler_vars)
+
+                        if not target_handler.in_scope(templar, handler_vars):
+                            return False
+
                         target_handler_name = templar.template(target_handler.name)
                         if target_handler_name == handler_name:
                             return True

--- a/test/integration/targets/handlers/roles/37512-master/meta/main.yml
+++ b/test/integration/targets/handlers/roles/37512-master/meta/main.yml
@@ -1,0 +1,3 @@
+dependencies:
+  - name: 37512-slave
+    when: False

--- a/test/integration/targets/handlers/roles/37512-master/tasks/main.yml
+++ b/test/integration/targets/handlers/roles/37512-master/tasks/main.yml
@@ -1,0 +1,3 @@
+- name: 'Include slave role'
+  include_role:
+    name: 37512-slave

--- a/test/integration/targets/handlers/roles/37512-slave/handlers/main.yml
+++ b/test/integration/targets/handlers/roles/37512-slave/handlers/main.yml
@@ -1,0 +1,2 @@
+- name: handler execute
+  command: /bin/echo 37512-handler-executed

--- a/test/integration/targets/handlers/roles/37512-slave/tasks/main.yml
+++ b/test/integration/targets/handlers/roles/37512-slave/tasks/main.yml
@@ -1,0 +1,5 @@
+- name: Changed command
+  debug:
+    msg: "Notifying handler"
+  changed_when: True
+  notify: handler execute

--- a/test/integration/targets/handlers/runme.sh
+++ b/test/integration/targets/handlers/runme.sh
@@ -66,3 +66,7 @@ set -e
 
 # https://github.com/ansible/ansible/issues/47287
 [ "$(ansible-playbook test_handlers_including_task.yml -i ../../inventory -v "$@" | egrep -o 'failed=[0-9]+')" = "failed=0" ]
+
+# https://github.com/ansible/ansible/issues/37512
+result="$(ansible-playbook test_handlers_37512.yml -v "$@")"
+grep '37512-handler-executed' <<< "$result"

--- a/test/integration/targets/handlers/test_handlers_37512.yml
+++ b/test/integration/targets/handlers/test_handlers_37512.yml
@@ -1,0 +1,3 @@
+- hosts: localhost
+  roles:
+    - 37512-master


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes scenario when handlers could be shadowed by handlers of the same
name from roles that were not imported.

Fixes https://github.com/ansible/ansible/issues/37512

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
roles
handlers

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->