### PR TITLE
Fix lastpass lookup plugin on python 3

### DIFF
--- a/lib/ansible/plugins/lookup/lastpass.py
+++ b/lib/ansible/plugins/lookup/lastpass.py
@@ -39,6 +39,7 @@ from subprocess import Popen, PIPE
 
 from ansible.errors import AnsibleError
 from ansible.plugins.lookup import LookupBase
+from ansible.module_utils._text import to_text, to_bytes
 
 
 class LPassException(AnsibleError):
@@ -60,12 +61,12 @@ class LPass(object):
         return err.startswith("Are you sure you would like to log out?")
 
     def _run(self, args, stdin=None, expected_rc=0):
-        p = Popen([self.cli_path] + args, stdout=PIPE, stderr=PIPE, stdin=PIPE)
-        out, err = p.communicate(stdin)
+        p = Popen([to_bytes(self.cli_path)] + [to_bytes(a) for a in args], stdout=PIPE, stderr=PIPE, stdin=PIPE)
+        out, err = p.communicate(to_bytes(stdin))
         rc = p.wait()
         if rc != expected_rc:
             raise LPassException(err)
-        return out, err
+        return to_text(out), to_text(err)
 
     def _build_args(self, command, args=None):
         if args is None:


### PR DESCRIPTION
- Open files in text mode instead of binary mode

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #42062, fixing the lastpass lookup plugin for python 3
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
lastpass
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0 (issue_42062_bugfix e6936f02e8) last updated 2018/06/28 13:04:38 (GMT -500)
  config file = None
  configured module search path = ['/home/imxxx021/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /c/Users/imxxx021/wsl/projects/ansible/lib/ansible
  executable location = /c/Users/imxxx021/wsl/projects/ansible/bin/ansible
  python version = 3.5.2 (default, Nov 23 2017, 16:37:01) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
