### PR TITLE
Run patch command with --check option instead of --dry-run to support older BSDs

### DIFF
--- a/lib/ansible/modules/files/patch.py
+++ b/lib/ansible/modules/files/patch.py
@@ -100,7 +100,7 @@ EXAMPLES = r'''
 
 import os
 from traceback import format_exc
-from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import AnsibleModule, get_platform
 from ansible.module_utils._text import to_native
 
 
@@ -108,10 +108,19 @@ class PatchError(Exception):
     pass
 
 
+def add_dry_run_option(opts):
+    # Older versions of FreeBSD, OpenBSD and NetBSD support the --check option only.
+    if get_platform().lower() in ['openbsd', 'netbsd', 'freebsd']:
+        opts.append('--check')
+    else:
+        opts.append('--dry-run')
+
+
 def is_already_applied(patch_func, patch_file, basedir, dest_file=None, binary=False, strip=0, state='present'):
-    opts = ['--quiet', '--forward', '--dry-run',
+    opts = ['--quiet', '--forward',
             "--strip=%s" % strip, "--directory='%s'" % basedir,
             "--input='%s'" % patch_file]
+    add_dry_run_option(opts)
     if binary:
         opts.append('--binary')
     if dest_file:
@@ -128,7 +137,7 @@ def apply_patch(patch_func, patch_file, basedir, dest_file=None, binary=False, s
             "--strip=%s" % strip, "--directory='%s'" % basedir,
             "--input='%s'" % patch_file]
     if dry_run:
-        opts.append('--dry-run')
+        add_dry_run_option(opts)
     if binary:
         opts.append('--binary')
     if dest_file:


### PR DESCRIPTION
##### SUMMARY
If executed on OpenBSD, FreeBSD or NetBSD run the patch command with the --check option instead of --dry-run. Some of them added the --dry-run option but in order support older versions of the BSDs we should use --check.
This fixes #41483
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
patch

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/flo/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python3.6/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 3.6.5 (default, May 11 2018, 04:00:52) [GCC 8.1.0]

```
