### PR TITLE
[stable-2.6] Fix file module with check_mode - Fixes #42111 (#42115)

### DIFF
--- a/changelogs/fragments/file_touch_check_mode.yaml
+++ b/changelogs/fragments/file_touch_check_mode.yaml
@@ -1,0 +1,5 @@
+---
+bugfixes:
+- file module - The touch subcommand had its diff output broken during the
+  2.6.x development cycle.  The patch to fix that broke check mode.
+  This is now fixed (https://github.com/ansible/ansible/issues/42111)

--- a/lib/ansible/modules/files/file.py
+++ b/lib/ansible/modules/files/file.py
@@ -322,6 +322,9 @@ def execute_touch(path, follow):
     b_path = to_bytes(path, errors='surrogate_or_strict')
     prev_state = get_state(b_path)
 
+    # Unfortunately, touch always changes the file because it updates file's timestamp
+    result = {'dest': path, 'changed': True}
+
     if not module.check_mode:
         if prev_state == 'absent':
             # Create an empty file if the filename did not already exist
@@ -369,8 +372,8 @@ def execute_touch(path, follow):
                     os.remove(b_path)
             raise
 
-    # Unfortunately, touch always changes the file because it updates file's timestamp
-    return {'dest': path, 'changed': True, 'diff': diff}
+        result['diff'] = diff
+    return result
 
 
 def ensure_file_attributes(path, follow):


### PR DESCRIPTION
* Fix file module check_mode
(cherry picked from commit 22a6927)

Co-authored-by: Sloane Hertel <shertel@redhat.com>

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/files/file.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6
```

