### PR TITLE
gluster_volume: Avoid error when deleting non-existent volume

### DIFF
--- a/lib/ansible/modules/storage/glusterfs/gluster_volume.py
+++ b/lib/ansible/modules/storage/glusterfs/gluster_volume.py
@@ -499,7 +499,7 @@ def main():
         else:
             module.fail_json(msg='failed to create volume %s' % volume_name)
 
-    if action != 'delete' and volume_name not in volumes:
+    if action != 'absent' and volume_name not in volumes:
         module.fail_json(msg='volume not found %s' % volume_name)
 
     if action == 'started':


### PR DESCRIPTION
##### SUMMARY
When a non-existent Gluster volume is to be deleted, i.e.:

```
gluster_volume:
  state: absent
  name: vol1-does-not-exist
```

the "gluster_volume" module would always fail with "volume not found
vol1-does-not-exist". The reason is that the code checked whether the
state is "delete", a value which isn't accepted for the "state"
parameter. Instead the expected value for volume deletion is, as above,
"absent".

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
`gluster_volume` module