### PR TITLE
[2.5] influxdb_query: fix use of common return

### DIFF
--- a/changelogs/fragments/influxdb_query_common_return.yml
+++ b/changelogs/fragments/influxdb_query_common_return.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "influxdb_query - fixed the use of the common return 'results' caused an unexpected fault. The return is renamed to 'query_results'"

--- a/lib/ansible/modules/database/influxdb/influxdb_query.py
+++ b/lib/ansible/modules/database/influxdb/influxdb_query.py
@@ -52,11 +52,11 @@ EXAMPLES = r'''
 
 - name: Print results from the query
   debug:
-    var: connection.results
+    var: connection.query_results
 '''
 
 RETURN = '''
-results:
+query_results:
   description: Result from the query
   returned: success
   type: list
@@ -96,7 +96,7 @@ def main():
     influx = AnsibleInfluxDBRead(module)
     query = module.params.get('query')
     results = influx.read_by_query(query)
-    module.exit_json(changed=True, results=results)
+    module.exit_json(changed=True, query_results=results)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
##### SUMMARY
backport of #39626, closes #42066 

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
influxdb_query

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
