### PR TITLE
Meraki - Removed any temporary get_net() methods

### DIFF
--- a/lib/ansible/modules/network/meraki/meraki_admin.py
+++ b/lib/ansible/modules/network/meraki/meraki_admin.py
@@ -249,13 +249,6 @@ def network_factory(meraki, networks, nets):
     return networks_new
 
 
-def get_nets_temp(meraki, org_id):  # Function won't be needed when get_nets is added to util
-    path = meraki.construct_path('get_all', function='network', org_id=org_id)
-    response = meraki.request(path, method='GET')
-    if meraki.status == 200:
-        return response
-
-
 def create_admin(meraki, org_id, name, email):
     payload = dict()
     payload['name'] = name
@@ -268,7 +261,7 @@ def create_admin(meraki, org_id, name, email):
     if meraki.params['tags'] is not None:
         payload['tags'] = json.loads(meraki.params['tags'])
     if meraki.params['networks'] is not None:
-        nets = get_nets_temp(meraki, org_id)
+        nets = meraki.get_nets(org_id=org_id)
         networks = network_factory(meraki, meraki.params['networks'], nets)
         # meraki.fail_json(msg=str(type(networks)), data=networks)
         payload['networks'] = networks

--- a/lib/ansible/modules/network/meraki/meraki_device.py
+++ b/lib/ansible/modules/network/meraki/meraki_device.py
@@ -219,13 +219,6 @@ def get_org_devices(meraki, org_id):
     return response
 
 
-def temp_get_nets(meraki, org_name, net_name):
-    org_id = meraki.get_org_id(org_name)
-    path = meraki.construct_path('get_all', function='network', org_id=org_id)
-    r = meraki.request(path, method='GET')
-    return r
-
-
 def main():
 
     # define the available arguments/parameters that a user can pass to
@@ -300,14 +293,14 @@ def main():
 
     # manipulate or modify the state as needed (this is going to be the
     # part where your module will do what it needs to do)
-
     org_id = meraki.params['org_id']
     if org_id is None:
         org_id = meraki.get_org_id(meraki.params['org_name'])
-    net_id = meraki.params['net_id']
-    if net_id is None:
-        if meraki.params['net_name']:
-            nets = temp_get_nets(meraki, meraki.params['org_name'], meraki.params['net_name'])
+    nets = meraki.get_nets(org_id=org_id)
+    net_id = None
+    if meraki.params['net_id'] or meraki.params['net_name']:
+        net_id = meraki.params['net_id']
+        if net_id is None:
             net_id = meraki.get_net_id(net_name=meraki.params['net_name'], data=nets)
 
     if meraki.params['state'] == 'query':


### PR DESCRIPTION
##### SUMMARY
I wrote some temporary get_net() methods while the proper one was being added to the module utility. It is now there so it's removing the old ones.
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
meraki

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (meraki/ditch_temps 9ff02e5c09) last updated 2018/07/05 20:39:57 (GMT -500)
  config file = None
  configured module search path = ['/Users/kbreit/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/kbreit/Documents/Programming/ansible/lib/ansible
  executable location = /Users/kbreit/Documents/Programming/ansible/bin/ansible
  python version = 3.5.4 (default, Feb 25 2018, 14:56:02) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]

```
