### PR TITLE
use SPDX license formats for role templates

### DIFF
--- a/lib/ansible/galaxy/data/apb/README.md
+++ b/lib/ansible/galaxy/data/apb/README.md
@@ -30,7 +30,7 @@ Including an example of how to use your APB (for instance, with variables passed
 License
 -------
 
-BSD
+BSD-2-Clause
 
 Author Information
 ------------------

--- a/lib/ansible/galaxy/data/apb/meta/main.yml.j2
+++ b/lib/ansible/galaxy/data/apb/meta/main.yml.j2
@@ -8,12 +8,14 @@ galaxy_info:
   # issue_tracker_url: {{ issue_tracker_url }}
 
   # Some suggested licenses:
-  # - BSD (default)
+  # - BSD-2-Clause (default)
   # - MIT
-  # - GPLv2
-  # - GPLv3
-  # - Apache
-  # - CC-BY
+  # - GPL-2.0
+  # - GPL-3.0
+  # - AGPL-3.0
+  # - GPL-3.0+
+  # - Apache-2.0
+  # - CC-BY-SA-4.0
   license: {{ license }}
 
   # Optionally specify the branch Galaxy will use when accessing the GitHub

--- a/lib/ansible/galaxy/data/container/README.md
+++ b/lib/ansible/galaxy/data/container/README.md
@@ -40,7 +40,7 @@ A list of other roles hosted on Galaxy should go here, plus any details in regar
 
 ## License
 
-BSD
+BSD-2-Clause
 
 ## Author Information
 

--- a/lib/ansible/galaxy/data/container/meta/main.yml.j2
+++ b/lib/ansible/galaxy/data/container/meta/main.yml.j2
@@ -8,12 +8,14 @@ galaxy_info:
   # issue_tracker_url: {{ issue_tracker_url }}
 
   # Some suggested licenses:
-  # - BSD (default)
+  # - BSD-2-Clause (default)
   # - MIT
-  # - GPLv2
-  # - GPLv3
-  # - Apache
-  # - CC-BY
+  # - GPL-2.0
+  # - GPL-3.0
+  # - AGPL-3.0
+  # - GPL-3.0+
+  # - Apache-2.0
+  # - CC-BY-SA-4.0
   license: {{ license }}
 
   min_ansible_container_version: 0.2.0

--- a/lib/ansible/galaxy/data/default/README.md
+++ b/lib/ansible/galaxy/data/default/README.md
@@ -30,7 +30,7 @@ Including an example of how to use your role (for instance, with variables passe
 License
 -------
 
-BSD
+BSD-2-Clause
 
 Author Information
 ------------------

--- a/lib/ansible/galaxy/data/default/meta/main.yml.j2
+++ b/lib/ansible/galaxy/data/default/meta/main.yml.j2
@@ -8,12 +8,14 @@ galaxy_info:
   # issue_tracker_url: {{ issue_tracker_url }}
 
   # Some suggested licenses:
-  # - BSD (default)
+  # - BSD-2-Clause (default)
   # - MIT
-  # - GPLv2
-  # - GPLv3
-  # - Apache
-  # - CC-BY
+  # - GPL-2.0
+  # - GPL-3.0
+  # - AGPL-3.0
+  # - GPL-3.0+
+  # - Apache-2.0
+  # - CC-BY-SA-4.0
   license: {{ license }}
 
   min_ansible_version: {{ min_ansible_version }}

--- a/lib/ansible/galaxy/data/network/README.md
+++ b/lib/ansible/galaxy/data/network/README.md
@@ -30,7 +30,7 @@ Including an example of how to use your role (for instance, with variables passe
 License
 -------
 
-BSD
+BSD-2-Clause
 
 Author Information
 ------------------

--- a/lib/ansible/galaxy/data/network/meta/main.yml.j2
+++ b/lib/ansible/galaxy/data/network/meta/main.yml.j2
@@ -8,12 +8,14 @@ galaxy_info:
   # issue_tracker_url: {{ issue_tracker_url }}
 
   # Some suggested licenses:
-  # - BSD (default)
+  # - BSD-2-Clause (default)
   # - MIT
-  # - GPLv2
-  # - GPLv3
-  # - Apache
-  # - CC-BY
+  # - GPL-2.0
+  # - GPL-3.0
+  # - AGPL-3.0
+  # - GPL-3.0+
+  # - Apache-2.0
+  # - CC-BY-SA-4.0
   license: {{ license }}
 
   min_ansible_version: {{ min_ansible_version }}


### PR DESCRIPTION
Signed-off-by: paulfantom <pawel@krupa.net.pl>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This should resolve https://github.com/ansible/galaxy/issues/82, by changing custom license names to SPDX format in galaxy role templates.

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
galaxy

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0
  config file = None
  configured module search path = [u'/home/paulfantom/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.15 (default, May 16 2018, 17:50:09) [GCC 8.1.1 20180502 (Red Hat 8.1.1-1)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
