### PR TITLE
add tests for exos_command module

### DIFF
--- a/test/units/modules/network/exos/exos_module.py
+++ b/test/units/modules/network/exos/exos_module.py
@@ -1,0 +1,87 @@
+# (c) 2018 Extreme Networks Inc.
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import os
+import json
+
+from units.modules.utils import AnsibleExitJson, AnsibleFailJson, ModuleTestCase
+
+
+fixture_path = os.path.join(os.path.dirname(__file__), 'fixtures')
+fixture_data = {}
+
+
+def load_fixture(name):
+    path = os.path.join(fixture_path, name)
+
+    if path in fixture_data:
+        return fixture_data[path]
+
+    with open(path) as file_desc:
+        data = file_desc.read()
+
+    try:
+        data = json.loads(data)
+    except:
+        pass
+
+    fixture_data[path] = data
+    return data
+
+
+class TestExosModule(ModuleTestCase):
+
+    def execute_module(self, failed=False, changed=False, commands=None, sort=True, defaults=False):
+
+        self.load_fixtures(commands)
+
+        if failed:
+            result = self.failed()
+            self.assertTrue(result['failed'], result)
+        else:
+            result = self.changed(changed)
+            self.assertEqual(result['changed'], changed, result)
+
+        if commands is not None:
+            if sort:
+                self.assertEqual(sorted(commands), sorted(result['commands']), result['commands'])
+            else:
+                self.assertEqual(commands, result['commands'], result['commands'])
+
+        return result
+
+    def failed(self):
+        with self.assertRaises(AnsibleFailJson) as exc:
+            self.module.main()
+
+        result = exc.exception.args[0]
+        self.assertTrue(result['failed'], result)
+        return result
+
+    def changed(self, changed=False):
+        with self.assertRaises(AnsibleExitJson) as exc:
+            self.module.main()
+
+        result = exc.exception.args[0]
+        self.assertEqual(result['changed'], changed, result)
+        return result
+
+    def load_fixtures(self, commands=None):
+        pass

--- a/test/units/modules/network/exos/fixtures/show_version
+++ b/test/units/modules/network/exos/fixtures/show_version
@@ -1,0 +1,6 @@
+Switch      : 800745-00-01 1604G-00175 Rev 01 IMG: 22.5.1.7  
+
+Image   : ExtremeXOS version 22.5.1.7 by release-manager
+          on Tue May 22 11:25:12 EDT 2018
+Diagnostics : 
+Certified Version : EXOS Linux  3.18.48, FIPS fips-ecp-2.0.16

--- a/test/units/modules/network/exos/test_exos_command.py
+++ b/test/units/modules/network/exos/test_exos_command.py
@@ -1,0 +1,120 @@
+#
+# (c) 2018 Extreme Networks Inc.
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import json
+
+from ansible.compat.tests.mock import patch
+from ansible.modules.network.exos import exos_command
+from units.modules.utils import set_module_args
+from .exos_module import TestExosModule, load_fixture
+
+
+class TestExosCommandModule(TestExosModule):
+
+    module = exos_command
+
+    def setUp(self):
+        super(TestExosCommandModule, self).setUp()
+
+        self.mock_run_commands = patch('ansible.modules.network.exos.exos_command.run_commands')
+        self.run_commands = self.mock_run_commands.start()
+
+    def tearDown(self):
+        super(TestExosCommandModule, self).tearDown()
+        self.mock_run_commands.stop()
+
+    def load_fixtures(self, commands=None):
+
+        def load_from_file(*args, **kwargs):
+            module, commands = args
+            output = list()
+
+            for item in commands:
+                try:
+                    obj = json.loads(item['command'])
+                    command = obj['command']
+                except ValueError:
+                    command = item['command']
+                filename = str(command).replace(' ', '_')
+                output.append(load_fixture(filename))
+            return output
+
+        self.run_commands.side_effect = load_from_file
+
+    def test_exos_command_simple(self):
+        set_module_args(dict(commands=['show version']))
+        result = self.execute_module()
+        self.assertEqual(len(result['stdout']), 1)
+        self.assertTrue(result['stdout'][0].startswith('Switch      :'))
+
+    def test_exos_command_multiple(self):
+        set_module_args(dict(commands=['show version', 'show version']))
+        result = self.execute_module()
+        self.assertEqual(len(result['stdout']), 2)
+        self.assertTrue(result['stdout'][0].startswith('Switch      :'))
+
+    def test_exos_command_wait_for(self):
+        wait_for = 'result[0] contains "Switch      :"'
+        set_module_args(dict(commands=['show version'], wait_for=wait_for))
+        self.execute_module()
+
+    def test_exos_command_wait_for_fails(self):
+        wait_for = 'result[0] contains "test string"'
+        set_module_args(dict(commands=['show version'], wait_for=wait_for))
+        self.execute_module(failed=True)
+        self.assertEqual(self.run_commands.call_count, 10)
+
+    def test_exos_command_retries(self):
+        wait_for = 'result[0] contains "test string"'
+        set_module_args(dict(commands=['show version'], wait_for=wait_for, retries=2))
+        self.execute_module(failed=True)
+        self.assertEqual(self.run_commands.call_count, 2)
+
+    def test_exos_command_match_any(self):
+        wait_for = ['result[0] contains "Switch"',
+                    'result[0] contains "test string"']
+        set_module_args(dict(commands=['show version'], wait_for=wait_for, match='any'))
+        self.execute_module()
+
+    def test_exos_command_match_all(self):
+        wait_for = ['result[0] contains "Switch"',
+                    'result[0] contains "Switch      :"']
+        set_module_args(dict(commands=['show version'], wait_for=wait_for, match='all'))
+        self.execute_module()
+
+    def test_exos_command_match_all_failure(self):
+        wait_for = ['result[0] contains "Switch      :"',
+                    'result[0] contains "test string"']
+        commands = ['show version', 'show version']
+        set_module_args(dict(commands=commands, wait_for=wait_for, match='all'))
+        self.execute_module(failed=True)
+
+    def test_exos_command_configure_error(self):
+        commands = ['disable ospf']
+        set_module_args({
+            'commands': commands,
+            '_ansible_check_mode': True,
+        })
+        result = self.execute_module()
+        self.assertEqual(
+            result['warnings'],
+            ['only show commands are supported when using check mode, not executing `disable ospf`']
+        )


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Add unit tests for exos_command module.

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
exos_command

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (add_exos_command_tests 6da986625b) last updated 2018/07/03 13:43:18 (GMT -400)
  config file = None
  configured module search path = [u'/home/lrichardson/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/lrichardson/git/ansible/lib/ansible
  executable location = /home/lrichardson/git/ansible/bin/ansible
  python version = 2.7.14 (default, Sep 23 2017, 22:06:14) [GCC 7.2.0]

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
$ ansible-test units --tox --python 2.7 exos_command
<snip>
Unit test with Python 2.7
======================================================================================= test session starts =======================================================================================
platform linux2 -- Python 2.7.14, pytest-3.6.2, py-1.5.4, pluggy-0.6.0
rootdir: /home/lrichardson/git/ansible, inifile: tox.ini
plugins: xdist-1.22.2, mock-1.10.0, forked-0.2, f5-sdk-3.0.17
collected 9 items                                                                                                                                                                                 

test/units/modules/network/exos/test_exos_command.py .........

---------------------------------------------------- generated xml file: /home/lrichardson/git/ansible/test/results/junit/python2.7-units.xml -----------------------------------------------------
==================================================================================== 9 passed in 22.14 seconds ====================================================================================
_____________________________________________________________________________________________ summary _____________________________________________________________________________________________
  py27: commands succeeded
  congratulations :)


```
