### PR TITLE
Document module links (#42308)

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
@@ -395,7 +395,14 @@ Starting with Ansible version 2.2, all new modules are required to use imports i
 Formatting functions
 --------------------
 
-These formatting functions are ``U()`` for URLs, ``I()`` for option names, ``C()`` for files and option values and ``M()`` for module names.
+The formatting functions are:
+
+* ``L()`` for Links with a heading
+* ``U()`` for URLs
+* ``I()`` for option names
+* ``C()`` for files and option values
+* ``M()`` for module names.
+
 Module names should be specified as ``M(module)`` to create a link to the online documentation for that module.
 
 
@@ -409,6 +416,7 @@ Example usage::
     ...
     See also M(win_copy) or M(win_template).
     ...
+    Time zone names are from the L(tz database,https://en.wikipedia.org/wiki/List_of_tz_database_time_zones)
     See U(https://www.ansible.com/tower) for an overview.
     ...
     See L(IOS Platform Options guide, ../network/user_guide/platform_ios.html)


### PR DESCRIPTION
(cherry picked from commit 6366df700d3e4b5ab0988ae98115bbd8cd270de4)

##### SUMMARY
Offers developers guidance on creating links from their module documentation to other modules, external sites, and more. 

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
docs.ansible.com

##### ANSIBLE VERSION
2.6
