### PR TITLE
Make ios_vlan identify vlans starting with 9

### DIFF
--- a/lib/ansible/modules/network/ios/ios_vlan.py
+++ b/lib/ansible/modules/network/ios/ios_vlan.py
@@ -218,7 +218,7 @@ def parse_to_logical_rows(out):
         if not l:
             """Skip empty lines."""
             continue
-        if '0' < l[0] < '9':
+        if '0' < l[0] <= '9':
             """Line starting with a number."""
             if started_yielding:
                 yield cur_row

--- a/lib/ansible/modules/network/ios/ios_vlan.py
+++ b/lib/ansible/modules/network/ios/ios_vlan.py
@@ -218,7 +218,7 @@ def parse_to_logical_rows(out):
         if not l:
             """Skip empty lines."""
             continue
-        if '0' < l[0] <= '9':
+        if l[0].isdigit():
             """Line starting with a number."""
             if started_yielding:
                 yield cur_row

--- a/lib/ansible/modules/network/ios/ios_vlan.py
+++ b/lib/ansible/modules/network/ios/ios_vlan.py
@@ -218,7 +218,7 @@ def parse_to_logical_rows(out):
         if not l:
             """Skip empty lines."""
             continue
-        if l[0].isdigit():
+        if '0' < l[0] <= '9':
             """Line starting with a number."""
             if started_yielding:
                 yield cur_row

--- a/test/units/modules/network/ios/fixtures/ios_vlan_config.cfg
+++ b/test/units/modules/network/ios/fixtures/ios_vlan_config.cfg
@@ -4,5 +4,6 @@ VLAN Name                             Status    Ports
                                                 Gi1/0/52
                                                 Gi1/0/54
 2    vlan2                            active    Gi1/0/6, Gi1/0/7
+9    vlan9                            active    Gi1/0/6
 1002 fddi-default                     act/unsup 
 1003 fddo-default                     act/unsup

--- a/test/units/modules/network/ios/test_ios_vlan.py
+++ b/test/units/modules/network/ios/test_ios_vlan.py
@@ -59,6 +59,12 @@ class TestIosVlanModule(TestIosModule):
         ]
         self.assertEqual(result['commands'], expected_commands)
 
+    def test_ios_vlan_id_startwith_9(self):
+        set_module_args({'vlan_id': '9', 'name': 'vlan9', 'state': 'present'})
+        result = self.execute_module(changed=False)
+        expected_commands = []
+        self.assertEqual(result['commands'], expected_commands)
+
     def test_ios_vlan_rename(self):
         set_module_args({'vlan_id': '2', 'name': 'test', 'state': 'present'})
         result = self.execute_module(changed=True)
@@ -120,6 +126,14 @@ class TestIosVlanModule(TestIosModule):
                 ],
                 'state': 'active',
                 'vlan_id': '2',
+            },
+            {
+                'name': 'vlan9',
+                'interfaces': [
+                    'GigabitEthernet1/0/6',
+                ],
+                'state': 'active',
+                'vlan_id': '9',
             },
             {
                 'name': 'fddi-default',


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
A minor bug that the parser in parse_to_logical_rows(out) ignores vlans starting with number 9. Details in #42242 
This PR fix that.
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
Fix #42242 
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
/ansible/lib/ansible/modules/network/ios
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (issue_42242 56a485e694) last updated 2018/07/03 09:19:55 (GMT -400)
  config file = None
  configured module search path = [u'/home/zhikangzhang/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/zhikangzhang/Desktop/ansible/lib/ansible
  executable location = /home/zhikangzhang/Desktop/ansible/bin/ansible
  python version = 2.7.15 (default, May 16 2018, 17:50:09) [GCC 8.1.1 20180502 (Red Hat 8.1.1-1)]
```