### PR TITLE
add endpoint_type parameter to examples

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_project.py
+++ b/lib/ansible/modules/cloud/openstack/os_project.py
@@ -58,6 +58,7 @@ EXAMPLES = '''
 # Create a project
 - os_project:
     cloud: mycloud
+    endpoint_type: admin
     state: present
     name: demoproject
     description: demodescription
@@ -67,6 +68,7 @@ EXAMPLES = '''
 # Delete a project
 - os_project:
     cloud: mycloud
+    endpoint_type: admin
     state: absent
     name: demoproject
 '''


### PR DESCRIPTION
Certain project functions are not available on the openstack public api. Creating and deleting projects are examples where you must use the admin api.

In most devstack or simple openstack deployments the public, internal and admin apis may live at the IP. However in most production deployments the admin APIs are on a separate network than the public APIs. Therefore for these examples to consistently work, we must specify the admin endpoint_type.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - New Module Pull Request
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
