### PR TITLE
change interface to endpoint_type

### DIFF
--- a/lib/ansible/utils/module_docs_fragments/openstack.py
+++ b/lib/ansible/utils/module_docs_fragments/openstack.py
@@ -86,7 +86,7 @@ options:
     description:
       - A path to a client key to use as part of the SSL transaction.
     required: false
-  interface:
+  endpoint_type:
     description:
         - Endpoint URL type to fetch from the service catalog.
     choices: [public, internal, admin]


### PR DESCRIPTION
interface is not a valid parameter. Should be endpoint_type

fatal: [localhost]: FAILED! => {"changed": false, "failed": true, "msg": "Unsupported parameters for (os_project) module: interface Supported parameters include: api_timeout,auth,auth_type,availability_zone,cacert,cert,cloud,description,domain_id,enabled,endpoint_type,key,name,region_name,state,timeout,verify,wait"}

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - New Module Pull Request
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
