### PR TITLE
Fix eos integration test failure

### DIFF
--- a/test/integration/targets/eos_config/tests/cli/check_mode.yaml
+++ b/test/integration/targets/eos_config/tests/cli/check_mode.yaml
@@ -17,7 +17,7 @@
    that:
    - "result.msg is defined"
    - "result.failed == true"
-   - "'Error on executing commands' in result.msg"
+   - "'Invalid input' in result.msg"
 
 - name: valid configuration in check mode
   eos_config:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
* Fix error message in eos_config integration test
* Fix set_become invoke login in httpapi connection plugin
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
connection/httpapi.py
eos_config/tests/cli/check_mode.yaml
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
