### PR TITLE
Adding Kubernetes authentication to hashi_vault lookup

### DIFF
--- a/lib/ansible/plugins/lookup/hashi_vault.py
+++ b/lib/ansible/plugins/lookup/hashi_vault.py
@@ -275,8 +275,8 @@ class HashiVault:
             mount_point = 'kubernetes'
 
         try:
-            with open('/var/run/secrets/kubernetes.io/serviceaccount/token') as file:
-                jwt = file.read()
+            with open('/var/run/secrets/kubernetes.io/serviceaccount/token') as k8s_token_file:
+                jwt = k8s_token_file.read()
         except IOError:
             raise AnsibleError("hashi_vault lookup failed to read JWT from file. Make sure you are running from a Kubernetes Pod")
 

--- a/lib/ansible/plugins/lookup/hashi_vault.py
+++ b/lib/ansible/plugins/lookup/hashi_vault.py
@@ -43,7 +43,7 @@ DOCUMENTATION = """
         - name: VAULT_SECRET_ID
     role:
       description: Role name for vault Kubernetes auth.
-      version_added: "2.8"
+      version_added: "2.9"
       env:
         - name: VAULT_ROLE
     auth_method:

--- a/lib/ansible/plugins/lookup/hashi_vault.py
+++ b/lib/ansible/plugins/lookup/hashi_vault.py
@@ -43,7 +43,7 @@ DOCUMENTATION = """
         - name: VAULT_SECRET_ID
     role:
       description: Role name for vault Kubernetes auth.
-      version_added: "2.8" 
+      version_added: "2.8"
       env:
         - name: VAULT_ROLE
     auth_method:

--- a/lib/ansible/plugins/lookup/hashi_vault.py
+++ b/lib/ansible/plugins/lookup/hashi_vault.py
@@ -296,7 +296,7 @@ class HashiVault:
             mount_point = 'kubernetes'
 
         try:
-            with open('/var/run/secrets/kubernetes.io/serviceaccount/token') as file
+            with open('/var/run/secrets/kubernetes.io/serviceaccount/token') as file:
                 jwt = file.read()
         except IOError:
             raise AnsibleError("hashi_vault lookup failed to read JWT from file. Make sure you are running from a Kubernetes Pod")

--- a/lib/ansible/plugins/lookup/hashi_vault.py
+++ b/lib/ansible/plugins/lookup/hashi_vault.py
@@ -172,7 +172,7 @@ class HashiVault:
                     self.client = hvac.Client(url=self.url, verify=self.verify)
                 # prefixing with auth_ to limit which methods can be accessed
                 getattr(self, 'auth_' + self.auth_method)(**kwargs)
-            except AttributeError as e:
+            except AttributeError:
                 raise AnsibleError("Authentication method '%s' not supported."
                                    " Available options are %r" % (self.auth_method, self.avail_auth_method))
         else:

--- a/lib/ansible/plugins/lookup/hashi_vault.py
+++ b/lib/ansible/plugins/lookup/hashi_vault.py
@@ -43,6 +43,7 @@ DOCUMENTATION = """
         - name: VAULT_SECRET_ID
     role:
       description: Role name for vault Kubernetes auth.
+      version_added: "2.8" 
       env:
         - name: VAULT_ROLE
     auth_method:

--- a/lib/ansible/plugins/lookup/hashi_vault.py
+++ b/lib/ansible/plugins/lookup/hashi_vault.py
@@ -42,7 +42,7 @@ DOCUMENTATION = """
       env:
         - name: VAULT_SECRET_ID
     role:
-      description: Role name for vault Kubernetes auth
+      description: Role name for vault Kubernetes auth.
       env:
         - name: VAULT_ROLE
     auth_method:


### PR DESCRIPTION
##### SUMMARY
Adding Kubernetes authentication to hashi_vault lookup
    
When running in a Kubernetes pod hashi_vault lookup can now authenticate
to HashiCorp Vault using Kubernetes authentication. The JWT is automatically
pulled from k8s pod, so credentials do not need to be supplied to
Ansible for Vault authentication.
    
https://www.vaultproject.io/docs/auth/kubernetes.html
    
The approle auth_method also gains the ability to specify the Vault
mount point using the mount_point configuration option.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
hashi_vault lookup

##### ANSIBLE VERSION
```
ansible 2.8.0.dev0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/sean/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/sean/projects/ansible/lib/ansible
  executable location = /home/sean/projects/ansible/bin/ansible
  python version = 2.7.15 (default, Oct 15 2018, 15:26:09) [GCC 8.2.1 20180801 (Red Hat 8.2.1-2)]
```


##### ADDITIONAL INFORMATION
N/A