### PR TITLE
Adding a new filter plugin that can encrypt and decrypt values using AWS KMS service

### DIFF
--- a/lib/ansible/plugins/filter/aws_kms.py
+++ b/lib/ansible/plugins/filter/aws_kms.py
@@ -1,0 +1,92 @@
+"""
+(c) 2018, Archie Gunasekara <contact@achinthagunasekara.com>.
+Module to handle encrypting and decrypting of items with AWS KMS.
+"""
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+import base64
+from ansible.errors import AnsibleError, AnsibleFilterError
+
+
+try:
+    import botocore
+    import aws_encryption_sdk
+    HAS_DEPENDENCIES = True
+except ImportError:
+    HAS_DEPENDENCIES = False
+
+
+def dependency_check():
+    """
+    Throw an AnsibleError if dependencies are missing.
+    Args:
+    Returns:
+        None
+    """
+    if not HAS_DEPENDENCIES:
+        raise AnsibleError('You need to install "botocore" and "aws_encryption_sdk"'
+                           'before using aws_kms filter')
+
+
+def aws_kms_encrypt(plaintext, key_arn):
+    """
+    Encrypt with AWS KMS.
+    Args:
+        plaintext (str): Plain text string to encrypt.
+        key_arn (str): ARN to the AWS KMS key to use for encryption.
+    Returns:
+        str: Encrypted string for the plain text input.
+    """
+    dependency_check()
+    try:
+        session = botocore.session.get_session()
+        kms_kwargs = {
+            'key_ids': [key_arn],
+            'botocore_session': session
+        }
+        master_key_provider = aws_encryption_sdk.KMSMasterKeyProvider(**kms_kwargs)
+        ciphertext, encryptor_header = aws_encryption_sdk.encrypt(  # pylint: disable=unused-variable
+            source=plaintext,
+            key_provider=master_key_provider
+        )
+        return base64.b64encode(ciphertext)
+    except aws_encryption_sdk.exceptions.AWSEncryptionSDKClientError as kms_ex:
+        raise AnsibleFilterError("Unable to encrypt value using KMS - %s" % kms_ex)
+
+
+def aws_kms_decrypt(ciphertext, key_arn):
+    """
+    Decrypt with AWS KMS.
+    Args:
+        ciphertext (str): Encrypted string to decrypt.
+        key_arn (str): ARN to the AWS KMS key to use for decryption.
+    Returns:
+        str: Plain text decrypted string.
+    """
+    dependency_check()
+    try:
+        session = botocore.session.get_session()
+        kms_kwargs = {
+            'key_ids': [key_arn],
+            'botocore_session': session
+        }
+        master_key_provider = aws_encryption_sdk.KMSMasterKeyProvider(**kms_kwargs)
+        cycled_plaintext, decrypted_header = aws_encryption_sdk.decrypt(  # pylint: disable=unused-variable
+            source=base64.b64decode(ciphertext),
+            key_provider=master_key_provider
+        )
+        return cycled_plaintext.rstrip()
+    except aws_encryption_sdk.exceptions.AWSEncryptionSDKClientError as kms_ex:
+        raise AnsibleFilterError("Unable to encrypt value using KMS - %s" % kms_ex)
+
+
+class FilterModule(object):  # pylint: disable=too-few-public-methods
+    """ Filter module to provide functions """
+    def filters(self):  # pylint: disable=no-self-use
+        """ Filter module to provide functions """
+        return {
+            'aws_kms_encrypt': aws_kms_encrypt,
+            'aws_kms_decrypt': aws_kms_decrypt
+        }

--- a/lib/ansible/plugins/filter/aws_kms.py
+++ b/lib/ansible/plugins/filter/aws_kms.py
@@ -1,13 +1,19 @@
-"""
-(c) 2018, Archie Gunasekara <contact@achinthagunasekara.com>.
-Module to handle encrypting and decrypting of items with AWS KMS.
-"""
+# (c) 2018, Archie Gunasekara <contact@achinthagunasekara.com>.
+# Module to handle encrypting and decrypting of items with AWS KMS.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 
 import base64
 from ansible.errors import AnsibleError, AnsibleFilterError
+
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
 
 
 try:
@@ -79,7 +85,7 @@ def aws_kms_decrypt(ciphertext, key_arn):
         )
         return cycled_plaintext.rstrip()
     except aws_encryption_sdk.exceptions.AWSEncryptionSDKClientError as kms_ex:
-        raise AnsibleFilterError("Unable to encrypt value using KMS - %s" % kms_ex)
+        raise AnsibleFilterError("Unable to decrypt value using KMS - %s" % kms_ex)
 
 
 class FilterModule(object):  # pylint: disable=too-few-public-methods

--- a/lib/ansible/plugins/filter/aws_kms.py
+++ b/lib/ansible/plugins/filter/aws_kms.py
@@ -33,7 +33,7 @@ def dependency_check():
     """
     if not HAS_DEPENDENCIES:
         raise AnsibleError('You need to install "botocore" and "aws_encryption_sdk"'
-                           'before using aws_kms filter')
+                           'before using aws_kms filter plugin')
 
 
 def aws_kms_encrypt(plaintext, key_arn):

--- a/lib/ansible/plugins/filter/aws_kms.py
+++ b/lib/ansible/plugins/filter/aws_kms.py
@@ -75,8 +75,13 @@ def get_key_provider(key_arn, **kwargs):
         raise AnsibleError('You need to install "boto3" and "aws_encryption_sdk"'
                            'before using aws_kms filter')
 
+    if 'region_name' in kwargs:
+        region_name = kwargs['region']
+    else:
+        region_name = 'us-east-1'
+
     session = get_session(**kwargs)
-    client = session.client('kms', region_name='ap-southeast-2')
+    client = session.client('kms', region_name=region_name)
     key_provider = KMSMasterKeyProvider()
     regional_master_key = KMSMasterKey(client=client, key_id=key_arn)
     key_provider.add_master_key_provider(regional_master_key)
@@ -93,7 +98,7 @@ def aws_kms_encrypt(plaintext, key_arn, **kwargs):
         str: Encrypted item with KMS.
     """
     try:
-        ciphertext, encryptor_header = encrypt(  # pylint: disable=unused-variable
+        ciphertext, _ = encrypt(
             source=plaintext,
             key_provider=get_key_provider(key_arn=key_arn, **kwargs)
         )
@@ -112,7 +117,7 @@ def aws_kms_decrypt(ciphertext, key_arn, **kwargs):
         str: Decrypted plaintext item.
     """
     try:
-        cycled_plaintext, decrypted_header = decrypt(  # pylint: disable=unused-variable
+        cycled_plaintext, _ = decrypt(
             source=base64.b64decode(ciphertext),
             key_provider=get_key_provider(key_arn=key_arn, **kwargs)
         )
@@ -122,9 +127,13 @@ def aws_kms_decrypt(ciphertext, key_arn, **kwargs):
 
 
 class FilterModule(object):  # pylint: disable=too-few-public-methods
-    """ Filter module to provide functions """
+    """
+    Filter module to provide functions.
+    """
     def filters(self):  # pylint: disable=no-self-use
-        """ Filter module to provide functions """
+        """
+        Filter module to provide functions.
+        """
         return {
             'aws_kms_encrypt': aws_kms_encrypt,
             'aws_kms_decrypt': aws_kms_decrypt

--- a/lib/ansible/plugins/filter/aws_kms.py
+++ b/lib/ansible/plugins/filter/aws_kms.py
@@ -59,7 +59,7 @@ def get_session(**kwargs):
         return boto3.session.Session()
     except Exception as ex:
         raise AnsibleError("Something went wrong while creating a "
-                           "boto3 session in aws_kms_plugin - {}".format(ex))
+                           "boto3 session in aws_kms_plugin - {0}".format(ex))
 
 
 def get_key_provider(key_arn, **kwargs):
@@ -98,13 +98,13 @@ def aws_kms_encrypt(plaintext, key_arn, **kwargs):
         str: Encrypted item with KMS.
     """
     try:
-        ciphertext, _ = encrypt(
+        ciphertext, dummy = encrypt(
             source=plaintext,
             key_provider=get_key_provider(key_arn=key_arn, **kwargs)
         )
         return base64.b64encode(ciphertext)
     except AWSEncryptionSDKClientError as kms_ex:
-        raise AnsibleFilterError("Unable to encrypt vaule using KMS - {}".format(kms_ex))
+        raise AnsibleFilterError("Unable to encrypt vaule using KMS - {0}".format(kms_ex))
 
 
 def aws_kms_decrypt(ciphertext, key_arn, **kwargs):
@@ -117,13 +117,13 @@ def aws_kms_decrypt(ciphertext, key_arn, **kwargs):
         str: Decrypted plaintext item.
     """
     try:
-        cycled_plaintext, _ = decrypt(
+        cycled_plaintext, dummy = decrypt(
             source=base64.b64decode(ciphertext),
             key_provider=get_key_provider(key_arn=key_arn, **kwargs)
         )
         return cycled_plaintext.rstrip()
     except AWSEncryptionSDKClientError as kms_ex:
-        raise AnsibleFilterError("Unable to encrypt vaule using KMS - {}".format(kms_ex))
+        raise AnsibleFilterError("Unable to encrypt vaule using KMS - {0}".format(kms_ex))
 
 
 class FilterModule(object):  # pylint: disable=too-few-public-methods

--- a/lib/ansible/plugins/filter/aws_kms.py
+++ b/lib/ansible/plugins/filter/aws_kms.py
@@ -1,91 +1,124 @@
-# (c) 2018, Archie Gunasekara <contact@achinthagunasekara.com>.
-# Module to handle encrypting and decrypting of items with AWS KMS.
-# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+"""
+(c) 2018, Archie Gunasekara <contact@achinthagunasekara.com>
+Module to handle encrypting and decrypting of items with KMS
+"""
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-
 import base64
+from os.path import basename
 from ansible.errors import AnsibleError, AnsibleFilterError
 
-
-ANSIBLE_METADATA = {
-    'metadata_version': '1.1',
-    'status': ['preview'],
-    'supported_by': 'community'
-}
-
-
 try:
-    import botocore
-    import aws_encryption_sdk
+    import boto3
+    from aws_encryption_sdk.key_providers.kms import KMSMasterKey
+    from aws_encryption_sdk import KMSMasterKeyProvider, encrypt, decrypt
+    from aws_encryption_sdk.exceptions import AWSEncryptionSDKClientError
     HAS_DEPENDENCIES = True
 except ImportError:
     HAS_DEPENDENCIES = False
 
 
-def dependency_check():
+def role_arn_to_session(**args):
     """
-    Throw an AnsibleError if dependencies are missing.
-    Args:
-    Returns:
-        None
+    Refer:
+    http://boto3.readthedocs.io/en/latest/reference/services/sts.html#STS.Client.assume_role
+    Usage :
+        session = role_arn_to_session(
+            RoleArn='arn:aws:iam::012345678901:role/example-role',
+            RoleSessionName='ExampleSessionName')
+        client = session.client('sqs')
     """
-    if not HAS_DEPENDENCIES:
-        raise AnsibleError('You need to install "botocore" and "aws_encryption_sdk"'
-                           'before using aws_kms filter plugin')
+    client = boto3.client('sts')
+    response = client.assume_role(**args)
+    return boto3.Session(
+        aws_access_key_id=response['Credentials']['AccessKeyId'],
+        aws_secret_access_key=response['Credentials']['SecretAccessKey'],
+        aws_session_token=response['Credentials']['SessionToken'])
 
 
-def aws_kms_encrypt(plaintext, key_arn):
+def get_session(**kwargs):
     """
-    Encrypt with AWS KMS.
-    Args:
-        plaintext (str): Plain text string to encrypt.
-        key_arn (str): ARN to the AWS KMS key to use for encryption.
-    Returns:
-        str: Encrypted string for the plain text input.
+    Get boto3 session object.
     """
-    dependency_check()
     try:
-        session = botocore.session.get_session()
-        kms_kwargs = {
-            'key_ids': [key_arn],
-            'botocore_session': session
-        }
-        master_key_provider = aws_encryption_sdk.KMSMasterKeyProvider(**kms_kwargs)
-        ciphertext, encryptor_header = aws_encryption_sdk.encrypt(  # pylint: disable=unused-variable
+        if 'profile_name' in kwargs:
+            return boto3.session.Session(profile_name=kwargs['profile_name'])
+
+        if 'role_to_assume' in kwargs:
+            return role_arn_to_session(
+                RoleArn=kwargs['prorole_to_assume'],
+                RoleSessionName=basename(kwargs['prorole_to_assume'])
+            )
+        elif 'aws_access_key_id' in kwargs and 'aws_secret_access_key' in kwargs:
+            return boto3.Session(
+                aws_access_key_id=kwargs['aws_access_key_id'],
+                aws_secret_access_key=kwargs['aws_secret_access_key'],
+            )
+
+        return boto3.session.Session()
+    except Exception as ex:
+        raise AnsibleError("Something went wrong while creating a "
+                           "boto3 session in aws_kms_plugin - {}".format(ex))
+
+
+def get_key_provider(key_arn, **kwargs):
+    """
+    Get KMS key provider object.
+    Args:
+      key_arn (str): AWS ARN to the KMS key.
+    Returns:
+      KMSMasterKeyProvider: KMS Master Key Provider object.
+    """
+
+    if not HAS_DEPENDENCIES:
+        raise AnsibleError('You need to install "boto3" and "aws_encryption_sdk"'
+                           'before using aws_kms filter')
+
+    session = get_session(**kwargs)
+    client = session.client('kms', region_name='ap-southeast-2')
+    key_provider = KMSMasterKeyProvider()
+    regional_master_key = KMSMasterKey(client=client, key_id=key_arn)
+    key_provider.add_master_key_provider(regional_master_key)
+    return key_provider
+
+
+def aws_kms_encrypt(plaintext, key_arn, **kwargs):
+    """
+    Encrypt with KMS.
+    Args:
+        plaintext (str): Plain text item to ecrypt.
+        key_arn (str): AWS ARN to the KMS key.
+    Returns:
+        str: Encrypted item with KMS.
+    """
+    try:
+        ciphertext, encryptor_header = encrypt(  # pylint: disable=unused-variable
             source=plaintext,
-            key_provider=master_key_provider
+            key_provider=get_key_provider(key_arn=key_arn, **kwargs)
         )
         return base64.b64encode(ciphertext)
-    except aws_encryption_sdk.exceptions.AWSEncryptionSDKClientError as kms_ex:
-        raise AnsibleFilterError("Unable to encrypt value using KMS - %s" % kms_ex)
+    except AWSEncryptionSDKClientError as kms_ex:
+        raise AnsibleFilterError("Unable to encrypt vaule using KMS - {}".format(kms_ex))
 
 
-def aws_kms_decrypt(ciphertext, key_arn):
+def aws_kms_decrypt(ciphertext, key_arn, **kwargs):
     """
-    Decrypt with AWS KMS.
+    Decrypt with KMS.
     Args:
-        ciphertext (str): Encrypted string to decrypt.
-        key_arn (str): ARN to the AWS KMS key to use for decryption.
+        ciphertext (str): Encrypted item to decrypt.
+        key_arn (str): AWS ARN to the KMS key.
     Returns:
-        str: Plain text decrypted string.
+        str: Decrypted plaintext item.
     """
-    dependency_check()
     try:
-        session = botocore.session.get_session()
-        kms_kwargs = {
-            'key_ids': [key_arn],
-            'botocore_session': session
-        }
-        master_key_provider = aws_encryption_sdk.KMSMasterKeyProvider(**kms_kwargs)
-        cycled_plaintext, decrypted_header = aws_encryption_sdk.decrypt(  # pylint: disable=unused-variable
+        cycled_plaintext, decrypted_header = decrypt(  # pylint: disable=unused-variable
             source=base64.b64decode(ciphertext),
-            key_provider=master_key_provider
+            key_provider=get_key_provider(key_arn=key_arn, **kwargs)
         )
         return cycled_plaintext.rstrip()
-    except aws_encryption_sdk.exceptions.AWSEncryptionSDKClientError as kms_ex:
-        raise AnsibleFilterError("Unable to decrypt value using KMS - %s" % kms_ex)
+    except AWSEncryptionSDKClientError as kms_ex:
+        raise AnsibleFilterError("Unable to encrypt vaule using KMS - {}".format(kms_ex))
 
 
 class FilterModule(object):  # pylint: disable=too-few-public-methods

--- a/lib/ansible/plugins/filter/aws_kms.py
+++ b/lib/ansible/plugins/filter/aws_kms.py
@@ -43,6 +43,8 @@ def role_arn_to_session(role_arn, role_session_name):
 def get_boto_session(**kwargs):
     """
     Get boto3 session object.
+    Returns:
+        boto3.Session: Returns a boto3.Session object.
     """
     valid_keys = [
         'profile_name',
@@ -103,7 +105,7 @@ def aws_kms_encrypt(plaintext, key_arn, **kwargs):
     """
     Encrypt with KMS.
     Args:
-        plaintext (str): Plain text item to ecrypt.
+        plaintext (str): Plain text item to encrypt.
         key_arn (str): AWS ARN to the KMS key.
     Returns:
         str: Encrypted item with KMS.
@@ -115,7 +117,7 @@ def aws_kms_encrypt(plaintext, key_arn, **kwargs):
         )
         return base64.b64encode(ciphertext)
     except AWSEncryptionSDKClientError as kms_ex:
-        raise AnsibleFilterError("Unable to encrypt vaule using KMS - {0}".format(kms_ex))
+        raise AnsibleFilterError("Unable to encrypt value using KMS - {0}".format(kms_ex))
 
 
 def aws_kms_decrypt(ciphertext, key_arn, **kwargs):
@@ -125,7 +127,7 @@ def aws_kms_decrypt(ciphertext, key_arn, **kwargs):
         ciphertext (str): Encrypted item to decrypt.
         key_arn (str): AWS ARN to the KMS key.
     Returns:
-        str: Decrypted plaintext item.
+        str: Decrypted plain text item.
     """
     try:
         cycled_plaintext, dummy = decrypt(
@@ -134,7 +136,7 @@ def aws_kms_decrypt(ciphertext, key_arn, **kwargs):
         )
         return cycled_plaintext.rstrip()
     except AWSEncryptionSDKClientError as kms_ex:
-        raise AnsibleFilterError("Unable to encrypt vaule using KMS - {0}".format(kms_ex))
+        raise AnsibleFilterError("Unable to encrypt value using KMS - {0}".format(kms_ex))
 
 
 class FilterModule(object):  # pylint: disable=too-few-public-methods
@@ -144,6 +146,8 @@ class FilterModule(object):  # pylint: disable=too-few-public-methods
     def filters(self):  # pylint: disable=no-self-use
         """
         Filter module to provide functions.
+        Returns:
+            dictionary: Dictionary with valid methods that can be called to use this plugin.
         """
         return {
             'aws_kms_encrypt': aws_kms_encrypt,


### PR DESCRIPTION
## SUMMARY

Adding a new filter plugin that can encrypt and decrypt values using AWS KMS service.
This filter plugin can be used to encrypt values using the AWS KMS service and store them within your repository, then decrypt then when you want to use them.

## Example

#### Decrypting

In `my_role\defaults\main.yml`
```
encrypted_value: >-
  {{ abcd123abcd13 abcd123abcd13abcd12abcd13
  abcd123abcd13abcd123abcd13abcd123ab1d1312
  abcd123abcd13abcd123abcd13abcd123ssdsas12
  sadsdsasd | aws_kms_decrypt(KEY_ARN) }}
```

In `my_role\tasks\main.yml`

```
- debug:
    msg: "Decrypted value is {{ encrypted_value }}"
```

Same can be done for encrypting values.

#### Encrypting

In `my_role\tasks\main.yml`

```
- debug:
    msg: "Encrypted value is {{ 'abc123abc123abc123' | aws_kms_encrypt(KEY_ARN) }}"
```

## Arguments

You can call `aws_kms_encrypt` and `aws_kms_encrypt` from this plugin with following variables.

* Mandatory - ciphertext (str): Encrypted item to decrypt.
* Mandatory - key_arn (str): AWS ARN to the KMS key.
* Optional - region_name (str): AWS region to use.
* Optional - profile_name (str): AWS credential profile to use.
* Optional - role_to_assume (str): AWS IAM role to use to get credentials.
* Optional - aws_access_key_id (str): AWS access key to use.
* Optional - aws_secret_access_key (str): AWS secret key to use.

Getting AWS Credentias will use following order.

`profile_name` > `role_to_assume` > `aws_access_key_id` and `aws_secret_access_key` > `instance IAM profile` or `default profile`

## ADDITIONAL INFORMATION

* https://aws.amazon.com/documentation/kms/
* https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/introduction.html