### PR TITLE
Changing example code block language from yaml to yaml+jinja. (#40365)

### DIFF
--- a/docs/templates/plugin.rst.j2
+++ b/docs/templates/plugin.rst.j2
@@ -222,7 +222,7 @@ Notes
 Examples
 --------
 
-.. code-block:: yaml
+.. code-block:: yaml+jinja
 
 {%   for example in examples %}
 {%     if example['description'] %}@{ example['description'] | indent(4, True) }@{% endif %}


### PR DESCRIPTION
(cherry picked from commit 9f84c09bf3ddeb7c0e0fb28a33a17def9748fa5e)

##### SUMMARY
Changes highlighting for plugin documentation to `yaml+jinja` to get nicer results. 

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
docs.ansible.com

##### ANSIBLE VERSION
2.6

##### ADDITIONAL INFORMATION
See #40365 for original discussion and example. 