### PR TITLE
Meraki integration test block and cleanup

### DIFF
--- a/test/integration/targets/meraki_admin/tasks/main.yml
+++ b/test/integration/targets/meraki_admin/tasks/main.yml
@@ -1,254 +1,260 @@
-# Test code for the Meraki Organization module
+# Test code for the Meraki Admin module
 # Copyright: (c) 2018, Kevin Breit (@kbreit)
 
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
-- name: Create new administrator
-  meraki_admin:
-    auth_key: '{{auth_key}}'
-    state: present
-    org_name: '{{test_org_name}}'
-    name: Jane Doe
-    email: '{{email_prefix}}+janedoe@{{email_domain}}'
-    orgAccess: read-only
-  delegate_to: localhost
-  register: create_orgaccess
+- block:
+  - name: Create new administrator
+    meraki_admin:
+      auth_key: '{{auth_key}}'
+      state: present
+      org_name: '{{test_org_name}}'
+      name: Jane Doe
+      email: '{{email_prefix}}+janedoe@{{email_domain}}'
+      orgAccess: read-only
+    delegate_to: localhost
+    register: create_orgaccess
 
-- name: Create new admin assertion
-  assert:
-    that:
-      - create_orgaccess.changed == true
-      - 'create_orgaccess.data.name == "Jane Doe"'
+  - name: Create new admin assertion
+    assert:
+      that:
+        - create_orgaccess.changed == true
+        - 'create_orgaccess.data.name == "Jane Doe"'
 
-- name: Delete recently created administrator
-  meraki_admin:
-    auth_key: '{{auth_key}}'
-    state: absent
-    org_name: '{{test_org_name}}'
-    email: '{{email_prefix}}+janedoe@{{email_domain}}'
-  delegate_to: localhost
-  register: delete_one
+  - name: Delete recently created administrator
+    meraki_admin:
+      auth_key: '{{auth_key}}'
+      state: absent
+      org_name: '{{test_org_name}}'
+      email: '{{email_prefix}}+janedoe@{{email_domain}}'
+    delegate_to: localhost
+    register: delete_one
 
-- name: Create new administrator with org_id
-  meraki_admin:
-    auth_key: '{{auth_key}}'
-    state: present
-    org_id: '{{test_org_id}}'
-    name: Jane Doe
-    email: '{{email_prefix}}+janedoe@{{email_domain}}'
-    orgAccess: read-only
-  delegate_to: localhost
-  register: create_orgaccess_id
+  - name: Create new administrator with org_id
+    meraki_admin:
+      auth_key: '{{auth_key}}'
+      state: present
+      org_id: '{{test_org_id}}'
+      name: Jane Doe
+      email: '{{email_prefix}}+janedoe@{{email_domain}}'
+      orgAccess: read-only
+    delegate_to: localhost
+    register: create_orgaccess_id
 
-- name: Create new admin assertion
-  assert:
-    that:
-      - create_orgaccess_id.changed == true
-      - 'create_orgaccess_id.data.name == "Jane Doe"'
+  - name: Create new admin assertion
+    assert:
+      that:
+        - create_orgaccess_id.changed == true
+        - 'create_orgaccess_id.data.name == "Jane Doe"'
 
-- name: Create administrator with tags
-  meraki_admin:
-    auth_key: '{{auth_key}}'
-    state: present
-    org_name: '{{test_org_name}}'
-    name: John Doe
-    email: '{{email_prefix}}+johndoe@{{email_domain}}'
-    orgAccess: none
-    tags:
-      - { "tag": "production", "access": "read-only" }
-      - { "tag": "beta", "access": "full" }
-  delegate_to: localhost
-  register: create_tags
+  - name: Create administrator with tags
+    meraki_admin:
+      auth_key: '{{auth_key}}'
+      state: present
+      org_name: '{{test_org_name}}'
+      name: John Doe
+      email: '{{email_prefix}}+johndoe@{{email_domain}}'
+      orgAccess: none
+      tags:
+        - { "tag": "production", "access": "read-only" }
+        - { "tag": "beta", "access": "full" }
+    delegate_to: localhost
+    register: create_tags
 
-- assert:
-    that:
-      - create_tags.changed == true
-      - create_tags.data.name == "John Doe"
-      - create_tags.data.tags | length == 2
+  - assert:
+      that:
+        - create_tags.changed == true
+        - create_tags.data.name == "John Doe"
+        - create_tags.data.tags | length == 2
 
-- name: Create administrator with invalid tags
-  meraki_admin:
-    auth_key: '{{auth_key}}'
-    state: present
-    org_name: '{{test_org_name}}'
-    name: Jake Doe
-    email: '{{email_prefix}}+jakedoe@{{email_domain}}'
-    orgAccess: none
-    tags:
-      - { "tag": "production", "access": "read-only" }
-      - { "tag": "alpha", "access": "invalid" }
-  delegate_to: localhost
-  register: create_tags_invalid
-  ignore_errors: yes
+  - name: Create administrator with invalid tags
+    meraki_admin:
+      auth_key: '{{auth_key}}'
+      state: present
+      org_name: '{{test_org_name}}'
+      name: Jake Doe
+      email: '{{email_prefix}}+jakedoe@{{email_domain}}'
+      orgAccess: none
+      tags:
+        - { "tag": "production", "access": "read-only" }
+        - { "tag": "alpha", "access": "invalid" }
+    delegate_to: localhost
+    register: create_tags_invalid
+    ignore_errors: yes
 
-- assert:
-    that:
-      - '"400" in create_tags_invalid.msg'
-      # - '"must contain only valid tags" in create_tags_invalid.msg'
+  - assert:
+      that:
+        - '"400" in create_tags_invalid.msg'
+        # - '"must contain only valid tags" in create_tags_invalid.msg'
 
-- name: Create administrator with invalid tag permission
-  meraki_admin:
-    auth_key: '{{auth_key}}'
-    state: present
-    org_name: '{{test_org_name}}'
-    name: Jake Doe
-    email: '{{email_prefix}}+jakedoe@{{email_domain}}'
-    orgAccess: none
-    tags:
-      - { "tag": "production", "access": "read-only" }
-      - { "tag": "beta", "access": "invalid" }
-  delegate_to: localhost
-  register: create_tags_invalid_permission
-  ignore_errors: yes
+  - name: Create administrator with invalid tag permission
+    meraki_admin:
+      auth_key: '{{auth_key}}'
+      state: present
+      org_name: '{{test_org_name}}'
+      name: Jake Doe
+      email: '{{email_prefix}}+jakedoe@{{email_domain}}'
+      orgAccess: none
+      tags:
+        - { "tag": "production", "access": "read-only" }
+        - { "tag": "beta", "access": "invalid" }
+    delegate_to: localhost
+    register: create_tags_invalid_permission
+    ignore_errors: yes
 
-- assert:
-    that:
-      - '"400" in create_tags_invalid_permission.msg'
-      # - '"Invalid permission type" in create_tags_invalid_permission.msg'
+  - assert:
+      that:
+        - '"400" in create_tags_invalid_permission.msg'
+        # - '"Invalid permission type" in create_tags_invalid_permission.msg'
 
-- name: Make sure TestNet and TestNet2 are created
-  meraki_network:
-    auth_key: '{{auth_key}}'
-    state: present
-    org_name: '{{test_org_name}}'
-    net_name: '{{item}}'
-    type: switch
-  loop:
-    - TestNet
-    - TestNet2
+  - name: Make sure TestNet and TestNet2 are created
+    meraki_network:
+      auth_key: '{{auth_key}}'
+      state: present
+      org_name: '{{test_org_name}}'
+      net_name: '{{item}}'
+      type: switch
+    loop:
+      - TestNet
+      - TestNet2
 
-- name: Create administrator with networks
-  meraki_admin:
-    auth_key: '{{auth_key}}'
-    state: present
-    org_name: '{{test_org_name}}'
-    name: Jim Doe
-    email: '{{email_prefix}}+jimdoe@{{email_domain}}'
-    orgAccess: none
-    networks:
-      - { "network": "TestNet", "access": "read-only" }
-      - { "network": "TestNet2", "access": "full" }
-  delegate_to: localhost
-  register: create_network
+  - name: Create administrator with networks
+    meraki_admin:
+      auth_key: '{{auth_key}}'
+      state: present
+      org_name: '{{test_org_name}}'
+      name: Jim Doe
+      email: '{{email_prefix}}+jimdoe@{{email_domain}}'
+      orgAccess: none
+      networks:
+        - { "network": "TestNet", "access": "read-only" }
+        - { "network": "TestNet2", "access": "full" }
+    delegate_to: localhost
+    register: create_network
 
-- assert:
-    that:
-      - create_network.changed == true
-      - create_network.data.name == "Jim Doe"
-      - create_network.data.networks | length == 2
+  - assert:
+      that:
+        - create_network.changed == true
+        - create_network.data.name == "Jim Doe"
+        - create_network.data.networks | length == 2
 
-- name: Update administrator
-  meraki_admin:
-    auth_key: '{{auth_key}}'
-    state: present
-    org_name: '{{test_org_name}}'
-    name: Jim Doe
-    email: '{{email_prefix}}+jimdoe@{{email_domain}}'
-    orgAccess: none
-    networks:
-      - { "network": "TestNet", "access": "full" }
-  delegate_to: localhost
-  register: update_network
+  - name: Update administrator
+    meraki_admin:
+      auth_key: '{{auth_key}}'
+      state: present
+      org_name: '{{test_org_name}}'
+      name: Jim Doe
+      email: '{{email_prefix}}+jimdoe@{{email_domain}}'
+      orgAccess: none
+      networks:
+        - { "network": "TestNet", "access": "full" }
+    delegate_to: localhost
+    register: update_network
 
-- assert:
-    that:
-      - update_network.changed == true
-      - update_network.data.networks.0.access == "full"
-      - update_network.data.networks | length == 1
+  - assert:
+      that:
+        - update_network.changed == true
+        - update_network.data.networks.0.access == "full"
+        - update_network.data.networks | length == 1
 
-- name: Update administrator for idempotency check
-  meraki_admin:
-    auth_key: '{{auth_key}}'
-    state: present
-    org_name: '{{test_org_name}}'
-    name: Jim Doe
-    email: '{{email_prefix}}+jimdoe@{{email_domain}}'
-    orgAccess: none
-    networks:
-      - { "network": "TestNet", "access": "full" }
-  delegate_to: localhost
-  register: update_network_idempotent
+  - name: Update administrator for idempotency check
+    meraki_admin:
+      auth_key: '{{auth_key}}'
+      state: present
+      org_name: '{{test_org_name}}'
+      name: Jim Doe
+      email: '{{email_prefix}}+jimdoe@{{email_domain}}'
+      orgAccess: none
+      networks:
+        - { "network": "TestNet", "access": "full" }
+    delegate_to: localhost
+    register: update_network_idempotent
 
-- assert:
-    that:
-      - update_network_idempotent.changed == false
+  - assert:
+      that:
+        - update_network_idempotent.changed == false
 
-- name: Create administrator with invalid network
-  meraki_admin:
-    auth_key: '{{auth_key}}'
-    state: present
-    org_name: '{{test_org_name}}'
-    name: John Doe
-    email: '{{email_prefix}}+John@{{email_domain}}'
-    orgAccess: none
-    networks:
-      - { "network": "readnet", "access": "read-only" }
-  delegate_to: localhost
-  register: create_network_invalid
-  ignore_errors: yes
+  - name: Create administrator with invalid network
+    meraki_admin:
+      auth_key: '{{auth_key}}'
+      state: present
+      org_name: '{{test_org_name}}'
+      name: John Doe
+      email: '{{email_prefix}}+John@{{email_domain}}'
+      orgAccess: none
+      networks:
+        - { "network": "readnet", "access": "read-only" }
+    delegate_to: localhost
+    register: create_network_invalid
+    ignore_errors: yes
 
-- assert:
-    that:
-      - '"No network found with the name" in create_network_invalid.msg'
-      # - '"400" in create_network_invalid.msg'
+  - assert:
+      that:
+        - '"No network found with the name" in create_network_invalid.msg'
+        # - '"400" in create_network_invalid.msg'
 
-- name: Query all administrators
-  meraki_admin:
-    auth_key: '{{auth_key}}'
-    state: query
-    org_name: '{{test_org_name}}'
-  delegate_to: localhost
-  register: query_all
+  - name: Query all administrators
+    meraki_admin:
+      auth_key: '{{auth_key}}'
+      state: query
+      org_name: '{{test_org_name}}'
+    delegate_to: localhost
+    register: query_all
 
-- assert:
-    that:
-      - query_all.data | length == 4
-      - query_all.changed == False
+  - assert:
+      that:
+        - query_all.data | length == 4
+        - query_all.changed == False
 
-- name: Query admin by name
-  meraki_admin:
-    auth_key: '{{auth_key}}'
-    state: query
-    org_name: '{{test_org_name}}'
-    name: Jane Doe
-  delegate_to: localhost
-  register: query_name
+  - name: Query admin by name
+    meraki_admin:
+      auth_key: '{{auth_key}}'
+      state: query
+      org_name: '{{test_org_name}}'
+      name: Jane Doe
+    delegate_to: localhost
+    register: query_name
 
-- name: Query admin by email
-  meraki_admin:
-    auth_key: '{{auth_key}}'
-    state: query
-    org_name: '{{test_org_name}}'
-    email: '{{email_prefix}}+janedoe@{{email_domain}}'
-  delegate_to: localhost
-  register: query_email
+  - name: Query admin by email
+    meraki_admin:
+      auth_key: '{{auth_key}}'
+      state: query
+      org_name: '{{test_org_name}}'
+      email: '{{email_prefix}}+janedoe@{{email_domain}}'
+    delegate_to: localhost
+    register: query_email
 
-- assert:
-    that:
-      - query_name.data.name == "Jane Doe"
-      - 'query_email.data.email == "{{email_prefix}}+janedoe@{{email_domain}}"'
+  - assert:
+      that:
+        - query_name.data.name == "Jane Doe"
+        - 'query_email.data.email == "{{email_prefix}}+janedoe@{{email_domain}}"'
 
-- name: Delete administrators
-  meraki_admin:
-    auth_key: '{{auth_key}}'
-    state: absent
-    org_name: '{{test_org_name}}'
-    email: '{{item}}'
-  delegate_to: localhost
-  register: delete_all
-  loop:
-      - '{{email_prefix}}+janedoe@{{email_domain}}'
-      - '{{email_prefix}}+johndoe@{{email_domain}}'
-      - '{{email_prefix}}+jimdoe@{{email_domain}}'
+  always:
+  #############################################################################
+  # Tear down starts here
+  #############################################################################
+  - name: Delete administrators
+    meraki_admin:
+      auth_key: '{{auth_key}}'
+      state: absent
+      org_name: '{{test_org_name}}'
+      email: '{{item}}'
+    delegate_to: localhost
+    register: delete_all
+    ignore_errors: yes
+    loop:
+        - '{{email_prefix}}+janedoe@{{email_domain}}'
+        - '{{email_prefix}}+johndoe@{{email_domain}}'
+        - '{{email_prefix}}+jimdoe@{{email_domain}}'
 
-- name: Query all administrators
-  meraki_admin:
-    auth_key: '{{auth_key}}'
-    state: query
-    org_name: '{{test_org_name}}'
-  delegate_to: localhost
-  register: query_all_deleted
+  - name: Query all administrators
+    meraki_admin:
+      auth_key: '{{auth_key}}'
+      state: query
+      org_name: '{{test_org_name}}'
+    delegate_to: localhost
+    register: query_all_deleted
 
-- assert:
-    that:
-      - query_all_deleted.data | length == 1
+  - assert:
+      that:
+        - query_all_deleted.data | length == 1

--- a/test/integration/targets/meraki_network/tasks/main.yml
+++ b/test/integration/targets/meraki_network/tasks/main.yml
@@ -3,245 +3,234 @@
 
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
-- name: Create network without type
-  meraki_network:
-    auth_key: '{{ auth_key }}'
-    state: present
-    org_name: '{{test_org_name}}'
-    net_name: IntTestNetwork
-    timezone: America/Chicago
-  delegate_to: localhost
-  register: create_net_no_type
-  ignore_errors: yes
+- block:
+  - name: Create network without type
+    meraki_network:
+      auth_key: '{{ auth_key }}'
+      state: present
+      org_name: '{{test_org_name}}'
+      net_name: IntTestNetwork
+      timezone: America/Chicago
+    delegate_to: localhost
+    register: create_net_no_type
+    ignore_errors: yes
 
-- name: Create network without organization
-  meraki_network:
-    auth_key: '{{ auth_key }}'
-    state: present
-    net_name: IntTestNetwork
-    timezone: America/Chicago
-  delegate_to: localhost
-  register: create_net_no_org
-  ignore_errors: yes
+  - name: Create network without organization
+    meraki_network:
+      auth_key: '{{ auth_key }}'
+      state: present
+      net_name: IntTestNetwork
+      timezone: America/Chicago
+    delegate_to: localhost
+    register: create_net_no_org
+    ignore_errors: yes
 
-- name: Create network with type switch
-  meraki_network:
-    auth_key: '{{ auth_key }}'
-    state: present
-    org_name: '{{test_org_name}}'
-    net_name: IntTestNetworkSwitch
-    type: switch
-    timezone: America/Chicago
-  delegate_to: localhost
-  register: create_net_switch
-  
-- name: Create network with type switch by org ID
-  meraki_network:
-    auth_key: '{{ auth_key }}'
-    state: present
-    org_id: '{{test_org_id}}'
-    net_name: IntTestNetworkSwitchOrgID
-    type: switch
-    timezone: America/Chicago
-  delegate_to: localhost
-  register: create_net_switch_org_id  
-  
-- name: Create network with type appliance and no timezone
-  meraki_network:
-    auth_key: '{{ auth_key }}'
-    state: present
-    org_name: '{{test_org_name}}'
-    net_name: IntTestNetworkAppliance
-    type: appliance
-  delegate_to: localhost
-  register: create_net_appliance_no_tz
-  
-- name: Create network with type wireless
-  meraki_network:
-    auth_key: '{{ auth_key }}'
-    state: present
-    org_name: '{{test_org_name}}'
-    net_name: IntTestNetworkWireless
-    type: wireless
-    timezone: America/Chicago
-  delegate_to: localhost
-  register: create_net_wireless
-
-- name: Create network with type wireless and check for idempotency
-  meraki_network:
-    auth_key: '{{ auth_key }}'
-    state: present
-    org_name: '{{test_org_name}}'
-    net_name: IntTestNetworkWireless
-    type: wireless
-    timezone: America/Chicago
-  delegate_to: localhost
-  register: create_net_wireless_idempotent
-
-- name: Create network with type combined
-  meraki_network:
-    auth_key: '{{ auth_key }}'
-    state: present
-    org_name: '{{test_org_name}}'
-    net_name: IntTestNetworkCombined
-    type: combined
-    timezone: America/Chicago
-  delegate_to: localhost
-  register: create_net_combined
-  
-- name: Create network with one tag
-  meraki_network:
-    auth_key: '{{ auth_key }}'
-    state: present
-    org_name: '{{test_org_name}}'
-    net_name: IntTestNetworkTag
-    type: switch
-    timezone: America/Chicago
-    tags: first_tag
-  delegate_to: localhost
-  register: create_net_tag
-
-- debug:
-    msg: '{{create_net_tag}}'
-  
-- name: Create network with two tags
-  meraki_network:
-    auth_key: '{{ auth_key }}'
-    state: present
-    org_name: '{{test_org_name}}'
-    net_name: IntTestNetworkTags
-    type: switch
-    timezone: America/Chicago
-    tags: first_tag, second_tag
-  delegate_to: localhost
-  register: create_net_tags
-
-- debug:
-    msg: '{{create_net_tags}}'
-
-- name: Modify network
-  meraki_network:
-    auth_key: '{{ auth_key }}'
-    state: present
-    org_name: '{{test_org_name}}'
-    net_name: IntTestNetworkTags
-    type: switch
-    timezone: America/Chicago
-    tags: first_tag, second_tag, third_tag
-  delegate_to: localhost
-  register: create_net_modified
-
-- name: Modify network with idempotency
-  meraki_network:
-    auth_key: '{{ auth_key }}'
-    state: present
-    org_name: '{{test_org_name}}'
-    net_name: IntTestNetworkTags
-    type: switch
-    timezone: America/Chicago
-    tags: first_tag, second_tag, third_tag
-  delegate_to: localhost
-  register: create_net_modified_idempotent
-
-- name: Present assertions
-  assert:
-    that:
-      - create_net_no_type.status == 500
-      - '"org_name or org_id parameters are required" in create_net_no_org.msg'
-      - '"IntTestNetworkAppliance" in create_net_appliance_no_tz.data.name'
-      - create_net_appliance_no_tz.changed == True
-      - '"IntTestNetworkSwitch" in create_net_switch.data.name'
-      - '"IntTestNetworkSwitchOrgID" in create_net_switch_org_id.data.name'
-      - '"IntTestNetworkWireless" in create_net_wireless.data.name'
-      - create_net_wireless_idempotent.changed == False
-      - '"first_tag" in create_net_tag.data.tags'
-      - '"second_tag" in create_net_tags.data.tags'
-      - '"third_tag" in create_net_modified.data.tags'
-      - create_net_modified.changed == True
-      - create_net_modified_idempotent.changed == False
-
-- name: Query all networks
-  meraki_network:
-    auth_key: '{{ auth_key }}'
-    state: query
-    org_name: '{{test_org_name}}'
-  delegate_to: localhost
-  register: net_query_all
+  - name: Create network with type switch
+    meraki_network:
+      auth_key: '{{ auth_key }}'
+      state: present
+      org_name: '{{test_org_name}}'
+      net_name: IntTestNetworkSwitch
+      type: switch
+      timezone: America/Chicago
+    delegate_to: localhost
+    register: create_net_switch
     
-- name: Query one network
-  meraki_network:
-    auth_key: '{{ auth_key }}'
-    state: query
-    org_name: '{{test_org_name}}'
-    net_name: IntTestNetworkSwitch
-  delegate_to: localhost
-  register: net_query_one
+  - name: Create network with type switch by org ID
+    meraki_network:
+      auth_key: '{{ auth_key }}'
+      state: present
+      org_id: '{{test_org_id}}'
+      net_name: IntTestNetworkSwitchOrgID
+      type: switch
+      timezone: America/Chicago
+    delegate_to: localhost
+    register: create_net_switch_org_id  
+    
+  - name: Create network with type appliance and no timezone
+    meraki_network:
+      auth_key: '{{ auth_key }}'
+      state: present
+      org_name: '{{test_org_name}}'
+      net_name: IntTestNetworkAppliance
+      type: appliance
+    delegate_to: localhost
+    register: create_net_appliance_no_tz
+    
+  - name: Create network with type wireless
+    meraki_network:
+      auth_key: '{{ auth_key }}'
+      state: present
+      org_name: '{{test_org_name}}'
+      net_name: IntTestNetworkWireless
+      type: wireless
+      timezone: America/Chicago
+    delegate_to: localhost
+    register: create_net_wireless
 
-- name: Query assertions
-  assert:
-    that:
-      # - net_query_all.data | length == 7
-      - 'net_query_one.data.name == "IntTestNetworkSwitch"'
+  - name: Create network with type wireless and check for idempotency
+    meraki_network:
+      auth_key: '{{ auth_key }}'
+      state: present
+      org_name: '{{test_org_name}}'
+      net_name: IntTestNetworkWireless
+      type: wireless
+      timezone: America/Chicago
+    delegate_to: localhost
+    register: create_net_wireless_idempotent
+
+  - name: Create network with type combined
+    meraki_network:
+      auth_key: '{{ auth_key }}'
+      state: present
+      org_name: '{{test_org_name}}'
+      net_name: IntTestNetworkCombined
+      type: combined
+      timezone: America/Chicago
+    delegate_to: localhost
+    register: create_net_combined
+    
+  - name: Create network with one tag
+    meraki_network:
+      auth_key: '{{ auth_key }}'
+      state: present
+      org_name: '{{test_org_name}}'
+      net_name: IntTestNetworkTag
+      type: switch
+      timezone: America/Chicago
+      tags: first_tag
+    delegate_to: localhost
+    register: create_net_tag
+
+  - debug:
+      msg: '{{create_net_tag}}'
+    
+  - name: Create network with two tags
+    meraki_network:
+      auth_key: '{{ auth_key }}'
+      state: present
+      org_name: '{{test_org_name}}'
+      net_name: IntTestNetworkTags
+      type: switch
+      timezone: America/Chicago
+      tags: first_tag, second_tag
+    delegate_to: localhost
+    register: create_net_tags
+
+  - debug:
+      msg: '{{create_net_tags}}'
+
+  - name: Modify network
+    meraki_network:
+      auth_key: '{{ auth_key }}'
+      state: present
+      org_name: '{{test_org_name}}'
+      net_name: IntTestNetworkTags
+      type: switch
+      timezone: America/Chicago
+      tags: first_tag, second_tag, third_tag
+    delegate_to: localhost
+    register: create_net_modified
+
+  - name: Modify network with idempotency
+    meraki_network:
+      auth_key: '{{ auth_key }}'
+      state: present
+      org_name: '{{test_org_name}}'
+      net_name: IntTestNetworkTags
+      type: switch
+      timezone: America/Chicago
+      tags: first_tag, second_tag, third_tag
+    delegate_to: localhost
+    register: create_net_modified_idempotent
+
+  - name: Present assertions
+    assert:
+      that:
+        - create_net_no_type.status == 500
+        - '"org_name or org_id parameters are required" in create_net_no_org.msg'
+        - '"IntTestNetworkAppliance" in create_net_appliance_no_tz.data.name'
+        - create_net_appliance_no_tz.changed == True
+        - '"IntTestNetworkSwitch" in create_net_switch.data.name'
+        - '"IntTestNetworkSwitchOrgID" in create_net_switch_org_id.data.name'
+        - '"IntTestNetworkWireless" in create_net_wireless.data.name'
+        - create_net_wireless_idempotent.changed == False
+        - '"first_tag" in create_net_tag.data.tags'
+        - '"second_tag" in create_net_tags.data.tags'
+        - '"third_tag" in create_net_modified.data.tags'
+        - create_net_modified.changed == True
+        - create_net_modified_idempotent.changed == False
+
+  - name: Query all networks
+    meraki_network:
+      auth_key: '{{ auth_key }}'
+      state: query
+      org_name: '{{test_org_name}}'
+    delegate_to: localhost
+    register: net_query_all
       
-- name: Delete network without org
-  meraki_network:
-    auth_key: '{{ auth_key }}'
-    state: absent
-    net_name: IntTestNetworkSwitch
-  delegate_to: localhost
-  register: delete_all_no_org
-  ignore_errors: yes
+  - name: Query one network
+    meraki_network:
+      auth_key: '{{ auth_key }}'
+      state: query
+      org_name: '{{test_org_name}}'
+      net_name: IntTestNetworkSwitch
+    delegate_to: localhost
+    register: net_query_one
 
-- debug:
-    msg: '{{delete_all_no_org}}'
-    
-- name: Delete network by org ID
-  meraki_network:
-    auth_key: '{{ auth_key }}'
-    state: absent
-    org_id: '{{test_org_id}}'
-    net_name: IntTestNetworkSwitchOrgID
-  delegate_to: localhost
-  register: delete_net_org_id
+  - name: Query assertions
+    assert:
+      that:
+        - 'net_query_one.data.name == "IntTestNetworkSwitch"'
+        
 
-- debug:
-    msg: '{{delete_net_org_id}}'
+#############################################################################
+# Tear down starts here
+#############################################################################
+  always:
+  - name: Delete network without org
+    meraki_network:
+      auth_key: '{{ auth_key }}'
+      state: absent
+      net_name: IntTestNetworkSwitch
+    delegate_to: localhost
+    register: delete_all_no_org
+    ignore_errors: yes
+      
+  - name: Delete network by org ID
+    meraki_network:
+      auth_key: '{{ auth_key }}'
+      state: absent
+      org_id: '{{test_org_id}}'
+      net_name: IntTestNetworkSwitchOrgID
+    delegate_to: localhost
+    register: delete_net_org_id
 
-- name: Query after delete with org ID
-  meraki_network:
-    auth_key: '{{ auth_key }}'
-    state: query
-    org_name: '{{test_org_name}}'
-  delegate_to: localhost
-  register: query_deleted_org_id
+  - name: Query after delete with org ID
+    meraki_network:
+      auth_key: '{{ auth_key }}'
+      state: query
+      org_name: '{{test_org_name}}'
+    delegate_to: localhost
+    register: query_deleted_org_id
 
-- name: Delete all networks
-  meraki_network:
-    auth_key: '{{ auth_key }}'
-    state: absent
-    org_name: '{{test_org_name}}'
-    net_name: '{{ item }}'
-  delegate_to: localhost
-  register: delete_all
-  loop:
-    - IntTestNetworkSwitch
-    - IntTestNetworkWireless
-    - IntTestNetworkAppliance
-    - IntTestNetworkCombined
-    - IntTestNetworkTag
-    - IntTestNetworkTags
-    
-- name: Query after delete all
-  meraki_network:
-    auth_key: '{{ auth_key }}'
-    state: query
-    org_name: '{{test_org_name}}'
-  delegate_to: localhost
-  register: query_deleted
-    
-- name: Delete assertions
-  assert:
-    that:
-      - '"org_name or org_id parameters are required" in delete_all_no_org.msg'
-      # - query_deleted_org_id.data | length == 6     
-      # - query_deleted.data | length == 0
+  - name: Delete all networks
+    meraki_network:
+      auth_key: '{{ auth_key }}'
+      state: absent
+      org_name: '{{test_org_name}}'
+      net_name: '{{ item }}'
+    delegate_to: localhost
+    register: delete_all
+    ignore_errors: yes
+    loop:
+      - IntTestNetworkSwitch
+      - IntTestNetworkWireless
+      - IntTestNetworkAppliance
+      - IntTestNetworkCombined
+      - IntTestNetworkTag
+      - IntTestNetworkTags
+
+  - assert:
+      that:
+        - 'delete_all_no_org.msg == "org_name or org_id parameters are required"'

--- a/test/integration/targets/meraki_vlan/tasks/main.yml
+++ b/test/integration/targets/meraki_vlan/tasks/main.yml
@@ -1,303 +1,307 @@
-# Test code for the Meraki Organization module
+# Test code for the Meraki VLAN module
 # Copyright: (c) 2018, Kevin Breit (@kbreit)
 
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
-- name: Test an API key is provided
-  fail:
-    msg: Please define an API key
-  when: auth_key is not defined
-  
-- name: Use an invalid domain
-  meraki_vlan:
-    auth_key: '{{ auth_key }}'
-    host: marrrraki.com
-    state: present
-    org_name: '{{test_org_name}}'
-    output_level: debug
-  delegate_to: localhost
-  register: invalid_domain
-  ignore_errors: yes
-  
-- name: Disable HTTP
-  meraki_vlan:
-    auth_key: '{{ auth_key }}'
-    use_https: false
-    state: query
-    org_name: '{{test_org_name}}'
-    output_level: debug
-  delegate_to: localhost
-  register: http
-  ignore_errors: yes
+- block:
+  - name: Test an API key is provided
+    fail:
+      msg: Please define an API key
+    when: auth_key is not defined
+    
+  - name: Use an invalid domain
+    meraki_vlan:
+      auth_key: '{{ auth_key }}'
+      host: marrrraki.com
+      state: present
+      org_name: IntTestOrg
+      output_level: debug
+    delegate_to: localhost
+    register: invalid_domain
+    ignore_errors: yes
+    
+  - name: Disable HTTP
+    meraki_vlan:
+      auth_key: '{{ auth_key }}'
+      use_https: false
+      state: query
+      output_level: debug
+    delegate_to: localhost
+    register: http
+    ignore_errors: yes
 
-- name: Connection assertions
-  assert:
-    that:
-      - '"Failed to connect to" in invalid_domain.msg'
-      - '"http" in http.url'
+  - name: Connection assertions
+    assert:
+      that:
+        - '"Failed to connect to" in invalid_domain.msg'
+        - '"http" in http.url'
 
-- name: Create test network
-  meraki_network:
-    auth_key: '{{auth_key}}'
-    state: present
-    org_name: '{{test_org_name}}'
-    net_name: '{{test_net_name}}'
-    type: appliance
-  delegate_to: localhost
+  - name: Create test network
+    meraki_network:
+      auth_key: '{{auth_key}}'
+      state: present
+      org_name: '{{test_org_name}}'
+      net_name: '{{test_net_name}}'
+      type: appliance
+    delegate_to: localhost
 
-- name: Create VLAN
-  meraki_vlan:
-    auth_key: '{{auth_key}}'
-    state: present
-    org_name: '{{test_org_name}}'
-    net_name: '{{test_net_name}}'
-    vlan_id: 2
-    name: TestVLAN
-    subnet: 192.168.250.0/24
-    appliance_ip: 192.168.250.1
-  delegate_to: localhost
-  register: create_vlan
+  - name: Create VLAN
+    meraki_vlan:
+      auth_key: '{{auth_key}}'
+      state: present
+      org_name: '{{test_org_name}}'
+      net_name: '{{test_net_name}}'
+      vlan_id: 2
+      name: TestVLAN
+      subnet: 192.168.250.0/24
+      appliance_ip: 192.168.250.1
+    delegate_to: localhost
+    register: create_vlan
 
-- debug:
-    msg: '{{create_vlan}}'
+  - debug:
+      msg: '{{create_vlan}}'
 
-- assert:
-    that:
-      - create_vlan.data.id == 2
-      - create_vlan.changed == True
+  - assert:
+      that:
+        - create_vlan.data.id == 2
+        - create_vlan.changed == True
 
-- name: Update VLAN
-  meraki_vlan:
-    auth_key: '{{auth_key}}'
-    state: present
-    org_name: '{{test_org_name}}'
-    net_name: '{{test_net_name}}'
-    vlan_id: 2
-    name: TestVLAN
-    subnet: 192.168.250.0/24
-    appliance_ip: 192.168.250.2
-    fixed_ip_assignments:
-      - mac: "13:37:de:ad:be:ef"
-        ip: 192.168.250.10
-        name: fixed_ip
-    reserved_ip_range:
-      - start: 192.168.250.10
-        end: 192.168.250.20
-        comment: reserved_range
-    dns_nameservers: opendns
-  delegate_to: localhost
-  register: update_vlan
+  - name: Update VLAN
+    meraki_vlan:
+      auth_key: '{{auth_key}}'
+      state: present
+      org_name: '{{test_org_name}}'
+      net_name: '{{test_net_name}}'
+      vlan_id: 2
+      name: TestVLAN
+      subnet: 192.168.250.0/24
+      appliance_ip: 192.168.250.2
+      fixed_ip_assignments:
+        - mac: "13:37:de:ad:be:ef"
+          ip: 192.168.250.10
+          name: fixed_ip
+      reserved_ip_range:
+        - start: 192.168.250.10
+          end: 192.168.250.20
+          comment: reserved_range
+      dns_nameservers: opendns
+    delegate_to: localhost
+    register: update_vlan
 
-- debug:
-    msg: '{{update_vlan}}'
+  - debug:
+      msg: '{{update_vlan}}'
 
-- assert:
-    that:
-      - update_vlan.data.applianceIp == '192.168.250.2'
-      - update_vlan.changed == True
+  - assert:
+      that:
+        - update_vlan.data.applianceIp == '192.168.250.2'
+        - update_vlan.changed == True
 
-- name: Update VLAN with idempotency
-  meraki_vlan:
-    auth_key: '{{auth_key}}'
-    state: present
-    org_name: '{{test_org_name}}'
-    net_name: '{{test_net_name}}'
-    vlan_id: 2
-    name: TestVLAN
-    subnet: 192.168.250.0/24
-    appliance_ip: 192.168.250.2
-    fixed_ip_assignments:
-      - mac: "13:37:de:ad:be:ef"
-        ip: 192.168.250.10
-        name: fixed_ip
-    reserved_ip_range:
-      - start: 192.168.250.10
-        end: 192.168.250.20
-        comment: reserved_range
-    dns_nameservers: opendns
-  delegate_to: localhost
-  register: update_vlan_idempotent
+  - name: Update VLAN with idempotency
+    meraki_vlan:
+      auth_key: '{{auth_key}}'
+      state: present
+      org_name: '{{test_org_name}}'
+      net_name: '{{test_net_name}}'
+      vlan_id: 2
+      name: TestVLAN
+      subnet: 192.168.250.0/24
+      appliance_ip: 192.168.250.2
+      fixed_ip_assignments:
+        - mac: "13:37:de:ad:be:ef"
+          ip: 192.168.250.10
+          name: fixed_ip
+      reserved_ip_range:
+        - start: 192.168.250.10
+          end: 192.168.250.20
+          comment: reserved_range
+      dns_nameservers: opendns
+    delegate_to: localhost
+    register: update_vlan_idempotent
 
-- debug:
-    msg: '{{update_vlan_idempotent}}'
+  - debug:
+      msg: '{{update_vlan_idempotent}}'
 
-- assert:
-    that:
-      - update_vlan_idempotent.changed == False
+  - assert:
+      that:
+        - update_vlan_idempotent.changed == False
 
-- name: Add IP assignments and reserved IP ranges
-  meraki_vlan:
-    auth_key: '{{auth_key}}'
-    state: present
-    org_name: '{{test_org_name}}'
-    net_name: '{{test_net_name}}'
-    vlan_id: 2
-    name: TestVLAN
-    subnet: 192.168.250.0/24
-    appliance_ip: 192.168.250.2
-    fixed_ip_assignments:
-      - mac: "13:37:de:ad:be:ef"
-        ip: 192.168.250.10
-        name: fixed_ip
-      - mac: "12:34:56:78:90:12"
-        ip: 192.168.250.11
-        name: another_fixed_ip
-    reserved_ip_range:
-      - start: 192.168.250.10
-        end: 192.168.250.20
-        comment: reserved_range
-      - start: 192.168.250.100
-        end: 192.168.250.120
-        comment: reserved_range_high
-    dns_nameservers: opendns
-  delegate_to: localhost
-  register: update_vlan_add_ip
+  - name: Add IP assignments and reserved IP ranges
+    meraki_vlan:
+      auth_key: '{{auth_key}}'
+      state: present
+      org_name: '{{test_org_name}}'
+      net_name: '{{test_net_name}}'
+      vlan_id: 2
+      name: TestVLAN
+      subnet: 192.168.250.0/24
+      appliance_ip: 192.168.250.2
+      fixed_ip_assignments:
+        - mac: "13:37:de:ad:be:ef"
+          ip: 192.168.250.10
+          name: fixed_ip
+        - mac: "12:34:56:78:90:12"
+          ip: 192.168.250.11
+          name: another_fixed_ip
+      reserved_ip_range:
+        - start: 192.168.250.10
+          end: 192.168.250.20
+          comment: reserved_range
+        - start: 192.168.250.100
+          end: 192.168.250.120
+          comment: reserved_range_high
+      dns_nameservers: opendns
+    delegate_to: localhost
+    register: update_vlan_add_ip
 
-- debug:
-    msg: '{{update_vlan_add_ip}}'
+  - debug:
+      msg: '{{update_vlan_add_ip}}'
 
-- assert:
-    that:
-      - update_vlan_add_ip.changed == True
-      - update_vlan_add_ip.data.fixedIpAssignments | length == 2
-      - update_vlan_add_ip.data.reservedIpRanges | length == 2
+  - assert:
+      that:
+        - update_vlan_add_ip.changed == True
+        - update_vlan_add_ip.data.fixed_ip_assignments | length == 2
+        - update_vlan_add_ip.data.reserved_ip_range | length == 2
 
-- name: Remove IP assignments and reserved IP ranges
-  meraki_vlan:
-    auth_key: '{{auth_key}}'
-    state: present
-    org_name: '{{test_org_name}}'
-    net_name: '{{test_net_name}}'
-    vlan_id: 2
-    name: TestVLAN
-    subnet: 192.168.250.0/24
-    appliance_ip: 192.168.250.2
-    fixed_ip_assignments:
-      - mac: "13:37:de:ad:be:ef"
-        ip: 192.168.250.10
-        name: fixed_ip
-    reserved_ip_range:
-      - start: 192.168.250.10
-        end: 192.168.250.20
-        comment: reserved_range
-    dns_nameservers: opendns
-  delegate_to: localhost
-  register: update_vlan_remove_ip
+  - name: Remove IP assignments and reserved IP ranges
+    meraki_vlan:
+      auth_key: '{{auth_key}}'
+      state: present
+      org_name: '{{test_org_name}}'
+      net_name: '{{test_net_name}}'
+      vlan_id: 2
+      name: TestVLAN
+      subnet: 192.168.250.0/24
+      appliance_ip: 192.168.250.2
+      fixed_ip_assignments:
+        - mac: "13:37:de:ad:be:ef"
+          ip: 192.168.250.10
+          name: fixed_ip
+      reserved_ip_range:
+        - start: 192.168.250.10
+          end: 192.168.250.20
+          comment: reserved_range
+      dns_nameservers: opendns
+    delegate_to: localhost
+    register: update_vlan_remove_ip
 
-- debug:
-    msg: '{{update_vlan_remove_ip}}'
+  - debug:
+      msg: '{{update_vlan_remove_ip}}'
 
-- assert:
-    that:
-      - update_vlan_remove_ip.changed == True
-      - update_vlan_remove_ip.data.fixedIpAssignments | length == 1
-      - update_vlan_remove_ip.data.reservedIpRanges | length == 1
+  - assert:
+      that:
+        - update_vlan_remove_ip.changed == True
+        - update_vlan_remove_ip.data.fixed_ip_assignments | length == 1
+        - update_vlan_remove_ip.data.reserved_ip_range | length == 1
 
-- name: Update VLAN with idempotency
-  meraki_vlan:
-    auth_key: '{{auth_key}}'
-    state: present
-    org_name: '{{test_org_name}}'
-    net_name: '{{test_net_name}}'
-    vlan_id: 2
-    name: TestVLAN
-    subnet: 192.168.250.0/24
-    appliance_ip: 192.168.250.2
-    fixed_ip_assignments:
-      - mac: "13:37:de:ad:be:ef"
-        ip: 192.168.250.10
-        name: fixed_ip
-    reserved_ip_range:
-      - start: 192.168.250.10
-        end: 192.168.250.20
-        comment: reserved_range
-    dns_nameservers: opendns
-  delegate_to: localhost
-  register: update_vlan_idempotent
+  - name: Update VLAN with idempotency
+    meraki_vlan:
+      auth_key: '{{auth_key}}'
+      state: present
+      org_name: '{{test_org_name}}'
+      net_name: '{{test_net_name}}'
+      vlan_id: 2
+      name: TestVLAN
+      subnet: 192.168.250.0/24
+      appliance_ip: 192.168.250.2
+      fixed_ip_assignments:
+        - mac: "13:37:de:ad:be:ef"
+          ip: 192.168.250.10
+          name: fixed_ip
+      reserved_ip_range:
+        - start: 192.168.250.10
+          end: 192.168.250.20
+          comment: reserved_range
+      dns_nameservers: opendns
+    delegate_to: localhost
+    register: update_vlan_idempotent
 
-- debug:
-    msg: '{{update_vlan_idempotent}}'
+  - debug:
+      msg: '{{update_vlan_idempotent}}'
 
-- assert:
-    that:
-      - update_vlan_idempotent.changed == False
+  - assert:
+      that:
+        - update_vlan_idempotent.changed == False
 
-- name: Update VLAN with list of DNS entries
-  meraki_vlan:
-    auth_key: '{{auth_key}}'
-    state: present
-    org_name: '{{test_org_name}}'
-    net_name: '{{test_net_name}}'
-    vlan_id: 2
-    name: TestVLAN
-    subnet: 192.168.250.0/24
-    appliance_ip: 192.168.250.2
-    fixed_ip_assignments:
-      - mac: "13:37:de:ad:be:ef"
-        ip: 192.168.250.10
-        name: fixed_ip
-    reserved_ip_range:
-      - start: 192.168.250.10
-        end: 192.168.250.20
-        comment: reserved_range
-    dns_nameservers: 1.1.1.1;8.8.8.8
-  delegate_to: localhost
-  register: update_vlan_dns_list
+  - name: Update VLAN with list of DNS entries
+    meraki_vlan:
+      auth_key: '{{auth_key}}'
+      state: present
+      org_name: '{{test_org_name}}'
+      net_name: '{{test_net_name}}'
+      vlan_id: 2
+      name: TestVLAN
+      subnet: 192.168.250.0/24
+      appliance_ip: 192.168.250.2
+      fixed_ip_assignments:
+        - mac: "13:37:de:ad:be:ef"
+          ip: 192.168.250.10
+          name: fixed_ip
+      reserved_ip_range:
+        - start: 192.168.250.10
+          end: 192.168.250.20
+          comment: reserved_range
+      dns_nameservers: 1.1.1.1;8.8.8.8
+    delegate_to: localhost
+    register: update_vlan_dns_list
 
-- debug:
-    msg: '{{update_vlan_dns_list}}'
+  - debug:
+      msg: '{{update_vlan_dns_list}}'
 
-- assert:
-    that:
-      - '"1.1.1.1" in update_vlan_dns_list.data.dnsNameservers'
-      - update_vlan_dns_list.changed == True
+  - assert:
+      that:
+        - '"1.1.1.1" in update_vlan_dns_list.data.dnsNameservers'
+        - update_vlan_dns_list.changed == True
 
-- name: Query all VLANs in network
-  meraki_vlan:
-    auth_key: '{{ auth_key }}'
-    org_name: '{{test_org_name}}'
-    net_name: '{{test_net_name}}'
-    state: query
-  delegate_to: localhost
-  register: query_vlans
+  - name: Query all VLANs in network
+    meraki_vlan:
+      auth_key: '{{ auth_key }}'
+      org_name: '{{test_org_name}}'
+      net_name: '{{test_net_name}}'
+      state: query
+    delegate_to: localhost
+    register: query_vlans
 
-- debug:
-    msg: '{{query_vlans}}'
+  - debug:
+      msg: '{{query_vlans}}'
 
-- assert:
-    that:
-      - query_vlans.data | length >= 2
-      - query_vlans.data.1.id == 2
-      - query_vlans.changed == False
+  - assert:
+      that:
+        - query_vlans.data | length >= 2
+        - query_vlans.data.1.id == 2
+        - query_vlans.changed == False
 
-- name: Query single VLAN
-  meraki_vlan:
-    auth_key: '{{ auth_key }}'
-    org_name: '{{test_org_name}}'
-    net_name: '{{test_net_name}}'
-    vlan_id: 2
-    state: query
-    output_level: debug
-  delegate_to: localhost
-  register: query_vlan
+  - name: Query single VLAN
+    meraki_vlan:
+      auth_key: '{{ auth_key }}'
+      org_name: '{{test_org_name}}'
+      net_name: '{{test_net_name}}'
+      vlan_id: 2
+      state: query
+      output_level: debug
+    delegate_to: localhost
+    register: query_vlan
 
-- debug:
-    msg: '{{query_vlan}}'
+  - debug:
+      msg: '{{query_vlan}}'
 
-- assert:
-    that:
-      - query_vlan.data.id == 2
-      - query_vlan.changed == False
+  - assert:
+      that:
+        - query_vlan.data.id == 2
+        - query_vlan.changed == False
 
-- name: Delete VLAN
-  meraki_vlan:
-    auth_key: '{{auth_key}}'
-    state: absent
-    org_name: '{{test_org_name}}'
-    net_name: '{{test_net_name}}'
-    vlan_id: 2
-  delegate_to: localhost
-  register: delete_vlan
+  always:
+  #############################################################################
+  # Tear down starts here
+  #############################################################################
+  - name: Delete VLAN
+    meraki_vlan:
+      auth_key: '{{auth_key}}'
+      state: absent
+      org_name: '{{test_org_name}}'
+      net_name: '{{test_net_name}}'
+      vlan_id: 2
+    delegate_to: localhost
+    register: delete_vlan
 
-- debug:
-    msg: '{{delete_vlan}}'
+  - debug:
+      msg: '{{delete_vlan}}'

--- a/test/integration/targets/meraki_vlan/tasks/main.yml
+++ b/test/integration/targets/meraki_vlan/tasks/main.yml
@@ -159,8 +159,8 @@
   - assert:
       that:
         - update_vlan_add_ip.changed == True
-        - update_vlan_add_ip.data.fixed_ip_assignments | length == 2
-        - update_vlan_add_ip.data.reserved_ip_range | length == 2
+        - update_vlan_add_ip.data.fixedIpAssignments | length == 2
+        - update_vlan_add_ip.data.reservedIpRange | length == 2
 
   - name: Remove IP assignments and reserved IP ranges
     meraki_vlan:
@@ -190,8 +190,8 @@
   - assert:
       that:
         - update_vlan_remove_ip.changed == True
-        - update_vlan_remove_ip.data.fixed_ip_assignments | length == 1
-        - update_vlan_remove_ip.data.reserved_ip_range | length == 1
+        - update_vlan_remove_ip.data.fixedIpAssignments | length == 1
+        - update_vlan_remove_ip.data.reservedIpRange | length == 1
 
   - name: Update VLAN with idempotency
     meraki_vlan:


### PR DESCRIPTION
##### SUMMARY
Some of the Meraki integration tests now clean up after themselves under failure by using `block` and `always` statements.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
meraki_admin
meraki_network
meraki_vlan

##### ANSIBLE VERSION
```
ansible 2.7.0.dev0 (devel 805d13f287) last updated 2018/07/03 09:18:21 (GMT -500)
  config file = None
  configured module search path = ['/Users/kbreit/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/kbreit/Documents/Programming/ansible/lib/ansible
  executable location = /Users/kbreit/Documents/Programming/ansible/bin/ansible
  python version = 3.5.4 (default, Feb 25 2018, 14:56:02) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```