### PR TITLE
parametrize allow_reassignment in ec2_eni

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_eni.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_eni.py
@@ -97,6 +97,13 @@ options:
       - The number of secondary IP addresses to assign to the network interface. This option is mutually exclusive of secondary_private_ip_addresses
     required: false
     version_added: 2.2
+  allow_reassignment:
+    description:
+      - Indicates whether to allow an IP address that is already assigned to another network interface or instance
+        to be reassigned to the specified network interface.
+   required: false
+   default: 'no'
+   version_added: 2.5 
 extends_documentation_fragment:
     - aws
     - ec2
@@ -365,6 +372,7 @@ def modify_eni(connection, vpc_id, module, eni):
     secondary_private_ip_addresses = module.params.get("secondary_private_ip_addresses")
     purge_secondary_private_ip_addresses = module.params.get("purge_secondary_private_ip_addresses")
     secondary_private_ip_address_count = module.params.get("secondary_private_ip_address_count")
+    allow_reassignment = module.params.get("allow_reassignment")
     changed = False
 
     try:
@@ -401,7 +409,7 @@ def modify_eni(connection, vpc_id, module, eni):
                 connection.assign_private_ip_addresses(network_interface_id=eni.id,
                                                        private_ip_addresses=secondary_addresses_to_add,
                                                        secondary_private_ip_address_count=None,
-                                                       allow_reassignment=False, dry_run=False)
+                                                       allow_reassignment=allow_reassignment, dry_run=False)
                 changed = True
         if secondary_private_ip_address_count is not None:
             current_secondary_address_count = len(current_secondary_addresses)
@@ -411,7 +419,7 @@ def modify_eni(connection, vpc_id, module, eni):
                                                        private_ip_addresses=None,
                                                        secondary_private_ip_address_count=(secondary_private_ip_address_count -
                                                                                            current_secondary_address_count),
-                                                       allow_reassignment=False, dry_run=False)
+                                                       allow_reassignment=allow_reassignment, dry_run=False)
                 changed = True
             elif secondary_private_ip_address_count < current_secondary_address_count:
                 # How many of these addresses do we want to remove
@@ -561,6 +569,7 @@ def main():
             secondary_private_ip_addresses=dict(default=None, type='list'),
             purge_secondary_private_ip_addresses=dict(default=False, type='bool'),
             secondary_private_ip_address_count=dict(default=None, type='int'),
+            allow_reassignment=dict(default=False, type='bool'),
             attached=dict(default=None, type='bool')
         )
     )

--- a/lib/ansible/modules/cloud/amazon/ec2_eni.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_eni.py
@@ -103,7 +103,7 @@ options:
         to be reassigned to the specified network interface.
     required: false
     default: 'no'
-    version_added: 2.5
+    version_added: 2.7
 extends_documentation_fragment:
     - aws
     - ec2

--- a/lib/ansible/modules/cloud/amazon/ec2_eni.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_eni.py
@@ -101,9 +101,9 @@ options:
     description:
       - Indicates whether to allow an IP address that is already assigned to another network interface or instance
         to be reassigned to the specified network interface.
-   required: false
-   default: 'no'
-   version_added: 2.5 
+    required: false
+    default: 'no'
+    version_added: 2.5
 extends_documentation_fragment:
     - aws
     - ec2


### PR DESCRIPTION
##### SUMMARY
Allow setting parameter `allow_reassignment` for EC2 ENI api
(Duplicates #41898 with `develop` branch as base)

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
modules/cloud/amazon/ec2_eni

##### ANSIBLE VERSION
2.7

##### ADDITIONAL INFORMATION
Otherwise, we can't reasign an IP address.

```
The full traceback is:
  File "/tmp/ansible_Nf3wB0/ansible_module_ec2_eni.py", line 422, in modify_eni
    allow_reassignment=False, dry_run=False)
  File "/usr/lib/python2.7/dist-packages/boto/ec2/connection.py", line 1880, in assign_private_ip_addresses
    return self.get_status('AssignPrivateIpAddresses', params, verb='POST')
  File "/usr/lib/python2.7/dist-packages/boto/connection.py", line 1223, in get_status
    raise self.ResponseError(response.status, response.reason, body)

fatal: [localhost]: FAILED! => {
    "changed": false,
    "invocation": {
        "module_args": {
            "allow_reassignment": false,
            "attached": null,
            "aws_access_key": "xxxxx",
            "aws_region": "us-east-1",
            "aws_secret_key": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "delete_on_termination": null,
            "description": null,
            "device_index": 0,
            "ec2_url": null,
            "eni_id": "eni-xxxxxxxx",
            "force_detach": false,
            "instance_id": null,
            "private_ip_address": null,
            "profile": null,
            "purge_secondary_private_ip_addresses": false,
            "secondary_private_ip_address_count": null,
            "secondary_private_ip_addresses": [
                "172.31.3.225"
            ],
            "security_groups": [],
            "security_token": null,
            "source_dest_check": null,
            "state": "present",
            "subnet_id": null,
            "validate_certs": true
        }
    },
    "msg": "[172.31.3.225] assigned, but move is not allowed."
}
```