### PR TITLE
Add fetching default filter in ios cliconf plugin

### DIFF
--- a/lib/ansible/module_utils/network/ios/ios.py
+++ b/lib/ansible/module_utils/network/ios/ios.py
@@ -93,18 +93,8 @@ def check_args(module, warnings):
 
 def get_defaults_flag(module):
     connection = get_connection(module)
-    out = connection.get('show running-config ?')
-    out = to_text(out, errors='surrogate_then_replace')
-
-    commands = set()
-    for line in out.splitlines():
-        if line.strip():
-            commands.add(line.strip().split()[0])
-
-    if 'all' in commands:
-        return ['all']
-    else:
-        return ['full']
+    out = connection.get_defaults_flag()
+    return to_text(out, errors='surrogate_then_replace').strip()
 
 
 def get_config(module, flags=None):

--- a/lib/ansible/plugins/cliconf/ios.py
+++ b/lib/ansible/plugins/cliconf/ios.py
@@ -219,7 +219,7 @@ class Cliconf(CliconfBase):
 
     def get_capabilities(self):
         result = dict()
-        result['rpc'] = self.get_base_rpc() + ['edit_banner', 'get_diff', 'run_commands']
+        result['rpc'] = self.get_base_rpc() + ['edit_banner', 'get_diff', 'run_commands', 'get_defaults_flag']
         result['network_api'] = 'cliconf'
         result['device_info'] = self.get_device_info()
         result['device_operations'] = self.get_device_operations()
@@ -278,6 +278,25 @@ class Cliconf(CliconfBase):
             responses.append(out)
 
         return responses
+
+    def get_defaults_flag(self):
+        """
+        The method identifies the filter that should be used to fetch running-configuration
+        with defaults.
+        :return: valid default filter
+        """
+        out = self.get('show running-config ?')
+        out = to_text(out, errors='surrogate_then_replace')
+
+        commands = set()
+        for line in out.splitlines():
+            if line.strip():
+                commands.add(line.strip().split()[0])
+
+        if 'all' in commands:
+            return 'all'
+        else:
+            return 'full'
 
     def _extract_banners(self, config):
         banners = {}


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
* Add capability to fetch default filter flag in
  ios cliconf plugin.
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
plugins/cliconf/ios.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
