### PR TITLE
ipa_group: Adds description to module documentation

### DIFF
--- a/lib/ansible/modules/identity/ipa/ipa_group.py
+++ b/lib/ansible/modules/identity/ipa/ipa_group.py
@@ -24,6 +24,9 @@ options:
     - Can not be changed as it is the unique identifier.
     required: true
     aliases: ['name']
+  description:
+    description:
+    - Description of the group.
   external:
     description:
     - Allow adding external non-IPA members from trusted domains.


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
I noticed today that we didn't have this in the documentation, despite it being available as a valid module argument.
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
ipa_group

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (ipa_group_description 9875d20bb5) last updated 2018/06/28 16:30:08 (GMT -500)
  config file = None
  configured module search path = [u'/Users/fxfitz/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/fxfitz/dev/ansible/lib/ansible
to  executable location = /Users/fxfitz/.pyenv/versions/ansible/bin/ansible
  python version = 2.7.15 (default, May 29 2018, 20:16:38) [GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.1)]
```


##### ADDITIONAL INFORMATION
Not Applicable
