### PR TITLE
Update eos_l2_interface.py

### DIFF
--- a/lib/ansible/modules/network/eos/eos_l2_interface.py
+++ b/lib/ansible/modules/network/eos/eos_l2_interface.py
@@ -207,8 +207,9 @@ def map_config_to_obj(module):
     instances = list()
 
     for item in set(match):
-        command = 'sh int {0} switchport | include Switchport'
-        switchport_cfg = run_commands(module, command.format(item))[0].split(':')[1].strip()
+        command = {'command': 'show interfaces {0} switchport | include Switchport'.format(item),
+                   'output': 'text'}
+        switchport_cfg = run_commands(module, command)[0].split(':')[1].strip()
         if switchport_cfg == 'Enabled':
             state = 'present'
         else:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

When using eapi we cannot use the shortened form of the command until ansible supports the 'expandAlias' attribute.  Also this command used in eos_l2_module needs to have the format returned as text from eapi because of the way the subsequent code parses it.

fixes #42269 

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
eos_l2_module
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.3
  config file = None
  configured module search path = [u'/home/dt/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Apr 10 2015, 08:09:05) [GCC 4.8.3 20140911 (Red Hat 4.8.3-7)]
```



