### PR TITLE
Fix EC2 example variable naming mismatch

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2.py
+++ b/lib/ansible/modules/cloud/amazon/ec2.py
@@ -359,7 +359,7 @@ EXAMPLES = '''
   hosts: localhost
   gather_facts: False
   vars:
-    key_name: my_keypair
+    keypair: my_keypair
     instance_type: m1.small
     security_group: my_securitygroup
     image: my_ami_id


### PR DESCRIPTION
Fix EC2 example where variable name mismatched usage.

+label: docsite_pr