### PR TITLE
Add run_commands api for ios and vyos cliconf plugin

### DIFF
--- a/lib/ansible/module_utils/network/vyos/vyos.py
+++ b/lib/ansible/module_utils/network/vyos/vyos.py
@@ -103,28 +103,21 @@ def run_commands(module, commands, check_rc=True):
     responses = list()
     connection = get_connection(module)
 
-    for cmd in to_list(commands):
-        try:
-            cmd = json.loads(cmd)
-            command = cmd['command']
-            prompt = cmd['prompt']
-            answer = cmd['answer']
-        except:
-            command = cmd
-            prompt = None
-            answer = None
-
-        try:
-            out = connection.get(command, prompt, answer)
-        except ConnectionError as exc:
+    try:
+        outputs = connection.run_commands(commands)
+    except ConnectionError as exc:
+        if check_rc:
             module.fail_json(msg=to_text(exc))
+        else:
+            outputs = exc
 
+    for item in to_list(outputs):
         try:
-            out = to_text(out, errors='surrogate_or_strict')
+            item = to_text(item, errors='surrogate_or_strict')
         except UnicodeError:
-            module.fail_json(msg=u'Failed to decode output from %s: %s' % (cmd, to_text(out)))
+            module.fail_json(msg=u'Failed to decode output from %s: %s' % (item, to_text(item)))
 
-        responses.append(out)
+        responses.append(item)
 
     return responses
 

--- a/lib/ansible/modules/network/vyos/vyos_command.py
+++ b/lib/ansible/modules/network/vyos/vyos_command.py
@@ -168,7 +168,7 @@ def parse_commands(module, warnings):
             warnings.append('only show commands are supported when using '
                             'check mode, not executing `%s`' % item['command'])
         else:
-            items.append(module.jsonify(item))
+            items.append(item)
 
     return items
 

--- a/lib/ansible/plugins/cliconf/__init__.py
+++ b/lib/ansible/plugins/cliconf/__init__.py
@@ -163,7 +163,7 @@ class CliconfBase(with_metaclass(ABCMeta, object)):
         self.response_logging = False
 
     @abstractmethod
-    def get_config(self, source='running', filter=None, format='text'):
+    def get_config(self, source='running', filter=None, format=None):
         """Retrieves the specified configuration from the device
 
         This method will retrieve the configuration specified by source and
@@ -215,7 +215,7 @@ class CliconfBase(with_metaclass(ABCMeta, object)):
         pass
 
     @abstractmethod
-    def get(self, command=None, prompt=None, answer=None, sendonly=False, newline=True):
+    def get(self, command=None, prompt=None, answer=None, sendonly=False, newline=True, output=None):
         """Execute specified command on remote device
         This method will retrieve the specified data and
         return it to the caller as a string.
@@ -225,6 +225,9 @@ class CliconfBase(with_metaclass(ABCMeta, object)):
         :param answer: the string to respond to the prompt with
         :param sendonly: bool to disable waiting for response, default is false
         :param newline: bool to indicate if newline should be added at end of answer or not
+        :param output: For devices that support fetching command output in different
+            format, this keyword argument is used to specify the output in which
+            response is to be retrieved.
         :return:
         """
         pass
@@ -264,6 +267,7 @@ class CliconfBase(with_metaclass(ABCMeta, object)):
                 'format': [list of supported configuration format],
                 'diff_match': [list of supported match values],
                 'diff_replace': [list of supported replace values],
+                'output': [list of supported command output format]
             }
         :return: capability as json string
         """
@@ -369,3 +373,22 @@ class CliconfBase(with_metaclass(ABCMeta, object)):
                }
 
         """
+        pass
+
+        def run_commands(self, commands):
+            """
+            Execute a list of commands on remote host and return the list of response
+            :param commands: The list of command that needs to be executed on remote host.
+                    The individual command in list can either be a command string or command dict.
+                    If the command is dict the valid keys are
+                    {
+                        'command': <command to be executed>
+                        'prompt': <expected prompt on executing the command>,
+                        'answer': <answer for the prompt>,
+                        'output': <the format in which command output should be rendered eg: 'json', 'text', if supported by platform>,
+                        'sendonly': <Boolean flag to indicate if it command execution response should be ignored or not>
+                    }
+
+            :return: List of returned response
+            """
+        pass

--- a/lib/ansible/plugins/cliconf/__init__.py
+++ b/lib/ansible/plugins/cliconf/__init__.py
@@ -375,20 +375,20 @@ class CliconfBase(with_metaclass(ABCMeta, object)):
         """
         pass
 
-        def run_commands(self, commands):
-            """
-            Execute a list of commands on remote host and return the list of response
-            :param commands: The list of command that needs to be executed on remote host.
-                    The individual command in list can either be a command string or command dict.
-                    If the command is dict the valid keys are
-                    {
-                        'command': <command to be executed>
-                        'prompt': <expected prompt on executing the command>,
-                        'answer': <answer for the prompt>,
-                        'output': <the format in which command output should be rendered eg: 'json', 'text', if supported by platform>,
-                        'sendonly': <Boolean flag to indicate if it command execution response should be ignored or not>
-                    }
+    def run_commands(self, commands):
+        """
+        Execute a list of commands on remote host and return the list of response
+        :param commands: The list of command that needs to be executed on remote host.
+                The individual command in list can either be a command string or command dict.
+                If the command is dict the valid keys are
+                {
+                    'command': <command to be executed>
+                    'prompt': <expected prompt on executing the command>,
+                    'answer': <answer for the prompt>,
+                    'output': <the format in which command output should be rendered eg: 'json', 'text', if supported by platform>,
+                    'sendonly': <Boolean flag to indicate if it command execution response should be ignored or not>
+                }
 
-            :return: List of returned response
-            """
+        :return: List of returned response
+        """
         pass

--- a/test/units/modules/network/vyos/test_vyos_command.py
+++ b/test/units/modules/network/vyos/test_vyos_command.py
@@ -47,8 +47,7 @@ class TestVyosCommandModule(TestVyosModule):
 
             for item in commands:
                 try:
-                    obj = json.loads(item)
-                    command = obj['command']
+                    command = item['command']
                 except ValueError:
                     command = item
                 filename = str(command).replace(' ', '_')


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
*  Add run_commands api to ios and vyos cliconf plugin
*  Refactor ios and vyos module_utils to check return code
   in run_commands
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
module_utils/network/ios/ios.py
module_utils/network/vyos/vyos.py
plugins/cliconf/ios.py
plugins/cliconf/vyos.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
