### PR TITLE
k8s_facts trivially supports check_mode

### DIFF
--- a/lib/ansible/modules/clustering/k8s/k8s_facts.py
+++ b/lib/ansible/modules/clustering/k8s/k8s_facts.py
@@ -136,6 +136,11 @@ import copy
 
 class KubernetesFactsModule(KubernetesAnsibleModule):
 
+    def __init__(self, *args, **kwargs):
+        KubernetesAnsibleModule.__init__(self, *args,
+                                         supports_check_mode=True,
+                                         **kwargs)
+
     def execute_module(self):
         self.client = self.get_api_client()
 


### PR DESCRIPTION
##### SUMMARY
Ensure k8s_facts runs in check mode

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
k8s_facts

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (devel da0f58787e) last updated 2018/07/05 16:16:50 (GMT +1000)
  config file = None
  configured module search path = [u'/Users/will/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/will/src/opensource/ansible/lib/ansible
  executable location = /Users/will/src/opensource/ansible/bin/ansible
  python version = 2.7.15 (default, Jun 17 2018, 12:46:58) [GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.2)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
