### PR TITLE
Ensure boolean value 'yes' is shown and add types

### DIFF
--- a/lib/ansible/utils/module_docs_fragments/vmware.py
+++ b/lib/ansible/utils/module_docs_fragments/vmware.py
@@ -12,35 +12,35 @@ options:
       - The hostname or IP address of the vSphere vCenter or ESXi server.
       - If the value is not specified in the task, the value of environment variable C(VMWARE_HOST) will be used instead.
       - Environment variable supported added in version 2.6.
-      required: False
+      type: str
     username:
       description:
       - The username of the vSphere vCenter or ESXi server.
       - If the value is not specified in the task, the value of environment variable C(VMWARE_USER) will be used instead.
       - Environment variable supported added in version 2.6.
-      required: False
-      aliases: ['user', 'admin']
+      type: str
+      aliases: [ admin, user ]
     password:
       description:
       - The password of the vSphere vCenter or ESXi server.
       - If the value is not specified in the task, the value of environment variable C(VMWARE_PASSWORD) will be used instead.
       - Environment variable supported added in version 2.6.
-      required: False
-      aliases: ['pass', 'pwd']
+      type: str
+      aliases: [ pass, pwd ]
     validate_certs:
       description:
       - Allows connection when SSL certificates are not valid. Set to C(false) when certificates are not trusted.
       - If the value is not specified in the task, the value of environment variable C(VMWARE_VALIDATE_CERTS) will be used instead.
       - Environment variable supported added in version 2.6.
-      - If set to C(True), please make sure Python >= 2.7.9 is installed on the given machine.
-      default: 'True'
+      - If set to C(yes), please make sure Python >= 2.7.9 is installed on the given machine.
       type: bool
+      default: 'yes'
     port:
       description:
       - The port number of the vSphere vCenter or ESXi server.
       - If the value is not specified in the task, the value of environment variable C(VMWARE_PORT) will be used instead.
       - Environment variable supported added in version 2.6.
-      required: False
+      type: int
       default: 443
       version_added: 2.5
 '''


### PR DESCRIPTION
##### SUMMARY
And a few small cosmetic changes.

This change ensures VMware module documentation includes proper defaults.
It fixes this:
![screenshot from 2018-07-05 17-33-35](https://user-images.githubusercontent.com/388198/42332927-9db94ffc-8079-11e8-8e02-014e0f5798e2.png)

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
vmware module_utils

##### ANSIBLE VERSION
v2.7