### PR TITLE
Documentation: show non-string non-iterable defaults for choices (#40…

### DIFF
--- a/docs/bin/plugin_formatter.py
+++ b/docs/bin/plugin_formatter.py
@@ -31,6 +31,7 @@ import sys
 import warnings
 from collections import defaultdict
 from distutils.version import LooseVersion
+from functools import partial
 from pprint import PrettyPrinter
 
 try:
@@ -49,6 +50,7 @@ from six import iteritems, string_types
 
 from ansible.errors import AnsibleError
 from ansible.module_utils._text import to_bytes, to_text
+from ansible.module_utils.common.collections import is_sequence
 from ansible.plugins.loader import fragment_loader
 from ansible.utils import plugin_docs
 from ansible.utils.display import Display
@@ -152,6 +154,9 @@ def rst_xline(width, char="="):
     ''' return a restructured text line of a given length '''
 
     return char * width
+
+
+test_list = partial(is_sequence, include_strings=False)
 
 
 def write_data(text, output_dir, outputname, module=None):
@@ -334,6 +339,7 @@ def jinja2_environment(template_dir, typ, plugin_type):
         env.filters['html_ify'] = html_ify
         env.filters['fmt'] = rst_fmt
         env.filters['xline'] = rst_xline
+        env.tests['list'] = test_list
         templates['plugin'] = env.get_template('plugin.rst.j2')
 
         if plugin_type == 'module':

--- a/docs/bin/plugin_formatter.py
+++ b/docs/bin/plugin_formatter.py
@@ -153,10 +153,12 @@ def rst_xline(width, char="="):
 
     return char * width
 
+
 def test_list(value):
     ''' Return true if the object is a list or tuple '''
 
     return isinstance(value, Sequence) and not isinstance(value, string_types)
+
 
 def write_data(text, output_dir, outputname, module=None):
     ''' dumps module output to a file or the screen, as requested '''

--- a/docs/bin/plugin_formatter.py
+++ b/docs/bin/plugin_formatter.py
@@ -29,9 +29,8 @@ import os
 import re
 import sys
 import warnings
-from collections import defaultdict
+from collections import defaultdict, Sequence
 from distutils.version import LooseVersion
-from functools import partial
 from pprint import PrettyPrinter
 
 try:
@@ -50,7 +49,6 @@ from six import iteritems, string_types
 
 from ansible.errors import AnsibleError
 from ansible.module_utils._text import to_bytes, to_text
-from ansible.module_utils.common.collections import is_sequence
 from ansible.plugins.loader import fragment_loader
 from ansible.utils import plugin_docs
 from ansible.utils.display import Display
@@ -155,9 +153,10 @@ def rst_xline(width, char="="):
 
     return char * width
 
+def test_list(value):
+    ''' Return true if the object is a list or tuple '''
 
-test_list = partial(is_sequence, include_strings=False)
-
+    return isinstance(value, Sequence) and not isinstance(value, string_types)
 
 def write_data(text, output_dir, outputname, module=None):
     ''' dumps module output to a file or the screen, as requested '''

--- a/docs/templates/plugin.rst.j2
+++ b/docs/templates/plugin.rst.j2
@@ -143,7 +143,7 @@ Parameters
                                 {% elif choice is sameas false %}
                                     {% set choice = 'no' %}
                                 {% endif %}
-                                {% if (value.default is string and value.default == choice) or (value.default is iterable and value.default is not string and choice in value.default) %}
+                                {% if (value.default is not list and value.default == choice) or (value.default is list and choice in value.default) %}
                                     <li><div style="color: blue"><b>@{ choice | escape }@</b>&nbsp;&larr;</div></li>
                                 {% else %}
                                     <li>@{ choice | escape }@</li>


### PR DESCRIPTION
…212)

* Also marking non-string defaults.

* Adding list filter from #37517 to plugin_formatter.

* Simplifying list test.

* Redistribute imports

(cherry picked from commit 0752dc12b79f81029341bc23a01df0757d81e475)

##### SUMMARY
Ensures all modules correctly display defaults for parameters, including modules with integer parameters like https://docs.ansible.com/ansible/devel/modules/acme_certificate_module.html

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
docs.ansible.com

##### ANSIBLE VERSION
2.6