### PR TITLE
Update docker pipy version to 2.3

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -96,7 +96,7 @@ options:
     description:
       - Path to a file containing environment variables I(FOO=BAR).
       - If variable also present in C(env), then C(env) value will override.
-      - Requires docker >= 1.4.0.
+      - Requires docker >= 2.3.0.
   entrypoint:
     description:
       - Command that overwrites the default ENTRYPOINT of the image.
@@ -421,7 +421,7 @@ author:
 
 requirements:
     - "python >= 2.6"
-    - "docker >= 1.7.0"
+    - "docker >= 2.3.0"
     - "Docker API >= 1.20"
 '''
 


### PR DESCRIPTION
##### SUMMARY
Per the discussion in #42370, updating the docker pipy version at which the `init` API dependency was introduced.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
docker-container

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/ry/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.15 (default, May 16 2018, 17:50:09) [GCC 8.1.1 20180502 (Red Hat 8.1.1-1)]
```