### PR TITLE
meraki_config_template - Check for HTTP status code

### DIFF
--- a/lib/ansible/modules/network/meraki/meraki_config_template.py
+++ b/lib/ansible/modules/network/meraki/meraki_config_template.py
@@ -83,7 +83,10 @@ from ansible.module_utils.network.meraki.meraki import MerakiModule, meraki_argu
 def get_config_templates(meraki, org_id):
     path = meraki.construct_path('get_all', org_id=org_id)
     response = meraki.request(path, 'GET')
-    return response
+    if meraki.status == 200:
+        return response
+    else:
+        meraki.fail_json(msg='Unable to get configuration templates')
 
 
 def get_template_id(meraki, name, data):
@@ -111,7 +114,10 @@ def delete_template(meraki, org_id, name, data):
     path = meraki.construct_path('delete', org_id=org_id)
     path = path + '/' + template_id
     response = meraki.request(path, 'DELETE')
-    return response
+    if meraki.status == 200:
+        return response
+    else:
+        meraki.fail_json(msg='Unable to remove configuration template')
 
 
 def bind(meraki, org_name, net_name, name, data):
@@ -126,7 +132,11 @@ def bind(meraki, org_name, net_name, name, data):
         if meraki.params['auto_bind']:
             payload['autoBind'] = meraki.params['auto_bind']
         meraki.result['changed'] = True
-        return meraki.request(path, method='POST', payload=json.dumps(payload))
+        r = meraki.request(path, method='POST', payload=json.dumps(payload))
+        if meraki.status == 200:
+            return r
+        else:
+            meraki.fail_json(msg='Unable to bind configuration template to network')
 
 
 def unbind(meraki, org_name, net_name, name, data):
@@ -136,7 +146,12 @@ def unbind(meraki, org_name, net_name, name, data):
     if is_network_bound(meraki, nets, net_name, template_id) is True:
         path = meraki.construct_path('unbind', function='config_template', net_id=net_id)
         meraki.result['changed'] = True
-        return meraki.request(path, method='POST')
+        r = meraki.request(path, method='POST')
+        if meraki.status == 200:
+            return r
+        else:
+            meraki.fail_json(msg='Unable to unbind configuration template from network')
+
 
 
 def main():

--- a/lib/ansible/modules/network/meraki/meraki_config_template.py
+++ b/lib/ansible/modules/network/meraki/meraki_config_template.py
@@ -83,10 +83,9 @@ from ansible.module_utils.network.meraki.meraki import MerakiModule, meraki_argu
 def get_config_templates(meraki, org_id):
     path = meraki.construct_path('get_all', org_id=org_id)
     response = meraki.request(path, 'GET')
-    if meraki.status == 200:
-        return response
-    else:
+    if meraki.status != 200:
         meraki.fail_json(msg='Unable to get configuration templates')
+    return response
 
 
 def get_template_id(meraki, name, data):
@@ -99,10 +98,8 @@ def get_template_id(meraki, name, data):
 def is_network_bound(meraki, nets, net_name, template_id):
     for net in nets:
         if net['name'] == net_name:
-            # meraki.fail_json(msg=net['name'])
             try:
                 if net['configTemplateId'] == template_id:
-                    # meraki.fail_json(msg='Network is already bound.')
                     return True
             except KeyError:
                 pass
@@ -114,10 +111,9 @@ def delete_template(meraki, org_id, name, data):
     path = meraki.construct_path('delete', org_id=org_id)
     path = path + '/' + template_id
     response = meraki.request(path, 'DELETE')
-    if meraki.status == 200:
-        return response
-    else:
+    if meraki.status != 200:
         meraki.fail_json(msg='Unable to remove configuration template')
+    return response
 
 
 def bind(meraki, org_name, net_name, name, data):
@@ -133,10 +129,9 @@ def bind(meraki, org_name, net_name, name, data):
             payload['autoBind'] = meraki.params['auto_bind']
         meraki.result['changed'] = True
         r = meraki.request(path, method='POST', payload=json.dumps(payload))
-        if meraki.status == 200:
-            return r
-        else:
+        if meraki.status != 200:
             meraki.fail_json(msg='Unable to bind configuration template to network')
+        return r
 
 
 def unbind(meraki, org_name, net_name, name, data):
@@ -147,10 +142,9 @@ def unbind(meraki, org_name, net_name, name, data):
         path = meraki.construct_path('unbind', function='config_template', net_id=net_id)
         meraki.result['changed'] = True
         r = meraki.request(path, method='POST')
-        if meraki.status == 200:
-            return r
-        else:
+        if meraki.status != 200:
             meraki.fail_json(msg='Unable to unbind configuration template from network')
+        return r
 
 
 def main():
@@ -229,8 +223,6 @@ def main():
                                  meraki.params['net_name'],
                                  meraki.params['config_template'],
                                  get_config_templates(meraki, org_id))
-            # meraki.fail_json(msg='Output', bind_output=template_bind)
-            # meraki.result['data'] = json.loads(template_bind)
     elif meraki.params['state'] == 'absent':
         if not meraki.params['net_name']:
             meraki.result['data'] = delete_template(meraki,
@@ -243,7 +235,6 @@ def main():
                                    meraki.params['net_name'],
                                    meraki.params['config_template'],
                                    get_config_templates(meraki, org_id))
-            # meraki.result['data'] = json.loads(config_unbind)
 
     # in the event of a successful module execution, you will want to
     # simple AnsibleModule.exit_json(), passing the key/value results

--- a/lib/ansible/modules/network/meraki/meraki_config_template.py
+++ b/lib/ansible/modules/network/meraki/meraki_config_template.py
@@ -153,7 +153,6 @@ def unbind(meraki, org_name, net_name, name, data):
             meraki.fail_json(msg='Unable to unbind configuration template from network')
 
 
-
 def main():
 
     # define the available arguments/parameters that a user can pass to

--- a/test/integration/targets/meraki_config_template/tasks/main.yml
+++ b/test/integration/targets/meraki_config_template/tasks/main.yml
@@ -47,6 +47,15 @@
     that:
       - '"No configuration template named" in deleted.msg'
 
+- name: Create a network
+  meraki_network:
+    auth_key: '{{auth_key}}'
+    state: present
+    org_name: '{{ test_org_name }}'
+    net_name: '{{ test_net_name }}'
+    type: appliance
+  delegate_to: localhost
+
 - name: Bind a template to a network
   meraki_config_template:
     auth_key: '{{auth_key}}'
@@ -102,3 +111,11 @@
 - assert:
     that:
       unbind_invalid.changed == False
+
+- name: Delete network
+  meraki_network:
+    auth_key: '{{auth_key}}'
+    state: absent
+    org_name: '{{ test_org_name }}'
+    net_name: '{{ test_net_name }}'
+  delegate_to: localhost


### PR DESCRIPTION
##### SUMMARY
- All requests now check returned status code
- Fail if status code isn’t what is expected

Fixes #41282

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
meraki_config_template

##### ANSIBLE VERSION
```
ansible 2.7.0.dev0 (meraki/2.7-http-code 88764165ad) last updated 2018/06/29 19:47:54 (GMT -500)
  config file = None
  configured module search path = ['/Users/kbreit/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/kbreit/Documents/Programming/ansible/lib/ansible
  executable location = /Users/kbreit/Documents/Programming/ansible/bin/ansible
  python version = 3.5.4 (default, Feb 25 2018, 14:56:02) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
