### PR TITLE
Update the minimum Ansible version to 2.4 for "ansible-galaxy init"

### DIFF
--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -223,7 +223,7 @@ class GalaxyCLI(CLI):
             company='your company (optional)',
             license='license (GPLv2, CC-BY, etc)',
             issue_tracker_url='http://example.com/issue/tracker',
-            min_ansible_version='1.2',
+            min_ansible_version='2.4',
             role_type=self.options.role_type
         )
 


### PR DESCRIPTION
##### SUMMARY
When creating a new role using `ansible-galaxy init <ROLE_NAME>`, the `meta/main.yml` is generated setting the `min_ansible_version` to 1.2. This is not ideal for new roles now-a-days. It ends up giving users incorrect information about compatibility if they are searching through Ansible Galaxy when the author has failed to change this default value.

Reasons to update this to 2.4:

* Ansible Engine 2.4 was the first fully supported release of Ansible by Red Hat.
* Ansible 2.4 is currently the last community supported version of Ansible right now.
* 2.4 happens to be twice as much as 1.2!

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
`ansible-galaxy` CLI utility

##### ANSIBLE VERSION
2.6

##### ADDITIONAL INFORMATION
Alternative solutions:

* The `min_ansible_version` line could be commented out with no value.
* Dynamically set the `min_ansible_version` to the version of Ansible that is actually running `ansible-galaxy init`.