### PR TITLE
Fix error message when using the params option

### DIFF
--- a/lib/ansible/modules/packaging/os/yum_repository.py
+++ b/lib/ansible/modules/packaging/os/yum_repository.py
@@ -613,8 +613,7 @@ def main():
     # Params was removed
     # https://meetbot.fedoraproject.org/ansible-meeting/2017-09-28/ansible_dev_meeting.2017-09-28-15.00.log.html
     if module.params['params']:
-        module.fail_json(msg="The params option to yum_repository was removed in Ansible 2.5"
-                         "since it circumvents Ansible's option handling")
+        module.fail_json(msg="The params option to yum_repository was removed in Ansible 2.5 since it circumvents Ansible's option handling")
 
     name = module.params['name']
     state = module.params['state']

--- a/lib/ansible/modules/web_infrastructure/jenkins_plugin.py
+++ b/lib/ansible/modules/web_infrastructure/jenkins_plugin.py
@@ -734,8 +734,7 @@ def main():
     # Params was removed
     # https://meetbot.fedoraproject.org/ansible-meeting/2017-09-28/ansible_dev_meeting.2017-09-28-15.00.log.html
     if module.params['params']:
-        module.fail_json(msg="The params option to jenkins_plugin was removed in Ansible 2.5"
-                         "since it circumvents Ansible's option handling")
+        module.fail_json(msg="The params option to jenkins_plugin was removed in Ansible 2.5 since it circumvents Ansible's option handling")
 
     # Force basic authentication
     module.params['force_basic_auth'] = True


### PR DESCRIPTION
##### SUMMARY
Fix the formatting of the error message. The current message error is `The params option to jenkins_plugin was removed in Ansible 2.5since it circumvents Ansible's option handling` (missing space).

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

- yum_repository
- jenkins_plugin

##### ANSIBLE VERSION

```
ansible 2.6.0
  config file = /Users/jbrochet/Projects/infrastructure-ansible/ansible.cfg
  configured module search path = [u'/Users/jbrochet/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.15 (default, Jun 17 2018, 12:46:58) [GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.2)]
```