### PR TITLE
Make ansible not parse template-like password in user's input

### DIFF
--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -38,6 +38,7 @@ from ansible.errors import AnsibleOptionsError, AnsibleError
 from ansible.inventory.manager import InventoryManager
 from ansible.module_utils.six import with_metaclass, string_types
 from ansible.module_utils._text import to_bytes, to_text
+from ansible.utils.unsafe_proxy import AnsibleUnsafeText
 from ansible.parsing.dataloader import DataLoader
 from ansible.release import __version__
 from ansible.utils.path import unfrackpath
@@ -329,7 +330,7 @@ class CLI(with_metaclass(ABCMeta, object)):
                 sshpass = getpass.getpass(prompt="SSH password: ")
                 become_prompt = "%s password[defaults to SSH password]: " % become_prompt_method
                 if sshpass:
-                    sshpass = to_bytes(sshpass, errors='strict', nonstring='simplerepr')
+                    sshpass = AnsibleUnsafeText(to_bytes(sshpass, errors='strict', nonstring='simplerepr'))
             else:
                 become_prompt = "%s password: " % become_prompt_method
 
@@ -338,7 +339,7 @@ class CLI(with_metaclass(ABCMeta, object)):
                 if op.ask_pass and becomepass == '':
                     becomepass = sshpass
                 if becomepass:
-                    becomepass = to_bytes(becomepass)
+                    becomepass = AnsibleUnsafeText(to_bytes(becomepass))
         except EOFError:
             pass
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Backport #42275

NOTE:
1. Use unsafe decorator but not builtin escape wrapper in jinja2
since ansible will try parse ssh password twice, the builtin
escape wrapper will be removed during the first parse.
2. Use class AnsibleUnsafeText but not '!unsafe' syntax since
passwords are not loaded by YAML env, '!unsafe' syntax doesn't
work for them.

(cherry picked from commit de40ac02a5cd4ac3bb758d4e284955763c013938)
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
ansible/lib/ansible/cli/__init__.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0.dev0 (backport/42275 b3f2b509f7) last updated 2018/07/05 13:41:53 (GMT -400)
  config file = None
  configured module search path = [u'/home/zhikangzhang/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/zhikangzhang/Desktop/ansible/lib/ansible
  executable location = /home/zhikangzhang/Desktop/ansible/bin/ansible
  python version = 2.7.15 (default, May 16 2018, 17:50:09) [GCC 8.1.1 20180502 (Red Hat 8.1.1-1)]

```