### PR TITLE
win_domain: fix typo in cmdlet call

### DIFF
--- a/changelogs/fragments/win_domain-dns-typo-fix.yml
+++ b/changelogs/fragments/win_domain-dns-typo-fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_domain - fixes typo in one of the AD cmdlets https://github.com/ansible/ansible/issues/41536

--- a/lib/ansible/modules/windows/win_domain.ps1
+++ b/lib/ansible/modules/windows/win_domain.ps1
@@ -72,7 +72,7 @@ If(-not $forest) {
             SafeModeAdministratorPassword=$sm_cred;
             Confirm=$false;
             SkipPreChecks=$true;
-            InstallDNS=$true;
+            InstallDns=$true;
             NoRebootOnCompletion=$true;
         }
         if ($database_path) {


### PR DESCRIPTION
##### SUMMARY
This normally shouldn't be an issue as PS cmdlet params are not case sensitive but in this case it is causing some issues.

Fixes https://github.com/ansible/ansible/issues/41536

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
win_domain

##### ANSIBLE VERSION
```
devel
```