### PR TITLE
win_domain: fix typo in cmdlet call (#41993)

### DIFF
--- a/changelogs/fragments/win_domain-dns-typo-fix.yml
+++ b/changelogs/fragments/win_domain-dns-typo-fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_domain - fixes typo in one of the AD cmdlets https://github.com/ansible/ansible/issues/41536

--- a/lib/ansible/modules/windows/win_domain.ps1
+++ b/lib/ansible/modules/windows/win_domain.ps1
@@ -72,7 +72,7 @@ If(-not $forest) {
             SafeModeAdministratorPassword=$sm_cred;
             Confirm=$false;
             SkipPreChecks=$true;
-            InstallDNS=$true;
+            InstallDns=$true;
             NoRebootOnCompletion=$true;
         }
         if ($database_path) {


### PR DESCRIPTION
(cherry picked from commit 77526a5036d9ad0638f7275c5b774f3fd919daea)

##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/41993

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
win_domain

##### ANSIBLE VERSION
```
2.6
```