### PR TITLE
[WIP]nxos_facts requires JSON structured output support

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_facts.py
+++ b/lib/ansible/modules/network/nxos/nxos_facts.py
@@ -37,6 +37,9 @@ description:
 author:
   - Jason Edelman (@jedelman8)
   - Gabriele Gerbino (@GGabriele)
+notes:
+  - This module is only supported on the NX-OS device that supports JSON
+    structured output. NX-OS OS version should be 7.x or greater.
 options:
   gather_subset:
     description:
@@ -169,6 +172,7 @@ vlan_list:
 import re
 
 from ansible.module_utils.network.nxos.nxos import run_commands, get_config
+from ansible.module_utils.network.nxos.nxos import get_capabilities
 from ansible.module_utils.network.nxos.nxos import nxos_argument_spec, check_args
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six import string_types, iteritems
@@ -545,6 +549,13 @@ def main():
 
     runable_subsets = set()
     exclude_subsets = set()
+
+    capabilities = get_capabilities(module)
+    if capabilities:
+        os_version = capabilities['device_info']['network_os_version']
+        os_version_major = int(os_version[0])
+        if os_version_major < 7:
+            module.fail_json(msg="this module requires JSON structured output support on the NX-OS device")
 
     for subset in gather_subset:
         if subset == 'all':


### PR DESCRIPTION
Signed-off-by: Trishna Guha <trishnaguha17@gmail.com>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
fixes https://github.com/ansible/ansible/issues/41828
fixes https://github.com/ansible/ansible/issues/41514
Add notes that JSON structured output is required on NX-OS device to use this module.
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
modules/network/nxos/nxos_facts.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel, 2.6
```