### PR TITLE
Make ansible doesn't parse template-like password in user's input

### DIFF
--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -38,6 +38,7 @@ from ansible.errors import AnsibleOptionsError, AnsibleError
 from ansible.inventory.manager import InventoryManager
 from ansible.module_utils.six import with_metaclass, string_types
 from ansible.module_utils._text import to_bytes, to_text
+from ansible.utils.unsafe_proxy import AnsibleUnsafeText
 from ansible.parsing.dataloader import DataLoader
 from ansible.release import __version__
 from ansible.utils.path import unfrackpath
@@ -329,7 +330,7 @@ class CLI(with_metaclass(ABCMeta, object)):
                 sshpass = getpass.getpass(prompt="SSH password: ")
                 become_prompt = "%s password[defaults to SSH password]: " % become_prompt_method
                 if sshpass:
-                    sshpass = to_bytes(sshpass, errors='strict', nonstring='simplerepr')
+                    sshpass = AnsibleUnsafeText(to_bytes(sshpass, errors='strict', nonstring='simplerepr'))
             else:
                 become_prompt = "%s password: " % become_prompt_method
 
@@ -338,7 +339,7 @@ class CLI(with_metaclass(ABCMeta, object)):
                 if op.ask_pass and becomepass == '':
                     becomepass = sshpass
                 if becomepass:
-                    becomepass = to_bytes("{{'%s'}}" % becomepass)
+                    becomepass = AnsibleUnsafeText(to_bytes(becomepass))
         except EOFError:
             pass
 

--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -338,7 +338,7 @@ class CLI(with_metaclass(ABCMeta, object)):
                 if op.ask_pass and becomepass == '':
                     becomepass = sshpass
                 if becomepass:
-                    becomepass = to_bytes(becomepass)
+                    becomepass = to_bytes("{{'%s'}}" % becomepass)
         except EOFError:
             pass
 

--- a/lib/ansible/cli/adhoc.py
+++ b/lib/ansible/cli/adhoc.py
@@ -106,7 +106,6 @@ class AdHocCLI(CLI):
 
         self.normalize_become_options()
         (sshpass, becomepass) = self.ask_passwords()
-        becomepass = "{{'%s'}}" % becomepass
         passwords = {'conn_pass': sshpass, 'become_pass': becomepass}
 
         # dynamically load any plugins

--- a/lib/ansible/cli/adhoc.py
+++ b/lib/ansible/cli/adhoc.py
@@ -106,6 +106,7 @@ class AdHocCLI(CLI):
 
         self.normalize_become_options()
         (sshpass, becomepass) = self.ask_passwords()
+        becomepass = "{{'%s'}}" % becomepass
         passwords = {'conn_pass': sshpass, 'become_pass': becomepass}
 
         # dynamically load any plugins


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
When using `ansible -K` or `-k`, users can interactively input passwords. Those passwords are always parsed by jinja2, so some template-like passwords will fail during the parsing. This PR makes input password as unsafe string and solve the problem.
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
Fix #35942 
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request
##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
ansible/lib/ansible/cli/__init__.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (pass_parse_issue 896160f17f) last updated 2018/07/02 17:31:31 (GMT -400)
  config file = None
  configured module search path = [u'/home/zhikangzhang/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/zhikangzhang/Desktop/ansible/lib/ansible
  executable location = /home/zhikangzhang/Desktop/ansible/bin/ansible
  python version = 2.7.15 (default, May 16 2018, 17:50:09) [GCC 8.1.1 20180502 (Red Hat 8.1.1-1)]
```

##### ADDITIONAL INFORMATION
After fix, ansible can recieve template-like password input without error.
```
[zhikangzhang@localhost cli]$ ansible -k -K -b vm -a "passwd -S root"
SSH password: {{test
SUDO password[defaults to SSH password]: {{test
192.168.122.23 | CHANGED | rc=0 >>
root LK 1969-12-30 0 99999 7 -1 (Password locked.)
```