### PR TITLE
FAQ: fix a typo, add link to 'vars' lookup

### DIFF
--- a/docs/docsite/rst/reference_appendices/faq.rst
+++ b/docs/docsite/rst/reference_appendices/faq.rst
@@ -533,7 +533,7 @@ The above DOES NOT WORK as you expect, if you need to use a dynamic variable use
 
     {{ hostvars[inventory_hostname]['somevar_' + other_var] }}
 
-For 'non host vars' you can use the vars lookup plugin:
+For 'non host vars' you can use the :ref:`vars lookup<vars_lookup>` plugin:
 
 .. code-block:: jinja
 

--- a/docs/docsite/rst/reference_appendices/faq.rst
+++ b/docs/docsite/rst/reference_appendices/faq.rst
@@ -344,7 +344,7 @@ Also see dynamic_variables_.
 How do I access a group variable?
 +++++++++++++++++++++++++++++++++
 
-Techinically, you don't, Ansible does not really use groups directly. Groups are label for host selection and a way to bulk assign variables, they are not a first class entity, Ansible only cares about Hosts and Tasks.
+Technically, you don't, Ansible does not really use groups directly. Groups are label for host selection and a way to bulk assign variables, they are not a first class entity, Ansible only cares about Hosts and Tasks.
 
 That said, you could just access the variable by selecting a host that is part of that group, see first_host_in_a_group_ below for an example.
 


### PR DESCRIPTION
##### SUMMARY
- ~use `vars` instead `hostvars`: there is no need to use `hostvars` here~
- fix a typo
- add link to `vars` lookup

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
docs/docsite/rst/reference_appendices/faq.rst

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (devel 5635848654) last updated 2018/07/06 10:32:40 (GMT +200)
```