### PR TITLE
Adds Prometheus Textfile Exporter Aggregate Callback Plugin

### DIFF
--- a/lib/ansible/plugins/callback/prometheus.py
+++ b/lib/ansible/plugins/callback/prometheus.py
@@ -1,0 +1,59 @@
+# Ansible-required imports
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from datetime import datetime
+import os
+
+from ansible.plugins.callback import CallbackBase
+
+DEFAULT_PROM_PATH = '/tmp/ansible-play.prom'
+
+DOCUMENTATION = '''
+  callback: prometheus
+  callback_type: aggregate
+  author: Devon Finninger (@dfinninger)
+  requirements:
+    - whitelist in configuration
+  short_description: Export Ansible play stats to Prometheus
+  version_added: "2.5"
+  description:
+      - Writes Ansible play stats as Prometheus Textfile metrics
+  options:
+    textfile_path:
+      description: Path to the prometheus textfile
+      env:
+        - name: ANSIBLE_CALLBACK_PROMETHEUS_PATH
+      default: "/tmp/ansible-play.prom"
+'''
+
+
+class CallbackModule(CallbackBase):
+    """
+    This callback module exports Play stats as Prometheus metrics.
+    """
+    CALLBACK_VERSION = 2.0
+    CALLBACK_TYPE = 'aggregate'
+    CALLBACK_NAME = 'prometheus'
+
+    # only needed if you ship it and don't want to enable by default
+    CALLBACK_NEEDS_WHITELIST = True
+
+    def __init__(self):
+
+        # make sure the expected objects are present, calling the base's __init__
+        super(CallbackModule, self).__init__()
+
+        self.start_time = datetime.utcnow()
+
+    def v2_playbook_on_stats(self, stats):
+        end_time = datetime.utcnow()
+        runtime = end_time - self.start_time
+
+        filepath = os.environ.get('ANSIBLE_CALLBACK_PROMETHEUS_PATH', DEFAULT_PROM_PATH)
+
+        with open(filepath, 'w') as f:
+            f.write('ansible_run_time {0}\n'.format(runtime.total_seconds()))
+            for host in sorted(stats.processed.keys()):
+                for key, value in stats.summarize(host).items():
+                    f.write('ansible_play_summary{{host="{0}", status="{1}"}} {2}\n'.format(host, key, value))


### PR DESCRIPTION
##### SUMMARY
This PR adds an ansible callback plugin that exposes some basic summary metrics in the [Prometheus](https://prometheus.io/) [Textfile](https://github.com/prometheus/node_exporter#textfile-collector) format.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
Prometheus Callback Plugin

##### ANSIBLE VERSION
```
ansible 2.4.2.0
  config file = /Users/dfinninger/repos/data/infrastructure/ansible/ansible.cfg
  configured module search path = [u'/Users/dfinninger/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/dfinninger/.virtualenvs/infra/lib/python2.7/site-packages/ansible
  executable location = /Users/dfinninger/.virtualenvs/infra/bin/ansible
  python version = 2.7.13 (default, Dec 18 2016, 07:03:39) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]
```


##### ADDITIONAL INFORMATION
When this call back is whitelisted, e.g.:
```
callback_whitelist = timer,profile_tasks,prometheus
```

It will produce metrics in a file (by default, `/tmp/ansible-play.prom`, adjustable with `ANSIBLE_CALLBACK_PROMETHEUS_PATH`), of the form:
```
ansible_run_time 18.134615
ansible_play_summary{host="server1.example.com", status="unreachable"} 0
ansible_play_summary{host="server1.example.com", status="skipped"} 0
ansible_play_summary{host="server1.example.com", status="ok"} 22
ansible_play_summary{host="server1.example.com", status="changed"} 3
ansible_play_summary{host="server1.example.com", status="failures"} 0
```

We're transitioning to Ansible-Pull, and this plugin is helpful for us to have a global view of how Ansible runs are going in all of our systems.
