### PR TITLE
[stable-2.4] avoid loading vars on unspecified basedir (cwd) (#42067)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,11 @@ Ansible Changes By Release
 
 <a id="2.4.6"></a>
 
-## 2.4.5 "Dancing Days" - TBD
+## 2.4.6 "Dancing Days" - TBD
 
 ### Bugfixes
+* **Security Fix** - avoid using ansible.cfg in a world readable dir
+  https://github.com/ansible/ansible/pull/42070
 
 
 <a id="2.4.5"></a>

--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -652,7 +652,7 @@ class CLI(with_metaclass(ABCMeta, object)):
                 ansible_versions[counter] = 0
             try:
                 ansible_versions[counter] = int(ansible_versions[counter])
-            except:
+            except Exception:
                 pass
         if len(ansible_versions) < 3:
             for counter in range(len(ansible_versions), 3):
@@ -792,6 +792,12 @@ class CLI(with_metaclass(ABCMeta, object)):
         # create the variable manager, which will be shared throughout
         # the code, ensuring a consistent view of global variables
         variable_manager = VariableManager(loader=loader, inventory=inventory)
+
+        if hasattr(options, 'basedir'):
+            if options.basedir:
+                variable_manager.safe_basedir = True
+        else:
+            variable_manager.safe_basedir = True
 
         # load vars from cli options
         variable_manager.extra_vars = load_extra_vars(loader=loader, options=options)

--- a/lib/ansible/vars/manager.py
+++ b/lib/ansible/vars/manager.py
@@ -122,6 +122,7 @@ class VariableManager:
         self._hostvars = None
         self._omit_token = '__omit_place_holder__%s' % sha1(os.urandom(64)).hexdigest()
         self._options_vars = defaultdict(dict)
+        self.safe_basedir = False
 
         # bad cache plugin is not fatal error
         try:
@@ -142,6 +143,7 @@ class VariableManager:
             omit_token=self._omit_token,
             options_vars=self._options_vars,
             inventory=self._inventory,
+            safe_basedir=self.safe_basedir,
         )
         return data
 
@@ -155,6 +157,7 @@ class VariableManager:
         self._omit_token = data.get('omit_token', '__omit_place_holder__%s' % sha1(os.urandom(64)).hexdigest())
         self._inventory = data.get('inventory', None)
         self._options_vars = data.get('options_vars', dict())
+        self.safe_basedir = data.get('safe_basedir', False)
 
     @property
     def extra_vars(self):
@@ -233,7 +236,9 @@ class VariableManager:
         )
 
         # default for all cases
-        basedirs = [self._loader.get_basedir()]
+        basedirs = []
+        if self.safe_basedir:  # avoid adhoc/console loading cwd
+            basedirs = [self._loader.get_basedir()]
 
         if play:
             # first we compile any vars specified in defaults/main.yml


### PR DESCRIPTION
* avoid loading vars on unspecified basedir (cwd)
(cherry picked from commit de0e11c)

Co-authored-by: Brian Coca <bcoca@users.noreply.github.com>


##### ISSUE TYPE

 - Bugfix Pull Request

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.4.5
```
