### PR TITLE
Support SubnetMappings in actual AWS create LB call

### DIFF
--- a/lib/ansible/module_utils/aws/elbv2.py
+++ b/lib/ansible/module_utils/aws/elbv2.py
@@ -246,6 +246,8 @@ class ApplicationLoadBalancer(ElasticLoadBalancerV2):
         # Other parameters
         if self.subnets is not None:
             params['Subnets'] = self.subnets
+        if self.subnet_mappings is not None:
+            params['SubnetMappings'] = self.subnet_mappings
         if self.security_groups is not None:
             params['SecurityGroups'] = self.security_groups
         params['Scheme'] = self.scheme
@@ -360,6 +362,8 @@ class NetworkLoadBalancer(ElasticLoadBalancerV2):
         # Other parameters
         if self.subnets is not None:
             params['Subnets'] = self.subnets
+        if self.subnet_mappings is not None:
+            params['SubnetMappings'] = self.subnet_mappings
         params['Scheme'] = self.scheme
         if self.tags:
             params['Tags'] = self.tags


### PR DESCRIPTION
##### SUMMARY
When using the `elb_network_lb` resource I was attempting to set the `subnet_mappings` attribute as documented but received this error when running the playbook:

```An error occurred (ValidationError) when calling the CreateLoadBalancer operation: At least one subnet must be specified```

Here is the full output, showing that `subnet_mappings` was indeed set:

```
The full traceback is:
Traceback (most recent call last):
  File "/tmp/ansible_Y9yjVK/ansible_modlib.zip/ansible/module_utils/aws/elbv2.py", line 370, in create_elb
    self.elb = AWSRetry.jittered_backoff()(self.connection.create_load_balancer)(**params)['LoadBalancers'][0]
  File "/tmp/ansible_Y9yjVK/ansible_modlib.zip/ansible/module_utils/cloud.py", line 150, in retry_func
    raise e
ClientError: An error occurred (ValidationError) when calling the CreateLoadBalancer operation: At least one subnet must be specified

fatal: [localhost]: FAILED! => {
    "boto3_version": "1.7.46", 
    "botocore_version": "1.10.46", 
    "changed": false, 
    "error": {
        "code": "ValidationError", 
        "message": "At least one subnet must be specified", 
        "type": "Sender"
    }, 
    "invocation": {
        "module_args": {
            "aws_access_key": null, 
            "aws_secret_key": null, 
            "cross_zone_load_balancing": null, 
            "deletion_protection": null, 
            "ec2_url": null, 
            "listeners": [
                {
                    "Certificates": null, 
                    "DefaultActions": [
                        {
                            "TargetGroupName": "stage-or1-std-http-edge-80", 
                            "Type": "forward"
                        }
                    ], 
                    "Port": 80, 
                    "Protocol": "TCP", 
                    "SslPolicy": null
                }, 
                {
                    "Certificates": null, 
                    "DefaultActions": [
                        {
                            "TargetGroupName": "stage-or1-std-http-edge-443", 
                            "Type": "forward"
                        }
                    ], 
                    "Port": 443, 
                    "Protocol": "TCP", 
                    "SslPolicy": null
                }
            ], 
            "name": "stage-or1-std-http-edge-2", 
            "profile": null, 
            "purge_listeners": true, 
            "purge_tags": true, 
            "region": "us-west-2", 
            "scheme": "internet-facing", 
            "security_token": null, 
            "state": "present", 
            "subnet_mappings": [
                {
                    "AllocationId": "eipalloc-4d6f3971", 
                    "SubnetId": "subnet-3f14c066"
                }, 
                {
                    "AllocationId": "eipalloc-0b6c3a37", 
                    "SubnetId": "subnet-fd4c9ab5"
                }
            ], 
            "subnets": null, 
            "tags": null, 
            "validate_certs": true, 
            "wait": null, 
            "wait_timeout": null
        }
    }, 
    "msg": "An error occurred (ValidationError) when calling the CreateLoadBalancer operation: At least one subnet must be specified", 
    "response_metadata": {
        "http_headers": {
            "connection": "close", 
            "content-length": "300", 
            "content-type": "text/xml", 
            "date": "Thu, 28 Jun 2018 17:20:04 GMT", 
            "x-amzn-requestid": "7f6e83a4-7af7-11e8-9084-b141012d5ac6"
        }, 
        "http_status_code": 400, 
        "request_id": "7f6e83a4-7af7-11e8-9084-b141012d5ac6", 
        "retry_attempts": 0
    }
}

```


<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
elb_network_lb

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/blamar/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/blamar/automation/venv/lib/python2.7/site-packages/ansible
  executable location = /home/blamar/automation/venv/bin/ansible
  python version = 2.7.9 (default, Apr 27 2015, 17:49:25) [GCC 4.6.3]
```

##### ADDITIONAL INFORMATION
To reproduce attempt to use the `subnet_mappings` feature of either an NLB or ALB.

After this change, NLBs and ALBs can be created with provided subnet mappings.
