### PR TITLE
meraki_vlan - Fix integration tests

### DIFF
--- a/test/integration/targets/meraki_vlan/tasks/main.yml
+++ b/test/integration/targets/meraki_vlan/tasks/main.yml
@@ -13,7 +13,7 @@
     auth_key: '{{ auth_key }}'
     host: marrrraki.com
     state: present
-    org_name: IntTestOrg
+    org_name: '{{test_org_name}}'
     output_level: debug
   delegate_to: localhost
   register: invalid_domain
@@ -24,6 +24,7 @@
     auth_key: '{{ auth_key }}'
     use_https: false
     state: query
+    org_name: '{{test_org_name}}'
     output_level: debug
   delegate_to: localhost
   register: http
@@ -158,8 +159,8 @@
 - assert:
     that:
       - update_vlan_add_ip.changed == True
-      - update_vlan_add_ip.data.fixed_ip_assignments | length == 2
-      - update_vlan_add_ip.data.reserved_ip_range | length == 2
+      - update_vlan_add_ip.data.fixedIpAssignments | length == 2
+      - update_vlan_add_ip.data.reservedIpRanges | length == 2
 
 - name: Remove IP assignments and reserved IP ranges
   meraki_vlan:
@@ -189,8 +190,8 @@
 - assert:
     that:
       - update_vlan_remove_ip.changed == True
-      - update_vlan_remove_ip.data.fixed_ip_assignments | length == 1
-      - update_vlan_remove_ip.data.reserved_ip_range | length == 1
+      - update_vlan_remove_ip.data.fixedIpAssignments | length == 1
+      - update_vlan_remove_ip.data.reservedIpRanges | length == 1
 
 - name: Update VLAN with idempotency
   meraki_vlan:


### PR DESCRIPTION


##### SUMMARY
- Integration test assertions had some invalid variables which caused assertions to fail

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
meraki_vlan

##### ANSIBLE VERSION
```
ansible 2.7.0.dev0 (meraki/test-vlan-fixes 2e3f64dc8f) last updated 2018/06/28 22:10:31 (GMT -500)
  config file = None
  configured module search path = ['/Users/kbreit/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/kbreit/Documents/Programming/ansible/lib/ansible
  executable location = /Users/kbreit/Documents/Programming/ansible/bin/ansible
  python version = 3.5.4 (default, Feb 25 2018, 14:56:02) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```