### PR TITLE
Fix #42000 : ovirt_host_pm documentation for slot parameter

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_host_pm.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_host_pm.py
@@ -61,13 +61,10 @@ options:
     port:
         description:
             - "Power management interface port."
-    slot:
-        description:
-            - "Power management slot."
     options:
         description:
-            - "Dictionary of additional fence agent options."
-            - "Additional information about options can be found at U(https://fedorahosted.org/cluster/wiki/FenceArguments)."
+            - "Dictionary of additional fence agent options (including Power Management slot)."
+            - "Additional information about options can be found at U(https://github.com/ClusterLabs/fence-agents/blob/master/doc/FenceAgentAPI.md)."
     encrypt_options:
         description:
             - "If (true) options will be encrypted when send to agent."
@@ -94,6 +91,20 @@ EXAMPLES = '''
     password: admin
     port: 3333
     type: ipmilan
+
+# Add fence agent to host 'myhost' using 'slot' option
+- ovirt_host_pm:
+    name: myhost
+    address: 1.2.3.4
+    options:
+      myoption1: x
+      myoption2: y
+      slot: myslot
+    username: admin
+    password: admin
+    port: 3333
+    type: ipmilan
+
 
 # Remove ipmilan fence agent with address 1.2.3.4 on host 'myhost'
 - ovirt_host_pm:
@@ -160,7 +171,6 @@ class HostPmModule(BaseModule):
             ] if self._module.params['options'] else None,
             password=self._module.params['password'],
             port=self._module.params['port'],
-            slot=self._module.params['slot'],
             type=self._module.params['type'],
             username=self._module.params['username'],
             order=self._module.params.get('order', 100),
@@ -173,7 +183,6 @@ class HostPmModule(BaseModule):
             equal(self._module.params.get('password'), entity.password) and
             equal(self._module.params.get('username'), entity.username) and
             equal(self._module.params.get('port'), entity.port) and
-            equal(self._module.params.get('slot'), entity.slot) and
             equal(self._module.params.get('type'), entity.type) and
             equal(self._module.params.get('order'), entity.order)
         )

--- a/lib/ansible/modules/cloud/ovirt/ovirt_host_pm.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_host_pm.py
@@ -201,7 +201,6 @@ def main():
         type=dict(default=None),
         port=dict(default=None, type='int'),
         order=dict(default=None, type='int'),
-        slot=dict(default=None),
         options=dict(default=None, type='dict'),
         encrypt_options=dict(default=None, type='bool', aliases=['encrypt']),
     )

--- a/lib/ansible/modules/cloud/ovirt/ovirt_host_pm.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_host_pm.py
@@ -160,6 +160,7 @@ class HostPmModule(BaseModule):
             ] if self._module.params['options'] else None,
             password=self._module.params['password'],
             port=self._module.params['port'],
+            slot=self._module.params['slot'],
             type=self._module.params['type'],
             username=self._module.params['username'],
             order=self._module.params.get('order', 100),
@@ -172,6 +173,7 @@ class HostPmModule(BaseModule):
             equal(self._module.params.get('password'), entity.password) and
             equal(self._module.params.get('username'), entity.username) and
             equal(self._module.params.get('port'), entity.port) and
+            equal(self._module.params.get('slot'), entity.slot) and
             equal(self._module.params.get('type'), entity.type) and
             equal(self._module.params.get('order'), entity.order)
         )


### PR DESCRIPTION
<!---
Verify first that your issue/request is not already reported on GitHub.
THIS FORM WILL BE READ BY A MACHINE, COMPLETE ALL SECTIONS AS DESCRIBED.
Also test if the latest release, and devel branch are affected too.
ALWAYS add information AFTER (OUTSIDE) these html comments.
Otherwise it may end up being automatically closed by our bot. -->

##### SUMMARY
<!--- Explain the problem briefly -->
ovirt_host_pm ignores the 'slot' parameter

##### ISSUE TYPE
 - Bug Report

##### COMPONENT NAME
<!--- Insert, BELOW THIS COMMENT, the name of the module, plugin, task or feature.
Do not include extra details here, e.g. "vyos_command" not "the network module vyos_command" or the full path-->
ovirt_host_pm
##### ANSIBLE VERSION
<!--- Paste, BELOW THIS COMMENT, verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.5
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/fran/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.15 (default, May 16 2018, 17:50:09) [GCC 8.1.1 20180502 (Red Hat 8.1.1-1)]
```

##### CONFIGURATION
<!--- If using Ansible 2.4 or above, paste, BELOW THIS COMMENT, the results of "ansible-config dump --only-changed"
Otherwise, mention any settings you have changed/added/removed in ansible.cfg
(or using the ANSIBLE_* environment variables).-->

##### OS / ENVIRONMENT
<!--- Mention, BELOW THIS COMMENT, the OS you are running Ansible from, and the OS you are
managing, or say "N/A" for anything that is not platform-specific.
Also mention the specific version of what you are trying to control,
e.g. if this is a network bug the version of firmware on the network device.-->
N/A
##### STEPS TO REPRODUCE
<!--- For bugs, show exactly how to reproduce the problem, using a minimal test-case.
For new features, show how the feature would be used. -->

<!--- Paste example playbooks or commands between quotes below -->
```yaml
- name: Configure Power Management
  ovirt_host_pm:
    auth: "{{ ovirt_auth }}"
    name: "{{ inventory_hostname }}"
    address: "{{ pm_ucs_manager }}"
    options:
      suborg: "{{ pm_suborg }}"
      ssl_insecure: "1"
    order: "1"
    username: "{{ pm_user }}"
    password: "{{ pm_pass_user }}"
    type: "cisco_ucs"
    slot: "{{ ansible_hostname }}"
  delegate_to: localhost
```

<!--- You can also paste gist.github.com links for larger files -->

##### EXPECTED RESULTS
<!--- What did you expect to happen when running the steps above? -->
The 'slot' parameter should be populated after checking in oVirt/RHVM web ui.

##### ACTUAL RESULTS
<!--- What actually happened? If possible run with extra verbosity (-vvvv) -->
The parameter is not populated; although no error is show when running the playbook  It seems the 'slot' parameter is never used within the ovirt_host_pm module and therefore not used when doing the RHV API call.

<!--- Paste verbatim command output between quotes below -->
```

```
