### PR TITLE
Restore BOOLEANS import in basic.py

### DIFF
--- a/changelogs/fragments/basic_booleans_backward_compat.yaml
+++ b/changelogs/fragments/basic_booleans_backward_compat.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+- Restore module_utils.basic.BOOLEANS variable for backwards compatibility with the module API in older ansible releases.

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -173,7 +173,7 @@ from ansible.module_utils.six import (
 )
 from ansible.module_utils.six.moves import map, reduce, shlex_quote
 from ansible.module_utils._text import to_native, to_bytes, to_text
-from ansible.module_utils.parsing.convert_bool import BOOLEANS_FALSE, BOOLEANS_TRUE, boolean
+from ansible.module_utils.parsing.convert_bool import BOOLEANS, BOOLEANS_FALSE, BOOLEANS_TRUE, boolean
 
 
 PASSWORD_MATCH = re.compile(r'^(?:.+[-_\s])?pass(?:[-_\s]?(?:word|phrase|wrd|wd)?)(?:[-_\s].+)?$', re.I)


### PR DESCRIPTION
##### SUMMARY
This import was removed by mistake. This is required for backward
compatibility.

Fixes: #41988

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/basic_booleans_backward_compat.yaml
lib/ansible/module_utils/basic.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
Stable-2.6
```