### PR TITLE
Fix junos_config confirm commit issue (#41527)

### DIFF
--- a/changelogs/fragments/junos_config_confirm_commit.yaml
+++ b/changelogs/fragments/junos_config_confirm_commit.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Fix junos_config confirm commit timeout issue (https://github.com/ansible/ansible/pull/41527)

--- a/lib/ansible/modules/network/junos/junos_config.py
+++ b/lib/ansible/modules/network/junos/junos_config.py
@@ -63,8 +63,8 @@ options:
         statements on the remote device.
   confirm:
     description:
-      - The C(confirm) argument will configure a time out value for
-        the commit to be confirmed before it is automatically
+      - The C(confirm) argument will configure a time out value in minutes
+        for the commit to be confirmed before it is automatically
         rolled back.  If the C(confirm) argument is set to False, this
         argument is silently ignored.  If the value for this argument
         is set to 0, the commit is confirmed immediately.


### PR DESCRIPTION




##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
* Fix junos_config confirm commit issue

Fixes #40626

* Due to issue in ncclient commit() method for Juniper
  device (ncclient/ncclient#238)
  add a workaround in junos netconf plugin to generate proper
  commit-configuration xml and execute it using ncclient
  generic `rpc()` method.

* Update junos_config doc

Merged to devel https://github.com/ansible/ansible/pull/41527
(cherry picked from commit 88b966e23bd655f56a713b3f6ce523d69a9f2c1a)
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
junos_config
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
