### PR TITLE
service_facts correct meaning of state for systemd service units

### DIFF
--- a/changelogs/fragments/service_facts_fix.yml
+++ b/changelogs/fragments/service_facts_fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - correct service facts systemd detection of state https://github.com/ansible/ansible/issues/40809

--- a/lib/ansible/modules/system/service_facts.py
+++ b/lib/ansible/modules/system/service_facts.py
@@ -178,16 +178,16 @@ class SystemctlScanService(BaseService):
         systemctl_path = self.module.get_bin_path("systemctl", opt_dirs=["/usr/bin", "/usr/local/bin"])
         if systemctl_path is None:
             return None
-        rc, stdout, stderr = self.module.run_command("%s list-unit-files --type=service | tail -n +2 | head -n -2" % systemctl_path, use_unsafe_shell=True)
-        for line in stdout.split("\n"):
-            line_data = line.split()
-            if len(line_data) != 2:
-                continue
-            if line_data[1] == "enabled":
+        rc, stdout, stderr = self.module.run_command("%s list-units --no-pager --type service --all" % systemctl_path, use_unsafe_shell=True)
+        for line in [svc_line for svc_line in stdout.split('\n') if '.service' in svc_line and 'not-found' not in svc_line]:
+            service_name = line.split()[0]
+            if "running" in line:
                 state_val = "running"
             else:
+                if 'failed' in line:
+                    service_name = line.split()[1]
                 state_val = "stopped"
-            services[line_data[0]] = {"name": line_data[0], "state": state_val, "source": "systemd"}
+            services[service_name] = {"name": service_name, "state": state_val, "source": "systemd"}
         return services
 
 


### PR DESCRIPTION
* service_facts correct meaning of state for systemd service units

Fixes #40809

Previously this module used the commend `systemctl list-unit-files
--type=service` to query state of services but list-unit-files only
shows enabled vs disabled which is not what we want for "state"

Signed-off-by: Adam Miller <admiller@redhat.com>

* make sure to define service_name before referencing it

Signed-off-by: Adam Miller <admiller@redhat.com>
(cherry picked from commit bf1cc2f1f4743929b7ef9f4f5c2ac169fbfbc108)

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
modules/service_facts
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```

```

```
