### PR TITLE
Add docs on how to write changelog fragments

### DIFF
--- a/docs/docsite/rst/community/development_process.rst
+++ b/docs/docsite/rst/community/development_process.rst
@@ -63,7 +63,7 @@ pull request to backport the change to a previous stable branch.
 
        git cherry-pick -x [SHA_FROM_DEVEL]
 
-#. Add a changelog entry for the change, and commit it.
+#. Add a :ref:`changelog fragment <changelogs_how_to>` for the change, and commit it.
 
 #. Push your feature branch to your fork on GitHub:
 

--- a/docs/docsite/rst/reference_appendices/release_and_maintenance.rst
+++ b/docs/docsite/rst/reference_appendices/release_and_maintenance.rst
@@ -102,7 +102,7 @@ releases of Ansible, there can sometimes be exceptions for critical issues.
 Changelogs
 ~~~~~~~~~~~~~~~~~~
 
-Since 2.5, we have switched to ``reno`` for generating changelogs based on fragments. When creating new features or fixing bugs, create a changelog fragment describing the change. A changelog entry is not needed for new modules or plugins. Details for those items will be generated from the commit message.
+Since 2.5, we have switched to generating changelogs based on fragments. When creating new features or fixing bugs, create a changelog fragment describing the change. A changelog entry is not needed for new modules or plugins. Details for those items will be generated from the module documentation.
 
 Creating New Fragments
 ----------------------
@@ -142,10 +142,6 @@ Most changelog entries will be ``bugfixes`` or ``minor_changes``. When writing a
     - lineinfile - add warning when using an empty regexp (https://github.com/ansible/ansible/issues/29443)
 
 Commit the changelog fragment and include it with the pull request.
-
-Also since 2.5, we've logged changes to ``stable-<version>`` git branches at ``stable-<version>/changelogs/CHANGELOG-v<version>.rst``. For example, here's the changelog for 2.5_ on GitHub.
-
-Older versions logged changes to ``stable-<version>/CHANGELOG.md``. For example, here's the CHANGELOG for 2.4_.
 
 
 Release candidates

--- a/docs/docsite/rst/reference_appendices/release_and_maintenance.rst
+++ b/docs/docsite/rst/reference_appendices/release_and_maintenance.rst
@@ -97,14 +97,55 @@ releases of Ansible, there can sometimes be exceptions for critical issues.
 
 .. _GitHub: https://github.com/ansible/ansible
 
+.. _changelogs_how_to:
+
 Changelogs
 ~~~~~~~~~~~~~~~~~~
 
-Since 2.5, we've logged changes to ``stable-<version>`` git branches at ``stable-<version>/changelogs/CHANGELOG-v<version>.rst``.
-For example, here's the changelog for 2.5_ on GitHub.
+Since 2.5, we have switched to ``reno`` for generating changelogs based on fragments. When creating new features or fixing bugs, create a changelog fragment describing the change. A changelog entry is not needed for new modules or plugins. Details for those items will be generated from the commit message.
 
-Older versions logged changes to ``stable-<version>/CHANGELOG.md``. For example,
-here's the CHANGELOG for 2.4_.
+Creating New Fragments
+----------------------
+
+Create a new file with a unique and descriptive name in ``changelogs/fragments/`` that ends in ``.yaml``.
+
+A single changelog fragment may contain multiple sections but most will only contain one section. Here are the valid sections and a description of each:
+
+**major_changes**
+    Major changes to Ansible itself. Generally does not include module or plugin changes.
+
+**minor_changes**
+  Minor changes to Ansible, modules, or plugins. This includes new features, new parameters added to modules, or behavior changes to existing parameters.
+
+**deprecated_features**
+  Features that have been deprecated and are scheduled for removal in a future release.
+
+**removed_features**
+  Features that were previously deprecated and are now removed.
+
+**bugfixes**
+  Fixes that resolve issues. If there is a specific issue related to this bugfix, add a link in the changelog entry.
+
+**known_issues**
+  Known issues that are currently not fixed or will not be fixed.
+
+Most changelog entries will be ``bugfixes`` or ``minor_changes``. When writing a changelog entry that pertains to a particular module, start the entry with ``- [module name] -`` and include a link to the related issue if one exists. Here are some examples:
+
+.. code-block:: yaml
+
+  bugfixes:
+    - win_updates - fixed issue where running win_updates on async fails without any error
+
+.. code-block:: yaml
+
+  minor_changes:
+    - lineinfile - add warning when using an empty regexp (https://github.com/ansible/ansible/issues/29443)
+
+Commit the changelog fragment and include it with the pull request.
+
+Also since 2.5, we've logged changes to ``stable-<version>`` git branches at ``stable-<version>/changelogs/CHANGELOG-v<version>.rst``. For example, here's the changelog for 2.5_ on GitHub.
+
+Older versions logged changes to ``stable-<version>/CHANGELOG.md``. For example, here's the CHANGELOG for 2.4_.
 
 
 Release candidates

--- a/docs/docsite/rst/reference_appendices/release_and_maintenance.rst
+++ b/docs/docsite/rst/reference_appendices/release_and_maintenance.rst
@@ -102,9 +102,9 @@ releases of Ansible, there can sometimes be exceptions for critical issues.
 Changelogs
 ~~~~~~~~~~~~~~~~~~
 
-Older versions logged changes in ``stable-<version>`` branches at ``stable-<version>/CHANGELOG.md``. For example, here's the changelog for 2.4_ on GitHub.
+Older versions logged changes in ``stable-<version>`` branches at ``stable-<version>/CHANGELOG.md``. For example, here is the changelog for 2.4_ on GitHub.
 
-We now generate changelogs based on fragments. When creating new features or fixing bugs, create a changelog fragment describing the change. A changelog entry is not needed for new modules or plugins. Details for those items will be generated from the module documentation.
+We now generate changelogs based on fragments. Here is the generated changelog for 2.6_ as an example. When creating new features or fixing bugs, create a changelog fragment describing the change. A changelog entry is not needed for new modules or plugins. Details for those items will be generated from the module documentation.
 
 Creating New Fragments
 ----------------------
@@ -144,8 +144,6 @@ Most changelog entries will be ``bugfixes`` or ``minor_changes``. When writing a
     - lineinfile - add warning when using an empty regexp (https://github.com/ansible/ansible/issues/29443)
 
 Commit the changelog fragment and include it with the pull request.
-
-Older versions logged changes to ``stable-<version>/CHANGELOG.md``. For example, here's the CHANGELOG for 2.5_.
 
 
 

--- a/docs/docsite/rst/reference_appendices/release_and_maintenance.rst
+++ b/docs/docsite/rst/reference_appendices/release_and_maintenance.rst
@@ -102,12 +102,14 @@ releases of Ansible, there can sometimes be exceptions for critical issues.
 Changelogs
 ~~~~~~~~~~~~~~~~~~
 
-Since 2.5, we have switched to generating changelogs based on fragments. When creating new features or fixing bugs, create a changelog fragment describing the change. A changelog entry is not needed for new modules or plugins. Details for those items will be generated from the module documentation.
+Older versions logged changes in ``stable-<version>`` branches at ``stable-<version>/CHANGELOG.md``. For example, here's the changelog for 2.4_ on GitHub.
+
+We now generate changelogs based on fragments. When creating new features or fixing bugs, create a changelog fragment describing the change. A changelog entry is not needed for new modules or plugins. Details for those items will be generated from the module documentation.
 
 Creating New Fragments
 ----------------------
 
-Create a new file with a unique and descriptive name in ``changelogs/fragments/`` that ends in ``.yaml``.
+Create a new file with a unique and descriptive name in ``changelogs/fragments/`` that ends in ``.yaml`` such as ``user-40696-backup-shadow-file.yaml``
 
 A single changelog fragment may contain multiple sections but most will only contain one section. Here are the valid sections and a description of each:
 
@@ -142,6 +144,9 @@ Most changelog entries will be ``bugfixes`` or ``minor_changes``. When writing a
     - lineinfile - add warning when using an empty regexp (https://github.com/ansible/ansible/issues/29443)
 
 Commit the changelog fragment and include it with the pull request.
+
+Older versions logged changes to ``stable-<version>/CHANGELOG.md``. For example, here's the CHANGELOG for 2.5_.
+
 
 
 Release candidates


### PR DESCRIPTION
##### SUMMARY

We generate the changelog from changelog fragments for release notes now, but don't have good docs on how to write them or  what sections are valid (without reading the `config.yaml`).

Here are some docs to address this.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
`release_and_maintenance.rst`

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7
```