### PR TITLE
Simple file locking feature

### DIFF
--- a/changelogs/fragments/add_file_lock_feature.yaml
+++ b/changelogs/fragments/add_file_lock_feature.yaml
@@ -1,0 +1,5 @@
+---
+minor_changes:
+- File locking feature added, making it possible to gain exclusive access
+  to given file through module_utils.common.file.FileLock
+  (https://github.com/ansible/ansible/issues/29962)

--- a/lib/ansible/module_utils/common/file.py
+++ b/lib/ansible/module_utils/common/file.py
@@ -12,6 +12,7 @@ import shutil
 import tempfile
 import traceback
 import fcntl
+import sys
 
 from ansible.module_utils._text import to_bytes, to_native, to_text
 from ansible.module_utils.six import b, binary_type
@@ -59,6 +60,9 @@ class FileLock():
         tmp_dir = tempfile.gettempdir()
         lock_path = os.path.join(tmp_dir, 'ansible-{0}.lock'.format(os.path.basename(path)))
         l_wait = 0.1
+        r_exception = IOError
+        if sys.version_info[0] == 3:
+            r_exception = BlockingIOError
 
         self.lockfd = open(lock_path, 'w')
 
@@ -74,7 +78,7 @@ class FileLock():
                     fcntl.flock(self.lockfd, fcntl.LOCK_EX | fcntl.LOCK_NB)
                     os.chmod(lock_path, stat.S_IWRITE | stat.S_IREAD)
                     return True
-                except IOError or BlockingIOError:
+                except r_exception:
                     time.sleep(l_wait)
                     e_secs += l_wait
                     continue

--- a/lib/ansible/module_utils/common/file.py
+++ b/lib/ansible/module_utils/common/file.py
@@ -40,10 +40,8 @@ class FileLock():
         '''
         try:
             self.set_lock(path, lock_timeout)
-            print('lock aquired')
             yield
         finally:
-            print('releasing lock')
             self.unlock()
 
     def set_lock(self, path, lock_timeout=None):

--- a/lib/ansible/module_utils/common/file.py
+++ b/lib/ansible/module_utils/common/file.py
@@ -23,6 +23,7 @@ try:
 except ImportError:
     HAVE_SELINUX = False
 
+
 class LockTimeout(Exception):
     pass
 

--- a/lib/ansible/module_utils/common/file.py
+++ b/lib/ansible/module_utils/common/file.py
@@ -14,9 +14,9 @@ import traceback
 import fcntl
 import sys
 
+from contextlib import contextmanager
 from ansible.module_utils._text import to_bytes, to_native, to_text
 from ansible.module_utils.six import b, binary_type
-from contextlib import contextmanager
 
 try:
     import selinux
@@ -50,10 +50,11 @@ class FileLock():
         using given path
 
         :kw path: Path (file) to lock
-        :kw lock_timeout: Wait n seconds for lock acquisition
-            Default is None (wait until lock is released)
-            0 = Do not wait
-        :returns: True if successful else an exception is raised
+        :kw lock_timeout:
+            Wait n seconds for lock acquisition, fail if timeout is reached.
+            0 = Do not wait, fail if lock cannot be acquired immediately,
+            Default is None, wait indefinitely until lock is released.
+        :returns: True
         '''
         tmp_dir = tempfile.gettempdir()
         lock_path = os.path.join(tmp_dir, 'ansible-{0}.lock'.format(os.path.basename(path)))

--- a/lib/ansible/module_utils/common/file.py
+++ b/lib/ansible/module_utils/common/file.py
@@ -1,0 +1,104 @@
+# Copyright (c) 2018, Ansible Project
+# Simplified BSD License (see licenses/simplified_bsd.txt or https://opensource.org/licenses/BSD-2-Clause)
+
+import errno
+import os
+import stat
+import re
+import pwd
+import grp
+import time
+import shutil
+import tempfile
+import traceback
+import fcntl
+
+from ansible.module_utils._text import to_bytes, to_native, to_text
+from ansible.module_utils.six import b, binary_type
+from contextlib import contextmanager
+
+try:
+    import selinux
+    HAVE_SELINUX = True
+except ImportError:
+    HAVE_SELINUX = False
+
+class LockTimeout(Exception):
+    pass
+
+
+class FileLock():
+    def __init__(self):
+        self.lockfd = None
+
+    @contextmanager
+    def lock_file(self, path, lock_timeout=None):
+        '''
+        Context for lock acquisition
+        '''
+        try:
+            self.set_lock(path, lock_timeout)
+            print('lock aquired')
+            yield
+        finally:
+            print('releasing lock')
+            self.unlock()
+
+    def set_lock(self, path, lock_timeout=None):
+        '''
+        Create a lock file based on path with flock to prevent other processes
+        using given path
+
+        :kw path: Path (file) to lock
+        :kw lock_timeout: Wait n seconds for lock acquisition
+            Default is None (wait until lock is released)
+            0 = Do not wait
+        :returns: True if successful else an exception is raised
+        '''
+        tmp_dir = tempfile.gettempdir()
+        lock_path = os.path.join(tmp_dir, 'ansible-{0}.lock'.format(os.path.basename(path)))
+        l_wait = 0.1
+
+        self.lockfd = open(lock_path, 'w')
+
+        if lock_timeout <= 0:
+            fcntl.flock(self.lockfd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            os.chmod(lock_path, stat.S_IWRITE | stat.S_IREAD)
+            return True
+
+        if lock_timeout:
+            e_secs = 0
+            while e_secs < lock_timeout:
+                try:
+                    fcntl.flock(self.lockfd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                    os.chmod(lock_path, stat.S_IWRITE | stat.S_IREAD)
+                    return True
+                except IOError or BlockingIOError:
+                    time.sleep(l_wait)
+                    e_secs += l_wait
+                    continue
+
+            self.lockfd.close()
+            raise LockTimeout('{0} sec'.format(lock_timeout))
+
+        fcntl.flock(self.lockfd, fcntl.LOCK_EX)
+        os.chmod(lock_path, stat.S_IWRITE | stat.S_IREAD)
+
+        return True
+
+    def unlock(self):
+        '''
+        Unlock the file descriptor locked by set_lock
+
+        :returns: True
+        '''
+        if not self.lockfd:
+            return True
+
+        try:
+            fcntl.flock(self.lockfd, fcntl.LOCK_UN)
+            self.lockfd.close()
+        except ValueError:  # file wasn't opened, let context manager fail gracefully
+            pass
+
+        return True

--- a/lib/ansible/module_utils/common/file.py
+++ b/lib/ansible/module_utils/common/file.py
@@ -30,6 +30,12 @@ class LockTimeout(Exception):
 
 
 class FileLock():
+    '''
+    Currently FileLock is implemented via fcntl.flock on a lock file, however this
+    behaviour may change in the future. Avoid mixing lock types fcntl.flock,
+    fcntl.lockf and module_utils.common.file.FileLock as it will certainly cause
+    unwanted and/or unexpected behaviour
+    '''
     def __init__(self):
         self.lockfd = None
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #29962 and replaces PR #41629
This adds a simple and generic file locking feature through fcntl.flock.
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
basic.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (29962-feature-pr-file-lock a0dc41119c) last updated 2018/06/28 00:13:49 (GMT +200)
  config file = None
  configured module search path = ['/home/acalm/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/acalm/venv/ansible/lib/python3.6/site-packages/ansible
  executable location = /home/acalm/venv/ansible/bin/ansible
  python version = 3.6.5 (default, Apr 20 2018, 08:08:06) [GCC 6.4.0]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->
use lock_file() as a context, like:
```
with lock_file('/file/to/lock'):
    # do stuff while file is locked
```
or use set_lock() and unlock() "manually"

This could be used to solve issues like #30413, also slightly related to #31096, however this PR just provides exclusive access to a given file. Also due to the nature of file locking on Linux, above only works IF all processes accessing the file utilizes flock of course.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```


```
