### PR TITLE
fixed boolean value for zone_redundant in azure_rm_sqldatabase.py

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_sqldatabase.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_sqldatabase.py
@@ -346,7 +346,7 @@ class AzureRMDatabases(AzureRMModuleBase):
                         ev = 'AdventureWorksLT'
                     self.parameters["sample_name"] = ev
                 elif key == "zone_redundant":
-                    self.parameters["zone_redundant"] = 'Enabled' if kwargs[key] else 'Disabled'
+                    self.parameters["zone_redundant"] = True if kwargs[key] else False
 
         old_response = None
         response = None


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Per https://docs.microsoft.com/en-us/azure/templates/microsoft.sql/servers/databases, the zone_redundant field is a boolean, but it's passed in as a string, causing a deserialization error while trying to create a sql database in azure.

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
Fixes #41742

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
azure_rm_sqldatabase.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.3
  config file = None
  configured module search path = ['/home/val/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python3.5/dist-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 3.5.2 (default, Nov 23 2017, 16:37:01) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

Please review the change carefully, I'm not sure why maintainer cannot replicate the issue.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
