### PR TITLE
meraki_config_template - Add net_id support

### DIFF
--- a/test/integration/targets/meraki_config_template/tasks/main.yml
+++ b/test/integration/targets/meraki_config_template/tasks/main.yml
@@ -3,119 +3,115 @@
 
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
-# - name: Test an API key is provided
-#   fail:
-#     msg: Please define an API key
-#   when: auth_key is not defined
-  
-# - name: Use an invalid domain
-#   meraki_config_template:
-#     auth_key: '{{ auth_key }}'
-#     host: marrrraki.com
-#     state: query
-#     org_name: DevTestOrg
-#     output_level: debug
-#   delegate_to: localhost
-#   register: invalid_domain
-#   ignore_errors: yes
+- block:
+  - name: Test an API key is provided
+    fail:
+      msg: Please define an API key
+    when: auth_key is not defined
+    
+  - name: Use an invalid domain
+    meraki_config_template:
+      auth_key: '{{ auth_key }}'
+      host: marrrraki.com
+      state: query
+      org_name: DevTestOrg
+      output_level: debug
+    delegate_to: localhost
+    register: invalid_domain
+    ignore_errors: yes
 
-# - name: Connection assertions
-#   assert:
-#     that:
-#       - '"Failed to connect to" in invalid_domain.msg'
+  - name: Connection assertions
+    assert:
+      that:
+        - '"Failed to connect to" in invalid_domain.msg'
 
-- name: Query all configuration templates
-  meraki_config_template:
-    auth_key: '{{auth_key}}'
-    state: query
-    org_name: DevTestOrg
-  register: get_all
+  - name: Query all configuration templates
+    meraki_config_template:
+      auth_key: '{{auth_key}}'
+      state: query
+      org_name: DevTestOrg
+    register: get_all
 
-- name: Delete non-existant configuration template
-  meraki_config_template:
-    auth_key: '{{auth_key}}'
-    state: absent
-    org_name: DevTestOrg
-    config_template: DevConfigTemplateInvalid
-  register: deleted
-  ignore_errors: yes
+  - name: Delete non-existant configuration template
+    meraki_config_template:
+      auth_key: '{{auth_key}}'
+      state: absent
+      org_name: DevTestOrg
+      config_template: DevConfigTemplateInvalid
+    register: deleted
+    ignore_errors: yes
 
-- debug:
-    msg: '{{deleted}}'
+  - assert:
+      that:
+        - '"No configuration template named" in deleted.msg'
 
-- assert:
-    that:
-      - '"No configuration template named" in deleted.msg'
+  - name: Create a network
+    meraki_network:
+      auth_key: '{{auth_key}}'
+      state: present
+      org_name: '{{ test_org_name }}'
+      net_name: '{{ test_net_name }}'
+      type: appliance
+    delegate_to: localhost
 
-- name: Create a network
-  meraki_network:
-    auth_key: '{{auth_key}}'
-    state: present
-    org_name: '{{ test_org_name }}'
-    net_name: '{{ test_net_name }}'
-    type: appliance
-  delegate_to: localhost
+  - name: Bind a template to a network
+    meraki_config_template:
+      auth_key: '{{auth_key}}'
+      state: present
+      org_name: '{{ test_org_name }}'
+      net_name: '{{ test_net_name }}'
+      config_template: DevConfigTemplate
+    register: bind
 
-- name: Bind a template to a network
-  meraki_config_template:
-    auth_key: '{{auth_key}}'
-    state: present
-    org_name: '{{ test_org_name }}'
-    net_name: '{{ test_net_name }}'
-    config_template: DevConfigTemplate
-  register: bind
+  - assert:
+      that:
+        bind.changed == True
 
-- assert:
-    that:
-      bind.changed == True
+  - name: Bind a template to a network when it's already bound
+    meraki_config_template:
+      auth_key: '{{auth_key}}'
+      state: present
+      org_name: '{{ test_org_name }}'
+      net_name: '{{ test_net_name }}'
+      config_template: DevConfigTemplate
+    register: bind_invalid
+    ignore_errors: yes
 
-- name: Bind a template to a network when it's already bound
-  meraki_config_template:
-    auth_key: '{{auth_key}}'
-    state: present
-    org_name: '{{ test_org_name }}'
-    net_name: '{{ test_net_name }}'
-    config_template: DevConfigTemplate
-  register: bind_invalid
-  ignore_errors: yes
+  - assert:
+      that:
+        - bind_invalid.changed == False
 
-- debug:
-    msg: '{{bind_invalid}}'
+  - name: Unbind a template from a network
+    meraki_config_template:
+      auth_key: '{{auth_key}}'
+      state: absent
+      org_name: '{{ test_org_name }}'
+      net_name: '{{ test_net_name }}'
+      config_template: DevConfigTemplate
+    register: unbind
 
-- assert:
-    that:
-      - bind_invalid.changed == False
+  - assert:
+      that:
+        unbind.changed == True
 
-- name: Unbind a template from a network
-  meraki_config_template:
-    auth_key: '{{auth_key}}'
-    state: absent
-    org_name: '{{ test_org_name }}'
-    net_name: '{{ test_net_name }}'
-    config_template: DevConfigTemplate
-  register: unbind
+  - name: Unbind a template from a network when it's not bound
+    meraki_config_template:
+      auth_key: '{{auth_key}}'
+      state: absent
+      org_name: '{{ test_org_name }}'
+      net_name: '{{ test_net_name }}'
+      config_template: DevConfigTemplate
+    register: unbind_invalid
 
-- assert:
-    that:
-      unbind.changed == True
+  - assert:
+      that:
+        unbind_invalid.changed == False
 
-- name: Unbind a template from a network when it's not bound
-  meraki_config_template:
-    auth_key: '{{auth_key}}'
-    state: absent
-    org_name: '{{ test_org_name }}'
-    net_name: '{{ test_net_name }}'
-    config_template: DevConfigTemplate
-  register: unbind_invalid
-
-- assert:
-    that:
-      unbind_invalid.changed == False
-
-- name: Delete network
-  meraki_network:
-    auth_key: '{{auth_key}}'
-    state: absent
-    org_name: '{{ test_org_name }}'
-    net_name: '{{ test_net_name }}'
-  delegate_to: localhost
+  always:
+  - name: Delete network
+    meraki_network:
+      auth_key: '{{auth_key}}'
+      state: absent
+      org_name: '{{ test_org_name }}'
+      net_name: '{{ test_net_name }}'
+    delegate_to: localhost


### PR DESCRIPTION
##### SUMMARY
- Added net_id support to config_template
- Changed integration test to use blocks to cleanup on failure

Fixes #42331

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
meraki_config_template

##### ANSIBLE VERSION
```
ansible 2.7.0.dev0 (meraki/config_template_net_id 2a39238d1d) last updated 2018/07/06 20:33:24 (GMT -500)
  config file = None
  configured module search path = ['/Users/kbreit/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/kbreit/Documents/Programming/ansible/lib/ansible
  executable location = /Users/kbreit/Documents/Programming/ansible/bin/ansible
  python version = 3.5.4 (default, Feb 25 2018, 14:56:02) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
