### PR TITLE
Deprecate foreman and katello modules

### DIFF
--- a/docs/docsite/rst/porting_guides/porting_guide_2.7.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.7.rst
@@ -156,8 +156,6 @@ Deprecation notices
 
 The following modules will be removed in Ansible 2.11. Please update your playbooks accordingly.
 
-* ``foreman`` use <https://github.com/theforeman/foreman-ansible-modules> instead.
-* ``katello`` use <https://github.com/theforeman/foreman-ansible-modules> instead.
 * ``na_cdot_aggregate`` use :ref:`na_ontap_aggregate <na_ontap_aggregate_module>` instead.
 * ``na_cdot_license`` use :ref:`na_ontap_license <na_ontap_license_module>` instead.
 * ``na_cdot_lun`` use :ref:`na_ontap_lun <na_ontap_lun_module>` instead.
@@ -194,10 +192,6 @@ Noteworthy module changes
   * ``days_of_week``, use ``monthlydow`` in a triggers entry instead
   * ``frequency``, use ``type``, in a triggers entry instead
   * ``time``, use ``start_boundary`` in a triggers entry instead
-
-* The ``foreman`` and ``katello`` modules have been deprecated in favor of a set of modules that are broken out per entity with better idempotency in mind.
-
-* The ``foreman`` and ``katello`` modules replacement is officially part of the Foreman Community and supported there.
 
 * The ``interface_name`` module option for ``na_ontap_net_vlan`` has been removed and should be removed from your playbooks
 

--- a/docs/docsite/rst/porting_guides/porting_guide_2.7.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.7.rst
@@ -156,6 +156,8 @@ Deprecation notices
 
 The following modules will be removed in Ansible 2.11. Please update your playbooks accordingly.
 
+* ``foreman`` use <https://github.com/theforeman/foreman-ansible-modules> instead.
+* ``katello`` use <https://github.com/theforeman/foreman-ansible-modules> instead.
 * ``na_cdot_aggregate`` use :ref:`na_ontap_aggregate <na_ontap_aggregate_module>` instead.
 * ``na_cdot_license`` use :ref:`na_ontap_license <na_ontap_license_module>` instead.
 * ``na_cdot_lun`` use :ref:`na_ontap_lun <na_ontap_lun_module>` instead.
@@ -192,6 +194,10 @@ Noteworthy module changes
   * ``days_of_week``, use ``monthlydow`` in a triggers entry instead
   * ``frequency``, use ``type``, in a triggers entry instead
   * ``time``, use ``start_boundary`` in a triggers entry instead
+
+* The ``foreman`` and ``katello`` modules have been deprecated in favor of a set of modules that are broken out per entity with better idempotency in mind.
+
+* The ``foreman`` and ``katello`` modules replacement is officially part of the Foreman Community and supported there.
 
 * The ``interface_name`` module option for ``na_ontap_net_vlan`` has been removed and should be removed from your playbooks
 

--- a/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
@@ -67,10 +67,15 @@ Deprecation notices
 
 The following modules will be removed in Ansible 2.12. Please update your playbooks accordingly.
 
+* ``foreman`` use <https://github.com/theforeman/foreman-ansible-modules> instead.
+* ``katello`` use <https://github.com/theforeman/foreman-ansible-modules> instead.
+
 
 Noteworthy module changes
 -------------------------
 
+* The ``foreman`` and ``katello`` modules have been deprecated in favor of a set of modules that are broken out per entity with better idempotency in mind.
+* The ``foreman`` and ``katello`` modules replacement is officially part of the Foreman Community and supported there.
 * The ``tower_credential`` module originally required the ``ssh_key_data`` to be the path to a ssh_key_file.
   In order to work like Tower/AWX, ``ssh_key_data`` now contains the content of the file.
   The previous behavior can be achieved with ``lookup('file', '/path/to/file')``.

--- a/lib/ansible/modules/remote_management/foreman/_foreman.py
+++ b/lib/ansible/modules/remote_management/foreman/_foreman.py
@@ -37,6 +37,11 @@ options:
         description:
             - Username on Foreman server.
         required: true
+    verify_ssl:
+        description:
+            - Whether to verify an SSL connection to Foreman server.
+        type: bool
+        default: False
     password:
         description:
             - Password for user accessing Foreman server.

--- a/lib/ansible/modules/remote_management/foreman/_foreman.py
+++ b/lib/ansible/modules/remote_management/foreman/_foreman.py
@@ -16,7 +16,7 @@ DOCUMENTATION = '''
 module: foreman
 short_description: Manage Foreman Resources
 deprecated:
-    removed_in: "2.11"
+    removed_in: "2.12"
     why: "Replaced by re-designed individual modules living at https://github.com/theforeman/foreman-ansible-modules"
     alternative: https://github.com/theforeman/foreman-ansible-modules
 description:

--- a/lib/ansible/modules/remote_management/foreman/_foreman.py
+++ b/lib/ansible/modules/remote_management/foreman/_foreman.py
@@ -8,13 +8,17 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
+                    'status': ['deprecated'],
                     'supported_by': 'community'}
 
 DOCUMENTATION = '''
 ---
 module: foreman
 short_description: Manage Foreman Resources
+deprecated:
+    removed_in: "2.11"
+    why: "Replaced by re-designed individual modules living at https://github.com/theforeman/foreman-ansible-modules"
+    alternative: https://github.com/theforeman/foreman-ansible-modules
 description:
     - Allows the management of Foreman resources inside your Foreman server.
 version_added: "2.3"

--- a/lib/ansible/modules/remote_management/foreman/_katello.py
+++ b/lib/ansible/modules/remote_management/foreman/_katello.py
@@ -16,7 +16,7 @@ DOCUMENTATION = '''
 module: katello
 short_description: Manage Katello Resources
 deprecated:
-    removed_in: "2.11"
+    removed_in: "2.12"
     why: "Replaced by re-designed individual modules living at https://github.com/theforeman/foreman-ansible-modules"
     alternative: https://github.com/theforeman/foreman-ansible-modules
 description:

--- a/lib/ansible/modules/remote_management/foreman/_katello.py
+++ b/lib/ansible/modules/remote_management/foreman/_katello.py
@@ -8,13 +8,17 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
+                    'status': ['deprecated'],
                     'supported_by': 'community'}
 
 DOCUMENTATION = '''
 ---
 module: katello
 short_description: Manage Katello Resources
+deprecated:
+    removed_in: "2.11"
+    why: "Replaced by re-designed individual modules living at https://github.com/theforeman/foreman-ansible-modules"
+    alternative: https://github.com/theforeman/foreman-ansible-modules
 description:
     - Allows the management of Katello resources inside your Foreman server.
 version_added: "2.3"

--- a/test/sanity/pylint/ignore.txt
+++ b/test/sanity/pylint/ignore.txt
@@ -51,8 +51,8 @@ lib/ansible/modules/network/nxos/nxos_snapshot.py ansible-format-automatic-speci
 lib/ansible/modules/network/vyos/vyos_vlan.py ansible-format-automatic-specification
 lib/ansible/modules/notification/cisco_spark.py ansible-format-automatic-specification
 lib/ansible/modules/notification/logentries_msg.py ansible-format-automatic-specification
-lib/ansible/modules/remote_management/foreman/foreman.py ansible-format-automatic-specification
-lib/ansible/modules/remote_management/foreman/katello.py ansible-format-automatic-specification
+lib/ansible/modules/remote_management/foreman/_foreman.py ansible-format-automatic-specification
+lib/ansible/modules/remote_management/foreman/_katello.py ansible-format-automatic-specification
 lib/ansible/modules/source_control/github_deploy_key.py ansible-format-automatic-specification
 lib/ansible/modules/source_control/github_key.py ansible-format-automatic-specification
 lib/ansible/modules/storage/infinidat/infini_export.py ansible-format-automatic-specification


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Deprecating the Foreman and Katello modules that were in preview in favor of the newer and re-designed modules that currently live at https://github.com/theforeman/foreman-ansible-modules. Users will find the same functionality and more in that repository.

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
foreman
katello
