### PR TITLE
friendly message when requirement is not installed

### DIFF
--- a/lib/ansible/modules/cloud/google/gc_storage.py
+++ b/lib/ansible/modules/cloud/google/gc_storage.py
@@ -421,7 +421,7 @@ def main():
     )
 
     if not HAS_BOTO:
-        module.fail_json(msg='boto 2.9+ required for this module')
+        module.fail_json(msg='boto package 2.9+ is required for this module. Try: pip install boto --upgrade')
 
     bucket = module.params.get('bucket')
     obj = module.params.get('object')

--- a/lib/ansible/modules/cloud/google/gc_storage.py
+++ b/lib/ansible/modules/cloud/google/gc_storage.py
@@ -421,7 +421,7 @@ def main():
     )
 
     if not HAS_BOTO:
-        module.fail_json(msg='boto package 2.9+ is required for this module. Try: pip install boto --upgrade')
+        module.fail_json(msg='`boto` 2.9+ is required for this module. Try: pip install `boto` --upgrade')
 
     bucket = module.params.get('bucket')
     obj = module.params.get('object')


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Friendly message when the requirement of minimal boto package is not satisfied.

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
gc_storage

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible --version
ansible 2.7.0.dev0 (devel 22b6b3416a) last updated 2018/06/18 23:38:03 (GMT +200)
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

The error message when boto is not installed leads to confusion, hence boto3 is higher than 2.9+.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
- from: 'boto 2.9+ required for this module'
- To: 'boto package 2.9+ is required for this module. Try: pip install boto --upgrade'
```