### PR TITLE
meraki_network - Add support for disableMyMerakiCom

### DIFF
--- a/lib/ansible/modules/network/meraki/meraki_network.py
+++ b/lib/ansible/modules/network/meraki/meraki_network.py
@@ -57,9 +57,9 @@ options:
         - Timezone associated to network.
         - See U(https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) for a list of valid timezones.
     disable_my_meraki:
-        description:
-        - Disables the local device status pages (U[my.meraki.com](my.meraki.com), U[ap.meraki.com](ap.meraki.com), U[switch.meraki.com](switch.meraki.com),
-        U[wired.meraki.com](wired.meraki.com))
+        description: >
+            - Disables the local device status pages (U[my.meraki.com](my.meraki.com), U[ap.meraki.com](ap.meraki.com), U[switch.meraki.com](switch.meraki.com),
+            U[wired.meraki.com](wired.meraki.com))
         type: bool
 
 author:
@@ -90,6 +90,7 @@ EXAMPLES = r'''
     type: switch
     timezone: America/Chicago
     tags: production, chicago
+  delegate_to: localhost
 '''
 
 RETURN = r'''

--- a/lib/ansible/modules/network/meraki/meraki_network.py
+++ b/lib/ansible/modules/network/meraki/meraki_network.py
@@ -58,9 +58,9 @@ options:
         - See U(https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) for a list of valid timezones.
     disable_my_meraki:
         description:
-        - Disables the local device status pages (U[my.meraki.com](my.meraki.com), U[ap.meraki.com](ap.meraki.com), U[switch.meraki.com](switch.meraki.com), U[wired.meraki.com](wired.meraki.com))
+        - Disables the local device status pages (U[my.meraki.com](my.meraki.com), U[ap.meraki.com](ap.meraki.com), U[switch.meraki.com](switch.meraki.com),
+        U[wired.meraki.com](wired.meraki.com))
         type: bool
-        default: yes
 
 author:
     - Kevin Breit (@kbreit)
@@ -189,8 +189,8 @@ def main():
     # Construct payload
     if meraki.params['state'] == 'present':
         payload = dict()
-        if meraki.params['type']:
-            payload['name'] = meraki.params['name']
+        if meraki.params['net_name']:
+            payload['name'] = meraki.params['net_name']
         if meraki.params['type']:
             payload['type'] = meraki.params['type']
             if meraki.params['type'] == 'combined':

--- a/lib/ansible/modules/network/meraki/meraki_network.py
+++ b/lib/ansible/modules/network/meraki/meraki_network.py
@@ -233,16 +233,6 @@ def main():
                     meraki.result['changed'] = True
             else:
                 net = meraki.get_net(meraki.params['org_name'], meraki.params['net_name'], data=nets)
-                proposed = payload
-                if meraki.params['timezone']:
-                    proposed['timeZone'] = meraki.params['timezone']
-                else:
-                    proposed['timeZone'] = 'America/Los_Angeles'
-                if not meraki.params['tags']:
-                    proposed['tags'] = None
-                if not proposed['type']:
-                    proposed['type'] = net['type']
-
                 if meraki.is_update_required(net, payload):
                     path = meraki.construct_path('update',
                                                  net_id=meraki.get_net_id(net_name=meraki.params['net_name'], data=nets)

--- a/lib/ansible/modules/network/meraki/meraki_network.py
+++ b/lib/ansible/modules/network/meraki/meraki_network.py
@@ -56,6 +56,11 @@ options:
         description:
         - Timezone associated to network.
         - See U(https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) for a list of valid timezones.
+    disable_my_meraki:
+        description:
+        - Disables the local device status pages (U[my.meraki.com](my.meraki.com), U[ap.meraki.com](ap.meraki.com), U[switch.meraki.com](switch.meraki.com), U[wired.meraki.com](wired.meraki.com))
+        type: bool
+        default: yes
 
 author:
     - Kevin Breit (@kbreit)
@@ -145,6 +150,7 @@ def main():
         timezone=dict(type='str'),
         net_name=dict(type='str', aliases=['name', 'network']),
         state=dict(type='str', choices=['present', 'query', 'absent'], default='present'),
+        disable_my_meraki=dict(type='bool'),
     )
 
     # the AnsibleModule object will be our abstraction working with Ansible
@@ -182,15 +188,19 @@ def main():
 
     # Construct payload
     if meraki.params['state'] == 'present':
-        payload = {'name': meraki.params['net_name'],
-                   'type': meraki.params['type'],
-                   }
+        payload = dict()
+        if meraki.params['type']:
+            payload['name'] = meraki.params['name']
+        if meraki.params['type']:
+            payload['type'] = meraki.params['type']
+            if meraki.params['type'] == 'combined':
+                payload['type'] = 'switch wireless appliance'
         if meraki.params['tags']:
             payload['tags'] = construct_tags(meraki.params['tags'])
         if meraki.params['timezone']:
             payload['timeZone'] = meraki.params['timezone']
-        if meraki.params['type'] == 'combined':
-            payload['type'] = 'switch wireless appliance'
+        if meraki.params['disable_my_meraki']:
+            payload['disableMyMerakiCom'] = meraki.params['disable_my_meraki']
 
     # manipulate or modify the state as needed (this is going to be the
     # part where your module will do what it needs to do)

--- a/lib/ansible/modules/network/meraki/meraki_network.py
+++ b/lib/ansible/modules/network/meraki/meraki_network.py
@@ -61,6 +61,7 @@ options:
             - Disables the local device status pages (U[my.meraki.com](my.meraki.com), U[ap.meraki.com](ap.meraki.com), U[switch.meraki.com](switch.meraki.com),
             U[wired.meraki.com](wired.meraki.com))
         type: bool
+        version_added: '2.7'
 
 author:
     - Kevin Breit (@kbreit)

--- a/test/integration/targets/meraki_network/tasks/main.yml
+++ b/test/integration/targets/meraki_network/tasks/main.yml
@@ -79,7 +79,7 @@
     delegate_to: localhost
     register: create_net_wireless_idempotent
 
-  - name: Create network with type combined
+  - name: Create network with type combined and disable my.meraki.com
     meraki_network:
       auth_key: '{{ auth_key }}'
       state: present
@@ -87,8 +87,19 @@
       net_name: IntTestNetworkCombined
       type: combined
       timezone: America/Chicago
+      disable_my_meraki: yes
     delegate_to: localhost
     register: create_net_combined
+
+  - name: Reenable my.meraki.com
+    meraki_network:
+      auth_key: '{{ auth_key }}'
+      state: present
+      org_name: '{{test_org_name}}'
+      net_name: IntTestNetworkCombined
+      disable_my_meraki: no
+    delegate_to: localhost
+    register: enable_meraki_com
     
   - name: Create network with one tag
     meraki_network:
@@ -148,6 +159,9 @@
     assert:
       that:
         - create_net_no_type.status == 500
+        - create_net_combined.data.type == 'combined'
+        - create_net_combined.data.disableMyMerakiCom == True
+        - enable_meraki_com.data.disableMyMerakiCom == False
         - '"org_name or org_id parameters are required" in create_net_no_org.msg'
         - '"IntTestNetworkAppliance" in create_net_appliance_no_tz.data.name'
         - create_net_appliance_no_tz.changed == True


### PR DESCRIPTION
##### SUMMARY
Meraki added a new parameter in their network API. This PR adds support for it targeted to the 2.7 release.

Fixes #42175 

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
meraki_network

##### ANSIBLE VERSION
```
ansible 2.7.0.dev0 (meraki/network_disableMyMerakiCom 8e7ae28919) last updated 2018/07/06 07:47:19 (GMT -500)
  config file = None
  configured module search path = ['/Users/kbreit/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/kbreit/Documents/Programming/ansible/lib/ansible
  executable location = /Users/kbreit/Documents/Programming/ansible/bin/ansible
  python version = 3.5.4 (default, Feb 25 2018, 14:56:02) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]

```