### PR TITLE
pamd module regression fix

### DIFF
--- a/lib/ansible/modules/system/pamd.py
+++ b/lib/ansible/modules/system/pamd.py
@@ -324,7 +324,7 @@ class PamdInclude(PamdLine):
 class PamdRule(PamdLine):
 
     valid_types = ['account', 'auth', 'password', 'session']
-    valid_simple_controls = ['required', 'requisite', 'sufficicent', 'optional', 'include', 'substack']
+    valid_simple_controls = ['required', 'requisite', 'sufficient', 'optional', 'include', 'substack']
     valid_control_values = ['success', 'open_err', 'symbol_err', 'service_err', 'system_err', 'buf_err',
                             'perm_denied', 'auth_err', 'cred_insufficient', 'authinfo_unavail', 'user_unknown',
                             'maxtries', 'new_authtok_reqd', 'acct_expired', 'session_err', 'cred_unavail',

--- a/lib/ansible/modules/system/pamd.py
+++ b/lib/ansible/modules/system/pamd.py
@@ -296,6 +296,11 @@ class PamdLine(object):
             return True
         return False
 
+    def validate(self):
+        if not self.is_valid:
+            return False, "Rule is not valid " + self.line
+        return True, "Rule is valid " + self.line
+
     # Method to check if a rule matches the type, control and path.
     def matches(self, rule_type, rule_control, rule_path, rule_args=None):
         return False
@@ -663,8 +668,8 @@ class PamdService(object):
         current_line = self._head
 
         while current_line is not None:
-            if not current_line.is_valid:
-                return current_line.is_valid, "Module is invalid"
+            if not current_line.validate()[0]:
+                return current_line.validate()
             current_line = current_line.next
         return True, "Module is valid"
 

--- a/lib/ansible/modules/system/pamd.py
+++ b/lib/ansible/modules/system/pamd.py
@@ -653,8 +653,8 @@ class PamdService(object):
         current_line = self._head
 
         while current_line is not None:
-            if not current_line.is_valid()[0]:
-                return current_line.is_valid()
+            if not current_line.is_valid:
+                return current_line.is_valid, "Module is invalid"
             current_line = current_line.next
         return True, "Module is valid"
 

--- a/lib/ansible/modules/system/pamd.py
+++ b/lib/ansible/modules/system/pamd.py
@@ -290,6 +290,12 @@ class PamdLine(object):
         self.prev = None
         self.next = None
 
+    @property
+    def is_valid(self):
+        if self.line == '':
+            return True
+        return False
+
     # Method to check if a rule matches the type, control and path.
     def matches(self, rule_type, rule_control, rule_path, rule_args=None):
         return False
@@ -404,6 +410,10 @@ class PamdRule(PamdLine):
         if number >= 0:
             return True
         return False
+
+    @property
+    def is_valid(self):
+        return self.validate()[0]
 
     def validate(self):
         # Validate the rule type

--- a/lib/ansible/modules/system/pamd.py
+++ b/lib/ansible/modules/system/pamd.py
@@ -425,10 +425,10 @@ class PamdRule(PamdLine):
         if self.rule_type not in PamdRule.valid_types:
             return False, "Rule type, " + self.rule_type + ", is not valid in rule " + self.line
         # Validate the rule control
-        if isinstance(self.rule_control, str) and self.rule_control not in PamdRule.valid_simple_controls:
+        if isinstance(self._control, str) and self.rule_control not in PamdRule.valid_simple_controls:
             return False, "Rule control, " + self.rule_control + ", is not valid in rule " + self.line
-        elif isinstance(self.rule_control, list):
-            for control in self.rule_control:
+        elif isinstance(self._control, list):
+            for control in self._control:
                 value, action = control.split("=")
                 if value not in PamdRule.valid_control_values:
                     return False, "Rule control value, " + value + ", is not valid in rule " + self.line


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fix for "TypeError: 'bool' object is not callable" when trying to use pamd module
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
Fixes #41179

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
pamd

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (issue41179 34358ce9b4) last updated 2018/06/27 18:49:52 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/user/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/user/ansible-ansible/lib/ansible
  executable location = /home/user/ansible-ansible/bin/ansible
  python version = 2.7.5 (default, Apr 11 2018, 07:36:10) [GCC 4.8.5 20150623 (Red Hat 4.8.5-28)]

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->
There were several issues here.  Each is described in the commit message fixing the respective issue.
See #41179 for the original problem.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
