### PR TITLE
docker_container: fix check mode for container creation

### DIFF
--- a/lib/ansible/module_utils/docker_common.py
+++ b/lib/ansible/module_utils/docker_common.py
@@ -132,7 +132,7 @@ def sanitize_result(data):
     to a list.
     """
     if isinstance(data, dict):
-        return {k: sanitize_result(v) for k, v in data.items()}
+        return dict((k, sanitize_result(v)) for k, v in data.items())
     elif isinstance(data, (list, tuple)):
         return [sanitize_result(v) for v in data]
     else:

--- a/lib/ansible/module_utils/docker_common.py
+++ b/lib/ansible/module_utils/docker_common.py
@@ -121,6 +121,24 @@ if not HAS_DOCKER_PY:
         pass
 
 
+def sanitize_result(data):
+    """Sanitize data object for return to Ansible.
+
+    When the data object contains types such as docker.types.containers.HostConfig,
+    Ansible will fail when these are returned via exit_json or fail_json.
+    HostConfig is derived from dict, but its constructor requires additional
+    arguments. This function sanitizes data structures by recursively converting
+    everything derived from dict to dict and everything derived from list (and tuple)
+    to a list.
+    """
+    if isinstance(data, dict):
+        return {k: sanitize_result(v) for k, v in data.items()}
+    elif isinstance(data, (list, tuple)):
+        return [sanitize_result(v) for v in data]
+    else:
+        return data
+
+
 class DockerBaseClass(object):
 
     def __init__(self):

--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -1894,7 +1894,12 @@ class ContainerManager(DockerBaseClass):
         self.log("create container")
         self.log("image: %s parameters:" % image)
         self.log(create_parameters, pretty_print=True)
-        self.results['actions'].append(dict(created="Created container", create_parameters=create_parameters))
+        # Parameters contains host_config of type docker.types.containers.HostConfig,
+        # derived from dict, which ansible cannot convert to JSON correctly.
+        # Therefore, we make sure we copy it to turn it into a regular dict.
+        debug_parameters = dict(create_parameters)
+        debug_parameters['host_config'] = dict(debug_parameters['host_config'])
+        self.results['actions'].append(dict(created="Created container", create_parameters=debug_parameters))
         self.results['changed'] = True
         new_container = None
         if not self.check_mode:


### PR DESCRIPTION
##### SUMMARY
Currently, `docker_container` will die when creating a container in check mode or debug mode (see #33578). The problem is that a `docker.types.containers.HostConfig` object is added to results (as part of `self.parameters.create_parameters`), which Ansible's JSON sanitizing code cannot handle.

Fixes #33578.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
docker_container

##### ANSIBLE VERSION
```
2.6.0
2.5.x
2.4.x
```
(I've used both 2.6 and the `devel` branch to reproduce this, but the bug has already been reported for 2.4.2; see #33578)
