### PR TITLE
Feature: Add bare-metal server support to 1&1 Server module (cloud/oneandone/oneandone_server)

### DIFF
--- a/lib/ansible/module_utils/oneandone.py
+++ b/lib/ansible/module_utils/oneandone.py
@@ -79,12 +79,12 @@ def get_fixed_instance_size(oneandone_conn, fixed_instance_size, full_object=Fal
             return _fixed_instance_size['id']
 
 
-def get_appliance(oneandone_conn, appliance, full_object=False):
+def get_appliance(oneandone_conn, appliance, full_object=False, appliance_type='IMAGE'):
     """
     Validates the appliance exists by ID or name.
     Return the appliance ID.
     """
-    for _appliance in oneandone_conn.list_appliances(q='IMAGE'):
+    for _appliance in oneandone_conn.list_appliances(q=appliance_type):
         if appliance in (_appliance['id'], _appliance['name']):
             if full_object:
                 return _appliance
@@ -202,6 +202,18 @@ def get_public_ip(oneandone_conn, public_ip, full_object=False):
             if full_object:
                 return _public_ip
             return _public_ip['id']
+
+
+def get_baremetal_model(oneandone_conn, baremetal_model, full_object=False):
+    """
+    Validates that the baremetal model exists by ID or a name.
+    Returns the baremetal model if one was found.
+    """
+    for _baremetal_model in oneandone_conn.list_baremetal_models(per_page=1000):
+        if baremetal_model in (_baremetal_model['id'], _baremetal_model['name']):
+            if full_object:
+                return _baremetal_model
+            return _baremetal_model['id']
 
 
 def wait_for_resource_creation_completion(oneandone_conn,

--- a/lib/ansible/modules/cloud/oneandone/oneandone_server.py
+++ b/lib/ansible/modules/cloud/oneandone/oneandone_server.py
@@ -135,7 +135,7 @@ options:
     default: 'yes'
 
 requirements:
-  - "1and1"
+  - "1and1 >= 1.7.3"
   - "python >= 2.6"
 
 author:

--- a/lib/ansible/modules/cloud/oneandone/oneandone_server.py
+++ b/lib/ansible/modules/cloud/oneandone/oneandone_server.py
@@ -110,6 +110,13 @@ options:
       - The type of server to be built.
     default: "cloud"
     choices: [ "cloud", "baremetal", "k8s_node" ]
+  baremetal_model_id:
+    description:
+      - The baremetal model name or ID for the server which must be provided when
+        creating a baremetal server. It is required only for 'present' state, and
+        it is mutually exclusive with vcore, cores_per_processor, ram, hdds,
+        and fixed_instance_size parameters.
+    choices: [ "BMC_L", "BMC_L_HDD", "BMC_S", "BMC_S_HDD", "BMC_XL", "BMC_XL_HDD" ]
   wait:
     description:
       - Wait for the server to be in state 'running' before returning.

--- a/lib/ansible/modules/cloud/oneandone/oneandone_server.py
+++ b/lib/ansible/modules/cloud/oneandone/oneandone_server.py
@@ -117,6 +117,7 @@ options:
         it is mutually exclusive with vcore, cores_per_processor, ram, hdds,
         and fixed_instance_size parameters.
     choices: [ "BMC_L", "BMC_L_HDD", "BMC_S", "BMC_S_HDD", "BMC_XL", "BMC_XL_HDD" ]
+    version_added: "2.7"
   wait:
     description:
       - Wait for the server to be in state 'running' before returning.


### PR DESCRIPTION
##### SUMMARY
Add bare-metal server support to 1&1 Server module (cloud/oneandone/oneandone_server)

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
oneandone_server cloud module
oneandone module_util

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (oneandone_add_baremetal_support cc1e9e1b1c) last updated 2018/07/03 03:34:55 (GMT +200)
  python version = 2.7.15 (default, Jul  3 2018, 02:34:00) [GCC 7.3.0]
```

##### ADDITIONAL INFORMATION
Below is the output from one of the test playbooks utilizing the new feature:

```
PLAY [localhost] ****************************************************************

TASK [Gathering Facts] *******************************************************
ok: [localhost]

TASK [Create a server] ********************************************************
changed: [localhost]

PLAY RECAP ********************************************************************
localhost                  : ok=2    changed=1    unreachable=0    failed=0   
```
