### PR TITLE
Fix set the correct key option in the docs

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_vmkernel.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_vmkernel.py
@@ -50,7 +50,7 @@ options:
             - ' - C(type) (string): Type of IP assignment (either C(dhcp) or C(static)).'
             - 'Following parameters are required in case of C(type) is set to C(static)'
             - ' - C(ip_address) (string): Static IP address (implies C(type: static)).'
-            - ' - C(netmask) (string): Static netmask required for C(ip).'
+            - ' - C(subnet_mask) (string): Static netmask required for C(ip).'
         version_added: 2.5
     ip_address:
         description:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Under the `network` dictionary the key expected is `subnet_mask` not `netmask`.
https://github.com/ansible/ansible/blob/0a6ab23f38f4afb8ecf11d37b34657e4f3bd1aba/lib/ansible/modules/cloud/vmware/vmware_vmkernel.py#L180

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
This  change will affect the `vmware_vmkernel` module.

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.1
  config file = None
  configured module search path = ['/root/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python3.6/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 3.6.5 (default, Apr 10 2018, 17:08:37) [GCC 4.8.5 20150623 (Red Hat 4.8.5-16)]

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
