### PR TITLE
add azure key vault secrets lookup plugin + MSI

### DIFF
--- a/lib/ansible/plugins/lookup/azure_keyvault_secret.py
+++ b/lib/ansible/plugins/lookup/azure_keyvault_secret.py
@@ -33,9 +33,9 @@ DOCUMENTATION = """
 """
 
 EXAMPLE = """
-- debug: msg="the value of this secret is {{lookup('azure_keyvault_secret','testSecret/version')}}"
+- debug: msg="the value of this secret is {{lookup('azure_keyvault_secret','testSecret/version',vault_url='https://yourvault.vault.azure.net')}}"
 
-- debug: msg="the value of this secret is {{lookup('azure_keyvault_secret','testSecret/version',vault_url='https://myvault.vault.azure.net', cliend_id='123456789', secret='abcdefg', tenant_id='uvwxyz')}}"
+- debug: msg="the value of this secret is {{lookup('azure_keyvault_secret','testSecret/version',vault_url='https://yourvault.vault.azure.net', cliend_id='123456789', secret='abcdefg', tenant_id='uvwxyz')}}"
 
 # Example below creates an Azure Virtual Machine with ssh public key from key vault using 'azure_keyvault_secret' lookup plugin.
 - name: Create Azure VM

--- a/lib/ansible/plugins/lookup/azure_keyvault_secret.py
+++ b/lib/ansible/plugins/lookup/azure_keyvault_secret.py
@@ -4,6 +4,9 @@ __metaclass__ = type
 
 DOCUMENTATION = """
     lookup: azure_keyvault_secret
+    author:
+        - Hai Cao <t-haicao@microsoft.com>
+    version_added: 2.6
     requirements:
         - requests
         - azure

--- a/lib/ansible/plugins/lookup/azure_keyvault_secret.py
+++ b/lib/ansible/plugins/lookup/azure_keyvault_secret.py
@@ -11,18 +11,18 @@ DOCUMENTATION = """
         - requests
         - azure
         - msrest
-    short_description: read secret from azure key vault.
+    short_description: read secret from Azure Key Vault.
     description:
-      - This lookup returns the content of a secret kept in azure key vault.
+      - This lookup returns the content of a secret kept in Azure Key Vault.
     options:
         _terms:
             description: secret name of the secret to retrieve, version can be included like secret_name/secret_version.
             required: True
         vault_url:
-            description: url of azure key vault to be retrieved from
+            description: url of Azure Key Vault to be retrieved from
             required: True
         client_id:
-            description: client_id of service principal that has access to the provided azure key vault
+            description: client_id of service principal that has access to the provided Azure Key Vault
         secret:
             description: secret of service principal provided above
         tenant_id:
@@ -31,6 +31,7 @@ DOCUMENTATION = """
         - If version is not provided, Key Vault will give the latest version.
         - If ansible is running on Azure Virtual Machine with MSI enabled, client_id, secret and tenant isn't necessary.
         - For how to enable MSI on Azure VM, please refer to this doc https://docs.microsoft.com/en-us/azure/active-directory/managed-service-identity/
+        - After enableing MSI on Azure VM, remember to grant this VM access to the Key Vault by adding a new Acess Policy in Azure Portal.
         - If MSI is not available on the machine, then you have to provide a valid service principal that has access to the key vault.
 """
 

--- a/lib/ansible/plugins/lookup/azure_keyvault_secret.py
+++ b/lib/ansible/plugins/lookup/azure_keyvault_secret.py
@@ -20,23 +20,48 @@ DOCUMENTATION = """
             required: True
         vault_url:
             description: url of azure key vault to be retrieved from
-            default: 'azure-key-vault'
             required: True
         client_id:
             description: client_id of service principal that has access to the provided azure key vault
-        key:
-            description: key of service principal provided above
+        secret:
+            description: secret of service principal provided above
         tenant_id:
             description: tenant_id of service principal provided above
     notes:
-        - If this plugin is called on an azure virtual machine and the machine has access to the desired key vault via MSI, then you don't need to provide client_id, key, tenant_id.
+        - If ansible is running on Azure Virtual Machine with MSI enabled, client_id, secret and tenant isn't necessary. For how to enable MSI on Azure Virutal Machine, please refer to this doc https://docs.microsoft.com/en-us/azure/active-directory/managed-service-identity/
         - If this plugin is called on a non-azure virtual machine or it's an azure machine has no access to the desired key vault via MSI, then you have to provide a valid service principal that has access to the key vault. 
 """
 
 EXAMPLE = """
 - debug: msg="the value of this secret is {{lookup('azure_keyvault_secret','testSecret/version')}}"
 
-- debug: msg="the value of this secret is {{lookup('azure_keyvault_secret','testSecret/version',vault_url='https://myvault.vault.azure.net', cliend_id='123456789', key='abcdefg', tenant_id='uvwxyz')}}"
+- debug: msg="the value of this secret is {{lookup('azure_keyvault_secret','testSecret/version',vault_url='https://myvault.vault.azure.net', cliend_id='123456789', secret='abcdefg', tenant_id='uvwxyz')}}"
+
+# Example below creates an Azure Virtual Machine with ssh public key from key vault using 'azure_keyvault_secret' lookup plugin.
+- name: Create Azure VM
+  hosts: localhost
+  connection: local
+  vars:
+    resource_group: myResourceGroup
+    vm_name: testvm
+    location: eastus
+    ssh_key: "{{ lookup('azure_keyvault_secret','myssh_key') }}"
+  - name: Create VM
+    azure_rm_virtualmachine:
+      resource_group: "{{ resource_group }}"
+      name: "{{ vm_name }}"
+      vm_size: Standard_DS1_v2
+      admin_username: azureuser
+      ssh_password_enabled: false
+      ssh_public_keys:
+        - path: /home/azureuser/.ssh/authorized_keys
+          key_data: "{{ ssh_key }}"
+      network_interfaces: "{{ vm_name }}"
+      image:
+        offer: UbuntuServer
+        publisher: Canonical
+        sku: 16.04-LTS
+        version: latest
 """
 
 RETURN = """
@@ -62,9 +87,48 @@ try:
     token_res = requests.get('http://169.254.169.254/metadata/identity/oauth2/token', params=token_params, headers=token_headers)
     token = token_res.json()["access_token"]
     TOKEN_ACQUIRED = True
-except requests.exceptions.RequestException as e:
+except requests.exceptions.RequestException:
     print('Unable to fetch MSI token. Will use service principal if provided.')
     TOKEN_ACQUIRED = False
+
+
+def lookup_sercret_non_msi(terms, vault_url, kwargs):
+    import logging
+    logging.getLogger('msrestazure.azure_active_directory').addHandler(logging.NullHandler())
+    logging.getLogger('msrest.service_client').addHandler(logging.NullHandler())
+
+    try:
+        from azure.common.credentials import ServicePrincipalCredentials
+        from azure.keyvault import KeyVaultClient
+        from msrest.exceptions import AuthenticationError, ClientRequestError
+        from azure.keyvault.models.key_vault_error import KeyVaultErrorException
+    except ImportError:
+        raise AnsibleError('The azure_keyvault_secret lookup plugin requires azure.keyvault and azure.common.credentials to be installed.')
+
+    client_id = kwargs.pop('client_id', None)
+    secret = kwargs.pop('secret', None)
+    tenant_id = kwargs.pop('tenant_id', None)
+
+    try:
+        credentials = ServicePrincipalCredentials(
+            client_id=client_id,
+            secret=secret,
+            tenant=tenant_id
+        )
+        client = KeyVaultClient(credentials)
+    except AuthenticationError:
+        raise AnsibleError('Invalid credentials provided.')
+
+    ret = []
+    for term in terms:
+        try:
+            secret_val = client.get_secret(vault_url, term, '').value
+            ret.append(secret_val)
+        except ClientRequestError:
+            raise AnsibleError('Error occurred in request')
+        except KeyVaultErrorException:
+            raise AnsibleError('Failed to fetch secret ' + term + '.')
+    return ret
 
 
 class LookupModule(LookupBase):
@@ -80,44 +144,10 @@ class LookupModule(LookupBase):
                 try:
                     secret_res = requests.get(vault_url + 'secrets/' + term, params=secret_params, headers=secret_headers)
                     ret.append(secret_res.json()["value"])
-                except requests.exceptions.RequestException as e:
+                except requests.exceptions.RequestException:
                     raise AnsibleError('Failed to fetch secret: ' + term + ' via MSI endpoint.')
                 except KeyError:
                     raise AnsibleError('Failed to fetch secret ' + term + '.')
             return ret
         else:
-            import logging
-            logging.getLogger('msrestazure.azure_active_directory').addHandler(logging.NullHandler())
-            logging.getLogger('msrest.service_client').addHandler(logging.NullHandler())
-
-            try:
-                from azure.common.credentials import ServicePrincipalCredentials
-                from azure.keyvault import KeyVaultClient
-                from msrest.exceptions import AuthenticationError, ClientRequestError
-                from azure.keyvault.models.key_vault_error import KeyVaultErrorException
-            except ImportError:
-                raise AnsibleError('The azure_keyvault_secret lookup plugin requires azure.keyvault and azure.common.credentials to be installed.')
-
-            client_id = kwargs.pop('client_id', None)
-            key = kwargs.pop('key', None)
-            tenant_id = kwargs.pop('tenant_id', None)
-
-            try:
-                credentials = ServicePrincipalCredentials(
-                    client_id=client_id,
-                    secret=key,
-                    tenant=tenant_id
-                )
-                client = KeyVaultClient(credentials)
-            except AuthenticationError as e:
-                raise AnsibleError('Invalid credentials provided.')
-
-            for term in terms:
-                try:
-                    secret = client.get_secret(vault_url, term, '').value
-                    ret.append(secret)
-                except ClientRequestError as e:
-                    raise AnsibleError('Error occurred in request')
-                except KeyVaultErrorException as e:
-                    raise AnsibleError('Failed to fetch secret ' + term + '.')
-            return ret
+            return lookup_sercret_non_msi(terms,vault_url,kwargs)

--- a/lib/ansible/plugins/lookup/azure_keyvault_secret.py
+++ b/lib/ansible/plugins/lookup/azure_keyvault_secret.py
@@ -16,7 +16,7 @@ DOCUMENTATION = """
       - This lookup returns the content of a secret kept in azure key vault.
     options:
         _terms:
-            description: secret name of the secret to retrieve, version can be included like this: secret_name/secret_version.
+            description: secret name of the secret to retrieve, version can be included like secret_name/secret_version.
             required: True
         vault_url:
             description: url of azure key vault to be retrieved from
@@ -29,7 +29,7 @@ DOCUMENTATION = """
             description: tenant_id of service principal provided above
     notes:
         - If version is not provided, Key Vault will give the latest version.
-        - If ansible is running on Azure Virtual Machine with MSI enabled, client_id, secret and tenant isn't necessary. 
+        - If ansible is running on Azure Virtual Machine with MSI enabled, client_id, secret and tenant isn't necessary.
         - For how to enable MSI on Azure VM, please refer to this doc https://docs.microsoft.com/en-us/azure/active-directory/managed-service-identity/
         - If MSI is not available on the machine, then you have to provide a valid service principal that has access to the key vault.
 """

--- a/lib/ansible/plugins/lookup/azure_keyvault_secret.py
+++ b/lib/ansible/plugins/lookup/azure_keyvault_secret.py
@@ -91,7 +91,6 @@ except requests.exceptions.RequestException:
     print('Unable to fetch MSI token. Will use service principal if provided.')
     TOKEN_ACQUIRED = False
 
-
 def lookup_sercret_non_msi(terms, vault_url, kwargs):
     import logging
     logging.getLogger('msrestazure.azure_active_directory').addHandler(logging.NullHandler())
@@ -137,6 +136,8 @@ class LookupModule(LookupBase):
 
         ret = []
         vault_url = kwargs.pop('vault_url', None)
+        if vault_url is None:
+            raise AnsibleError('Failed to get valid vault url.')
         if TOKEN_ACQUIRED:
             secret_params = {'api-version': '2016-10-01'}
             secret_headers = {'Authorization': 'Bearer ' + token}

--- a/lib/ansible/plugins/lookup/azure_keyvault_secret.py
+++ b/lib/ansible/plugins/lookup/azure_keyvault_secret.py
@@ -52,6 +52,7 @@ EXAMPLE = """
 - name: Create Azure VM
   hosts: localhost
   connection: local
+  no_log: True
   vars:
     resource_group: myResourceGroup
     vm_name: testvm

--- a/lib/ansible/plugins/lookup/azure_keyvault_secret.py
+++ b/lib/ansible/plugins/lookup/azure_keyvault_secret.py
@@ -6,7 +6,7 @@ DOCUMENTATION = """
     lookup: azure_keyvault_secret
     author:
         - Hai Cao <t-haicao@microsoft.com>
-    version_added: 2.6
+    version_added: 2.7
     requirements:
         - requests
         - azure
@@ -29,7 +29,7 @@ DOCUMENTATION = """
             description: tenant_id of service principal provided above
     notes:
         - If ansible is running on Azure Virtual Machine with MSI enabled, client_id, secret and tenant isn't necessary. For how to enable MSI on Azure Virutal Machine, please refer to this doc https://docs.microsoft.com/en-us/azure/active-directory/managed-service-identity/
-        - If this plugin is called on a non-azure virtual machine or it's an azure machine has no access to the desired key vault via MSI, then you have to provide a valid service principal that has access to the key vault. 
+        - If this plugin is called on a non-Azure Virtual Machine or it's an Azure Virtual Machine that has no access to the desired key vault via MSI, then you have to provide a valid service principal that has access to the key vault. 
 """
 
 EXAMPLE = """

--- a/lib/ansible/plugins/lookup/azure_keyvault_secret.py
+++ b/lib/ansible/plugins/lookup/azure_keyvault_secret.py
@@ -1,0 +1,120 @@
+# python 3 headers, required if submitting to Ansible
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+DOCUMENTATION = """
+    lookup: azure_keyvault_secret
+    requirements:
+        - requests
+        - azure
+        - msrest
+    short_description: read secret from azure key vault.
+    description:
+      - This lookup returns the content of a secret kept in azure key vault.
+    options:
+        _terms:
+            description: secret name of the secret to retrieve, version can be included like this: secret_name/secret_version, note that if version is not provided, key vault will give the latest version.
+            required: True
+        vault_url:
+            description: url of azure key vault to be retrieved from
+            default: 'azure-key-vault'
+            required: True
+        client_id:
+            description: client_id of service principal that has access to the provided azure key vault
+        key:
+            description: key of service principal provided above
+        tenant_id:
+            description: tenant_id of service principal provided above
+    notes:
+        - If this plugin is called on an azure virtual machine and the machine has access to the desired key vault via MSI, then you don't need to provide client_id, key, tenant_id.
+        - If this plugin is called on a non-azure virtual machine or it's an azure machine has no access to the desired key vault via MSI, then you have to provide a valid service principal that has access to the key vault. 
+"""
+
+EXAMPLE = """
+- debug: msg="the value of this secret is {{lookup('azure_keyvault_secret','testSecret/version')}}"
+
+- debug: msg="the value of this secret is {{lookup('azure_keyvault_secret','testSecret/version',vault_url='https://myvault.vault.azure.net', cliend_id='123456789', key='abcdefg', tenant_id='uvwxyz')}}"
+"""
+
+RETURN = """
+  _raw:
+    description: secret content
+"""
+
+from ansible.errors import AnsibleError, AnsibleParserError
+from ansible.plugins.lookup import LookupBase
+import requests
+
+TOKEN_ACQUIRED = False
+
+token_params = {
+    'api-version': '2018-02-01',
+    'resource': 'https://vault.azure.net'
+}
+token_headers = {
+    'Metadata': 'true'
+}
+token = None
+try:
+    token_res = requests.get('http://169.254.169.254/metadata/identity/oauth2/token', params=token_params, headers=token_headers)
+    token = token_res.json()["access_token"]
+    TOKEN_ACQUIRED = True
+except requests.exceptions.RequestException as e:
+    print('Unable to fetch MSI token. Will use service principal if provided.')
+    TOKEN_ACQUIRED = False
+
+
+class LookupModule(LookupBase):
+
+    def run(self, terms, variables, **kwargs):
+
+        ret = []
+        vault_url = kwargs.pop('vault_url', None)
+        if TOKEN_ACQUIRED:
+            secret_params = {'api-version': '2016-10-01'}
+            secret_headers = {'Authorization': 'Bearer ' + token}
+            for term in terms:
+                try:
+                    secret_res = requests.get(vault_url + 'secrets/' + term, params=secret_params, headers=secret_headers)
+                    ret.append(secret_res.json()["value"])
+                except requests.exceptions.RequestException as e:
+                    raise AnsibleError('Failed to fetch secret: ' + term + ' via MSI endpoint.')
+                except KeyError:
+                    raise AnsibleError('Failed to fetch secret ' + term + '.')
+            return ret
+        else:
+            import logging
+            logging.getLogger('msrestazure.azure_active_directory').addHandler(logging.NullHandler())
+            logging.getLogger('msrest.service_client').addHandler(logging.NullHandler())
+
+            try:
+                from azure.common.credentials import ServicePrincipalCredentials
+                from azure.keyvault import KeyVaultClient
+                from msrest.exceptions import AuthenticationError, ClientRequestError
+                from azure.keyvault.models.key_vault_error import KeyVaultErrorException
+            except ImportError:
+                raise AnsibleError('The azure_keyvault_secret lookup plugin requires azure.keyvault and azure.common.credentials to be installed.')
+
+            client_id = kwargs.pop('client_id', None)
+            key = kwargs.pop('key', None)
+            tenant_id = kwargs.pop('tenant_id', None)
+
+            try:
+                credentials = ServicePrincipalCredentials(
+                    client_id=client_id,
+                    secret=key,
+                    tenant=tenant_id
+                )
+                client = KeyVaultClient(credentials)
+            except AuthenticationError as e:
+                raise AnsibleError('Invalid credentials provided.')
+
+            for term in terms:
+                try:
+                    secret = client.get_secret(vault_url, term, '').value
+                    ret.append(secret)
+                except ClientRequestError as e:
+                    raise AnsibleError('Error occurred in request')
+                except KeyVaultErrorException as e:
+                    raise AnsibleError('Failed to fetch secret ' + term + '.')
+            return ret


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This PR adds a new lookup plugin that retrieve secret value from Azure Key Vault.
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
azure_keyvault_secret
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (haicao-azurekv-msi 1aec409b16) last updated 2018/07/04 07:39:18 (GMT +000)
  config file = None
  configured module search path = [u'/home/haicao/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/haicao/vs/ansible/lib/ansible
  executable location = /home/haicao/vs/ansible/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->
This plugin will use MSI(Managed Service Identity) if possible.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
