### PR TITLE
To fix the NoneType error raised in ios_l2_interface when Access Mode VLAN is unassigned

### DIFF
--- a/changelogs/fragments/eos_facts_failure-fix.yml
+++ b/changelogs/fragments/eos_facts_failure-fix.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - To fix the NoneType error raised in ios_l2_interface when Access Mode VLAN is unassigned 
+    (https://github.com/ansible/ansible/pull/42312)

--- a/changelogs/fragments/eos_facts_failure-fix.yml
+++ b/changelogs/fragments/eos_facts_failure-fix.yml
@@ -1,4 +1,0 @@
----
-bugfixes:
-  - To fix the NoneType error raised in ios_l2_interface when Access Mode VLAN is unassigned 
-    (https://github.com/ansible/ansible/pull/42312)

--- a/changelogs/fragments/ios_l2_interface-fix.yml
+++ b/changelogs/fragments/ios_l2_interface-fix.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - To fix the NoneType error raised in ios_l2_interface when Access Mode VLAN is unassigned 
+    (https://github.com/ansible/ansible/pull/42312)

--- a/lib/ansible/modules/network/ios/ios_l2_interface.py
+++ b/lib/ansible/modules/network/ios/ios_l2_interface.py
@@ -154,10 +154,18 @@ def interface_is_portchannel(name, module):
 
 def get_switchport(name, module):
     config = run_commands(module, ['show interface {0} switchport'.format(name)])[0]
-    mode = re.search(r'Administrative Mode: (?:.* )?(\w+)$', config, re.M).group(1)
-    access = re.search(r'Access Mode VLAN: (\d+)', config).group(1)
-    native = re.search(r'Trunking Native Mode VLAN: (\d+)', config).group(1)
-    trunk = re.search(r'Trunking VLANs Enabled: (.+)$', config, re.M).group(1)
+    mode = re.search(r'Administrative Mode: (?:.* )?(\w+)$', config, re.M)
+    access = re.search(r'Access Mode VLAN: (\d+)', config)
+    native = re.search(r'Trunking Native Mode VLAN: (\d+)', config)
+    trunk = re.search(r'Trunking VLANs Enabled: (.+)$', config, re.M)
+    if mode:
+        mode = mode.group(1)
+    if access:
+        access = access.group(1)
+    if native:
+        native = native.group(1)
+    if trunk:
+        trunk = trunk.group(1)
     if trunk == 'ALL':
         trunk = '1-4094'
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
 This PR is cherry-picked from PR #42312 which resolves the bug #41657.

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
iosl2

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
(cherry picked from commit 828dd1a663ffae1ea074ea45f3e707f15385f235)
```
