### PR TITLE
Refactor nxos cliconf get_device_info and add requirements for JSON structured output support in nxos_facts module

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_facts.py
+++ b/lib/ansible/modules/network/nxos/nxos_facts.py
@@ -37,6 +37,9 @@ description:
 author:
   - Jason Edelman (@jedelman8)
   - Gabriele Gerbino (@GGabriele)
+notes:
+  - This module is only supported on the NX-OS device that supports JSON
+    structured output. NX-OS OS version should be 6.0(2)A8 or 7.x or later.
 options:
   gather_subset:
     description:
@@ -169,6 +172,7 @@ vlan_list:
 import re
 
 from ansible.module_utils.network.nxos.nxos import run_commands, get_config
+from ansible.module_utils.network.nxos.nxos import get_capabilities
 from ansible.module_utils.network.nxos.nxos import nxos_argument_spec, check_args
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six import string_types, iteritems
@@ -537,6 +541,13 @@ def main():
     spec.update(nxos_argument_spec)
 
     module = AnsibleModule(argument_spec=spec, supports_check_mode=True)
+
+    capabilities = get_capabilities(module)
+    if capabilities:
+        os_version = capabilities['device_info']['network_os_version']
+        os_version_major = int(os_version[0])
+        if os_version_major < 7 and "6.0(2)A8" not in os_version:
+            module.fail_json(msg="this module requires JSON structured output support on the NX-OS device")
 
     warnings = list()
     check_args(module, warnings)

--- a/lib/ansible/plugins/cliconf/nxos.py
+++ b/lib/ansible/plugins/cliconf/nxos.py
@@ -68,6 +68,11 @@ class Cliconf(CliconfBase):
             if match_kick_ver:
                 device_info['network_os_version'] = match_kick_ver.group(1)
 
+        if 'network_os_version' not in device_info:
+            match_sys_ver = re.search(r'\s+NXOS:\s+version (\S+)', reply, re.M)
+            if match_sys_ver:
+                device_info['network_os_version'] = match_sys_ver.group(1)
+
         match_chassis_id = re.search(r'Hardware\n\s+cisco\s+(\S+\s+\S+)', reply, re.M)
         if match_chassis_id:
             device_info['network_os_model'] = match_chassis_id.group(1)
@@ -83,6 +88,11 @@ class Cliconf(CliconfBase):
             match_kick_file_name = re.search(r'\s+kickstart image file is:\s+(\S+)', reply, re.M)
             if match_kick_file_name:
                 device_info['network_os_image'] = match_kick_file_name.group(1)
+
+        if 'network_os_image' not in device_info:
+            match_isan_file_name = re.search(r'\s+NXOS image file is:\s+(\S+)', reply, re.M)
+            if match_isan_file_name:
+                device_info['network_os_image'] = match_isan_file_name.group(1)
 
         match_os_platform = re.search(r'NAME: "Chassis",\s+DESCR: "NX-OSv Chassis\s?"\s+\n'
                                       r'PID:\s+(\S+)', platform_reply, re.M)

--- a/lib/ansible/plugins/cliconf/nxos.py
+++ b/lib/ansible/plugins/cliconf/nxos.py
@@ -20,6 +20,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import json
+import re
 
 from itertools import chain
 
@@ -56,20 +57,37 @@ class Cliconf(CliconfBase):
         device_info = {}
 
         device_info['network_os'] = 'nxos'
-        reply = self.get('show version | json')
-        data = json.loads(reply)
-        platform_reply = self.get('show inventory | json')
-        platform_info = json.loads(platform_reply)
+        reply = self.get('show version')
+        platform_reply = self.get('show inventory')
 
-        device_info['network_os_version'] = data.get('sys_ver_str') or data.get('kickstart_ver_str')
-        device_info['network_os_model'] = data['chassis_id']
-        device_info['network_os_hostname'] = data['host_name']
-        device_info['network_os_image'] = data.get('isan_file_name') or data.get('kick_file_name')
+        match_sys_ver = re.search(r'\s+system:\s+version (\S+)', reply, re.M)
+        if match_sys_ver:
+            device_info['network_os_version'] = match_sys_ver.group(1)
+        else:
+            match_kick_ver = re.search(r'\s+kickstart:\s+version (\S+)', reply, re.M)
+            if match_kick_ver:
+                device_info['network_os_version'] = match_kick_ver.group(1)
 
-        inventory_table = platform_info['TABLE_inv']['ROW_inv']
-        for info in inventory_table:
-            if 'Chassis' in info['name']:
-                device_info['network_os_platform'] = info['productid']
+        match_chassis_id = re.search(r'Hardware\n\s+cisco\s+(\S+\s+\S+)', reply, re.M)
+        if match_chassis_id:
+            device_info['network_os_model'] = match_chassis_id.group(1)
+
+        match_host_name = re.search(r'\s+Device name:\s+(\S+)', reply, re.M)
+        if match_host_name:
+            device_info['network_os_hostname'] = match_host_name.group(1)
+
+        match_isan_file_name = re.search(r'\s+system image file is:\s+(\S+)', reply, re.M)
+        if match_isan_file_name:
+            device_info['network_os_image'] = match_isan_file_name.group(1)
+        else:
+            match_kick_file_name = re.search(r'\s+kickstart image file is:\s+(\S+)', reply, re.M)
+            if match_kick_file_name:
+                device_info['network_os_image'] = match_kick_file_name.group(1)
+
+        match_os_platform = re.search(r'NAME: "Chassis",\s+DESCR: "NX-OSv Chassis\s?"\s+\n'
+                                      r'PID:\s+(\S+)', platform_reply, re.M)
+        if match_os_platform:
+            device_info['network_os_platform'] = match_os_platform.group(1)
 
         return device_info
 


### PR DESCRIPTION
Signed-off-by: Trishna Guha <trishnaguha17@gmail.com>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
- fixes https://github.com/ansible/ansible/issues/41828
- fixes https://github.com/ansible/ansible/issues/41514
- Refactor cliconf `get_device_info` - remove json pipeline from commands so that `get_capabilities` can work against legacy devices where JSON structured output isn't supported.
- Add note that JSON structured output is required on NX-OS device to use nxos_facts module.
- Fail the module if JSON output isn't supported on the device

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
modules/network/nxos/nxos_facts.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel, 2.6
```