### PR TITLE
nxos_file_copy enhancement

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_file_copy.py
+++ b/lib/ansible/modules/network/nxos/nxos_file_copy.py
@@ -35,21 +35,28 @@ author:
   - Gabriele Gerbino (@GGabriele)
 notes:
   - Tested against NXOSv 7.3.(0)D1(1) on VIRL
-  - The feature must be enabled with feature scp-server.
-  - If the file is already present (md5 sums match), no transfer will
-    take place.
+  - The feature must be enabled with feature scp-server if
+    the file is being pushed to the device. If file_pull
+    is True, feature scp-server is not needed.
+  - If the file is already present, no transfer will
+    take place if file_pull is False.
   - Check mode will tell you if the file would be copied.
 requirements:
   - paramiko
+  - SCPClient
+  - pexpect
 options:
   local_file:
     description:
       - Path to local file. Local directory must exist.
-    required: true
+        If file_pull is True, this is optional, but when
+        specified, the remote file name is renamed to this.
   remote_file:
     description:
       - Remote file path of the copy. Remote directories must exist.
         If omitted, the name of the local file will be used.
+        If file_pull is True, this is the full path of the file
+        to be copied on the device and this is required.
   file_system:
     description:
       - The remote file system of the device. If omitted,
@@ -60,6 +67,35 @@ options:
       - SSH port to connect to server during transfer of file
     default: 22
     version_added: "2.5"
+  file_pull:
+    description:
+      - Whether or not to pull the remote file from the device. If True,
+        remote file will be copied to local file on the device. If the
+        file already exists on the device, it will be overwritten, and
+        the operation is NOT idempotent.
+    default: False
+    version_added: "2.7"
+  file_pull_timeout:
+    description:
+      - Use this parameter to set timeout in seconds, when transferring
+        large files or when the network is slow.
+    default: 300
+    version_added: "2.7"
+  remote_scp_server:
+    description:
+      - The remote scp server address which is used to pull the file.
+        This is required if file_pull is True.
+    version_added: "2.7"
+  remote_scp_server_user:
+    description:
+      - The remote scp server username which is used to pull the file.
+        This is required if file_pull is True.
+    version_added: "2.7"
+  remote_scp_server_password:
+    description:
+      - The remote scp server password which is used to pull the file.
+        This is required if file_pull is True.
+    version_added: "2.7"
 '''
 
 EXAMPLES = '''
@@ -71,6 +107,7 @@ EXAMPLES = '''
 RETURN = '''
 transfer_status:
     description: Whether a file was transferred. "No Transfer" or "Sent".
+                 If file_pull is successful, it is set to "Received".
     returned: success
     type: string
     sample: 'Sent'
@@ -89,10 +126,12 @@ remote_file:
 import os
 import re
 import time
+import traceback
 
 from ansible.module_utils.network.nxos.nxos import run_commands
 from ansible.module_utils.network.nxos.nxos import nxos_argument_spec, check_args
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_native, to_text
 
 try:
     import paramiko
@@ -105,6 +144,12 @@ try:
     HAS_SCP = True
 except ImportError:
     HAS_SCP = False
+
+try:
+    import pexpect
+    HAS_PEXPECT = True
+except ImportError:
+    HAS_PEXPECT = False
 
 
 def remote_file_exists(module, dst, file_system='bootflash:'):
@@ -146,7 +191,7 @@ def enough_space(module):
     return True
 
 
-def transfer_file(module, dest):
+def transfer_file_to_device(module, dest):
     file_size = os.path.getsize(module.params['local_file'])
 
     if not enough_space(module):
@@ -185,29 +230,121 @@ def transfer_file(module, dest):
     return True
 
 
+def copy_file_from_remote(module, local, file_system='bootflash:'):
+    hostname = module.params['host']
+    username = module.params['username']
+    password = module.params['password']
+    port = module.params['connect_ssh_port']
+
+    try:
+        child = pexpect.spawn('ssh ' + username + '@' + hostname + ' -p' + str(port))
+        # response could be unknown host addition or Password
+        index = child.expect(['yes', 'Password'])
+        if index == 0:
+            child.sendline('yes')
+            child.expect('Password')
+        child.sendline(password)
+        child.expect('#')
+        command = ('copy scp://' + module.params['remote_scp_server_user'] +
+                   '@' + module.params['remote_scp_server'] + module.params['remote_file'] +
+                   ' ' + file_system + local + ' vrf management')
+        child.sendline(command)
+        # response could be remote host connection time out,
+        # there is already an existing file with the same name,
+        # unknown host addition or password
+        index = child.expect(['timed out', 'existing', 'yes', 'password'], timeout=180)
+        if index == 0:
+            module.fail_json(msg='Timeout occured due to remote scp server not responding')
+        elif index == 1:
+            child.sendline('y')
+            # response could be unknown host addition or Password
+            sub_index = child.expect(['yes', 'password'])
+            if sub_index == 0:
+                child.sendline('yes')
+                child.expect('password')
+        elif index == 2:
+            child.sendline('yes')
+            child.expect('password')
+        child.sendline(module.params['remote_scp_server_password'])
+        fpt = module.params['file_pull_timeout']
+        # response could be that there is no space left on device,
+        # permission denied due to wrong user/password,
+        # remote file non-existent or success
+        index = child.expect(['No space', 'Permission denied', 'No such file', '#'], timeout=fpt)
+        if index == 0:
+            module.fail_json(msg='File copy failed due to no space left on the device')
+        elif index == 1:
+            module.fail_json(msg='Username/Password for remote scp server is wrong')
+        elif index == 2:
+            module.fail_json(msg='File copy failed due to remote file not present')
+    except pexpect.ExceptionPexpect as e:
+        module.fail_json(msg='%s' % to_native(e), exception=traceback.format_exc())
+
+    child.close()
+
+
 def main():
     argument_spec = dict(
-        local_file=dict(required=True),
-        remote_file=dict(required=False),
+        local_file=dict(type='str'),
+        remote_file=dict(type='str'),
         file_system=dict(required=False, default='bootflash:'),
         connect_ssh_port=dict(required=False, type='int', default=22),
+        file_pull=dict(type='bool', default=False),
+        file_pull_timeout=dict(type='int', default=300),
+        remote_scp_server=dict(type='str'),
+        remote_scp_server_user=dict(type='str'),
+        remote_scp_server_password=dict(no_log=True),
     )
 
     argument_spec.update(nxos_argument_spec)
 
-    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
+    rt = [['remote_scp_server',
+           'remote_scp_server_user',
+           'remote_scp_server_password']]
 
-    if not HAS_PARAMIKO:
-        module.fail_json(
-            msg='library paramiko is required but does not appear to be '
-                'installed. It can be installed using `pip install paramiko`'
-        )
+    module = AnsibleModule(argument_spec=argument_spec,
+                           required_together=rt,
+                           supports_check_mode=True)
 
-    if not HAS_SCP:
-        module.fail_json(
-            msg='library scp is required but does not appear to be '
-                'installed. It can be installed using `pip install scp`'
-        )
+    file_pull = module.params['file_pull']
+    local_file = module.params['local_file']
+    remote_file = module.params['remote_file']
+    remote_scp_server = module.params['remote_scp_server']
+
+    if file_pull:
+        if not HAS_PEXPECT:
+            module.fail_json(
+                msg='library pexpect is required but does not appear to be '
+                    'installed. It can be installed using `pip install pexpect`'
+            )
+
+        if not remote_file:
+            module.fail_json(
+                msg='remote file is required when it is copied from the device'
+            )
+
+        if not remote_scp_server:
+            module.fail_json(
+                msg='remote scp server is required when a file is copied from the device'
+            )
+
+    else:
+        if not HAS_PARAMIKO:
+            module.fail_json(
+                msg='library paramiko is required but does not appear to be '
+                    'installed. It can be installed using `pip install paramiko`'
+            )
+
+        if not HAS_SCP:
+            module.fail_json(
+                msg='library scp is required but does not appear to be '
+                    'installed. It can be installed using `pip install scp`'
+            )
+
+        if not local_file:
+            module.fail_json(
+                msg='local file is required when it is copied to the device'
+            )
 
     warnings = list()
     check_args(module, warnings)
@@ -218,28 +355,40 @@ def main():
     file_system = module.params['file_system']
 
     results['transfer_status'] = 'No Transfer'
-    results['local_file'] = local_file
     results['file_system'] = file_system
 
-    if not local_file_exists(module):
-        module.fail_json(msg="Local file {0} not found".format(local_file))
+    if file_pull:
+        src = remote_file.split('/')[-1]
+        local = local_file or src
 
-    dest = remote_file or os.path.basename(local_file)
-    remote_exists = remote_file_exists(module, dest, file_system=file_system)
+        if not module.check_mode:
+            copy_file_from_remote(module, local, file_system=file_system)
+            results['transfer_status'] = 'Received'
 
-    if not remote_exists:
         results['changed'] = True
-        file_exists = False
+        results['remote_file'] = src
+        results['local_file'] = local
     else:
-        file_exists = True
+        if not local_file_exists(module):
+            module.fail_json(msg="Local file {0} not found".format(local_file))
 
-    if not module.check_mode and not file_exists:
-        transfer_file(module, dest)
-        results['transfer_status'] = 'Sent'
+        dest = remote_file or os.path.basename(local_file)
+        remote_exists = remote_file_exists(module, dest, file_system=file_system)
 
-    if remote_file is None:
-        remote_file = os.path.basename(local_file)
-    results['remote_file'] = remote_file
+        if not remote_exists:
+            results['changed'] = True
+            file_exists = False
+        else:
+            file_exists = True
+
+        if not module.check_mode and not file_exists:
+            transfer_file_to_device(module, dest)
+            results['transfer_status'] = 'Sent'
+
+        results['local_file'] = local_file
+        if remote_file is None:
+            remote_file = os.path.basename(local_file)
+        results['remote_file'] = remote_file
 
     module.exit_json(**results)
 

--- a/lib/ansible/modules/network/nxos/nxos_file_copy.py
+++ b/lib/ansible/modules/network/nxos/nxos_file_copy.py
@@ -299,18 +299,19 @@ def main():
 
     argument_spec.update(nxos_argument_spec)
 
+    required_if = [("file_pull", True, ["remote_file", "remote_scp_server"]),
+                   ("file_pull", False, ["local_file"])]
+
     rt = [['remote_scp_server',
            'remote_scp_server_user',
            'remote_scp_server_password']]
 
     module = AnsibleModule(argument_spec=argument_spec,
+                           required_if=required_if,
                            required_together=rt,
                            supports_check_mode=True)
 
     file_pull = module.params['file_pull']
-    local_file = module.params['local_file']
-    remote_file = module.params['remote_file']
-    remote_scp_server = module.params['remote_scp_server']
 
     if file_pull:
         if not HAS_PEXPECT:
@@ -318,17 +319,6 @@ def main():
                 msg='library pexpect is required but does not appear to be '
                     'installed. It can be installed using `pip install pexpect`'
             )
-
-        if not remote_file:
-            module.fail_json(
-                msg='remote file is required when it is copied from the device'
-            )
-
-        if not remote_scp_server:
-            module.fail_json(
-                msg='remote scp server is required when a file is copied from the device'
-            )
-
     else:
         if not HAS_PARAMIKO:
             module.fail_json(
@@ -341,12 +331,6 @@ def main():
                 msg='library scp is required but does not appear to be '
                     'installed. It can be installed using `pip install scp`'
             )
-
-        if not local_file:
-            module.fail_json(
-                msg='local file is required when it is copied to the device'
-            )
-
     warnings = list()
     check_args(module, warnings)
     results = dict(changed=False, warnings=warnings)

--- a/lib/ansible/modules/network/nxos/nxos_file_copy.py
+++ b/lib/ansible/modules/network/nxos/nxos_file_copy.py
@@ -71,7 +71,7 @@ options:
       - The remote file system of the device. If omitted,
         devices that support a I(file_system) parameter will use
         their default values.
-    default: bootflash:
+    default: "bootflash:"
   connect_ssh_port:
     description:
       - SSH port to connect to server during transfer of file

--- a/lib/ansible/modules/network/nxos/nxos_file_copy.py
+++ b/lib/ansible/modules/network/nxos/nxos_file_copy.py
@@ -73,6 +73,7 @@ options:
         remote file will be copied to local file on the device. If the
         file already exists on the device, it will be overwritten, and
         the operation is NOT idempotent.
+    type: bool
     default: False
     version_added: "2.7"
   file_pull_timeout:

--- a/lib/ansible/modules/network/nxos/nxos_file_copy.py
+++ b/lib/ansible/modules/network/nxos/nxos_file_copy.py
@@ -262,32 +262,33 @@ def copy_file_from_remote(module, local, file_system='bootflash:'):
     try:
         child = pexpect.spawn('ssh ' + username + '@' + hostname + ' -p' + str(port))
         # response could be unknown host addition or Password
-        index = child.expect(['yes', 'Password'])
+        index = child.expect(['yes', '(?i)Password'])
         if index == 0:
             child.sendline('yes')
-            child.expect('Password')
+            child.expect('(?i)Password')
         child.sendline(password)
         child.expect('#')
         command = ('copy scp://' + module.params['remote_scp_server_user'] +
                    '@' + module.params['remote_scp_server'] + module.params['remote_file'] +
                    ' ' + file_system + local + ' vrf management')
+
         child.sendline(command)
         # response could be remote host connection time out,
         # there is already an existing file with the same name,
         # unknown host addition or password
-        index = child.expect(['timed out', 'existing', 'yes', 'password'], timeout=180)
+        index = child.expect(['timed out', 'existing', 'yes', '(?i)password'], timeout=180)
         if index == 0:
             module.fail_json(msg='Timeout occured due to remote scp server not responding')
         elif index == 1:
             child.sendline('y')
             # response could be unknown host addition or Password
-            sub_index = child.expect(['yes', 'password'])
+            sub_index = child.expect(['yes', '(?i)password'])
             if sub_index == 0:
                 child.sendline('yes')
-                child.expect('password')
+                child.expect('(?i)password')
         elif index == 2:
             child.sendline('yes')
-            child.expect('password')
+            child.expect('(?i)password')
         child.sendline(module.params['remote_scp_server_password'])
         fpt = module.params['file_pull_timeout']
         # response could be that there is no space left on device,

--- a/lib/ansible/modules/network/nxos/nxos_file_copy.py
+++ b/lib/ansible/modules/network/nxos/nxos_file_copy.py
@@ -40,7 +40,6 @@ notes:
   - Tested against NXOS 7.0(3)I2(5), 7.0(3)I4(6), 7.0(3)I5(3),
     7.0(3)I6(1), 7.0(3)I7(3), 6.0(2)A8(8), 7.0(3)F3(4), 7.3(0)D1(1),
     8.3(0)
-
   - When pushing files (file_pull is False) to the NXOS device,
     feature scp-server must be enabled.
   - When pulling files (file_pull is True) to the NXOS device,
@@ -57,11 +56,11 @@ options:
     description:
       - When (file_pull is False) this is the path to the local file on the Ansible Server.
         The local directory must exist.
-      - When (file_pull is True) this is the file name used rename the remote file when copied.
-        This is optional when file_pull is True.
+      - When (file_pull is True) this is the file name used when the remote file is copied
+        from the SCP server to the NXOS device.
   remote_file:
     description:
-      - When (file_pull is False) this is remote file path on the NXOS device.
+      - When (file_pull is False) this is the remote file path on the NXOS device.
         If omitted, the name of the local file will be used.
         The remote directory must exist.
       - When (file_pull is True) this is the full path to the file on the remote SCP
@@ -117,7 +116,7 @@ EXAMPLES = '''
       local_file: "./test_file.txt"
       remote_file: "test_file.txt"
 
-# Initiate file copy from nxos device from SCP server to copy it to the nxos device
+# Initiate file copy from the nxos device to transfer file from an SCP server back to the nxos device
   - name: "initiate file copy from device"
     nxos_file_copy:
       nxos_file_copy:

--- a/lib/ansible/modules/network/nxos/nxos_file_copy.py
+++ b/lib/ansible/modules/network/nxos/nxos_file_copy.py
@@ -29,7 +29,7 @@ short_description: Copy a file to a remote NXOS device.
 description:
   - This module supports two different workflows for copying a file
     to flash (or bootflash) on NXOS devices.  Files can either be (1) pushed
-    from the Ansible Server to the device or (2) pulled from a remote SCP
+    from the Ansible controller to the device or (2) pulled from a remote SCP
     file server to the device.  File copies are initiated from the NXOS
     device to the remote SCP server.  This module only supports the
     use of connection C(network_cli) or C(Cli) transport with connection C(local).
@@ -54,10 +54,9 @@ requirements:
 options:
   local_file:
     description:
-      - When (file_pull is False) this is the path to the local file on the Ansible Server.
+      - When (file_pull is False) this is the path to the local file on the Ansible controller.
         The local directory must exist.
-      - When (file_pull is True) this is the file name used when the remote file is copied
-        from the SCP server to the NXOS device.
+      - When (file_pull is True) this is the file name used on the NXOS device.
   remote_file:
     description:
       - When (file_pull is False) this is the remote file path on the NXOS device.
@@ -78,8 +77,8 @@ options:
     version_added: "2.5"
   file_pull:
     description:
-      - When (False) File is copied from the Ansible Server to the NXOS device.
-      - When (True) File is copied from a remote SCP server to the NXOS device.
+      - When (False) file is copied from the Ansible controller to the NXOS device.
+      - When (True) file is copied from a remote SCP server to the NXOS device.
         In this mode, the file copy is initiated from the NXOS device.
       - If the file is already present on the device it will be overwritten and
         therefore the operation is NOT idempotent.
@@ -110,7 +109,7 @@ options:
 '''
 
 EXAMPLES = '''
-# File copy from ansible server to nxos device
+# File copy from ansible controller to nxos device
   - name: "copy from server to device"
     nxos_file_copy:
       local_file: "./test_file.txt"
@@ -121,6 +120,7 @@ EXAMPLES = '''
     nxos_file_copy:
       nxos_file_copy:
       file_pull: True
+      local_file: "xyz"
       remote_file: "/mydir/abc"
       remote_scp_server: "192.168.0.1"
       remote_scp_server_user: "myUser"
@@ -338,19 +338,19 @@ def main():
     if file_pull:
         if not HAS_PEXPECT:
             module.fail_json(
-                msg='library pexpect is required but does not appear to be '
+                msg='library pexpect is required when file_pull is True but does not appear to be '
                     'installed. It can be installed using `pip install pexpect`'
             )
     else:
         if not HAS_PARAMIKO:
             module.fail_json(
-                msg='library paramiko is required but does not appear to be '
+                msg='library paramiko is required when file_pull is False but does not appear to be '
                     'installed. It can be installed using `pip install paramiko`'
             )
 
         if not HAS_SCP:
             module.fail_json(
-                msg='library scp is required but does not appear to be '
+                msg='library scp is required when file_pull is False but does not appear to be '
                     'installed. It can be installed using `pip install scp`'
             )
     warnings = list()

--- a/test/integration/targets/nxos_file_copy/tests/cli/sanity.yaml
+++ b/test/integration/targets/nxos_file_copy/tests/cli/sanity.yaml
@@ -58,7 +58,7 @@
     nxos_command: *remove_file
     register: result
 
-# Uncomment the follwoing tasks with proper filename, scp server details
+# Uncomment the following tasks with proper filename, scp server information
 #  - name: "Copy file abc"
 #    nxos_file_copy: &copy_pull
 #      file_pull: True

--- a/test/integration/targets/nxos_file_copy/tests/cli/sanity.yaml
+++ b/test/integration/targets/nxos_file_copy/tests/cli/sanity.yaml
@@ -6,6 +6,7 @@
     commands:
       - terminal dont-ask
       - delete network-integration.cfg
+#     - delete abc
   ignore_errors: yes
 
 - name: "Setup - Turn on feature scp-server"
@@ -56,6 +57,37 @@
   - name: "Setup - Remove existing file"
     nxos_command: *remove_file
     register: result
+
+# Uncomment the follwoing tasks with proper filename, scp server details
+#  - name: "Copy file abc"
+#    nxos_file_copy: &copy_pull
+#      file_pull: True
+#      remote_file: "/mydir/abc"
+#      remote_scp_server: "192.168.0.1"
+#      remote_scp_server_user: "myUser"
+#      remote_scp_server_password: "myPassword"
+#    register: result
+#
+#  - assert: *true
+#
+#  - name: "Overwrite the file"
+#    nxos_file_copy: *copy_pull
+#    register: result
+#
+#  - assert: *true
+#
+#  - name: "Copy different file as abc"
+#    nxos_file_copy: &copy_pull_diff
+#      file_pull: True
+#      file_pull_timeout: 1200
+#      local_file: "abc"
+#      remote_file: "/mydir/xyz"
+#      remote_scp_server: "192.168.0.1"
+#      remote_scp_server_user: "myUser"
+#      remote_scp_server_password: "myPassword"
+#    register: result
+#
+#  - assert: *true
 
   rescue:
 

--- a/test/integration/targets/nxos_file_copy/tests/cli/sanity.yaml
+++ b/test/integration/targets/nxos_file_copy/tests/cli/sanity.yaml
@@ -6,7 +6,7 @@
     commands:
       - terminal dont-ask
       - delete network-integration.cfg
-#     - delete abc
+      - delete network-integration_copy.cfg
   ignore_errors: yes
 
 - name: "Setup - Turn on feature scp-server"
@@ -54,40 +54,24 @@
 
   - assert: *false
 
-  - name: "Setup - Remove existing file"
-    nxos_command: *remove_file
+  - name: "Copy file using file_pull"
+    nxos_file_copy: &copy_pull
+      file_pull: True
+      file_pull_timeout: 60
+      local_file: "network-integration_copy.cfg"
+      remote_file: "/network-integration.cfg"
+      remote_scp_server: "{{ inventory_hostname_short }}"
+      remote_scp_server_user: "{{ ansible_ssh_user }}"
+      remote_scp_server_password: "{{ ansible_ssh_pass }}"
     register: result
 
-# Uncomment the following tasks with proper filename, scp server information
-#  - name: "Copy file abc"
-#    nxos_file_copy: &copy_pull
-#      file_pull: True
-#      remote_file: "/mydir/abc"
-#      remote_scp_server: "192.168.0.1"
-#      remote_scp_server_user: "myUser"
-#      remote_scp_server_password: "myPassword"
-#    register: result
-#
-#  - assert: *true
-#
-#  - name: "Overwrite the file"
-#    nxos_file_copy: *copy_pull
-#    register: result
-#
-#  - assert: *true
-#
-#  - name: "Copy different file as abc"
-#    nxos_file_copy: &copy_pull_diff
-#      file_pull: True
-#      file_pull_timeout: 1200
-#      local_file: "abc"
-#      remote_file: "/mydir/xyz"
-#      remote_scp_server: "192.168.0.1"
-#      remote_scp_server_user: "myUser"
-#      remote_scp_server_password: "myPassword"
-#    register: result
-#
-#  - assert: *true
+  - assert: *true
+
+  - name: "Overwrite the file"
+    nxos_file_copy: *copy_pull
+    register: result
+
+  - assert: *true
 
   rescue:
 

--- a/test/integration/targets/nxos_file_copy/tests/cli/sanity.yaml
+++ b/test/integration/targets/nxos_file_copy/tests/cli/sanity.yaml
@@ -57,7 +57,7 @@
   - name: "Copy file using file_pull"
     nxos_file_copy: &copy_pull
       file_pull: True
-      file_pull_timeout: 60
+      file_pull_timeout: 1200
       local_file: "network-integration_copy.cfg"
       remote_file: "/network-integration.cfg"
       remote_scp_server: "{{ inventory_hostname_short }}"

--- a/test/sanity/validate-modules/ignore.txt
+++ b/test/sanity/validate-modules/ignore.txt
@@ -911,7 +911,6 @@ lib/ansible/modules/network/nxos/nxos_bgp_neighbor_af.py E325
 lib/ansible/modules/network/nxos/nxos_bgp_neighbor_af.py E326
 lib/ansible/modules/network/nxos/nxos_command.py E326
 lib/ansible/modules/network/nxos/nxos_config.py E324
-lib/ansible/modules/network/nxos/nxos_file_copy.py E324
 lib/ansible/modules/network/nxos/nxos_gir.py E326
 lib/ansible/modules/network/nxos/nxos_igmp_interface.py E326
 lib/ansible/modules/network/nxos/nxos_interface.py E324


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Enhancement of nxos_file_copy module to include pulling a file from the device.
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
nxos_file_copy
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (devel 313e7ba55e) last updated 2018/07/03 11:49:34 (GMT -400)
  config file = /root/agents-ci/ansible/test/integration/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /root/agents-ci/ansible/lib/ansible
  executable location = /root/agents-ci/ansible/bin/ansible
  python version = 2.7.6 (default, Oct 26 2016, 20:30:19) [GCC 4.8.4]

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->
* Currently nxos_file_copy module allows to copy a file from the ansible server to the device.
* For simultaneous transfers this may not be scalable, if there are too many devices and the file size is large (for ex. image bin file for the device)
* The proposed PR uses "copy scp" command to initiate file transfer from the device. 
* Since this needs passwords and can potentially go through multiple state machines, pexpect is used to traverse the states.
* Tested on all platforms and for the error conditions as well.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
