### PR TITLE
Documentation: add parameter types, and version_added for return values and facts

### DIFF
--- a/docs/templates/plugin.rst.j2
+++ b/docs/templates/plugin.rst.j2
@@ -271,6 +271,7 @@ Facts returned by this module are added/updated in the ``hostvars`` host facts a
                 <td colspan="@{ from_kludge_ns('maxdepth') - loop.depth0 }@" colspan="@{ from_kludge_ns('maxdepth') - loop.depth0 }@">
                     <b>@{ key }@</b>
                     <br/><div style="font-size: small; color: red">@{ value.type }@</div>
+                    {% if value.version_added %}<br/><div style="font-size: small; color: darkgreen">(added in @{value.version_added}@)</div>{% endif %}
                 </td>
                 <td>@{ value.returned | html_ify }@</td>
                 <td>
@@ -342,6 +343,7 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
                 <td colspan="@{ from_kludge_ns('maxdepth') - loop.depth0 }@">
                     <b>@{ key }@</b>
                     <br/><div style="font-size: small; color: red">@{ value.type }@</div>
+                    {% if value.version_added %}<br/><div style="font-size: small; color: darkgreen">(added in @{value.version_added}@)</div>{% endif %}
                 </td>
                 <td>@{ value.returned | html_ify }@</td>
                 <td>

--- a/docs/templates/plugin.rst.j2
+++ b/docs/templates/plugin.rst.j2
@@ -118,6 +118,7 @@ Parameters
                 {# parameter name with required and/or introduced label #}
                 <td colspan="@{ from_kludge_ns('maxdepth') - loop.depth0 }@">
                     <b>@{ key }@</b>
+                    {% if value.get('type', None) %}<br/><div style="font-size: small; color: red">@{ value.type }@</div>{% endif %}
                     {% if value.get('required', False) %}<br/><div style="font-size: small; color: red">required</div>{% endif %}
                     {% if value.version_added %}<br/><div style="font-size: small; color: darkgreen">(added in @{value.version_added}@)</div>{% endif %}
                 </td>


### PR DESCRIPTION
##### SUMMARY
Adds types to parameters (if available), and adds version_added to return facts and return values. Fixes #41905.

##### ISSUE TYPE
Docs Pull Request

##### COMPONENT NAME
docs/templates/plugin.rst.j2

##### ANSIBLE VERSION
```
2.6.0
2.7.0
```


##### ADDITIONAL INFORMATION
At the moment, neither parameter types are printed in the HTML documentation, nor is version_added mentioned for return values and return facts in the HTML documentation.

Parameters before:
![parameters-before](https://user-images.githubusercontent.com/5781356/41956010-c0855584-79d1-11e8-8cc9-b69fa25288f0.png)

Parameters after:
![parameters-after](https://user-images.githubusercontent.com/5781356/41956009-c05443cc-79d1-11e8-849f-173446748884.png)

Return values before:
![return-values-before](https://user-images.githubusercontent.com/5781356/41956015-c4682a1e-79d1-11e8-940a-fe4b6b4fac53.png)

Return values after:
![return-values-after](https://user-images.githubusercontent.com/5781356/41956014-c43ee082-79d1-11e8-9b50-d1352ab23604.png)
