### PR TITLE
Add integration tests for flatpak_remote module

### DIFF
--- a/test/integration/targets/flatpak_remote/aliases
+++ b/test/integration/targets/flatpak_remote/aliases
@@ -1,0 +1,7 @@
+unsupported
+destructive
+skip/freebsd
+skip/osx
+skip/rhel
+needs/root
+needs/privileged

--- a/test/integration/targets/flatpak_remote/meta/main.yml
+++ b/test/integration/targets/flatpak_remote/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_tests

--- a/test/integration/targets/flatpak_remote/tasks/check_mode.yml
+++ b/test/integration/targets/flatpak_remote/tasks/check_mode.yml
@@ -1,0 +1,101 @@
+# - Tests with absent flatpak remote -------------------------------------------
+
+# state=present
+
+- name: Test addition of absent flatpak remote (check mode)
+  flatpak_remote:
+    name: flatpak-test
+    flatpakrepo_url: https://dl.flathub.org/repo/flathub.flatpakrepo
+    state: present
+  register: addition_result
+  check_mode: true
+
+- name: Verify addition of absent flatpak remote test result (check mode)
+  assert:
+    that:
+      - "addition_result.changed == true"
+    msg: "Adding an absent flatpak remote shall mark module execution as changed"
+
+- name: Test non-existent idempotency of addition of absent flatpak remote (check mode)
+  flatpak_remote:
+    name: flatpak-test
+    flatpakrepo_url: https://dl.flathub.org/repo/flathub.flatpakrepo
+    state: present
+  register: double_addition_result
+  check_mode: true
+
+- name: >
+      Verify non-existent idempotency of addition of absent flatpak remote
+      test result (check mode)
+  assert:
+    that:
+      - "double_addition_result.changed == true"
+    msg: |
+        Adding an absent flatpak remote a second time shall still mark module execution
+        as changed in check mode
+
+# state=absent
+
+- name: Test removal of absent flatpak remote not doing anything in check mode
+  flatpak_remote:
+    name: flatpak-test
+    state: absent
+  register: removal_result
+  check_mode: true
+
+- name: Verify removal of absent flatpak remote test result (check mode)
+  assert:
+    that:
+      - "removal_result.changed == false"
+    msg: "Removing an absent flatpak remote shall mark module execution as not changed"
+
+
+# - Tests with present flatpak remote -------------------------------------------
+
+# state=present
+
+- name: Test addition of present flatpak remote (check mode)
+  flatpak_remote:
+    name: check-mode-test-remote
+    flatpakrepo_url: https://dl.flathub.org/repo/flathub.flatpakrepo
+    state: present
+  register: addition_result
+  check_mode: true
+
+- name: Verify addition of present flatpak remote test result (check mode)
+  assert:
+    that:
+      - "addition_result.changed == false"
+    msg: "Adding a present flatpak remote shall mark module execution as not changed"
+
+# state=absent
+
+- name: Test removal of present flatpak remote not doing anything in check mode
+  flatpak_remote:
+    name: check-mode-test-remote
+    state: absent
+  register: removal_result
+  check_mode: true
+
+- name: Verify removal of present flatpak remote test result (check mode)
+  assert:
+    that:
+      - "removal_result.changed == true"
+    msg: "Removing a present flatpak remote shall mark module execution as changed"
+
+- name: Test non-existent idempotency of removal of present flatpak remote (check mode)
+  flatpak_remote:
+    name: check-mode-test-remote
+    state: absent
+  register: double_removal_result
+  check_mode: true
+
+- name: >
+      Verify non-existent idempotency of removal of present flatpak remote
+      test result (check mode)
+  assert:
+    that:
+      - "double_removal_result.changed == true"
+    msg: |
+        Removing a present flatpak remote a second time shall still mark module execution
+        as changed in check mode

--- a/test/integration/targets/flatpak_remote/tasks/main.yml
+++ b/test/integration/targets/flatpak_remote/tasks/main.yml
@@ -1,0 +1,56 @@
+# (c) 2018, Alexander Bethke <oolongbrothers@gmx.net>
+# (c) 2018, Ansible Project
+
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+- block:
+
+  - import_tasks: setup.yml
+    become: true
+
+  # executable override
+
+  - name: Test executable override
+    flatpak:
+      name: org.gnome.Characters
+      remote: flathub
+      state: present
+      executable: nothing-that-exists
+    ignore_errors: true
+    register: executable_override_result
+
+  - name: Verify executable override test result
+    assert:
+      that:
+        - "executable_override_result.failed == true"
+        - "executable_override_result.changed == false"
+      msg: "Specifying non-existing executable shall fail module execution"
+
+  - import_tasks: check_mode.yml
+    become: false
+
+  - import_tasks: test.yml
+    become: false
+    vars:
+      method: user
+
+  - import_tasks: test.yml
+    become: true
+    vars:
+      method: system
+
+  when: |
+      ansible_distribution in ('Fedora', 'Ubuntu')

--- a/test/integration/targets/flatpak_remote/tasks/setup.yml
+++ b/test/integration/targets/flatpak_remote/tasks/setup.yml
@@ -1,0 +1,26 @@
+- name: Install flatpak on Fedora
+  dnf:
+    name: flatpak
+    state: present
+
+  when: ansible_distribution == 'Fedora'
+
+- block:
+  - name: Activate flatpak ppa on Ubuntu
+    apt_repository:
+      repo: "ppa:alexlarsson/flatpak"
+      state: present
+      mode: 0644
+
+  - name: Install flatpak package on Ubuntu
+    apt:
+      name: flatpak
+      state: present
+
+  when: ansible_distribution == 'Ubuntu'
+
+- name: Install flatpak_remote for testing check mode
+  flatpak_remote:
+    name: check-mode-test-remote
+    flatpakrepo_url: https://dl.flathub.org/repo/flathub.flatpakrepo
+    state: present

--- a/test/integration/targets/flatpak_remote/tasks/test.yml
+++ b/test/integration/targets/flatpak_remote/tasks/test.yml
@@ -1,0 +1,72 @@
+# state=present
+
+- name: Test addition - {{ method }}
+  flatpak_remote:
+    name: flatpak-test
+    flatpakrepo_url: https://dl.flathub.org/repo/flathub.flatpakrepo
+    state: present
+    method: "{{ method }}"
+  register: addition_result
+
+- name: Verify addition test result - {{ method }}
+  assert:
+    that:
+      - "addition_result.changed == true"
+    msg: "state=preset shall add flatpak when absent"
+
+- name: Test idempotency of addition - {{ method }}
+  flatpak_remote:
+    name: flatpak-test
+    flatpakrepo_url: https://dl.flathub.org/repo/flathub.flatpakrepo
+    state: present
+    method: "{{ method }}"
+  register: double_addition_result
+
+- name: Verify idempotency of addition test result - {{ method }}
+  assert:
+    that:
+      - "double_addition_result.changed == false"
+    msg: "state=present shall not do anything when flatpak is already present"
+
+- name: Test updating remote url does not do anything - {{ method }}
+  flatpak_remote:
+    name: flatpak-test
+    flatpakrepo_url: https://a.different/repo.flatpakrepo
+    state: present
+    method: "{{ method }}"
+  register: url_update_result
+
+- name: Verify updating remote url does not do anything - {{ method }}
+  assert:
+    that:
+      - "url_update_result.changed == false"
+    msg: "Trying to update the URL of an existing flatpak remote shall not do anything"
+
+
+# state=absent
+
+- name: Test removal - {{ method }}
+  flatpak_remote:
+    name: flatpak-test
+    state: absent
+    method: "{{ method }}"
+  register: removal_result
+
+- name: Verify removal test result - {{ method }}
+  assert:
+    that:
+      - "removal_result.changed == true"
+    msg: "state=absent shall remove flatpak when present"
+
+- name: Test idempotency of removal - {{ method }}
+  flatpak_remote:
+    name: flatpak-test
+    state: absent
+    method: "{{ method }}"
+  register: double_removal_result
+
+- name: Verify idempotency of removal test result - {{ method }}
+  assert:
+    that:
+      - "double_removal_result.changed == false"
+    msg: "state=absent shall not do anything when flatpak is not present"


### PR DESCRIPTION
##### SUMMARY
This adds integration tests for the `flatpak_remote` module.

I promised these when the module PR was merged. There is a companion pull request open that accomplishes the same for the companion `flatpak` module: https://github.com/ansible/ansible/pull/42169 

I did not include these in any of the ci groups, since there a a number of external dependencies (additional information below) and thus can not guarantee the highest level of reliability.

##### ISSUE TYPE
 - Bugfix Pull Request

In the sense that not having integration tests could be regarded as a bug. But seriously, none of the categories really fit this.

##### COMPONENT NAME
`flatpak_remote`

##### ANSIBLE VERSION
```
ansible 2.7.0.dev0 (flatpak_remote_integration_tests fb61f29858) last updated 2018/07/04 17:57:41 (GMT +200)
  config file = None
  configured module search path = [u'/home/[redacted]/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/[redacted]/Code/ansible/lib/ansible
  executable location = /home/[redacted]/Code/ansible/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```

##### ADDITIONAL INFORMATION
The tests:

- Are destructive and should thus be run using docker or vagrant. Only the docker method was verified by me.
- Require privileged mode when run with docker, because flatpak requires access to container control features and docker does not support container nesting in a less-privileged way. **So these tests are not fully contained when running in docker**. If this concerns you, you should try vagrant.
- Can run on the following distributions : Ubuntu 16.04+, Fedora 24+
- Rely on the external flathub repository to test the functionality
- Rely on the official flatpak PPA repo to set up flatpak on Ubuntu

When developing, I use a local docker image based on `ansible/ansible:fedora25`, that caches the flatpak installation for improved turnaround time:
```
$ ansible-test integration -v --docker fedora25-flatpak --docker-privileged --docker-no-pull --allow-unsupported flatpak_remote
WARNING: Skipping docker pull for "ansible/ansible:fedora25-flatpak". Image may be out-of-date.
Creating a compressed tar archive of path: .
Resulting archive is 29905364 bytes.
Run command: docker run --detach --volume /sys/fs/cgroup:/sys/fs/cgroup:ro --privileged=true --volume /var/run/docker.sock:/var/run/docker.sock ansible/a ...
Run command: docker exec -i 5ac5f4f32f0e3c3de648769dc36ff43f2bf9c229fa99021a6fc072bf06d84827 dd of=/root/docker.sh bs=65536
Run command: docker exec 5ac5f4f32f0e3c3de648769dc36ff43f2bf9c229fa99021a6fc072bf06d84827 /bin/bash /root/docker.sh
Run command: docker exec -i 5ac5f4f32f0e3c3de648769dc36ff43f2bf9c229fa99021a6fc072bf06d84827 dd of=/root/ansible.tgz bs=65536
Run command: docker exec 5ac5f4f32f0e3c3de648769dc36ff43f2bf9c229fa99021a6fc072bf06d84827 mkdir /root/ansible
Run command: docker exec 5ac5f4f32f0e3c3de648769dc36ff43f2bf9c229fa99021a6fc072bf06d84827 tar oxzf /root/ansible.tgz -C /root/ansible
Run command: docker exec 5ac5f4f32f0e3c3de648769dc36ff43f2bf9c229fa99021a6fc072bf06d84827 /root/ansible/test/runner/test.py integration -v --docker-no-pu ...
Run command: /usr/bin/python setup.py egg_info
Run command: /usr/bin/python -m pip.__main__ install --disable-pip-version-check -c test/runner/requirements/constraints.txt -r test/runner/requirements/ ...
Ignoring cryptography: markers u"python_version < '2.7'" don't match your environment
Ignoring astroid: markers u"python_version >= '3.5'" don't match your environment
Ignoring pylint: markers u"python_version >= '3.5'" don't match your environment
Ignoring sphinx: markers u"python_version < '2.7'" don't match your environment
Ignoring wheel: markers u"python_version < '2.7'" don't match your environment
Ignoring yamllint: markers u"python_version < '2.7'" don't match your environment
Ignoring paramiko: markers u"python_version < '2.7'" don't match your environment
Ignoring pytest: markers u"python_version < '2.7'" don't match your environment
Ignoring ordereddict: markers u"python_version < '2.7'" don't match your environment
Requirement already satisfied (use --upgrade to upgrade): cryptography in /usr/lib64/python2.7/site-packages (from -r test/runner/requirements/integration.txt (line 1))
Requirement already satisfied (use --upgrade to upgrade): jinja2 in /usr/lib/python2.7/site-packages (from -r test/runner/requirements/integration.txt (line 2))
Requirement already satisfied (use --upgrade to upgrade): junit-xml in /usr/lib/python2.7/site-packages (from -r test/runner/requirements/integration.txt (line 3))
Requirement already satisfied (use --upgrade to upgrade): paramiko in /usr/lib/python2.7/site-packages (from -r test/runner/requirements/integration.txt (line 5))
Requirement already satisfied (use --upgrade to upgrade): pyyaml in /usr/lib64/python2.7/site-packages (from -r test/runner/requirements/integration.txt (line 6))
Requirement already satisfied (use --upgrade to upgrade): idna<2.6 in /usr/lib/python2.7/site-packages (from -c test/runner/requirements/constraints.txt (line 13))
Requirement already satisfied (use --upgrade to upgrade): pyasn1>=0.1.8 in /usr/lib/python2.7/site-packages (from cryptography->-r test/runner/requirements/integration.txt (line 1))
Requirement already satisfied (use --upgrade to upgrade): six>=1.4.1 in /usr/lib/python2.7/site-packages (from cryptography->-r test/runner/requirements/integration.txt (line 1))
Requirement already satisfied (use --upgrade to upgrade): setuptools>=11.3 in /usr/lib/python2.7/site-packages (from cryptography->-r test/runner/requirements/integration.txt (line 1))
Requirement already satisfied (use --upgrade to upgrade): enum34 in /usr/lib/python2.7/site-packages (from cryptography->-r test/runner/requirements/integration.txt (line 1))
Requirement already satisfied (use --upgrade to upgrade): ipaddress in /usr/lib/python2.7/site-packages (from cryptography->-r test/runner/requirements/integration.txt (line 1))
Requirement already satisfied (use --upgrade to upgrade): cffi>=1.4.1 in /usr/lib64/python2.7/site-packages (from cryptography->-r test/runner/requirements/integration.txt (line 1))
Requirement already satisfied (use --upgrade to upgrade): MarkupSafe in /usr/lib64/python2.7/site-packages (from jinja2->-r test/runner/requirements/integration.txt (line 2))
Requirement already satisfied (use --upgrade to upgrade): pycparser in /usr/lib/python2.7/site-packages (from cffi>=1.4.1->cryptography->-r test/runner/requirements/integration.txt (line 1))
Running flatpak_remote integration test role
Run command: ansible-playbook flatpak_remote-t6BNvf.yml -i inventory -e @integration_config.yml -v
Using /root/ansible/test/integration/integration.cfg as config file

PLAY [testhost] ****************************************************************

TASK [Gathering Facts] *********************************************************
ok: [testhost]

TASK [flatpak_remote : Install flatpak on Fedora] ******************************
ok: [testhost] => {"changed": false, "msg": "Nothing to do"}

TASK [flatpak_remote : Activate flatpak ppa on Ubuntu] *************************
skipping: [testhost] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [flatpak_remote : Install flatpak package on Ubuntu] **********************
skipping: [testhost] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [flatpak_remote : Install flatpak_remote for testing check mode] **********
changed: [testhost] => {"changed": true, "command": "/usr/bin/flatpak remote-add --system check-mode-test-remote https://dl.flathub.org/repo/flathub.flatpakrepo", "rc": 0, "stderr": "GLib-GIO-Message: Using the 'memory' GSettings backend.  Your settings will not be saved or shared with other applications.\n", "stderr_lines": ["GLib-GIO-Message: Using the 'memory' GSettings backend.  Your settings will not be saved or shared with other applications."], "stdout": "", "stdout_lines": []}

TASK [flatpak_remote : Test executable override] *******************************
fatal: [testhost]: FAILED! => {"changed": false, "msg": "Executable 'nothing-that-exists' was not found on the system."}
...ignoring

TASK [flatpak_remote : Verify executable override test result] *****************
ok: [testhost] => {
    "changed": false, 
    "msg": "All assertions passed"
}

TASK [flatpak_remote : Test addition of absent flatpak remote (check mode)] ****
changed: [testhost] => {"changed": true, "command": "/usr/bin/flatpak remote-add --system flatpak-test https://dl.flathub.org/repo/flathub.flatpakrepo", "rc": 0, "stderr": "", "stderr_lines": [], "stdout": "check-mode-test-remote Flathub https://dl.flathub.org/repo/ 1               \n", "stdout_lines": ["check-mode-test-remote Flathub https://dl.flathub.org/repo/ 1               "]}

TASK [flatpak_remote : Verify addition of absent flatpak remote test result (check mode)] ***
ok: [testhost] => {
    "changed": false, 
    "msg": "All assertions passed"
}
```
...