### PR TITLE
Update link to GitHub admin process

### DIFF
--- a/docs/docsite/rst/community/github_admins.rst
+++ b/docs/docsite/rst/community/github_admins.rst
@@ -25,5 +25,5 @@ the release has been made.  The Release manager will let the GitHub Admin know w
 done.
 
 .. seealso:: The `GitHub Admin Process Docs
-    <https://github.com/ansible/ansible/blob/devel/hacking/release-branches.rst>`_ for instructions
+    <https://docs.google.com/document/d/1gWPtxNX4J39uIzwqQWLIsTZ1dY_AwEZzAd9bJ4XtZso/edit#heading=h.2wezayw9xsqz>`_ for instructions
     on how to change branch permissions.


### PR DESCRIPTION
##### SUMMARY
The GitHub admin process moved to a public location at discussed [here](https://github.com/ansible/ansible/pull/32175#issuecomment-356822326) but the link in the docs was never updated. This updates the link in the docs to point to the new home of the GitHub Admin Process.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
`github_admins.rst`

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
