### PR TITLE
WIP: npm module: added "options" argument

### DIFF
--- a/lib/ansible/modules/packaging/language/npm.py
+++ b/lib/ansible/modules/packaging/language/npm.py
@@ -221,7 +221,11 @@ class Npm(object):
 
         installed = list()
         missing = list()
-        data = json.loads(self._exec(cmd, True, False))
+        pkglist = self._exec(cmd, True, False)
+        try:
+            data = json.loads(pkglist)
+        except ValueError as e:
+            self.module.fail_json(msg='error %s for data %s' % (e, pkglist))
         if 'dependencies' in data:
             for dep in data['dependencies']:
                 if 'missing' in data['dependencies'][dep] and data['dependencies'][dep]['missing']:

--- a/lib/ansible/modules/packaging/language/npm.py
+++ b/lib/ansible/modules/packaging/language/npm.py
@@ -135,6 +135,7 @@ EXAMPLES = '''
 
 import os
 import re
+import sys
 
 from ansible.module_utils.basic import AnsibleModule
 
@@ -224,7 +225,8 @@ class Npm(object):
         pkglist = self._exec(cmd, True, False)
         try:
             data = json.loads(pkglist)
-        except ValueError as e:
+        except ValueError:
+            _, e, _ = sys.exc_info()
             self.module.fail_json(msg='error %s for data %s' % (e, pkglist))
         if 'dependencies' in data:
             for dep in data['dependencies']:

--- a/lib/ansible/modules/packaging/language/npm.py
+++ b/lib/ansible/modules/packaging/language/npm.py
@@ -162,6 +162,7 @@ class Npm(object):
         self.ignore_scripts = kwargs['ignore_scripts']
         self.state = kwargs['state']
         self.options = self._build_options(kwargs['options'])
+        self._debug = True
 
         if kwargs['executable']:
             self.executable = kwargs['executable'].split(' ')
@@ -212,7 +213,11 @@ class Npm(object):
                     self.module.fail_json(msg="path %s is not a directory" % self.path)
                 cwd = self.path
 
+            self.module.log('Executing: %s' % ' '.join(cmd))
             rc, out, err = self.module.run_command(cmd, check_rc=check_rc, cwd=cwd)
+            self.module.log('  --> rc: %s' % rc)
+            self.module.log('  --> stdout: %s' % out)
+            self.module.log('  --> stderr: %s' % err)
             return out
         return ''
 

--- a/lib/ansible/modules/packaging/language/npm.py
+++ b/lib/ansible/modules/packaging/language/npm.py
@@ -72,11 +72,10 @@ options:
     choices: [ "present", "absent", "latest" ]
   options:
     description:
-      - Extra arguments passed to C(npm) command.
+      - Extra arguments dictionary passed to C(npm) command.
       - Note that C('--global'), C('--production'), C('--ignore-scripts') and C('--registry')
         options can be controlled by other arguments.
     required: false
-    type: dict
     version_added: "2.7"
 requirements:
     - npm installed in bin path (recommended /usr/local/bin)
@@ -225,7 +224,7 @@ class Npm(object):
         pkglist = self._exec(cmd, True, False)
         try:
             data = json.loads(pkglist)
-        except ValueError:
+        except Exception:
             _, e, _ = sys.exc_info()
             self.module.fail_json(msg='error %s for data %s' % (e, pkglist))
         if 'dependencies' in data:

--- a/lib/ansible/modules/packaging/language/npm.py
+++ b/lib/ansible/modules/packaging/language/npm.py
@@ -222,10 +222,8 @@ class Npm(object):
         installed = list()
         missing = list()
         pkglist = self._exec(cmd, True, False)
-        try:
-            data = json.loads(pkglist)
-        except Exception:
-            self.module.fail_json(msg='error with data %s' % pkglist)
+        self.module.fail_json(msg='error with data %s' % pkglist)
+        data = json.loads(pkglist)
         if 'dependencies' in data:
             for dep in data['dependencies']:
                 if 'missing' in data['dependencies'][dep] and data['dependencies'][dep]['missing']:

--- a/lib/ansible/modules/packaging/language/npm.py
+++ b/lib/ansible/modules/packaging/language/npm.py
@@ -222,8 +222,12 @@ class Npm(object):
         installed = list()
         missing = list()
         pkglist = self._exec(cmd, True, False)
-        self.module.fail_json(msg='error with data %s' % pkglist)
-        data = json.loads(pkglist)
+        try:
+            data = json.loads(pkglist)
+        except Exception:
+            data = None
+        if data is None:
+            self.module.fail_json(msg='error with data %s' % pkglist)
         if 'dependencies' in data:
             for dep in data['dependencies']:
                 if 'missing' in data['dependencies'][dep] and data['dependencies'][dep]['missing']:

--- a/lib/ansible/modules/packaging/language/npm.py
+++ b/lib/ansible/modules/packaging/language/npm.py
@@ -225,8 +225,7 @@ class Npm(object):
         try:
             data = json.loads(pkglist)
         except Exception:
-            _, e, _ = sys.exc_info()
-            self.module.fail_json(msg='error %s for data %s' % (e, pkglist))
+            self.module.fail_json(msg='error with data %s' % pkglist)
         if 'dependencies' in data:
             for dep in data['dependencies']:
                 if 'missing' in data['dependencies'][dep] and data['dependencies'][dep]['missing']:

--- a/test/integration/targets/npm/tasks/test.yml
+++ b/test/integration/targets/npm/tasks/test.yml
@@ -67,3 +67,60 @@
         that:
           - npm_fix_install is success
           - npm_fix_install is changed
+
+- vars:
+    # sample: node-v8.2.0-linux-x64.tar.xz
+    node_path: '{{ remote_dir }}/{{ nodejs_path }}/bin'
+    package:
+      to_save: moment
+      not_to_save: lodash
+
+  block:
+    - name: make sure no packages installed
+      file:
+        path: '{{ remote_dir }}/{{ item }}'
+        state: absent
+      with_items:
+        - node_modules
+        - package-lock.json
+
+    - name: prepare package.json
+      copy:
+        dest: '{{ remote_dir }}/package.json'
+        content: '{}'
+
+    - name: 'install {{ package.to_save }}'
+      npm:
+        path: '{{ remote_dir }}'
+        executable: '{{ node_path }}/npm'
+        name: '{{ package.to_save }}'
+        options:
+          save: yes
+
+    - name: check if package.json is edited
+      lineinfile:
+        path: '{{ remote_dir }}/package.json'
+        regex: '^(\s*"{{ package.to_save }}":.*)$'
+        line: '\1'
+        backref: yes
+        state: present
+      check_mode: yes
+      register: package_json_edited
+      failed_when: package_json_edited.changed
+
+    - name: 'install {{ package.not_to_save }}'
+      npm:
+        path: '{{ remote_dir }}'
+        executable: '{{ node_path }}/npm'
+        name: '{{ package.not_to_save }}'
+        options:
+          save: no
+
+    - name: check if package.json is not edited
+      lineinfile:
+        path: '{{ remote_dir }}/package.json'
+        regex: '^(\s*"{{ package.not_to_save }}":.*)$'
+        state: absent
+      check_mode: yes
+      register: package_json_not_edited
+      failed_when: package_json_not_edited.changed


### PR DESCRIPTION
##### SUMMARY

`npm` command provides [many options](https://github.com/npm/npm/blob/latest/doc/misc/npm-config.md) such as `save`, `package-lock` and `ignore-scripts`.
Although some options are supported by the module arguments, still there are many options not supported.

Rather than implementing arguments for each of them, I added `options` argument to support them all.

Usage example:

```yaml
- name: install node modules without editing package.json
  npm:
    path: '{{ repo.path }}'
    options:
      save: no
```

##### ISSUE TYPE

 - Feature Pull Request

##### COMPONENT NAME

`npm` module

##### ANSIBLE VERSION

```
ansible 2.7.0.dev0 (npm-options ea38792fb2) last updated 2018/06/30 23:38:02 (GMT +900)
  config file = None
  configured module search path = [u'/Users/01014505/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/01014505/Documents/dev/oss/ansible/lib/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.15 (default, May  1 2018, 16:44:14) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]
```