### PR TITLE
To fix the NoneType error raised in ios_l2_interface when Access Mode VLAN is unassigned

### DIFF
--- a/lib/ansible/modules/network/ios/ios_l2_interface.py
+++ b/lib/ansible/modules/network/ios/ios_l2_interface.py
@@ -155,7 +155,9 @@ def interface_is_portchannel(name, module):
 def get_switchport(name, module):
     config = run_commands(module, ['show interface {0} switchport'.format(name)])[0]
     mode = re.search(r'Administrative Mode: (?:.* )?(\w+)$', config, re.M).group(1)
-    access = re.search(r'Access Mode VLAN: (\d+)', config).group(1)
+    access = re.search(r'Access Mode VLAN: (\d+)', config)
+    if access:
+        access = access.group(1)
     native = re.search(r'Trunking Native Mode VLAN: (\d+)', config).group(1)
     trunk = re.search(r'Trunking VLANs Enabled: (.+)$', config, re.M).group(1)
     if trunk == 'ALL':

--- a/lib/ansible/modules/network/ios/ios_l2_interface.py
+++ b/lib/ansible/modules/network/ios/ios_l2_interface.py
@@ -154,12 +154,18 @@ def interface_is_portchannel(name, module):
 
 def get_switchport(name, module):
     config = run_commands(module, ['show interface {0} switchport'.format(name)])[0]
-    mode = re.search(r'Administrative Mode: (?:.* )?(\w+)$', config, re.M).group(1)
+    mode = re.search(r'Administrative Mode: (?:.* )?(\w+)$', config, re.M)
     access = re.search(r'Access Mode VLAN: (\d+)', config)
+    native = re.search(r'Trunking Native Mode VLAN: (\d+)', config)
+    trunk = re.search(r'Trunking VLANs Enabled: (.+)$', config, re.M)
+    if mode:
+        mode = mode.group(1)
     if access:
         access = access.group(1)
-    native = re.search(r'Trunking Native Mode VLAN: (\d+)', config).group(1)
-    trunk = re.search(r'Trunking VLANs Enabled: (.+)$', config, re.M).group(1)
+    if native:
+        native = native.group(1)
+    if trunk:
+        trunk = trunk.group(1)
     if trunk == 'ALL':
         trunk = '1-4094'
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This PR is raised to fix the bug #41657, where NoneType error is raised when Access Mode VLAN is unassigned for the _port-channel swtichport_
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
Ios_l2_interface
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
