### PR TITLE
Added documentation for collectstatic --clear.

### DIFF
--- a/lib/ansible/modules/web_infrastructure/django_manage.py
+++ b/lib/ansible/modules/web_infrastructure/django_manage.py
@@ -54,6 +54,13 @@ options:
     description:
       - The name of the table used for database-backed caching. Used by the 'createcachetable' command.
     required: false
+  clear:
+    description:
+      - Clear the existing files before trying to copy or link the original file. 
+      - Used only with the 'collectstatic' command. The --noinput argument will be supplied automatically.
+    required: false
+    default: "no"
+    type: bool 
   database:
     description:
       - The database to target. Used by the 'createcachetable', 'flush', 'loaddata', and 'syncdb' commands.

--- a/lib/ansible/modules/web_infrastructure/django_manage.py
+++ b/lib/ansible/modules/web_infrastructure/django_manage.py
@@ -57,9 +57,9 @@ options:
   clear:
     description:
       - Clear the existing files before trying to copy or link the original file.
-      - Used only with the 'collectstatic' command. The --noinput argument will be supplied automatically.
+      - Used only with the 'collectstatic' command. The C(--noinput) argument will be added automatically.
     required: false
-    default: "no"
+    default: no
     type: bool
   database:
     description:

--- a/lib/ansible/modules/web_infrastructure/django_manage.py
+++ b/lib/ansible/modules/web_infrastructure/django_manage.py
@@ -56,11 +56,11 @@ options:
     required: false
   clear:
     description:
-      - Clear the existing files before trying to copy or link the original file. 
+      - Clear the existing files before trying to copy or link the original file.
       - Used only with the 'collectstatic' command. The --noinput argument will be supplied automatically.
     required: false
     default: "no"
-    type: bool 
+    type: bool
   database:
     description:
       - The database to target. Used by the 'createcachetable', 'flush', 'loaddata', and 'syncdb' commands.


### PR DESCRIPTION
##### SUMMARY
Documents the clear argument to the django_manage module that can be used to delete existing files when the collectstatic management command is run.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
django_manage

##### ANSIBLE VERSION
```
ansible 2.5.5
  config file = /home/stuart/.ansible.cfg
  configured module search path = [u'/home/stuart/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```

##### ADDITIONAL INFORMATION
When https://github.com/ansible/ansible-modules-core/pull/1810  was submitted there was no corresponding update to the documentation for the django_manage module.

The PR was merged on 17 Sep 2015 but I do not know what version this was added to. This will need to be added to the change here.

Sample output from anisble when running the command.
```
changed: [papyrus.local] => {
    "app_path": "/webapps/papyrus/papyrus/backend", 
    "changed": [
        ...
        "Deleting 'rest_framework/js/csrf.js'", 
        "Deleting 'rest_framework/js/bootstrap.min.js'", 
        "Deleting 'rest_framework/js/default.js'", 
        ...
        "Copying '/webapps/papyrus/lib/python3.6/site-packages/rest_framework/static/rest_framework/js/csrf.js'", 
        "Copying '/webapps/papyrus/lib/python3.6/site-packages/rest_framework/static/rest_framework/js/bootstrap.min.js'", 
        "Copying '/webapps/papyrus/lib/python3.6/site-packages/rest_framework/static/rest_framework/js/default.js'", 
        ...
    "cmd": "./manage.py collectstatic --noinput --settings=settings --clear", 
    "out": "Deleting ...
   "pythonpath": null, 
    "settings": "papyrus.settings", 
    "virtualenv": "/webapps/papyrus"
}
```
