### PR TITLE
To fix EOS_FACTS failure when lldp will be disabled.

### DIFF
--- a/changelogs/fragments/eos_facts-failure.yml
+++ b/changelogs/fragments/eos_facts-failure.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - To fix EOS_FACTS failure when lldp will be disabled 
+    (https://github.com/ansible/ansible/pull/42347)

--- a/changelogs/fragments/eos_facts-failure.yml
+++ b/changelogs/fragments/eos_facts-failure.yml
@@ -1,4 +1,4 @@
 ---
 bugfixes:
-  - To fix EOS_FACTS failure when lldp will be disabled 
+  - eos_facts - fix failure when lldp will be disabled 
     (https://github.com/ansible/ansible/pull/42347)

--- a/lib/ansible/module_utils/network/eos/eos.py
+++ b/lib/ansible/module_utils/network/eos/eos.py
@@ -176,7 +176,12 @@ class Cli:
                 prompt = None
                 answer = None
 
-            out = connection.get(command, prompt, answer)
+            try:
+                out = connection.get(command, prompt, answer)
+            except ConnectionError as exc:
+                if check_rc:
+                    raise
+                out = getattr(exc, 'err', exc)
             out = to_text(out, errors='surrogate_or_strict')
 
             try:
@@ -338,7 +343,7 @@ class Eapi:
 
         return response
 
-    def run_commands(self, commands):
+    def run_commands(self, commands, check_rc=True):
         """Runs list of commands on remote device and returns results
         """
         output = None
@@ -489,9 +494,9 @@ def get_config(module, flags=None):
     return conn.get_config(flags)
 
 
-def run_commands(module, commands):
+def run_commands(module, commands, check_rc=True):
     conn = get_connection(module)
-    return conn.run_commands(to_command(module, commands))
+    return conn.run_commands(to_command(module, commands), check_rc)
 
 
 def load_config(module, config, commit=False, replace=False):

--- a/lib/ansible/modules/network/eos/eos_facts.py
+++ b/lib/ansible/modules/network/eos/eos_facts.py
@@ -258,7 +258,8 @@ class Interfaces(FactsBase):
         self.facts['interfaces'] = self.populate_interfaces(data)
 
         data = self.responses[1]
-        self.facts['neighbors'] = self.populate_neighbors(data['lldpNeighbors'])
+        if data:
+            self.facts['neighbors'] = self.populate_neighbors(data['lldpNeighbors'])
 
     def populate_interfaces(self, data):
         facts = dict()

--- a/lib/ansible/modules/network/eos/eos_facts.py
+++ b/lib/ansible/modules/network/eos/eos_facts.py
@@ -153,7 +153,7 @@ class FactsBase(object):
         self.responses = None
 
     def populate(self):
-        self.responses = run_commands(self.module, list(self.COMMANDS))
+        self.responses = run_commands(self.module, list(self.COMMANDS), check_rc=False)
 
 
 class Default(FactsBase):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This PR is raised to fix the bug #41165, where `eos_facts` will fail when lldp will be disabled.
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
eos

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->
Fix for respective issue was done in `2.6` in PR #39224, but since the PR included major changes for HTTP(S) API connection, new PR is raised to fix #41165 issue in `2.5`
<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
