### PR TITLE
fix issue #22399 [pip.py supports that specify version conditions]

### DIFF
--- a/lib/ansible/modules/packaging/language/pip.py
+++ b/lib/ansible/modules/packaging/language/pip.py
@@ -7,8 +7,6 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-import re
-
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],
                     'supported_by': 'core'}

--- a/lib/ansible/modules/packaging/language/pip.py
+++ b/lib/ansible/modules/packaging/language/pip.py
@@ -223,7 +223,7 @@ def _get_cmd_options(module, cmd):
 def _get_full_name(name, version=None):
     if version is None or version == "":
         resp = name
-    elif re.match('^\d', version) != None :
+    elif re.match(r'^\d', version) != None :
         resp = name + '==' + version
     else:
         resp = name + version

--- a/lib/ansible/modules/packaging/language/pip.py
+++ b/lib/ansible/modules/packaging/language/pip.py
@@ -221,7 +221,7 @@ def _get_cmd_options(module, cmd):
 def _get_full_name(name, version=None):
     if version is None or version == "":
         resp = name
-    elif re.match(r'^\d', version) != None :
+    elif re.match(r'^\d', version) is not None:
         resp = name + '==' + version
     else:
         resp = name + version

--- a/lib/ansible/modules/packaging/language/pip.py
+++ b/lib/ansible/modules/packaging/language/pip.py
@@ -26,7 +26,7 @@ options:
       - As of 2.2 you can supply a list of names.
   version:
     description:
-      - The version number to install of the Python library specified in the I(name) parameter.
+      - The version expression to install of the Python library specified in the I(name) parameter.
   requirements:
     description:
       - The path to a pip requirements file, which should be local to the remote system.
@@ -123,7 +123,7 @@ EXAMPLES = '''
 # Install (Bottle) python package on version 0.11.
 - pip:
     name: bottle
-    version: 0.11
+    version: "==0.11"
 
 # Install (MyApp) using one of the remote protocols (bzr+,hg+,git+,svn+). You do not have to supply '-e' option in extra_args.
 - pip:
@@ -220,7 +220,7 @@ def _get_cmd_options(module, cmd):
 
 def _get_full_name(name, version=None):
     if version is None or version == "":
-        resp = name
+        resp = name + '=='
     else:
         resp = name + version
     return resp

--- a/lib/ansible/modules/packaging/language/pip.py
+++ b/lib/ansible/modules/packaging/language/pip.py
@@ -7,6 +7,8 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
+import re
+
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],
                     'supported_by': 'core'}
@@ -26,7 +28,7 @@ options:
       - As of 2.2 you can supply a list of names.
   version:
     description:
-      - The version expression to install of the Python library specified in the I(name) parameter.
+      - The version number or expression to install of the Python library specified in the I(name) parameter.
   requirements:
     description:
       - The path to a pip requirements file, which should be local to the remote system.
@@ -123,7 +125,7 @@ EXAMPLES = '''
 # Install (Bottle) python package on version 0.11.
 - pip:
     name: bottle
-    version: "==0.11"
+    version: 0.11
 
 # Install (MyApp) using one of the remote protocols (bzr+,hg+,git+,svn+). You do not have to supply '-e' option in extra_args.
 - pip:
@@ -220,7 +222,9 @@ def _get_cmd_options(module, cmd):
 
 def _get_full_name(name, version=None):
     if version is None or version == "":
-        resp = name + '=='
+        resp = name
+    elif re.match('^\d', version) != None :
+        resp = name + '==' + version
     else:
         resp = name + version
     return resp

--- a/lib/ansible/modules/packaging/language/pip.py
+++ b/lib/ansible/modules/packaging/language/pip.py
@@ -222,7 +222,7 @@ def _get_full_name(name, version=None):
     if version is None or version == "":
         resp = name
     else:
-        resp = name + '==' + version
+        resp = name + version
     return resp
 
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

fix issue #22399 
Ansible pip module fails to use version conditionals or environment markers

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
module pip.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

This will be successful with the commit I created.

```
    - name: Installing pip modules with conditions and environment markers
      pip:
        name=stevedore
        state=present
        executable=pip2.7
        version=">=1.3.0,<1.4.0"
```