### PR TITLE
mongodb_user: don't call buildInfo with Pymongo > 3.5

### DIFF
--- a/lib/ansible/modules/database/mongodb/mongodb_user.py
+++ b/lib/ansible/modules/database/mongodb/mongodb_user.py
@@ -383,8 +383,9 @@ def main():
         client = MongoClient(**connection_params)
 
         # NOTE: this check must be done ASAP.
-        # We doesn't need to be authenticated.
-        check_compatibility(module, client)
+        # We doesn't need to be authenticated (this ability has lost in PyMongo 3.6)
+        if LooseVersion(PyMongoVersion) <= LooseVersion('3.5'):
+            check_compatibility(module, client)
 
         if login_user is None and login_password is None:
             mongocnf_creds = load_mongocnf()


### PR DESCRIPTION
Fixes #35155

##### SUMMARY

Pymongo 3.6 creates an implicit session even for unauthenticated users, so the call to buildInfo without credentials fails.
https://jira.mongodb.org/browse/SERVER-34820

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
pymongo_user

##### ANSIBLE VERSION
```
ansible 2.5.4
```


##### ADDITIONAL INFORMATION
