### PR TITLE
openvswitch_db: Make 'key' parameter optional

### DIFF
--- a/test/integration/targets/openvswitch_db/tests/basic.yaml
+++ b/test/integration/targets/openvswitch_db/tests/basic.yaml
@@ -33,7 +33,7 @@
     that:
       - "result.changed == false"
 
-- name: Change column value
+- name: Change column value in a map
   openvswitch_db:
     table: Bridge
     record: br-test
@@ -46,7 +46,7 @@
     that:
       - "result.changed == true"
 
-- name: Change column value again (idempotent)
+- name: Change column value in a map again (idempotent)
   openvswitch_db:
     table: Bridge
     record: br-test
@@ -58,6 +58,43 @@
 - assert:
     that:
       - "result.changed == false"
+
+- name: Change column value
+  openvswitch_db:
+    table: Bridge
+    record: br-test
+    col: stp_enable
+    value: true
+  register: result
+
+- assert:
+    that:
+      - "result.changed == true"
+
+- name: Change column value again (idempotent)
+  openvswitch_db:
+    table: Bridge
+    record: br-test
+    col: stp_enable
+    value: true
+  register: result
+
+- assert:
+    that:
+      - "result.changed == false"
+
+- name: Try to set value on a map type without a key (negative)
+  ignore_errors: true
+  openvswitch_db:
+    table: Bridge
+    record: br-test
+    col: other_config
+    value: true
+  register: result
+
+- assert:
+    that:
+      - "result.failed == true"
 
 - name: Remove bridge
   openvswitch_db:

--- a/test/units/modules/network/ovs/test_openvswitch_db.py
+++ b/test/units/modules/network/ovs/test_openvswitch_db.py
@@ -41,6 +41,12 @@ test_name_side_effect_matrix = {
     'test_openvswitch_db_present_updates_key': [
         (0, 'openvswitch_db_disable_in_band_true.cfg', None),
         (0, None, None)],
+    'test_openvswitch_db_present_missing_key_on_map': [
+        (0, 'openvswitch_db_disable_in_band_true.cfg', None),
+        (0, None, None)],
+    'test_openvswitch_db_present_stp_enable': [
+        (0, 'openvswitch_db_disable_in_band_true.cfg', None),
+        (0, None, None)],
 }
 
 
@@ -122,3 +128,20 @@ class TestOpenVSwitchDBModule(TestOpenVSwitchModule):
             commands=['/usr/bin/ovs-vsctl -t 5 set Bridge test-br other_config'
                       ':disable-in-band=False'],
             test_name='test_openvswitch_db_present_updates_key')
+
+    def test_openvswitch_db_present_missing_key_on_map(self):
+        set_module_args(dict(state='present',
+                             table='Bridge', record='test-br',
+                             col='other_config',
+                             value='False'))
+        self.execute_module(
+            failed=True,
+            test_name='test_openvswitch_db_present_idempotent')
+
+    def test_openvswitch_db_present_stp_enable(self):
+        set_module_args(dict(state='present',
+                             table='Bridge', record='test-br',
+                             col='stp_enable',
+                             value='False'))
+        self.execute_module(changed=True,
+                            test_name='test_openvswitch_db_present_stp_enable')


### PR DESCRIPTION
The OVSDB schema consists of typed columns. The 'key' parameter is
required only for columns with type of a 'map'. This patch makes 'key'
an optional parameter to allow setting values for other column types
like int.

Fixes #42108

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
openvswitch_db

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

Before:
```
ansible-playbook 2.5.5
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/vagrant/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible-playbook
  python version = 2.7.5 (default, Apr 11 2018, 07:36:10) [GCC 4.8.5 20150623 (Red Hat 4.8.5-28)]
Using /etc/ansible/ansible.cfg as config file
setting up inventory plugins
Parsed /etc/ansible/hosts inventory source with ini plugin
 [WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'

Loading callback plugin default of type stdout, v2.0 from /usr/lib/python2.7/site-packages/ansible/plugins/callback/default.pyc

PLAYBOOK: test-playbook.yml *************************************************************************************************************************************************************
1 plays in test-playbook.yml

PLAY [openvswitch: run update_port] *****************************************************************************************************************************************************

TASK [Gathering Facts] ******************************************************************************************************************************************************************
task path: /home/vagrant/networking-ansible/test-playbook.yml:2
Using module file /usr/lib/python2.7/site-packages/ansible/modules/system/setup.py
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: vagrant
<127.0.0.1> EXEC /bin/sh -c 'echo ~vagrant && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/vagrant/.ansible/tmp/ansible-tmp-1530280901.98-145822743403315 `" && echo ansible-tmp-1530280901.98-145822743403315="` echo /home/vagrant/.ansible/tmp/ansible-tmp-1530280901.98-145822743403315 `" ) && sleep 0'
<127.0.0.1> PUT /home/vagrant/.ansible/tmp/ansible-local-29171pVygKZ/tmpFnjIYb TO /home/vagrant/.ansible/tmp/ansible-tmp-1530280901.98-145822743403315/setup.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /home/vagrant/.ansible/tmp/ansible-tmp-1530280901.98-145822743403315/ /home/vagrant/.ansible/tmp/ansible-tmp-1530280901.98-145822743403315/setup.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/usr/bin/python2 /home/vagrant/.ansible/tmp/ansible-tmp-1530280901.98-145822743403315/setup.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /home/vagrant/.ansible/tmp/ansible-tmp-1530280901.98-145822743403315/ > /dev/null 2>&1 && sleep 0'
ok: [localhost]
META: ran handlers

TASK [openvswitch_db] *******************************************************************************************************************************************************************
task path: /home/vagrant/networking-ansible/test-playbook.yml:5
Using module file /usr/lib/python2.7/site-packages/ansible/modules/network/ovs/openvswitch_db.py
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: vagrant
<127.0.0.1> EXEC /bin/sh -c 'echo ~vagrant && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/vagrant/.ansible/tmp/ansible-tmp-1530280902.48-128404859669014 `" && echo ansible-tmp-1530280902.48-128404859669014="` echo /home/vagrant/.ansible/tmp/ansible-tmp-1530280902.48-128404859669014 `" ) && sleep 0'
<127.0.0.1> PUT /home/vagrant/.ansible/tmp/ansible-local-29171pVygKZ/tmpQBJLuq TO /home/vagrant/.ansible/tmp/ansible-tmp-1530280902.48-128404859669014/openvswitch_db.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /home/vagrant/.ansible/tmp/ansible-tmp-1530280902.48-128404859669014/ /home/vagrant/.ansible/tmp/ansible-tmp-1530280902.48-128404859669014/openvswitch_db.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'sudo -H -S -n -u root /bin/sh -c '"'"'echo BECOME-SUCCESS-rnyzkgtjykoxtnypsistbvemltyxwkpb; /usr/bin/python2 /home/vagrant/.ansible/tmp/ansible-tmp-1530280902.48-128404859669014/openvswitch_db.py'"'"' && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /home/vagrant/.ansible/tmp/ansible-tmp-1530280902.48-128404859669014/ > /dev/null 2>&1 && sleep 0'
fatal: [localhost]: FAILED! => {
    "changed": false,
    "invocation": {
        "module_args": {
            "col": "tag",
            "record": "port0",
            "state": "present",
            "table": "Port",
            "timeout": 5,
            "value": "1"
        }
    },
    "msg": "missing required arguments: key"
}
	to retry, use: --limit @/home/vagrant/networking-ansible/test-playbook.retry

PLAY RECAP ******************************************************************************************************************************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=1


```

After:
```
ansible-playbook 2.5.5
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/vagrant/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible-playbook
  python version = 2.7.5 (default, Apr 11 2018, 07:36:10) [GCC 4.8.5 20150623 (Red Hat 4.8.5-28)]
Using /etc/ansible/ansible.cfg as config file
setting up inventory plugins
Parsed /etc/ansible/hosts inventory source with ini plugin
 [WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'

Loading callback plugin default of type stdout, v2.0 from /usr/lib/python2.7/site-packages/ansible/plugins/callback/default.pyc

PLAYBOOK: test-playbook.yml *************************************************************************************************************************************************************
1 plays in test-playbook.yml

PLAY [openvswitch: run update_port] *****************************************************************************************************************************************************

TASK [Gathering Facts] ******************************************************************************************************************************************************************
task path: /home/vagrant/networking-ansible/test-playbook.yml:2
Using module file /usr/lib/python2.7/site-packages/ansible/modules/system/setup.py
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: vagrant
<127.0.0.1> EXEC /bin/sh -c 'echo ~vagrant && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/vagrant/.ansible/tmp/ansible-tmp-1530281209.23-239244825372697 `" && echo ansible-tmp-1530281209.23-239244825372697="` echo /home/vagrant/.ansible/tmp/ansible-tmp-1530281209.23-239244825372697 `" ) && sleep 0'
<127.0.0.1> PUT /home/vagrant/.ansible/tmp/ansible-local-299095rrz15/tmpIDVMKC TO /home/vagrant/.ansible/tmp/ansible-tmp-1530281209.23-239244825372697/setup.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /home/vagrant/.ansible/tmp/ansible-tmp-1530281209.23-239244825372697/ /home/vagrant/.ansible/tmp/ansible-tmp-1530281209.23-239244825372697/setup.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/usr/bin/python2 /home/vagrant/.ansible/tmp/ansible-tmp-1530281209.23-239244825372697/setup.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /home/vagrant/.ansible/tmp/ansible-tmp-1530281209.23-239244825372697/ > /dev/null 2>&1 && sleep 0'
ok: [localhost]
META: ran handlers

TASK [openvswitch_db] *******************************************************************************************************************************************************************
task path: /home/vagrant/networking-ansible/test-playbook.yml:5
Using module file /usr/lib/python2.7/site-packages/ansible/modules/network/ovs/openvswitch_db.py
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: vagrant
<127.0.0.1> EXEC /bin/sh -c 'echo ~vagrant && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/vagrant/.ansible/tmp/ansible-tmp-1530281209.76-49723031212363 `" && echo ansible-tmp-1530281209.76-49723031212363="` echo /home/vagrant/.ansible/tmp/ansible-tmp-1530281209.76-49723031212363 `" ) && sleep 0'
<127.0.0.1> PUT /home/vagrant/.ansible/tmp/ansible-local-299095rrz15/tmpJBwk9c TO /home/vagrant/.ansible/tmp/ansible-tmp-1530281209.76-49723031212363/openvswitch_db.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /home/vagrant/.ansible/tmp/ansible-tmp-1530281209.76-49723031212363/ /home/vagrant/.ansible/tmp/ansible-tmp-1530281209.76-49723031212363/openvswitch_db.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'sudo -H -S -n -u root /bin/sh -c '"'"'echo BECOME-SUCCESS-kninhinyephefmmxeszabvdjfkjdplwv; /usr/bin/python2 /home/vagrant/.ansible/tmp/ansible-tmp-1530281209.76-49723031212363/openvswitch_db.py'"'"' && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /home/vagrant/.ansible/tmp/ansible-tmp-1530281209.76-49723031212363/ > /dev/null 2>&1 && sleep 0'
changed: [localhost] => {
    "changed": true,
    "commands": [
        "/usr/bin/ovs-vsctl -t 5 set Port port0 tag=1"
    ],
    "invocation": {
        "module_args": {
            "col": "tag",
            "key": null,
            "ovs-vsctl": "/usr/bin/ovs-vsctl",
            "record": "port0",
            "state": "present",
            "table": "Port",
            "timeout": 5,
            "value": "1"
        }
    }
}
META: ran handlers
META: ran handlers

PLAY RECAP ******************************************************************************************************************************************************************************
localhost                  : ok=2    changed=1    unreachable=0    failed=0
```