### PR TITLE
Add ability to override openstack keystone endpoint

### DIFF
--- a/lib/ansible/module_utils/openstack.py
+++ b/lib/ansible/module_utils/openstack.py
@@ -74,7 +74,7 @@ def openstack_find_nova_addresses(addresses, ext_tag, key_name=None):
     return ret
 
 
-def openstack_full_argument_spec(**kwargs):
+def openstack_full_argument_spec(service_type=None, **kwargs):
     spec = dict(
         cloud=dict(default=None, type='raw'),
         auth_type=dict(default=None),
@@ -92,6 +92,9 @@ def openstack_full_argument_spec(**kwargs):
             default='public', choices=['public', 'internal', 'admin'],
             aliases=['endpoint_type']),
     )
+    if service_type:
+        key = '{service_type}_endpoint_override'
+        spec[key] = dict(default=None)
     spec.update(kwargs)
     return spec
 

--- a/lib/ansible/modules/cloud/openstack/os_keystone_endpoint.py
+++ b/lib/ansible/modules/cloud/openstack/os_keystone_endpoint.py
@@ -50,6 +50,12 @@ options:
        - Should the resource be C(present) or C(absent).
      choices: [present, absent]
      default: present
+   identity_endpoint_override:
+     description:
+       - Endpoint to use to talk to the keystone service, bypassing the
+         catalog. Useful for bootstrapping a keystone installation.
+     required: false
+     version_added: "2.7"
 requirements:
     - openstacksdk >= 0.13.0
 '''
@@ -132,6 +138,7 @@ def _system_state_change(module, endpoint):
 
 def main():
     argument_spec = openstack_full_argument_spec(
+        service_type='identity',
         service=dict(type='str', required=True),
         endpoint_interface=dict(type='str', required=True, choices=['admin', 'public', 'internal']),
         url=dict(type='str', required=True),

--- a/lib/ansible/modules/cloud/openstack/os_keystone_service.py
+++ b/lib/ansible/modules/cloud/openstack/os_keystone_service.py
@@ -47,6 +47,12 @@ options:
    availability_zone:
      description:
        - Ignored. Present for backwards compatibility
+   identity_endpoint_override:
+     description:
+       - Endpoint to use to talk to the keystone service, bypassing the
+         catalog. Useful for bootstrapping a keystone installation.
+     required: false
+     version_added: "2.7"
 requirements:
     - "python >= 2.7"
     - "openstacksdk"
@@ -129,6 +135,7 @@ def _system_state_change(module, service):
 
 def main():
     argument_spec = openstack_full_argument_spec(
+        service_type='identity',
         description=dict(default=None),
         enabled=dict(default=True, type='bool'),
         name=dict(required=True),


### PR DESCRIPTION
##### SUMMARY

For bootstrapping installations, keystone needs to be manipulated before
the service catalog is there. While identity_endpoint_override can be
provided in clouds.yaml - in this case it's only a useful setting during
the bootstrap stage, which means it would be more handy to be in a
module parameter.

We don't just add the parameter to the main module kwargs because ALL of
the services in openstack potentially have an endpoint_override setting
but only specific ones are useful - and only in certain modules.

##### ISSUE TYPE
 - Feature Pull Request

##### ADDITIONAL INFORMATION

Inspired by https://github.com/openstack/openstack-ansible-plugins/commit/cc7c9249d4323bc6434d2cb951d06054a1804420 and is part of allowing the openstack-ansible team to get rid of things.