### PR TITLE
Format fix on VMware Guide (#41272)

### DIFF
--- a/docs/docsite/rst/scenario_guides/guide_vmware.rst
+++ b/docs/docsite/rst/scenario_guides/guide_vmware.rst
@@ -22,8 +22,7 @@ and vCenter infrastcture. You can install pyVmomi using pip:
 vmware_guest module
 ```````````````````
 
-The :ref:vmware_guest <vmware_guest>module is used to manage various operations related to virtual machines in
-the given ESXi or vCenter server.
+The :ref:`vmware_guest<vmware_guest_module>` module manages various operations related to virtual machines in the given ESXi or vCenter server.
 
 Prior to Ansible version 2.5, ``folder`` was an optional parameter with a default value of ``/vm``. The folder parameter
  was used to discover information about virtual machines in the given infrastructure.


### PR DESCRIPTION
* Updating format of VMware Guide: small formatting error - hyperlink to module
(cherry picked from commit 91803c6ad31781d0042a65817e87284a00e84306)

##### SUMMARY
Corrects link to module docs from VMWare Guide.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
docs.ansible.com

##### ANSIBLE VERSION
2.6
