### PR TITLE
Adding aws_secret_facts module for AWS Secrets Manager

### DIFF
--- a/lib/ansible/modules/cloud/amazon/aws_secret_facts.py
+++ b/lib/ansible/modules/cloud/amazon/aws_secret_facts.py
@@ -18,7 +18,7 @@ short_description: Access facts for secrets stored in AWS Secrets Manager.
 description:
     - Access facts for secrets stored in AWS Secrets Manager.
 author: "Aaron Smith (@slapula)"
-version_added: "2.7"
+version_added: "2.8"
 requirements: [ 'botocore>=1.10.0', 'boto3' ]
 options:
   name:

--- a/lib/ansible/modules/cloud/amazon/aws_secret_facts.py
+++ b/lib/ansible/modules/cloud/amazon/aws_secret_facts.py
@@ -152,11 +152,14 @@ def main():
             'suffix': dict(type='str'),
             'regex': dict(type='str'),
         },
+        mutually_exclusive=[
+            ['name', 'prefix', 'suffix', 'regex']
+        ],
         supports_check_mode=True,
     )
 
     result = {
-        'changed': True,
+        'changed': False,
         'desired_secrets': []
     }
 

--- a/lib/ansible/modules/cloud/amazon/aws_secret_facts.py
+++ b/lib/ansible/modules/cloud/amazon/aws_secret_facts.py
@@ -1,0 +1,203 @@
+#!/usr/bin/python
+
+# Copyright: (c) 2018, Aaron Smith <ajsmith10381@gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = r'''
+---
+module: aws_secret_facts
+short_description: Access facts for secrets stored in AWS Secrets Manager.
+description:
+    - Access facts for secrets stored in AWS Secrets Manager.
+author: "Aaron Smith (@slapula)"
+version_added: "2.7"
+requirements: [ 'botocore>=1.10.0', 'boto3' ]
+options:
+  name:
+    description:
+    - Friendly name of the secret you are looking up.
+  prefix:
+    description:
+    - Common string identifier that has been added to the beginning of a secret name.
+  suffix:
+    description:
+    - Common string identifier that has been added to the end of a secret name.
+  regex:
+    description:
+    - Regex pattern that can be used to identify a specific secret or set of secrets.
+notes:
+  - Leaving all parameters empty will cause the module to look up the information of all secrets stored
+    in Secrets Manager.
+extends_documentation_fragment:
+    - ec2
+    - aws
+'''
+
+
+EXAMPLES = r'''
+- name: Get facts for all secrets
+  aws_secret_facts:
+  register: all_secrets
+
+- name: Get facts for specific secret
+  aws_secret_facts:
+    name: 'example_secret'
+  register: specific_secret
+
+- name: Get facts for specific prefix of secrets
+  aws_secret_facts:
+    prefix: 'example_'
+  register: specific_prefix_set
+'''
+
+
+RETURN = r'''
+arn:
+    description: The Amazon Resource Name (ARN) of the secret.
+    returned: always
+    type: string
+name:
+    description: The friendly name of the secret.
+    returned: always
+    type: string
+description:
+    description: The user-provided description of the secret.
+    returned: always
+    type: string
+kms_key_id:
+    description:
+      - The ARN or alias of the AWS KMS customer master key (CMK) that's used to encrypt the SecretString and SecretBinary fields in each
+        version of the secret.  If you don't provide a key, then Secrets Manager defaults to encrypting the secret fields with the default
+        KMS CMK (the one named awssecretsmanager ) for this account.
+    returned: always
+    type: string
+rotation_enabled:
+    description: Indicated whether automatic, scheduled rotation is enabled for this secret.
+    returned: always
+    type: boolean
+rotation_lambda_arn:
+    description:
+      - The ARN of an AWS Lambda function that's invoked by Secrets Manager to rotate and expire the secret either automatically per
+        the schedule or manually by a call to RotateSecret .
+    returned: always
+    type: string
+rotation_rules:
+    description: A structure that defines the rotation configuration for the secret.
+    returned: always
+    type: dict
+automatically_after_days:
+    description: Specifies the number of days between automatic scheduled rotations of the secret.
+    returned: always
+    type: int
+last_rotate_date:
+    description: The last date and time that the rotation process for this secret was invoked.
+    returned: always
+    type: string
+last_changed_date:
+    description: The last date and time that this secret was modified in any way.
+    returned: always
+    type: string
+last_access_date:
+    description: The last date that this secret was accessed. This value is truncated to midnight of the date and therefore shows only the date, not the time.
+    returned: always
+    type: string
+deleted_date:
+    description:
+      - The date and time on which this secret was deleted. Not present on active secrets. The secret can be recovered until the number of days
+        in the recovery window has passed, as specified in the RecoveryWindowInDays parameter of the DeleteSecret operation.
+    returned: always
+    type: string
+tags:
+    description: The list of user-defined tags that are associated with the secret.
+    returned: always
+    type: list
+secret_versions_to_stages:
+    description: A list of all of the currently assigned SecretVersionStage staging labels and the SecretVersionId that each is attached to.
+    returned: always
+    type: dict
+'''
+
+import os
+import re
+
+from ansible.module_utils.aws.core import AnsibleAWSModule
+from ansible.module_utils.ec2 import camel_dict_to_snake_dict
+
+try:
+    from botocore.exceptions import BotoCoreError, ClientError
+except ImportError:
+    pass  # handled by AnsibleAWSModule
+
+
+def camel_list_to_snake_list(list):
+    conv_list = []
+    for i in list:
+        conv_list.append(camel_dict_to_snake_dict(i))
+    return conv_list
+
+
+def main():
+    module = AnsibleAWSModule(
+        argument_spec={
+            'name': dict(type='str'),
+            'prefix': dict(type='str'),
+            'suffix': dict(type='str'),
+            'regex': dict(type='str'),
+        },
+        supports_check_mode=True,
+    )
+
+    result = {
+        'changed': True,
+        'desired_secrets': []
+    }
+
+    client = module.client('secretsmanager')
+
+    kwargs = {}
+    all_secrets = []
+
+    try:
+        while True:
+            response = client.list_secrets(**kwargs)
+            for i in response['SecretList']:
+                all_secrets.append(i)
+            try:
+                kwargs['nextToken'] = response['nextToken']
+            except KeyError:
+                break
+    except (BotoCoreError, ClientError) as e:
+        module.fail_json_aws(e, msg="Failed to look up secret data")
+
+    if module.params.get('name'):
+        for i in all_secrets:
+            if i['Name'] == module.params.get('name'):
+                result['desired_secrets'].append(camel_dict_to_snake_dict(i))
+    elif module.params.get('prefix'):
+        for i in all_secrets:
+            if i['Name'].startswith(module.params.get('prefix')):
+                result['desired_secrets'].append(camel_dict_to_snake_dict(i))
+    elif module.params.get('suffix'):
+        for i in all_secrets:
+            if i['Name'].endswith(module.params.get('suffix')):
+                result['desired_secrets'].append(camel_dict_to_snake_dict(i))
+    elif module.params.get('regex'):
+        for i in all_secrets:
+            if re.match(module.params.get('regex'), i['Name']):
+                result['desired_secrets'].append(camel_dict_to_snake_dict(i))
+    else:
+        result['desired_secrets'] = camel_list_to_snake_list(all_secrets)
+
+    module.exit_json(changed=result['changed'], facts=result['desired_secrets'])
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/cloud/amazon/aws_secret_facts.py
+++ b/lib/ansible/modules/cloud/amazon/aws_secret_facts.py
@@ -34,6 +34,7 @@ options:
     description:
     - Regex pattern that can be used to identify a specific secret or set of secrets.
 notes:
+  - Each lookup option is mutually exclusive.
   - Leaving all parameters empty will cause the module to look up the information of all secrets stored
     in Secrets Manager.
 extends_documentation_fragment:

--- a/test/integration/targets/aws_secret_facts/aliases
+++ b/test/integration/targets/aws_secret_facts/aliases
@@ -1,0 +1,2 @@
+cloud/aws
+posix/ci/cloud/group4/aws

--- a/test/integration/targets/aws_secret_facts/aliases
+++ b/test/integration/targets/aws_secret_facts/aliases
@@ -1,2 +1,3 @@
 cloud/aws
 posix/ci/cloud/group4/aws
+shippable/aws/group[1-2]

--- a/test/integration/targets/aws_secret_facts/aliases
+++ b/test/integration/targets/aws_secret_facts/aliases
@@ -1,3 +1,3 @@
 cloud/aws
 posix/ci/cloud/group4/aws
-shippable/aws/group[1-2]
+shippable/aws/group1

--- a/test/integration/targets/aws_secret_facts/defaults/main.yaml
+++ b/test/integration/targets/aws_secret_facts/defaults/main.yaml
@@ -1,0 +1,2 @@
+---
+super_secret_string: 'Test12345'

--- a/test/integration/targets/aws_secret_facts/meta/main.yaml
+++ b/test/integration/targets/aws_secret_facts/meta/main.yaml
@@ -1,0 +1,3 @@
+dependencies:
+  - prepare_tests
+  - setup_ec2

--- a/test/integration/targets/aws_secret_facts/tasks/main.yaml
+++ b/test/integration/targets/aws_secret_facts/tasks/main.yaml
@@ -1,0 +1,90 @@
+---
+- block:
+  - name: set connection information for all tasks
+    set_fact:
+      aws_connection_info: &aws_connection_info
+        aws_access_key: "{{ aws_access_key }}"
+        aws_secret_key: "{{ aws_secret_key }}"
+        region: "{{ aws_region }}"
+        #security_token: "{{ security_token }}"
+    no_log: true
+
+  - name: add secret to AWS Secrets Manager
+    aws_secret:
+      <<: *aws_connection_info
+      name: "{{ resource_prefix }}-test-secret-string"
+      state: present
+      secret_type: 'string'
+      secret: "{{ super_secret_string }}"
+    register: result
+
+  - name: pausing for secret creation
+    pause:
+      seconds: 30
+
+  # ============================================================
+  # Creation/Deletion testing
+  # ============================================================
+  - name: get all secrets
+    aws_secret_facts:
+      <<: *aws_connection_info
+    register: result
+
+  - name: assert correct keys are returned
+    assert:
+      that:
+        - result.facts is not none
+
+  - name: get specific secret
+    aws_secret_facts:
+      <<: *aws_connection_info
+      name: "{{ resource_prefix }}-test-secret-string"
+    register: result
+
+  - name: assert correct keys are returned
+    assert:
+      that:
+        - result.facts is not none
+
+  - name: get specific prefix
+    aws_secret_facts:
+      <<: *aws_connection_info
+      prefix: "{{ resource_prefix }}"
+    register: result
+
+  - name: assert correct keys are returned
+    assert:
+      that:
+        - result.facts is not none
+
+  - name: get specific suffix
+    aws_secret_facts:
+      <<: *aws_connection_info
+      suffix: "string"
+    register: result
+
+  - name: assert correct keys are returned
+    assert:
+      that:
+        - result.facts is not none
+
+  - name: get a general regex
+    aws_secret_facts:
+      <<: *aws_connection_info
+      regex: "(.*?)"
+    register: result
+
+  - name: assert correct keys are returned
+    assert:
+      that:
+        - result.facts is not none
+
+  always:
+  - name: remove secret
+    aws_secret:
+      <<: *aws_connection_info
+      name: "{{ resource_prefix }}-test-secret-string"
+      state: absent
+      secret_type: 'string'
+      secret: "{{ super_secret_string }}"
+    ignore_errors: yes

--- a/test/integration/targets/aws_secret_facts/tasks/main.yaml
+++ b/test/integration/targets/aws_secret_facts/tasks/main.yaml
@@ -6,7 +6,7 @@
         aws_access_key: "{{ aws_access_key }}"
         aws_secret_key: "{{ aws_secret_key }}"
         region: "{{ aws_region }}"
-        #security_token: "{{ security_token }}"
+        security_token: "{{ security_token | omit() }}"
     no_log: true
 
   - name: add secret to AWS Secrets Manager

--- a/test/runner/requirements/constraints.txt
+++ b/test/runner/requirements/constraints.txt
@@ -21,6 +21,7 @@ virtualenv < 16.0.0 ; python_version < '2.7' # virtualenv 16.0.0 and later requi
 pyopenssl < 18.0.0 ; python_version < '2.7' # pyOpenSSL 18.0.0 and later require python 2.7 or later
 pyfmg == 0.6.1 # newer versions do not pass current unit tests
 pycparser < 2.19 ; python_version < '2.7' # pycparser 2.19 and later require python 2.7 or later
+botocore >= 1.10.0 # adds support for the following AWS services: secretsmanager, fms, and acm-pca
 
 # freeze pylint and its requirements for consistent test results
 astroid == 2.0.4


### PR DESCRIPTION
##### SUMMARY
This PR contains a facts module for secrets managed by AWS Secrets Manager. This work is related to the `aws_secret` module I submitted in #40093. The integration tests use the `aws_secret` module from that PR which means they will fail here until that PR is merged into this one.

@wknapik I believe this is relevant to your interests.

##### ISSUE TYPE
 - New Module Pull Request

##### COMPONENT NAME
`aws_secret_facts`

##### ANSIBLE VERSION
```
ansible 2.5.4
  config file = None
  configured module search path = [u'/home/ajsmith/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/ajsmith/.local/lib/python2.7/site-packages/ansible
  executable location = /home/ajsmith/.local/bin/ansible
  python version = 2.7.15rc1 (default, Apr 15 2018, 21:51:34) [GCC 7.3.0]
```