### PR TITLE
Fix setting required options for inventory plugins

### DIFF
--- a/lib/ansible/inventory/manager.py
+++ b/lib/ansible/inventory/manager.py
@@ -183,7 +183,6 @@ class InventoryManager(object):
         for name in C.INVENTORY_ENABLED:
             plugin = inventory_loader.get(name)
             if plugin:
-                plugin.set_options()
                 self._inventory_plugins.append(plugin)
             else:
                 display.warning('Failed to load inventory plugin, skipping %s' % name)

--- a/lib/ansible/plugins/inventory/script.py
+++ b/lib/ansible/plugins/inventory/script.py
@@ -85,6 +85,7 @@ class InventoryModule(BaseInventoryPlugin, Cacheable):
     def parse(self, inventory, loader, path, cache=None):
 
         super(InventoryModule, self).parse(inventory, loader, path)
+        self.set_options()
 
         if cache is None:
             cache = self.get_option('cache')

--- a/lib/ansible/plugins/inventory/yaml.py
+++ b/lib/ansible/plugins/inventory/yaml.py
@@ -90,6 +90,7 @@ class InventoryModule(BaseFileInventoryPlugin):
         ''' parses the inventory file '''
 
         super(InventoryModule, self).parse(inventory, loader, path)
+        self.set_options()
 
         try:
             data = self.loader.load_from_file(path, cache=False)


### PR DESCRIPTION
##### SUMMARY
Fixes requiring options for inventory plugins. Right now environment vars are found first, and if no environment var is able to be provided for the required option the plugin fails.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/inventory/manager.py

##### ANSIBLE VERSION
```
ansible 2.7.0.dev0
```