### PR TITLE
VMware: vmware_vm_facts check for template config

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_vm_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_vm_facts.py
@@ -151,9 +151,10 @@ class VmwareVmFacts(PyVmomi):
             }
 
             vm_type = self.module.params.get('vm_type')
-            if vm_type == 'vm' and vm.config.template is False:
+            is_template = _get_vm_prop(vm, ('config', 'template'))
+            if vm_type == 'vm' and not is_template:
                 _virtual_machines.update(virtual_machine)
-            elif vm_type == 'template' and vm.config.template:
+            elif vm_type == 'template' and is_template:
                 _virtual_machines.update(virtual_machine)
             elif vm_type == 'all':
                 _virtual_machines.update(virtual_machine)


### PR DESCRIPTION
##### SUMMARY
This fix adds additional check for getting template from
virtual machine before using it.

Fixes: #42011

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/vmware/vmware_vm_facts.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7-devel
```