### PR TITLE
Fix the doc to reflect the 'scaleway' group

### DIFF
--- a/contrib/inventory/scaleway.py
+++ b/contrib/inventory/scaleway.py
@@ -18,7 +18,7 @@ This script generates an Ansible hosts file with these host groups:
 <hostname>: Defines host itself with Scaleway's hostname as group name.
 <tag>: Contains all hosts which has "<tag>" as tag.
 <region>: Contains all hosts which are in the "<region>" region.
-all: Contains all hosts defined in Scaleway.
+scaleway: Contains all hosts defined in Scaleway.
 '''
 
 # (c) 2017, Paul B. <paul@bonaud.fr>


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Update the module's documentation about the group 'scaleway'.


<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
contrib/inventory/scaleway.py


##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/marcos/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.15rc1 (default, Apr 15 2018, 21:51:34) [GCC 7.3.0]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

I forgot to change this line on my last pull request. This line is important because is part of the documentation.



<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
