### PR TITLE
Add espeak ng support to 'say' module. Closes #42438

### DIFF
--- a/contrib/inventory/scaleway.py
+++ b/contrib/inventory/scaleway.py
@@ -18,7 +18,7 @@ This script generates an Ansible hosts file with these host groups:
 <hostname>: Defines host itself with Scaleway's hostname as group name.
 <tag>: Contains all hosts which has "<tag>" as tag.
 <region>: Contains all hosts which are in the "<region>" region.
-all: Contains all hosts defined in Scaleway.
+scaleway: Contains all hosts defined in Scaleway.
 '''
 
 # (c) 2017, Paul B. <paul@bonaud.fr>

--- a/contrib/inventory/scaleway.py
+++ b/contrib/inventory/scaleway.py
@@ -18,7 +18,7 @@ This script generates an Ansible hosts file with these host groups:
 <hostname>: Defines host itself with Scaleway's hostname as group name.
 <tag>: Contains all hosts which has "<tag>" as tag.
 <region>: Contains all hosts which are in the "<region>" region.
-scaleway: Contains all hosts defined in Scaleway.
+all: Contains all hosts defined in Scaleway.
 '''
 
 # (c) 2017, Paul B. <paul@bonaud.fr>

--- a/lib/ansible/modules/notification/say.py
+++ b/lib/ansible/modules/notification/say.py
@@ -80,7 +80,7 @@ def main():
         module.warn("'say' executable found but system is '%s': ignoring voice parameter" % get_platform())
 
     if not executable:
-        module.fail_json(msg="Unable to find either 'say' or 'espeak' executable")
+        module.fail_json(msg="Unable to find either 'say', 'espeak' or 'espeak-ng' executable")
 
     if module.check_mode:
         module.exit_json(msg=msg, changed=False)

--- a/lib/ansible/modules/notification/say.py
+++ b/lib/ansible/modules/notification/say.py
@@ -32,7 +32,7 @@ options:
     description:
       What voice to use
     required: false
-requirements: [ say or espeak ]
+requirements: [ say or espeak or espeak-ng ]
 author:
     - "Ansible Core Team"
     - "Michael DeHaan (@mpdehaan)"
@@ -72,6 +72,8 @@ def main():
     executable = module.get_bin_path('say')
     if not executable:
         executable = module.get_bin_path('espeak')
+        if not executable:
+            executable = module.get_bin_path('espeak-ng')
     elif get_platform() != 'Darwin':
         # 'say' binary available, it might be GNUstep tool which doesn't support 'voice' parameter
         voice = None


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

I added two lines on Python code (and some changes to documentation) which checks if 'espeak-ng' executable exists if 'espeak' executable was not found.

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
Fixes #42438 


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
say


##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/marcos/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.15rc1 (default, Apr 15 2018, 21:51:34) [GCC 7.3.0]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->



<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
