### PR TITLE
Backport/2.6/40783

### DIFF
--- a/lib/ansible/modules/packaging/language/maven_artifact.py
+++ b/lib/ansible/modules/packaging/language/maven_artifact.py
@@ -304,8 +304,7 @@ class MavenDownloader:
             path = "/%s/%s" % (artifact.path(), self.metadata_file_name)
             content = self._getContent(self.base + path, "Failed to retrieve the maven metadata file: " + path)
             xml = etree.fromstring(content)
-            timestamp = xml.xpath("/metadata/versioning/snapshot/timestamp/text()")[0]
-            buildNumber = xml.xpath("/metadata/versioning/snapshot/buildNumber/text()")[0]
+
             for snapshotArtifact in xml.xpath("/metadata/versioning/snapshotVersions/snapshotVersion"):
                 classifier = snapshotArtifact.xpath("classifier/text()")
                 artifact_classifier = classifier[0] if classifier else ''
@@ -313,7 +312,11 @@ class MavenDownloader:
                 artifact_extension = extension[0] if extension else ''
                 if artifact_classifier == artifact.classifier and artifact_extension == artifact.extension:
                     return self._uri_for_artifact(artifact, snapshotArtifact.xpath("value/text()")[0])
-            return self._uri_for_artifact(artifact, artifact.version.replace("SNAPSHOT", timestamp + "-" + buildNumber))
+            timestamp_xmlpath = xml.xpath("/metadata/versioning/snapshot/timestamp/text()")
+            if timestamp_xmlpath:
+                timestamp = timestamp_xmlpath[0]
+                build_number = xml.xpath("/metadata/versioning/snapshot/buildNumber/text()")[0]
+                return self._uri_for_artifact(artifact, artifact.version.replace("SNAPSHOT", timestamp + "-" + build_number))
 
         return self._uri_for_artifact(artifact, artifact.version)
 


### PR DESCRIPTION
##### SUMMARY
Backport the fix for #40782 into the stable-2.6 branch

check if timestamp is set in maven-metadata.xml. 
If it is not set, we don't have unique snapshot artifacts and can return the artifact name with the appended -SNAPSHOT

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
maven_artifact

##### ANSIBLE VERSION
```
ansible 2.5.3 (detached HEAD 778cb5bd8b) last updated 2018/05/24 14:24:47 (GMT +000)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /opt/ansible/lib/ansible
  executable location = /opt/ansible/bin/ansible
  python version = 2.7.13 (default, Jan 31 2018, 00:17:36) [GCC 4.8.5 20150623 (Red Hat 4.8.5-11)]
```
