### PR TITLE
Add additional puppet options

### DIFF
--- a/changelogs/fragments/puppet_debugging_options.yaml
+++ b/changelogs/fragments/puppet_debugging_options.yaml
@@ -1,3 +1,4 @@
+---
 features:
-- Add support for --debug, --verbose, --summarize
-- Add support for setting logdest to both stdout and syslog via 'all'
+  - Add support for --debug, --verbose, --summarize
+  - Add support for setting logdest to both stdout and syslog via 'all'

--- a/changelogs/fragments/puppet_debugging_options.yaml
+++ b/changelogs/fragments/puppet_debugging_options.yaml
@@ -1,0 +1,3 @@
+features:
+- Add support for --debug, --verbose, --summarize
+- Add support for setting logdest to both stdout and syslog via 'all'

--- a/changelogs/fragments/puppet_debugging_options.yaml
+++ b/changelogs/fragments/puppet_debugging_options.yaml
@@ -1,4 +1,5 @@
 ---
-features:
-  - Add support for --debug, --verbose, --summarize
-  - Add support for setting logdest to both stdout and syslog via 'all'
+minor_changes:
+  - puppet - Add support for --debug, --verbose, --summarize 
+    https://github.com/ansible/ansible/issues/37986
+  - puppet - Add support for setting logdest to both stdout and syslog via 'all'

--- a/lib/ansible/modules/system/puppet.py
+++ b/lib/ansible/modules/system/puppet.py
@@ -45,7 +45,7 @@ options:
   logdest:
     description:
       - Where the puppet logs should go, if puppet apply is being used.
-    choices: [ stdout, syslog ]
+    choices: [ stdout, syslog, all ]
     default: stdout
     version_added: "2.1"
   certname:
@@ -64,12 +64,15 @@ options:
   summarize:
     description:
       - Whether to print a transaction summary
+    version_added: "2.7"
   verbose:
     description:
       - Print extra information
+    version_added: "2.7"
   debug:
     description:
       - Enable full debugging
+    version_added: "2.7"
 requirements:
 - puppet
 author:

--- a/lib/ansible/modules/system/puppet.py
+++ b/lib/ansible/modules/system/puppet.py
@@ -43,8 +43,9 @@ options:
     description:
       - Puppet environment to be used.
   logdest:
-    description:
-      - Where the puppet logs should go, if puppet apply is being used.
+    description: |
+      Where the puppet logs should go, if puppet apply is being used. 'all' 
+      will go to both stdout and syslog.
     choices: [ stdout, syslog, all ]
     default: stdout
     version_added: "2.1"

--- a/lib/ansible/modules/system/puppet.py
+++ b/lib/ansible/modules/system/puppet.py
@@ -61,6 +61,15 @@ options:
       - Execute a specific piece of Puppet code.
       - It has no effect with a puppetmaster.
     version_added: "2.1"
+  summarize:
+    description:
+      - Whether to print a transaction summary
+  verbose:
+    description:
+      - Print extra information
+  debug:
+    description:
+      - Enable full debugging
 requirements:
 - puppet
 author:
@@ -90,6 +99,12 @@ EXAMPLES = '''
 - name: Run puppet using a specific tags
   puppet:
     tags: update,nginx
+
+- name: Run a manifest with debug, log to both syslog and stdout, specify module path
+  puppet:
+    modulepath: /etc/puppet/modules:/opt/stack/puppet-modules:/usr/share/openstack-puppet/modules
+    logdest: all
+    manifest: /var/lib/example/puppet_step_config.pp
 '''
 
 import json
@@ -129,7 +144,9 @@ def main():
             puppetmaster=dict(type='str'),
             modulepath=dict(type='str'),
             manifest=dict(type='str'),
-            logdest=dict(type='str', default='stdout', choices=['stdout', 'syslog']),
+            logdest=dict(type='str', default='stdout', choices=['stdout',
+                                                                'syslog',
+                                                                'all']),
             # internal code to work with --diff, do not use
             show_diff=dict(type='bool', default=False, aliases=['show-diff']),
             facts=dict(type='dict'),
@@ -138,6 +155,9 @@ def main():
             certname=dict(type='str'),
             tags=dict(type='list'),
             execute=dict(type='str'),
+            summarize=dict(type='bool', default=False),
+            debug=dict(type='bool', default=False),
+            verbose=dict(type='bool', default=False),
         ),
         supports_check_mode=True,
         mutually_exclusive=[
@@ -212,6 +232,8 @@ def main():
         cmd = "%s apply --detailed-exitcodes " % base_cmd
         if p['logdest'] == 'syslog':
             cmd += "--logdest syslog "
+        if p['logdest'] == 'all':
+            cmd += " --logdest syslog --logdest stdout"
         if p['modulepath']:
             cmd += "--modulepath='%s'" % p['modulepath']
         if p['environment']:
@@ -228,6 +250,12 @@ def main():
             cmd += " --execute '%s'" % p['execute']
         else:
             cmd += pipes.quote(p['manifest'])
+        if p['summarize']:
+            cmd += " --summarize"
+        if p['debug']:
+            cmd += " --debug"
+        if p['verbose']:
+            cmd += " --verbose"
     rc, stdout, stderr = module.run_command(cmd)
 
     if rc == 0:

--- a/lib/ansible/modules/system/puppet.py
+++ b/lib/ansible/modules/system/puppet.py
@@ -44,8 +44,8 @@ options:
       - Puppet environment to be used.
   logdest:
     description: |
-      Where the puppet logs should go, if puppet apply is being used. 'all' 
-      will go to both stdout and syslog.
+      Where the puppet logs should go, if puppet apply is being used. C(all)
+      will go to both C(stdout) and C(syslog).
     choices: [ stdout, syslog, all ]
     default: stdout
     version_added: "2.1"


### PR DESCRIPTION
Add support for puppet options --debug, --verbose, --summary,
and extend logdest to support logging to stdout and syslog at
the same time.

Fixes #37986

##### SUMMARY
Add support for additional puppet output options; --debug, --verbose, --summary.

Also extends 'logdest' to support multiple log destinations as puppet cli accepts multiple --logdest args.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
puppet module

##### ANSIBLE VERSION
ansible 2.5.2
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/stack/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Apr 11 2018, 07:36:10) [GCC 4.8.5 20150623 (Red Hat 4.8.5-28)]


##### ADDITIONAL INFORMATION
Notably, this change will allow OpenStack TripleO to replace existing puppet tasks currently run via the command module with tasks using the puppet module, and have better check mode support.  lp:1779408