### PR TITLE
fix regex cliconf nxos

### DIFF
--- a/lib/ansible/plugins/cliconf/nxos.py
+++ b/lib/ansible/plugins/cliconf/nxos.py
@@ -94,7 +94,7 @@ class Cliconf(CliconfBase):
             if match_isan_file_name:
                 device_info['network_os_image'] = match_isan_file_name.group(1)
 
-        match_os_platform = re.search(r'NAME: "Chassis",\s+DESCR: "NX-OSv Chassis\s?"\s+\n'
+        match_os_platform = re.search(r'NAME: "Chassis",\s+DESCR:.*\n'
                                       r'PID:\s+(\S+)', platform_reply, re.M)
         if match_os_platform:
             device_info['network_os_platform'] = match_os_platform.group(1)


### PR DESCRIPTION
Signed-off-by: Trishna Guha <trishnaguha17@gmail.com>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
N3K has output like `NAME: "Chassis", DESCR: "Nexus 3548 Chassis"\nPID: N3K-C3548P-10G    , VID:V01 , SN: FOC1701R0RD` of `show inventory`.
Remove Chassis check from DESCR in network_os_platform.
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
plugins/cliconf/nxos.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```