### PR TITLE
Fix NameError in pause module

### DIFF
--- a/lib/ansible/plugins/action/pause.py
+++ b/lib/ansible/plugins/action/pause.py
@@ -39,9 +39,12 @@ except ImportError:
 
 try:
     import curses
-    curses.setupterm()
-    HAS_CURSES = True
-except (ImportError, curses.error):
+    try:
+        curses.setupterm()
+        HAS_CURSES = True
+    except curses.error:
+        HAS_CURSES = False
+except ImportError:
     HAS_CURSES = False
 
 if HAS_CURSES:


### PR DESCRIPTION
##### SUMMARY
This fixes #42004 by nesting the try-catch for curses.error, which would otherwise be triggered when the curses library is not installed.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
pause

##### ANSIBLE VERSION
ansible 2.5.4
