### PR TITLE
Catch the raised exception so we can report failure

### DIFF
--- a/lib/ansible/module_utils/network/iosxr/iosxr.py
+++ b/lib/ansible/module_utils/network/iosxr/iosxr.py
@@ -410,7 +410,7 @@ def load_config(module, command_filter, commit=False, replace=False,
 
         try:
             conn.edit_config(cmd_filter)
-        except ConnectionError:
+        except ConnectionError as exc:
             module.fail_json(msg=to_text(exc))
 
         if module._diff:


### PR DESCRIPTION
Avoid the _undefined name_ and mirror lines 389 and 459 by catching the raised exception into the variable __exc__ so it can be reported on the following line.

flake8 testing of https://github.com/ansible/ansible on Python 3.6.3

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./lib/ansible/module_utils/network/iosxr/iosxr.py:414:42: F821 undefined name 'exc'
            module.fail_json(msg=to_text(exc))
                                         ^
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - New Module Pull Request
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
