### PR TITLE
Setup module: use C() formatting function in parameter descriptions, add a task based example

### DIFF
--- a/lib/ansible/modules/system/setup.py
+++ b/lib/ansible/modules/system/setup.py
@@ -23,14 +23,14 @@ options:
         version_added: "2.1"
         description:
             - "if supplied, restrict the additional facts collected to the given subset.
-              Possible values: all, min, hardware, network, virtual, ohai, and
-              facter Can specify a list of values to specify a larger subset.
+              Possible values: C(all), C(min), C(hardware), C(network), C(virtual), C(ohai), and
+              C(facter). Can specify a list of values to specify a larger subset.
               Values can also be used with an initial C(!) to specify that
               that specific subset should not be collected.  For instance:
-              !hardware, !network, !virtual, !ohai, !facter. If !all is specified
+              C(!hardware,!network,!virtual,!ohai,!facter). If C(!all) is specified
               then only the min subset is collected. To avoid collecting even the
-              min subset, specify !all and !min subsets. To collect only specific facts,
-              use !all, !min, and specify the particular fact subsets.
+              min subset, specify C(!all,!min). To collect only specific facts,
+              use C(!all,!min), and specify the particular fact subsets.
               Use the filter parameter if you do not want to display some collected
               facts."
         required: false
@@ -50,8 +50,8 @@ options:
     fact_path:
         version_added: "1.3"
         description:
-            - path used for local ansible facts (*.fact) - files in this dir
-              will be run (if executable) and their results be added to ansible_local facts
+            - path used for local ansible facts (C(*.fact)) - files in this dir
+              will be run (if executable) and their results be added to C(ansible_local) facts
               if a file is not executable it is read. Check notes for Windows options. (from 2.1 on)
               File/results format can be json or ini-format
         required: false

--- a/lib/ansible/modules/system/setup.py
+++ b/lib/ansible/modules/system/setup.py
@@ -99,6 +99,13 @@ EXAMPLES = """
 # Collect only facts returned by facter.
 # ansible all -m setup -a 'gather_subset=!all,!any,facter'
 
+- name: Collect only facts returned by facter
+  setup:
+    gather_subset:
+      - '!all'
+      - '!any'
+      - facter
+
 # Display only facts about certain interfaces.
 # ansible all -m setup -a 'filter=ansible_eth[0-2]'
 


### PR DESCRIPTION
##### SUMMARY
- Use `C()` formatting function in parameter descriptions
  It improves the readability, besides spaces aren't allowed between `gather_subset` values, the following command fails: `ansible all -m setup -a 'gather_subset=!all, !min'`.
- add an example using a task instead of `ansible` command

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
setup

##### ANSIBLE VERSION
```
ansible 2.7.0.dev0 (devel 5635848654) last updated 2018/07/06 10:32:40 (GMT +200)
```