### PR TITLE
Fix NameError in pause module

### DIFF
--- a/changelogs/fragments/pause-try-except-curses.yaml
+++ b/changelogs/fragments/pause-try-except-curses.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - pause - nest try except when importing curses to gracefully fail if curses is not present (https://github.com/ansible/ansible/issues/42004)

--- a/lib/ansible/plugins/action/pause.py
+++ b/lib/ansible/plugins/action/pause.py
@@ -39,9 +39,12 @@ except ImportError:
 
 try:
     import curses
-    curses.setupterm()
-    HAS_CURSES = True
-except (ImportError, curses.error):
+    try:
+        curses.setupterm()
+        HAS_CURSES = True
+    except curses.error:
+        HAS_CURSES = False
+except ImportError:
     HAS_CURSES = False
 
 if HAS_CURSES:

--- a/lib/ansible/plugins/action/pause.py
+++ b/lib/ansible/plugins/action/pause.py
@@ -39,6 +39,8 @@ except ImportError:
 
 try:
     import curses
+
+    # Nest the try except since curses.error is not available if curses did not import
     try:
         curses.setupterm()
         HAS_CURSES = True


### PR DESCRIPTION
##### SUMMARY
This fixes #42004 by nesting the try-catch for curses.error, which would otherwise be triggered when the curses library is not installed.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/action/pause.py

##### ANSIBLE VERSION
ansible 2.5.4


##### ADDITIONAL INFORMATION
See #42004 