### PR TITLE
Fix 'ansible-doc' command in action plugin docs

### DIFF
--- a/docs/docsite/rst/plugins/action.rst
+++ b/docs/docsite/rst/plugins/action.rst
@@ -27,8 +27,8 @@ Action plugin are executed by default when an associated module is used; no acti
 Plugin List
 -----------
 
-You can use ``ansible-doc -t cache -l`` to see the list of available plugins.
-Use ``ansible-doc -t cache <plugin name>`` to see specific documentation and examples.
+You can use ``ansible-doc -t action -l`` to see the list of available plugins.
+Use ``ansible-doc -t action <plugin name>`` to see specific documentation and examples.
 
 .. seealso::
 


### PR DESCRIPTION
##### SUMMARY
The wrong plugin type was shown in the `ansible-doc` command to list action plugins. This fixes it.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
docs

##### ANSIBLE VERSION
```
ansible 2.7.0.dev0 (action_plugin_docs_fix_list_command 7499347d10) last updated 2018/07/02 13:12:35 (GMT -500)
```

##### ADDITIONAL INFORMATION
N/A