### PR TITLE
New module for azure custom image facts

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_image_facts.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_image_facts.py
@@ -1,0 +1,300 @@
+#!/usr/bin/python
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = '''
+---
+module: azure_rm_image_facts
+
+version_added: "2.7"
+
+short_description: Get facts about azure custom images.
+
+description:
+    - List azure custom images. The images can be listed where scope of listing can be based on subscription, resource group, name or tags.
+
+options:
+    resource_group:
+        description:
+            - Name of resource group.
+    name:
+        description:
+            - Name of the image to filter from existing images.
+    tags:
+        description:
+            - List of tags to be matched.
+
+extends_documentation_fragment:
+    - azure
+
+author:
+    - "Madhura Naniwadekar(@Madhura-CSI)"
+'''
+
+
+EXAMPLES = '''
+- name: List images with name
+  azure_rm_image_facts:
+    name: test-image
+    resource_group: test-resource-group
+
+- name: List images by resource group
+  azure_rm_image_facts:
+    resource_group: test-resource-group
+    tags:
+      - testing
+      - foo:bar
+
+- name: List all available images under current subscription
+  azure_rm_image_facts:
+'''
+
+
+RETURN = '''
+images:
+    description: List of image dicts.
+    returned: always
+    type: complex
+    contains:
+        id:
+            description:
+                - Id of the image.
+            returned: always
+            type: str
+            sample: /subscriptions/xxxx/resourceGroups/xxx/providers/Microsoft.Compute/images/xx
+        name:
+            description:
+                - Name of the image.
+            returned: always
+            type: str
+        resource_group:
+            description:
+                - Resource group of the image.
+            returned: always
+            type: str
+        location:
+            description:
+                - Location of the image.
+            returned: always
+            type: str
+        os_disk:
+            description:
+                - Id of os disk for image.
+            type: str
+            sample: /subscriptions/xxxx/resourceGroups/xxx/providers/Microsoft.Compute/disks/xx
+        os_disk_caching:
+            description:
+                - Specifies caching requirements for the image.
+            returned: always
+            type: str
+        os_state:
+            description:
+                - Specifies image operating system state. Possible values are 'Generalized' or 'Specialized'.
+            returned: always
+            type: str
+            sample: Generalized
+        os_storage_account_type:
+            description:
+                - Specifies the storage account type for the managed disk.
+            type: str
+            sample: Standard_LRS
+        os_type:
+            description:
+                - Type of OS for image.
+            returned: always
+            type: str
+            sample: Linux
+        provisioning_state:
+            description:
+                - State of image.
+            returned: always
+            type: str
+            sample: Succeeded
+        source:
+            description:
+                - Resource id of source VM from which the image is created
+            type: str
+            sample: /subscriptions/xxx/resourceGroups/xxx/providers/Microsoft.Compute/virtualMachines/xx
+        tags:
+            description:
+                - Dictionary of tags associated with the image.
+            type: complex
+        data_disks:
+            description:
+                - List of data disks associated with the image.
+            type: complex
+            returned: always
+            contains:
+                caching:
+                    description:
+                        - Type of caching of data disk.
+                    sample: read_only
+                disk_size_gb:
+                    description:
+                        - Specifies the size of empty data disks in gigabytes.
+                    returned: always
+                    type: int
+                    sample: 50
+                lun:
+                    description:
+                        - Specifies the logical unit number of the data disk.
+                    returned: always
+                    type: int
+                    sample: 0
+                storage_account_type:
+                    description:
+                        - Specifies the storage account type for the managed disk data disk.
+                    type: str
+                    sample: Standard_LRS
+                managed_disk:
+                    description:
+                        - Id of managed disk.
+                    type: complex
+                    contains:
+                        id:
+                            description:
+                                - Specified Id of managed disk.
+                            type: str
+                            sample: /subscriptions/xxxx/resourceGroups/xxx/providers/Microsoft.Compute/disks/xx
+                blob_uri:
+                    description:
+                        - The virtual hard disk.
+'''
+
+
+try:
+    from msrestazure.azure_exceptions import CloudError
+except:
+    # This is handled in azure_rm_common
+    pass
+
+from ansible.module_utils.azure_rm_common import AzureRMModuleBase
+
+
+AZURE_ENUM_MODULES = ['azure.mgmt.compute.models']
+
+
+class AzureRMImageFacts(AzureRMModuleBase):
+
+    def __init__(self, **kwargs):
+
+        self.module_arg_spec = dict(
+            resource_group=dict(type='str'),
+            name=dict(type='str'),
+            tags=dict(type='list')
+        )
+
+        self.results = dict(
+            changed=False
+        )
+
+        self.resource_group = None
+        self.name = None
+        self.format = None
+        self.tags = None
+
+        super(AzureRMImageFacts, self).__init__(
+            derived_arg_spec=self.module_arg_spec,
+            supports_tags=False,
+            facts_module=True
+        )
+
+    def exec_module(self, **kwargs):
+
+        for key in self.module_arg_spec:
+            setattr(self, key, kwargs[key])
+
+        if self.name and self.resource_group:
+            self.results['images'] = self.get_image(self.resource_group, self.name)
+        elif self.name and not self.resource_group:
+            self.results['images'] = self.list_images(self.name)
+        elif not self.name and self.resource_group:
+            self.results['images'] = self.list_images_by_resource_group(self.resource_group)
+        elif not self.name and not self.resource_group:
+            self.results['images'] = self.list_images()
+        return self.results
+
+    def get_image(self, resource_group, image_name):
+        '''
+        Returns image details based on its name
+        '''
+
+        self.log('Get properties for {0}'.format(self.name))
+
+        result = []
+        item = None
+        try:
+            item = self.compute_client.images.get(resource_group, image_name)
+        except CloudError as exc:
+            self.fail('Failed to list images - {0}'.format(str(exc)))
+
+        result = [self.format_item(item)]
+        return result
+
+    def list_images_by_resource_group(self, resource_group):
+        '''
+        Returns image details based on its resource group
+        '''
+
+        self.log('List images filtered by resource group')
+        response = None
+        try:
+            response = self.compute_client.images.list_by_resource_group(resource_group)
+        except CloudError as exc:
+            self.fail("Failed to list images: {0}".format(str(exc)))
+
+        return [self.format_item(x) for x in response if self.has_tags(x.tags, self.tags)] if response else []
+
+    def list_images(self, image_name=None):
+        '''
+        Returns image details in current subscription
+        '''
+
+        self.log('List images within current subscription')
+        response = None
+        results = []
+        try:
+            response = self.compute_client.images.list()
+        except CloudError as exc:
+            self.fail("Failed to list all images: {0}".format(str(exc)))
+
+        results = [self.format_item(x) for x in response if self.has_tags(x.tags, self.tags)] if response else []
+        if image_name:
+            results = [result for result in results if result['name'] == image_name]
+        return results
+
+    def format_item(self, item):
+        d = item.as_dict()
+        d = {
+            'id': d['id'],
+            'resource_group': d['id'].split('/')[4],
+            'name': d['name'],
+            'location': d['location'],
+            'tags': d.get('tags'),
+            'source': d['source_virtual_machine']['id'] if 'source_virtual_machine' in d.keys() else None,
+            'os_type': d['storage_profile']['os_disk']['os_type'],
+            'os_state': d['storage_profile']['os_disk']['os_state'],
+            'os_disk_caching': d['storage_profile']['os_disk']['caching'],
+            'os_storage_account_type': d['storage_profile']['os_disk']['storage_account_type'],
+            'os_disk': d['storage_profile']['os_disk']['managed_disk']['id'] if 'managed_disk' in d['storage_profile']['os_disk'].keys() else None,
+            'os_blob_uri': d['storage_profile']['os_disk']['blob_uri'] if 'blob_uri' in d['storage_profile']['os_disk'].keys() else None,
+            'provisioning_state': d['provisioning_state'],
+            'data_disks': d['storage_profile']['data_disks']
+        }
+        return d
+
+
+def main():
+    AzureRMImageFacts()
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/cloud/azure/azure_rm_image_facts.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_image_facts.py
@@ -14,7 +14,7 @@ DOCUMENTATION = '''
 ---
 module: azure_rm_image_facts
 
-version_added: "2.7"
+version_added: "2.8"
 
 short_description: Get facts about azure custom images.
 

--- a/lib/ansible/modules/cloud/azure/azure_rm_image_facts.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_image_facts.py
@@ -154,16 +154,11 @@ images:
                         - Specifies the storage account type for the managed disk data disk.
                     type: str
                     sample: Standard_LRS
-                managed_disk:
+                managed_disk_id:
                     description:
                         - Id of managed disk.
-                    type: complex
-                    contains:
-                        id:
-                            description:
-                                - Specified Id of managed disk.
-                            type: str
-                            sample: /subscriptions/xxxx/resourceGroups/xxx/providers/Microsoft.Compute/disks/xx
+                    type: str
+                    sample: /subscriptions/xxxx/resourceGroups/xxx/providers/Microsoft.Compute/disks/xx
                 blob_uri:
                     description:
                         - The virtual hard disk.
@@ -273,6 +268,12 @@ class AzureRMImageFacts(AzureRMModuleBase):
 
     def format_item(self, item):
         d = item.as_dict()
+
+        for data_disk in d['storage_profile']['data_disks']:
+            if 'managed_disk' in data_disk.keys():
+                data_disk['managed_disk_id'] = data_disk['managed_disk']['id']
+                data_disk.pop('managed_disk', None)
+
         d = {
             'id': d['id'],
             'resource_group': d['id'].split('/')[4],

--- a/test/integration/targets/azure_rm_image/aliases
+++ b/test/integration/targets/azure_rm_image/aliases
@@ -1,3 +1,4 @@
 cloud/azure
 shippable/azure/group3
 destructive
+azure_rm_image_facts

--- a/test/integration/targets/azure_rm_image/tasks/main.yml
+++ b/test/integration/targets/azure_rm_image/tasks/main.yml
@@ -124,7 +124,7 @@
 
 - assert:
       that:
-          - output.ansible_facts.azure_images != []
+          - output.images != []
 
 - name: Delete image (check mode)
   azure_rm_image:

--- a/test/integration/targets/azure_rm_image/tasks/main.yml
+++ b/test/integration/targets/azure_rm_image/tasks/main.yml
@@ -116,6 +116,16 @@
           - not output.changed
           - output.id
 
+- name: Gather information about image created
+  azure_rm_image_facts:
+    resource_group: "{{ resource_group }}"
+    name: testimage001
+  register: output
+
+- assert:
+      that:
+          - output.ansible_facts.azure_images != []
+
 - name: Delete image (check mode)
   azure_rm_image:
       resource_group: "{{ resource_group }}"


### PR DESCRIPTION
##### SUMMARY
New module to collect facts about azure custom images.
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 
 - New Module Pull Request


##### COMPONENT NAME
azure_rm_image_facts

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.4
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/centos-dev/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Aug  4 2017, 00:39:18) [GCC 4.8.5 20150623 (Red Hat 4.8.5-16)]
```


##### ADDITIONAL INFORMATION
Currently we have module to gather information about Virtual Machine Images based on location, sku, offer, etc. But we don't seem to have module to collect information about custom images created from virtual machines. This module helps us in retrieving those data.

Module Details:
It takes 2 parameters(both optional)
1. resource_group
2. Name

Flow of module execution:
1. If name and resource group both are specified, it gets information about particular image in a resource group.
2. If only name is specified, gets information about all matching images with 'name' in a current subscription.
3. If only resource group is specified, gets information about all custom images within a resource group.
4. If no parameter is specified, gets information about all custom images in a current subscription.

Sample module invocations are:
<!--- Paste verbatim command output below, e.g. before and after your change -->
```
- name: List images with name
  azure_rm_image_facts:
    name: test-image
    resource_group: test-resource-group

- name: List all available images under current subscription
  azure_rm_image_facts:
  register: all_images
```
I would like to contribute this module to community.
