### PR TITLE
Fix virt role detection for Hetzner cloud servers

### DIFF
--- a/lib/ansible/module_utils/facts/virtual/linux.py
+++ b/lib/ansible/module_utils/facts/virtual/linux.py
@@ -114,7 +114,7 @@ class LinuxVirtual(Virtual):
             virtual_facts['virtualization_role'] = 'guest'
             return virtual_facts
 
-        if bios_vendor == 'Amazon EC2':
+        if bios_vendor in ['Amazon EC2', 'Hetzner']:
             virtual_facts['virtualization_type'] = 'kvm'
             virtual_facts['virtualization_role'] = 'guest'
             return virtual_facts


### PR DESCRIPTION
See also https://wiki.hetzner.de/index.php/CloudServer/en

##### SUMMARY
This patch fixes the virtual facts `virtualization_type` and `virtualization_role`.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
Virtual facts module for Linux

##### ANSIBLE VERSION
```
ansible 2.5.5
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.15rc1 (default, Apr 15 2018, 21:51:34) [GCC 7.3.0]
```


##### ADDITIONAL INFORMATION
Before my change:
```
        "ansible_system_vendor": "Hetzner", 
        "ansible_virtualization_role": "NA", 
        "ansible_virtualization_type": "NA", 
```

After my change:
```
        "ansible_system_vendor": "Hetzner", 
        "ansible_virtualization_role": "guest", 
        "ansible_virtualization_type": "kvm", 
```