### PR TITLE
Correct typo in win_domain_computer doc

### DIFF
--- a/lib/ansible/modules/windows/win_domain_computer.py
+++ b/lib/ansible/modules/windows/win_domain_computer.py
@@ -16,7 +16,7 @@ module: win_domain_computer
 short_description: Manage computers in Active Directory
 description:
   - Create, read, update and delete computers in Active Directory using a
-    windows brigde computer to launch New-ADComputer, Get-ADComputer,
+    windows bridge computer to launch New-ADComputer, Get-ADComputer,
     Set-ADComputer, Remove-ADComputer and Move-ADObject powershell commands.
 options:
   name:


### PR DESCRIPTION
<!--- Your description here -->
Change 
> brigde

to
> bridge

+label: docsite_pr

##### SUMMARY
Fix doc typo

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
Docs

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0
  config file = None
  configured module search path = [u'/Users/tgregory/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/Cellar/ansible/2.6.0/libexec/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.15 (default, Jun 17 2018, 12:46:58) [GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.2)]

```
