### PR TITLE
[WIP] integrate azure keyvault +MSI with ansible

### DIFF
--- a/lib/ansible/parsing/azurekeyvault/__init__.py
+++ b/lib/ansible/parsing/azurekeyvault/__init__.py
@@ -32,13 +32,7 @@ from binascii import unhexlify
 from binascii import Error as BinasciiError
 
 from ansible.errors import AnsibleError, AnsibleAssertionError
-from ansible import constants as C
-from ansible.module_utils.six import PY3, binary_type
-# Note: on py2, this zip is izip not the list based zip() builtin
-from ansible.module_utils.six.moves import zip
 from ansible.module_utils._text import to_bytes, to_text, to_native
-from ansible.utils.path import makedirs_safe
-#from azure.keyvault.models.key_vault_error import KeyVaultErrorException
 
 try:
     from __main__ import display
@@ -56,14 +50,12 @@ def get_secret(vault_uri, secret_name, secret_version):
 
     try:
         client = get_client()
-        display.warning("uri {0} secert {1} version {2}".format(vault_uri, secret_name, secret_version))
         secret_bundle = client.get_secret(vault_uri, secret_name, secret_version)
 
         if secret_bundle:
             return secret_bundle.value
-    except KeyVaultErrorException:
-#        raise AnsibleError("Failed to get secret from Azure Key Vault: {0}".format(str(e)))
-        raise AnsibleError("Failed to get secret from Azure Key Vault")
+    except KeyVaultErrorException as e:
+        raise AnsibleError("Failed to get secret from Azure Key Vault: {0}".format(str(e)))
 
     return None
 

--- a/lib/ansible/parsing/azurekeyvault/__init__.py
+++ b/lib/ansible/parsing/azurekeyvault/__init__.py
@@ -1,0 +1,87 @@
+# (c) 2018, Yunge Zhu <yungez@microsoft.com>
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import copy
+import os
+import random
+import requests
+import shlex
+import shutil
+import subprocess
+import sys
+import tempfile
+import warnings
+from binascii import hexlify
+from binascii import unhexlify
+from binascii import Error as BinasciiError
+
+from ansible.errors import AnsibleError, AnsibleAssertionError
+from ansible import constants as C
+from ansible.module_utils.six import PY3, binary_type
+# Note: on py2, this zip is izip not the list based zip() builtin
+from ansible.module_utils.six.moves import zip
+from ansible.module_utils._text import to_bytes, to_text, to_native
+from ansible.utils.path import makedirs_safe
+
+try:
+    from __main__ import display
+    from azure.keyvault import KeyVaultClient, KeyVaultAuthentication, KeyVaultId
+    from azure.keyvault.models.key_vault_error import KeyVaultErrorException
+except ImportError:
+    from ansible.utils.display import Display
+    display = Display()
+
+MSI_ENDPOINT = 'http://169.254.169.254/metadata/identity/oauth2/token'
+AZURE_VAULT_RESOURCE_URI = 'https://vault.azure.net'
+
+
+def get_secret(vault_uri, secret_name, secret_version):
+
+    try:
+        client = get_client()
+        display.warning("uri {0} secert {1} version {2}".format(vault_uri, secret_name, secret_version))
+        secret_bundle = client.get_secret(vault_uri, secret_name, secret_version)
+
+        if secret_bundle:
+            return secret_bundle.value
+    except KeyVaultErrorException as e:
+        raise AnsibleError("Failed to get secret from Azure Key Vault: {0}".format(str(e)))
+
+    return None
+
+
+def get_client():
+    def get_token_from_MSI(server, resource, scope):
+        token_params = {
+            'api-version': '2018-02-01',
+            'resource': AZURE_VAULT_RESOURCE_URI
+        }
+        token_headers = { 'Metadata': 'true'}
+
+        try:
+            token_res = requests.get(MSI_ENDPOINT, params=token_params, headers=token_headers)
+            token = token_res.json()["access_token"]
+            token_type = token_res.json()["token_type"]
+            return token_type, token
+        except requests.exceptions.RequestException as e:
+            display.warning("Unable to fetch MSI token. {0}".format(e))
+        return None
+    
+    return KeyVaultClient(KeyVaultAuthentication(get_token_from_MSI))
+

--- a/lib/ansible/parsing/azurekeyvault/__init__.py
+++ b/lib/ansible/parsing/azurekeyvault/__init__.py
@@ -38,6 +38,7 @@ from ansible.module_utils.six import PY3, binary_type
 from ansible.module_utils.six.moves import zip
 from ansible.module_utils._text import to_bytes, to_text, to_native
 from ansible.utils.path import makedirs_safe
+#from azure.keyvault.models.key_vault_error import KeyVaultErrorException
 
 try:
     from __main__ import display
@@ -60,8 +61,9 @@ def get_secret(vault_uri, secret_name, secret_version):
 
         if secret_bundle:
             return secret_bundle.value
-    except KeyVaultErrorException as e:
-        raise AnsibleError("Failed to get secret from Azure Key Vault: {0}".format(str(e)))
+    except KeyVaultErrorException:
+#        raise AnsibleError("Failed to get secret from Azure Key Vault: {0}".format(str(e)))
+        raise AnsibleError("Failed to get secret from Azure Key Vault")
 
     return None
 

--- a/lib/ansible/parsing/yaml/azurekeyvaultunicode.py
+++ b/lib/ansible/parsing/yaml/azurekeyvaultunicode.py
@@ -1,0 +1,74 @@
+# (c) 2018, Yunge Zhu <yungez@microsoft.com>
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import yaml
+
+from ansible.module_utils.six import text_type
+from ansible.module_utils._text import to_bytes, to_text
+from ansible.parsing.azurekeyvault import is_azure_keyvault_secret, get_if_azure_keyvault_secret, get_secret
+from ansible.parsing.yaml.objects import AnsibleBaseYAMLObject
+
+class AzureKeyVaultUnicode(yaml.YAMLObject, AnsibleBaseYAMLObject):
+    yaml_tag = u'!azurekeyvault'
+
+    def __init__(self, envelope):
+        '''Azure Key Vault with vault uri and secret name, secret version(optional).
+
+        The .data attribute is a property that returns the secret value in Azure Key Vault.
+        '''
+        super(AzureKeyVaultUnicode, self).__init__()
+
+        self.envelope = envelope
+        tempdata = envelope.strip().split(';')
+
+        if len(tempdata) == 2
+            vault_uri = tempdata[0]
+            secret = tempdata[1]
+            tempsecret = secret.split('/')
+
+            self.vault_uri = tempdata[1]
+            self.secret_name = tempsecret[0]
+            self.secret_version = tempsecret[1] if len(tempsecret) >1 else ''
+
+    @property
+    def data(self):
+        if hasattr(self, vault_uri) and hasattr(self, secret_name) and hasattr(self, secret_name):
+            return get_secret(self.vault_uri, self.secret_name, self.secret_version)
+        else:
+            self.envelope
+
+    @data.setter
+    def data(self, value):
+        self.envelope = value
+
+    def __repr__(self):
+        return repr(self.data)
+
+    def __eq__(self, other):
+        return self.envelope == other
+
+    def __hash__(self):
+        return id(self)
+
+    def __ne__(self, other):
+        return self.envelope != other
+
+    def __str__(self):
+        return str(self.data)
+
+    def __unicode__(self):
+        return to_text(self.data, errors='surrogate_or_strict')
+
+    def encode(self, encoding=None, errors=None):
+        return self.data.encode(encoding, errors)

--- a/lib/ansible/parsing/yaml/azurekeyvaultunicode.py
+++ b/lib/ansible/parsing/yaml/azurekeyvaultunicode.py
@@ -16,7 +16,7 @@ import yaml
 
 from ansible.module_utils.six import text_type
 from ansible.module_utils._text import to_bytes, to_text
-from ansible.parsing.azurekeyvault import is_azure_keyvault_secret, get_if_azure_keyvault_secret, get_secret
+from ansible.parsing.azurekeyvault import get_secret
 from ansible.parsing.yaml.objects import AnsibleBaseYAMLObject
 
 class AzureKeyVaultUnicode(yaml.YAMLObject, AnsibleBaseYAMLObject):
@@ -32,18 +32,17 @@ class AzureKeyVaultUnicode(yaml.YAMLObject, AnsibleBaseYAMLObject):
         self.envelope = envelope
         tempdata = envelope.strip().split(';')
 
-        if len(tempdata) == 2
-            vault_uri = tempdata[0]
+        if len(tempdata) == 2:
             secret = tempdata[1]
             tempsecret = secret.split('/')
 
-            self.vault_uri = tempdata[1]
+            self.vault_uri = tempdata[0]
             self.secret_name = tempsecret[0]
             self.secret_version = tempsecret[1] if len(tempsecret) >1 else ''
 
     @property
     def data(self):
-        if hasattr(self, vault_uri) and hasattr(self, secret_name) and hasattr(self, secret_name):
+        if hasattr(self, 'vault_uri') and hasattr(self, 'secret_name') and hasattr(self, 'secret_name'):
             return get_secret(self.vault_uri, self.secret_name, self.secret_version)
         else:
             self.envelope

--- a/lib/ansible/parsing/yaml/constructor.py
+++ b/lib/ansible/parsing/yaml/constructor.py
@@ -23,6 +23,7 @@ from yaml.constructor import SafeConstructor, ConstructorError
 from yaml.nodes import MappingNode
 
 from ansible.module_utils._text import to_bytes
+from ansible.parsing.yaml.azurekeyvaultunicode import AzureKeyVaultUnicode
 from ansible.parsing.yaml.objects import AnsibleMapping, AnsibleSequence, AnsibleUnicode
 from ansible.parsing.yaml.objects import AnsibleVaultEncryptedUnicode
 from ansible.utils.unsafe_proxy import wrap_var
@@ -109,6 +110,12 @@ class AnsibleConstructor(SafeConstructor):
         ret.vault = vault
         return ret
 
+    def construct_azure_keyvault_secrets(self, node):
+        value = self.construct_scalar(node)
+        # get secrets from azure key vault
+        ret = AzureKeyVaultUnicode(value)
+        return ret
+
     def construct_yaml_seq(self, node):
         data = AnsibleSequence()
         yield data
@@ -160,5 +167,9 @@ AnsibleConstructor.add_constructor(
 AnsibleConstructor.add_constructor(
     u'!vault',
     AnsibleConstructor.construct_vault_encrypted_unicode)
+
+AnsibleConstructor.add_constructor(
+    u'!azurekeyvault',
+    AnsibleConstructor.construct_azure_keyvault_secrets)
 
 AnsibleConstructor.add_constructor(u'!vault-encrypted', AnsibleConstructor.construct_vault_encrypted_unicode)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Integrate Azure key vault + MSI with Ansible. User save credentials used in playbook as Azure Key Vault secrets. Ansible retrieve secrets when parsing yaml.

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
