### PR TITLE
Extend DMI form factors list to match SMBIOS standard 3.2.0 (2018-04-26)

### DIFF
--- a/lib/ansible/module_utils/facts/hardware/linux.py
+++ b/lib/ansible/module_utils/facts/hardware/linux.py
@@ -267,7 +267,7 @@ class LinuxHardware(Hardware):
         if os.path.exists('/sys/devices/virtual/dmi/id/product_name'):
             # Use kernel DMI info, if available
 
-            # DMI SPEC -- http://www.dmtf.org/sites/default/files/standards/documents/DSP0134_2.7.0.pdf
+            # DMI SPEC -- https://www.dmtf.org/sites/default/files/standards/documents/DSP0134_3.2.0.pdf
             FORM_FACTOR = ["Unknown", "Other", "Unknown", "Desktop",
                            "Low Profile Desktop", "Pizza Box", "Mini Tower", "Tower",
                            "Portable", "Laptop", "Notebook", "Hand Held", "Docking Station",
@@ -275,7 +275,9 @@ class LinuxHardware(Hardware):
                            "Main Server Chassis", "Expansion Chassis", "Sub Chassis",
                            "Bus Expansion Chassis", "Peripheral Chassis", "RAID Chassis",
                            "Rack Mount Chassis", "Sealed-case PC", "Multi-system",
-                           "CompactPCI", "AdvancedTCA", "Blade"]
+                           "CompactPCI", "AdvancedTCA", "Blade", "Blade Enclosure",
+                           "Tablet", "Convertible", "Detachable", "IoT Gateway",
+                           "Embedded PC", "Mini PC", "Stick PC"]
 
             DMI_DICT = {
                 'bios_date': '/sys/devices/virtual/dmi/id/bios_date',


### PR DESCRIPTION
##### SUMMARY
Extend DMI form factors list to match SMBIOS standard 3.2.0 (2018-04-26)

https://www.dmtf.org/sites/default/files/standards/documents/DSP0134_3.2.0.pdf

Adds
- Blade Enclosure
- Tablet
- Convertible
- Detachable
- IoT Gateway
- Embedded PC
- Mini PC
- Stick PC

as possibilities for `ansible_form_factor`

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
Hardware facts (Linux)

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (devel f9cbdcd426) last updated 2018/07/03 10:35:09 (GMT +000)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/doug/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/doug/ansible/src/lib/ansible
  executable location = /home/doug/ansible/src/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```

