### PR TITLE
Revert "Temporarily switch RHEL and Windows tests to AWS."

### DIFF
--- a/test/runner/lib/core_ci.py
+++ b/test/runner/lib/core_ci.py
@@ -70,10 +70,13 @@ class AnsibleCoreCI(object):
                 'junos',
                 'ios',
                 'tower',
-                'rhel',
             ),
             azure=(
                 'azure',
+                'rhel',
+                'windows/2012',
+                'windows/2012-R2',
+                'windows/2016',
             ),
             parallels=(
                 'osx',


### PR DESCRIPTION
##### SUMMARY

Revert "Temporarily switch RHEL and Windows tests to AWS."

This reverts commit c3134ce6e2ac27e70feddb8c65a1aec6bfdbce52.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.7.0.dev0 (azure-testing 342d1623ac) last updated 2018/07/02 12:14:01 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
