### PR TITLE
added timestamps to response of asa_command and iosxr_command modules

### DIFF
--- a/lib/ansible/module_utils/network/asa/asa.py
+++ b/lib/ansible/module_utils/network/asa/asa.py
@@ -30,6 +30,7 @@ from ansible.module_utils.basic import env_fallback, return_values
 from ansible.module_utils.network.common.utils import to_list, EntityCollection
 from ansible.module_utils.connection import exec_command
 from ansible.module_utils.connection import Connection, ConnectionError
+from datetime import datetime
 
 _DEVICE_CONFIGS = {}
 _CONNECTION = None
@@ -119,12 +120,15 @@ def run_commands(module, commands, check_rc=True):
     commands = to_commands(module, to_list(commands))
 
     responses = list()
+    timestamps = list()
 
     for cmd in commands:
+        timestamp = datetime.now().replace(microsecond=0).isoformat()
         out = connection.get(**cmd)
         responses.append(to_text(out, errors='surrogate_then_replace'))
+        timestamps.append(timestamp)
 
-    return responses
+    return responses, timestamps
 
 
 def get_config(module, flags=None):

--- a/lib/ansible/module_utils/network/iosxr/iosxr.py
+++ b/lib/ansible/module_utils/network/iosxr/iosxr.py
@@ -29,7 +29,7 @@
 import json
 from difflib import Differ
 from copy import deepcopy
-from time import sleep
+from datetime import datetime
 
 from ansible.module_utils._text import to_text, to_bytes
 from ansible.module_utils.basic import env_fallback
@@ -437,6 +437,7 @@ def load_config(module, command_filter, commit=False, replace=False,
 def run_command(module, commands):
     conn = get_connection(module)
     responses = list()
+    timestamps = list()
     for cmd in to_list(commands):
 
         try:
@@ -455,18 +456,20 @@ def run_command(module, commands):
             newline = True
 
         try:
+            timestamp = datetime.now().replace(microsecond=0).isoformat()
             out = conn.get(command=command, prompt=prompt, answer=answer, sendonly=sendonly, newline=newline)
         except ConnectionError as exc:
             module.fail_json(msg=to_text(exc))
 
         try:
             out = to_text(out, errors='surrogate_or_strict')
+            timestamps.append(timestamp)
         except UnicodeError:
             module.fail_json(msg=u'Failed to decode output from {0}: {1}'.format(cmd, to_text(out)))
 
         responses.append(out)
 
-    return responses
+    return responses, timestamps
 
 
 def copy_file(module, src, dst, proto='scp'):

--- a/lib/ansible/modules/network/asa/asa_command.py
+++ b/lib/ansible/modules/network/asa/asa_command.py
@@ -162,7 +162,7 @@ def main():
     match = module.params['match']
 
     while retries > 0:
-        responses = run_commands(module, commands)
+        responses, timestamps = run_commands(module, commands)
 
         for item in list(conditionals):
             if item(responses):
@@ -185,7 +185,8 @@ def main():
     result.update({
         'changed': False,
         'stdout': responses,
-        'stdout_lines': list(to_lines(responses))
+        'stdout_lines': list(to_lines(responses)),
+        'timestamps': timestamps
     })
 
     module.exit_json(**result)

--- a/lib/ansible/modules/network/iosxr/iosxr_command.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_command.py
@@ -188,7 +188,7 @@ def main():
     match = module.params['match']
 
     while retries > 0:
-        responses = run_command(module, commands)
+        responses, timestamps = run_command(module, commands)
 
         for item in list(conditionals):
             if item(responses):
@@ -212,7 +212,8 @@ def main():
         'changed': False,
         'stdout': responses,
         'warnings': warnings,
-        'stdout_lines': list(to_lines(responses))
+        'stdout_lines': list(to_lines(responses)),
+        'timestamps': timestamps
     }
 
     module.exit_json(**result)

--- a/lib/ansible/modules/network/iosxr/iosxr_facts.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_facts.py
@@ -407,7 +407,7 @@ def main():
     try:
         for inst in instances:
             commands = inst.commands()
-            responses = run_command(module, commands)
+            responses, timestamps = run_command(module, commands)
             results = dict(zip(commands, responses))
             inst.populate(results)
             facts.update(inst.facts)

--- a/lib/ansible/modules/network/iosxr/iosxr_interface.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_interface.py
@@ -382,7 +382,7 @@ class CliConfiguration(ConfigBase):
                 sleep(want_item['delay'])
 
             command = 'show interfaces {!s}'.format(want_item['name'])
-            out = run_command(self._module, command)[0]
+            out, timestamps = run_command(self._module, command)[0]
 
             if want_state in ('up', 'down'):
                 match = re.search(r'%s (\w+)' % 'line protocol is', out, re.M)

--- a/test/units/modules/network/iosxr/test_iosxr_command.py
+++ b/test/units/modules/network/iosxr/test_iosxr_command.py
@@ -23,6 +23,7 @@ from ansible.compat.tests.mock import patch
 from ansible.modules.network.iosxr import iosxr_command
 from units.modules.utils import set_module_args
 from .iosxr_module import TestIosxrModule, load_fixture
+from datetime import datetime
 
 
 class TestIosxrCommandModule(TestIosxrModule):
@@ -45,6 +46,7 @@ class TestIosxrCommandModule(TestIosxrModule):
         def load_from_file(*args, **kwargs):
             module, commands = args
             output = list()
+            timestamps = list()
 
             for item in commands:
                 try:
@@ -53,7 +55,8 @@ class TestIosxrCommandModule(TestIosxrModule):
                     command = item
                 filename = str(command).replace(' ', '_')
                 output.append(load_fixture(filename))
-            return output
+                timestamps.append(datetime.now().replace(microsecond=0).isoformat())
+            return output, timestamps
 
         self.run_command.side_effect = load_from_file
 

--- a/test/units/modules/network/iosxr/test_iosxr_facts.py
+++ b/test/units/modules/network/iosxr/test_iosxr_facts.py
@@ -25,6 +25,7 @@ from ansible.compat.tests.mock import patch
 from units.modules.utils import set_module_args
 from .iosxr_module import TestIosxrModule, load_fixture
 from ansible.modules.network.iosxr import iosxr_facts
+from datetime import datetime
 
 
 class TestIosxrFacts(TestIosxrModule):
@@ -48,6 +49,7 @@ class TestIosxrFacts(TestIosxrModule):
         def load_from_file(*args, **kwargs):
             module, commands = args
             output = list()
+            timestamps = list()
 
             for item in commands:
                 try:
@@ -59,7 +61,8 @@ class TestIosxrFacts(TestIosxrModule):
                 filename = filename.replace('/', '7')
                 filename = filename.replace('|', '_')
                 output.append(load_fixture(filename))
-            return output
+                timestamps.append(datetime.now().replace(microsecond=0).isoformat())
+            return output, timestamps
 
         self.run_command.side_effect = load_from_file
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Added information about time when command was issued on remote device.

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
iosxr_command
asa_command
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/srv/ansible_modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.15rc1 (default, Apr 15 2018, 21:51:34) [GCC 7.3.0]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
**example playbook**
```yaml
- name: collect show commands from devices
  hosts: test_group
  connection: network_cli

  tasks:

    - name: collect show commands
      iosxr_command:
        commands:
          - "show clock"
          - "show run vrf mgmt"
      register: output

    - name: debug task
      debug:
        var: output
```

**before**
```
ok: [R01] => {
    "output": {
        "changed": false, 
        "failed": false, 
        "stdout": [
            "16:23:19.904 MSK Fri Jun 29 2018", 
            "vrf mgmt\n!"
        ], 
        "stdout_lines": [
            [
                "16:23:19.904 MSK Fri Jun 29 2018"
            ], 
            [
                "vrf mgmt", 
                "!"
            ]
        ]
    }
}
```

**after**
```
ok: [R01] => {
    "output": {
        "changed": false, 
        "failed": false, 
        "stdout": [
            "16:24:58.318 MSK Fri Jun 29 2018", 
            "vrf mgmt\n!"
        ], 
        "stdout_lines": [
            [
                "16:24:58.318 MSK Fri Jun 29 2018"
            ], 
            [
                "vrf mgmt", 
                "!"
            ]
        ], 
        "timestamps": [
            "2018-06-29T16:24:58", 
            "2018-06-29T16:24:58"
        ]
    }
}
```