### PR TITLE
Fix junos integration test CI failures

### DIFF
--- a/test/integration/targets/prepare_junos_tests/tasks/main.yml
+++ b/test/integration/targets/prepare_junos_tests/tasks/main.yml
@@ -1,9 +1,6 @@
 ---
 - debug: msg="START prepare_junos_tests/main.yaml"
 
-- name: reset persistent connection
-  meta: reset_connection
-
 - name: Ensure netconf is enabled
   junos_netconf:
     state: present


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
*  reset_connection task is not required as the persistent
   connection to the remote host is closed at end of playbook
   run

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Test Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
prepare_junos_tests/tasks/main.yml

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
