### PR TITLE
Add options for jumphost in netconf connetion

### DIFF
--- a/docs/docsite/rst/network/user_guide/network_debug_troubleshooting.rst
+++ b/docs/docsite/rst/network/user_guide/network_debug_troubleshooting.rst
@@ -618,7 +618,7 @@ Example ssh config file (~/.ssh/config)
 
 .. code-block:: ini
 
-   Host junos
+   Host junos01
    HostName junos01
    User myuser
 
@@ -627,14 +627,16 @@ Example ssh config file (~/.ssh/config)
 Example Ansible inventory file
 
 .. code-block:: ini
+
     [junos]
-    junos
+    junos01
 
     [junos:vars]
     ansible_connection=netconf
     ansible_network_os=junos
     ansible_user=myuser
     ansible_ssh_pass=!vault...
+
 
 .. note:: Using ``ProxyCommand`` with passwords via variables
 

--- a/docs/docsite/rst/network/user_guide/network_debug_troubleshooting.rst
+++ b/docs/docsite/rst/network/user_guide/network_debug_troubleshooting.rst
@@ -627,14 +627,14 @@ Example ssh config file (~/.ssh/config)
 Example Ansible inventory file
 
 .. code-block:: ini
-   [junos]
-   junos
+    [junos]
+    junos
 
-   [junos:vars]
-   ansible_connection=netconf
-   ansible_network_os=junos
-   ansible_user=myuser
-   ansible_ssh_pass=!vault...
+    [junos:vars]
+    ansible_connection=netconf
+    ansible_network_os=junos
+    ansible_user=myuser
+    ansible_ssh_pass=!vault...
 
 .. note:: Using ``ProxyCommand`` with passwords via variables
 

--- a/docs/docsite/rst/network/user_guide/network_debug_troubleshooting.rst
+++ b/docs/docsite/rst/network/user_guide/network_debug_troubleshooting.rst
@@ -624,14 +624,14 @@ Example ssh config file (~/.ssh/config)
 Example Ansible inventory file
 
 .. code-block:: ini
-    [junos]
-    junos
+   [junos]
+   junos
 
-    [junos:vars]
-    ansible_connection=netconf
-    ansible_network_os=junos
-    ansible_user=myuser
-    ansible_ssh_pass=!vault...
+   [junos:vars]
+   ansible_connection=netconf
+   ansible_network_os=junos
+   ansible_user=myuser
+   ansible_ssh_pass=!vault...
 
 .. note:: Using ``ProxyCommand`` with passwords via variables
 

--- a/docs/docsite/rst/network/user_guide/network_debug_troubleshooting.rst
+++ b/docs/docsite/rst/network/user_guide/network_debug_troubleshooting.rst
@@ -604,11 +604,14 @@ Enabling jump host setting
 --------------------------
 
 Bastion/jump host with netconf connection can be enable using
-- Setting Ansible variable``ansible_netconf_ssh_config`` or
-- Setting environment variable ``ANSIBLE_NETCONF_SSH_CONFIG`` or
-- Setting ``ssh_config=Ture`` under ``netconf_connection`` section in ansible configuration file
+- Setting Ansible variable``ansible_netconf_ssh_config`` either to ``True`` or custom ssh config file path
+- Setting environment variable ``ANSIBLE_NETCONF_SSH_CONFIG`` to ``True`` or custom ssh config file path
+- Setting ``ssh_config = 1`` or ``ssh_config = <ssh-file-path>``under ``netconf_connection`` section
 
-The ssh config file (~/.ssh/config) should have the correct proxycommand and required ssh configuration variables
+If the configuration variable is set to 1 the proxycommand and other ssh variables are read from
+default ssh config file (~/.ssh/config).
+If the configuration variable is set to file path the proxycommand and other ssh variables are read
+from the given custom ssh file path
 
 Example ssh config file (~/.ssh/config)
 ---------------------------------------

--- a/docs/docsite/rst/network/user_guide/network_debug_troubleshooting.rst
+++ b/docs/docsite/rst/network/user_guide/network_debug_troubleshooting.rst
@@ -615,7 +615,7 @@ Example ssh config file (~/.ssh/config)
 
 .. code-block:: ini
 
-   Host junoshost
+   Host junos
    HostName junos01
    User myuser
 
@@ -625,13 +625,13 @@ Example Ansible inventory file
 
 .. code-block:: ini
     [junos]
-    junoshost
+    junos
 
-   [junos:vars]
-   ansible_connection=netconf
-   ansible_network_os=junos
-   ansible_user=myuser
-   ansible_ssh_pass=!vault...
+    [junos:vars]
+    ansible_connection=netconf
+    ansible_network_os=junos
+    ansible_user=myuser
+    ansible_ssh_pass=!vault...
 
 .. note:: Using ``ProxyCommand`` with passwords via variables
 

--- a/docs/docsite/rst/network/user_guide/network_debug_troubleshooting.rst
+++ b/docs/docsite/rst/network/user_guide/network_debug_troubleshooting.rst
@@ -597,6 +597,41 @@ no additional changes necessary.  The network module will now connect to the
 network device by first connecting to the host specified in
 ``ansible_ssh_common_args``, which is ``bastion01`` in the above example.
 
+Using bastion/jump host with netconf connection
+-----------------------------------------------
+
+Enabling jump host setting
+--------------------------
+
+Bastion/jump host with netconf connection can be enable using
+- Setting Ansible variable``ansible_netconf_ssh_config`` or
+- Setting environment variable ``ANSIBLE_NETCONF_SSH_CONFIG`` or
+- Setting ``ssh_config=Ture`` under ``netconf_connection`` section in ansible configuration file
+
+The ssh config file (~/.ssh/config) should have the correct proxycommand and required ssh configuration variables
+
+Example ssh config file (~/.ssh/config)
+---------------------------------------
+
+.. code-block:: ini
+
+   Host junoshost
+   HostName junos01
+   User myuser
+
+   ProxyCommand ssh user@bastion01 nc %h %p %r
+
+Example Ansible inventory file
+
+.. code-block:: ini
+    [junos]
+    junoshost
+
+   [junos:vars]
+   ansible_connection=netconf
+   ansible_network_os=junos
+   ansible_user=myuser
+   ansible_ssh_pass=!vault...
 
 .. note:: Using ``ProxyCommand`` with passwords via variables
 

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1632,4 +1632,12 @@ YAML_FILENAME_EXTENSIONS:
     - section: defaults
       key: yaml_valid_extensions
   type: list
+NETCONF_SSH_CONFIG:
+  description: This variable is used to enable bastion/jump host with netconf connection. The bastion/jump
+               host ssh settings should be present in ssh configuration file (~/.ssh/config).
+  env: [{name: ANSIBLE_NETCONF_SSH_CONFIG}]
+  ini:
+  - {key: ssh_config, section: netconf_connection}
+  yaml: {key: netconf_connection.ssh_config}
+  type: boolean
 ...

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1640,5 +1640,5 @@ NETCONF_SSH_CONFIG:
   ini:
   - {key: ssh_config, section: netconf_connection}
   yaml: {key: netconf_connection.ssh_config}
-  default: None
+  default: null
 ...

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1633,11 +1633,12 @@ YAML_FILENAME_EXTENSIONS:
       key: yaml_valid_extensions
   type: list
 NETCONF_SSH_CONFIG:
-  description: This variable is used to enable bastion/jump host with netconf connection. The bastion/jump
-               host ssh settings should be present in ssh configuration file (~/.ssh/config).
+  description: This variable is used to enable bastion/jump host with netconf connection. If set to True the bastion/jump
+               host ssh settings should be present in ~/.ssh/config file, alternatively it can be set
+               to custom ssh configuration file path to read the bastion/jump host settings.
   env: [{name: ANSIBLE_NETCONF_SSH_CONFIG}]
   ini:
   - {key: ssh_config, section: netconf_connection}
   yaml: {key: netconf_connection.ssh_config}
-  type: boolean
+  default: None
 ...

--- a/lib/ansible/plugins/connection/netconf.py
+++ b/lib/ansible/plugins/connection/netconf.py
@@ -153,11 +153,12 @@ options:
     env:
       - name: ANSIBLE_PERSISTENT_COMMAND_TIMEOUT
   netconf_ssh_config:
-    type: boolean
-    default: False
+    default: None
     description:
-      - This variable is used to enable bastion/jump host with netconf connection. The bastion/jump
-        host ssh settings should be present in ssh configuration file (~/.ssh/config).
+      - This variable is used to enable bastion/jump host with netconf connection. If set to
+        True the bastion/jump host ssh settings should be present in ~/.ssh/config file,
+        alternatively it can be set to custom ssh configuration file path to read the
+        bastion/jump host settings.
     ini:
       - section: netconf_connection
         key: ssh_config
@@ -175,7 +176,7 @@ import json
 
 from ansible.errors import AnsibleConnectionFailure, AnsibleError
 from ansible.module_utils._text import to_bytes, to_native, to_text
-from ansible.module_utils.parsing.convert_bool import BOOLEANS_TRUE
+from ansible.module_utils.parsing.convert_bool import BOOLEANS_TRUE, BOOLEANS_FALSE
 from ansible.plugins.loader import netconf_loader
 from ansible.plugins.connection import NetworkConnectionBase
 
@@ -202,7 +203,7 @@ NETWORK_OS_DEVICE_PARAM_MAP = {
     "ce": "huawei"
 }
 
-
+import q
 class Connection(NetworkConnectionBase):
     """NetConf connections"""
 
@@ -266,7 +267,7 @@ class Connection(NetworkConnectionBase):
         ssh_config = self.get_option('netconf_ssh_config')
         if ssh_config in BOOLEANS_TRUE:
             ssh_config = True
-        else:
+        elif ssh_config in BOOLEANS_FALSE:
             ssh_config = None
 
         try:

--- a/lib/ansible/plugins/connection/netconf.py
+++ b/lib/ansible/plugins/connection/netconf.py
@@ -153,7 +153,6 @@ options:
     env:
       - name: ANSIBLE_PERSISTENT_COMMAND_TIMEOUT
   netconf_ssh_config:
-    default: None
     description:
       - This variable is used to enable bastion/jump host with netconf connection. If set to
         True the bastion/jump host ssh settings should be present in ~/.ssh/config file,
@@ -203,7 +202,7 @@ NETWORK_OS_DEVICE_PARAM_MAP = {
     "ce": "huawei"
 }
 
-import q
+
 class Connection(NetworkConnectionBase):
     """NetConf connections"""
 

--- a/lib/ansible/plugins/connection/netconf.py
+++ b/lib/ansible/plugins/connection/netconf.py
@@ -152,6 +152,21 @@ options:
         key: command_timeout
     env:
       - name: ANSIBLE_PERSISTENT_COMMAND_TIMEOUT
+  netconf_ssh_config:
+    type: boolean
+    default: False
+    description:
+      - This variable is used to enable bastion/jump host with netconf connection. The bastion/jump
+        host ssh settings should be present in ssh configuration file (~/.ssh/config).
+    ini:
+      - section: netconf_connection
+        key: ssh_config
+        version_added: '2.7'
+    env:
+      - name: ANSIBLE_NETCONF_SSH_CONFIG
+    vars:
+      - name: ansible_netconf_ssh_config
+        version_added: '2.7'
 """
 
 import os
@@ -248,7 +263,7 @@ class Connection(NetworkConnectionBase):
 
         device_params = {'name': NETWORK_OS_DEVICE_PARAM_MAP.get(self._network_os) or self._network_os}
 
-        ssh_config = os.getenv('ANSIBLE_NETCONF_SSH_CONFIG', False)
+        ssh_config = self.get_option('netconf_ssh_config')
         if ssh_config in BOOLEANS_TRUE:
             ssh_config = True
         else:


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #37262
Fixes #36284

*  Updates options in netconf connection to enable
   bastion/jump host setting using configuration/enviornment
   variables.
*  Update troubleshooting docs from using bastion host with netconf
   connection
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
plugins/connection/netconf.py 
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
