### PR TITLE
callback/grafana_annotations: define validate_grafana_certs type as bool

### DIFF
--- a/lib/ansible/plugins/callback/grafana_annotations.py
+++ b/lib/ansible/plugins/callback/grafana_annotations.py
@@ -48,13 +48,14 @@ DOCUMENTATION = """
           - section: callback_grafana_annotations
             key: grafana_url
       validate_grafana_certs:
-        description: (bool) validate the SSL certificate of the Grafana server. (For HTTPS url)
+        description: validate the SSL certificate of the Grafana server. (For HTTPS url)
         env:
           - name: GRAFANA_VALIDATE_CERT
         ini:
           - section: callback_grafana_annotations
             key: validate_grafana_certs
         default: True
+        type: bool
       http_agent:
         description: The HTTP 'User-agent' value to set in HTTP requets.
         env:


### PR DESCRIPTION
##### SUMMARY

Fixes #42317 
`validate_grafana_certs` parameter was not interpreted as a bool leading to the variable being always evaluated as True.

##### ISSUE TYPE
 - Bugfix Pull Request


##### COMPONENT NAME
grafana_annotations

##### ANSIBLE VERSION

```
ansible 2.6.0
  config file = /Users/remirey/dev/grtgas/avignon/ansible.cfg
  configured module search path = [u'/Users/remirey/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/remirey/.virtualenvs/avignon/lib/python2.7/site-packages/ansible
  executable location = /Users/remirey/.virtualenvs/avignon/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```
