### PR TITLE
FreeIPA: new module ipa_config

### DIFF
--- a/lib/ansible/module_utils/ipa.py
+++ b/lib/ansible/module_utils/ipa.py
@@ -97,10 +97,14 @@ class IPAClient(object):
             item = {}
         url = '%s/session/json' % self.get_base_url()
         data = dict(method=method)
-        if method != 'ping':
-            data['params'] = [[name], item]
-        else:
+
+        # TODO: We should probably handle this a little better.
+        if method in ('ping', 'config_show'):
             data['params'] = [[], {}]
+        elif method == 'config_mod':
+            data['params'] = [[], item]
+        else:
+            data['params'] = [[name], item]
 
         try:
             resp, info = fetch_url(module=self.module, url=url, data=to_bytes(json.dumps(data)), headers=self.headers)

--- a/lib/ansible/modules/identity/ipa/ipa_config.py
+++ b/lib/ansible/modules/identity/ipa/ipa_config.py
@@ -28,9 +28,16 @@ version_added: "2.7"
 '''
 
 EXAMPLES = '''
-# Ensure the default login shell is bash
+# Ensure the default login shell is bash.
 - ipa_config:
     ipadefaultloginshell: /bin/bash
+    ipa_host: localhost
+    ipa_user: admin
+    ipa_pass: supersecret
+
+# Ensure the default e-mail domain is ansible.com.
+- ipa_config:
+    ipadefaultemaildomain: ansible.com
     ipa_host: localhost
     ipa_user: admin
     ipa_pass: supersecret
@@ -38,7 +45,7 @@ EXAMPLES = '''
 
 RETURN = '''
 config:
-  description: Configuration as returned by IPA API
+  description: Configuration as returned by IPA API.
   returned: always
   type: dict
 '''

--- a/lib/ansible/modules/identity/ipa/ipa_config.py
+++ b/lib/ansible/modules/identity/ipa/ipa_config.py
@@ -17,12 +17,12 @@ module: ipa_config
 author: Fran Fitzpatrick (@fxfitz)
 short_description: Manage Global FreeIPA Configuration Settings
 description:
-- Modify global configuration settings of a FreeIPA Server
+- Modify global configuration settings of a FreeIPA Server.
 options:
   ipadefaultloginshell:
-    description: Default shell for new users
+    description: Default shell for new users.
   ipadefaultemaildomain:
-    description: Default e-mail domain
+    description: Default e-mail domain for new users.
 extends_documentation_fragment: ipa.documentation
 version_added: "2.7"
 '''

--- a/lib/ansible/modules/identity/ipa/ipa_config.py
+++ b/lib/ansible/modules/identity/ipa/ipa_config.py
@@ -1,0 +1,130 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2017, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = '''
+---
+module: ipa_config
+author: Fran Fitzpatrick (@fxfitz)
+short_description: Manage Global FreeIPA Configuration Settings
+description:
+- Modify global configuration settings of a FreeIPA Server
+options:
+  ipadefaultloginshell:
+    description: Default shell for new users
+  ipadefaultemaildomain:
+    description: Default e-mail domain
+extends_documentation_fragment: ipa.documentation
+version_added: "2.7"
+'''
+
+EXAMPLES = '''
+# Ensure the default login shell is bash
+- ipa_config:
+    ipadefaultloginshell: /bin/bash
+    ipa_host: localhost
+    ipa_user: admin
+    ipa_pass: supersecret
+'''
+
+RETURN = '''
+user:
+  description: Configuration as returned by IPA API
+  returned: always
+  type: dict
+'''
+
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.ipa import IPAClient, ipa_argument_spec
+from ansible.module_utils._text import to_native
+
+
+class ConfigIPAClient(IPAClient):
+    def __init__(self, module, host, port, protocol):
+        super(ConfigIPAClient, self).__init__(module, host, port, protocol)
+
+    def config_show(self):
+        return self._post_json(method='config_show', name=None)
+
+    def config_mod(self, name, item):
+        return self._post_json(method='config_mod', name=name, item=item)
+
+
+def get_config_dict(ipadefaultloginshell=None, ipadefaultemaildomain=None):
+    config = {}
+    if ipadefaultloginshell is not None:
+        config['ipadefaultloginshell'] = ipadefaultloginshell
+    if ipadefaultemaildomain is not None:
+        config['ipadefaultemaildomain'] = ipadefaultemaildomain
+
+    return config
+
+
+def get_config_diff(client, ipa_config, module_config):
+    return client.get_diff(ipa_data=ipa_config, module_data=module_config)
+
+
+def ensure(module, client):
+    module_config = get_config_dict(
+        ipadefaultloginshell=module.params.get('ipadefaultloginshell'),
+        ipadefaultemaildomain=module.params.get('ipadefaultemaildomain'),
+    )
+    ipa_config = client.config_show()
+    diff = get_config_diff(client, ipa_config, module_config)
+
+    changed = False
+    new_config = {}
+    for module_key in diff:
+        if module_config.get(module_key) != ipa_config.get(module_key, None):
+            changed = True
+            new_config.update({module_key: module_config.get(module_key)})
+
+    if changed and not module.check_mode:
+        client.config_mod(name=None, item=new_config)
+
+    return changed, client.config_show()
+
+
+def main():
+    argument_spec = ipa_argument_spec()
+    argument_spec.update(
+        ipadefaultloginshell=dict(type='str'),
+        ipadefaultemaildomain=dict(type='str'),
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True
+    )
+
+    client = ConfigIPAClient(
+        module=module,
+        host=module.params['ipa_host'],
+        port=module.params['ipa_port'],
+        protocol=module.params['ipa_prot']
+    )
+
+    try:
+        client.login(
+            username=module.params['ipa_user'],
+            password=module.params['ipa_pass']
+        )
+        changed, user = ensure(module, client)
+        module.exit_json(changed=changed, user=user)
+    except Exception as e:
+        module.fail_json(msg=to_native(e), exception=traceback.format_exc())
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/identity/ipa/ipa_config.py
+++ b/lib/ansible/modules/identity/ipa/ipa_config.py
@@ -21,8 +21,10 @@ description:
 options:
   ipadefaultloginshell:
     description: Default shell for new users.
+    aliases: ["loginshell"]
   ipadefaultemaildomain:
     description: Default e-mail domain for new users.
+    aliases: ["emaildomain"]
 extends_documentation_fragment: ipa.documentation
 version_added: "2.7"
 '''
@@ -106,8 +108,8 @@ def ensure(module, client):
 def main():
     argument_spec = ipa_argument_spec()
     argument_spec.update(
-        ipadefaultloginshell=dict(type='str'),
-        ipadefaultemaildomain=dict(type='str'),
+        ipadefaultloginshell=dict(type='str', aliases=['loginshell']),
+        ipadefaultemaildomain=dict(type='str', aliases=['emaildomain']),
     )
 
     module = AnsibleModule(

--- a/lib/ansible/modules/identity/ipa/ipa_config.py
+++ b/lib/ansible/modules/identity/ipa/ipa_config.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
-# Copyright: (c) 2017, Ansible Project
+# Copyright: (c) 2018, Fran Fitzpatrick <francis.x.fitzpatrick@gmail.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
@@ -37,7 +37,7 @@ EXAMPLES = '''
 '''
 
 RETURN = '''
-user:
+config:
   description: Configuration as returned by IPA API
   returned: always
   type: dict


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
I recently came across the need to modify some global settings in FreeIPA, so this module allows us to do that.

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New Module Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
ipa_config

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (ipa_config_module df4dbc9ace) last updated 2018/07/03 16:30:19 (GMT -500)
  config file = None
  configured module search path = [u'/Users/fxfitz/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/fxfitz/dev/ansible/lib/ansible
  executable location = /Users/fxfitz/.pyenv/versions/ansible/bin/ansible
  python version = 2.7.15 (default, May 29 2018, 20:16:38) [GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.1)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->
Right now I have it set up only to modify the `ipadefaultloginshell` and `ipadefaultloginshell` keys of the API, but I think I want to add all of the possible options, I just haven't done that yet.

Additionally, I want to make sure the module arguments match up with the other FreeIPA modules as best as possible.  For example, in `ipa_user` the login shell argument is just `loginshell`, so I think we should probably set aliases so the modules have the same "feel".
<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
