### PR TITLE
Catch the raised exception so we can report failure

### DIFF
--- a/lib/ansible/modules/cloud/amazon/iam_policy.py
+++ b/lib/ansible/modules/cloud/amazon/iam_policy.py
@@ -301,7 +301,7 @@ def main():
             with open(policy_document, 'r') as json_data:
                 pdoc = json.dumps(json.load(json_data))
                 json_data.close()
-        except IOError:
+        except IOError as e:
             if e.errno == 2:
                 module.fail_json(
                     msg='policy_document {0:!r} does not exist'.format(policy_document))


### PR DESCRIPTION
Just like #42072

Avoid the _undefined name_ by catching the raised exception into the variable __e__ so it can be reported on the following line.

flake8 testing of https://github.com/ansible/ansible on Python 3.6.3

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./lib/ansible/modules/cloud/amazon/iam_policy.py:305:16: F821 undefined name 'e'
            if e.errno == 2:
               ^
./lib/ansible/modules/cloud/misc/rhevm.py:594:24: F821 undefined name 'e'
            setMsg(str(e))
                       ^
./lib/ansible/modules/files/archive.py:391:92: F821 undefined name 'e'
                module.fail_json(dest=dest, msg='Error deleting some source files: ' + str(e), files=errors)
                                                                                           ^
3    F821 undefined name 'e'
3
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - New Module Pull Request
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
