### PR TITLE
Fix invalid Dockerfile created by "galaxy init foo --type=apb"

### DIFF
--- a/lib/ansible/galaxy/data/apb/Dockerfile.j2
+++ b/lib/ansible/galaxy/data/apb/Dockerfile.j2
@@ -1,6 +1,7 @@
 FROM ansibleplaybookbundle/apb-base
 
 LABEL "com.redhat.apb.spec"=\
+""
 
 COPY playbooks /opt/apb/actions
 COPY . /opt/ansible/roles/{{ role_name }}


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fix unbuildable initial Dockerfile created by `galaxy init foo --type=apb` by adding a default value of `""` for the apb spec `LABEL`. 

Previously we could count on the user running `apb prepare` to load ` LABEL "com.redhat.apb.spec"=\	` with a value, but now that we are using APBs (bundles) outside of an Automation Broker context in some scenarios, we don't always expect `apb prepare` to have been a part of the build process.

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
Galaxy

<!--- Paste verbatim output from "ansible --version" between quotes below -->




<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

