### PR TITLE
Allow documentation of module options type

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
@@ -239,7 +239,9 @@ The following fields can be used and are all required unless specified otherwise
   :choices:
     List of option values. Should be absent if empty.
   :type:
-    If an argument is ``type='bool'``, this field should be set to ``type: bool`` and no ``choices`` should be specified.
+
+    * Specifies the data type that option accepts, must match the ``argspec``.
+    * If an argument is ``type='bool'``, this field should be set to ``type: bool`` and no ``choices`` should be specified.
   :aliases:
     List of option name aliases; generally not needed.
   :version_added:

--- a/test/sanity/validate-modules/schema.py
+++ b/test/sanity/validate-modules/schema.py
@@ -50,7 +50,7 @@ option_schema = Schema(
         'default': Any(None, float, int, bool, list, dict, *string_types),
         'suboptions': Any(None, *list_dict_suboption_schema),
         # Note: Types are strings, not literal bools, such as True or False
-        'type': Any(None, "bool")
+        'type': Any(None, 'str', 'list', 'dict', 'bool', 'int', 'float', 'path', 'raw', 'jsonarg', 'json', 'bytes', 'bits')
     },
     extra=PREVENT_EXTRA
 )


### PR DESCRIPTION
##### SUMMARY
Pass through the `type` of a modules option so it's displayed on the
html module docs.

The list of types is based on `basic.py`

![types](https://user-images.githubusercontent.com/940557/42254411-67b2bbac-7efb-11e8-85e8-58198b7f85b6.png)


fixes #42033 

##### ISSUE TYPE
 - Feature Pull Request

