### PR TITLE
[stable-2.4] ignore ansible.cfg in world writable cwd (#42070)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Ansible Changes By Release
 ### Bugfixes
 * **Security Fix** - avoid loading host/group vars from cwd when not specifying
   a playbook or playbook base dir (https://github.com/ansible/ansible/pull/42067)
+* **Security Fix** - avoid using ansible.cfg in a world readable dir
+  https://github.com/ansible/ansible/pull/42070
 
 
 <a id="2.4.5"></a>

--- a/docs/templates/man.j2
+++ b/docs/templates/man.j2
@@ -76,17 +76,18 @@ ENVIRONMENT
 The following environment variables may be specified.
 
 {% if inventory %}
-ANSIBLE_INVENTORY  -- Override the default ansible inventory file
+ANSIBLE_INVENTORY  -- Override the default ansible inventory sources
 
 {% endif %}
 {% if library %}
 ANSIBLE_LIBRARY -- Override the default ansible module library path
 
 {% endif %}
-ANSIBLE_CONFIG -- Override the default ansible config file
+ANSIBLE_CONFIG -- Specify override location for the ansible config file
 
 Many more are available for most options in ansible.cfg
 
+For a full list check https://docs.ansible.com/. or use the `ansible-config` command.
 
 FILES
 -----
@@ -99,6 +100,9 @@ FILES
 
 ~/.ansible.cfg -- User config file, overrides the default config if present
 
+./ansible.cfg -- Local config file (in current working direcotry) assumed to be 'project specific' and overrides the rest if present.
+
+As mentioned above, the ANSIBLE_CONFIG environment variable will override all others.
 
 AUTHOR
 ------
@@ -110,8 +114,8 @@ See the AUTHORS file for a complete list of contributors.
 COPYRIGHT
 ---------
 
-Copyright © 2017 Red Hat, Inc | Ansible.
-Ansible is released under the terms of the GPLv3 License.
+Copyright © 2018 Red Hat, Inc | Ansible.
+Ansible is released under the terms of the GPLv3 license.
 
 
 SEE ALSO

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -18,6 +18,16 @@ from ansible.module_utils.six import string_types
 from ansible.config.manager import ConfigManager, ensure_type, get_ini_config_value
 
 
+def _warning(msg):
+    ''' display is not guaranteed here, nor it being the full class, but try anyways, fallback to sys.stderr.write '''
+    try:
+        from __main__ import display
+        display.warning(msg)
+    except:
+        import sys
+        sys.stderr.write(' [WARNING] %s\n' % (msg))
+
+
 def _deprecated(msg):
     ''' display is not guaranteed here, nor it being the full class, but try anyways, fallback to sys.stderr.write '''
     try:
@@ -122,3 +132,6 @@ for setting in config.data.get_settings():
         value = ensure_type(value, setting.name)
 
     set_constant(setting.name, value)
+
+for warn in config.WARNINGS:
+    _warning(warn)


### PR DESCRIPTION
* ignore ansible.cfg in world writable cwd
 * also added 'warnings' to config
 * updated man page template.
(cherry picked from commit b6f2aad600662a2eee2c3079b3713827163f3fd4)

Co-authored-by: Brian Coca <bcoca@users.noreply.github.com>


##### ISSUE TYPE

 - Bugfix Pull Request

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
stable-2.4
```
