### PR TITLE
Fix test_create_jks_success failing on SELinux machine

### DIFF
--- a/test/units/modules/system/test_java_keystore.py
+++ b/test/units/modules/system/test_java_keystore.py
@@ -5,6 +5,8 @@
 #
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+import os
+
 from units.modules.utils import ModuleTestCase, set_module_args
 from ansible.compat.tests.mock import patch
 from ansible.compat.tests.mock import Mock
@@ -18,24 +20,38 @@ class TestCreateJavaKeystore(ModuleTestCase):
     def setUp(self):
         """Setup."""
         super(TestCreateJavaKeystore, self).setUp()
+
+        orig_exists = os.path.exists
         self.spec = ArgumentSpec()
         self.mock_create_file = patch('ansible.modules.system.java_keystore.create_file',
                                       side_effect=lambda path, content: path)
         self.mock_run_commands = patch('ansible.modules.system.java_keystore.run_commands')
+        self.mock_os_path_exists = patch('os.path.exists',
+                                         side_effect=lambda path: True if path == '/path/to/keystore.jks' else orig_exists(path))
+        self.mock_selinux_context = patch('ansible.module_utils.basic.AnsibleModule.selinux_context',
+                                          side_effect=lambda path: ['unconfined_u', 'object_r', 'user_home_t', 's0'])
+        self.mock_is_special_selinux_path = patch('ansible.module_utils.basic.AnsibleModule.is_special_selinux_path',
+                                                  side_effect=lambda path: (False, None))
         self.run_commands = self.mock_run_commands.start()
         self.create_file = self.mock_create_file.start()
+        self.selinux_context = self.mock_selinux_context.start()
+        self.is_special_selinux_path = self.mock_is_special_selinux_path.start()
+        self.os_path_exists = self.mock_os_path_exists.start()
 
     def tearDown(self):
         """Teardown."""
         super(TestCreateJavaKeystore, self).tearDown()
         self.mock_create_file.stop()
         self.mock_run_commands.stop()
+        self.mock_selinux_context.stop()
+        self.mock_is_special_selinux_path.stop()
+        self.mock_os_path_exists.stop()
 
     def test_create_jks_success(self):
         set_module_args(dict(
             certificate='cert-foo',
             private_key='private-foo',
-            dest='/etc/security/keystore.jks',
+            dest='/path/to/keystore.jks',
             name='foo',
             password='changeit'
         ))
@@ -49,11 +65,11 @@ class TestCreateJavaKeystore(ModuleTestCase):
 
         with patch('os.remove', return_value=True):
             self.run_commands.side_effect = lambda args, kwargs: (0, '', '')
-            create_jks(module, "test", "openssl", "keytool", "/etc/security/keystore.jks", "changeit")
+            create_jks(module, "test", "openssl", "keytool", "/path/to/keystore.jks", "changeit")
             module.exit_json.assert_called_once_with(
                 changed=True,
                 cmd="keytool -importkeystore "
-                    "-destkeystore '/etc/security/keystore.jks' "
+                    "-destkeystore '/path/to/keystore.jks' "
                     "-srckeystore '/tmp/keystore.p12' -srcstoretype pkcs12 -alias 'test' "
                     "-deststorepass 'changeit' -srcstorepass 'changeit' -noprompt",
                 msg='',
@@ -65,7 +81,7 @@ class TestCreateJavaKeystore(ModuleTestCase):
         set_module_args(dict(
             certificate='cert-foo',
             private_key='private-foo',
-            dest='/etc/security/keystore.jks',
+            dest='/path/to/keystore.jks',
             name='foo',
             password='changeit'
         ))
@@ -79,7 +95,7 @@ class TestCreateJavaKeystore(ModuleTestCase):
 
         with patch('os.remove', return_value=True):
             self.run_commands.side_effect = [(1, '', ''), (0, '', '')]
-            create_jks(module, "test", "openssl", "keytool", "/etc/security/keystore.jks", "changeit")
+            create_jks(module, "test", "openssl", "keytool", "/path/to/keystore.jks", "changeit")
             module.fail_json.assert_called_once_with(
                 cmd="openssl pkcs12 -export -name 'test' "
                     "-in '/tmp/foo.crt' -inkey '/tmp/foo.key' "
@@ -93,7 +109,7 @@ class TestCreateJavaKeystore(ModuleTestCase):
         set_module_args(dict(
             certificate='cert-foo',
             private_key='private-foo',
-            dest='/etc/security/keystore.jks',
+            dest='/path/to/keystore.jks',
             name='foo',
             password='changeit'
         ))
@@ -107,10 +123,10 @@ class TestCreateJavaKeystore(ModuleTestCase):
 
         with patch('os.remove', return_value=True):
             self.run_commands.side_effect = [(0, '', ''), (1, '', '')]
-            create_jks(module, "test", "openssl", "keytool", "/etc/security/keystore.jks", "changeit")
+            create_jks(module, "test", "openssl", "keytool", "/path/to/keystore.jks", "changeit")
             module.fail_json.assert_called_once_with(
                 cmd="keytool -importkeystore "
-                    "-destkeystore '/etc/security/keystore.jks' "
+                    "-destkeystore '/path/to/keystore.jks' "
                     "-srckeystore '/tmp/keystore.p12' -srcstoretype pkcs12 -alias 'test' "
                     "-deststorepass 'changeit' -srcstorepass 'changeit' -noprompt",
                 msg='',
@@ -141,7 +157,7 @@ class TestCertChanged(ModuleTestCase):
         set_module_args(dict(
             certificate='cert-foo',
             private_key='private-foo',
-            dest='/etc/security/keystore.jks',
+            dest='/path/to/keystore.jks',
             name='foo',
             password='changeit'
         ))
@@ -153,14 +169,14 @@ class TestCertChanged(ModuleTestCase):
 
         with patch('os.remove', return_value=True):
             self.run_commands.side_effect = [(0, 'foo=abcd:1234:efgh', ''), (0, 'foo: abcd:1234:efgh', '')]
-            result = cert_changed(module, "openssl", "keytool", "/etc/security/keystore.jks", "changeit", 'foo')
+            result = cert_changed(module, "openssl", "keytool", "/path/to/keystore.jks", "changeit", 'foo')
             self.assertFalse(result, 'Fingerprint is identical')
 
     def test_cert_changed_fingerprint_mismatch(self):
         set_module_args(dict(
             certificate='cert-foo',
             private_key='private-foo',
-            dest='/etc/security/keystore.jks',
+            dest='/path/to/keystore.jks',
             name='foo',
             password='changeit'
         ))
@@ -172,14 +188,14 @@ class TestCertChanged(ModuleTestCase):
 
         with patch('os.remove', return_value=True):
             self.run_commands.side_effect = [(0, 'foo=abcd:1234:efgh', ''), (0, 'foo: wxyz:9876:stuv', '')]
-            result = cert_changed(module, "openssl", "keytool", "/etc/security/keystore.jks", "changeit", 'foo')
+            result = cert_changed(module, "openssl", "keytool", "/path/to/keystore.jks", "changeit", 'foo')
             self.assertTrue(result, 'Fingerprint mismatch')
 
     def test_cert_changed_alias_does_not_exist(self):
         set_module_args(dict(
             certificate='cert-foo',
             private_key='private-foo',
-            dest='/etc/security/keystore.jks',
+            dest='/path/to/keystore.jks',
             name='foo',
             password='changeit'
         ))
@@ -192,14 +208,14 @@ class TestCertChanged(ModuleTestCase):
         with patch('os.remove', return_value=True):
             self.run_commands.side_effect = [(0, 'foo=abcd:1234:efgh', ''),
                                              (1, 'keytool error: java.lang.Exception: Alias <foo> does not exist', '')]
-            result = cert_changed(module, "openssl", "keytool", "/etc/security/keystore.jks", "changeit", 'foo')
+            result = cert_changed(module, "openssl", "keytool", "/path/to/keystore.jks", "changeit", 'foo')
             self.assertTrue(result, 'Certificate does not exist')
 
     def test_cert_changed_fail_read_cert(self):
         set_module_args(dict(
             certificate='cert-foo',
             private_key='private-foo',
-            dest='/etc/security/keystore.jks',
+            dest='/path/to/keystore.jks',
             name='foo',
             password='changeit'
         ))
@@ -213,7 +229,7 @@ class TestCertChanged(ModuleTestCase):
 
         with patch('os.remove', return_value=True):
             self.run_commands.side_effect = [(1, '', 'Oops'), (0, 'foo: wxyz:9876:stuv', '')]
-            cert_changed(module, "openssl", "keytool", "/etc/security/keystore.jks", "changeit", 'foo')
+            cert_changed(module, "openssl", "keytool", "/path/to/keystore.jks", "changeit", 'foo')
             module.fail_json.assert_called_once_with(
                 cmd="openssl x509 -noout -in /tmp/foo.crt -fingerprint -sha1",
                 msg='',
@@ -225,7 +241,7 @@ class TestCertChanged(ModuleTestCase):
         set_module_args(dict(
             certificate='cert-foo',
             private_key='private-foo',
-            dest='/etc/security/keystore.jks',
+            dest='/path/to/keystore.jks',
             name='foo',
             password='changeit'
         ))
@@ -239,9 +255,9 @@ class TestCertChanged(ModuleTestCase):
 
         with patch('os.remove', return_value=True):
             self.run_commands.side_effect = [(0, 'foo: wxyz:9876:stuv', ''), (1, '', 'Oops')]
-            cert_changed(module, "openssl", "keytool", "/etc/security/keystore.jks", "changeit", 'foo')
+            cert_changed(module, "openssl", "keytool", "/path/to/keystore.jks", "changeit", 'foo')
             module.fail_json.assert_called_with(
-                cmd="keytool -list -alias 'foo' -keystore '/etc/security/keystore.jks' -storepass 'changeit'",
+                cmd="keytool -list -alias 'foo' -keystore '/path/to/keystore.jks' -storepass 'changeit'",
                 msg='',
                 err='Oops',
                 rc=1


### PR DESCRIPTION
##### SUMMARY

Currently TestCreateJavaKeystore::test_create_jks_success is failing on
a machine with SELinux because set_context_if_different is not mocked
and hence tries to access a file that doesn't exist because it has been
mocked previously.

Also, changing path to a path that won't exist for sure.

##### ISSUE TYPE
 
- Bugfix Pull Request
 
##### COMPONENT NAME

  - system/java_keystore

##### ANSIBLE VERSION

  - devel

##### ADDITIONAL INFORMATION

```
_______________________________________________________________________ TestCreateJavaKeystore.test_create_jks_success ________________________________________________________________________
self = <units.modules.system.test_java_keystore.TestCreateJavaKeystore testMethod=test_create_jks_success>                                                                                     

    def test_create_jks_success(self):                        
        set_module_args(dict(                                                                                                                                                                 
            certificate='cert-foo',
            private_key='private-foo',
            dest='/etc/security/keystore.jks',
            name='foo',
            password='changeit'
        ))

        module = AnsibleModule(
            argument_spec=self.spec.argument_spec,
            supports_check_mode=self.spec.supports_check_mode
        )

        module.exit_json = Mock()

        with patch('os.remove', return_value=True):
            self.run_commands.side_effect = lambda args, kwargs: (0, '', '')
>           create_jks(module, "test", "openssl", "keytool", "/etc/security/keystore.jks", "changeit")

test/units/modules/system/test_java_keystore.py:52:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
lib/ansible/modules/system/java_keystore.py:219: in create_jks
    update_jks_perm(module, keystore_path)
lib/ansible/modules/system/java_keystore.py:237: in update_jks_perm
    module.set_fs_attributes_if_different(file_args, False)
lib/ansible/module_utils/basic.py:1539: in set_fs_attributes_if_different
    file_args['path'], file_args['secontext'], changed, diff
lib/ansible/module_utils/basic.py:1145: in set_context_if_different
    cur_context = self.selinux_context(path)
lib/ansible/module_utils/basic.py:1075: in selinux_context
    self.fail_json(path=path, msg='path %s does not exist' % path)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

args = (<ansible.module_utils.basic.AnsibleModule object at 0x7f645a649a50>,)
kwargs = {'failed': True, 'msg': 'path /etc/security/keystore.jks does not exist', 'path': '/etc/security/keystore.jks'}

    def fail_json(*args, **kwargs):
        kwargs['failed'] = True
>       raise AnsibleFailJson(kwargs)
E       AnsibleFailJson: {'msg': 'path /etc/security/keystore.jks does not exist', 'path': '/etc/security/keystore.jks', 'failed': True}_______________________________________________________________________ TestCreateJavaKeystore.test_create_jks_success ________________________________________________________________________
self = <units.modules.system.test_java_keystore.TestCreateJavaKeystore testMethod=test_create_jks_success>                                                                                     

    def test_create_jks_success(self):                        
        set_module_args(dict(                                                                                                                                                                 
            certificate='cert-foo',
            private_key='private-foo',
            dest='/etc/security/keystore.jks',
            name='foo',
            password='changeit'
        ))

        module = AnsibleModule(
            argument_spec=self.spec.argument_spec,
            supports_check_mode=self.spec.supports_check_mode
        )

        module.exit_json = Mock()

        with patch('os.remove', return_value=True):
            self.run_commands.side_effect = lambda args, kwargs: (0, '', '')
>           create_jks(module, "test", "openssl", "keytool", "/etc/security/keystore.jks", "changeit")

test/units/modules/system/test_java_keystore.py:52:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
lib/ansible/modules/system/java_keystore.py:219: in create_jks
    update_jks_perm(module, keystore_path)
lib/ansible/modules/system/java_keystore.py:237: in update_jks_perm
    module.set_fs_attributes_if_different(file_args, False)
lib/ansible/module_utils/basic.py:1539: in set_fs_attributes_if_different
    file_args['path'], file_args['secontext'], changed, diff
lib/ansible/module_utils/basic.py:1145: in set_context_if_different
    cur_context = self.selinux_context(path)
lib/ansible/module_utils/basic.py:1075: in selinux_context
    self.fail_json(path=path, msg='path %s does not exist' % path)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

args = (<ansible.module_utils.basic.AnsibleModule object at 0x7f645a649a50>,)
kwargs = {'failed': True, 'msg': 'path /etc/security/keystore.jks does not exist', 'path': '/etc/security/keystore.jks'}

    def fail_json(*args, **kwargs):
        kwargs['failed'] = True
>       raise AnsibleFailJson(kwargs)
E       AnsibleFailJson: {'msg': 'path /etc/security/keystore.jks does not exist', 'path': '/etc/security/keystore.jks', 'failed': True}

test/units/modules/utils.py:30: AnsibleFailJson
================================================================================== 1 failed in 0.26 seconds ===================================================================================
````