### PR TITLE
Fix galaxy client executing queries with invalid http method

### DIFF
--- a/lib/ansible/galaxy/api.py
+++ b/lib/ansible/galaxy/api.py
@@ -152,7 +152,7 @@ class GalaxyAPI(object):
             args['alternate_role_name'] = role_name
         elif github_repo.startswith('ansible-role'):
             args['alternate_role_name'] = github_repo[len('ansible-role') + 1:]
-        data = self.__call_galaxy(url, args=urlencode(args))
+        data = self.__call_galaxy(url, args=urlencode(args), method="POST")
         if data.get('results', None):
             return data['results']
         return data
@@ -279,7 +279,7 @@ class GalaxyAPI(object):
             "github_repo": github_repo,
             "secret": secret
         })
-        data = self.__call_galaxy(url, args=args)
+        data = self.__call_galaxy(url, args=args, method="POST")
         return data
 
     @g_connect


### PR DESCRIPTION
Fixes: ansible/galaxy#796

##### SUMMARY
Galaxy API client relied on implicit mechanism that determined method for http requests. If `data=` field was specified, 'POST' method was automatically used. 
This behaviour had changed after http layer in `ansible/module_utils/urls.py` got updated.

This patch adds explicit http method argument for Galaxy API client where it's required.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ansible-galaxy

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (fix/galaxy-client 6e79419f15) last updated 2018/07/02 17:45:35 (GMT +200)
  config file = /Users/cutwater/.ansible.cfg
  configured module search path = [u'/Users/cutwater/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/cutwater/work/rh/ansible/lib/ansible
  executable location = /Users/cutwater/work/rh/ansible/.venv/bin/ansible
  python version = 2.7.13 (default, Feb 15 2017, 15:26:02) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.38)]
```