### PR TITLE
Fix starttls for notification mail module

### DIFF
--- a/lib/ansible/modules/notification/mail.py
+++ b/lib/ansible/modules/notification/mail.py
@@ -263,6 +263,11 @@ def main():
     except smtplib.SMTPException as e:
         module.fail_json(rc=1, msg='Unable to Connect %s:%s: %s' % (host, port, to_native(e)), exception=traceback.format_exc())
 
+    try:
+        smtp.ehlo()
+    except smtplib.SMTPException as e:
+        module.fail_json(rc=1, msg='Helo failed for host %s:%s: %s' % (host, port, to_native(e)), exception=traceback.format_exc())
+
     if int(code) > 0:
         if not secure_state and secure in ('starttls', 'try'):
             if smtp.has_extn('STARTTLS'):


### PR DESCRIPTION
Fixes #42338

##### SUMMARY
function smtp.has_extn can return true only after smtp.ehlo() are done. Without what smtp.has_extn('STARTTLS') always return false and startls connection didn't start.

##### ISSUE TYPE
 - Bugfix Pull Request


##### COMPONENT NAME
mail

##### ANSIBLE VERSION
```
ansible 2.6.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = ./ansible
  python version = 2.7.5 (default, Apr 11 2018, 07:36:10) [GCC 4.8.5 20150623 (Red Hat 4.8.5-28)]
```
