### PR TITLE
Fix setting required options for inventory plugins - backport/2.6/42049

### DIFF
--- a/changelogs/fragments/inventory_manager_fix_required_options_override.yaml
+++ b/changelogs/fragments/inventory_manager_fix_required_options_override.yaml
@@ -1,0 +1,5 @@
+---
+bugfixes:
+- inventory manager - This fixes required options being populated before the
+  inventory config file is read, so the required options may be set in the
+  config file.

--- a/lib/ansible/inventory/manager.py
+++ b/lib/ansible/inventory/manager.py
@@ -183,7 +183,6 @@ class InventoryManager(object):
         for name in C.INVENTORY_ENABLED:
             plugin = inventory_loader.get(name)
             if plugin:
-                plugin.set_options()
                 self._inventory_plugins.append(plugin)
             else:
                 display.warning('Failed to load inventory plugin, skipping %s' % name)

--- a/lib/ansible/plugins/inventory/script.py
+++ b/lib/ansible/plugins/inventory/script.py
@@ -85,6 +85,7 @@ class InventoryModule(BaseInventoryPlugin, Cacheable):
     def parse(self, inventory, loader, path, cache=None):
 
         super(InventoryModule, self).parse(inventory, loader, path)
+        self.set_options()
 
         if cache is None:
             cache = self.get_option('cache')

--- a/lib/ansible/plugins/inventory/yaml.py
+++ b/lib/ansible/plugins/inventory/yaml.py
@@ -90,6 +90,7 @@ class InventoryModule(BaseFileInventoryPlugin):
         ''' parses the inventory file '''
 
         super(InventoryModule, self).parse(inventory, loader, path)
+        self.set_options()
 
         try:
             data = self.loader.load_from_file(path, cache=False)


### PR DESCRIPTION
##### SUMMARY
Backport #42049

Fix setting required options for inventory plugins in a inventory config file. For 2.6 this only affects the scaleway inventory plugin, which can use setting environment variables as a workaround.

(cherry picked from commit 44e58863855b939de2e5911f94e291d36bad7516)

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/inventory/manager.py

##### ANSIBLE VERSION
```
ansible 2.6.0.dev0
```
