### PR TITLE
Fix for starttls connections for notification mail module (#42381)

### DIFF
--- a/lib/ansible/modules/notification/mail.py
+++ b/lib/ansible/modules/notification/mail.py
@@ -263,6 +263,11 @@ def main():
     except smtplib.SMTPException as e:
         module.fail_json(rc=1, msg='Unable to Connect %s:%s: %s' % (host, port, to_native(e)), exception=traceback.format_exc())
 
+    try:
+        smtp.ehlo()
+    except smtplib.SMTPException as e:
+            module.fail_json(rc=1, msg='Helo failed for host %s:%s: %s' % (host, port, to_native(e)), exception=traceback.format_exc())
+
     if int(code) > 0:
         if not secure_state and secure in ('starttls', 'try'):
             if smtp.has_extn('STARTTLS'):
@@ -272,13 +277,13 @@ def main():
                 except smtplib.SMTPException as e:
                     module.fail_json(rc=1, msg='Unable to start an encrypted session to %s:%s: %s' %
                                      (host, port, to_native(e)), exception=traceback.format_exc())
+                try:
+                    smtp.ehlo()
+                except smtplib.SMTPException as e:
+                    module.fail_json(rc=1, msg='Helo failed for host %s:%s: %s' % (host, port, to_native(e)), exception=traceback.format_exc())
             else:
                 if secure == 'starttls':
                     module.fail_json(rc=1, msg='StartTLS is not offered on server %s:%s' % (host, port))
-        try:
-            smtp.ehlo()
-        except smtplib.SMTPException as e:
-            module.fail_json(rc=1, msg='Helo failed for host %s:%s: %s' % (host, port, to_native(e)), exception=traceback.format_exc())
 
     if username and password:
         if smtp.has_extn('AUTH'):


### PR DESCRIPTION
Fixes #42338
Fixed starttls connection usage by adding smtp.ehlo before smtp.has_extn function.

remove Trailing whitespace
marged bcoca requested changes
move ehlo for starttls section only.


(cherry picked from commit 5df01abd58a98b39f7f21432a6e56fea5e0e7c51)

##### SUMMARY
function smtp.has_extn can return true only after smtp.ehlo() are done. Without what smtp.has_extn('STARTTLS') always return false and startls connection didn't start.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
mail

##### ANSIBLE VERSION
```
2.6
```