### PR TITLE
Cache items when task.loop/with_items is evaluated to set delegate_to vars

### DIFF
--- a/lib/ansible/vars/manager.py
+++ b/lib/ansible/vars/manager.py
@@ -498,19 +498,21 @@ class VariableManager:
                     # This task will be skipped later due to this, so we just setup
                     # a dummy array for the later code so it doesn't fail
                     items = [None]
-                # We cache the results of the loop for later, set this to None, so we don't do extra
-                # unexpected processing on the cached items later in TaskExecutor
+                # Update task.loop with templated items, this ensures that delegate_to+loop
+                # doesn't produce different restuls than TaskExecutor which may reprocess the loop
+                # Set loop_with to None, so we don't do extra unexpected processing on the cached items later
+                # in TaskExecutor
                 task.loop_with = None
+                task.loop = items
             else:
                 raise AnsibleError("Failed to find the lookup named '%s' in the available lookup plugins" % task.loop_with)
         elif task.loop is not None:
             items = templar.template(task.loop)
+            # Update task.loop with templated items, this ensures that delegate_to+loop
+            # doesn't produce different restuls than TaskExecutor which may reprocess the loop
+            task.loop = items
         else:
             items = [None]
-
-        # Update task.loop with templated items, this ensures that delegate_to+loop
-        # doesn't produce different restuls than TaskExecutor which may reprocess the loop
-        task.loop = items
 
         delegated_host_vars = dict()
         item_var = getattr(task.loop_control, 'loop_var', 'item')

--- a/lib/ansible/vars/manager.py
+++ b/lib/ansible/vars/manager.py
@@ -498,6 +498,8 @@ class VariableManager:
                     # This task will be skipped later due to this, so we just setup
                     # a dummy array for the later code so it doesn't fail
                     items = [None]
+                # We cache the results of the loop for later, set this to None, so we don't do extra
+                # unexpected processing on the cached items later in TaskExecutor
                 task.loop_with = None
             else:
                 raise AnsibleError("Failed to find the lookup named '%s' in the available lookup plugins" % task.loop_with)
@@ -506,6 +508,8 @@ class VariableManager:
         else:
             items = [None]
 
+        # Update task.loop with templated items, this ensures that delegate_to+loop
+        # doesn't produce different restuls than TaskExecutor which may reprocess the loop
         task.loop = items
 
         delegated_host_vars = dict()

--- a/lib/ansible/vars/manager.py
+++ b/lib/ansible/vars/manager.py
@@ -498,12 +498,15 @@ class VariableManager:
                     # This task will be skipped later due to this, so we just setup
                     # a dummy array for the later code so it doesn't fail
                     items = [None]
+                task.loop_with = None
             else:
                 raise AnsibleError("Failed to find the lookup named '%s' in the available lookup plugins" % task.loop_with)
         elif task.loop is not None:
             items = templar.template(task.loop)
         else:
             items = [None]
+
+        task.loop = items
 
         delegated_host_vars = dict()
         item_var = getattr(task.loop_control, 'loop_var', 'item')

--- a/test/integration/targets/delegate_to/runme.sh
+++ b/test/integration/targets/delegate_to/runme.sh
@@ -6,3 +6,5 @@ ANSIBLE_SSH_ARGS='-C -o ControlMaster=auto -o ControlPersist=60s -o UserKnownHos
     ANSIBLE_HOST_KEY_CHECKING=false ansible-playbook test_delegate_to.yml -i ../../inventory -v "$@"
 
 ansible-playbook test_loop_control.yml -v "$@"
+
+ansible-playbook test_delegate_to_loop_randomness.yml -v "$@"

--- a/test/integration/targets/delegate_to/test_delegate_to_loop_randomness.yml
+++ b/test/integration/targets/delegate_to/test_delegate_to_loop_randomness.yml
@@ -1,0 +1,58 @@
+---
+- name: Integration tests for #28231
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Add some test hosts
+      add_host:
+        name: "foo{{item}}"
+        groups: foo
+      loop: "{{ range(10)|list }}"
+
+    # We expect all of the next 3 runs to succeeed
+    # this is done multiple times to increase randomness
+    - assert:
+        that:
+          - item in ansible_delegated_vars
+      delegate_to: "{{ item }}"
+      loop:
+        - "{{ groups.foo|random }}"
+      ignore_errors: true
+      register: result1
+
+    - assert:
+        that:
+          - item in ansible_delegated_vars
+      delegate_to: "{{ item }}"
+      loop:
+        - "{{ groups.foo|random }}"
+      ignore_errors: true
+      register: result2
+
+    - assert:
+        that:
+          - item in ansible_delegated_vars
+      delegate_to: "{{ item }}"
+      loop:
+        - "{{ groups.foo|random }}"
+      ignore_errors: true
+      register: result3
+
+    - debug:
+        var: result1
+
+    - debug:
+        var: result2
+
+    - debug:
+        var: result3
+
+    - name: Ensure all of the 3 asserts were successful
+      assert:
+        that:
+          - results is all
+      vars:
+        results:
+          - "{{ (result1.results|first) is successful }}"
+          - "{{ (result2.results|first) is successful }}"
+          - "{{ (result3.results|first) is successful }}"


### PR DESCRIPTION
##### SUMMARY
Cache items when task.loop/with_items is evaluated to set delegate_to vars. Fixes #28231

The problem:

The loop is first evaluated in `VariableManager._get_delegated_vars` and then again in `TaskExecutor._run_loop`.  As such, if the expression does not produce the same result each time, it may cause templating of both to produce different results.

Due to this, `_get_delegated_vars` may create `ansible_delegated_vars` for a different host than the one targeted by `delegate_to`, and results in no `ansible_host` being found, falling back to just the literal name of the host to connect to.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/vars/manager.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
2.6
2.7
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```