### PR TITLE
Meraki utility - construct_path() now supports custom keys

### DIFF
--- a/lib/ansible/module_utils/network/meraki/meraki.py
+++ b/lib/ansible/module_utils/network/meraki/meraki.py
@@ -249,7 +249,7 @@ class MerakiModule(object):
                 return template['id']
         self.fail_json(msg='No configuration template named {0} found'.format(name))
 
-    def construct_path(self, action, function=None, org_id=None, net_id=None, org_name=None):
+    def construct_path(self, action, function=None, org_id=None, net_id=None, org_name=None, custom=None):
         """Build a path from the URL catalog.
 
         Uses function property from class for catalog lookup.
@@ -261,8 +261,10 @@ class MerakiModule(object):
             built_path = self.url_catalog[action][function]
         if org_name:
             org_id = self.get_org_id(org_name)
-
-        built_path = built_path.format(org_id=org_id, net_id=net_id)
+        if custom:
+            built_path = built_path.format(org_id=org_id, net_id=net_id, **custom)
+        else:
+            built_path = built_path.format(org_id=org_id, net_id=net_id)
         return built_path
 
     def request(self, path, method=None, payload=None):

--- a/lib/ansible/modules/network/meraki/meraki_vlan.py
+++ b/lib/ansible/modules/network/meraki/meraki_vlan.py
@@ -234,7 +234,7 @@ def main():
     meraki.params['follow_redirects'] = 'all'
 
     query_urls = {'vlan': '/networks/{net_id}/vlans'}
-    query_url = {'vlan': '/networks/{net_id}/vlans/'}
+    query_url = {'vlan': '/networks/{net_id}/vlans/{vlan_id}'}
     create_url = {'vlan': '/networks/{net_id}/vlans'}
     update_url = {'vlan': '/networks/{net_id}/vlans/'}
     delete_url = {'vlan': '/networks/{net_id}/vlans/'}
@@ -261,7 +261,7 @@ def main():
         if not meraki.params['vlan_id']:
             meraki.result['data'] = get_vlans(meraki, net_id)
         else:
-            path = meraki.construct_path('get_one', net_id=net_id) + str(meraki.params['vlan_id'])
+            path = meraki.construct_path('get_one', net_id=net_id, custom={'vlan_id': meraki.params['vlan_id']})  # + str(meraki.params['vlan_id'])
             response = meraki.request(path, method='GET')
             meraki.result['data'] = response
     elif meraki.params['state'] == 'present':
@@ -276,7 +276,7 @@ def main():
             meraki.result['changed'] = True
             meraki.result['data'] = response
         else:
-            path = meraki.construct_path('get_one', net_id=net_id) + str(meraki.params['vlan_id'])
+            path = meraki.construct_path('get_one', net_id=net_id, custom={'vlan_id': meraki.params['vlan_id']}) #+ str(meraki.params['vlan_id'])
             original = meraki.request(path, method='GET')
             if meraki.params['dns_nameservers']:
                 if meraki.params['dns_nameservers'] not in ('opendns', 'google_dns', 'upstream_dns'):

--- a/lib/ansible/modules/network/meraki/meraki_vlan.py
+++ b/lib/ansible/modules/network/meraki/meraki_vlan.py
@@ -261,7 +261,7 @@ def main():
         if not meraki.params['vlan_id']:
             meraki.result['data'] = get_vlans(meraki, net_id)
         else:
-            path = meraki.construct_path('get_one', net_id=net_id, custom={'vlan_id': meraki.params['vlan_id']})  # + str(meraki.params['vlan_id'])
+            path = meraki.construct_path('get_one', net_id=net_id, custom={'vlan_id': meraki.params['vlan_id']})
             response = meraki.request(path, method='GET')
             meraki.result['data'] = response
     elif meraki.params['state'] == 'present':
@@ -276,7 +276,7 @@ def main():
             meraki.result['changed'] = True
             meraki.result['data'] = response
         else:
-            path = meraki.construct_path('get_one', net_id=net_id, custom={'vlan_id': meraki.params['vlan_id']}) #+ str(meraki.params['vlan_id'])
+            path = meraki.construct_path('get_one', net_id=net_id, custom={'vlan_id': meraki.params['vlan_id']})
             original = meraki.request(path, method='GET')
             if meraki.params['dns_nameservers']:
                 if meraki.params['dns_nameservers'] not in ('opendns', 'google_dns', 'upstream_dns'):


### PR DESCRIPTION
##### SUMMARY
- Allows for much more flexible test substitution
- Implemented functionality in meraki_vlan for test case

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
meraki

##### ANSIBLE VERSION
```
ansible 2.7.0.dev0 (meraki/util_construct_any e5bcb4d159) last updated 2018/07/03 22:36:37 (GMT -500)
  config file = None
  configured module search path = ['/Users/kbreit/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/kbreit/Documents/Programming/ansible/lib/ansible
  executable location = /Users/kbreit/Documents/Programming/ansible/bin/ansible
  python version = 3.5.4 (default, Feb 25 2018, 14:56:02) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```