### PR TITLE
added account_alias in the response of module aws_caller_facts

### DIFF
--- a/changelogs/fragments/aws_caller_facts_add_account_alias.yaml
+++ b/changelogs/fragments/aws_caller_facts_add_account_alias.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - aws_caller_facts - The module now outputs the "account_alias" as well

--- a/hacking/aws_config/testing_policies/security-policy.json
+++ b/hacking/aws_config/testing_policies/security-policy.json
@@ -12,7 +12,8 @@
                 "iam:ListPolicies",
                 "iam:ListRoles",
                 "iam:ListRolePolicies",
-                "iam:ListUsers"
+                "iam:ListUsers",
+                "iam:ListAccountAliases"
             ],
             "Resource": "*",
             "Effect": "Allow",

--- a/lib/ansible/modules/cloud/amazon/aws_caller_facts.py
+++ b/lib/ansible/modules/cloud/amazon/aws_caller_facts.py
@@ -17,7 +17,7 @@ description:
     - The primary use of this is to get the account id for templating into ARNs or similar to avoid needing to specify this information in inventory.
 version_added: "2.6"
 
-author: 
+author:
     - Ed Costello (@orthanc)
     - Stijn Dubrul (@sdubrul)
 

--- a/lib/ansible/modules/cloud/amazon/aws_caller_facts.py
+++ b/lib/ansible/modules/cloud/amazon/aws_caller_facts.py
@@ -76,8 +76,8 @@ def main():
     client = module.client('sts')
 
     try:
-        caller_identity = client.get_caller_identity()
-        caller_identity.pop('ResponseMetadata', None)
+        caller_facts = client.get_caller_identity()
+        caller_facts.pop('ResponseMetadata', None)
     except (BotoCoreError, ClientError) as e:
         module.fail_json_aws(e, msg='Failed to retrieve caller identity')
 
@@ -94,11 +94,11 @@ def main():
     except (BotoCoreError, ClientError) as e:
         module.fail_json_aws(e, msg='Failed to retrieve account aliases')
 
-    caller_identity['account_alias'] = alias
+    caller_facts['account_alias'] = alias
 
     module.exit_json(
         changed=False,
-        **camel_dict_to_snake_dict(caller_identity))
+        **camel_dict_to_snake_dict(caller_facts))
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/cloud/amazon/aws_caller_facts.py
+++ b/lib/ansible/modules/cloud/amazon/aws_caller_facts.py
@@ -85,6 +85,9 @@ def main():
     alias = ''
 
     try:
+        # Although a list is returned by list_account_aliases AWS supports maximum one alias per account.
+        # If an alias is defined it will be returned otherwise a blank string is filled in as account_alias.
+        # see https://docs.aws.amazon.com/cli/latest/reference/iam/list-account-aliases.html#output
         response = iam_client.list_account_aliases()
         if response and response['AccountAliases']:
             alias = response['AccountAliases'][0]

--- a/test/integration/targets/aws_caller_facts/tasks/main.yaml
+++ b/test/integration/targets/aws_caller_facts/tasks/main.yaml
@@ -3,7 +3,7 @@
     region: "{{ aws_region }}"
     aws_access_key: "{{ aws_access_key }}"
     aws_secret_key: "{{ aws_secret_key }}"
-    security_token: "{{security_token}}"
+    security_token: "{{ security_token }}"
   register: result
 
 - name: assert correct keys are returned
@@ -12,3 +12,4 @@
       - result.account is not none
       - result.arn is not none
       - result.user_id is not none
+      - result.account_alias is not none


### PR DESCRIPTION
##### SUMMARY
Added an account_alias field in the output of the aws_caller_facts module.
I believe this fits nicely with the other information that is returned by this module and is a bit more  verbal in explaining what the used aws account actually is.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
aws_caller_facts

##### ANSIBLE VERSION
```
ansible 2.7.0.dev0 (aws_caller_facts_alias 66dea8c065) last updated 2018/07/05 11:50:44 (GMT +200)
  config file = None
  configured module search path = [u'/Users/sdubrul/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/sdubrul/code/github/ansible/lib/ansible
  executable location = /Users/sdubrul/code/github/ansible/bin/ansible
  python version = 2.7.15 (default, Jun 17 2018, 12:46:58) [GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.2)]
```

##### ADDITIONAL INFORMATION
before:
```
$ansible localhost -m aws_caller_facts -v

localhost | SUCCESS => {
    "account": "133256760XXX",
    "arn": "arn:aws:sts::1332567XXXXX:assumed-role/admin/sdubrul@xxxx.com",
    "changed": false,
    "user_id": "AROAJYFVM4AKNXXXXXXXX:sdubrul@xxxx.com"
}
```

after: 
```
$ansible localhost -m aws_caller_facts -v

localhost | SUCCESS => {
    "account": "1332567XXXXX",
    "account_alias": "cisco-prodops-dev",
    "arn": "arn:aws:sts::1332567XXXXX:assumed-role/admin/sdubrul@xxxx.com",
    "changed": false,
    "user_id": "AROAJYFVM4AKNXXXXXXXX:sdubrul@xxxx.com"
}

```