### PR TITLE
Fix examples in azure_rm_securitygroup

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_securitygroup.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_securitygroup.py
@@ -141,13 +141,13 @@ EXAMPLES = '''
       purge_rules: yes
       rules:
           - name: DenySSH
-            protocol: TCP
+            protocol: Tcp
             destination_port_range: 22
             access: Deny
             priority: 100
             direction: Inbound
           - name: 'AllowSSH'
-            protocol: TCP
+            protocol: Tcp
             source_address_prefix:
               - '174.109.158.0/24'
               - '174.109.159.0/24'
@@ -162,13 +162,13 @@ EXAMPLES = '''
       name: mysecgroup
       rules:
           - name: DenySSH
-            protocol: TCP
+            protocol: Tcp
             destination_port_range: 22-23
             access: Deny
             priority: 100
             direction: Inbound
           - name: AllowSSHFromHome
-            protocol: TCP
+            protocol: Tcp
             source_address_prefix: '174.109.158.0/24'
             destination_port_range: 22-23
             access: Allow

--- a/lib/ansible/modules/cloud/azure/azure_rm_securitygroup.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_securitygroup.py
@@ -155,6 +155,16 @@ EXAMPLES = '''
             access: Allow
             priority: 101
             direction: Inbound
+          - name: 'AllowMultiplePorts'
+            protocol: Tcp
+            source_address_prefix:
+              - '174.109.158.0/24'
+              - '174.109.159.0/24'
+            destination_port_range:
+              - 80
+              - 443
+            access: Allow
+            priority: 102
 
 # Update rules on existing security group
 - azure_rm_securitygroup:


### PR DESCRIPTION
##### SUMMARY

The examples for the `azure_rm_securitygroup` module were using an invalid value of `TCP` for `protocol`.

I also added an additional example to show the syntax for specifying multiple ports (not a range, but multiple individual ports) for `destination_port_range`.

##### ISSUE TYPE

 - Docs Pull Request

##### COMPONENT NAME

azure_rm_securitygroup

##### ANSIBLE VERSION

```
ansible 2.5.5
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/jhocutt/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.15 (default, May 16 2018, 17:50:09) [GCC 8.1.1 20180502 (Red Hat 8.1.1-1)]

```

##### ADDITIONAL INFORMATION

None