### PR TITLE
Fix typo in cliconf plugin

### DIFF
--- a/lib/ansible/plugins/cliconf/__init__.py
+++ b/lib/ansible/plugins/cliconf/__init__.py
@@ -262,9 +262,9 @@ class CliconfBase(AnsiblePlugin):
                     'supports_onbox_diff: <bool>,          # identify if on box diff capability is supported or not
                     'supports_generate_diff: <bool>,       # identify if diff capability is supported within plugin
                     'supports_multiline_delimiter: <bool>, # identify if multiline demiliter is supported within config
-                    'support_diff_match: <bool>,           # identify if match is supported
-                    'support_diff_ignore_lines: <bool>,    # identify if ignore line in diff is supported
-                    'support_config_replace': <bool>,      # identify if running config replace with candidate config is supported
+                    'supports_diff_match: <bool>,           # identify if match is supported
+                    'supports_diff_ignore_lines: <bool>,    # identify if ignore line in diff is supported
+                    'supports_config_replace': <bool>,      # identify if running config replace with candidate config is supported
                 }
                 'format': [list of supported configuration format],
                 'diff_match': [list of supported match values],

--- a/lib/ansible/plugins/cliconf/eos.py
+++ b/lib/ansible/plugins/cliconf/eos.py
@@ -298,8 +298,8 @@ class Cliconf(CliconfBase):
             'supports_onbox_diff': True if self.supports_sessions else False,
             'supports_commit_comment': False,
             'supports_multiline_delimiter': False,
-            'support_diff_match': True,
-            'support_diff_ignore_lines': True,
+            'supports_diff_match': True,
+            'supports_diff_ignore_lines': True,
             'supports_generate_diff': True,
             'supports_replace': True if self.supports_sessions else False
         }

--- a/lib/ansible/plugins/cliconf/ios.py
+++ b/lib/ansible/plugins/cliconf/ios.py
@@ -203,8 +203,8 @@ class Cliconf(CliconfBase):
             'supports_onbox_diff': False,
             'supports_commit_comment': False,
             'supports_multiline_delimiter': False,
-            'support_diff_match': True,
-            'support_diff_ignore_lines': True,
+            'supports_diff_match': True,
+            'supports_diff_ignore_lines': True,
             'supports_generate_diff': True,
             'supports_replace': False
         }

--- a/lib/ansible/plugins/cliconf/vyos.py
+++ b/lib/ansible/plugins/cliconf/vyos.py
@@ -233,8 +233,8 @@ class Cliconf(CliconfBase):
             'supports_onbox_diff': True,
             'supports_commit_comment': True,
             'supports_multiline_delimiter': False,
-            'support_diff_match': True,
-            'support_diff_ignore_lines': False,
+            'supports_diff_match': True,
+            'supports_diff_ignore_lines': False,
             'supports_generate_diff': True,
             'supports_replace': False
         }


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
* Fix capability key typo error in ios, eos and
  vyos cliconf plugins.
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
plugins/cliconf/eos.py
plugins/cliconf/vyos.py
plugins/cliconf/ios.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
