### PR TITLE
Adds an ipmath filter

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_filters_ipaddr.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters_ipaddr.rst
@@ -379,25 +379,25 @@ be automatically converted to a router address (with ``::1/48`` host address)::
 
 .. _6to4: https://en.wikipedia.org/wiki/6to4
 
-IP Arithmetic
-^^^^^^^^^^^^^
+IP Math
+^^^^^^^
 
 .. versionadded:: 2.7
 
-``iparithmetic()`` filter can be used to do simple IP arithmetic.
+``ipmath()`` filter can be used to do simple IP math/arithmetic.
 
 Here are a few simple examples::
 
-    # {{ '192.168.1.5' | iparithmetic(5) }}
+    # {{ '192.168.1.5' | ipmath(5) }}
     192.168.1.10
 
-    # {{ '192.168.0.5' | iparithmetic(-10) }}
+    # {{ '192.168.0.5' | ipmath(-10) }}
     192.167.255.251
 
-    # {{ '2001::1' | iparithmetic(10) }}
+    # {{ '2001::1' | ipmath(10) }}
     2001::b
 
-    # {{ '2001::5' | iparithmetic(-10) }}
+    # {{ '2001::5' | ipmath(-10) }}
     2000:ffff:ffff:ffff:ffff:ffff:ffff:fffb
 
 

--- a/docs/docsite/rst/user_guide/playbooks_filters_ipaddr.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters_ipaddr.rst
@@ -295,15 +295,15 @@ Converting subnet masks to CIDR notation
 Given a subnet in the form of network address and subnet mask, it can be converted into CIDR notation using ``ipaddr()``.  This can be useful for converting Ansible facts gathered about network configuration from subnet masks into CIDR format::
 
     ansible_default_ipv4: {
-        address: "192.168.0.11", 
-        alias: "eth0", 
-        broadcast: "192.168.0.255", 
-        gateway: "192.168.0.1", 
-        interface: "eth0", 
-        macaddress: "fa:16:3e:c4:bd:89", 
-        mtu: 1500, 
-        netmask: "255.255.255.0", 
-        network: "192.168.0.0", 
+        address: "192.168.0.11",
+        alias: "eth0",
+        broadcast: "192.168.0.255",
+        gateway: "192.168.0.1",
+        interface: "eth0",
+        macaddress: "fa:16:3e:c4:bd:89",
+        mtu: 1500,
+        netmask: "255.255.255.0",
+        network: "192.168.0.0",
         type: "ether"
     }
 
@@ -378,6 +378,28 @@ be automatically converted to a router address (with ``::1/48`` host address)::
     2002:c100:0200::1/48
 
 .. _6to4: https://en.wikipedia.org/wiki/6to4
+
+IP Arithmetic
+^^^^^^^^^^^^^^^^^^^
+
+.. versionadded:: 2.6
+
+``iparithmetic()`` filter can be used to do simple IP arithmetic.
+
+Here are a few simple examples::
+
+    # {{ '192.168.1.5' | iparithmetic(5) }}
+    192.168.1.10
+
+    # {{ '192.168.0.5' | iparithmetic(-10) }}
+    192.167.255.251
+
+    # {{ '2001::1' | iparithmetic(10) }}
+    2001::b
+
+    # {{ '2001::5' | iparithmetic(-10) }}
+    2000:ffff:ffff:ffff:ffff:ffff:ffff:fffb
+
 
 
 Subnet manipulation
@@ -527,5 +549,3 @@ convert it between various formats. Examples::
        Have a question?  Stop by the google group!
    `irc.freenode.net <http://irc.freenode.net>`_
        #ansible IRC chat channel
-
-

--- a/docs/docsite/rst/user_guide/playbooks_filters_ipaddr.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters_ipaddr.rst
@@ -380,9 +380,9 @@ be automatically converted to a router address (with ``::1/48`` host address)::
 .. _6to4: https://en.wikipedia.org/wiki/6to4
 
 IP Arithmetic
-^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^
 
-.. versionadded:: 2.6
+.. versionadded:: 2.7
 
 ``iparithmetic()`` filter can be used to do simple IP arithmetic.
 

--- a/lib/ansible/plugins/filter/ipaddr.py
+++ b/lib/ansible/plugins/filter/ipaddr.py
@@ -24,7 +24,6 @@ import types
 
 try:
     import netaddr
-    import netaddr.core
 except ImportError:
     # in this case, we'll make the filters return error messages (see bottom)
     netaddr = None
@@ -674,7 +673,7 @@ def ipaddr(value, query='', version=False, alias='ipaddr'):
 def iparithmetic(value, amount):
     try:
         ip = netaddr.IPAddress(value)
-    except netaddr.core.AddrFormatError:
+    except netaddr.AddrFormatError:
         msg = 'You must pass a valid IP address; {0} is invalid'.format(value)
         raise errors.AnsibleFilterError(msg)
 

--- a/lib/ansible/plugins/filter/ipaddr.py
+++ b/lib/ansible/plugins/filter/ipaddr.py
@@ -670,6 +670,11 @@ def ipaddr(value, query='', version=False, alias='ipaddr'):
     return False
 
 
+def iparithmetic(value, amount):
+    ip = netaddr.IPAddress(value)
+    return str(ip + amount)
+
+
 def ipwrap(value, query=''):
     try:
         if isinstance(value, (list, tuple, types.GeneratorType)):
@@ -1060,6 +1065,7 @@ class FilterModule(object):
         # IP addresses and networks
         'cidr_merge': cidr_merge,
         'ipaddr': ipaddr,
+        'iparithmetic': iparithmetic,
         'ipwrap': ipwrap,
         'ip4_hex': ip4_hex,
         'ipv4': ipv4,

--- a/lib/ansible/plugins/filter/ipaddr.py
+++ b/lib/ansible/plugins/filter/ipaddr.py
@@ -675,13 +675,13 @@ def iparithmetic(value, amount):
     try:
         ip = netaddr.IPAddress(value)
     except netaddr.core.AddrFormatError:
-        msg = 'You must pass a valid IP address; {} is invalid'.format(value)
+        msg = 'You must pass a valid IP address; {0} is invalid'.format(value)
         raise errors.AnsibleFilterError(msg)
 
     if not isinstance(amount, int):
         msg = (
             'You must pass an integer for arithmetic; '
-            '{} is not a valid integer'
+            '{0} is not a valid integer'
         ).format(amount)
         raise errors.AnsibleFilterError(msg)
 

--- a/lib/ansible/plugins/filter/ipaddr.py
+++ b/lib/ansible/plugins/filter/ipaddr.py
@@ -24,6 +24,7 @@ import types
 
 try:
     import netaddr
+    import netaddr.core
 except ImportError:
     # in this case, we'll make the filters return error messages (see bottom)
     netaddr = None
@@ -671,7 +672,12 @@ def ipaddr(value, query='', version=False, alias='ipaddr'):
 
 
 def iparithmetic(value, amount):
-    ip = netaddr.IPAddress(value)
+    try:
+        ip = netaddr.IPAddress(value)
+    except netaddr.core.AddrFormatError:
+        msg = 'You must pass a valid IP address; {} is invalid'.format(value)
+        raise errors.AnsibleFilterError(msg)
+
     return str(ip + amount)
 
 

--- a/lib/ansible/plugins/filter/ipaddr.py
+++ b/lib/ansible/plugins/filter/ipaddr.py
@@ -678,6 +678,13 @@ def iparithmetic(value, amount):
         msg = 'You must pass a valid IP address; {} is invalid'.format(value)
         raise errors.AnsibleFilterError(msg)
 
+    if not isinstance(amount, int):
+        msg = (
+            'You must pass an integer for arithmetic; '
+            '{} is not a valid integer'
+        ).format(amount)
+        raise errors.AnsibleFilterError(msg)
+
     return str(ip + amount)
 
 

--- a/lib/ansible/plugins/filter/ipaddr.py
+++ b/lib/ansible/plugins/filter/ipaddr.py
@@ -670,7 +670,7 @@ def ipaddr(value, query='', version=False, alias='ipaddr'):
     return False
 
 
-def iparithmetic(value, amount):
+def ipmath(value, amount):
     try:
         ip = netaddr.IPAddress(value)
     except netaddr.AddrFormatError:
@@ -1077,7 +1077,7 @@ class FilterModule(object):
         # IP addresses and networks
         'cidr_merge': cidr_merge,
         'ipaddr': ipaddr,
-        'iparithmetic': iparithmetic,
+        'ipmath': ipmath,
         'ipwrap': ipwrap,
         'ip4_hex': ip4_hex,
         'ipv4': ipv4,

--- a/test/units/plugins/filter/test_ipaddr.py
+++ b/test/units/plugins/filter/test_ipaddr.py
@@ -494,3 +494,11 @@ class TestIpFilter(unittest.TestCase):
         with self.assertRaises(AnsibleFilterError) as exc:
             iparithmetic('invalid_ip', 8)
         self.assertEqual(exc.exception.message, expected)
+
+        expected = (
+            'You must pass an integer for arithmetic; '
+            'some_number is not a valid integer'
+        )
+        with self.assertRaises(AnsibleFilterError) as exc:
+            iparithmetic('1.2.3.4', 'some_number')
+        self.assertEqual(exc.exception.message, expected)

--- a/test/units/plugins/filter/test_ipaddr.py
+++ b/test/units/plugins/filter/test_ipaddr.py
@@ -23,7 +23,7 @@ from ansible.compat.tests import unittest
 from ansible.errors import AnsibleFilterError
 from ansible.plugins.filter.ipaddr import (ipaddr, _netmask_query, nthhost, next_nth_usable,
                                            previous_nth_usable, network_in_usable, network_in_network,
-                                           cidr_merge, iparithmetic)
+                                           cidr_merge, ipmath)
 netaddr = pytest.importorskip('netaddr')
 
 
@@ -476,23 +476,23 @@ class TestIpFilter(unittest.TestCase):
         self.assertEqual(cidr_merge(subnets), ['1.12.1.1/32', '1.12.1.255/32'])
         self.assertEqual(cidr_merge(subnets, 'span'), '1.12.1.0/24')
 
-    def test_iparithmetic(self):
-        self.assertEqual(iparithmetic('192.168.1.5', 5), '192.168.1.10')
-        self.assertEqual(iparithmetic('192.168.1.5', -5), '192.168.1.0')
-        self.assertEqual(iparithmetic('192.168.0.5', -10), '192.167.255.251')
+    def test_ipmath(self):
+        self.assertEqual(ipmath('192.168.1.5', 5), '192.168.1.10')
+        self.assertEqual(ipmath('192.168.1.5', -5), '192.168.1.0')
+        self.assertEqual(ipmath('192.168.0.5', -10), '192.167.255.251')
 
-        self.assertEqual(iparithmetic('2001::1', 8), '2001::9')
-        self.assertEqual(iparithmetic('2001::1', 9), '2001::a')
-        self.assertEqual(iparithmetic('2001::1', 10), '2001::b')
-        self.assertEqual(iparithmetic('2001::5', -3), '2001::2')
+        self.assertEqual(ipmath('2001::1', 8), '2001::9')
+        self.assertEqual(ipmath('2001::1', 9), '2001::a')
+        self.assertEqual(ipmath('2001::1', 10), '2001::b')
+        self.assertEqual(ipmath('2001::5', -3), '2001::2')
         self.assertEqual(
-            iparithmetic('2001::5', -10),
+            ipmath('2001::5', -10),
             '2000:ffff:ffff:ffff:ffff:ffff:ffff:fffb'
         )
 
         expected = 'You must pass a valid IP address; invalid_ip is invalid'
         with self.assertRaises(AnsibleFilterError) as exc:
-            iparithmetic('invalid_ip', 8)
+            ipmath('invalid_ip', 8)
         self.assertEqual(exc.exception.message, expected)
 
         expected = (
@@ -500,5 +500,5 @@ class TestIpFilter(unittest.TestCase):
             'some_number is not a valid integer'
         )
         with self.assertRaises(AnsibleFilterError) as exc:
-            iparithmetic('1.2.3.4', 'some_number')
+            ipmath('1.2.3.4', 'some_number')
         self.assertEqual(exc.exception.message, expected)

--- a/test/units/plugins/filter/test_ipaddr.py
+++ b/test/units/plugins/filter/test_ipaddr.py
@@ -479,3 +479,12 @@ class TestIpFilter(unittest.TestCase):
         self.assertEqual(iparithmetic('192.168.1.5', 5), '192.168.1.10')
         self.assertEqual(iparithmetic('192.168.1.5', -5), '192.168.1.0')
         self.assertEqual(iparithmetic('192.168.0.5', -10), '192.167.255.251')
+
+        self.assertEqual(iparithmetic('2001::1', 8), '2001::9')
+        self.assertEqual(iparithmetic('2001::1', 9), '2001::a')
+        self.assertEqual(iparithmetic('2001::1', 10), '2001::b')
+        self.assertEqual(iparithmetic('2001::5', -3), '2001::2')
+        self.assertEqual(
+            iparithmetic('2001::5', -10),
+            '2000:ffff:ffff:ffff:ffff:ffff:ffff:fffb'
+        )

--- a/test/units/plugins/filter/test_ipaddr.py
+++ b/test/units/plugins/filter/test_ipaddr.py
@@ -20,6 +20,7 @@ __metaclass__ = type
 import pytest
 
 from ansible.compat.tests import unittest
+from ansible.errors import AnsibleFilterError
 from ansible.plugins.filter.ipaddr import (ipaddr, _netmask_query, nthhost, next_nth_usable,
                                            previous_nth_usable, network_in_usable, network_in_network,
                                            cidr_merge, iparithmetic)
@@ -488,3 +489,8 @@ class TestIpFilter(unittest.TestCase):
             iparithmetic('2001::5', -10),
             '2000:ffff:ffff:ffff:ffff:ffff:ffff:fffb'
         )
+
+        expected = 'You must pass a valid IP address; invalid_ip is invalid'
+        with self.assertRaises(AnsibleFilterError) as exc:
+            iparithmetic('invalid_ip', 8)
+        self.assertEqual(exc.exception.message, expected)

--- a/test/units/plugins/filter/test_ipaddr.py
+++ b/test/units/plugins/filter/test_ipaddr.py
@@ -21,7 +21,8 @@ import pytest
 
 from ansible.compat.tests import unittest
 from ansible.plugins.filter.ipaddr import (ipaddr, _netmask_query, nthhost, next_nth_usable,
-                                           previous_nth_usable, network_in_usable, network_in_network, cidr_merge)
+                                           previous_nth_usable, network_in_usable, network_in_network,
+                                           cidr_merge, iparithmetic)
 netaddr = pytest.importorskip('netaddr')
 
 
@@ -473,3 +474,8 @@ class TestIpFilter(unittest.TestCase):
         subnets = ['1.12.1.1', '1.12.1.255']
         self.assertEqual(cidr_merge(subnets), ['1.12.1.1/32', '1.12.1.255/32'])
         self.assertEqual(cidr_merge(subnets, 'span'), '1.12.1.0/24')
+
+    def test_iparithmetic(self):
+        self.assertEqual(iparithmetic('192.168.1.5', 5), '192.168.1.10')
+        self.assertEqual(iparithmetic('192.168.1.5', -5), '192.168.1.0')
+        self.assertEqual(iparithmetic('192.168.0.5', -10), '192.167.255.251')


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

I recently came into the need of doing some simple arithmetic on some IPs.  This patch adds an `ipmath` filter in case other people need to do similar things.

Note: I kept my tests the same style and consistency of the other tests within test_ipaddr.py, which is essentially one test function that tests all of it's functionality.

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->

- ipaddr
- ipmath (new)

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (iparithmetic_filter 097d40931d) last updated 2018/06/26 17:16:08 (GMT -500)
  config file = None
  configured module search path = ['/Users/fxfitz/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/fxfitz/dev/ansible/lib/ansible
  executable location = /Users/fxfitz/dev/ansible/bin/ansible
  python version = 3.6.5 (default, May 29 2018, 20:18:53) [GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.1)]
```


##### ADDITIONAL INFORMATION
Not Applicable
