### PR TITLE
Meraki utility - Add properties for orgs and nets

### DIFF
--- a/lib/ansible/module_utils/network/meraki/meraki.py
+++ b/lib/ansible/module_utils/network/meraki/meraki.py
@@ -56,6 +56,10 @@ class MerakiModule(object):
         self.result = dict(changed=False)
         self.headers = dict()
         self.function = function
+        self.orgs = None
+        self.nets = None
+        self.org_id = None
+        self.net_id = None
 
         # normal output
         self.existing = None
@@ -153,7 +157,8 @@ class MerakiModule(object):
         response = self.request('/organizations', method='GET')
         if self.status != 200:
             self.fail_json(msg='Organization lookup failed')
-        return response
+        self.orgs = self.request('/organizations', method='GET')
+        return self.orgs
 
     def is_org_valid(self, data, org_name=None, org_id=None):
         """Checks whether a specific org exists and is duplicated.
@@ -200,7 +205,8 @@ class MerakiModule(object):
         r = self.request(path, method='GET')
         if self.status != 200:
             self.fail_json(msg='Network lookup failed')
-        return r
+        self.nets = self.request(path, method='GET')
+        return self.nets
 
     def get_net(self, org_name, net_name, data=None):
         """Return network information about a particular network."""


### PR DESCRIPTION
##### SUMMARY
- Module utility now has orgs, nets, org_id, and net_id properties
- get_nets and get_orgs sets nets and orgs properties respectively
- Allows for storage of this data in the module. org_id and net_id aren’t set as I cannot guarantee that’s always desired.


##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
meraki

##### ANSIBLE VERSION
```
ansible 2.7.0.dev0 (meraki/util_org_net_properties 9b6a032139) last updated 2018/06/28 21:44:31 (GMT -500)
  config file = None
  configured module search path = ['/Users/kbreit/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/kbreit/Documents/Programming/ansible/lib/ansible
  executable location = /Users/kbreit/Documents/Programming/ansible/bin/ansible
  python version = 3.5.4 (default, Feb 25 2018, 14:56:02) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
