### PR TITLE
Added license_type, vm_identety and win_rm attributes to azure_rm_virtualmachine module

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
@@ -321,7 +321,6 @@ options:
         choices:
             - Windows_Server
             - Windows_Client
-            - None
     vm_identity:
         description:
             - Identity for the virtual machine.
@@ -796,7 +795,7 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
             plan=dict(type='dict'),
             zones=dict(type='list'),
             accept_terms=dict(type='bool', default=False),
-            license_type=dict(type='str', choices=['Windows_Server', 'Windows_Client', 'None']),
+            license_type=dict(type='str', choices=['Windows_Server', 'Windows_Client']),
             vm_identity=dict(type='str', choices=['SystemAssigned']),
             winrm=dict(type='list')
         )

--- a/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
@@ -328,7 +328,7 @@ options:
         version_added: 2.8
         choices:
             - SystemAssigned
-    win_rm:
+    winrm:
         description:
             - List of Windows Remote Management configurations of the VM.
         version_added: 2.8
@@ -798,7 +798,7 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
             accept_terms=dict(type='bool', default=False),
             license_type=dict(type='str', choices=['Windows_Server', 'Windows_Client', 'None']),
             vm_identity=dict(type='str', choices=['SystemAssigned']),
-            win_rm=dict(type='list')
+            winrm=dict(type='list')
         )
 
         self.resource_group = None
@@ -1172,39 +1172,39 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
                     if self.vm_identity:
                         vm_resource.identity = self.compute_models.VirtualMachineIdentity(type=self.vm_identity)
 
-                    if self.win_rm:
-                        win_rm_listeners = list()
-                        for win_rm_listener in self.win_rm:
-                            win_rm_listeners.append(self.compute_models.WinRMListener(
-                                protocol=win_rm_listener.get('protocol'),
-                                certificate_url=win_rm_listener.get('certificate_url')
+                    if self.winrm:
+                        winrm_listeners = list()
+                        for winrm_listener in self.winrm:
+                            winrm_listeners.append(self.compute_models.WinRMListener(
+                                protocol=winrm_listener.get('protocol'),
+                                certificate_url=winrm_listener.get('certificate_url')
                             ))
-                            if win_rm_listener.get('source_vault'):
+                            if winrm_listener.get('source_vault'):
                                 if not vm_resource.os_profile.secrets:
                                     vm_resource.os_profile.secrets = list()
 
                                 vm_resource.os_profile.secrets.append(self.compute_models.VaultSecretGroup(
                                     source_vault=self.compute_models.SubResource(
-                                        id=win_rm_listener.get('source_vault')
+                                        id=winrm_listener.get('source_vault')
                                     ),
                                     vault_certificates=[
                                         self.compute_models.VaultCertificate(
-                                            certificate_url=win_rm_listener.get('certificate_url'),
-                                            certificate_store=win_rm_listener.get('certificate_store')
+                                            certificate_url=winrm_listener.get('certificate_url'),
+                                            certificate_store=winrm_listener.get('certificate_store')
                                         ),
                                     ]
                                 ))
 
-                        win_rm = self.compute_models.WinRMConfiguration(
-                            listeners=win_rm_listeners
+                        winrm = self.compute_models.WinRMConfiguration(
+                            listeners=winrm_listeners
                         )
 
                         if not vm_resource.os_profile.windows_configuration:
                             vm_resource.os_profile.windows_configuration = self.compute_models.WindowsConfiguration(
-                                win_rm=win_rm
+                                win_rm=winrm
                             )
                         elif not vm_resource.os_profile.windows_configuration.win_rm:
-                            vm_resource.os_profile.windows_configuration.win_rm = win_rm
+                            vm_resource.os_profile.windows_configuration.win_rm = winrm
 
                     if self.admin_password:
                         vm_resource.os_profile.admin_password = self.admin_password

--- a/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
@@ -1040,7 +1040,7 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
                     differences.append('Zones')
                     changed = True
 
-                if vm_dict['properties'].get('licenseType') != self.license_type:
+                if self.license_type is not None and vm_dict['properties'].get('licenseType') != self.license_type:
                     differences.append('License Type')
                     changed = True
                 self.differences = differences

--- a/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
@@ -796,8 +796,8 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
             plan=dict(type='dict'),
             zones=dict(type='list'),
             accept_terms=dict(type='bool', default=False),
-            license_type=dict(type='str'),
-            vm_identity=dict(type='str'),
+            license_type=dict(type='str', choices=['Windows_Server', 'Windows_Client', 'None']),
+            vm_identity=dict(type='str', choices=['SystemAssigned']),
             win_rm=dict(type='list')
         )
 
@@ -1196,12 +1196,12 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
                                 ))
 
                         win_rm = self.compute_models.WinRMConfiguration(
-                            listeners = win_rm_listeners
+                            listeners=win_rm_listeners
                         )
 
                         if not vm_resource.os_profile.windows_configuration:
                             vm_resource.os_profile.windows_configuration = self.compute_models.WindowsConfiguration(
-                                win_rm = win_rm
+                                win_rm=win_rm
                             )
                         elif not vm_resource.os_profile.windows_configuration.win_rm:
                             vm_resource.os_profile.windows_configuration.win_rm = win_rm

--- a/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
@@ -1305,6 +1305,7 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
                         network_profile=self.compute_models.NetworkProfile(
                             network_interfaces=nics
                         ),
+                        license_type=license_type
                     )
 
                     if vm_dict.get('tags'):

--- a/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
@@ -1176,21 +1176,21 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
                         win_rm_listeners = list()
                         for win_rm_listener in self.win_rm:
                             win_rm_listeners.append(self.compute_models.WinRMListener(
-                                protocol = win_rm_listener.get('protocol'),
-                                certificate_url = win_rm_listener.get('certificate_url')
+                                protocol=win_rm_listener.get('protocol'),
+                                certificate_url=win_rm_listener.get('certificate_url')
                             ))
                             if win_rm_listener.get('source_vault'):
                                 if not vm_resource.os_profile.secrets:
                                     vm_resource.os_profile.secrets = list()
 
                                 vm_resource.os_profile.secrets.append(self.compute_models.VaultSecretGroup(
-                                    source_vault = self.compute_models.SubResource(
+                                    source_vault=self.compute_models.SubResource(
                                         id=win_rm_listener.get('source_vault')
                                     ),
-                                    vault_certificates = [
+                                    vault_certificates=[
                                         self.compute_models.VaultCertificate(
-                                            certificate_url = win_rm_listener.get('certificate_url'),
-                                            certificate_store = win_rm_listener.get('certificate_store')
+                                            certificate_url=win_rm_listener.get('certificate_url'),
+                                            certificate_store=win_rm_listener.get('certificate_store')
                                         ),
                                     ]
                                 ))

--- a/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
@@ -312,6 +312,11 @@ options:
             - A list of Availability Zones for your virtual machine
         type: list
         version_added: "2.8"
+    license_type:
+        description:
+            - Specifies that the image or disk that is being used was licensed on-premises. This element is only
+              used for images that contain the Windows Server operating system.
+        version_added: 2.7
 
 extends_documentation_fragment:
     - azure
@@ -320,6 +325,8 @@ extends_documentation_fragment:
 author:
     - "Chris Houseknecht (@chouseknecht)"
     - "Matt Davis (@nitzmahone)"
+    - "Christopher Perrin (@cperrin88)"
+
 '''
 EXAMPLES = '''
 
@@ -754,8 +761,9 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
             generalized=dict(type='bool', default=False),
             data_disks=dict(type='list'),
             plan=dict(type='dict'),
+            zones=dict(type='list'),
             accept_terms=dict(type='bool', default=False),
-            zones=dict(type='list')
+            license_type=dict(type='str')
         )
 
         self.resource_group = None
@@ -797,6 +805,7 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
         self.plan = None
         self.accept_terms = None
         self.zones = None
+        self.license_type = None
 
         self.results = dict(
             changed=False,
@@ -1115,6 +1124,9 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
                         plan=plan,
                         zones=self.zones,
                     )
+
+                    if self.license_type:
+                        vm_resource['license_type'] = license_type
 
                     if self.admin_password:
                         vm_resource.os_profile.admin_password = self.admin_password

--- a/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
@@ -317,7 +317,7 @@ options:
             - Specifies that the image or disk that is being used was licensed on-premises. This element is only
               used for images that contain the Windows Server operating system.
             - "Note: To unset this value, it has to be set to the string 'None'."
-        version_added: 2.7
+        version_added: 2.8
         choices:
             - Windows_Server
             - Windows_Client
@@ -325,13 +325,13 @@ options:
     vm_identity:
         description:
             - Identity for the virtual machine.
-        version_added: 2.7
+        version_added: 2.8
         choices:
             - SystemAssigned
     win_rm:
         description:
             - List of Windows Remote Management configurations of the VM.
-        version_added: 2.7
+        version_added: 2.8
         suboptions:
             protocol:
                 description:

--- a/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
@@ -316,19 +316,18 @@ options:
         description:
             - Specifies that the image or disk that is being used was licensed on-premises. This element is only
               used for images that contain the Windows Server operating system.
-            - Note: To unset this value, it has to be set to the string "None"
+            - "Note: To unset this value, it has to be set to the string 'None'."
         version_added: 2.7
         choices:
             - Windows_Server
             - Windows_Client
             - None
-
     vm_identity:
         description:
             - Identity for the virtual machine.
         version_added: 2.7
-            Choices:
-                - SystemAssigned
+        choices:
+            - SystemAssigned
     win_rm:
         description:
             - List of Windows Remote Management configurations of the VM.
@@ -337,6 +336,7 @@ options:
             protocol:
                 description:
                     - Specifies the protocol of listener
+                required: true
                 choices:
                     - http
                     - https
@@ -350,8 +350,6 @@ options:
                 description:
                     - Specifies the certificate store on the Virtual Machine to which the certificate
                       should be added. The specified certificate store is implicitly in the LocalMachine account.
-
-
 
 extends_documentation_fragment:
     - azure

--- a/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
@@ -1096,6 +1096,10 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
                                                         publisher=self.plan.get('publisher'),
                                                         promotion_code=self.plan.get('promotion_code'))
 
+                    license_type = None
+                    if self.license_type is None:
+                        license_type = "None"
+
                     vm_resource = self.compute_models.VirtualMachine(
                         location=self.location,
                         tags=self.tags,
@@ -1275,6 +1279,9 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
                         )
                     else:
                         os_profile = None
+                    license_type = None
+                    if self.license_type is None:
+                        license_type = "None"
 
                     vm_resource = self.compute_models.VirtualMachine(
                         location=vm_dict['location'],

--- a/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
@@ -1096,7 +1096,7 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
                                                         publisher=self.plan.get('publisher'),
                                                         promotion_code=self.plan.get('promotion_code'))
 
-                    license_type = None
+                    license_type = self.license_type
                     if self.license_type is None:
                         license_type = "None"
 


### PR DESCRIPTION
##### SUMMARY
I added the license_type attribute to azure_rm_virtualmachine module. This makes it possible to change to use the [hybrid benefit licensing for windows server](https://docs.microsoft.com/de-de/azure/virtual-machines/windows/hybrid-use-benefit-licensing). I also added the vm_identity and win_rm modules. Especially the WinRM module is very useful to prepare a Windows VM for a connection from Ansible.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
azure_rm_virtualmachine

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/cperrin/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION
The docuementation for the attribute can be found here: https://docs.microsoft.com/de-de/python/api/azure.mgmt.compute.v2017_12_01.models.virtualmachine?view=azure-python