### PR TITLE
Fix Ansible Galaxy documentation link.

### DIFF
--- a/docs/docsite/rst/reference_appendices/galaxy.rst
+++ b/docs/docsite/rst/reference_appendices/galaxy.rst
@@ -18,7 +18,7 @@ You can also use the site to share roles that you create. By authenticating with
 them available to the Ansible community. Imported roles become available in the Galaxy search index and visible on the site, allowing users to
 discover and download them.
 
-Learn more by viewing `the About page <https://galaxy.ansible.com/intro>`_.
+Learn more by viewing `the About page <https://galaxy.ansible.com/docs/>`_.
 
 The command line tool
 `````````````````````

--- a/docs/docsite/rst/user_guide/playbooks_reuse_roles.rst
+++ b/docs/docsite/rst/user_guide/playbooks_reuse_roles.rst
@@ -397,7 +397,7 @@ Ansible Galaxy
 
 The client ``ansible-galaxy`` is included in Ansible. The Galaxy client allows you to download roles from Ansible Galaxy, and also provides an excellent default framework for creating your own roles. 
 
-Read the Ansible Galaxy introduction <https://galaxy.ansible.com/intro>_ page for more information
+Read the Ansible Galaxy documentation <https://galaxy.ansible.com/docs/>_ page for more information
 
 .. seealso::
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

The link [https://galaxy.ansible.com/intro](https://galaxy.ansible.com/intro) returns 404. It was moved to [https://galaxy.ansible.com/docs/](https://galaxy.ansible.com/docs/).

More info: https://github.com/ansible/galaxy/issues/830

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->

docs
