### PR TITLE
[k8s] allow user to pass list of resources in to definition parameter

### DIFF
--- a/lib/ansible/module_utils/k8s/common.py
+++ b/lib/ansible/module_utils/k8s/common.py
@@ -22,8 +22,8 @@ import os
 import copy
 
 
-from ansible.module_utils.six import iteritems
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.six import iteritems, string_types
 
 try:
     import kubernetes
@@ -51,6 +51,15 @@ try:
 except ImportError:
     pass
 
+def list_dict_str(value):
+    if isinstance(value, list):
+        return value
+    elif isinstance(value, dict):
+        return value
+    elif isinstance(value, string_types):
+        return value
+    raise TypeError
+
 ARG_ATTRIBUTES_BLACKLIST = ('property_path',)
 
 COMMON_ARG_SPEC = {
@@ -63,6 +72,7 @@ COMMON_ARG_SPEC = {
         'default': False,
     },
     'resource_definition': {
+        'type': list_dict_str,
         'aliases': ['definition', 'inline']
     },
     'src': {

--- a/lib/ansible/module_utils/k8s/common.py
+++ b/lib/ansible/module_utils/k8s/common.py
@@ -51,6 +51,7 @@ try:
 except ImportError:
     pass
 
+
 def list_dict_str(value):
     if isinstance(value, list):
         return value

--- a/lib/ansible/module_utils/k8s/raw.py
+++ b/lib/ansible/module_utils/k8s/raw.py
@@ -55,6 +55,8 @@ class KubernetesRawModule(KubernetesAnsibleModule):
                     self.resource_definitions = yaml.safe_load_all(resource_definition)
                 except (IOError, yaml.YAMLError) as exc:
                     self.fail(msg="Error loading resource_definition: {0}".format(exc))
+            elif isinstance(resource_definition, list):
+                self.resource_definitions = resource_definition
             else:
                 self.resource_definitions = [resource_definition]
         src = self.params.pop('src')

--- a/lib/ansible/module_utils/k8s/raw.py
+++ b/lib/ansible/module_utils/k8s/raw.py
@@ -19,6 +19,7 @@
 from __future__ import absolute_import, division, print_function
 
 
+from ansible.module_utils.six import string_types
 from ansible.module_utils.k8s.common import KubernetesAnsibleModule
 
 
@@ -50,7 +51,7 @@ class KubernetesRawModule(KubernetesAnsibleModule):
         namespace = self.params.pop('namespace')
         resource_definition = self.params.pop('resource_definition')
         if resource_definition:
-            if isinstance(resource_definition, str):
+            if isinstance(resource_definition, string_types):
                 try:
                     self.resource_definitions = yaml.safe_load_all(resource_definition)
                 except (IOError, yaml.YAMLError) as exc:

--- a/lib/ansible/module_utils/k8s/raw.py
+++ b/lib/ansible/module_utils/k8s/raw.py
@@ -103,8 +103,8 @@ class KubernetesRawModule(KubernetesAnsibleModule):
 
     def perform_action(self, resource, definition):
         result = {'changed': False, 'result': {}}
-        state = self.params.pop('state', None)
-        force = self.params.pop('force', False)
+        state = self.params.get('state', None)
+        force = self.params.get('force', False)
         name = definition.get('metadata', {}).get('name')
         namespace = definition.get('metadata', {}).get('namespace')
         existing = None

--- a/lib/ansible/utils/module_docs_fragments/k8s_resource_options.py
+++ b/lib/ansible/utils/module_docs_fragments/k8s_resource_options.py
@@ -25,7 +25,7 @@ class ModuleDocFragment(object):
 options:
   resource_definition:
     description:
-    - "Provide a valid YAML definition (either as a string or a dict) for an object when creating or updating. NOTE: I(kind), I(api_version), I(name),
+    - "Provide a valid YAML definition (either as a string, list, or dict) for an object when creating or updating. NOTE: I(kind), I(api_version), I(name),
       and I(namespace) will be overwritten by corresponding values found in the provided I(resource_definition)."
     aliases:
     - definition

--- a/test/integration/targets/k8s/tasks/main.yml
+++ b/test/integration/targets/k8s/tasks/main.yml
@@ -2,12 +2,18 @@
   pip:
     name: openshift
 
+# TODO: This is the only way I could get the kubeconfig, I don't know why. Running the lookup outside of debug seems to return an empty string
+- debug: msg={{ lookup('env', 'K8S_AUTH_KUBECONFIG') }}
+  register: kubeconfig
+
 # Kubernetes resources
 - name: Create a namespace
   k8s:
     name: testing
     kind: namespace
   register: output
+
+- debug: msg={{ lookup("k8s", kind="Namespace", api_version="v1", resource_name='testing', kubeconfig=kubeconfig.msg) }}
 
 - name: show output
   debug:
@@ -188,3 +194,103 @@
 - name: DC creation should be idempotent
   assert:
     that: not output.changed
+
+### Type tests
+- name: Create a namespace from a string
+  k8s:
+    definition: |+
+      ---
+      kind: Namespace
+      apiVersion: v1
+      metadata:
+        name: testing1
+
+- name: Namespace should exist
+  assert:
+    that: '{{ lookup("k8s", kind="Namespace", api_version="v1", resource_name="testing1", kubeconfig=kubeconfig.msg).status.phase == "Active" }}'
+
+- name: Create resources from a multidocument yaml string
+  k8s:
+    definition: |+
+      ---
+      kind: Namespace
+      apiVersion: v1
+      metadata:
+        name: testing2
+      ---
+      kind: Namespace
+      apiVersion: v1
+      metadata:
+        name: testing3
+
+- name: Resources should exist
+  assert:
+    that: lookup("k8s", kind="Namespace", api_version="v1", resource_name=item, kubeconfig=kubeconfig.msg).status.phase == "Active"
+  loop:
+    - testing2
+    - testing3
+
+- name: Delete resources from a multidocument yaml string
+  k8s:
+    state: absent
+    definition: |+
+      ---
+      kind: Namespace
+      apiVersion: v1
+      metadata:
+        name: testing2
+      ---
+      kind: Namespace
+      apiVersion: v1
+      metadata:
+        name: testing3
+
+- name: Resources should not exist
+  assert:
+    that: not ns or ns.status.phase == "Terminating"
+  loop:
+    - testing2
+    - testing3
+  vars:
+    ns: '{{ lookup("k8s", kind="Namespace", api_version="v1", resource_name=item, kubeconfig=kubeconfig.msg) }}'
+
+- name: Create resources from a list
+  k8s:
+    definition:
+      - kind: Namespace
+        apiVersion: v1
+        metadata:
+          name: testing4
+      - kind: Namespace
+        apiVersion: v1
+        metadata:
+          name: testing5
+
+- name: Resources should exist
+  assert:
+    that: lookup("k8s", kind="Namespace", api_version="v1", resource_name=item, kubeconfig=kubeconfig.msg).status.phase == "Active"
+  loop:
+    - testing4
+    - testing5
+
+- name: Delete resources from a list
+  k8s:
+    state: absent
+    definition:
+      - kind: Namespace
+        apiVersion: v1
+        metadata:
+          name: testing4
+      - kind: Namespace
+        apiVersion: v1
+        metadata:
+          name: testing5
+
+- name: Resources should not exist
+  assert:
+    that: not ns or ns.status.phase == "Terminating"
+  loop:
+    - testing4
+    - testing5
+  vars:
+    ns: '{{ lookup("k8s", kind="Namespace", api_version="v1", resource_name=item, kubeconfig=kubeconfig.msg) }}'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Accepts a list of objects passed to resource_definition, will process each resource in the list independently. This is already basically supported because we accept strings which can contain lists of objects, if the string parses to a list we will handle it properly, but if the value is just a list we will error out. It seems strange to support more functionality if you first dump your value to a string, so I think we should unify the behavior. This would also get us one step closer to supporting `*List` types.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request




##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
k8s

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->
Backport to 2.6 would be nice

Related to https://github.com/openshift/openshift-restclient-python/issues/175
