### PR TITLE
Add info about loop based on jinja2 loop var

### DIFF
--- a/changelogs/fragments/loop-info.yaml
+++ b/changelogs/fragments/loop-info.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- loop_control - Add new ``extended`` option to return extended loop information (https://github.com/ansible/ansible/pull/42134)

--- a/docs/docsite/rst/reference_appendices/special_variables.rst
+++ b/docs/docsite/rst/reference_appendices/special_variables.rst
@@ -22,6 +22,9 @@ ansible_inventory_sources
 ansible_limit
     Contents of the ``--limit`` CLI option for the current execution of Ansible
 
+ansible_loop
+    A dictionary/map containing extended loop information when enabled via ``loop_control.extended``
+
 ansible_play_batch
     List of active hosts in the current play run limited by the serial, aka 'batch'. Failed/Unreachable hosts are not considered 'active'.
 

--- a/docs/docsite/rst/user_guide/playbooks_loops.rst
+++ b/docs/docsite/rst/user_guide/playbooks_loops.rst
@@ -330,6 +330,28 @@ If you need to keep track of where you are in a loop, you can use the ``index_va
       loop_control:
         index_var: my_idx
 
+.. versionadded:: 2.8
+
+As of Ansible 2.8 you can get extended loop information using the ``extended`` option to loop control. This option will expose the following information.
+
+=====================  ===========
+Variable               Description
+---------------------  -----------
+ansible_loop.items     list of all items in the loop
+ansible_loop.index     The current iteration of the loop. (1 indexed)
+ansible_loop.index0    The current iteration of the loop. (0 indexed)
+ansible_loop.first     True if first iteration
+ansible_loop.last      True if last iteration
+ansible_loop.length    The number of items in the sequence
+ansible_loop.previtem  The item from the previous iteration of the loop. Undefined during the first iteration.
+ansible_loop.nextitem  The item from the following iteration of the loop. Undefined during the last iteration.
+=====================  ===========
+
+::
+
+      loop_control:
+        extended: yes
+
 Migrating from with_X to loop
 `````````````````````````````
 

--- a/docs/docsite/rst/user_guide/playbooks_loops.rst
+++ b/docs/docsite/rst/user_guide/playbooks_loops.rst
@@ -334,18 +334,20 @@ If you need to keep track of where you are in a loop, you can use the ``index_va
 
 As of Ansible 2.8 you can get extended loop information using the ``extended`` option to loop control. This option will expose the following information.
 
-=====================  ===========
-Variable               Description
----------------------  -----------
-ansible_loop.items     list of all items in the loop
-ansible_loop.index     The current iteration of the loop. (1 indexed)
-ansible_loop.index0    The current iteration of the loop. (0 indexed)
-ansible_loop.first     True if first iteration
-ansible_loop.last      True if last iteration
-ansible_loop.length    The number of items in the sequence
-ansible_loop.previtem  The item from the previous iteration of the loop. Undefined during the first iteration.
-ansible_loop.nextitem  The item from the following iteration of the loop. Undefined during the last iteration.
-=====================  ===========
+==========================  ===========
+Variable                    Description
+--------------------------  -----------
+``ansible_loop.items``      The list of all items in the loop
+``ansible_loop.index``      The current iteration of the loop. (1 indexed)
+``ansible_loop.index0``     The current iteration of the loop. (0 indexed)
+``ansible_loop.revindex``   The number of iterations from the end of the loop (1 indexed)
+``ansible_loop.revindex0``  The number of iterations from the end of the loop (0 indexed)
+``ansible_loop.first``      ``True`` if first iteration
+``ansible_loop.last``       ``True`` if last iteration
+``ansible_loop.length``     The number of items in the sequence
+``ansible_loop.previtem``   The item from the previous iteration of the loop. Undefined during the first iteration.
+``ansible_loop.nextitem``   The item from the following iteration of the loop. Undefined during the last iteration.
+==========================  ===========
 
 ::
 

--- a/docs/docsite/rst/user_guide/playbooks_loops.rst
+++ b/docs/docsite/rst/user_guide/playbooks_loops.rst
@@ -337,14 +337,14 @@ As of Ansible 2.8 you can get extended loop information using the ``extended`` o
 ==========================  ===========
 Variable                    Description
 --------------------------  -----------
-``ansible_loop.items``      The list of all items in the loop
+``ansible_loop.allitems``   The list of all items in the loop
 ``ansible_loop.index``      The current iteration of the loop. (1 indexed)
 ``ansible_loop.index0``     The current iteration of the loop. (0 indexed)
 ``ansible_loop.revindex``   The number of iterations from the end of the loop (1 indexed)
 ``ansible_loop.revindex0``  The number of iterations from the end of the loop (0 indexed)
 ``ansible_loop.first``      ``True`` if first iteration
 ``ansible_loop.last``       ``True`` if last iteration
-``ansible_loop.length``     The number of items in the sequence
+``ansible_loop.length``     The number of items in the loop
 ``ansible_loop.previtem``   The item from the previous iteration of the loop. Undefined during the first iteration.
 ``ansible_loop.nextitem``   The item from the following iteration of the loop. Undefined during the last iteration.
 ==========================  ===========

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -296,6 +296,7 @@ class TaskExecutor:
             loop_var = templar.template(self._task.loop_control.loop_var)
             index_var = templar.template(self._task.loop_control.index_var)
             loop_pause = templar.template(self._task.loop_control.pause)
+            extended = templar.template(self._task.loop_control.extended)
 
             # This may be 'None',so it is tempalted below after we ensure a value and an item is assigned
             label = self._task.loop_control.label
@@ -358,22 +359,23 @@ class TaskExecutor:
             res[loop_var] = item
             if index_var:
                 res[index_var] = item_index
-            res['ansible_loop'] = {
-                'items': items,
-                'index': item_index + 1,
-                'index0': item_index,
-                'first': item_index == 0,
-                'last': item_index + 1 == items_len,
-                'length': items_len,
-            }
-            try:
-                res['ansible_loop']['nextitem'] = items[item_index + 1]
-            except IndexError:
-                pass
-            try:
-                res['ansible_loop']['previtem'] = items[item_index - 1]
-            except IndexError:
-                pass
+            if extended:
+                res['ansible_loop'] = {
+                    'items': items,
+                    'index': item_index + 1,
+                    'index0': item_index,
+                    'first': item_index == 0,
+                    'last': item_index + 1 == items_len,
+                    'length': items_len,
+                }
+                try:
+                    res['ansible_loop']['nextitem'] = items[item_index + 1]
+                except IndexError:
+                    pass
+                try:
+                    res['ansible_loop']['previtem'] = items[item_index - 1]
+                except IndexError:
+                    pass
             res['_ansible_item_result'] = True
             res['_ansible_ignore_errors'] = task_fields.get('ignore_errors')
 

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -323,6 +323,26 @@ class TaskExecutor:
             if index_var:
                 task_vars[index_var] = item_index
 
+            if extended:
+                task_vars['ansible_loop'] = {
+                    'items': items,
+                    'index': item_index + 1,
+                    'index0': item_index,
+                    'first': item_index == 0,
+                    'last': item_index + 1 == items_len,
+                    'length': items_len,
+                    'revindex': items_len - item_index,
+                    'revindex0': items_len - item_index - 1,
+                }
+                try:
+                    task_vars['ansible_loop']['nextitem'] = items[item_index + 1]
+                except IndexError:
+                    pass
+                try:
+                    task_vars['ansible_loop']['previtem'] = items[item_index - 1]
+                except IndexError:
+                    pass
+
             # Update template vars to reflect current loop iteration
             templar.set_available_variables(task_vars)
 
@@ -361,22 +381,8 @@ class TaskExecutor:
             if index_var:
                 res[index_var] = item_index
             if extended:
-                res['ansible_loop'] = {
-                    'items': items,
-                    'index': item_index + 1,
-                    'index0': item_index,
-                    'first': item_index == 0,
-                    'last': item_index + 1 == items_len,
-                    'length': items_len,
-                }
-                try:
-                    res['ansible_loop']['nextitem'] = items[item_index + 1]
-                except IndexError:
-                    pass
-                try:
-                    res['ansible_loop']['previtem'] = items[item_index - 1]
-                except IndexError:
-                    pass
+                res['ansible_loop'] = task_vars['ansible_loop']
+
             res['_ansible_item_result'] = True
             res['_ansible_ignore_errors'] = task_fields.get('ignore_errors')
 

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -358,7 +358,7 @@ class TaskExecutor:
             res[loop_var] = item
             if index_var:
                 res[index_var] = item_index
-            res['loop'] = {
+            res['ansible_loop'] = {
                 'items': items,
                 'index': item_index + 1,
                 'index0': item_index,
@@ -367,11 +367,11 @@ class TaskExecutor:
                 'length': items_len,
             }
             try:
-                res['loop']['nextitem'] = items[item_index + 1]
+                res['ansible_loop']['nextitem'] = items[item_index + 1]
             except IndexError:
                 pass
             try:
-                res['loop']['previtem'] = items[item_index - 1]
+                res['ansible_loop']['previtem'] = items[item_index - 1]
             except IndexError:
                 pass
             res['_ansible_item_result'] = True

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -315,6 +315,7 @@ class TaskExecutor:
             items = self._squash_items(items, loop_var, task_vars)
 
         no_log = False
+        items_len = len(items)
         for item_index, item in enumerate(items):
             task_vars[loop_var] = item
             if index_var:
@@ -357,6 +358,22 @@ class TaskExecutor:
             res[loop_var] = item
             if index_var:
                 res[index_var] = item_index
+            res['loop'] = {
+                'items': items,
+                'index': item_index + 1,
+                'index0': item_index,
+                'first': item_index == 0,
+                'last': item_index + 1 == items_len,
+                'length': items_len,
+            }
+            try:
+                res['loop']['nextitem'] = items[item_index + 1]
+            except IndexError:
+                pass
+            try:
+                res['loop']['previtem'] = items[item_index - 1]
+            except IndexError:
+                pass
             res['_ansible_item_result'] = True
             res['_ansible_ignore_errors'] = task_fields.get('ignore_errors')
 

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -289,6 +289,7 @@ class TaskExecutor:
         index_var = None
         label = None
         loop_pause = 0
+        extended = False
         templar = Templar(loader=self._loader, shared_loader_obj=self._shared_loader_obj, variables=self._job_vars)
 
         # FIXME: move this to the object itself to allow post_validate to take care of templating (loop_control.post_validate)

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -325,7 +325,7 @@ class TaskExecutor:
 
             if extended:
                 task_vars['ansible_loop'] = {
-                    'items': items,
+                    'allitems': items,
                     'index': item_index + 1,
                     'index0': item_index,
                     'first': item_index == 0,
@@ -338,10 +338,8 @@ class TaskExecutor:
                     task_vars['ansible_loop']['nextitem'] = items[item_index + 1]
                 except IndexError:
                     pass
-                try:
+                if item_index - 1 >= 0:
                     task_vars['ansible_loop']['previtem'] = items[item_index - 1]
-                except IndexError:
-                    pass
 
             # Update template vars to reflect current loop iteration
             templar.set_available_variables(task_vars)

--- a/lib/ansible/playbook/loop_control.py
+++ b/lib/ansible/playbook/loop_control.py
@@ -29,6 +29,7 @@ class LoopControl(FieldAttributeBase):
     _index_var = FieldAttribute(isa='str')
     _label = FieldAttribute(isa='str')
     _pause = FieldAttribute(isa='int', default=0)
+    _extended = FieldAttribute(isa='bool')
 
     def __init__(self):
         super(LoopControl, self).__init__()

--- a/test/integration/targets/loops/tasks/main.yml
+++ b/test/integration/targets/loops/tasks/main.yml
@@ -268,3 +268,66 @@
     things:
       - !unsafe foo
       - !unsafe bar
+
+- name: extended loop info
+  assert:
+    that:
+      - ansible_loop.nextitem == 'orange'
+      - ansible_loop.index == 1
+      - ansible_loop.index0 == 0
+      - ansible_loop.first
+      - not ansible_loop.last
+      - ansible_loop.previtem is undefined
+      - ansible_loop.allitems == ['apple', 'orange', 'banana']
+      - ansible_loop.revindex == 3
+      - ansible_loop.revindex0 == 2
+      - ansible_loop.length == 3
+  loop:
+    - apple
+    - orange
+    - banana
+  loop_control:
+    extended: true
+  when: item == 'apple'
+
+- name: extended loop info 2
+  assert:
+    that:
+      - ansible_loop.nextitem == 'banana'
+      - ansible_loop.index == 2
+      - ansible_loop.index0 == 1
+      - not ansible_loop.first
+      - not ansible_loop.last
+      - ansible_loop.previtem == 'apple'
+      - ansible_loop.allitems == ['apple', 'orange', 'banana']
+      - ansible_loop.revindex == 2
+      - ansible_loop.revindex0 == 1
+      - ansible_loop.length == 3
+  loop:
+    - apple
+    - orange
+    - banana
+  loop_control:
+    extended: true
+  when: item == 'orange'
+
+- name: extended loop info 3
+  assert:
+    that:
+      - ansible_loop.nextitem is undefined
+      - ansible_loop.index == 3
+      - ansible_loop.index0 == 2
+      - not ansible_loop.first
+      - ansible_loop.last
+      - ansible_loop.previtem == 'orange'
+      - ansible_loop.allitems == ['apple', 'orange', 'banana']
+      - ansible_loop.revindex == 1
+      - ansible_loop.revindex0 == 0
+      - ansible_loop.length == 3
+  loop:
+    - apple
+    - orange
+    - banana
+  loop_control:
+    extended: true
+  when: item == 'banana'

--- a/test/integration/targets/no_log/runme.sh
+++ b/test/integration/targets/no_log/runme.sh
@@ -5,7 +5,7 @@ set -eux
 # This test expects 7 loggable vars and 0 non-loggable ones.
 # If either mismatches it fails, run the ansible-playbook command to debug.
 [ "$(ansible-playbook no_log_local.yml -i ../../inventory -vvvvv "$@" | awk \
-'BEGIN { logme = 0; nolog = 0; } /LOG_ME/ { logme += 1;} /DO_NOT_LOG/ { nolog += 1;} END { printf "%d/%d", logme, nolog; }')" = "40/0" ]
+'BEGIN { logme = 0; nolog = 0; } /LOG_ME/ { logme += 1;} /DO_NOT_LOG/ { nolog += 1;} END { printf "%d/%d", logme, nolog; }')" = "26/0" ]
 
 # deal with corner cases with no log and loops
 # no log enabled, should produce 6 censored messages

--- a/test/integration/targets/no_log/runme.sh
+++ b/test/integration/targets/no_log/runme.sh
@@ -5,7 +5,7 @@ set -eux
 # This test expects 7 loggable vars and 0 non-loggable ones.
 # If either mismatches it fails, run the ansible-playbook command to debug.
 [ "$(ansible-playbook no_log_local.yml -i ../../inventory -vvvvv "$@" | awk \
-'BEGIN { logme = 0; nolog = 0; } /LOG_ME/ { logme += 1;} /DO_NOT_LOG/ { nolog += 1;} END { printf "%d/%d", logme, nolog; }')" = "26/0" ]
+'BEGIN { logme = 0; nolog = 0; } /LOG_ME/ { logme += 1;} /DO_NOT_LOG/ { nolog += 1;} END { printf "%d/%d", logme, nolog; }')" = "40/0" ]
 
 # deal with corner cases with no log and loops
 # no log enabled, should produce 6 censored messages


### PR DESCRIPTION
##### SUMMARY

This is a proof of concept PR that adds a `ansible_loop` "variable" that follows the semantics of the `loop` variable accessible in the jinja2 `{% for %}` loop construct (http://jinja.pocoo.org/docs/dev/templates/#for)

Adds:

* `ansible_loop.items` - list of all items in the loop
* `ansible_loop.index` - The current iteration of the loop. (1 indexed)
* `ansible_loop.index0` - The current iteration of the loop. (0 indexed)
* `ansible_loop.first` - True if first iteration
* `ansible_loop.last` - True if last iteration
* `ansible_loop.length` - The number of items in the sequence
* `ansible_loop.previtem` - The item from the previous iteration of the loop. Undefined during the first iteration.
* `ansible_loop.nextitem` - The item from the following iteration of the loop. Undefined during the last iteration.



##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
lib/ansible/executor/task_executor.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```