### PR TITLE
Update docker-container docs to current docker python package name

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -96,7 +96,7 @@ options:
     description:
       - Path to a file containing environment variables I(FOO=BAR).
       - If variable also present in C(env), then C(env) value will override.
-      - Requires docker-py >= 1.4.0.
+      - Requires docker >= 1.4.0.
   entrypoint:
     description:
       - Command that overwrites the default ENTRYPOINT of the image.
@@ -421,7 +421,7 @@ author:
 
 requirements:
     - "python >= 2.6"
-    - "docker-py >= 1.7.0"
+    - "docker >= 1.7.0"
     - "Docker API >= 1.20"
 '''
 
@@ -617,7 +617,7 @@ try:
     else:
         from docker.utils.types import Ulimit, LogConfig
 except:
-    # missing docker-py handled in ansible.module_utils.docker
+    # missing docker handled in ansible.module_utils.docker
     pass
 
 


### PR DESCRIPTION
##### SUMMARY
The docs for docker-container suggest installing `docker-py` as a dependency. But `docker-py` is no longer a thing, and will not work with Ansible 2.6+

https://github.com/docker/docker-py/issues/1431

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
docker-container

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/ry/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.15 (default, May 16 2018, 17:50:09) [GCC 8.1.1 20180502 (Red Hat 8.1.1-1)]
```

