### PR TITLE
Changed 'all' group to 'scaleway' group to avoid conflict with real '…

### DIFF
--- a/contrib/inventory/scaleway.py
+++ b/contrib/inventory/scaleway.py
@@ -150,7 +150,7 @@ def cache_available(config):
 
 def generate_inv_from_api(config):
     try:
-        inventory['all'] = copy.deepcopy(EMPTY_GROUP)
+        inventory['scaleway'] = copy.deepcopy(EMPTY_GROUP)
 
         if config.has_option('auth', 'api_token'):
             auth_token = config.get('auth', 'api_token')
@@ -186,7 +186,7 @@ def generate_inv_from_api(config):
                 if region not in inventory:
                     inventory[region] = copy.deepcopy(EMPTY_GROUP)
                 inventory[region]['children'].append(hostname)
-                inventory['all']['children'].append(hostname)
+                inventory['scaleway']['children'].append(hostname)
                 inventory[hostname] = []
                 inventory[hostname].append(ip)
 
@@ -194,7 +194,7 @@ def generate_inv_from_api(config):
     except Exception:
         # Return empty hosts output
         traceback.print_exc()
-        return {'all': {'hosts': []}, '_meta': {'hostvars': {}}}
+        return {'scaleway': {'hosts': []}, '_meta': {'hostvars': {}}}
 
 
 def get_inventory(config):


### PR DESCRIPTION
…all' group. Closes ##35092

##### SUMMARY
I changed the main group for scaleway dynamic inventory script from "all" to "scaleway", so no wpeople would be able to apply a task or a role just on Scaleway machines.

Fixes #35092 


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
scaleway dynamic inventory script

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/marcos/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.15rc1 (default, Apr 15 2018, 21:51:34) [GCC 7.3.0]
```


##### ADDITIONAL INFORMATION
Before this pull request, wasn't a group just for machines on Scaleway like in other dynamic inventory scripts.
